### PR TITLE
add var-lib-openqa-share.mount as dependency

### DIFF
--- a/systemd/openqa-worker.target
+++ b/systemd/openqa-worker.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=openQA Worker
+Wants=var-lib-openqa-share.mount
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes sure the shared openqa directory gets mounted even if
remote-fs.target is not enabled explicitly on the machine.