### PR TITLE
when formatting a date/time for display, specify the timezone

### DIFF
--- a/lib/OpenQA/Plugin/Helpers.pm
+++ b/lib/OpenQA/Plugin/Helpers.pm
@@ -31,7 +31,7 @@ sub register {
         format_time => sub {
             my ($c, $timedate, $format) = @_;
             return unless $timedate;
-            $format ||= "%Y-%m-%d %H:%M:%S";
+            $format ||= "%Y-%m-%d %H:%M:%S %Z";
             return $timedate->strftime($format);
         }
     );


### PR DESCRIPTION
This changes the format_time() helper which is used in a few
places to produce a human-readable date/time string to specify
the timezone. We could try doing something cleverer using
JavaScript to display them in the user's local time, but that's
more complicated, and this is an easy improvement for now.

This format is not compliant with ISO8601 or RFC2822 or any
other such standard, it's strictly intended for human reading.