### PR TITLE
uncomment [openid] tag

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -38,7 +38,7 @@
 #sql_debug = true
 
 ## Configuration for OpenID auth method
-#[openid]
+[openid]
 ## base url for openid provider
 #provider = https://www.opensuse.org/openid/user/
 ## enforce redirect back to https


### PR DESCRIPTION
this avoids people setting only httpsonly = 0
which gets ignored when the [openid] tag is commented
and confuses+frustrates people