### PR TITLE
Update  GettingStarted.asciidoc - fix path of template load script

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -416,7 +416,7 @@ following command:
 
 [source,sh]
 --------------------------------------------------------------------------------
-/var/lib/openqa/share/tests/opensuse/templates [--apikey API_KEY] [--apisecret API_SECRET]
+/var/lib/openqa/share/tests/opensuse/products/opensuse/templates [--apikey API_KEY] [--apisecret API_SECRET]
 --------------------------------------------------------------------------------
 
 This will load some default settings that were used at some point of time in


### PR DESCRIPTION
The path for script  loading opensuse templates has changed:

-/var/lib/openqa/share/tests/opensuse/templates
+/var/lib/openqa/share/tests/opensuse/products/opensuse/templates

/var/lib/openqa/share/tests/fedora/templates