### PR TITLE
action #3582 - openqa: make dents work again

### DIFF
--- a/lib/OpenQA/Test.pm
+++ b/lib/OpenQA/Test.pm
@@ -192,6 +192,7 @@ sub show {
             {
                 name => $module->{'name'},
                 result => $module->{'result'},
+                dents => $module->{'dents'},
                 screenshots => \@imglist,
                 wavs => \@wavlist,
                 ocrs => \@ocrlist,

--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -64,6 +64,7 @@ table th.table-sorted-asc i.sort-arrows {
 .overview_passed {color: #248509 ;}		/* dark Lemon */
 .overview_passed a {color: #248509 ;}
 .overview_unknown {background-color:#ff9 ;}
+.overview_dent {background-color:#ff0 ;}
 .overview_failed {background-color:#fbb ;}
 .overview_incomplete {background-color:#bebebe;}
 

--- a/templates/test/list.html.ep
+++ b/templates/test/list.html.ep
@@ -45,6 +45,7 @@
                 <th class="table-sortable:alphanumeric">testtime</th>
                 <th class="table-sortable:numeric">OK</th>
                 <th class="table-sortable:numeric">unk</th>
+                <th class="table-sortable:numeric">dents</th>
                 <th class="table-sortable:numeric">fail</th>
             </tr>
         </thead>
@@ -108,6 +109,7 @@
                 % } else {
                     <td><span class="overview_passed"><%= ($test->{'res_ok'})?$test->{'res_ok'}:'' %></span></td>
                     <td><span class="overview_unknown"><%= ($test->{'res_unknown'}?$test->{'res_unknown'}:'') %></span></td>
+		    <td><span class="overview_dent"><%= ($test->{'res_dents'}?$test->{'res_dents'}:'') %></span></td>
                     <td><span class="overview_failed"><%= ($test->{'res_fail'}?$test->{'res_fail'}:'') %></span></td>
                 % }
             </tr>

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -198,7 +198,11 @@
 				<td class="component">
 				  %= link_to $module->{'name'} => url_for('src_step', stepid => 1, moduleid => $module->{'name'})
 				</td>
-				<td class="<%= "result$res_css->{$module->{'result'}}" %>"><%= $res_display->{$module->{'result'}} %></td>
+				% my $result_class = $res_css->{$module->{'result'}};
+				% if (($result_class eq 'ok') && ($module->{'dents'})) {
+				%   $result_class = 'warning';
+				% }
+				<td class="<%= "result$result_class" %>"><%= $res_display->{$module->{'result'}} %></td>
 				<td class="links" style="width: 60%;">
                                   % for my $screenshot (@{$module->{'screenshots'}}) {
                                      %= link_to url_for('step', moduleid => $module->{'name'}, stepid => $screenshot->{'num'}) => (class => 'no_hover') => begin


### PR DESCRIPTION
This patch show the dents in the user interface.  After talking
with coolo and lnussel we agreed that this is not the best approach:

os-autoins needs to mark as fails the test when there is a dent.

This patch is submitted meanwhile, because can be used to track the
dents.
