### PR TITLE
Show more intuitive finished time on finished jobs

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -131,7 +131,7 @@ sub list_ajax {
     my $jobs = $self->db->resultset("Jobs")->search(
         {'me.id' => {in => \@ids}},
         {
-            columns  => [qw/me.id state clone_id test result group_id t_created/],
+            columns  => [qw/me.id state clone_id test result group_id t_finished/],
             order_by => ['me.id DESC'],
             prefetch => [qw/children parents/],
         });
@@ -162,7 +162,7 @@ sub list_ajax {
             flavor  => $js->{FLAVOR}  // '',
             arch    => $js->{ARCH}    // '',
             build   => $js->{BUILD}   // '',
-            testtime => $job->t_created,
+            testtime => $job->t_finished,
             result   => $job->result,
             group    => $job->group_id,
             state    => $job->state

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -68,7 +68,7 @@ my @tds = $driver->find_child_elements($job99946, "td");
 is((shift @tds)->get_text(), 'Build0091 of opensuse-13.1-DVD.i586', "medium of 99946");
 is((shift @tds)->get_text(), 'textmode@32bit',                      "test of 99946");
 is((shift @tds)->get_text(), '29 1',                                "result of 99946");
-like((shift @tds)->get_text(), qr/a minute ago/, "time of 99946");
+like((shift @tds)->get_text(), qr/about 3 hours ago/, "finish time of 99946");
 
 # Test 99963 is still running
 isnt($driver->find_element('#running #job_99963', 'css'), undef, '99963 still running');


### PR DESCRIPTION
't_finished' is more meaningful for "finished" jobs than 't_created' which
would be the time when the job was initially scheduled but not yet started.

Fixes https://progress.opensuse.org/issues/12238