### PR TITLE
fix limit_assets

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -127,7 +127,7 @@ sub limit_assets {
             },
             {
                 prefetch => 'asset',
-                order_by => 'asset.t_created desc',
+                order_by => 'me.t_created desc',
             });
         my %seen_asset;
         while (my $a = $assets->next) {


### PR DESCRIPTION
the creating time of the asset is not important, we want to make sure
it's not used in a while - and that's coded in the relationship to the jobs