### PR TITLE
don't let assetpack guess on the out_dir but give it explicitly

### DIFF
--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -158,7 +158,9 @@ sub startup {
 
     # Documentation browser under "/perldoc"
     $self->plugin('PODRenderer');
-    $self->plugin('AssetPack');
+    # just give it some out_dir to generate the assets in
+    # to avoid it trying to guess, which will break on deployment by packages
+    $self->plugin('AssetPack' => {out_dir => $self->static->paths->[0]});
     $self->plugin('OpenQA::Plugin::Helpers');
     $self->plugin('OpenQA::Plugin::CSRF');
     $self->plugin('OpenQA::Plugin::REST');


### PR DESCRIPTION
assetpack tries to guess the out_dir by means of -w and as our deployed
packages don't allow writing anywhere, out_dir is empty and assetpack will
regenerate the assets into memory, which is slow and painful