### PR TITLE
Show bug or label icon on overview if labeled

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -87,6 +87,7 @@ package CommentsMarkdownParser;
 require Text::Markdown;
 our @ISA = qw/Text::Markdown/;
 use Regexp::Common qw/URI/;
+use OpenQA::Utils qw/bugref_to_href/;
 
 sub _DoAutoLinks {
     my ($self, $text) = @_;
@@ -96,10 +97,7 @@ sub _DoAutoLinks {
     # URL markers '<>'
     $text =~ s@(?<!['"(<>])($RE{URI})@<$1>@gi;
 
-    $text =~ s{(bnc#(\d+))}{<a href="https://bugzilla.novell.com/show_bug.cgi?id=$2">$1</a>}gi;
-    $text =~ s{(bsc#(\d+))}{<a href="https://bugzilla.suse.com/show_bug.cgi?id=$2">$1</a>}gi;
-    $text =~ s{(boo#(\d+))}{<a href="https://bugzilla.opensuse.org/show_bug.cgi?id=$2">$1</a>}gi;
-    $text =~ s{(poo#(\d+))}{<a href="https://progress.opensuse.org/issues/$2">$1</a>}gi;
+    $text = bugref_to_href($text);
     # For tests make sure that references into test modules and needling steps also work
     $text =~ s{(t#([\w/]+))}{<a href="/tests/$2">$1</a>}gi;
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -25,6 +25,8 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &run_cmd_with_log
   &commit_git
   &parse_assets_from_settings
+  &bugurl
+  &bugref_to_href
 );
 
 
@@ -253,6 +255,24 @@ sub parse_assets_from_settings {
     return $assets;
 }
 
+sub bugurl {
+    my ($bugref) = @_;
+    my %bugrefs = (
+        bnc => 'https://bugzilla.novell.com/show_bug.cgi?id=',
+        bsc => 'https://bugzilla.suse.com/show_bug.cgi?id=',
+        boo => 'https://bugzilla.opensuse.org/show_bug.cgi?id=',
+        poo => 'https://progress.opensuse.org/issues/',
+    );
+    return $bugrefs{$bugref};
+}
+
+sub bugref_to_href {
+    my ($text) = @_;
+
+    $text =~ s{((bnc|bsc|boo|poo)#(\d+))}{<a href="@{[bugurl($2)]}$3">$1</a>}gi;
+
+    return $text;
+}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -19,6 +19,7 @@ package OpenQA::WebAPI::Plugin::Helpers;
 use strict;
 use warnings;
 use Mojo::ByteStream;
+use OpenQA::Utils qw(bugurl);
 use db_helpers;
 
 use base 'Mojolicious::Plugin';
@@ -45,6 +46,13 @@ sub register {
             else {
                 sprintf("%02d:%02d minutes", $timedate->minutes(), $timedate->seconds());
             }
+        });
+
+    $app->helper(
+        bugurl_for => sub {
+            my ($c, $text) = @_;
+            $text =~ /(.*)#(.*)/;
+            return bugurl($1) . $2;
         });
 
     # Breadcrumbs generation can be centralized, since it's really simple

--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -533,7 +533,7 @@ table.overview .failedmodule {
 .fa.result_incomplete { color: #AF1E11;}
 .fa.module_none { color:#bebebe;}
 
-.fa.comment { color: Grey; }
+.fa.comment, .fa.bookmark, .fa.bug { color: Grey; }
 
 table#users td.role {
     white-space: nowrap;

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -31,7 +31,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
 if ($driver) {
-    plan tests => 28;
+    plan tests => 31;
 }
 else {
     plan skip_all => 'Install phantomjs to run these tests';
@@ -43,6 +43,7 @@ else {
 #
 
 is($driver->get_title(), "openQA", "on main page");
+my $baseurl = $driver->get_current_url();
 $driver->find_element('Login', 'link_text')->click();
 # we are back on the main page
 is($driver->get_title(), "openQA", "back on main page");
@@ -112,6 +113,19 @@ $driver->find_element('Build0048@opensuse', 'link_text')->click();
 is($driver->get_title(), "openQA: Test summary", "back on test group overview");
 is($driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'), '1 comment available', "test results show available comment(s)");
 
+# add label and bug and check availability sign
+$driver->get($baseurl . 'tests/99938#comments');
+$driver->find_element('textarea',           'css')->send_keys('label:true_positive');
+$driver->find_element('#submitComment',     'css')->click();
+$driver->find_element('Build0048@opensuse', 'link_text')->click();
+is($driver->find_element('#res_DVD_x86_64_doc .fa-bookmark', 'css')->get_attribute('title'), 'true_positive');
+$driver->get($baseurl . 'tests/99938#comments');
+$driver->find_element('textarea',           'css')->send_keys('bsc#1234');
+$driver->find_element('#submitComment',     'css')->click();
+$driver->find_element('Build0048@opensuse', 'link_text')->click();
+is($driver->find_element('#res_DVD_x86_64_doc .fa-bug', 'css')->get_attribute('title'), 'Bug(s) referenced: bsc#1234');
+my @labels = $driver->find_elements('#res_DVD_x86_64_doc .test-label', 'css');
+is(scalar @labels, 1, 'Only one label is shown at a time');
 
 t::ui::PhantomTest::kill_phantom();
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -31,7 +31,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
 if ($driver) {
-    plan tests => 31;
+    plan tests => 34;
 }
 else {
     plan skip_all => 'Install phantomjs to run these tests';
@@ -126,6 +126,8 @@ $driver->find_element('Build0048@opensuse', 'link_text')->click();
 is($driver->find_element('#res_DVD_x86_64_doc .fa-bug', 'css')->get_attribute('title'), 'Bug(s) referenced: bsc#1234');
 my @labels = $driver->find_elements('#res_DVD_x86_64_doc .test-label', 'css');
 is(scalar @labels, 1, 'Only one label is shown at a time');
+my $get = $t->get_ok($driver->get_current_url())->status_is(200);
+is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href}, 'https://bugzilla.suse.com/show_bug.cgi?id=1234');
 
 t::ui::PhantomTest::kill_phantom();
 

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -144,7 +144,9 @@
                                     % my $bug = $res->{bug};
                                     % if ($bug) {
                                         <span id="bug-<%= $jobid %>">
-                                            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: <%= $bug %>"></i>
+                                            <a href="<%= bugurl_for $bug %>">
+                                                <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: <%= $bug %>"></i>
+                                            </a>
                                         </span>
                                     % }
                                     % elsif ($res->{label}) {

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -139,10 +139,24 @@
                                             </span>
                                         % }
                                     % }
-                                    % if ($res->{comments}) {
+                                    %# 'bentostrap' has an item 'label' which
+                                    %# we do not want to use so we use 'test-label'
+                                    % my $bug = $res->{bug};
+                                    % if ($bug) {
+                                        <span id="bug-<%= $jobid %>">
+                                            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: <%= $bug %>"></i>
+                                        </span>
+                                    % }
+                                    % elsif ($res->{label}) {
+                                        % my $label = $res->{label};
+                                        <span id="test-label-<%= $jobid %>">
+                                            <i class="test-label label_<%= $label %> fa fa-bookmark" title="<%= $label %>"></i>
+                                        </span>
+                                    % }
+                                    % elsif ($res->{comments}) {
                                         <span id="comment-<%= $jobid %>">
                                             <a href="<%= url_for('test', 'testid' => $jobid).'#comments' %>">
-                                                <i class="comment fa fa-comment" title="<%= $res->{comments} %> <%= $res->{comments} > 1 ? "comments" : "comment" %> available"></i>
+                                                <i class="test-label label_comment fa fa-comment" title="<%= $res->{comments} %> <%= $res->{comments} > 1 ? "comments" : "comment" %> available"></i>
                                             </a>
                                         </span>
                                     % }


### PR DESCRIPTION
* Show bug icon with URL if mentioned in test comments
* Show bug or label icon on overview if labeled

Example for a generic label:
![openqa_generic_label](https://cloud.githubusercontent.com/assets/1693432/13027322/7bce7992-d24a-11e5-99ee-839fb5e82169.png)

Example for bug label:
![openqa_bug_label](https://cloud.githubusercontent.com/assets/1693432/13027323/8555238a-d24a-11e5-83d5-5bb2d2140860.png)

I would like to update documentation and help texts accordingly if someone could provide me a hint where this would be appropriate or how we can add the corresponding user documentation.

Related issue: https://progress.opensuse.org/issues/10212

Tested against production database dump from openqa.opensuse.org, querying with
```
time sudo -u geekotest OPENQA_CONFIG=local/stage OPENQA_DATABASE=stage script/openqa get '/tests/overview?version=Tumbleweed&groupid=1&build=20160130&distri=opensuse' >/dev/null 2>&1 | grep real ; time sudo -u geekotest OPENQA_CONFIG=local/stage OPENQA_DATABASE=stage script/openqa get '/tests/117629' >/dev/null 2>&1 | grep real
```
yields comparable results for before and after change (, e.g. *origin/master*: 1.7s+0.8s, *feature/bug_and_label*: 1.8s+0.8s)
