### PR TITLE
auditing configuration

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -21,6 +21,9 @@
 # http://en.wikipedia.org/wiki/Strict-Transport-Security
 # hsts = 365
 
+## Set to 0 to disable auditing backend
+# audit_enabled = 1
+
 #[scm git]
 #do_push = no
 
@@ -40,3 +43,8 @@
 #provider = https://www.opensuse.org/openid/user/
 ## enforce redirect back to https
 #httpsonly = 1
+
+## Configuration for auditing plugin
+[audit]
+# disable auditing of chatty events by default
+blacklist = job_grab job_done

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -44,6 +44,7 @@ sub _read_config {
             suse_mirror   => undef,
             scm           => undef,
             hsts          => 365,
+            audit_enabled => 1,
         },
         auth => {
             method => 'OpenID',
@@ -63,6 +64,9 @@ sub _read_config {
         hypnotoad => {
             listen => ['http://localhost:9526/'],
             proxy  => 1,
+        },
+        audit => {
+            blacklist => '',
         },
     );
 
@@ -174,7 +178,9 @@ sub startup {
     $self->plugin('OpenQA::WebAPI::Plugin::REST');
     $self->plugin('OpenQA::WebAPI::Plugin::HashedParams');
     $self->plugin('OpenQA::WebAPI::Plugin::Gru');
-    $self->plugin('OpenQA::WebAPI::Plugin::AuditLog', Mojo::IOLoop->singleton);
+    if ($self->config->{global}{audit_enabled}) {
+        $self->plugin('OpenQA::WebAPI::Plugin::AuditLog', Mojo::IOLoop->singleton);
+    }
 
     $self->plugin(bootstrap3 => {css => [], js => []});
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -37,9 +37,9 @@ sub _read_config {
 
     my %defaults = (
         global => {
-            appname       => "openQA",
+            appname       => 'openQA',
             base_url      => undef,
-            branding      => "openSUSE",
+            branding      => 'openSUSE',
             allowed_hosts => undef,
             suse_mirror   => undef,
             scm           => undef,
@@ -54,12 +54,12 @@ sub _read_config {
         },
         logging => {
             level     => undef,
-            file      => "/var/log/openqa",
+            file      => '/var/log/openqa',
             sql_debug => undef,
         },
         openid => {
             provider  => 'https://www.opensuse.org/openid/user/',
-            httpsonly => '1',
+            httpsonly => 1,
         },
         hypnotoad => {
             listen => ['http://localhost:9526/'],

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -20,6 +20,7 @@ use parent 'Mojolicious::Controller';
 
 sub index {
     my ($self) = @_;
+    $self->stash('audit_enabled' => $self->app->config->{global}{audit_enabled});
     $self->render('admin/audit_log/index');
 }
 

--- a/t/config.t
+++ b/t/config.t
@@ -35,9 +35,10 @@ is_deeply(
     $cfg,
     {
         global => {
-            appname  => 'openQA',
-            branding => "openSUSE",
-            hsts     => '365',
+            appname       => 'openQA',
+            branding      => "openSUSE",
+            hsts          => '365',
+            audit_enabled => 1,
         },
         auth => {
             method => 'Fake',
@@ -56,7 +57,9 @@ is_deeply(
             listen => ['http://localhost:9526/'],
             proxy  => 1,
         },
-    });
+        audit => {
+            blacklist => 'job_grab job_done',
+        }});
 
 $ENV{OPENQA_CONFIG} = 't';
 open(my $fd, '>', $ENV{OPENQA_CONFIG} . '/openqa.ini');

--- a/t/config.t
+++ b/t/config.t
@@ -36,8 +36,8 @@ is_deeply(
     {
         global => {
             appname       => 'openQA',
-            branding      => "openSUSE",
-            hsts          => '365',
+            branding      => 'openSUSE',
+            hsts          => 365,
             audit_enabled => 1,
         },
         auth => {
@@ -51,7 +51,7 @@ is_deeply(
         },
         openid => {
             provider  => 'https://www.opensuse.org/openid/user/',
-            httpsonly => '1',
+            httpsonly => 1,
         },
         hypnotoad => {
             listen => ['http://localhost:9526/'],

--- a/templates/admin/audit_log/index.html.ep
+++ b/templates/admin/audit_log/index.html.ep
@@ -11,7 +11,11 @@
     %= include 'layouts/admin_nav'
 
     <div class="col-sm-10">
-        <h2><%= title %></h2>
+        <h2><%= title %>
+            % if (!$audit_enabled) {
+                <em class="text-warning">(auditing disabled)</em>
+            % }
+        </h2>
 
     %= include 'layouts/info'
 


### PR DESCRIPTION
- use [global]:audit_enabled to switch auditing off/on
- use [audit]:blacklist to list events which should not be logged
  (by default job_grab and job_done)
- audit log admin page prints "auditing disabled" if auditing is globaly
  disabled