### PR TITLE
Fix pagination of scheduled table

### DIFF
--- a/templates/test/scheduled_table.html.ep
+++ b/templates/test/scheduled_table.html.ep
@@ -1,7 +1,7 @@
 % content_for 'ready_function' => begin
   $('#scheduled').DataTable( {
         "pagingType" : 'simple',
-        "order": [[3, 'asc'], [0, 'asc']],
+        "order": [[2, 'asc'], [0, 'asc']],
 	"columnDefs": [
 	    { targets: 0,
               className: "name" }


### PR DESCRIPTION
983e9de33d7fac0db36a3c980754356b6ac536bf removed the deps table, so we
need to adapt the index of the priority column