### PR TITLE
fix overall result calculation: check for PASSED not 'ok'

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -353,7 +353,7 @@ sub calculate_result($) {
     my $important_overall; # just counting importants
 
     for my $m ($job->modules->all) {
-        if ( $m->result eq "ok" ) {
+        if ( $m->result eq PASSED ) {
             if ($m->important) {
                 $important_overall ||= PASSED;
             }


### PR DESCRIPTION
When calculating the overall job result from the modules, check
whether each module's result equals the const PASSED, not the
string 'ok'. Fixes the problem where jobs would show overall
result 'failed' even when all tests passed.