### PR TITLE
cpanfile: require Test::MockModule for tests

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -90,6 +90,7 @@ on 'test' => sub {
   requires 'Test::Output';
   requires 'Test::Pod';
   requires 'Test::Warnings';
+  requires 'Test::MockModule';
 };
 
 feature 'coverage', 'coverage for travis' => sub {


### PR DESCRIPTION
this requirement comes with the fedmsg plugin tests, I forgot
to add it in that commit. Sorry!