### PR TITLE
Improve query_jobs performance

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -376,18 +376,11 @@ sub query_jobs {
             });
     }
 
-    # Search into the following job_settings
-    for my $setting (qw(build iso distri version flavor arch)) {
-        if ($args{$setting}) {
-            my $subquery = schema->resultset("JobSettings")->search(
-                {
-                    key   => uc($setting),
-                    value => $args{$setting}});
-            push(@conds, {'me.id' => {-in => $subquery->get_column('job_id')->as_query}});
-        }
+    if ($args{ids}) {
+        push(@conds, {'me.id' => {-in => $args{ids}}});
     }
-    # Text search across some settings
-    if ($args{match}) {
+    elsif ($args{match}) {
+        # Text search across some settings
         my $subquery = schema->resultset("JobSettings")->search(
             {
                 key => ['DISTRI', 'FLAVOR', 'BUILD', 'TEST', 'VERSION'],
@@ -395,8 +388,30 @@ sub query_jobs {
             });
         push(@conds, {'me.id' => {-in => $subquery->get_column('job_id')->as_query}});
     }
-    if ($args{ids}) {
-        push(@conds, {'me.id' => {-in => $args{ids}}});
+    else {
+        my @js_joins;
+        my @js_conds;
+        # Search into the following job_settings
+        for my $setting (qw(build iso distri version flavor arch)) {
+            if ($args{$setting}) {
+                # for dynamic self joins we need to be creative ;(
+                my $tname = 'me';
+                if (@js_conds) {
+                    $tname = "siblings";
+                    if (@js_joins) {
+                        $tname = "siblings_" . (int(@js_joins) + 1);
+                    }
+                    push(@js_joins, 'siblings');
+                }
+                push(
+                    @js_conds,
+                    {
+                        "$tname.key"   => uc($setting),
+                        "$tname.value" => $args{$setting}});
+            }
+        }
+        my $subquery = schema->resultset("JobSettings")->search({-and => \@js_conds}, {join => \@js_joins});
+        push(@conds, {'me.id' => {-in => $subquery->get_column('job_id')->as_query}});
     }
 
     $attrs{order_by} = ['me.id DESC'];

--- a/lib/OpenQA/Schema/Result/JobSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobSettings.pm
@@ -41,8 +41,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(
-    "job",
-    "OpenQA::Schema::Result::Jobs",
+    job => "OpenQA::Schema::Result::Jobs",
     {'foreign.id' => "self.job_id"},
     {
         is_deferrable => 1,
@@ -51,6 +50,9 @@ __PACKAGE__->belongs_to(
         on_update     => "CASCADE",
     },
 );
+__PACKAGE__->has_many(
+    siblings => "OpenQA::Schema::Result::JobSettings",
+    {"foreign.job_id" => "self.job_id"});
 
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
Split the JobSettings query into a subquery. This helps the query analyzer
getting the jobs with the right settings in one loop instead of 3 intersected
loops.

Reduces the runtime from 55s to 0.02s