### PR TITLE
refactor cloning from Scheduler to Jobs schema

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -600,40 +600,6 @@ sub _job_stop_children {
     }
 }
 
-# parent job has been cloned, move the scheduled children to the new one
-sub _job_update_parent {
-    my $jobid     = shift;
-    my $new_jobid = shift;
-
-    my $children = schema->resultset("JobDependencies")->search(
-        {
-            dependency    => {-in => [OpenQA::Schema::Result::JobDependencies::CHAINED, OpenQA::Schema::Result::JobDependencies::PARALLEL]},
-            parent_job_id => $jobid,
-            state         => OpenQA::Schema::Result::Jobs::SCHEDULED,
-        },
-        {
-            join => 'child',
-        }
-      )->update(
-        {
-            parent_job_id => $new_jobid,
-        });
-
-    #    my $result = schema->resultset("JobDependencies")->search(
-    #        {
-    #            dependency => OpenQA::Schema::Result::JobDependencies::CHAINED,
-    #            parent_job_id => $jobid,
-    #            child_job_id => { -in => $children->get_column('child_job_id')->as_query},
-    #        }
-    #      )->update(
-    #        {
-    #            parent_job_id => $new_jobid,
-    #        }
-    #      );
-}
-
-
-
 =item job_set_done
 
 mark job as done. No error check. Meant to be called from worker!

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -641,7 +641,8 @@ mark job as done. No error check. Meant to be called from worker!
 =cut
 # XXX TODO Parameters is a hash, check if is better use normal parameters
 sub job_set_done {
-    my %args     = @_;
+    my %args = @_;
+    return unless ($args{jobid});
     my $jobid    = int($args{jobid});
     my $newbuild = 0;
     $newbuild = int($args{newbuild}) if defined $args{newbuild};
@@ -764,6 +765,19 @@ sub _job_find_smart($$$) {
     }
 }
 
+=head2 job_duplicate
+
+=over
+
+=item Arguments: HASH { jobid => SCALAR, dup_type_auto => SCALAR, retry_avbl => SCALAR }
+
+=item Return value: ID of new job
+
+=back
+
+Handle individual job restart including associated job and asset dependencies
+
+=cut
 sub job_duplicate {
     my %args = @_;
     # set this clone was triggered by manually if it's not auto-clone
@@ -771,9 +785,6 @@ sub job_duplicate {
 
     my $job = schema->resultset("Jobs")->find({id => $args{jobid}});
     return unless $job;
-    return unless $job->can_be_duplicated;    # already cloned
-
-    log_debug("duplicating $args{jobid}");
 
     if ($args{dup_type_auto}) {
         if (int($job->retry_avbl) > 0) {
@@ -781,7 +792,7 @@ sub job_duplicate {
         }
         else {
             log_debug("Could not auto-duplicated! The job are auto-duplicated too many times. Please restart the job manually.");
-            return undef;
+            return;
         }
     }
     else {
@@ -793,51 +804,16 @@ sub job_duplicate {
         }
     }
 
-    # find jobs that must be cloned due to dependencies:
-    # all parents + all running jobs connected with the parents
-    my %to_clone;
-    _job_duplicate_find_parents($job, undef, \%to_clone);
-
-    my $clone;
-
-    # clone the jobs
+    my %clones = $job->duplicate(\%args);
+    unless (%clones) {
+        log_debug('duplication failed');
+        return;
+    }
+    my @originals = keys %clones;
+    # abort jobs restarted because of dependencies (exclude the original $args{jobid})
     my $jobs = schema->resultset("Jobs")->search(
         {
-            id => [keys %to_clone],
-        });
-    while (my $j = $jobs->next) {
-        if ($j->id == $job->id) {
-            #the requested job
-            $clone = $to_clone{$j->id}->{clone} = $j->duplicate(\%args);
-            $clone->set_property('JOBTOKEN');
-        }
-        else {
-            #dependencies
-            my $c = $to_clone{$j->id}->{clone} = $j->duplicate();
-            $c->set_property('JOBTOKEN');
-        }
-        _job_update_parent($j->id, $to_clone{$j->id}->{clone}->id);
-    }
-
-    # create dependencies for the clones
-    for my $child_id (keys %to_clone) {
-        my $cl_child_id = $to_clone{$child_id}->{clone}->id;
-        for my $parent_id (keys %{$to_clone{$child_id}->{parent}}) {
-            my $cl_parent_id = $parent_id;    # scheduled parents were not cloned
-            $cl_parent_id = $to_clone{$parent_id}->{clone}->id if defined $to_clone{$parent_id};
-            schema->resultset("JobDependencies")->create(
-                {
-                    parent_job_id => $cl_parent_id,
-                    child_job_id  => $cl_child_id,
-                    dependency    => OpenQA::Schema::Result::JobDependencies::PARALLEL,
-                });
-        }
-    }
-
-    # abort jobs restarted because of dependencies (exclude the original $args{jobid})
-    $jobs = schema->resultset("Jobs")->search(
-        {
-            id    => {'!=', $job->id, '-in' => [keys %to_clone]},
+            id    => {'!=' => $job->id, '-in' => \@originals},
             state => [OpenQA::Schema::Result::Jobs::EXECUTION_STATES],
         },
         {
@@ -857,113 +833,38 @@ sub job_duplicate {
         command_enqueue(workerid => $j->worker_id, command => 'abort', job_id => $j->id);
     }
 
-    if (defined($clone)) {
-        log_debug("new job " . $clone->id);
-
-        job_notify_workers();
-        return $clone->id;
-    }
-    else {
-        log_debug("clone failed");
-        return undef;
-    }
+    log_debug('new job ' . $clones{$job->id});
+    job_notify_workers();
+    return $clones{$job->id};
 }
 
+=head2 job_restart
 
-sub _job_duplicate_find_parents {
-    my ($job, $child_id, $to_clone) = @_;
+=over
 
-    while ($job->clone_id) {    # find the most recent clone
-        $job = $job->clone;
-    }
+=item Arguments: SCALAR or ARRAYREF of Job IDs
 
-    $to_clone->{$child_id}{parent}{$job->id} = 1 if $child_id;
+=item Return value: ARRAY of new job ids
 
-    # if a parent is already scheduled, we can connect to it without cloning
-    # do not create $to_clone->{$job->id} entry
-    # just link it in $to_clone->{$child_id}{parent}
-    return
-      if (
-        $child_id &&    # this is a parent
-        $job->state eq OpenQA::Schema::Result::Jobs::SCHEDULED
-      );
+=back
 
-    $to_clone->{$job->id} //= {clone => undef, parent => {}};
+Handle job restart by user (using API or WebUI). Job is only restarted when either running
+or done. Scheduled jobs can't be restarted.
 
-    my $parents = schema->resultset("JobDependencies")->search(
-        {
-            dependency   => OpenQA::Schema::Result::JobDependencies::PARALLEL,
-            child_job_id => $job->id,
-        },
-        {
-            join => 'parent',
-        });
-
-    my $have_parents = 0;
-    while (my $j = $parents->next) {
-        $have_parents = 1;
-        my $parent = $j->parent;
-        _job_duplicate_find_parents($parent, $job->id, $to_clone);
-    }
-
-    _job_duplicate_find_running($job, $to_clone) unless $have_parents;
-}
-
-sub _job_duplicate_find_running {
-    my ($job, $to_clone) = @_;
-
-    $to_clone->{$job->id} //= {clone => undef, parent => {}};
-    $to_clone->{$job->id}->{running} = 1;
-
-    my $children = schema->resultset("JobDependencies")->search(
-        {
-            dependency    => OpenQA::Schema::Result::JobDependencies::PARALLEL,
-            parent_job_id => $job->id,
-            state         => [OpenQA::Schema::Result::Jobs::EXECUTION_STATES],
-        },
-        {
-            join => 'child',
-        });
-
-    while (my $j = $children->next) {
-        my $child = $j->child;
-        next if $to_clone->{$child->id} && $to_clone->{$child->id}->{running};    #already seen
-        _job_duplicate_find_running($child, $to_clone);
-        $to_clone->{$child->id}{parent}{$job->id} = 1;
-    }
-
-    my $parents = schema->resultset("JobDependencies")->search(
-        {
-            dependency   => OpenQA::Schema::Result::JobDependencies::PARALLEL,
-            child_job_id => $job->id,
-            state        => [OpenQA::Schema::Result::Jobs::EXECUTION_STATES],
-        },
-        {
-            join => 'parent',
-        });
-
-    while (my $j = $parents->next) {
-        my $parent = $j->parent;
-        next if $to_clone->{$parent->id} && $to_clone->{$parent->id}->{running};    #already seen
-        $to_clone->{$job->id}{parent}{$parent->id} = 1;
-        _job_duplicate_find_running($parent, $to_clone);
-    }
-}
-
+=cut
 sub job_restart {
-    my $name = shift or die "missing name parameter\n";
-
-    # TODO: support by name and by iso here
-    my $idqry = $name;
+    my ($jobids) = @_ or die "missing name parameter\n";
 
     # first, duplicate all jobs that are either running, waiting or done
     my $jobs = schema->resultset("Jobs")->search(
         {
-            id    => $idqry,
+            id    => $jobids,
             state => [OpenQA::Schema::Result::Jobs::EXECUTION_STATES, OpenQA::Schema::Result::Jobs::FINAL_STATES],
         },
         {
-            columns => [qw/id/]});
+            columns => [qw/id/],
+        });
+
     my @duplicated;
     while (my $j = $jobs->next) {
         my $id = job_duplicate(jobid => $j->id);
@@ -973,11 +874,12 @@ sub job_restart {
     # then tell workers to abort
     $jobs = schema->resultset("Jobs")->search(
         {
-            id    => $idqry,
+            id    => $jobids,
             state => [OpenQA::Schema::Result::Jobs::EXECUTION_STATES],
         },
         {
-            colums => [qw/id worker_id/]});
+            colums => [qw/id worker_id/],
+        });
 
     $jobs->search(
         {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -455,7 +455,7 @@ sub duplicate {
         return;
     }
 
-    # recreate dependency if exists
+    # recreate dependency if exists for cloned parents/children
     for my $p (@direct_deps_parents) {
         $res->parents->create(
             {
@@ -470,6 +470,19 @@ sub duplicate {
                 dependency   => OpenQA::Schema::Result::JobDependencies->PARALLEL,
             });
     }
+
+    # reroute scheduled children
+    my $children = $self->children->search(
+        {
+            'child.state' => SCHEDULED,
+        },
+        {
+            join => 'child',
+        }
+      )->update(
+        {
+            parent_job_id => $res->id,
+        });
 
     return ($self->id => $res->id, %duplicated_ids);
 }

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -46,6 +46,7 @@ $job1 = OpenQA::Scheduler::job_get(99926);
 is($job1->{state}, OpenQA::Schema::Result::Jobs::DONE, 'trying to duplicate done job');
 $id = OpenQA::Scheduler::job_duplicate(jobid => 99926);
 ok(defined $id, "duplication works");
+isnt($id, $job1->{id}, 'clone id is different than original job id');
 
 my $jobs = list_jobs();
 is(@$jobs, @$current_jobs + 1, "one more job after duplicating one job");

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -53,10 +53,9 @@ is(@$jobs, @$current_jobs + 1, "one more job after duplicating one job");
 $current_jobs = $jobs;
 
 my $job2 = OpenQA::Scheduler::job_get($id);
+# delete the obviously different fields
 delete $job1->{id};
-delete $job1->{settings}->{NAME};
 delete $job2->{id};
-delete $job2->{settings}->{NAME};
 delete $job1->{state};
 delete $job2->{state};
 delete $job1->{result};
@@ -65,6 +64,10 @@ delete $job1->{t_finished};
 delete $job2->{t_finished};
 delete $job1->{t_started};
 delete $job2->{t_started};
+# the name has job id as prefix, delete that too
+delete $job1->{settings}->{NAME};
+delete $job2->{settings}->{NAME};
+# assets are assigned during job grab and not cloned
 delete $job1->{assets};
 is_deeply($job1, $job2, "duplicated job equal");
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -30,7 +30,8 @@ OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA');
 
 my $minimalx = $t->app->db->resultset("Jobs")->find({id => 99926});
-my $clone = $minimalx->duplicate;
+my %clones   = $minimalx->duplicate();
+my $clone    = $t->app->db->resultset("Jobs")->find({id => $clones{$minimalx->id}});
 
 isnt($clone->id, $minimalx->id, "is not the same job");
 is($clone->test,       "minimalx",  "but is the same test");
@@ -68,7 +69,8 @@ is($minimalx->duplicate, undef, "cannot clone after reloading");
 
 # But cloning the clone should be possible after job state change
 $clone->state(OpenQA::Schema::Result::Jobs::CANCELLED);
-my $second = $clone->duplicate({prio => 35, retry_avbl => 2});
+%clones = $clone->duplicate({prio => 35, retry_avbl => 2});
+my $second = $t->app->db->resultset("Jobs")->find({id => $clones{$clone->id}});
 is($second->test,       "minimalx", "same test again");
 is($second->priority,   35,         "with adjusted priority");
 is($second->retry_avbl, 2,          "with adjusted retry_avbl");

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -50,19 +50,6 @@ is($minimalx->clone_id,  $clone->id,    "relationship is set");
 is($minimalx->clone->id, $clone->id,    "relationship works");
 is($clone->origin->id,   $minimalx->id, "reverse relationship works");
 
-# Let's check the job_settings (sorry for Perl's antipatterns)
-my @m_settings = $minimalx->settings;
-my $m_hashed   = {};
-for my $i (@m_settings) {
-    $m_hashed->{$i->key} = $i->value unless $i->key eq "NAME";
-}
-my @c_settings = $clone->settings;
-my $c_hashed   = {};
-for my $i (@c_settings) {
-    $c_hashed->{$i->key} = $i->value;
-}
-is_deeply($m_hashed, $c_hashed, "equivalent job settings (skipping NAME)");
-
 # After reloading minimalx, it doesn't look cloneable anymore
 ok(!$minimalx->can_be_duplicated, "doesn't look cloneable after reloading");
 is($minimalx->duplicate, undef, "cannot clone after reloading");

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -1,0 +1,108 @@
+#!/bin/perl
+
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use strict;
+use warnings;
+use Data::Dump qw/pp dd/;
+use Test::More;
+use OpenQA::Scheduler qw/job_create job_grab job_get job_restart job_set_done/;
+use OpenQA::Controller::API::V1::Worker;
+use OpenQA::Test::Database;
+
+my $schema;
+ok($schema = OpenQA::Test::Database->new->create(), 'create database') || BAIL_OUT('failed to create database');
+## test asset is not assigned to scheduled jobs after job creation
+# create new job
+my %settings = (
+    DISTRI       => 'Unicorn',
+    FLAVOR       => 'pink',
+    VERSION      => '42',
+    BUILD        => '666',
+    ISO          => 'whatever.iso',
+    DESKTOP      => 'DESKTOP',
+    KVM          => 'KVM',
+    ISO_MAXSIZE  => 1,
+    MACHINE      => 'RainbowPC',
+    ARCH         => 'x86_64',
+    TEST         => 'testA',
+    WORKER_CLASS => 'testAworker',
+);
+
+my $workercaps = {
+    cpu_modelname => 'Rainbow CPU',
+    cpu_arch      => 'x86_64',
+    cpu_opmode    => '32-bit, 64-bit',
+    mem_max       => '4096',
+    WORKER_CLASS  => 'testAworker',
+};
+
+my $jobA   = job_create(\%settings);
+my @assets = $jobA->jobs_assets;
+ok(!@assets, 'no asset assigned before grabbing');
+$jobA->set_prio(1);
+
+## test asset is assigned after grab_job
+# register worker
+my $c = OpenQA::Controller::API::V1::Worker->new;
+my $w = $c->_register($schema, 'host', '1', $workercaps);
+# grab job
+my $job = job_grab(workerid => $w);
+is($job->{id}, $jobA->id, 'jobA grabbed');
+@assets = $jobA->jobs_assets;
+ok(@assets, 'job has asset assigned after grabbing');
+
+# test asset is not assigned to scheduled jobs after duping
+my ($cloneA) = job_restart($jobA->id);
+$cloneA = $schema->resultset('Jobs')->find(
+    {
+        id => $cloneA,
+    });
+@assets = $cloneA->jobs_assets;
+ok(!@assets, 'clone does not have asset assigned');
+
+## test job is duped when depends on asset created by duping job
+# set jobA (normally this is done by worker after abort) and cloneA to done
+ok(job_set_done(jobid => $jobA->id,   result => 'passed'), 'jobA set to done');
+ok(job_set_done(jobid => $cloneA->id, result => 'passed'), 'cloneA job set to done');
+# register asset as created by cloneA
+$schema->resultset('JobsAssets')->create(
+    {
+        job_id     => $cloneA->id,
+        asset_id   => 2,             # took one from fictures
+        created_by => 1,
+    });
+# create new job depending on this asset
+$settings{_START_AFTER_JOBS} = [$cloneA->id];
+$settings{ISO}               = 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso';    # asset_id 2
+$settings{TEST}              = 'testB';
+my $jobB = job_create(\%settings);
+# set jobB to running
+$jobB->set_prio(1);
+$job = job_grab(workerid => $w);
+is($job->{id},                           $jobB->id, 'jobB grabbed');
+is($jobB->jobs_assets->single->asset_id, 2,         'using correct asset');
+# clone cloneA
+($cloneA) = job_restart($cloneA->id);
+# check jobB was also duplicated
+$jobB->discard_changes();
+ok($jobB->clone, 'jobB has a clone after cloning asset creator');
+
+done_testing();


### PR DESCRIPTION
- move cloning of test dependencies to Jobs schema
- scheduler's job is to set proper states and notify workers
- add asset dependency cloning
  + all children using any asset created by duping job will get
    duplicated as well