### PR TITLE
add job_id to worker commands

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -894,7 +894,7 @@ sub job_restart {
     );
     while (my $j = $jobs->next) {
         print STDERR "enqueuing abort for ".$j->id." ".$j->worker_id."\n" if $debug;
-        command_enqueue(workerid => $j->worker_id, command => 'abort');
+        command_enqueue(workerid => $j->worker_id, command => 'abort', job_id => $j->id);
     }
 
     # now set all cancelled jobs to scheduled again
@@ -937,11 +937,11 @@ sub job_cancel($;$) {
     while (my $j = $jobs->next) {
         if ($newbuild) {
             print STDERR "enqueuing obsolete for ".$j->id." ".$j->worker_id."\n" if $debug;
-            command_enqueue(workerid => $j->worker_id, command => 'obsolete');
+            command_enqueue(workerid => $j->worker_id, command => 'obsolete', job_id => $j->id);
         }
         else {
             print STDERR "enqueuing cancel for ".$j->id." ".$j->worker_id."\n" if $debug;
-            command_enqueue(workerid => $j->worker_id, command => 'cancel');
+            command_enqueue(workerid => $j->worker_id, command => 'cancel', job_id => $j->id);
         }
         ++$r;
     }
@@ -969,7 +969,9 @@ sub command_enqueue {
     my %args = @_;
 
     die "invalid command\n" unless $worker_commands{$args{command}};
-    ws_send($args{workerid}, $args{command});
+    my $msg = $args{command};
+    $msg .= " job_id=" . $args{job_id} if $args{job_id};
+    ws_send($args{workerid}, $msg);
 }
 
 #

--- a/script/worker
+++ b/script/worker
@@ -555,11 +555,12 @@ sub check_job {
     }
 }
 
-sub stop_job($) {
-    my ($aborted) = @_;
+sub stop_job($;$) {
+    my ($aborted, $job_id) = @_;
 
     # we call this function in all situations, so better check
     return unless $job;
+    return if $job_id && $job_id != $job->{'id'};
 
     print "stop_job $aborted\n" if $verbose;
 
@@ -741,17 +742,21 @@ sub update_status {
 
 sub handle_commands {
     my ($tx, $msg) = @_;
-    if ($msg eq 'quit') { # quit_worker and reschedule the job
-        stop_job('quit');
+    if ($msg =~ /^quit(\s*job_id=([0-9]*))?$/) { # quit_worker and reschedule the job
+        my $job_id = $2;
+        stop_job('quit', $job_id);
     }
-    elsif ($msg eq 'abort') { # the work is live and the job is rescheduled
-        stop_job('abort');
+    elsif ($msg =~ /^abort(\s*job_id=([0-9]*))?$/) { # the work is live and the job is rescheduled
+        my $job_id = $2;
+        stop_job('abort', $job_id);
     }
-    elsif ($msg eq 'cancel') { # The jobs is droped and the work is still alive
-        stop_job('cancel');
+    elsif ($msg =~ /^cancel(\s*job_id=([0-9]*))?$/) { # The jobs is droped and the work is still alive
+        my $job_id = $2;
+        stop_job('cancel', $job_id);
     }
-    elsif ($msg eq 'obsolete') { # The jobs is droped and a new build job replaced it
-        stop_job('obsolete');
+    elsif ($msg =~ /^obsolete(\s*job_id=([0-9]*))?$/) { # The jobs is droped and a new build job replaced it
+        my $job_id = $2;
+        stop_job('obsolete', $job_id);
     }
     elsif ($msg eq 'stop_waitforneedle') { # Plan: Enable interactive mode -- Now osautoinst decides what that means
         if ($worker) {


### PR DESCRIPTION
If job_cancel (and maybe other functions) is called too fast, it can send duplicate "cancel" commands to the worker. The worker then kills the next job too.

This pach allows cancel commands in form "cancel job_id=1234" and checks if the job_id is the current one.
