### PR TITLE
Do not allow passing unescaped quotes in admin tables

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
+++ b/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
@@ -21,10 +21,14 @@ sub register {
                 foreach my $p (keys %$hprms) {
                     my $key = $p;
                     my $val = $hprms->{$p};
+                    $val =~ s/\\/\\\\/g;
+                    $val =~ s/\'/\\\'/g;
 
                     $key =~ s/[^\]\[0-9a-zA-Z_]//g;
                     $key =~ s/\[{2,}/\[/g;
                     $key =~ s/\]{2,}/\]/g;
+                    $key =~ s/\\//g;
+                    $key =~ s/\'//g;
 
                     my @list;
                     foreach my $n (split /[\[\]]/, $key) {

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -98,6 +98,16 @@ my $machine_id = $res->tx->res->json->{id};
 $res = $t->get_ok('/api/v1/machines', form => {name => "testmachine"})->status_is(200);
 is($res->tx->res->json->{Machines}->[0]->{id}, $machine_id);
 
+$res = $t->post_ok('/api/v1/machines', form => {name => "testmachineQ", backend => "qemu", "settings[TEST]" => "'v'al1", "settings[TEST2]" => "va'l\'1"})->status_is(200);
+$res = $t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
+is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
+is($res->tx->res->json->{Machines}->[0]->{settings}->[1]->{value}, "va'l\'1");
+
+$t->post_ok('/api/v1/machines', form => {name => "testmachineZ", backend => "qemu", "settings[TE'S\'T]" => "'v'al1"})->status_is(200);
+$res = $t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
+is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{key},   "TEST");
+is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
+
 $res = $t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu"})->status_is(400);    #already exists
 
 $get = $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);


### PR DESCRIPTION
- escape quotes for values
- remove quotes for keys

partly fixes gh#666

Note: this preserve the API, but I'm not very happy with that since the `eval` is still there. This only tries to prevent escaping '' enclosure. I have another fix for that using JSON instead of perl-like strings for data transfer, but that would break API. How much we insist on not braking it?