### PR TITLE
make sure systemd kills the worker first

### DIFF
--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -12,6 +12,7 @@ PartOf=openqa-worker.target
 Type=simple
 ExecStart=/usr/share/openqa/script/worker --instance %i
 User=geekotest
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
the default for systemd is sending all processes in the control group
a TERM, but we want a defined shut down procedure, so only send the
worker a TERM

If the process doesn't go away after a timeout, systemd will send
SIGKILL to all processes again, so no worries there