### PR TITLE
Add possibility to query jobs by HDD_1

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -241,7 +241,7 @@ sub query_jobs {
         push(@conds, {'me.id' => {-in => $subquery->get_column('job_id')->as_query}});
     }
     else {
-        my %js_settings = map { uc($_) => $args{$_} } qw(build iso distri version flavor arch);
+        my %js_settings = map { uc($_) => $args{$_} } qw(build iso distri version flavor arch hdd_1);
         my $subquery = schema->resultset("JobSettings")->query_for_settings(\%js_settings);
         push(@conds, {'me.id' => {-in => $subquery->get_column('job_id')->as_query}});
     }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -24,7 +24,7 @@ sub list {
     my $self = shift;
 
     my %args;
-    for my $arg (qw/build iso distri version flavor maxage scope group groupid limit arch/) {
+    for my $arg (qw/build iso distri version flavor maxage scope group groupid limit arch hdd_1/) {
         next unless defined $self->param($arg);
         $args{$arg} = $self->param($arg);
     }

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -97,6 +97,20 @@ is($get->tx->res->json->{jobs}->[0]->{id}, 99961);
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current', group => 'foo bar'});
 is(scalar(@{$get->tx->res->json->{jobs}}), 0);
 
+# Test restricting list
+
+# query for existing jobs by iso
+$get = $t->get_ok('/api/v1/jobs?iso=openSUSE-13.1-DVD-i586-Build0091-Media.iso');
+is(scalar(@{$get->tx->res->json->{jobs}}), 5);
+
+# query for existing jobs by build
+$get = $t->get_ok('/api/v1/jobs?build=0091');
+is(scalar(@{$get->tx->res->json->{jobs}}), 9);
+
+# query for existing jobs by hdd_1
+$get = $t->get_ok('/api/v1/jobs?hdd_1=openSUSE-13.1-x86_64.hda');
+is(scalar(@{$get->tx->res->json->{jobs}}), 2);
+
 # Test /jobs/restart
 my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927]})->status_is(200);
 

--- a/t/fixtures/02-jobs.pl
+++ b/t/fixtures/02-jobs.pl
@@ -119,7 +119,7 @@
         retry_avbl => 3,
         # no result dir, let us assume that this is an old test that has
         # already be pruned
-        settings => [{key => 'DVD', value => '1'}, {key => 'VERSION', value => 'Factory'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'TEST', value => 'kde'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}, {key => 'FLAVOR', value => 'DVD'}, {key => 'BUILD', value => '0048'}, {key => 'DISTRI', value => 'opensuse'}, {key => 'ARCH', value => 'x86_64'}, {key => 'MACHINE', value => '64bit'},]
+        settings => [{key => 'DVD', value => '1'}, {key => 'VERSION', value => 'Factory'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'TEST', value => 'kde'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}, {key => 'FLAVOR', value => 'DVD'}, {key => 'BUILD', value => '0048'}, {key => 'DISTRI', value => 'opensuse'}, {key => 'ARCH', value => 'x86_64'}, {key => 'MACHINE', value => '64bit'}, {key => 'HDD_1', value => 'openSUSE-13.1-x86_64.hda'},]
     },
     Jobs => {
         id         => 99946,
@@ -135,7 +135,7 @@
         jobs_assets => [{asset_id => 1},],
         retry_avbl  => 3,
         result_dir  => '00099946-opensuse-13.1-DVD-i586-Build0091-textmode',
-        settings => [{key => 'FLAVOR', value => 'DVD'}, {key => 'QEMUCPU', value => 'qemu32'}, {key => 'ARCH', value => 'i586'}, {key => 'DISTRI', value => 'opensuse'}, {key => 'BUILD', value => '0091'}, {key => 'VERSION', value => '13.1'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'TEST', value => 'textmode'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'MACHINE', value => '32bit'},]
+        settings => [{key => 'FLAVOR', value => 'DVD'}, {key => 'QEMUCPU', value => 'qemu32'}, {key => 'ARCH', value => 'i586'}, {key => 'DISTRI', value => 'opensuse'}, {key => 'BUILD', value => '0091'}, {key => 'VERSION', value => '13.1'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'TEST', value => 'textmode'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'MACHINE', value => '32bit'}, {key => 'HDD_1', value => 'openSUSE-13.1-x86_64.hda'},]
     },
     Jobs => {
         id         => 99945,


### PR DESCRIPTION
This fixes #636. We need to be able to list jobs with specified `HDD_1` (because some of our tests will not have `ISO` set). This adds this functionality rather trivially - being able to specify what HDD to query would make code more complex and it's not needed by us, but it's doable if required.