### PR TITLE
Highlight available test result comments on overview

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -92,7 +92,7 @@ sub latest_jobs {
         my $test     = $settings->{TEST};
         my $flavor   = $settings->{FLAVOR} || 'sweet';
         my $arch     = $settings->{ARCH} || 'noarch';
-        my $machine  = $settings->{MACHINE};
+        my $machine  = $settings->{MACHINE} || 'nomachine';
         my $key      = "$distri-$version-$build-$test-$flavor-$arch-$machine";
         next if $seen{$key}++;
         push(@latest, $job);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -310,6 +310,17 @@ sub _calculate_preferred_machines {
     return $pms;
 }
 
+sub _job_comments {
+    my ($self, $jobs) = @_;
+
+    my %comments;
+    my $c = $self->db->resultset("Comments")->search({job_id => {in => [map { $_->id } @$jobs]}});
+    while (my $comment = $c->next()) {
+        $comments{$comment->job_id}++;
+    }
+    return \%comments;
+}
+
 # Custom action enabling the openSUSE Release Team
 # to see the quality at a glance
 sub overview {
@@ -352,10 +363,14 @@ sub overview {
     %search_args = (%search_args, %$req_params);
     my $jobs = query_jobs(%search_args);
 
+    my @latest_jobs = $jobs->latest_jobs;
+
     my $all_result_stats   = OpenQA::Schema::Result::JobModules::job_module_stats($jobs);
     my $preferred_machines = _calculate_preferred_machines($jobs);
 
-    my @latest_jobs = $jobs->latest_jobs;
+    # prefetch the number of available comments for those jobs
+    my $job_comments = $self->_job_comments(\@latest_jobs);
+
     foreach my $job (@latest_jobs) {
         my $settings = $job->settings_hash;
         my $test     = $job->test;
@@ -378,7 +393,7 @@ sub overview {
                 jobid    => $job->id,
                 state    => "done",
                 failures => $job->failed_modules_with_needles(),
-                comments => scalar $job->comments,
+                comments => $job_comments->{$job->id},
             };
             $aggregated->{$overall}++;
         }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -378,6 +378,7 @@ sub overview {
                 jobid    => $job->id,
                 state    => "done",
                 failures => $job->failed_modules_with_needles(),
+                comments => scalar $job->comments > 0,
             };
             $aggregated->{$overall}++;
         }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -378,7 +378,7 @@ sub overview {
                 jobid    => $job->id,
                 state    => "done",
                 failures => $job->failed_modules_with_needles(),
-                comments => scalar $job->comments > 0,
+                comments => scalar $job->comments,
             };
             $aggregated->{$overall}++;
         }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -292,6 +292,7 @@ sub _calculate_preferred_machines {
     my %machines;
     while (my $job = $jobs->next()) {
         my $sh = $job->settings_hash;
+        next unless $sh->{MACHINE};
         $machines{$sh->{ARCH}} ||= {};
         $machines{$sh->{ARCH}}->{$sh->{MACHINE}}++;
     }
@@ -402,7 +403,7 @@ sub overview {
         }
 
         # Populate @configs and %archs
-        if ($preferred_machines->{$settings->{ARCH}} ne $settings->{MACHINE}) {
+        if ($settings->{MACHINE} && $preferred_machines->{$settings->{ARCH}} && $preferred_machines->{$settings->{ARCH}} ne $settings->{MACHINE}) {
             $test .= "@" . $settings->{MACHINE};
         }
         push(@configs, $test) unless (grep { $test eq $_ } @configs);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -287,7 +287,7 @@ sub show {
     $self->render('test/result');
 }
 
-sub _caclulate_preferred_machines {
+sub _calculate_preferred_machines {
     my ($jobs) = @_;
     my %machines;
     while (my $job = $jobs->next()) {
@@ -352,7 +352,7 @@ sub overview {
     my $jobs = query_jobs(%search_args);
 
     my $all_result_stats   = OpenQA::Schema::Result::JobModules::job_module_stats($jobs);
-    my $preferred_machines = _caclulate_preferred_machines($jobs);
+    my $preferred_machines = _calculate_preferred_machines($jobs);
 
     my @latest_jobs = $jobs->latest_jobs;
     foreach my $job (@latest_jobs) {

--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -533,6 +533,8 @@ table.overview .failedmodule {
 .fa.result_incomplete { color: #AF1E11;}
 .fa.module_none { color:#bebebe;}
 
+.fa.comment { color: Grey; }
+
 table#users td.role {
     white-space: nowrap;
 }

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -70,7 +70,7 @@ $t->app($app);
 my $get        = $t->get_ok('/api/v1/jobs');
 my @jobs       = @{$get->tx->res->json->{jobs}};
 my $jobs_count = scalar @jobs;
-is($jobs_count, 11);
+is($jobs_count, 12);
 my %jobs = map { $_->{id} => $_ } @jobs;
 is($jobs{99981}->{state},    'cancelled');
 is($jobs{99963}->{state},    'running');
@@ -80,9 +80,9 @@ is($jobs{99963}->{clone_id}, undef);
 
 # That means that only 9 are current and only 10 are relevant
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 9);
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
 is(scalar(@{$get->tx->res->json->{jobs}}), 10);
+$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
+is(scalar(@{$get->tx->res->json->{jobs}}), 11);
 
 # check limit quantity
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current', limit => 5});
@@ -110,7 +110,7 @@ like($new_jobs{99981}->{clone_id}, qr/\d/, 'job cloned');
 
 # The number of current jobs doesn't change
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 9, 'job count stay the same');
+is(scalar(@{$get->tx->res->json->{jobs}}), 10, 'job count stay the same');
 
 # Test /jobs/X/restart and /jobs/X
 $get = $t->get_ok('/api/v1/jobs/99926')->status_is(200);

--- a/t/fixtures/02-jobs.pl
+++ b/t/fixtures/02-jobs.pl
@@ -101,6 +101,22 @@
         settings   => [{key => 'DVD', value => '1'}, {key => 'VERSION', value => 'Factory'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'TEST', value => 'doc'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}, {key => 'FLAVOR', value => 'DVD'}, {key => 'BUILD', value => '0048'}, {key => 'DISTRI', value => 'opensuse'}, {key => 'ARCH', value => 'x86_64'}, {key => 'MACHINE', value => '64bit'},]
     },
     Jobs => {
+        id         => 99939,
+        group_id   => 1001,
+        priority   => 36,
+        result     => "passed",
+        state      => "done",
+        t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),    # One hour ago
+        t_started  => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),    # Two hours ago
+        test       => "kde",
+        backend    => 'qemu',
+        worker_id  => 0,
+        retry_avbl => 3,
+        # no result dir, let us assume that this is an old test that has
+        # already be pruned
+        settings => [{key => 'DVD', value => '1'}, {key => 'VERSION', value => 'Factory'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'TEST', value => 'kde'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}, {key => 'FLAVOR', value => 'DVD'}, {key => 'BUILD', value => '0048'}, {key => 'DISTRI', value => 'opensuse'}, {key => 'ARCH', value => 'x86_64'}, {key => 'MACHINE', value => '64bit'},]
+    },
+    Jobs => {
         id         => 99946,
         group_id   => 1001,
         priority   => 35,

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -124,7 +124,7 @@ is($parent_e->get_attribute('data-parents'),  "[]",              "no parents");
 # first check the relevant jobs
 my @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
 
-is_deeply(\@jobs, [qw(job_99981 job_99962 job_99946 job_99938 job_99937 job_99926)], '5 rows (relevant) displayed');
+is_deeply(\@jobs, [qw(job_99981 job_99962 job_99946 job_99939 job_99938 job_99937 job_99926)], '6 rows (relevant) displayed');
 $driver->find_element('#relevantfilter', 'css')->click();
 # leave the ajax some time
 while (!$driver->execute_script("return jQuery.active == 0")) {
@@ -132,7 +132,7 @@ while (!$driver->execute_script("return jQuery.active == 0")) {
 }
 # Test 99945 is not longer relevant (replaced by 99946) - but displayed for all
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply(\@jobs, [qw(job_99981 job_99962 job_99946 job_99945 job_99938 job_99937 job_99926)], '6 rows (all) displayed');
+is_deeply(\@jobs, [qw(job_99981 job_99962 job_99946 job_99945 job_99939 job_99938 job_99937 job_99926)], '7 rows (all) displayed');
 
 # now toggle back
 #print $driver->get_page_source();
@@ -142,7 +142,7 @@ while (!$driver->execute_script("return jQuery.active == 0")) {
     sleep 1;
 }
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply(\@jobs, [qw(job_99981 job_99962 job_99946 job_99938 job_99937 job_99926)], '5 rows (relevant) again displayed');
+is_deeply(\@jobs, [qw(job_99981 job_99962 job_99946 job_99939 job_99938 job_99937 job_99926)], '6 rows (relevant) again displayed');
 
 $driver->get($baseurl . "tests?match=staging_e");
 #print $driver->get_page_source();

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -64,7 +64,7 @@ $get->element_exists_not('#res_DVD_x86_64_doc');
 $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048'});
 $get->status_is(200);
 $summary = $t->tx->res->dom->at('#summary')->all_text;
-like($summary, qr/Passed: 0 Failed: 1/i);
+like($summary, qr/Passed: 1 Failed: 1/i);
 
 # Check the headers
 $get->element_exists('#flavor_DVD_arch_x86_64');
@@ -73,9 +73,9 @@ $get->element_exists_not('#flavor_GNOME-Live_arch_i686');
 
 # Check some results (and it's overview_xxx classes)
 $get->element_exists('#res_DVD_x86_64_doc .result_failed');
+$get->element_exists('#res_DVD_x86_64_kde .result_passed');
 $get->element_exists_not('#res_DVD_i586_doc');
 $get->element_exists_not('#res_DVD_i686_doc');
-$get->element_exists_not('#res_DVD_x86_64_kde');
 
 my $failedmodules = $t->tx->res->dom->at('#res_DVD_x86_64_doc .failedmodule a')->all_text;
 like($failedmodules, qr/logpackages/i, "failed modules are listed");
@@ -96,7 +96,7 @@ $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version =>
 $get->status_is(200);
 $summary = $t->tx->res->dom->at('#summary')->all_text;
 like($summary, qr/Summary of opensuse Factory build 0048/i);
-like($summary, qr/Passed: 0 Failed: 1/i);
+like($summary, qr/Passed: 1 Failed: 1/i);
 
 
 #
@@ -120,5 +120,12 @@ $get->element_exists_not('#res_DVD_x86_64_kde .state_running');
 $get->element_exists_not('#res_GNOME-Live_i686_RAID0 .state_cancelled');
 $get->element_exists_not('.result_failed');
 $get->element_exists_not('.state_cancelled');
+
+# this time show only failed
+$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', result => 'failed'})->status_is(200);
+$summary = $t->tx->res->dom->at('#summary')->all_text;
+like($summary, qr/Passed: 0 Failed: 1/i);
+$get->element_exists('#res_DVD_x86_64_doc .result_failed');
+$get->element_exists_not('#res_DVD_x86_64_kde .result_passed');
 
 done_testing();

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -110,7 +110,8 @@ is($driver->find_element('blockquote.ui-state-highlight', 'css')->get_text(), "C
 # go back to test result overview and check comment availability sign
 $driver->find_element('Build0048@opensuse', 'link_text')->click();
 is($driver->get_title(), "openQA: Test summary", "back on test group overview");
-is($driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'), 'Comment available', "test results show available comment(s)");
+is($driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'), '1 comment available', "test results show available comment(s)");
+
 
 t::ui::PhantomTest::kill_phantom();
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -31,7 +31,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
 if ($driver) {
-    plan tests => 27;
+    plan tests => 28;
 }
 else {
     plan skip_all => 'Install phantomjs to run these tests';
@@ -110,6 +110,8 @@ is($driver->find_element('blockquote.ui-state-highlight', 'css')->get_text(), "C
 # go back to test result overview and check comment availability sign
 $driver->find_element('Build0048@opensuse', 'link_text')->click();
 is($driver->get_title(), "openQA: Test summary", "back on test group overview");
+is($driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'), 'Comment available', "test results show available comment(s)");
+
 t::ui::PhantomTest::kill_phantom();
 
 done_testing();

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -35,7 +35,7 @@
 </div>
 
 <div id="change-match-form" title="Change match level">
-    <div>The needle area is matched using fuzzy image comparision. The pixels don't have to match completely but need to be close enough.
+    <div>The needle area is matched using fuzzy image comparison. The pixels don't have to match completely but need to be close enough.
         The colors are reduced and there is some noise reduction too and the match is calculated in percentages. By default everything
         above 96% is considered good enough. Sometimes this is too much and you want to lower the limit for noisy areas and sometimes
         you need to express that every detail matters, so you can change that per area. Note that a 96% for a smaller area is stricter

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -139,6 +139,14 @@
                                             </span>
                                         % }
                                     % }
+                                    % if ($res->{comments}) {
+                                        <span id="comment-<%= $jobid %>">
+                                            %# TODO link to #comments tab on result page does not currently work
+                                            <a href="<%= url_for('test', 'testid' => $jobid).'#comments' %>">
+                                                <i class="comment fa fa-comment" title="Comment available"></i>
+                                            </a>
+                                        </span>
+                                    % }
                                 % }
                             </td>
                         % }

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -141,7 +141,6 @@
                                     % }
                                     % if ($res->{comments}) {
                                         <span id="comment-<%= $jobid %>">
-                                            %# TODO link to #comments tab on result page does not currently work
                                             <a href="<%= url_for('test', 'testid' => $jobid).'#comments' %>">
                                                 <i class="comment fa fa-comment" title="<%= $res->{comments} %> <%= $res->{comments} > 1 ? "comments" : "comment" %> available"></i>
                                             </a>

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -143,7 +143,7 @@
                                         <span id="comment-<%= $jobid %>">
                                             %# TODO link to #comments tab on result page does not currently work
                                             <a href="<%= url_for('test', 'testid' => $jobid).'#comments' %>">
-                                                <i class="comment fa fa-comment" title="Comment available"></i>
+                                                <i class="comment fa fa-comment" title="<%= $res->{comments} %> <%= $res->{comments} > 1 ? "comments" : "comment" %> available"></i>
                                             </a>
                                         </span>
                                     % }

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -4,6 +4,12 @@
 % content_for 'ready_function' => begin
     $('.timeago').timeago();
     setupResultButtons();
+    %# Enable links into tabs and show same tab again on page reload
+    %# ref: https://github.com/twbs/bootstrap/issues/2415
+    %# Does not yet redirect to same tab on login.
+    var hash = window.location.hash || '#details';
+    var link = $('[href=' + hash + ']');
+    link && link.tab('show');
 % end
 
 % if (!@$modlist) {


### PR DESCRIPTION
The availability of comments on the test result page is shown on the test
result overview page next to the status icon and failed modules if available and if selected with the corresponding query parameter "show_comment=1".

The icon only appears if comments are available. This way it should be much
easier for reviewers of test runs to exchange and see if an issue has already
been noticed by someone else.
    
Be aware that so far the comments are per test result not per test case or
scenario.

Related issue: https://progress.opensuse.org/issues/10212

see screenshot for example with hover info:
![openqa_comment_bubble](https://cloud.githubusercontent.com/assets/1693432/12575830/e16a1e3a-c40f-11e5-98b0-70cc8fef62d0.png)
