### PR TITLE
[DISCUSSION]Skip job groups in _group_result when starting with '~'

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -24,9 +24,15 @@ use OpenQA::Schema::Result::Jobs;
 sub _group_result {
     my ($self, $group, $limit) = @_;
 
+    my %res;
+    # WORKAROUND for https://progress.opensuse.org/issues/10960
+    if ($group->name =~ /^(~)/) {
+        $self->app->log->warn("job group '" . $group->name . "' matching '~' skipped, see poo#10960 for reason");
+        return \%res;
+    }
+
     my $timecond = {">" => time2str('%Y-%m-%d %H:%M:%S', time - 24 * 3600 * 14, 'UTC')};
 
-    my %res;
     my $jobs = $group->jobs->search({"me.t_created" => $timecond,});
     my $builds = $self->db->resultset('JobSettings')->search(
         {


### PR DESCRIPTION
As of 2016-02-26 we encountered a major performance regression on
openqa.suse.de as for yet unknown reason many more jobs than in before are
considered for parsing the group results on the index page and group overview
pages in specific job groups.

As more than 20k jobs are fetched from the database the query itself for job
settings is slow as well as the subsequent processing in
OpenQA::WebAPI::Controller::Main::_group_result.

This is a workaround to skip the parsing of job groups if they start with a
'~'. This way "special job groups" can be renamed accordingly to ensure
acceptable performance.

Performance was measured retrieving the index page with a database dump from
openqa.suse.de from 2016-02-26 with the command:
    export date=2016-02-26; time sudo -u geekotest \
    OPENQA_CONFIG=local/stage_openqa_suse_de_2016-02-26 \
    OPENQA_DATABASE=stage script/openqa get / > /dev/null 2>&1

Performance results:
 - before: 15.4s
 - after: 2.3s

Related issue: https://progress.opensuse.org/issues/10960