### PR TITLE
Do not have the white spaces inside of textarea

### DIFF
--- a/templates/step/src.html.ep
+++ b/templates/step/src.html.ep
@@ -36,9 +36,7 @@
                 <tt><%= $scriptpath %></tt>
             % end
         </p>
-        <textarea class='code' id='script'>
-            %= $script
-        </textarea>
+        <textarea class='code' id='script'><%= $script %></textarea>
 
         <script type="text/javascript">
          var editor = CodeMirror.fromTextArea(document.getElementById("script"), {


### PR DESCRIPTION
The white spaces in <textarea></textarea> are considered as real white space rather than the indentation. This patch fixes the weird indentation at the souce code view.