### PR TITLE
improve speed of tests/overview page

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -516,5 +516,29 @@ sub create_artefact {
     1;
 }
 
+sub failed_modules_with_needles {
+
+    my ($self) = @_;
+
+    my $fails = $self->modules->search({result => 'failed'});
+    my $failedmodules = {};
+
+    while (my $module = $fails->next) {
+
+        my @needles;
+
+        my $counter = 0;
+        for my $detail (@{$module->details}) {
+            $counter++;
+            next unless $detail->{result} eq 'fail';
+            for my $needle (@{$detail->{needles}}) {
+                push( @needles, [ $needle->{name}, $counter ] );
+            }
+        }
+        $failedmodules->{$module->name} = \@needles;
+    }
+    return $failedmodules;
+}
+
 1;
 # vim: set sw=4 et:

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -52,9 +52,9 @@ $get->element_exists_not('#flavor_GNOME-Live_arch_x86_64');
 $get->element_exists_not('#flavor_DVD_arch_i686');
 
 # Check some results (and it's overview_xxx classes)
-$get->text_is('#res_DVD_i586_kde span.overview_passed a' => '47 3');
-$get->text_is('#res_GNOME-Live_i686_RAID0 span' => 'cancelled');
-$get->text_is('#res_DVD_i586_RAID1 span' => 'sched.(46)');
+$get->text_is('#res_DVD_i586_kde@32bit span.overview_passed' => '47 3');
+$get->text_is('#res_GNOME-Live_i686_RAID0@32bit span' => 'cancelled');
+$get->text_is('#res_DVD_i586_RAID1@32bit span' => 'scheduled@46');
 $get->element_exists_not('#res_DVD_x86_64_doc');
 
 #
@@ -70,7 +70,7 @@ $get->element_exists_not('#flavor_DVD_arch_i586');
 $get->element_exists_not('#flavor_GNOME-Live_arch_i686');
 
 # Check some results (and it's overview_xxx classes)
-$get->text_is('#res_DVD_x86_64_doc span.overview_failed a' => '7 1');
+$get->text_is('#res_DVD_x86_64_doc@64bit span.overview_failed' => '7 1');
 $get->element_exists_not('#res_DVD_i586_doc');
 $get->element_exists_not('#res_DVD_i686_doc');
 $get->element_exists_not('#res_DVD_x86_64_kde');

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -33,7 +33,7 @@
                         next if !defined($state);
                     %>
                     <tr>
-                        <td><%= $config %></td>
+                        <td><a href="<%= url_for('test', 'testid' => $jobid) %>"><%= $config %></a></td>
                         <td id="res_<%= $type %>_<%= $arch %>_<%= $config %>">
                         <% if ($res) { %>
                             <%
@@ -46,11 +46,11 @@
                                 <span class="<%=$css%>" id="res-<%= $jobid %>">
                             % }
                             <% if ($state eq "done") { %>
-                                <a href="<%= url_for('test', 'testid' => $jobid) %>"><%= module_result($res) %></a>
+                                <%= module_result($res) %>
                             <% } elsif ($state eq "running") { %>
-                                <a href="<%= url_for('test', 'testid' => $jobid) %>">running</a>
+			        running
                             <% } elsif ($state eq "scheduled") { %>
-                                sched.(<%= $res->{priority} %>)
+                                scheduled@<%= $res->{priority} %>
                             <% } else { %>
                                 <%= $state %>
                             <% } %>
@@ -58,20 +58,23 @@
                         <% } %>
                         </td>
                         <td style="text-align: left; margin: 0px;">
-                            <% if ($state eq "done" && $res->{'failures'}) { %>
-                                <% my $failedmodules = $res->{'failures'}->{$res->{'testname'}}->{'failedmodules'}; %>
-                                <% if ($failedmodules) { %>
-                                    <% for my $failedmodule (@$failedmodules) { %>
-                                        % if (my $failedneedles = $res->{'failures'}->{$res->{'testname'}}->{'failedneedles'}) {
-                                          <span data-ot="<ul><li><%= join('</li><li>', @$failedneedles) %></li></ul>" data-ot-title="Failed needles">
-                                        % } else {
-                                          <span>
-                                        % }
-                                            <a href="<%= url_for('step', 'testid' => $jobid, 'moduleid' => $failedmodule, 'stepid' => 1) %>"><%= $failedmodule %></a>
-                                        </span>
-                                    <% } %>
-                                <% } %>
-                            <% } %>
+                          % if ($state eq "done") {
+                            % my $failedmodules = $res->{'failures'};
+                            % if ($failedmodules) {
+                              % for my $failedmodule (sort keys %$failedmodules) {
+				% my $failedneedles = $failedmodules->{$failedmodule};
+				% my $step = 1;
+  				% if (@$failedneedles) {
+				  % $step = $failedneedles->[0]->[1];
+                                  <span data-ot="<ul><li><%= join('</li><li>', sort map { $_->[0] } @$failedneedles) %></li></ul>" data-ot-title="Failed needles">
+                                % } else {
+                                  <span>
+                                % }
+                                <a href="<%= url_for('step', 'testid' => $jobid, 'moduleid' => $failedmodule, 'stepid' => $step) %>"><%= $failedmodule %></a>
+                                </span>
+                              % }
+                            % }
+                          % }
                         </td>
                     </tr>
                 <% } %>


### PR DESCRIPTION
only look at the DB and only check details of failed modules

while I was at it:
 - I moved the link from results to test (also makes sense for
   running and scheduled tests)
 - I made the failed test jump to the proper step