### PR TITLE
Admin UI for operators

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -397,40 +397,42 @@ sub startup {
     #
     ## Admin area starts here
     ###
-    my $admin_auth = $r->under('/admin')->to("session#ensure_admin");
-    my $admin_r = $admin_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
+    my $admin_auth = $r->under('/admin')->to('session#ensure_admin');
+    my $admin_r    = $admin_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
+    my $op_auth    = $r->under('/admin')->to('session#ensure_operator');
+    my $op_r       = $op_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
 
+    # operators accessible tables
+    $op_r->get('/products')->name('admin_products')->to('product#index');
+    $op_r->get('/machines')->name('admin_machines')->to('machine#index');
+    $op_r->get('/test_suites')->name('admin_test_suites')->to('test_suite#index');
+
+    $op_r->get('/job_templates/:groupid')->name('admin_job_templates')->to('job_template#index');
+
+    $op_r->get('/groups')->name('admin_groups')->to('job_group#index');
+    $op_r->post('/groups')->name('admin_new_group')->to('job_group#create');
+    $op_r->get('/groups/connect/:groupid')->name('job_group_new_media')->to('job_group#connect');
+    $op_r->post('/groups/connect/:groupid')->name('job_group_save_media')->to('job_group#save_connect');
+
+    $op_r->get('/assets')->name('admin_assets')->to('asset#index');
+
+    $op_r->get('/workers')->name('admin_workers')->to('workers#index');
+    $op_r->get('/workers/:worker_id')->name('admin_worker_show')->to('workers#show');
+
+    $op_r->get('/productlog')->name('admin_product_log')->to('audit_log#productlog');
+
+    # admins accessible tables
     $admin_r->get('/users')->name('admin_users')->to('user#index');
     $admin_r->post('/users/:userid')->name('admin_user')->to('user#update');
-
-    $admin_r->get('/products')->name('admin_products')->to('product#index');
-    $admin_r->get('/machines')->name('admin_machines')->to('machine#index');
-    $admin_r->get('/test_suites')->name('admin_test_suites')->to('test_suite#index');
-
-    $admin_r->get('/job_templates/:groupid')->name('admin_job_templates')->to('job_template#index');
-
-
-    $admin_r->get('/groups')->name('admin_groups')->to('job_group#index');
-    $admin_r->post('/groups')->name('admin_new_group')->to('job_group#create');
-    $admin_r->get('/groups/connect/:groupid')->name('job_group_new_media')->to('job_group#connect');
-    $admin_r->post('/groups/connect/:groupid')->name('job_group_save_media')->to('job_group#save_connect');
-
-    $admin_r->get('/assets')->name('admin_assets')->to('asset#index');
-
-    $admin_r->get('/workers')->name('admin_workers')->to('workers#index');
-    $admin_r->get('/workers/:worker_id')->name('admin_worker_show')->to('workers#show');
-
     $admin_r->get('/needles')->name('admin_needles')->to('needle#index');
     $admin_r->get('/needles/:module_id/:needle_id')->name('admin_needle_module')->to('needle#module');
     $admin_r->get('/needles/ajax')->name('admin_needle_ajax')->to('needle#ajax');
     $admin_r->delete('/needles/delete')->name('admin_needle_delete')->to('needle#delete');
-
     $admin_r->get('/auditlog')->name('audit_log')->to('audit_log#index');
     $admin_r->get('/auditlog/ajax')->name('audit_ajax')->to('audit_log#ajax');
-    $admin_r->get('/productlog')->name('admin_product_log')->to('audit_log#productlog');
 
-    # Users list as default option
-    $admin_r->get('/')->name('admin')->to('user#index');
+    # Workers list as default option
+    $op_r->get('/')->name('admin')->to('workers#index');
     ###
     ## Admin area ends here
     #

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 BEGIN {
     unshift @INC, 'lib';
@@ -23,10 +22,17 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
+use OpenQA::Test::Database;
 use Data::Dumper;
+use t::ui::PhantomTest;
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data;
+my $driver = t::ui::PhantomTest::call_phantom();
+unless ($driver) {
+    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    exit(0);
+}
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
@@ -62,4 +68,39 @@ $test_case->login($t, 'lancelot', email => 'lancelot@example.com');
 $get = $t->get_ok('/tests')->status_is(200);
 $get->element_exists_not('#scheduled #job_99928 a.cancel');
 
+# operator has access to part of admin menu - using phantomjs
+is($driver->get_title(), "openQA", "on main page");
+$driver->find_element('Login', 'link_text')->click();
+# we're back on the main page
+is($driver->get_title(), "openQA", "back on main page");
+# but ...
+
+like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged in as Demo.*Logout/, "logged in as demo");
+
+# Demo is admin, so go there
+$driver->find_element('admin', 'link_text')->click();
+is($driver->get_title(), "openQA: Workers", "on workers overview");
+
+# now hack ourselves to be just operator - this is stupid procedure, but we don't have API for user management
+$driver->find_element('Users', 'link_text')->click;
+$driver->execute_script('$("#users").off("change")');
+$driver->execute_script('$("#users").on("change", "input[name=\"role\"]:radio", function() {$(this).parent("form").submit();})');
+$driver->find_element('//tr[./td[@class="nick" and text()="Demo"]]/td[@class="role"]//label[2]')->click;
+
+# refresh and return to admin pages
+$driver->refresh;
+$driver->get($driver->get_current_url =~ s/users//r);
+$driver->find_element('admin', 'link_text')->click();
+
+# we should see test templates, groups, machines
+for my $item ('Medium types', 'Machines', 'Workers', 'Assets', 'Scheduled products') {
+    ok($driver->find_element($item, 'link_text'), "can see $item");
+}
+# we shouldn't see users, audit
+for my $item ('Users', 'Audit log') {
+    eval { $driver->find_element($item, 'link_text') };
+    ok($@, "can not see $item");
+}
+
+t::ui::PhantomTest::kill_phantom();
 done_testing();

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -56,7 +56,7 @@ like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged in as Dem
 # Demo is admin, so go there
 $driver->find_element('admin', 'link_text')->click();
 
-is($driver->get_title(), "openQA: Users", "on user overview");
+is($driver->get_title(), "openQA: Workers", "on workers overview");
 
 sub add_job_group() {
     $driver->find_element('Job groups', 'link_text')->click();

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -60,7 +60,7 @@ like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged in as Dem
 # Demo is admin, so go there
 $driver->find_element('admin', 'link_text')->click();
 
-is($driver->get_title(), "openQA: Users", "on user overview");
+is($driver->get_title(), "openQA: Workers", "on workers overview");
 
 $driver->find_element('Workers', 'link_text')->click();
 

--- a/templates/layouts/admin_nav.html.ep
+++ b/templates/layouts/admin_nav.html.ep
@@ -1,9 +1,8 @@
 <div class="col-sm-2">
     <div class="panel panel-default" id="actions_box">
-        <div class="panel-heading">Menu</div>
+        <div class="panel-heading">Operators Menu</div>
         <div class="panel-body">
             <ul>
-                <li><%= link_to('Users' => url_for('admin_users')) %></li>
                 <li><%= link_to('Medium types' => url_for('admin_products')) %></li>
                 <li><%= link_to('Machines' => url_for('admin_machines')) %></li>
                 <li><%= link_to('Test suites' => url_for('admin_test_suites')) %></li>
@@ -14,9 +13,17 @@
                 <!-- Sure this is not the proper place for the workers view,
                 but the previous one was even more annoying -->
                 <li><%= link_to('Workers' => url_for('admin_workers')) %></li>
+            </ul>
+        </div>
+            % if (is_admin) {
+        <div class="panel-heading">Administrators Menu</div>
+        <div class="panel-body">
+            <ul>
+                <li><%= link_to('Users' => url_for('admin_users')) %></li>
                 <li><%= link_to('Needles' => url_for('admin_needles')) %></li>
                 <li><%= link_to('Audit log' => url_for('audit_log')) %></li>
             </ul>
         </div>
+            % }
     </div>
 </div>

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -51,8 +51,6 @@
               % my $out = 'Logged in as '. current_user->name.' (';
               % if (is_operator) {
                   % $out = $out.link_to('manage API keys' => url_for('api_keys')).' | ';
-              % }
-              % if (is_admin) {
                   % $out = $out.link_to('admin' => url_for('admin')).' | ';
               % }
               %= b($out.link_to('Logout' => url_for('logout') => 'data-method' => 'delete').')');


### PR DESCRIPTION
Operators can change things like test templates, media, machines already, but only using API. This PR allows operators to use web ui to view and modify test templates, job groups, product media, etc.

User management, audit log and needle management remain as admin only.

Screen from admin perspective:
![openqa-operatorsmenu](https://cloud.githubusercontent.com/assets/1260795/14002787/6441e4b2-f14e-11e5-9717-0bcda09dbf01.png)

Screen from operator perspective:
![shot2](https://cloud.githubusercontent.com/assets/1260795/14002794/73965998-f14e-11e5-80e7-1b662aa7f50c.png)

