### PR TITLE
allow loading of arbitrary plugins from config file

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -33,6 +33,11 @@
 ## Set to 0 to disable auditing backend
 # audit_enabled = 1
 
+## space-separated list of extra plugins to load; plugin must be under
+## OpenQA::WebAPI::Plugin and correctly-cased module name given here,
+## this example loads OpenQA::WebAPI::Plugin::Fedmsg
+#plugins = Fedmsg
+
 #[scm git]
 #do_push = no
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -46,6 +46,7 @@ sub _read_config {
             scm              => undef,
             hsts             => 365,
             audit_enabled    => 1,
+            plugins          => undef,
         },
         auth => {
             method => 'OpenID',
@@ -200,6 +201,13 @@ sub startup {
     $self->plugin('OpenQA::WebAPI::Plugin::Gru');
     if ($self->config->{global}{audit_enabled}) {
         $self->plugin('OpenQA::WebAPI::Plugin::AuditLog', Mojo::IOLoop->singleton);
+    }
+    if (defined $self->config->{global}->{plugins}) {
+        my @plugins = split(' ', $self->config->{global}->{plugins});
+        for my $plugin (@plugins) {
+            $self->log->info("Loading external plugin $plugin");
+            $self->plugin("OpenQA::WebAPI::Plugin::$plugin");
+        }
     }
 
     $self->plugin(bootstrap3 => {css => [], js => []});


### PR DESCRIPTION
For now this only loads plugins for openqa-webui, and expects
them to be placed in WebAPI/Plugin . You can specify the config
setting 'plugins' as a space-separated list of module names of
plugins to be loaded, e.g. 'plugins = Fedmsg' would cause the
plugin WebAPI::Plugin::Fedmsg to be loaded.

We might want to define a different location for external
plugins, or allow loading of plugins for other bits of openQA,
or allow some kind of way to specify arguments to be passed to
the plugin...this is just a simple starting point for a PR.

The motivation here is to let me load a fedmsg plugin for
Fedora's openQA; I could just send a PR with a special config
key like the one for the AuditLog plugin, but that doesn't
seem like a particularly extensible approach, and it'd be odd
for openQA to have code specifically for loading a plugin it
doesn't actually include (I don't think the plugin itself needs
to be part of the openQA codebase, I was expecting to maintain
it externally).