### PR TITLE
Improve log message about 'setup failure'

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -83,8 +83,8 @@ sub engine_workit($) {
         if (my $iso = $job->{settings}->{$isokey}) {
             $iso = join('/', ISO_DIR, $iso);
             unless (-e $iso) {
-                warn "$iso does not exist!\n";
-                return;
+                my $error = "$iso does not exist!";
+                return {error => $error};
             }
             $job->{settings}->{$isokey} = $iso;
         }
@@ -94,8 +94,8 @@ sub engine_workit($) {
         if (my $file = $job->{settings}->{$otherkey}) {
             $file = join('/', OTHER_DIR, $file);
             unless (-e $file) {
-                warn "$file does not exist!\n";
-                return;
+                my $error = "$file does not exist!";
+                return {error => $error};
             }
             $job->{settings}->{$otherkey} = $file;
         }
@@ -107,8 +107,8 @@ sub engine_workit($) {
         if ($hdd) {
             $hdd = join('/', HDD_DIR, $hdd);
             unless (-e $hdd) {
-                warn "$hdd does not exist!\n";
-                return;
+                my $error = "$hdd does not exist!";
+                return {error => $error};
             }
             $job->{settings}->{"HDD_$i"} = $hdd;
         }

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -50,7 +50,7 @@ our $do_livelog;
 sub _kill_worker($) {
     my ($worker) = @_;
 
-    return unless $worker;
+    return unless $worker->{pid};
 
     warn "killing $worker->{pid}\n";
     kill(SIGTERM, $worker->{pid});
@@ -319,9 +319,9 @@ sub start_job {
     $tosend_files    = [];
 
     $worker = engine_workit($job);
-    unless ($worker) {
+    if ($worker->{error}) {
         warn "job is missing files, releasing job\n";
-        return stop_job('setup failure');
+        return stop_job("setup failure: $worker->{error}");
     }
 
     # start updating status - slow updates if livelog is not running

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -144,7 +144,7 @@ is($job3->{retry_avbl}, 0, "the retry counter decreased");
 # need to change state from scheduled
 OpenQA::Scheduler::Scheduler::job_set_done(jobid => $round3_id, result => OpenQA::Schema::Result::Jobs::INCOMPLETE);
 my $round4_id = OpenQA::Scheduler::Scheduler::job_duplicate((jobid => $round3_id, dup_type_auto => 1));
-ok(!defined $round4_id, "no logner auto-duplicating");
+ok(!defined $round4_id, "no longer auto-duplicating");
 # need to change state from scheduled
 OpenQA::Scheduler::Scheduler::job_set_done(jobid => $round3_id, result => OpenQA::Schema::Result::Jobs::INCOMPLETE);
 my $round5_id = OpenQA::Scheduler::Scheduler::job_duplicate(jobid => $round3_id);


### PR DESCRIPTION
The detailed error message what happens on
the "infamous" 'setup failure' was already
there but lost in system logs not easily
accessible. As the statement 'setup failure'
is already forwarded and ends up in
autoinst-log.txt which is accessible over
the WebUI now the detailed explanation
is returned and displayed.

**Example output:**

*old:* `result: setup failure`

*new:* `result: setup failure: /var/lib/openqa/ \
    share/factory/iso/openSUSE-Tumbleweed-DVD-x86_64-Snapshot20160105-Media.iso \
    does not exist!`

**Manual test procedure:**
* Pre: Any existing job result
* Remove/rename used ISO asset
* Reschedule job over WebUI
* Post: Observe result using logfile over WebUI

Related issue: https://progress.opensuse.org/issues/10314