### PR TITLE
Don't sort undef (avoid warning and empty dot in tooltip)

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -908,9 +908,9 @@ sub failed_modules_with_needles {
             for my $needle (@{$detail->{needles}}) {
                 push @needles, [$needle->{name}, $counter];
             }
-            if (!@{$detail->{needles}}) {
-                push @needles, [undef, $counter];
-            }
+        }
+        if (!@needles) {
+            push @needles, [undef, $counter];
         }
         $failedmodules->{$module->name} = \@needles;
     }


### PR DESCRIPTION
The undef is only meant as last resort not as part of a list, so the
template either expects undef and a counter or a list, not a mix.