### PR TITLE
Allow symlinked test and needle directory structure

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -29,6 +29,7 @@ requires 'File::Basename';
 requires 'File::Copy';
 requires 'File::Copy::Recursive';
 requires 'File::Path';
+requires 'File::Spec';
 requires 'FindBin';
 requires 'Getopt::Long';
 requires 'IO::Socket::INET6';

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -21,7 +21,7 @@ use Mojo::Base 'Mojolicious::Controller';
 BEGIN { $ENV{MAGICK_THREAD_LIMIT} = 1; }
 use OpenQA::Utils;
 use File::Basename;
-use Cwd;
+use File::Spec;
 
 use Data::Dump qw(pp);
 
@@ -39,7 +39,7 @@ sub needle {
     # make sure the directory of the file parameter is a real subdir of
     # testcasedir before applying it as needledir to prevent access
     # outside of the zoo
-    if ($jsonfile && index(Cwd::realpath($jsonfile), Cwd::realpath($OpenQA::Utils::testcasedir)) != 0) {
+    if ($jsonfile && index(File::Spec->rel2abs($jsonfile), File::Spec->rel2abs($OpenQA::Utils::testcasedir)) != 0) {
         warn "$jsonfile is not in a subdir of $OpenQA::Utils::testcasedir";
         return $self->render(text => "Forbidden", status => 403);
     }


### PR DESCRIPTION
As a followup to 8016a44b4d2591a50764731f38c94c58e78a69e2 this change allows
to symlink e.g. the needle directory into the tests distribution directory
within the filesystem while still not allowing to inject outside paths over
URL requests.

It would be ok to not support this feature but 403/404 responses to needle
images are not properly handled in the javascript code which would leave users
stumbled why the images don't update unless looking at server logs.