### PR TITLE
identify job module by name

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -619,10 +619,10 @@ sub update_backend($) {
 
 sub insert_module($$) {
     my ($self, $tm) = @_;
-    my $r = $self->modules->find_or_new({script => $tm->{script}});
+    my $r = $self->modules->find_or_new({name => $tm->{name}});
     if (!$r->in_storage) {
         $r->category($tm->{category});
-        $r->name($tm->{name});
+        $r->script($tm->{script});
         $r->insert;
     }
     $r->update(


### PR DESCRIPTION
name must be unique, it is also used in step url
script does not have to be unique, one script can upload more
modules (for example parsed from junit file)