### PR TITLE
add DB backed mutex locks

### DIFF
--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -14,6 +14,7 @@ DBIx::Class::DynamicDefault
 DBIx::Class::ResultClass::HashRefInflator
 DBIx::Class::Schema
 DBIx::Class::Storage::Statistics
+DBIx::Class::OptimisticLocking
 Data::Dump
 Data::Dumper
 Data::OptList

--- a/dbicdh/MySQL/deploy/25/001-auto-__VERSION.sql
+++ b/dbicdh/MySQL/deploy/25/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Wed Feb 18 09:44:27 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `dbix_class_deploymenthandler_versions`
+--
+CREATE TABLE `dbix_class_deploymenthandler_versions` (
+  `id` integer NOT NULL auto_increment,
+  `version` varchar(50) NOT NULL,
+  `ddl` text NULL,
+  `upgrade_sql` text NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `dbix_class_deploymenthandler_versions_version` (`version`)
+);
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/deploy/25/001-auto.sql
+++ b/dbicdh/MySQL/deploy/25/001-auto.sql
@@ -1,0 +1,298 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Wed Feb 18 09:44:26 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `assets`
+--
+CREATE TABLE `assets` (
+  `id` integer NOT NULL auto_increment,
+  `type` text NOT NULL,
+  `name` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `assets_type_name` (`type`, `name`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_modules`
+--
+CREATE TABLE `job_modules` (
+  `id` integer NOT NULL auto_increment,
+  `job_id` integer NOT NULL,
+  `name` text NOT NULL,
+  `script` text NOT NULL,
+  `category` text NOT NULL,
+  `soft_failure` integer NOT NULL DEFAULT 0,
+  `milestone` integer NOT NULL DEFAULT 0,
+  `important` integer NOT NULL DEFAULT 0,
+  `fatal` integer NOT NULL DEFAULT 0,
+  `result` varchar(255) NOT NULL DEFAULT 'none',
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_modules_idx_job_id` (`job_id`),
+  INDEX `idx_job_modules_result` (`result`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_modules_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_settings`
+--
+CREATE TABLE `job_settings` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `job_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_settings_idx_job_id` (`job_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_settings_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `machine_settings`
+--
+CREATE TABLE `machine_settings` (
+  `id` integer NOT NULL auto_increment,
+  `machine_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `machine_settings_idx_machine_id` (`machine_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `machine_settings_machine_id_key` (`machine_id`, `key`),
+  CONSTRAINT `machine_settings_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `machines`
+--
+CREATE TABLE `machines` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `backend` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `machines_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `product_settings`
+--
+CREATE TABLE `product_settings` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `product_settings_idx_product_id` (`product_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `product_settings_product_id_key` (`product_id`, `key`),
+  CONSTRAINT `product_settings_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `products`
+--
+CREATE TABLE `products` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `distri` text NOT NULL,
+  `version` text NOT NULL DEFAULT '',
+  `arch` text NOT NULL,
+  `flavor` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `products_distri_version_arch_flavor` (`distri`, `version`, `arch`, `flavor`)
+) ENGINE=InnoDB;
+--
+-- Table: `secrets`
+--
+CREATE TABLE `secrets` (
+  `id` integer NOT NULL auto_increment,
+  `secret` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `secrets_secret` (`secret`)
+);
+--
+-- Table: `test_suite_settings`
+--
+CREATE TABLE `test_suite_settings` (
+  `id` integer NOT NULL auto_increment,
+  `test_suite_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `test_suite_settings_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suite_settings_test_suite_id_key` (`test_suite_id`, `key`),
+  CONSTRAINT `test_suite_settings_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `test_suites`
+--
+CREATE TABLE `test_suites` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `variables` text NOT NULL,
+  `prio` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suites_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `users`
+--
+CREATE TABLE `users` (
+  `id` integer NOT NULL auto_increment,
+  `username` text NOT NULL,
+  `email` text NULL,
+  `fullname` text NULL,
+  `nickname` text NULL,
+  `is_operator` integer NOT NULL DEFAULT 0,
+  `is_admin` integer NOT NULL DEFAULT 0,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `users_username` (`username`)
+) ENGINE=InnoDB;
+--
+-- Table: `worker_properties`
+--
+CREATE TABLE `worker_properties` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `worker_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `worker_properties_idx_worker_id` (`worker_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `worker_properties_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `workers`
+--
+CREATE TABLE `workers` (
+  `id` integer NOT NULL auto_increment,
+  `host` text NOT NULL,
+  `instance` integer NOT NULL,
+  `backend` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `workers_host_instance` (`host`, `instance`)
+) ENGINE=InnoDB;
+--
+-- Table: `api_keys`
+--
+CREATE TABLE `api_keys` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `secret` text NOT NULL,
+  `user_id` integer NOT NULL,
+  `t_expiration` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `api_keys_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `api_keys_key` (`key`),
+  CONSTRAINT `api_keys_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `jobs`
+--
+CREATE TABLE `jobs` (
+  `id` integer NOT NULL auto_increment,
+  `slug` text NULL,
+  `state` varchar(255) NOT NULL DEFAULT 'scheduled',
+  `priority` integer NOT NULL DEFAULT 50,
+  `result` varchar(255) NOT NULL DEFAULT 'none',
+  `worker_id` integer NOT NULL DEFAULT 0,
+  `test` text NOT NULL,
+  `clone_id` integer NULL,
+  `retry_avbl` integer NOT NULL DEFAULT 3,
+  `backend_info` text NULL,
+  `t_started` timestamp NULL,
+  `t_finished` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_idx_clone_id` (`clone_id`),
+  INDEX `jobs_idx_worker_id` (`worker_id`),
+  INDEX `idx_jobs_state` (`state`),
+  INDEX `idx_jobs_result` (`result`),
+  PRIMARY KEY (`id`),
+  UNIQUE `jobs_slug` (`slug`),
+  CONSTRAINT `jobs_fk_clone_id` FOREIGN KEY (`clone_id`) REFERENCES `jobs` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `jobs_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_dependencies`
+--
+CREATE TABLE `job_dependencies` (
+  `child_job_id` integer NOT NULL,
+  `parent_job_id` integer NOT NULL,
+  `dependency` integer NOT NULL,
+  INDEX `job_dependencies_idx_child_job_id` (`child_job_id`),
+  INDEX `job_dependencies_idx_parent_job_id` (`parent_job_id`),
+  INDEX `idx_job_dependencies_dependency` (`dependency`),
+  PRIMARY KEY (`child_job_id`, `parent_job_id`, `dependency`),
+  CONSTRAINT `job_dependencies_fk_child_job_id` FOREIGN KEY (`child_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_dependencies_fk_parent_job_id` FOREIGN KEY (`parent_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_locks`
+--
+CREATE TABLE `job_locks` (
+  `name` text NOT NULL,
+  `owner` integer NOT NULL,
+  `locked_by` integer NULL,
+  INDEX `job_locks_idx_locked_by` (`locked_by`),
+  INDEX `job_locks_idx_owner` (`owner`),
+  PRIMARY KEY (`name`, `owner`),
+  CONSTRAINT `job_locks_fk_locked_by` FOREIGN KEY (`locked_by`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_locks_fk_owner` FOREIGN KEY (`owner`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_templates`
+--
+CREATE TABLE `job_templates` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `machine_id` integer NOT NULL,
+  `test_suite_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_templates_idx_machine_id` (`machine_id`),
+  INDEX `job_templates_idx_product_id` (`product_id`),
+  INDEX `job_templates_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `job_templates_product_id_machine_id_test_suite_id` (`product_id`, `machine_id`, `test_suite_id`),
+  CONSTRAINT `job_templates_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `jobs_assets`
+--
+CREATE TABLE `jobs_assets` (
+  `job_id` integer NOT NULL,
+  `asset_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_assets_idx_asset_id` (`asset_id`),
+  INDEX `jobs_assets_idx_job_id` (`job_id`),
+  UNIQUE `jobs_assets_job_id_asset_id` (`job_id`, `asset_id`),
+  CONSTRAINT `jobs_assets_fk_asset_id` FOREIGN KEY (`asset_id`) REFERENCES `assets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `jobs_assets_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/upgrade/24-25/001-auto.sql
+++ b/dbicdh/MySQL/upgrade/24-25/001-auto.sql
@@ -1,0 +1,27 @@
+-- Convert schema '/home/openQA/script/../dbicdh/_source/deploy/24/001-auto.yml' to '/home/openQA/script/../dbicdh/_source/deploy/25/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+SET foreign_key_checks=0;
+
+;
+CREATE TABLE `job_locks` (
+  `name` text NOT NULL,
+  `owner` integer NOT NULL,
+  `locked_by` integer NULL,
+  INDEX `job_locks_idx_locked_by` (`locked_by`),
+  INDEX `job_locks_idx_owner` (`owner`),
+  PRIMARY KEY (`name`, `owner`),
+  CONSTRAINT `job_locks_fk_locked_by` FOREIGN KEY (`locked_by`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_locks_fk_owner` FOREIGN KEY (`owner`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+
+;
+SET foreign_key_checks=1;
+
+;
+
+COMMIT;
+

--- a/dbicdh/PostgreSQL/deploy/25/001-auto-__VERSION.sql
+++ b/dbicdh/PostgreSQL/deploy/25/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Wed Feb 18 09:44:27 2015
+-- 
+;
+--
+-- Table: dbix_class_deploymenthandler_versions.
+--
+CREATE TABLE "dbix_class_deploymenthandler_versions" (
+  "id" serial NOT NULL,
+  "version" character varying(50) NOT NULL,
+  "ddl" text,
+  "upgrade_sql" text,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "dbix_class_deploymenthandler_versions_version" UNIQUE ("version")
+);
+
+;

--- a/dbicdh/PostgreSQL/deploy/25/001-auto.sql
+++ b/dbicdh/PostgreSQL/deploy/25/001-auto.sql
@@ -1,0 +1,393 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Wed Feb 18 09:44:27 2015
+-- 
+;
+--
+-- Table: assets.
+--
+CREATE TABLE "assets" (
+  "id" serial NOT NULL,
+  "type" text NOT NULL,
+  "name" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "assets_type_name" UNIQUE ("type", "name")
+);
+
+;
+--
+-- Table: job_modules.
+--
+CREATE TABLE "job_modules" (
+  "id" serial NOT NULL,
+  "job_id" integer NOT NULL,
+  "name" text NOT NULL,
+  "script" text NOT NULL,
+  "category" text NOT NULL,
+  "soft_failure" integer DEFAULT 0 NOT NULL,
+  "milestone" integer DEFAULT 0 NOT NULL,
+  "important" integer DEFAULT 0 NOT NULL,
+  "fatal" integer DEFAULT 0 NOT NULL,
+  "result" character varying DEFAULT 'none' NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_modules_idx_job_id" on "job_modules" ("job_id");
+CREATE INDEX "idx_job_modules_result" on "job_modules" ("result");
+
+;
+--
+-- Table: job_settings.
+--
+CREATE TABLE "job_settings" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "job_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_settings_idx_job_id" on "job_settings" ("job_id");
+
+;
+--
+-- Table: machine_settings.
+--
+CREATE TABLE "machine_settings" (
+  "id" serial NOT NULL,
+  "machine_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machine_settings_machine_id_key" UNIQUE ("machine_id", "key")
+);
+CREATE INDEX "machine_settings_idx_machine_id" on "machine_settings" ("machine_id");
+
+;
+--
+-- Table: machines.
+--
+CREATE TABLE "machines" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "backend" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machines_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: product_settings.
+--
+CREATE TABLE "product_settings" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "product_settings_product_id_key" UNIQUE ("product_id", "key")
+);
+CREATE INDEX "product_settings_idx_product_id" on "product_settings" ("product_id");
+
+;
+--
+-- Table: products.
+--
+CREATE TABLE "products" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "distri" text NOT NULL,
+  "version" text DEFAULT '' NOT NULL,
+  "arch" text NOT NULL,
+  "flavor" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "products_distri_version_arch_flavor" UNIQUE ("distri", "version", "arch", "flavor")
+);
+
+;
+--
+-- Table: secrets.
+--
+CREATE TABLE "secrets" (
+  "id" serial NOT NULL,
+  "secret" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "secrets_secret" UNIQUE ("secret")
+);
+
+;
+--
+-- Table: test_suite_settings.
+--
+CREATE TABLE "test_suite_settings" (
+  "id" serial NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suite_settings_test_suite_id_key" UNIQUE ("test_suite_id", "key")
+);
+CREATE INDEX "test_suite_settings_idx_test_suite_id" on "test_suite_settings" ("test_suite_id");
+
+;
+--
+-- Table: test_suites.
+--
+CREATE TABLE "test_suites" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "variables" text NOT NULL,
+  "prio" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suites_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: users.
+--
+CREATE TABLE "users" (
+  "id" serial NOT NULL,
+  "username" text NOT NULL,
+  "email" text,
+  "fullname" text,
+  "nickname" text,
+  "is_operator" integer DEFAULT 0 NOT NULL,
+  "is_admin" integer DEFAULT 0 NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "users_username" UNIQUE ("username")
+);
+
+;
+--
+-- Table: worker_properties.
+--
+CREATE TABLE "worker_properties" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "worker_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "worker_properties_idx_worker_id" on "worker_properties" ("worker_id");
+
+;
+--
+-- Table: workers.
+--
+CREATE TABLE "workers" (
+  "id" serial NOT NULL,
+  "host" text NOT NULL,
+  "instance" integer NOT NULL,
+  "backend" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "workers_host_instance" UNIQUE ("host", "instance")
+);
+
+;
+--
+-- Table: api_keys.
+--
+CREATE TABLE "api_keys" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "secret" text NOT NULL,
+  "user_id" integer NOT NULL,
+  "t_expiration" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "api_keys_key" UNIQUE ("key")
+);
+CREATE INDEX "api_keys_idx_user_id" on "api_keys" ("user_id");
+
+;
+--
+-- Table: jobs.
+--
+CREATE TABLE "jobs" (
+  "id" serial NOT NULL,
+  "slug" text,
+  "state" character varying DEFAULT 'scheduled' NOT NULL,
+  "priority" integer DEFAULT 50 NOT NULL,
+  "result" character varying DEFAULT 'none' NOT NULL,
+  "worker_id" integer DEFAULT 0 NOT NULL,
+  "test" text NOT NULL,
+  "clone_id" integer,
+  "retry_avbl" integer DEFAULT 3 NOT NULL,
+  "backend_info" text,
+  "t_started" timestamp,
+  "t_finished" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "jobs_slug" UNIQUE ("slug")
+);
+CREATE INDEX "jobs_idx_clone_id" on "jobs" ("clone_id");
+CREATE INDEX "jobs_idx_worker_id" on "jobs" ("worker_id");
+CREATE INDEX "idx_jobs_state" on "jobs" ("state");
+CREATE INDEX "idx_jobs_result" on "jobs" ("result");
+
+;
+--
+-- Table: job_dependencies.
+--
+CREATE TABLE "job_dependencies" (
+  "child_job_id" integer NOT NULL,
+  "parent_job_id" integer NOT NULL,
+  "dependency" integer NOT NULL,
+  PRIMARY KEY ("child_job_id", "parent_job_id", "dependency")
+);
+CREATE INDEX "job_dependencies_idx_child_job_id" on "job_dependencies" ("child_job_id");
+CREATE INDEX "job_dependencies_idx_parent_job_id" on "job_dependencies" ("parent_job_id");
+CREATE INDEX "idx_job_dependencies_dependency" on "job_dependencies" ("dependency");
+
+;
+--
+-- Table: job_locks.
+--
+CREATE TABLE "job_locks" (
+  "name" text NOT NULL,
+  "owner" integer NOT NULL,
+  "locked_by" integer,
+  PRIMARY KEY ("name", "owner")
+);
+CREATE INDEX "job_locks_idx_locked_by" on "job_locks" ("locked_by");
+CREATE INDEX "job_locks_idx_owner" on "job_locks" ("owner");
+
+;
+--
+-- Table: job_templates.
+--
+CREATE TABLE "job_templates" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "machine_id" integer NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "job_templates_product_id_machine_id_test_suite_id" UNIQUE ("product_id", "machine_id", "test_suite_id")
+);
+CREATE INDEX "job_templates_idx_machine_id" on "job_templates" ("machine_id");
+CREATE INDEX "job_templates_idx_product_id" on "job_templates" ("product_id");
+CREATE INDEX "job_templates_idx_test_suite_id" on "job_templates" ("test_suite_id");
+
+;
+--
+-- Table: jobs_assets.
+--
+CREATE TABLE "jobs_assets" (
+  "job_id" integer NOT NULL,
+  "asset_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  CONSTRAINT "jobs_assets_job_id_asset_id" UNIQUE ("job_id", "asset_id")
+);
+CREATE INDEX "jobs_assets_idx_asset_id" on "jobs_assets" ("asset_id");
+CREATE INDEX "jobs_assets_idx_job_id" on "jobs_assets" ("job_id");
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE "job_modules" ADD CONSTRAINT "job_modules_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_settings" ADD CONSTRAINT "job_settings_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "machine_settings" ADD CONSTRAINT "machine_settings_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "product_settings" ADD CONSTRAINT "product_settings_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "test_suite_settings" ADD CONSTRAINT "test_suite_settings_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "worker_properties" ADD CONSTRAINT "worker_properties_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_clone_id" FOREIGN KEY ("clone_id")
+  REFERENCES "jobs" ("id") ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_child_job_id" FOREIGN KEY ("child_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_parent_job_id" FOREIGN KEY ("parent_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_locked_by" FOREIGN KEY ("locked_by")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_owner" FOREIGN KEY ("owner")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_asset_id" FOREIGN KEY ("asset_id")
+  REFERENCES "assets" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;

--- a/dbicdh/PostgreSQL/upgrade/24-25/001-auto.sql
+++ b/dbicdh/PostgreSQL/upgrade/24-25/001-auto.sql
@@ -1,0 +1,27 @@
+-- Convert schema '/home/openQA/script/../dbicdh/_source/deploy/24/001-auto.yml' to '/home/openQA/script/../dbicdh/_source/deploy/25/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TABLE "job_locks" (
+  "name" text NOT NULL,
+  "owner" integer NOT NULL,
+  "locked_by" integer,
+  PRIMARY KEY ("name", "owner")
+);
+CREATE INDEX "job_locks_idx_locked_by" on "job_locks" ("locked_by");
+CREATE INDEX "job_locks_idx_owner" on "job_locks" ("owner");
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_locked_by" FOREIGN KEY ("locked_by")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_owner" FOREIGN KEY ("owner")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+
+COMMIT;
+

--- a/dbicdh/SQLite/deploy/25/001-auto-__VERSION.sql
+++ b/dbicdh/SQLite/deploy/25/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Wed Feb 18 09:44:27 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id INTEGER PRIMARY KEY NOT NULL,
+  version varchar(50) NOT NULL,
+  ddl text,
+  upgrade_sql text
+);
+CREATE UNIQUE INDEX dbix_class_deploymenthandler_versions_version ON dbix_class_deploymenthandler_versions (version);
+COMMIT;

--- a/dbicdh/SQLite/deploy/25/001-auto.sql
+++ b/dbicdh/SQLite/deploy/25/001-auto.sql
@@ -1,0 +1,283 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Wed Feb 18 09:44:27 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX assets_type_name ON assets (type, name);
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  soft_failure integer NOT NULL DEFAULT 0,
+  milestone integer NOT NULL DEFAULT 0,
+  important integer NOT NULL DEFAULT 0,
+  fatal integer NOT NULL DEFAULT 0,
+  result varchar NOT NULL DEFAULT 'none',
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_modules_idx_job_id ON job_modules (job_id);
+CREATE INDEX idx_job_modules_result ON job_modules (result);
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_settings_idx_job_id ON job_settings (job_id);
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX machine_settings_idx_machine_id ON machine_settings (machine_id);
+CREATE UNIQUE INDEX machine_settings_machine_id_key ON machine_settings (machine_id, key);
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX machines_name ON machines (name);
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX product_settings_idx_product_id ON product_settings (product_id);
+CREATE UNIQUE INDEX product_settings_product_id_key ON product_settings (product_id, key);
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX products_distri_version_arch_flavor ON products (distri, version, arch, flavor);
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX secrets_secret ON secrets (secret);
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id ON test_suite_settings (test_suite_id);
+CREATE UNIQUE INDEX test_suite_settings_test_suite_id_key ON test_suite_settings (test_suite_id, key);
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  prio integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX test_suites_name ON test_suites (name);
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY NOT NULL,
+  username text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX users_username ON users (username);
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX worker_properties_idx_worker_id ON worker_properties (worker_id);
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  backend text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX workers_host_instance ON workers (host, instance);
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX api_keys_idx_user_id ON api_keys (user_id);
+CREATE UNIQUE INDEX api_keys_key ON api_keys (key);
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  slug text,
+  state varchar NOT NULL DEFAULT 'scheduled',
+  priority integer NOT NULL DEFAULT 50,
+  result varchar NOT NULL DEFAULT 'none',
+  worker_id integer NOT NULL DEFAULT 0,
+  test text NOT NULL,
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  backend_info text,
+  t_started timestamp,
+  t_finished timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_idx_clone_id ON jobs (clone_id);
+CREATE INDEX jobs_idx_worker_id ON jobs (worker_id);
+CREATE INDEX idx_jobs_state ON jobs (state);
+CREATE INDEX idx_jobs_result ON jobs (result);
+CREATE UNIQUE INDEX jobs_slug ON jobs (slug);
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency),
+  FOREIGN KEY (child_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (parent_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_dependencies_idx_child_job_id ON job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id ON job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency ON job_dependencies (dependency);
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by integer,
+  PRIMARY KEY (name, owner),
+  FOREIGN KEY (locked_by) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (owner) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_locks_idx_locked_by ON job_locks (locked_by);
+CREATE INDEX job_locks_idx_owner ON job_locks (owner);
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_templates_idx_machine_id ON job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id ON job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id ON job_templates (test_suite_id);
+CREATE UNIQUE INDEX job_templates_product_id_machine_id_test_suite_id ON job_templates (product_id, machine_id, test_suite_id);
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_assets_idx_asset_id ON jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id ON jobs_assets (job_id);
+CREATE UNIQUE INDEX jobs_assets_job_id_asset_id ON jobs_assets (job_id, asset_id);
+COMMIT;

--- a/dbicdh/SQLite/upgrade/24-25/001-auto.sql
+++ b/dbicdh/SQLite/upgrade/24-25/001-auto.sql
@@ -1,0 +1,25 @@
+-- Convert schema '/home/openQA/script/../dbicdh/_source/deploy/24/001-auto.yml' to '/home/openQA/script/../dbicdh/_source/deploy/25/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by integer,
+  PRIMARY KEY (name, owner),
+  FOREIGN KEY (locked_by) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (owner) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX job_locks_idx_locked_by ON job_locks (locked_by);
+
+;
+CREATE INDEX job_locks_idx_owner ON job_locks (owner);
+
+;
+
+COMMIT;
+

--- a/dbicdh/_source/deploy/25/001-auto-__VERSION.yml
+++ b/dbicdh/_source/deploy/25/001-auto-__VERSION.yml
@@ -1,0 +1,92 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11020

--- a/dbicdh/_source/deploy/25/001-auto.yml
+++ b/dbicdh/_source/deploy/25/001-auto.yml
@@ -1,0 +1,2169 @@
+---
+schema:
+  procedures: {}
+  tables:
+    api_keys:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - key
+          match_type: ''
+          name: api_keys_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: api_keys_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 2
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: secret
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_expiration:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_expiration
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: api_keys_idx_user_id
+          options: []
+          type: NORMAL
+      name: api_keys
+      options: []
+      order: 14
+    assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - type
+            - name
+          match_type: ''
+          name: assets_type_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+        type:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: type
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: assets
+      options: []
+      order: 1
+    job_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+            - parent_job_id
+            - dependency
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+          match_type: ''
+          name: job_dependencies_fk_child_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_job_id
+          match_type: ''
+          name: job_dependencies_fk_parent_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        child_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: child_job_id
+          order: 1
+          size:
+            - 0
+        dependency:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: dependency
+          order: 3
+          size:
+            - 0
+        parent_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: parent_job_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - child_job_id
+          name: job_dependencies_idx_child_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_job_id
+          name: job_dependencies_idx_parent_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - dependency
+          name: idx_job_dependencies_dependency
+          options: []
+          type: NORMAL
+      name: job_dependencies
+      options: []
+      order: 16
+    job_locks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - owner
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - locked_by
+          match_type: ''
+          name: job_locks_fk_locked_by
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - owner
+          match_type: ''
+          name: job_locks_fk_owner
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        locked_by:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: locked_by
+          order: 3
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        owner:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: owner
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - locked_by
+          name: job_locks_idx_locked_by
+          options: []
+          type: NORMAL
+        - fields:
+            - owner
+          name: job_locks_idx_owner
+          options: []
+          type: NORMAL
+      name: job_locks
+      options: []
+      order: 17
+    job_modules:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_modules_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        category:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: category
+          order: 5
+          size:
+            - 0
+        fatal:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: fatal
+          order: 9
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        important:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: important
+          order: 8
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        milestone:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: milestone
+          order: 7
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 10
+          size:
+            - 0
+        script:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: script
+          order: 4
+          size:
+            - 0
+        soft_failure:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: soft_failure
+          order: 6
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 12
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_modules_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_job_modules_result
+          options: []
+          type: NORMAL
+      name: job_modules
+      options: []
+      order: 2
+    job_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_settings_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 4
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_settings_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_settings
+      options: []
+      order: 3
+    job_templates:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - machine_id
+            - test_suite_id
+          match_type: ''
+          name: job_templates_product_id_machine_id_test_suite_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: job_templates_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: job_templates_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: job_templates_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: job_templates_idx_machine_id
+          options: []
+          type: NORMAL
+        - fields:
+            - product_id
+          name: job_templates_idx_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - test_suite_id
+          name: job_templates_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: job_templates
+      options: []
+      order: 18
+    jobs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - slug
+          match_type: ''
+          name: jobs_slug
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - clone_id
+          match_type: ''
+          name: jobs_fk_clone_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: jobs_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        backend_info:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend_info
+          order: 10
+          size:
+            - 0
+        clone_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: clone_id
+          order: 8
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: 50
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 4
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 5
+          size:
+            - 0
+        retry_avbl:
+          data_type: integer
+          default_value: 3
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: retry_avbl
+          order: 9
+          size:
+            - 0
+        slug:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: slug
+          order: 2
+          size:
+            - 0
+        state:
+          data_type: varchar
+          default_value: scheduled
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: state
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 13
+          size:
+            - 0
+        t_finished:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_finished
+          order: 12
+          size:
+            - 0
+        t_started:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_started
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 14
+          size:
+            - 0
+        test:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: test
+          order: 7
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 6
+          size:
+            - 0
+      indices:
+        - fields:
+            - clone_id
+          name: jobs_idx_clone_id
+          options: []
+          type: NORMAL
+        - fields:
+            - worker_id
+          name: jobs_idx_worker_id
+          options: []
+          type: NORMAL
+        - fields:
+            - state
+          name: idx_jobs_state
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_jobs_result
+          options: []
+          type: NORMAL
+      name: jobs
+      options: []
+      order: 15
+    jobs_assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - asset_id
+          match_type: ''
+          name: jobs_assets_job_id_asset_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - asset_id
+          match_type: ''
+          name: jobs_assets_fk_asset_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: assets
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: jobs_assets_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        asset_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: asset_id
+          order: 2
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - asset_id
+          name: jobs_assets_idx_asset_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: jobs_assets_idx_job_id
+          options: []
+          type: NORMAL
+      name: jobs_assets
+      options: []
+      order: 19
+    machine_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+            - key
+          match_type: ''
+          name: machine_settings_machine_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: machine_settings_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: machine_settings_idx_machine_id
+          options: []
+          type: NORMAL
+      name: machine_settings
+      options: []
+      order: 4
+    machines:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: machines_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: machines
+      options: []
+      order: 5
+    product_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - key
+          match_type: ''
+          name: product_settings_product_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: product_settings_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - product_id
+          name: product_settings_idx_product_id
+          options: []
+          type: NORMAL
+      name: product_settings
+      options: []
+      order: 6
+    products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - distri
+            - version
+            - arch
+            - flavor
+          match_type: ''
+          name: products_distri_version_arch_flavor
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        arch:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: arch
+          order: 5
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: distri
+          order: 3
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: flavor
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 7
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: products
+      options: []
+      order: 7
+    secrets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - secret
+          match_type: ''
+          name: secrets_secret
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: secret
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: secrets
+      options: []
+      order: 8
+    test_suite_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+            - key
+          match_type: ''
+          name: test_suite_settings_test_suite_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: test_suite_settings_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 2
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - test_suite_id
+          name: test_suite_settings_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: test_suite_settings
+      options: []
+      order: 9
+    test_suites:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: test_suites_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        prio:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: prio
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: test_suites
+      options: []
+      order: 10
+    users:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - username
+          match_type: ''
+          name: users_username
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        email:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: email
+          order: 3
+          size:
+            - 0
+        fullname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: fullname
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        is_admin:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_admin
+          order: 7
+          size:
+            - 0
+        is_operator:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_operator
+          order: 6
+          size:
+            - 0
+        nickname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: nickname
+          order: 5
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        username:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: username
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: users
+      options: []
+      order: 11
+    worker_properties:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: worker_properties_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: worker_properties_idx_worker_id
+          options: []
+          type: NORMAL
+      name: worker_properties
+      options: []
+      order: 12
+    workers:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - host
+            - instance
+          match_type: ''
+          name: workers_host_instance
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 4
+          size:
+            - 0
+        host:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: host
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        instance:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: instance
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices: []
+      name: workers
+      options: []
+      order: 13
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - ApiKeys
+      - Assets
+      - JobDependencies
+      - JobLocks
+      - JobModules
+      - JobSettings
+      - JobTemplates
+      - Jobs
+      - JobsAssets
+      - MachineSettings
+      - Machines
+      - ProductSettings
+      - Products
+      - Secrets
+      - TestSuiteSettings
+      - TestSuites
+      - Users
+      - WorkerProperties
+      - Workers
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11020

--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -341,8 +341,8 @@ sub startup {
     my $api_r = $api_auth->route('/')->to(namespace => 'OpenQA::Controller::API::V1');
     my $api_public_r = $r->route('/api/v1')->to(namespace => 'OpenQA::Controller::API::V1');
     my $api_job_auth = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_jobtoken');
-    my $api_job = $api_job_auth->route('/')->to(namespace => 'OpenQA::Controller::API::V1');
-    $api_job->get('/whoami')->name('apiv1_jobauth_whoami')->to('job#whoami'); # primarily for tests
+    my $api_r_job = $api_job_auth->route('/')->to(namespace => 'OpenQA::Controller::API::V1');
+    $api_r_job->get('/whoami')->name('apiv1_jobauth_whoami')->to('job#whoami'); # primarily for tests
 
     # api/v1/jobs
     $api_public_r->get('/jobs')->name('apiv1_jobs')->to('job#list'); # list_jobs
@@ -376,6 +376,11 @@ sub startup {
     $worker_r->post('/commands/')->name('apiv1_create_command')->to('command#create'); #command_enqueue
     $worker_r->post('/grab_job')->name('apiv1_grab_job')->to('job#grab'); # job_grab
     $worker_r->websocket('/ws')->name('apiv1_worker_ws')->to('worker#websocket_create'); #websocket connection
+
+    # api/v1/mutex
+    $api_r_job->post('/mutex/lock/:name')->name('apiv1_mutex_create')->to('locks#mutex_create');
+    $api_r_job->get('/mutex/lock/:name')->name('apiv1_mutex_lock')->to('locks#mutex_lock');
+    $api_r_job->get('/mutex/unlock/:name')->name('apiv1_mutex_unlock')->to('locks#mutex_unlock');
 
     # api/v1/isos
     $api_r->post('/isos')->name('apiv1_create_iso')->to('iso#create'); # iso_new

--- a/lib/OpenQA/Controller/API/V1/Locks.pm
+++ b/lib/OpenQA/Controller/API/V1/Locks.pm
@@ -1,0 +1,49 @@
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Controller::API::V1::Locks;
+use Mojo::Base 'Mojolicious::Controller';
+
+use OpenQA::Locks;
+
+sub mutex_lock {
+    my ($self) = @_;
+    my $name = $self->stash('name');
+    my $jobid = $self->stash('job_id');
+    my $res = OpenQA::Locks::lock($name, $jobid);
+    return $self->render(text => 'ack', status => 200) if $res;
+    return $self->render(text => 'nack', status => 409);
+}
+
+sub mutex_unlock {
+    my ($self) = @_;
+    my $name = $self->stash('name');
+    my $jobid = $self->stash('job_id');
+    my $res = OpenQA::Locks::unlock($name, $jobid);
+    return $self->render(text => 'ack', status => 200) if $res;
+    return $self->render(text => 'nack', status => 409);
+}
+
+sub mutex_create {
+    my ($self) = @_;
+    my $name = $self->stash('name');
+    my $jobid = $self->stash('job_id');
+    my $res = OpenQA::Locks::create($name, $jobid);
+    return $self->render(text => 'ack', status => 200) if $res;
+    return $self->render(text => 'nack', status => 409);
+}
+
+1;
+# vim: set sw=4 et:

--- a/lib/OpenQA/Locks.pm
+++ b/lib/OpenQA/Locks.pm
@@ -1,0 +1,84 @@
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Locks;
+
+use strict;
+use warnings;
+
+use OpenQA::Schema::Result::Jobs;
+use OpenQA::Schema::Result::JobLocks;
+use OpenQA::Scheduler;
+
+sub _get_lock {
+    my ($name, $jobid) = @_;
+    return unless defined $name && defined $jobid;
+    my $schema = OpenQA::Scheduler::schema();
+    my $job = $schema->resultset('Jobs')->single({id => $jobid});
+    return unless $job;
+
+    # We need to get owner of the lock
+    # owner can be one of the parents or ourselves if we have no parent
+    my $lock;
+    my @maybeowners = $job->parents->all || ($job);
+    for (@maybeowners) {
+        $lock = $schema->resultset('JobLocks')->single({name => $name, owner => $_->id});
+        last if ($lock);
+    }
+    return $lock;
+}
+
+# returns undef on error, 1 on have lock, 0 on try later (lock unavailable)
+sub lock {
+    my ($name, $jobid) = @_;
+    my $lock = _get_lock($name, $jobid);
+
+    # if no lock so far, there is no lock, return as locked
+    return unless $lock;
+    # lock is locked and not by us
+    return if ($lock->locked_by && $lock->locked_by->id != $jobid);
+    # we're using optimistic locking, if this succeded, we were first
+    return 1 if ($lock->update({'locked_by' => $jobid}));
+    return;
+}
+
+sub unlock {
+    my ($name, $jobid) = @_;
+    my $lock = _get_lock($name, $jobid);
+    return unless $lock;
+    $DB::single=1;
+    # return if not locked
+    return unless $lock->locked_by;
+    # return if not locked by us
+    return unless ($lock->locked_by->id == $jobid);
+    return 1 if ($lock->update({'locked_by' => undef}));
+    return;
+}
+
+sub create {
+    my ($name, $jobid) = @_;
+    my $lock = _get_lock($name, $jobid);
+    # nothing if lock already exist
+    return if $lock;
+    return unless defined $name && defined $jobid;
+
+    # if no lock so far, there is no lock, create one as unlocked
+    my $schema = OpenQA::Scheduler::schema();
+    $lock = $schema->resultset('JobLocks')->create({name => $name, owner => $jobid});
+    return unless $lock;
+    return 1;
+}
+
+1;

--- a/lib/OpenQA/Schema/Result/JobLocks.pm
+++ b/lib/OpenQA/Schema/Result/JobLocks.pm
@@ -1,0 +1,45 @@
+# Copyright (C) 2015 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Schema::Result::JobLocks;
+use base qw/DBIx::Class::Core/;
+
+__PACKAGE__->load_components(qw/OptimisticLocking Core/);
+__PACKAGE__->load_components(qw/Core/);
+__PACKAGE__->table('job_locks');
+__PACKAGE__->add_columns(
+    name  => {
+        data_type => 'text',
+        is_nullable => 0,
+    },
+    owner => {
+        data_type => 'integer',
+        is_foreign_key => 1,
+        is_nullable => 0,
+    },
+    locked_by => {
+        data_type => 'integer',
+        is_foreign_key => 1,
+        is_nullable => 1,
+        default_value => undef,
+    }
+);
+
+__PACKAGE__->set_primary_key('name', 'owner');
+
+__PACKAGE__->belongs_to( owner => 'OpenQA::Schema::Result::Jobs', 'owner' );
+__PACKAGE__->belongs_to( locked_by => 'OpenQA::Schema::Result::Jobs', 'locked_by' );
+
+1;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -111,6 +111,9 @@ __PACKAGE__->many_to_many(assets => 'jobs_assets', 'asset');
 __PACKAGE__->has_many(children => 'OpenQA::Schema::Result::JobDependencies', 'parent_job_id');
 __PACKAGE__->has_many(parents => 'OpenQA::Schema::Result::JobDependencies', 'child_job_id');
 __PACKAGE__->has_many(modules => 'OpenQA::Schema::Result::JobModules', 'job_id');
+# Locks
+__PACKAGE__->has_many(owned_locks => 'OpenQA::Schema::Result::JobLocks', 'owner');
+__PACKAGE__->has_many(locked_locks => 'OpenQA::Schema::Result::JobLocks', 'locked_by');
 
 __PACKAGE__->add_unique_constraint([qw/slug/]);
 

--- a/lib/OpenQA/Schema/Schema.pm
+++ b/lib/OpenQA/Schema/Schema.pm
@@ -23,7 +23,7 @@ use FindBin qw($Bin);
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION = 24;
+our $VERSION = 25;
 
 __PACKAGE__->load_namespaces;
 

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -44,37 +44,6 @@ sub check_authorized {
     return 1;
 }
 
-## Synchronization API
-sub _mutex_call {
-    my ($self, $action, $name) = @_;
-    $self->render_later;
-    my $res = api_call('get',"workers/$workerid/$action/$name", undef, undef, 1);
-    if ($res) {
-        $self->render(status => 200);
-    }
-    else {
-        $self->render(status => 412);
-    }
-}
-
-sub mutex_lock {
-    my ($self) = @_;
-    my $name = $self->param('name');
-    _mutex_call($self, 'lock', $name);
-}
-
-sub mutex_unlock {
-    my ($self) = @_;
-    my $name = $self->param('name');
-    _mutex_call($self, 'unlock', $name);
-}
-
-sub mutex_create {
-    my ($self) = @_;
-    my $name = $self->param('name');
-    _mutex_call($self, 'createlock', $name);
-}
-
 ## WEBSOCKET commands
 sub websocket_commands {
     my ($tx, $msg) = @_;

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -27,7 +27,6 @@ use Test::Mojo;
 
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA');
-$t->app->log->path(undef);
 
 # test jobtoken login is possible with correct jobtoken
 $t->ua->on(
@@ -39,6 +38,7 @@ $t->ua->on(
 $t->get_ok('/api/v1/whoami')->status_is(200)->json_is({'id' => 99963});
 
 # test jobtoken login is not possible with wrong jobtoken
+$t->ua->unsubscribe('start');
 $t->ua->on(
     start => sub {
         my ($ua, $tx) = @_;

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -1,0 +1,87 @@
+#!/usr/bin/env perl -w
+
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use strict;
+use OpenQA::Utils;
+use OpenQA::Test::Database;
+use Test::More;
+use Test::Mojo;
+
+my $schema = OpenQA::Test::Database->new->create();
+my $t = Test::Mojo->new('OpenQA');
+
+# mutex API is inaccesible without jobtoken auth
+$t->post_ok('/api/v1/mutex/lock/test_lock')->status_is(403);
+$t->get_ok('/api/v1/mutex/lock/test_lock')->status_is(403);
+$t->get_ok('/api/v1/mutex/unlock/test_lock')->status_is(403);
+
+$t->ua->on(
+    start => sub {
+        my ($ua, $tx) = @_;
+        $tx->req->headers->add('X-API-JobToken' => 'token99963');
+    }
+);
+# try locking before mutex is created
+$t->get_ok('/api/v1/mutex/lock/test_lock')->status_is(409);
+
+# create test mutex
+$t->post_ok('/api/v1/mutex/lock/test_lock')->status_is(200);
+## lock in DB
+my $res = $schema->resultset('JobLocks')->find({owner => 99963, name => 'test_lock'});
+ok($res, 'mutex is in database');
+## mutex is not locked
+ok(!$res->locked_by, 'mutex is not locked');
+
+# lock mutex
+$t->get_ok('/api/v1/mutex/lock/test_lock')->status_is(200);
+## mutex is locked
+$res = $schema->resultset('JobLocks')->find({owner => 99963, name => 'test_lock'});
+ok($res->locked_by, 'mutex is locked');
+# try double lock
+$t->get_ok('/api/v1/mutex/lock/test_lock')->status_is(200);
+
+$t->ua->unsubscribe('start');
+$t->ua->on(
+    start => sub {
+        my ($ua, $tx) = @_;
+        $tx->req->headers->add('X-API-JobToken' => 'token99961');
+    }
+);
+# try to lock as another job
+$t->get_ok('/api/v1/mutex/lock/test_lock')->status_is(409);
+# try to unlock as another job
+$t->get_ok('/api/v1/mutex/unlock/test_lock')->status_is(409);
+
+$t->ua->unsubscribe('start');
+$t->ua->on(
+    start => sub {
+        my ($ua, $tx) = @_;
+        $tx->req->headers->add('X-API-JobToken' => 'token99963');
+    }
+);
+
+# unlock mutex
+$t->get_ok('/api/v1/mutex/unlock/test_lock')->status_is(200);
+## mutex unlocked in DB
+$res = $schema->resultset('JobLocks')->find({owner => 99963, name => 'test_lock'});
+ok(!$res->locked_by, 'mutex is unlocked');
+
+done_testing();

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -54,6 +54,6 @@ is($ret->tx->res->json->{id}, 1, "worker id is 1");
 
 $ret = $t->post_ok('/api/v1/workers', form => {host => 'localhost', instance => 42, backend => 'qemu' });
 is($ret->tx->res->code, 200, "register new worker");
-is($ret->tx->res->json->{id}, 2, "new worker id is 2");
+is($ret->tx->res->json->{id}, 3, "new worker id is 3");
 
 done_testing();

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -52,7 +52,7 @@ $t->app($app);
 my $get = $t->get_ok('/api/v1/jobs');
 my @jobs = @{$get->tx->res->json->{jobs}};
 my $jobs_count = scalar @jobs;
-is $jobs_count, 10;
+is $jobs_count, 11;
 my %jobs = map { $_->{id} => $_ } @jobs;
 is $jobs{99981}->{state}, 'cancelled';
 is $jobs{99963}->{state}, 'running';
@@ -60,11 +60,11 @@ is $jobs{99927}->{state}, 'scheduled';
 is $jobs{99946}->{clone_id}, undef;
 is $jobs{99963}->{clone_id}, undef;
 
-# That means that only 8 are current and only 9 are relevant
+# That means that only 9 are current and only 10 are relevant
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is scalar(@{$get->tx->res->json->{jobs}}), 8;
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
 is scalar(@{$get->tx->res->json->{jobs}}), 9;
+$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
+is scalar(@{$get->tx->res->json->{jobs}}), 10;
 
 # Test /jobs/restart
 my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927] })->status_is(200);
@@ -80,7 +80,7 @@ isnt $new_jobs{99963}->{clone_id}, undef;
 
 # The number of current jobs doesn't change
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is scalar(@{$get->tx->res->json->{jobs}}), 8;
+is scalar(@{$get->tx->res->json->{jobs}}), 9;
 
 # Test /jobs/X/restart and /jobs/X
 $get = $t->get_ok('/api/v1/jobs/99926')->status_is(200);

--- a/t/fixtures/01-workers.pl
+++ b/t/fixtures/01-workers.pl
@@ -4,6 +4,12 @@
         host => 'localhost',
         instance => 1,
         backend => 'qemu'
+    },
+    Workers => {
+        id => 2,
+        host => 'remotehost',
+        instance => 1,
+        backend => 'qemu'
     }
 ]
 # vim: set sw=4 et:

--- a/t/fixtures/02-jobs.pl
+++ b/t/fixtures/02-jobs.pl
@@ -162,7 +162,7 @@
         worker_id => 2,
         jobs_assets => [{ asset_id => 2 },],
         retry_avbl => 3,
-        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'DVD'},{ key => 'MACHINE', value => '64bit'}, {key => 'JOBTOKEN', value => 'token99961'}]
+        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'NET'},{ key => 'MACHINE', value => '64bit'}, {key => 'JOBTOKEN', value => 'token99961'}]
     },
 ]
 # vim: set sw=4 et:

--- a/t/fixtures/02-jobs.pl
+++ b/t/fixtures/02-jobs.pl
@@ -150,6 +150,19 @@
         jobs_assets => [{ asset_id => 3 },],
         retry_avbl => 3,
         settings => [{ key => 'DESKTOP', value => 'gnome'},{ key => 'ISO_MAXSIZE', value => '999999999'},{ key => 'LIVECD', value => '1'},{ key => 'ISO', value => 'openSUSE-13.1-GNOME-Live-i686-Build0091-Media.iso'},{ key => 'TEST', value => 'RAID0'},{ key => 'VERSION', value => '13.1'},{ key => 'RAIDLEVEL', value => '0'},{ key => 'INSTALLONLY', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'i686'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'GNOME', value => '1'},{ key => 'QEMUCPU', value => 'qemu32'},{ key => 'FLAVOR', value => 'GNOME-Live'},{ key => 'MACHINE', value => '32bit'},]
-    }
+    },
+    Jobs => {
+        id => 99961,
+        priority => 35,
+        result => "none",
+        state => "running",
+        t_finished => undef,
+        t_started => time2str('%Y-%m-%d %H:%M:%S', time-600, 'UTC'), # 10 minutes ago
+        test => "kde",
+        worker_id => 2,
+        jobs_assets => [{ asset_id => 2 },],
+        retry_avbl => 3,
+        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'DVD'},{ key => 'MACHINE', value => '64bit'}, {key => 'JOBTOKEN', value => 'token99961'}]
+    },
 ]
 # vim: set sw=4 et:

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -42,7 +42,7 @@ my $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version
 $get->status_is(200);
 
 $get->content_like(qr/current results for.*opensuse 13\.1 build 0091/i);
-$get->content_like(qr/passed: 2, failed: 0, unknown: 0, incomplete: 0, scheduled: 2, running: 1, none: 1/i);
+$get->content_like(qr/passed: 2, failed: 0, unknown: 0, incomplete: 0, scheduled: 2, running: 2, none: 1/i);
 
 # Check the headers
 $get->element_exists('#flavor_DVD_arch_i586');
@@ -81,7 +81,7 @@ $get->element_exists_not('#res_DVD_x86_64_kde');
 $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1'});
 $get->status_is(200);
 $get->content_like(qr/current results for.*opensuse 13\.1 build 0091/i);
-$get->content_like(qr/passed: 2, failed: 0, unknown: 0, incomplete: 0, scheduled: 2, running: 1, none: 1/i);
+$get->content_like(qr/passed: 2, failed: 0, unknown: 0, incomplete: 0, scheduled: 2, running: 2, none: 1/i);
 
 #
 # Default overview for Factory


### PR DESCRIPTION
This does **not** pass tests yet since it depends on #188 (and even after merge, there are some renames todo).
**only for *idea* review currently**
One thing I'm considering is to move locking functions (from OpenQA::Locks) directly to DB Object (OpenQA::Schema::Result::JobLocks)

* API is /api/v1/mutex/$cmd/:lockname behind jobtoken auth
* DB consistency managed by optimistic locking
* OpenQA::Worker daemon is removed