### PR TITLE
templates: Use common code for bootstrap+default layout

### DIFF
--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -45,18 +45,7 @@
           </div>
           <div class='col-md-5 text-right'>
           <div id="user-info">
-              %# Using a variable to avoid additional whitespaces
-              % if (current_user) {
-              %# Using a variable to avoid additional whitespaces
-              % my $out = 'Logged in as '. current_user->name.' (';
-              % if (is_operator) {
-                  % $out = $out.link_to('manage API keys' => url_for('api_keys')).' | ';
-                  % $out = $out.link_to('admin' => url_for('admin')).' | ';
-              % }
-              %= b($out.link_to('Logout' => url_for('logout') => 'data-method' => 'delete').')');
-              % } else {
-              %= link_to('Login' => url_for('login'));
-              % }
+              %= include 'layouts/subheader_user'
           </div>
           </div>
       </div>

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -14,20 +14,7 @@
     <div id="subheader" class="container_16">
         %= breadcrumbs
         <div id="user-info" class="grid_6 omega">
-            %# Using a variable to avoid additional whitespaces
-            % if (current_user) {
-                %# Using a variable to avoid additional whitespaces
-                % my $out = 'Logged in as '.current_user->name.' (';
-                % if (is_operator) {
-                    % $out = $out.link_to('manage API keys' => url_for('api_keys')).' | ';
-                % }
-                % if (is_admin) {
-                    % $out = $out.link_to('admin' => url_for('admin')).' | ';
-                % }
-                %= b($out.link_to('Logout' => url_for('logout') => 'data-method' => 'delete').')');
-            % } else {
-                %= link_to('Login' => url_for('login'));
-            % }
+            %= include 'layouts/subheader_user'
         </div>
     </div>
 

--- a/templates/layouts/subheader_user.html.ep
+++ b/templates/layouts/subheader_user.html.ep
@@ -1,0 +1,12 @@
+%# Using a variable to avoid additional whitespaces
+% if (current_user) {
+    %# Using a variable to avoid additional whitespaces
+    % my $out = 'Logged in as '. current_user->name.' (';
+    % if (is_operator) {
+        % $out = $out.link_to('manage API keys' => url_for('api_keys')).' | ';
+        % $out = $out.link_to('admin' => url_for('admin')).' | ';
+    % }
+    %= b($out.link_to('Logout' => url_for('logout') => 'data-method' => 'delete').')');
+    % } else {
+    %= link_to('Login' => url_for('login'));
+% }

--- a/templates/test/running.html.ep
+++ b/templates/test/running.html.ep
@@ -14,9 +14,7 @@
     <div class="box box-shadow" id="actions_box" data-url="<%= url_for('apiv1_create_command', workerid => 'WORKERID') %>">
         <div class="box-header aligncenter">Actions</div>
         <div class="aligncenter">
-            %# TODO: to use can_be_duplicated we have to wait for https://progress.opensuse.org/issues/1393
-            %#       in the meantime, just check clone_id
-            % unless ($job->clone_id) {
+            % if ($job->can_be_duplicated) {
                 %= link_post url_for('apiv1_restart', jobid => $job->id) => ('data-remote' => 'true', id => 'restart_running') => begin
                   %= image '/images/toggle.png', alt => "restart", title => "Restart job"
                 % end


### PR DESCRIPTION
I am repeating myself here: DRY!

Fixes an irregularity introduced with 7e5333ba for operators not having access
to the "operators page" using the admin link depending on the template being
used for individual subpages, e.g. for edit, running, src, screenshot view.
I am sure this was not intended.