### PR TITLE
set correct tap device when NICTYPE is tap

### DIFF
--- a/script/worker
+++ b/script/worker
@@ -256,9 +256,7 @@ sub workit($){
     # and allow MAC addresses for more than 256 workers (up to 65535)
     if ($job->{'settings'}->{'NICTYPE'} eq 'tap') {
         $job->{'settings'}->{'TAPDEV'} = 'tap' . ($options{'instance'} - 1);
-        $job->{'settings'}->{'NICMAC'} = sprintf("52:54:00:12:%02x:%02x",
-                                                 int($options{'instance'} / 256),
-                                                 $options{'instance'} % 256);
+        $job->{'settings'}->{'NICMAC'} = sprintf("52:54:00:12:%02x:%02x", int($options{'instance'} / 256), $options{'instance'} % 256);
     }
 
     if (my $iso = $job->{'settings'}->{'ISO'}) {


### PR DESCRIPTION
- set TAPDEV to tap + (worker id -1) - 
  because tap devices are by default enumerated from 0, workers from 1
- no check for existing device, let qemu to fail.
- assign different MAC for each worker - 
  the code looks more cryptic then should, initially I modified only last number of MAC, but that would limit max number of workers with tap networking to 255 and then starts to produce MAC conflicts.
