### PR TITLE
t: Catch all expected warnings

### DIFF
--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -18,6 +18,7 @@ BEGIN {
 }
 
 use Test::More;
+use Test::Output;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::Scheduler::Scheduler;
@@ -52,7 +53,7 @@ for my $cmd (@valid_commands) {
 }
 
 #issue invalid commands
-OpenQA::Scheduler::Scheduler::command_enqueue(workerid => 1, command => 'foo', job_id => 0);
+stderr_like { OpenQA::Scheduler::Scheduler::command_enqueue(workerid => 1, command => 'foo', job_id => 0) } qr/invalid command "foo"/;
 isnt($OpenQA::WebSockets::Server::last_command, 'foo', 'refuse invalid commands');
 
 done_testing();

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
+use Test::Output;
 use Mojo::URL;
 use OpenQA::Test::Case;
 use OpenQA::Client;
@@ -44,7 +45,7 @@ $t->app($app);
 
 my $ret;
 
-$ret = $t->post_ok('/api/v1/workers', form => {host => 'localhost', instance => 1, backend => 'qemu'});
+stderr_like { $ret = $t->post_ok('/api/v1/workers', form => {host => 'localhost', instance => 1, backend => 'qemu'}) } qr/missing apisecret/;
 is($ret->tx->res->code, 403, "register worker without API key fails");
 
 $t->ua(OpenQA::Client->new(api => 'testapi')->ioloop(Mojo::IOLoop->singleton));

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
+use Test::Output;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
@@ -153,10 +154,10 @@ $ret = $t->get_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(200)
 la;
 
 # try to register with invalid type
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'foo', name => $iso1})->status_is(400);
+stderr_like { $ret = $t->post_ok('/api/v1/assets', form => {type => 'foo', name => $iso1})->status_is(400) } qr/asset type \'foo\' invalid/;
 
 # try to register non existing asset
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})->status_is(400);
+stderr_like { $ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})->status_is(400) } qr/asset name \'foo.iso\' invalid/;
 
 
 for my $i ($iso1, $iso2) {

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
+use Test::Output;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
@@ -98,7 +99,8 @@ lj;
 
 # schedule the iso, this should not actually be possible. Only isos
 # with different name should result in new tests...
-$ret = $t->post_ok('/api/v1/isos', form => {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})->status_is(200);
+my $warning = qr/START_AFTER_TEST=kde:32bit not found - check for typos and dependency cycles/;
+stderr_like { $ret = $t->post_ok('/api/v1/isos', form => {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})->status_is(200) } $warning;
 
 is($ret->tx->res->json->{count}, 10, "10 new jobs created");
 my @newids = @{$ret->tx->res->json->{ids}};

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
+use Test::Output;
 use OpenQA::Test::Case;
 use Data::Dumper;
 
@@ -70,7 +71,9 @@ $t->post_ok('/api/v1/jobs/99928/cancel' => form => {csrf_token => $token})->stat
 # test restart with and without CSRF token
 $t->post_ok('/api/v1/jobs/99928/restart' => form => {csrf_token => 'foobar'})->status_is(403);
 $t->post_ok('/api/v1/jobs/99928/restart' => {'X-CSRF-Token' => $token} => form => {})->status_is(200);
-$t->post_ok('/api/v1/jobs/99928/restart' => form => {csrf_token => $token})->status_is(200);
+# TODO why is this warning acceptable?
+my $warning = qr/Use of uninitialized value \$array_type in numeric eq/;
+stderr_like { $t->post_ok('/api/v1/jobs/99928/restart' => form => {csrf_token => $token})->status_is(200) } $warning;
 
 # test prio with and without CSRF token
 $t->post_ok('/api/v1/jobs/99928/prio?prio=33' => form => {csrf_token => 'foobar'})->status_is(403);

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
+use Test::Output;
 use OpenQA::Test::Case;
 
 use OpenQA::IPC;
@@ -69,7 +70,9 @@ is($req->tx->res->dom->at('#downloads #asset_1')->{'href'}, '/tests/99946/asset/
 $req = $t->get_ok('/tests/99946/asset/1')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
 $req = $t->get_ok('/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
 # verify error on invalid downloads
-$req = $t->get_ok('/tests/99946/asset/iso/foobar.iso')->status_is(404);
+# TODO why is this warning acceptable?
+my $warning = qr/Use of uninitialized value \$array_type in numeric eq/;
+stderr_like { $req = $t->get_ok('/tests/99946/asset/iso/foobar.iso')->status_is(404) } $warning;
 
 # TODO: also test repos
 


### PR DESCRIPTION
All expected warnings should be catched in tests. Actually I would like the
tests to fail if an unexpected warning is encountered but I don't know yet how
this could be done.

This makes the test output look really nice, i.e. all lines end with "ok" and
not some ugly warning in between.

Doesn't this look nice?:
```
./t/00-tidy.t ............................. ok   
./t/01-compile-check-all.t ................ ok     
./t/04-scheduler.t ........................ ok     
./t/05-scheduler-cancel.t ................. ok    
./t/05-scheduler-capabilities.t ........... ok   
./t/05-scheduler-dependencies.t ........... ok       
./t/05-scheduler-iso.t .................... ok   
./t/05-scheduler-restart-and-duplicate.t .. ok    
./t/06-users.t ............................ ok   
./t/07-api_jobtokens.t .................... ok   
./t/07-api_keys.t ......................... ok   
./t/09-job_clone.t ........................ ok    
./t/10-jobs.t ............................. ok   
./t/11-commands.t ......................... ok    
./t/12-profiler.t ......................... ok   
./t/13-joblocks.t ......................... ok    
./t/14-grutasks.t ......................... ok   
./t/15-assets.t ........................... ok    
./t/16-utils-runcmd.t ..................... ok   
./t/17-labels_carry_over.t ................ ok   
./t/api/01-workers.t ...................... ok    
./t/api/02-assets.t ....................... ok    
./t/api/02-iso.t .......................... ok    
./t/api/03-auth.t ......................... ok   
./t/api/04-jobs.t ......................... ok     
./t/api/05-machines.t ..................... ok    
./t/api/06-products.t ..................... ok    
./t/api/07-testsuites.t ................... ok    
./t/api/08-jobtemplates.t ................. ok    
./t/basic.t ............................... ok   
./t/config.t .............................. ok   
./t/deploy.t .............................. ok   
./t/rand.t ................................ ok    
./t/ui/01-list.t .......................... ok    
./t/ui/02-csrf.t .......................... ok    
./t/ui/02-list-group.t .................... ok   
./t/ui/03-source.t ........................ ok   
./t/ui/04-api_keys.t ...................... ok    
./t/ui/05-auth.t .......................... ok    
./t/ui/06-operator_links.t ................ ok     
./t/ui/07-file.t .......................... ok    
./t/ui/09-admin_creation.t ................ ok    
./t/ui/09-users-list.t .................... ok     
./t/ui/10-tests_overview.t ................ ok    
./t/ui/12-needle-edit.t ................... ok    
./t/ui/13-admin.t ......................... ok    
./t/ui/14-dashboard.t ..................... ok   
./t/ui/15-admin-workers.t ................. ok    
./t/ui/15-comments.t ...................... ok    
./t/ui/16-tests_previous_results.t ........ ok    
All tests successful.
Files=50, Tests=1348, 187 wallclock secs ( 0.36 usr  0.04 sys + 151.59 cusr  8.26 csys = 160.25 CPU)
Result: PASS
```