### PR TITLE
Add make targets for coverage analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - gem install sass
 script:
   - make checkstyle
-  - MOJO_LOG_LEVEL=debug OPENQA_LOGFILE=/tmp/openqa-debug.log cover -test -report coveralls -ignore_re "t/.*" -coverage default,-pod
+  - COVERAGE_REPORT=coveralls make coverage
 after_failure:
   - cat /tmp/openqa-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
   - cpanm -nq --installdeps --with-feature=coverage .
   - gem install sass
 script:
-  - make checkstyle
-  - COVERAGE_REPORT=coveralls make coverage
+  # 'coverage-coveralls' calls checkstyle, tests and coverage analysis in
+  # coveralls format
+  - make coverage-coveralls
 after_failure:
   - cat /tmp/openqa-debug.log

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+COVERAGE_REPORT ?= html
+
 .PHONY: all
 all:
 
@@ -63,3 +65,7 @@ checkstyle:
 .PHONY: test
 test: checkstyle
 	OPENQA_CONFIG= prove -r
+
+.PHONY: coverage
+coverage:
+	MOJO_LOG_LEVEL=debug OPENQA_LOGFILE=/tmp/openqa-debug.log cover -test -report ${COVERAGE_REPORT} -ignore_re "t/.*" -coverage default,-pod

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-COVERAGE_REPORT ?= html
 
 .PHONY: all
 all:
@@ -66,6 +65,21 @@ checkstyle:
 test: checkstyle
 	OPENQA_CONFIG= prove -r
 
+cover_db/:
+	MOJO_LOG_LEVEL=debug OPENQA_LOGFILE=/tmp/openqa-debug.log cover -test -ignore_re "t/.*" -coverage default,-pod
+
+.PHONY: coverage-test
+coverage-test: cover_db/
+
 .PHONY: coverage
-coverage:
-	MOJO_LOG_LEVEL=debug OPENQA_LOGFILE=/tmp/openqa-debug.log cover -test -report ${COVERAGE_REPORT} -ignore_re "t/.*" -coverage default,-pod
+coverage: coverage-html
+
+.PHONY: coverage-coveralls
+coverage-coveralls: cover_db/
+	cover -report coveralls
+
+cover_db/coverage.html: cover_db/
+	cover -report html
+
+.PHONY: coverage-html
+coverage-html: cover_db/coverage.html


### PR DESCRIPTION
The Makefile now features separate target to execute tests and gather coverage
data plus explicit target names for the report generation in 'coveralls'
format for travis CI and coveralls checks and 'html' format which we can use
for displaying locally.

Related issue: https://progress.opensuse.org/issues/10262