### PR TITLE
move the TMPDIR of qemu to the pool directory

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -68,11 +68,12 @@
   /var/lib/openqa/pool/*/qemuscreenshot/* rw,
   /var/lib/openqa/pool/*/raid/ rw,
   /var/lib/openqa/pool/*/raid/* rw,
+  /var/lib/openqa/pool/*/tmp/ rw,
+  /var/lib/openqa/pool/*/tmp/* rw,
   /var/lib/openqa/pool/*/testresults/ rw,
   /var/lib/openqa/pool/*/testresults/** rwk,
   /var/lib/openqa/pool/*/video/ rw,
   /var/lib/openqa/testresults/** rwk,
   /var/lib/openqa/logupload/** rwk,
   /var/lib/os-autoinst/tests/** r,
-  /var/tmp/* w,
 }

--- a/script/worker
+++ b/script/worker
@@ -405,6 +405,11 @@ sub main(){
     my $workerid = api_call('post', 'workers', {host => $hostname, instance => $options{'instance'}, backend => $worker_settings->{'BACKEND'}})->{id};
     $ENV{'WORKERID'} = $workerid;
 
+    # create tmpdir for qemu to write here
+    my $tmpdir = "$pooldir/tmp";
+    mkdir($tmpdir) unless (-d $tmpdir);
+    $ENV{'TMPDIR'} = $tmpdir;
+
     my $job;
     my $worker;
     my $worker_start_time;


### PR DESCRIPTION
fixes problems with apparmor on using /var/tmp
