### PR TITLE
Use password to connect to worker's ip address

### DIFF
--- a/lib/OpenQA/API/V1/Job.pm
+++ b/lib/OpenQA/API/V1/Job.pm
@@ -58,8 +58,9 @@ sub grab {
 
     my $workerid = $self->stash('workerid');
     my $blocking = int($self->param('blocking') || 0);
+    my $workerip = $self->tx->remote_address;
 
-    my $res = Scheduler::job_grab(workerid => $workerid, blocking => $blocking);
+    my $res = Scheduler::job_grab(workerid => $workerid, blocking => $blocking, workerip => $workerip);
     $self->render(json => {job => $res});
 }
 

--- a/lib/OpenQA/Running.pm
+++ b/lib/OpenQA/Running.pm
@@ -42,7 +42,7 @@ sub init {
     my $workerid = $job->{'worker_id'};
     my $worker = Scheduler::worker_get($workerid);
     my $workerport = $worker->{'instance'} * 10 + $WORKER_PORT_START;
-    my $workerurl = $worker->{'host'} . ':' . $workerport;
+    my $workerurl = $job->{'settings'}->{'CONNECT_IP'} . ':' . $workerport;
     $self->stash('workerurl', $workerurl);
     $self->stash('jobpassword', $job->{'settings'}->{'CONNECT_PASSWORD'});
 

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -96,7 +96,8 @@ my $job_ref = {
         KVM => "KVM",
         MACHINE => "RainbowPC",
         NAME => '00000001-Unicorn-42-pink-Build666-rainbow',
-        CONNECT_PASSWORD => ''
+        CONNECT_PASSWORD => '',
+        CONNECT_IP => ''
     },
     assets => {
         iso => ['whatever.iso'],
@@ -155,7 +156,8 @@ my $jobs = [
             KVM => "KVM",
             MACHINE => "RainbowPC",
             NAME => '00000002-OTHER NAME',
-            CONNECT_PASSWORD => ''
+            CONNECT_PASSWORD => '',
+            CONNECT_IP => ''
         },
         assets => {
             iso => ['whatever.iso'],
@@ -187,7 +189,8 @@ my $jobs = [
             KVM => "KVM",
             MACHINE => "RainbowPC",
             NAME => '00000001-Unicorn-42-pink-Build666-rainbow',
-            CONNECT_PASSWORD => ''
+            CONNECT_PASSWORD => '',
+            CONNECT_IP => ''
         },
         assets => {
             iso => ['whatever.iso'],
@@ -255,6 +258,8 @@ $job_ref->{settings}->{NAME} = '00000003-Unicorn-42-pink-Build666-rainbow';
 
 isnt($job->{settings}->{CONNECT_PASSWORD}, '', 'Connect password must be set');
 is(length($job->{settings}->{CONNECT_PASSWORD}), 32, 'We expect a long string');
+
+isnt($job->{settings}->{CONNECT_IP}, '', 'Worker IP address must be set');
 
 # it's hard to test that we have a valid random string - so remove them from the test
 delete $job->{settings}->{CONNECT_PASSWORD};


### PR DESCRIPTION
- generated password must also be added to requested job hash since we already queried database.
- use IP address instead of plain hostname, IP is obtained from worker grab_job request
