### PR TITLE
Fix use of symlinked needle dirs from outside of basedir

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -105,12 +105,13 @@ sub needle_info {
     }
     else {
         $needledir = dirname($fn);
-    }
-
-    # make sure needledir is a subdir of testcasedir
-    if (index(Cwd::realpath($needledir), Cwd::realpath($testcasedir)) != 0) {
-        warn "$needledir is not a subdir of $testcasedir";
-        return;
+        # make sure the directory of the file parameter is a real subdir of
+        # testcasedir when applying it as needledir to prevent access
+        # outside of the zoo
+        if (index(Cwd::realpath($needledir), Cwd::realpath($testcasedir)) != 0) {
+            warn "$needledir is not a subdir of $testcasedir";
+            return;
+        }
     }
 
     my $JF;


### PR DESCRIPTION
This fixes a problem introduced with 2b8ac3c859e6db1296fbf7f6ff71d0306d9501e8.
The check for the needledir has been moved where an external file path is used
coming from a REST request where additional care should be taken to ensure a
valid and secure directory. For a "local" definition of the needledir the
check was removed changing the behaviour back to the old way supporting
symlinked needle dirs, e.g. when /local/needles is symlinked into
/var/lib/openqa/share/tests/... instead of being a real subdirectory.

For the "new" feature of an external definition of needle dirs test cases are
(still) missing and should be added before another related change is done.

Fixes gh #667.