### PR TITLE
add fedmsg emitter plugin, bit more commenting for plugin load

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -237,6 +237,9 @@ sub startup {
     if ($self->config->{global}{audit_enabled}) {
         $self->plugin('OpenQA::WebAPI::Plugin::AuditLog', Mojo::IOLoop->singleton);
     }
+    # Load arbitrary plugins defined in config: 'plugins' in section
+    # '[global]' can be a space-separated list of plugins to load, by
+    # module name under OpenQA::WebAPI::Plugin::
     if (defined $self->config->{global}->{plugins}) {
         my @plugins = split(' ', $self->config->{global}->{plugins});
         for my $plugin (@plugins) {

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -1,0 +1,78 @@
+# Copyright (C) 2016 Red Hat
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Plugin::Fedmsg;
+
+use strict;
+use warnings;
+
+use parent qw/Mojolicious::Plugin/;
+use IPC::Run;
+use JSON;
+use Mojo::IOLoop;
+use OpenQA::Schema::Result::Jobs;
+
+my @events = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_done/;
+
+sub register {
+    my ($self, $app) = @_;
+    my $reactor = Mojo::IOLoop->singleton;
+
+    # register for events
+    for my $e (@events) {
+        $reactor->on("openqa_$e" => sub { shift; $self->on_event($app, @_) });
+    }
+}
+
+# when we get an event, convert it to fedmsg format and send it
+sub on_event {
+    my ($self, $app, $args) = @_;
+    my ($user_id, $connection_id, $event, $event_data) = @$args;
+    # we're going to explicitly pass this as the modname
+    $event =~ s/^openqa_//;
+    # fedmsg uses dot separators
+    $event =~ s/_/\./;
+    # find count of pending jobs for the same build
+    # this is so we can tell when all tests for a build are done
+    my $job = $app->db->resultset('Jobs')->find({id => $event_data->{id}});
+    my $build = $job->settings_hash->{BUILD};
+    $event_data->{remaining} = $app->db->resultset('Jobs')->search(
+        {
+            'settings.key'   => 'BUILD',
+            'settings.value' => $build,
+            state            => [OpenQA::Schema::Result::Jobs::PENDING_STATES],
+        },
+        {join => qw/settings/})->count;
+    # add various useful properties for consumers if not there already
+    $event_data->{BUILD}   //= $build;
+    $event_data->{TEST}    //= $job->test;
+    $event_data->{ARCH}    //= $job->settings_hash->{ARCH};
+    $event_data->{MACHINE} //= $job->settings_hash->{MACHINE};
+    $event_data->{FLAVOR}  //= $job->settings_hash->{FLAVOR};
+    $event_data->{ISO}     //= $job->settings_hash->{ISO} if ($job->settings_hash->{ISO});
+    $event_data->{HDD_1}   //= $job->settings_hash->{HDD_1} if ($job->settings_hash->{HDD_1});
+    # convert data to JSON, with reliable key ordering (helps the tests)
+    $event_data = to_json($event_data, {canonical => 1});
+    $app->log->debug("Sending fedmsg for $event");
+    # do you want to write perl bindings for fedmsg? no? me either.
+    # FIXME: should be some way for plugins to have configuration and then
+    # cert-prefix could be configurable, for now we hard code it
+    # we use IPC::Run rather than system() as it's easier to mock for testing
+    my @command = ("fedmsg-logger", "--cert-prefix=openqa", "--modname=openqa", "--topic=$event", "--json-input", "--message=$event_data");
+    my ($stdin, $stderr, $output) = (undef, undef, undef);
+    IPC::Run::run(\@command, \$stdin, \$output, \$stderr);
+}
+
+1;

--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -1,0 +1,109 @@
+BEGIN { unshift @INC, 'lib'; }
+
+# Copyright (C) 2016 Red Hat
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Mojo::Base;
+use Mojo::IOLoop;
+
+use OpenQA::Client;
+use OpenQA::IPC;
+use OpenQA::Scheduler;
+use OpenQA::WebSockets;
+use OpenQA::Test::Database;
+use Net::DBus;
+use Net::DBus::Test::MockObject;
+use Test::MockModule;
+use Test::More;
+use Test::Mojo;
+use Test::Warnings;
+
+my $args;
+
+# this is a mock IPC::Run which just stores the args it's called with
+# so we can check the plugin did the right thing
+sub mock_ipc_run {
+    my ($cmd, $stdin, $stdout, $stderr) = @_;
+    $args = join(" ", @$cmd);
+}
+
+my $module = new Test::MockModule('IPC::Run');
+$module->mock('run', \&mock_ipc_run);
+
+my $schema = OpenQA::Test::Database->new->create();
+
+# this test also serves to test plugin loading via config file
+$ENV{OPENQA_CONFIG} = 't';
+open(my $fd, '>', $ENV{OPENQA_CONFIG} . '/openqa.ini');
+print $fd "[global]\n";
+print $fd "plugins=Fedmsg\n";
+close $fd;
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+# XXX: Test::Mojo loses its app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+my $app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+# create Test DBus bus and service for fake WebSockets
+my $ipc = OpenQA::IPC->ipc('', 1);
+my $ws  = OpenQA::WebSockets->new();
+my $sh  = OpenQA::Scheduler->new();
+
+my $settings = {
+    DISTRI      => 'Unicorn',
+    FLAVOR      => 'pink',
+    VERSION     => '42',
+    BUILD       => '666',
+    TEST        => 'rainbow',
+    ISO         => 'whatever.iso',
+    DESKTOP     => 'DESKTOP',
+    KVM         => 'KVM',
+    ISO_MAXSIZE => 1,
+    MACHINE     => "RainbowPC",
+    ARCH        => 'x86_64'
+};
+
+# create a job via API
+my $post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+my $job = $post->tx->res->json->{id};
+is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.create --json-input --message={"ARCH":"x86_64","BUILD":"666","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink","ISO":"whatever.iso","ISO_MAXSIZE":"1","KVM":"KVM","MACHINE":"RainbowPC","TEST":"rainbow","VERSION":"42","id":' . $job . ',"remaining":1}', "job create triggers fedmsg");
+
+# FIXME: restarting job via API emits an event in real use, but not if we do it here
+
+# set the job as done via API
+$post = $t->post_ok("/api/v1/jobs/" . $job . "/set_done")->status_is(200);
+# check plugin called fedmsg-logger correctly
+is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.done --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":' . $job . ',"newbuild":null,"remaining":0,"result":null}', "job done triggers fedmsg");
+
+# we don't test update_results as comment indicates it's obsolete
+
+# duplicate the job via API
+$post = $t->post_ok("/api/v1/jobs/" . $job . "/duplicate")->status_is(200);
+my $newjob = $post->tx->res->json->{id};
+# check plugin called fedmsg-logger correctly
+is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.duplicate --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","auto":null,"id":' . $job . ',"remaining":1,"result":' . $newjob . '}', "job duplicate triggers fedmsg");
+
+# cancel the new job via API
+$post = $t->post_ok("/api/v1/jobs/" . $newjob . "/cancel")->status_is(200);
+# check plugin called fedmsg-logger correctly
+is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.cancel --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":' . $newjob . ',"remaining":0}', "job cancel triggers fedmsg");
+
+# FIXME: deleting job via DELETE call to api/v1/jobs/$newjob fails with 500?
+
+done_testing();


### PR DESCRIPTION
As @aaannz is interested in using this plugin, we may as well
make it part of upstream openQA. It simply relays some openQA
signals as fedmsg signals, for now using the 'fedmsg-logger'
command as we don't have Perl bindings for fedmsg and I don't
feel a lot like writing them. You need to have a correct fedmsg
relay config in place to use this; for local testing it will
suffice to install fedmsg-relay with its default config and run
it, that will emit the messages on the local fedmsg instance.
For production use, you need an appropriate relay_inbound
setting which points to an active->passive relay for the real
fedmsg instance, and probably you'll want to ensure a cert and
key are in place for message signing, with prefix 'openqa'.

The logic for adding the 'remaining' count could perhaps move
to the place where the openQA job_done message is constructed,
I guess.