### PR TITLE
sort the build numbers according to time not actual number

### DIFF
--- a/lib/OpenQA/Controller/Main.pm
+++ b/lib/OpenQA/Controller/Main.pm
@@ -36,10 +36,15 @@ sub index {
                 job_id => {-in => $jobs->get_column('id')->as_query},
                 key    => 'BUILD'
             },
-            {columns => qw/value/, distinct => 1});
+            {
+                'select' => ['value', {min => 't_created', -as => 'first_hit'}],
+                'as'     => [qw/value first_hit/],
+                order_by => {-desc => 'first_hit'},
+                group_by => [qw/value/]});
         my $max_jobs = 0;
         my $buildnr  = 0;
-        for my $b (sort { $b <=> $a } map { $_->value } $builds->all) {
+        for my $b (map { $_->value } $builds->all) {
+            #print "B $b\n";
             my $jobs = $self->db->resultset('Jobs')->search(
                 {
                     'settings.key'   => 'BUILD',


### PR DESCRIPTION
our staging prjs have <CI_CNT>.<BUILD_CNT> which makes sorting by number
much harder. So just give up and sort by the timestamp of the oldest job
per build id

This will lead to other use cases being wrongly sorted, but unless we inject
a correct sort externally, there is no perfect sorting