### PR TITLE
check for json data on success to mark it as success

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -185,7 +185,7 @@ sub api_call {
     $cb = sub {
         my ($ua, $tx, $tries) = @_;
         remove_timer('api_call');
-        if ($tx->success) {
+        if ($tx->success && $tx->success->json) {
             $res = $tx->success->json;
             $done = 1;
             return;


### PR DESCRIPTION
- simple check if json data are there. I briefly checked and all api calls used by worker should return some json data on success