### PR TITLE
action#7966 - transactionalize job_schedule_iso

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -201,6 +201,46 @@ sub job_create {
     return $job;
 }
 
+sub job_create_dependencies {
+    my ($job, $testsuite_mapping) = @_;
+
+    my $settings = $job->settings_hash;
+    for my $depname ('START_AFTER_TEST', 'PARALLEL_WITH') {
+        next unless defined $settings->{$depname};
+        for my $testsuite (_parse_dep_variable($settings->{$depname}, $settings)) {
+            if (!defined $testsuite_mapping->{$testsuite}) {
+                warn sprintf('%s=%s not found - check for typos and dependency cycles', $depname, $testsuite);
+            }
+            else {
+                my $dep;
+                if ($depname eq 'START_AFTER_TEST') {
+                    $dep = OpenQA::Schema::Result::JobDependencies::CHAINED;
+                }
+                elsif ($depname eq 'PARALLEL_WITH') {
+                    $dep = OpenQA::Schema::Result::JobDependencies::PARALLEL;
+                }
+                else {
+                    die 'Unknown dependency type';
+                }
+                for my $parent (@{$testsuite_mapping->{$testsuite}}) {
+                    try {
+                        schema->resultset('JobDependencies')->create(
+                            {
+                                child_job_id  => $job->id,
+                                parent_job_id => $parent,
+                                dependency    => $dep,
+                            });
+                    }
+                    catch {
+                        chomp;
+                        warn "job_create_dependencies: $_";
+                    };
+                }
+            }
+        }
+    }
+}
+
 sub job_get($) {
     my $value = shift;
 
@@ -1091,57 +1131,61 @@ sub job_schedule_iso {
         }
     }
 
-    my @ids;
+    my @jobs = ();
 
     # the jobs are now sorted parents first
     # remember ids of created parents and pass them to _START_AFTER_JOBS/_PARALLEL_JOBS of children
     my %testsuite_ids;    # key: "suite:machine", value: array of job ids
 
-    for my $settings (@{$jobs || []}) {
-        my $prio     = delete $settings->{PRIO};
-        my $group_id = delete $settings->{GROUP_ID};
+    my @ids     = ();
+    my $coderef = sub {
+        for my $settings (@{$jobs || []}) {
+            my $prio     = delete $settings->{PRIO};
+            my $group_id = delete $settings->{GROUP_ID};
 
-        # convert testsuite names in START_AFTER_TEST/PARALLEL_WITH to job ids
-        for my $after (_parse_dep_variable($settings->{START_AFTER_TEST}, $settings)) {
-            if (defined $testsuite_ids{$after}) {
-                $settings->{_START_AFTER_JOBS} //= [];
-                push @{$settings->{_START_AFTER_JOBS}}, @{$testsuite_ids{$after}};
+            # create a new job with these parameters and count if successful, do not send job notifies yet
+            my $job;
+            try {
+                $job = job_create($settings, 1);
             }
-            else {
-                warn "START_AFTER_TEST=" . $after . " not found, maybe a typo or a dependency cycle";
+            catch {
+                chomp;
+                warn "job_create: $_";
+            };
+            if ($job) {
+                push @jobs, $job;
+
+                $testsuite_ids{_settings_key($settings)} //= [];
+                push @{$testsuite_ids{_settings_key($settings)}}, $job->id;
+
+                # change prio only if other than default prio
+                if (defined($prio) && $prio != 50) {
+                    $job->priority($prio);
+                }
+                $job->group_id($group_id);
+                $job->update;
             }
         }
-        for my $after (_parse_dep_variable($settings->{PARALLEL_WITH}, $settings)) {
-            if (defined $testsuite_ids{$after}) {
-                $settings->{_PARALLEL_JOBS} //= [];
-                push @{$settings->{_PARALLEL_JOBS}}, @{$testsuite_ids{$after}};
-            }
-            else {
-                warn "PARALLEL_WITH=" . $after . " not found, maybe a typo or a dependency cycle";
-            }
-        }
-        # create a new job with these parameters and count if successful, do not send job notifies yet
-        my $job;
-        try {
-            $job = job_create($settings, 1);
-        }
-        catch {
-            chomp;
-            warn "job_create: $_";
-        };
-        if ($job) {
+
+        # jobs are created, now recreate dependencies and extract ids
+        for my $job (@jobs) {
+            job_create_dependencies($job, \%testsuite_ids);
             push @ids, $job->id;
-
-            $testsuite_ids{_settings_key($settings)} //= [];
-            push @{$testsuite_ids{_settings_key($settings)}}, $job->id;
-
-            # change prio only if other than default prio
-            if (defined($prio) && $prio != 50) {
-                $job->set_prio($prio);
-            }
-            $job->update({group_id => $group_id});
         }
+    };
+
+    my $res;
+    try {
+        schema->txn_do($coderef);
     }
+    catch {
+        my $error = shift;
+        OpenQA::Utils::log_debug("rollback job_schedule_iso: $error");
+        die "Rollback failed during failed job cloning!"
+          if ($error =~ /Rollback failed/);
+        $res = undef;
+    };
+
     #notify workers new jobs are available
     job_notify_workers;
     return @ids;

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -223,18 +223,13 @@ sub job_create_dependencies {
                     die 'Unknown dependency type';
                 }
                 for my $parent (@{$testsuite_mapping->{$testsuite}}) {
-                    try {
-                        schema->resultset('JobDependencies')->create(
-                            {
-                                child_job_id  => $job->id,
-                                parent_job_id => $parent,
-                                dependency    => $dep,
-                            });
-                    }
-                    catch {
-                        chomp;
-                        warn "job_create_dependencies: $_";
-                    };
+
+                    schema->resultset('JobDependencies')->create(
+                        {
+                            child_job_id  => $job->id,
+                            parent_job_id => $parent,
+                            dependency    => $dep,
+                        });
                 }
             }
         }
@@ -1144,14 +1139,8 @@ sub job_schedule_iso {
             my $group_id = delete $settings->{GROUP_ID};
 
             # create a new job with these parameters and count if successful, do not send job notifies yet
-            my $job;
-            try {
-                $job = job_create($settings, 1);
-            }
-            catch {
-                chomp;
-                warn "job_create: $_";
-            };
+            my $job = job_create($settings, 1);
+
             if ($job) {
                 push @jobs, $job;
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -134,6 +134,9 @@ is_deeply($server_64->{parents},  {Parallel => [],                 Chained => []
 is($textmode_64, undef, "textmode is not created for 64bit machine");
 is_deeply($advanced_kde_64->{parents}, {Parallel => [], Chained => [$kde_64->{id}]}, "kde_64 is only parent of advanced_kde_64");    # textmode is not defined for 64bit machine
 
+is($server_32->{group_id}, 1001, 'server_32 part of opensuse group');
+is($server_64->{group_id}, 1001, 'server_64 part of opensuse group');
+
 lj;
 
 # check that the old tests are cancelled


### PR DESCRIPTION
I did two things here:
1) refactored algorithm to at first create all jobs and create mappings *TESTNAME* -> job_id and then create dependencies
2) put this all as one DB transaction

At first I tried to put the whole original routine to coderef for transaction, but that didn't work. I thought because of mixing create and search calls (which still may be the reason) so I did the refactoring 1).
Initially I put only job creation to transaction, that made perfect sense. But then I added dependency creation to the same transaction and I'm wondering why that works? I thought DBIx transaction worked by executing the perl code and intercepting DB calls, but in that case this workflow should not work (job ids shouldn't be available when dependencies are about to be created). Can this be that i.e. sqlite 'memory' does not support transactions and thus it is ignored, but on pg it would not work?