### PR TITLE
Change backend logic

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -394,7 +394,7 @@ sub startup {
 
     # api/v1/workers
     $api_public_r->get('/workers')->name('apiv1_workers')->to('worker#list');
-    $api_r->post('/workers')->name('apiv1_create_worker')->to('worker#create'); # worker_register
+    $api_r->post('/workers')->name('apiv1_create_worker')->to('worker#create');
     my $worker_r = $api_r->route('/workers/:workerid', workerid => qr/\d+/);
     $api_public_r->route('/workers/:workerid', workerid => qr/\d+/)->get('/')->name('apiv1_worker')->to('worker#show');
     $worker_r->post('/commands/')->name('apiv1_create_command')->to('command#create'); #command_enqueue

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -122,7 +122,7 @@ sub connected {
     OpenQA::WebSockets::ws_is_worker_connected($self);
 }
 
-sub info() {
+sub info {
     my ($self) = @_;
 
     my $settings = {

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -335,7 +335,7 @@ sub register_worker {
     $worker_caps = _get_capabilities;
     $worker_caps->{host} = $hostname;
     $worker_caps->{instance} = $instance;
-    $worker_caps->{worker_class} = $worker_settings->{WORKER_CLASS} if $worker_settings->{WORKER_CLASS};
+    $worker_caps->{worker_class} = $worker_settings->{WORKER_CLASS} || "qemu_" .  $worker_caps->{cpu_arch};
 
     print "registering worker ...\n" if $verbose;
 

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -58,14 +58,18 @@ $workercaps->{cpu_arch} = 'x86_64';
 $workercaps->{cpu_opmode} = '32-bit, 64-bit';
 $workercaps->{mem_max} = '4096';
 
-my $id = worker_register("host", "1", $workercaps);
+use OpenQA::Controller::API::V1::Worker;
+my $c = OpenQA::Controller::API::V1::Worker->new;
+
+# this really should be an integration test
+my $id = $c->_register($schema, "host", "1", $workercaps);
 ok($id == 1, "New worker registered");
 my $worker = $schema->resultset("Workers")->find($id)->info();
 ok($worker->{id} == $id&& $worker->{host} eq "host"&& $worker->{instance} eq "1", "New worker_get");
 
 # Update worker
 sleep(1);
-my $id2 = worker_register("host", "1", "backend", $workercaps);
+my $id2 = $c->_register($schema, "host", "1", "backend", $workercaps);
 ok($id == $id2, "Known worker_register");
 my $worker2 = $schema->resultset("Workers")->find($id2)->info();
 ok($worker2->{id} == $id2 && $worker2->{host} eq "host"&& $worker2->{instance} == 1, "Known worker_get");
@@ -245,7 +249,7 @@ $grabed = OpenQA::Scheduler::job_get($job->id);
 ok($grabed->{state} eq "running", "Job is in running state"); # After job_grab the job is in running state.
 
 # register worker again while it has a running job
-$id2 = worker_register("host", "1", "backend", $workercaps);
+$id2 = $c->_register($schema, "host", "1", "backend", $workercaps);
 ok($id == $id2, "re-register worker got same id");
 
 # Now it's previous job must be set to done

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -112,12 +112,15 @@ $jobF->set_prio(1);
 #diag "jobE ", $jobE;
 #diag "jobF ", $jobF;
 
-my $w1_id = worker_register("host", "1",  $workercaps);
-my $w2_id = worker_register("host", "2",  $workercaps);
-my $w3_id = worker_register("host", "3",  $workercaps);
-my $w4_id = worker_register("host", "4",  $workercaps);
-my $w5_id = worker_register("host", "5",  $workercaps);
-my $w6_id = worker_register("host", "6",  $workercaps);
+use OpenQA::Controller::API::V1::Worker;
+my $c = OpenQA::Controller::API::V1::Worker->new;
+
+my $w1_id = $c->_register($schema, "host", "1",  $workercaps);
+my $w2_id = $c->_register($schema, "host", "2",  $workercaps);
+my $w3_id = $c->_register($schema, "host", "3",  $workercaps);
+my $w4_id = $c->_register($schema, "host", "4",  $workercaps);
+my $w5_id = $c->_register($schema, "host", "5",  $workercaps);
+my $w6_id = $c->_register($schema, "host", "6",  $workercaps);
 
 #websocket
 #my $ws1 = $t->websocket_ok("/api/v1/workers/$w1_id/ws");


### PR DESCRIPTION
machines have now a worker_class as can have tests (less likely for products, but possible) - this gives jobs a list of classes to expect

and workers have a list of classes they support and only workers that fullfill all job classes can grab a job. CPU_ARCH is by now only a mean to define a default WORKER_CLASS (e.g. qemu_x86_64)