### PR TITLE
Harmonize use of MACHINE in 'name' of job

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -176,7 +176,8 @@ sub name {
             push @a, sprintf(($formats{$c} || '%s'), $job_settings->{$c});
         }
         my $name = join('-', @a);
-        $name =~ s/[^a-zA-Z0-9._+:-]/_/g;
+        $name .= ('@' . $job_settings->{MACHINE}) if $job_settings->{MACHINE};
+        $name =~ s/[^a-zA-Z0-9@._+:-]/_/g;
         $self->{_name} = $name;
     }
     return $self->{_name};

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -102,7 +102,7 @@ my %settings = (
 my $job_ref = {
     t_finished => undef,
     id         => 1,
-    name       => 'Unicorn-42-pink-x86_64-Build666-rainbow',
+    name       => 'Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
     priority   => 40,
     result     => 'none',
     settings   => {
@@ -117,7 +117,7 @@ my $job_ref = {
         KVM         => "KVM",
         MACHINE     => "RainbowPC",
         ARCH        => 'x86_64',
-        NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow',
+        NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
     },
     assets => {
         iso => ['whatever.iso'],
@@ -180,7 +180,7 @@ my $jobs = [
     {
         t_finished => undef,
         id         => 1,
-        name       => 'Unicorn-42-pink-x86_64-Build666-rainbow',
+        name       => 'Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
         priority   => 40,
         result     => 'none',
         t_started  => undef,
@@ -202,7 +202,7 @@ my $jobs = [
             KVM         => "KVM",
             MACHINE     => "RainbowPC",
             ARCH        => 'x86_64',
-            NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow',
+            NAME        => '00000001-Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC',
         },
         assets => {
             iso => ['whatever.iso'],
@@ -279,7 +279,7 @@ ok(!$grabed->{settings}->{JOBTOKEN}, "job token no longer present");
 $grabed = OpenQA::Scheduler::Scheduler::job_grab(%args);
 isnt($job->id, $grabed->{id}, "new job grabbed");
 isnt($grabed->{settings}->{JOBTOKEN}, $job_ref->{settings}->{JOBTOKEN}, "job token differs");
-$job_ref->{settings}->{NAME} = '00000003-Unicorn-42-pink-x86_64-Build666-rainbow';
+$job_ref->{settings}->{NAME} = '00000003-Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC';
 
 ## update JOBTOKEN for isdeeply compare
 $job_ref->{settings}->{JOBTOKEN} = $grabed->{settings}->{JOBTOKEN};

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -33,19 +33,19 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # export all jobs
 my $r = $t->get_ok("/tests/export")->status_is(200);
 $t->content_type_is('text/plain');
-$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde is passed/);
-$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0 is none/);
+$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
+$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is none/);
 
 # filter
 $r = $t->get_ok("/tests/export?from=99981")->status_is(200);
 $t->content_type_is('text/plain');
-$t->content_unlike(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde is passed/);
-$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0 is none/);
+$t->content_unlike(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
+$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is none/);
 
 $r = $t->get_ok("/tests/export?to=99981")->status_is(200);
 $t->content_type_is('text/plain');
-$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde is passed/);
+$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
 # to is exclusiv
-$t->content_unlike(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0 is none/);
+$t->content_unlike(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is none/);
 
 done_testing();

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -100,7 +100,7 @@ is($driver->get($baseurl . "tests"), 1, "/tests gets");
 isnt($driver->find_element('#scheduled #job_99928', 'css'), undef, '99928 scheduled');
 is($driver->find_element('#scheduled #job_99928 td.test a', 'css')->get_attribute('href'), "$baseurl" . "tests/99928", 'right link');
 $driver->find_element('#scheduled #job_99928 td.test a', 'css')->click();
-is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-RAID1 test results', 'tests/99928 followed');
+is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-RAID1@32bit test results', 'tests/99928 followed');
 
 # return
 is($driver->get($baseurl . "tests"), 1, "/tests gets");
@@ -111,7 +111,7 @@ my $job99938 = $driver->find_element('#results #job_99946', 'css');
 is($driver->find_element('#results #job_99938 .test .status.result_failed', 'css')->get_text(), '', '99938 failed');
 is($driver->find_element('#results #job_99938 td.test a', 'css')->get_attribute('href'), "$baseurl" . "tests/99938", 'right link');
 $driver->find_element('#results #job_99938 td.test a', 'css')->click();
-is($driver->get_title(), 'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc test results', 'tests/99938 followed');
+is($driver->get_title(), 'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results', 'tests/99938 followed');
 
 # return
 is($driver->get($baseurl . "tests"), 1, "/tests gets");

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -80,7 +80,7 @@ sub goto_editpage() {
     like($driver->find_element('#user-info', 'css')->get_text(), qr/Logged in as Demo.*Logout/, "logged in as demo");
 
     $driver->get($baseurl . "tests/99946");
-    is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode test results', 'tests/99946 followed');
+    is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results', 'tests/99946 followed');
 
     $driver->find_element('installer_timezone', 'link_text')->click();
     is($driver->get_current_url(), $baseurl . "tests/99946/modules/installer_timezone/steps/1/src", "on src page for nstaller_timezone test");

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -210,7 +210,7 @@ subtest 'commenting in test results including labels' => sub {
     # navigate to comments tab of test result page
     $driver->find_element('Build0048', 'link_text')->click();
     $driver->find_element('.status',   'css')->click();
-    is($driver->get_title(), "openQA: opensuse-Factory-DVD-x86_64-Build0048-doc test results", "on test result page");
+    is($driver->get_title(), 'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results', "on test result page");
     switch_to_comments_tab(0);
 
     # do the same tests for comments as in the group overview

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -53,7 +53,7 @@
         % }
         <div class="panel <%= $panelclass %>" id="info_box">
             <div class="panel-heading">
-                Results for <%= $job->name %>@<%= $job->settings_hash->{MACHINE} %>
+                Results for <%= $job->name %>
             </div>
             <div class="panel-body">
                 <div>


### PR DESCRIPTION
$job->name is used in the result view where the MACHINE tag was added
explicitly. Also it is used for git commit messages. Adding the MACHINE should
not harm but makes the use of it more consistent.