### PR TITLE
move workers view into admin with admin layout

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -217,8 +217,6 @@ sub startup {
     $test_r->get('/')->name('test')->to('test#show');
     $test_auth->get('/menu')->name('test_menu')->to('test#menu');
 
-    $r->get('/workers')->name('workers')->to('worker#list');
-
     $test_r->get('/modlist')->name('modlist')->to('running#modlist');
     $test_r->get('/status')->name('status')->to('running#status');
     $test_r->get('/livelog')->name('livelog')->to('running#livelog');
@@ -298,6 +296,8 @@ sub startup {
     $admin_r->post('/job_templates')->to('job_template#update');
 
     $admin_r->get('/assets')->name('admin_assets')->to('asset#index');
+
+    $admin_r->get('/workers')->name('admin_workers')->to('workers#index');
 
     # Users list as default option
     $admin_r->get('/')->name('admin')->to('user#index');

--- a/lib/OpenQA/Admin/Workers.pm
+++ b/lib/OpenQA/Admin/Workers.pm
@@ -1,0 +1,38 @@
+# Copyright (C) 2014 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::Admin::Workers;
+use Mojo::Base 'Mojolicious::Controller';
+use openqa;
+use OpenQA::Worker ();
+
+sub index {
+    my $self = shift;
+
+    my $workers_amount = 0;
+    my @workers_list = ();
+
+    $workers_amount = OpenQA::Worker::workers_amount();
+    @workers_list = OpenQA::Worker::workers_list();
+
+    $self->stash(wamount => $workers_amount);
+    $self->stash(wlist => \@workers_list);
+
+    $self->render('admin/workers/index');
+}
+
+1;
+# vim: set sw=4 et:

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -19,15 +19,23 @@ use Mojo::Base 'Mojolicious::Controller';
 use openqa;
 use Scheduler qw/list_workers worker_get workers_get_dead_worker job_get_by_workerid/;
 
-sub list {
+sub workers_amount {
     my $self = shift;
 
     my $workers_ref = list_workers();
-    my $workers_cnt = scalar(@$workers_ref) - 1;
+    my $workers_amount = scalar(@$workers_ref) - 1;
+
+    return $workers_amount;
+}
+
+sub workers_list {
+    my $self = shift;
+
+    my $workers_amount = workers_amount();
 
     my @wlist=();
 
-    for my $workerid (1..$workers_cnt) {
+    for my $workerid (1..$workers_amount) {
         my $worker = worker_get($workerid);
         my $job = job_get_by_workerid($workerid);
         my $settings = {
@@ -56,8 +64,7 @@ sub list {
         }
         push @wlist, $settings;
     }
-    $self->stash(wlist => \@wlist);
-    $self->stash(workers_cnt => $workers_cnt);
+    return @wlist;
 }
 
 1;

--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -1,9 +1,12 @@
-% layout 'default';
-% title 'Workers view';
+% layout 'admin';
+% title 'Workers';
 
 <div class="grid_16 box box-shadow alpha">
 	<h2><%= title %></h2>
-	<p>This page lists the status of <%= $workers_cnt %> workers.</p>
+
+    %= include 'layouts/info'
+
+	<p>This page lists the status of <%= $wamount %> workers.</p>
 	<p />
 	<table id="results" class="table-autosort table-autofilter table-autostripe">
 		<thead>

--- a/templates/layouts/admin.html.ep
+++ b/templates/layouts/admin.html.ep
@@ -36,7 +36,7 @@
                     <li><%= link_to('Assets' => url_for('admin_assets')) %></li>
                     <!-- Sure this is not the proper place for the workers view,
                          but the previous one was even more annoying -->
-                    <li><%= link_to('Workers' => url_for('workers')) %></li>
+                    <li><%= link_to('Workers' => url_for('admin_workers')) %></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
ah, I found this changes keeps in my branch stills, this is not an important change, but I just lazy to switch admin page and workers page, so I moved workers view page into admin page with admin layout, I know we have a task that prefer showing workers summary view in the top page, thus I leaves Workers library there that could reuse if need to get workers status.
