### PR TITLE
Fix unobtrusive scripting by reincluding jquery-ujs

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -43,15 +43,7 @@
 < javascripts/openqa.js
 < https://cdn.datatables.net/1.10.12/js/jquery.dataTables.js
 < http://timeago.yarp.com/jquery.timeago.js
-< javascripts/admintable.js
-< javascripts/admin_user.js
-< javascripts/admin_needle.js
-< javascripts/audit_log.js
 < javascripts/tests.js
-< javascripts/assets.js
-< javascripts/job_templates.js
-< javascripts/overview.js
-< javascripts/comments.js
 
 ! bootstrap.js
 < http://code.jquery.com/jquery-1.12.4.js
@@ -74,4 +66,5 @@
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap/transition.js
 < http://harvesthq.github.io/chosen/chosen.jquery.js
+< https://cdnjs.cloudflare.com/ajax/libs/jquery-ujs/1.2.1/rails.js
 


### PR DESCRIPTION
This is actually a technique from the rails stack, but we can easily use it
in mojoliocus too. I just wasn't aware we relied on it (as we have no phantomjs
test cases for it)