### PR TITLE
Init or upgrade schema from openQA

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,39 +14,109 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema;
-use base qw/DBIx::Class::Schema/;
+use parent qw/DBIx::Class::Schema/;
 use strict;
+use warnings;
+
+use DBIx::Class::DeploymentHandler;
 use Config::IniFiles;
-use IO::Dir;
-use SQL::SplitStatement;
-use Fcntl ':mode';
-use FindBin qw($Bin);
+use Cwd qw/abs_path/;
+use Try::Tiny;
+use FindBin qw/$Bin/;
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION = 36;
+our $VERSION   = 36;
+our @databases = qw/MySQL SQLite PostgreSQL/;
 
 __PACKAGE__->load_namespaces;
 
-
-
-
 sub connect_db {
     my $mode = shift || $ENV{OPENQA_DATABASE} || 'production';
+    my $prepare_mode;
+    if ($mode eq 'prepare_production') {
+        $prepare_mode = 1;
+        $mode         = 'production';
+    }
     CORE::state $schema;
     unless ($schema) {
         my %ini;
         my $cfgpath = $ENV{OPENQA_CONFIG} || "$Bin/../etc/openqa";
         tie %ini, 'Config::IniFiles', (-file => $cfgpath . '/database.ini');
         $schema = __PACKAGE__->connect($ini{$mode});
+
+        if (!$prepare_mode) {
+            deployment_check($schema);
+        }
     }
     return $schema;
 }
 
 sub dsn {
     my $self = shift;
-
     $self->storage->connect_info->[0]->{dsn};
+}
+
+sub deployment_check {
+    my ($schema) = @_;
+    my $dir = $FindBin::Bin;
+    while (abs_path($dir) ne '/') {
+        last if (-d "$dir/dbicdh");
+        $dir = "$dir/..";
+    }
+    $dir = "$dir/dbicdh";
+    die 'Cannot find database schema files' if (!-d $dir);
+
+    my $dh = DBIx::Class::DeploymentHandler->new(
+        {
+            schema              => $schema,
+            script_directory    => $dir,
+            databases           => \@databases,
+            sql_translator_args => {add_drop_table => 0},
+            force_overwrite     => 0
+        });
+    _try_deploy_db($dh) or _try_upgrade_db($dh);
+}
+
+sub _db_tweaks {
+    my ($schema, $tweak) = @_;
+    $schema->storage->dbh_do(
+        sub {
+            my ($storage, $dbh, @args) = @_;
+            $dbh->do($tweak);
+        });
+}
+
+sub _try_deploy_db {
+    my ($dh) = @_;
+    my $schema = $dh->schema;
+    umask 027;
+    my $version;
+    try {
+        $version = $dh->version_storage->database_version;
+    }
+    catch {
+        if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
+            # speed this up a bit
+            _db_tweaks($schema, 'PRAGMA synchronous = OFF;');
+        }
+        $dh->install;
+    };
+    return !$version;
+}
+
+sub _try_upgrade_db {
+    my ($dh) = @_;
+    my $schema = $dh->schema;
+    if ($dh->schema_version > $dh->version_storage->database_version) {
+        if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
+            # Some SQLite update scripts do not work correctly with foreign keys on
+            _db_tweaks($schema, 'PRAGMA foreign_keys = OFF;');
+        }
+        $dh->upgrade;
+        return 1;
+    }
+    return;
 }
 
 1;

--- a/lib/OpenQA/Test/Database.pm
+++ b/lib/OpenQA/Test/Database.pm
@@ -25,8 +25,6 @@ sub create {
 
     # New db
     my $schema = OpenQA::Schema::connect_db('test');
-    # when testing UI, new openQA instance is forked. CORE::state $schema is not going to be reinitialized
-    # but the database is actually empty now. Explicitely call check to initialize it.
     OpenQA::Schema::deployment_check($schema);
     $self->insert_fixtures($schema) unless $options{skip_fixtures};
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -293,6 +293,10 @@ sub startup {
 
     $OpenQA::Utils::app = $self;
 
+    # take care of DB deployment or migration before starting the main app
+    my $schema = OpenQA::Schema::connect_db;
+    OpenQA::Schema::deployment_check($schema);
+
     # load auth module
     my $auth_method = $self->config->{auth}->{method};
     my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";

--- a/script/initdb
+++ b/script/initdb
@@ -75,7 +75,7 @@ umask 027;
 
 my $script_directory = "$FindBin::Bin/../dbicdh";
 my @databases        = qw( MySQL SQLite PostgreSQL );
-my $schema           = OpenQA::Schema::connect_db();
+my $schema           = OpenQA::Schema::connect_db('prepare_production');
 
 if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
     my $dbdir = dirname($1);

--- a/script/initdb
+++ b/script/initdb
@@ -75,7 +75,7 @@ umask 027;
 
 my $script_directory = "$FindBin::Bin/../dbicdh";
 my @databases        = qw( MySQL SQLite PostgreSQL );
-my $schema           = OpenQA::Schema::connect_db('prepare_production');
+my $schema           = OpenQA::Schema::connect_db;
 
 if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
     my $dbdir = dirname($1);

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -76,7 +76,7 @@ if ($user) {
     setuid($uid) || die "can't suid to $user";
 }
 
-my $schema = OpenQA::Schema::connect_db('prepare_production');
+my $schema = OpenQA::Schema::connect_db;
 
 my $script_directory = "$FindBin::Bin/../dbicdh";
 my @databases        = qw( MySQL SQLite PostgreSQL );

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -76,7 +76,7 @@ if ($user) {
     setuid($uid) || die "can't suid to $user";
 }
 
-my $schema = OpenQA::Schema::connect_db();
+my $schema = OpenQA::Schema::connect_db('prepare_production');
 
 my $script_directory = "$FindBin::Bin/../dbicdh";
 my @databases        = qw( MySQL SQLite PostgreSQL );

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl -w
 
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -36,7 +36,8 @@ my $dh = DBIx::Class::DeploymentHandler->new(
         sql_translator_args => {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}},
         force_overwrite     => 0,
     });
-ok(defined $dh->install, "deployed");
+ok($dh->version_storage->database_version, 'DB deployed');
+is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
 
 SKIP: {
     eval { require SQL::Translator::Producer::Diagram; };


### PR DESCRIPTION
Preparing the database upgrade is the same as before, but manual
initdb resp. upgradedb call to perform initialization resp. upgrade
is not needed.
Upon first connect, openQA will check if database contain schema version.
If none is found, db is initialized. Else it is compared to current available
schema version and if not matching, upgrade is done automatically.