### PR TITLE
fix testdirname for Running and Test (#209)

### DIFF
--- a/lib/OpenQA/Controller/Running.pm
+++ b/lib/OpenQA/Controller/Running.pm
@@ -34,7 +34,7 @@ sub init {
     }
     $self->stash('job', $job);
 
-    my $testdirname = $job->name;
+    my $testdirname = $job->settings_hash->{NAME};
     $self->stash('testdirname', $testdirname);
 
     my $basepath = running_log($testdirname);

--- a/lib/OpenQA/Controller/Test.pm
+++ b/lib/OpenQA/Controller/Test.pm
@@ -121,7 +121,7 @@ sub show {
 
     return $self->reply->not_found unless $job;
 
-    my $testdirname = $job->name;
+    my $testdirname = $job->settings_hash->{NAME};
     my $testresultdir = OpenQA::Utils::testresultdir($testdirname);
 
     $self->stash(testname => $job->settings_hash->{NAME});


### PR DESCRIPTION
This mismatch broke the live log and live view for running tests, and result files and thumbnails for completed tests.