### PR TITLE
Avoid using uninitialed variable

### DIFF
--- a/lib/OpenQA/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/Controller/Admin/JobGroup.pm
@@ -36,7 +36,7 @@ sub create {
             $self->flash('info', 'Group ' . $ng->name . ' created');
         }
         else {
-            $self->flash('error', 'Creating group ' . $ng->name . ' failed');
+            $self->flash('error', "Creating group $groupname failed");
         }
     }
     else {


### PR DESCRIPTION
If $ng is not exist then definitely no $ng->name there, just use $groupname here.