### PR TITLE
add correct OpenQA repos to Dockerfiles

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -65,7 +65,7 @@ To add more workers, increase number that is used in hostname, container name an
 You have to put your tests under `data/tests` directory and ISOs under `data/factory/iso` directory. For example, for testing Fedora, run:
 
     git clone https://bitbucket.org/rajcze/openqa_fedora data/tests/fedora
-    wget https://dl.fedoraproject.org/pub/alt/stage/22_Beta_RC3/Server/x86_64/iso/Fedora-Server-netinst-x86_64-22_Beta.iso -O data/factory/iso/Fedora-Server-netinst-x86_64-22_Beta_RC3
+    wget https://dl.fedoraproject.org/pub/alt/stage/22_Beta_RC3/Server/x86_64/iso/Fedora-Server-netinst-x86_64-22_Beta.iso -O data/factory/iso/Fedora-Server-netinst-x86_64-22_Beta_RC3.iso
 
 And set permissions, so any user can read/write the data:
 

--- a/docker/openqa_data/Dockerfile
+++ b/docker/openqa_data/Dockerfile
@@ -1,7 +1,7 @@
 FROM opensuse:13.2
-MAINTAINER Jan Sedlak <jsedlak@redhat.com> Josef Skladanka <jskladan@redhat.com>
+MAINTAINER Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>
 
-RUN zypper --non-interactive --gpg-auto-import-keys in ca-certificates git wget
+RUN zypper --non-interactive --gpg-auto-import-keys in ca-certificates-mozilla git wget
 
 ADD data.template /data
 ADD scripts /scripts

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -1,11 +1,13 @@
 FROM opensuse:13.2
-MAINTAINER Jan Sedlak <jsedlak@redhat.com> Josef Skladanka <jskladan@redhat.com>
+MAINTAINER Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>
 
 RUN useradd -m geekotest && \
+    zypper --non-interactive --gpg-auto-import-keys in ca-certificates-mozilla curl && \
     zypper ar -f http://download.opensuse.org/repositories/devel:openQA:stable/openSUSE_13.2/devel:openQA:stable.repo && \
+    zypper ar -f obs://devel:openQA/openSUSE_13.2 openQA && \
     zypper ar -f obs://devel:openQA:13.2/openSUSE_13.2 openQA-perl-modules && \
-    zypper ar -f http://download.opensuse.org/repositories/devel:/languages:/perl/openSUSE_13.2 perl-libs && \
-    zypper --non-interactive --gpg-auto-import-keys in openQA ca-certificates
+    curl https://build.opensuse.org/source/devel:openQA/_pubkey > /tmp/openQA-pubkey && rpm --import /tmp/openQA-pubkey && \
+    zypper --non-interactive in --from devel_openQA_stable openQA
 
 # setup apache
 RUN gensslcert && \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,11 +1,13 @@
 FROM opensuse:13.2
-MAINTAINER Jan Sedlak <jsedlak@redhat.com> Josef Skladanka <jskladan@redhat.com>
+MAINTAINER Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>
 
 RUN useradd -m geekotest && \
+    zypper --non-interactive --gpg-auto-import-keys in ca-certificates-mozilla curl && \
     zypper ar -f http://download.opensuse.org/repositories/devel:openQA:stable/openSUSE_13.2/devel:openQA:stable.repo && \
+    zypper ar -f obs://devel:openQA/openSUSE_13.2 openQA && \
     zypper ar -f obs://devel:openQA:13.2/openSUSE_13.2 openQA-perl-modules && \
-    zypper ar -f http://download.opensuse.org/repositories/devel:/languages:/perl/openSUSE_13.2 perl-libs && \
-    zypper --non-interactive --gpg-auto-import-keys in openQA-worker qemu-kvm
+    curl https://build.opensuse.org/source/devel:openQA/_pubkey > /tmp/pubkey && rpm --import /tmp/pubkey && \
+    zypper --non-interactive in --from devel_openQA_stable openQA-worker qemu-kvm
 
 # set-up qemu
 RUN mkdir -p /root/qemu


### PR DESCRIPTION
I have updated Dockerfiles according to comments in #340. Changed perl-libs repo to openQA-devel repo (as suggested). Removed `--gpg-auto-import-keys` where is not necessary. Imported openQA repo GPG key rather than accepting it automatically.

There are still some caveats with this. `ca-certificates` is now included in opensuse Docker image, but `ca-certificates-mozilla` is missing, so SSL still doesn't work.

This creates chicken and egg situation - we could download and import GPG keys for repositories instead of importing them with `--gpg-auto-import-keys`, but we are unable to do so, because we are unable to verify destination from where we are downloading them. And passing `--insecure` to curl is in my opinion worse than using `--gpg-auto-import-keys`.

Another problem is that I don't know where to find and how to import GPG keys of standard repositories (`repo-non-oss` etc.). So I think that the best we can do now is to use `--gpg-auto-import-keys` to import GPG keys of standard repositories and deal with this as soon as we will have SSL certificates in opensuse Docker image.