### PR TITLE
apparmor: allow webui to create /tmp directories

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -20,6 +20,7 @@
   /etc/openqa/openqa.ini r,
   /proc/meminfo r,
   /tmp/** rw,
+  /tmp/*/ rw,
   /usr/bin/optipng rix,
   /usr/bin/perl ix,
   /usr/bin/ssh rcx,


### PR DESCRIPTION
It seems /tmp/** doesn't allow creation of subdirectories of /tmp (?!), this does. ** BUT NOTE **: I am not confident this is the 'right' fix, it seems like something to talk to AA folks about. I don't see any other OpenSUSE profiles doing this, and some of the search engine hits I got sort of implied that apps shouldn't be just creating /tmp subdirectories like this?

I was getting denials like this in `/var/log/audit/audit.log`:

    type=AVC msg=audit(1425931485.550:11862): apparmor="DENIED" operation="mkdir" profile="/usr/share/openqa/script/openqa" name="/tmp/BmHsd8D12b/" pid=12137 comm="openqa" requested_mask="c" denied_mask="c" fsuid=482 ouid=482

and changing the policy like this certainly fixes it, but I definitely think someone who knows more about AA should check it.