### PR TITLE
treat kernels / initrds as assets, allow download of all assets

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -11,6 +11,15 @@
 ## space seaparated list of IPs or regular expressions that match IPs
 #allowed_hosts = 127.0.0.1 ::1
 
+## space separated list of domains from which asset download with
+## _URL params is allowed. Matched at the end of the hostname in
+## the URL. with these values downloads from opensuse.org,
+## dl.fedoraproject.org, and a.b.c.opensuse.org are allowed; downloads
+## from moo.net, dl.opensuse and fedoraproject.org.evil are not
+## default is undefined, meaning asset download is *disabled*, you
+## must set this option to enable it
+#download_domains = fedoraproject.org opensuse.org
+
 ## set if you have a local repo mirror
 #suse_mirror = http://FIXME
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -37,14 +37,15 @@ sub _read_config {
 
     my %defaults = (
         global => {
-            appname       => 'openQA',
-            base_url      => undef,
-            branding      => 'openSUSE',
-            allowed_hosts => undef,
-            suse_mirror   => undef,
-            scm           => undef,
-            hsts          => 365,
-            audit_enabled => 1,
+            appname          => 'openQA',
+            base_url         => undef,
+            branding         => 'openSUSE',
+            allowed_hosts    => undef,
+            download_domains => undef,
+            suse_mirror      => undef,
+            scm              => undef,
+            hsts             => 365,
+            audit_enabled    => 1,
         },
         auth => {
             method => 'OpenID',
@@ -518,12 +519,12 @@ sub startup {
     ## JSON API ends here
     #
 
-    $self->gru->add_task(optipng       => \&OpenQA::Schema::Result::Jobs::optipng);
-    $self->gru->add_task(reduce_result => \&OpenQA::Schema::Result::Jobs::reduce_result);
-    $self->gru->add_task(limit_assets  => \&OpenQA::Schema::Result::Assets::limit_assets);
-    $self->gru->add_task(download_iso  => \&OpenQA::Schema::Result::Assets::download_iso);
-    $self->gru->add_task(scan_old_jobs => \&OpenQA::Schema::Result::Needles::scan_old_jobs);
-    $self->gru->add_task(scan_needles  => \&OpenQA::Schema::Result::Needles::scan_needles);
+    $self->gru->add_task(optipng        => \&OpenQA::Schema::Result::Jobs::optipng);
+    $self->gru->add_task(reduce_result  => \&OpenQA::Schema::Result::Jobs::reduce_result);
+    $self->gru->add_task(limit_assets   => \&OpenQA::Schema::Result::Assets::limit_assets);
+    $self->gru->add_task(download_asset => \&OpenQA::Schema::Result::Assets::download_asset);
+    $self->gru->add_task(scan_old_jobs  => \&OpenQA::Schema::Result::Needles::scan_old_jobs);
+    $self->gru->add_task(scan_needles   => \&OpenQA::Schema::Result::Needles::scan_needles);
 
     # start workers checker
     $self->_workers_checker;

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -23,7 +23,7 @@ use POSIX qw/uname/;
 
 use base qw/Exporter/;
 our @EXPORT = qw/$job $workerid $verbose $instance $worker_settings $pooldir $nocleanup $worker_caps $testresults $openqa_url
-  OPENQA_BASE OPENQA_SHARE ISO_DIR HDD_DIR ASSET_DIR STATUS_UPDATES_SLOW STATUS_UPDATES_FAST
+  OPENQA_BASE OPENQA_SHARE ISO_DIR HDD_DIR OTHER_DIR ASSET_DIR STATUS_UPDATES_SLOW STATUS_UPDATES_FAST
   add_timer remove_timer change_timer
   api_call verify_workerid register_worker ws_call/;
 
@@ -50,8 +50,9 @@ use constant OPENQA_BASE  => '/var/lib/openqa';
 use constant OPENQA_SHARE => OPENQA_BASE . '/share';
 use constant ASSET_DIR    => OPENQA_SHARE . '/factory';
 use constant {
-    ISO_DIR => ASSET_DIR . '/iso',
-    HDD_DIR => ASSET_DIR . '/hdd',
+    ISO_DIR   => ASSET_DIR . '/iso',
+    HDD_DIR   => ASSET_DIR . '/hdd',
+    OTHER_DIR => ASSET_DIR . '/other',
 };
 use constant {
     STATUS_UPDATES_SLOW => 10,

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -90,6 +90,17 @@ sub engine_workit($) {
         }
     }
 
+    for my $otherkey (qw/KERNEL INITRD/) {
+        if (my $file = $job->{settings}->{$otherkey}) {
+            $file = join('/', OTHER_DIR, $file);
+            unless (-e $file) {
+                warn "$file does not exist!\n";
+                return;
+            }
+            $job->{settings}->{$otherkey} = $file;
+        }
+    }
+
     my $nd = $job->{settings}->{NUMDISKS} || 2;
     for my $i (1 .. $nd) {
         my $hdd = $job->{settings}->{"HDD_$i"} || undef;

--- a/t/05-scheduler-iso.t
+++ b/t/05-scheduler-iso.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl -w
+
+# Copyright (C) 2016 Red Hat
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Test job creation with job_create_iso.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use strict;
+use OpenQA::IPC;
+use OpenQA::Scheduler;
+use OpenQA::WebSockets;
+use OpenQA::Test::Database;
+use Net::DBus;
+use Net::DBus::Test::MockObject;
+
+use Test::More tests => 4;
+
+# We need the fixtures so we have job templates
+my $schema = OpenQA::Test::Database->new->create;
+
+# create Test DBus bus and service for fake WebSockets
+my $ipc = OpenQA::IPC->ipc('', 1);
+my $ws  = OpenQA::WebSockets->new();
+my $sh  = OpenQA::Scheduler->new();
+
+# check we have no gru download tasks to start with
+my @tasks = $schema->resultset("GruTasks")->search({taskname => 'download_asset'});
+ok(scalar @tasks == 0);
+
+# check a regular ISO post creates the expected number of jobs
+my $ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso');
+ok($ids == 10);
+
+# Schedule download of an existing ISO; gru task should not be created
+$ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso');
+@tasks = $schema->resultset("GruTasks")->search({taskname => 'download_asset'});
+ok(scalar @tasks == 0);
+
+# Schedule download of a non-existing ISO; gru task should be created
+$ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'nonexistent.iso');
+@tasks = $schema->resultset("GruTasks")->search({taskname => 'download_asset'});
+ok(scalar @tasks == 1);


### PR DESCRIPTION
this is to make it possible to do 'remote scheduling' (where
the scheduler runs on some machine which does not have access
to the openQA 'factory' directory) of jobs that boot using a
kernel and/or initrd and/or hdd image, just as the 'ISOURL'
feature made it possible for jobs that boot using an ISO. I had
to change a few other things to be happy with it, though.

The convention now is you can request openQA download for any
asset type, by adding _URL to the appropriate setting name. To
download the ISO set 'ISO_URL', to download a kernel set
'KERNEL_URL', and so on. The POST will error out if you try to
download something that is *not* an asset type. This is because
we can't really guess where we should store non-assets.

As with the old ISOURL code, if you set the normal setting
(ISO, KERNEL etc.), that value will be used as the filename of
the downloaded file, otherwise the original filename will be
split out from the URL and used.

Of course, in order to achieve the original goal, I had to make
kernels and initrds be treated as assets :) In garretraziel's
initial patch they were not. We have another good reason to
treat them as assets, though - it will allow us to clean them
up with the limit_assets gru task (this patch does not change
that yet, but it's necessary to make it possible). For now we
treat kernels and initrds as 'other' assets, they could be
given a new asset type instead if we think that's a good idea.
HDDs of course already have an asset type.

It seemed clean to factor the 'figure out the asset type for
a given setting' code in parse_assets_from_settings, because we
need to do that same thing in job_schedule_iso now, to decide
where the asset should be downloaded to (we need to know its
type). So this adds 'asset_type_from_setting' to Utils, and
has both parse_assets_from_settings and job_schedule_iso use
it.

It's also necessary to define OTHER_DIR (like HDD_DIR and
ISO_DIR) in Common.pm so isotovideo can use it. The code for
attaching the appropriate path to the KERNEL and INITRD values
is almost identical to the code for ISO, but it's not easy to
reuse unfortunately.

Finally I added a bit more handling of potential error cases
in download_asset (renamed from download_iso) to try and avoid
triggering the Eternal Gru Failure Loop Of Pain (it now checks
if it can write to the target path, and catches errors when
moving the temporary file to the final location, since we found
out that was possible).