### PR TITLE
docs: Update OBS references

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -25,17 +25,19 @@ Installation
 
 The easiest way to install openQA is from packages. You can find openSUSE
 packages in OBS in the
-https://build.opensuse.org/project/show/devel:openQA[openQA] repository or
-the latest development version can also be found in OBS in the
-https://build.opensuse.org/project/show/devel:openQA[openQA:devel]
-repository. For Fedora, packages are available in the official repositories
-for Fedora 23 and later. Installation on these distributions is therefore
-pretty simple:
+https://build.opensuse.org/project/show/devel:openQA:stable[openQA:stable]
+repository.
+
+The the latest development version can also be found in OBS in the
+https://build.opensuse.org/project/show/devel:openQA[openQA:devel] repository.
+
+For Fedora, packages are available in the official repositories for Fedora 23
+and later. Installation on these distributions is therefore pretty simple:
 
 [source,sh]
 --------------------------------------------------------------------------------
-# openSUSE 13.2
-zypper ar -f obs://devel:openQA/openSUSE_13.2 openQA
+# openSUSE 13.2 (stable version)
+zypper ar -f obs://devel:openQA:stable/openSUSE_13.2 openQA
 zypper ar -f obs://devel:openQA:13.2/openSUSE_13.2 openQA-perl-modules
 
 # openSUSE Leap 42.1


### PR DESCRIPTION
openSUSE 13.2 is not provided anymore in the current development version but
only in the stable version.

I would prefer a version-agnostic reference, e.g.
http://software.opensuse.org/download.html?project=devel:openQA&package=openQA
could work but requires manual clicking in browsers and not simple command
line execution so I did not change this now.