### PR TITLE
limit_assets: when sizelimit is exceeded, remove more

### DIFF
--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -22,6 +22,7 @@ BEGIN {
 use strict;
 use warnings;
 use Data::Dump qw/pp dd/;
+use File::Path qw/remove_tree/;
 use Test::More;
 use Test::Warnings;
 use OpenQA::Scheduler::Scheduler qw/job_grab job_restart job_set_done/;
@@ -107,6 +108,8 @@ ok(job_set_done(jobid => $cloneA->id, result => 'passed'), 'cloneA job set to do
 # register asset and mark as created by cloneA
 my $ja = sprintf('%08d-%s', $cloneA->id, 'jobasset.raw');
 open(my $fh, '>', join('/', $OpenQA::Utils::assetdir, 'hdd', $ja));
+# give it some content to test ensure_size
+print $fh "foobar";
 close($fh);
 $ja = $schema->resultset('Assets')->create(
     {
@@ -135,5 +138,39 @@ is_deeply(\@assets, [$theasset, $ja->id], 'using correct assets');
 # check jobB was also duplicated
 $jobB->discard_changes();
 ok($jobB->clone, 'jobB has a clone after cloning asset creator');
+
+# create a repo asset for the following tests
+my $repo = join('/', $OpenQA::Utils::assetdir, 'repo', 'testrepo');
+# ensure no leftovers from previous testing
+remove_tree($repo);
+# create the dir
+mkdir($repo);
+# create some test content to test nested dir size discovery
+my $testdir = join('/', $repo, 'testdir');
+mkdir($testdir);
+open($fh, '>', join('/', $repo, 'testfile'));
+print $fh 'foobar';
+close($fh);
+open($fh, '>', join('/', $testdir, 'testfile2'));
+print $fh 'meep';
+close($fh);
+$repo = $schema->resultset('Assets')->create(
+    {
+        name => 'testrepo',
+        type => 'repo',
+    });
+
+# test ensure_size
+is($ja->ensure_size(),   6,  'ja asset size should be 6');
+is($repo->ensure_size(), 10, 'repo asset size should be 10');
+
+# test remove_from_disk
+$ja->remove_from_disk();
+$repo->remove_from_disk();
+ok(!-e $ja,   "ja asset should have been removed");
+ok(!-e $repo, "repo asset should have been removed");
+
+# for safety
 unlink($ja->disk_file);
+remove_tree($repo->disk_file);
 done_testing();

--- a/t/data/openqa/factory/repo/.gitignore
+++ b/t/data/openqa/factory/repo/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
We still occasionally seem to hit edge cases with this. When I wrote this patch
we had a lot of jobs running simultaneously and one uploaded
hdd image went missing, even though we've reduced the number of
tests that upload images as far as possible and upped the asset
size limit to 300GB. I think this may help deal with it. This
makes limit_assets reduce total asset size to 80% of the limit
when the limit is exceeded, instead of just removing enough to
get back under the limit (which, if you think about it, means
any long-lived openQA instance is perpetually teetering on the
brink of exceeding its asset size limit). This way there's a
bit of breathing room each time the size limit is hit, so it
doesn't immediately get hit *again* the next time any ISO is
downloaded or hdd image uploaded.

I've had this change live on Fedora's openQA since April and it hasn't broken anything AFAICT, and it does seem to be preventing mysterious uploaded image disappearances.