### PR TITLE
Prevent error in group_overview with '-important' builds

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -151,6 +151,8 @@ sub group_overview {
         my @tag   = $comment->tag;
         my $build = $tag[0];
         next unless $build;
+        # Next line fixes poo#12028
+        next unless $res->{$build};
         $self->app->log->debug('Tag found on build ' . $tag[0] . ' of type ' . $tag[1]);
         $self->app->log->debug('description: ' . $tag[2]) if $tag[2];
         if ($tag[1] eq '-important') {

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -85,6 +85,15 @@ subtest 'tag on non-existant build does not show up' => sub {
     is(scalar @tags, 0, 'no builds tagged');
 };
 
+subtest 'builds first tagged important, then unimportant dissappear (poo#12028)' => sub {
+    post_comment_1001 'tag:0091:important';
+    post_comment_1001 'tag:0091:-important';
+    my $get  = $t->get_ok('/group_overview/1001?limit_builds=1')->status_is(200);
+    my @tags = $t->tx->res->dom->find('a[href^=/tests]')->map('text')->each;
+    is(scalar @tags, 1,           'only one build');
+    is($tags[0],     'Build0048', 'only youngest build present');
+};
+
 =pod
 Given a comment C<tag:<build_ref>:important> exists on a job group comments
 When GRU cleanup task is run

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -5,7 +5,7 @@
         <div class="col-md-4 text-nowrap">
             <h4>
                 <%= link_to "Build$build" => url_for('tests_overview')->query(distri => $build_res->{distri}, version => $build_res->{version}, build => $build, groupid => $group->id ) %>
-                (<abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">
+                (<abbr class="timeago" title="<%= $build_res->{oldest} ?  $build_res->{oldest}->datetime().'Z' : 'unknown'%>">
                 <%= delete $build_res->{oldest} %>
                 </abbr>)
             % my $group_build_id = $group->id . '-' . $build;

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -5,7 +5,7 @@
         <div class="col-md-4 text-nowrap">
             <h4>
                 <%= link_to "Build$build" => url_for('tests_overview')->query(distri => $build_res->{distri}, version => $build_res->{version}, build => $build, groupid => $group->id ) %>
-                (<abbr class="timeago" title="<%= $build_res->{oldest} ?  $build_res->{oldest}->datetime().'Z' : 'unknown'%>">
+                (<abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">
                 <%= delete $build_res->{oldest} %>
                 </abbr>)
             % my $group_build_id = $group->id . '-' . $build;


### PR DESCRIPTION
Calling 'delete $res->{$build}->{tag};' in case $res->{$build} does not
exist will actually create $res->{$build} as '{}' causing the build structure
to be defined but incomplete causing an error in
templates/main/group_builds.html.ep

Corresponding lightning talk:
https://www.destroyallsoftware.com/talks/wat

Fixes https://progress.opensuse.org/issues/12028