### PR TITLE
setgid as well in upgradedb (like in initdb)

### DIFF
--- a/script/upgradedb
+++ b/script/upgradedb
@@ -30,7 +30,7 @@ use OpenQA::Schema;
 use Getopt::Long;
 use IO::Dir;
 use Fcntl ':mode';
-use POSIX qw/setuid/;
+use POSIX qw/setuid setgid/;
 
 my $prepare_upgrades            = 0;
 my $upgrade_database            = 0;
@@ -69,6 +69,10 @@ if ($help) {
 
 if ($user) {
     my $uid = getpwnam($user) || die "No such login $user";
+    my $gid = getgrnam($user);
+    if ($gid) {
+        setgid($gid) || die "can't sgid to $user group";
+    }
     setuid($uid) || die "can't suid to $user";
 }
 


### PR DESCRIPTION
This just matches the recent change for initdb, so we switch to
the appropriate GID for the user specified with --user as well
as the appropriate UID.