### PR TITLE
action 5792 - job notify command

### DIFF
--- a/lib/OpenQA/API/V1/Iso.pm
+++ b/lib/OpenQA/API/V1/Iso.pm
@@ -182,10 +182,10 @@ sub create {
                 $self->app->log->error("START_AFTER_TEST=" . $settings->{START_AFTER_TEST} . " not sorted");
             }
         }
-        # create a new job with these parameters and count if successful
+        # create a new job with these parameters and count if successful, do not send job notifies yet
         my $id;
         try {
-            $id = Scheduler::job_create(%$settings);
+            $id = Scheduler::job_create($settings, 1);
         }
         catch {
             chomp;
@@ -205,6 +205,8 @@ sub create {
             }
         }
     }
+    #notify workers new jobs are available
+    Scheduler::job_notify_workers();
     $self->app->log->debug("created $cnt jobs");
     $self->render(json => {count => $cnt, ids => \@ids });
 }

--- a/lib/OpenQA/API/V1/Job.pm
+++ b/lib/OpenQA/API/V1/Job.pm
@@ -43,7 +43,7 @@ sub create {
     my $json = {};
     my $status;
     try {
-        my $res = Scheduler::job_create(%up_params);
+        my $res = Scheduler::job_create(\%up_params);
         $json->{id} = $res;
     }
     catch {

--- a/lib/OpenQA/modules/Scheduler.pm
+++ b/lib/OpenQA/modules/Scheduler.pm
@@ -51,7 +51,7 @@ our (@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 
 @EXPORT = qw(worker_register worker_get workers_get_dead_worker list_workers job_create
   job_get job_get_by_workerid jobs_get_dead_worker list_jobs job_grab job_set_done
-  job_set_waiting job_set_running job_set_prio
+  job_set_waiting job_set_running job_set_prio job_notify_workers
   job_delete job_update_result job_restart job_cancel command_enqueue
   iso_cancel_old_builds
   job_set_stop job_stop iso_stop_old_builds
@@ -70,6 +70,7 @@ our %worker_commands = map { $_ => 1 } qw/
   enable_interactive_mode
   disable_interactive_mode
   continue_waitforneedle
+  job_available
   livelog_stop
   livelog_start
   /;
@@ -262,6 +263,10 @@ sub _seen_worker($;$) {
 #
 # Jobs API
 #
+sub job_notify_workers {
+    # notify workers about new job
+    ws_send_all('job_available');
+}
 
 =item job_create
 

--- a/lib/OpenQA/modules/Scheduler.pm
+++ b/lib/OpenQA/modules/Scheduler.pm
@@ -988,18 +988,7 @@ sub command_enqueue {
     my %args = @_;
 
     die "invalid command\n" unless $worker_commands{$args{command}};
-
-    my $res = ws_send($args{workerid}, $args{command});
-    if (!$res) {
-        $args{retries} ||= 0;
-        if ($args{retries} < 3) {
-            $args{retries} += 1;
-            Mojo::IOLoop->timer(2 => sub {command_enqueue(%args);});
-        }
-        else {
-            printf(STDERR "Unable to send command %s to worker %s\n", $args{command}, $args{workerid});
-        }
-    }
+    ws_send($args{workerid}, $args{command});
 }
 
 #

--- a/lib/OpenQA/modules/Scheduler.pm
+++ b/lib/OpenQA/modules/Scheduler.pm
@@ -274,7 +274,8 @@ create a job
 
 =cut
 sub job_create {
-    my %settings = @_;
+    my ($settings, $no_notify) = @_;
+    my %settings = %$settings;
 
     if (my $error = OpenQA::Variables->new()->check(%settings)) {
         die "$error\n";
@@ -334,6 +335,8 @@ sub job_create {
     }
 
     my $job = schema->resultset("Jobs")->create(\%new_job_args);
+
+    job_notify_workers() unless $no_notify;
     return $job->id;
 }
 
@@ -870,6 +873,7 @@ sub job_duplicate {
 
         _job_update_parent($job->id, $clone->id);
 
+        job_notify_workers();
         return $clone->id;
     }
     else {

--- a/script/worker
+++ b/script/worker
@@ -635,8 +635,10 @@ sub stop_job($) {
     $job = undef;
     $worker = undef;
     $worker_start_time = undef;
-    # start checking for job
-    add_timer('check_job', 2, \&check_job);
+    # immediatelly check for already scheduled job
+    check_job();
+    # and start backup checking for job
+    add_timer('check_job', 10, \&check_job);
 }
 
 sub start_job {
@@ -797,6 +799,11 @@ sub handle_commands {
     elsif ($msg eq 'ok') {
         # ignore keepalives, but dont' report as unknown
     }
+    elsif ($msg eq 'job_available') {
+        if (!$job) {
+            check_job
+        }
+    }
     else {
         print STDERR "got unknown command $msg\n";
     }
@@ -913,7 +920,8 @@ sub main(){
 
     ## initial Mojo::IO timers
     add_timer('ws_keepalive', 5, \&ws_keepalive);
-    add_timer('check_job', 2, \&check_job);
+    # backup check_job in case notification command does not get through
+    add_timer('check_job', 10, \&check_job);
 
     # start event loop - this will block until stop is called
     Mojo::IOLoop->start;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -125,7 +125,7 @@ my $job_ref = {
 
 my $iso = sprintf("%s/%s", $openqa::isodir, $settings{ISO});
 open my $fh, ">", $iso;
-my $job_id = Scheduler::job_create(%settings);
+my $job_id = Scheduler::job_create(\%settings);
 is($job_id, 1, "job_create");
 
 my $assets = Scheduler::job_get_assets($job_id);
@@ -134,7 +134,7 @@ is_deeply($assets, [{ id => 1, name => "whatever.iso", type => "iso" }], "job cr
 my %settings2 = %settings;
 $settings2{NAME} = "OTHER NAME";
 $settings2{BUILD} = "44";
-my $job2_id= Scheduler::job_create(%settings2);
+my $job2_id= Scheduler::job_create(\%settings2);
 
 Scheduler::job_set_prio(jobid => $job_id, prio => 40);
 my $new_job = Scheduler::job_get($job_id);

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -18,7 +18,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 25;
+use Test::More tests => 27;
 use Test::Mojo;
 use Mojo::URL;
 use OpenQA::Test::Case;
@@ -43,7 +43,7 @@ my $ws = $t->websocket_ok('/api/v1/workers/1/ws');
 #issue valid commands for worker 1
 my @valid_commands = qw/quit abort cancel obsolete
   stop_waitforneedle reload_needles_and_retry continue_waitforneedle
-  enable_interactive_mode disable_interactive_mode
+  enable_interactive_mode disable_interactive_mode job_available
   livelog_stop livelog_start/;
 
 for my $cmd (@valid_commands) {


### PR DESCRIPTION
* When new job is scheduled, 'job_available' command is send to all connected workers. Depending if they are idle or not workers will try to grab a job.
* In case of POST isos command, job notification is send after all jobs are scheduled.
* After worker finish its job, immediately asks for new one if available. This is to solve when all jobs are scheduled and notifications were already sent.
* There is backup call to grab job each 10s.