### PR TITLE
fix 'timeago' display in various places for timezones

### DIFF
--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -73,14 +73,14 @@
                 <tr>
                     <td>Started</td>
                     <td>
-			<abbr class="timeago" title="<%= $job->t_started->datetime() %>"><%= format_time($job->t_started) %></abbr>
+			<abbr class="timeago" title="<%= $job->t_started->datetime() %>Z"><%= format_time($job->t_started) %></abbr>
 		    </td>
                 </tr>
                 % if ($job->t_finished) {
                     <tr>
                         <td>Finished</td>
                         <td>
-			    <abbr class="timeago" title="<%= $job->t_finished->datetime() %>"><%= format_time($job->t_finished) %></abbr>
+			    <abbr class="timeago" title="<%= $job->t_finished->datetime() %>Z"><%= format_time($job->t_finished) %></abbr>
 			</td>
                     </tr>
                     <tr>

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -59,7 +59,7 @@
 		</td>
 		
 		% my $href = url_for('tests_overview')->query(build => $build, distri => $distri, version => $version);
-		<td class="testtime" title="<%= $job->t_started %>"><%= $job->t_started->datetime() %></td>
+		<td class="testtime" title="<%= $job->t_started %>"><%= $job->t_started->datetime() %>Z</td>
 		
 		<td style="padding: 3px 4px;" class="progress">
 		    <div class="pbox">


### PR DESCRIPTION
This fixes the display of the 'Testtime' column in the 'running
tests' table and the 'Started' and 'Finished' values in single
test pages, when the browser's timezone is not UTC. The openQA
t_started and t_finished values are always UTC, but when it
passes the values to JScript's timeago() it uses the perl date
objects' datetime() method. This produces a valid ISO8601 date/
time string but with no timezone offset, and an ISO8601 string
with no timezone offset is presumed (per the spec) to be in
the 'local' time. Thus JQuery goes ahead and calculates the
'time ago' value as if the started or finished time was given
in the local timezone, not UTC.

A simple 'Z' as the timezone offset indicates that the date/
time is in UTC, so this simply stuffs a 'Z' on the end of the
datetime() call's output in all the necessary places. I had
another implementation which added a helper function that would
produce a valid ISO8601 string for any perl datetime object with
a tz identifier, not just ones that we know are UTC, and had the
templates call that instead of datetime(), but coolo considered
it over-complex.

I've tested that this results in the 'X hours ago' / 'X minutes
ago' display being accurate for me in each of the affected
places, with my server and client both in PST.