### PR TITLE
don't stop isotovideo while shutting down

### DIFF
--- a/script/worker
+++ b/script/worker
@@ -398,16 +398,13 @@ sub _kill_worker($) {
 
     return unless $worker;
 
+    warn "killing $worker->{pid}\n";
+    kill(SIGTERM, $worker->{pid});
+
     # don't leave here before the worker is dead
-    while (1) {
-        kill(SIGTERM, $worker->{pid});
-        sleep 2;
-        my $pid = waitpid($worker->{pid}, WNOHANG);
-        if ($pid == -1) {
-            warn "waitpid returned error: $!\n";
-            last;
-        }
-        last if ($pid == $worker->{pid});
+    my $pid = waitpid($worker->{pid}, 0);
+    if ($pid == -1) {
+        warn "waitpid returned error: $!\n";
     }
 
     $worker = undef;


### PR DESCRIPTION
sending a TERM twice while isotovideo is shuting down makes it likely
that we leave qemu running and this can lead to desaster. so better
be patient

In case isotovideo won't shut down, systemd will kill the whole cgroup
and we have something to debug