### PR TITLE
Truncate the number of jobs parsed to prevent overload

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -30,6 +30,12 @@ sub _group_result {
 
     my %res;
     my $jobs = $group->jobs->search({"me.t_created" => $timecond,});
+    # arbitrary default limit
+    my $limit_jobs = $self->param('limit_jobs') // 4000;
+    if ($jobs->all > $limit_jobs) {
+        $self->app->log->error('too many jobs for group ' . $group->id . ', ' . $group->name . ', truncating search from ' . $jobs->all . ' to ' . $limit_jobs);
+        $jobs = $jobs->slice(0, $limit_jobs);
+    }
     my $builds = $self->db->resultset('JobSettings')->search(
         {
             job_id => {-in => $jobs->get_column('id')->as_query},
@@ -50,7 +56,7 @@ sub _group_result {
                 'me.group_id'    => $group->id,
                 'me.clone_id'    => undef,
             },
-            {join => qw/settings/, order_by => 'me.id DESC'});
+            {join => qw/settings/, order_by => 'me.id DESC', rows => $limit_jobs});
         my %jr = (oldest => DateTime->now, passed => 0, failed => 0, inprogress => 0, labeled => 0);
 
         my $count = 0;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -56,6 +56,9 @@ $driver->find_element('opensuse', 'link_text')->click();
 is(scalar @{$driver->find_elements('h4', 'css')}, 3, 'default number of builds shown');
 is($driver->get($baseurl . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
 
+is($driver->get($baseurl . '?limit_jobs=1'), 1, 'we can limit the jobs, mainly used as error recovery');
+is(scalar @{$driver->find_elements('.progress-bar', 'css')}, 9, 'less/incomplete build results are shown');
+
 #t::ui::PhantomTest::make_screenshot('mojoResults.png');
 
 t::ui::PhantomTest::kill_phantom();


### PR DESCRIPTION
In case too many jobs are found, the group result parsing truncates the number
to prevent a query on too many jobs to cope with in reasonable time.

Related progress issue: https://progress.opensuse.org/issues/10960