### PR TITLE
action#6344 - prevent JOBTOKEN leak

### DIFF
--- a/lib/OpenQA/Controller/API/V1.pm
+++ b/lib/OpenQA/Controller/API/V1.pm
@@ -55,10 +55,10 @@ sub auth_jobtoken {
 
     if ($token) {
         $self->app->log->debug("Received JobToken: $token");
-        my $jobtoken = $self->db->resultset('JobSettings')->find({key => 'JOBTOKEN', value => $token});
-        if ($jobtoken) {
-            $self->stash('job_id', $jobtoken->job_id);
-            $self->app->log->debug(sprintf('Found associated job %u', $jobtoken->job_id));
+        my $job = $self->db->resultset('Jobs')->search({'properties.key' => 'JOBTOKEN', 'properties.value' => $token}, {columns => ['id'], join => { 'worker' => 'properties'}})->single;
+        if ($job) {
+            $self->stash('job_id', $job->id);
+            $self->app->log->debug(sprintf('Found associated job %u', $job->id));
             return 1;
         }
     }

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -641,11 +641,11 @@ sub job_grab {
     )->single;
     return {} unless ($job);
 
-    # generate jobtoken for test access
-    $job->set_property('JOBTOKEN', rndstr);
-
     my $job_hashref = {};
     $job_hashref = _job_get({'me.id' => $job->id});
+
+    # JOBTOKEN for test access to API
+    worker_set_property($workerid, 'JOBTOKEN', rndstr);
     worker_set_property($workerid, 'WORKER_IP', $workerip) if $workerip;
 
     return $job_hashref;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -25,7 +25,7 @@ use Data::Dump qw/pp dd/;
 use OpenQA::Scheduler;
 use OpenQA::Test::Database;
 
-use Test::More tests => 55;
+use Test::More tests => 51;
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
@@ -238,9 +238,6 @@ my $rjobs_before = OpenQA::Scheduler::list_jobs(state => 'running');
 my $job = OpenQA::Scheduler::job_grab(%args);
 my $rjobs_after = OpenQA::Scheduler::list_jobs(state => 'running');
 
-## test and add JOBTOKEN to job_ref after job_grab
-ok($job->{settings}->{JOBTOKEN}, "job token present");
-$job_ref->{settings}->{JOBTOKEN} = $job->{settings}->{JOBTOKEN};
 is_deeply($job->{settings}, $job_ref->{settings}, "settings correct");
 ok($job->{t_started} =~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "job start timestamp updated");
 is(scalar(@{$rjobs_before})+1, scalar(@{$rjobs_after}), "number of running jobs");
@@ -257,15 +254,11 @@ ok($id == $id2, "re-register worker got same id");
 $job = OpenQA::Scheduler::job_get($job_id);
 is($job->{state}, "done", "Previous job is in done state");
 is($job->{result}, "incomplete", "result is incomplete");
-ok(!$job->{settings}->{JOBTOKEN}, "job token no longer present");
 
 $job = OpenQA::Scheduler::job_grab(%args);
 isnt($job_id, $job->{id}, "new job grabbed");
-isnt($job->{settings}->{JOBTOKEN}, $job_ref->{settings}->{JOBTOKEN}, "job token differs");
 $job_ref->{settings}->{NAME} = '00000003-Unicorn-42-pink-x86_64-Build666-rainbow';
 
-## update JOBTOKEN for isdeeply compare
-$job_ref->{settings}->{JOBTOKEN} = $job->{settings}->{JOBTOKEN};
 is_deeply($job->{settings}, $job_ref->{settings}, "settings correct");
 my $job3_id = $job_id;
 $job_id = $job->{id};
@@ -296,7 +289,6 @@ $job = OpenQA::Scheduler::job_get($job_id);
 is($job->{state}, "done", "job_set_done changed state");
 is($job->{result}, "passed", "job_set_done changed result");
 ok($job->{t_finished} =~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "job end timestamp updated");
-ok(!$job->{settings}->{JOBTOKEN}, "job token not present after job done");
 
 # we cannot test maxage here as it depends too much on too small
 # time slots. The ui tests check maxage instead too

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -333,13 +333,13 @@ is_deeply($job->{parents}, [$jobC2], "cloned deps");
 # sch     sch     sch
 
 # check MM API for children status - available only for running jobs
-$job = OpenQA::Scheduler::job_get($jobC);
+my $worker = OpenQA::Scheduler::worker_get($w2_id);
 
 my $t = Test::Mojo->new('OpenQA');
 $t->ua->on(
     start => sub {
         my ($ua, $tx) = @_;
-        $tx->req->headers->add('X-API-JobToken' => $job->{'settings'}->{'JOBTOKEN'});
+        $tx->req->headers->add('X-API-JobToken' => $worker->{'properties'}->{'JOBTOKEN'});
     }
 );
 

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -82,7 +82,7 @@ $current_jobs = $jobs;
 OpenQA::Scheduler::job_restart(99963);
 
 $jobs = list_jobs();
-is(@$jobs, @$current_jobs+1, "one more job after restarting running job");
+is(@$jobs, @$current_jobs+2, "two more job after restarting running job with parallel dependency");
 
 $job1 = OpenQA::Scheduler::job_get(99963);
 OpenQA::Scheduler::job_cancel(99963);

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -71,7 +71,7 @@ my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 9
 
 $get = $t->get_ok('/api/v1/jobs');
 my @new_jobs = @{$get->tx->res->json->{jobs}};
-is scalar(@new_jobs), $jobs_count + 2;
+is scalar(@new_jobs), $jobs_count + 3, 'three new jobs - for 63, 46 and 61 from dependency';
 my %new_jobs = map { $_->{id} => $_ } @new_jobs;
 is $new_jobs{99981}->{state}, 'scheduled';
 is $new_jobs{99927}->{state}, 'scheduled';

--- a/t/fixtures/01-workers.pl
+++ b/t/fixtures/01-workers.pl
@@ -3,13 +3,15 @@
         id => 1,
         host => 'localhost',
         instance => 1,
-        backend => 'qemu'
+        backend => 'qemu',
+        properties => [{key => 'JOBTOKEN', value => 'token99963'}],
     },
     Workers => {
         id => 2,
         host => 'remotehost',
         instance => 1,
-        backend => 'qemu'
+        backend => 'qemu',
+        properties => [{key => 'JOBTOKEN', value => 'token99961'}],
     }
 ]
 # vim: set sw=4 et:

--- a/t/fixtures/02-jobs.pl
+++ b/t/fixtures/02-jobs.pl
@@ -122,7 +122,7 @@
         worker_id => 1,
         jobs_assets => [{ asset_id => 2 },],
         retry_avbl => 3,
-        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'DVD'},{ key => 'MACHINE', value => '64bit'}, {key => 'JOBTOKEN', value => 'token99963'}]
+        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'DVD'},{ key => 'MACHINE', value => '64bit'},]
     },
     Jobs => {
         id => 99962,
@@ -162,7 +162,7 @@
         worker_id => 2,
         jobs_assets => [{ asset_id => 2 },],
         retry_avbl => 3,
-        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'NET'},{ key => 'MACHINE', value => '64bit'}, {key => 'JOBTOKEN', value => 'token99961'}]
+        settings => [{ key => 'DESKTOP', value => 'kde'},{ key => 'ISO_MAXSIZE', value => '4700372992'},{ key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},{ key => 'TEST', value => 'kde'},{ key => 'VERSION', value => '13.1'},{ key => 'DVD', value => '1'},{ key => 'BUILD', value => '0091'},{ key => 'ARCH', value => 'x86_64'},{ key => 'DISTRI', value => 'opensuse'},{ key => 'FLAVOR', value => 'NET'},{ key => 'MACHINE', value => '64bit'},]
     },
 ]
 # vim: set sw=4 et:

--- a/t/fixtures/06-job_dependencies.pl
+++ b/t/fixtures/06-job_dependencies.pl
@@ -1,0 +1,9 @@
+[
+    # parallel dependency for running test
+    JobDependencies => {
+        parent_job_id => 99961,
+        child_job_id => 99963,
+        dependency => 2
+    },
+]
+# vim: set sw=4 et:


### PR DESCRIPTION
- store JOBTOKEN as WorkerProperty instead of JobSetting
- add dependencies fixtures
- adapt tests