### PR TITLE
Make sure EV is not polluting our signals

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -23,6 +23,7 @@ use OpenQA::Utils qw//;
 use POSIX qw/:sys_wait_h strftime SIGTERM SIGKILL uname/;
 use JSON qw/to_json/;
 use Fcntl;
+use Errno;
 
 my $isotovideo = "/usr/bin/isotovideo";
 my $workerpid;
@@ -173,6 +174,10 @@ sub engine_check {
     my $pid = waitpid($workerpid, WNOHANG);
     if ($verbose) {
         printf "waitpid %d returned %d\n", $workerpid, $pid;
+    }
+    if ($pid == -1 && $!{ECHILD}) {
+        warn "we lost our child\n";
+        return 'died';
     }
 
     if ($pid == $workerpid) {

--- a/script/openqa
+++ b/script/openqa
@@ -27,6 +27,8 @@ $ENV{'MOJO_LISTEN'} ||= 'http://localhost:9526/';
 # allow up to 20GB - hdd images
 $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
 $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
+# the default is EV, and this heavily screws with our children handling
+$ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
 
 use OpenQA::WebAPI;
 

--- a/script/worker
+++ b/script/worker
@@ -90,6 +90,8 @@ BEGIN {
     $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
     $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
     $ENV{MOJO_CONNECT_TIMEOUT}    = 300;
+    # the default is EV, and this heavily screws with our children handling
+    $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
     #$ENV{MOJO_LOG_LEVEL} = 'debug';
     #$ENV{MOJO_USERAGENT_DEBUG} = 1;
     #$ENV{MOJO_IOLOOP_DEBUG} = 1;


### PR DESCRIPTION
adam made me install perl-EV and now I know it's broken. Once it's in,
it will install a SIGCHLD handler reaping all children and we no longer
have any way to get the exit status of isotovideo