### PR TITLE
adjust config permissions: openqa.ini 0644, database.ini 0640

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ install:
 
 	install -D -m 640 etc/openqa/client.conf "$(DESTDIR)"/etc/openqa/client.conf
 	install -D -m 644 etc/openqa/workers.ini "$(DESTDIR)"/etc/openqa/workers.ini
-	install -D -m 640 etc/openqa/openqa.ini "$(DESTDIR)"/etc/openqa/openqa.ini
-	install -D -m 644 etc/openqa/database.ini "$(DESTDIR)"/etc/openqa/database.ini
+	install -D -m 644 etc/openqa/openqa.ini "$(DESTDIR)"/etc/openqa/openqa.ini
+	install -D -m 640 etc/openqa/database.ini "$(DESTDIR)"/etc/openqa/database.ini
 
 	install -D -m 644 etc/logrotate.d/openqa "$(DESTDIR)"/etc/logrotate.d/openqa
 #


### PR DESCRIPTION
openqa.ini doesn't contain anything particularly secret so far
as I can tell, but database.ini may contain a password, for
mysql / pgsql cases. So it seems to make much more sense this
way around.