### PR TITLE
Adding argument docs to template loading script

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -395,12 +395,13 @@ following command:
 
 [source,sh]
 --------------------------------------------------------------------------------
-/var/lib/openqa/tests/opensuse/templates
+/var/lib/openqa/tests/opensuse/templates --apikey [API_KEY] --apisecret [API_SECRET]
 --------------------------------------------------------------------------------
 
 This will load some default settings that were used at some point of time in
 openSUSE production openQA. Therefore those should work reasonably well with
-openSUSE tests and needles.
+openSUSE tests and needles. This script uses +/usr/share/openqa/script/load_templates+, 
+consider reading its help page (+--help+) for documentation on possible extra arguments.
 
 Adding a new iso to test
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -395,7 +395,7 @@ following command:
 
 [source,sh]
 --------------------------------------------------------------------------------
-/var/lib/openqa/tests/opensuse/templates --apikey [API_KEY] --apisecret [API_SECRET]
+/var/lib/openqa/tests/opensuse/templates [--apikey API_KEY] [--apisecret API_SECRET]
 --------------------------------------------------------------------------------
 
 This will load some default settings that were used at some point of time in


### PR DESCRIPTION
I was trying to load the templates using the script and kept getting *missing apisecret and/or apikey at /usr/share/openqa/script/load_templates line 204.*. Decided to had documentation on setting them, after reading the docs for */usr/share/openqa/script/load_templates*. Please consider.