### PR TITLE
Always finish tagged aka. 'important' builds

### DIFF
--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -117,12 +117,13 @@ $t->app->db->resultset("Jobs")->find(99928)->comments->create({text => 'any text
 # schedule the iso, this should not actually be possible. Only isos
 # with different name should result in new tests...
 my $expected = qr/START_AFTER_TEST=.* not found - check for typos and dependency cycles/;
-my @warnings = warnings { $ret = $t->post_ok('/api/v1/isos', form => {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})->status_is(200) };
+my $res;
+my @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'}) };
 is(scalar @warnings, 2, 'two warnings expected');
 map { like($_, $expected) } @warnings;
 
-is($ret->tx->res->json->{count}, 10, "10 new jobs created");
-my @newids = @{$ret->tx->res->json->{ids}};
+is($res->json->{count}, 10, "10 new jobs created");
+my @newids = @{$res->json->{ids}};
 my $newid  = $newids[0];
 
 
@@ -187,23 +188,23 @@ $ret = $t->get_ok("/api/v1/jobs/$newid")->status_is(200);
 is($ret->tx->res->json->{job}->{state}, 'cancelled', "job $newid is cancelled");
 
 # make sure we can't post invalid parameters
-$ret = $t->post_ok('/api/v1/isos', form => {iso => $iso, tests => "kde/usb"})->status_is(400);
+$res = schedule_iso({iso => $iso, tests => "kde/usb"}, 400);
 
 # handle list of tests
-my $iso2 = 'openSUSE-13.1-DVD-i586-Build0091-Media.iso';
-$ret = $t->post_ok(
-    '/api/v1/isos',
-    form => {
-        ISO     => $iso2,
+$res = schedule_iso(
+    {
+        ISO     => $iso,
         DISTRI  => 'opensuse',
         VERSION => '13.1',
         FLAVOR  => 'DVD',
         ARCH    => 'i586',
         TEST    => 'server,kde,textmode',
         BUILD   => '0091'
-    })->status_is(200);
+    },
+    200
+);
 
-is($ret->tx->res->json->{count}, 4, "4 new jobs created (one twice for both machine types)");
+is($res->json->{count}, 4, "4 new jobs created (one twice for both machine types)");
 
 # delete the iso
 # can not do as operator
@@ -215,6 +216,29 @@ $t->app($app);
 $ret = $t->delete_ok("/api/v1/isos/$iso")->status_is(200);
 # now the jobs should be gone
 $ret = $t->get_ok('/api/v1/jobs/$newid')->status_is(404);
+
+subtest 'jobs belonging to important builds are not cancelled by new iso post' => sub {
+    $ret = $t->get_ok('/api/v1/jobs/99963')->status_is(200);
+    is($ret->tx->res->json->{job}->{state}, 'running', 'job in build 0091 running');
+    my $tag = 'tag:0091:important';
+    $t->app->db->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
+    @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'}) };
+    is(scalar @warnings,    2,  'two warnings expected');
+    is($res->json->{count}, 10, '10 jobs created');
+    $ret = $t->get_ok('/api/v1/jobs/99992')->status_is(200);
+    is($ret->tx->res->json->{job}->{state}, 'scheduled');
+    @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0092'}) };
+    is(scalar @warnings, 2, 'two warnings expected');
+    $ret = $t->get_ok('/api/v1/jobs/99992')->status_is(200);
+    is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job in old important build still scheduled');
+    @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0093'}) };
+    is(scalar @warnings, 2, 'two warnings expected');
+    $ret = $t->get_ok('/api/v1/jobs?state=scheduled');
+    my @jobs = @{$ret->tx->res->json->{jobs}};
+    lj;
+    ok(!grep({ $_->{settings}->{BUILD} =~ '009[2]' } @jobs), 'no jobs from intermediate, not-important build');
+    is(scalar @jobs, 21, 'only the important jobs, jobs from the current build and the important build are scheduled');
+};
 
 $t->app->config->{global}->{download_domains} = 'localhost';
 


### PR DESCRIPTION
All tests in a build that has been tagged are not obsoleted if a new build
is triggered. Actually any tag is regarded as 'important' but if it has been
tagged there is not much lost if we finish this build. The obsoletion feature
is especially important for fast paced re-scheduling when no one cares to
put a comment anywhere.

As a tag comment can be created at any time regardless if the corresponding
build exists or not builds to come can be marked to be important already
upfront.

Related progress issue: https://progress.opensuse.org/issues/11072