### PR TITLE
change lock api to POST method

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -395,9 +395,9 @@ sub startup {
     $worker_r->websocket('/ws')->name('apiv1_worker_ws')->to('worker#websocket_create');    #websocket connection
 
     # api/v1/mutex
-    $api_r_job->post('/mutex/lock/:name')->name('apiv1_mutex_create')->to('locks#mutex_create');
-    $api_r_job->get('/mutex/lock/:name')->name('apiv1_mutex_lock')->to('locks#mutex_lock');
-    $api_r_job->get('/mutex/unlock/:name')->name('apiv1_mutex_unlock')->to('locks#mutex_unlock');
+    $api_r_job->post('/mutex/:name')->name('apiv1_mutex_create')->to('locks#mutex_create');
+    $api_r_job->post('/mutex/:name/lock')->name('apiv1_mutex_lock')->to('locks#mutex_lock');
+    $api_r_job->post('/mutex/:name/unlock')->name('apiv1_mutex_unlock')->to('locks#mutex_unlock');
 
     # api/v1/mm
     my $mm_api = $api_r_job->route('/mm');


### PR DESCRIPTION
- using GET for lock operations was a bad idea (due to possible GET caching by proxy), so get it fixed before wider usage (action#6478)
- has os-autoinst part, so worker&scheduler needs to be redeployed at the same time