### PR TITLE
needlediff is not really prototype, so porting it to jquery

### DIFF
--- a/public/javascripts/needlediff.js
+++ b/public/javascripts/needlediff.js
@@ -3,12 +3,12 @@ function NeedleDiff(id, width, height) {
     return new NeedleDiff(id, width, height);
   }
 
-  var canvas = document.createElement('canvas');
-  var container = document.getElementById(id);
+  var canvas = $('<canvas/>');
+  var container = $("#" + id);
   var divide = 0.5;
   
-  canvas.writeAttribute('style','position: absolute;');
-  this.ctx = canvas.getContext('2d');
+  canvas.css('position", "absolute');
+  this.ctx = canvas[0].getContext('2d');
   this.screenshotImg = null;
   this.needleImg = null;
   this.areas = [];
@@ -16,15 +16,15 @@ function NeedleDiff(id, width, height) {
   this.showSimilarity = [];
   
   // Event handlers
-  canvas.addEventListener('mousemove', handler, false);
-  canvas.addEventListener('mousedown', handler, false);
-  canvas.addEventListener('mouseup', handler, false);
+  canvas.on('mousemove', handler);
+  canvas.on('mousedown', handler);
+  canvas.on('mouseup', handler);
 
   var self = this;
 
   function handler(ev) {
-    ev._x = ev.layerX;
-    ev._y = ev.layerY;
+    ev._x = ev.offsetX;
+    ev._y = ev.offsetY;
 
     var eventHandler = self[ev.type];
     if (typeof eventHandler == 'function') {
@@ -33,10 +33,10 @@ function NeedleDiff(id, width, height) {
   }
 
   // Draw canvas into its container
-  canvas.setAttribute('width', width);
-  canvas.setAttribute('height', height);
-  container.writeAttribute('style','border: 1px solid black; margin: 0px; position: relative; width: '+width+'px; height: '+height+'px;');
-  container.appendChild(canvas);
+  canvas.attr('width', width);
+  canvas.attr('height', height);
+  container.css('border: 1px solid black; margin: 0px; position: relative; width: '+width+'px; height: '+height+'px;');
+  container.append(canvas);
 
   Object.defineProperty(this, 'container', {
     get: function() {
@@ -178,11 +178,12 @@ NeedleDiff.prototype.mousemove = function(event) {
     // FIXME: Really ugly
     this.draw();
   }
+
   // Change cursor
   if (Math.abs(this.divide - divide) < 0.01) {
-    this.container.style.cursor = 'col-resize';
+    this.container.css("cursor", "col-resize");
   } else {
-    this.container.style.cursor = 'auto';
+    this.container.css("cursor", "auto");
   }
 };
 

--- a/public/javascripts/openqa.js
+++ b/public/javascripts/openqa.js
@@ -1,4 +1,4 @@
-function updateModuleslist(modlist, testname, testmodule) {
+function prototype_updateModuleslist(modlist, testname, testmodule) {
 	var container = $("modlist_content");
 	container.innerHTML = "";
 	modlist.each(function(category) {
@@ -15,6 +15,30 @@ function updateModuleslist(modlist, testname, testmodule) {
 		container.insert(title);
 		container.insert(ul);
 	});
+}
+
+function updateModuleslist(modlist, testname, testmodule) {
+    var container = $('<div/>');
+    
+    $.each(modlist, function(index, category) {
+	var title = $('<h2 class="box-subheader modcategory">' + category.category + "</h2>");
+	container.append(title);
+
+	var ul = $('<ul class="navigation modcategory"></ul>');
+	$.each(category.modules, function(index, module) {
+	    var li = $('<li/>');
+	    li.addClass("mod-"+module.state);
+	    li.addClass("result"+module.result);
+	    if (testmodule == module.name) { li.addClass("selected"); }
+	    var link = $('<a>' + module.name + '</a>');
+	    li.html(link);
+	    link.attr('href', "/tests/"+testname+"/modules/"+module.name+"/steps/1");
+	    ul.append(li);
+	});
+	
+	container.append(ul);
+    });
+    $("#modlist_content").replaceWith(container);
 }
 
 function scrollModuleThumbnails() {

--- a/public/javascripts/running.js
+++ b/public/javascripts/running.js
@@ -38,7 +38,7 @@ function updateTestStatus(newStatus) {
             onSuccess: function(resp) {
                 var modlist = resp.responseJSON;
                 if (modlist.length > 0) {
-                    window.updateModuleslist(modlist, window.testStatus.testname, window.testStatus.running);
+                    window.prototype_updateModuleslist(modlist, window.testStatus.testname, window.testStatus.running);
                     window.testStatus.modlist_initialized = 1;
                 }
             }

--- a/templates/layouts/head.html.ep
+++ b/templates/layouts/head.html.ep
@@ -36,7 +36,6 @@
     %= javascript '/javascripts/cropimg.js'
     %= javascript '/javascripts/datetime.js'
     %= javascript '/javascripts/keyevent.js'
-    %= javascript '/javascripts/needlediff.js'
     %= javascript '/javascripts/running.js'
     %= javascript '/javascripts/chosen.proto.min.js'
     %= javascript '/javascripts/openqa.js'

--- a/templates/step/moduleslist.html.ep
+++ b/templates/step/moduleslist.html.ep
@@ -1,7 +1,14 @@
 <div class="box box-shadow alpha" id="testmodules_box">
 	<div class="box-header aligncenter">Test modules</div>
 	<div id="modlist_content"></div>
+	% if (!$use_prototype) {
+	% content_for 'ready_function' => begin
+	updateModuleslist(JSON.parse('<%= b(JSON::to_json($modinfo->{'modlist'})) %>'), "<%= $testid %>", "<%= $moduleid %>");
+	% end
+	% } else
+	% {
 	<script type="text/javascript">
 		window.updateModuleslist(JSON.parse('<%= b(JSON::to_json($modinfo->{'modlist'})) %>'), "<%= $testid %>", "<%= $moduleid %>");
 	</script>
+	% }
 </div>

--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -1,27 +1,29 @@
-% stash 'use_prototype' => 1;
 % layout 'default';
 % title $moduleid;
 
-<script type="text/javascript">
-<!--
+% content_for 'head' => begin
+%= javascript '/javascripts/needlediff.js'
+% end
+
+% content_for 'head_javascript' => begin
+
+var diff;
 
 function setNeedle() {
-	var sel = $('needlediff_selector');
-	var dset = sel.options[sel.selectedIndex].dataset;
-	window.diff.setNeedle(dset.image, JSON.parse(dset.areas), JSON.parse(dset.matches));
+        var sel = $('#needlediff_selector').find('option:selected');
+	diff.setNeedle(sel.data('image'), sel.data('areas'), sel.data('matches'));
 }
+% end
 
-window.onload=function(){
-	window.diff = new NeedleDiff('needle_diff', <%= $img_width %>, <%= $img_height %>);
-	window.diff.setScreenshot('<%= url_for('test_img', filename => $screenshot) %>');
-	window.setNeedle(); // Just in case is a page reload
+% content_for 'ready_function' => begin
+	diff = new NeedleDiff('needle_diff', <%= $img_width %>, <%= $img_height %>);
+        diff.setScreenshot('<%= url_for('test_img', filename => $screenshot) %>');
+	setNeedle(); // Just in case is a page reload
 
-	$('needlediff_selector').onchange = function() {
-		window.setNeedle();
-	};
-};
--->
-</script>
+	$('#needlediff_selector').change(function() {
+            setNeedle();
+        });
+%end
 
 <div class="grid_3 alpha" id="sidebar">
   <div class="box box-shadow alpha" id="actions_box">


### PR DESCRIPTION
while doing this I noticed that the step/src route also used prototype
indirectly through moduleslist.html fragement. So fixing this to
use jquery on jquery routes too

This leaves step/edit and test/running as prototype users (our toughest ones :)