### PR TITLE
Enable brackets inside keys in client script

### DIFF
--- a/script/client
+++ b/script/client
@@ -117,7 +117,7 @@ for my $arg (@ARGV) {
     if ($arg =~ /^(?:get|post|delete|put)$/i) {
         $method = lc $arg;
     }
-    elsif ($arg =~ /^([[:alnum:]_]+)=(.+)/) {
+    elsif ($arg =~ /^([[:alnum:]_\[\]]+)=(.+)/) {
         my $key   = $1;
         my $value = $2;
         # Mojo::URL no longer escapes / (https://github.com/kraih/mojo/commit/aab2f1f)


### PR DESCRIPTION
- adding/modifying test_suites by client script requires user to be able
to put keys in format 'settings[$key]=value'