### PR TITLE
Fix issues with editable comments

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -244,8 +244,7 @@ sub remove_comment {
 
     my $rs = $group->comments->search(
         {
-            id      => $comment_id,
-            user_id => $self->current_user->id
+            id => $comment_id
         })->delete();
 
     $self->emit_event('openqa_user_comment', {id => $comment_id});

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -589,9 +589,7 @@ sub remove_comment {
 
     my $rs = $job->comments->search(
         {
-            id      => $self->param("comment_id"),
-            user_id => $self->current_user->id
-        });
+            id => $self->param("comment_id")});
 
     if ($rs) {
         $rs->delete();

--- a/public/javascripts/comments.js
+++ b/public/javascripts/comments.js
@@ -1,7 +1,10 @@
 function showCommentEditor(commentId, form) {
     form.text.style.display = "block";
     form.editComment.style.display = "none";
-    document.getElementById("removeComment_" + commentId).style.display = "none";
+    var removeCommentElement = document.getElementById("removeComment_" + commentId);
+    if(removeCommentElement) {
+        removeCommentElement.style.display = "none";
+    }
     form.applyChanges.style.display = "inline";
     form.discardChanges.style.display = "inline";
     document.getElementById("commentMd_" + commentId).style.display = "none";
@@ -10,7 +13,10 @@ function showCommentEditor(commentId, form) {
 function hideCommentEditor(commentId, form) {
     form.text.style.display = "none";
     form.editComment.style.display = "inline";
-    document.getElementById("removeComment_" + commentId).style.display = "inline";
+    var removeCommentElement = document.getElementById("removeComment_" + commentId);
+    if(removeCommentElement) {
+        removeCommentElement.style.display = "inline";
+    }
     form.applyChanges.style.display = "none";
     form.discardChanges.style.display = "none";
     document.getElementById("commentMd_" + commentId).style.display = "block";


### PR DESCRIPTION
- Fixes the issue https://progress.opensuse.org/issues/12116 as far as I can reproduce it.
- Editing buttons are now shown correctly when not logged-in as an admin.