### PR TITLE
run workers as _openqa-worker, not geekotest

### DIFF
--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -11,7 +11,7 @@ PartOf=openqa-worker.target
 [Service]
 Type=simple
 ExecStart=/usr/share/openqa/script/worker --instance %i
-User=geekotest
+User=_openqa-worker
 KillMode=mixed
 
 [Install]


### PR DESCRIPTION
This seems to be the new plan, as `/var/lib/openqa/pool/*` are now owned by _openqa-worker. Without this change, worker instances cannot create their lock file and fail to start.

Note there's a follow-up issue: workers require the API credentials, but those are in file `/etc/openqa/client.conf` which is owned by geekotest.root with 0640 permissions. I don't know what the most appropriate fix for that is, as presumably we can't just change it to be owned by _openqa-worker.