### PR TITLE
use '/etc/openqa' as default config dir

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -73,7 +73,7 @@ sub _read_config {
 
     # Mojo's built in config plugins suck. JSON for example does not
     # support comments
-    my $cfgpath=$ENV{OPENQA_CONFIG} || $self->app->home.'/etc/openqa';
+    my $cfgpath=$ENV{OPENQA_CONFIG} || '/etc/openqa';
     my $cfg = Config::IniFiles->new(-file => $cfgpath.'/openqa.ini') || undef;
 
     for my $section (sort keys %defaults) {

--- a/lib/OpenQA/Schema/Schema.pm
+++ b/lib/OpenQA/Schema/Schema.pm
@@ -35,7 +35,7 @@ sub connect_db {
     CORE::state $schema;
     unless ($schema) {
         my %ini;
-        my $cfgpath=$ENV{OPENQA_CONFIG} || "$Bin/../etc/openqa";
+        my $cfgpath=$ENV{OPENQA_CONFIG} || '/etc/openqa';
         tie %ini, 'Config::IniFiles', ( -file => $cfgpath.'/database.ini' );
         $schema=__PACKAGE__->connect($ini{$mode});
     }


### PR DESCRIPTION
After Pavel finished his config files moving, I "fixed" the spec by removing config files build time shuffle, that however broke the code as it expects config files to be under $bindir.
This PR removes that expectation and point directly to '/etc/openqa'. Was there any reason it was done in such way? Some best practice I don't know about?