### PR TITLE
Allow /api/v1/jobs get request to filter by result

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -33,7 +33,7 @@ sub list {
     # arg. In all cases we're going to convert to an array ref of values:
     # we could let query_jobs do the string splitting for us, but this is
     # clearer.
-    for my $arg (qw/state ids/) {
+    for my $arg (qw/state ids result/) {
         next unless defined $self->param($arg);
         if (index($self->param($arg), ',') != -1) {
             $args{$arg} = [split(',', $self->param($arg))];


### PR DESCRIPTION
@k0da would like this for some TTM hacking and I think it's generally useful.

This allow `/api/v1/jobs` to accept result parameter either with single value or comma separated values.