### PR TITLE
Administration API

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -147,6 +147,7 @@ sub startup {
     $self->plugin('OpenQA::Plugin::CSRF');
     $self->plugin('OpenQA::Plugin::REST');
 
+    $self->plugin('HashedParams');
     # set secure flag on cookies of https connections
     $self->hook(
         before_dispatch => sub {
@@ -357,6 +358,34 @@ sub startup {
     $api_public_r->get('/assets/#type/#name')->name('apiv1_get_asset_name')->to('asset#get');
     $api_r->delete('/assets/#id')->name('apiv1_delete_asset')->to('asset#delete');
     $api_r->delete('/assets/#type/#name')->name('apiv1_delete_asset_name')->to('asset#delete');
+
+    # api/v1/test_suites
+    $api_r->get('test_suites')->name('apiv1_test_suites')->to('table#list', table => 'TestSuites');
+    $api_r->post('test_suites')->to('table#create', table => 'TestSuites');
+    $api_r->get('test_suites/:id')->name('apiv1_test_suite')->to('table#list', table => 'TestSuites');
+    $api_r->put('test_suites/:id')->to('table#update', table => 'TestSuites');
+    $api_r->delete('test_suites/:id')->to('table#destroy', table => 'TestSuites');
+
+    # api/v1/machines
+    $api_r->get('machines')->name('apiv1_machines')->to('table#list', table => 'Machines');
+    $api_r->post('machines')->to('table#create', table => 'Machines');
+    $api_r->get('machines/:id')->name('apiv1_machine')->to('table#list', table => 'Machines');
+    $api_r->put('machines/:id')->to('table#update', table => 'Machines');
+    $api_r->delete('machines/:id')->to('table#destroy', table => 'Machines');
+
+    # api/v1/products
+    $api_r->get('products')->name('apiv1_products')->to('table#list', table => 'Products');
+    $api_r->post('products')->to('table#create', table => 'Products');
+    $api_r->get('products/:id')->name('apiv1_product')->to('table#list', table => 'Products');
+    $api_r->put('products/:id')->to('table#update', table => 'Products');
+    $api_r->delete('products/:id')->to('table#destroy', table => 'Products');
+
+    # api/v1/job_templates
+    $api_r->get('job_templates')->name('apiv1_job_templates')->to('job_template#list');
+    $api_r->post('job_templates')->to('job_template#create');
+    $api_r->get('job_templates/:job_template_id')->name('apiv1_job_template')->to('job_template#list');
+    $api_r->delete('job_templates/:job_template_id')->to('job_template#destroy');
+
     # json-rpc methods not migrated to this api: echo, list_commands
     ###
     ## JSON API ends here

--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -146,8 +146,8 @@ sub startup {
     $self->plugin('OpenQA::Plugin::Helpers');
     $self->plugin('OpenQA::Plugin::CSRF');
     $self->plugin('OpenQA::Plugin::REST');
+    $self->plugin('OpenQA::Plugin::HashedParams');
 
-    $self->plugin('HashedParams');
     # set secure flag on cookies of https connections
     $self->hook(
         before_dispatch => sub {

--- a/lib/OpenQA/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/API/V1/JobTemplate.pm
@@ -1,0 +1,148 @@
+# Copyright (C) 2014 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::API::V1::JobTemplate;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub list {
+    my $self = shift;
+
+    my @templates;
+    eval {
+        if ($self->param("job_template_id")) {
+            @templates = $self->db->resultset("JobTemplates")->search({id => $self->param("job_template_id")});
+        }
+        else {
+            @templates = $self->db->resultset("JobTemplates")->all;
+        }
+    };
+    my $error = $@;
+
+    if ($error) {
+        $self->render(json => {error => $error}, status => 404);
+        return;
+    }
+
+    $self->render(json => {JobTemplates => [map { { id => $_->id,product => {id => $_->product_id,arch => $_->product->arch,distri => $_->product->distri,flavor => $_->product->flavor,version => $_->product->version},machine => {id => $_->machine_id, name => $_->machine->name},test_suite => {id => $_->test_suite_id, name => $_->test_suite->name}} } @templates]});
+}
+
+sub create {
+    my $self = shift;
+    my $error;
+    my $id;
+    my $validation = $self->validation;
+
+    if ($validation->optional('product_id')->like(qr/^[0-9]+$/)->is_valid) {
+        $validation->required('machine_id')->like(qr/^[0-9]+$/);
+        $validation->required('test_suite_id')->like(qr/^[0-9]+$/);
+
+        if ($validation->has_error) {
+            $error = "wrong parameter: ";
+            for my $k (qw/product_id machine_id test_suite_id/) {
+                $error .= $k if $validation->has_error($k);
+            }
+        }
+        else {
+            eval { $id = $self->db->resultset("JobTemplates")->create({product_id => $self->param('product_id'), machine_id => $self->param('machine_id'),test_suite_id => $self->param('test_suite_id')})->id};
+            $error = $@;
+        }
+    }
+    else {
+        $validation->required('machine_name');
+        $validation->required('test_suite_name');
+        $validation->required('arch');
+        $validation->required('distri');
+        $validation->required('flavor');
+        $validation->required('version');
+
+        if ($validation->has_error) {
+            $error = "wrong parameter: ";
+            for my $k (qw/machine_name test_suite_name arch distri flavor version/) {
+                $error .= $k if $validation->has_error($k);
+            }
+        }
+        else {
+            eval { $id = $self->db->resultset("JobTemplates")->create({product =>{arch => $self->param('arch'),distri => $self->param('distri'),flavor => $self->param('flavor'),version => $self->param('version')},machine => {name => $self->param('machine_name')},test_suite => {name => $self->param('test_suite_name')},})->id};
+            $error = $@;
+        }
+    }
+
+    my $status;
+    my $json = {};
+
+    if ($error) {
+        $json->{error} = $error;
+        $status = 400;
+    }
+    else {
+        $json->{id} = $id;
+    }
+
+    $self->respond_to(
+        json => {json => $json, status => $status},
+        html => sub {
+            if ($error) {
+                $self->flash('error', "Error adding the job template: $error");
+            }
+            else {
+                $self->flash(info => 'Job template added');
+            }
+            $self->res->code(303);
+            $self->redirect_to($self->req->headers->referrer);
+        }
+    );
+}
+
+sub destroy {
+    my $self = shift;
+    my $job_templates = $self->db->resultset('JobTemplates');
+
+    my $status;
+    my $json = {};
+
+    my $rs;
+    eval {$rs = $job_templates->search({id => $self->param('job_template_id')})->delete };
+    my $error = $@;
+
+    if ($rs) {
+        if ($rs == 0) {
+            $status = 404;
+            $error = 'Not found';
+        }
+        else {
+            $json->{result} = int($rs);
+        }
+    }
+    else {
+        $json->{error} = $error;
+        $status = 400;
+    }
+    $self->respond_to(
+        json => {json => $json, status => $status},
+        html => sub {
+            if ($error) {
+                $self->flash('error', "Error deleting the job template: $error");
+            }
+            else {
+                $self->flash(info => 'Job template deleted');
+            }
+            $self->res->code(303);
+            $self->redirect_to($self->req->headers->referrer);
+        }
+    );
+}
+
+1;

--- a/lib/OpenQA/API/V1/Table.pm
+++ b/lib/OpenQA/API/V1/Table.pm
@@ -1,0 +1,242 @@
+# Copyright (C) 2014 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::API::V1::Table;
+use Mojo::Base 'Mojolicious::Controller';
+
+my %tables = (
+    'Machines' => {
+        'keys' => [['id'],['name'],],
+        'cols' => [ 'id', 'name', 'backend' ],
+        'required' => [ 'name', 'backend' ],
+        'defaults' => { 'variables' => "" },
+    },
+    'TestSuites' => {
+        'keys' => [['id'],['name'],],
+        'cols' => [ 'id', 'name', 'prio' ],
+        'required' => [ 'name', 'prio' ],
+        'defaults' => { 'variables' => "" },
+    },
+    'Products' => {
+        'keys' => [['id'],['distri', 'version', 'arch', 'flavor' ],],
+        'cols' => [ 'id', 'distri', 'version', 'arch', 'flavor' ],
+        'required' => [ 'distri', 'version', 'arch', 'flavor' ],
+        'defaults' => { 'variables' => "", 'name' => "" },
+    },
+);
+
+
+sub list {
+    my $self = shift;
+
+    my $table = $self->param("table");
+    my %search;
+
+    for my $key (@{$tables{$table}->{'keys'}}) {
+        my $have = 1;
+        for my $par (@$key) {
+            $have &&= $self->param($par);
+        }
+        if ($have) {
+            for my $par (@$key) {
+                $search{$par} = $self->param($par);
+            }
+        }
+    }
+
+    my @result;
+    eval {
+        if (%search) {
+            @result = $self->db->resultset($table)->search(\%search);
+        }
+        else {
+            @result = $self->db->resultset($table)->all;
+        }
+    };
+    my $error = $@;
+
+    if ($error) {
+        $self->render(json => {error => $error}, status => 404);
+        return;
+    }
+
+    $self->render(
+        json => {
+            $table => [
+                map {
+                    my $row = $_;
+                    my %hash = (( map { ( $_ => $row->get_column($_) ) } @{$tables{$table}->{'cols'}} ),settings => [ map { { key => $_->key, value => $_->value } } $row->settings ]);
+                    \%hash;
+                } @result
+            ]
+        }
+    );
+}
+
+sub create {
+    my $self = shift;
+    my $table = $self->param("table");
+
+    my $error;
+    my $id;
+
+    my %entry = %{$tables{$table}->{'defaults'}};
+    my $validation = $self->validation;
+
+    for my $par (@{$tables{$table}->{'required'}}) {
+        $validation->required($par);
+        $entry{$par} = $self->param($par);
+    }
+    my $hp = $self->hparams();
+    my @settings;
+    if ($hp->{'settings'}) {
+        for my $k (keys %{$hp->{'settings'}}) {
+            push @settings, {'key' => $k, 'value' => $hp->{'settings'}->{$k} };
+        }
+    }
+    $entry{'settings'} = \@settings;
+
+    if ($validation->has_error) {
+        $error = "wrong parameter: ";
+        for my $par (@{$tables{$table}->{'required'}}) {
+            $error .= " $par" if $validation->has_error($par);
+        }
+    }
+    else {
+        eval { $id = $self->db->resultset($table)->create(\%entry)->id};
+        $error = $@;
+    }
+
+    my $status;
+    my $json = {};
+
+    if ($error) {
+        $json->{error} = $error;
+        $status = 400;
+    }
+    else {
+        $json->{id} = $id;
+    }
+
+    $self->render(json => $json, status => $status);
+}
+
+sub update {
+    my $self = shift;
+    my $table = $self->param("table");
+
+    my $error;
+    my $ret;
+    my %entry;
+    my $validation = $self->validation;
+
+    for my $par (@{$tables{$table}->{'required'}}) {
+        $validation->required($par);
+        $entry{$par} = $self->param($par);
+    }
+
+    my $hp = $self->hparams();
+    my @settings;
+    my @keys;
+    if ($hp->{'settings'}) {
+        for my $k (keys %{$hp->{'settings'}}) {
+            push @settings, {'key' => $k, 'value' => $hp->{'settings'}->{$k} };
+            push @keys, $k;
+        }
+    }
+
+    $entry{'variables'} = '';
+
+    if ($validation->has_error) {
+        $error = "wrong parameter: ";
+        for my $par (@{$tables{$table}->{'required'}}) {
+            $error .= " $par" if $validation->has_error($par);
+        }
+    }
+    else {
+        eval {
+            my $rc = $self->db->resultset($table)->find({id => $self->param('id')});
+            if ($rc) {
+                $rc->update(\%entry);
+                for my $var (@settings) {
+                    $rc->update_or_create_related('settings', $var);
+                }
+                $rc->delete_related('settings', {'key' => { 'not in' => [@keys] }});
+                $ret = 1;
+            }
+            else {
+                $ret = 0;
+            }
+        };
+        $error = $@;
+    }
+
+    my $status;
+    my $json = {};
+
+    if ($ret) {
+        if ($ret == 0) {
+            $status = 404;
+            $error = 'Not found';
+        }
+        else {
+            $json->{result} = int($ret);
+        }
+    }
+    else {
+        $json->{error} = $error;
+        $status = 400;
+    }
+
+    $self->render(json => $json, status => $status);
+}
+
+
+sub destroy {
+    my $self = shift;
+    my $table = $self->param("table");
+
+    my $machines = $self->db->resultset('Machines');
+
+    my $status;
+    my $json = {};
+
+    my $ret;
+
+    eval {
+        my $rs = $self->db->resultset($table);
+        $ret = $rs->search({id => $self->param('id')})->delete;
+    };
+    my $error = $@;
+
+    if ($ret) {
+        if ($ret == 0) {
+            $status = 404;
+            $error = 'Not found';
+        }
+        else {
+            $json->{result} = int($ret);
+        }
+    }
+    else {
+        $json->{error} = $error;
+        $status = 400;
+    }
+
+    $self->render(json => $json, status => $status);
+}
+
+1;

--- a/lib/OpenQA/Plugin/HashedParams.pm
+++ b/lib/OpenQA/Plugin/HashedParams.pm
@@ -1,0 +1,109 @@
+package OpenQA::Plugin::HashedParams;
+
+use Mojo::Base 'Mojolicious::Plugin';
+
+our $VERSION = '0.04';
+
+sub register {
+    my ( $plugin, $app ) = @_;
+
+    $app->helper(
+        hparams => sub {
+            my ( $self, @permit ) = @_;
+
+            if ( !$self->stash('hparams') ) {
+                my $hprms = $self->req->params->to_hash;
+                my $index = 0;
+                my @array;
+
+                foreach my $p ( keys %$hprms ) {
+                    my $key = $p;
+                    my $val = $hprms->{$p};
+
+                    $key =~ s/[^\]\[0-9a-zA-Z_]//g;
+                    $key =~ s/\[{2,}/\[/g;
+                    $key =~ s/\]{2,}/\]/g;
+
+                    my @list;
+                    foreach my $n ( split /[\[\]]/, $key ) {
+                        push @list, $n if length($n) > 0;
+                    }
+
+                    map $array[$index] .= "{$list[$_]}", 0 .. $#list;
+
+                    $array[$index] .= " = '$val';";
+                    $index++;
+                }
+
+                my $code = 'my $h = {};';
+                map { $code .= "\$h->$_" } @array;
+                $code .= '$h;';
+
+                my $ret = eval $code;
+
+                if ($@) {
+                    $self->stash( hparams       => {} );
+                    $self->stash( hparams_error => $@ );
+                    return $self->stash('hparams');
+                }
+
+                if (%$ret) {
+                    if (@permit) {
+                        foreach my $k ( keys %$ret ) {
+                            delete $ret->{$k} if grep( /\Q$k/, @permit );
+                        }
+                    }
+
+                    $self->stash( hparams => $ret );
+                }
+            }
+            else {
+                $self->stash( hparams => {} );
+            }
+            return $self->stash('hparams');
+        }
+    );
+}
+
+1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+Mojolicious::Plugin::HashedParams - Transformation request parameters into a hash and multi-hash
+
+=head1 SYNOPSIS
+
+  plugin 'HashedParams';
+
+  # Transmit params:
+  /route?message[body]=PerlOrDie&message[task][id]=32
+    or
+  <input type="text" name="message[task][id]" value="32"> 
+
+  get '/route' => sub {
+    my $self = shift;
+    # you can also use permit parameters
+    $self->hparams( qw/message/ );
+    # return all parameters in the hash
+    $self->hparams();
+  };
+
+=head1 AUTHOR
+
+Grishkovelli L<grishkovelli@gmail.com>
+
+=head1 Git
+
+L<https://github.com/grishkovelli/Mojolicious-Plugin-HashedParams>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2013, Grishkovelli.
+
+This library is free software; you can redistribute it and/or modify it under the same terms as Perl itself.
+
+=cut

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -1,0 +1,149 @@
+# Copyright (C) 2014 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+BEGIN {
+    unshift @INC, 'lib', 'lib/OpenQA/modules';
+}
+
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use OpenQA::Test::Case;
+use OpenQA::API::V1::Client;
+use Mojo::IOLoop;
+use Data::Dump;
+
+OpenQA::Test::Case->new->init_data;
+
+my $t = Test::Mojo->new('OpenQA');
+
+# XXX: Test::Mojo loses it's app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+my $app = $t->app;
+$t->ua(OpenQA::API::V1::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+my $get = $t->get_ok('/api/v1/machines')->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'Machines' => [
+            {
+                'backend' => 'qemu',
+                'id' => 1001,
+                'name' => '32bit',
+                'settings' => [
+                    {
+                        'key' => 'QEMUCPU',
+                        'value' => 'qemu32'
+                    }
+                ]
+            },
+            {
+                'backend' => 'qemu',
+                'id' => 1002,
+                'name' => '64bit',
+                'settings' => [
+                    {
+                        'key' => 'QEMUCPU',
+                        'value' => 'qemu64'
+                    }
+                ]
+            },
+            {
+                'backend' => 'qemu',
+                'id' => 1008,
+                'name' => 'Laptop_64',
+                'settings' => [
+                    {
+                        'key' => 'LAPTOP',
+                        'value' => '1'
+                    },
+                    {
+                        'key' => 'QEMUCPU',
+                        'value' => 'qemu64'
+                    }
+                ]
+            }
+        ]
+    },
+    "Initial machines"
+) || diag explain $get->tx->res->json;
+
+
+my $res = $t->post_ok('/api/v1/machines', form => { name => "testmachine" })->status_is(400); # missing backend
+$res = $t->post_ok('/api/v1/machines', form => { backend => "kde/usb" })->status_is(400); #missing name
+
+$res = $t->post_ok('/api/v1/machines', form => { name => "testmachine", backend => "qemu", "settings[TEST]" => "val1", "settings[TEST2]" => "val1" })->status_is(200);
+my $machine_id = $res->tx->res->json->{id};
+
+$res = $t->get_ok('/api/v1/machines', form => { name => "testmachine" })->status_is(200);
+is($res->tx->res->json->{Machines}->[0]->{id}, $machine_id);
+
+$res = $t->post_ok('/api/v1/machines', form => { name => "testmachine", backend => "qemu"})->status_is(400); #already exists
+
+$get = $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'Machines' => [
+            {
+                'backend' => 'qemu',
+                'id' => $machine_id,
+                'name' => 'testmachine',
+                'settings' => [
+                    {
+                        'key' => 'TEST',
+                        'value' => 'val1'
+                    },
+                    {
+                        'key' => 'TEST2',
+                        'value' => 'val1'
+                    }
+                ]
+            }
+        ]
+    },
+    "Add machine"
+) || diag explain $get->tx->res->json;
+
+$res = $t->put_ok("/api/v1/machines/$machine_id", form => { name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1" })->status_is(200);
+
+$get = $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'Machines' => [
+            {
+                'backend' => 'qemu',
+                'id' => $machine_id,
+                'name' => 'testmachine',
+                'settings' => [
+                    {
+                        'key' => 'TEST2',
+                        'value' => 'val1'
+                    }
+                ]
+            }
+        ]
+    },
+    "Delete machine variable"
+) || diag explain $get->tx->res->json;
+
+$res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(200);
+$res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(404); #not found
+
+done_testing();

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -1,0 +1,133 @@
+# Copyright (C) 2014 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+BEGIN {
+    unshift @INC, 'lib', 'lib/OpenQA/modules';
+}
+
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use OpenQA::Test::Case;
+use OpenQA::API::V1::Client;
+use Mojo::IOLoop;
+use Data::Dump;
+
+OpenQA::Test::Case->new->init_data;
+
+my $t = Test::Mojo->new('OpenQA');
+
+# XXX: Test::Mojo loses it's app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+my $app = $t->app;
+$t->ua(OpenQA::API::V1::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+
+my $get = $t->get_ok('/api/v1/products')->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'Products' => [
+            {
+                'arch' => 'i586',
+                'distri' => 'opensuse',
+                'flavor' => 'DVD',
+                'id' => 1,
+                'settings' => [
+                    {
+                        'key' => 'DVD',
+                        'value' => '1'
+                    },
+                    {
+                        'key' => 'ISO_MAXSIZE',
+                        'value' => '4700372992'
+                    }
+                ],
+                'version' => '13.1'
+            }
+        ]
+    },
+    "Initial products"
+) || diag explain $get->tx->res->json;
+
+
+$t->post_ok('/api/v1/products', form => { distri => "opensuse", flavor => "DVD", version => 13.2 })->status_is(400); #no arch
+$t->post_ok('/api/v1/products', form => { arch => "x86_64", flavor => "DVD", version => 13.2 })->status_is(400); # no distri
+$t->post_ok('/api/v1/products', form => { arch => "x86_64", distri => "opensuse", version => 13.2 })->status_is(400); # no flavor
+$t->post_ok('/api/v1/products', form => { arch => "x86_64", distri => "opensuse", flavor => "DVD" })->status_is(400); # no version
+
+my $res = $t->post_ok('/api/v1/products', form => { arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2, "settings[TEST]" => "val1", "settings[TEST2]" => "val1" })->status_is(200);
+my $product_id = $res->tx->res->json->{id};
+
+$res = $t->post_ok('/api/v1/products', form => { arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2 })->status_is(400); #already exists
+
+$get = $t->get_ok("/api/v1/products/$product_id")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'Products' => [
+            {
+                'arch' => 'x86_64',
+                'distri' => 'opensuse',
+                'flavor' => 'DVD',
+                'id' => $product_id,
+                'settings' => [
+                    {
+                        'key' => 'TEST',
+                        'value' => 'val1'
+                    },
+                    {
+                        'key' => 'TEST2',
+                        'value' => 'val1'
+                    }
+                ],
+                'version' => '13.2'
+            }
+        ]
+    },
+    "Add product"
+) || diag explain $get->tx->res->json;
+
+$t->put_ok("/api/v1/products/$product_id", form => { arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2, "settings[TEST2]" => "val1" })->status_is(200);
+
+$get = $t->get_ok("/api/v1/products/$product_id")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'Products' => [
+            {
+                'arch' => 'x86_64',
+                'distri' => 'opensuse',
+                'flavor' => 'DVD',
+                'id' => $product_id,
+                'settings' => [
+                    {
+                        'key' => 'TEST2',
+                        'value' => 'val1'
+                    }
+                ],
+                'version' => '13.2'
+            }
+        ]
+    },
+    "Delete product variable"
+) || diag explain $get->tx->res->json;
+
+$res = $t->delete_ok("/api/v1/products/$product_id")->status_is(200);
+$res = $t->delete_ok("/api/v1/products/$product_id")->status_is(404); #not found
+
+done_testing();

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -1,0 +1,154 @@
+# Copyright (C) 2014 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+BEGIN {
+    unshift @INC, 'lib', 'lib/OpenQA/modules';
+}
+
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use OpenQA::Test::Case;
+use OpenQA::API::V1::Client;
+use Mojo::IOLoop;
+use Data::Dump;
+
+OpenQA::Test::Case->new->init_data;
+
+my $t = Test::Mojo->new('OpenQA');
+
+# XXX: Test::Mojo loses it's app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+my $app = $t->app;
+$t->ua(OpenQA::API::V1::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+my $get = $t->get_ok('/api/v1/test_suites')->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'TestSuites' => [
+            {
+                'id' => 1001,
+                'name' => 'textmode',
+                'prio' => 40,
+                'settings' => [
+                    {
+                        'key' => 'DESKTOP',
+                        'value' => 'textmode'
+                    },
+                    {
+                        'key' => 'VIDEOMODE',
+                        'value' => 'text'
+                    }
+                ]
+            },
+            {
+                'id' => 1002,
+                'name' => 'kde',
+                'prio' => 40,
+                'settings' => [
+                    {
+                        'key' => 'DESKTOP',
+                        'value' => 'kde'
+                    }
+                ]
+            },
+            {
+                'id' => 1013,
+                'name' => 'RAID0',
+                'prio' => 50,
+                'settings' => [
+                    {
+                        'key' => 'DESKTOP',
+                        'value' => 'kde'
+                    },
+                    {
+                        'key' => 'INSTALLONLY',
+                        'value' => '1'
+                    },
+                    {
+                        'key' => 'RAIDLEVEL',
+                        'value' => '0'
+                    }
+                ]
+            }
+        ]
+    },
+    "Initial test suites"
+) || diag explain $get->tx->res->json;
+
+$t->post_ok('/api/v1/test_suites', form => { name => "testsuite"})->status_is(400); #no prio
+$t->post_ok('/api/v1/test_suites', form => { prio => "30" })->status_is(400); #no name
+
+
+my $res = $t->post_ok('/api/v1/test_suites', form => { name => "testsuite", prio => "30", "settings[TEST]" => "val1", "settings[TEST2]" => "val1" })->status_is(200);
+my $test_suite_id = $res->tx->res->json->{id};
+
+$res = $t->post_ok('/api/v1/test_suites', form => { name => "testsuite", prio => "30" })->status_is(400); #already exists
+
+$get = $t->get_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'TestSuites' => [
+            {
+                'id' => $test_suite_id,
+                'name' => 'testsuite',
+                'prio' => 30,
+                'settings' => [
+                    {
+                        'key' => 'TEST',
+                        'value' => 'val1'
+                    },
+                    {
+                        'key' => 'TEST2',
+                        'value' => 'val1'
+                    }
+                ]
+            }
+        ]
+    },
+    "Add test_suite"
+) || diag explain $get->tx->res->json;
+
+$t->put_ok("/api/v1/test_suites/$test_suite_id", form => { name => "testsuite", prio => "30", "settings[TEST2]" => "val1" })->status_is(200);
+
+$get = $t->get_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'TestSuites' => [
+            {
+                'id' => $test_suite_id,
+                'name' => 'testsuite',
+                'prio' => 30,
+                'settings' => [
+                    {
+                        'key' => 'TEST2',
+                        'value' => 'val1'
+                    }
+                ]
+            }
+        ]
+    },
+    "Delete test_suite variable"
+) || diag explain $get->tx->res->json;
+
+$res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
+$res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(404); #not found
+
+done_testing();

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -1,0 +1,165 @@
+# Copyright (C) 2014 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+BEGIN {
+    unshift @INC, 'lib', 'lib/OpenQA/modules';
+}
+
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use OpenQA::Test::Case;
+use OpenQA::API::V1::Client;
+use Mojo::IOLoop;
+use Data::Dump;
+
+OpenQA::Test::Case->new->init_data;
+
+my $t = Test::Mojo->new('OpenQA');
+
+# XXX: Test::Mojo loses it's app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+my $app = $t->app;
+$t->ua(OpenQA::API::V1::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+my $get = $t->get_ok('/api/v1/job_templates')->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'JobTemplates' => [
+            {
+                'id' => 1,
+                'machine' => {
+                    'id' => 1001,
+                    'name' => '32bit'
+                },
+                'product' => {
+                    'arch' => 'i586',
+                    'distri' => 'opensuse',
+                    'flavor' => 'DVD',
+                    'id' => 1,
+                    'version' => '13.1'
+                },
+                'test_suite' => {
+                    'id' => 1001,
+                    'name' => 'textmode'
+                }
+            },
+            {
+                'id' => 2,
+                'machine' => {
+                    'id' => 1002,
+                    'name' => '64bit'
+                },
+                'product' => {
+                    'arch' => 'i586',
+                    'distri' => 'opensuse',
+                    'flavor' => 'DVD',
+                    'id' => 1,
+                    'version' => '13.1'
+                },
+                'test_suite' => {
+                    'id' => 1002,
+                    'name' => 'kde'
+                }
+            }
+        ]
+    },
+    "Initial job templates"
+) || diag explain $get->tx->res->json;
+
+
+my $res = $t->post_ok('/api/v1/job_templates', form => { machine_id => 1001, test_suite_id => 1002, product_id=>1 })->status_is(200);
+my $job_template_id1 = $res->tx->res->json->{id};
+
+$res = $t->post_ok(
+    '/api/v1/job_templates',
+    form =>{
+        machine_name => '64bit',
+        test_suite_name => 'RAID0',
+        'arch' => 'i586',
+        'distri' => 'opensuse',
+        'flavor' => 'DVD',
+        'version' => '13.1'
+    }
+)->status_is(200);
+my $job_template_id2 = $res->tx->res->json->{id};
+
+$get = $t->get_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'JobTemplates' => [
+            {
+                'id' => $job_template_id1,
+                'machine' => {
+                    'id' => 1001,
+                    'name' => '32bit'
+                },
+                'product' => {
+                    'arch' => 'i586',
+                    'distri' => 'opensuse',
+                    'flavor' => 'DVD',
+                    'id' => 1,
+                    'version' => '13.1'
+                },
+                'test_suite' => {
+                    'id' => 1002,
+                    'name' => 'kde'
+                }
+            }
+          ]
+
+    },
+    "Initial job templates"
+) || diag explain $get->tx->res->json;
+
+$get = $t->get_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
+is_deeply(
+    $get->tx->res->json,
+    {
+        'JobTemplates' => [
+            {
+                'id' => $job_template_id2,
+                'machine' => {
+                    'id' => 1002,
+                    'name' => '64bit'
+                },
+                'product' => {
+                    'arch' => 'i586',
+                    'distri' => 'opensuse',
+                    'flavor' => 'DVD',
+                    'id' => 1,
+                    'version' => '13.1'
+                },
+                'test_suite' => {
+                    'id' => 1013,
+                    'name' => 'RAID0'
+                }
+            }
+        ]
+    },
+    "Initial job templates"
+) || diag explain $get->tx->res->json;
+
+$res = $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
+$res = $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(404); #not found
+
+$res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
+$res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(404); #not found
+
+done_testing();


### PR DESCRIPTION
https://progress.opensuse.org/issues/5568

The API works OK for web pages where the main entry (machine. product, test suite) is created first and the variables are added later. For load_tempates script it is usable but not efficient so I will probably have to add
another function that creates whole entry at once.