### PR TITLE
Comment URL rendering; Merge Makefile/travis style checks; gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ video
 .sass-cache/
 www/htdocs/includes/knownissues.html
 *~
+mojoResults.png
+openqa.log
+t/data/openqa/factory/hdd/00099963-hdd_image2.qcow2
+t/data/openqa/factory/hdd/hdd_image.qcow2
+t/diagram-v*.png

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ install:
   - cpanm -nq --installdeps --with-feature=coverage .
   - gem install sass
 script:
-  - ./script/tidy --check
-  - perlcritic --gentle lib
+  - make checkstyle
   - MOJO_LOG_LEVEL=debug OPENQA_LOGFILE=/tmp/openqa-debug.log cover -test -report coveralls -ignore_re "t/.*" -coverage default,-pod
 after_failure:
   - cat /tmp/openqa-debug.log

--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,12 @@ install:
 
 	cp -Ra dbicdh "$(DESTDIR)"/usr/share/openqa/dbicdh
 
-test:
-	OPENQA_CONFIG= prove -r
+
+checkstyle:
 	./script/tidy --check
 	PERL5LIB=lib/perlcritic:$$PERL5LIB perlcritic --gentle --include Perl::Critic::Policy::HashKeyQuote lib
 
-.PHONY: all install test
+test: checkstyle
+	OPENQA_CONFIG= prove -r
+
+.PHONY: all install checkstyle test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+.PHONY: all
 all:
 
+.PHONY: install
 install:
 	for i in lib public script templates; do \
 		mkdir -p "$(DESTDIR)"/usr/share/openqa/$$i ;\
@@ -54,11 +56,11 @@ install:
 	cp -Ra dbicdh "$(DESTDIR)"/usr/share/openqa/dbicdh
 
 
+.PHONY: checkstyle
 checkstyle:
 	./script/tidy --check
 	PERL5LIB=lib/perlcritic:$$PERL5LIB perlcritic --gentle --include Perl::Critic::Policy::HashKeyQuote lib
 
+.PHONY: test
 test: checkstyle
 	OPENQA_CONFIG= prove -r
-
-.PHONY: all install checkstyle test

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ install:
 
 .PHONY: checkstyle
 checkstyle:
-	./script/tidy --check
 	PERL5LIB=lib/perlcritic:$$PERL5LIB perlcritic --gentle --include Perl::Critic::Policy::HashKeyQuote lib
 
 .PHONY: test

--- a/cpanfile
+++ b/cpanfile
@@ -57,6 +57,7 @@ requires 'Package::Stash';
 requires 'Params::Util';
 requires 'Params::Validate';
 requires 'Perl::Tidy';
+requires 'Regexp::Common';
 requires 'SQL::Translator';
 requires 'SQL::SplitStatement';
 requires 'Scalar::Util';

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -100,7 +100,8 @@ sub _DoAutoLinks {
     $text =~ s{(bsc#(\d+))}{<a href="https://bugzilla.suse.com/show_bug.cgi?id=$2">$1</a>}gi;
     $text =~ s{(boo#(\d+))}{<a href="https://bugzilla.opensuse.org/show_bug.cgi?id=$2">$1</a>}gi;
     $text =~ s{(poo#(\d+))}{<a href="https://progress.opensuse.org/issues/$2">$1</a>}gi;
-    $text =~ s{(t#(\d+))}{<a href="/tests/$2">$1</a>}gi;
+    # For tests make sure that references into test modules and needling steps also work
+    $text =~ s{(t#([\w/]+))}{<a href="/tests/$2">$1</a>}gi;
 
     $text =~ s{(http://\S*\.gif$)}{<img src="$1"/>}gi;
     $self->SUPER::_DoAutoLinks($text);

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -86,13 +86,15 @@ sub rendered_markdown {
 package CommentsMarkdownParser;
 require Text::Markdown;
 our @ISA = qw/Text::Markdown/;
+use Regexp::Common qw/URI/;
 
 sub _DoAutoLinks {
     my ($self, $text) = @_;
 
     # auto-replace every http(s) reference which is not already either html
-    # 'a href...' or markdown link '[link](url)'
-    $text =~ s{(?<!['"(])(http[s]?://[^\s]*)}{<a href="$1">$1</a>}gi;
+    # 'a href...' or markdown link '[link](url)' or enclosed by Text::Markdown
+    # URL markers '<>'
+    $text =~ s@(?<!['"(<>])($RE{URI})@<$1>@gi;
 
     $text =~ s{(bnc#(\d+))}{<a href="https://bugzilla.novell.com/show_bug.cgi?id=$2">$1</a>}gi;
     $text =~ s{(bsc#(\d+))}{<a href="https://bugzilla.suse.com/show_bug.cgi?id=$2">$1</a>}gi;

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -200,7 +200,7 @@ sub edit {
         my $needleinfo;
         my $needlename;
         my $area;
-        # For each candidate we will use theee variables:
+        # For each candidate we will use the following variables:
         # $needle: needle information from result, in which 'areas' refers to the best matches
         # $needlename: read from the above
         # $needleinfo: actual definition of the needle, with the original areas

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -31,7 +31,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
 if ($driver) {
-    plan tests => 21;
+    plan tests => 23;
 }
 else {
     plan skip_all => 'Install phantomjs to run these tests';
@@ -66,7 +66,8 @@ $driver->find_element('textarea', 'css')->send_keys('
     foo@bar foo#bar
     <a href="https://openqa.example.com/foo/bar">https://openqa.example.com/foo/bar</a>: http://localhost:9562
     https://openqa.example.com/tests/181148 (reference http://localhost/foo/bar )
-    bsc#1234 boo#2345 poo#3456 t#4567'
+    bsc#1234 boo#2345 poo#3456 t#4567
+    t#5678/modules/welcome/steps/1'
 );
 $driver->find_element('#submitComment', 'css')->click();
 
@@ -79,6 +80,7 @@ is((shift @urls)->get_text(), 'bsc#1234',                                "url5")
 is((shift @urls)->get_text(), 'boo#2345',                                "url6");
 is((shift @urls)->get_text(), 'poo#3456',                                "url7");
 is((shift @urls)->get_text(), 't#4567',                                  "url8");
+is((shift @urls)->get_text(), 't#5678/modules/welcome/steps/1',          "url9");
 
 my @urls2 = $driver->find_elements('div.media-comment a', 'css');
 is((shift @urls2)->get_attribute('href'), 'https://openqa.example.com/foo/bar',                 "url1-href");
@@ -89,6 +91,7 @@ is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cg
 is((shift @urls2)->get_attribute('href'), 'https://bugzilla.opensuse.org/show_bug.cgi?id=2345', "url6-href");
 is((shift @urls2)->get_attribute('href'), 'https://progress.opensuse.org/issues/3456',          "url7-href");
 like((shift @urls2)->get_attribute('href'), qr{/tests/4567}, "url8-href");
+like((shift @urls2)->get_attribute('href'), qr{/tests/5678/modules/welcome/steps}, "url9-href");
 
 t::ui::PhantomTest::kill_phantom();
 


### PR DESCRIPTION
WebAPI: Correct typo in comment
Extend URL replace for 't#' references into test modules
Correct rendering of URLs in comments
Makefile: Prevent double call of 'tidy --check'
Call same style checks from both Makefile and .travis.yml
.gitignore: Ignore all test generated data