### PR TITLE
.travis.yml: Fix warning about unwriteable MOJO_TMPDIR in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
 script:
   # 'coverage-coveralls' calls checkstyle, tests and coverage analysis in
   # coveralls format
-  - make coverage-coveralls coverage-check
+  - MOJO_TMPDIR=$(mktemp -d) make coverage-coveralls coverage-check
 after_failure:
   - cat /tmp/openqa-debug.log


### PR DESCRIPTION
Before this travis CI tests fail with ugly warnings like
```
./t/05-scheduler-dependencies.t ........... 5/155 Can not create MOJO_TMPDIR :
    mkdir /var/lib/openqa: Permission denied at lib/OpenQA/WebAPI.pm line 267.
```
like in https://travis-ci.org/os-autoinst/openQA/builds/111199183