### PR TITLE
fix redirect for assets

### DIFF
--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -9,12 +9,12 @@ DocumentRoot /usr/share/openqa/public
     Allow from all
 </Directory>
 
-<Directory "/var/lib/openqa/factory">
+<Directory "/var/lib/openqa/share/factory">
     AllowOverride None
     Order allow,deny
     Allow from all
 </Directory>
-Alias /assets "/var/lib/openqa/factory"
+Alias /assets "/var/lib/openqa/share/factory"
 
 <Directory "/var/lib/os-autoinst/tests">
     AllowOverride None


### PR DESCRIPTION
Apache gives 403 if we access the repos through the symlink
