### PR TITLE
Some fixes for the new results / running page

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -16,7 +16,7 @@ function checkPreviewVisible(a, preview) {
   }
 }
 
-function previewSuccess(data) {
+function previewSuccess(data, force) {
   $('#preview_container_in').html(data);
   var a = $('.current_preview');
   var td = a.parent();
@@ -37,22 +37,19 @@ function previewSuccess(data) {
   pout.insertAfter(td.children('.links_a').eq(preview_offset));
 
   var pin = $('#preview_container_in');
-  if (pin.find('pre').length || pin.find('audio').length ) {
-    pin.find('pre, div').css('width', $('.links').width());
-  } else {
+  if (!(pin.find('pre').length || pin.find('audio').length)) {
     window.differ = new NeedleDiff('needle_diff', 1024, 768);
     setDiffScreenshot(window.differ, $('#preview_container_in #step_view').data('image'));
     setNeedle();
   }
   pin.css('left', -($('.result').width()+$('.component').width()+2*16));
   var tdWidth = $('.current_preview').parents('td').width();
-  pout.width(tdWidth).hide().fadeIn(
-    {
-      duration: 150,
-      complete: function() {
-	checkPreviewVisible(a, pin);
-      }
-    });
+  pout.width(tdWidth).hide().fadeIn({
+    duration: (force?0:150),
+    complete: function() {
+      checkPreviewVisible(a, pin);
+    }
+  });
 }
 
 function setResultHash(hash) {
@@ -77,7 +74,7 @@ function setCurrentPreview(a, force) {
     }
     a.addClass('current_preview');
     setResultHash(link.attr('href'));
-    $.get({ url: link.data('url'), success: previewSuccess}).fail(function() { setCurrentPreview(); });
+    $.get({ url: link.data('url'), success: function(data) { previewSuccess(data, force); }}).fail(function() { setCurrentPreview(); });
   }
   else {
     // hide

--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -7,7 +7,7 @@
 }
 
 #preview_container_in {
-    padding-top: 7px;
+    padding: 5px;
     position: absolute;
     right: 0;
     text-align: center;
@@ -33,7 +33,7 @@
     #audiodiv {
         padding-top: 10px;
         margin-bottom: 0;
-	border: none;
+        border: none;
         background-color: inherit;
     }
 
@@ -74,4 +74,10 @@
 #canholder {
     text-align: center;
     width: 100%;
+
+    // live view
+    canvas {
+        max-width: 100%;
+        border: #ddd 1px solid;
+    }
 }

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -70,8 +70,13 @@ ok($driver->find_element('#preview_container_out', 'css')->is_hidden(), "preview
 
 # test running view with Test::Mojo as phantomjs would get stuck on the
 # liveview/livelog forever
-my $t               = Test::Mojo->new('OpenQA::WebAPI');
-my $get             = $t->get_ok($baseurl . 'tests/99963')->status_is(200);
+my $t   = Test::Mojo->new('OpenQA::WebAPI');
+my $get = $t->get_ok($baseurl . 'tests/99963')->status_is(200);
+
+# test that only one tab is active when using step url
+my $num_active_tabs = $t->tx->res->dom->find('.tab-pane.active')->size;
+is($num_active_tabs, 1, 'only one tab visible at the same time');
+
 my $href_to_isosize = $t->tx->res->dom->at('.component a[href*=installer_timezone]')->{href};
 $t->get_ok($baseurl . ($href_to_isosize =~ s@^/@@r))->status_is(200);
 

--- a/templates/step/viewaudio.html.ep
+++ b/templates/step/viewaudio.html.ep
@@ -1,3 +1,1 @@
-<div class="panel panel-default" id="audiodiv">
-    <audio style="margin: 0 10px;" src="<%= url_for('test_file', filename => $module_detail->{'audio'}) %>" controls="controls"></audio>
-</div>
+<audio style="margin: 0 10px; padding-top: 10px;" src="<%= url_for('test_file', filename => $module_detail->{'audio'}) %>" controls="controls"></audio>

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -39,7 +39,7 @@
                 </div>
 
                 % if ($job->running_or_waiting) {
-                    <div role="tabpanel" class="tab-pane active" id="live">
+                    <div role="tabpanel" class="tab-pane" id="live">
                         %= include 'test/live'
                     </div>
                 % }


### PR DESCRIPTION
- Resize live canvas, when the layout is too small (css: max-width: 100%) (Progress 12390)
- Skip fadein animation for needle diff box on page resize
- Fix padding for text result box
- Remove audiodiv (not needed with new container anymore)
- Fix edge case where live and running tab content are both visible (when #step link was used)