### PR TITLE
Optimize overview page rendering by only acting on latest jobs

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -319,7 +319,8 @@ sub show {
 sub _calculate_preferred_machines {
     my ($jobs) = @_;
     my %machines;
-    while (my $job = $jobs->next()) {
+
+    foreach my $job (@$jobs) {
         my $sh = $job->settings_hash;
         next unless $sh->{MACHINE};
         $machines{$sh->{ARCH}} ||= {};
@@ -335,7 +336,6 @@ sub _calculate_preferred_machines {
             }
         }
     }
-    $jobs->reset();
     return $pms;
 }
 
@@ -403,12 +403,10 @@ sub overview {
     # query parameters which are then properly shown on the overview.
     my $req_params = $self->req->params->to_hash;
     %search_args = (%search_args, %$req_params);
-    my $jobs = query_jobs(%search_args);
-
-    my @latest_jobs = $jobs->latest_jobs;
-
-    my $all_result_stats   = OpenQA::Schema::Result::JobModules::job_module_stats($jobs);
-    my $preferred_machines = _calculate_preferred_machines($jobs);
+    my @latest_jobs        = query_jobs(%search_args)->latest_jobs;
+    my $preferred_machines = _calculate_preferred_machines(\@latest_jobs);
+    my @latest_jobs_ids    = map { $_->id } @latest_jobs;
+    my $all_result_stats   = OpenQA::Schema::Result::JobModules::job_module_stats(\@latest_jobs_ids);
 
     # prefetch the number of available labels for those jobs
     my $job_labels = $self->_job_labels(\@latest_jobs);


### PR DESCRIPTION
The 'latest_jobs' are queried anyway and gathering job module stats as well
as calculating the preferred machines should be done on latest jobs. Acting
on all potential jobs returned by the query is a stupid idea especially if
there are many jobs within a build but not necessarily the latest.

This fixes a performance regression when calling the overview page on
openqa.suse.de for some builds.

Performance was measured retrieving
'/tests/overview?distri=sle&version=12-SP2&build=1204&groupid=25'
with a database dump from openqa.suse.de from 2016-02-26.

Performance results:

    before: 120s
    after: 27s

Obviously "27s" is still not what we would desire or what we are used to in
other builds but this is the "worst case scenario" I found.

The four most expensive queries are:

```
before:
12.45848107 seconds executed: SELECT ... FROM job_modules
5.55346823 seconds executed: SELECT ... FROM job_settings
5.53332710 seconds executed: SELECT ... FROM job_settings
4.64096379 seconds executed: SELECT ... FROM job_settings

after:
4.69238210 seconds executed: SELECT ... FROM job_settings
0.00488114 seconds executed: SELECT ... FROM job_modules
0.00128818 seconds executed: SELECT ... FROM comments
0.00120902 seconds executed: SELECT ... FROM job_modules
```

For "Build1205" it is comparably fast but still a significant improvement:
```
before:
0.04589987 seconds executed: SELECT ... FROM job_settings
0.02579093 seconds executed: SELECT ... FROM job_settings
0.02407908 seconds executed: SELECT ... FROM job_settings
0.00323987 seconds executed: SELECT ... FROM job_modules

after:
0.02771688 seconds executed: SELECT ... FROM job_settings
0.00262713 seconds executed: SELECT ... FROM job_modules
0.00092506 seconds executed: SELECT ... FROM comments
0.00058603 seconds executed: SELECT ... FROM job_modules
```

Related issue:
https://progress.opensuse.org/issues/10966