### PR TITLE
Add apache2 because it will not autoselected as dependency

### DIFF
--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -1,11 +1,13 @@
 FROM opensuse:13.2
 MAINTAINER Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>
 
+# apache2 was added, otherwise it can not installed as dependecy and following setup steps will fail.
 RUN zypper --non-interactive in ca-certificates-mozilla curl && \
     zypper ar -f obs://devel:openQA:stable/openSUSE_13.2 openQA && \
     zypper ar -f obs://devel:openQA:13.2/openSUSE_13.2 openQA-perl-modules && \
     curl https://build.opensuse.org/source/devel:openQA/_pubkey > /tmp/openQA-pubkey && rpm --import /tmp/openQA-pubkey && \
     zypper --non-interactive in openQA apache2
+
 
 # setup apache
 RUN gensslcert && \

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -5,7 +5,7 @@ RUN zypper --non-interactive in ca-certificates-mozilla curl && \
     zypper ar -f obs://devel:openQA:stable/openSUSE_13.2 openQA && \
     zypper ar -f obs://devel:openQA:13.2/openSUSE_13.2 openQA-perl-modules && \
     curl https://build.opensuse.org/source/devel:openQA/_pubkey > /tmp/openQA-pubkey && rpm --import /tmp/openQA-pubkey && \
-    zypper --non-interactive in openQA
+    zypper --non-interactive in openQA apache2
 
 # setup apache
 RUN gensslcert && \


### PR DESCRIPTION
The package "apache2" need to be installed which did not a dependency of openQA. 