### PR TITLE
log to stderr (so journal) by default

### DIFF
--- a/docker/openqa_data/data.template/conf/openqa.ini
+++ b/docker/openqa_data/data.template/conf/openqa.ini
@@ -30,7 +30,8 @@ branding = plain
 method = OpenID
 
 [logging]
-#if you use another file, remember the apparmor profile!
+#logging is to stderr (so systemd journal) by default
+#if you use a file, remember the apparmor profile!
 #file = /var/log/openqa
 level = info
 #sql_debug = true

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -32,7 +32,8 @@
 # method = Fake|OpenID|iChain
 
 [logging]
-#if you use another file, remember the apparmor profile!
+#logging is to stderr (so systemd journal) by default
+#if you use a file, remember the apparmor profile!
 #file = /var/log/openqa
 #level = debug
 #sql_debug = true

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -54,7 +54,7 @@ sub _read_config {
         },
         logging => {
             level     => undef,
-            file      => '/var/log/openqa',
+            file      => undef,
             sql_debug => undef,
         },
         openid => {


### PR DESCRIPTION
in Fedora package review it became apparent that logging to a
file is rather more complex in terms of packaging and system
security than it might appear. Logging to the journal is kinda
a good practice on systemd distros (i.e. all the ones we care
about) in any case, and we can easily default to it by leaving
the 'file' setting undefined by default. Admins who want to log
to a file still easily can by defining the 'file' setting, and
then the security issues are all theirs to deal with...

This isn't very sophisticated (the severity of the messages
isn't transmitted to journald, for instance) but works well
enough, seemingly.

This change will affect existing deployments which do not have
the `file` setting in the config file explicitly specified.

This is a trivial change technically speaking, the question is more whether or not we think it's a good idea. I'm just throwing it out there for discussion. The Fedora package review ticket is https://bugzilla.redhat.com/show_bug.cgi?id=1304882 , for reference, the discussion of logging bits begins in earnest around comment 17 or so.

Just to be clear, logging to file is still perfectly possible with this change, it only changes the *default* behaviour when the `file` setting isn't explicitly specified in `openqa.ini` (or as `OPENQA_LOGFILE` env var).