### PR TITLE
Check database configuration with better user feedback

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -42,7 +42,9 @@ sub connect_db {
     unless ($$schema) {
         my %ini;
         my $cfgpath = $ENV{OPENQA_CONFIG} || "$Bin/../etc/openqa";
-        tie %ini, 'Config::IniFiles', (-file => $cfgpath . '/database.ini');
+        my $database_file = $cfgpath . '/database.ini';
+        tie %ini, 'Config::IniFiles', (-file => $database_file);
+        die 'Could not find database section \'' . $mode . '\' in ' . $database_file unless $ini{$mode};
         $$schema = __PACKAGE__->connect($ini{$mode});
     }
     return $$schema;


### PR DESCRIPTION
Instead of a ambiguous message "You did not provide any connection_info" the
configuration file 'database.ini' is now checked for a properly configured
database section matching the specified mode.

Helps when running against a customized database configuration, e.g. for
crosschecking with database dumps.