### PR TITLE
register assets directly when posting an iso

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -25,7 +25,7 @@ use Mojo::UserAgent;
 
 use db_helpers;
 
-our %types = map { $_ => 1 } qw/iso repo hdd/;
+our %types = map { $_ => 1 } qw/iso repo hdd other/;
 
 __PACKAGE__->table('assets');
 __PACKAGE__->load_components(qw/Timestamps/);

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -21,7 +21,7 @@ use JSON;
 use Fcntl;
 use DateTime;
 use db_helpers;
-use OpenQA::Utils qw/log_debug/;
+use OpenQA::Utils qw/log_debug parse_assets_from_settings/;
 use File::Basename qw/basename dirname/;
 use File::Path ();
 use File::Which qw(which);
@@ -550,7 +550,7 @@ sub duplicate {
     }
 
     # when dependency network is recreated, associate assets
-    $res->assets_from_settings;
+    $res->register_assets_from_settings;
     return ($self->id => $res->id, %duplicated_ids);
 }
 
@@ -882,28 +882,11 @@ sub update_status {
     return $ret;
 }
 
-sub assets_from_settings {
+sub register_assets_from_settings {
     my ($self) = @_;
-    my %assets;
     my $settings = $self->settings_hash;
 
-    for my $k (keys %$settings) {
-        if ($k eq 'ISO') {
-            $assets{$k} = {type => 'iso', name => $settings->{$k}};
-        }
-        if ($k =~ /^ISO_\d$/) {
-            $assets{$k} = {type => 'iso', name => $settings->{$k}};
-        }
-        if ($k =~ /^HDD_\d$/) {
-            $assets{$k} = {type => 'hdd', name => $settings->{$k}};
-        }
-        if ($k =~ /^REPO_\d$/) {
-            $assets{$k} = {type => 'repo', name => $settings->{$k}};
-        }
-        if ($k =~ /^ASSET_\d$/) {
-            $assets{$k} = {type => 'other', name => $settings->{$k}};
-        }
-    }
+    my %assets = %{parse_assets_from_settings($settings)};
 
     return unless keys %assets;
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -23,6 +23,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &save_base64_png
   &run_cmd_with_log
   &commit_git
+  &parse_assets_from_settings
 );
 
 
@@ -204,6 +205,32 @@ sub commit_git {
     }
     return 1;
 }
+
+sub parse_assets_from_settings {
+    my ($settings) = (@_);
+    my $assets = {};
+
+    for my $k (keys %$settings) {
+        if ($k eq 'ISO') {
+            $assets->{$k} = {type => 'iso', name => $settings->{$k}};
+        }
+        if ($k =~ /^ISO_\d$/) {
+            $assets->{$k} = {type => 'iso', name => $settings->{$k}};
+        }
+        if ($k =~ /^HDD_\d$/) {
+            $assets->{$k} = {type => 'hdd', name => $settings->{$k}};
+        }
+        if ($k =~ /^REPO_\d$/) {
+            $assets->{$k} = {type => 'repo', name => $settings->{$k}};
+        }
+        if ($k =~ /^ASSET_\d$/) {
+            $assets->{$k} = {type => 'other', name => $settings->{$k}};
+        }
+    }
+
+    return $assets;
+}
+
 
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
posting to the iso controller may not generate jobs if job templates
don't exist. Still the assets might already be there but unknown to
openQA.