### PR TITLE
Assets remove_from_disk: actually delete hdd images

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -82,7 +82,7 @@ sub remove_from_disk {
 
     my $file = $self->disk_file;
     OpenQA::Utils::log_debug("remove_from_disk $file");
-    if ($self->type eq 'iso') {
+    if ($self->type eq 'iso' || $self->type eq 'hdd') {
         return unless -f $file;
         unlink($file) || die "can't remove $file";
     }


### PR DESCRIPTION
95bdd266 should've set up cleanup of job-created HDD snapshots
in limit_assets, only it didn't quite, because remove_from_disk
doesn't work for hdd assets; the upshot is that the asset gets
removed from the database but the file is left on disk.

It's also worth noting that two other checks in limit_assets
don't work for job-created HDD snapshots: the check for assets
that aren't in any job group, and the check for files that are
not registered assets. I took a shot at fixing those but it
seems like it doesn't really work for the snapshot assets, I'm
not entirely sure why, probably something to do with the file
names that include job IDs.