### PR TITLE
Add the PID to the log output

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -172,6 +172,11 @@ has secrets => sub {
     return $ret;
 };
 
+sub _log_format {
+    my ($time, $level, @lines) = @_;
+    return '[' . localtime($time) . "] [$$:$level] " . join "\n", @lines, '';
+}
+
 # This method will run once at server start
 sub startup {
     my $self = shift;
@@ -183,6 +188,7 @@ sub startup {
 
     my $logfile = $ENV{OPENQA_LOGFILE} || $self->config->{logging}->{file};
     $self->log->path($logfile);
+    $self->log->format(\&_log_format);
 
     unshift @{$self->renderer->paths}, '/etc/openqa/templates';
 

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -42,6 +42,6 @@ open(FILE, $filename);
 my @lines = <FILE>;
 close(FILE);
 
-like(join('', @lines), qr/.*\[debug\] \[DBIx debug\] Took .* seconds executed: SELECT.*/, "seconds in log file");
+like(join('', @lines), qr/.*debug\] \[DBIx debug\] Took .* seconds executed: SELECT.*/, "seconds in log file");
 
 done_testing();


### PR DESCRIPTION
Without it the prefork workers pollute each other and it makes hard to follow
what's going on