### PR TITLE
use websockets for status update

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -1244,8 +1244,7 @@ sub command_enqueue {
         $worker_commands{$args{command}}->($worker);
     }
     my $msg = $args{command};
-    $msg .= " job_id=" . $args{job_id} if $args{job_id};
-    ws_send($args{workerid}, $msg);
+    ws_send($args{workerid}, $msg, $args{job_id});
 }
 
 #

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -23,6 +23,7 @@ use OpenQA::Worker::Jobs;
 ## WEBSOCKET commands
 sub websocket_commands {
     my ($tx, $msg) = @_;
+    return unless $msg;
     if ($msg =~ /^quit(\s*job_id=([0-9]*))?$/) { # quit_worker and reschedule the job
         my $job_id = $2;
         stop_job('quit', $job_id);
@@ -120,4 +121,18 @@ sub websocket_commands {
     }
 }
 
+sub JSON_commands {
+    my ($tx, $json) = @_;
+    # result indicates response to our data
+    if ($json->{'result'}) {
+        if ($json->{'known_images'}) {
+            # response to update_status, filter known images
+            OpenQA::Worker::Jobs::upload_images($json->{'known_images'});
+        }
+    }
+    else {
+        my $type = $json->{'type'};
+        websocket_commands($type);
+    }
+}
 1;

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -22,117 +22,107 @@ use OpenQA::Worker::Jobs;
 
 ## WEBSOCKET commands
 sub websocket_commands {
-    my ($tx, $msg) = @_;
-    return unless $msg;
-    if ($msg =~ /^quit(\s*job_id=([0-9]*))?$/) { # quit_worker and reschedule the job
-        my $job_id = $2;
-        stop_job('quit', $job_id);
-        Mojo::IOLoop->stop;
-    }
-    elsif ($msg =~ /^abort(\s*job_id=([0-9]*))?$/) { # the work is live and the job is rescheduled
-        my $job_id = $2;
-        stop_job('abort', $job_id);
-    }
-    elsif ($msg =~ /^cancel(\s*job_id=([0-9]*))?$/) { # The jobs is droped and the work is still alive
-        my $job_id = $2;
-        stop_job('cancel', $job_id);
-    }
-    elsif ($msg =~ /^obsolete(\s*job_id=([0-9]*))?$/) { # The jobs is droped and a new build job replaced it
-        my $job_id = $2;
-        stop_job('obsolete', $job_id);
-    }
-    elsif ($msg eq 'stop_waitforneedle') { # Plan: Enable interactive mode -- Now osautoinst decides what that means
-        if (backend_running) {
-            if (open(my $f, '>', "$pooldir/stop_waitforneedle")) {
-                close $f;
-                print "waitforneedle will be stopped";
-            }
-            else {
-                warn "can't stop waitforneedle: $!";
-            }
-        }
-    }
-    elsif ($msg eq 'reload_needles_and_retry') { #
-        if (backend_running) {
-            if (open(my $f, '>', "$pooldir/reload_needles_and_retry")) {
-                close $f;
-                print "needles will be reloaded";
-            }
-            else {
-                warn "can't reload needles: $!";
-            }
-        }
-    }
-    elsif ($msg eq 'enable_interactive_mode') {
-        if (backend_running) {
-            if (open(my $f, '>', "$pooldir/interactive_mode")) {
-                close $f;
-                print "interactive mode enabled\n";
-            }
-            else {
-                warn "can't enable interactive mode: $!";
-            }
-        }
-    }
-    elsif ($msg eq 'disable_interactive_mode') {
-        if (backend_running) {
-            unlink("$pooldir/interactive_mode");
-            print "interactive mode disabled\n";
-        }
-    }
-    elsif ($msg eq 'continue_waitforneedle') {
-        if (backend_running) {
-            unlink("$pooldir/stop_waitforneedle");
-            print "continuing waitforneedle";
-        }
-    }
-    elsif ($msg eq 'livelog_start') {
-        # change update_status timer if $job running
-        if (backend_running) {
-            unless ($OpenQA::Worker::Jobs::do_livelog) {
-                print "starting livelog\n" if $verbose;
-                change_timer('update_status', STATUS_UPDATES_FAST);
-            }
-            $OpenQA::Worker::Jobs::do_livelog += 1;
-        }
-    }
-    elsif ($msg eq 'livelog_stop') {
-        # change update_status timer
-        if (backend_running) {
-            if ($OpenQA::Worker::Jobs::do_livelog) {
-                $OpenQA::Worker::Jobs::do_livelog -= 1;
-            }
-            else {
-                print "stopping livelog\n" if $verbose;
-                change_timer('update_status', STATUS_UPDATES_SLOW);
-            }
-        }
-    }
-    elsif ($msg eq 'ok') {
-        # ignore keepalives, but dont' report as unknown
-    }
-    elsif ($msg eq 'job_available') {
-        if (!$job) {
-            check_job
-        }
-    }
-    else {
-        print STDERR "got unknown command $msg\n";
-    }
-}
-
-sub JSON_commands {
     my ($tx, $json) = @_;
     # result indicates response to our data
     if ($json->{'result'}) {
+        # responses
         if ($json->{'known_images'}) {
             # response to update_status, filter known images
             OpenQA::Worker::Jobs::upload_images($json->{'known_images'});
         }
     }
     else {
+        # requests
         my $type = $json->{'type'};
-        websocket_commands($type);
+        my $jobid = $json->{'jobid'};
+        if ($jobid && $jobid ne $job->{'id'}) {
+            printf STDERR 'Received command for different job id %u (our %u)%s', $jobid, $job->{'id'}, "\n";
+            return;
+        }
+        if ($type =~ m/quit|abort|cancel|obsolete/) {
+            print "received command: $type" if $verbose;
+            stop_job($type);
+        }
+        elsif ($type eq 'stop_waitforneedle') { # Plan: Enable interactive mode -- Now osautoinst decides what that means
+            if (backend_running) {
+                if (open(my $f, '>', "$pooldir/stop_waitforneedle")) {
+                    close $f;
+                    print "waitforneedle will be stopped\n" if $verbose;
+                }
+                else {
+                    warn "can't stop waitforneedle: $!";
+                }
+            }
+        }
+        elsif ($type eq 'reload_needles_and_retry') { #
+            if (backend_running) {
+                if (open(my $f, '>', "$pooldir/reload_needles_and_retry")) {
+                    close $f;
+                    print "needles will be reloaded\n" if $verbose;
+                }
+                else {
+                    warn "can't reload needles: $!";
+                }
+            }
+        }
+        elsif ($type eq 'enable_interactive_mode') {
+            if (backend_running) {
+                if (open(my $f, '>', "$pooldir/interactive_mode")) {
+                    close $f;
+                    print "interactive mode enabled\n" if $verbose;
+                }
+                else {
+                    warn "can't enable interactive mode: $!";
+                }
+            }
+        }
+        elsif ($type eq 'disable_interactive_mode') {
+            if (backend_running) {
+                unlink("$pooldir/interactive_mode");
+                print "interactive mode disabled\n" if $verbose;
+            }
+        }
+        elsif ($type eq 'continue_waitforneedle') {
+            if (backend_running) {
+                unlink("$pooldir/stop_waitforneedle");
+                print "continuing waitforneedle\n" if $verbose;
+            }
+        }
+        elsif ($type eq 'livelog_start') {
+            # change update_status timer if $job running
+            if (backend_running) {
+                unless ($OpenQA::Worker::Jobs::do_livelog) {
+                    print "starting livelog\n" if $verbose;
+                    change_timer('update_status', STATUS_UPDATES_FAST);
+                }
+                $OpenQA::Worker::Jobs::do_livelog += 1;
+            }
+        }
+        elsif ($type eq 'livelog_stop') {
+            # change update_status timer
+            if (backend_running) {
+                if ($OpenQA::Worker::Jobs::do_livelog) {
+                    $OpenQA::Worker::Jobs::do_livelog -= 1;
+                }
+                else {
+                    print "stopping livelog\n" if $verbose;
+                    change_timer('update_status', STATUS_UPDATES_SLOW);
+                }
+            }
+        }
+        elsif ($type eq 'ok') {
+            # ignore keepalives, but dont' report as unknown
+        }
+        elsif ($type eq 'job_available') {
+            if (!$job) {
+                check_job
+            }
+        }
+        else {
+            print STDERR "got unknown command $type\n";
+        }
+
     }
 }
+
 1;

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -18,7 +18,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 27;
+use Test::More tests => 39;
 use Test::Mojo;
 use Mojo::URL;
 use OpenQA::Test::Case;
@@ -38,7 +38,7 @@ $t->app($app);
 #get websocket connection
 $t->ua->apikey('PERCIVALKEY02');
 $t->ua->apisecret('PERCIVALSECRET02');
-my $ws = $t->websocket_ok('/api/v1/workers/1/ws');
+my $ws = $t->websocket_ok('/api/v1/workers/1/ws' => {'Sec-WebSocket-Extensions' => 'permessage-deflate'});
 
 #issue valid commands for worker 1
 my @valid_commands = qw/quit abort cancel obsolete
@@ -48,8 +48,7 @@ my @valid_commands = qw/quit abort cancel obsolete
 
 for my $cmd (@valid_commands) {
     OpenQA::Scheduler::command_enqueue(workerid => 1, command => $cmd);
-    $ws->message_ok;
-    $ws->message_is($cmd);
+    $ws->message_ok->json_message_is('/type' => $cmd)->json_message_has('/jobid');
 }
 
 #issue invalid commands


### PR DESCRIPTION
- by default status updates are send by POST requests, use env var WORKER_USE_WEBSOCKETS to use WS path
- enabled compression for websockets ~~so this needs to be deployed on openqa scheduler and worker at once else nothing will work (I should rewrite this I guess)~~ - should be autonegotiated