### PR TITLE
Prevent test coverage drop with automatic check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+COVERAGE_THRESHOLD ?= 59.4
 
 .PHONY: all
 all:
@@ -83,3 +84,7 @@ cover_db/coverage.html: cover_db/
 
 .PHONY: coverage-html
 coverage-html: cover_db/coverage.html
+
+.PHONY: coverage-check
+coverage-check: cover_db/coverage.html
+	./script/check_coverage ${COVERAGE_THRESHOLD}

--- a/script/check_coverage
+++ b/script/check_coverage
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use autodie;
+
+
+die "Need threshold as argument" unless @ARGV;
+
+my $filename = 'cover_db/coverage.html';
+
+open (my $fh, '<', $filename);
+my @log = <$fh>;
+close($fh);
+my @summary = grep { /Total/ } @log;
+chomp @summary;
+my $summary_line = $summary[0];
+
+my @matches = $summary_line =~ /(?<=>)[0-9.]+(?=<)/g;
+# for now just compare the last number, i.e. the total coverage against a
+# threshold
+die "No coverage found" unless scalar @matches > 0;
+die "Coverage is below threshold: $matches[-1] < $ARGV[0]" if ($matches[-1] < $ARGV[0]);


### PR DESCRIPTION
Prevent test coverage drop with automatic check

The Makefile now features separate target to execute tests and gather coverage
data plus explicit target names for the report generation in 'coveralls'
format for travis CI and coveralls checks and 'html' format which we can use
for displaying locally.

We can now also call the new script 'check_coverage' which parses the HTML
coverage report for the 'total' coverage. The check fails with an error
message if the coverage drops below the threshold defined in the Makefile.

This way we can prevent further unintended coverage drop while allowing to
adjust the threshold when necessary. However we should try to increase the
threshold over time which could also be done by marking "uncoverable"
statements.

Fixes https://progress.opensuse.org/issues/10262

~~Merge this if you also approve #512 to supersede, else #512 first.~~

Verification by travis running the adjusted make targets itself:
https://travis-ci.org/os-autoinst/openQA/builds/105931851