### PR TITLE
Quick fix for needlediff.js: Improve similarity text look

### DIFF
--- a/public/javascripts/needlediff.js
+++ b/public/javascripts/needlediff.js
@@ -139,8 +139,9 @@ NeedleDiff.prototype.draw = function() {
     this.ctx.strokeRect(x, a['ypos'], a['width'], a['height']);
     // And the similarity, if needed
     if (this.showSimilarity[idx]) {
-      this.ctx.fillStyle = "rgb(255, 255, 255)";
-      this.ctx.fillRect(x+2, a['ypos']+2, 50, 20);
+      this.ctx.strokeStyle = "rgb(0, 0, 0)";
+      this.ctx.lineWidth = 3;
+      this.ctx.strokeText(a['similarity']+"%", x+4, a['ypos']+20);
       this.ctx.fillStyle = NeedleDiff.shapecolor(a['type']);
       this.ctx.font = "bold 24px Arial";
       this.ctx.fillText(a['similarity']+"%", x+4, a['ypos']+20);


### PR DESCRIPTION
I just noticed that the white rectangle below the similarity display looks weird and displaced
and reporting that would've taken the same amount of time as fixing.

Draw a 3px wide black stroke around the similarity on needles
instead of a white rectangle which doesn't even match the text size.

Result (new on the right):

![qa1](https://cloud.githubusercontent.com/assets/1622084/15385748/f19f2f3c-1da3-11e6-97ae-efbed4689804.png)![qa2](https://cloud.githubusercontent.com/assets/1622084/15385755/f6bce1e4-1da3-11e6-92d9-8a282a1cb96d.png)
![qa3](https://cloud.githubusercontent.com/assets/1622084/15385756/fa3543ac-1da3-11e6-8d2d-42e7bf1a801f.png)![qa4](https://cloud.githubusercontent.com/assets/1622084/15385759/fecab9f6-1da3-11e6-8a3c-c53a52c6095d.png)




