### PR TITLE
Reverse auditlog event sorting order

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -26,7 +26,7 @@ sub index {
 
 sub ajax {
     my ($self) = @_;
-    my $events_rs = $self->app->db->resultset("AuditEvents")->search(undef, {order_by => 'me.id', prefetch => 'owner', rows => 300});
+    my $events_rs = $self->app->db->resultset("AuditEvents")->search(undef, {order_by => {-desc => 'me.id'}, prefetch => 'owner', rows => 300});
     my @events;
     while (my $event = $events_rs->next) {
         my $data = {


### PR DESCRIPTION
- else audit log prints first 300 events instead of latest