### PR TITLE
initdb: when --user set, setgid and don't guess db owner

### DIFF
--- a/script/initdb
+++ b/script/initdb
@@ -63,6 +63,10 @@ if ($help) {
 
 if ($user) {
     my $uid = getpwnam($user) || die "No such login $user";
+    my $gid = getgrnam($user);
+    if ($gid) {
+        setgid($gid) || die "can't sgid to $user group";
+    }
     setuid($uid) || die "can't suid to $user";
 }
 
@@ -76,12 +80,15 @@ my $schema           = OpenQA::Schema::connect_db();
 if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
     my $dbdir = dirname($1);
     die "$dbdir does not exist\n" unless -d $dbdir;
-    my @s = stat(_);
-    if (getgid() != $s[5]) {
-        setgid($s[5]) or die "can't change gid to $s[5]: $!\n";
-    }
-    if (getuid() != $s[4]) {
-        setuid($s[4]) or die "can't change uid to $s[4]: $!\n";
+    unless ($user) {
+        # if --user wasn't set, try to guess appropriate owner for db
+        my @s = stat(_);
+        if (getgid() != $s[5]) {
+            setgid($s[5]) or die "can't change gid to $s[5]: $!\n";
+        }
+        if (getuid() != $s[4]) {
+            setuid($s[4]) or die "can't change uid to $s[4]: $!\n";
+        }
     }
 
     # speed this up a bit


### PR DESCRIPTION
Fedora package review pointed out that `database.ini` should
probably be owned by root with permissions 0640 - there is no
need for geekotest to be able to write to it. However, if we
do this, `initdb` has problems. If you pass --user it wants to
switch to that user; then, when writing an sqlite file, it
tries to switch to the user and group that owns the directory
the file will live in (so it writes the file owned by that user
and group).

This kinda breaks if we do the initial user switch before
reading the config file (i.e. calling `connect_db`). If the
config file is root.geekotest 0640 and we `setuid` to geekotest
because we were called with `--user geekotest`, we now cannot
read the config file and we fail. If we `setgid` to geekotest's
GID as well, then we can read the config file, but we then die
further on when we try to `setgid` back to 0 (root) because
/var/lib/openqa/db is owned by geekotest.root (you can't raise
your privileges again after dropping them).

Looking into it, the code to setuid and setgid before writing
the SQLite db predates the creation of the `--user` arg. When
that code was introduced, the script didn't do any other setuid
or setgid stuff. Adding the `--user` arg created kind of a mess.

I think the double switching ought to go; this isn't the only
bug it's susceptible to. If the script was called with `--user`,
then it should try to create the database as that user and not
second-guess it.

So this makes the script also setgid to the appropriate group
when `--user` is passed, and makes it *not* try to setuid and
setgid to the directory owner's uid/gid when creating an sqlite
db if `--user` was passed. It will now only do that if `--user`
was not passed.