### PR TITLE
Fix bootstrap tooltips in testresults

### DIFF
--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -2,6 +2,7 @@
 % title $job->name . " test results";
 
 % content_for 'ready_function' => begin
+    $('[data-toggle="tooltip"]').tooltip({html: true});
     $('.timeago').timeago();
     setupResultButtons();
 % end


### PR DESCRIPTION
`$('[data-toggle="tooltip"]').tooltip({html: true})` must be called to enable bootstrap tooltips (like in overview.js).
