### PR TITLE
Increase left padding of status icons

### DIFF
--- a/public/stylesheets/openqa.css
+++ b/public/stylesheets/openqa.css
@@ -481,6 +481,7 @@ span.status .fa {
 
 .status.fa {
     font-size: 110%;
+    padding-left: 1em;
 }
 
 .action.fa {


### PR DESCRIPTION
- to avoid accidental click on job restart or cancel icon increase left
padding of job status icons