### PR TITLE
dropped deps column, show deps together with name

### DIFF
--- a/lib/OpenQA/Controller/Test.pm
+++ b/lib/OpenQA/Controller/Test.pm
@@ -94,13 +94,12 @@ sub list_ajax {
     my @list;
     while (my $job = $jobs->next) {
         my $settings = $job->settings_hash;
-        my @deps = map { $_->parent_job_id } $job->parents;
         my $data = {
             "DT_RowId" => "job_" .  $job->id,
             id => $job->id,
             result_stats => $result_stats->{$job->id},
             overall=>$job->state||'unk',
-            deps => \@deps,
+            deps => $job->deps_hash,
             clone => $job->clone_id,
             test => $job->test . "@" . $settings->{MACHINE},
             distri => $settings->{DISTRI} // '',

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -363,6 +363,7 @@ sub query_jobs {
     unless ($args{idsonly}) {
         push @{$attrs{'prefetch'}}, 'settings';
         push @{$attrs{'prefetch'}}, 'parents';
+        push @{$attrs{'prefetch'}}, 'children';
     }
 
     if ($args{state}) {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -189,6 +189,25 @@ sub settings_hash {
     return $self->{_settings};
 }
 
+sub deps_hash {
+    my ($self) = @_;
+
+    if (!defined($self->{_deps_hash})) {
+        $self->{_deps_hash} = {
+            parents => {'Chained' => [], 'Parallel' => []},
+            children => {'Chained' => [], 'Parallel' => []}
+        };
+        for my $dep ($self->parents) {
+            push @{$self->{_deps_hash}->{parents}->{$dep->to_string}}, $dep->parent_job_id;
+        }
+        for my $dep ($self->children) {
+            push @{$self->{_deps_hash}->{children}->{$dep->to_string}}, $dep->child_job_id;
+        }
+    }
+
+    return $self->{_deps_hash};
+}
+
 sub add_result_dir_prefix {
     my $rd = $_[1];
     $rd = $OpenQA::Utils::resultdir . "/$rd" if $rd;

--- a/public/javascripts/tests.js
+++ b/public/javascripts/tests.js
@@ -1,21 +1,26 @@
 var is_operator;
 var restart_url;
 
-function highlight_jobs ( enable, children, parents ) {
-    if (enable) {
-        for (i = 0; i < children.length; ++i) $("#job_" + children[i]).addClass('highlight_child');
-        for (i = 0; i < parents.length; ++i) $("#job_" + parents[i]).addClass('highlight_parent');
-    }
-    else {
-        for (i = 0; i < children.length; ++i) $("#job_" + children[i]).removeClass('highlight_child');
-        for (i = 0; i < parents.length; ++i) $("#job_" + parents[i]).removeClass('highlight_parent');
-    }
+function addClassToArray(data, theclass) {
+    for (i = 0; i < data.length; ++i) $("#job_" + data[i]).addClass(theclass);
 }
 
+function removeClassFromArray(data, theclass) {
+    for (i = 0; i < data.length; ++i) $("#job_" + data[i]).removeClass(theclass);
+}
 
-function highlight_jobs_html (children, parents) {
-    return ' onmouseover="highlight_jobs(true, [' + children.toString() + '], [' + parents.toString() + '])" ' +
-           ' onmouseout="highlight_jobs(false, [' + children.toString() + '], [' + parents.toString() + '])" ';
+function highlightJobs () {
+    addClassToArray($(this).data('children'), 'highlight_child');
+    addClassToArray($(this).data('parents'), 'highlight_parent');
+}
+
+function unhighlightJobs( children, parents ) {
+    removeClassFromArray($(this).data('children'), 'highlight_child');
+    removeClassFromArray($(this).data('parents'), 'highlight_parent');
+}
+
+function highlightJobsHtml (children, parents) {
+    return ' data-children="[' + children.toString() + ']" data-parents="[' + parents.toString() + ']" class="parent_child"';
 }
 
 
@@ -42,7 +47,7 @@ function renderTestName ( data, type, row ) {
                 deps += '1 Chained parent';
             }
             else {
-                deps += row['deps']['parents']['Chained'].length + ' Chained parents'
+                deps += row['deps']['parents']['Chained'].length + ' Chained parents';
             }
         }
         if (row['deps']['parents']['Parallel'].length) {
@@ -51,7 +56,7 @@ function renderTestName ( data, type, row ) {
                 deps += '1 Parallel parent';
             }
             else {
-                deps += row['deps']['parents']['Parallel'].length + ' Parallel parents'
+                deps += row['deps']['parents']['Parallel'].length + ' Parallel parents';
             }
         }
         if (row['deps']['children']['Chained'].length) {
@@ -60,7 +65,7 @@ function renderTestName ( data, type, row ) {
                 deps += '1 Chained child';
             }
             else {
-                deps += row['deps']['children']['Chained'].length + ' Chained children'
+                deps += row['deps']['children']['Chained'].length + ' Chained children';
             }
         }
         if (row['deps']['children']['Parallel'].length) {
@@ -69,13 +74,13 @@ function renderTestName ( data, type, row ) {
                 deps += '1 Parallel child';
             }
             else {
-                deps += row['deps']['children']['Parallel'].length + ' Parallel children'
+                deps += row['deps']['children']['Parallel'].length + ' Parallel children';
             }
         }
 
         if (deps != '') {
                 html += ' <a href="/tests/' + row['id'] + '" title="' + deps + '"' +
-                highlight_jobs_html(row['deps']['children']['Parallel'].concat(row['deps']['children']['Chained']),
+                highlightJobsHtml(row['deps']['children']['Parallel'].concat(row['deps']['children']['Chained']),
                                     row['deps']['parents']['Parallel'].concat(row['deps']['parents']['Chained'])) +
                 '><i class="fa fa-code-fork"></i></a>';
         }
@@ -198,4 +203,6 @@ function renderTestsList(jobs) {
 	$.post(restart_link.attr("href")).done( function( data ) { $(link).append(' (restarted)'); });
 	$(this).html('');
     });
+    $(document).on('mouseover', '.parent_child', highlightJobs);
+    $(document).on('mouseout', '.parent_child', unhighlightJobs);
 };

--- a/public/javascripts/tests.js
+++ b/public/javascripts/tests.js
@@ -77,7 +77,7 @@ function renderTestName ( data, type, row ) {
                 html += ' <a href="/tests/' + row['id'] + '" title="' + deps + '"' +
                 highlight_jobs_html(row['deps']['children']['Parallel'].concat(row['deps']['children']['Chained']),
                                     row['deps']['parents']['Parallel'].concat(row['deps']['parents']['Chained'])) +
-                '><i class="fa fa-plus"></i></a>';
+                '><i class="fa fa-code-fork"></i></a>';
         }
 
 	if (row['clone'])

--- a/public/javascripts/tests.js
+++ b/public/javascripts/tests.js
@@ -17,25 +17,55 @@ function renderTestName ( data, type, row ) {
 	html += '<a href="/tests/' + row['id'] + '" class="name">' + data + '</a>';
 	html += '</span>';
 
+        var deps = '';
+        if (row['deps']['parents']['Chained'].length) {
+            if (deps != '') deps += ', ';
+            if (row['deps']['parents']['Chained'].length == 1) {
+                deps += '1 Chained parent';
+            }
+            else {
+                deps += row['deps']['parents']['Chained'].length + ' Chained parents'
+            }
+        }
+        if (row['deps']['parents']['Parallel'].length) {
+            if (deps != '') deps += ', ';
+            if (row['deps']['parents']['Parallel'].length == 1) {
+                deps += '1 Parallel parent';
+            }
+            else {
+                deps += row['deps']['parents']['Parallel'].length + ' Parallel parents'
+            }
+        }
+        if (row['deps']['children']['Chained'].length) {
+            if (deps != '') deps += ', ';
+            if (row['deps']['children']['Chained'].length == 1) {
+                deps += '1 Chained child';
+            }
+            else {
+                deps += row['deps']['children']['Chained'].length + ' Chained children'
+            }
+        }
+        if (row['deps']['children']['Parallel'].length) {
+            if (deps != '') deps += ', ';
+            if (row['deps']['children']['Parallel'].length == 1) {
+                deps += '1 Parallel child';
+            }
+            else {
+                deps += row['deps']['children']['Parallel'].length + ' Parallel children'
+            }
+        }
+
+        if (deps != '') {
+                html += ' <a href="/tests/' + row['id'] + '" title="' + deps + '"' +
+                '><i class="fa fa-plus"></i></a>';
+        }
+
 	if (row['clone'])
             html += ' <a href="/tests/' + row['clone'] + '">(restarted)</a>';
 
         return html;
     } else {
 	return data;
-    }
-}
-
-function renderDependencyName ( data, type, row ) {
-    if (type === 'display') {
-        var html = '';
-        for (var index = 0; index < row['deps'].length; index++) {
-            html += '<a href="/tests/' + row['deps'][index] + '">#' + row['deps'][index] + '</a> ';
-        }
-        return html;
-    }
-    else {
-        return data;
     }
 }
 
@@ -57,7 +87,7 @@ function renderTestResult( data, type, row ) {
 	if (row['state'] === 'cancelled') {
 	    html += "<i class='fa fa-times' title='canceled'></i>";
 	}
-	if (row['deps'].length > 0) {
+	if (row['deps']['parents']['Parallel'].length + row['deps']['parents']['Chained'].length > 0) {
 	    if (row['result'] === 'skipped' ||
 		row['result'] === 'parallel_failed') {
 		html += "<i class='fa fa-chain-broken' title='dependency failed'></i>";
@@ -99,7 +129,6 @@ function renderTestsList(jobs) {
 	    { "data": "name" },
 	    { "data": "test" },
 	    { "data": "result_stats" },
-	    { "data": "deps" },
 	    { "data": "testtime" },
 	],
 	"columnDefs": [
@@ -121,11 +150,7 @@ function renderTestsList(jobs) {
 	      className: "test",
 	      "render": renderTestName
 	    },
-        { targets: 3,
-          className: "deps",
-          "render": renderDependencyName
-        },
-	    { targets: 4,
+	    { targets: 3,
 	      "render": function ( data, type, row ) {
 		  if (type === 'display')
 		      return jQuery.timeago(data + " UTC");

--- a/public/javascripts/tests.js
+++ b/public/javascripts/tests.js
@@ -1,6 +1,24 @@
 var is_operator;
 var restart_url;
 
+function highlight_jobs ( enable, children, parents ) {
+    if (enable) {
+        for (i = 0; i < children.length; ++i) $("#job_" + children[i]).addClass('highlight_child');
+        for (i = 0; i < parents.length; ++i) $("#job_" + parents[i]).addClass('highlight_parent');
+    }
+    else {
+        for (i = 0; i < children.length; ++i) $("#job_" + children[i]).removeClass('highlight_child');
+        for (i = 0; i < parents.length; ++i) $("#job_" + parents[i]).removeClass('highlight_parent');
+    }
+}
+
+
+function highlight_jobs_html (children, parents) {
+    return ' onmouseover="highlight_jobs(true, [' + children.toString() + '], [' + parents.toString() + '])" ' +
+           ' onmouseout="highlight_jobs(false, [' + children.toString() + '], [' + parents.toString() + '])" ';
+}
+
+
 function renderTestName ( data, type, row ) {
     if (type === 'display') {
 	var html = '<span class="result_' + row['result'] + '">';
@@ -57,6 +75,8 @@ function renderTestName ( data, type, row ) {
 
         if (deps != '') {
                 html += ' <a href="/tests/' + row['id'] + '" title="' + deps + '"' +
+                highlight_jobs_html(row['deps']['children']['Parallel'].concat(row['deps']['children']['Chained']),
+                                    row['deps']['parents']['Parallel'].concat(row['deps']['parents']['Chained'])) +
                 '><i class="fa fa-plus"></i></a>';
         }
 

--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -18,6 +18,14 @@ thead tr th, thread tr {
     font-weight: 100;
 }
 
+.highlight_parent {
+    background-color:#ffe0e0 !important;
+}
+
+.highlight_child {
+    background-color:#d0f0ff !important;
+}
+
 .resultok {background-color:#d4f291 ;} 
 .resultpassed {background-color:#d4f291 ;}
 .resultunknown {background-color:#ff9 ;}

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -31,7 +31,7 @@ my $t = Test::Mojo->new('OpenQA');
 
 my $driver = t::ui::PhantomTest::call_phantom();
 if ($driver) {
-    plan tests => 32;
+    plan tests => 31;
 }
 else {
     plan skip_all => 'Install phantomjs to run these tests';
@@ -62,7 +62,6 @@ my @tds = $driver->find_child_elements($job99946, "td");
 is((shift @tds)->get_text(), 'Build0091 of opensuse-13.1-DVD.i586', "medium of 99946");
 is((shift @tds)->get_text(), 'textmode@32bit', "test of 99946");
 is((shift @tds)->get_text(), '29 1', "result of 99946");
-is((shift @tds)->get_text(), "", "no deps of 99946");
 like((shift @tds)->get_text(), qr/a minute ago/, "time of 99946");
 
 # Test 99963 is still running

--- a/templates/test/list.html.ep
+++ b/templates/test/list.html.ep
@@ -47,7 +47,6 @@
                 <th class="name">Medium</th>
 		<th>Test</th>
 		<th>Result</th>
-                <th>Deps</th>
                 <th>Testtime</th>
             </tr>
         </thead>

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -5,7 +5,7 @@
 	"columnDefs": [
 	    { targets: 0,
               className: "name" },
-            { targets: 3,
+            { targets: 2,
               className: "time",
               "render": function ( data, type, row ) {
                     if (type === 'display') {
@@ -23,7 +23,6 @@
         <tr>
 	    <th class="name">Medium</th>
 	    <th class="test">Test</th>
-            <th>Deps</th>
             <th>Testtime</th>
             <th>Result</th>
         </tr>
@@ -59,13 +58,6 @@
                     %= $testname
                     % end
 		</td>
-		<td class="parents">
-		    % my $parents = $job->parents;
-		    % while (my $parent = $parents->next ) {
-			<a href="<%= url_for('test', 'testid' => $parent->parent_job_id) %>">#<%= $parent->parent_job_id %></a>
-		    % }
-		</td>
-
 		% my $href = url_for('tests_overview')->query(build => $build, distri => $distri, version => $version);
 		<td class="testtime" title="<%= $job->t_started %>"><%= $job->t_started->datetime() %>Z</td>
 		<td style="padding: 3px 4px;" class="progress">

--- a/templates/test/scheduled_table.html.ep
+++ b/templates/test/scheduled_table.html.ep
@@ -14,7 +14,6 @@
         <tr>
 	    <th class="name">Medium</th>
 	    <th class="name">Test</th>
-            <th>Deps</th>
             <th>Priority</th>
         </tr>
     </thead>
@@ -49,12 +48,6 @@
                     %= $test
                     % end
 		</td>
-                <td class="parents">
-		    % my $parents = $job->parents;
-		    % while (my $parent = $parents->next) {
-                        <a href="<%= url_for('test', 'testid' => $parent->parent_job_id) %>">#<%= $parent->parent_job_id %></a>
-		    % }
-                </td>
                 % my $href = url_for('tests_overview')->query(build => $build, distri => $distri, version => $version);
                 <td class="actions">
 		    %= link_post url_for('apiv1_job_prio', 'jobid' => $job->id)->query(prio => $prio-10) => (class => 'prio-down') =>  ('data-remote' => 'true') => begin


### PR DESCRIPTION
Now I indicate depencencies with one icon + tooltip and highlighting of related jobs.

The same should be probably done in scheduled and running table but I don't want to implement the same functionality in templates when there is pull request #216