### PR TITLE
Job states and results cleanup

### DIFF
--- a/lib/OpenQA/Controller/Test.pm
+++ b/lib/OpenQA/Controller/Test.pm
@@ -39,7 +39,7 @@ sub list {
     my $assetid = $self->param('assetid');
 
     my $jobs = OpenQA::Scheduler::query_jobs(
-        state => 'done',
+        state => 'done,cancelled',
         match => $match,
         scope => $scope,
         assetid => $assetid,
@@ -82,7 +82,7 @@ sub list_ajax {
         $scope = 'relevant' if $self->param('relevant') ne 'false';
 
         $jobs = OpenQA::Scheduler::query_jobs(
-            state => 'done',
+            state => 'done,cancelled',
             scope => $scope,
             limit => 500,
         );
@@ -106,7 +106,8 @@ sub list_ajax {
             arch => $settings->{ARCH} // '',
             build => $settings->{BUILD} // '',
             testtime => $job->t_created,
-            result => $job->result
+            result => $job->result,
+            state => $job->state
         };
         push @list, $data;
     }

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -396,7 +396,7 @@ sub query_jobs {
         );
     }
     if ($args{ignore_incomplete}) {
-        push(@conds, {'me.result' => { '!=' => OpenQA::Schema::Result::Jobs::INCOMPLETE}});
+        push(@conds, {'me.result' => { -not_in => [OpenQA::Schema::Result::Jobs::INCOMPLETE_RESULTS] }});
     }
     my $scope = $args{scope} || '';
     if ($scope eq 'relevant') {

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -407,7 +407,13 @@ sub query_jobs {
                 -or => [
                     'me.clone_id' => undef,
                     'clone.state' => [OpenQA::Schema::Result::Jobs::PENDING_STATES],
-                ]
+                ],
+                'me.result' => { # these results should be hidden by default
+                    -not_in => [
+                        OpenQA::Schema::Result::Jobs::OBSOLETED,
+                        # OpenQA::Schema::Result::Jobs::USER_CANCELLED  I think USER_CANCELLED jobs should be available for restart
+                    ]
+                }
             }
         );
     }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -30,21 +30,29 @@ use constant {
     CANCELLED => 'cancelled',
     WAITING => 'waiting',
     DONE => 'done',
-    OBSOLETED => 'obsoleted',
+    #    OBSOLETED => 'obsoleted',
 };
-use constant STATES => ( SCHEDULED, RUNNING, CANCELLED, WAITING, DONE, OBSOLETED );
+use constant STATES => ( SCHEDULED, RUNNING, CANCELLED, WAITING, DONE );
 use constant PENDING_STATES => ( SCHEDULED, RUNNING, WAITING );
 use constant EXECUTION_STATES => ( RUNNING, WAITING );
+use constant FINAL_STATES => ( DONE, CANCELLED );
 
 # Results
 use constant {
     NONE => 'none',
     PASSED => 'passed',
     FAILED => 'failed',
-    INCOMPLETE => 'incomplete',
-    SKIPPED => 'skipped',
+    INCOMPLETE => 'incomplete',                   # worker died or reported some problem
+    SKIPPED => 'skipped',                         # dependencies failed before starting this job
+    OBSOLETED => 'obsoleted',                     # new iso was posted
+    PARALLEL_FAILED => 'parallel_failed',         # parallel job failed, this job can't continue
+    PARALLEL_RESTARTED => 'parallel_restarted',   # parallel job was restarted, this job has to be restarted too
+    USER_CANCELLED => 'user_cancelled',           # cancelled by user via job_cancel
+    USER_RESTARTED => 'user_restarted',           # restarted by user via job_restart
 };
-use constant RESULTS => ( NONE, PASSED, FAILED, INCOMPLETE, SKIPPED );
+use constant RESULTS => ( NONE, PASSED, FAILED, INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED );
+use constant COMPLETE_RESULTS => ( PASSED, FAILED );
+use constant INCOMPLETE_RESULTS => ( INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED );
 
 __PACKAGE__->table('jobs');
 __PACKAGE__->load_components(qw/InflateColumn::DateTime FilterColumn Timestamps/);

--- a/public/javascripts/tests.js
+++ b/public/javascripts/tests.js
@@ -65,16 +65,31 @@ function renderTestsList(jobs, is_operator, restart_url) {
 	    },
 	    { targets: 4,
 	      "render": function ( data, type, row ) {
-		  if (type === 'display') {
-		      var html = data['passed'] + "<i class='fa fa-star'></i>";
-		      if (data['dents']) {
-			  html +=  " " + data['dents'] + "<i class='fa fa-star-half-empty'></i> ";
+		    if (type === 'display') {
+		      var html = '' 
+		      if (row['state'] === 'done') {
+		          html += data['passed'] + "<i class='fa fa-star'></i>";
+		          if (data['dents']) {
+			      html +=  " " + data['dents'] + "<i class='fa fa-star-half-empty'></i> ";
+		          }
+		          if (data['failed']) {
+			      html +=  " " + data['failed'] + "<i class='fa fa-star-o'></i> ";
+		          }
+		          if (data['none']) {
+			      html +=  " " + data['none'] + "<i class='fa fa-ban'></i> ";
+		          }
 		      }
-		      if (data['failed']) {
-			  html +=  " " + data['failed'] + "<i class='fa fa-star-o'></i> ";
+		      if (row['state'] === 'cancelled') {
+		          html += "<i class='fa fa-times'></i>";
 		      }
-		      if (data['none']) {
-			  html +=  " " + data['none'] + "<i class='fa fa-ban'></i> ";
+		      if (row['deps']) {
+		          if (row['result'] === 'skipped' ||
+		              row['result'] === 'parallel_failed') {
+		              html += "<i class='fa fa-chain-broken'></i>";
+		          }
+		          else {
+		              html += "<i class='fa fa-link'></i>";
+		          }
 		      }
                       return '<a class="overview_' + row['result'] + '" href="/tests/' + row['id'] + '">' + html + '</a>';
 		  } else {

--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -49,6 +49,12 @@ thead { background: #eee; }
 .overview_dent {background-color:#ff0 ;}
 .overview_failed {background-color:#fbb ;}
 .overview_incomplete {background-color:#bebebe;}
+.overview_skipped {background-color:#eeff5f;}
+.overview_obsoleted {background-color:#b7b7b7;}
+.overview_parallel_failed {background-color:#e08050 ;}
+.overview_parallel_restarted {background-color:#b0c090 ;}
+.overview_user_cancelled {background-color:#d7d7d7;}
+.overview_user_restarted {background-color:#90c090 ;}
 
 .component { text-align: right; }
 .links { text-align: left; padding-top: 0; }

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -173,11 +173,11 @@ is($job->{state}, "running", "job_set_done changed state");
 
 $job = OpenQA::Scheduler::job_get($jobD);
 is($job->{state}, "done", "job_set_done changed state");
-is($job->{result}, "incomplete", "job_set_done changed result");
+is($job->{result}, "parallel_failed", "job_set_done changed result, jobD failed because of jobA");
 
 $job = OpenQA::Scheduler::job_get($jobE);
 is($job->{state}, "done", "job_set_done changed state");
-is($job->{result}, "incomplete", "job_set_done changed result");
+is($job->{result}, "parallel_failed", "job_set_done changed result, jobE failed because of jobD");
 
 $job = OpenQA::Scheduler::job_get($jobF);
 is($job->{state}, "running", "job_set_done changed state");
@@ -204,12 +204,12 @@ my $jobC2 = $job->{clone_id};
 
 $job = OpenQA::Scheduler::job_get($jobD); #unchanged
 is($job->{state}, "done", "no change");
-is($job->{result}, "incomplete", "no change");
+is($job->{result}, "parallel_failed", "no change");
 is($job->{clone_id}, undef, "no clones");
 
 $job = OpenQA::Scheduler::job_get($jobE); #unchanged
 is($job->{state}, "done", "no change");
-is($job->{result}, "incomplete", "no change");
+is($job->{result}, "parallel_failed", "no change");
 is($job->{clone_id}, undef, "no clones");
 
 $job = OpenQA::Scheduler::job_get($jobF); # cloned
@@ -268,13 +268,13 @@ is($job->{clone_id}, $jobC2, "cloned");
 
 $job = OpenQA::Scheduler::job_get($jobD); #cloned
 is($job->{state}, "done", "no change");
-is($job->{result}, "incomplete", "no change");
+is($job->{result}, "parallel_failed", "no change");
 ok(defined $job->{clone_id}, "cloned");
 my $jobD2 = $job->{clone_id};
 
 $job = OpenQA::Scheduler::job_get($jobE); #cloned
 is($job->{state}, "done", "no change");
-is($job->{result}, "incomplete", "no change");
+is($job->{result}, "parallel_failed", "no change");
 ok(defined $job->{clone_id}, "cloned");
 my $jobE2 = $job->{clone_id};
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -79,6 +79,12 @@ is($ret->tx->res->json->{job}->{state}, 'cancelled', 'job 99981 is cancelled');
 
 $ret = $t->post_ok('/api/v1/jobs/99981/restart')->status_is(200);
 
+$ret = $t->get_ok('/api/v1/jobs/99981')->status_is(200);
+my $clone99981 = $ret->tx->res->json->{job}->{clone_id};
+
+$ret = $t->get_ok("/api/v1/jobs/$clone99981")->status_is(200);
+is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job $clone99981 is scheduled');
+
 lj;
 
 # schedule the iso, this should not actually be possible. Only isos
@@ -131,8 +137,8 @@ $ret = $t->get_ok('/api/v1/jobs/99963')->status_is(200);
 is($ret->tx->res->json->{job}->{state}, 'running', 'job 99963 is running');
 
 # make sure unrelated jobs are not cancelled
-$ret = $t->get_ok('/api/v1/jobs/99981')->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'scheduled', "job 99981 is still scheduled");
+$ret = $t->get_ok("/api/v1/jobs/$clone99981")->status_is(200);
+is($ret->tx->res->json->{job}->{state}, 'scheduled', "job $clone99981 is still scheduled");
 
 # ... and we have a new test
 $ret = $t->get_ok("/api/v1/jobs/$newid")->status_is(200);

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 38;
+use Test::More tests => 39;
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -73,12 +73,13 @@ my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 9
 
 $get = $t->get_ok('/api/v1/jobs');
 my @new_jobs = @{$get->tx->res->json->{jobs}};
-is scalar(@new_jobs), $jobs_count + 3, 'three new jobs - for 63, 46 and 61 from dependency';
+is scalar(@new_jobs), $jobs_count + 4, '4 new jobs - for 81, 63, 46 and 61 from dependency';
 my %new_jobs = map { $_->{id} => $_ } @new_jobs;
-is $new_jobs{99981}->{state}, 'scheduled';
+is $new_jobs{99981}->{state}, 'cancelled';
 is $new_jobs{99927}->{state}, 'scheduled';
 isnt $new_jobs{99946}->{clone_id}, undef;
 isnt $new_jobs{99963}->{clone_id}, undef;
+isnt $new_jobs{99981}->{clone_id}, undef;
 
 # The number of current jobs doesn't change
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -104,7 +104,7 @@ is('minimalx@32bit', $driver->find_element('#results #job_99926 .test .overview_
 # first check the relevant jobs
 my @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
 
-is_deeply([qw(job_99962 job_99946 job_99938 job_99937 job_99926)], \@jobs, '5 rows (relevant) displayed');
+is_deeply([qw(job_99981 job_99962 job_99946 job_99938 job_99937 job_99926)], \@jobs, '5 rows (relevant) displayed');
 $driver->find_element('#relevantfilter', 'css')->click();
 # leave the ajax some time
 while (!$driver->execute_script("return jQuery.active == 0")) {
@@ -112,7 +112,7 @@ while (!$driver->execute_script("return jQuery.active == 0")) {
 }
 # Test 99945 is not longer relevant (replaced by 99946) - but displayed for all
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply([qw(job_99962 job_99946 job_99945 job_99938 job_99937 job_99926)], \@jobs, '6 rows (all) displayed');
+is_deeply([qw(job_99981 job_99962 job_99946 job_99945 job_99938 job_99937 job_99926)], \@jobs, '6 rows (all) displayed');
 
 # now toggle back
 #print $driver->get_page_source();
@@ -122,7 +122,7 @@ while (!$driver->execute_script("return jQuery.active == 0")) {
     sleep 1;
 }
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply([qw(job_99962 job_99946 job_99938 job_99937 job_99926)], \@jobs, '5 rows (relevant) again displayed');
+is_deeply([qw(job_99981 job_99962 job_99946 job_99938 job_99937 job_99926)], \@jobs, '5 rows (relevant) again displayed');
 
 $driver->get($baseurl . "tests?match=staging_e");
 #print $driver->get_page_source();


### PR DESCRIPTION
https://progress.opensuse.org/issues/6148

This is not yet ready for production, the UI part is missing. 

plan for UI:
- add cancelled jobs to the list of results
- allow filtering by any combination of results (maybe a multiple selection combobox with all possible results), use reasonable default
