### PR TITLE
limit operators ability to modify admin tables

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -410,9 +410,7 @@ sub startup {
     $op_r->get('/job_templates/:groupid')->name('admin_job_templates')->to('job_template#index');
 
     $op_r->get('/groups')->name('admin_groups')->to('job_group#index');
-    $op_r->post('/groups')->name('admin_new_group')->to('job_group#create');
     $op_r->get('/groups/connect/:groupid')->name('job_group_new_media')->to('job_group#connect');
-    $op_r->post('/groups/connect/:groupid')->name('job_group_save_media')->to('job_group#save_connect');
 
     $op_r->get('/assets')->name('admin_assets')->to('asset#index');
 
@@ -430,6 +428,8 @@ sub startup {
     $admin_r->delete('/needles/delete')->name('admin_needle_delete')->to('needle#delete');
     $admin_r->get('/auditlog')->name('audit_log')->to('audit_log#index');
     $admin_r->get('/auditlog/ajax')->name('audit_ajax')->to('audit_log#ajax');
+    $admin_r->post('/groups')->name('admin_new_group')->to('job_group#create');
+    $admin_r->post('/groups/connect/:groupid')->name('job_group_save_media')->to('job_group#save_connect');
 
     # Workers list as default option
     $op_r->get('/')->name('admin')->to('workers#index');
@@ -440,8 +440,10 @@ sub startup {
     #
     ## JSON API starts here
     ###
-    my $api_auth = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth');
+    my $api_auth  = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth');
+    my $api_admin = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_admin');
     my $api_r = $api_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_ra = $api_admin->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     my $api_public_r = $r->route('/api/v1')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     # this is fallback redirect if one does not use apache
     $api_public_r->websocket(
@@ -516,7 +518,7 @@ sub startup {
 
     # api/v1/isos
     $api_r->post('/isos')->name('apiv1_create_iso')->to('iso#create');                 # iso_new
-    $api_r->delete('/isos/#name')->name('apiv1_destroy_iso')->to('iso#destroy');       # iso_delete
+    $api_ra->delete('/isos/#name')->name('apiv1_destroy_iso')->to('iso#destroy');      # iso_delete
     $api_r->post('/isos/#name/cancel')->name('apiv1_cancel_iso')->to('iso#cancel');    # iso_cancel
 
     # api/v1/assets
@@ -524,38 +526,38 @@ sub startup {
     $api_public_r->get('/assets')->name('apiv1_get_asset')->to('asset#list');
     $api_public_r->get('/assets/#id')->name('apiv1_get_asset_id')->to('asset#get');
     $api_public_r->get('/assets/#type/#name')->name('apiv1_get_asset_name')->to('asset#get');
-    $api_r->delete('/assets/#id')->name('apiv1_delete_asset')->to('asset#delete');
-    $api_r->delete('/assets/#type/#name')->name('apiv1_delete_asset_name')->to('asset#delete');
+    $api_ra->delete('/assets/#id')->name('apiv1_delete_asset')->to('asset#delete');
+    $api_ra->delete('/assets/#type/#name')->name('apiv1_delete_asset_name')->to('asset#delete');
 
     # api/v1/test_suites
     $api_r->get('test_suites')->name('apiv1_test_suites')->to('table#list', table => 'TestSuites');
-    $api_r->post('test_suites')->to('table#create', table => 'TestSuites');
+    $api_ra->post('test_suites')->to('table#create', table => 'TestSuites');
     $api_r->get('test_suites/:id')->name('apiv1_test_suite')->to('table#list', table => 'TestSuites');
-    $api_r->put('test_suites/:id')->to('table#update', table => 'TestSuites');
-    $api_r->post('test_suites/:id')->to('table#update', table => 'TestSuites');    #in case PUT is not supported
-    $api_r->delete('test_suites/:id')->to('table#destroy', table => 'TestSuites');
+    $api_ra->put('test_suites/:id')->to('table#update', table => 'TestSuites');
+    $api_ra->post('test_suites/:id')->to('table#update', table => 'TestSuites');    #in case PUT is not supported
+    $api_ra->delete('test_suites/:id')->to('table#destroy', table => 'TestSuites');
 
     # api/v1/machines
     $api_r->get('machines')->name('apiv1_machines')->to('table#list', table => 'Machines');
-    $api_r->post('machines')->to('table#create', table => 'Machines');
+    $api_ra->post('machines')->to('table#create', table => 'Machines');
     $api_r->get('machines/:id')->name('apiv1_machine')->to('table#list', table => 'Machines');
-    $api_r->put('machines/:id')->to('table#update', table => 'Machines');
-    $api_r->post('machines/:id')->to('table#update', table => 'Machines');         #in case PUT is not supported
-    $api_r->delete('machines/:id')->to('table#destroy', table => 'Machines');
+    $api_ra->put('machines/:id')->to('table#update', table => 'Machines');
+    $api_ra->post('machines/:id')->to('table#update', table => 'Machines');         #in case PUT is not supported
+    $api_ra->delete('machines/:id')->to('table#destroy', table => 'Machines');
 
     # api/v1/products
     $api_r->get('products')->name('apiv1_products')->to('table#list', table => 'Products');
-    $api_r->post('products')->to('table#create', table => 'Products');
+    $api_ra->post('products')->to('table#create', table => 'Products');
     $api_r->get('products/:id')->name('apiv1_product')->to('table#list', table => 'Products');
-    $api_r->put('products/:id')->to('table#update', table => 'Products');
-    $api_r->post('products/:id')->to('table#update', table => 'Products');         #in case PUT is not supported
-    $api_r->delete('products/:id')->to('table#destroy', table => 'Products');
+    $api_ra->put('products/:id')->to('table#update', table => 'Products');
+    $api_ra->post('products/:id')->to('table#update', table => 'Products');         #in case PUT is not supported
+    $api_ra->delete('products/:id')->to('table#destroy', table => 'Products');
 
     # api/v1/job_templates
     $api_r->get('job_templates')->name('apiv1_job_templates')->to('job_template#list');
-    $api_r->post('job_templates')->to('job_template#create');
+    $api_ra->post('job_templates')->to('job_template#create');
     $api_r->get('job_templates/:job_template_id')->name('apiv1_job_template')->to('job_template#list');
-    $api_r->delete('job_templates/:job_template_id')->to('job_template#destroy');
+    $api_ra->delete('job_templates/:job_template_id')->to('job_template#destroy');
 
     # json-rpc methods not migrated to this api: echo, list_commands
     ###

--- a/lib/OpenQA/WebAPI/Controller/API/V1.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1.pm
@@ -76,6 +76,15 @@ sub auth {
     return 0;
 }
 
+sub auth_admin {
+    my ($self) = @_;
+    return 0 if (!$self->auth);
+    return 1 if ($self->is_admin);
+
+    $self->render(json => {error => 'Administrator level required'}, status => 403);
+    return 0;
+}
+
 sub auth_jobtoken {
     my ($self)  = @_;
     my $headers = $self->req->headers;

--- a/public/javascripts/admintable.js
+++ b/public/javascripts/admintable.js
@@ -1,12 +1,12 @@
 
-function table_row (data, table, edit)
+function table_row (data, table, edit, is_admin)
 {
     var html = "<tr>";
-    
+
     table.find('th').each (function() {
         var th = $(this);
         var name = th.text().trim().toLowerCase();
-        
+
         if (th.hasClass("col_value")) {
             var value = '';
             if (data[name]) value = data[name];
@@ -72,31 +72,27 @@ function table_row (data, table, edit)
             }
             html += '</td>';
         } else if (th.hasClass("col_action")) {
+            html += '<td>';
             if (edit) {
                 if (data['id']) {
                     // edit existing
                     html +=
-                    '<td>' +
                          '<button type="submit" class="btn" alt="Update" title="Update" onclick="submit_table_row_button( this, ' + data['id'] + ');"><i class="fa fa-floppy-o"></i></button>' +
                          '<button type="submit" class="btn" alt="Cancel" title="Cancel" onclick="refresh_table_row_button( this, ' + data['id'] + ' , false);"><i class="fa fa-undo"></i></button>' +
-                         '<button type="submit" class="btn" alt="Delete" title="Delete" onclick="delete_table_row_button( this, ' + data['id'] + ');"><i class="fa fa-trash"></i></button>' +
-                     '</td>';
+                         '<button type="submit" class="btn" alt="Delete" title="Delete" onclick="delete_table_row_button( this, ' + data['id'] + ');"><i class="fa fa-trash"></i></button>';
                 }
                 else {
                     // add new
                     html +=
-                    '<td>' +
                          '<button type="submit" class="btn" alt="Add" title="Add" onclick="submit_table_row_button( this );"><i class="fa fa-floppy-o"></i></button>' +
-                         '<button type="submit" class="btn" alt="Cancel" title="Cancel" onclick="delete_table_row_button( this );"><i class="fa fa-undo"></i></button>' +
-                     '</td>';
+                         '<button type="submit" class="btn" alt="Cancel" title="Cancel" onclick="delete_table_row_button( this );"><i class="fa fa-undo"></i></button>';
                 }
             }
-            else {
+            else if (is_admin) {
                 html +=
-                '<td>' +
-                     '<button type="submit" class="btn" alt="Edit" title="Edit" onclick="refresh_table_row_button( this, ' + data['id'] + ' , true);"><i class="fa fa-pencil-square-o"></i></button>' +
-                '</td>';
+                     '<button type="submit" class="btn" alt="Edit" title="Edit" onclick="refresh_table_row_button( this, ' + data['id'] + ' , true);"><i class="fa fa-pencil-square-o"></i></button>';
             }
+            html += '</td>';
         }
     });
     html += "</tr>";
@@ -124,7 +120,7 @@ function refresh_table_row (tr, id, edit)
             var db_table = Object.keys(resp)[0];
             var json_row = resp[db_table][0];
             var table = $(tr).closest('table');
-            var new_tr_html = table_row(json_row, table, edit);
+            var new_tr_html = table_row(json_row, table, edit, 1);
             $(tr).replaceWith(new_tr_html);
         },
         error: admintable_api_error
@@ -259,7 +255,7 @@ function add_table_row_button ()
     table.find('tr:last').after(html);
 }
 
-function populate_admin_table ()
+function populate_admin_table (is_admin)
 {
     var url = $("#admintable_api_url").val();
     if (url) {
@@ -273,7 +269,7 @@ function populate_admin_table ()
                 var table = $('.admintable');
                 var html = '';
                 for (var i = 0; i < json_table.length; i++) {
-                    html += table_row(json_table[i], table, false);
+                    html += table_row(json_table[i], table, false, is_admin);
                 }
                 table.find('tbody').html(html);
 		// a really stupid datatable

--- a/public/javascripts/assets.js
+++ b/public/javascripts/assets.js
@@ -6,7 +6,6 @@ function setup_asset_table()
 		{ targets: 3,
 		  "render": function ( data, type, row ) {
 		      if (type === 'display') {
-			  console.log(data);
 			  return jQuery.timeago(data + "Z");
 		      } else
 			  return data;

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -60,7 +60,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 sub la {
@@ -159,6 +159,17 @@ like(warning { $ret = $t->post_ok('/api/v1/assets', form => {type => 'foo', name
 # try to register non existing asset
 like(warning { $ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})->status_is(400) }, qr/asset name \'foo.iso\' invalid/);
 
+# switch to operator (percival) and try some modifications
+$app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+# test delete operation
+$ret = $t->delete_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(403, 'asset deletion forbidden for operator');
+# delete by name
+$ret = $t->delete_ok('/api/v1/assets/iso/' . $iso1)->status_is(403, 'asset deletion forbidden for operator');
+# asset must be still there
+$ret = $t->get_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(200);
 
 for my $i ($iso1, $iso2) {
     ok(unlink("t/data/openqa/factory/iso/$i"), "rm $i");

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -186,6 +186,12 @@ is($ret->tx->res->json->{job}->{state}, 'cancelled', "job $newid is cancelled");
 $ret = $t->post_ok('/api/v1/isos', form => {iso => $iso, tests => "kde/usb"})->status_is(400);
 
 # delete the iso
+# can not do as operator
+$ret = $t->delete_ok("/api/v1/isos/$iso")->status_is(403);
+# switch to admin and continue
+$app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
 $ret = $t->delete_ok("/api/v1/isos/$iso")->status_is(200);
 # now the jobs should be gone
 $ret = $t->get_ok('/api/v1/jobs/$newid')->status_is(404);

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -43,7 +43,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 my $get = $t->get_ok('/api/v1/machines')->status_is(200);
@@ -144,5 +144,13 @@ is_deeply(
 
 $res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(200);
 $res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(404);    #not found
+
+# switch to operator (percival) and try some modifications
+$app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+$t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu", "settings[TEST]" => "val1", "settings[TEST2]" => "val1"})->status_is(403);
+$t->put_ok("/api/v1/machines/$machine_id", form => {name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1"})->status_is(403);
+$t->delete_ok("/api/v1/machines/$machine_id")->status_is(403);
 
 done_testing();

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -43,7 +43,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 
@@ -136,5 +136,13 @@ is_deeply(
 
 $res = $t->delete_ok("/api/v1/products/$product_id")->status_is(200);
 $res = $t->delete_ok("/api/v1/products/$product_id")->status_is(404);    #not found
+
+# switch to operator (percival) and try some modifications
+$app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+$t->post_ok('/api/v1/products', form => {arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2, "settings[TEST]" => "val1", "settings[TEST2]" => "val1"})->status_is(403);
+$t->put_ok("/api/v1/products/$product_id", form => {arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2, "settings[TEST2]" => "val1"})->status_is(403);
+$res = $t->delete_ok("/api/v1/products/$product_id")->status_is(403);
 
 done_testing();

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -43,7 +43,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 my $get = $t->get_ok('/api/v1/test_suites')->status_is(200);
@@ -201,5 +201,13 @@ is_deeply(
 
 $res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
 $res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(404);    #not found
+
+# switch to operator (percival) and try some modifications
+$app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+$t->post_ok('/api/v1/test_suites', form => {name => "testsuite"})->status_is(403);
+$t->put_ok("/api/v1/test_suites/$test_suite_id", form => {name => "testsuite", "settings[TEST2]" => "val1"})->status_is(403);
+$res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(403);
 
 done_testing();

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -34,7 +34,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 my $get = $t->get_ok('/api/v1/job_templates')->status_is(200);
@@ -427,5 +427,20 @@ $res = $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(404);
 
 $res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
 $res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(404);    #not found
+
+# switch to operator (percival) and try some modifications
+$app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+$t->post_ok(
+    '/api/v1/job_templates',
+    form => {
+        group_id      => 1001,
+        machine_id    => 1001,
+        test_suite_id => 1002,
+        product_id    => 1,
+        prio          => 30
+    })->status_is(403);
+$t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(403);
 
 done_testing();

--- a/t/fixtures/03-users.pl
+++ b/t/fixtures/03-users.pl
@@ -7,6 +7,7 @@
         nickname    => 'artie',
         is_operator => 1,
         is_admin    => 1,
+        api_keys    => [{key => 'ARTHURKEY01', secret => 'EXCALIBUR', id => 99905},]
     },
     Users => {
         id => 99902,

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -55,24 +55,24 @@ $req->text_is('#api_key_99904 .expiration' => 'never');
 $req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {})->status_is(302);
 $req = $t->get_ok('/api_keys')->status_is(200);
 $req->element_exists('#api_key_99902', 'keys are there');
-$req->element_exists('#api_key_99905', 'keys are there');
+$req->element_exists('#api_key_99906', 'keys are there');
 
 # It's also possible to specify an expiration date
 $req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {t_expiration => '2016-01-05'})->status_is(302);
 $req = $t->get_ok('/api_keys')->status_is(200);
-$req->text_is('#api_key_99905 .expiration' => 'never');
-$req->text_like('#api_key_99906 .expiration' => qr/2016-01-05/);
+$req->text_is('#api_key_99906 .expiration' => 'never');
+$req->text_like('#api_key_99907 .expiration' => qr/2016-01-05/);
 
 # check invalid expiration date
 $req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {t_expiration => 'asdlfj'})->status_is(302);
 $req = $t->get_ok('/api_keys')->status_is(200);
-$req->element_exists_not('#api_key_99907', "No invalid key created");
+$req->element_exists_not('#api_key_99908', "No invalid key created");
 $req->element_exists('.ui-state-error', "Error message displayed");
 
 # And to delete keys
-$req = $t->delete_ok('/api_keys/99905', {'X-CSRF-Token' => $token})->status_is(302);
+$req = $t->delete_ok('/api_keys/99906', {'X-CSRF-Token' => $token})->status_is(302);
 $req = $t->get_ok('/api_keys')->status_is(200);
-$req->element_exists_not('#api_key_99905', 'API key 99905 is gone');
+$req->element_exists_not('#api_key_99906', 'API key 99906 is gone');
 $req->content_like(qr/API key deleted/, 'deletion is reported');
 
 #
@@ -87,6 +87,6 @@ $req->content_like(qr/API key not found/, 'error is displayed');
 $req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {user_id => 99902, user => 99902})->status_is(302);
 $req = $t->get_ok('/api_keys')->status_is(200);
 $req->element_exists('#api_key_99902', 'Percival keys are there');
-$req->element_exists('#api_key_99907', 'and the new one belongs to Percival, not Lancelot');
+$req->element_exists('#api_key_99908', 'and the new one belongs to Percival, not Lancelot');
 
 done_testing();

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -127,6 +127,7 @@ sub add_machine() {
     while (!$driver->execute_script("return jQuery.active == 0")) {
         sleep 1;
     }
+    $driver->capture_screenshot('add_machine.png');
     is(@{$driver->find_elements('//button[@title="Edit"]')}, 4, "4 edit buttons afterwards");
 }
 
@@ -173,6 +174,7 @@ sub add_test_suite() {
     while (!$driver->execute_script("return jQuery.active == 0")) {
         sleep 1;
     }
+    $driver->capture_screenshot('add_test.png');
     is(@{$driver->find_elements('//button[@title="Edit"]')}, 8, "8 edit buttons afterwards");
 }
 #
@@ -230,6 +232,7 @@ sub add_product() {
     while (!$driver->execute_script("return jQuery.active == 0")) {
         sleep 1;
     }
+    $driver->capture_screenshot('add_product.png');
     is(@{$driver->find_elements('//button[@title="Edit"]')}, 2, "2 edit buttons afterwards");
 
     # check the distri name will be lowercase after added a new one
@@ -249,6 +252,7 @@ sub add_product() {
     while (!$driver->execute_script("return jQuery.active == 0")) {
         sleep 1;
     }
+    $driver->capture_screenshot('add_product2.png');
     is(@{$driver->find_elements('//button[@title="Edit"]')}, 3, "3 edit buttons afterwards");
 
 }

--- a/templates/admin/group/index.html.ep
+++ b/templates/admin/group/index.html.ep
@@ -30,6 +30,7 @@
         </tbody>
     </table>
 
+    % if (is_admin) {
     <p>
     %= form_for admin_new_group => (id => 'new_group_form') => (method => 'POST') => begin
       <label for="name">New group:</label>
@@ -37,6 +38,7 @@
       <input type="submit" name="submit" value="Create" id="submit" class="btn btn-default">
     % end
     </p>
+    % }
 </div>
 
 </div>

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -2,7 +2,7 @@
 % title "Jobs for " . $group->name;
 
 % content_for 'ready_function' => begin
-    setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>);
+    setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>, <%= is_admin %>);
 % end
 
 <div class="row">
@@ -16,7 +16,10 @@
             <p id="loading">Loading... <i class="fa fa-spinner fa-spin"></i></p>
 
             <select id="machines-template" multiple="true"
-                    data-placeholder="None" style="display: none">
+                % if (! is_admin ) {
+                    disabled
+                % }
+                data-placeholder="None" style="display: none">
                 % for my $machine (@$machines) {
                     <option value="<%= $machine->name %>"
                             data-machine-id="<%= $machine->id %>" >
@@ -25,7 +28,11 @@
                 % }
             </select>
 
-            <select id="tests-template" style="display: none">
+            <select id="tests-template"
+                % if (! is_admin ) {
+                    disabled
+                % }
+                style="display: none">
                 <option value="">Select...</option>
                 % for my $test (@$tests) {
                     <option value="<%= $test->name %>" data-test-id="<%= $test->id %>">
@@ -36,11 +43,13 @@
 
         </div>
 
+        % if (is_admin) {
         <p>
             %= link_to url_for('job_group_new_media', groupid => $group->id) => begin
                 <i class="fa fa-plus-square"></i> Test new medium as part of this group
             % end
         </p>
+        % }
     </div>
 
 </div>

--- a/templates/admin/machine/index.html.ep
+++ b/templates/admin/machine/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Machines';
 
 % content_for 'ready_function' => begin
-    populate_admin_table();
+    populate_admin_table(<%= is_admin %>);
 % end
 
 <div class="row">
@@ -25,9 +25,11 @@
             <tbody>
             </tbody>
         </table>
+        % if (is_admin) {
         <div class="text-center">
             <input value="New machine" onclick="add_table_row_button( );" type="button" class="btn btn-default"/>
         </div>
+        % }
         <input type="hidden" id="admintable_api_url" value="/api/v1/machines"/>
     </div>
 

--- a/templates/admin/product/index.html.ep
+++ b/templates/admin/product/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Medium types';
 
 % content_for 'ready_function' => begin
-   populate_admin_table();
+   populate_admin_table(<%= is_admin %>);
 % end
 
 <div class="row">
@@ -28,9 +28,11 @@
         <tbody>
         </tbody>
     </table>
+    % if (is_admin) {
     <div class="text-center">
         <input value="New medium" onclick="add_table_row_button();" type="button" class="btn btn-default"/>
     </div>
+    % }
     <input type="hidden" id="admintable_api_url" value="/api/v1/products"/>
 </div>
 

--- a/templates/admin/test_suite/index.html.ep
+++ b/templates/admin/test_suite/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Test suites';
 
 % content_for 'ready_function' => begin
-    populate_admin_table();
+    populate_admin_table(<%= is_admin %>);
 % end
 
 <div class="row">
@@ -24,9 +24,11 @@
             <tbody>
             </tbody>
         </table>
+        % if (is_admin) {
         <div class="text-center">
             <input value="New test suite" onclick="add_table_row_button();" type="button" class="btn btn-default"/>
         </div>
+        % }
         <input type="hidden" id="admintable_api_url" value="/api/v1/test_suites"/>
     </div>
 


### PR DESCRIPTION
Operators are supposed to handle job management and not managing admin templates. But it is useful for them to see how is it all set up. This PR at first limit API and UI access to modifying operations for operators and then set all admin tables as disabled to signal r/o access.

Tests are adapted and extended.

Action#11368