### PR TITLE
adjust openqa-worker service for new systemd

### DIFF
--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -11,7 +11,7 @@ PartOf=openqa-worker.target
 [Service]
 Type=simple
 PermissionsStartOnly=True
-ExecStartPre=/usr/bin/install -d -m 0755 -o %u /var/lib/openqa/pool/%i
+ExecStartPre=/usr/bin/install -d -m 0755 -o _openqa-worker /var/lib/openqa/pool/%i
 ExecStart=/usr/share/openqa/script/worker --instance %i
 User=_openqa-worker
 KillMode=mixed


### PR DESCRIPTION
systemd interprets %u differently now:
https://github.com/systemd/systemd/commit/79413b673b45adc98dfeaec882bbdda2343cb2f9

That results in pool directories owned by root