### PR TITLE
PostgreSQL and MySQL support

### DIFF
--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -4,14 +4,17 @@ Cache::Cache
 Carp
 Clone
 Config::IniFiles
+Config::Tiny
 Crypt::DH::GMP
 Cwd
 DBD::SQLite
 DBIx::Class
 DBIx::Class::Core
 DBIx::Class::DeploymentHandler
+DBIx::Class::DynamicDefault
 DBIx::Class::ResultClass::HashRefInflator
 DBIx::Class::Schema
+DBIx::Class::Schema::Config
 Data::Dump
 Data::Dumper
 Data::OptList

--- a/dbicdh/MySQL/deploy/18/001-auto-__VERSION.sql
+++ b/dbicdh/MySQL/deploy/18/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Tue Jan 13 08:10:06 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `dbix_class_deploymenthandler_versions`
+--
+CREATE TABLE `dbix_class_deploymenthandler_versions` (
+  `id` integer NOT NULL auto_increment,
+  `version` varchar(50) NOT NULL,
+  `ddl` text NULL,
+  `upgrade_sql` text NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `dbix_class_deploymenthandler_versions_version` (`version`)
+);
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/deploy/18/001-auto.sql
+++ b/dbicdh/MySQL/deploy/18/001-auto.sql
@@ -1,0 +1,323 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Tue Jan 13 08:10:05 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `assets`
+--
+CREATE TABLE `assets` (
+  `id` integer NOT NULL auto_increment,
+  `type` text NOT NULL,
+  `name` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `assets_type_name` (`type`, `name`)
+) ENGINE=InnoDB;
+--
+-- Table: `dependencies`
+--
+CREATE TABLE `dependencies` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_results`
+--
+CREATE TABLE `job_results` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_settings`
+--
+CREATE TABLE `job_settings` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `job_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_settings_idx_job_id` (`job_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_settings_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_states`
+--
+CREATE TABLE `job_states` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `machine_settings`
+--
+CREATE TABLE `machine_settings` (
+  `id` integer NOT NULL auto_increment,
+  `machine_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `machine_settings_idx_machine_id` (`machine_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `machine_settings_machine_id_key` (`machine_id`, `key`),
+  CONSTRAINT `machine_settings_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `machines`
+--
+CREATE TABLE `machines` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `backend` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `machines_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `product_settings`
+--
+CREATE TABLE `product_settings` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `product_settings_idx_product_id` (`product_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `product_settings_product_id_key` (`product_id`, `key`),
+  CONSTRAINT `product_settings_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `products`
+--
+CREATE TABLE `products` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `distri` text NOT NULL,
+  `version` text NOT NULL DEFAULT '',
+  `arch` text NOT NULL,
+  `flavor` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `products_distri_version_arch_flavor` (`distri`, `version`, `arch`, `flavor`)
+) ENGINE=InnoDB;
+--
+-- Table: `secrets`
+--
+CREATE TABLE `secrets` (
+  `id` integer NOT NULL auto_increment,
+  `secret` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `secrets_secret` (`secret`)
+);
+--
+-- Table: `test_suite_settings`
+--
+CREATE TABLE `test_suite_settings` (
+  `id` integer NOT NULL auto_increment,
+  `test_suite_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `test_suite_settings_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suite_settings_test_suite_id_key` (`test_suite_id`, `key`),
+  CONSTRAINT `test_suite_settings_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `test_suites`
+--
+CREATE TABLE `test_suites` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `variables` text NOT NULL,
+  `prio` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suites_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `users`
+--
+CREATE TABLE `users` (
+  `id` integer NOT NULL auto_increment,
+  `openid` text NOT NULL,
+  `email` text NULL,
+  `fullname` text NULL,
+  `nickname` text NULL,
+  `is_operator` integer NOT NULL DEFAULT 0,
+  `is_admin` integer NOT NULL DEFAULT 0,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `users_openid` (`openid`)
+) ENGINE=InnoDB;
+--
+-- Table: `worker_properties`
+--
+CREATE TABLE `worker_properties` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `worker_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `worker_properties_idx_worker_id` (`worker_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `worker_properties_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `workers`
+--
+CREATE TABLE `workers` (
+  `id` integer NOT NULL auto_increment,
+  `host` text NOT NULL,
+  `instance` integer NOT NULL,
+  `backend` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `workers_host_instance` (`host`, `instance`)
+) ENGINE=InnoDB;
+--
+-- Table: `api_keys`
+--
+CREATE TABLE `api_keys` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `secret` text NOT NULL,
+  `user_id` integer NOT NULL,
+  `t_expiration` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `api_keys_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `api_keys_key` (`key`),
+  CONSTRAINT `api_keys_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `commands`
+--
+CREATE TABLE `commands` (
+  `id` integer NOT NULL auto_increment,
+  `command` text NOT NULL,
+  `t_processed` timestamp NULL,
+  `worker_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `commands_idx_worker_id` (`worker_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `commands_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_modules`
+--
+CREATE TABLE `job_modules` (
+  `id` integer NOT NULL auto_increment,
+  `job_id` integer NOT NULL,
+  `name` text NOT NULL,
+  `script` text NOT NULL,
+  `category` text NOT NULL,
+  `result_id` integer NOT NULL DEFAULT 0,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_modules_idx_job_id` (`job_id`),
+  INDEX `job_modules_idx_result_id` (`result_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_modules_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_modules_fk_result_id` FOREIGN KEY (`result_id`) REFERENCES `job_results` (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_templates`
+--
+CREATE TABLE `job_templates` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `machine_id` integer NOT NULL,
+  `test_suite_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_templates_idx_machine_id` (`machine_id`),
+  INDEX `job_templates_idx_product_id` (`product_id`),
+  INDEX `job_templates_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `job_templates_product_id_machine_id_test_suite_id` (`product_id`, `machine_id`, `test_suite_id`),
+  CONSTRAINT `job_templates_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `jobs`
+--
+CREATE TABLE `jobs` (
+  `id` integer NOT NULL auto_increment,
+  `slug` text NULL,
+  `state_id` integer NOT NULL DEFAULT 0,
+  `priority` integer NOT NULL DEFAULT 50,
+  `result_id` integer NOT NULL DEFAULT 0,
+  `worker_id` integer NOT NULL DEFAULT 0,
+  `test` text NOT NULL,
+  `test_branch` text NULL,
+  `clone_id` integer NULL,
+  `retry_avbl` integer NOT NULL DEFAULT 3,
+  `t_started` timestamp NULL,
+  `t_finished` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_idx_clone_id` (`clone_id`),
+  INDEX `jobs_idx_result_id` (`result_id`),
+  INDEX `jobs_idx_state_id` (`state_id`),
+  INDEX `jobs_idx_worker_id` (`worker_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `jobs_slug` (`slug`),
+  CONSTRAINT `jobs_fk_clone_id` FOREIGN KEY (`clone_id`) REFERENCES `jobs` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `jobs_fk_result_id` FOREIGN KEY (`result_id`) REFERENCES `job_results` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `jobs_fk_state_id` FOREIGN KEY (`state_id`) REFERENCES `job_states` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `jobs_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_dependencies`
+--
+CREATE TABLE `job_dependencies` (
+  `child_job_id` integer NOT NULL,
+  `parent_job_id` integer NOT NULL,
+  `dep_id` integer NOT NULL,
+  INDEX `job_dependencies_idx_child_job_id` (`child_job_id`),
+  INDEX `job_dependencies_idx_dep_id` (`dep_id`),
+  INDEX `job_dependencies_idx_parent_job_id` (`parent_job_id`),
+  PRIMARY KEY (`child_job_id`, `parent_job_id`, `dep_id`),
+  CONSTRAINT `job_dependencies_fk_child_job_id` FOREIGN KEY (`child_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_dependencies_fk_dep_id` FOREIGN KEY (`dep_id`) REFERENCES `dependencies` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_dependencies_fk_parent_job_id` FOREIGN KEY (`parent_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `jobs_assets`
+--
+CREATE TABLE `jobs_assets` (
+  `job_id` integer NOT NULL,
+  `asset_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_assets_idx_asset_id` (`asset_id`),
+  INDEX `jobs_assets_idx_job_id` (`job_id`),
+  UNIQUE `jobs_assets_job_id_asset_id` (`job_id`, `asset_id`),
+  CONSTRAINT `jobs_assets_fk_asset_id` FOREIGN KEY (`asset_id`) REFERENCES `assets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `jobs_assets_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/upgrade/17-18/001-auto.sql
+++ b/dbicdh/MySQL/upgrade/17-18/001-auto.sql
@@ -1,0 +1,87 @@
+-- Convert schema '/home/ags/projects/openqa/openqa/script/../dbicdh/_source/deploy/17/001-auto.yml' to '/home/ags/projects/openqa/openqa/script/../dbicdh/_source/deploy/18/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+ALTER TABLE api_keys CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                     CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE assets CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                   CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE commands CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                     CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE job_modules CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                        CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE job_settings DROP INDEX job_settings_kv_index,
+                         CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                         CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE job_templates CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                          CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE jobs CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                 CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE jobs_assets CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                        CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE machine_settings CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                             CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE machines CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                     CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE product_settings CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                             CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE products CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                     CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE secrets CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                    CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE test_suite_settings CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                                CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE test_suites CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                        CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE users CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                  CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+ALTER TABLE worker_properties DROP FOREIGN KEY worker_properties_fk_worker_id;
+
+;
+ALTER TABLE worker_properties DROP INDEX worker_properties_kv_index,
+                              CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                              CHANGE COLUMN t_updated t_updated timestamp NOT NULL,
+                              ADD CONSTRAINT worker_properties_fk_worker_id FOREIGN KEY (worker_id) REFERENCES workers (id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+;
+ALTER TABLE workers CHANGE COLUMN t_created t_created timestamp NOT NULL,
+                    CHANGE COLUMN t_updated t_updated timestamp NOT NULL;
+
+;
+
+COMMIT;
+

--- a/dbicdh/PostgreSQL/deploy/18/001-auto-__VERSION.sql
+++ b/dbicdh/PostgreSQL/deploy/18/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Tue Jan 13 08:10:06 2015
+-- 
+;
+--
+-- Table: dbix_class_deploymenthandler_versions.
+--
+CREATE TABLE "dbix_class_deploymenthandler_versions" (
+  "id" serial NOT NULL,
+  "version" character varying(50) NOT NULL,
+  "ddl" text,
+  "upgrade_sql" text,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "dbix_class_deploymenthandler_versions_version" UNIQUE ("version")
+);
+
+;

--- a/dbicdh/PostgreSQL/deploy/18/001-auto.sql
+++ b/dbicdh/PostgreSQL/deploy/18/001-auto.sql
@@ -1,0 +1,433 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Tue Jan 13 08:10:06 2015
+-- 
+;
+--
+-- Table: assets.
+--
+CREATE TABLE "assets" (
+  "id" serial NOT NULL,
+  "type" text NOT NULL,
+  "name" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "assets_type_name" UNIQUE ("type", "name")
+);
+
+;
+--
+-- Table: dependencies.
+--
+CREATE TABLE "dependencies" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+;
+--
+-- Table: job_results.
+--
+CREATE TABLE "job_results" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+;
+--
+-- Table: job_settings.
+--
+CREATE TABLE "job_settings" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "job_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_settings_idx_job_id" on "job_settings" ("job_id");
+
+;
+--
+-- Table: job_states.
+--
+CREATE TABLE "job_states" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+;
+--
+-- Table: machine_settings.
+--
+CREATE TABLE "machine_settings" (
+  "id" serial NOT NULL,
+  "machine_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machine_settings_machine_id_key" UNIQUE ("machine_id", "key")
+);
+CREATE INDEX "machine_settings_idx_machine_id" on "machine_settings" ("machine_id");
+
+;
+--
+-- Table: machines.
+--
+CREATE TABLE "machines" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "backend" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machines_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: product_settings.
+--
+CREATE TABLE "product_settings" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "product_settings_product_id_key" UNIQUE ("product_id", "key")
+);
+CREATE INDEX "product_settings_idx_product_id" on "product_settings" ("product_id");
+
+;
+--
+-- Table: products.
+--
+CREATE TABLE "products" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "distri" text NOT NULL,
+  "version" text DEFAULT '' NOT NULL,
+  "arch" text NOT NULL,
+  "flavor" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "products_distri_version_arch_flavor" UNIQUE ("distri", "version", "arch", "flavor")
+);
+
+;
+--
+-- Table: secrets.
+--
+CREATE TABLE "secrets" (
+  "id" serial NOT NULL,
+  "secret" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "secrets_secret" UNIQUE ("secret")
+);
+
+;
+--
+-- Table: test_suite_settings.
+--
+CREATE TABLE "test_suite_settings" (
+  "id" serial NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suite_settings_test_suite_id_key" UNIQUE ("test_suite_id", "key")
+);
+CREATE INDEX "test_suite_settings_idx_test_suite_id" on "test_suite_settings" ("test_suite_id");
+
+;
+--
+-- Table: test_suites.
+--
+CREATE TABLE "test_suites" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "variables" text NOT NULL,
+  "prio" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suites_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: users.
+--
+CREATE TABLE "users" (
+  "id" serial NOT NULL,
+  "openid" text NOT NULL,
+  "email" text,
+  "fullname" text,
+  "nickname" text,
+  "is_operator" integer DEFAULT 0 NOT NULL,
+  "is_admin" integer DEFAULT 0 NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "users_openid" UNIQUE ("openid")
+);
+
+;
+--
+-- Table: worker_properties.
+--
+CREATE TABLE "worker_properties" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "worker_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "worker_properties_idx_worker_id" on "worker_properties" ("worker_id");
+
+;
+--
+-- Table: workers.
+--
+CREATE TABLE "workers" (
+  "id" serial NOT NULL,
+  "host" text NOT NULL,
+  "instance" integer NOT NULL,
+  "backend" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "workers_host_instance" UNIQUE ("host", "instance")
+);
+
+;
+--
+-- Table: api_keys.
+--
+CREATE TABLE "api_keys" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "secret" text NOT NULL,
+  "user_id" integer NOT NULL,
+  "t_expiration" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "api_keys_key" UNIQUE ("key")
+);
+CREATE INDEX "api_keys_idx_user_id" on "api_keys" ("user_id");
+
+;
+--
+-- Table: commands.
+--
+CREATE TABLE "commands" (
+  "id" serial NOT NULL,
+  "command" text NOT NULL,
+  "t_processed" timestamp,
+  "worker_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "commands_idx_worker_id" on "commands" ("worker_id");
+
+;
+--
+-- Table: job_modules.
+--
+CREATE TABLE "job_modules" (
+  "id" serial NOT NULL,
+  "job_id" integer NOT NULL,
+  "name" text NOT NULL,
+  "script" text NOT NULL,
+  "category" text NOT NULL,
+  "result_id" integer DEFAULT 0 NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_modules_idx_job_id" on "job_modules" ("job_id");
+CREATE INDEX "job_modules_idx_result_id" on "job_modules" ("result_id");
+
+;
+--
+-- Table: job_templates.
+--
+CREATE TABLE "job_templates" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "machine_id" integer NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "job_templates_product_id_machine_id_test_suite_id" UNIQUE ("product_id", "machine_id", "test_suite_id")
+);
+CREATE INDEX "job_templates_idx_machine_id" on "job_templates" ("machine_id");
+CREATE INDEX "job_templates_idx_product_id" on "job_templates" ("product_id");
+CREATE INDEX "job_templates_idx_test_suite_id" on "job_templates" ("test_suite_id");
+
+;
+--
+-- Table: jobs.
+--
+CREATE TABLE "jobs" (
+  "id" serial NOT NULL,
+  "slug" text,
+  "state_id" integer DEFAULT 0 NOT NULL,
+  "priority" integer DEFAULT 50 NOT NULL,
+  "result_id" integer DEFAULT 0 NOT NULL,
+  "worker_id" integer DEFAULT 0 NOT NULL,
+  "test" text NOT NULL,
+  "test_branch" text,
+  "clone_id" integer,
+  "retry_avbl" integer DEFAULT 3 NOT NULL,
+  "t_started" timestamp,
+  "t_finished" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "jobs_slug" UNIQUE ("slug")
+);
+CREATE INDEX "jobs_idx_clone_id" on "jobs" ("clone_id");
+CREATE INDEX "jobs_idx_result_id" on "jobs" ("result_id");
+CREATE INDEX "jobs_idx_state_id" on "jobs" ("state_id");
+CREATE INDEX "jobs_idx_worker_id" on "jobs" ("worker_id");
+
+;
+--
+-- Table: job_dependencies.
+--
+CREATE TABLE "job_dependencies" (
+  "child_job_id" integer NOT NULL,
+  "parent_job_id" integer NOT NULL,
+  "dep_id" integer NOT NULL,
+  PRIMARY KEY ("child_job_id", "parent_job_id", "dep_id")
+);
+CREATE INDEX "job_dependencies_idx_child_job_id" on "job_dependencies" ("child_job_id");
+CREATE INDEX "job_dependencies_idx_dep_id" on "job_dependencies" ("dep_id");
+CREATE INDEX "job_dependencies_idx_parent_job_id" on "job_dependencies" ("parent_job_id");
+
+;
+--
+-- Table: jobs_assets.
+--
+CREATE TABLE "jobs_assets" (
+  "job_id" integer NOT NULL,
+  "asset_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  CONSTRAINT "jobs_assets_job_id_asset_id" UNIQUE ("job_id", "asset_id")
+);
+CREATE INDEX "jobs_assets_idx_asset_id" on "jobs_assets" ("asset_id");
+CREATE INDEX "jobs_assets_idx_job_id" on "jobs_assets" ("job_id");
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE "job_settings" ADD CONSTRAINT "job_settings_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "machine_settings" ADD CONSTRAINT "machine_settings_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "product_settings" ADD CONSTRAINT "product_settings_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "test_suite_settings" ADD CONSTRAINT "test_suite_settings_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "worker_properties" ADD CONSTRAINT "worker_properties_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "commands" ADD CONSTRAINT "commands_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_modules" ADD CONSTRAINT "job_modules_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_modules" ADD CONSTRAINT "job_modules_fk_result_id" FOREIGN KEY ("result_id")
+  REFERENCES "job_results" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_clone_id" FOREIGN KEY ("clone_id")
+  REFERENCES "jobs" ("id") ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_result_id" FOREIGN KEY ("result_id")
+  REFERENCES "job_results" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_state_id" FOREIGN KEY ("state_id")
+  REFERENCES "job_states" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_child_job_id" FOREIGN KEY ("child_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_dep_id" FOREIGN KEY ("dep_id")
+  REFERENCES "dependencies" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_parent_job_id" FOREIGN KEY ("parent_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_asset_id" FOREIGN KEY ("asset_id")
+  REFERENCES "assets" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;

--- a/dbicdh/PostgreSQL/upgrade/17-18/001-auto.sql
+++ b/dbicdh/PostgreSQL/upgrade/17-18/001-auto.sql
@@ -1,0 +1,130 @@
+-- Convert schema '/home/ags/projects/openqa/openqa/script/../dbicdh/_source/deploy/17/001-auto.yml' to '/home/ags/projects/openqa/openqa/script/../dbicdh/_source/deploy/18/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+ALTER TABLE api_keys ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE api_keys ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE assets ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE assets ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE commands ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE commands ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE job_modules ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE job_modules ALTER COLUMN t_updated SET NOT NULL;
+
+;
+DROP INDEX job_settings_kv_index;
+
+;
+ALTER TABLE job_settings ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE job_settings ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE job_templates ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE job_templates ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE jobs_assets ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE jobs_assets ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE machine_settings ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE machine_settings ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE machines ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE machines ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE product_settings ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE product_settings ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE products ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE products ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE secrets ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE secrets ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE test_suite_settings ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE test_suite_settings ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE test_suites ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE test_suites ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE users ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE users ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE worker_properties DROP CONSTRAINT worker_properties_fk_worker_id;
+
+;
+DROP INDEX worker_properties_kv_index;
+
+;
+ALTER TABLE worker_properties ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE worker_properties ALTER COLUMN t_updated SET NOT NULL;
+
+;
+ALTER TABLE worker_properties ADD CONSTRAINT worker_properties_fk_worker_id FOREIGN KEY (worker_id)
+  REFERENCES workers (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE workers ALTER COLUMN t_created SET NOT NULL;
+
+;
+ALTER TABLE workers ALTER COLUMN t_updated SET NOT NULL;
+
+;
+
+COMMIT;
+

--- a/dbicdh/SQLite/deploy/18/001-auto-__VERSION.sql
+++ b/dbicdh/SQLite/deploy/18/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Tue Jan 13 08:10:06 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id INTEGER PRIMARY KEY NOT NULL,
+  version varchar(50) NOT NULL,
+  ddl text,
+  upgrade_sql text
+);
+CREATE UNIQUE INDEX dbix_class_deploymenthandler_versions_version ON dbix_class_deploymenthandler_versions (version);
+COMMIT;

--- a/dbicdh/SQLite/deploy/18/001-auto.sql
+++ b/dbicdh/SQLite/deploy/18/001-auto.sql
@@ -1,0 +1,304 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Tue Jan 13 08:10:05 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX assets_type_name ON assets (type, name);
+--
+-- Table: dependencies
+--
+CREATE TABLE dependencies (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL
+);
+--
+-- Table: job_results
+--
+CREATE TABLE job_results (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL
+);
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_settings_idx_job_id ON job_settings (job_id);
+--
+-- Table: job_states
+--
+CREATE TABLE job_states (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL
+);
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX machine_settings_idx_machine_id ON machine_settings (machine_id);
+CREATE UNIQUE INDEX machine_settings_machine_id_key ON machine_settings (machine_id, key);
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX machines_name ON machines (name);
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX product_settings_idx_product_id ON product_settings (product_id);
+CREATE UNIQUE INDEX product_settings_product_id_key ON product_settings (product_id, key);
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX products_distri_version_arch_flavor ON products (distri, version, arch, flavor);
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX secrets_secret ON secrets (secret);
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id ON test_suite_settings (test_suite_id);
+CREATE UNIQUE INDEX test_suite_settings_test_suite_id_key ON test_suite_settings (test_suite_id, key);
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  prio integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX test_suites_name ON test_suites (name);
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY NOT NULL,
+  openid text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX users_openid ON users (openid);
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX worker_properties_idx_worker_id ON worker_properties (worker_id);
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  backend text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX workers_host_instance ON workers (host, instance);
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX api_keys_idx_user_id ON api_keys (user_id);
+CREATE UNIQUE INDEX api_keys_key ON api_keys (key);
+--
+-- Table: commands
+--
+CREATE TABLE commands (
+  id INTEGER PRIMARY KEY NOT NULL,
+  command text NOT NULL,
+  t_processed timestamp,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX commands_idx_worker_id ON commands (worker_id);
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  result_id integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (result_id) REFERENCES job_results(id)
+);
+CREATE INDEX job_modules_idx_job_id ON job_modules (job_id);
+CREATE INDEX job_modules_idx_result_id ON job_modules (result_id);
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_templates_idx_machine_id ON job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id ON job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id ON job_templates (test_suite_id);
+CREATE UNIQUE INDEX job_templates_product_id_machine_id_test_suite_id ON job_templates (product_id, machine_id, test_suite_id);
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  slug text,
+  state_id integer NOT NULL DEFAULT 0,
+  priority integer NOT NULL DEFAULT 50,
+  result_id integer NOT NULL DEFAULT 0,
+  worker_id integer NOT NULL DEFAULT 0,
+  test text NOT NULL,
+  test_branch text,
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  t_started timestamp,
+  t_finished timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (result_id) REFERENCES job_results(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (state_id) REFERENCES job_states(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_idx_clone_id ON jobs (clone_id);
+CREATE INDEX jobs_idx_result_id ON jobs (result_id);
+CREATE INDEX jobs_idx_state_id ON jobs (state_id);
+CREATE INDEX jobs_idx_worker_id ON jobs (worker_id);
+CREATE UNIQUE INDEX jobs_slug ON jobs (slug);
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dep_id integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dep_id),
+  FOREIGN KEY (child_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (dep_id) REFERENCES dependencies(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (parent_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_dependencies_idx_child_job_id ON job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_dep_id ON job_dependencies (dep_id);
+CREATE INDEX job_dependencies_idx_parent_job_id ON job_dependencies (parent_job_id);
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_assets_idx_asset_id ON jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id ON jobs_assets (job_id);
+CREATE UNIQUE INDEX jobs_assets_job_id_asset_id ON jobs_assets (job_id, asset_id);
+COMMIT;

--- a/dbicdh/SQLite/upgrade/17-18/001-auto.sql
+++ b/dbicdh/SQLite/upgrade/17-18/001-auto.sql
@@ -1,0 +1,741 @@
+-- Convert schema '/home/ags/projects/openqa/openqa/script/../dbicdh/_source/deploy/17/001-auto.yml' to '/home/ags/projects/openqa/openqa/script/../dbicdh/_source/deploy/18/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TEMPORARY TABLE api_keys_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO api_keys_temp_alter( id, key, secret, user_id, t_expiration, t_created, t_updated) SELECT id, key, secret, user_id, t_expiration, t_created, t_updated FROM api_keys;
+
+;
+DROP TABLE api_keys;
+
+;
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX api_keys_idx_user_id02 ON api_keys (user_id);
+
+;
+CREATE UNIQUE INDEX api_keys_key02 ON api_keys (key);
+
+;
+INSERT INTO api_keys SELECT id, key, secret, user_id, t_expiration, t_created, t_updated FROM api_keys_temp_alter;
+
+;
+DROP TABLE api_keys_temp_alter;
+
+;
+CREATE TEMPORARY TABLE assets_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+INSERT INTO assets_temp_alter( id, type, name, t_created, t_updated) SELECT id, type, name, t_created, t_updated FROM assets;
+
+;
+DROP TABLE assets;
+
+;
+CREATE TABLE assets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+CREATE UNIQUE INDEX assets_type_name02 ON assets (type, name);
+
+;
+INSERT INTO assets SELECT id, type, name, t_created, t_updated FROM assets_temp_alter;
+
+;
+DROP TABLE assets_temp_alter;
+
+;
+CREATE TEMPORARY TABLE commands_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  command text NOT NULL,
+  t_processed timestamp,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO commands_temp_alter( id, command, t_processed, worker_id, t_created, t_updated) SELECT id, command, t_processed, worker_id, t_created, t_updated FROM commands;
+
+;
+DROP TABLE commands;
+
+;
+CREATE TABLE commands (
+  id INTEGER PRIMARY KEY NOT NULL,
+  command text NOT NULL,
+  t_processed timestamp,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX commands_idx_worker_id02 ON commands (worker_id);
+
+;
+INSERT INTO commands SELECT id, command, t_processed, worker_id, t_created, t_updated FROM commands_temp_alter;
+
+;
+DROP TABLE commands_temp_alter;
+
+;
+CREATE TEMPORARY TABLE job_modules_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  result_id integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (result_id) REFERENCES job_results(id)
+);
+
+;
+INSERT INTO job_modules_temp_alter( id, job_id, name, script, category, result_id, t_created, t_updated) SELECT id, job_id, name, script, category, result_id, t_created, t_updated FROM job_modules;
+
+;
+DROP TABLE job_modules;
+
+;
+CREATE TABLE job_modules (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  result_id integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (result_id) REFERENCES job_results(id)
+);
+
+;
+CREATE INDEX job_modules_idx_job_id02 ON job_modules (job_id);
+
+;
+CREATE INDEX job_modules_idx_result_id02 ON job_modules (result_id);
+
+;
+INSERT INTO job_modules SELECT id, job_id, name, script, category, result_id, t_created, t_updated FROM job_modules_temp_alter;
+
+;
+DROP TABLE job_modules_temp_alter;
+
+;
+CREATE TEMPORARY TABLE job_settings_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO job_settings_temp_alter( id, key, value, job_id, t_created, t_updated) SELECT id, key, value, job_id, t_created, t_updated FROM job_settings;
+
+;
+DROP TABLE job_settings;
+
+;
+CREATE TABLE job_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX job_settings_idx_job_id02 ON job_settings (job_id);
+
+;
+INSERT INTO job_settings SELECT id, key, value, job_id, t_created, t_updated FROM job_settings_temp_alter;
+
+;
+DROP TABLE job_settings_temp_alter;
+
+;
+CREATE TEMPORARY TABLE job_templates_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO job_templates_temp_alter( id, product_id, machine_id, test_suite_id, t_created, t_updated) SELECT id, product_id, machine_id, test_suite_id, t_created, t_updated FROM job_templates;
+
+;
+DROP TABLE job_templates;
+
+;
+CREATE TABLE job_templates (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX job_templates_idx_machine_id02 ON job_templates (machine_id);
+
+;
+CREATE INDEX job_templates_idx_product_id02 ON job_templates (product_id);
+
+;
+CREATE INDEX job_templates_idx_test_suit00 ON job_templates (test_suite_id);
+
+;
+CREATE UNIQUE INDEX job_templates_product_id_ma00 ON job_templates (product_id, machine_id, test_suite_id);
+
+;
+INSERT INTO job_templates SELECT id, product_id, machine_id, test_suite_id, t_created, t_updated FROM job_templates_temp_alter;
+
+;
+DROP TABLE job_templates_temp_alter;
+
+;
+CREATE TEMPORARY TABLE jobs_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  slug text,
+  state_id integer NOT NULL DEFAULT 0,
+  priority integer NOT NULL DEFAULT 50,
+  result_id integer NOT NULL DEFAULT 0,
+  worker_id integer NOT NULL DEFAULT 0,
+  test text NOT NULL,
+  test_branch text,
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  t_started timestamp,
+  t_finished timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (result_id) REFERENCES job_results(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (state_id) REFERENCES job_states(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO jobs_temp_alter( id, slug, state_id, priority, result_id, worker_id, test, test_branch, clone_id, retry_avbl, t_started, t_finished, t_created, t_updated) SELECT id, slug, state_id, priority, result_id, worker_id, test, test_branch, clone_id, retry_avbl, t_started, t_finished, t_created, t_updated FROM jobs;
+
+;
+DROP TABLE jobs;
+
+;
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  slug text,
+  state_id integer NOT NULL DEFAULT 0,
+  priority integer NOT NULL DEFAULT 50,
+  result_id integer NOT NULL DEFAULT 0,
+  worker_id integer NOT NULL DEFAULT 0,
+  test text NOT NULL,
+  test_branch text,
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  t_started timestamp,
+  t_finished timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (result_id) REFERENCES job_results(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (state_id) REFERENCES job_states(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX jobs_idx_clone_id02 ON jobs (clone_id);
+
+;
+CREATE INDEX jobs_idx_result_id02 ON jobs (result_id);
+
+;
+CREATE INDEX jobs_idx_state_id02 ON jobs (state_id);
+
+;
+CREATE INDEX jobs_idx_worker_id02 ON jobs (worker_id);
+
+;
+CREATE UNIQUE INDEX jobs_slug02 ON jobs (slug);
+
+;
+INSERT INTO jobs SELECT id, slug, state_id, priority, result_id, worker_id, test, test_branch, clone_id, retry_avbl, t_started, t_finished, t_created, t_updated FROM jobs_temp_alter;
+
+;
+DROP TABLE jobs_temp_alter;
+
+;
+CREATE TEMPORARY TABLE jobs_assets_temp_alter (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO jobs_assets_temp_alter( job_id, asset_id, t_created, t_updated) SELECT job_id, asset_id, t_created, t_updated FROM jobs_assets;
+
+;
+DROP TABLE jobs_assets;
+
+;
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX jobs_assets_idx_asset_id02 ON jobs_assets (asset_id);
+
+;
+CREATE INDEX jobs_assets_idx_job_id02 ON jobs_assets (job_id);
+
+;
+CREATE UNIQUE INDEX jobs_assets_job_id_asset_id02 ON jobs_assets (job_id, asset_id);
+
+;
+INSERT INTO jobs_assets SELECT job_id, asset_id, t_created, t_updated FROM jobs_assets_temp_alter;
+
+;
+DROP TABLE jobs_assets_temp_alter;
+
+;
+CREATE TEMPORARY TABLE machine_settings_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO machine_settings_temp_alter( id, machine_id, key, value, t_created, t_updated) SELECT id, machine_id, key, value, t_created, t_updated FROM machine_settings;
+
+;
+DROP TABLE machine_settings;
+
+;
+CREATE TABLE machine_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX machine_settings_idx_machin00 ON machine_settings (machine_id);
+
+;
+CREATE UNIQUE INDEX machine_settings_machine_id00 ON machine_settings (machine_id, key);
+
+;
+INSERT INTO machine_settings SELECT id, machine_id, key, value, t_created, t_updated FROM machine_settings_temp_alter;
+
+;
+DROP TABLE machine_settings_temp_alter;
+
+;
+CREATE TEMPORARY TABLE machines_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+INSERT INTO machines_temp_alter( id, name, backend, variables, t_created, t_updated) SELECT id, name, backend, variables, t_created, t_updated FROM machines;
+
+;
+DROP TABLE machines;
+
+;
+CREATE TABLE machines (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+CREATE UNIQUE INDEX machines_name02 ON machines (name);
+
+;
+INSERT INTO machines SELECT id, name, backend, variables, t_created, t_updated FROM machines_temp_alter;
+
+;
+DROP TABLE machines_temp_alter;
+
+;
+CREATE TEMPORARY TABLE product_settings_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO product_settings_temp_alter( id, product_id, key, value, t_created, t_updated) SELECT id, product_id, key, value, t_created, t_updated FROM product_settings;
+
+;
+DROP TABLE product_settings;
+
+;
+CREATE TABLE product_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX product_settings_idx_produc00 ON product_settings (product_id);
+
+;
+CREATE UNIQUE INDEX product_settings_product_id00 ON product_settings (product_id, key);
+
+;
+INSERT INTO product_settings SELECT id, product_id, key, value, t_created, t_updated FROM product_settings_temp_alter;
+
+;
+DROP TABLE product_settings_temp_alter;
+
+;
+CREATE TEMPORARY TABLE products_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+INSERT INTO products_temp_alter( id, name, distri, version, arch, flavor, variables, t_created, t_updated) SELECT id, name, distri, version, arch, flavor, variables, t_created, t_updated FROM products;
+
+;
+DROP TABLE products;
+
+;
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+CREATE UNIQUE INDEX products_distri_version_arc00 ON products (distri, version, arch, flavor);
+
+;
+INSERT INTO products SELECT id, name, distri, version, arch, flavor, variables, t_created, t_updated FROM products_temp_alter;
+
+;
+DROP TABLE products_temp_alter;
+
+;
+CREATE TEMPORARY TABLE secrets_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+INSERT INTO secrets_temp_alter( id, secret, t_created, t_updated) SELECT id, secret, t_created, t_updated FROM secrets;
+
+;
+DROP TABLE secrets;
+
+;
+CREATE TABLE secrets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+CREATE UNIQUE INDEX secrets_secret02 ON secrets (secret);
+
+;
+INSERT INTO secrets SELECT id, secret, t_created, t_updated FROM secrets_temp_alter;
+
+;
+DROP TABLE secrets_temp_alter;
+
+;
+CREATE TEMPORARY TABLE test_suite_settings_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO test_suite_settings_temp_alter( id, test_suite_id, key, value, t_created, t_updated) SELECT id, test_suite_id, key, value, t_created, t_updated FROM test_suite_settings;
+
+;
+DROP TABLE test_suite_settings;
+
+;
+CREATE TABLE test_suite_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX test_suite_settings_idx_tes00 ON test_suite_settings (test_suite_id);
+
+;
+CREATE UNIQUE INDEX test_suite_settings_test_su00 ON test_suite_settings (test_suite_id, key);
+
+;
+INSERT INTO test_suite_settings SELECT id, test_suite_id, key, value, t_created, t_updated FROM test_suite_settings_temp_alter;
+
+;
+DROP TABLE test_suite_settings_temp_alter;
+
+;
+CREATE TEMPORARY TABLE test_suites_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  prio integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+INSERT INTO test_suites_temp_alter( id, name, variables, prio, t_created, t_updated) SELECT id, name, variables, prio, t_created, t_updated FROM test_suites;
+
+;
+DROP TABLE test_suites;
+
+;
+CREATE TABLE test_suites (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  prio integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+CREATE UNIQUE INDEX test_suites_name02 ON test_suites (name);
+
+;
+INSERT INTO test_suites SELECT id, name, variables, prio, t_created, t_updated FROM test_suites_temp_alter;
+
+;
+DROP TABLE test_suites_temp_alter;
+
+;
+CREATE TEMPORARY TABLE users_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  openid text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+INSERT INTO users_temp_alter( id, openid, email, fullname, nickname, is_operator, is_admin, t_created, t_updated) SELECT id, openid, email, fullname, nickname, is_operator, is_admin, t_created, t_updated FROM users;
+
+;
+DROP TABLE users;
+
+;
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY NOT NULL,
+  openid text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+CREATE UNIQUE INDEX users_openid02 ON users (openid);
+
+;
+INSERT INTO users SELECT id, openid, email, fullname, nickname, is_operator, is_admin, t_created, t_updated FROM users_temp_alter;
+
+;
+DROP TABLE users_temp_alter;
+
+;
+CREATE TEMPORARY TABLE worker_properties_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+INSERT INTO worker_properties_temp_alter( id, key, value, worker_id, t_created, t_updated) SELECT id, key, value, worker_id, t_created, t_updated FROM worker_properties;
+
+;
+DROP TABLE worker_properties;
+
+;
+CREATE TABLE worker_properties (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX worker_properties_idx_worke00 ON worker_properties (worker_id);
+
+;
+INSERT INTO worker_properties SELECT id, key, value, worker_id, t_created, t_updated FROM worker_properties_temp_alter;
+
+;
+DROP TABLE worker_properties_temp_alter;
+
+;
+CREATE TEMPORARY TABLE workers_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  backend text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+INSERT INTO workers_temp_alter( id, host, instance, backend, t_created, t_updated) SELECT id, host, instance, backend, t_created, t_updated FROM workers;
+
+;
+DROP TABLE workers;
+
+;
+CREATE TABLE workers (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  backend text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+
+;
+CREATE UNIQUE INDEX workers_host_instance02 ON workers (host, instance);
+
+;
+INSERT INTO workers SELECT id, host, instance, backend, t_created, t_updated FROM workers_temp_alter;
+
+;
+DROP TABLE workers_temp_alter;
+
+;
+
+COMMIT;
+

--- a/dbicdh/_common/deploy/_any/10-seeds.pl
+++ b/dbicdh/_common/deploy/_any/10-seeds.pl
@@ -34,7 +34,7 @@ sub {
     $schema->resultset('JobResults')->populate([[qw/id name/],[ 0,'none' ],[ 1,'passed' ],[ 2,'failed' ],[ 3,'incomplete' ],]);
 
     # XXX: get rid of worker zero at some point
-    $schema->resultset('Workers')->populate([[qw/id host instance backend/],[ 0, 'NONE', 0, 'NONE' ],]);
+    $schema->resultset('Workers')->create({id => 0, host => 'NONE', instance => 0, backend => 'NONE'});
 
     $schema->resultset('Dependencies')->populate([[qw/id name/],[ 0,'chained' ],]);
 

--- a/dbicdh/_source/deploy/18/001-auto-__VERSION.yml
+++ b/dbicdh/_source/deploy/18/001-auto-__VERSION.yml
@@ -1,0 +1,92 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11020

--- a/dbicdh/_source/deploy/18/001-auto.yml
+++ b/dbicdh/_source/deploy/18/001-auto.yml
@@ -1,0 +1,2316 @@
+---
+schema:
+  procedures: {}
+  tables:
+    api_keys:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - key
+          match_type: ''
+          name: api_keys_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: api_keys_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 2
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: secret
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_expiration:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_expiration
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: api_keys_idx_user_id
+          options: []
+          type: NORMAL
+      name: api_keys
+      options: []
+      order: 16
+    assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - type
+            - name
+          match_type: ''
+          name: assets_type_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+        type:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: type
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: assets
+      options: []
+      order: 1
+    commands:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: commands_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        command:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: command
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_processed:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_processed
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: commands_idx_worker_id
+          options: []
+          type: NORMAL
+      name: commands
+      options: []
+      order: 17
+    dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: dependencies
+      options: []
+      order: 2
+    job_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+            - parent_job_id
+            - dep_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+          match_type: ''
+          name: job_dependencies_fk_child_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dep_id
+          match_type: ''
+          name: job_dependencies_fk_dep_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: dependencies
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_job_id
+          match_type: ''
+          name: job_dependencies_fk_parent_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        child_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: child_job_id
+          order: 1
+          size:
+            - 0
+        dep_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: dep_id
+          order: 3
+          size:
+            - 0
+        parent_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: parent_job_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - child_job_id
+          name: job_dependencies_idx_child_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - dep_id
+          name: job_dependencies_idx_dep_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_job_id
+          name: job_dependencies_idx_parent_job_id
+          options: []
+          type: NORMAL
+      name: job_dependencies
+      options: []
+      order: 21
+    job_modules:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_modules_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - result_id
+          match_type: ''
+          name: job_modules_fk_result_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_results
+          type: FOREIGN KEY
+      fields:
+        category:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: category
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        result_id:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result_id
+          order: 6
+          size:
+            - 0
+        script:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: script
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_modules_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result_id
+          name: job_modules_idx_result_id
+          options: []
+          type: NORMAL
+      name: job_modules
+      options: []
+      order: 18
+    job_results:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: job_results
+      options: []
+      order: 3
+    job_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_settings_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 4
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_settings_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_settings
+      options: []
+      order: 4
+    job_states:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: job_states
+      options: []
+      order: 5
+    job_templates:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - machine_id
+            - test_suite_id
+          match_type: ''
+          name: job_templates_product_id_machine_id_test_suite_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: job_templates_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: job_templates_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: job_templates_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: job_templates_idx_machine_id
+          options: []
+          type: NORMAL
+        - fields:
+            - product_id
+          name: job_templates_idx_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - test_suite_id
+          name: job_templates_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: job_templates
+      options: []
+      order: 19
+    jobs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - slug
+          match_type: ''
+          name: jobs_slug
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - clone_id
+          match_type: ''
+          name: jobs_fk_clone_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - result_id
+          match_type: ''
+          name: jobs_fk_result_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_results
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - state_id
+          match_type: ''
+          name: jobs_fk_state_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_states
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: jobs_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        clone_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: clone_id
+          order: 9
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: 50
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 4
+          size:
+            - 0
+        result_id:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result_id
+          order: 5
+          size:
+            - 0
+        retry_avbl:
+          data_type: integer
+          default_value: 3
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: retry_avbl
+          order: 10
+          size:
+            - 0
+        slug:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: slug
+          order: 2
+          size:
+            - 0
+        state_id:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: state_id
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 13
+          size:
+            - 0
+        t_finished:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_finished
+          order: 12
+          size:
+            - 0
+        t_started:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_started
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 14
+          size:
+            - 0
+        test:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: test
+          order: 7
+          size:
+            - 0
+        test_branch:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: test_branch
+          order: 8
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 6
+          size:
+            - 0
+      indices:
+        - fields:
+            - clone_id
+          name: jobs_idx_clone_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result_id
+          name: jobs_idx_result_id
+          options: []
+          type: NORMAL
+        - fields:
+            - state_id
+          name: jobs_idx_state_id
+          options: []
+          type: NORMAL
+        - fields:
+            - worker_id
+          name: jobs_idx_worker_id
+          options: []
+          type: NORMAL
+      name: jobs
+      options: []
+      order: 20
+    jobs_assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - asset_id
+          match_type: ''
+          name: jobs_assets_job_id_asset_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - asset_id
+          match_type: ''
+          name: jobs_assets_fk_asset_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: assets
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: jobs_assets_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        asset_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: asset_id
+          order: 2
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - asset_id
+          name: jobs_assets_idx_asset_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: jobs_assets_idx_job_id
+          options: []
+          type: NORMAL
+      name: jobs_assets
+      options: []
+      order: 22
+    machine_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+            - key
+          match_type: ''
+          name: machine_settings_machine_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: machine_settings_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: machine_settings_idx_machine_id
+          options: []
+          type: NORMAL
+      name: machine_settings
+      options: []
+      order: 6
+    machines:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: machines_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: machines
+      options: []
+      order: 7
+    product_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - key
+          match_type: ''
+          name: product_settings_product_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: product_settings_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - product_id
+          name: product_settings_idx_product_id
+          options: []
+          type: NORMAL
+      name: product_settings
+      options: []
+      order: 8
+    products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - distri
+            - version
+            - arch
+            - flavor
+          match_type: ''
+          name: products_distri_version_arch_flavor
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        arch:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: arch
+          order: 5
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: distri
+          order: 3
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: flavor
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 7
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: products
+      options: []
+      order: 9
+    secrets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - secret
+          match_type: ''
+          name: secrets_secret
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: secret
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: secrets
+      options: []
+      order: 10
+    test_suite_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+            - key
+          match_type: ''
+          name: test_suite_settings_test_suite_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: test_suite_settings_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 2
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - test_suite_id
+          name: test_suite_settings_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: test_suite_settings
+      options: []
+      order: 11
+    test_suites:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: test_suites_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        prio:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: prio
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: test_suites
+      options: []
+      order: 12
+    users:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - openid
+          match_type: ''
+          name: users_openid
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        email:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: email
+          order: 3
+          size:
+            - 0
+        fullname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: fullname
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        is_admin:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_admin
+          order: 7
+          size:
+            - 0
+        is_operator:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_operator
+          order: 6
+          size:
+            - 0
+        nickname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: nickname
+          order: 5
+          size:
+            - 0
+        openid:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: openid
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+      indices: []
+      name: users
+      options: []
+      order: 13
+    worker_properties:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: worker_properties_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: worker_properties_idx_worker_id
+          options: []
+          type: NORMAL
+      name: worker_properties
+      options: []
+      order: 14
+    workers:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - host
+            - instance
+          match_type: ''
+          name: workers_host_instance
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 4
+          size:
+            - 0
+        host:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: host
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        instance:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: instance
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices: []
+      name: workers
+      options: []
+      order: 15
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - ApiKeys
+      - Assets
+      - Commands
+      - Dependencies
+      - JobDependencies
+      - JobModules
+      - JobResults
+      - JobSettings
+      - JobStates
+      - JobTemplates
+      - Jobs
+      - JobsAssets
+      - MachineSettings
+      - Machines
+      - ProductSettings
+      - Products
+      - Secrets
+      - TestSuiteSettings
+      - TestSuites
+      - Users
+      - WorkerProperties
+      - Workers
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11020

--- a/lib/OpenQA/Test/Database.pm
+++ b/lib/OpenQA/Test/Database.pm
@@ -25,7 +25,7 @@ sub create {
     );
 
     # New db
-    my $schema = openqa::connect_db(':memory:');
+    my $schema = openqa::connect_db('test');
     my $script_directory = "$FindBin::Bin/../dbicdh";
     if (!-d $script_directory) {
         $script_directory = "$FindBin::Bin/../../dbicdh";  # For tests
@@ -103,19 +103,16 @@ Deploy schema & load fixtures
 
 =head1 USAGE
 
-    # Creates an sqlite3 test.db database from DBIC Schema without fixtures
-    my $schema = Test::Database->new->create(file => 'test.db', skip_fixtures => 1);
-
-    # Creates an in-memory sqlite3 database from DBIC Schema (both are equivalent)
-    my $schema = Test::Database->new->create(file => ':memory:');
+    # Creates an test database from DBIC Schema with or without fixtures
     my $schema = Test::Database->new->create;
+    my $schema = Test::Database->new->create(skip_fixtures => 1);
 
 =head1 METHODS
 
 =head2 create (%args)
 
-Create new sqlite3 database from DBIC schema. Use file to specify the filename
-(or ':memory:') and skip_fixtures to prevent loading fixtures.
+Create new database from DBIC schema.
+Use skip_fixtures to prevent loading fixtures.
 
 =head2 insert_fixtures
 

--- a/lib/OpenQA/modules/DBIx/Class/Timestamps.pm
+++ b/lib/OpenQA/modules/DBIx/Class/Timestamps.pm
@@ -1,0 +1,31 @@
+package DBIx::Class::Timestamps;
+use base qw(DBIx::Class);
+use DateTime;
+
+require Exporter;
+@ISA = qw(Exporter);
+@EXPORT_OK = qw/now/;
+
+sub add_timestamps {
+    my $self = shift;
+
+    $self->load_components(qw/InflateColumn::DateTime DynamicDefault/);
+
+    $self->add_columns(
+        t_created => {
+            data_type => 'timestamp',
+            dynamic_default_on_create => 'now'
+        },
+        t_updated => {
+            data_type => 'timestamp',
+            dynamic_default_on_create => 'now',
+            dynamic_default_on_update => 'now'
+        },
+    );
+}
+
+sub now {
+    DateTime->now(time_zone=>'UTC');
+}
+
+1;

--- a/lib/OpenQA/modules/Schema/Result/ApiKeys.pm
+++ b/lib/OpenQA/modules/Schema/Result/ApiKeys.pm
@@ -20,7 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('api_keys');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -40,24 +40,11 @@ __PACKAGE__->add_columns(
         data_type => 'timestamp',
         is_nullable => 1,
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
-__PACKAGE__->add_unique_constraint(constraint_name => [qw/key/]);
+__PACKAGE__->add_unique_constraint([qw/key/]);
 __PACKAGE__->belongs_to(user => 'Schema::Result::Users', 'user_id');
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 sub new {
     my ( $class, $attrs ) = @_;

--- a/lib/OpenQA/modules/Schema/Result/Assets.pm
+++ b/lib/OpenQA/modules/Schema/Result/Assets.pm
@@ -22,6 +22,7 @@ use db_helpers;
 our %types = map { $_ => 1 } qw/iso repo hdd/;
 
 __PACKAGE__->table('assets');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -33,24 +34,11 @@ __PACKAGE__->add_columns(
     name => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/type name/]);
 __PACKAGE__->has_many(jobs_assets => 'Schema::Result::JobsAssets', 'asset_id');
 __PACKAGE__->many_to_many(jobs => 'jobs_assets', 'job');
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/Commands.pm
+++ b/lib/OpenQA/modules/Schema/Result/Commands.pm
@@ -20,7 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('commands');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -36,24 +36,11 @@ __PACKAGE__->add_columns(
     worker_id => {
         data_type => 'integer',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(worker => 'Schema::Result::Workers', 'worker_id');
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/modules/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/modules/Schema/Result/JobModules.pm
@@ -21,7 +21,7 @@ use db_helpers;
 use Scheduler;
 
 __PACKAGE__->table('job_modules');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -45,15 +45,8 @@ __PACKAGE__->add_columns(
         default_value => 0,
         is_foreign_key => 1,
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(
     "job",
@@ -67,13 +60,6 @@ __PACKAGE__->belongs_to(
     },
 );
 __PACKAGE__->belongs_to(result => 'Schema::Result::JobResults', 'result_id');
-
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 our $result_cache;
 

--- a/lib/OpenQA/modules/Schema/Result/JobSettings.pm
+++ b/lib/OpenQA/modules/Schema/Result/JobSettings.pm
@@ -20,7 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('job_settings');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -36,15 +36,8 @@ __PACKAGE__->add_columns(
         data_type => 'integer',
         is_foreign_key => 1,
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(
     "job",
@@ -57,14 +50,6 @@ __PACKAGE__->belongs_to(
         on_update     => "CASCADE",
     },
 );
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-
-    $sqlt_table->add_index(name => 'job_settings_kv_index', fields => [qw/key value/]);
-}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/modules/Schema/Result/JobTemplates.pm
+++ b/lib/OpenQA/modules/Schema/Result/JobTemplates.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('job_templates');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -34,26 +35,13 @@ __PACKAGE__->add_columns(
     test_suite_id => {
         data_type => 'integer',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(product => 'Schema::Result::Products', 'product_id');
 __PACKAGE__->belongs_to(machine => 'Schema::Result::Machines', 'machine_id');
 __PACKAGE__->belongs_to(test_suite => 'Schema::Result::TestSuites', 'test_suite_id');
 __PACKAGE__->add_unique_constraint([qw/product_id machine_id test_suite_id/]);
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 sub variables {
     my $self = shift;

--- a/lib/OpenQA/modules/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/modules/Schema/Result/Jobs.pm
@@ -21,7 +21,7 @@ use Try::Tiny;
 use db_helpers;
 
 __PACKAGE__->table('jobs');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -76,16 +76,9 @@ __PACKAGE__->add_columns(
         data_type => 'timestamp',
         is_nullable => 1,
     },
-
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
+
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->has_many(settings => 'Schema::Result::JobSettings', 'job_id');
 __PACKAGE__->belongs_to(state => 'Schema::Result::JobStates', 'state_id');
@@ -99,13 +92,7 @@ __PACKAGE__->has_many(children => 'Schema::Result::JobDependencies', 'parent_job
 __PACKAGE__->has_many(parents => 'Schema::Result::JobDependencies', 'child_job_id');
 __PACKAGE__->has_many(modules => 'Schema::Result::JobModules', 'job_id');
 
-__PACKAGE__->add_unique_constraint(constraint_name => [qw/slug/]);
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
+__PACKAGE__->add_unique_constraint([qw/slug/]);
 
 sub name{
     my $self = shift;

--- a/lib/OpenQA/modules/Schema/Result/JobsAssets.pm
+++ b/lib/OpenQA/modules/Schema/Result/JobsAssets.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('jobs_assets');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     job_id => {
         data_type => 'integer',
@@ -29,25 +30,12 @@ __PACKAGE__->add_columns(
         data_type => 'integer',
         is_foreign_key => 1,
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 
-__PACKAGE__->add_unique_constraint(constraint_name => [qw/job_id asset_id/]);
+__PACKAGE__->add_unique_constraint([qw/job_id asset_id/]);
 
 __PACKAGE__->belongs_to( job => 'Schema::Result::Jobs', 'job_id' );
 __PACKAGE__->belongs_to( asset => 'Schema::Result::Assets', 'asset_id' );
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/MachineSettings.pm
+++ b/lib/OpenQA/modules/Schema/Result/MachineSettings.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('machine_settings');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -35,15 +36,8 @@ __PACKAGE__->add_columns(
     value => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/machine_id key/]);
 
@@ -58,11 +52,5 @@ __PACKAGE__->belongs_to(
         on_update     => "CASCADE",
     },
 );
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/Machines.pm
+++ b/lib/OpenQA/modules/Schema/Result/Machines.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('machines');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -34,24 +35,11 @@ __PACKAGE__->add_columns(
     variables => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/name/]);
 __PACKAGE__->has_many(job_templates => 'Schema::Result::JobTemplates', 'machine_id');
 __PACKAGE__->has_many(settings => 'Schema::Result::MachineSettings', 'machine_id', { order_by => { -asc => 'key' } } );
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/ProductSettings.pm
+++ b/lib/OpenQA/modules/Schema/Result/ProductSettings.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('product_settings');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -35,15 +36,8 @@ __PACKAGE__->add_columns(
     value => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/product_id key/]);
 
@@ -58,11 +52,5 @@ __PACKAGE__->belongs_to(
         on_update     => "CASCADE",
     },
 );
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/Products.pm
+++ b/lib/OpenQA/modules/Schema/Result/Products.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('products');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -45,15 +46,8 @@ __PACKAGE__->add_columns(
     variables => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->has_many(job_templates => 'Schema::Result::JobTemplates', 'product_id');
 __PACKAGE__->add_unique_constraint([qw/distri version arch flavor/]);
@@ -62,12 +56,6 @@ __PACKAGE__->has_many(settings => 'Schema::Result::ProductSettings', 'product_id
 sub name {
     my ($self) = @_;
     join('-', map { $self->$_ } qw/distri version flavor arch/);
-}
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
 }
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/Secrets.pm
+++ b/lib/OpenQA/modules/Schema/Result/Secrets.pm
@@ -20,7 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('secrets');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -29,23 +29,10 @@ __PACKAGE__->add_columns(
     secret => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
-__PACKAGE__->add_unique_constraint(constraint_name => [qw/secret/]);
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
+__PACKAGE__->add_unique_constraint([qw/secret/]);
 
 sub new {
     my ( $class, $attrs ) = @_;

--- a/lib/OpenQA/modules/Schema/Result/TestSuiteSettings.pm
+++ b/lib/OpenQA/modules/Schema/Result/TestSuiteSettings.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('test_suite_settings');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -35,15 +36,8 @@ __PACKAGE__->add_columns(
     value => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/test_suite_id key/]);
 
@@ -58,11 +52,5 @@ __PACKAGE__->belongs_to(
         on_update     => "CASCADE",
     },
 );
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/TestSuites.pm
+++ b/lib/OpenQA/modules/Schema/Result/TestSuites.pm
@@ -20,6 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('test_suites');
+__PACKAGE__->load_components(qw/Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -34,24 +35,11 @@ __PACKAGE__->add_columns(
     prio => {
         data_type => 'integer',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/name/]);
 __PACKAGE__->has_many(job_templates => 'Schema::Result::JobTemplates', 'test_suite_id');
 __PACKAGE__->has_many(settings => 'Schema::Result::TestSuiteSettings', 'test_suite_id', { order_by => { -asc => 'key' } });
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;

--- a/lib/OpenQA/modules/Schema/Result/Users.pm
+++ b/lib/OpenQA/modules/Schema/Result/Users.pm
@@ -20,7 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('users');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -53,24 +53,11 @@ __PACKAGE__->add_columns(
         false_id => ['0', '-1'],
         default_value => '0',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
-__PACKAGE__->add_unique_constraint(constraint_name => [qw/openid/]);
+__PACKAGE__->add_unique_constraint([qw/openid/]);
 __PACKAGE__->has_many(api_keys => 'Schema::Result::ApiKeys', 'user_id');
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 sub name{
     my $self = shift;

--- a/lib/OpenQA/modules/Schema/Result/WorkerProperties.pm
+++ b/lib/OpenQA/modules/Schema/Result/WorkerProperties.pm
@@ -20,7 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('worker_properties');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -36,15 +36,8 @@ __PACKAGE__->add_columns(
         data_type => 'integer',
         is_foreign_key => 1,
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(
     "worker",
@@ -57,14 +50,6 @@ __PACKAGE__->belongs_to(
         on_update     => "CASCADE",
     },
 );
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-
-    $sqlt_table->add_index(name => 'worker_properties_kv_index', fields => [qw/key value/]);
-}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/modules/Schema/Result/Workers.pm
+++ b/lib/OpenQA/modules/Schema/Result/Workers.pm
@@ -20,7 +20,7 @@ use base qw/DBIx::Class::Core/;
 use db_helpers;
 
 __PACKAGE__->table('workers');
-__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+__PACKAGE__->load_components(qw/InflateColumn::DateTime Timestamps/);
 __PACKAGE__->add_columns(
     id => {
         data_type => 'integer',
@@ -35,29 +35,16 @@ __PACKAGE__->add_columns(
     backend => {
         data_type => 'text',
     },
-    t_created => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
-    t_updated => {
-        data_type => 'timestamp',
-        is_nullable => 1,
-    },
 );
+__PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
-__PACKAGE__->add_unique_constraint(constraint_name => [qw/host instance/]);
+__PACKAGE__->add_unique_constraint([qw/host instance/]);
 __PACKAGE__->has_many(jobs => 'Schema::Result::Jobs', 'worker_id');
 __PACKAGE__->has_many(commands => 'Schema::Result::Commands', 'worker_id');
 __PACKAGE__->has_many(properties => 'Schema::Result::WorkerProperties', 'worker_id');
 
 # TODO
 # INSERT INTO workers (id, t_created) VALUES(0, datetime('now'));
-
-sub sqlt_deploy_hook {
-    my ($self, $sqlt_table) = @_;
-
-    db_helpers::create_auto_timestamps($sqlt_table->schema, __PACKAGE__->table);
-}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/modules/Schema/Schema.pm
+++ b/lib/OpenQA/modules/Schema/Schema.pm
@@ -15,16 +15,28 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package Schema;
-use base qw/DBIx::Class::Schema/;
+use base qw/DBIx::Class::Schema::Config/;
 use IO::Dir;
+use File::Basename qw/dirname/;
 use SQL::SplitStatement;
 use Fcntl ':mode';
+use FindBin qw($Bin);
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION = 17;
+our $VERSION = 18;
 
 __PACKAGE__->load_namespaces;
+
+my @paths = ( "$Bin/../lib/database", "$Bin/../../lib/database" );
+unshift(@paths, dirname($ENV{OPENQA_CONFIG}).'/database') if ($ENV{OPENQA_CONFIG});
+__PACKAGE__->config_paths(\@paths);
+
+sub dsn {
+    my $self = shift;
+
+    $self->storage->connect_info->[0]->{dsn};
+}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/modules/db_helpers.pm
+++ b/lib/OpenQA/modules/db_helpers.pm
@@ -21,42 +21,6 @@ our @EXPORT_OK = qw/create_auto_timestamps rndstr rndhex rndstrU rndhexU/;
 
 use Carp;
 
-sub _create_timestamp_trigger{
-    my $schema = shift;
-    my $table = shift;
-    my $action = shift;
-
-    my $timestamp;
-    if ($action eq 'UPDATE') {
-        $timestamp = 't_updated';
-    }
-    elsif ($action eq 'INSERT') {
-        $timestamp = 't_created';
-    }
-    else {
-        die "invalid action, must be INSERT or UPDATE\n";
-    }
-
-    $schema->add_trigger(
-        name                => 'trigger_'.$table.'_'.$timestamp,
-        perform_action_when => 'AFTER',
-        database_events     => [$action],
-        fields              => [$timestamp],
-        on_table            => $table,
-        action              => "UPDATE $table SET $timestamp = datetime('now') WHERE _rowid_ = NEW._rowid_;",
-        schema              => $schema,
-    );
-
-}
-
-sub create_auto_timestamps{
-    my $schema = shift;
-    my $table = shift;
-
-    _create_timestamp_trigger($schema, $table, 'INSERT');
-    _create_timestamp_trigger($schema, $table, 'UPDATE');
-}
-
 sub rndstr{
     my $length = shift || 16;
     my $chars = shift || ['a'..'z', 'A'..'Z', '0'..'9', '_'];

--- a/lib/database.ini
+++ b/lib/database.ini
@@ -1,0 +1,9 @@
+[test]
+dsn = dbi:SQLite:dbname=:memory:
+on_connect_call = use_foreign_keys
+on_connect_do = PRAGMA synchronous = OFF
+
+[production]
+dsn = dbi:SQLite:dbname=/var/lib/openqa/db/db.sqlite
+on_connect_call = use_foreign_keys
+on_connect_do = PRAGMA synchronous = OFF

--- a/script/initdb
+++ b/script/initdb
@@ -59,33 +59,36 @@ if ($help) {
     exit;
 }
 
-my $dbdir = dirname($openqa::dbfile);
-die "$dbdir does not exist\n" unless -d $dbdir;
-my @s = stat(_);
-if (getgid() != $s[5]) {
-    setgid($s[5]) or die "can't change gid to $s[5]: $!\n";
-}
-if (getuid() != $s[4]) {
-    setuid($s[4]) or die "can't change uid to $s[4]: $!\n";
-}
-
 my $script_directory = "$FindBin::Bin/../dbicdh";
+my @databases = qw( MySQL SQLite PostgreSQL );
 my $schema = openqa::connect_db();
 
-# speed this up a bit
-$schema->storage->dbh_do(
-    sub {
-        my ($storage, $dbh, @args) = @_;
-        $dbh->do("PRAGMA synchronous = OFF");
+if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
+    my $dbdir = dirname($1);
+    die "$dbdir does not exist\n" unless -d $dbdir;
+    my @s = stat(_);
+    if (getgid() != $s[5]) {
+        setgid($s[5]) or die "can't change gid to $s[5]: $!\n";
     }
-);
+    if (getuid() != $s[4]) {
+        setuid($s[4]) or die "can't change uid to $s[4]: $!\n";
+    }
+
+    # speed this up a bit
+    $schema->storage->dbh_do(
+        sub {
+            my ($storage, $dbh, @args) = @_;
+            $dbh->do("PRAGMA synchronous = OFF");
+        }
+    );
+}
 
 my $dh = DBIx::Class::DeploymentHandler->new(
     {
         schema              => $schema,
         script_directory    => $script_directory,
-        databases           => 'SQLite',
-        sql_translator_args => { add_drop_table => 1, producer_args => { sqlite_version => '3.7' } },
+        databases           => \@databases,
+        sql_translator_args => { add_drop_table => 0, producer_args => { sqlite_version => '3.7' }},
         force_overwrite     => $force,
     }
 );
@@ -93,13 +96,15 @@ my $dh = DBIx::Class::DeploymentHandler->new(
 my $version    = $dh->schema_version;
 
 my %deploy_dir;
-tie %deploy_dir, 'IO::Dir', "$script_directory/SQLite/deploy";
-
 if ($prepare_init) {
-    if ( exists $deploy_dir{$version} and not $force) {
-        print "The deploy directory already contains the schema for the current version.\n";
-        print "Use the --force option if you want to overwrite the contents of the $script_directory/SQLite/upgrade/$version directory\n";
-        exit 1;
+    foreach my $db (@databases) {
+        tie %deploy_dir, 'IO::Dir', "$script_directory/$db/deploy";
+
+        if ( exists $deploy_dir{$version} and not $force) {
+            print "The deploy directory already contains the schema for the current version.\n";
+            print "Use the --force option if you want to overwrite the contents of the $script_directory/$db/deploy/$version directory\n";
+            exit 1;
+        }
     }
 
     $dh->prepare_install;

--- a/script/load_templates
+++ b/script/load_templates
@@ -95,25 +95,27 @@ else {
     }
 }
 
-my $dbdir = dirname($openqa::dbfile);
-die "$dbdir does not exist\n" unless -d $dbdir;
-my @s = stat(_);
-if (getgid() != $s[5]) {
-    setgid($s[5]) or die "can't change gid to $s[5]: $!\n";
-}
-if (getuid() != $s[4]) {
-    setuid($s[4]) or die "can't change uid to $s[4]: $!\n";
-}
-
 my $schema = openqa::connect_db();
 
-# speed this up a bit
-$schema->storage->dbh_do(
-    sub {
-        my ($storage, $dbh, @args) = @_;
-        $dbh->do("PRAGMA synchronous = OFF");
+if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
+    my $dbdir = dirname($1);
+    die "$dbdir does not exist\n" unless -d $dbdir;
+    my @s = stat(_);
+    if (getgid() != $s[5]) {
+        setgid($s[5]) or die "can't change gid to $s[5]: $!\n";
     }
-);
+    if (getuid() != $s[4]) {
+        setuid($s[4]) or die "can't change uid to $s[4]: $!\n";
+    }
+
+    # speed this up a bit
+    $schema->storage->dbh_do(
+        sub {
+            my ($storage, $dbh, @args) = @_;
+            $dbh->do("PRAGMA synchronous = OFF");
+        }
+    );
+}
 
 my @tables = (qw/Machines TestSuites Products JobTemplates/);
 my %added;

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -67,12 +67,23 @@ if ($help) {
 my $schema = openqa::connect_db();
 
 my $script_directory = "$FindBin::Bin/../dbicdh";
+my @databases = qw( MySQL SQLite PostgreSQL );
+
+if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
+    # Some SQLite update scripts do not work correctly with foreign keys on
+    $schema->storage->dbh_do(
+        sub {
+            my ($storage, $dbh, @args) = @_;
+            $dbh->do("PRAGMA foreign_keys = OFF;");
+        }
+    );
+}
 
 my $dh = DH->new(
     {
         schema              => $schema,
         script_directory    => $script_directory,
-        databases           => 'SQLite',
+        databases           => \@databases,
         sql_translator_args => { add_drop_table => 0, producer_args => { sqlite_version => '3.7' } },
         force_overwrite     => $force,
     }
@@ -88,15 +99,16 @@ my $prev_version      = $version - 1;
 my $upgrade_directory = "$prev_version-$version";
 
 my %upgrade_dir;
-tie %upgrade_dir, 'IO::Dir', "$script_directory/SQLite/upgrade";
-my %deploy_dir;
-tie %deploy_dir, 'IO::Dir', "$script_directory/SQLite/deploy";
 
 if ($prepare_upgrades) {
-    if ( exists $upgrade_dir{$upgrade_directory} and not $force) {
-        print "The upgrade directory already contains files to upgrade to the current version ($version)\n";
-        print "Use the --force option if you want to overwrite the contents of the $script_directory/SQLite/upgrade/$upgrade_directory directory\n";
-        exit 1;
+    foreach my $db (@databases) {
+        tie %upgrade_dir, 'IO::Dir', "$script_directory/$db/upgrade";
+
+        if ( exists $upgrade_dir{$upgrade_directory} and not $force) {
+            print "The upgrade directory already contains files to upgrade to the current version ($version)\n";
+            print "Use the --force option if you want to overwrite the contents of the $script_directory/$db/upgrade/$upgrade_directory directory\n";
+            exit 1;
+        }
     }
 
     $dh->prepare_upgrade({ from_version => $prev_version, to_version => $version } );

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -26,9 +26,7 @@ use SQL::Translator;
 
 use openqa ();
 
-unlink $openqa::dbfile;
-
-my $schema = openqa::connect_db();
+my $schema = openqa::connect_db('test');
 
 my $dh = DBIx::Class::DeploymentHandler->new(
     {


### PR DESCRIPTION
 * Tested PostgreSQL (fresh install) and SQLite (both fresh and update)
 * t_created and t_updated are now managed in Perl code
   (custom DBIx::Class:Timestamps module) instead of database triggers
 * A new configuration file introduced: /etc/openqa/database.ini
 * Some dependencies introduced
    DBIx::Class::DynamicDefault, DBIx::Class::Schema::Config, Config::Tiny (needed by Schema::Config to read database.ini), DBD::Pg (optional), DateTime::Format::Pg (optional), DBD::MySQL (optional), DateTime::Format::MySQL (optional)