### PR TITLE
add job token auth and job mapping

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -339,6 +339,9 @@ sub startup {
     my $api_auth = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth');
     my $api_r = $api_auth->route('/')->to(namespace => 'OpenQA::Controller::API::V1');
     my $api_public_r = $r->route('/api/v1')->to(namespace => 'OpenQA::Controller::API::V1');
+    my $api_job_auth = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_jobtoken');
+    my $api_job = $api_job_auth->route('/')->to(namespace => 'OpenQA::Controller::API::V1');
+    $api_job->get('/whoami')->name('apiv1_jobauth_whoami')->to('job#whoami'); # primarily for tests
 
     # api/v1/jobs
     $api_public_r->get('/jobs')->name('apiv1_jobs')->to('job#list'); # list_jobs

--- a/lib/OpenQA/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/Controller/API/V1/Job.pm
@@ -188,5 +188,11 @@ sub duplicate {
     $self->render(json => {id => $id});
 }
 
+sub whoami {
+    my ($self) = @_;
+    my $jobid = $self->stash('job_id');
+    $self->render(json => {id => $jobid});
+}
+
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -286,5 +286,27 @@ sub duplicate{
     return $res;
 }
 
+sub set_property {
+    my ($self, $key, $value) = @_;
+    my $r = $self->settings->find({key => $key});
+    if (defined $value) {
+        if ($r) {
+            $r->update({value => $value});
+        }
+        else {
+            $self->settings->create(
+                {
+                    job_id => $self->id,
+                    key => $key,
+                    value => $value
+                }
+            );
+        }
+    }
+    elsif ($r) {
+        $r->delete;
+    }
+}
+
 1;
 # vim: set sw=4 et:

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -143,7 +143,7 @@ is($job->{id}, $jobE, "jobE"); # C and D are now running so we can start E
 
 # jobA failed
 my $result = OpenQA::Scheduler::job_set_done(jobid => $jobA, result => 'failed');
-ok($result == 1, "job_set_done");
+ok($result, "job_set_done");
 
 # then jobD and jobE, workers 5 and 6 must be canceled
 #$ws5->message_ok;
@@ -153,10 +153,10 @@ ok($result == 1, "job_set_done");
 #$ws6->message_is('cancel');
 
 $result = OpenQA::Scheduler::job_set_done(jobid => $jobD, result => 'incomplete');
-ok($result == 1, "job_set_done");
+ok($result, "job_set_done");
 
 $result = OpenQA::Scheduler::job_set_done(jobid => $jobE, result => 'incomplete');
-ok($result == 1, "job_set_done");
+ok($result, "job_set_done");
 
 
 

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -1,0 +1,54 @@
+#!/usr/bin/env perl -w
+
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use strict;
+use OpenQA::Utils;
+use OpenQA::Test::Database;
+use Test::More;
+use Test::Mojo;
+
+OpenQA::Test::Database->new->create();
+my $t = Test::Mojo->new('OpenQA');
+$t->app->log->path(undef);
+
+# test jobtoken login is possible with correct jobtoken
+$t->ua->on(
+    start => sub {
+        my ($ua, $tx) = @_;
+        $tx->req->headers->add('X-API-JobToken' => 'token99963');
+    }
+);
+$t->get_ok('/api/v1/whoami')->status_is(200)->json_is({'id' => 99963});
+
+# test jobtoken login is not possible with wrong jobtoken
+$t->ua->on(
+    start => sub {
+        my ($ua, $tx) = @_;
+        $tx->req->headers->add('X-API-JobToken' => 'wrongtoken');
+    }
+);
+$t->get_ok('/api/v1/whoami')->status_is(403);
+
+# and without jobtoken
+$t->ua->unsubscribe('start');
+$t->get_ok('/api/v1/whoami')->status_is(403);
+
+done_testing();

--- a/t/fixtures/02-jobs.pl
+++ b/t/fixtures/02-jobs.pl
@@ -122,7 +122,7 @@
         worker_id => 1,
         jobs_assets => [{ asset_id => 2 },],
         retry_avbl => 3,
-        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'DVD'},{ key => 'MACHINE', value => '64bit'},]
+        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'DVD'},{ key => 'MACHINE', value => '64bit'}, {key => 'JOBTOKEN', value => 'token99963'}]
     },
     Jobs => {
         id => 99962,


### PR DESCRIPTION
This adds simple job token authentication. Token is stored as JOBTOKEN key in JobSettings table for running jobs only (added during job_grab and removed when job_done and cloning).

For testing purposes added route /api/v1/whoami returning jobid.

added function job_set_settings($jobid, $key, [$value]) for adding (and removing if $value is undef) job settings data