### PR TITLE
Made website name (openQA) customizable.

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -1,4 +1,7 @@
 [global]
+## Web site name for tab titles and bookmarks
+#appname = openQA
+
 ## type of branding - [ openSUSE,  plain ]
 #branding = plain
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -36,6 +36,7 @@ sub _read_config {
 
     my %defaults = (
         global => {
+            appname       => "openQA",
             base_url      => undef,
             branding      => "openSUSE",
             allowed_hosts => undef,
@@ -156,10 +157,11 @@ has secrets => sub {
 sub startup {
     my $self = shift;
 
-    # Set some application defaults
-    $self->defaults(appname => 'openQA');
-
     $self->_read_config;
+
+    # Set some application defaults
+    $self->defaults(appname => $self->app->config->{global}->{appname});
+
     my $logfile = $ENV{OPENQA_LOGFILE} || $self->config->{logging}->{file};
     $self->log->path($logfile);
 

--- a/t/config.t
+++ b/t/config.t
@@ -35,6 +35,7 @@ is_deeply(
     $cfg,
     {
         global => {
+            appname  => 'openQA',
             branding => "openSUSE",
             scm      => 'git',
             hsts     => '365',


### PR DESCRIPTION
If you need to deal with two or more instances of openQA at the same
time it will help if all the browser tabs start with something more
unique than "openQA".

Tested to work on https://mrakoplas.suse.cz