### PR TITLE
Show certificate next to builds on overview if all failures are labeled

### DIFF
--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -533,7 +533,7 @@ table.overview .failedmodule {
 .fa.result_incomplete { color: #AF1E11;}
 .fa.module_none { color:#bebebe;}
 
-.fa.comment, .fa.bookmark, .fa.bug { color: Grey; }
+.fa.comment, .fa.bookmark, .fa.bug, .fa.certificate { color: Grey; }
 
 table#users td.role {
     white-space: nowrap;

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -31,7 +31,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = t::ui::PhantomTest::call_phantom();
 if ($driver) {
-    plan tests => 34;
+    plan tests => 38;
 }
 else {
     plan skip_all => 'Install phantomjs to run these tests';
@@ -47,6 +47,10 @@ my $baseurl = $driver->get_current_url();
 $driver->find_element('Login', 'link_text')->click();
 # we are back on the main page
 is($driver->get_title(), "openQA", "back on main page");
+
+# make sure no build is marked as 'reviewed' as there are no comments yet
+my $get = $t->get_ok($driver->get_current_url())->status_is(200);
+$get->element_exists_not('.fa-certificate');
 
 $driver->find_element('opensuse', 'link_text')->click();
 
@@ -118,16 +122,18 @@ $driver->get($baseurl . 'tests/99938#comments');
 $driver->find_element('textarea',           'css')->send_keys('label:true_positive');
 $driver->find_element('#submitComment',     'css')->click();
 $driver->find_element('Build0048@opensuse', 'link_text')->click();
-is($driver->find_element('#res_DVD_x86_64_doc .fa-bookmark', 'css')->get_attribute('title'), 'true_positive');
+is($driver->find_element('#res_DVD_x86_64_doc .fa-bookmark', 'css')->get_attribute('title'), 'true_positive', 'label icon shown');
 $driver->get($baseurl . 'tests/99938#comments');
 $driver->find_element('textarea',           'css')->send_keys('bsc#1234');
 $driver->find_element('#submitComment',     'css')->click();
 $driver->find_element('Build0048@opensuse', 'link_text')->click();
-is($driver->find_element('#res_DVD_x86_64_doc .fa-bug', 'css')->get_attribute('title'), 'Bug(s) referenced: bsc#1234');
+is($driver->find_element('#res_DVD_x86_64_doc .fa-bug', 'css')->get_attribute('title'), 'Bug(s) referenced: bsc#1234', 'bug icon shown');
 my @labels = $driver->find_elements('#res_DVD_x86_64_doc .test-label', 'css');
 is(scalar @labels, 1, 'Only one label is shown at a time');
-my $get = $t->get_ok($driver->get_current_url())->status_is(200);
+$get = $t->get_ok($driver->get_current_url())->status_is(200);
 is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href}, 'https://bugzilla.suse.com/show_bug.cgi?id=1234');
+$driver->find_element('opensuse', 'link_text')->click();
+is($driver->find_element('.fa-certificate', 'css')->get_attribute('title'), 'Reviewed (1 comments)', 'build should be marked as labeled');
 
 t::ui::PhantomTest::kill_phantom();
 

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -7,6 +7,13 @@
                 (<abbr class="timeago" title="<%= $result->{$build}->{oldest}->datetime() %>Z">
                 <%= delete $result->{$build}->{oldest} %>
                 </abbr>)
+            % my $reviewed = $result->{$build}->{reviewed};
+            % if ($reviewed) {
+                <span id="review-<%= $group->id . '-' . $build %>">
+                    <i class="review fa fa-certificate" title="Reviewed (<%= $result->{$build}->{labeled}; %> comments)"></i>
+                </span>
+            % }
+
             </h4>
         </div>
         <div class="col-md-8">


### PR DESCRIPTION
Based on comments in the individual job results for each build a certificate
icon is shown on the group overview page as well as the index page to indicate
that every failure has been reviewed, e.g. a bug reference or a test issue
reason is stated. Only the failed and incomplete jobs are regarded for the
evaluation if a build is considered "reviewed".

Tested against a production database dump and no performance impact could be
found when rendering the index page.

Example screenshot:
![openqa_reviewed_label](https://cloud.githubusercontent.com/assets/1693432/13145996/eb1bb78a-d653-11e5-9f0f-40898915578e.png)
