### PR TITLE
fix issue #6826: make columns consistent on /test

### DIFF
--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -5,7 +5,7 @@
         "columnDefs": [
             { targets: 0,
               className: "name" },
-            { targets: 2,
+            { targets: 3,
               className: "time",
               "render": function ( data, type, row ) {
                     if (type === 'display') {
@@ -23,8 +23,8 @@
         <tr>
             <th class="name">Medium</th>
             <th class="test">Test</th>
+            <th>Progress</th>
             <th>Testtime</th>
-            <th>Result</th>
         </tr>
     </thead>
     <tbody>
@@ -58,8 +58,6 @@
                         %= $testname
                     % end
                 </td>
-                % my $href = url_for('tests_overview')->query(build => $build, distri => $distri, version => $version);
-                <td class="testtime" title="<%= $job->t_started %>"><%= $job->t_started->datetime() %>Z</td>
                 <td style="padding: 7px 4px;" class="tprogress">
                     <div class="progress" style="margin-bottom: 0;">
                         % my $ptext = "";
@@ -82,6 +80,7 @@
                         </div>
                     </div>
                 </td>
+                <td class="testtime" title="<%= $job->t_started %>"><%= $job->t_started->datetime() %>Z</td>
             </tr>
         % }
     </tbody>

--- a/templates/test/scheduled_table.html.ep
+++ b/templates/test/scheduled_table.html.ep
@@ -4,7 +4,16 @@
         "order": [[2, 'asc'], [0, 'asc']],
 	"columnDefs": [
 	    { targets: 0,
-              className: "name" }
+              className: "name" },
+	    { targets: 3,
+              className: "time",
+              "render": function ( data, type, row ) {
+                    if (type === 'display') {
+                      return jQuery.timeago(new Date(data));
+                  } else
+                      return data;
+              }
+            },
         ],
   } );
 % end
@@ -15,6 +24,7 @@
 	    <th class="name">Medium</th>
 	    <th class="name">Test</th>
             <th>Priority</th>
+            <th>Testtime</th>
         </tr>
     </thead>
     <tbody>
@@ -58,6 +68,7 @@
 		    <i class="fa fa-plus-square-o"></i>
 		    % end
 		</td>
+		<td class="testtime" title="<%= $job->t_created %>"><%= $job->t_created->datetime() %>Z</td>
             </tr>
         % }
     </tbody>


### PR DESCRIPTION
- the time is now always in the last column
- the creation time of scheduled tests is now shown