### PR TITLE
Add PRODUCTDIR variable to support multiple main.pm/needles - Alt. to #505

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1016,8 +1016,7 @@ sub needle_dir() {
     unless ($self->{_needle_dir}) {
         my $distri  = $self->settings_hash->{DISTRI};
         my $version = $self->settings_hash->{VERSION};
-        my $dir     = OpenQA::Utils::testcasedir($distri, $version);
-        $self->{_needle_dir} = "$dir/needles";
+        $self->{_needle_dir} = OpenQA::Utils::needledir($distri, $version);
     }
     return $self->{_needle_dir};
 }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -111,8 +111,9 @@ sub engine_workit($) {
         print "setting $k=$v\n" if $verbose;
         $vars{$k} = $v;
     }
-    $vars{ASSETDIR} = ASSET_DIR;
-    $vars{CASEDIR} = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION});
+    $vars{ASSETDIR}   = ASSET_DIR;
+    $vars{CASEDIR}    = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION});
+    $vars{PRODUCTDIR} = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION});
     _save_vars(\%vars);
 
     # create tmpdir for qemu to write here


### PR DESCRIPTION
Allow to accomodate multiple "main.pm" and accompanying needles directory
depending on product while still sharing same tests.

PRODUCTDIR is discovered from trying to find directories inside "casedir".
PRODUCTDIR is forwarded to os-autoinst along with CASEDIR.

If a test distribution with the new folder structure is used it needs support
for PRODUCTDIR in os-autoinst. It should be save to install this new version
of openQA in an environment with old os-autoinst as well as an old set of
test.

Verified with a local installation of os-autoinst, openQA and
os-autoinst-distri-opensuse.

os-autoinst added support for a productdir in:
https://github.com/os-autoinst/os-autoinst/pull/376