### PR TITLE
initialize the log path as first step

### DIFF
--- a/lib/OpenQA/Plugin/Helpers.pm
+++ b/lib/OpenQA/Plugin/Helpers.pm
@@ -133,12 +133,6 @@ sub register {
         });
 
     $app->helper(
-        rndstr => sub {
-            my $c = shift;
-            db_helpers::rndstr(@_);
-        });
-
-    $app->helper(
         is_operator => sub {
             my $c = shift;
             my $user = shift || $c->current_user;


### PR DESCRIPTION
if the plugins create log output, they set the handle in Mojo::Log to STDERR
and it won't be reset afterwards