### PR TITLE
fixed support for results other than screenshots

### DIFF
--- a/lib/OpenQA/Controller/Step.pm
+++ b/lib/OpenQA/Controller/Step.pm
@@ -65,7 +65,13 @@ sub init {
     }
     else {
         my $module_detail = $details->[$testindex - 1];
-        $tabmode = 'audio' if ($module_detail->{'audio'});
+        if ($module_detail->{audio}) {
+            $tabmode = 'audio';
+        }
+        elsif ($module_detail->{text}) {
+            $self->stash('textresult', file_content(join('/', $job->result_dir(), $module_detail->{text})));
+            $tabmode = 'text';
+        }
         $self->stash('module_detail', $module_detail);
     }
     $self->stash('tabmode', $tabmode);
@@ -92,6 +98,9 @@ sub view {
 
     if ('audio' eq $self->stash('tabmode')) {
         $self->render('step/viewaudio');
+    }
+    elsif ('text' eq $self->stash('tabmode')) {
+        $self->render('step/viewtext');
     }
     else {
         $self->viewimg;

--- a/lib/OpenQA/Controller/Test.pm
+++ b/lib/OpenQA/Controller/Test.pm
@@ -186,6 +186,7 @@ sub read_test_modules {
         # add link to $testresultdir/$name*.png via png CGI
         my @imglist;
         my @wavlist;
+        my @textlist;
         my $num = 1;
         for my $img (@{$module->details}) {
             $img->{num} = $num++;
@@ -195,16 +196,9 @@ sub read_test_modules {
             elsif ($img->{audio}) {
                 push(@wavlist, $img);
             }
-        }
-
-        # add link to $testresultdir/$name*.txt as direct link
-        my @ocrlist;
-        for my $ocrpath (<$testresultdir/$name-[0-9]*.txt>) {
-            $ocrpath = data_name($ocrpath);
-            my $ocrscreenshotid = $ocrpath;
-            $ocrscreenshotid =~ s/^\w+-(\d+)/$1/;
-            my $ocrres = $module->{screenshots}->[--$ocrscreenshotid]->{ocr_result} || 'na';
-            push(@ocrlist, {name => $ocrpath, result => $ocrres});
+            elsif ($img->{text}) {
+                push(@textlist, $img);
+            }
         }
 
         push(
@@ -214,7 +208,7 @@ sub read_test_modules {
                 result       => $module->result,
                 screenshots  => \@imglist,
                 wavs         => \@wavlist,
-                ocrs         => \@ocrlist,
+                texts        => \@textlist,
                 soft_failure => $module->soft_failure,
                 milestone    => $module->milestone,
                 important    => $module->important,

--- a/templates/step/moduleslisttabs.html.ep
+++ b/templates/step/moduleslisttabs.html.ep
@@ -4,6 +4,10 @@
 		<li <%= ($action eq 'view') ? 'class=selected' : '' %>>
       %= link_to 'Audio' => url_for('step')
 		</li>
+		<% } elsif ($tabmode eq 'text') { %>
+		<li <%= ($action eq 'view') ? 'class=selected' : '' %>>
+      %= link_to 'Text' => url_for('step')
+		</li>
 		<% } elsif($tabmode eq 'screenshot') { %>
 		<li <%= ($action eq 'view') ? 'class=selected' : '' %>>
       %= link_to 'Screenshot' => url_for('step')

--- a/templates/step/moduleslistthumbnails.html.ep
+++ b/templates/step/moduleslistthumbnails.html.ep
@@ -13,6 +13,10 @@
                     %= link_to url_for('step', stepid => $img_count) => (class => 'no_hover') => begin
                         %= image '/images/audio.svg', alt => $refimg->{audio}, title => $refimg->{audio}, width => $ref_width, height => $ref_height, class=> "resborder_\L$refimg->{result}"
                     % end
+                % } elsif ($refimg->{text}) {
+                    %= link_to url_for('step', stepid => $img_count) => (class => 'no_hover') => begin
+                        %= image '/images/text.png', alt => $refimg->{text}, title => $refimg->{text}, width => $ref_width, height => $ref_height, class=> "resborder_\L$refimg->{result}"
+                    % end
                 % }
             </span>
             <% $img_count++; %>

--- a/templates/step/viewtext.html.ep
+++ b/templates/step/viewtext.html.ep
@@ -1,0 +1,33 @@
+% layout 'default';
+% title $moduleid;
+
+% content_for 'ready_function' => begin
+    setupResultButtons();
+% end
+
+<div class="grid_3 alpha" id="sidebar">
+    <div class="box box-shadow alpha" id="actions_box">
+        <div class="box-header aligncenter">Actions</div>
+        <div class="aligncenter">
+            % if (is_operator && $job->can_be_duplicated) {
+                %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
+                    <i class="fa fa-2 fa-repeat" title="Restart Job"></i>
+                %= end
+            % }
+        </div>
+    </div>
+
+    %= include 'step/moduleslist'
+</div>
+
+<div class="grid_13 omega">
+    %= include 'step/moduleslistthumbnails'
+
+    <div class="box box-shadow">
+        %= include 'step/moduleslisttabs'
+
+        <div style="margin: 6px;">
+            <pre><%= $textresult %></pre>
+        </div>
+    </div>
+</div>

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -142,8 +142,8 @@
                                                 % end
                                             % }
 
-                                            <% for my $ocr (@{$module->{ocrs}}) { %>
-                                                <a href="<%= url_for('step', moduleid => $module->{name}, stepid => $ocr->{num}) %>.txt"><img src="/images/text.png" width="26" height="26" alt="<%= $ocr->{name} %>.txt" class="<%= "resborder_\L$ocr->{result}" %>" /></a>
+                                            <% for my $text (@{$module->{texts}}) { %>
+                                                <a href="<%= url_for('step', moduleid => $module->{name}, stepid => $text->{num}) %>"><img src="/images/text.png" width="26" height="26" alt="<%= $text->{name} %>.txt" class="<%= "resborder_\L$text->{result}" %>" /></a>
                                             <% } %>
                                         </td>
                                     </tr>


### PR DESCRIPTION
- support screenshots (png), audio (wav) and text (txt)
- use md5 for all these files
- dropped broken ocr results, use more generic 'text' instead