### PR TITLE
Remove timeout

### DIFF
--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -51,8 +51,8 @@ ProxyPass /error !
 #webSocket proxy pass to different port
 ProxyPass "/api/v1/ws/" "ws://localhost:9527/ws/" keepalive=On
 
-ProxyPass / http://localhost:9526/ keepalive=On timeout=600
-ProxyPassReverse / http://localhost:9526/ timeout=600
+ProxyPass / http://localhost:9526/ keepalive=On
+ProxyPassReverse / http://localhost:9526/
 
 <If "%{HTTPS} == 'on'">
 RequestHeader set X-Forwarded-HTTPS "1"

--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -51,8 +51,8 @@ ProxyPass /error !
 #webSocket proxy pass to different port
 ProxyPass "/api/v1/ws/" "ws://localhost:9527/ws/" keepalive=On
 
-ProxyPass / http://localhost:9526/ keepalive=On
-ProxyPassReverse / http://localhost:9526/
+ProxyPass / http://localhost:9526/ keepalive=On timeout=600
+ProxyPassReverse / http://localhost:9526/ timeout=600
 
 <If "%{HTTPS} == 'on'">
 RequestHeader set X-Forwarded-HTTPS "1"

--- a/lib/OpenQA/Client.pm
+++ b/lib/OpenQA/Client.pm
@@ -52,9 +52,9 @@ sub new {
             last;
         }
     }
-    # When database locking arises, the server takes some time to reply.
-    # We could also adjust sqlite_busy_timeout in DBI server side.
-    $self->inactivity_timeout(40);
+    # Scheduling a couple of hundred jobs takes quite some time - so we better don't
+    # have any timeout at all (default is 20 seconds)
+    $self->inactivity_timeout(0);
 
     $self->on(
         start => sub {

--- a/lib/OpenQA/Client.pm
+++ b/lib/OpenQA/Client.pm
@@ -52,9 +52,9 @@ sub new {
             last;
         }
     }
-    # Scheduling a couple of hundred jobs takes quite some time - so we better don't
-    # have any timeout at all (default is 20 seconds)
-    $self->inactivity_timeout(0);
+    # Scheduling a couple of hundred jobs takes quite some time - so we better wait a couple of minutes
+    # (default is 20 seconds)
+    $self->inactivity_timeout(600);
 
     $self->on(
         start => sub {

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -9,7 +9,8 @@ Requires=openqa-scheduler.service openqa-websockets.service
 # TODO: define whether we want to run the web ui with the same user
 User=geekotest
 Environment="DBUS_STARTER_BUS_TYPE=system"
-ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy
+# Our API commands are very expensive, so the default timeouts are too tight
+ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To make scheduling our ISOs more reliable, we need to bump timeouts - our API is just not made for short timeouts ;(