### PR TITLE
Make color choice for softfails more dominant

### DIFF
--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -115,7 +115,7 @@ img.resborder_unk {
 }
 
 img.resborder_softfail {
-    border: 2px solid #A3C16C;
+    border: 2px solid #ff9;
     padding: 1px;
 }
 


### PR DESCRIPTION
The same 'yellow' is chosen as for the test module background on "soft fail".

Related issue: https://progress.opensuse.org/issues/10620