### PR TITLE
action 6440 - canceling reactions

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -879,11 +879,11 @@ sub job_duplicate {
     # set this clone was triggered by manually if it's not auto-clone
     $args{dup_type_auto} = 0 unless defined $args{dup_type_auto};
 
-    log_debug("duplicating $args{jobid}");
-
     my $job = schema->resultset("Jobs")->find({id => $args{jobid}});
-    return undef unless $job;
-    return undef if $job->clone; # already cloned
+    return unless $job;
+    return unless $job->can_be_duplicated; # already cloned
+
+    log_debug("duplicating $args{jobid}");
 
     if($args{dup_type_auto}) {
         if ( int($job->retry_avbl) > 0) {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -266,17 +266,20 @@ sub to_hash {
 
 =item Arguments: none
 
-=item Return value: 1 if a new clon can be created. 0 otherwise.
+=item Return value: 1 if a new clone can be created. undef otherwise.
 
 =back
 
-Checks if a given job can be duplicated.
+Checks if a given job can be duplicated - not cloned yet and in correct state.
 
 =cut
 sub can_be_duplicated{
-    my $self = shift;
+    my ($self) = @_;
 
-    $self->clone ? 0 : 1;
+    my $state = $self->state;
+    return unless (grep {/$state/} (EXECUTION_STATES, FINAL_STATES) );
+    return if $self->clone;
+    return 1;
 }
 
 =head2 duplicate

--- a/public/javascripts/tests.js
+++ b/public/javascripts/tests.js
@@ -197,12 +197,21 @@ function renderTestsList(jobs) {
 	    $('#relevantbox').css('color', 'inherit');
 	} );
     } );
-    $(document).on("click", '.restart', function() {
-	var restart_link = $(this);
-	var link = $(this).parent('span').find('.name');
-	$.post(restart_link.attr("href")).done( function( data ) { $(link).append(' (restarted)'); });
-	$(this).html('');
-    });
-    $(document).on('mouseover', '.parent_child', highlightJobs);
-    $(document).on('mouseout', '.parent_child', unhighlightJobs);
 };
+
+$(document).on("click", '.restart', function() {
+    var restart_link = $(this);
+    var link = $(this).parent('span').find('.name');
+    $.post(restart_link.attr("href")).done( function( data ) { $(link).append(' (restarted)'); });
+    $(this).html('');
+});
+
+$(document).on('click', '.cancel', function() {
+    var cancel_link = $(this);
+    var test = $(this).parent('td');
+    $.post(cancel_link.attr("href")).done( function( data ) { $(test).append(' (cancelled)'); });
+    $(this).html('');
+});
+
+$(document).on('mouseover', '.parent_child', highlightJobs);
+$(document).on('mouseout', '.parent_child', unhighlightJobs);

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -66,7 +66,8 @@ is_deeply($m_hashed, $c_hashed, "equivalent job settings (skipping NAME)");
 ok(!$minimalx->can_be_duplicated, "doesn't look cloneable after reloading");
 is($minimalx->duplicate, undef, "cannot clone after reloading");
 
-# But cloning the clone should be possible
+# But cloning the clone should be possible after job state change
+$clone->state(OpenQA::Schema::Result::Jobs::CANCELLED);
 my $second = $clone->duplicate({prio => 35, retry_avbl => 2});
 is($second->test, "minimalx", "same test again");
 is($second->priority, 35, "with adjusted priority");

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -3,17 +3,28 @@
 
 % content_for 'ready_function' => begin
     $('.timeago').timeago();
+    $( '#restart-result' ).click( function(event) {
+            event.preventDefault();
+            var doc_url = document.URL.substring(0, document.URL.lastIndexOf("/") + 1);
+            var restart_link = $(this);
+            $.post(restart_link.attr("href")).done( function( data, res, xhr ) {
+                var jobid = xhr.responseJSON.result;
+                if (jobid) {
+                    var url = doc_url + jobid;
+                    window.location = url;
+                }
+            });
+            $(this).html('');
+    });
 % end
 
 <div class="grid_2 alpha">
     <div class="box box-shadow" id="actions_box">
 	<div class="box-header aligncenter">Actions</div>
 	<div class="aligncenter">
-            %# TODO: to use can_be_duplicated we have to wait for https://progress.opensuse.org/issues/1393
-            %#       in the meantime, just check clone_id
-            % unless ($job->clone_id) {
+            % if ($job->can_be_duplicated) {
                 %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
-                %= image "/images/toggle.png", alt => "schedule", title => "re-schedule"
+                %= image "/images/toggle.png", alt => "schedule", title => "restart"
                 %= end
             % }
 	</div>

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -49,15 +49,17 @@
                     %= link_to "Build$build" => url_for('tests_overview')->query(%$query);
                     of <%= "$settings->{DISTRI}-$settings->{VERSION}-$settings->{FLAVOR}.$settings->{ARCH}" %>
 		</td>
-		<td class="test">
-		    %= link_to url_for('test', 'testid' => $job->id) => begin
-                    <i class="status state_running fa fa-circle" title="Running"></i>
-		    %= link_post url_for('apiv1_cancel', 'name' => $job->id) => ('data-remote' => 'true') => (class => 'cancel') => begin
-		      <i class="action fa fa-times-circle-o"></i>
-		    % end
-                    %= $testname
-                    % end
-		</td>
+        <td class="test">
+            %= link_to url_for('test', 'testid' => $job->id) => begin
+                <i class="status state_running fa fa-circle" title="Running"></i>
+            % end
+            %= link_post url_for('apiv1_cancel', 'name' => $job->id) => ('data-remote' => 'true') => (class => 'cancel') => begin
+                <i class="action fa fa-times-circle-o"></i>
+            % end
+            %= link_to url_for('test', 'testid' => $job->id) => begin
+                %= $testname
+            % end
+        </td>
 		% my $href = url_for('tests_overview')->query(build => $build, distri => $distri, version => $version);
 		<td class="testtime" title="<%= $job->t_started %>"><%= $job->t_started->datetime() %>Z</td>
 		<td style="padding: 3px 4px;" class="progress">

--- a/templates/test/scheduled_table.html.ep
+++ b/templates/test/scheduled_table.html.ep
@@ -39,13 +39,15 @@
                     %= link_to "Build$build" => url_for('tests_overview')->query(%$query);
                     of <%= "$settings->{DISTRI}-$settings->{VERSION}-$settings->{FLAVOR}.$settings->{ARCH}" %>
                 </td>
-		<td class="test">
+                <td class="test">
                     %= link_to url_for('test', 'testid' => $job->id) => begin
-                    <i class="status state_scheduled fa fa-circle" title="Scheduled"></i>
-		    %= link_post url_for('apiv1_cancel', 'name' => $job->id) => ('data-remote' => 'true') => (class => 'cancel') => begin
-		      <i class="action fa fa-times-circle-o"></i>
-		    % end
-                    %= $test
+                        <i class="status state_scheduled fa fa-circle" title="Scheduled"></i>
+                    % end
+                    %= link_post url_for('apiv1_cancel', 'name' => $job->id) => ('data-remote' => 'true') => (class => 'cancel') => begin
+                        <i class="action fa fa-times-circle-o"></i>
+                    % end
+                    %= link_to url_for('test', 'testid' => $job->id) => begin
+                        %= $test
                     % end
 		</td>
                 % my $href = url_for('tests_overview')->query(build => $build, distri => $distri, version => $version);


### PR DESCRIPTION
- append (cancelled) when job is cancelled from test list
- redirect to new test if test is restarted from result view
- use $job->can_be_duplicated to check if even to display restart icon
- use test name as link even for scheduled tests

There is things I'm not happy about:
- I had a problem with firing double events for restart link until I stopped using $(document).on(..) and moved to $('#restart-result').click. This however needs to be called when restart-result id is know so I added it directly to result.html.ep. I don't think this is right approach.