### PR TITLE
Fix bug references in overview:

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -355,7 +355,7 @@ sub _job_labels {
     my ($self, $jobs) = @_;
 
     my %labels;
-    my $c = $self->db->resultset("Comments")->search({job_id => {in => [map { $_->id } @$jobs]}});
+    my $c = $self->db->resultset("Comments")->search({job_id => {in => [map { $_->id } @$jobs]}}, {order_by => 'me.id'});
     # previous occurences of bug or label are overwritten here so the
     # behaviour for multiple bugs or label references within one job is
     # undefined.


### PR DESCRIPTION
for bug references it's important we look for the comments in the right order