### PR TITLE
[DISCUSSION] Add PRODUCTDIR variable to support multiple main.pm/needles

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1005,8 +1005,7 @@ sub needle_dir() {
     unless ($self->{_needle_dir}) {
         my $distri  = $self->settings_hash->{DISTRI};
         my $version = $self->settings_hash->{VERSION};
-        my $dir     = OpenQA::Utils::testcasedir($distri, $version);
-        $self->{_needle_dir} = "$dir/needles";
+        $self->{_needle_dir} = OpenQA::Utils::needledir($distri, $version);
     }
     return $self->{_needle_dir};
 }

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -16,6 +16,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &data_name
   &needle_info
   &needledir
+  &productdir
   &testcasedir
   &testresultdir
   &file_content
@@ -47,10 +48,33 @@ our $hostname    = $ENV{SERVER_NAME};
 our $testcasedir = "$basedir/openqa/share/tests";
 our $app;
 
+sub productdir {
+    my ($distri, $version, $test_variant) = @_;
+
+    my $dir = "$testcasedir/$distri";
+    if ($test_variant && -e "$dir/products/$test_variant") {
+        $dir .= "/products/$test_variant";
+    }
+    elsif (-e "$dir/products/$distri") {
+        $dir .= "/products/$distri";
+    }
+    elsif ($version && -e "$dir/products/$distri/$version") {
+        $dir .= "/products/$distri/$version";
+    }
+    # @deprecated old structure
+    else {
+        $dir .= "-$version" if $version && -e "$dir-$version";
+    }
+
+    return $dir;
+}
+
+
 sub testcasedir($$) {
     my $distri  = shift;
     my $version = shift;
-
+    # TODO actually "distri" is misused here. It should rather be something
+    # like the name of the repository with all tests
     my $dir = "$testcasedir/$distri";
     $dir .= "-$version" if $version && -e "$dir-$version";
 
@@ -69,7 +93,7 @@ sub data_name($) {
 }
 
 sub needledir($$) {
-    return testcasedir($_[0], $_[1]) . '/needles';
+    return productdir($_[0], $_[1]) . '/needles';
 }
 
 sub needle_info($$$) {

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -111,8 +111,9 @@ sub engine_workit($) {
         print "setting $k=$v\n" if $verbose;
         $vars{$k} = $v;
     }
-    $vars{ASSETDIR} = ASSET_DIR;
-    $vars{CASEDIR} = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION});
+    $vars{ASSETDIR}   = ASSET_DIR;
+    $vars{CASEDIR}    = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION});
+    $vars{PRODUCTDIR} = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION});
     _save_vars(\%vars);
 
     # create tmpdir for qemu to write here


### PR DESCRIPTION
Allow to accomodate multiple "main.pm" and accompanying needles directory
depending on product while still sharing same tests.

PRODUCTDIR is discovered from trying to find directories inside "casedir".
PRODUCTDIR is forwarded to os-autoinst along with CASEDIR.

If a test distribution with the new folder structure is used it needs support
for PRODUCTDIR in os-autoinst. It should be save to install this new version
of openQA in an environment with old os-autoinst as well as an old set of
test.

Verified with a local installation of os-autoinst, openQA and
os-autoinst-distri-opensuse.

Related os-autoinst change: https://github.com/os-autoinst/os-autoinst/pull/376