### PR TITLE
Add web UI controls to select 20/50/100/400 previous results

### DIFF
--- a/t/ui/16-tests_previous_results.t
+++ b/t/ui/16-tests_previous_results.t
@@ -42,5 +42,9 @@ is($build, '0091', 'build of previous job is shown');
 $get                     = $t->get_ok('/tests/99946?limit_previous=1#previous')->status_is(200);
 $previous_results_header = $t->tx->res->dom->at('#previous #scenario')->all_text;
 is($previous_results_header, q/Results for opensuse-13.1-DVD-i586-textmode@32bit, limited to 1/, 'can be limited with query parameter');
+my $more_results = $t->tx->res->dom->at('#previous #more_results');
+is($more_results->all_text, q{Show 20 / 50 / 100 / 400 previous results}, 'more results can be requested');
+$get = $t->get_ok($more_results->find('a[href]')->last->{href})->status_is(200);
+is($t->tx->res->dom->at('#previous #scenario')->all_text, q/Results for opensuse-13.1-DVD-i586-textmode@32bit, limited to 400/, 'limited to the selected number');
 
 done_testing();

--- a/templates/test/previous.html.ep
+++ b/templates/test/previous.html.ep
@@ -39,3 +39,8 @@
 </tbody>
 </table>
 </div>
+<div id="more_results">
+    Show
+    %= b join(' / ', map { link_to($_ => url_with->query(limit_previous => $_) . '#previous') } (20, 50, 100, 400));
+    previous results
+</div>


### PR DESCRIPTION
The query parameter 'limit_previous' allows to show more than the default 10
previous results on demand for some time. The current commit adds web UI
selections below the table of the previous build to reload the same page with
higher number of previous results on demand.

Example screenshot:
![openqa_limit_previous_results_gui_100percent_padded](https://cloud.githubusercontent.com/assets/1693432/16642470/7f3cf080-440b-11e6-84b2-0485b2fd1810.png)

