### PR TITLE
t: Catch expected warnings in 05-scheduler-iso

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -84,6 +84,7 @@ requires 'warnings';
 on 'test' => sub {
   requires 'Perl::Tidy';
   requires 'Perl::Critic';
+  requires 'Test::Output';
 };
 
 feature 'coverage', 'coverage for travis' => sub {


### PR DESCRIPTION
Cleanup test to not spill expected warnings. Also use better test comparison
methods with better feedback on the expected and actual values when a test
fails.