### PR TITLE
Show scenario name within results details view

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -184,7 +184,8 @@ sub name {
             push @a, sprintf(($formats{$c} || '%s'), $job_settings->{$c});
         }
         my $name = join('-', @a);
-        $name =~ s/[^a-zA-Z0-9._+:-]/_/g;
+        $name .= ('@' . $job_settings->{MACHINE}) if $job_settings->{MACHINE};
+        $name =~ s/[^a-zA-Z0-9@._+:-]/_/g;
         $self->{_name} = $name;
     }
     return $self->{_name};

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -102,7 +102,7 @@ my %settings = (
 my $job_ref = {
     t_finished => undef,
     id         => 1,
-    name       => 'Unicorn-42-pink-x86_64-Build666-rainbow',
+    name       => 'Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
     priority   => 40,
     result     => 'none',
     settings   => {
@@ -117,7 +117,7 @@ my $job_ref = {
         KVM         => "KVM",
         MACHINE     => "RainbowPC",
         ARCH        => 'x86_64',
-        NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow',
+        NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
     },
     assets => {
         iso => ['whatever.iso'],
@@ -180,7 +180,7 @@ my $jobs = [
     {
         t_finished => undef,
         id         => 1,
-        name       => 'Unicorn-42-pink-x86_64-Build666-rainbow',
+        name       => 'Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
         priority   => 40,
         result     => 'none',
         t_started  => undef,
@@ -202,7 +202,7 @@ my $jobs = [
             KVM         => "KVM",
             MACHINE     => "RainbowPC",
             ARCH        => 'x86_64',
-            NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow',
+            NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
         },
         assets => {
             iso => ['whatever.iso'],
@@ -279,7 +279,7 @@ ok(!$grabed->{settings}->{JOBTOKEN}, "job token no longer present");
 $grabed = OpenQA::Scheduler::Scheduler::job_grab(%args);
 isnt($job->id, $grabed->{id}, "new job grabbed");
 isnt($grabed->{settings}->{JOBTOKEN}, $job_ref->{settings}->{JOBTOKEN}, "job token differs");
-$job_ref->{settings}->{NAME} = '00000003-Unicorn-42-pink-x86_64-Build666-rainbow';
+$job_ref->{settings}->{NAME} = '00000003-Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC';
 
 ## update JOBTOKEN for isdeeply compare
 $job_ref->{settings}->{JOBTOKEN} = $grabed->{settings}->{JOBTOKEN};

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -33,19 +33,19 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # export all jobs
 my $r = $t->get_ok("/tests/export")->status_is(200);
 $t->content_type_is('text/plain');
-$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde is passed/);
-$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0 is none/);
+$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
+$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is none/);
 
 # filter
 $r = $t->get_ok("/tests/export?from=99981")->status_is(200);
 $t->content_type_is('text/plain');
-$t->content_unlike(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde is passed/);
-$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0 is none/);
+$t->content_unlike(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
+$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is none/);
 
 $r = $t->get_ok("/tests/export?to=99981")->status_is(200);
 $t->content_type_is('text/plain');
-$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde is passed/);
+$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
 # to is exclusiv
-$t->content_unlike(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0 is none/);
+$t->content_unlike(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is none/);
 
 done_testing();

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -117,7 +117,6 @@
 
 <div class="container-fluid">
     %= include 'layouts/info'
-
     <div class="row">
 
         <div class="panel panel-default">

--- a/templates/step/src.html.ep
+++ b/templates/step/src.html.ep
@@ -26,6 +26,7 @@
 </div>
 
 <div class="grid_13 omega">
+    <div id="scenario">Scenario: <%= $job->scenario %></div>
     %= include 'step/moduleslistthumbnails' unless ($tabmode eq 'onlysrc')
 
     <div class="box box-shadow">

--- a/templates/step/viewaudio.html.ep
+++ b/templates/step/viewaudio.html.ep
@@ -22,6 +22,7 @@
 </div>
 
 <div class="grid_13 omega">
+    <div id="scenario">Scenario: <%= $job->scenario %></div>
     %= include 'step/moduleslistthumbnails'
 
     <div class="box box-shadow">

--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -41,6 +41,7 @@ function setNeedle() {
 </div>
 
 <div class="grid_13 omega">
+    <div id="scenario">Scenario: <%= $job->scenario %></div>
     %= include 'step/moduleslistthumbnails'
 
     <div class="box box-shadow">

--- a/templates/step/viewtext.html.ep
+++ b/templates/step/viewtext.html.ep
@@ -22,6 +22,7 @@
 </div>
 
 <div class="grid_13 omega">
+    <div id="scenario">Scenario: <%= $job->scenario %></div>
     %= include 'step/moduleslistthumbnails'
 
     <div class="box box-shadow">

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -45,7 +45,7 @@
         % }
         <div class="panel <%= $panelclass %>" id="info_box">
             <div class="panel-heading">
-                Results for <%= $job->name %>@<%= $job->settings_hash->{MACHINE} %>
+                Results for <%= $job->name %>
             </div>
             <div class="panel-body">
                 <div>

--- a/templates/test/running.html.ep
+++ b/templates/test/running.html.ep
@@ -81,6 +81,7 @@
     % if (my $msg = flash 'code') {
         <blockquote class="ui-state-highlight" style="margin-bottom: 0.6em;"><%== $msg %></blockquote>
     % }
+    <div id="scenario">Scenario: <%= $job->scenario %></div>
     <div class="box box-shadow">
         <!--<h2>Live view of <i><%= $testname %></i></h2>-->
         <div class="box-header aligncenter">Live view of <i><%= $testname %></i></div>


### PR DESCRIPTION
 Show scenario within results details view

The scenario is becoming more and more important in referencing results. When
working with many test results at the same time or using deep links to
failed modules it was not possible to find out the scenario from the details
view page but one had to click and load the results page.

Fixes https://progress.opensuse.org/issues/12084

Example screenshot:
![openqa_job_name_in_details_view_alt2](https://cloud.githubusercontent.com/assets/1693432/15819169/d76530ac-2be1-11e6-8148-0641f7480d8b.png)
