### PR TITLE
.travis.yml: Arm coverage check against threshold after tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
 script:
   # 'coverage-coveralls' calls checkstyle, tests and coverage analysis in
   # coveralls format
-  - make coverage-coveralls
+  - make coverage-coveralls coverage-check
 after_failure:
   - cat /tmp/openqa-debug.log


### PR DESCRIPTION
The coverage analysis with 'make coverage-check' has been working for some
commits and the 'coveralls' integration is still not reporting anything on
pull requests. This change enables checking coverage against the threshold as
defined in the Makefile and will make the travis builds report a failure if
the coverage is decreased below the threshold. Acceptable coverage drops can
be accepted by decreasing the threshold.