### PR TITLE
Link to All Test Results from the front page.

### DIFF
--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -36,3 +36,7 @@
     </h2>
     %= include 'main/group_builds', result => $groupresults, group => $group
 % }
+
+<h2>
+%= link_to 'All Test Results' => url_for('tests')
+</h2>


### PR DESCRIPTION
When you install a new openQA front end, the title page has just the
project advertisement, without linking to the actual results most people
are interested in.

Groups only help once you learn how to define some.

Therefore a link to /tests is added.