### PR TITLE
since mojo-assetpack 0.42 the perl binding works for me

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -204,8 +204,6 @@ sub startup {
     $self->asset( 'app.css' => @css );
     $self->asset( 'app.js'  => @js );
     my $path = Mojolicious::Plugin::Bootstrap3->asset_path('sass');
-    # the perl binding is just bad it seems
-    $ENV{ENABLE_LIBSASS_BINDINGS} = 0;
     $ENV{SASS_PATH} = ".:$path";
     unshift(@css, "/sass/bentostrap.scss");
     $self->asset( 'bootstrap.css' => @css);


### PR DESCRIPTION
If you have CSS::Sass installed, it will take preference - but our packages
will continue building without to avoid one more dependency (and rubygem-sass
was in the distro first :)