### PR TITLE
speed up lists_ajax by calculating only what we need

### DIFF
--- a/lib/OpenQA/Controller/Test.pm
+++ b/lib/OpenQA/Controller/Test.pm
@@ -105,7 +105,7 @@ sub list_ajax {
         }
     );
     while (my $s = $query->next) {
-        $settings{$s->job_id . "-" . $s->key} = $s->value;
+        $settings{$s->job_id}->{$s->key} = $s->value;
     }
 
     my %deps;
@@ -132,15 +132,14 @@ sub list_ajax {
             "DT_RowId" => "job_" .  $job->id,
             id => $job->id,
             result_stats => $result_stats->{$job->id},
-            overall=>$job->state||'unk',
             deps => $deps{$job->id},
             clone => $job->clone_id,
-            test => $job->test . "@" . $settings{$job->id . '-MACHINE'} // '',
-            distri => $settings{$job->id . '-DISTRI'} // '',
-            version => $settings{$job->id . '-VERSION'} // '',
-            flavor => $settings{$job->id . '-FLAVOR'} // '',
-            arch => $settings{$job->id . '-ARCH'} // '',
-            build => $settings{$job->id . '-BUILD'} // '',
+            test => $job->test . "@" . $settings{$job->id}->{MACHINE} // '',
+            distri => $settings{$job->id}->{DISTRI} // '',
+            version => $settings{$job->id}->{VERSION} // '',
+            flavor => $settings{$job->id}->{FLAVOR} // '',
+            arch => $settings{$job->id}->{ARCH} // '',
+            build => $settings{$job->id}->{BUILD} // '',
             testtime => $job->t_created,
             result => $job->result,
             group => $job->group_id,

--- a/lib/OpenQA/Controller/Test.pm
+++ b/lib/OpenQA/Controller/Test.pm
@@ -73,12 +73,16 @@ sub list_ajax {
 
     my $jobs;
 
+    my $st = time;
+    my $result_stats;
+    my @ids;
     # we have to seperate the initial loading and the reload
     if ($self->param('initial')) {
-        $jobs = OpenQA::Scheduler::query_jobs(ids => [ map { scalar($_) } $self->every_param('jobs[]') ]);
+        @ids = map { scalar($_) } @{$self->every_param('jobs[]')};
+        $jobs = OpenQA::Scheduler::query_jobs(ids => \@ids);
+        $result_stats = OpenQA::Schema::Result::JobModules::job_module_stats(\@ids);
     }
     else {
-
         my $scope = '';
         $scope = 'relevant' if $self->param('relevant') ne 'false';
 
@@ -87,26 +91,56 @@ sub list_ajax {
             scope => $scope,
             limit => 500,
         );
+        while (my $j = $jobs->next) { push(@ids, $j->id); }
+        $jobs->reset;
+        $result_stats = OpenQA::Schema::Result::JobModules::job_module_stats(\@ids);
     }
 
-    my $result_stats = OpenQA::Schema::Result::JobModules::job_module_stats($jobs);
+    my %settings;
+
+    my $query = $self->db->resultset("JobSettings")->search(
+        {
+            job_id => { in => \@ids },
+            key => { in => [qw/DISTRI VERSION ARCH FLAVOR BUILD MACHINE/] }
+        }
+    );
+    while (my $s = $query->next) {
+        $settings{$s->job_id . "-" . $s->key} = $s->value;
+    }
+
+    my %deps;
+
+    for my $id (@ids) {
+        $deps{$id} = {
+            parents => {'Chained' => [], 'Parallel' => []},
+            children => {'Chained' => [], 'Parallel' => []}
+        };
+    }
+
+    $query = $self->db->resultset("JobDependencies")->search({ child_job_id => { in => \@ids } },{ parent_job_id => { in => \@ids } });
+
+    while (my $s = $query->next) {
+        push(@{$deps{$s->parent_job_id}->{children}->{$s->dependency}}, $s->child_job_id);
+        push(@{$deps{$s->child_job_id}->{children}->{$s->dependency}}, $s->parent_job_id);
+    }
+
+    $jobs = $self->db->resultset("Jobs")->search({ id => { in => \@ids } },{ columns => [qw/id state clone_id test result group_id t_created/], order_by => ['me.id DESC'] });
 
     my @list;
     while (my $job = $jobs->next) {
-        my $settings = $job->settings_hash;
         my $data = {
             "DT_RowId" => "job_" .  $job->id,
             id => $job->id,
             result_stats => $result_stats->{$job->id},
             overall=>$job->state||'unk',
-            deps => $job->deps_hash,
+            deps => $deps{$job->id},
             clone => $job->clone_id,
-            test => $job->test . "@" . $settings->{MACHINE},
-            distri => $settings->{DISTRI} // '',
-            version => $settings->{VERSION} // '',
-            flavor => $settings->{FLAVOR} // '',
-            arch => $settings->{ARCH} // '',
-            build => $settings->{BUILD} // '',
+            test => $job->test . "@" . $settings{$job->id . '-MACHINE'} // '',
+            distri => $settings{$job->id . '-DISTRI'} // '',
+            version => $settings{$job->id . '-VERSION'} // '',
+            flavor => $settings{$job->id . '-FLAVOR'} // '',
+            arch => $settings{$job->id . '-ARCH'} // '',
+            build => $settings{$job->id . '-BUILD'} // '',
             testtime => $job->t_created,
             result => $job->result,
             group => $job->group_id,

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -359,7 +359,6 @@ sub query_jobs {
     my %attrs;
     my @joins;
 
-    OpenQA::Utils::log_debug("query_jobs");
     unless ($args{idsonly}) {
         push @{$attrs{'prefetch'}}, 'settings';
         push @{$attrs{'prefetch'}}, 'parents';
@@ -452,14 +451,13 @@ sub query_jobs {
         push(@conds, { 'me.id' => { -in => $subquery->get_column('job_id')->as_query }});
     }
     if ($args{ids}) {
-        push(@conds, { 'me.id' => { -in => @{$args{ids}} } });
+        push(@conds, { 'me.id' => { -in => $args{ids} } });
     }
 
     $attrs{order_by} = ['me.id DESC'];
 
     $attrs{join} = \@joins if @joins;
     my $jobs = schema->resultset("Jobs")->search({-and => \@conds}, \%attrs);
-    OpenQA::Utils::log_debug("query_jobs " . scalar($jobs->all));
     return $jobs;
 }
 

--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -134,19 +134,24 @@ sub job_module_stats($) {
 
     my $schema = OpenQA::Scheduler::schema();
 
+    my $ids;
+
     if (ref($jobs) ne 'ARRAY') {
         my @ids;
         while (my $j = $jobs->next) { push(@ids, $j->id); }
         $jobs->reset;
-        $jobs = \@ids;
+        $ids = \@ids;
+    }
+    else {
+        $ids = $jobs;
     }
 
-    for my $id (@$jobs) {
+    for my $id (@$ids) {
         $result_stat->{$id} = { 'passed' => 0, 'failed' => 0, 'dents' => 0, 'none' => 0 };
     }
 
     my $query = $schema->resultset("JobModules")->search(
-        { job_id => { in => $jobs } },
+        { job_id => { in => $ids } },
         {
             select => ['job_id', 'result', 'soft_failure', { 'count' => 'id' } ],
             as => [qw/job_id result soft_failure count/],


### PR DESCRIPTION
Personal note: Flightplan (2005) is a horribly stupid and boring moving allowing all kind of hacks :)

avoid building hashes that some values are used from and avoid huge
joins. The joins (caused by prefetch) cause a lot of result rows to
be evaluated and dbix needs to pick out the duplicates

In my tests avoiding this leads to a load time reduction from 4s to 0.8s
on /tests (including ajax)