### PR TITLE
Fix non-ASCII characters in comments

### DIFF
--- a/etc/openqa/database.ini
+++ b/etc/openqa/database.ini
@@ -2,8 +2,10 @@
 dsn = dbi:SQLite:dbname=:memory:
 on_connect_call = use_foreign_keys
 on_connect_do = PRAGMA synchronous = OFF
+sqlite_unicode = 1
 
 [production]
 dsn = dbi:SQLite:dbname=/var/lib/openqa/db/db.sqlite
 on_connect_call = use_foreign_keys
 on_connect_do = PRAGMA synchronous = OFF
+sqlite_unicode = 1

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -57,9 +57,8 @@ $driver->find_element('opensuse', 'link_text')->click();
 is($driver->find_element('h1:first-of-type', 'css')->get_text(), 'Last Builds for Group opensuse', "on group overview");
 
 # define test message
-# TODO: break it by adding UTF-8 character
-my $test_message         = "This is a cool test";
-my $another_test_message = " - this message will be appended if editing works";
+my $test_message         = "This is a cool test ☠";
+my $another_test_message = " - this message will be appended if editing works ☠";
 my $edited_test_message  = $test_message . $another_test_message;
 my $user_name            = 'Demo';
 


### PR DESCRIPTION
- Fix issue https://github.com/os-autoinst/openQA/issues/655
- Test non-ASCII characters in t/ui/15-comments.t
- Decode UTF-8 strings because Mojo doesn't seem
  to expect UTF-8 strings (the website is still rendered
  as UTF-8 after all)
- Comments added before this fix are  correctly displayed, too.