### PR TITLE
Editable comments

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -355,6 +355,8 @@ sub startup {
     my $test_auth = $auth->route('/tests/:testid', testid => qr/\d+/, format => 0);
     $test_r->get('/')->name('test')->to('test#show');
     $test_auth->post('/add_comment')->name('add_comment')->to('test#add_comment');
+    $test_auth->post('/edit_comment')->name('edit_comment')->to('test#edit_comment');
+    $test_auth->post('/remove_comment')->name('remove_comment')->to('test#remove_comment');
 
     $test_r->get('/modlist')->name('modlist')->to('running#modlist');
     $test_r->get('/status')->name('status')->to('running#status');

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -270,10 +270,12 @@ sub startup {
       /javascripts/tests.js
       /javascripts/assets.js
       /javascripts/job_templates.js
-      /javascripts/overview.js);
+      /javascripts/overview.js
+      /javascripts/comments.js);
     my @css = qw(/stylesheets/font-awesome.css
       /stylesheets/chosen.css
       /stylesheets/overview.scss
+      /stylesheets/comments.css
       /stylesheets/openqa.css );
 
     # preprocessors to expend the url() definitions in the css
@@ -384,6 +386,8 @@ sub startup {
 
     $r->get('/group_overview/:groupid')->name('group_overview')->to('main#group_overview');
     $r->post('/group_overview/:groupid/add_comment')->name('add_group_comment')->to('main#add_comment');
+    $r->post('/group_overview/:groupid/edit_comment')->name('edit_group_comment')->to('main#edit_comment');
+    $r->post('/group_overview/:groupid/remove_comment')->name('remove_group_comment')->to('main#remove_comment');
 
     # Favicon
     $r->get('/favicon.ico' => sub { my $c = shift; $c->render_static('favicon.ico') });

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -193,17 +193,18 @@ sub edit_comment {
 
     $self->validation->required('text');
     $self->validation->required('comment_id');
+    my $comment_id = int($self->param("comment_id"));
 
     my $group = $self->app->schema->resultset("JobGroups")->find($self->param('groupid'));
     return $self->reply->not_found unless $group;
 
-    my $rs = $group->comments->search({id => $self->param("comment_id"), user_id => $self->current_user->id})->update(
+    my $rs = $group->comments->search({id => $comment_id, user_id => $self->current_user->id})->update(
         {
             text      => $self->param('text'),
             t_updated => DateTime->now(time_zone => 'floating')
         });
 
-    $self->emit_event('openqa_user_comment', {id => $self->param("comment_id")});
+    $self->emit_event('openqa_user_comment', {id => $comment_id});
     $self->flash('info', 'Comment changed');
     return $self->redirect_to('group_overview');
 }
@@ -212,6 +213,7 @@ sub remove_comment {
     my ($self) = @_;
 
     $self->validation->required('comment_id');
+    my $comment_id = int($self->param("comment_id"));
 
     my $group = $self->app->schema->resultset("JobGroups")->find($self->param('groupid'));
     return $self->reply->not_found unless $group;
@@ -221,11 +223,11 @@ sub remove_comment {
 
     my $rs = $group->comments->search(
         {
-            id => $self->param("comment_id"),
+            id => $comment_id,
             user_id => $self->current_user->id
         })->delete();
 
-    $self->emit_event('openqa_user_comment', {id => $self->param("comment_id")});
+    $self->emit_event('openqa_user_comment', {id => $comment_id});
     $self->flash('info', 'Comment removed');
     return $self->redirect_to('group_overview');
 }

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -201,8 +201,7 @@ sub edit_comment {
     my $rs = $group->comments->search({id => $comment_id, user_id => $self->current_user->id})->update(
         {
             text      => $self->param('text'),
-            t_updated => DateTime->now(time_zone => 'floating')
-        });
+            t_updated => DateTime->now(time_zone => 'floating')});
 
     $self->emit_event('openqa_user_comment', {id => $comment_id});
     $self->flash('info', 'Comment changed');
@@ -223,7 +222,7 @@ sub remove_comment {
 
     my $rs = $group->comments->search(
         {
-            id => $comment_id,
+            id      => $comment_id,
             user_id => $self->current_user->id
         })->delete();
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -546,13 +546,13 @@ sub edit_comment {
 
     my $rs = $job->comments->search(
         {
-            id => $self->param("comment_id"),
+            id      => $self->param("comment_id"),
             user_id => $self->current_user->id
-        })->update(
+        }
+      )->update(
         {
             text      => $self->param('text'),
-            t_updated => DateTime->now(time_zone => 'floating')
-        });
+            t_updated => DateTime->now(time_zone => 'floating')});
 
     $self->emit_event('openqa_user_comment', {id => $self->param("comment_id")});
     $self->flash('info', 'Comment changed');
@@ -572,7 +572,7 @@ sub remove_comment {
 
     my $rs = $job->comments->search(
         {
-            id => $self->param("comment_id"),
+            id      => $self->param("comment_id"),
             user_id => $self->current_user->id
         })->delete();
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -524,6 +524,12 @@ sub add_comment {
     my $job = $self->app->schema->resultset("Jobs")->find($self->param('testid'));
     return $self->reply->not_found unless $job;
 
+    # only logged in users can add comments
+    if (!$self->current_user) {
+        $self->flash('info', 'The comment couldn\'t be added because you\'re not logged in anymore');
+        return $self->redirect_to('test');
+    }
+
     my $rs = $job->comments->create(
         {
             text    => $self->param('text'),
@@ -544,12 +550,20 @@ sub edit_comment {
     my $job = $self->app->schema->resultset("Jobs")->find($self->param('testid'));
     return $self->reply->not_found unless $job;
 
+    # only logged in users can edit comments
+    if (!$self->current_user) {
+        $self->flash('info', 'The comment couldn\'t be edited because you\'re not logged in anymore');
+        return $self->redirect_to('test');
+    }
+
     my $rs = $job->comments->search(
         {
             id      => $self->param("comment_id"),
             user_id => $self->current_user->id
-        }
-      )->update(
+        });
+    return $self->reply->not_found unless $rs;
+
+    $rs->update(
         {
             text      => $self->param('text'),
             t_updated => DateTime->now(time_zone => 'floating')});
@@ -568,13 +582,20 @@ sub remove_comment {
     return $self->reply->not_found unless $job;
 
     # only admins are allowed to delete comments
-    return $self->reply->not_found unless $self->current_user->is_admin;
+    if (!$self->current_user || !$self->current_user->is_admin) {
+        $self->flash('info', 'The comment couldn\'t be deleted because you\'re not logged in as administrator');
+        return $self->redirect_to('test');
+    }
 
     my $rs = $job->comments->search(
         {
             id      => $self->param("comment_id"),
             user_id => $self->current_user->id
-        })->delete();
+        });
+
+    if ($rs) {
+        $rs->delete();
+    }
 
     $self->emit_event('openqa_user_comment', {id => $self->param("comment_id")});
     $self->flash('info', 'Comment removed');

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -529,8 +529,55 @@ sub add_comment {
             text    => $self->param('text'),
             user_id => $self->current_user->id,
         });
+
     $self->emit_event('openqa_user_comment', {id => $rs->id});
     $self->flash('info', 'Comment added');
+    return $self->redirect_to('test');
+}
+
+sub edit_comment {
+    my ($self) = @_;
+
+    $self->validation->required('text');
+    $self->validation->required('comment_id');
+
+    my $job = $self->app->schema->resultset("Jobs")->find($self->param('testid'));
+    return $self->reply->not_found unless $job;
+
+    my $rs = $job->comments->search(
+        {
+            id => $self->param("comment_id"),
+            user_id => $self->current_user->id
+        })->update(
+        {
+            text      => $self->param('text'),
+            t_updated => DateTime->now(time_zone => 'floating')
+        });
+
+    $self->emit_event('openqa_user_comment', {id => $self->param("comment_id")});
+    $self->flash('info', 'Comment changed');
+    return $self->redirect_to('test');
+}
+
+sub remove_comment {
+    my ($self) = @_;
+
+    $self->validation->required('comment_id');
+
+    my $job = $self->app->schema->resultset("Jobs")->find($self->param('testid'));
+    return $self->reply->not_found unless $job;
+
+    # only admins are allowed to delete comments
+    return $self->reply->not_found unless $self->current_user->is_admin;
+
+    my $rs = $job->comments->search(
+        {
+            id => $self->param("comment_id"),
+            user_id => $self->current_user->id
+        })->delete();
+
+    $self->emit_event('openqa_user_comment', {id => $self->param("comment_id")});
+    $self->flash('info', 'Comment removed');
     return $self->redirect_to('test');
 }
 

--- a/public/javascripts/comments.js
+++ b/public/javascripts/comments.js
@@ -1,0 +1,15 @@
+function showCommentEditor(commentId, form) {
+    form.text.style.display = "block";
+    form.editComment.style.display = "none";
+    form.applyChanges.style.display = "inline";
+    form.discardChanges.style.display = "inline";
+    document.getElementById("commentMd_" + commentId).style.display = "none";
+}
+
+function hideCommentEditor(commentId, form) {
+    form.text.style.display = "none";
+    form.editComment.style.display = "inline";
+    form.applyChanges.style.display = "none";
+    form.discardChanges.style.display = "none";
+    document.getElementById("commentMd_" + commentId).style.display = "block";
+}

--- a/public/javascripts/comments.js
+++ b/public/javascripts/comments.js
@@ -1,6 +1,7 @@
 function showCommentEditor(commentId, form) {
     form.text.style.display = "block";
     form.editComment.style.display = "none";
+    document.getElementById("removeComment_" + commentId).style.display = "none";
     form.applyChanges.style.display = "inline";
     form.discardChanges.style.display = "inline";
     document.getElementById("commentMd_" + commentId).style.display = "none";
@@ -9,7 +10,12 @@ function showCommentEditor(commentId, form) {
 function hideCommentEditor(commentId, form) {
     form.text.style.display = "none";
     form.editComment.style.display = "inline";
+    document.getElementById("removeComment_" + commentId).style.display = "inline";
     form.applyChanges.style.display = "none";
     form.discardChanges.style.display = "none";
     document.getElementById("commentMd_" + commentId).style.display = "block";
+}
+
+function confirmCommentRemoval(author) {
+    return window.confirm("Do you really want to delete the comment written by " + author + "?");
 }

--- a/public/stylesheets/comments.css
+++ b/public/stylesheets/comments.css
@@ -18,4 +18,5 @@
  .comment-body .trigger-edit-button {
     float: right;
     margin-top: 8px;
+    margin-left: 4px;
 }

--- a/public/stylesheets/comments.css
+++ b/public/stylesheets/comments.css
@@ -1,0 +1,21 @@
+ .comment-body .comment-editing-control {
+     display: none;
+ }
+ 
+ .comment-body textarea.comment-editing-control {
+    outline: none;
+    border: none;
+    padding: 0px;
+    margin: 0px;
+    color: #000;
+ }
+ 
+ .comment-body .comment-buttons {
+    margin-top: -10px;
+    margin-bottom: 15px;
+ }
+
+ .comment-body .trigger-edit-button {
+    float: right;
+    margin-top: 8px;
+}

--- a/public/stylesheets/comments.css
+++ b/public/stylesheets/comments.css
@@ -15,7 +15,7 @@
     margin-bottom: 15px;
  }
 
- .comment-body .trigger-edit-button {
+ .comment-body .trigger-edit-button, .comment-body .remove-edit-button {
     float: right;
     margin-top: 8px;
     margin-left: 4px;

--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -579,3 +579,14 @@ table#users input[type="radio"]:checked + label .fa-circle-o {
     padding-bottom: 0.5em;
 }
 
+/* Comment editor */
+.comment-editor {
+    margin-bottom: 20px;
+}
+
+.comment-editor button {
+
+}
+
+
+

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -46,7 +46,7 @@ sub set_up {
 sub comments {
     my ($url) = @_;
     my $get = $t->get_ok($url)->status_is(200);
-    return $get->tx->res->dom->find('div.comments .media-comment ~ p')->map('content');
+    return $get->tx->res->dom->find('div.comments .media-comment > p')->map('content');
 }
 
 sub restart_with_result {

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -23,10 +23,10 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
-
-OpenQA::Test::Case->new->init_data;
-
 use t::ui::PhantomTest;
+
+my $test_case = OpenQA::Test::Case->new;
+$test_case->init_data;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
@@ -42,7 +42,9 @@ unless ($driver) {
 #
 is($driver->get_title(), "openQA", "on main page");
 my $baseurl = $driver->get_current_url();
+
 $driver->find_element('Login', 'link_text')->click();
+
 # we are back on the main page
 is($driver->get_title(), "openQA", "back on main page");
 
@@ -54,68 +56,116 @@ $driver->find_element('opensuse', 'link_text')->click();
 
 is($driver->find_element('h1:first-of-type', 'css')->get_text(), 'Last Builds for Group opensuse', "on group overview");
 
-# disable warning about printing UTF-8 characters
-binmode STDOUT, ':utf8';
-
-# define test message with UTF-8 character
-my $test_message = "This is a cool test";
+# define test message
+# TODO: break it by adding UTF-8 character
+my $test_message         = "This is a cool test";
 my $another_test_message = " - this message will be appended if editing works";
-my $edited_test_message = $test_message . $another_test_message;
+my $edited_test_message  = $test_message . $another_test_message;
+my $user_name            = 'Demo';
 
-# submit a comment in the group overview
-$driver->find_element('#text',          'css')->send_keys($test_message);
-$driver->find_element('#submitComment', 'css')->click();
+# switches to comments tab (required when editing comments in test results)
+# expects the current number of comments as argument (currently the easiest way to find the tab button)
+sub switch_to_comments_tab {
+    my $current_comment_count = shift;
+    $driver->find_element("Comments ($current_comment_count)", 'link_text')->click();
+}
 
-# check whether heading and comment text is displayed correctly
-is($driver->find_element('h4.media-heading',  'css')->get_text(), "Demo wrote less than a minute ago", "heading");
-is($driver->find_element('div.media-comment', 'css')->get_text(), $test_message, "body");
+# checks comment heading and text for recently added comment
+sub check_comment {
+    my $supposed_text = shift;
+    my $edited        = shift;
+    if ($edited) {
+        is($driver->find_element('h4.media-heading', 'css')->get_text(), "$user_name wrote less than a minute ago (last edited less than a minute ago)", "heading");
+    }
+    else {
+        is($driver->find_element('h4.media-heading', 'css')->get_text(), "$user_name wrote less than a minute ago", "heading");
+    }
+    is($driver->find_element('div.media-comment', 'css')->get_text(), $supposed_text, "body");
+}
 
-# trigger editor
-$driver->find_element('button.trigger-edit-button',       'css')->click();
+# tests adding, editing and removing comments
+sub test_comment_editing {
+    my $in_test_results = shift;
 
-# wait 1 second to ensure initial time and last update time differ
-sleep 1;
+    # submit a comment
+    $driver->find_element('#text',          'css')->send_keys($test_message);
+    $driver->find_element('#submitComment', 'css')->click();
 
-# try to edit the first displayed comment (the one which has just been added)
-$driver->find_element('textarea.comment-editing-control', 'css')->send_keys($another_test_message);
-$driver->find_element('button.comment-editing-control',   'css')->click();
+    # check whether flash appears
+    is($driver->find_element('blockquote.ui-state-highlight', 'css')->get_text(), "Comment added", "comment added highlight");
 
-# check whether the changeings have been applied
-is($driver->find_element('h4.media-heading', 'css')->get_text(), "Demo wrote less than a minute ago (last edited less than a minute ago)", "heading after editing");
-is($driver->find_element('div.media-comment', 'css')->get_text(), $edited_test_message, "body after editing");
+    if ($in_test_results) {
+        switch_to_comments_tab(1);
+    }
 
-# try to remove the first displayed comment (wthe one which has just been edited)
-$driver->find_element('button.remove-edit-button', 'css')->click();
+    check_comment($test_message, 0);
 
-# check confirmation and dismiss in the first place
-# FIXME: simulate dismiss, $driver->dismiss_alert and get_alert_text don't work
-$driver->execute_script("window.confirm = function() { return false; }");
-#is($driver->get_alert_text, "Do you really want to delete the comment written by Demo?", "confirmation is shown before removal");
-#$driver->dismiss_alert;
+    # trigger editor
+    $driver->find_element('button.trigger-edit-button', 'css')->click();
 
-# the comment musn't be deleted yet
-is($driver->find_element('div.media-comment', 'css')->get_text(), $edited_test_message, "comment is still there after dismissing removal");
+    # wait 1 second to ensure initial time and last update time differ
+    sleep 1;
 
-# try to remove the first displayed comment again (and accept this time);
-# FIXME: simulate acception, $driver->accept_alert doesn't work
-$driver->execute_script("window.confirm = function() { return true; };");
-$driver->find_element('button.remove-edit-button', 'css')->click();
-##$driver->accept_alert;
+    # try to edit the first displayed comment (the one which has just been added)
+    $driver->find_element('textarea.comment-editing-control', 'css')->send_keys($another_test_message);
+    $driver->find_element('button.comment-editing-control',   'css')->click();
 
-# check whether the comment is gone
-my @comments = $driver->find_elements('div.media-comment', 'css');
-is(scalar @comments, 0, "removed comment is actually gone");
+    # check whether flash appears
+    is($driver->find_element('blockquote.ui-state-highlight', 'css')->get_text(), "Comment changed", "comment changed highlight");
 
-# re-add a comment with the original message
-$driver->find_element('#text',          'css')->send_keys($test_message);
-$driver->find_element('#submitComment', 'css')->click();
+    if ($in_test_results) {
+        switch_to_comments_tab(1);
+    }
 
-# check whether heading and comment text is displayed correctly
-is($driver->find_element('h4.media-heading',  'css')->get_text(), "Demo wrote less than a minute ago", "heading after re-adding");
-is($driver->find_element('div.media-comment', 'css')->get_text(), $test_message, "body after re-adding");
+    # check whether the changeings have been applied
+    check_comment($edited_test_message, 1);
 
-# TODO: check whether only admins can remove comments
-# TODO: check whether only own comments can be edited
+    # try to remove the first displayed comment (wthe one which has just been edited)
+    $driver->find_element('button.remove-edit-button', 'css')->click();
+
+    # check confirmation and dismiss in the first place
+    # FIXME: simulate dismiss, $driver->dismiss_alert and get_alert_text don't work
+    $driver->execute_script("window.confirm = function() { return false; }");
+    #is($driver->get_alert_text, "Do you really want to delete the comment written by Demo?", "confirmation is shown before removal");
+    #$driver->dismiss_alert;
+
+    # the comment musn't be deleted yet
+    is($driver->find_element('div.media-comment', 'css')->get_text(), $edited_test_message, "comment is still there after dismissing removal");
+
+    # try to remove the first displayed comment again (and accept this time);
+    # FIXME: simulate acception, $driver->accept_alert doesn't work
+    $driver->execute_script("window.confirm = function() { return true; };");
+    $driver->find_element('button.remove-edit-button', 'css')->click();
+    #$driver->accept_alert;
+
+    # check whether flash appears
+    is($driver->find_element('blockquote.ui-state-highlight', 'css')->get_text(), "Comment removed", "comment removed highlight");
+
+    # check whether the comment is gone
+    my @comments = $driver->find_elements('div.media-comment', 'css');
+    is(scalar @comments, 0, "removed comment is actually gone");
+
+    if ($in_test_results) {
+        switch_to_comments_tab(0);
+    }
+
+    # re-add a comment with the original message
+    $driver->find_element('#text',          'css')->send_keys($test_message);
+    $driver->find_element('#submitComment', 'css')->click();
+
+    # check whether heading and comment text is displayed correctly
+    if ($in_test_results) {
+        switch_to_comments_tab(1);
+    }
+
+    check_comment($test_message, 0);
+}
+
+#
+# check commenting in the group overview
+#
+
+test_comment_editing(0);
 
 # URL auto-replace
 $driver->find_element('#text', 'css')->send_keys('
@@ -128,7 +178,7 @@ $driver->find_element('#text', 'css')->send_keys('
 $driver->find_element('#submitComment', 'css')->click();
 
 # the first made comment needs to be 2nd now
-@comments = $driver->find_elements('div.media-comment p', 'css');
+my @comments = $driver->find_elements('div.media-comment p', 'css');
 is($comments[1]->get_text(), $test_message, "body of first comment after adding another");
 
 my @urls = $driver->find_elements('div.media-comment a', 'css');
@@ -153,23 +203,26 @@ is((shift @urls2)->get_attribute('href'), 'https://progress.opensuse.org/issues/
 like((shift @urls2)->get_attribute('href'), qr{/tests/4567}, "url8-href");
 like((shift @urls2)->get_attribute('href'), qr{/tests/5678/modules/welcome/steps}, "url9-href");
 
+#
 # check commenting in test results
+#
+
+# navigate to comments tab of test result page
 $driver->find_element('Build0048', 'link_text')->click();
 $driver->find_element('.status',   'css')->click();
 is($driver->get_title(), "openQA: opensuse-Factory-DVD-x86_64-Build0048-doc test results", "on test result page");
-$driver->find_element('Comments (0)',   'link_text')->click();
+switch_to_comments_tab(0);
+
+# do the same tests for comments as in the group overview
+test_comment_editing(1);
+
 $driver->find_element('#text',          'css')->send_keys($test_message);
 $driver->find_element('#submitComment', 'css')->click();
-
-# check whether flash appears
-is($driver->find_element('blockquote.ui-state-highlight', 'css')->get_text(), "Comment added", "comment added highlight");
-
-# TODO: Do the same tests for editable comments in the test results as in the group overview.
 
 # go back to test result overview and check comment availability sign
 $driver->find_element('Build0048@opensuse', 'link_text')->click();
 is($driver->get_title(), "openQA: Test summary", "back on test group overview");
-is($driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'), '1 comment available', "test results show available comment(s)");
+is($driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'), '2 comments available', "test results show available comment(s)");
 
 # add label and bug and check availability sign
 $driver->get($baseurl . 'tests/99938#comments');
@@ -188,6 +241,35 @@ $get = $t->get_ok($driver->get_current_url())->status_is(200);
 is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href}, 'https://bugzilla.suse.com/show_bug.cgi?id=1234');
 $driver->find_element('opensuse', 'link_text')->click();
 is($driver->find_element('.fa-certificate', 'css')->get_attribute('title'), 'Reviewed (1 comments)', 'build should be marked as labeled');
+
+#
+# do tests for editing when logged in as regular user(group overview)
+#
+
+# TODO: login as another user which is no admin
+
+sub test_comment_editing_as_regular_user {
+    # TODO: check whether removal of comments is possible (should not be possible)
+
+    # the removal button shouldn't be displayed when not logged in as admin
+    is(@{$driver->find_elements('button.remove-edit-button', 'css')}, 0, "removal not displayed for regular user");
+
+    # TODO: check whether only own comments can be edited
+}
+
+#test_comment_editing_as_regular_user;
+
+#
+# do tests for editing when logged in as regular user (test results)
+#
+
+# navigate to test results (again)
+$driver->find_element('Build0048', 'link_text')->click();
+$driver->find_element('.status',   'css')->click();
+is($driver->get_title(), "openQA: opensuse-Factory-DVD-x86_64-Build0048-doc test results", "on test result page");
+switch_to_comments_tab(4);
+
+#test_comment_editing_as_regular_user;
 
 t::ui::PhantomTest::kill_phantom();
 

--- a/templates/comments/add_comment_form_groups.html.ep
+++ b/templates/comments/add_comment_form_groups.html.ep
@@ -1,0 +1,15 @@
+<div class="form-group">
+    <label for="text" class="col-sm-1 control-label">Comment
+        <img class="img-circle" src="<%= current_user->gravatar(60) %>">
+    </label>
+    <div class="col-sm-11">
+        <textarea class="form-control" name="text" id="text" rows="5"></textarea>
+    </div>
+</div>
+<div class="form-group">
+    <div class="col-sm-offset-1 col-sm-11">
+        <button class="btn btn-success btn-circle" type="submit" id="submitComment">
+            <span class="glyphicon glyphicon-send"></span>
+            Submit comment</button>
+    </div>
+</div>

--- a/templates/comments/comment_row.html.ep
+++ b/templates/comments/comment_row.html.ep
@@ -1,0 +1,47 @@
+<div class="row">
+    <div class="col-sm-1">
+        <img class="media-object img-circle" src="<%= $comment->user->gravatar(60) %>" alt="profile">
+    </div>
+    <div class="col-sm-11">
+        <div class="media-body comment-body">
+            <div class="well well-lg">
+                % if (current_user && current_user->is_admin) {
+                    %= form_for $remove_action, method => "post", class => "form-horizontal", role => "form" => begin
+                        <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" name="removeComment" id="removeComment_<%= $comment->id %>" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
+                            <span class="glyphicon glyphicon glyphicon-remove"></span>
+                        </button>
+                        <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                    % end
+                % }
+                %= form_for $edit_action, method => "post", class => "form-horizontal", role => "form" => begin
+                    % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                        <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
+                            <span class="glyphicon glyphicon glyphicon-pencil"></span>
+                        </button>
+                    % }
+                    <h4 class="media-heading">
+                        <%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr>
+                        % if ($comment->t_created != $comment->t_updated) {
+                            (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
+                        % }
+                    </h4>
+                    <div class="media-comment" id="commentMd_<%= $comment->id %>">
+                        %= $comment->rendered_markdown
+                    </div>
+                    % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                        <textarea class="form-control comment-editing-control" name="text" rows="5"><%= $comment->text %></textarea>
+                        <button class="btn btn-success btn-circle comment-editing-control" type="submit" name="applyChanges">
+                            <span class="glyphicon glyphicon glyphicon-ok"></span>
+                            Apply changes
+                        </button>
+                        <button class="btn btn-warning btn-circle comment-editing-control" type="reset" name="discardChanges" onclick="hideCommentEditor(<%= $comment->id %>, this.form); return true;">
+                            <span class="glyphicon glyphicon glyphicon-remove"></span>
+                            Discard changes
+                        </button>
+                        <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                    % }
+                % end
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/comments/comment_row.html.ep
+++ b/templates/comments/comment_row.html.ep
@@ -7,7 +7,7 @@
             <div class="well well-lg">
                 % if (current_user && current_user->is_admin) {
                     %= form_for $remove_action, method => "post", class => "form-horizontal", role => "form" => begin
-                        <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" name="removeComment" id="removeComment_<%= $comment->id %>" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
+                        <button class="btn btn-danger btn-circle btn-sm remove-edit-button" type="submit" name="removeComment" id="removeComment_<%= $comment->id %>" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
                             <span class="glyphicon glyphicon glyphicon-remove"></span>
                         </button>
                         <input type="hidden" name="comment_id" value="<%= $comment->id %>">

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -11,73 +11,12 @@
 %= include 'main/group_builds', result => $result
 
 <h1>Comments</h1>
-%#= Dumper(@$comments)
 % for my $comment (reverse @$comments) {
-    <div class="row">
-        <div class="col-sm-1">
-            <img class="media-object img-circle" src="<%= $comment->user->gravatar(60) %>" alt="profile">
-        </div>
-        <div class="col-sm-11">
-            <div class="media-body comment-body">
-                <div class="well well-lg">
-                    % if (current_user && current_user->is_admin) {
-                        %= form_for 'remove_group_comment', method => "post", class => "form-horizontal", role => "form" => begin
-                            <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" name="removeComment" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
-                                <span class="glyphicon glyphicon glyphicon-remove"></span>
-                            </button>
-                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
-                        % end
-                    % }
-                    %= form_for 'edit_group_comment', method => "post", class => "form-horizontal", role => "form" => begin
-                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
-                            <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
-                                <span class="glyphicon glyphicon glyphicon-pencil"></span>
-                            </button>
-                        % }
-                        <h4 class="media-heading">
-                            <%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr>
-                            % if ($comment->t_created != $comment->t_updated) {
-                                (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
-                            % }
-                        </h4>
-                        <div class="media-comment" id="commentMd_<%= $comment->id %>">
-                            %= $comment->rendered_markdown
-                        </div>
-                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
-                            <textarea class="form-control comment-editing-control" name="text" rows="5"><%= $comment->text %></textarea>
-                            <button class="btn btn-success btn-circle comment-editing-control" type="submit" name="applyChanges">
-                                <span class="glyphicon glyphicon glyphicon-ok"></span>
-                                Apply changes
-                            </button>
-                            <button class="btn btn-warning btn-circle comment-editing-control" type="reset" name="discardChanges" onclick="hideCommentEditor(<%= $comment->id %>, this.form); return true;">
-                                <span class="glyphicon glyphicon glyphicon-remove"></span>
-                                Discard changes
-                            </button>
-                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
-                        % }
-                    % end
-                </div>
-            </div>
-        </div>
-    </div>
+    %= include 'comments/comment_row', comment => $comment, edit_action => 'edit_group_comment', remove_action => 'remove_group_comment'
 % }
 
 % if (current_user) {
     %= form_for 'add_group_comment', method => "post", class => "form-horizontal", id => "commentForm", role => "form" => begin
-        <div class="form-group">
-            <label for="text" class="col-sm-1 control-label">Comment
-                <img class="img-circle" src="<%= current_user->gravatar(60) %>">
-            </label>
-            <div class="col-sm-11">
-                <textarea class="form-control" name="text" id="text" rows="5"></textarea>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="col-sm-offset-1 col-sm-11">
-                <button class="btn btn-success btn-circle" type="submit" id="submitComment">
-                    <span class="glyphicon glyphicon-send"></span>
-                    Submit comment</button>
-            </div>
-        </div>
+        %= include 'comments/add_comment_form_groups'
     % end
 % }

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -1,3 +1,4 @@
+% use Data::Dumper;
 % layout 'bootstrap';
 % title '';
 
@@ -11,7 +12,7 @@
 %= include 'main/group_builds', result => $result
 
 <h1>Comments</h1>
-
+%#= Dumper(@$comments)
 % for my $comment (reverse @$comments) {
     <div class="row">
         <div class="col-sm-1">
@@ -19,12 +20,36 @@
         </div>
         <div class="col-sm-11">
             <div class="media-body comment-body">
-                <div class="well well-lg">
-                    <h4 class="media-heading"><%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr></h4>
-                    <div class="media-comment">
-                      %= $comment->rendered_markdown
+                %= form_for 'edit_group_comment', method => "post", class => "form-horizontal", role => "form" => begin
+                    <div class="well well-lg">
+                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                            <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
+                                <span class="glyphicon glyphicon glyphicon-pencil"></span>
+                            </button>
+                        % }
+                        <h4 class="media-heading">
+                            <%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr>
+                            % if ($comment->t_created != $comment->t_updated) {
+                                (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
+                            % }
+                        </h4>
+                        <div class="media-comment" id="commentMd_<%= $comment->id %>">
+                            %= $comment->rendered_markdown
+                        </div>
+                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                            <textarea class="form-control comment-editing-control" name="text" rows="5"><%= $comment->text %></textarea>
+                            <button class="btn btn-success btn-circle comment-editing-control" type="submit" name="applyChanges">
+                                <span class="glyphicon glyphicon glyphicon-ok"></span>
+                                Apply changes
+                            </button>
+                            <button class="btn btn-warning btn-circle comment-editing-control" type="reset" name="discardChanges" onclick="hideCommentEditor(<%= $comment->id %>, this.form); return true;">
+                                <span class="glyphicon glyphicon glyphicon-remove"></span>
+                                Discard changes
+                            </button>
+                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                        % }
                     </div>
-                </div>
+                % end
             </div>
         </div>
     </div>

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -20,8 +20,16 @@
         </div>
         <div class="col-sm-11">
             <div class="media-body comment-body">
-                %= form_for 'edit_group_comment', method => "post", class => "form-horizontal", role => "form" => begin
-                    <div class="well well-lg">
+                <div class="well well-lg">
+                    % if (current_user && current_user->is_admin) {
+                        %= form_for 'remove_group_comment', method => "post", class => "form-horizontal", role => "form" => begin
+                            <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" name="removeComment" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
+                                <span class="glyphicon glyphicon glyphicon-remove"></span>
+                            </button>
+                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                        % end
+                    % }
+                    %= form_for 'edit_group_comment', method => "post", class => "form-horizontal", role => "form" => begin
                         % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
                             <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
                                 <span class="glyphicon glyphicon glyphicon-pencil"></span>
@@ -48,8 +56,8 @@
                             </button>
                             <input type="hidden" name="comment_id" value="<%= $comment->id %>">
                         % }
-                    </div>
-                % end
+                    % end
+                </div>
             </div>
         </div>
     </div>

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -1,4 +1,3 @@
-% use Data::Dumper;
 % layout 'bootstrap';
 % title '';
 

--- a/templates/test/comments.html.ep
+++ b/templates/test/comments.html.ep
@@ -1,45 +1,49 @@
 % for my $comment ($job->comments) {
-    <div class="pull-left">
-        <img class="media-object img-circle" src="<%= $comment->user->gravatar(60) %>" alt="profile">
-    </div>
-    <div class="media-body comment-body">
-        <div class="well well-lg">
-            % if (current_user && current_user->is_admin) {
-                %= form_for 'remove_comment', method => "post", class => "form-horizontal", role => "form" => begin
-                    <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" id="removeComment_<%= $comment->id %>" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
-                        <span class="glyphicon glyphicon glyphicon-remove"></span>
-                    </button>
-                    <input type="hidden" name="comment_id" value="<%= $comment->id %>">
-                % end
-            % }
-            %= form_for 'edit_comment', method => "post", class => "form-horizontal", role => "form" => begin
-                % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
-                    <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
-                        <span class="glyphicon glyphicon glyphicon-pencil"></span>
-                    </button>
-                % }
-                <h4 class="media-heading">
-                    <%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr>
-                    % if ($comment->t_created != $comment->t_updated) {
-                        (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
+    <div class="row">
+        <div class="col-sm-1">
+            <img class="media-object img-circle" src="<%= $comment->user->gravatar(60) %>" alt="profile">
+        </div>
+        <div class="col-sm-11">
+            <div class="media-body comment-body">
+                <div class="well well-lg">
+                    % if (current_user && current_user->is_admin) {
+                        %= form_for 'remove_comment', method => "post", class => "form-horizontal", role => "form" => begin
+                            <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" id="removeComment_<%= $comment->id %>" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
+                                <span class="glyphicon glyphicon glyphicon-remove"></span>
+                            </button>
+                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                        % end
                     % }
-                </h4>
-                <div class="media-comment" id="commentMd_<%= $comment->id %>">
-                    %= $comment->rendered_markdown
+                    %= form_for 'edit_comment', method => "post", class => "form-horizontal", role => "form" => begin
+                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                            <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
+                                <span class="glyphicon glyphicon glyphicon-pencil"></span>
+                            </button>
+                        % }
+                        <h4 class="media-heading">
+                            <%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr>
+                            % if ($comment->t_created != $comment->t_updated) {
+                                (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
+                            % }
+                        </h4>
+                        <div class="media-comment" id="commentMd_<%= $comment->id %>">
+                            %= $comment->rendered_markdown
+                        </div>
+                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                            <textarea class="form-control comment-editing-control" name="text" rows="5"><%= $comment->text %></textarea>
+                            <button class="btn btn-success btn-circle comment-editing-control" type="submit" name="applyChanges">
+                                <span class="glyphicon glyphicon glyphicon-ok"></span>
+                                Apply changes
+                            </button>
+                            <button class="btn btn-warning btn-circle comment-editing-control" type="reset" name="discardChanges" onclick="hideCommentEditor(<%= $comment->id %>, this.form); return true;">
+                                <span class="glyphicon glyphicon glyphicon-remove"></span>
+                                Discard changes
+                            </button>
+                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                        % }
+                    % end
                 </div>
-                % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
-                    <textarea class="form-control comment-editing-control" name="text" rows="5"><%= $comment->text %></textarea>
-                    <button class="btn btn-success btn-circle comment-editing-control" type="submit" name="applyChanges">
-                        <span class="glyphicon glyphicon glyphicon-ok"></span>
-                        Apply changes
-                    </button>
-                    <button class="btn btn-warning btn-circle comment-editing-control" type="reset" name="discardChanges" onclick="hideCommentEditor(<%= $comment->id %>, this.form); return true;">
-                        <span class="glyphicon glyphicon glyphicon-remove"></span>
-                        Discard changes
-                    </button>
-                    <input type="hidden" name="comment_id" value="<%= $comment->id %>">
-                % }
-            % end
+            </div>
         </div>
     </div>
 % }

--- a/templates/test/comments.html.ep
+++ b/templates/test/comments.html.ep
@@ -4,10 +4,42 @@
     </div>
     <div class="media-body comment-body">
         <div class="well well-lg">
-            <h4 class="media-heading"><%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr></h4>
-            <p class="media-comment">
-                %= $comment->rendered_markdown
-            </p>
+            % if (current_user && current_user->is_admin) {
+                %= form_for 'remove_comment', method => "post", class => "form-horizontal", role => "form" => begin
+                    <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" id="removeComment_<%= $comment->id %>" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
+                        <span class="glyphicon glyphicon glyphicon-remove"></span>
+                    </button>
+                    <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                % end
+            % }
+            %= form_for 'edit_comment', method => "post", class => "form-horizontal", role => "form" => begin
+                % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                    <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
+                        <span class="glyphicon glyphicon glyphicon-pencil"></span>
+                    </button>
+                % }
+                <h4 class="media-heading">
+                    <%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr>
+                    % if ($comment->t_created != $comment->t_updated) {
+                        (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
+                    % }
+                </h4>
+                <div class="media-comment" id="commentMd_<%= $comment->id %>">
+                    %= $comment->rendered_markdown
+                </div>
+                % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
+                    <textarea class="form-control comment-editing-control" name="text" rows="5"><%= $comment->text %></textarea>
+                    <button class="btn btn-success btn-circle comment-editing-control" type="submit" name="applyChanges">
+                        <span class="glyphicon glyphicon glyphicon-ok"></span>
+                        Apply changes
+                    </button>
+                    <button class="btn btn-warning btn-circle comment-editing-control" type="reset" name="discardChanges" onclick="hideCommentEditor(<%= $comment->id %>, this.form); return true;">
+                        <span class="glyphicon glyphicon glyphicon-remove"></span>
+                        Discard changes
+                    </button>
+                    <input type="hidden" name="comment_id" value="<%= $comment->id %>">
+                % }
+            % end
         </div>
     </div>
 % }

--- a/templates/test/comments.html.ep
+++ b/templates/test/comments.html.ep
@@ -1,69 +1,9 @@
 % for my $comment ($job->comments) {
-    <div class="row">
-        <div class="col-sm-1">
-            <img class="media-object img-circle" src="<%= $comment->user->gravatar(60) %>" alt="profile">
-        </div>
-        <div class="col-sm-11">
-            <div class="media-body comment-body">
-                <div class="well well-lg">
-                    % if (current_user && current_user->is_admin) {
-                        %= form_for 'remove_comment', method => "post", class => "form-horizontal", role => "form" => begin
-                            <button class="btn btn-danger btn-circle btn-sm trigger-edit-button" type="submit" id="removeComment_<%= $comment->id %>" onclick="return confirmCommentRemoval('<%= $comment->user->name %>');">
-                                <span class="glyphicon glyphicon glyphicon-remove"></span>
-                            </button>
-                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
-                        % end
-                    % }
-                    %= form_for 'edit_comment', method => "post", class => "form-horizontal", role => "form" => begin
-                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
-                            <button class="btn btn-info btn-circle btn-sm trigger-edit-button" type="button" name="editComment" onclick="showCommentEditor(<%= $comment->id %>, this.form);">
-                                <span class="glyphicon glyphicon glyphicon-pencil"></span>
-                            </button>
-                        % }
-                        <h4 class="media-heading">
-                            <%= $comment->user->name %> wrote <abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr>
-                            % if ($comment->t_created != $comment->t_updated) {
-                                (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
-                            % }
-                        </h4>
-                        <div class="media-comment" id="commentMd_<%= $comment->id %>">
-                            %= $comment->rendered_markdown
-                        </div>
-                        % if (current_user && ((current_user->id eq $comment->user->id))) { # TODO: test also for || current_user->is_admin
-                            <textarea class="form-control comment-editing-control" name="text" rows="5"><%= $comment->text %></textarea>
-                            <button class="btn btn-success btn-circle comment-editing-control" type="submit" name="applyChanges">
-                                <span class="glyphicon glyphicon glyphicon-ok"></span>
-                                Apply changes
-                            </button>
-                            <button class="btn btn-warning btn-circle comment-editing-control" type="reset" name="discardChanges" onclick="hideCommentEditor(<%= $comment->id %>, this.form); return true;">
-                                <span class="glyphicon glyphicon glyphicon-remove"></span>
-                                Discard changes
-                            </button>
-                            <input type="hidden" name="comment_id" value="<%= $comment->id %>">
-                        % }
-                    % end
-                </div>
-            </div>
-        </div>
-    </div>
+    %= include 'comments/comment_row', comment => $comment, edit_action => 'edit_comment', remove_action => 'remove_comment'
 % }
 
 % if (current_user) {
     %= form_for 'add_comment', method => "post", class => "form-horizontal", id => "commentForm", role => "form" => begin
-        <div class="form-group">
-            <label for="text" class="col-sm-1 control-label">Comment
-                <img class="img-circle" src="<%= current_user->gravatar(60) %>">
-            </label>
-            <div class="col-sm-11">
-                <textarea class="form-control" name="text" id="text" rows="5"></textarea>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="col-sm-offset-1 col-sm-11">
-                <button class="btn btn-success btn-circle" type="submit" id="submitComment">
-                    <span class="glyphicon glyphicon-send"></span>
-                    Submit comment</button>
-            </div>
-        </div>
+        %= include 'comments/add_comment_form_groups'
     % end
 % }

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -23,7 +23,7 @@
 % end
 
 <div class="row">
-    <div class="col-sm-push-3 col-sm-9">
+    <div class="col-sm-9">
         %= include 'layouts/info'
         % if (my $msg = flash 'code') {
             <blockquote class="ui-state-highlight"><%== $msg %></blockquote>

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -23,7 +23,7 @@
 % end
 
 <div class="row">
-    <div class="col-sm-9">
+    <div>
         %= include 'layouts/info'
         % if (my $msg = flash 'code') {
             <blockquote class="ui-state-highlight"><%== $msg %></blockquote>


### PR DESCRIPTION
- This PR implements editable comments: https://progress.opensuse.org/issues/10622
- I also fixed some other details regarding the comments (see the different commit messages).
- I'm not sure where to put the required CSS and JavaScript, so I decided to create separate files.
- I'm not sure about ```$self->emit_event('openqa_user_comment', {id => $self->param("comment_id")});```
- When testing, I also noticed that Non-ASCII characters aren't displayed correctly: https://github.com/os-autoinst/openQA/issues/655
- Allowing admins to edit comments (and not only the initial author) would required an "last_editor" field in the database. However, I don't know how to add an additional field. Hence currently only the user itself can edit comments.
- Only admins can remove comments completely.