### PR TITLE
Allow group overview query by result

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -297,7 +297,7 @@ sub query_jobs {
     my %args = @_;
     # For args where we accept a list of values, allow passing either an
     # array ref or a comma-separated list
-    for my $arg (qw/state ids/) {
+    for my $arg (qw/state ids result/) {
         next unless $args{$arg};
         $args{$arg} = [split(',', $args{$arg})] unless (ref($args{$arg}) eq 'ARRAY');
     }
@@ -325,6 +325,10 @@ sub query_jobs {
                     'me.t_started'  => $agecond,
                     'me.t_finished' => $agecond
                 ]});
+    }
+    # allows explicit filtering, e.g. in query url "...&result=failed&result=incomplete"
+    if ($args{result}) {
+        push(@conds, {'me.result' => {-in => $args{result}}});
     }
     if ($args{ignore_incomplete}) {
         push(@conds, {'me.result' => {-not_in => [OpenQA::Schema::Result::Jobs::INCOMPLETE_RESULTS]}});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -23,7 +23,7 @@ sub list {
     my $self = shift;
 
     my %args;
-    for my $arg (qw/build iso distri version flavor maxage scope group limit arch/) {
+    for my $arg (qw/build iso distri version flavor maxage scope group groupid limit arch/) {
         next unless defined $self->param($arg);
         $args{$arg} = $self->param($arg);
     }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -59,23 +59,24 @@ sub list {
     }
 
     #<<< do not let perltidy touch this
-    $self->render(json => 
-		  { JobTemplates => 
-		        [map { { id => $_->id,
-			         prio => $_->prio,
-				 group_name => $_->group->name,
-				 product => {id => $_->product_id,
-					     arch => $_->product->arch,
-					     distri => $_->product->distri,
-					     flavor => $_->product->flavor,
-					     group => $_->product->mediagroup,
-					     version => $_->product->version},
-				 machine => {id => $_->machine_id,
-					     name => $_->machine->name},
-				 test_suite => {id => $_->test_suite_id, name => $_->test_suite->name}}
-			 } @templates
-			]
-		  });
+    $self->render(json =>
+                 { JobTemplates =>
+                     [map { { id => $_->id,
+                              prio => $_->prio,
+                              group_name => $_->group ? $_->group->name : '',
+                              product => {id => $_->product_id,
+                                          arch => $_->product->arch,
+                                          distri => $_->product->distri,
+                                          flavor => $_->product->flavor,
+                                          group => $_->product->mediagroup,
+                                          version => $_->product->version},
+                              machine => {id => $_->machine_id,
+                                          name => $_->machine ? $_->machine->name : ''},
+                              test_suite => {id => $_->test_suite_id,
+                                             name => $_->test_suite->name}}
+             } @templates
+            ]
+          });
     #>>>
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -328,13 +328,9 @@ sub overview {
         $search_args{$arg} = $self->param($arg);
     }
 
-    if ($self->param('groupid')) {
-        $group = $self->db->resultset("JobGroups")->find($self->param('groupid'));
-        return $self->reply->not_found if (!$group);
-        $search_args{groupid} = $group->id;
-    }
-    elsif ($self->param('group')) {
-        $group = $self->db->resultset("JobGroups")->find({name => $self->param('group')});
+    if ($self->param('groupid') or $self->param('group')) {
+        my $search_term = $self->param('groupid') ? $self->param('groupid') : {name => $self->param('group')};
+        $group = $self->db->resultset("JobGroups")->find($search_term);
         return $self->reply->not_found if (!$group);
         $search_args{groupid} = $group->id;
     }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -348,9 +348,8 @@ sub overview {
         $build = $self->db->resultset("Jobs")->latest_build(%search_args);
     }
 
-    $search_args{build}       = $build;
-    $search_args{fulldetails} = 1;
-    $search_args{scope}       = 'current';
+    $search_args{build} = $build;
+    $search_args{scope} = 'current';
 
     my @configs;
     my %archs;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -345,6 +345,10 @@ sub overview {
     my %results;
     my $aggregated = {none => 0, passed => 0, failed => 0, incomplete => 0, scheduled => 0, running => 0, unknown => 0};
 
+    # Forward all query parameters to query_jobs to allow specifying additional
+    # query parameters which are then properly shown on the overview.
+    my $req_params = $self->req->params->to_hash;
+    %search_args = (%search_args, %$req_params);
     my $jobs = query_jobs(%search_args);
 
     my $all_result_stats   = OpenQA::Schema::Result::JobModules::job_module_stats($jobs);

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -316,11 +316,11 @@ ok(!$job->{settings}->{JOBTOKEN},                               "job token not p
 
 # we cannot test maxage here as it depends too much on too small
 # time slots. The ui tests check maxage instead too
-#%args = (maxage => 2, fulldetails => 1);
+#%args = (maxage => 2);
 #$current_jobs = list_jobs(%args);
 #is_deeply($current_jobs, [$job], "list_jobs with finish in past");
 #sleep 1;
-#%args = (maxage => 1, fulldetails => 1);
+#%args = (maxage => 1);
 #$current_jobs = list_jobs(%args);
 #is_deeply($current_jobs, [], "list_jobs with finish in future");
 

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -28,7 +28,7 @@ use OpenQA::Test::Database;
 use Net::DBus;
 use Net::DBus::Test::MockObject;
 
-use Test::More tests => 54;
+use Test::More tests => 55;
 
 my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
@@ -313,6 +313,10 @@ is($job->{state},  "done",   "job_set_done changed state");
 is($job->{result}, "passed", "job_set_done changed result");
 ok($job->{t_finished} =~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "job end timestamp updated");
 ok(!$job->{settings}->{JOBTOKEN},                               "job token not present after job done");
+
+%args = (result => "passed");
+$current_jobs = list_jobs(%args);
+is(scalar @{$current_jobs}, 1, "there is one passed job listed");
 
 # we cannot test maxage here as it depends too much on too small
 # time slots. The ui tests check maxage instead too

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -105,4 +105,17 @@ $summary = $t->tx->res->dom->at('#summary')->all_text;
 like($summary, qr/Summary of opensuse Factory build 87.5011/);
 like($summary, qr/Passed: 0 Incomplete: 1 Failed: 0/);
 
+# Advanced query parameters can be forwarded
+$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', result => 'passed'})->status_is(200);
+$summary = $t->tx->res->dom->at('#summary')->all_text;
+like($summary, qr/Summary of opensuse 13\.1 build 0091/i, "Still references the last build");
+like($summary, qr/Passed: 2 Failed: 0/i, "Only passed are shown");
+$get->element_exists('#res_DVD_i586_kde .result_passed');
+$get->element_exists('#res_DVD_i586_textmode .result_passed');
+$get->element_exists_not('#res_DVD_i586_RAID0 .state_scheduled');
+$get->element_exists_not('#res_DVD_x86_64_kde .state_running');
+$get->element_exists_not('#res_GNOME-Live_i686_RAID0 .state_cancelled');
+$get->element_exists_not('.result_failed');
+$get->element_exists_not('.state_cancelled');
+
 done_testing();


### PR DESCRIPTION
This allows e.g. to show only failed builds. Could be included like in http://lists.opensuse.org/opensuse-factory/2016-02/msg00018.html for "known defects"

* WebAPI: Test: Provide advanced query parameters for filtering
* Scheduler: Allow build filtering by result
* WebAPI: Test: Simplify group search
* WebAPI: Test: Simplify use of args
* Delete obsolete references to 'fulldetail'
* Fix api/v1/job_templates for empty groups/machines