### PR TITLE
add a config setting to specify asset types not to link to

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -38,6 +38,10 @@
 ## this example loads OpenQA::WebAPI::Plugin::Fedmsg
 #plugins = Fedmsg
 
+## space-separated list of asset types *not* to show links for in the
+# web UI. Default is 'repo'
+#hide_asset_types = repo iso
+
 #[scm git]
 #do_push = no
 

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -117,6 +117,14 @@ sub ensure_size {
     return $size;
 }
 
+sub hidden {
+    # 1 if asset should not be linked from the web UI (as set by
+    # 'hide_asset_types' config setting), otherwise 0
+    my ($self) = @_;
+    my @types = split(/ /, $OpenQA::Utils::app->config->{global}->{hide_asset_types});
+    return grep { $_ eq $self->type } @types;
+}
+
 # A GRU task...arguments are the URL to grab and the full path to save
 # it in. scheduled in ISO controller
 sub download_asset {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -48,6 +48,7 @@ sub _read_config {
             hsts             => 365,
             audit_enabled    => 1,
             plugins          => undef,
+            hide_asset_types => 'repo',
         },
         auth => {
             method => 'OpenID',

--- a/t/config.t
+++ b/t/config.t
@@ -36,10 +36,11 @@ is_deeply(
     $cfg,
     {
         global => {
-            appname       => 'openQA',
-            branding      => 'openSUSE',
-            hsts          => 365,
-            audit_enabled => 1,
+            appname          => 'openQA',
+            branding         => 'openSUSE',
+            hsts             => 365,
+            audit_enabled    => 1,
+            hide_asset_types => 'repo',
         },
         auth => {
             method => 'Fake',

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -227,7 +227,7 @@
                 % my $assets = $job->jobs_assets;
                 % while (my $a = $assets->next) {
                     % $a = $a->asset;
-                    % if ($a->type ne 'repo') {
+                    % unless ($a->hidden) {
                         % content_for 'asset_box' => begin
                             <li>
                                 %= link_to url_for('test_asset_name', testid => $testid, assettype => $a->type, assetname => $a->name) => (id => "asset_".$a->id) => begin


### PR DESCRIPTION
We (Fedora) really don't want .iso files to be linked in the
Logs & Assets tab. Fedora's openQA is not a download server and
there is a more appropriate place to download those ISOs from.
So this changes things a bit so the admin can specify a list of
types not to include links to, rather than just hardcoding it.