### PR TITLE
allow ISO to be a URL, download if needed

### DIFF
--- a/dbicdh/MySQL/deploy/33/001-auto-__VERSION.sql
+++ b/dbicdh/MySQL/deploy/33/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Fri Sep 25 18:00:12 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `dbix_class_deploymenthandler_versions`
+--
+CREATE TABLE `dbix_class_deploymenthandler_versions` (
+  `id` integer NOT NULL auto_increment,
+  `version` varchar(50) NOT NULL,
+  `ddl` text NULL,
+  `upgrade_sql` text NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `dbix_class_deploymenthandler_versions_version` (`version`)
+);
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/deploy/33/001-auto.sql
+++ b/dbicdh/MySQL/deploy/33/001-auto.sql
@@ -1,0 +1,376 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Fri Sep 25 18:00:12 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `assets`
+--
+CREATE TABLE `assets` (
+  `id` integer NOT NULL auto_increment,
+  `type` text NOT NULL,
+  `name` text NOT NULL,
+  `size` bigint NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `assets_type_name` (`type`, `name`)
+) ENGINE=InnoDB;
+--
+-- Table: `gru_tasks`
+--
+CREATE TABLE `gru_tasks` (
+  `id` integer NOT NULL auto_increment,
+  `taskname` text NOT NULL,
+  `args` text NOT NULL,
+  `run_at` datetime NOT NULL,
+  `priority` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_groups`
+--
+CREATE TABLE `job_groups` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `size_limit_gb` integer NOT NULL DEFAULT 100,
+  `keep_logs_in_days` integer NOT NULL DEFAULT 30,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `job_groups_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_modules`
+--
+CREATE TABLE `job_modules` (
+  `id` integer NOT NULL auto_increment,
+  `job_id` integer NOT NULL,
+  `name` text NOT NULL,
+  `script` text NOT NULL,
+  `category` text NOT NULL,
+  `soft_failure` integer NOT NULL DEFAULT 0,
+  `milestone` integer NOT NULL DEFAULT 0,
+  `important` integer NOT NULL DEFAULT 0,
+  `fatal` integer NOT NULL DEFAULT 0,
+  `result` varchar(255) NOT NULL DEFAULT 'none',
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_modules_idx_job_id` (`job_id`),
+  INDEX `idx_job_modules_result` (`result`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_modules_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_settings`
+--
+CREATE TABLE `job_settings` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `job_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_settings_idx_job_id` (`job_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_settings_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `machine_settings`
+--
+CREATE TABLE `machine_settings` (
+  `id` integer NOT NULL auto_increment,
+  `machine_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `machine_settings_idx_machine_id` (`machine_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `machine_settings_machine_id_key` (`machine_id`, `key`),
+  CONSTRAINT `machine_settings_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `machines`
+--
+CREATE TABLE `machines` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `backend` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `machines_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `product_settings`
+--
+CREATE TABLE `product_settings` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `product_settings_idx_product_id` (`product_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `product_settings_product_id_key` (`product_id`, `key`),
+  CONSTRAINT `product_settings_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `products`
+--
+CREATE TABLE `products` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `distri` text NOT NULL,
+  `version` text NOT NULL DEFAULT '',
+  `arch` text NOT NULL,
+  `flavor` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `products_distri_version_arch_flavor` (`distri`, `version`, `arch`, `flavor`)
+) ENGINE=InnoDB;
+--
+-- Table: `secrets`
+--
+CREATE TABLE `secrets` (
+  `id` integer NOT NULL auto_increment,
+  `secret` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `secrets_secret` (`secret`)
+);
+--
+-- Table: `test_suite_settings`
+--
+CREATE TABLE `test_suite_settings` (
+  `id` integer NOT NULL auto_increment,
+  `test_suite_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `test_suite_settings_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suite_settings_test_suite_id_key` (`test_suite_id`, `key`),
+  CONSTRAINT `test_suite_settings_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `test_suites`
+--
+CREATE TABLE `test_suites` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suites_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `users`
+--
+CREATE TABLE `users` (
+  `id` integer NOT NULL auto_increment,
+  `username` text NOT NULL,
+  `email` text NULL,
+  `fullname` text NULL,
+  `nickname` text NULL,
+  `is_operator` integer NOT NULL DEFAULT 0,
+  `is_admin` integer NOT NULL DEFAULT 0,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `users_username` (`username`)
+) ENGINE=InnoDB;
+--
+-- Table: `worker_properties`
+--
+CREATE TABLE `worker_properties` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `worker_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `worker_properties_idx_worker_id` (`worker_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `worker_properties_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `workers`
+--
+CREATE TABLE `workers` (
+  `id` integer NOT NULL auto_increment,
+  `host` text NOT NULL,
+  `instance` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `workers_host_instance` (`host`, `instance`)
+) ENGINE=InnoDB;
+--
+-- Table: `api_keys`
+--
+CREATE TABLE `api_keys` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `secret` text NOT NULL,
+  `user_id` integer NOT NULL,
+  `t_expiration` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `api_keys_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `api_keys_key` (`key`),
+  CONSTRAINT `api_keys_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `comments`
+--
+CREATE TABLE `comments` (
+  `id` integer NOT NULL auto_increment,
+  `job_id` integer NULL,
+  `group_id` integer NULL,
+  `text` text NOT NULL,
+  `user_id` integer NOT NULL,
+  `hidden` enum('0','1') NOT NULL DEFAULT '0',
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `comments_idx_group_id` (`group_id`),
+  INDEX `comments_idx_job_id` (`job_id`),
+  INDEX `comments_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `comments_fk_group_id` FOREIGN KEY (`group_id`) REFERENCES `job_groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `comments_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `comments_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `jobs`
+--
+CREATE TABLE `jobs` (
+  `id` integer NOT NULL auto_increment,
+  `slug` text NULL,
+  `result_dir` text NULL,
+  `state` varchar(255) NOT NULL DEFAULT 'scheduled',
+  `priority` integer NOT NULL DEFAULT 50,
+  `result` varchar(255) NOT NULL DEFAULT 'none',
+  `worker_id` integer NOT NULL DEFAULT 0,
+  `test` text NOT NULL,
+  `clone_id` integer NULL,
+  `retry_avbl` integer NOT NULL DEFAULT 3,
+  `backend` varchar(255) NULL,
+  `backend_info` text NULL,
+  `group_id` integer NULL,
+  `t_started` timestamp NULL,
+  `t_finished` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_idx_clone_id` (`clone_id`),
+  INDEX `jobs_idx_group_id` (`group_id`),
+  INDEX `jobs_idx_worker_id` (`worker_id`),
+  INDEX `idx_jobs_state` (`state`),
+  INDEX `idx_jobs_result` (`result`),
+  PRIMARY KEY (`id`),
+  UNIQUE `jobs_slug` (`slug`),
+  CONSTRAINT `jobs_fk_clone_id` FOREIGN KEY (`clone_id`) REFERENCES `jobs` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `jobs_fk_group_id` FOREIGN KEY (`group_id`) REFERENCES `job_groups` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `jobs_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_dependencies`
+--
+CREATE TABLE `job_dependencies` (
+  `child_job_id` integer NOT NULL,
+  `parent_job_id` integer NOT NULL,
+  `dependency` integer NOT NULL,
+  INDEX `job_dependencies_idx_child_job_id` (`child_job_id`),
+  INDEX `job_dependencies_idx_parent_job_id` (`parent_job_id`),
+  INDEX `idx_job_dependencies_dependency` (`dependency`),
+  PRIMARY KEY (`child_job_id`, `parent_job_id`, `dependency`),
+  CONSTRAINT `job_dependencies_fk_child_job_id` FOREIGN KEY (`child_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_dependencies_fk_parent_job_id` FOREIGN KEY (`parent_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_locks`
+--
+CREATE TABLE `job_locks` (
+  `name` text NOT NULL,
+  `owner` integer NOT NULL,
+  `locked_by` integer NULL,
+  INDEX `job_locks_idx_locked_by` (`locked_by`),
+  INDEX `job_locks_idx_owner` (`owner`),
+  PRIMARY KEY (`name`, `owner`),
+  CONSTRAINT `job_locks_fk_locked_by` FOREIGN KEY (`locked_by`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_locks_fk_owner` FOREIGN KEY (`owner`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_networks`
+--
+CREATE TABLE `job_networks` (
+  `name` text NOT NULL,
+  `job_id` integer NOT NULL,
+  `vlan` integer NOT NULL,
+  INDEX `job_networks_idx_job_id` (`job_id`),
+  PRIMARY KEY (`name`, `job_id`),
+  CONSTRAINT `job_networks_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `gru_dependencies`
+--
+CREATE TABLE `gru_dependencies` (
+  `job_id` integer NOT NULL,
+  `gru_task_id` integer NOT NULL,
+  INDEX `gru_dependencies_idx_gru_task_id` (`gru_task_id`),
+  INDEX `gru_dependencies_idx_job_id` (`job_id`),
+  PRIMARY KEY (`job_id`, `gru_task_id`),
+  CONSTRAINT `gru_dependencies_fk_gru_task_id` FOREIGN KEY (`gru_task_id`) REFERENCES `gru_tasks` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `gru_dependencies_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_templates`
+--
+CREATE TABLE `job_templates` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `machine_id` integer NOT NULL,
+  `test_suite_id` integer NOT NULL,
+  `prio` integer NOT NULL,
+  `group_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_templates_idx_group_id` (`group_id`),
+  INDEX `job_templates_idx_machine_id` (`machine_id`),
+  INDEX `job_templates_idx_product_id` (`product_id`),
+  INDEX `job_templates_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `job_templates_product_id_machine_id_test_suite_id` (`product_id`, `machine_id`, `test_suite_id`),
+  CONSTRAINT `job_templates_fk_group_id` FOREIGN KEY (`group_id`) REFERENCES `job_groups` (`id`),
+  CONSTRAINT `job_templates_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `jobs_assets`
+--
+CREATE TABLE `jobs_assets` (
+  `job_id` integer NOT NULL,
+  `asset_id` integer NOT NULL,
+  `created_by` enum('0','1') NOT NULL DEFAULT '0',
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_assets_idx_asset_id` (`asset_id`),
+  INDEX `jobs_assets_idx_job_id` (`job_id`),
+  UNIQUE `jobs_assets_job_id_asset_id` (`job_id`, `asset_id`),
+  CONSTRAINT `jobs_assets_fk_asset_id` FOREIGN KEY (`asset_id`) REFERENCES `assets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `jobs_assets_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/upgrade/32-33/001-auto.sql
+++ b/dbicdh/MySQL/upgrade/32-33/001-auto.sql
@@ -1,0 +1,29 @@
+-- Convert schema '/home/adamw/openQA/script/../dbicdh/_source/deploy/32/001-auto.yml' to '/home/adamw/openQA/script/../dbicdh/_source/deploy/33/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+SET foreign_key_checks=0;
+
+;
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  INDEX gru_dependencies_idx_gru_task_id (gru_task_id),
+  INDEX gru_dependencies_idx_job_id (job_id),
+  PRIMARY KEY (job_id, gru_task_id),
+  CONSTRAINT gru_dependencies_fk_gru_task_id FOREIGN KEY (gru_task_id) REFERENCES gru_tasks (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT gru_dependencies_fk_job_id FOREIGN KEY (job_id) REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+
+;
+SET foreign_key_checks=1;
+
+;
+ALTER TABLE gru_tasks ENGINE=InnoDB;
+
+;
+
+COMMIT;
+

--- a/dbicdh/PostgreSQL/deploy/33/001-auto-__VERSION.sql
+++ b/dbicdh/PostgreSQL/deploy/33/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Fri Sep 25 18:00:12 2015
+-- 
+;
+--
+-- Table: dbix_class_deploymenthandler_versions.
+--
+CREATE TABLE "dbix_class_deploymenthandler_versions" (
+  "id" serial NOT NULL,
+  "version" character varying(50) NOT NULL,
+  "ddl" text,
+  "upgrade_sql" text,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "dbix_class_deploymenthandler_versions_version" UNIQUE ("version")
+);
+
+;

--- a/dbicdh/PostgreSQL/deploy/33/001-auto.sql
+++ b/dbicdh/PostgreSQL/deploy/33/001-auto.sql
@@ -1,0 +1,505 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Fri Sep 25 18:00:12 2015
+-- 
+;
+--
+-- Table: assets.
+--
+CREATE TABLE "assets" (
+  "id" serial NOT NULL,
+  "type" text NOT NULL,
+  "name" text NOT NULL,
+  "size" bigint,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "assets_type_name" UNIQUE ("type", "name")
+);
+
+;
+--
+-- Table: gru_tasks.
+--
+CREATE TABLE "gru_tasks" (
+  "id" serial NOT NULL,
+  "taskname" text NOT NULL,
+  "args" text NOT NULL,
+  "run_at" timestamp NOT NULL,
+  "priority" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+;
+--
+-- Table: job_groups.
+--
+CREATE TABLE "job_groups" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "size_limit_gb" integer DEFAULT 100 NOT NULL,
+  "keep_logs_in_days" integer DEFAULT 30 NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "job_groups_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: job_modules.
+--
+CREATE TABLE "job_modules" (
+  "id" serial NOT NULL,
+  "job_id" integer NOT NULL,
+  "name" text NOT NULL,
+  "script" text NOT NULL,
+  "category" text NOT NULL,
+  "soft_failure" integer DEFAULT 0 NOT NULL,
+  "milestone" integer DEFAULT 0 NOT NULL,
+  "important" integer DEFAULT 0 NOT NULL,
+  "fatal" integer DEFAULT 0 NOT NULL,
+  "result" character varying DEFAULT 'none' NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_modules_idx_job_id" on "job_modules" ("job_id");
+CREATE INDEX "idx_job_modules_result" on "job_modules" ("result");
+
+;
+--
+-- Table: job_settings.
+--
+CREATE TABLE "job_settings" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "job_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_settings_idx_job_id" on "job_settings" ("job_id");
+
+;
+--
+-- Table: machine_settings.
+--
+CREATE TABLE "machine_settings" (
+  "id" serial NOT NULL,
+  "machine_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machine_settings_machine_id_key" UNIQUE ("machine_id", "key")
+);
+CREATE INDEX "machine_settings_idx_machine_id" on "machine_settings" ("machine_id");
+
+;
+--
+-- Table: machines.
+--
+CREATE TABLE "machines" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "backend" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machines_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: product_settings.
+--
+CREATE TABLE "product_settings" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "product_settings_product_id_key" UNIQUE ("product_id", "key")
+);
+CREATE INDEX "product_settings_idx_product_id" on "product_settings" ("product_id");
+
+;
+--
+-- Table: products.
+--
+CREATE TABLE "products" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "distri" text NOT NULL,
+  "version" text DEFAULT '' NOT NULL,
+  "arch" text NOT NULL,
+  "flavor" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "products_distri_version_arch_flavor" UNIQUE ("distri", "version", "arch", "flavor")
+);
+
+;
+--
+-- Table: secrets.
+--
+CREATE TABLE "secrets" (
+  "id" serial NOT NULL,
+  "secret" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "secrets_secret" UNIQUE ("secret")
+);
+
+;
+--
+-- Table: test_suite_settings.
+--
+CREATE TABLE "test_suite_settings" (
+  "id" serial NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suite_settings_test_suite_id_key" UNIQUE ("test_suite_id", "key")
+);
+CREATE INDEX "test_suite_settings_idx_test_suite_id" on "test_suite_settings" ("test_suite_id");
+
+;
+--
+-- Table: test_suites.
+--
+CREATE TABLE "test_suites" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suites_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: users.
+--
+CREATE TABLE "users" (
+  "id" serial NOT NULL,
+  "username" text NOT NULL,
+  "email" text,
+  "fullname" text,
+  "nickname" text,
+  "is_operator" integer DEFAULT 0 NOT NULL,
+  "is_admin" integer DEFAULT 0 NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "users_username" UNIQUE ("username")
+);
+
+;
+--
+-- Table: worker_properties.
+--
+CREATE TABLE "worker_properties" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "worker_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "worker_properties_idx_worker_id" on "worker_properties" ("worker_id");
+
+;
+--
+-- Table: workers.
+--
+CREATE TABLE "workers" (
+  "id" serial NOT NULL,
+  "host" text NOT NULL,
+  "instance" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "workers_host_instance" UNIQUE ("host", "instance")
+);
+
+;
+--
+-- Table: api_keys.
+--
+CREATE TABLE "api_keys" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "secret" text NOT NULL,
+  "user_id" integer NOT NULL,
+  "t_expiration" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "api_keys_key" UNIQUE ("key")
+);
+CREATE INDEX "api_keys_idx_user_id" on "api_keys" ("user_id");
+
+;
+--
+-- Table: comments.
+--
+CREATE TABLE "comments" (
+  "id" serial NOT NULL,
+  "job_id" integer,
+  "group_id" integer,
+  "text" text NOT NULL,
+  "user_id" integer NOT NULL,
+  "hidden" boolean DEFAULT '0' NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "comments_idx_group_id" on "comments" ("group_id");
+CREATE INDEX "comments_idx_job_id" on "comments" ("job_id");
+CREATE INDEX "comments_idx_user_id" on "comments" ("user_id");
+
+;
+--
+-- Table: jobs.
+--
+CREATE TABLE "jobs" (
+  "id" serial NOT NULL,
+  "slug" text,
+  "result_dir" text,
+  "state" character varying DEFAULT 'scheduled' NOT NULL,
+  "priority" integer DEFAULT 50 NOT NULL,
+  "result" character varying DEFAULT 'none' NOT NULL,
+  "worker_id" integer DEFAULT 0 NOT NULL,
+  "test" text NOT NULL,
+  "clone_id" integer,
+  "retry_avbl" integer DEFAULT 3 NOT NULL,
+  "backend" character varying,
+  "backend_info" text,
+  "group_id" integer,
+  "t_started" timestamp,
+  "t_finished" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "jobs_slug" UNIQUE ("slug")
+);
+CREATE INDEX "jobs_idx_clone_id" on "jobs" ("clone_id");
+CREATE INDEX "jobs_idx_group_id" on "jobs" ("group_id");
+CREATE INDEX "jobs_idx_worker_id" on "jobs" ("worker_id");
+CREATE INDEX "idx_jobs_state" on "jobs" ("state");
+CREATE INDEX "idx_jobs_result" on "jobs" ("result");
+
+;
+--
+-- Table: job_dependencies.
+--
+CREATE TABLE "job_dependencies" (
+  "child_job_id" integer NOT NULL,
+  "parent_job_id" integer NOT NULL,
+  "dependency" integer NOT NULL,
+  PRIMARY KEY ("child_job_id", "parent_job_id", "dependency")
+);
+CREATE INDEX "job_dependencies_idx_child_job_id" on "job_dependencies" ("child_job_id");
+CREATE INDEX "job_dependencies_idx_parent_job_id" on "job_dependencies" ("parent_job_id");
+CREATE INDEX "idx_job_dependencies_dependency" on "job_dependencies" ("dependency");
+
+;
+--
+-- Table: job_locks.
+--
+CREATE TABLE "job_locks" (
+  "name" text NOT NULL,
+  "owner" integer NOT NULL,
+  "locked_by" integer,
+  PRIMARY KEY ("name", "owner")
+);
+CREATE INDEX "job_locks_idx_locked_by" on "job_locks" ("locked_by");
+CREATE INDEX "job_locks_idx_owner" on "job_locks" ("owner");
+
+;
+--
+-- Table: job_networks.
+--
+CREATE TABLE "job_networks" (
+  "name" text NOT NULL,
+  "job_id" integer NOT NULL,
+  "vlan" integer NOT NULL,
+  PRIMARY KEY ("name", "job_id")
+);
+CREATE INDEX "job_networks_idx_job_id" on "job_networks" ("job_id");
+
+;
+--
+-- Table: gru_dependencies.
+--
+CREATE TABLE "gru_dependencies" (
+  "job_id" integer NOT NULL,
+  "gru_task_id" integer NOT NULL,
+  PRIMARY KEY ("job_id", "gru_task_id")
+);
+CREATE INDEX "gru_dependencies_idx_gru_task_id" on "gru_dependencies" ("gru_task_id");
+CREATE INDEX "gru_dependencies_idx_job_id" on "gru_dependencies" ("job_id");
+
+;
+--
+-- Table: job_templates.
+--
+CREATE TABLE "job_templates" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "machine_id" integer NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "prio" integer NOT NULL,
+  "group_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "job_templates_product_id_machine_id_test_suite_id" UNIQUE ("product_id", "machine_id", "test_suite_id")
+);
+CREATE INDEX "job_templates_idx_group_id" on "job_templates" ("group_id");
+CREATE INDEX "job_templates_idx_machine_id" on "job_templates" ("machine_id");
+CREATE INDEX "job_templates_idx_product_id" on "job_templates" ("product_id");
+CREATE INDEX "job_templates_idx_test_suite_id" on "job_templates" ("test_suite_id");
+
+;
+--
+-- Table: jobs_assets.
+--
+CREATE TABLE "jobs_assets" (
+  "job_id" integer NOT NULL,
+  "asset_id" integer NOT NULL,
+  "created_by" boolean DEFAULT '0' NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  CONSTRAINT "jobs_assets_job_id_asset_id" UNIQUE ("job_id", "asset_id")
+);
+CREATE INDEX "jobs_assets_idx_asset_id" on "jobs_assets" ("asset_id");
+CREATE INDEX "jobs_assets_idx_job_id" on "jobs_assets" ("job_id");
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE "job_modules" ADD CONSTRAINT "job_modules_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_settings" ADD CONSTRAINT "job_settings_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "machine_settings" ADD CONSTRAINT "machine_settings_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "product_settings" ADD CONSTRAINT "product_settings_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "test_suite_settings" ADD CONSTRAINT "test_suite_settings_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "worker_properties" ADD CONSTRAINT "worker_properties_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "comments" ADD CONSTRAINT "comments_fk_group_id" FOREIGN KEY ("group_id")
+  REFERENCES "job_groups" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "comments" ADD CONSTRAINT "comments_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "comments" ADD CONSTRAINT "comments_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_clone_id" FOREIGN KEY ("clone_id")
+  REFERENCES "jobs" ("id") ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_group_id" FOREIGN KEY ("group_id")
+  REFERENCES "job_groups" ("id") ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_child_job_id" FOREIGN KEY ("child_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_parent_job_id" FOREIGN KEY ("parent_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_locked_by" FOREIGN KEY ("locked_by")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_owner" FOREIGN KEY ("owner")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_networks" ADD CONSTRAINT "job_networks_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "gru_dependencies" ADD CONSTRAINT "gru_dependencies_fk_gru_task_id" FOREIGN KEY ("gru_task_id")
+  REFERENCES "gru_tasks" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "gru_dependencies" ADD CONSTRAINT "gru_dependencies_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_group_id" FOREIGN KEY ("group_id")
+  REFERENCES "job_groups" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_asset_id" FOREIGN KEY ("asset_id")
+  REFERENCES "assets" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;

--- a/dbicdh/PostgreSQL/upgrade/32-33/001-auto.sql
+++ b/dbicdh/PostgreSQL/upgrade/32-33/001-auto.sql
@@ -1,0 +1,26 @@
+-- Convert schema '/home/adamw/openQA/script/../dbicdh/_source/deploy/32/001-auto.yml' to '/home/adamw/openQA/script/../dbicdh/_source/deploy/33/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id)
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id on gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id on gru_dependencies (job_id);
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_gru_task_id FOREIGN KEY (gru_task_id)
+  REFERENCES gru_tasks (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+
+COMMIT;
+

--- a/dbicdh/SQLite/deploy/33/001-auto-__VERSION.sql
+++ b/dbicdh/SQLite/deploy/33/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Fri Sep 25 18:00:12 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id INTEGER PRIMARY KEY NOT NULL,
+  version varchar(50) NOT NULL,
+  ddl text,
+  upgrade_sql text
+);
+CREATE UNIQUE INDEX dbix_class_deploymenthandler_versions_version ON dbix_class_deploymenthandler_versions (version);
+COMMIT;

--- a/dbicdh/SQLite/deploy/33/001-auto.sql
+++ b/dbicdh/SQLite/deploy/33/001-auto.sql
@@ -1,0 +1,358 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Fri Sep 25 18:00:12 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  size bigint,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX assets_type_name ON assets (type, name);
+--
+-- Table: gru_tasks
+--
+CREATE TABLE gru_tasks (
+  id INTEGER PRIMARY KEY NOT NULL,
+  taskname text NOT NULL,
+  args text NOT NULL,
+  run_at datetime NOT NULL,
+  priority integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+--
+-- Table: job_groups
+--
+CREATE TABLE job_groups (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  size_limit_gb integer NOT NULL DEFAULT 100,
+  keep_logs_in_days integer NOT NULL DEFAULT 30,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX job_groups_name ON job_groups (name);
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  soft_failure integer NOT NULL DEFAULT 0,
+  milestone integer NOT NULL DEFAULT 0,
+  important integer NOT NULL DEFAULT 0,
+  fatal integer NOT NULL DEFAULT 0,
+  result varchar NOT NULL DEFAULT 'none',
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_modules_idx_job_id ON job_modules (job_id);
+CREATE INDEX idx_job_modules_result ON job_modules (result);
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_settings_idx_job_id ON job_settings (job_id);
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX machine_settings_idx_machine_id ON machine_settings (machine_id);
+CREATE UNIQUE INDEX machine_settings_machine_id_key ON machine_settings (machine_id, key);
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX machines_name ON machines (name);
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX product_settings_idx_product_id ON product_settings (product_id);
+CREATE UNIQUE INDEX product_settings_product_id_key ON product_settings (product_id, key);
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX products_distri_version_arch_flavor ON products (distri, version, arch, flavor);
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX secrets_secret ON secrets (secret);
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id ON test_suite_settings (test_suite_id);
+CREATE UNIQUE INDEX test_suite_settings_test_suite_id_key ON test_suite_settings (test_suite_id, key);
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX test_suites_name ON test_suites (name);
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY NOT NULL,
+  username text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX users_username ON users (username);
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX worker_properties_idx_worker_id ON worker_properties (worker_id);
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX workers_host_instance ON workers (host, instance);
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX api_keys_idx_user_id ON api_keys (user_id);
+CREATE UNIQUE INDEX api_keys_key ON api_keys (key);
+--
+-- Table: comments
+--
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer,
+  group_id integer,
+  text text NOT NULL,
+  user_id integer NOT NULL,
+  hidden boolean NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX comments_idx_group_id ON comments (group_id);
+CREATE INDEX comments_idx_job_id ON comments (job_id);
+CREATE INDEX comments_idx_user_id ON comments (user_id);
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  slug text,
+  result_dir text,
+  state varchar NOT NULL DEFAULT 'scheduled',
+  priority integer NOT NULL DEFAULT 50,
+  result varchar NOT NULL DEFAULT 'none',
+  worker_id integer NOT NULL DEFAULT 0,
+  test text NOT NULL,
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  backend varchar,
+  backend_info text,
+  group_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE
+);
+CREATE INDEX jobs_idx_clone_id ON jobs (clone_id);
+CREATE INDEX jobs_idx_group_id ON jobs (group_id);
+CREATE INDEX jobs_idx_worker_id ON jobs (worker_id);
+CREATE INDEX idx_jobs_state ON jobs (state);
+CREATE INDEX idx_jobs_result ON jobs (result);
+CREATE UNIQUE INDEX jobs_slug ON jobs (slug);
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency),
+  FOREIGN KEY (child_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (parent_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_dependencies_idx_child_job_id ON job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id ON job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency ON job_dependencies (dependency);
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by integer,
+  PRIMARY KEY (name, owner),
+  FOREIGN KEY (locked_by) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (owner) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_locks_idx_locked_by ON job_locks (locked_by);
+CREATE INDEX job_locks_idx_owner ON job_locks (owner);
+--
+-- Table: job_networks
+--
+CREATE TABLE job_networks (
+  name text NOT NULL,
+  job_id integer NOT NULL,
+  vlan integer NOT NULL,
+  PRIMARY KEY (name, job_id),
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_networks_idx_job_id ON job_networks (job_id);
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id),
+  FOREIGN KEY (gru_task_id) REFERENCES gru_tasks(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id ON gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id ON gru_dependencies (job_id);
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  prio integer NOT NULL,
+  group_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id),
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_templates_idx_group_id ON job_templates (group_id);
+CREATE INDEX job_templates_idx_machine_id ON job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id ON job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id ON job_templates (test_suite_id);
+CREATE UNIQUE INDEX job_templates_product_id_machine_id_test_suite_id ON job_templates (product_id, machine_id, test_suite_id);
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  created_by boolean NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_assets_idx_asset_id ON jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id ON jobs_assets (job_id);
+CREATE UNIQUE INDEX jobs_assets_job_id_asset_id ON jobs_assets (job_id, asset_id);
+COMMIT;

--- a/dbicdh/SQLite/upgrade/32-33/001-auto.sql
+++ b/dbicdh/SQLite/upgrade/32-33/001-auto.sql
@@ -1,0 +1,24 @@
+-- Convert schema '/home/adamw/openQA/script/../dbicdh/_source/deploy/32/001-auto.yml' to '/home/adamw/openQA/script/../dbicdh/_source/deploy/33/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id),
+  FOREIGN KEY (gru_task_id) REFERENCES gru_tasks(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX gru_dependencies_idx_gru_task_id ON gru_dependencies (gru_task_id);
+
+;
+CREATE INDEX gru_dependencies_idx_job_id ON gru_dependencies (job_id);
+
+;
+
+COMMIT;
+

--- a/dbicdh/_source/deploy/33/001-auto-__VERSION.yml
+++ b/dbicdh/_source/deploy/33/001-auto-__VERSION.yml
@@ -1,0 +1,92 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11020

--- a/dbicdh/_source/deploy/33/001-auto.yml
+++ b/dbicdh/_source/deploy/33/001-auto.yml
@@ -1,0 +1,2740 @@
+---
+schema:
+  procedures: {}
+  tables:
+    api_keys:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - key
+          match_type: ''
+          name: api_keys_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: api_keys_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 2
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: secret
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_expiration:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_expiration
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: api_keys_idx_user_id
+          options: []
+          type: NORMAL
+      name: api_keys
+      options: []
+      order: 16
+    assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - type
+            - name
+          match_type: ''
+          name: assets_type_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        type:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: type
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: assets
+      options: []
+      order: 1
+    comments:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: comments_fk_group_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: comments_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: comments_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 3
+          size:
+            - 0
+        hidden:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: hidden
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        text:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: text
+          order: 4
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: comments_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: comments_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - user_id
+          name: comments_idx_user_id
+          options: []
+          type: NORMAL
+      name: comments
+      options: []
+      order: 17
+    gru_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - gru_task_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - gru_task_id
+          match_type: ''
+          name: gru_dependencies_fk_gru_task_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: gru_tasks
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: gru_dependencies_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        gru_task_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: gru_task_id
+          order: 2
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - gru_task_id
+          name: gru_dependencies_idx_gru_task_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: gru_dependencies_idx_job_id
+          options: []
+          type: NORMAL
+      name: gru_dependencies
+      options: []
+      order: 22
+    gru_tasks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        args:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: args
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        run_at:
+          data_type: datetime
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: run_at
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        taskname:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: taskname
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: gru_tasks
+      options: []
+      order: 2
+    job_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+            - parent_job_id
+            - dependency
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+          match_type: ''
+          name: job_dependencies_fk_child_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_job_id
+          match_type: ''
+          name: job_dependencies_fk_parent_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        child_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: child_job_id
+          order: 1
+          size:
+            - 0
+        dependency:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: dependency
+          order: 3
+          size:
+            - 0
+        parent_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: parent_job_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - child_job_id
+          name: job_dependencies_idx_child_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_job_id
+          name: job_dependencies_idx_parent_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - dependency
+          name: idx_job_dependencies_dependency
+          options: []
+          type: NORMAL
+      name: job_dependencies
+      options: []
+      order: 19
+    job_groups:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: job_groups_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        keep_logs_in_days:
+          data_type: integer
+          default_value: 30
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_logs_in_days
+          order: 4
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        size_limit_gb:
+          data_type: integer
+          default_value: 100
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: size_limit_gb
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices: []
+      name: job_groups
+      options: []
+      order: 3
+    job_locks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - owner
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - locked_by
+          match_type: ''
+          name: job_locks_fk_locked_by
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - owner
+          match_type: ''
+          name: job_locks_fk_owner
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        locked_by:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: locked_by
+          order: 3
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        owner:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: owner
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - locked_by
+          name: job_locks_idx_locked_by
+          options: []
+          type: NORMAL
+        - fields:
+            - owner
+          name: job_locks_idx_owner
+          options: []
+          type: NORMAL
+      name: job_locks
+      options: []
+      order: 20
+    job_modules:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_modules_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        category:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: category
+          order: 5
+          size:
+            - 0
+        fatal:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: fatal
+          order: 9
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        important:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: important
+          order: 8
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        milestone:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: milestone
+          order: 7
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 10
+          size:
+            - 0
+        script:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: script
+          order: 4
+          size:
+            - 0
+        soft_failure:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: soft_failure
+          order: 6
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 12
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_modules_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_job_modules_result
+          options: []
+          type: NORMAL
+      name: job_modules
+      options: []
+      order: 4
+    job_networks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - job_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_networks_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        vlan:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: vlan
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_networks_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_networks
+      options: []
+      order: 21
+    job_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_settings_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 4
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_settings_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_settings
+      options: []
+      order: 5
+    job_templates:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - machine_id
+            - test_suite_id
+          match_type: ''
+          name: job_templates_product_id_machine_id_test_suite_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: job_templates_fk_group_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: job_templates_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: job_templates_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: job_templates_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 3
+          size:
+            - 0
+        prio:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: prio
+          order: 5
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: job_templates_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - machine_id
+          name: job_templates_idx_machine_id
+          options: []
+          type: NORMAL
+        - fields:
+            - product_id
+          name: job_templates_idx_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - test_suite_id
+          name: job_templates_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: job_templates
+      options: []
+      order: 23
+    jobs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - slug
+          match_type: ''
+          name: jobs_slug
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - clone_id
+          match_type: ''
+          name: jobs_fk_clone_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: jobs_fk_group_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: jobs_fk_worker_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        backend:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 11
+          size:
+            - 0
+        backend_info:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend_info
+          order: 12
+          size:
+            - 0
+        clone_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: clone_id
+          order: 9
+          size:
+            - 0
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 13
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: 50
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 6
+          size:
+            - 0
+        result_dir:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: result_dir
+          order: 3
+          size:
+            - 0
+        retry_avbl:
+          data_type: integer
+          default_value: 3
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: retry_avbl
+          order: 10
+          size:
+            - 0
+        slug:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: slug
+          order: 2
+          size:
+            - 0
+        state:
+          data_type: varchar
+          default_value: scheduled
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: state
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 16
+          size:
+            - 0
+        t_finished:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_finished
+          order: 15
+          size:
+            - 0
+        t_started:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_started
+          order: 14
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 17
+          size:
+            - 0
+        test:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: test
+          order: 8
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 7
+          size:
+            - 0
+      indices:
+        - fields:
+            - clone_id
+          name: jobs_idx_clone_id
+          options: []
+          type: NORMAL
+        - fields:
+            - group_id
+          name: jobs_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - worker_id
+          name: jobs_idx_worker_id
+          options: []
+          type: NORMAL
+        - fields:
+            - state
+          name: idx_jobs_state
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_jobs_result
+          options: []
+          type: NORMAL
+      name: jobs
+      options: []
+      order: 18
+    jobs_assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - asset_id
+          match_type: ''
+          name: jobs_assets_job_id_asset_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - asset_id
+          match_type: ''
+          name: jobs_assets_fk_asset_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: assets
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: jobs_assets_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        asset_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: asset_id
+          order: 2
+          size:
+            - 0
+        created_by:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: created_by
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - asset_id
+          name: jobs_assets_idx_asset_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: jobs_assets_idx_job_id
+          options: []
+          type: NORMAL
+      name: jobs_assets
+      options: []
+      order: 24
+    machine_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+            - key
+          match_type: ''
+          name: machine_settings_machine_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: machine_settings_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: machine_settings_idx_machine_id
+          options: []
+          type: NORMAL
+      name: machine_settings
+      options: []
+      order: 6
+    machines:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: machines_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: machines
+      options: []
+      order: 7
+    product_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - key
+          match_type: ''
+          name: product_settings_product_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: product_settings_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - product_id
+          name: product_settings_idx_product_id
+          options: []
+          type: NORMAL
+      name: product_settings
+      options: []
+      order: 8
+    products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - distri
+            - version
+            - arch
+            - flavor
+          match_type: ''
+          name: products_distri_version_arch_flavor
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        arch:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: arch
+          order: 5
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: distri
+          order: 3
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: flavor
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 7
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: products
+      options: []
+      order: 9
+    secrets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - secret
+          match_type: ''
+          name: secrets_secret
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: secret
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: secrets
+      options: []
+      order: 10
+    test_suite_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+            - key
+          match_type: ''
+          name: test_suite_settings_test_suite_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: test_suite_settings_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 2
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - test_suite_id
+          name: test_suite_settings_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: test_suite_settings
+      options: []
+      order: 11
+    test_suites:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: test_suites_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: test_suites
+      options: []
+      order: 12
+    users:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - username
+          match_type: ''
+          name: users_username
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        email:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: email
+          order: 3
+          size:
+            - 0
+        fullname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: fullname
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        is_admin:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_admin
+          order: 7
+          size:
+            - 0
+        is_operator:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_operator
+          order: 6
+          size:
+            - 0
+        nickname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: nickname
+          order: 5
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        username:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: username
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: users
+      options: []
+      order: 13
+    worker_properties:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: worker_properties_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: worker_properties_idx_worker_id
+          options: []
+          type: NORMAL
+      name: worker_properties
+      options: []
+      order: 14
+    workers:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - host
+            - instance
+          match_type: ''
+          name: workers_host_instance
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        host:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: host
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        instance:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: instance
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices: []
+      name: workers
+      options: []
+      order: 15
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - ApiKeys
+      - Assets
+      - Comments
+      - GruDependencies
+      - GruTasks
+      - JobDependencies
+      - JobGroups
+      - JobLocks
+      - JobModules
+      - JobNetworks
+      - JobSettings
+      - JobTemplates
+      - Jobs
+      - JobsAssets
+      - MachineSettings
+      - Machines
+      - ProductSettings
+      - Products
+      - Secrets
+      - TestSuiteSettings
+      - TestSuites
+      - Users
+      - WorkerProperties
+      - Workers
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11020

--- a/lib/OpenQA/Schema/Result/GruDependencies.pm
+++ b/lib/OpenQA/Schema/Result/GruDependencies.pm
@@ -1,0 +1,44 @@
+# Copyright (C) 2015 SUSE LLC
+# Copyright (C) 2015 Red Hat
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Entries in this table are transient; when a job that depends on a
+# gru task is created a row should be added here, when the task
+# completes, the entry will be deleted.
+
+package OpenQA::Schema::Result::GruDependencies;
+use base qw/DBIx::Class::Core/;
+
+use db_helpers;
+
+__PACKAGE__->table('gru_dependencies');
+__PACKAGE__->add_columns(
+    job_id => {
+        data_type      => 'integer',
+        is_foreign_key => 1,
+    },
+    gru_task_id => {
+        data_type      => 'integer',
+        is_foreign_key => 1,
+    },
+);
+
+__PACKAGE__->set_primary_key('job_id', 'gru_task_id');
+
+__PACKAGE__->belongs_to(job      => 'OpenQA::Schema::Result::Jobs',     'job_id');
+__PACKAGE__->belongs_to(gru_task => 'OpenQA::Schema::Result::GruTasks', 'gru_task_id');
+
+1;

--- a/lib/OpenQA/Schema/Result/GruTasks.pm
+++ b/lib/OpenQA/Schema/Result/GruTasks.pm
@@ -47,6 +47,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 
+__PACKAGE__->has_many(jobs => 'OpenQA::Schema::Result::GruDependencies', 'gru_task_id');
+
 __PACKAGE__->filter_column(
     args => {
         filter_to_storage   => 'encode_json_to_db',

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -149,6 +149,8 @@ __PACKAGE__->has_many(comments     => 'OpenQA::Schema::Result::Comments', 'job_i
 
 __PACKAGE__->has_many(networks => 'OpenQA::Schema::Result::JobNetworks', 'job_id');
 
+__PACKAGE__->has_many(gru_dependencies => 'OpenQA::Schema::Result::GruDependencies', 'job_id');
+
 __PACKAGE__->add_unique_constraint([qw/slug/]);
 
 __PACKAGE__->filter_column(

--- a/lib/OpenQA/Schema/Schema.pm
+++ b/lib/OpenQA/Schema/Schema.pm
@@ -23,7 +23,7 @@ use FindBin qw($Bin);
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION = 32;
+our $VERSION = 33;
 
 __PACKAGE__->load_namespaces;
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -494,6 +494,7 @@ sub startup {
     $self->gru->add_task(optipng       => \&OpenQA::Schema::Result::Jobs::optipng);
     $self->gru->add_task(reduce_result => \&OpenQA::Schema::Result::Jobs::reduce_result);
     $self->gru->add_task(limit_assets  => \&OpenQA::Schema::Result::Assets::limit_assets);
+    $self->gru->add_task(download_iso  => \&OpenQA::Schema::Result::Assets::download_iso);
 
     # start workers checker
     $self->_workers_checker;

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -44,6 +44,14 @@
                     % } else
                     % {
                         State:<%= $job->state %>
+                        % if (scalar($job->gru_dependencies) > 0) {
+                            % my $grutext = '';
+                            % for my $grudep ($job->gru_dependencies) {
+                                % $grutext .= join(",", $grudep->gru_task->id, $grudep->gru_task->taskname);
+                                % $grutext .= " ";
+                            % }
+                            waiting for background (GRU) tasks: <%= $grutext %>
+                        % }
                     % }
                     % if ($job->t_finished) {
                         finished


### PR DESCRIPTION
This is an extremely stupid PoC implementation; it blocks the
POST request until the download is done, which likely isn't
what we want. But for some value of 'work', it does work: when
I tried it, the 'client' command returned some ERROR, but the
ISO was downloaded and the job scheduled and ran successfully.

I think a sane implementation might use this 'GRU' thing I'm
now trying to grok. It might look something like 'create the
jobs, tell the GRU to download the ISO and notify workers when
it's done, return job IDs'. It occurs to me that might be
rather racy, though - if any other job-create-y type thing
happens while the ISO is downloading, workers will presumably
try and pick up the jobs and Bad Stuff will happen.

Perhaps jobs should have some kind of 'not ready yet' attribute
which workers could look for, and skip if it's set? Perhaps
they already do and I don't know about it?

This is probably also some kind of security hole if you don't
trust people who are authorized to run POSTs, but I think the
design is broadly that only trusted people should be allowed
to do that.

Comments welcome!

edit: further thoughts: a proper implementation would of course also check if the ISO is already downloaded and skip the download if so, and I'd also want it to allow specifying a target name (because Fedora has hilarious collisions for `boot.iso`); have to figure the best way to allow that. If the way to do this is through the GRU, it should also presumably be able to delete the jobs if it can't manage to download the ISO.