### PR TITLE
Re-create the symbolic link of screenshot in interactive mode

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -704,13 +704,14 @@ sub create_result_dir {
 }
 
 sub update_module {
-    my ($self, $name, $result) = @_;
+    my ($self, $name, $result, $cleanup) = @_;
+    $cleanup //= 0;
     my $mod = $self->modules->find({name => $name});
     return unless $mod;
     $self->create_result_dir();
 
     $mod->update_result($result);
-    $mod->save_details($result->{details});
+    $mod->save_details($result->{details}, $cleanup);
 }
 
 sub running_modinfo() {
@@ -858,7 +859,14 @@ sub update_status {
     my %known;
     if ($status->{result}) {
         while (my ($name, $result) = each %{$status->{result}}) {
-            my $existant = $self->update_module($name, $result) || [];
+            my $existant;
+            if ($status->{status}->{needinput}) {
+                # in interactive mode, updating the symbolic link if needed
+                $existant = $self->update_module($name, $result, 1) || [];
+            }
+            else {
+                $existant = $self->update_module($name, $result) || [];
+            }
             for (@$existant) { $known{$_} = 1; }
         }
     }


### PR DESCRIPTION
Need to update the symbolic link of screenshot in interactive mode if
the screen is changed, therefore updating the symbolic link once the
screenshot's md5 was changed.