### PR TITLE
Make fail/softfail thumbnails more eye-catching

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -19,6 +19,8 @@ $color-state-scheduled: #67A2B7;
 $color-state-cancelled: $color-module-none;
 $color-state-running: #8BDFFF;
 
+$border-style-fail: dashed;
+
 .build-dashboard {
 
         .progress-bar-passed {
@@ -118,6 +120,7 @@ td .resborder {
 
 .resborder_fail {
         border-color: $color-resborder-fail;
+        border-style: $border-style-fail;
 }
 
 .resborder_unk, .resborder_missing {
@@ -126,6 +129,7 @@ td .resborder {
 
 .resborder_softfail {
         border-color: $color-softfail;
+        border-style: $border-style-fail;
 }
 
 img.resborder_na {

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -47,7 +47,7 @@ $driver->get($baseurl . "tests/99946");
 is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results', 'tests/99946 followed');
 
 $driver->find_element('installer_timezone', 'link_text')->click();
-is($driver->get_current_url(), $baseurl . "tests/99946/modules/installer_timezone/steps/1/src", "on src page for nstaller_timezone test");
+is($driver->get_current_url(), $baseurl . "tests/99946/modules/installer_timezone/steps/1/src", "on src page for installer_timezone test");
 
 is($driver->find_element('.cm-comment', 'css')->get_text(), '#!/usr/bin/perl -w', "we have a perl comment");
 


### PR DESCRIPTION
For fail and softfail thumbnails the border style is additionally set so that
these important steps are even more distinguishable. This way the status can
be determined without relying on color. This change has been recommended by a
person with color vision deficiency. For softfail thumbnails the border is
dotted, for fail thumbnails the border is dashed to resemble the higher
importance of fail over softfail.

Example screenshot:

![openqa_dashed_fail_windows](https://cloud.githubusercontent.com/assets/1693432/15992388/174d0d82-30cb-11e6-85fb-e2c20285139d.png)