### PR TITLE
make failing fatal tests have an impact on overall state

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -101,9 +101,9 @@ sub run {
 
 sub test_flags {
     # without anything - rollback to 'lastgood' snapshot if failed
-    # 'fatal' - whole test suite is in danger if this fails
+    # 'fatal' - abort whole test suite if this fails (and set overall state)
     # 'milestone' - after this test succeeds, update 'lastgood'
-    # 'important' - if this fails, set the overall state to 'fail'
+    # 'important' - if this fails, set the overall state to 'failed'
     return { important => 1 };
 }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -387,7 +387,7 @@ sub calculate_result($) {
 
     for my $m ($job->modules->all) {
         if ( $m->result eq PASSED ) {
-            if ($m->important) {
+            if ($m->important || $m->fatal) {
                 $important_overall ||= PASSED;
             }
             else {
@@ -395,7 +395,7 @@ sub calculate_result($) {
             }
         }
         else {
-            if ($m->important) {
+            if ($m->important || $m->fatal) {
                 $important_overall = FAILED;
             }
             else {


### PR DESCRIPTION
If there is only one important test at the beginning, it can happen that
half the test suite doesn't run, but the test is considered passed. This
is highly confusing, so make fatal have an impact on the overall state
too

The original documentation is
"whole test suite is in danger if this fails" - so it clearly gives the
impression it *does* have impact on the whole