### PR TITLE
API for job cancel|restart|duplicate can use only job ids

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -479,21 +479,18 @@ sub startup {
     # job_set_waiting, job_set_continue
     my $command_r = $job_r->route('/set_:command', command => [qw(waiting running)]);
     $command_r->post('/')->name('apiv1_set_command')->to('job#set_command');
-    # restart and cancel are valid both by job id or by job name (which is
-    # exactly the same, but with less restrictive format)
-    my $job_name_r = $api_r->route('/jobs/#name');
-    $job_name_r->post('/restart')->name('apiv1_restart')->to('job#restart');          # job_restart
-    $job_name_r->post('/cancel')->name('apiv1_cancel')->to('job#cancel');             # job_cancel
-    $job_name_r->post('/duplicate')->name('apiv1_duplicate')->to('job#duplicate');    # job_duplicate
+    $job_r->post('/restart')->name('apiv1_restart')->to('job#restart');                                     # job_restart
+    $job_r->post('/cancel')->name('apiv1_cancel')->to('job#cancel');                                        # job_cancel
+    $job_r->post('/duplicate')->name('apiv1_duplicate')->to('job#duplicate');                               # job_duplicate
 
     # api/v1/workers
     $api_public_r->get('/workers')->name('apiv1_workers')->to('worker#list');
     $api_r->post('/workers')->name('apiv1_create_worker')->to('worker#create');
     my $worker_r = $api_r->route('/workers/:workerid', workerid => qr/\d+/);
     $api_public_r->route('/workers/:workerid', workerid => qr/\d+/)->get('/')->name('apiv1_worker')->to('worker#show');
-    $worker_r->post('/commands/')->name('apiv1_create_command')->to('command#create');    #command_enqueue
-    $worker_r->post('/grab_job')->name('apiv1_grab_job')->to('job#grab');                 # job_grab
-                                                                                          # redirect for older workers
+    $worker_r->post('/commands/')->name('apiv1_create_command')->to('command#create');                      #command_enqueue
+    $worker_r->post('/grab_job')->name('apiv1_grab_job')->to('job#grab');                                   # job_grab
+                                                                                                            # redirect for older workers
     $worker_r->websocket(
         '/ws' => sub {
             my $c        = shift;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -278,7 +278,7 @@ sub done {
 # Used for both apiv1_restart and apiv1_restart_jobs
 sub restart {
     my ($self) = @_;
-    my $jobs = $self->param('name');
+    my $jobs = $self->param('jobid');
     if ($jobs) {
         $self->app->log->debug("Restarting job $jobs");
         $jobs = [$jobs];
@@ -301,19 +301,19 @@ sub restart {
 }
 
 sub cancel {
-    my $self = shift;
-    my $name = $self->param('name');
+    my ($self) = @_;
+    my $jobid = int($self->param('jobid'));
 
     my $ipc = OpenQA::IPC->ipc;
-    my $res = $ipc->scheduler('job_cancel', $name, 0);
-    $self->emit_event('openqa_job_cancel', {id => $name}) if ($res);
+    my $res = $ipc->scheduler('job_cancel', $jobid, 0);
+    $self->emit_event('openqa_job_cancel', {id => $jobid}) if ($res);
     $self->render(json => {result => $res});
 }
 
 sub duplicate {
-    my $self  = shift;
-    my $jobid = int($self->param('name'));
-    my %args  = (jobid => $jobid);
+    my ($self) = @_;
+    my $jobid = int($self->param('jobid'));
+    my %args = (jobid => $jobid);
     if (defined $self->param('prio')) {
         $args{prio} = int($self->param('prio'));
     }

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -63,7 +63,7 @@
         <div class="aligncenter">
             % if (is_operator) {
                 % if ($job->can_be_duplicated) {
-                    %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
+                    %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
                         <i class="fa fa-2 fa-repeat" title="Restart Job"></i>
                     %= end
                 % }

--- a/templates/step/src.html.ep
+++ b/templates/step/src.html.ep
@@ -14,7 +14,7 @@
         <div class="box-header aligncenter">Actions</div>
         <div class="aligncenter">
             % if (is_operator && $job->can_be_duplicated) {
-                %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
+                %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
                     <i class="fa fa-2 fa-repeat" title="Restart Job"></i>
                 %= end
             % }

--- a/templates/step/viewaudio.html.ep
+++ b/templates/step/viewaudio.html.ep
@@ -11,7 +11,7 @@
         <div class="box-header aligncenter">Actions</div>
         <div class="aligncenter">
             % if (is_operator && $job->can_be_duplicated) {
-                %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
+                %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
                     <i class="fa fa-2 fa-repeat" title="Restart Job"></i>
                 %= end
             % }

--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -30,7 +30,7 @@ function setNeedle() {
         <div class="box-header aligncenter">Actions</div>
         <div class="aligncenter">
             % if (is_operator && $job->can_be_duplicated) {
-                %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
+                %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
                     <i class="fa fa-2 fa-repeat" title="Restart Job"></i>
                 %= end
             % }

--- a/templates/step/viewtext.html.ep
+++ b/templates/step/viewtext.html.ep
@@ -11,7 +11,7 @@
         <div class="box-header aligncenter">Actions</div>
         <div class="aligncenter">
             % if (is_operator && $job->can_be_duplicated) {
-                %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
+                %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
                     <i class="fa fa-2 fa-repeat" title="Restart Job"></i>
                 %= end
             % }

--- a/templates/test/list.html.ep
+++ b/templates/test/list.html.ep
@@ -3,7 +3,7 @@
 
 % content_for 'ready_function' => begin
   is_operator = <%= (is_operator) ? 'true' : 'false' %>;
-  restart_url = "<%= url_for("apiv1_restart", name => 'REPLACEIT') %>";
+  restart_url = "<%= url_for("apiv1_restart", jobid => 'REPLACEIT') %>";
   renderTestsList([ <%= join(',', map { $_->id } $jobs->all) %> ]);
 % end
 

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -75,7 +75,7 @@
                         <abbr class="timeago" title="<%= $job->t_started->datetime() %>Z"><%= format_time($job->t_started) %></abbr>
                     % }
                     % if (is_operator && $job->can_be_duplicated) {
-                        %= link_post url_for('apiv1_restart', name => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
+                        %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result') => begin
                             <i class="fa fa-2 fa-repeat" title="Restart Job"></i>
                         %= end
                     % }

--- a/templates/test/running.html.ep
+++ b/templates/test/running.html.ep
@@ -17,11 +17,11 @@
             %# TODO: to use can_be_duplicated we have to wait for https://progress.opensuse.org/issues/1393
             %#       in the meantime, just check clone_id
             % unless ($job->clone_id) {
-                %= link_post url_for('apiv1_restart', name => $job->id) => ('data-remote' => 'true', id => 'restart_running') => begin
+                %= link_post url_for('apiv1_restart', jobid => $job->id) => ('data-remote' => 'true', id => 'restart_running') => begin
                   %= image '/images/toggle.png', alt => "restart", title => "Restart job"
                 % end
             % }
-            %= link_post url_for('apiv1_cancel', name => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin
+            %= link_post url_for('apiv1_cancel', jobid => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin
               %= image '/images/cancel.png', alt => "stop", title => "Stop job"
             % end
         </div>

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -47,7 +47,7 @@
                 </td>
                 <td class="test">
 		    % if (is_operator) {
-			%= link_to url_for('apiv1_cancel', 'name' => $job->id) => (class => 'cancel') => begin
+			%= link_to url_for('apiv1_cancel', jobid => $job->id) => (class => 'cancel') => begin
                           <i class="action fa fa-fw fa-times-circle-o"></i>
 			% end
 		    % }

--- a/templates/test/scheduled_table.html.ep
+++ b/templates/test/scheduled_table.html.ep
@@ -47,7 +47,7 @@
                 </td>
                 <td class="test">
 		    % if (is_operator) {
-		      %= link_to url_for('apiv1_cancel', 'name' => $job->id) => (class => 'cancel') => begin
+		      %= link_to url_for('apiv1_cancel', jobid => $job->id) => (class => 'cancel') => begin
                          <i class="action fa fa-fw fa-times-circle-o"></i>
 		      % end
 		    % }

--- a/templates/test/tr_job_result.html.ep
+++ b/templates/test/tr_job_result.html.ep
@@ -2,12 +2,12 @@
      % if ($res) {
          % if (is_operator) {
              % if ($state eq "done" || $state eq "cancelled") {
-                 %= link_post url_for('apiv1_restart', 'name' => $jobid) => ('data-remote' => 'true', class => 'restart', 'data-jobid' => $jobid) => begin
+                 %= link_post url_for('apiv1_restart', jobid => $jobid) => ('data-remote' => 'true', class => 'restart', 'data-jobid' => $jobid) => begin
                  <i class="action fa fa-repeat" title="Restart the job"></i>
                  % end
              % } elsif ($state eq "running" || $state eq "scheduled")
              % {
-                 %= link_post url_for('apiv1_cancel', 'name' => $jobid) => ('data-remote' => 'true', class => 'cancel', 'data-jobid' => $jobid) => begin
+                 %= link_post url_for('apiv1_cancel', jobid => $jobid) => ('data-remote' => 'true', class => 'cancel', 'data-jobid' => $jobid) => begin
                      <i class="action fa fa-times-circle-o" title="Cancel the job"></i>
                  % end
              % }


### PR DESCRIPTION
- for some reason the comment suggested one can use job name instead of
job id, but mentioned routes called functions which doesn't work with
jobs names quite a long time so move them to retular jobid based route
- also ensure that passed jobid is interpretted as numeric value ( this solves https://github.com/os-autoinst/openQA/pull/617#discussion_r57637315 )