### PR TITLE
set 0640 perms on sqlite db when creating it

### DIFF
--- a/script/initdb
+++ b/script/initdb
@@ -69,8 +69,11 @@ if ($user) {
 my $script_directory = "$FindBin::Bin/../dbicdh";
 my @databases        = qw( MySQL SQLite PostgreSQL );
 my $schema           = OpenQA::Schema::connect_db();
+my $dbfile           = "";
 
 if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
+    # store this so we can set its permissions after creating it
+    $dbfile = $1;
     my $dbdir = dirname($1);
     die "$dbdir does not exist\n" unless -d $dbdir;
     my @s = stat(_);
@@ -117,6 +120,9 @@ if ($prepare_init) {
 if ($init_database) {
     # Create the schema
     $dh->install;
+    if ($dbfile) {
+        chmod 0640, $dbfile;
+    }
 }
 
 # vim: set sw=4 sts=4 et:


### PR DESCRIPTION
It seems to me that the openQA database really should not be
world-readable, since it contains the API keys (and perhaps
other sensitive stuff, I dunno). This changes initdb to set
0640 perms on the sqlite database file when creating it. Would
probably go along with a change in the spec file to set the
same perms on the %ghost line for the database file. For more
advanced databases I guess access control should be up to the
admin.

Note: I'm not 100% sure about this one, please review it carefully. I'm not at all sure it'd DTRT when using `dsn = dbi:SQLite:dbname=:memory:` , but then I'm not sure the current code does either - that `dirname` is never going to work on a value of `:memory:`, is it?