### PR TITLE
[WIP][DISCUSSION] fail on warnings in tests

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -86,7 +86,7 @@ requires 'warnings';
 on 'test' => sub {
   requires 'Perl::Tidy';
   requires 'Perl::Critic';
-  requires 'Test::Output';
+  requires 'Test::Warnings';
 };
 
 feature 'coverage', 'coverage for travis' => sub {

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -16,8 +16,6 @@ BEGIN { unshift @INC, 'lib'; }
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use Test::More;
+use Test::More 'no_plan';
 
 is(system('script/tidy', '--check'), 0, "tidy");
-
-done_testing();

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -17,5 +17,6 @@ BEGIN { unshift @INC, 'lib'; }
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 use Test::More 'no_plan';
+use Test::Warnings;
 
 is(system('script/tidy', '--check'), 0, "tidy");

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -28,7 +28,7 @@ use OpenQA::Test::Database;
 use Net::DBus;
 use Net::DBus::Test::MockObject;
 
-use Test::More tests => 55;
+use Test::More 'no_plan';
 
 my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
@@ -402,5 +402,3 @@ is($asset->id, 1, "asset register returns same");
 
 $asset = OpenQA::Scheduler::Scheduler::asset_delete(type => 'iso', name => $settings{ISO});
 is($asset, 1, "asset delete");
-
-done_testing;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -29,6 +29,7 @@ use Net::DBus;
 use Net::DBus::Test::MockObject;
 
 use Test::More 'no_plan';
+use Test::Warnings;
 
 my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
 

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -28,7 +28,7 @@ use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 use Net::DBus;
 
-use Test::More;
+use Test::More 'no_plan';
 
 OpenQA::Test::Database->new->create();
 # create Test DBus bus and service for fake WebSockets call
@@ -94,5 +94,3 @@ is($ret, 1, "one job cancelled by iso");
 
 $job = OpenQA::Scheduler::Scheduler::job_get(99927);
 is($job->{state}, 'scheduled', "unrelated job 99927 still scheduled");
-
-done_testing();

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -29,6 +29,7 @@ use OpenQA::Test::Database;
 use Net::DBus;
 
 use Test::More 'no_plan';
+use Test::Warnings;
 
 OpenQA::Test::Database->new->create();
 # create Test DBus bus and service for fake WebSockets call

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -27,7 +27,7 @@ use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::More tests => 9;
+use Test::More 'no_plan';
 
 my $schema = OpenQA::Test::Database->new->create;    #(skip_fixtures => 1);
 
@@ -189,5 +189,3 @@ is($job->{id}, $jobI->id, "this worker can do jobI, child - client");
 
 
 # job G is not grabbed because there is no worker with class 'special'
-
-done_testing();

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -28,6 +28,7 @@ use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 use Test::Mojo;
 use Test::More 'no_plan';
+use Test::Warnings;
 
 my $schema = OpenQA::Test::Database->new->create;    #(skip_fixtures => 1);
 

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -26,7 +26,7 @@ use OpenQA::Scheduler::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::More tests => 155;
+use Test::More 'no_plan';
 
 my $schema = OpenQA::Test::Database->new->create();
 
@@ -732,5 +732,3 @@ my $jobP3 = job_get_deps($jobP2->clone->id);
 
 is_deeply($jobI2->{parents}->{Parallel}, [$jobO3->{id}], 'jobI2 got new parent jobO3');
 is_deeply($jobO3->{parents}->{Parallel}, [$jobP3->{id}], 'clone jobO3 gets new parent jobP3');
-
-done_testing();

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -27,6 +27,7 @@ use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 use Test::Mojo;
 use Test::More 'no_plan';
+use Test::Warnings;
 
 my $schema = OpenQA::Test::Database->new->create();
 

--- a/t/05-scheduler-iso.t
+++ b/t/05-scheduler-iso.t
@@ -31,8 +31,8 @@ use OpenQA::Test::Database;
 use Net::DBus;
 use Net::DBus::Test::MockObject;
 
-use Test::More;
 use Test::Output;
+use Test::More 'no_plan';
 
 # We need the fixtures so we have job templates
 my $schema = OpenQA::Test::Database->new->create;
@@ -59,5 +59,3 @@ is($schema->resultset("GruTasks")->search({taskname => 'download_asset'}), 0, 'g
 # Schedule download of a non-existing ISO
 stderr_like { $ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'nonexistent.iso') } $warning, 'expected warnings';
 is($schema->resultset("GruTasks")->search({taskname => 'download_asset'}), 1, 'gru task should be created');
-
-done_testing();

--- a/t/05-scheduler-iso.t
+++ b/t/05-scheduler-iso.t
@@ -31,8 +31,9 @@ use OpenQA::Test::Database;
 use Net::DBus;
 use Net::DBus::Test::MockObject;
 
-use Test::Output;
 use Test::More 'no_plan';
+use Test::Deep;
+use Test::Warnings ':all';
 
 # We need the fixtures so we have job templates
 my $schema = OpenQA::Test::Database->new->create;
@@ -47,15 +48,18 @@ my @tasks;
 @tasks = $schema->resultset("GruTasks")->search({taskname => 'download_asset'});
 is(scalar @tasks, 0, 'we have no gru download tasks to start with');
 
-my $warning = qr/START_AFTER_TEST=.* not found - check for typos and dependency cycles/;
-stderr_like { @tasks = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso') } $warning, 'warnings expected about test dependencies';
+my $expected = qr/START_AFTER_TEST=.* not found - check for typos and dependency cycles/;
+like(warning { warn "START_AFTER_TEST=kde:32bit not found - check for typos and dependency cycles at lib/OpenQA/Scheduler/Scheduler.pm line 226" }, $expected);
+my @warnings = warnings { @tasks = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso') };
+map { like($_, $expected, 'warning expected about test dependencies') } @warnings;
 is(scalar @tasks, 10, 'a regular ISO post creates the expected number of jobs');
 
 # Schedule download of an existing ISO
-my $ids;
-stderr_like { $ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso') } $warning, 'expected warnings';
+@warnings = warnings { my $ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso') };
+map { like($_, $expected, 'expected warning') } @warnings;
 is($schema->resultset("GruTasks")->search({taskname => 'download_asset'}), 0, 'gru task should not be created');
 
 # Schedule download of a non-existing ISO
-stderr_like { $ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'nonexistent.iso') } $warning, 'expected warnings';
+@warnings = warnings { my $ids = OpenQA::Scheduler::Scheduler::job_schedule_iso(DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'nonexistent.iso') };
+map { like($_, $expected, 'expected warning') } @warnings;
 is($schema->resultset("GruTasks")->search({taskname => 'download_asset'}), 1, 'gru task should be created');

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -28,6 +28,7 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 
 use Test::More 'no_plan';
+use Test::Warnings;
 
 
 # create Test DBus bus and service for fake WebSockets call

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -27,7 +27,7 @@ use OpenQA::WebSockets;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 
-use Test::More;
+use Test::More 'no_plan';
 
 
 # create Test DBus bus and service for fake WebSockets call
@@ -150,5 +150,3 @@ my $round5_id = OpenQA::Scheduler::Scheduler::job_duplicate(jobid => $round3_id)
 ok(defined $round5_id, "manual-duplicate works");
 $job3 = OpenQA::Scheduler::Scheduler::job_get($round5_id);
 is($job3->{retry_avbl}, 1, "the retry counter increased");
-
-done_testing;

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -23,7 +23,7 @@ BEGIN {
 use strict;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
@@ -33,5 +33,3 @@ my $mordred_id = 'https://openid.badguys.uk/mordred';
 my $user = $t->app->db->resultset("Users")->create({username => $mordred_id});
 ok(!$user->is_admin,    'new users are not admin by default');
 ok(!$user->is_operator, 'new users are not operator by default');
-
-done_testing();

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -25,6 +25,7 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -24,6 +24,7 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -22,7 +22,7 @@ BEGIN {
 use strict;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 
 OpenQA::Test::Database->new->create();
@@ -48,5 +48,3 @@ $t->get_ok('/api/v1/whoami')->status_is(403);
 # and without jobtoken
 $t->ua->unsubscribe('start');
 $t->get_ok('/api/v1/whoami')->status_is(403);
-
-done_testing();

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -24,7 +24,7 @@ BEGIN {
 
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 
 OpenQA::Test::Database->new->create();
@@ -35,5 +35,3 @@ my $arthur = $t->app->db->resultset("Users")->find({username => 'arthur'});
 my $key = $t->app->db->resultset("ApiKeys")->create({user_id => $arthur->id});
 like($key->key,    qr/[0-9a-fA-F]{16}/, 'new keys have a valid random key attribute');
 like($key->secret, qr/[0-9a-fA-F]{16}/, 'new keys have a valid random secret attribute');
-
-done_testing();

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -26,6 +26,7 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -25,6 +25,7 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -23,7 +23,7 @@ BEGIN {
 use strict;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 
 OpenQA::Test::Database->new->create();
@@ -61,5 +61,3 @@ my $second = $t->app->db->resultset("Jobs")->find({id => $clones{$clone->id}});
 is($second->test,       "minimalx", "same test again");
 is($second->priority,   35,         "with adjusted priority");
 is($second->retry_avbl, 2,          "with adjusted retry_avbl");
-
-done_testing();

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -23,7 +23,7 @@ BEGIN {
 use strict;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 
 OpenQA::Test::Database->new->create();
@@ -41,5 +41,3 @@ ok(grep(!/^(99962|99945)$/, @ids));
 # These are the later clones, they should appear
 ok(grep(/^99963$/, @ids));
 ok(grep(/^99946$/, @ids));
-
-done_testing();

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -25,6 +25,7 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 
 OpenQA::Test::Database->new->create();
 my $t  = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -17,7 +17,7 @@ BEGIN {
     unshift @INC, 'lib';
 }
 
-use Test::More;
+use Test::More 'no_plan';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::Scheduler::Scheduler;
@@ -54,5 +54,3 @@ for my $cmd (@valid_commands) {
 #issue invalid commands
 OpenQA::Scheduler::Scheduler::command_enqueue(workerid => 1, command => 'foo', job_id => 0);
 isnt($OpenQA::WebSockets::Server::last_command, 'foo', 'refuse invalid commands');
-
-done_testing();

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -18,6 +18,7 @@ BEGIN {
 }
 
 use Test::More 'no_plan';
+use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::Scheduler::Scheduler;
@@ -52,5 +53,5 @@ for my $cmd (@valid_commands) {
 }
 
 #issue invalid commands
-OpenQA::Scheduler::Scheduler::command_enqueue(workerid => 1, command => 'foo', job_id => 0);
+like(warning { OpenQA::Scheduler::Scheduler::command_enqueue(workerid => 1, command => 'foo', job_id => 0) }, qr/invalid command "foo"/);
 isnt($OpenQA::WebSockets::Server::last_command, 'foo', 'refuse invalid commands');

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -20,6 +20,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 use File::Temp qw/tempfile/;

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -18,7 +18,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 3;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -42,5 +42,3 @@ my @lines = <FILE>;
 close(FILE);
 
 like(join('', @lines), qr/.*\[debug\] \[DBIx debug\] Took .* seconds executed: SELECT.*/, "seconds in log file");
-
-done_testing();

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -23,7 +23,7 @@ use strict;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Scheduler;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 
 # create Test DBus bus and service for fake WebSockets call
@@ -114,5 +114,3 @@ ok(!$res->locked_by, 'mutex is unlocked');
 $t->post_ok('/api/v1/mutex/test_lock', form => {action => 'lock'})->status_is(200);
 $res = $schema->resultset('JobLocks')->find({owner => $jobA, name => 'test_lock'});
 is($res->locked_by->id, $jobB, 'mutex is locked');
-
-done_testing();

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -25,6 +25,7 @@ use OpenQA::Test::Database;
 use OpenQA::Scheduler;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 
 # create Test DBus bus and service for fake WebSockets call
 my $ipc = OpenQA::IPC->ipc('', 1);

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -23,7 +23,7 @@ use strict;
 use OpenQA::Utils;
 use File::Copy;
 use OpenQA::Test::Database;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use File::Which qw(which);
@@ -57,5 +57,3 @@ $c->run('run', '-o');
 
 ok(-f "t/data/openqa/factory/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso",   "iso 1 is still there");
 ok(-f "t/data/openqa/factory/iso/openSUSE-13.1-DVD-x86_64-Build0091-Media.iso", "iso 2 is still there");
-
-done_testing();

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -25,6 +25,7 @@ use File::Copy;
 use OpenQA::Test::Database;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use File::Which qw(which);
 

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use Data::Dump qw/pp dd/;
 use Test::More 'no_plan';
+use Test::Warnings;
 use OpenQA::Scheduler::Scheduler qw/job_create job_grab job_get job_restart job_set_done/;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::IPC;

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -22,7 +22,7 @@ BEGIN {
 use strict;
 use warnings;
 use Data::Dump qw/pp dd/;
-use Test::More;
+use Test::More 'no_plan';
 use OpenQA::Scheduler::Scheduler qw/job_create job_grab job_get job_restart job_set_done/;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::IPC;
@@ -135,4 +135,3 @@ is_deeply(\@assets, [$theasset, $ja->id], 'using correct assets');
 $jobB->discard_changes();
 ok($jobB->clone, 'jobB has a clone after cloning asset creator');
 unlink($ja->disk_file);
-done_testing();

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -22,9 +22,7 @@ BEGIN {
 
 use strict;
 use OpenQA::Utils;
-use Test::More;
+use Test::More 'no_plan';
 
 ok(run_cmd_with_log(['echo', 'Hallo', 'Welt']));
 is(run_cmd_with_log(['false']), "");
-
-done_testing();

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -23,6 +23,7 @@ BEGIN {
 use strict;
 use OpenQA::Utils;
 use Test::More 'no_plan';
+use Test::Warnings;
 
 ok(run_cmd_with_log(['echo', 'Hallo', 'Welt']));
 is(run_cmd_with_log(['false']), "");

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use Mojo::URL;
 use OpenQA::Test::Case;
@@ -107,6 +107,3 @@ $worker_caps->{instance} = 42;
 $ret = $t->post_ok('/api/v1/workers', form => $worker_caps);
 is($ret->tx->res->code,       200, "register new worker");
 is($ret->tx->res->json->{id}, 3,   "new worker id is 3");
-
-
-done_testing();

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings ':all';
 use Mojo::URL;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -44,7 +45,7 @@ $t->app($app);
 
 my $ret;
 
-$ret = $t->post_ok('/api/v1/workers', form => {host => 'localhost', instance => 1, backend => 'qemu'});
+like(warning { $ret = $t->post_ok('/api/v1/workers', form => {host => 'localhost', instance => 1, backend => 'qemu'}) }, qr/missing apisecret/);
 is($ret->tx->res->code, 403, "register worker without API key fails");
 
 $t->ua(OpenQA::Client->new(api => 'testapi')->ioloop(Mojo::IOLoop->singleton));

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
@@ -153,10 +154,10 @@ $ret = $t->get_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(200)
 la;
 
 # try to register with invalid type
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'foo', name => $iso1})->status_is(400);
+like(warning { $ret = $t->post_ok('/api/v1/assets', form => {type => 'foo', name => $iso1})->status_is(400) }, qr/asset type \'foo\' invalid/);
 
 # try to register non existing asset
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})->status_is(400);
+like(warning { $ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})->status_is(400) }, qr/asset name \'foo.iso\' invalid/);
 
 
 for my $i ($iso1, $iso2) {

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -162,5 +162,3 @@ $ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})
 for my $i ($iso1, $iso2) {
     ok(unlink("t/data/openqa/factory/iso/$i"), "rm $i");
 }
-
-done_testing();

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -172,5 +172,3 @@ $ret = $t->post_ok('/api/v1/isos', form => {iso => $iso, tests => "kde/usb"})->s
 $ret = $t->delete_ok("/api/v1/isos/$iso")->status_is(200);
 # now the jobs should be gone
 $ret = $t->get_ok('/api/v1/jobs/$newid')->status_is(404);
-
-done_testing();

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
@@ -98,7 +99,9 @@ lj;
 
 # schedule the iso, this should not actually be possible. Only isos
 # with different name should result in new tests...
-$ret = $t->post_ok('/api/v1/isos', form => {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})->status_is(200);
+my $expected = qr/START_AFTER_TEST=.* not found - check for typos and dependency cycles/;
+my @warnings = warnings { $ret = $t->post_ok('/api/v1/isos', form => {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})->status_is(200) };
+map { like($_, $expected) } @warnings;
 
 is($ret->tx->res->json->{count}, 10, "10 new jobs created");
 my @newids = @{$ret->tx->res->json->{ids}};

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use Mojo::URL;
 use Mojo::Util qw(encode);
@@ -104,5 +104,3 @@ SKIP: {
     $t->ua->apisecret('MANYPEOPLEKNOW');
     $ret = $t->websocket_nok('/api/v1/workers/1/ws');
 }
-
-done_testing();

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use Mojo::URL;
 use Mojo::Util qw(encode);
 use OpenQA::Test::Case;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -20,6 +20,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -18,7 +18,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 60;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -156,5 +156,3 @@ $post->content_is('OK');
 ok(-e $rp, 'asset exist after');
 $ret = $t->get_ok('/api/v1/assets/hdd/00099963-hdd_image2.qcow2')->status_is(200);
 is($ret->tx->res->json->{name}, '00099963-hdd_image2.qcow2');
-
-done_testing();

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -143,5 +143,3 @@ is_deeply(
 
 $res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(200);
 $res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(404);    #not found
-
-done_testing();

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -135,5 +135,3 @@ is_deeply(
 
 $res = $t->delete_ok("/api/v1/products/$product_id")->status_is(200);
 $res = $t->delete_ok("/api/v1/products/$product_id")->status_is(404);    #not found
-
-done_testing();

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -200,5 +200,3 @@ is_deeply(
 
 $res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
 $res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(404);    #not found
-
-done_testing();

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -426,5 +426,3 @@ $res = $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(404);
 
 $res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
 $res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(404);    #not found
-
-done_testing();

--- a/t/basic.t
+++ b/t/basic.t
@@ -18,7 +18,7 @@ BEGIN { unshift @INC, 'lib'; }
 
 use Mojo::Base -strict;
 
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Database;
 
@@ -26,5 +26,3 @@ OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 $t->get_ok('/')->status_is(200)->content_like(qr/Welcome to openQA/i);
-
-done_testing();

--- a/t/basic.t
+++ b/t/basic.t
@@ -20,6 +20,7 @@ use Mojo::Base -strict;
 
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Database;
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);

--- a/t/config.t
+++ b/t/config.t
@@ -18,7 +18,7 @@ BEGIN { unshift @INC, 'lib'; }
 
 use Mojo::Base -strict;
 
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Database;
 
@@ -73,5 +73,3 @@ ok($t->app->config->{'global'}->{'allowed_hosts'} eq 'foo bar',    'allowed host
 ok($t->app->config->{'global'}->{'suse_mirror'} eq 'http://blah/', 'suse mirror');
 
 unlink($ENV{OPENQA_CONFIG} . '/openqa.ini');
-
-done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -20,6 +20,7 @@ use Mojo::Base -strict;
 
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Database;
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -21,6 +21,7 @@ BEGIN { unshift @INC, 'lib'; }
 use strict;
 
 use Test::More 'no_plan';
+use Test::Warnings;
 use DBIx::Class::DeploymentHandler;
 use SQL::Translator;
 use OpenQA::Schema;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -20,7 +20,7 @@ BEGIN { unshift @INC, 'lib'; }
 
 use strict;
 
-use Test::More;
+use Test::More 'no_plan';
 use DBIx::Class::DeploymentHandler;
 use SQL::Translator;
 use OpenQA::Schema;
@@ -60,5 +60,3 @@ SKIP: {
     ok($trans->translate, "generate graph");
     ok(-e $fn,            "graph png exists");
 }
-
-done_testing();

--- a/t/rand.t
+++ b/t/rand.t
@@ -20,6 +20,7 @@ use Mojo::Base -strict;
 use db_helpers qw/rndstr rndhex rndstrU rndhexU/;
 
 use Test::More 'no_plan';
+use Test::Warnings;
 
 my $r;
 my $r2;

--- a/t/rand.t
+++ b/t/rand.t
@@ -19,7 +19,7 @@ BEGIN { unshift @INC, 'lib'; }
 use Mojo::Base -strict;
 use db_helpers qw/rndstr rndhex rndstrU rndhexU/;
 
-use Test::More;
+use Test::More 'no_plan';
 
 my $r;
 my $r2;
@@ -65,5 +65,3 @@ is(length($r), 97, "length 97");
 like($r, qr/^[0-9A-F]+$/a, "rndhexU only consists of hex characters");
 is(length($r), length($r2), "same length");
 isnt($r, $r2, "rndhexU produces different results");
-
-done_testing();

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 use OpenQA::IPC;

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -39,10 +39,7 @@ use t::ui::PhantomTest;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
-if ($driver) {
-    plan tests => 40;
-}
-else {
+unless ($driver) {
     plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
     exit(0);
 }
@@ -170,4 +167,3 @@ is($td->get_text(), 'textmode@32bit (restarted)', 'restart removes link');
 #t::ui::PhantomTest::make_screenshot('mojoResults.png');
 
 t::ui::PhantomTest::kill_phantom();
-done_testing();

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use Data::Dumper;
@@ -76,5 +76,3 @@ $t->post_ok('/api/v1/jobs/99928/restart' => form => {csrf_token => $token})->sta
 $t->post_ok('/api/v1/jobs/99928/prio?prio=33' => form => {csrf_token => 'foobar'})->status_is(403);
 $t->post_ok('/api/v1/jobs/99928/prio?prio=34' => {'X-CSRF-Token' => $token} => form => {})->status_is(200);
 $t->post_ok('/api/v1/jobs/99928/prio?prio=35' => form => {csrf_token => $token})->status_is(200);
-
-done_testing();

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use Data::Dumper;
 
@@ -70,7 +71,10 @@ $t->post_ok('/api/v1/jobs/99928/cancel' => form => {csrf_token => $token})->stat
 # test restart with and without CSRF token
 $t->post_ok('/api/v1/jobs/99928/restart' => form => {csrf_token => 'foobar'})->status_is(403);
 $t->post_ok('/api/v1/jobs/99928/restart' => {'X-CSRF-Token' => $token} => form => {})->status_is(200);
-$t->post_ok('/api/v1/jobs/99928/restart' => form => {csrf_token => $token})->status_is(200);
+# TODO why is this warning acceptable?
+my $expected = qr/Use of uninitialized value \$(array_type|type) in numeric (eq|ne)/;
+my @warnings = warnings { $t->post_ok('/api/v1/jobs/99928/restart' => form => {csrf_token => $token})->status_is(200) };
+map { like($_, $expected) } @warnings;
 
 # test prio with and without CSRF token
 $t->post_ok('/api/v1/jobs/99928/prio?prio=33' => form => {csrf_token => 'foobar'})->status_is(403);

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -30,10 +30,7 @@ use t::ui::PhantomTest;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
-if ($driver) {
-    plan tests => 7;
-}
-else {
+unless ($driver) {
     plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
     exit(0);
 }
@@ -64,4 +61,3 @@ t::ui::PhantomTest::make_screenshot('mojoResults.png');
 
 
 t::ui::PhantomTest::kill_phantom();
-done_testing();

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 SKIP: {

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 4;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -36,5 +36,3 @@ SKIP: {
     $get->content_like(qr|inst\.d/.*$test_name.pm|i, "$test_name test source found");
     $get->content_like(qr/ISO_MAXSIZE/i,             "$test_name test source shown");
 }
-
-done_testing();

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -87,5 +87,3 @@ $req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {user_id =
 $req = $t->get_ok('/api_keys')->status_is(200);
 $req->element_exists('#api_key_99902', 'Percival keys are there');
 $req->element_exists('#api_key_99907', 'and the new one belongs to Percival, not Lancelot');
-
-done_testing();

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -18,7 +18,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -60,5 +60,3 @@ $t->get_ok('/tests')->status_is(200)->content_unlike(qr/Logged in as/);
 $test_case->login($t, 'percival');
 $t->get_ok('/tests')->status_is(200)->content_like(qr/Logged in as perci (.*manage API keys.* | .*logout.*)/);
 $t->get_ok('/api_keys')->status_is(200);
-
-done_testing();

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -20,6 +20,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use Data::Dumper;
 

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 20;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use Data::Dumper;
@@ -60,5 +60,3 @@ $get->element_exists('#scheduled #job_99928 a.cancel');
 $test_case->login($t, 'lancelot', email => 'lancelot@example.com');
 $get = $t->get_ok('/tests')->status_is(200);
 $get->element_exists_not('#scheduled #job_99928 a.cancel');
-
-done_testing();

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -90,5 +90,3 @@ SKIP: {
     $t->get_ok('/needles/opensuse/doesntexist.png')->status_is(404);
 
 }
-
-done_testing();

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings ':all';
 use OpenQA::Test::Case;
 
 use OpenQA::IPC;
@@ -69,7 +70,10 @@ is($req->tx->res->dom->at('#downloads #asset_1')->{'href'}, '/tests/99946/asset/
 $req = $t->get_ok('/tests/99946/asset/1')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
 $req = $t->get_ok('/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
 # verify error on invalid downloads
-$req = $t->get_ok('/tests/99946/asset/iso/foobar.iso')->status_is(404);
+# TODO why is this warning acceptable?
+my $expected = qr/Use of uninitialized value \$(array_type|type) in numeric (eq|ne)/;
+my @warnings = warnings { $req = $t->get_ok('/tests/99946/asset/iso/foobar.iso')->status_is(404) };
+map { like($_, $expected) } @warnings;
 
 # TODO: also test repos
 

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -61,5 +61,3 @@ $t->delete_ok('/logout')->status_is(302);
 # No-one else can claim the kingdom
 $test_case->login($t, 'merlin');
 $get = $t->get_ok('/admin/users')->status_is(403);
-
-done_testing();

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More tests => 34;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -72,5 +72,3 @@ $get = $t->get_ok('/admin/users')->status_is(200);
 $get->content_like(qr/User lance updated/);
 $get->text_is('#user_99902 .username' => 'https://openid.camelot.uk/lancelot');
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '00');
-
-done_testing();

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -127,5 +127,3 @@ $summary = $t->tx->res->dom->at('#summary')->all_text;
 like($summary, qr/Passed: 0 Failed: 1/i);
 $get->element_exists('#res_DVD_x86_64_doc .result_failed');
 $get->element_exists_not('#res_DVD_x86_64_kde .result_passed');
-
-done_testing();

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -42,10 +42,7 @@ $test_case->init_data;
 use t::ui::PhantomTest;
 
 my $driver = t::ui::PhantomTest::call_phantom();
-if ($driver) {
-    plan tests => 51;
-}
-else {
+unless ($driver) {
     plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
     exit(0);
 }
@@ -276,4 +273,3 @@ is($decode_json->{'area'}[0]->{xpos}, $decode_textarea->{'area'}[0]->{xpos} + $x
 is($decode_json->{'area'}[0]->{ypos}, $decode_textarea->{'area'}[0]->{ypos} + $yoffset, "new ypos stored to new needle");
 
 t::ui::PhantomTest::kill_phantom();
-done_testing();

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 use File::Path qw/make_path remove_tree/;

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use Data::Dumper;
@@ -39,11 +39,7 @@ use t::ui::PhantomTest;
 
 # skip if phantomjs or Selenium::Remote::WDKeys isn't available
 my $driver = t::ui::PhantomTest::call_phantom();
-if ($driver && can_load(modules => {'Selenium::Remote::WDKeys' => undef,})) {
-    # for some reason, loading the module this way doesn't import the constant
-    plan tests => 71;
-}
-else {
+unless ($driver && can_load(modules => {'Selenium::Remote::WDKeys' => undef,})) {
     plan skip_all => 'Install phantomjs, Selenium::Remote::Driver, and Selenium::Remote::WDKeys to run these tests';
     exit(0);
 }
@@ -328,4 +324,3 @@ $td = $driver->find_element('tr#asset_1 td.t_created', 'css');
 is('about 2 hours ago', $td->get_text(), 'timeago 2h');
 
 t::ui::PhantomTest::kill_phantom();
-done_testing();

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use Data::Dumper;
 use IO::Socket::INET;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -30,10 +30,7 @@ use t::ui::PhantomTest;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
-if ($driver) {
-    plan tests => 2;
-}
-else {
+unless ($driver) {
     plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
     exit(0);
 }
@@ -51,4 +48,3 @@ like($driver->find_element('#summary', 'css')->get_text(), qr/Overall Summary of
 #t::ui::PhantomTest::make_screenshot('mojoResults.png');
 
 t::ui::PhantomTest::kill_phantom();
-done_testing();

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 use Data::Dumper;
 

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 use Data::Dumper;
@@ -43,10 +43,7 @@ $test_case->init_data;
 use t::ui::PhantomTest;
 
 my $driver = t::ui::PhantomTest::call_phantom();
-if ($driver) {
-    plan tests => 12;
-}
-else {
+unless ($driver) {
     plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
     exit(0);
 }
@@ -86,4 +83,3 @@ like($body->get_text(), qr/JOBTOKEN token99963/,  'token for 99963');
 #t::ui::PhantomTest::make_screenshot('mojoResults.png');
 
 t::ui::PhantomTest::kill_phantom();
-done_testing();

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -30,10 +30,7 @@ use t::ui::PhantomTest;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
-if ($driver) {
-    plan tests => 38;
-}
-else {
+unless ($driver) {
     plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
     exit(0);
 }
@@ -136,5 +133,3 @@ $driver->find_element('opensuse', 'link_text')->click();
 is($driver->find_element('.fa-certificate', 'css')->get_attribute('title'), 'Reviewed (1 comments)', 'build should be marked as labeled');
 
 t::ui::PhantomTest::kill_phantom();
-
-done_testing();

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/16-tests_previous_results.t
+++ b/t/ui/16-tests_previous_results.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More 'no_plan';
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/16-tests_previous_results.t
+++ b/t/ui/16-tests_previous_results.t
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Mojo::Base -strict;
-use Test::More;
+use Test::More 'no_plan';
 use Test::Mojo;
 use OpenQA::Test::Case;
 
@@ -41,5 +41,3 @@ is($build, '0091', 'build of previous job is shown');
 $get                     = $t->get_ok('/tests/99946?limit_previous=1#previous')->status_is(200);
 $previous_results_header = $t->tx->res->dom->at('#previous #scenario')->all_text;
 is($previous_results_header, q/Results for opensuse-13.1-DVD-i586-textmode, limited to 1/, 'can be limited with query parameter');
-
-done_testing();


### PR DESCRIPTION
all tests fail because the no warnings is one test that would need explicit counting -- use Test::NoWarning to fail on any warning

also see https://rt.cpan.org/Public/Bug/Display.html?id=66485
and https://rt.cpan.org/Public/Bug/Display.html?id=36603
about the "test plan" issue.

see http://search.cpan.org/~adamk/Test-NoWarnings-1.04/lib/Test/NoWarnings.pm
for the manual