### PR TITLE
Travis badge should show only master branch

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,4 +1,4 @@
-openQA image:https://api.travis-ci.org/os-autoinst/openQA.svg[link=https://travis-ci.org/os-autoinst/openQA] image:https://coveralls.io/repos/os-autoinst/openQA/badge.png[link=https://coveralls.io/r/os-autoinst/openQA]
+openQA image:https://api.travis-ci.org/os-autoinst/openQA.svg?branch=master[link=https://travis-ci.org/os-autoinst/openQA] image:https://coveralls.io/repos/os-autoinst/openQA/badge.png[link=https://coveralls.io/r/os-autoinst/openQA]
 ==========================================================================================================================================================================================================================
 
 openQA is a testing framework that allows you to test GUI applications on one


### PR DESCRIPTION
No need to confuse people with a 'random' last PR build status.