### PR TITLE
IPC: Catch unavailable service properly

### DIFF
--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -24,6 +24,8 @@ use Net::DBus::Binding::Watch;
 
 use Mojo::IOLoop;
 use Data::Dump qw/pp/;
+use Try::Tiny;
+use Carp;
 
 use Scalar::Util qw/weaken/;
 
@@ -197,7 +199,14 @@ sub _get_fh_from_fd {
 
 sub _dispatch {
     my ($self, $target, $command, @data) = @_;
-    my $service = $self->{bus}->get_service(join('.', $openqa_prefix, $services{$target}));
+    my $service_name = join('.', $openqa_prefix, $services{$target});
+    my $service;
+    try {
+        $service = $self->{bus}->get_service($service_name);
+    }
+    catch {
+        confess "error getting ipc service: $_";
+    };
     my $object = $service->get_object('/' . $services{$target}, join('.', $openqa_prefix, $services{$target}));
     return $object->$command(@data);
 }

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -51,6 +51,11 @@ __PACKAGE__->has_many(properties => 'OpenQA::Schema::Result::WorkerProperties', 
 # TODO
 # INSERT INTO workers (id, t_created) VALUES(0, datetime('now'));
 
+sub name {
+    my ($self) = @_;
+    return $self->host . ":" . $self->instance;
+}
+
 sub seen(;$) {
     my ($self, $workercaps) = @_;
     $self->update({t_updated => now()});
@@ -137,7 +142,7 @@ sub info {
         id       => $self->id,
         host     => $self->host,
         instance => $self->instance,
-        status   => $self->status
+        status   => $self->status,
     };
     $settings->{properties} = {};
     for my $p ($self->properties->all) {

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -18,11 +18,24 @@ package OpenQA::WebAPI::Controller::Admin::Workers;
 use Mojo::Base 'Mojolicious::Controller';
 use OpenQA::Utils;
 
+sub _extend_info {
+    my ($w) = @_;
+    my $info = $w->info;
+    $info->{name}      = $w->name;
+    $info->{t_updated} = $w->t_updated;
+    return $info;
+}
+
 sub index {
     my ($self) = @_;
 
     my $workers = $self->db->resultset('Workers');
-    $self->stash(workers => $workers);
+    my %workers;
+    while (my $w = $workers->next) {
+        next unless $w->id;
+        $workers{$w->name} = _extend_info($w);
+    }
+    $self->stash(workers => \%workers);
 
     $self->render('admin/workers/index');
 }
@@ -30,8 +43,8 @@ sub index {
 sub show {
     my ($self) = @_;
 
-    my $worker = $self->db->resultset('Workers')->find($self->param('worker_id'));
-    $self->stash(worker => $worker);
+    my $w = $self->db->resultset('Workers')->find($self->param('worker_id'));
+    $self->stash(worker => _extend_info($w));
 
     $self->render('admin/workers/show');
 }

--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -23,32 +23,26 @@
                 </tr>
             </thead>
             <tbody>
-                % my %workers; # for sorting
-                % while (my $w = $workers->next) {
-                    % next unless $w->id;
-                    % my $workername = $w->host . ":" . $w->instance;
-                    % $workers{$workername} = $w;
-                % }
-                % for my $workername (sort keys %workers) {
-                    %   my $worker = $workers{$workername};
-                    <tr id="worker_<%= $worker->id %>" >
+                % for my $workername (sort keys $workers) {
+                    %   my $worker = $workers->{$workername};
+                    <tr id="worker_<%= $worker->{id} %>" >
                         <td class="worker">
-                            %= link_to( $workername => url_for('admin_worker_show', worker_id => $worker->id) )
+                            %= link_to( $workername => url_for('admin_worker_show', worker_id => $worker->{id}) )
                         </td>
                         <td class="status">
-                            % stash('worker', $worker);
+                            % stash(workername => $workername, worker => $worker);
                             %= include 'admin/workers/worker_status'
                         </td>
                         <td class="ws_connected">
-                            % if($worker->connected) {
+                            % if($worker->{connected}) {
                                 online
                             % } else {
                                 offline
                             % }
                         </td>
                         <td class="currentstep">
-                            % if(defined($worker->currentstep) && $worker->status eq 'running') {
-                                %= $worker->currentstep
+                            % if(defined($worker->{currentstep}) && $worker->{status} eq 'running') {
+                                %= $worker->{currentstep}
                             % }
                         </td>
                     </tr>

--- a/templates/admin/workers/show.html.ep
+++ b/templates/admin/workers/show.html.ep
@@ -1,5 +1,5 @@
 % layout 'bootstrap';
-% title "Worker " . $worker->host . ":" . $worker->instance;
+% title "Worker " . $worker->{name};
 
 % content_for 'ready_function' => begin
     $('.timeago').timeago();
@@ -14,9 +14,9 @@
 
     %= include 'layouts/info'
 
-    <div><span>Host: </span><%= $worker->host %></div>
-    <div><span>Instance: </span><%= $worker->instance %></div>
-    <div><span>Seen: </span><abbr class="timeago" title="<%= $worker->t_updated->datetime() %>Z"><%= format_time($worker->t_updated) %></abbr></div>
+    <div><span>Host: </span><%= $worker->{host} %></div>
+    <div><span>Instance: </span><%= $worker->{instance} %></div>
+    <div><span>Seen: </span><abbr class="timeago" title="<%= $worker->{t_updated}->datetime() %>Z"><%= format_time($worker->{t_updated}) %></abbr></div>
     <div><span>Status: </span>
         %= include 'admin/workers/worker_status'
     </div>
@@ -28,10 +28,10 @@
             <th>Value</th>
         </thead>
         <tbody>
-            % for my $p ( sort map { $_->key } $worker->properties->all ) {
+            % for my $k (sort keys $worker->{properties}) {
                 <tr>
-                    <td><%= $p %></td>
-                    <td><%= $worker->get_property($p) %></td>
+                    <td><%= $k %></td>
+                    <td><%= $worker->{properties}->{$k} %></td>
                 </tr>
             % }
         </tbody>

--- a/templates/admin/workers/worker_status.html.ep
+++ b/templates/admin/workers/worker_status.html.ep
@@ -1,15 +1,15 @@
-% if($worker->status eq 'idle') {
+% if($worker->{status} eq 'idle') {
     Idle
-% } elsif ($worker->status eq 'running')
+% } elsif ($worker->{status} eq 'running')
 % {
-    Working on job <%= link_to $worker->job->id, url_for('test', testid => $worker->job->id) %>
-% } elsif ($worker->status eq 'dead' && $worker->job )
+    Working on job <%= link_to $worker->{jobid}, url_for('test', testid => $worker->{jobid}) %>
+% } elsif ($worker->{status} eq 'dead' && $worker->{job} )
 % {
-    Dead with job <%= link_to $worker->job->id, url_for('test', testid => $worker->job->id) %>
+    Dead with job <%= link_to $worker->{jobid}, url_for('test', testid => $worker->{jobid}) %>
 % } else
 % {
     Dead
 % }
-% if($worker->status eq 'running' && defined($worker->currentstep) ) {
-    - <%= $worker->currentstep %>
+% if($worker->{status} eq 'running' && defined($worker->{currentstep}) ) {
+    - <%= $worker->{currentstep} %>
 % }


### PR DESCRIPTION
Fixes the problem that no real error was shown in the web UI in case of an
IPC, e.g. websockets, not being available.

The error message and backtrace from "confess" call actually end up in the
rendered error page.

Example screenshot:
![openqa_ipc_exception](https://cloud.githubusercontent.com/assets/1693432/15928816/8421cb20-2e49-11e6-988e-176c6238389b.png)
