### PR TITLE
Fix SQL query to query important jobs

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -653,7 +653,7 @@ sub job_cancel {
         # this might be even the tag 'not important' but not much is lost if
         # we still not cancel these builds
         my $groups_query = $scheduled_jobs->get_column('group_id')->as_query;
-        my @important_builds = grep defined, map { ($_->tag)[0] } schema->resultset("Comments")->search($groups_query);
+        my @important_builds = grep defined, map { ($_->tag)[0] } schema->resultset("Comments")->search({"me.group_id" => {-in => $groups_query}});
         my @unimportant_jobs;
         while (my $j = $jobs_to_cancel->next) {
             next if grep ($j->BUILD eq $_, @important_builds);


### PR DESCRIPTION
This works in test DB:
  SELECT * from jobs where (select group_id from jobs);

but gives an exception "where needs a boolean not a number" in
postgresql. (Unfortunately) this exception was caught rather
globally in ISO controller and only resulted in a "job couldn't be
cancelled" - which led to tons of builds with unfinished jobs