### PR TITLE
clone_job.pl: Skip downloading assets generated by parent jobs

### DIFF
--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -189,7 +189,7 @@ sub clone_job {
         my $parallel = $job->{parents}->{Parallel} unless ($options{'skip-deps'});
         $parallel //= [];
 
-        print "Clonning dependencies of $job->{name}\n" if (@$chained || @$parallel);
+        print "Cloning dependencies of $job->{name}\n" if (@$chained || @$parallel);
 
         for my $p (@$chained, @$parallel) {
             clone_job($p, $clone_map, $depth + 1);


### PR DESCRIPTION
In case all dependencies on a job are cloned including a parent job which will
generate an asset which is used by the cloned child there is no need to
download the corresponding asset when it will get overwritten by the new
scheduled parent job anyway.

This might also help to prevent confusion when the option
'--skip-chained-deps' is not used as the qcow image is downloaded but not
used.

Example test run:
```
$ clone_job.pl --from https://openqa 1002                           
Cloning dependencies of foo
downloading                                                    
https://openqa/tests/1002/asset/iso/foo.iso
to                                                             
/var/lib/openqa/factory/iso/foo.iso
Created job #1: bar
downloading
https://openqa/tests/1002/asset/iso/foo.iso
to
/var/lib/openqa/factory/iso/foo.iso
Created job #2: foo
$ clone_job.pl --skip-chained-deps --from https://openqa 1002
downloading
https://openqa/tests/1002/asset/iso/foo.iso
to
/var/lib/openqa/factory/iso/foo.iso
downloading
https://openqa/tests/1002/asset/hdd/baz.qcow2
to
/var/lib/openqa/factory/hdd/baz.qcow2
Created job #3: foo
```