### PR TITLE
add missing quotes

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -364,7 +364,7 @@ sub _commit_git {
         die "failed to git commit $name";
     }
 
-    if (($self->app->config->{scm git}->{do_push} || '') eq 'yes') {
+    if (($self->app->config->{'scm git'}->{do_push} || '') eq 'yes') {
         unless (run_cmd_with_log([@git, 'push'])) {
             die "failed to git push $name";
         }


### PR DESCRIPTION
Can't locate object method "scm" via package "git" (perhaps you
forgot to load "git"?) at
/usr/share/openqa/script/../lib/OpenQA/WebAPI/Controller/Step.pm
line 367.