### PR TITLE
Foundations for directory nesting for needles

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -2,6 +2,7 @@ package OpenQA::Utils;
 use strict;
 require 5.002;
 
+use Cwd;
 use Carp;
 use IPC::Run();
 use Mojo::URL;
@@ -102,6 +103,12 @@ sub needle_info {
     }
     else {
         $needledir = dirname($fn);
+    }
+
+    # make sure needledir is a subdir of testcasedir
+    if (index(Cwd::realpath($needledir), Cwd::realpath($testcasedir)) != 0) {
+        warn "$needledir is not a subdir of $testcasedir";
+        return;
     }
 
     my $JF;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -88,15 +88,22 @@ sub needledir {
     return productdir($distri, $version) . '/needles';
 }
 
-sub needle_info($$$) {
+sub needle_info($$$$) {
     my $name    = shift;
     my $distri  = shift;
     my $version = shift;
+    my $jsonfile= shift;
     local $/;
 
     my $needledir = needledir($distri, $version);
 
-    my $fn = "$needledir/$name.json";
+    if (! $jsonfile){
+        $jsonfile = "$needledir/$name.json";
+    } else {
+        $needledir = dirname($jsonfile);
+    }
+
+    my $fn = $jsonfile;
     my $JF;
     unless (open($JF, '<', $fn)) {
         warn "$fn: $!";
@@ -112,9 +119,12 @@ sub needle_info($$$) {
         return;
     }
 
+    my $fname = basename($jsonfile, '.json') . ".png";
+    my $pngfile = File::Spec->catpath('', dirname($jsonfile), $fname);
+
     $needle->{needledir} = $needledir;
-    $needle->{image}     = "$needledir/$name.png";
-    $needle->{json}      = "$needledir/$name.json";
+    $needle->{image}     = $pngfile;
+    $needle->{json}      = $jsonfile;
     $needle->{name}      = $name;
     $needle->{distri}    = $distri;
     $needle->{version}   = $version;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -119,21 +119,18 @@ sub needle_info {
     }
 
     my $needle;
-    # try-catch actually resolves functions, so we can not "return from needle_info"
-    #   while inside the catch clause
-    # thus `return unless` aborts the needle_info method when the `return undef` in
-    #   the catch clause is evaluated
-    return unless try {
+    try {
         $needle = decode_json(<$JF>);
-        return 1;
     }
     catch {
         warn "failed to parse $fn: $_";
-        return 0;
+        # technically not required, $needle should remain undefined. Being superstitious human I add:
+        undef $needle;
     }
     finally {
         close($JF);
     };
+    return unless $needle;
 
     my $png_fname = basename($fn, '.json') . ".png";
     my $pngfile = File::Spec->catpath('', $needledir, $png_fname);

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -88,22 +88,22 @@ sub needledir {
     return productdir($distri, $version) . '/needles';
 }
 
-sub needle_info($$$$) {
+sub needle_info {
     my $name    = shift;
     my $distri  = shift;
     my $version = shift;
-    my $jsonfile= shift;
+    my $fn      = shift;
     local $/;
 
     my $needledir = needledir($distri, $version);
 
-    if (! $jsonfile){
-        $jsonfile = "$needledir/$name.json";
-    } else {
-        $needledir = dirname($jsonfile);
+    if (!$fn) {
+        $fn = "$needledir/$name.json";
+    }
+    else {
+        $needledir = dirname($fn);
     }
 
-    my $fn = $jsonfile;
     my $JF;
     unless (open($JF, '<', $fn)) {
         warn "$fn: $!";
@@ -115,16 +115,16 @@ sub needle_info($$$$) {
     close($JF);
 
     if ($@) {
-        warn "failed to parse $needledir/$name.json: $@";
+        warn "failed to parse $fn: $@";
         return;
     }
 
-    my $fname = basename($jsonfile, '.json') . ".png";
-    my $pngfile = File::Spec->catpath('', dirname($jsonfile), $fname);
+    my $png_fname = basename($fn, '.json') . ".png";
+    my $pngfile = File::Spec->catpath('', $needledir, $png_fname);
 
     $needle->{needledir} = $needledir;
     $needle->{image}     = $pngfile;
-    $needle->{json}      = $jsonfile;
+    $needle->{json}      = $fn;
     $needle->{name}      = $name;
     $needle->{distri}    = $distri;
     $needle->{version}   = $version;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -358,7 +358,7 @@ sub startup {
     $step_auth->post('/')->name('save_needle')->to('step#save_needle');
     $step_r->get('/')->name('step')->to(action => 'view');
 
-    $r->get('/needles/:distri/#name')->name('needle_file')->to('file#needle');
+    $r->get('/needles/:distri/*name')->name('needle_file')->to('file#needle');
     $r->get('/image/:md5_dirname/.thumbs/#md5_basename')->name('thumb_image')->to('file#thumb_image');
 
     $r->get('/group_overview/:groupid')->name('group_overview')->to('main#group_overview');

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -358,7 +358,7 @@ sub startup {
     $step_auth->post('/')->name('save_needle')->to('step#save_needle');
     $step_r->get('/')->name('step')->to(action => 'view');
 
-    $r->get('/needles/:distri/*name')->name('needle_file')->to('file#needle');
+    $r->get('/needles/:distri/#name')->name('needle_file')->to('file#needle');
     $r->get('/image/:md5_dirname/.thumbs/#md5_basename')->name('thumb_image')->to('file#thumb_image');
 
     $r->get('/group_overview/:groupid')->name('group_overview')->to('main#group_overview');

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -32,10 +32,10 @@ sub needle {
     # do the format splitting ourselves instead of using mojo to restrict the suffixes
     # 13.1.png would be format 1.png otherwise
     my ($name, $dummy, $format) = fileparse($self->param('name'), qw(.png .txt));
-    my $distri  = $self->param('distri');
-    my $version = $self->param('version') || '';
+    my $distri   = $self->param('distri');
+    my $version  = $self->param('version') || '';
     my $jsonfile = $self->param('jsonfile') || '';
-    my $needle  = OpenQA::Utils::needle_info($name, $distri, $version, $jsonfile);
+    my $needle   = OpenQA::Utils::needle_info($name, $distri, $version, $jsonfile);
     return $self->reply->not_found unless $needle;
 
     $self->{static} = Mojolicious::Static->new;

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -34,7 +34,8 @@ sub needle {
     my ($name, $dummy, $format) = fileparse($self->param('name'), qw(.png .txt));
     my $distri  = $self->param('distri');
     my $version = $self->param('version') || '';
-    my $needle  = OpenQA::Utils::needle_info($name, $distri, $version);
+    my $jsonfile = $self->param('jsonfile') || '';
+    my $needle  = OpenQA::Utils::needle_info($name, $distri, $version, $jsonfile);
     return $self->reply->not_found unless $needle;
 
     $self->{static} = Mojolicious::Static->new;

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -82,21 +82,22 @@ sub init {
 sub needle_url {
     my ($self, $distri, $name, $version, $jsonfile) = @_;
 
-    if(defined($jsonfile) && $jsonfile) {
+    if (defined($jsonfile) && $jsonfile) {
         if (defined($version) && $version) {
             $self->url_for('needle_file', distri => $distri, name => $name)->query(version => $version, jsonfile => $jsonfile);
         }
         else {
             $self->url_for('needle_file', distri => $distri, name => $name)->query(jsonfile => $jsonfile);
         }
-    } else {
+    }
+    else {
         if (defined($version) && $version) {
             $self->url_for('needle_file', distri => $distri, name => $name)->query(version => $version);
         }
         else {
             $self->url_for('needle_file', distri => $distri, name => $name);
         }
-     }
+    }
 }
 
 # Call to viewimg or viewaudio
@@ -154,7 +155,7 @@ sub edit {
             area       => [],
             matches    => [],
             properties => [],
-            file       => "",
+            json       => "",
             tags       => []};
         for my $tag (@$tags) {
             push(@{$screenshot->{tags}}, $tag);
@@ -170,7 +171,7 @@ sub edit {
             push(@{$screenshot->{matches}}, $narea);
         }
         # Second position: the only needle (with the same matches)
-        my $needle = needle_info($module_detail->{needle}, $distribution, $dversion, $module_detail->{file});
+        my $needle = needle_info($module_detail->{needle}, $distribution, $dversion, $module_detail->{json});
 
         $self->app->log->error(sprintf("Could not find needle: %s for %s %s", $module_detail->{needle}, $distribution, $dversion)) if !defined $needle;
 
@@ -184,9 +185,9 @@ sub edit {
             imageversion   => $needle->{version},
             area           => $needle->{area},
             tags           => $needle->{tags},
-            file           => $needle->{json} || "",
+            json       => $needle->{json}       || "",
             properties => $needle->{properties} || [],
-            matches => $screenshot->{matches}};
+            matches    => $screenshot->{matches}};
         calc_min_similarity($matched, $module_detail->{area});
         push(@needles, $matched);
 
@@ -206,7 +207,7 @@ sub edit {
             area       => [],
             matches    => [],
             properties => [],
-            file       => "",
+            json       => "",
             tags       => []};
         for my $tag (@$tags) {
             push(@{$screenshot->{tags}}, $tag);
@@ -222,7 +223,7 @@ sub edit {
         # We also use $area for transforming the match information intro a real area
         for my $needle (@{$module_detail->{needles}}) {
             $needlename = $needle->{name};
-            $needleinfo = needle_info($needlename, $distribution, $dversion || '', $needle->{file});
+            $needleinfo = needle_info($needlename, $distribution, $dversion || '', $needle->{json});
 
             if (!defined $needleinfo) {
                 $self->app->log->error(sprintf("Could not parse needle: %s for %s %s", $needlename, $distribution, $dversion || ''));
@@ -245,7 +246,7 @@ sub edit {
                     imageversion   => $needleinfo->{version},
                     tags           => $needleinfo->{tags},
                     area           => $needleinfo->{area},
-                    file           => $needleinfo->{json} || "",
+                    json       => $needleinfo->{json}       || "",
                     properties => $needleinfo->{properties} || [],
                     matches    => [],
                     broken     => $needleinfo->{broken}});
@@ -278,7 +279,7 @@ sub edit {
             area       => [],
             matches    => [],
             tags       => $tags,
-            file       => "",
+            json       => "",
             properties => []};
     }
 
@@ -467,7 +468,7 @@ sub save_needle {
     my $imagename    = $validation->param('imagename');
     my $imagedistri  = $validation->param('imagedistri');
     my $imageversion = $validation->param('imageversion');
-    my $imagedir     = $self->param('imagedir') }|| "";
+    my $imagedir     = $self->param('imagedir') || "";
     my $needlename   = $validation->param('needlename');
     my $overwrite    = $validation->param('overwrite');
     my $needledir    = needledir($job->settings_hash->{DISTRI}, $job->settings_hash->{VERSION});
@@ -594,7 +595,7 @@ sub viewimg {
 
     my @needles;
     if ($module_detail->{needle}) {
-        my $needle = needle_info($module_detail->{needle}, $distribution, $dversion, $module_detail->{file});
+        my $needle = needle_info($module_detail->{needle}, $distribution, $dversion, $module_detail->{json});
         if ($needle) {    # possibly missing/broken file
             my $info = {
                 name    => $module_detail->{needle},
@@ -610,7 +611,7 @@ sub viewimg {
         my $needleinfo;
         for my $needle (@{$module_detail->{needles}}) {
             $needlename = $needle->{name};
-            $needleinfo = needle_info($needlename, $distribution, $dversion, $needle->{file});
+            $needleinfo = needle_info($needlename, $distribution, $dversion, $needle->{json});
             next unless $needleinfo;
             my $info = {
                 name    => $needlename,

--- a/public/javascripts/needleedit.js
+++ b/public/javascripts/needleedit.js
@@ -7,6 +7,7 @@ function loadBackground() {
     $("#needleeditor_image").val($(this).data('image'));
     $("#needleeditor_imagedistri").val($(this).data('distri'));
     $("#needleeditor_imageversion").val($(this).data('version'));
+    $("#needleeditor_imagedir").val($(this).data('imagedir'));
 }
 
 function loadTagsAndName() {

--- a/script/clean_needles
+++ b/script/clean_needles
@@ -122,7 +122,7 @@ sub load_needles($$) {
     my @names = grep { s/\.json$// } readdir($dh);
     closedir $dh;
     for my $name (@names) {
-        my $needle = needle_info($name, $distri, $version);
+        my $needle = needle_info($name, $distri, $version, "");
         $needles_by_name{$distri}{$version // ''}{$name} = $needle;
         for my $tag (@{$needle->{tags}}) {
             push @{$needles_by_tag{$distri}{$version // ''}{$tag}}, $needle;

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -105,6 +105,7 @@
                 <input type="hidden" id="needleeditor_image" name="imagename" value="<%= ${@$needles[0]}{'imagename'} %>"/>
                 <input type="hidden" id="needleeditor_imagedistri" name="imagedistri" value="<%= ${@$needles[0]}{'imagedistri'} %>"/>
                 <input type="hidden" id="needleeditor_imageversion" name="imageversion" value="<%= ${@$needles[0]}{'imageversion'} %>"/>
+                <input type="hidden" id="needleeditor_imagedir" name="imagedir" value="<%= ${@$needles[0]}{'imagedir'} %>"/>
             </div>
         </div>
         % if (is_operator) {
@@ -146,6 +147,7 @@
                                data-distri="<%= $needle->{'imagedistri'} %>"
                                data-version="<%= $needle->{'imageversion'} %>"
                                data-url="<%= $needle->{'imageurl'} %>"
+                               data-imagedir="<%= $needle->{'imagedir'} %>"
                         <%= 'checked="checked"' if ($i == 0); %>
                         <%= 'disabled="disabled"' if ($needle->{'broken'}); %> />
                     </td>


### PR DESCRIPTION
This is a part of implementation (together with a patch for os-autoinst <https://github.com/os-autoinst/os-autoinst/pull/452>) that adds the foundations for directory nesting of needles. The problem is initially described in this issue: https://github.com/os-autoinst/os-autoinst/issues/426

Overall, the implementation strives to make backward-compatible changes, so although new testruns will store additional information, there should not be errors in viewing older results.

This patch uses the newly added `file` item from the result's matchfile, which contains path to the respective needle's json file definition. This item is then used in the OpenQA's needle editor to provide the desired functionality.

Most of the changes are about handling the (possible) reference to the needle's json file. Changes in frontend allow for handling the directory path of the needle.