### PR TITLE
make docs more distro-agnostic, update a bit

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -55,7 +55,7 @@ interface and infrastructure to run 'os-autoinst' in a distributed
 way. The web interface also provides a JSON based REST-like API for
 external scripting and for use by the worker program. Workers
 fetch data and input files from openQA for os-autoinst to run the
-tests. A host system can run serveral workers. The openQA web
+tests. A host system can run several workers. The openQA web
 application takes care of distributing test jobs among workers. Web
 application and workers don't have to run on the same machine but
 can be connected via network instead.
@@ -228,6 +228,17 @@ from scratch, you should probably go through the following order:
 . Go to the template matrix in 'Job templates' menu and decide what
   combinations do make sense and need to be tested
 
+Machines, mediums and test suites can all set various configuration variables.
+Job templates define how the test suites, mediums and machines should be
+combined in various ways to produce individual 'jobs'. All the variables
+from the test suite, medium and machine for the 'job' are combined and made
+available to the actual test code run by the 'job', along with variables
+specified as part of the job creation request. Certain variables also influence
+openQA's and/or os-autoinst's own behavior in terms of how it configures the
+environment for the job. Variables that influence os-autoinst's behavior
+are documented in the file +doc/backend_vars.asciidoc+ in the os-autoinst
+repository.
+
 In openQA we can parametrize a test to describe for what product it will
 run and for what kind of machines it will be executed. For example, a
 test like KDE can be run for any product that has KDE installed, and
@@ -249,18 +260,13 @@ For every triplet, we need to configure a different instance of
 os-autoinst with a different set of parameters.
 
 Medium Types (products)
-~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 A medium type (product) in openQA is a simple description without any concrete
 meaning. It basically consists of a name and a set of variables that
 define or characterize this product in os-autoinst.
 
-For example, the product openSUSE-DVD-x86_64 requires the variables
-+ISO_MAXSIZE+ and +DVD+ to be set up.
-
-The list of variables is dynamic. The semantic of a variable is defined
-by the tests using it. Some usual
-variables are:
+Some example variables used by openSUSE are:
 
 * +ISO_MAXSIZE+ contains the maximum size of the product. There is a
   test that checks that the current size of the product is less or
@@ -273,7 +279,6 @@ variables are:
 * +PROMO+ marks the promotional product.
 * +RESCUECD+ is set to 1 for rescue CD images.
 
-
 Test Suites
 ~~~~~~~~~~~
 
@@ -282,8 +287,7 @@ for openQA. A test consists of a name, a priority (used in the
 scheduler to choose the next job) and a set of variables that are used
 inside this particular test.
 
-Again, the list of variables is not complete, because they are
-test-dependent, but some of the usual ones are:
+Some sample variables used by openSUSE are:
 
 * +BTRFS+ if set, the file system will be BtrFS.
 * +DESKTOP+ possible values are 'kde' 'gnome' 'lxde' 'xfce' or
@@ -292,11 +296,8 @@ test-dependent, but some of the usual ones are:
 * +DOCRUN+ used for documentation tests.
 * +DUALBOOT+ dual boot testing, needs HDD_1 and HDDVERSION.
 * +ENCRYPT+ encrypt the home directory via YaST.
-* +HDDMODEL+ variable to set the HDD hardware model.
-* +HDDSIZEGB+ hard disk size in GB. Used together with BtrFS variable.
 * +HDDVERSION+ used together with HDD_1 to set the operating system
   previously installed on the hard disk.
-* +HDD_1+ path for the pre-created hard disk.
 * +INSTALLONLY+ only basic installation.
 * +INSTLANG+ installation language. Actually used only in documentation
   tests.
@@ -306,8 +307,6 @@ test-dependent, but some of the usual ones are:
   skipping ugly and boring tests.
 * +NOAUTOLOGIN+ unmark autologin in YaST
 * +NUMDISKS+ total number of disks in QEMU.
-* +QEMUVGA+ parameter to declare the video hardware configuration in QEMU.
-* +RAIDLEVEL+ RAID configuration variable
 * +REBOOTAFTERINSTALL+ if set to 1, will reboot after the installation.
 * +SCREENSHOTINTERVAL+ used with NICEVIDEO to improve the video quality.
 * +SPLITUSR+ a YaST configuration option.
@@ -315,6 +314,15 @@ test-dependent, but some of the usual ones are:
 * +UPGRADE+ upgrade testing, need HDD_1 and HDDVERSION.
 * +VIDEOMODE+ if the value is 'text', the installation will be done in
   text mode.
+
+Some of the variables usually set in test suites that influence openQA
+and/or os-autoinst's own behavior are:
+
+* +HDDMODEL+ variable to set the HDD hardware model
+* +HDDSIZEGB+ hard disk size in GB. Used together with BtrFS variable
+* +HDD_1+ path for the pre-created hard disk
+* +RAIDLEVEL+ RAID configuration variable
+* +QEMUVGA+ parameter to declare the video hardware configuration in QEMU
 
 Machines
 ~~~~~~~~
@@ -331,20 +339,20 @@ configuration.
 +qemu+ as it is the most tested one, but other options (such as +kvm2usb+ or +vbox+)
 are also possible.
 
-* *Variables* Variables represent a way how to influence backend behaviour.
-Few important examples:
+* *Variables* Most machine variables influence os-autoinst's behavior in terms
+of how the test machine is set up. A few important examples:
 ** +QEMUCPU+ can be 'qemu32' or 'qemu64' and specifies the architecture of the
    virtual CPU.
 ** +QEMUCPUS+ is an integer that specifies the number of cores you wish for.
 ** +LAPTOP+ if set to 1, QEMU will create a laptop profile.
 ** +USBBOOT+ when set to 1, the image will be loaded through an
    emulated USB stick.
-** +SMP+ enables smp when set to 1, disables when set to 0.
 
 Variable expansion
 ~~~~~~~~~~~~~~~~~~
 Any variable defined in Test Suite, Machine or Product table can refer to another
-variable using this syntax: %NAME%
+variable using this syntax: +%NAME%+. When the test job is created, the string
+will be substituted with the value of the specified variable at that time.
 
 For example this variable defined for Test Suite:
 
@@ -353,20 +361,20 @@ For example this variable defined for Test Suite:
 PUBLISH_HDD_1 = %DISTRI%-%VERSION%-%ARCH%-%DESKTOP%.qcow2
 --------------------------------------------------------------------------------
 
-is expanded to this job variable:
+may be expanded to this job variable:
 
 [source,sh]
 --------------------------------------------------------------------------------
 PUBLISH_HDD_1 = opensuse-13.1-i586-kde.qcow2
 --------------------------------------------------------------------------------
 
-Testing openSUSE
-----------------
+Testing openSUSE or Fedora
+--------------------------
 
-Easiest way to start using openQA is to start testing openSUSE as we have
-everything setup and prepared to ease the initial deployment. If you want to
-play deeper, you can configure the whole openQA manually from scratch, but this
-document should help you to get started faster.
+An easy way to start using openQA is to start testing openSUSE or Fedora as they
+have everything setup and prepared to ease the initial deployment. If you want
+to play deeper, you can configure the whole openQA manually from scratch, but
+this document should help you to get started faster.
 
 Getting tests
 ~~~~~~~~~~~~~
@@ -385,6 +393,19 @@ run
 Which will download the tests to the correct location and will set the correct
 rights as well.
 
+Fedora's tests are also in https://bitbucket.org/rajcze/openqa_fedora[git]. To
+use them, you may do:
+
+[source,sh]
+--------------------------------------------------------------------------------
+cd /var/lib/openqa/share/tests
+mkdir fedora
+cd fedora
+git clone https://bitbucket.org/rajcze/openqa_fedora_tools.git
+cd ..
+chown -R geekotest fedora/
+--------------------------------------------------------------------------------
+
 Getting openQA configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -395,7 +416,7 @@ following command:
 
 [source,sh]
 --------------------------------------------------------------------------------
-/var/lib/openqa/tests/opensuse/templates [--apikey API_KEY] [--apisecret API_SECRET]
+/var/lib/openqa/share/tests/opensuse/templates [--apikey API_KEY] [--apisecret API_SECRET]
 --------------------------------------------------------------------------------
 
 This will load some default settings that were used at some point of time in
@@ -403,10 +424,23 @@ openSUSE production openQA. Therefore those should work reasonably well with
 openSUSE tests and needles. This script uses +/usr/share/openqa/script/load_templates+, 
 consider reading its help page (+--help+) for documentation on possible extra arguments.
 
-Adding a new iso to test
+For Fedora, similarly, you can call:
+
+[source,sh]
+--------------------------------------------------------------------------------
+/var/lib/openqa/share/tests/fedora/templates [--apikey API_KEY] [--apisecret API_SECRET]
+--------------------------------------------------------------------------------
+
+Some Fedora tests require special hard disk images to be present in
++/var/lib/openqa/share/factory/hdd+. The +createhdds.py+ script in the
+https://bitbucket.org/rajcze/openqa_fedora_tools.git[openqa_fedora_tools]
+repository can be used to create these. See the documentation in that repo
+for more information.
+
+Adding a new ISO to test
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To start testing a new ISO put it in +/var/lib/openqa/factory/iso+ and call
+To start testing a new ISO put it in +/var/lib/openqa/share/factory/iso+ and call
 the following commands:
 
 [source,sh]
@@ -424,9 +458,23 @@ the following commands:
 If your openQA is not running on port 80 on 'localhost', you can add option
 +--host=http://otherhost:9526+ to specify a different port or host.
 
-WARNING: Using only iso name in 'client' command and saving it in
-+/var/lib/openqa/factory/iso+ is recommended as is using Factory isos. ISOs are
-not uploaded from the path that you would specify.
+WARNING: Use only the ISO filename in the 'client' command. You must place the
+file in +/var/lib/openqa/factory/iso+. You cannot place the file elsewhere and
+specify its path in the command.
+
+For Fedora, a sample run might be:
+
+[source,sh]
+--------------------------------------------------------------------------------
+# Run the first test
+/usr/share/openqa/script/client isos post \
+         ISO=Fedora-Everything-boot-x86_64-Rawhide-20160308.n.0.iso \
+         DISTRI=fedora \
+         VERSION=Rawhide \
+         FLAVOR=Everything-boot-iso \
+         ARCH=x86_64 \
+         BUILD=Rawhide-20160308.n.0
+--------------------------------------------------------------------------------
 
 Pitfalls
 --------

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -1,6 +1,6 @@
 openQA installation guide
 =========================
-:author: openSUSE Team at SUSE
+:author: openQA developers
 :toc:
 
 Introduction
@@ -23,26 +23,33 @@ Installation
 ------------
 [id="installation"]
 
-The easiest way to install openQA is from packages. You can find them in OBS in
-the https://build.opensuse.org/project/show/devel:openQA[openQA] repository or
+The easiest way to install openQA is from packages. You can find openSUSE
+packages in OBS in the
+https://build.opensuse.org/project/show/devel:openQA[openQA] repository or
 the latest development version can also be found in OBS in the
 https://build.opensuse.org/project/show/devel:openQA[openQA:devel]
-repository. Installation on openSUSE is therefore pretty simple:
+repository. For Fedora, packages are available in the official repositories
+for Fedora 23 and later. Installation on these distributions is therefore
+pretty simple:
 
 [source,sh]
 --------------------------------------------------------------------------------
-# 13.2
+# openSUSE 13.2
 zypper ar -f obs://devel:openQA/openSUSE_13.2 openQA
 zypper ar -f obs://devel:openQA:13.2/openSUSE_13.2 openQA-perl-modules
 
-# Leap 42.1
+# openSUSE Leap 42.1
 zypper ar -f obs://devel:openQA/openSUSE_Leap_42.1 openQA
 zypper ar -f obs://devel:openQA:Leap:42.1/openSUSE_Leap_42.1 openQA-perl-modules
 
-# Tumbleweed
+# openSUSE Tumbleweed
 zypper ar -f obs://devel:openQA/openSUSE_Factory openQA
 
+# all openSUSE
 zypper in openQA
+
+# Fedora 23+
+dnf install openqa openqa-httpd
 --------------------------------------------------------------------------------
 
 Basic configuration
@@ -53,16 +60,23 @@ Apache proxy
 ~~~~~~~~~~~~
 
 It's recommended to run openQA behind an apache proxy. See the
-+openqa.conf.template+ config file in +/etc/apache2/vhosts.d+. To make
-everything work correctly, you need to enable the 'headers', 'proxy',
-'proxy_http' and 'proxy_wstunnel' modules using 'a2enmod'.
++openqa.conf.template+ config file in +/etc/apache2/vhosts.d+ (openSUSE) or
++/etc/httpd/conf.d+ (Fedora). To make everything work correctly on openSUSE,
+you need to enable the 'headers', 'proxy', 'proxy_http' and 'proxy_wstunnel'
+modules using 'a2enmod'. This is not necessary on Fedora. For a basic setup,
+you can copy +openqa.conf.template+ to +openqa.conf+ and modify the
++ServerName+ setting. This will direct all HTTP traffic to openQA.
 
-SSL
-~~~
+TLS/SSL
+~~~~~~~
 
-By default openQA expects to be run with HTTPS. If you don't have an
-SSL certificate for your host you need to turn HTTPS off. You can do
-that in +/etc/openqa/openqa.ini+:
+By default openQA expects to be run with HTTPS. The +openqa-ssl.conf.template+
+Apache config file is available as a base for creating the Apache config; you
+can copy it to +openqa-ssl.conf+ and uncomment any lines you like, then
+ensure a key and certificate are installed to the appropriate location
+(depending on distribution and whether you uncommented the lines for key and
+cert location in the config file). If you don't have a TLS/SSL certificate for
+your host you must turn HTTPS off. You can do that in +/etc/openqa/openqa.ini+:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -74,11 +88,20 @@ Run the web UI
 ~~~~~~~~~~~~~~
 [source,sh]
 --------------------------------------------------------------------------------
+systemctl start openqa-scheduler
+systemctl start openqa-gru
+systemctl start openqa-websockets
 systemctl start openqa-webui
+# openSUSE
 systemctl restart apache2
+# Fedora
+# for now this is necessary to allow Apache to connect to openQA
+setsebool -P httpd_can_network_connect 1
+systemctl restart httpd
 --------------------------------------------------------------------------------
 
-The openQA web UI should be available on http://localhost/ now.
+The openQA web UI should be available on http://localhost/ now. To ensure
+openQA runs on each boot, you should also +systemctl enable+ the same services.
 
 Run workers
 ~~~~~~~~~~~
@@ -89,16 +112,22 @@ multiple machines but still using only one WebUI.
 
 [source,sh]
 --------------------------------------------------------------------------------
+# openSUSE
 zypper in openQA-worker
+# Fedora
+dnf install openqa-worker
 --------------------------------------------------------------------------------
 
 To allow workers to access your instance, you need to log into
 openQA as operator and create a pair of API key and secret. Once you
 are logged in, follow the link 'manage API keys' in the top right
-corner. Click the 'create' button to generate +key+ and +secret+.
-Copy&Paste them into +/etc/openqa/client.conf+ on machine where openQA-worker
+corner. Click the 'create' button to generate +key+ and +secret+. There is
+also a script available for creating an admin user and an API key+secret
+pair non-interactively, +/usr/share/openqa/script/create_admin+, which can
+be useful for scripted deployments of openQA. Copy and paste the key and
+secrent into +/etc/openqa/client.conf+ on the machine(s) where the worker
 is installed. Make sure to put in a section reflecting your webserver URL.
-In the simplemost case, your +client.conf+ may look like this:
+In the simplest case, your +client.conf+ may look like this:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -106,6 +135,7 @@ In the simplemost case, your +client.conf+ may look like this:
 key = 0123456789ABCDEF
 secret = 0123456789ABCDEF
 --------------------------------------------------------------------------------
+
 
 To start the workers you can use the provided systemd files via +systemctl
 start openqa-worker@1+. This will start worker number one. You can start as
@@ -223,7 +253,7 @@ ssh keys for user 'geekotest' to be able to push.
 Worker settings
 ~~~~~~~~~~~~~~~
 
-Default behaviour for all workers is to use the 'Qemu' backend and connect to
+Default behavior for all workers is to use the 'Qemu' backend and connect to
 'http://localhost'. If you want to change some of those options, you can do so
 in +/etc/openqa/workers.ini+. For example to point the workers to the FQDN of
 your host (needed if test cases need to access files of the host) use the
@@ -319,16 +349,40 @@ The openQA web interface can be started via +MOJO_REVERSE_PROXY=1 morbo script/o
 development mode.
 
 +/var/lib/openqa/+ must be owned by root and contain several sub
-directories owned by the user that runs openqa (default 'geekotest'):
+directories, most of which must be owned by the user that runs openQA
+(default 'geekotest'):
 
-* +cache+ (cache directory, needs to be owned by the user who runs openqa)
-* +factory/iso+
-* +share+ (shared directories for remote workers)
-* +testresults+
-* +tools+ (symlink to +/usr/share/openqa/tools/+)
 * +db+ contains the sqlite database
+* +images+ is where the server stores test screenshots and thumbnails
+* +share+ contains shared directories for remote workers, can be owned by root
+* +share/factory+ contains test assets and temp directory, can be owned by root but sysadmin must create subdirs
+* +share/factory/iso+ contains ISOs for tests
+* +share/factory/hdd+ contains hard disk images for tests
+* +share/factory/repo+ contains repositories for tests
+* +share/factory/other+ contains miscellaneous test assets (e.g. kernels and initrds)
+* +share/factory/tmp+ is used as a temporary directory (openQA will create it if it owns +share/factory+)
+* +share/tests+ contains the tests themselves
+* +testresults+ is where the server stores test logs and test-generated assets
 
-To initially create the database, you need to run +script/initdb+.
+It also contains several symlinks which are necessary due to various things
+moving around over the course of openQA's development. All the symlinks
+can of course be owned by root:
+
+* +script+ (symlink to +/usr/share/openqa/script/+)
+* +tests+ (symlink to +share/tests+)
+* +factory+ (symlink to +share/factory+)
+
+It is always best to use the canonical locations, not the compatibility
+symlinks - so run scripts from +/usr/share/openqa/script+, not
++/var/lib/openqa/script+.
+
+You only need the asset directories for the asset types you will actually use,
+e.g. if none of your tests refer to openQA-stored repositories, you will need
+no +factory/repo+ directory. The distribution packages may not create all
+asset directories, so make sure the ones you need are created if necessary.
+Packages will likewise usually not contain any tests; you must create your
+own tests, or use existing tests for some distribution or other piece of
+software.
 
 The worker needs to own +/var/lib/openqa/pool/$INSTANCE+, e.g.
 * +/var/lib/openqa/pool/1+
@@ -337,6 +391,41 @@ The worker needs to own +/var/lib/openqa/pool/$INSTANCE+, e.g.
 
 You can also give the whole pool directory to the +_openqa-worker+ user and let
 the workers create their own instance directories.
+
+Other database engines
+----------------------
+[id="otherdb"]
+
+By default, openQA will use an SQLite database: +/var/lib/openqa/db/db.sqlite+.
+This will be automatically created on first access to the openQA web UI, if it
+does not exist.
+
+It is possible to use PostgreSQL or MariaDB / MySQL instead of SQLite, and
+indeed this is recommended for production deployments of openQA. You should
+create a database and a dedicated user account with full access to it. To
+configure access to the chosen database in openQA, edit +/etc/openqa/database.ini+
+and change the settings in the +[production]+ section. Here is an example for
+connecting to a remote PostgreSQL database with a username and password:
+[source, ini]
+--------------------------------------------------------------------------------
+[production]
+dsn = dbi:Pg:dbname=openqa;host=db.example.org
+user = openqa
+password = somepassword
+--------------------------------------------------------------------------------
+The +dsn+ value format technically depends on the database type (though at
+time of writing it's in fact identical for both supported databases). For
+PostgreSQL it's documented at
+http://search.cpan.org/~rudy/DBD-Pg/Pg.pm#DBI_Class_Methods ,
+for MySQL / MariaDB it's documented at
+http://search.cpan.org/~capttofu/DBD-mysql/lib/DBD/mysql.pm#Class_Methods
+
+If you intend to use a different database, it is best to create the database
+and configuration file before starting the services and connecting to the
+web UI for the first time, otherwise openQA will set itself up with an SQLite
+database and may get confused when you try to switch to a different one. See
+the following section if you want to migrate an existing openQA-on-SQLite
+deployment to a different database.
 
 Changing the database engine
 ----------------------------


### PR DESCRIPTION
This updates InstallGuide and GettingStarted to be a little
more distro-agnostic (i.e. include instructions for Fedora, and
flag up openSUSE-specific things like some variables). It also
just brings a few things up to date, and adds some missing bits
like instructions on how to set up pgsql/mysql.