### PR TITLE
move 'latest jobs' logic from overview to ResultSet::Jobs

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -43,11 +43,14 @@ sub list {
     }
 
     # TODO: convert to DBus call or move query_jobs helper to WebAPI
-    my $jobquery = OpenQA::Scheduler::Scheduler::query_jobs(%args);
-    my %jobs;
-    while (my $job = $jobquery->next) {
-        $jobs{$job->id} = $job;
+    my @jobarray;
+    if (defined $self->param('latest')) {
+        @jobarray = OpenQA::Scheduler::Scheduler::query_jobs(%args)->latest_jobs;
     }
+    else {
+        @jobarray = OpenQA::Scheduler::Scheduler::query_jobs(%args)->all;
+    }
+    my %jobs = map { $_->id => $_ } @jobarray;
 
     # we can't prefetch too much at once as the resulting JOIN will kill our performance horribly
     # (not so much the JOIN itself, but parsing the result containing duplicated information)

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -372,15 +372,12 @@ sub overview {
     my $all_result_stats   = OpenQA::Schema::Result::JobModules::job_module_stats($jobs);
     my $preferred_machines = _caclulate_preferred_machines($jobs);
 
-    my %seen;
-    while (my $job = $jobs->next) {
+    my @latest_jobs = $jobs->latest_jobs;
+    foreach my $job (@latest_jobs) {
         my $settings = $job->settings_hash;
-        my $testname = $settings->{NAME};
         my $test     = $job->test;
         my $flavor   = $settings->{FLAVOR} || 'sweet';
         my $arch     = $settings->{ARCH} || 'noarch';
-        my $key      = "$test-$flavor-$arch-" . $settings->{MACHINE};
-        next if $seen{$key}++;
 
         my $result;
         if ($job->state eq 'done') {

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -34,4 +34,12 @@ is($rs->latest_build, "0091");
 is($rs->latest_build(version => 'Factory', distri => 'opensuse'), "0048");
 is($rs->latest_build(version => '13.1',    distri => 'opensuse'), "0091");
 
+my @latest = $t->app->db->resultset("Jobs")->latest_jobs;
+my @ids = map { $_->id } @latest;
+# These two jobs have later clones in the fixture set, so should not appear
+ok(grep(!/^(99962|99945)$/, @ids));
+# These are the later clones, they should appear
+ok(grep(/^99963$/, @ids));
+ok(grep(/^99946$/, @ids));
+
 done_testing();


### PR DESCRIPTION
This is my first cut at #436. It takes the 'latest jobs' logic
from the 'overview' web UI function and makes it into a method
in ResultSet::Jobs. Then it exposes it via the web API: you
can pass 'latest' as a query parameter (set to anything) and
only the latest jobs will be included in the results. The logic
works as before.

This is broadly along the lines suggested by @coolo in #436,
but I'm not sure how happy I am with the result, improvement
suggestions welcome. We *could* still put this in query_jobs
by having it iterate through the resultset and find the IDs of
the 'latest' jobs then produce a new resultset filtered by
those IDs, but I'm not sure if that'd be better.