### PR TITLE
Misc fix 0311

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -23,7 +23,7 @@
 
 ## Authentication method to use for user management
 [auth]
-# method = Fake|OpenID|IChain
+# method = Fake|OpenID|iChain
 
 [logging]
 #if you use another file, remember the apparmor profile!

--- a/templates/layouts/admin.html.ep
+++ b/templates/layouts/admin.html.ep
@@ -16,7 +16,7 @@
         %= breadcrumbs
         <div id="user-info" class="grid_6 omega">
             %# Using a variable to avoid additional whitespaces
-            % my $out = 'Logged as '.current_user->username.' (';
+            % my $out = 'Logged as '.current_user->name.' (';
             % if (is_operator) {
                 % $out = $out.link_to('manage API keys' => url_for('api_keys')).' | ';
             % }


### PR DESCRIPTION
proposing just use current->name, the logic inside of schema is nickname first than username, also it's the same way in default view. for fake login it's not a problem, but for openid login is too long.