### PR TITLE
Trying to get a grip on our worker->webui bandwidth:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 		cp -a $$i/* "$(DESTDIR)"/usr/share/openqa/$$i ;\
 	done
 #
-	for i in testresults cache pool ; do \
+	for i in images testresults pool ; do \
 		mkdir -p "$(DESTDIR)"/var/lib/openqa/$$i ;\
 	done
 # shared dirs between openQA web and workers + compatibility links

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -40,7 +40,7 @@ our $prj="openqa";
 our $resultdir="$basedir/$prj/testresults";
 our $assetdir="$basedir/$prj/factory";
 our $isodir="$assetdir/iso";
-our $cachedir="$basedir/$prj/cache";
+our $imagesdir="$basedir/$prj/images";
 our $hostname=$ENV{'SERVER_NAME'};
 our $app_title = 'openQA test instance';
 our $app_subtitle = 'openSUSE automated testing';
@@ -129,6 +129,14 @@ sub save_base64_png($$$) {
     $fh->print(decode_base64($png));
     close($fh);
     return $newfile;
+}
+
+sub image_md5_filename($) {
+    my ($md5) = @_;
+
+    my $prefix = substr($md5, 0, 2);
+    $md5 = substr($md5, 2);
+    return ($imagesdir . "/$prefix/$md5.png",$imagesdir . "/$prefix/.thumbs/$md5.png");
 }
 
 1;

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -88,12 +88,14 @@ sub websocket_commands {
     elsif ($msg eq 'livelog_start') {
         # change update_status timer if $job running
         if (backend_running) {
+            $OpenQA::Worker::Jobs::do_livelog = 1;
             change_timer('update_status', STATUS_UPDATES_FAST);
         }
     }
     elsif ($msg eq 'livelog_stop') {
         # change update_status timer
         if (backend_running) {
+            $OpenQA::Worker::Jobs::do_livelog = 0;
             change_timer('update_status', STATUS_UPDATES_SLOW);
         }
     }

--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -40,6 +40,8 @@
   /var/lib/openqa/share/factory/iso/* r,
   /var/lib/openqa/testresults/ r,
   /var/lib/openqa/testresults/** rw,
+  /var/lib/openqa/images/ r,
+  /var/lib/openqa/images/** rw,
   /var/lib/openqa/share/tests/ r,
   /var/lib/openqa/share/tests/** rw,
   /var/lib/openqa/share/tests/*/needles/.git/objects/*/* rwl,

--- a/script/migrate_images
+++ b/script/migrate_images
@@ -1,0 +1,54 @@
+#! /usr/bin/perl
+
+# this script is only useful once to deduplicate images
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use strict;
+use Digest::MD5;
+use OpenQA::Utils;
+use File::Basename;
+
+# reads the content of a file below pooldir and returns its md5
+sub calculate_file_md5($) {
+  my ($file) = @_;
+  my $c = OpenQA::Utils::file_content($file);
+  my $md5 = Digest::MD5->new;
+  $md5->add($c);
+  return $md5->clone->hexdigest;
+}
+
+for (glob("/var/lib/openqa/testresults/*/*.png")) {
+  next if m,/.thumbs/,;
+  next unless -f $_;
+  next if -l $_;
+  next if m,/template-,;
+  my $file = $_;
+  my $md5 = calculate_file_md5($file);
+  print "$file " . calculate_file_md5($file) . "\n";
+
+  my $thumbpath = dirname($file) . "/.thumbs/" . basename($file);
+  
+  my ($full, $thumb) = OpenQA::Utils::image_md5_filename($md5);
+  unless (-f $full) {
+    my $dir = dirname($full);
+    mkdir($dir) unless -d $dir;
+    $dir .= "/.thumbs";
+    mkdir($dir) unless -d $dir;
+    rename($file, $full);
+    rename($thumbpath, $thumb);
+    my $fh;
+    open($fh, ">", "$full.unoptimized");
+    close($fh);
+    open($fh, ">", "$thumb.unoptimized");
+    close($fh);
+  } else {
+    unlink($file);
+    unlink($thumbpath);
+  }
+
+  symlink($full, $file);
+  symlink($thumb, $thumbpath);
+}

--- a/script/optimize_images
+++ b/script/optimize_images
@@ -1,0 +1,14 @@
+#! /usr/bin/perl
+
+# this script needs to be called periodically to reduce the size of the
+# stored images 
+
+use strict;
+use File::Basename;
+
+for (glob("/var/lib/openqa/images/*/*.unoptimized /var/lib/openqa/images/*/.thumbs/*.unoptimized")) {
+    my ($name,$path,$suffix) = fileparse($_, qw/.unoptimized/);
+    print "NAME $path/$name\n";
+    system("optipng", "-preserve", "-quiet", "$path/$name");
+    unlink("$path/$name$suffix");
+}


### PR DESCRIPTION
- only upload log and screenshot if livelog is wanted
- only update status if there is some, e.g. stay silent if nothing
  to say
- upload only the md5sum of the images and wait for the webui
  to tell the worker which of these md5sums it already knows
- upload uknown images one by one to avoid long wait times for other
  workers/users
- these images are stored in /var/lib/openqa/images under their
  md5 and the testresults only get a symlink