### PR TITLE
Query job ids

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -292,6 +292,12 @@ sub _job_get($) {
 
 sub query_jobs {
     my %args = @_;
+    # For args where we accept a list of values, allow passing either an
+    # array ref or a comma-separated list
+    for my $arg (qw/state ids/) {
+        next unless $args{$arg};
+        $args{$arg} = [split(',', $args{$arg})] unless (ref($args{$arg}) eq 'ARRAY');
+    }
 
     my @conds;
     my %attrs;
@@ -304,7 +310,7 @@ sub query_jobs {
     }
 
     if ($args{state}) {
-        push(@conds, {'me.state' => [split(',', $args{state})]});
+        push(@conds, {'me.state' => $args{state}});
     }
     if ($args{maxage}) {
         my $agecond = {'>' => time2str('%Y-%m-%d %H:%M:%S', time - $args{maxage}, 'UTC')};

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -23,7 +23,7 @@ sub list {
     my $self = shift;
 
     my %args;
-    for my $arg (qw/state build iso distri version flavor maxage scope group limit/) {
+    for my $arg (qw/state build iso distri version flavor maxage scope group limit ids/) {
         next unless defined $self->param($arg);
         $args{$arg} = $self->param($arg);
     }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -23,9 +23,23 @@ sub list {
     my $self = shift;
 
     my %args;
-    for my $arg (qw/state build iso distri version flavor maxage scope group limit ids/) {
+    for my $arg (qw/build iso distri version flavor maxage scope group limit/) {
         next unless defined $self->param($arg);
         $args{$arg} = $self->param($arg);
+    }
+    # For these, we accept a single value, a single instance of the arg
+    # with a comma-separated list of values, or multiple instances of the
+    # arg. In all cases we're going to convert to an array ref of values:
+    # we could let query_jobs do the string splitting for us, but this is
+    # clearer.
+    for my $arg (qw/state ids/) {
+        next unless defined $self->param($arg);
+        if (index($self->param($arg), ',') != -1) {
+            $args{$arg} = [split(',', $self->param($arg))];
+        }
+        else {
+            $args{$arg} = $self->every_param($arg);
+        }
     }
 
     # TODO: convert to DBus call or move query_jobs helper to WebAPI

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -28,7 +28,7 @@ use OpenQA::Test::Database;
 use Net::DBus;
 use Net::DBus::Test::MockObject;
 
-use Test::More tests => 52;
+use Test::More tests => 54;
 
 my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
@@ -239,6 +239,14 @@ is_deeply($current_jobs, [$jobs->[1]], "list_jobs combining two settings (ISO an
 %args = (build => "whatever.iso", iso => "666");
 $current_jobs = list_jobs(%args);
 is_deeply($current_jobs, [], "list_jobs messing two settings up");
+
+%args = (ids => [1, 2], state => ["scheduled", "done"]);
+$current_jobs = list_jobs(%args);
+is_deeply($current_jobs, $jobs, "jobs with specified IDs and states (array ref)");
+
+%args = (ids => "2,3", state => "scheduled,done");
+$current_jobs = list_jobs(%args);
+is_deeply($current_jobs, [$jobs->[0]], "jobs with specified IDs (comma list)");
 
 # Testing job_grab
 %args = (workerid => $worker->{id},);


### PR DESCRIPTION
The main thing I wanted to do here was allow for specifying job IDs when searching. Sometimes we just want to query some specific set of jobs; this lets us do it with one query instead of running a single query for each job.

While I was working on it I noticed there's kind of an inconsistency in how `query_jobs()` handles args which can be lists of values (`ids` and `state`, for now). For `state` it expects a comma-separated list, but for `ids` it expects (I think) an array reference. I thought it would be a good idea to clean that up a bit: the safest thing to do seemed to be to handle both of the styles for both cases (and make it so others can be added if wanted). With this, comma-separated lists get turned into array refs right at the start, everything further down can assume it's getting an array ref. (Single-value strings will become single-member arrays).

NOTE: I'm not totally sure if this `ref($args{$arg}) eq 'ARRAY'` test is the best, let me know if anyone knows of any pitfalls.

While I was working on this it made me curious about what the conventions for URL querying lists of values actually are, and it seems like one of the standard ways to do it is to allow the same query name to be passed multiple times - `?ids=1&ids=2&ids=3...`. So I thought it might be a good idea to support that; the second commit adds it. Without the second commit, you have to use the comma-separated style when doing queries via the web API.