### PR TITLE
don't pass worker class if none is set

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -322,7 +322,7 @@ sub register_worker {
     $worker_caps->{host} = $hostname;
     $worker_caps->{instance} = $instance;
     $worker_caps->{backend} = $worker_settings->{'BACKEND'};
-    $worker_caps->{worker_class} = $worker_settings->{'WORKER_CLASS'};
+    $worker_caps->{worker_class} = $worker_settings->{'WORKER_CLASS'} if $worker_settings->{'WORKER_CLASS'};
 
     print "registering worker ...\n" if $verbose;
 


### PR DESCRIPTION
fixes
Use of uninitialized value $_[1] in string at /usr/lib/perl5/vendor_perl/5.20.1/Mojo/Util.pm line 114.