### PR TITLE
Distinguish product and test issues bugref

### DIFF
--- a/assets/stylesheets/openqa.css
+++ b/assets/stylesheets/openqa.css
@@ -416,6 +416,7 @@ table.overview .failedmodule {
 .fa.module_none { color:#bebebe;}
 
 .fa.comment, .fa.bookmark, .fa.bug, .fa.certificate, .fa.tag { color: Grey; }
+.fa-bolt { color: #FFBF00; } /* Amber */
 
 table#users td.role {
     white-space: nowrap;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -57,6 +57,12 @@ sub register {
             return;
         });
 
+    $app->helper(
+        bugicon_for => sub {
+            my ($c, $text) = @_;
+            return ($text =~ /poo#/) ? 'label_bug fa fa-bolt' : 'label_bug fa fa-bug';
+        });
+
     # Breadcrumbs generation can be centralized, since it's really simple
     $app->helper(
         breadcrumbs => sub {

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -240,6 +240,12 @@ $get = $t->get_ok($driver->get_current_url())->status_is(200);
 is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href}, 'https://bugzilla.suse.com/show_bug.cgi?id=1234');
 $driver->find_element('opensuse', 'link_text')->click();
 is($driver->find_element('.fa-certificate', 'css')->get_attribute('title'), 'Reviewed (1 comments)', 'build should be marked as labeled');
+$driver->get($baseurl . 'tests/99926#comments');
+$driver->find_element('#text',                 'css')->send_keys('poo#9876');
+$driver->find_element('#submitComment',        'css')->click();
+$driver->find_element('Build87.5011@opensuse', 'link_text')->click();
+is($driver->find_element('#res_staging_e_x86_64_minimalx .fa-bolt', 'css')->get_attribute('title'), 'Bug(s) referenced: poo#9876', 'bolt icon shown for progress issues');
+$driver->find_element('opensuse', 'link_text')->click();
 
 #
 # do tests for editing when logged in as regular user(group overview)

--- a/templates/test/tr_job_result_details.html.ep
+++ b/templates/test/tr_job_result_details.html.ep
@@ -4,7 +4,7 @@
 % if ($bug) {
     <span id="bug-<%= $jobid %>">
         <a href="<%= bugurl_for $bug %>">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: <%= $bug %>"></i>
+            <i class="test-label <%= bugicon_for $bug %>" title="Bug(s) referenced: <%= $bug %>"></i>
         </a>
     </span>
 % }


### PR DESCRIPTION
Progress is used to track test issues, bugzilla for product issues, at least
for SUSE/openSUSE. This might be a lot different for other groups so a more
flexible approach could be thought of but probably it is not as easy as
just distinguishing on the issue tracker URL being used, e.g. if a group
uses just one issue tracker but different components or issue types to
differentiate, it is not that easy. That is why this simple solution is
done here, first. At least others can follow the approach and have a test
and CSS rule available ;-)

Example screenshot:
![openqa_bolt_icon_for_progress_issue](https://cloud.githubusercontent.com/assets/1693432/15814910/e4e74bf6-2bc9-11e6-83de-20f18a7494de.png)

*Alternative 1*: Inverted bug icon, vote for this, if you like it more than what has been currently implemented:
![openqa_inverted_red_bug_for_progress_issue](https://cloud.githubusercontent.com/assets/1693432/15814911/e4e8e880-2bc9-11e6-822f-83b92a51b605.png)
