### PR TITLE
Add possibility to cancel jobs by settings via API

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -467,6 +467,7 @@ sub startup {
     # api/v1/jobs
     $api_public_r->get('/jobs')->name('apiv1_jobs')->to('job#list');
     $api_r->post('/jobs')->name('apiv1_create_job')->to('job#create');             # job_create
+    $api_r->post('/jobs/cancel')->name('apiv1_cancel_jobs')->to('job#cancel');
     $api_r->post('/jobs/restart')->name('apiv1_restart_jobs')->to('job#restart');
 
     my $job_r = $api_r->route('/jobs/:jobid', jobid => qr/\d+/);


### PR DESCRIPTION
This adds possibility to cancel jobs by settings, for example to cancel all jobs for specified BUILD. This functionality was already provided by `job_cancel_by_settings` call, but it wasn't in API.

Note that although I tried to add tests, they fail - canceling running jobs in tests doesn't work for some reason (even canceling by `id`).