### PR TITLE
systemd: start scheduler (and webui and websockets) after dbs

### DIFF
--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The openQA gru daemon
-After=postgresql.service
+After=postgresql.service mariadb.service
 
 [Service]
 User=geekotest

--- a/systemd/openqa-scheduler.service
+++ b/systemd/openqa-scheduler.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=The openQA Scheduler
 Before=openqa-webui.service openqa-websockets.service
+After=postgresql.service mariadb.service
 
 [Service]
 User=geekotest

--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -2,7 +2,7 @@
 Description=The openQA WebSockets server
 Wants=apache2.service
 Before=apache2.service openqa-webui.service
-After=openqa-scheduler.service
+After=openqa-scheduler.service postgresql.service mariadb.service
 Requires=openqa-scheduler.service
 
 [Service]

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -2,6 +2,7 @@
 Description=The openQA web UI
 Wants=apache2.service
 Before=apache2.service
+After=postgresql.service mariadb.service
 Requires=openqa-scheduler.service openqa-websockets.service
 
 [Service]


### PR DESCRIPTION
If the database is running on the same system, we want to make
sure it's up before we try and start the scheduler, webUI and
websockets. As we support both postgre and mariadb, list both.
gru already has postgresql, but add mariadb for it.

webui and websockets currently are ordered after scheduler, so
we don't really need to do this in all three, but we may as
well just in case that changes.