### PR TITLE
Replace 'Logged as' with 'Logged in as'

### DIFF
--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -29,36 +29,36 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 #
 # No login, no user-info and no api_keys
-$t->get_ok('/tests')->status_is(200)->content_unlike(qr/Logged as/);
+$t->get_ok('/tests')->status_is(200)->content_unlike(qr/Logged in as/);
 $t->get_ok('/api_keys')->status_is(302);
 
 # So let's log in as an unpriviledged user
 $test_case->login($t, 'https://openid.camelot.uk/lancelot');
 # ...who should see a logout option but no link to API keys
-$t->get_ok('/tests')->status_is(200)->content_like(qr/Logged as lance (.*logout.*)/);
+$t->get_ok('/tests')->status_is(200)->content_like(qr/Logged in as lance (.*logout.*)/);
 $t->get_ok('/api_keys')->status_is(403);
 
 #
 # Then logout
 $t->delete_ok('/logout')->status_is(302);
-$t->get_ok('/tests')->status_is(200)->content_unlike(qr/Logged as/);
+$t->get_ok('/tests')->status_is(200)->content_unlike(qr/Logged in as/);
 
 #
 # Try creating new user by logging in
 $test_case->login($t, 'morgana');
 # ...who should see a logout option but no link to API keys
-$t->get_ok('/tests')->status_is(200)->content_like(qr/Logged as morgana (.*logout.*)/);
+$t->get_ok('/tests')->status_is(200)->content_like(qr/Logged in as morgana (.*logout.*)/);
 $t->get_ok('/api_keys')->status_is(403);
 
 #
 # Then logout
 $t->delete_ok('/logout')->status_is(302);
-$t->get_ok('/tests')->status_is(200)->content_unlike(qr/Logged as/);
+$t->get_ok('/tests')->status_is(200)->content_unlike(qr/Logged in as/);
 
 #
 # And log in as operator
 $test_case->login($t, 'percival');
-$t->get_ok('/tests')->status_is(200)->content_like(qr/Logged as perci (.*manage API keys.* | .*logout.*)/);
+$t->get_ok('/tests')->status_is(200)->content_like(qr/Logged in as perci (.*manage API keys.* | .*logout.*)/);
 $t->get_ok('/api_keys')->status_is(200);
 
 done_testing();

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -78,7 +78,7 @@ sub goto_editpage() {
     # we're back on the main page
     is($driver->get_title(), "openQA", "back on main page");
 
-    like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged as Demo.*Logout/, "logged in as demo");
+    like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged in as Demo.*Logout/, "logged in as demo");
 
     $driver->get($baseurl . "tests/99946");
     is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode test results', 'tests/99946 followed');

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -51,7 +51,7 @@ $driver->find_element('Login', 'link_text')->click();
 is($driver->get_title(), "openQA", "back on main page");
 # but ...
 
-like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged as Demo.*Logout/, "logged in as demo");
+like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged in as Demo.*Logout/, "logged in as demo");
 
 # Demo is admin, so go there
 $driver->find_element('admin', 'link_text')->click();

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -57,7 +57,7 @@ $driver->find_element('Login', 'link_text')->click();
 is($driver->get_title(), "openQA", "back on main page");
 # but ...
 
-like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged as Demo.*Logout/, "logged in as demo");
+like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged in as Demo.*Logout/, "logged in as demo");
 
 # Demo is admin, so go there
 $driver->find_element('admin', 'link_text')->click();

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -48,7 +48,7 @@
               %# Using a variable to avoid additional whitespaces
               % if (current_user) {
               %# Using a variable to avoid additional whitespaces
-              % my $out = 'Logged as '. current_user->name.' (';
+              % my $out = 'Logged in as '. current_user->name.' (';
               % if (is_operator) {
                   % $out = $out.link_to('manage API keys' => url_for('api_keys')).' | ';
               % }

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -17,7 +17,7 @@
             %# Using a variable to avoid additional whitespaces
             % if (current_user) {
                 %# Using a variable to avoid additional whitespaces
-                % my $out = 'Logged as '.current_user->name.' (';
+                % my $out = 'Logged in as '.current_user->name.' (';
                 % if (is_operator) {
                     % $out = $out.link_to('manage API keys' => url_for('api_keys')).' | ';
                 % }


### PR DESCRIPTION
The description when a user is logged in was "Logged as". This change corrects all code references by providing the more usual "Logged in as" as text.