### PR TITLE
Redirect to index page when referral is missing

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Session.pm
+++ b/lib/OpenQA/WebAPI/Controller/Session.pm
@@ -100,7 +100,7 @@ sub create {
     $auth_module->import('auth_login');
 
     # prevent redirecting loop when referrer is login page
-    if ($ref eq $self->url_for('login')) {
+    if (!$ref or $ref eq $self->url_for('login')) {
         $ref = 'index';
     }
 


### PR DESCRIPTION
When `/login` path is entered manually then there is no referral and final redirect is either back to '/login' in case of Fake and iChain auth, or to '/response' in case of openID auth. Either way it results in openQA error.
Redirect to index if referral is missing.