### PR TITLE
enabled dbix profiling for sql debugging

### DIFF
--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -15,6 +15,7 @@ DBIx::Class::DynamicDefault
 DBIx::Class::ResultClass::HashRefInflator
 DBIx::Class::Schema
 DBIx::Class::Schema::Config
+DBIx::Class::Storage::Statistics
 Data::Dump
 Data::Dumper
 Data::OptList

--- a/lib/OpenQA/modules/db_profiler.pm
+++ b/lib/OpenQA/modules/db_profiler.pm
@@ -1,0 +1,31 @@
+package db_profiler;
+
+use strict;
+use base 'DBIx::Class::Storage::Statistics';
+
+use Time::HiRes qw(time);
+
+my $start;
+my $msg;
+
+sub query_start {
+    my $self = shift();
+    my $sql = shift();
+    my @params = @_;
+
+    $msg = "$sql: ".join(', ', @params);
+    $start = time();
+}
+
+sub query_end {
+    my $self = shift();
+    my $sql = shift();
+    my @params = @_;
+
+    my $elapsed = time() - $start;
+    $self->print(sprintf("[DBIx debug] Took %.8f seconds executed: %s.\n", $elapsed, $msg));
+    $start = undef;
+    $msg = '';
+}
+
+1;

--- a/lib/database.ini
+++ b/lib/database.ini
@@ -7,3 +7,6 @@ on_connect_do = PRAGMA synchronous = OFF
 dsn = dbi:SQLite:dbname=/var/lib/openqa/db/db.sqlite
 on_connect_call = use_foreign_keys
 on_connect_do = PRAGMA synchronous = OFF
+
+[logging]
+debug = 0


### PR DESCRIPTION
the output like below

[DBIx debug] Took 0.00005913 seconds executed: SELECT me.id, me.name FROM dependencies me WHERE ( name = ? ): 'chained'.
[DBIx debug] Took 0.00006008 seconds executed: SELECT me.id, me.name FROM job_states me WHERE ( name = ? ): 'done'.
[DBIx debug] Took 0.00005889 seconds executed: SELECT me.id, me.name FROM job_results me WHERE ( name = ? ): 'passed'.
[DBIx debug] Took 0.00006008 seconds executed: SELECT me.id, me.host, me.instance, me.backend, me.t_created, me.t_updated FROM workers me WHERE ( me.id = ? ): '1'.
[DBIx debug] Took 0.00006199 seconds executed: SELECT me.id, me.key, me.value, me.worker_id, me.t_created, me.t_updated FROM worker_properties me WHERE ( worker_id = ? ): '1'.
[DBIx debug] Took 0.00005603 seconds executed: SELECT me.id, me.name FROM job_states me WHERE ( name = ? ): 'scheduled'.
[DBIx debug] Took 0.00005984 seconds executed: SELECT me.id, me.name FROM job_states me WHERE ( name = ? ): 'running'.
[DBIx debug] Took 0.00054908 seconds executed: UPDATE jobs SET state_id = ?, t_started = ?, worker_id = ? WHERE ( id IN ( SELECT me.id FROM jobs me WHERE ( ( ( id IN ( SELECT me.job_id FROM job_settings me WHERE ( ( key = ? AND ( value = ? OR value = ? OR value = ? ) ) ) ) AND id NOT IN ( SELECT me.child_job_id FROM job_dependencies me  JOIN jobs parent ON parent.id = me.parent_job_id WHERE ( ( ( result_id != ? OR state_id != ? ) AND dep_id = ? ) ) ) ) AND state_id = ? AND worker_id = ? ) ) ORDER BY priority ASC, id ASC LIMIT ? ) ): '1', '2015-01-15T11:12:23', '1', 'ARCH', 'x86_64', 'i586', 'i686', '1', '4', '0', '0', '0', '1'.
