### PR TITLE
Auditing using Mojo events

### DIFF
--- a/dbicdh/MySQL/deploy/36/001-auto-__VERSION.sql
+++ b/dbicdh/MySQL/deploy/36/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Mon Dec 14 14:43:04 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `dbix_class_deploymenthandler_versions`
+--
+CREATE TABLE `dbix_class_deploymenthandler_versions` (
+  `id` integer NOT NULL auto_increment,
+  `version` varchar(50) NOT NULL,
+  `ddl` text NULL,
+  `upgrade_sql` text NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `dbix_class_deploymenthandler_versions_version` (`version`)
+);
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/deploy/36/001-auto.sql
+++ b/dbicdh/MySQL/deploy/36/001-auto.sql
@@ -1,0 +1,436 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Mon Dec 14 14:43:03 2015
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `assets`
+--
+CREATE TABLE `assets` (
+  `id` integer NOT NULL auto_increment,
+  `type` text NOT NULL,
+  `name` text NOT NULL,
+  `size` bigint NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `assets_type_name` (`type`, `name`)
+) ENGINE=InnoDB;
+--
+-- Table: `gru_tasks`
+--
+CREATE TABLE `gru_tasks` (
+  `id` integer NOT NULL auto_increment,
+  `taskname` text NOT NULL,
+  `args` text NOT NULL,
+  `run_at` datetime NOT NULL,
+  `priority` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_groups`
+--
+CREATE TABLE `job_groups` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `size_limit_gb` integer NOT NULL DEFAULT 100,
+  `keep_logs_in_days` integer NOT NULL DEFAULT 30,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `job_groups_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_modules`
+--
+CREATE TABLE `job_modules` (
+  `id` integer NOT NULL auto_increment,
+  `job_id` integer NOT NULL,
+  `name` text NOT NULL,
+  `script` text NOT NULL,
+  `category` text NOT NULL,
+  `soft_failure` integer NOT NULL DEFAULT 0,
+  `milestone` integer NOT NULL DEFAULT 0,
+  `important` integer NOT NULL DEFAULT 0,
+  `fatal` integer NOT NULL DEFAULT 0,
+  `result` varchar(255) NOT NULL DEFAULT 'none',
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_modules_idx_job_id` (`job_id`),
+  INDEX `idx_job_modules_result` (`result`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_modules_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_settings`
+--
+CREATE TABLE `job_settings` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `job_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_settings_idx_job_id` (`job_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `job_settings_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `machine_settings`
+--
+CREATE TABLE `machine_settings` (
+  `id` integer NOT NULL auto_increment,
+  `machine_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `machine_settings_idx_machine_id` (`machine_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `machine_settings_machine_id_key` (`machine_id`, `key`),
+  CONSTRAINT `machine_settings_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `machines`
+--
+CREATE TABLE `machines` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `backend` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `machines_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `needle_dirs`
+--
+CREATE TABLE `needle_dirs` (
+  `id` integer NOT NULL auto_increment,
+  `path` text NOT NULL,
+  `name` text NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `needle_dirs_path` (`path`)
+) ENGINE=InnoDB;
+--
+-- Table: `product_settings`
+--
+CREATE TABLE `product_settings` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `product_settings_idx_product_id` (`product_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `product_settings_product_id_key` (`product_id`, `key`),
+  CONSTRAINT `product_settings_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `products`
+--
+CREATE TABLE `products` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `distri` text NOT NULL,
+  `version` text NOT NULL DEFAULT '',
+  `arch` text NOT NULL,
+  `flavor` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `products_distri_version_arch_flavor` (`distri`, `version`, `arch`, `flavor`)
+) ENGINE=InnoDB;
+--
+-- Table: `secrets`
+--
+CREATE TABLE `secrets` (
+  `id` integer NOT NULL auto_increment,
+  `secret` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `secrets_secret` (`secret`)
+);
+--
+-- Table: `test_suite_settings`
+--
+CREATE TABLE `test_suite_settings` (
+  `id` integer NOT NULL auto_increment,
+  `test_suite_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `test_suite_settings_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suite_settings_test_suite_id_key` (`test_suite_id`, `key`),
+  CONSTRAINT `test_suite_settings_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `test_suites`
+--
+CREATE TABLE `test_suites` (
+  `id` integer NOT NULL auto_increment,
+  `name` text NOT NULL,
+  `variables` text NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `test_suites_name` (`name`)
+) ENGINE=InnoDB;
+--
+-- Table: `users`
+--
+CREATE TABLE `users` (
+  `id` integer NOT NULL auto_increment,
+  `username` text NOT NULL,
+  `email` text NULL,
+  `fullname` text NULL,
+  `nickname` text NULL,
+  `is_operator` integer NOT NULL DEFAULT 0,
+  `is_admin` integer NOT NULL DEFAULT 0,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `users_username` (`username`)
+) ENGINE=InnoDB;
+--
+-- Table: `worker_properties`
+--
+CREATE TABLE `worker_properties` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `value` text NOT NULL,
+  `worker_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `worker_properties_idx_worker_id` (`worker_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `worker_properties_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `workers`
+--
+CREATE TABLE `workers` (
+  `id` integer NOT NULL auto_increment,
+  `host` text NOT NULL,
+  `instance` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `workers_host_instance` (`host`, `instance`)
+) ENGINE=InnoDB;
+--
+-- Table: `api_keys`
+--
+CREATE TABLE `api_keys` (
+  `id` integer NOT NULL auto_increment,
+  `key` text NOT NULL,
+  `secret` text NOT NULL,
+  `user_id` integer NOT NULL,
+  `t_expiration` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `api_keys_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `api_keys_key` (`key`),
+  CONSTRAINT `api_keys_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `audit_events`
+--
+CREATE TABLE `audit_events` (
+  `id` integer NOT NULL auto_increment,
+  `user_id` integer NULL,
+  `connection_id` text NULL,
+  `event` text NOT NULL,
+  `event_data` text NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `audit_events_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `audit_events_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `comments`
+--
+CREATE TABLE `comments` (
+  `id` integer NOT NULL auto_increment,
+  `job_id` integer NULL,
+  `group_id` integer NULL,
+  `text` text NOT NULL,
+  `user_id` integer NOT NULL,
+  `hidden` enum('0','1') NOT NULL DEFAULT '0',
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `comments_idx_group_id` (`group_id`),
+  INDEX `comments_idx_job_id` (`job_id`),
+  INDEX `comments_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `comments_fk_group_id` FOREIGN KEY (`group_id`) REFERENCES `job_groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `comments_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `comments_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `jobs`
+--
+CREATE TABLE `jobs` (
+  `id` integer NOT NULL auto_increment,
+  `slug` text NULL,
+  `result_dir` text NULL,
+  `state` varchar(255) NOT NULL DEFAULT 'scheduled',
+  `priority` integer NOT NULL DEFAULT 50,
+  `result` varchar(255) NOT NULL DEFAULT 'none',
+  `worker_id` integer NOT NULL DEFAULT 0,
+  `test` text NOT NULL,
+  `clone_id` integer NULL,
+  `retry_avbl` integer NOT NULL DEFAULT 3,
+  `backend` varchar(255) NULL,
+  `backend_info` text NULL,
+  `group_id` integer NULL,
+  `t_started` timestamp NULL,
+  `t_finished` timestamp NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_idx_clone_id` (`clone_id`),
+  INDEX `jobs_idx_group_id` (`group_id`),
+  INDEX `jobs_idx_worker_id` (`worker_id`),
+  INDEX `idx_jobs_state` (`state`),
+  INDEX `idx_jobs_result` (`result`),
+  PRIMARY KEY (`id`),
+  UNIQUE `jobs_slug` (`slug`),
+  CONSTRAINT `jobs_fk_clone_id` FOREIGN KEY (`clone_id`) REFERENCES `jobs` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `jobs_fk_group_id` FOREIGN KEY (`group_id`) REFERENCES `job_groups` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `jobs_fk_worker_id` FOREIGN KEY (`worker_id`) REFERENCES `workers` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `needles`
+--
+CREATE TABLE `needles` (
+  `id` integer NOT NULL auto_increment,
+  `dir_id` integer NOT NULL,
+  `filename` text NOT NULL,
+  `first_seen_module_id` integer NOT NULL,
+  `last_seen_module_id` integer NOT NULL,
+  `last_matched_module_id` integer NULL,
+  `file_present` enum('0','1') NOT NULL DEFAULT '1',
+  INDEX `needles_idx_dir_id` (`dir_id`),
+  INDEX `needles_idx_first_seen_module_id` (`first_seen_module_id`),
+  INDEX `needles_idx_last_matched_module_id` (`last_matched_module_id`),
+  INDEX `needles_idx_last_seen_module_id` (`last_seen_module_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `needles_dir_id_filename` (`dir_id`, `filename`),
+  CONSTRAINT `needles_fk_dir_id` FOREIGN KEY (`dir_id`) REFERENCES `needle_dirs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `needles_fk_first_seen_module_id` FOREIGN KEY (`first_seen_module_id`) REFERENCES `job_modules` (`id`),
+  CONSTRAINT `needles_fk_last_matched_module_id` FOREIGN KEY (`last_matched_module_id`) REFERENCES `job_modules` (`id`),
+  CONSTRAINT `needles_fk_last_seen_module_id` FOREIGN KEY (`last_seen_module_id`) REFERENCES `job_modules` (`id`)
+) ENGINE=InnoDB;
+--
+-- Table: `job_dependencies`
+--
+CREATE TABLE `job_dependencies` (
+  `child_job_id` integer NOT NULL,
+  `parent_job_id` integer NOT NULL,
+  `dependency` integer NOT NULL,
+  INDEX `job_dependencies_idx_child_job_id` (`child_job_id`),
+  INDEX `job_dependencies_idx_parent_job_id` (`parent_job_id`),
+  INDEX `idx_job_dependencies_dependency` (`dependency`),
+  PRIMARY KEY (`child_job_id`, `parent_job_id`, `dependency`),
+  CONSTRAINT `job_dependencies_fk_child_job_id` FOREIGN KEY (`child_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_dependencies_fk_parent_job_id` FOREIGN KEY (`parent_job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_locks`
+--
+CREATE TABLE `job_locks` (
+  `name` text NOT NULL,
+  `owner` integer NOT NULL,
+  `locked_by` integer NULL,
+  INDEX `job_locks_idx_locked_by` (`locked_by`),
+  INDEX `job_locks_idx_owner` (`owner`),
+  PRIMARY KEY (`name`, `owner`),
+  CONSTRAINT `job_locks_fk_locked_by` FOREIGN KEY (`locked_by`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_locks_fk_owner` FOREIGN KEY (`owner`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_module_needles`
+--
+CREATE TABLE `job_module_needles` (
+  `needle_id` integer NOT NULL,
+  `job_module_id` integer NOT NULL,
+  `matched` enum('0','1') NOT NULL DEFAULT '1',
+  INDEX `job_module_needles_idx_job_module_id` (`job_module_id`),
+  INDEX `job_module_needles_idx_needle_id` (`needle_id`),
+  UNIQUE `job_module_needles_needle_id_job_module_id` (`needle_id`, `job_module_id`),
+  CONSTRAINT `job_module_needles_fk_job_module_id` FOREIGN KEY (`job_module_id`) REFERENCES `job_modules` (`id`),
+  CONSTRAINT `job_module_needles_fk_needle_id` FOREIGN KEY (`needle_id`) REFERENCES `needles` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_networks`
+--
+CREATE TABLE `job_networks` (
+  `name` text NOT NULL,
+  `job_id` integer NOT NULL,
+  `vlan` integer NOT NULL,
+  INDEX `job_networks_idx_job_id` (`job_id`),
+  PRIMARY KEY (`name`, `job_id`),
+  CONSTRAINT `job_networks_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `gru_dependencies`
+--
+CREATE TABLE `gru_dependencies` (
+  `job_id` integer NOT NULL,
+  `gru_task_id` integer NOT NULL,
+  INDEX `gru_dependencies_idx_gru_task_id` (`gru_task_id`),
+  INDEX `gru_dependencies_idx_job_id` (`job_id`),
+  PRIMARY KEY (`job_id`, `gru_task_id`),
+  CONSTRAINT `gru_dependencies_fk_gru_task_id` FOREIGN KEY (`gru_task_id`) REFERENCES `gru_tasks` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `gru_dependencies_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `job_templates`
+--
+CREATE TABLE `job_templates` (
+  `id` integer NOT NULL auto_increment,
+  `product_id` integer NOT NULL,
+  `machine_id` integer NOT NULL,
+  `test_suite_id` integer NOT NULL,
+  `prio` integer NOT NULL,
+  `group_id` integer NOT NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `job_templates_idx_group_id` (`group_id`),
+  INDEX `job_templates_idx_machine_id` (`machine_id`),
+  INDEX `job_templates_idx_product_id` (`product_id`),
+  INDEX `job_templates_idx_test_suite_id` (`test_suite_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE `job_templates_product_id_machine_id_test_suite_id` (`product_id`, `machine_id`, `test_suite_id`),
+  CONSTRAINT `job_templates_fk_group_id` FOREIGN KEY (`group_id`) REFERENCES `job_groups` (`id`),
+  CONSTRAINT `job_templates_fk_machine_id` FOREIGN KEY (`machine_id`) REFERENCES `machines` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `job_templates_fk_test_suite_id` FOREIGN KEY (`test_suite_id`) REFERENCES `test_suites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `jobs_assets`
+--
+CREATE TABLE `jobs_assets` (
+  `job_id` integer NOT NULL,
+  `asset_id` integer NOT NULL,
+  `created_by` enum('0','1') NOT NULL DEFAULT '0',
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `jobs_assets_idx_asset_id` (`asset_id`),
+  INDEX `jobs_assets_idx_job_id` (`job_id`),
+  UNIQUE `jobs_assets_job_id_asset_id` (`job_id`, `asset_id`),
+  CONSTRAINT `jobs_assets_fk_asset_id` FOREIGN KEY (`asset_id`) REFERENCES `assets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `jobs_assets_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+SET foreign_key_checks=1;

--- a/dbicdh/MySQL/upgrade/35-36/001-auto.sql
+++ b/dbicdh/MySQL/upgrade/35-36/001-auto.sql
@@ -1,0 +1,29 @@
+-- Convert schema '/home/openQA/openQA/script/../dbicdh/_source/deploy/35/001-auto.yml' to '/home/openQA/openQA/script/../dbicdh/_source/deploy/36/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+SET foreign_key_checks=0;
+
+;
+CREATE TABLE `audit_events` (
+  `id` integer NOT NULL auto_increment,
+  `user_id` integer NULL,
+  `connection_id` text NULL,
+  `event` text NOT NULL,
+  `event_data` text NULL,
+  `t_created` timestamp NOT NULL,
+  `t_updated` timestamp NOT NULL,
+  INDEX `audit_events_idx_user_id` (`user_id`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `audit_events_fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB;
+
+;
+SET foreign_key_checks=1;
+
+;
+
+COMMIT;
+

--- a/dbicdh/PostgreSQL/deploy/36/001-auto-__VERSION.sql
+++ b/dbicdh/PostgreSQL/deploy/36/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Mon Dec 14 14:43:04 2015
+-- 
+;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE "dbix_class_deploymenthandler_versions" (
+  "id" serial NOT NULL,
+  "version" character varying(50) NOT NULL,
+  "ddl" text,
+  "upgrade_sql" text,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "dbix_class_deploymenthandler_versions_version" UNIQUE ("version")
+);
+
+;

--- a/dbicdh/PostgreSQL/deploy/36/001-auto.sql
+++ b/dbicdh/PostgreSQL/deploy/36/001-auto.sql
@@ -1,0 +1,594 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Mon Dec 14 14:43:03 2015
+-- 
+;
+--
+-- Table: assets
+--
+CREATE TABLE "assets" (
+  "id" serial NOT NULL,
+  "type" text NOT NULL,
+  "name" text NOT NULL,
+  "size" bigint,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "assets_type_name" UNIQUE ("type", "name")
+);
+
+;
+--
+-- Table: gru_tasks
+--
+CREATE TABLE "gru_tasks" (
+  "id" serial NOT NULL,
+  "taskname" text NOT NULL,
+  "args" text NOT NULL,
+  "run_at" timestamp NOT NULL,
+  "priority" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+;
+--
+-- Table: job_groups
+--
+CREATE TABLE "job_groups" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "size_limit_gb" integer DEFAULT 100 NOT NULL,
+  "keep_logs_in_days" integer DEFAULT 30 NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "job_groups_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: job_modules
+--
+CREATE TABLE "job_modules" (
+  "id" serial NOT NULL,
+  "job_id" integer NOT NULL,
+  "name" text NOT NULL,
+  "script" text NOT NULL,
+  "category" text NOT NULL,
+  "soft_failure" integer DEFAULT 0 NOT NULL,
+  "milestone" integer DEFAULT 0 NOT NULL,
+  "important" integer DEFAULT 0 NOT NULL,
+  "fatal" integer DEFAULT 0 NOT NULL,
+  "result" character varying DEFAULT 'none' NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_modules_idx_job_id" on "job_modules" ("job_id");
+CREATE INDEX "idx_job_modules_result" on "job_modules" ("result");
+
+;
+--
+-- Table: job_settings
+--
+CREATE TABLE "job_settings" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "job_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "job_settings_idx_job_id" on "job_settings" ("job_id");
+
+;
+--
+-- Table: machine_settings
+--
+CREATE TABLE "machine_settings" (
+  "id" serial NOT NULL,
+  "machine_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machine_settings_machine_id_key" UNIQUE ("machine_id", "key")
+);
+CREATE INDEX "machine_settings_idx_machine_id" on "machine_settings" ("machine_id");
+
+;
+--
+-- Table: machines
+--
+CREATE TABLE "machines" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "backend" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "machines_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: needle_dirs
+--
+CREATE TABLE "needle_dirs" (
+  "id" serial NOT NULL,
+  "path" text NOT NULL,
+  "name" text NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "needle_dirs_path" UNIQUE ("path")
+);
+
+;
+--
+-- Table: product_settings
+--
+CREATE TABLE "product_settings" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "product_settings_product_id_key" UNIQUE ("product_id", "key")
+);
+CREATE INDEX "product_settings_idx_product_id" on "product_settings" ("product_id");
+
+;
+--
+-- Table: products
+--
+CREATE TABLE "products" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "distri" text NOT NULL,
+  "version" text DEFAULT '' NOT NULL,
+  "arch" text NOT NULL,
+  "flavor" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "products_distri_version_arch_flavor" UNIQUE ("distri", "version", "arch", "flavor")
+);
+
+;
+--
+-- Table: secrets
+--
+CREATE TABLE "secrets" (
+  "id" serial NOT NULL,
+  "secret" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "secrets_secret" UNIQUE ("secret")
+);
+
+;
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE "test_suite_settings" (
+  "id" serial NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suite_settings_test_suite_id_key" UNIQUE ("test_suite_id", "key")
+);
+CREATE INDEX "test_suite_settings_idx_test_suite_id" on "test_suite_settings" ("test_suite_id");
+
+;
+--
+-- Table: test_suites
+--
+CREATE TABLE "test_suites" (
+  "id" serial NOT NULL,
+  "name" text NOT NULL,
+  "variables" text NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "test_suites_name" UNIQUE ("name")
+);
+
+;
+--
+-- Table: users
+--
+CREATE TABLE "users" (
+  "id" serial NOT NULL,
+  "username" text NOT NULL,
+  "email" text,
+  "fullname" text,
+  "nickname" text,
+  "is_operator" integer DEFAULT 0 NOT NULL,
+  "is_admin" integer DEFAULT 0 NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "users_username" UNIQUE ("username")
+);
+
+;
+--
+-- Table: worker_properties
+--
+CREATE TABLE "worker_properties" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "value" text NOT NULL,
+  "worker_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "worker_properties_idx_worker_id" on "worker_properties" ("worker_id");
+
+;
+--
+-- Table: workers
+--
+CREATE TABLE "workers" (
+  "id" serial NOT NULL,
+  "host" text NOT NULL,
+  "instance" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "workers_host_instance" UNIQUE ("host", "instance")
+);
+
+;
+--
+-- Table: api_keys
+--
+CREATE TABLE "api_keys" (
+  "id" serial NOT NULL,
+  "key" text NOT NULL,
+  "secret" text NOT NULL,
+  "user_id" integer NOT NULL,
+  "t_expiration" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "api_keys_key" UNIQUE ("key")
+);
+CREATE INDEX "api_keys_idx_user_id" on "api_keys" ("user_id");
+
+;
+--
+-- Table: audit_events
+--
+CREATE TABLE "audit_events" (
+  "id" serial NOT NULL,
+  "user_id" integer,
+  "connection_id" text,
+  "event" text NOT NULL,
+  "event_data" text,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "audit_events_idx_user_id" on "audit_events" ("user_id");
+
+;
+--
+-- Table: comments
+--
+CREATE TABLE "comments" (
+  "id" serial NOT NULL,
+  "job_id" integer,
+  "group_id" integer,
+  "text" text NOT NULL,
+  "user_id" integer NOT NULL,
+  "hidden" boolean DEFAULT '0' NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "comments_idx_group_id" on "comments" ("group_id");
+CREATE INDEX "comments_idx_job_id" on "comments" ("job_id");
+CREATE INDEX "comments_idx_user_id" on "comments" ("user_id");
+
+;
+--
+-- Table: jobs
+--
+CREATE TABLE "jobs" (
+  "id" serial NOT NULL,
+  "slug" text,
+  "result_dir" text,
+  "state" character varying DEFAULT 'scheduled' NOT NULL,
+  "priority" integer DEFAULT 50 NOT NULL,
+  "result" character varying DEFAULT 'none' NOT NULL,
+  "worker_id" integer DEFAULT 0 NOT NULL,
+  "test" text NOT NULL,
+  "clone_id" integer,
+  "retry_avbl" integer DEFAULT 3 NOT NULL,
+  "backend" character varying,
+  "backend_info" text,
+  "group_id" integer,
+  "t_started" timestamp,
+  "t_finished" timestamp,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "jobs_slug" UNIQUE ("slug")
+);
+CREATE INDEX "jobs_idx_clone_id" on "jobs" ("clone_id");
+CREATE INDEX "jobs_idx_group_id" on "jobs" ("group_id");
+CREATE INDEX "jobs_idx_worker_id" on "jobs" ("worker_id");
+CREATE INDEX "idx_jobs_state" on "jobs" ("state");
+CREATE INDEX "idx_jobs_result" on "jobs" ("result");
+
+;
+--
+-- Table: needles
+--
+CREATE TABLE "needles" (
+  "id" serial NOT NULL,
+  "dir_id" integer NOT NULL,
+  "filename" text NOT NULL,
+  "first_seen_module_id" integer NOT NULL,
+  "last_seen_module_id" integer NOT NULL,
+  "last_matched_module_id" integer,
+  "file_present" boolean DEFAULT '1' NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "needles_dir_id_filename" UNIQUE ("dir_id", "filename")
+);
+CREATE INDEX "needles_idx_dir_id" on "needles" ("dir_id");
+CREATE INDEX "needles_idx_first_seen_module_id" on "needles" ("first_seen_module_id");
+CREATE INDEX "needles_idx_last_matched_module_id" on "needles" ("last_matched_module_id");
+CREATE INDEX "needles_idx_last_seen_module_id" on "needles" ("last_seen_module_id");
+
+;
+--
+-- Table: job_dependencies
+--
+CREATE TABLE "job_dependencies" (
+  "child_job_id" integer NOT NULL,
+  "parent_job_id" integer NOT NULL,
+  "dependency" integer NOT NULL,
+  PRIMARY KEY ("child_job_id", "parent_job_id", "dependency")
+);
+CREATE INDEX "job_dependencies_idx_child_job_id" on "job_dependencies" ("child_job_id");
+CREATE INDEX "job_dependencies_idx_parent_job_id" on "job_dependencies" ("parent_job_id");
+CREATE INDEX "idx_job_dependencies_dependency" on "job_dependencies" ("dependency");
+
+;
+--
+-- Table: job_locks
+--
+CREATE TABLE "job_locks" (
+  "name" text NOT NULL,
+  "owner" integer NOT NULL,
+  "locked_by" integer,
+  PRIMARY KEY ("name", "owner")
+);
+CREATE INDEX "job_locks_idx_locked_by" on "job_locks" ("locked_by");
+CREATE INDEX "job_locks_idx_owner" on "job_locks" ("owner");
+
+;
+--
+-- Table: job_module_needles
+--
+CREATE TABLE "job_module_needles" (
+  "needle_id" integer NOT NULL,
+  "job_module_id" integer NOT NULL,
+  "matched" boolean DEFAULT '1' NOT NULL,
+  CONSTRAINT "job_module_needles_needle_id_job_module_id" UNIQUE ("needle_id", "job_module_id")
+);
+CREATE INDEX "job_module_needles_idx_job_module_id" on "job_module_needles" ("job_module_id");
+CREATE INDEX "job_module_needles_idx_needle_id" on "job_module_needles" ("needle_id");
+
+;
+--
+-- Table: job_networks
+--
+CREATE TABLE "job_networks" (
+  "name" text NOT NULL,
+  "job_id" integer NOT NULL,
+  "vlan" integer NOT NULL,
+  PRIMARY KEY ("name", "job_id")
+);
+CREATE INDEX "job_networks_idx_job_id" on "job_networks" ("job_id");
+
+;
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE "gru_dependencies" (
+  "job_id" integer NOT NULL,
+  "gru_task_id" integer NOT NULL,
+  PRIMARY KEY ("job_id", "gru_task_id")
+);
+CREATE INDEX "gru_dependencies_idx_gru_task_id" on "gru_dependencies" ("gru_task_id");
+CREATE INDEX "gru_dependencies_idx_job_id" on "gru_dependencies" ("job_id");
+
+;
+--
+-- Table: job_templates
+--
+CREATE TABLE "job_templates" (
+  "id" serial NOT NULL,
+  "product_id" integer NOT NULL,
+  "machine_id" integer NOT NULL,
+  "test_suite_id" integer NOT NULL,
+  "prio" integer NOT NULL,
+  "group_id" integer NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "job_templates_product_id_machine_id_test_suite_id" UNIQUE ("product_id", "machine_id", "test_suite_id")
+);
+CREATE INDEX "job_templates_idx_group_id" on "job_templates" ("group_id");
+CREATE INDEX "job_templates_idx_machine_id" on "job_templates" ("machine_id");
+CREATE INDEX "job_templates_idx_product_id" on "job_templates" ("product_id");
+CREATE INDEX "job_templates_idx_test_suite_id" on "job_templates" ("test_suite_id");
+
+;
+--
+-- Table: jobs_assets
+--
+CREATE TABLE "jobs_assets" (
+  "job_id" integer NOT NULL,
+  "asset_id" integer NOT NULL,
+  "created_by" boolean DEFAULT '0' NOT NULL,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  CONSTRAINT "jobs_assets_job_id_asset_id" UNIQUE ("job_id", "asset_id")
+);
+CREATE INDEX "jobs_assets_idx_asset_id" on "jobs_assets" ("asset_id");
+CREATE INDEX "jobs_assets_idx_job_id" on "jobs_assets" ("job_id");
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE "job_modules" ADD CONSTRAINT "job_modules_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_settings" ADD CONSTRAINT "job_settings_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "machine_settings" ADD CONSTRAINT "machine_settings_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "product_settings" ADD CONSTRAINT "product_settings_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "test_suite_settings" ADD CONSTRAINT "test_suite_settings_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "worker_properties" ADD CONSTRAINT "worker_properties_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "audit_events" ADD CONSTRAINT "audit_events_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "comments" ADD CONSTRAINT "comments_fk_group_id" FOREIGN KEY ("group_id")
+  REFERENCES "job_groups" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "comments" ADD CONSTRAINT "comments_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "comments" ADD CONSTRAINT "comments_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_clone_id" FOREIGN KEY ("clone_id")
+  REFERENCES "jobs" ("id") ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_group_id" FOREIGN KEY ("group_id")
+  REFERENCES "job_groups" ("id") ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_fk_worker_id" FOREIGN KEY ("worker_id")
+  REFERENCES "workers" ("id") ON DELETE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "needles" ADD CONSTRAINT "needles_fk_dir_id" FOREIGN KEY ("dir_id")
+  REFERENCES "needle_dirs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "needles" ADD CONSTRAINT "needles_fk_first_seen_module_id" FOREIGN KEY ("first_seen_module_id")
+  REFERENCES "job_modules" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "needles" ADD CONSTRAINT "needles_fk_last_matched_module_id" FOREIGN KEY ("last_matched_module_id")
+  REFERENCES "job_modules" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "needles" ADD CONSTRAINT "needles_fk_last_seen_module_id" FOREIGN KEY ("last_seen_module_id")
+  REFERENCES "job_modules" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_child_job_id" FOREIGN KEY ("child_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_dependencies" ADD CONSTRAINT "job_dependencies_fk_parent_job_id" FOREIGN KEY ("parent_job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_locked_by" FOREIGN KEY ("locked_by")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_locks" ADD CONSTRAINT "job_locks_fk_owner" FOREIGN KEY ("owner")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_module_needles" ADD CONSTRAINT "job_module_needles_fk_job_module_id" FOREIGN KEY ("job_module_id")
+  REFERENCES "job_modules" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "job_module_needles" ADD CONSTRAINT "job_module_needles_fk_needle_id" FOREIGN KEY ("needle_id")
+  REFERENCES "needles" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_networks" ADD CONSTRAINT "job_networks_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "gru_dependencies" ADD CONSTRAINT "gru_dependencies_fk_gru_task_id" FOREIGN KEY ("gru_task_id")
+  REFERENCES "gru_tasks" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "gru_dependencies" ADD CONSTRAINT "gru_dependencies_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_group_id" FOREIGN KEY ("group_id")
+  REFERENCES "job_groups" ("id") DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_machine_id" FOREIGN KEY ("machine_id")
+  REFERENCES "machines" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_product_id" FOREIGN KEY ("product_id")
+  REFERENCES "products" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "job_templates" ADD CONSTRAINT "job_templates_fk_test_suite_id" FOREIGN KEY ("test_suite_id")
+  REFERENCES "test_suites" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_asset_id" FOREIGN KEY ("asset_id")
+  REFERENCES "assets" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "jobs_assets" ADD CONSTRAINT "jobs_assets_fk_job_id" FOREIGN KEY ("job_id")
+  REFERENCES "jobs" ("id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;

--- a/dbicdh/PostgreSQL/upgrade/35-36/001-auto.sql
+++ b/dbicdh/PostgreSQL/upgrade/35-36/001-auto.sql
@@ -1,0 +1,26 @@
+-- Convert schema '/home/openQA/openQA/script/../dbicdh/_source/deploy/35/001-auto.yml' to '/home/openQA/openQA/script/../dbicdh/_source/deploy/36/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TABLE "audit_events" (
+  "id" serial NOT NULL,
+  "user_id" integer,
+  "connection_id" text,
+  "event" text NOT NULL,
+  "event_data" text,
+  "t_created" timestamp NOT NULL,
+  "t_updated" timestamp NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "audit_events_idx_user_id" on "audit_events" ("user_id");
+
+;
+ALTER TABLE "audit_events" ADD CONSTRAINT "audit_events_fk_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id") DEFERRABLE;
+
+;
+
+COMMIT;
+

--- a/dbicdh/SQLite/deploy/36/001-auto-__VERSION.sql
+++ b/dbicdh/SQLite/deploy/36/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Mon Dec 14 14:43:04 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id INTEGER PRIMARY KEY NOT NULL,
+  version varchar(50) NOT NULL,
+  ddl text,
+  upgrade_sql text
+);
+CREATE UNIQUE INDEX dbix_class_deploymenthandler_versions_version ON dbix_class_deploymenthandler_versions (version);
+COMMIT;

--- a/dbicdh/SQLite/deploy/36/001-auto.sql
+++ b/dbicdh/SQLite/deploy/36/001-auto.sql
@@ -1,0 +1,415 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Mon Dec 14 14:43:03 2015
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  size bigint,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX assets_type_name ON assets (type, name);
+--
+-- Table: gru_tasks
+--
+CREATE TABLE gru_tasks (
+  id INTEGER PRIMARY KEY NOT NULL,
+  taskname text NOT NULL,
+  args text NOT NULL,
+  run_at datetime NOT NULL,
+  priority integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+--
+-- Table: job_groups
+--
+CREATE TABLE job_groups (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  size_limit_gb integer NOT NULL DEFAULT 100,
+  keep_logs_in_days integer NOT NULL DEFAULT 30,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX job_groups_name ON job_groups (name);
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  soft_failure integer NOT NULL DEFAULT 0,
+  milestone integer NOT NULL DEFAULT 0,
+  important integer NOT NULL DEFAULT 0,
+  fatal integer NOT NULL DEFAULT 0,
+  result varchar NOT NULL DEFAULT 'none',
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_modules_idx_job_id ON job_modules (job_id);
+CREATE INDEX idx_job_modules_result ON job_modules (result);
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_settings_idx_job_id ON job_settings (job_id);
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX machine_settings_idx_machine_id ON machine_settings (machine_id);
+CREATE UNIQUE INDEX machine_settings_machine_id_key ON machine_settings (machine_id, key);
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX machines_name ON machines (name);
+--
+-- Table: needle_dirs
+--
+CREATE TABLE needle_dirs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  path text NOT NULL,
+  name text NOT NULL
+);
+CREATE UNIQUE INDEX needle_dirs_path ON needle_dirs (path);
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX product_settings_idx_product_id ON product_settings (product_id);
+CREATE UNIQUE INDEX product_settings_product_id_key ON product_settings (product_id, key);
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX products_distri_version_arch_flavor ON products (distri, version, arch, flavor);
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX secrets_secret ON secrets (secret);
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id ON test_suite_settings (test_suite_id);
+CREATE UNIQUE INDEX test_suite_settings_test_suite_id_key ON test_suite_settings (test_suite_id, key);
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX test_suites_name ON test_suites (name);
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY NOT NULL,
+  username text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX users_username ON users (username);
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX worker_properties_idx_worker_id ON worker_properties (worker_id);
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX workers_host_instance ON workers (host, instance);
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX api_keys_idx_user_id ON api_keys (user_id);
+CREATE UNIQUE INDEX api_keys_key ON api_keys (key);
+--
+-- Table: audit_events
+--
+CREATE TABLE audit_events (
+  id INTEGER PRIMARY KEY NOT NULL,
+  user_id integer,
+  connection_id text,
+  event text NOT NULL,
+  event_data text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX audit_events_idx_user_id ON audit_events (user_id);
+--
+-- Table: comments
+--
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer,
+  group_id integer,
+  text text NOT NULL,
+  user_id integer NOT NULL,
+  hidden boolean NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX comments_idx_group_id ON comments (group_id);
+CREATE INDEX comments_idx_job_id ON comments (job_id);
+CREATE INDEX comments_idx_user_id ON comments (user_id);
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  slug text,
+  result_dir text,
+  state varchar NOT NULL DEFAULT 'scheduled',
+  priority integer NOT NULL DEFAULT 50,
+  result varchar NOT NULL DEFAULT 'none',
+  worker_id integer NOT NULL DEFAULT 0,
+  test text NOT NULL,
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  backend varchar,
+  backend_info text,
+  group_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE
+);
+CREATE INDEX jobs_idx_clone_id ON jobs (clone_id);
+CREATE INDEX jobs_idx_group_id ON jobs (group_id);
+CREATE INDEX jobs_idx_worker_id ON jobs (worker_id);
+CREATE INDEX idx_jobs_state ON jobs (state);
+CREATE INDEX idx_jobs_result ON jobs (result);
+CREATE UNIQUE INDEX jobs_slug ON jobs (slug);
+--
+-- Table: needles
+--
+CREATE TABLE needles (
+  id INTEGER PRIMARY KEY NOT NULL,
+  dir_id integer NOT NULL,
+  filename text NOT NULL,
+  first_seen_module_id integer NOT NULL,
+  last_seen_module_id integer NOT NULL,
+  last_matched_module_id integer,
+  file_present boolean NOT NULL DEFAULT 1,
+  FOREIGN KEY (dir_id) REFERENCES needle_dirs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (first_seen_module_id) REFERENCES job_modules(id),
+  FOREIGN KEY (last_matched_module_id) REFERENCES job_modules(id),
+  FOREIGN KEY (last_seen_module_id) REFERENCES job_modules(id)
+);
+CREATE INDEX needles_idx_dir_id ON needles (dir_id);
+CREATE INDEX needles_idx_first_seen_module_id ON needles (first_seen_module_id);
+CREATE INDEX needles_idx_last_matched_module_id ON needles (last_matched_module_id);
+CREATE INDEX needles_idx_last_seen_module_id ON needles (last_seen_module_id);
+CREATE UNIQUE INDEX needles_dir_id_filename ON needles (dir_id, filename);
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency),
+  FOREIGN KEY (child_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (parent_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_dependencies_idx_child_job_id ON job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id ON job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency ON job_dependencies (dependency);
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by integer,
+  PRIMARY KEY (name, owner),
+  FOREIGN KEY (locked_by) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (owner) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_locks_idx_locked_by ON job_locks (locked_by);
+CREATE INDEX job_locks_idx_owner ON job_locks (owner);
+--
+-- Table: job_module_needles
+--
+CREATE TABLE job_module_needles (
+  needle_id integer NOT NULL,
+  job_module_id integer NOT NULL,
+  matched boolean NOT NULL DEFAULT 1,
+  FOREIGN KEY (job_module_id) REFERENCES job_modules(id),
+  FOREIGN KEY (needle_id) REFERENCES needles(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_module_needles_idx_job_module_id ON job_module_needles (job_module_id);
+CREATE INDEX job_module_needles_idx_needle_id ON job_module_needles (needle_id);
+CREATE UNIQUE INDEX job_module_needles_needle_id_job_module_id ON job_module_needles (needle_id, job_module_id);
+--
+-- Table: job_networks
+--
+CREATE TABLE job_networks (
+  name text NOT NULL,
+  job_id integer NOT NULL,
+  vlan integer NOT NULL,
+  PRIMARY KEY (name, job_id),
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_networks_idx_job_id ON job_networks (job_id);
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id),
+  FOREIGN KEY (gru_task_id) REFERENCES gru_tasks(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id ON gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id ON gru_dependencies (job_id);
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  prio integer NOT NULL,
+  group_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id),
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_templates_idx_group_id ON job_templates (group_id);
+CREATE INDEX job_templates_idx_machine_id ON job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id ON job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id ON job_templates (test_suite_id);
+CREATE UNIQUE INDEX job_templates_product_id_machine_id_test_suite_id ON job_templates (product_id, machine_id, test_suite_id);
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  created_by boolean NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_assets_idx_asset_id ON jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id ON jobs_assets (job_id);
+CREATE UNIQUE INDEX jobs_assets_job_id_asset_id ON jobs_assets (job_id, asset_id);
+COMMIT;

--- a/dbicdh/SQLite/upgrade/35-36/001-auto.sql
+++ b/dbicdh/SQLite/upgrade/35-36/001-auto.sql
@@ -1,0 +1,24 @@
+-- Convert schema '/home/openQA/openQA/script/../dbicdh/_source/deploy/35/001-auto.yml' to '/home/openQA/openQA/script/../dbicdh/_source/deploy/36/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TABLE audit_events (
+  id INTEGER PRIMARY KEY NOT NULL,
+  user_id integer,
+  connection_id text,
+  event text NOT NULL,
+  event_data text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+;
+CREATE INDEX audit_events_idx_user_id ON audit_events (user_id);
+
+;
+
+COMMIT;
+

--- a/dbicdh/_source/deploy/36/001-auto-__VERSION.yml
+++ b/dbicdh/_source/deploy/36/001-auto-__VERSION.yml
@@ -1,0 +1,92 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/dbicdh/_source/deploy/36/001-auto.yml
+++ b/dbicdh/_source/deploy/36/001-auto.yml
@@ -1,0 +1,3175 @@
+---
+schema:
+  procedures: {}
+  tables:
+    api_keys:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - key
+          match_type: ''
+          name: api_keys_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: api_keys_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 2
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: secret
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_expiration:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_expiration
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: api_keys_idx_user_id
+          options: []
+          type: NORMAL
+      name: api_keys
+      options: []
+      order: 17
+    assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - type
+            - name
+          match_type: ''
+          name: assets_type_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        type:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: type
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: assets
+      options: []
+      order: 1
+    audit_events:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: audit_events_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        connection_id:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: connection_id
+          order: 3
+          size:
+            - 0
+        event:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: event
+          order: 4
+          size:
+            - 0
+        event_data:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: event_data
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: audit_events_idx_user_id
+          options: []
+          type: NORMAL
+      name: audit_events
+      options: []
+      order: 18
+    comments:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: comments_fk_group_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: comments_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: comments_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 3
+          size:
+            - 0
+        hidden:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: hidden
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        text:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: text
+          order: 4
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: comments_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: comments_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - user_id
+          name: comments_idx_user_id
+          options: []
+          type: NORMAL
+      name: comments
+      options: []
+      order: 19
+    gru_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - gru_task_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - gru_task_id
+          match_type: ''
+          name: gru_dependencies_fk_gru_task_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: gru_tasks
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: gru_dependencies_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        gru_task_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: gru_task_id
+          order: 2
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - gru_task_id
+          name: gru_dependencies_idx_gru_task_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: gru_dependencies_idx_job_id
+          options: []
+          type: NORMAL
+      name: gru_dependencies
+      options: []
+      order: 26
+    gru_tasks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        args:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: args
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        run_at:
+          data_type: datetime
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: run_at
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        taskname:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: taskname
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: gru_tasks
+      options: []
+      order: 2
+    job_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+            - parent_job_id
+            - dependency
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+          match_type: ''
+          name: job_dependencies_fk_child_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_job_id
+          match_type: ''
+          name: job_dependencies_fk_parent_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        child_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: child_job_id
+          order: 1
+          size:
+            - 0
+        dependency:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: dependency
+          order: 3
+          size:
+            - 0
+        parent_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: parent_job_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - child_job_id
+          name: job_dependencies_idx_child_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_job_id
+          name: job_dependencies_idx_parent_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - dependency
+          name: idx_job_dependencies_dependency
+          options: []
+          type: NORMAL
+      name: job_dependencies
+      options: []
+      order: 22
+    job_groups:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: job_groups_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        keep_logs_in_days:
+          data_type: integer
+          default_value: 30
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_logs_in_days
+          order: 4
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        size_limit_gb:
+          data_type: integer
+          default_value: 100
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: size_limit_gb
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices: []
+      name: job_groups
+      options: []
+      order: 3
+    job_locks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - owner
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - locked_by
+          match_type: ''
+          name: job_locks_fk_locked_by
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - owner
+          match_type: ''
+          name: job_locks_fk_owner
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        locked_by:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: locked_by
+          order: 3
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        owner:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: owner
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - locked_by
+          name: job_locks_idx_locked_by
+          options: []
+          type: NORMAL
+        - fields:
+            - owner
+          name: job_locks_idx_owner
+          options: []
+          type: NORMAL
+      name: job_locks
+      options: []
+      order: 23
+    job_module_needles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - needle_id
+            - job_module_id
+          match_type: ''
+          name: job_module_needles_needle_id_job_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_module_id
+          match_type: ''
+          name: job_module_needles_fk_job_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - needle_id
+          match_type: ''
+          name: job_module_needles_fk_needle_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: needles
+          type: FOREIGN KEY
+      fields:
+        job_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_module_id
+          order: 2
+          size:
+            - 0
+        matched:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: matched
+          order: 3
+          size:
+            - 0
+        needle_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: needle_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_module_id
+          name: job_module_needles_idx_job_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - needle_id
+          name: job_module_needles_idx_needle_id
+          options: []
+          type: NORMAL
+      name: job_module_needles
+      options: []
+      order: 24
+    job_modules:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_modules_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        category:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: category
+          order: 5
+          size:
+            - 0
+        fatal:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: fatal
+          order: 9
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        important:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: important
+          order: 8
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        milestone:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: milestone
+          order: 7
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 10
+          size:
+            - 0
+        script:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: script
+          order: 4
+          size:
+            - 0
+        soft_failure:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: soft_failure
+          order: 6
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 12
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_modules_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_job_modules_result
+          options: []
+          type: NORMAL
+      name: job_modules
+      options: []
+      order: 4
+    job_networks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - job_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_networks_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        vlan:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: vlan
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_networks_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_networks
+      options: []
+      order: 25
+    job_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_settings_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 4
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_settings_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_settings
+      options: []
+      order: 5
+    job_templates:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - machine_id
+            - test_suite_id
+          match_type: ''
+          name: job_templates_product_id_machine_id_test_suite_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: job_templates_fk_group_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: job_templates_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: job_templates_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: job_templates_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 3
+          size:
+            - 0
+        prio:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: prio
+          order: 5
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: job_templates_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - machine_id
+          name: job_templates_idx_machine_id
+          options: []
+          type: NORMAL
+        - fields:
+            - product_id
+          name: job_templates_idx_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - test_suite_id
+          name: job_templates_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: job_templates
+      options: []
+      order: 27
+    jobs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - slug
+          match_type: ''
+          name: jobs_slug
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - clone_id
+          match_type: ''
+          name: jobs_fk_clone_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: jobs_fk_group_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: jobs_fk_worker_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        backend:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 11
+          size:
+            - 0
+        backend_info:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend_info
+          order: 12
+          size:
+            - 0
+        clone_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: clone_id
+          order: 9
+          size:
+            - 0
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 13
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: 50
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 6
+          size:
+            - 0
+        result_dir:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: result_dir
+          order: 3
+          size:
+            - 0
+        retry_avbl:
+          data_type: integer
+          default_value: 3
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: retry_avbl
+          order: 10
+          size:
+            - 0
+        slug:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: slug
+          order: 2
+          size:
+            - 0
+        state:
+          data_type: varchar
+          default_value: scheduled
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: state
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 16
+          size:
+            - 0
+        t_finished:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_finished
+          order: 15
+          size:
+            - 0
+        t_started:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_started
+          order: 14
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 17
+          size:
+            - 0
+        test:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: test
+          order: 8
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 7
+          size:
+            - 0
+      indices:
+        - fields:
+            - clone_id
+          name: jobs_idx_clone_id
+          options: []
+          type: NORMAL
+        - fields:
+            - group_id
+          name: jobs_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - worker_id
+          name: jobs_idx_worker_id
+          options: []
+          type: NORMAL
+        - fields:
+            - state
+          name: idx_jobs_state
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_jobs_result
+          options: []
+          type: NORMAL
+      name: jobs
+      options: []
+      order: 20
+    jobs_assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - asset_id
+          match_type: ''
+          name: jobs_assets_job_id_asset_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - asset_id
+          match_type: ''
+          name: jobs_assets_fk_asset_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: assets
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: jobs_assets_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        asset_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: asset_id
+          order: 2
+          size:
+            - 0
+        created_by:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: created_by
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - asset_id
+          name: jobs_assets_idx_asset_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: jobs_assets_idx_job_id
+          options: []
+          type: NORMAL
+      name: jobs_assets
+      options: []
+      order: 28
+    machine_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+            - key
+          match_type: ''
+          name: machine_settings_machine_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: machine_settings_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: machine_settings_idx_machine_id
+          options: []
+          type: NORMAL
+      name: machine_settings
+      options: []
+      order: 6
+    machines:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: machines_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: machines
+      options: []
+      order: 7
+    needle_dirs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - path
+          match_type: ''
+          name: needle_dirs_path
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        path:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: path
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: needle_dirs
+      options: []
+      order: 8
+    needles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+            - filename
+          match_type: ''
+          name: needles_dir_id_filename
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+          match_type: ''
+          name: needles_fk_dir_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: needle_dirs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - first_seen_module_id
+          match_type: ''
+          name: needles_fk_first_seen_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_matched_module_id
+          match_type: ''
+          name: needles_fk_last_matched_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_seen_module_id
+          match_type: ''
+          name: needles_fk_last_seen_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+      fields:
+        dir_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: dir_id
+          order: 2
+          size:
+            - 0
+        file_present:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: file_present
+          order: 7
+          size:
+            - 0
+        filename:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: filename
+          order: 3
+          size:
+            - 0
+        first_seen_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: first_seen_module_id
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        last_matched_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_matched_module_id
+          order: 6
+          size:
+            - 0
+        last_seen_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: last_seen_module_id
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - dir_id
+          name: needles_idx_dir_id
+          options: []
+          type: NORMAL
+        - fields:
+            - first_seen_module_id
+          name: needles_idx_first_seen_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_matched_module_id
+          name: needles_idx_last_matched_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_seen_module_id
+          name: needles_idx_last_seen_module_id
+          options: []
+          type: NORMAL
+      name: needles
+      options: []
+      order: 21
+    product_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - key
+          match_type: ''
+          name: product_settings_product_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: product_settings_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - product_id
+          name: product_settings_idx_product_id
+          options: []
+          type: NORMAL
+      name: product_settings
+      options: []
+      order: 9
+    products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - distri
+            - version
+            - arch
+            - flavor
+          match_type: ''
+          name: products_distri_version_arch_flavor
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        arch:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: arch
+          order: 5
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: distri
+          order: 3
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: flavor
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 7
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: products
+      options: []
+      order: 10
+    secrets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - secret
+          match_type: ''
+          name: secrets_secret
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: secret
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: secrets
+      options: []
+      order: 11
+    test_suite_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+            - key
+          match_type: ''
+          name: test_suite_settings_test_suite_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: test_suite_settings_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 2
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - test_suite_id
+          name: test_suite_settings_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: test_suite_settings
+      options: []
+      order: 12
+    test_suites:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: test_suites_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: test_suites
+      options: []
+      order: 13
+    users:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - username
+          match_type: ''
+          name: users_username
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        email:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: email
+          order: 3
+          size:
+            - 0
+        fullname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: fullname
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        is_admin:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_admin
+          order: 7
+          size:
+            - 0
+        is_operator:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_operator
+          order: 6
+          size:
+            - 0
+        nickname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: nickname
+          order: 5
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        username:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: username
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: users
+      options: []
+      order: 14
+    worker_properties:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: worker_properties_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: worker_properties_idx_worker_id
+          options: []
+          type: NORMAL
+      name: worker_properties
+      options: []
+      order: 15
+    workers:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - host
+            - instance
+          match_type: ''
+          name: workers_host_instance
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        host:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: host
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        instance:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: instance
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices: []
+      name: workers
+      options: []
+      order: 16
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - ApiKeys
+      - Assets
+      - AuditEvents
+      - Comments
+      - GruDependencies
+      - GruTasks
+      - JobDependencies
+      - JobGroups
+      - JobLocks
+      - JobModuleNeedles
+      - JobModules
+      - JobNetworks
+      - JobSettings
+      - JobTemplates
+      - Jobs
+      - JobsAssets
+      - MachineSettings
+      - Machines
+      - NeedleDirs
+      - Needles
+      - ProductSettings
+      - Products
+      - Secrets
+      - TestSuiteSettings
+      - TestSuites
+      - Users
+      - WorkerProperties
+      - Workers
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -24,7 +24,7 @@ use FindBin qw($Bin);
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION = 35;
+our $VERSION = 36;
 
 __PACKAGE__->load_namespaces;
 

--- a/lib/OpenQA/Schema/Result/AuditEvents.pm
+++ b/lib/OpenQA/Schema/Result/AuditEvents.pm
@@ -1,0 +1,50 @@
+# Copyright (C) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Schema::Result::AuditEvents;
+use strict;
+use base qw/DBIx::Class::Core/;
+
+# use db_helpers;
+
+__PACKAGE__->table('audit_events');
+__PACKAGE__->load_components(qw/Timestamps/);
+__PACKAGE__->add_columns(
+    id => {
+        data_type         => 'integer',
+        is_auto_increment => 1,
+    },
+    user_id => {
+        data_type   => 'integer',
+        is_nullable => 1
+    },
+    connection_id => {
+        data_type   => 'text',
+        is_nullable => 1
+    },
+    event => {
+        data_type   => 'text',
+        is_nullable => 0
+    },
+    event_data => {
+        data_type   => 'text',
+        is_nullable => 1
+    });
+__PACKAGE__->add_timestamps;
+__PACKAGE__->set_primary_key('id');
+__PACKAGE__->belongs_to(user => 'OpenQA::Schema::Result::Users', 'user_id', {join_type => 'left'});
+
+1;
+# vim: set sw=4 et:

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -21,6 +21,7 @@ use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
 use OpenQA::IPC;
 use OpenQA::Worker::Common qw/ASSET_DIR/;
+use Data::Dump qw/pp/;
 
 use Mojo::IOLoop;
 use Mojolicious::Commands;
@@ -517,6 +518,11 @@ sub startup {
     # start workers checker
     $self->_workers_checker;
     $self->_init_rand;
+
+    # load extensions
+    push @{$self->plugins->namespaces}, 'OpenQA::WebAPI::Extensions';
+    # TODO: use config, for now always load auditing plugin
+    $self->plugin('AuditLog', Mojo::IOLoop->singleton);
 }
 
 sub run {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -176,6 +176,7 @@ sub startup {
     $self->plugin('OpenQA::WebAPI::Plugin::REST');
     $self->plugin('OpenQA::WebAPI::Plugin::HashedParams');
     $self->plugin('OpenQA::WebAPI::Plugin::Gru');
+    $self->plugin('OpenQA::WebAPI::Plugin::AuditLog', Mojo::IOLoop->singleton);
 
     $self->plugin(bootstrap3 => {css => [], js => []});
 
@@ -521,11 +522,6 @@ sub startup {
     # start workers checker
     $self->_workers_checker;
     $self->_init_rand;
-
-    # load extensions
-    push @{$self->plugins->namespaces}, 'OpenQA::WebAPI::Extensions';
-    # TODO: use config, for now always load auditing plugin
-    $self->plugin('AuditLog', Mojo::IOLoop->singleton);
 }
 
 sub run {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -21,7 +21,6 @@ use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
 use OpenQA::IPC;
 use OpenQA::Worker::Common qw/ASSET_DIR/;
-use Data::Dump qw/pp/;
 
 use Mojo::IOLoop;
 use Mojolicious::Commands;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -55,7 +55,6 @@ sub _read_config {
             level     => undef,
             file      => "/var/log/openqa",
             sql_debug => undef,
-            audit_log => "/var/log/openqa-audit",
         },
         openid => {
             provider  => 'https://www.opensuse.org/openid/user/',

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -55,7 +55,8 @@ sub _read_config {
         logging => {
             level     => undef,
             file      => "/var/log/openqa",
-            sql_debug => undef
+            sql_debug => undef,
+            audit_log => "/var/log/openqa-audit",
         },
         openid => {
             provider  => 'https://www.opensuse.org/openid/user/',
@@ -376,6 +377,8 @@ sub startup {
     $admin_r->get('/needles/:module_id/:needle_id')->name('admin_needle_module')->to('needle#module');
     $admin_r->get('/needles/ajax')->name('admin_needle_ajax')->to('needle#ajax');
     $admin_r->delete('/needles/delete')->name('admin_needle_delete')->to('needle#delete');
+
+    $admin_r->get('/auditlog')->name('audit_log')->to('audit_log#index');
 
     # Users list as default option
     $admin_r->get('/')->name('admin')->to('user#index');

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -194,11 +194,12 @@ sub startup {
       /javascripts/admintable.js
       /javascripts/admin_user.js
       /javascripts/admin_needle.js
+      /javascripts/audit_log.js
       /javascripts/jquery.timeago.js
       /javascripts/tests.js
       /javascripts/assets.js
       /javascripts/job_templates.js
-      /javascripts/overview.js );
+      /javascripts/overview.js);
     my @css = qw(/stylesheets/font-awesome.css
       /stylesheets/chosen.css
       /stylesheets/overview.scss
@@ -379,6 +380,7 @@ sub startup {
     $admin_r->delete('/needles/delete')->name('admin_needle_delete')->to('needle#delete');
 
     $admin_r->get('/auditlog')->name('audit_log')->to('audit_log#index');
+    $admin_r->get('/auditlog/ajax')->name('audit_ajax')->to('audit_log#ajax');
 
     # Users list as default option
     $admin_r->get('/')->name('admin')->to('user#index');

--- a/lib/OpenQA/WebAPI/Controller/API/V1.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1.pm
@@ -68,6 +68,7 @@ sub auth {
 
     if ($user) {
         $self->app->log->debug(sprintf "API auth by user: %s, operator: %d", $user->username, $user->is_operator);
+        $self->stash('current_user' => {user => $user});
         return $self->is_operator($user);
     }
     $self->render(json => {error => $reason}, status => 403);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -23,7 +23,6 @@ sub register {
 
     my $type = $self->param('type');
     my $name = $self->param('name');
-    $self->emit_event('asset_register_req', {type => $type, name => $name});
 
     my $ipc = OpenQA::IPC->ipc;
     my $id = $ipc->scheduler('asset_register', {type => $type, name => $name});
@@ -32,6 +31,7 @@ sub register {
     my $json   = {};
     if ($id) {
         $json->{id} = $id;
+        $self->emit_event('openqa_asset_register', {id => $id, type => $type, name => $name});
     }
     else {
         $status = 400;
@@ -75,10 +75,10 @@ sub delete {
     for my $arg (qw/id type name/) {
         $args{$arg} = $self->stash($arg) if defined $self->stash($arg);
     }
-    $self->emit_event('asset_delete_req', \%args);
 
     my $ipc = OpenQA::IPC->ipc;
     my $rs = $ipc->scheduler('asset_delete', \%args);
+    $self->emit_event('openqa_asset_delete', \%args);
 
     $self->render(json => {count => $rs});
 }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -23,6 +23,7 @@ sub register {
 
     my $type = $self->param('type');
     my $name = $self->param('name');
+    $self->emit_event('asset_register_req', {type => $type, name => $name});
 
     my $ipc = OpenQA::IPC->ipc;
     my $id = $ipc->scheduler('asset_register', {type => $type, name => $name});
@@ -74,6 +75,7 @@ sub delete {
     for my $arg (qw/id type name/) {
         $args{$arg} = $self->stash($arg) if defined $self->stash($arg);
     }
+    $self->emit_event('asset_delete_req', \%args);
 
     my $ipc = OpenQA::IPC->ipc;
     my $rs = $ipc->scheduler('asset_delete', \%args);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
@@ -24,6 +24,7 @@ sub create {
     my $workerid = $self->stash('workerid');
     my $command  = $self->param('command');
     my $ipc      = OpenQA::IPC->ipc;
+    $self->emit_event('command_enqueue_req', {workerid => $workerid, command => $command});
 
     my $res;
     try {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
@@ -24,7 +24,7 @@ sub create {
     my $workerid = $self->stash('workerid');
     my $command  = $self->param('command');
     my $ipc      = OpenQA::IPC->ipc;
-    $self->emit_event('command_enqueue_req', {workerid => $workerid, command => $command});
+    $self->emit_event('openqa_command_enqueue', {workerid => $workerid, command => $command});
 
     my $res;
     try {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -43,6 +43,7 @@ sub create {
     my %up_params = map { uc $_ => $params->{$_} } keys %$params;
     # restore URL encoded /
     my %params = map { $_ => $up_params{$_} =~ s@%2F@/@gr } keys %up_params;
+    $self->emit_event('iso_create_req', \%params);
 
     my $ids = $ipc->scheduler('job_schedule_iso', \%params);
     my $cnt = scalar(@$ids);
@@ -55,6 +56,7 @@ sub destroy {
     my $self = shift;
     my $iso  = $self->stash('name');
     my $ipc  = OpenQA::IPC->ipc;
+    $self->emit_event('iso_delete_req', {iso => $iso});
 
     my $res = $ipc->scheduler('job_delete_by_iso', $iso);
     $self->render(json => {count => $res});
@@ -64,6 +66,7 @@ sub cancel {
     my $self = shift;
     my $iso  = $self->stash('name');
     my $ipc  = OpenQA::IPC->ipc;
+    $self->emit_event('iso_cancel_req', {iso => $iso});
 
     my $res = $ipc->scheduler('job_cancel_by_iso', $iso, 0);
     $self->render(json => {result => $res});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -43,7 +43,7 @@ sub create {
     my %up_params = map { uc $_ => $params->{$_} } keys %$params;
     # restore URL encoded /
     my %params = map { $_ => $up_params{$_} =~ s@%2F@/@gr } keys %up_params;
-    $self->emit_event('iso_create_req', \%params);
+    $self->emit_event('openqa_iso_create', \%params);
 
     my $ids = $ipc->scheduler('job_schedule_iso', \%params);
     my $cnt = scalar(@$ids);
@@ -56,7 +56,7 @@ sub destroy {
     my $self = shift;
     my $iso  = $self->stash('name');
     my $ipc  = OpenQA::IPC->ipc;
-    $self->emit_event('iso_delete_req', {iso => $iso});
+    $self->emit_event('openqa_iso_delete', {iso => $iso});
 
     my $res = $ipc->scheduler('job_delete_by_iso', $iso);
     $self->render(json => {count => $res});
@@ -66,7 +66,7 @@ sub cancel {
     my $self = shift;
     my $iso  = $self->stash('name');
     my $ipc  = OpenQA::IPC->ipc;
-    $self->emit_event('iso_cancel_req', {iso => $iso});
+    $self->emit_event('openqa_iso_cancel', {iso => $iso});
 
     my $res = $ipc->scheduler('job_cancel_by_iso', $iso, 0);
     $self->render(json => {result => $res});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -108,12 +108,12 @@ sub create {
     my %up_params = map { uc $_ => $params->{$_} } keys %$params;
     # restore URL encoded /
     my %params = map { $_ => $up_params{$_} =~ s@%2F@/@gr } keys %up_params;
-    $self->emit_event('job_create_req', \%params);
 
     my $json = {};
     my $status;
     try {
         my $job = $ipc->scheduler('job_create', \%params, 0);
+        $self->emit_event('openqa_job_create', {id => $job->{id}, %params});
         $json->{id} = $job->{id};
     }
     catch {
@@ -137,8 +137,8 @@ sub grab {
     $caps->{cpu_opmode}    = $self->param('cpu_opmode');
     $caps->{mem_max}       = $self->param('mem_max');
 
-    $self->emit_event('job_grab_req', {workerid => $workerid, blocking => $blocking, workerip => $workerip});
     my $res = $ipc->scheduler('job_grab', {workerid => $workerid, blocking => $blocking, workerip => $workerip, workercaps => $caps});
+    $self->emit_event('openqa_job_grab', {workerid => $workerid, blocking => $blocking, workerip => $workerip, id => $res->{id}});
     $self->render(json => {job => $res});
 }
 
@@ -161,9 +161,9 @@ sub set_command {
     my $jobid   = int($self->stash('jobid'));
     my $command = 'job_set_' . $self->stash('command');
     my $ipc     = OpenQA::IPC->ipc;
-    $self->emit_event('job_set_command_reg', {jobid => $jobid, command => $self->stash('command')});
 
     my $res = try { $ipc->scheduler($command, $jobid) };
+    $self->emit_event('openqa_' . $command, {id => $jobid}) if ($res);
     # Referencing the scalar will result in true or false
     # (see http://mojolicio.us/perldoc/Mojo/JSON)
     $self->render(json => {result => \$res});
@@ -172,8 +172,9 @@ sub set_command {
 sub destroy {
     my $self = shift;
     my $ipc  = OpenQA::IPC->ipc;
-    $self->emit_event('job_delete_req', {jobid => $self->stash('jobid')});
+
     my $res = $ipc->scheduler('job_delete', int($self->stash('jobid')));
+    $self->emit_event('openqa_job_delete', {id => $self->stash('jobid')}) if ($res);
     # See comment in set_command
     $self->render(json => {result => \$res});
 }
@@ -193,8 +194,9 @@ sub result {
     my $jobid  = int($self->stash('jobid'));
     my $result = $self->param('result');
     my $ipc    = OpenQA::IPC->ipc;
-    $self->emit_event('job_update_result_req', {jobid => $jobid, result => $result});
+
     my $res = $ipc->scheduler('job_update_result', {jobid => $jobid, result => $result});
+    $self->emit_event('openqa_job_update_result', {id => $jobid, result => $result}) if ($res);
     # See comment in set_command
     $self->render(json => {result => \$res});
 }
@@ -253,6 +255,7 @@ sub done {
     else {
         $res = $ipc->scheduler('job_set_done', {jobid => $jobid, result => $result});
     }
+    $self->emit_event('openqa_job_done', {id => $jobid, result => $result, newbuild => $newbuild}) if ($res);
     # See comment in set_command
     $self->render(json => {result => \$res});
 }
@@ -270,8 +273,14 @@ sub restart {
         $self->app->log->debug("Restarting jobs @$jobs");
     }
 
-    my $ipc  = OpenQA::IPC->ipc;
-    my $res  = $ipc->scheduler('job_restart', $jobs);
+    my $ipc = OpenQA::IPC->ipc;
+    my $res = $ipc->scheduler('job_restart', $jobs);
+    if (@$res > 1) {
+        $self->emit_event('openqa_jobs_restart', {ids => $jobs, results => $res});
+    }
+    elsif (@$res == 1) {
+        $self->emit_event('openqa_job_restart', {id => $jobs->[0], result => $res->[0]});
+    }
     my @urls = map { $self->url_for('test', testid => $_) } @$res;
     $self->render(json => {result => $res, test_url => \@urls});
 }
@@ -282,6 +291,7 @@ sub cancel {
 
     my $ipc = OpenQA::IPC->ipc;
     my $res = $ipc->scheduler('job_cancel', $name, 0);
+    $self->emit_event('openqa_job_cancel', {id => $name}) if ($res);
     $self->render(json => {result => $res});
 }
 
@@ -298,6 +308,7 @@ sub duplicate {
 
     my $ipc = OpenQA::IPC->ipc;
     my $id = $ipc->scheduler('job_duplicate', \%args);
+    $self->emit_event('openqa_job_duplicate', {id => $jobid, auto => $args{dup_type_auto}, result => $id}) if ($id);
     $self->render(json => {id => $id});
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -151,6 +151,7 @@ sub create {
     }
     else {
         $json->{id} = $id;
+        $self->emit_event('openqa_jobtemplate_create', {id => $id});
     }
 
     $self->respond_to(
@@ -185,6 +186,7 @@ sub destroy {
         }
         else {
             $json->{result} = int($rs);
+            $self->emit_event('openqa_jobtemplate_delete', {id => $self->param('job_template_id')});
         }
     }
     else {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -112,6 +112,7 @@ sub create {
     $caps->{worker_class}  = $self->param('worker_class');
 
     my $id = $self->_register($self->db, $host, $instance, $caps);
+    $self->emit_event('openqa_worker_register', {id => $id, host => $host, instance => $instance, caps => $caps});
     $self->render(json => {id => $id});
 
 }

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -21,7 +21,7 @@ use Fcntl qw/SEEK_CUR SEEK_END/;
 
 sub index {
     my $self = shift;
-    #my $assets = $self->db->resultset("AuditLog")->search(undef, {order_by => 'id', prefetch => 'user', limit => 100});
+    #my $assets = $self->db->resultset("AuditEvents")->search(undef, {order_by => 'id', prefetch => 'user', limit => 100});
 
     my $auditfh;
     return unless open($auditfh, '<', $self->app->config->{logging}->{audit_log});

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -1,0 +1,47 @@
+# Copyright (C) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+
+package OpenQA::WebAPI::Controller::Admin::AuditLog;
+use strict;
+use parent 'Mojolicious::Controller';
+use Fcntl qw/SEEK_CUR SEEK_END/;
+
+sub index {
+    my $self = shift;
+    #my $assets = $self->db->resultset("AuditLog")->search(undef, {order_by => 'id', prefetch => 'user', limit => 100});
+
+    my $auditfh;
+    return unless open($auditfh, '<', $self->app->config->{logging}->{audit_log});
+    my $log;
+    my $size = -s $self->app->config->{logging}->{audit_log};
+    if ($size > 10 * 1024 && seek $auditfh, -10 * 1024, SEEK_END) {
+        # Discard one (probably) partial line
+        my $dummy = <$auditfh>;
+    }
+    while (defined(my $l = <$auditfh>)) {
+        $log .= $l;
+    }
+    seek $auditfh, 0, SEEK_CUR;
+    close($auditfh);
+    $self->stash('log' => $log);
+    $self->render('admin/audit_log/index');
+}
+
+sub ajax {
+    # follow audit log
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -31,15 +31,13 @@ sub create {
     my $groupname = $self->param('name');
 
     if ($groupname) {
-        $self->emit_event('jobgroup_create_req', {groupname => $groupname});
         my $ng = $self->db->resultset("JobGroups")->create({name => $groupname});
         if ($ng) {
+            $self->emit_event('openqa_jobgroup_create', {groupname => $ng->name, id => $ng->id});
             $self->flash('info', 'Group ' . $ng->name . ' created');
-            $self->emit_event('jobgroup_create_res', {result => 'success'});
         }
         else {
             $self->flash('error', "Creating group $groupname failed");
-            $self->emit_event('jobgroup_create_res', {result => 'failure'});
         }
     }
     else {
@@ -76,15 +74,13 @@ sub save_connect {
         machine_id    => $self->param('machine'),
         group_id      => $group->id,
         test_suite_id => $self->param('test')};
-    $self->emit_event('jobgroup_connect_req', $values);
     eval { $self->db->resultset("JobTemplates")->create($values)->id };
     if ($@) {
         $self->flash(error => $@);
-        $self->emit_event('jobgroup_connect_res', {result => 'failure'});
         $self->redirect_to('job_group_new_media', groupid => $group->id);
     }
     else {
-        $self->emit_event('jobgroup_connect_res', {result => 'success'});
+        $self->emit_event('openqa_jobgroup_connect', $values);
         $self->redirect_to('admin_job_templates', groupid => $group->id);
     }
 }

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -31,12 +31,15 @@ sub create {
     my $groupname = $self->param('name');
 
     if ($groupname) {
+        $self->emit_event('jobgroup_create_req', {groupname => $groupname});
         my $ng = $self->db->resultset("JobGroups")->create({name => $groupname});
         if ($ng) {
             $self->flash('info', 'Group ' . $ng->name . ' created');
+            $self->emit_event('jobgroup_create_res', {result => 'success'});
         }
         else {
             $self->flash('error', "Creating group $groupname failed");
+            $self->emit_event('jobgroup_create_res', {result => 'failure'});
         }
     }
     else {
@@ -73,12 +76,15 @@ sub save_connect {
         machine_id    => $self->param('machine'),
         group_id      => $group->id,
         test_suite_id => $self->param('test')};
+    $self->emit_event('jobgroup_connect_req', $values);
     eval { $self->db->resultset("JobTemplates")->create($values)->id };
     if ($@) {
         $self->flash(error => $@);
+        $self->emit_event('jobgroup_connect_res', {result => 'failure'});
         $self->redirect_to('job_group_new_media', groupid => $group->id);
     }
     else {
+        $self->emit_event('jobgroup_connect_res', {result => 'success'});
         $self->redirect_to('admin_job_templates', groupid => $group->id);
     }
 }

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -127,13 +127,15 @@ sub module {
 
 sub delete {
     my ($self) = @_;
-
+    my @removed_ids;
     for my $p (@{$self->every_param('id[]')}) {
         if (!$self->app->db->resultset('Needles')->find($p)->remove($self->current_user)) {
             $self->stash(error => "Error removing $p");
             last;
         }
+        push @removed_ids, $p;
     }
+    $self->emit_event('openqa_needle_delete', {id => \@removed_ids});
     $self->render(text => 'ok');
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Admin/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/User.pm
@@ -47,6 +47,7 @@ sub update {
     else {
         $user->update({is_admin => $is_admin, is_operator => $is_operator});
         $self->flash('info', 'User ' . $user->nickname . ' updated');
+        $self->emit_event('user_update_success', {nickname => $user->nickname, role => $role});
     }
 
     $self->redirect_to($self->url_for('admin_users'));

--- a/lib/OpenQA/WebAPI/Controller/Admin/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/User.pm
@@ -47,7 +47,7 @@ sub update {
     else {
         $user->update({is_admin => $is_admin, is_operator => $is_operator});
         $self->flash('info', 'User ' . $user->nickname . ' updated');
-        $self->emit_event('user_update_success', {nickname => $user->nickname, role => $role});
+        $self->emit_event('user_update_res', {nickname => $user->nickname, role => $role});
     }
 
     $self->redirect_to($self->url_for('admin_users'));

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -143,11 +143,12 @@ sub add_comment {
     my $group = $self->app->schema->resultset("JobGroups")->find($self->param('groupid'));
     return $self->reply->not_found unless $group;
 
-    $group->comments->create(
+    my $rs = $group->comments->create(
         {
             text    => $self->param('text'),
             user_id => $self->current_user->id,
         });
+    $self->emit_event('openqa_user_comment', {id => $rs->id});
     $self->flash('info', 'Comment added');
     return $self->redirect_to('group_overview');
 }

--- a/lib/OpenQA/WebAPI/Controller/Session.pm
+++ b/lib/OpenQA/WebAPI/Controller/Session.pm
@@ -106,6 +106,7 @@ sub create {
         elsif ($res{'error'}) {
             return $self->render(text => $res{'error'}, status => 403);
         }
+        $self->emit_event('openqa_user_login');
         return $self->redirect_to('index');
     }
     return $self->render(text => 'Forbidden', status => 403);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -466,11 +466,12 @@ sub add_comment {
     my $job = $self->app->schema->resultset("Jobs")->find($self->param('testid'));
     return $self->reply->not_found unless $job;
 
-    $job->comments->create(
+    my $rs = $job->comments->create(
         {
             text    => $self->param('text'),
             user_id => $self->current_user->id,
         });
+    $self->emit_event('openqa_user_comment', {id => $rs->id});
     $self->flash('info', 'Comment added');
     return $self->redirect_to('test');
 }

--- a/lib/OpenQA/WebAPI/Extensions/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Extensions/AuditLog.pm
@@ -54,7 +54,7 @@ sub append_auditlog {
     my $self = shift;
     die 'Wrong append call' unless $self;
     my $auditfh;
-    die "Can't open " . $self->{audit_log} . "\n" unless open($auditfh, '>>', $self->{audit_log});
+    return unless open($auditfh, '>>', $self->{audit_log});
     my $line = '[' . localtime(time) . '] ' . join "\n", @_, '';
     flock $auditfh, LOCK_EX;
     print $auditfh $line;

--- a/lib/OpenQA/WebAPI/Extensions/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Extensions/AuditLog.pm
@@ -1,0 +1,65 @@
+# Copyright (C) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Extensions::AuditLog;
+
+use strict;
+use warnings;
+
+use parent qw/Mojolicious::Plugin/;
+use Mojo::IOLoop;
+use Data::Dump qw/pp/;
+use Fcntl qw/:flock/;
+use Scalar::Util qw/weaken/;
+
+our @table_events = qw/table_create_req table_create_res table_update_req table_update_res table_delete_req table_delete_res/;
+
+sub register {
+    my ($self, $app, $reactor) = @_;
+    $self->{audit_log} = $app->config->{logging}->{audit_log};
+
+    # add table events
+    for my $event (@table_events) {
+        $reactor->on($event => sub { $self->on_table_event($event, @_) });
+    }
+
+    # add global mojolicious events
+    $reactor->on('finish' => sub { $self->append_auditlog('exiting openQA') });
+    $self->append_auditlog('openQA started, auditing initialized');
+}
+
+# table events
+sub on_table_event {
+    my ($self, $table_event, $e, $args) = @_;
+    my ($user_id, $connection_id, $event_data) = @$args;
+    #$self->db->resultset('AuditLog')->create( {user_id => $user_id, connection_id => $connection_id, event => $event, event_data => pp($event_data)} );
+    $self->append_auditlog("${user_id}:${connection_id} - $table_event - " . pp($event_data));
+}
+
+# job events
+
+sub append_auditlog {
+    my $self = shift;
+    die 'Wrong append call' unless $self;
+    my $auditfh;
+    die "Can't open " . $self->{audit_log} . "\n" unless open($auditfh, '>>', $self->{audit_log});
+    my $line = '[' . localtime(time) . '] ' . join "\n", @_, '';
+    flock $auditfh, LOCK_EX;
+    print $auditfh $line;
+    flock $auditfh, LOCK_UN;
+    close($auditfh);
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -37,7 +37,7 @@ sub register {
 
     # add table events
     for my $event (@table_events, @job_events, @jobgroup_events, @user_events, @asset_events, @iso_events) {
-        $reactor->on($event => sub { shift; $self->on_event($event, @_) });
+        $reactor->on($event => sub { shift; $self->on_event(@_) });
     }
 
     # add global mojolicious events
@@ -47,8 +47,8 @@ sub register {
 
 # table events
 sub on_event {
-    my ($self,    $event,         $args)       = @_;
-    my ($user_id, $connection_id, $event_data) = @$args;
+    my ($self, $args) = @_;
+    my ($user_id, $connection_id, $event, $event_data) = @$args;
     #$self->db->resultset('AuditLog')->create( {user_id => $user_id, connection_id => $connection_id, event => $event, event_data => pp($event_data)} );
     $self->append_auditlog("${user_id}:${connection_id} - $event - " . pp($event_data));
 }
@@ -62,7 +62,7 @@ sub append_auditlog {
     flock $auditfh, LOCK_EX;
     print $auditfh $line;
     flock $auditfh, LOCK_UN;
-    close($auditfh);
+    close $auditfh;
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -41,7 +41,7 @@ sub register {
         $reactor->on("openqa_$event" => sub { shift; $self->on_event($app, @_) });
     }
 
-    $app->db->resultset('AuditEvents')->create({user_id => 0, connection_id => 0, event => 'startup', event_data => 'openQA restarted'});
+    $app->db->resultset('AuditEvents')->create({user_id => undef, connection_id => 0, event => 'startup', event_data => 'openQA restarted'});
 }
 
 # table events

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::WebAPI::Extensions::AuditLog;
+package OpenQA::WebAPI::Plugin::AuditLog;
 
 use strict;
 use warnings;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -205,6 +205,14 @@ sub register {
 
     $app->helper(step_thumbnail => \&_step_thumbnail);
 
+    $app->helper(
+        emit_event => sub {
+            my ($self, $event, $data) = @_;
+            die 'Missing event name' unless $event;
+            return Mojo::IOLoop->singleton->emit($event, [$self->current_user->id, $self->tx->connection, $data]);
+        }
+    );
+
 }
 
 sub _step_thumbnail {

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -210,7 +210,7 @@ sub register {
         emit_event => sub {
             my ($self, $event, $data) = @_;
             die 'Missing event name' unless $event;
-            return Mojo::IOLoop->singleton->emit($event, [$self->current_user->id, $self->tx->connection, $data]);
+            return Mojo::IOLoop->singleton->emit($event, [$self->current_user->id, $self->tx->connection, $event, $data]);
         });
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -206,13 +206,12 @@ sub register {
     $app->helper(step_thumbnail => \&_step_thumbnail);
 
     $app->helper(
+        # emit_event helper, adds user, connection to events
         emit_event => sub {
             my ($self, $event, $data) = @_;
             die 'Missing event name' unless $event;
             return Mojo::IOLoop->singleton->emit($event, [$self->current_user->id, $self->tx->connection, $data]);
-        }
-    );
-
+        });
 }
 
 sub _step_thumbnail {

--- a/public/javascripts/audit_log.js
+++ b/public/javascripts/audit_log.js
@@ -1,0 +1,78 @@
+var audit_url;
+var ajax_url;
+
+function htmlEscape(str) {
+    return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// FIXME: this isn't working yet and is not active
+function auditSeach(search_string) {
+    var ids    = search_string.match(/id: ?([^ ]+)/g);
+    var events = search_string.match(/event: ?([^ ]+)/g);
+    var users  = search_string.match(/user: ?([^ ]+)/g);
+    var conns  = search_string.match(/connection: ?([^ ]+)/g);
+    $('#audit_log_table').DataTable().column(1).search(ids, null, true).column(4).search(events, null, true).column(2).search(users. null, true).column(3).search(conns, null, true);
+    $('#audit_log_table').DataTable().draw();
+}
+
+$.fn.dataTable.ext.search.push(
+    // TODO: patch in auditSearch
+);
+
+function loadAuditLogTable ()
+{
+    $('#audit_log_table').DataTable( {
+    lengthMenu: [10, 25, 50],
+    ajax: {
+        url: ajax_url,
+        type: "GET",
+        dataType: 'json',
+    },
+    columns: [
+        { data: 'event_time' },
+        { data: 'id' },
+        { data: 'user' },
+        { data: 'connection' },
+        { data: 'event' },
+        { data: 'event_data' }
+    ],
+    order: [[1, 'desc']],
+    columnDefs: [
+        { 
+            targets: 0,
+            render: function ( data, type, row ) {
+                if (type === 'display')
+                    return jQuery.timeago(data + " UTC");
+                else
+                    return data;
+            }
+        },
+        {
+            targets: 1,
+            className: "event_id",
+            render: function ( data, type, row ) {
+                // I want to have a link to events for cases when one wants to share interesing event
+                if (type === 'display')
+                    return '<a href="' + audit_url + '?eventid=' + data + '">' + data + '</a>';
+                else
+                    return data;
+            }
+        },
+        { 
+            targets: 5,
+            render: function ( data, type, row ) {
+                // Limit length of displayed event data, expand on click
+                if (type === 'display' && data.length > 40)
+                    return '<span id="audit_event_data" title="'+htmlEscape(data)+'">' + htmlEscape(data.substr( 0, 38 )) + '...</span>';
+                else
+                    return data;
+            }
+        },
+    ],
+    });
+}

--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -297,6 +297,17 @@ input[type='image'] {
     overflow-y: scroll;
 }
 
+#auditlog {
+    padding: 0;
+    margin: 0;
+    border: none;
+    background: none;
+    width: 100%;
+    height: 60em;
+    overflow-x: scroll;
+    overflow-y: scroll;
+}
+
 /* User info header */
 
 #user-info {

--- a/t/config.t
+++ b/t/config.t
@@ -46,8 +46,7 @@ is_deeply(
             do_push => 'no',
         },
         logging => {
-            level     => 'debug',
-            audit_log => '/var/log/openqa-audit'
+            level => 'debug',
         },
         openid => {
             provider  => 'https://www.opensuse.org/openid/user/',

--- a/t/config.t
+++ b/t/config.t
@@ -46,7 +46,8 @@ is_deeply(
             do_push => 'no',
         },
         logging => {
-            level => 'debug'
+            level     => 'debug',
+            audit_log => '/var/log/openqa-audit'
         },
         openid => {
             provider  => 'https://www.opensuse.org/openid/user/',

--- a/templates/admin/audit_log/index.html.ep
+++ b/templates/admin/audit_log/index.html.ep
@@ -1,6 +1,12 @@
 % layout 'bootstrap';
 % title 'Audit log';
 
+% content_for 'ready_function' => begin
+    audit_url = "<%= url_for('audit_log') %>";
+    ajax_url  = "<%= url_for('audit_ajax') %>";
+    loadAuditLogTable();
+% end
+
 <div class="row">
     %= include 'layouts/admin_nav'
 
@@ -9,7 +15,19 @@
 
     %= include 'layouts/info'
 
-    <div style="margin: 0 10px;">
-        <pre id="auditlog"><%= $log %></pre>
+    <table id="audit_log_table" class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>ID</th>
+                    <th>User</th>
+                    <th>Connection</th>
+                    <th>Event</th>
+                    <th>Event data</th>
+                </tr>
+            </thead>
+            <tbody>
+             </tbody>
+        </table>
     </div>
 </div>

--- a/templates/admin/audit_log/index.html.ep
+++ b/templates/admin/audit_log/index.html.ep
@@ -1,0 +1,15 @@
+% layout 'bootstrap';
+% title 'Audit log';
+
+<div class="row">
+    %= include 'layouts/admin_nav'
+
+    <div class="col-sm-10">
+        <h2><%= title %></h2>
+
+    %= include 'layouts/info'
+
+    <div style="margin: 0 10px;">
+        <pre id="auditlog"><%= $log %></pre>
+    </div>
+</div>

--- a/templates/layouts/admin_nav.html.ep
+++ b/templates/layouts/admin_nav.html.ep
@@ -15,7 +15,7 @@
                 but the previous one was even more annoying -->
                 <li><%= link_to('Workers' => url_for('admin_workers')) %></li>
                 <li><%= link_to('Needles' => url_for('admin_needles')) %></li>
-
+                <li><%= link_to('Audit log' => url_for('audit_log')) %></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
This is proof-of-concept for auditing using mojo events.
Idea: when something happen, event is fired and audit log will write down what happened.

I added multiple event emitters throughout the code (3dfbd2c). These emitter use emit_event helper which adds current user id and connection id to the event (0fd9246).
So far, for demonstration purposes, audit plugin logs only to audit log file (08055f5), but proposed DB schema is included (82c84f1) and db migration files are not yet included.
I have an idea to link those events to event source, if applicable, but to avoid cluttering audit db I propose to update other db tables with event id field which can than point to audit db to see who and when did what.

I needed to stash current user even when going through API access (551661b). I don't think it has any negative side effects, but please check.