### PR TITLE
preprocess hdd image names

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -358,6 +358,25 @@ Few important examples:
    emulated USB stick.
 ** +SMP+ enables smp when set to 1, disables when set to 0.
 
+Variable expansion
+~~~~~~~~~~~~~~~~~~
+Any variable defined in Test Suite, Machine or Product table can refer to another
+variable using this syntax: %NAME%
+
+For example this variable defined for Test Suite:
+
+[source,sh]
+--------------------------------------------------------------------------------
+PUBLISH_HDD_1 = %DISTRI%-%VERSION%-%ARCH%-%DESKTOP%.qcow2
+--------------------------------------------------------------------------------
+
+is expanded to this job variable:
+
+[source,sh]
+--------------------------------------------------------------------------------
+PUBLISH_HDD_1 = opensuse-13.1-i586-kde.qcow2
+--------------------------------------------------------------------------------
+
 Testing openSUSE
 ----------------
 

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -1122,6 +1122,7 @@ sub _generate_jobs {
                         my $replace_var = $1;
                         $replace_var =~ s/^%(\w+)%$/$1/;
                         my $replace_val = $settings{$replace_var};
+                        next unless defined $replace_val;
                         $replace_val = '' if $replace_var eq $var;    #stop infinite recursion
                         $val =~ s/%${replace_var}%/$replace_val/g;
                         $settings{$var} = $val;

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -1112,6 +1112,24 @@ sub _generate_jobs {
             $settings{PRIO}     = $job_template->prio;
             $settings{GROUP_ID} = $job_template->group_id;
 
+            # variable expansion
+            # replace %NAME% with $settings{NAME}
+            my $expanded;
+            do {
+                $expanded = 0;
+                for my $var (keys %settings) {
+                    if ((my $val = $settings{$var}) =~ /(%\w+%)/) {
+                        my $replace_var = $1;
+                        $replace_var =~ s/^%(\w+)%$/$1/;
+                        my $replace_val = $settings{$replace_var};
+                        $replace_val = '' if $replace_var eq $var;    #stop infinite recursion
+                        $val =~ s/%${replace_var}%/$replace_val/g;
+                        $settings{$var} = $val;
+                        $expanded = 1;
+                    }
+                }
+            } while ($expanded);
+
             push @$ret, \%settings;
         }
     }

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -137,6 +137,9 @@ is_deeply($advanced_kde_64->{parents}, {Parallel => [], Chained => [$kde_64->{id
 is($server_32->{group_id}, 1001, 'server_32 part of opensuse group');
 is($server_64->{group_id}, 1001, 'server_64 part of opensuse group');
 
+is($advanced_kde_32->{settings}->{PUBLISH_HDD_1}, 'opensuse-13.1-i586-kde-qemu32.qcow2', "variable expansion");
+is($advanced_kde_64->{settings}->{PUBLISH_HDD_1}, 'opensuse-13.1-i586-kde-qemu64.qcow2', "variable expansion");
+
 lj;
 
 # check that the old tests are cancelled

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -133,6 +133,10 @@ is_deeply(
                         'value' => 'kde'
                     },
                     {
+                        'key'   => 'PUBLISH_HDD_1',
+                        'value' => '%DISTRI%-%VERSION%-%ARCH%-%DESKTOP%-%QEMUCPU%.qcow2'
+                    },
+                    {
                         'key'   => 'START_AFTER_TEST',
                         'value' => 'kde,textmode'
                     }]}]

--- a/t/fixtures/04-products.pl
+++ b/t/fixtures/04-products.pl
@@ -68,7 +68,7 @@
         id => 1017,
         name => "advanced_kde",
         variables => '',
-        settings => [{ key => "DESKTOP", value => "kde" }, { key => "START_AFTER_TEST", value => "kde,textmode" }],
+        settings => [{ key => "DESKTOP", value => "kde" }, { key => "START_AFTER_TEST", value => "kde,textmode" }, { key => "PUBLISH_HDD_1", value => "%DISTRI%-%VERSION%-%ARCH%-%DESKTOP%-%QEMUCPU%.qcow2" }],
     },
     Products => {
 		 name => '',


### PR DESCRIPTION
This allows easy building of images with naming scheme
distribution-architecture-variant.qcow2
which was requested by Eric for slenkins.


