### PR TITLE
remove test-data alias - no tests should use it

### DIFF
--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -21,7 +21,6 @@ Alias /assets "/var/lib/openqa/factory"
     Order allow,deny
     Allow from all
 </Directory>
-Alias /test-data "/var/lib/os-autoinst/tests"
 
 <Proxy *>
 Order deny,allow
@@ -36,7 +35,6 @@ ProxyPass /images !
 ProxyPass /javascripts !
 ProxyPass /stylesheets !
 ProxyPass /assets !
-ProxyPass /test-data !
 ProxyPass /error !
 
 ProxyPass / http://localhost:9526/ keepalive=On


### PR DESCRIPTION
It's very unreliable (see issue 4568)

Only merge it after https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/149
