### PR TITLE
Use correct job result in openqa events

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -94,18 +94,6 @@ sub command_enqueue_checked {
 }
 
 ## Jobs
-dbus_method('job_cancel', ['uint32', 'bool'], ['uint32']);
-sub job_cancel {
-    my ($self, $jobid, $newbuild) = @_;
-    return OpenQA::Scheduler::Scheduler::job_cancel($jobid, $newbuild);
-}
-
-dbus_method('job_cancel_by_settings', [['dict', 'string', 'string'], 'bool'], ['uint32']);
-sub job_cancel_by_settings {
-    my ($self, $settings, $newbuild) = @_;
-    return OpenQA::Scheduler::Scheduler::job_cancel($settings, $newbuild);
-}
-
 dbus_method('job_duplicate', [['dict', 'string', 'string']], ['uint32']);
 sub job_duplicate {
     my ($self, $args) = @_;
@@ -131,12 +119,6 @@ sub job_restart {
     my ($self, $args) = @_;
     my @res = OpenQA::Scheduler::Scheduler::job_restart($args);
     return \@res;
-}
-
-dbus_method('job_set_done', [['dict', 'string', 'string']], ['string']);
-sub job_set_done {
-    my ($self, $args) = @_;
-    return OpenQA::Scheduler::Scheduler::job_set_done(%$args);
 }
 
 dbus_method('job_update_status', ['uint32', ['dict', 'string', ['variant']]], ['uint32']);

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -79,20 +79,6 @@ sub asset_register {
     return $rs->id;
 }
 
-## Worker commands
-dbus_method('command_enqueue', [['dict', 'string', 'string']], ['bool']);
-sub command_enqueue {
-    my ($self, $args) = @_;
-    return OpenQA::Scheduler::Scheduler::command_enqueue(%$args);
-}
-
-# this is here for legacy reasons, command_enqueue is the command_enqueue_checked
-dbus_method('command_enqueue_checked', [['dict', 'string', 'uint32']], ['bool']);
-sub command_enqueue_checked {
-    my ($self, $args) = @_;
-    return OpenQA::Scheduler::Scheduler::command_enqueue(%$args);
-}
-
 ## Jobs
 dbus_method('job_duplicate', [['dict', 'string', 'string']], ['uint32']);
 sub job_duplicate {

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -133,7 +133,7 @@ sub job_restart {
     return \@res;
 }
 
-dbus_method('job_set_done', [['dict', 'string', 'string']], ['uint32']);
+dbus_method('job_set_done', [['dict', 'string', 'string']], ['string']);
 sub job_set_done {
     my ($self, $args) = @_;
     return OpenQA::Scheduler::Scheduler::job_set_done(%$args);

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -423,7 +423,8 @@ sub job_set_done {
         # free the worker
         $job->worker->update({job_id => undef});
     }
-    my $r = $job->update(\%new_val);
+
+    $job->update(\%new_val);
 
     if ($result ne OpenQA::Schema::Result::Jobs::PASSED) {
         _job_skip_children($jobid);
@@ -431,7 +432,8 @@ sub job_set_done {
         # labels are there to mark reasons of failure
         $job->carry_over_labels;
     }
-    return $r;
+
+    return $result;
 }
 
 =head2 job_set_waiting

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -397,7 +397,7 @@ sub job_duplicate {
         });
 
     while (my $j = $jobs->next) {
-        next unless $job->worker;
+        next unless $j->worker;
         log_debug("enqueuing abort for " . $j->id . " " . $j->worker_id);
         $j->worker->send_command(command => 'abort', job_id => $j->id);
     }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1271,20 +1271,20 @@ sub store_column {
 
 # parent job failed, handle scheduled children - set them to done incomplete immediately
 sub _job_skip_children {
-    my ($self)   = @_;
-    my $children = $self->children;
-    my $count    = $children->search(
+    my ($self) = @_;
+    my $jobs = $self->children->search(
         {
             'child.state' => SCHEDULED,
         },
-        {join => 'child'}
-      )->update_all(
-        {
-            'child.state'  => CANCELLED,
-            'child.result' => SKIPPED,
-        });
+        {join => 'child'});
 
-    while (my $j = $children->next) {
+    my $count = 0;
+    while (my $j = $jobs->next) {
+        $j->update(
+            {
+                'child.state'  => CANCELLED,
+                'child.result' => SKIPPED,
+            });
         $count += $j->child->_job_skip_children;
     }
     return $count;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1269,5 +1269,121 @@ sub store_column {
     return $self->SUPER::store_column(%args);
 }
 
+# parent job failed, handle scheduled children - set them to done incomplete immediately
+sub _job_skip_children {
+    my ($self)   = @_;
+    my $children = $self->children;
+    my $count    = $children->search(
+        {
+            'child.state' => SCHEDULED,
+        },
+        {join => 'child'}
+      )->update_all(
+        {
+            'child.state'  => CANCELLED,
+            'child.result' => SKIPPED,
+        });
+
+    while (my $j = $children->next) {
+        $count += $j->child->_job_skip_children;
+    }
+    return $count;
+}
+
+# parent job failed, handle running children - send stop command
+sub _job_stop_children {
+    my ($self) = @_;
+
+    my $children = $self->children->search(
+        {
+            dependency    => OpenQA::Schema::Result::JobDependencies->PARALLEL,
+            'child.state' => [EXECUTION_STATES],
+        },
+        {join => 'child'});
+
+    my $count = 0;
+    my $jobs  = $children->search(
+        {
+            result => NONE,
+        });
+    while (my $j = $jobs->next) {
+        $j->child->update(
+            {
+                result => PARALLEL_FAILED,
+            });
+        $count += 1;
+    }
+
+    while (my $j = $children->next) {
+        $j->child->worker->send_command(command => 'cancel', job_id => $j->child->id);
+        $count += $j->child->_job_stop_children;
+    }
+    return $count;
+}
+
+=head2 done
+
+Finalize job by setting it as DONE.
+
+Accepted optional arguments:
+  newbuild => 0/1
+  result   => see RESULTS
+
+newbuild set marks build as OBSOLETED
+if result is not set (expected default situation) result is computed from the results of individual
+test modules
+
+=cut
+sub done {
+    my ($self, %args) = @_;
+    my $newbuild = 0;
+    $newbuild = int($args{newbuild}) if defined $args{newbuild};
+    $args{result} = OBSOLETED if $newbuild;
+
+    # cleanup
+    $self->set_property('JOBTOKEN');
+    $self->release_networks();
+    $self->owned_locks->delete;
+    $self->locked_locks->update({locked_by => undef});
+    if ($self->worker) {
+        # free the worker
+        $self->worker->update({job_id => undef});
+    }
+
+    # update result if not provided
+    my $result = $args{result} || $self->calculate_result();
+    my %new_val = (state => DONE);
+    # for cancelled jobs the result is already known
+    $new_val{result} = $result if $self->result eq NONE;
+
+    $self->update(\%new_val);
+
+    if ($result ne PASSED) {
+        $self->_job_skip_children;
+        $self->_job_stop_children;
+        # labels are there to mark reasons of failure
+        $self->carry_over_labels;
+    }
+    return $result;
+}
+
+sub cancel {
+    my ($self) = @_;
+
+    my $count = 1;
+    return if ($self->result ne NONE);
+    $self->update(
+        {
+            state  => CANCELLED,
+            result => USER_CANCELLED
+        });
+
+    if (grep { $self->state eq $_ } EXECUTION_STATES) {
+        $self->worker(command => 'cancel', job_id => $self->id);
+        $count += $self->_job_skip_children;
+        $count += $self->_job_stop_children;
+    }
+    return $count;
+}
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -301,5 +301,69 @@ sub complex_query {
     return $jobs;
 }
 
+sub cancel_by_settings {
+    my ($self, $settings, $newbuild) = @_;
+    my $rsource = $self->result_source;
+    my $schema  = $rsource->schema;
+    $newbuild //= 0;
+    my %cond;
+
+    for my $key (qw/DISTRI VERSION FLAVOR MACHINE ARCH BUILD TEST/) {
+        if (defined $settings->{$key}) {
+            $cond{$key} = delete $settings->{$key};
+        }
+    }
+    if (%$settings) {
+        my $subquery = $schema->resultset('JobSettings')->query_for_settings($settings);
+        $cond{id} = {-in => $subquery->get_column('job_id')->as_query};
+    }
+    $cond{state} = OpenQA::Schema::Result::Jobs::SCHEDULED;
+    my $scheduled_jobs = $schema->resultset('Jobs')->search(\%cond);
+    my $jobs_to_cancel;
+    my $new_result;
+    if ($newbuild) {
+        $new_result = OpenQA::Schema::Result::Jobs::OBSOLETED;
+        # 'monkey patch' cond to be useable in chained search
+        $cond{'me.id'} = delete $cond{id} if $cond{id};
+        # filter out all jobs that have any comment (they are considered 'important') ...
+        $jobs_to_cancel = $scheduled_jobs->search({'comments.job_id' => undef}, {join => 'comments'});
+        # ... or belong to a tagged build, i.e. is considered important
+        # this might be even the tag 'not important' but not much is lost if
+        # we still not cancel these builds
+        my $groups_query = $scheduled_jobs->get_column('group_id')->as_query;
+        my @important_builds = grep defined, map { ($_->tag)[0] } $schema->resultset('Comments')->search({'me.group_id' => {-in => $groups_query}});
+        my @unimportant_jobs;
+        while (my $j = $jobs_to_cancel->next) {
+            next if grep ($j->BUILD eq $_, @important_builds);
+            push @unimportant_jobs, $j->id;
+        }
+        # if there are only important jobs there is nothing left for us to do
+        return 0 unless @unimportant_jobs;
+        $jobs_to_cancel = $jobs_to_cancel->search({'me.id' => {-in => \@unimportant_jobs}});
+    }
+    else {
+        $new_result     = OpenQA::Schema::Result::Jobs::USER_CANCELLED;
+        $jobs_to_cancel = $scheduled_jobs;
+    }
+    # first cancel scheduled jobs
+    my $cancelled_jobs = $jobs_to_cancel->update_all(
+        {
+            state  => OpenQA::Schema::Result::Jobs::CANCELLED,
+            result => $new_result,
+        });
+
+    # then tell workers to cancel their jobs
+    $cond{state} = [OpenQA::Schema::Result::Jobs::EXECUTION_STATES];
+    while (my $j = $jobs_to_cancel->next) {
+        my $command = $newbuild ? 'obsolete' : 'cancel';
+        $j->worker->send_command(command => $command, job_id => $j->id);
+        $j->_job_skip_children;
+        $j->_job_stop_children;
+
+        ++$cancelled_jobs;
+    }
+    return $cancelled_jobs;
+}
+
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -23,6 +23,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &file_content
   &log_debug
   &log_warning
+  &log_error
   &save_base64_png
   &run_cmd_with_log
   &commit_git

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -339,7 +339,7 @@ sub schedule_iso {
         }
         if (%cond) {
             try {
-                OpenQA::Scheduler::Scheduler::job_cancel(\%cond, 1);    # have new build jobs instead
+                $self->db->resultset('Jobs')->cancel_by_settings(\%cond, 1);    # have new build jobs instead
             }
             catch {
                 my $error = shift;
@@ -500,7 +500,7 @@ sub cancel {
     my $ipc  = OpenQA::IPC->ipc;
     $self->emit_event('openqa_iso_cancel', {iso => $iso});
 
-    my $res = OpenQA::Scheduler::Scheduler::job_cancel({ISO => $iso}, 0);
+    my $res = $self->db->resultset('Jobs')->cancel_by_settings({ISO => $iso}, 0);
     $self->render(json => {result => $res});
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -262,7 +262,6 @@ sub job_create_dependencies {
 # internal function not exported - but called by create
 sub schedule_iso {
     my ($self, $args) = @_;
-    $self->emit_event('openqa_iso_create', $args);
     # register assets posted here right away, in case no job
     # templates produce jobs.
     for my $a (values %{parse_assets_from_settings($args)}) {
@@ -339,6 +338,7 @@ sub schedule_iso {
         }
         if (%cond) {
             try {
+                $self->emit_event('openqa_iso_cancel', \%cond);
                 $self->db->resultset('Jobs')->cancel_by_settings(\%cond, 1);    # have new build jobs instead
             }
             catch {
@@ -428,6 +428,7 @@ sub schedule_iso {
     catch {
         $self->app->log->warn("Failed to notify workers");
     };
+    $self->emit_event('openqa_iso_create', $args);
     return @ids;
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -277,7 +277,10 @@ sub done {
     else {
         $res = $ipc->scheduler('job_set_done', {jobid => $jobid, result => $result});
     }
-    $self->emit_event('openqa_job_done', {id => $jobid, result => $result, newbuild => $newbuild}) if ($res);
+
+    # use $res as a result, it is recomputed result by scheduler
+    $self->emit_event('openqa_job_done', {id => $jobid, result => $res, newbuild => $newbuild});
+
     # See comment in set_command
     $self->render(json => {result => \$res});
 }

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -23,7 +23,7 @@ use Mojo::IOLoop;
 use JSON ();
 
 my @table_events       = qw/table_create table_update table_delete/;
-my @job_events         = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_set_waiting job_set_running job_done job_grab/;
+my @job_events         = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_set_waiting job_set_running job_done job_grab job_cancel_by_settings/;
 my @jobgroup_events    = qw/jobgroup_create jobgroup_connect/;
 my @jobtemplate_events = qw/jobtemplate_create jobtemplate_delete/;
 my @user_events        = qw/user_update user_login user_comment/;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -227,7 +227,8 @@ sub register {
         emit_event => sub {
             my ($self, $event, $data) = @_;
             die 'Missing event name' unless $event;
-            return Mojo::IOLoop->singleton->emit($event, [$self->current_user->id, $self->tx->connection, $event, $data]);
+            my $user = $self->current_user ? $self->current_user->id : undef;
+            return Mojo::IOLoop->singleton->emit($event, [$user, $self->tx->connection, $event, $data]);
         });
 
     $app->helper(

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -183,16 +183,15 @@ sub _message {
         $ws->tx->send({json => $ret});
     }
     elsif ($json->{type} eq 'property_change') {
-        my $prop = $json->{propery};
-        my $value = $json->{value} ? 1 : 0;
-        if ($prop eq 'interactive_mode') {
-            $worker->set_property('INTERACTIVE_REQUESTED', $value);
+        my $prop = $json->{data};
+        if (defined $prop->{interactive_mode}) {
+            $worker->set_property('INTERACTIVE_REQUESTED', $prop->{interactive_mode} ? 1 : 0);
         }
-        elsif ($prop eq 'waitforneedle') {
-            $worker->set_property('STOP_WAITFORNEEDLE_REQUESTED', $value);
+        elsif (defined $prop->{waitforneedle}) {
+            $worker->set_property('STOP_WAITFORNEEDLE_REQUESTED', $prop->{waitforneedle} ? 1 : 0);
         }
         else {
-            $ws->app->log->error(sprintf('Unknown worker property "%s"', $prop));
+            $ws->app->log->error("Unknown property received from worker $workerid");
         }
     }
     else {

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -182,6 +182,19 @@ sub _message {
         my $ret = $job->update_status($status);
         $ws->tx->send({json => $ret});
     }
+    elsif ($json->{type} eq 'property_change') {
+        my $prop = $json->{propery};
+        my $value = $json->{value} ? 1 : 0;
+        if ($prop eq 'interactive_mode') {
+            $worker->set_property('INTERACTIVE_REQUESTED', $value);
+        }
+        elsif ($prop eq 'waitforneedle') {
+            $worker->set_property('STOP_WAITFORNEEDLE_REQUESTED', $value);
+        }
+        else {
+            $ws->app->log->error(sprintf('Unknown worker property "%s"', $prop));
+        }
+    }
     else {
         $ws->app->log->error(sprintf('Received unknown message type "%s" from worker %u', $json->{type}, $workerid));
     }

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -58,7 +58,7 @@ sub websocket_commands {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/stop_waitforneedle");
                 print "stop_waitforneedle triggered\n" if $verbose;
-                $tx->tx->send('waitforneedle', 1);
+                ws_call('property_change', {waitforneedle => 1});
             }
         }
         elsif ($type eq 'reload_needles_and_retry') {
@@ -71,21 +71,21 @@ sub websocket_commands {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=1");
                 print "interactive mode enabled\n" if $verbose;
-                $tx->tx->send('interactive_mode', 1);
+                ws_call('property_change', {interactive_mode => 1});
             }
         }
         elsif ($type eq 'disable_interactive_mode') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=0");
                 print "interactive mode disabled\n" if $verbose;
-                $tx->tx->send('interactive_mode', 0);
+                ws_call('property_change', {interactive_mode => 0});
             }
         }
         elsif ($type eq 'continue_waitforneedle') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/continue_waitforneedle");
                 print "waitforneedle will continue\n" if $verbose;
-                $tx->tx->send('waitforneedle', 0);
+                ws_call('property_change', {waitforneedle => 0});
             }
         }
         elsif ($type eq 'livelog_start') {

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -58,9 +58,10 @@ sub websocket_commands {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/stop_waitforneedle");
                 print "stop_waitforneedle triggered\n" if $verbose;
+                $tx->tx->send('waitforneedle', 1);
             }
         }
-        elsif ($type eq 'reload_needles_and_retry') {    #
+        elsif ($type eq 'reload_needles_and_retry') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/reload_needles");
                 print "needles will be reloaded\n" if $verbose;
@@ -70,18 +71,21 @@ sub websocket_commands {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=1");
                 print "interactive mode enabled\n" if $verbose;
+                $tx->tx->send('interactive_mode', 1);
             }
         }
         elsif ($type eq 'disable_interactive_mode') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=0");
                 print "interactive mode disabled\n" if $verbose;
+                $tx->tx->send('interactive_mode', 0);
             }
         }
         elsif ($type eq 'continue_waitforneedle') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/continue_waitforneedle");
                 print "waitforneedle will continue\n" if $verbose;
+                $tx->tx->send('waitforneedle', 0);
             }
         }
         elsif ($type eq 'livelog_start') {

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -318,7 +318,7 @@ sleep 1;
     result => 'passed',
 );
 $result = OpenQA::Scheduler::Scheduler::job_set_done(%args);
-ok($result, "job_set_done");
+is($result, 'passed', "job_set_done");
 $job = job_get($job_id);
 is($job->{state},  "done",   "job_set_done changed state");
 is($job->{result}, "passed", "job_set_done changed result");

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -40,8 +40,14 @@ sub list_jobs {
 
 sub job_get {
     my ($id) = @_;
-
     my $job = $schema->resultset("Jobs")->find({id => $id});
+    return $job;
+}
+
+sub job_get_hash {
+    my ($id) = @_;
+
+    my $job = job_get($id);
     return unless $job;
     my $ref = $job->to_hash(assets => 1);
     $ref->{worker_id} = $job->worker_id;
@@ -152,7 +158,7 @@ $settings2{BUILD} = "44";
 my $job2 = $schema->resultset('Jobs')->create_from_settings(\%settings2);
 
 $job->set_prio(40);
-my $new_job = job_get($job->id);
+my $new_job = job_get_hash($job->id);
 is_deeply($new_job, $job_ref, "job_get");
 
 # Testing list_jobs
@@ -272,8 +278,8 @@ ok($grabed->{t_started} =~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "job start tim
 is(scalar(@{$rjobs_before}) + 1, scalar(@{$rjobs_after}), "number of running jobs");
 
 $grabed = job_get($job->id);
-is($grabed->{worker_id}, $worker->{id}, "correct worker assigned");
-ok($grabed->{state} eq "running", "Job is in running state");    # After job_grab the job is in running state.
+is($grabed->worker->id, $worker->{id}, "correct worker assigned");
+ok($grabed->state eq "running", "Job is in running state");    # After job_grab the job is in running state.
 
 # register worker again while it has a running job
 $id2 = $c->_register($schema, "host", "1", $workercaps);
@@ -281,9 +287,9 @@ ok($id == $id2, "re-register worker got same id");
 
 # Now it's previous job must be set to done
 $grabed = job_get($job->id);
-is($grabed->{state},  "done",       "Previous job is in done state");
-is($grabed->{result}, "incomplete", "result is incomplete");
-ok(!$grabed->{settings}->{JOBTOKEN}, "job token no longer present");
+is($grabed->state,  "done",       "Previous job is in done state");
+is($grabed->result, "incomplete", "result is incomplete");
+ok(!$grabed->settings_hash->{JOBTOKEN}, "job token no longer present");
 
 $grabed = OpenQA::Scheduler::Scheduler::job_grab(%args);
 isnt($job->id, $grabed->{id}, "new job grabbed");
@@ -300,30 +306,27 @@ my $job_id  = $grabed->{id};
 # Testing job_set_waiting
 $result = OpenQA::Scheduler::Scheduler::job_set_waiting($job_id);
 $job    = job_get($job_id);
-ok($result == 1 && $job->{state} eq "waiting", "job_set_waiting");
+ok($result == 1 && $job->state eq "waiting", "job_set_waiting");
 
 # Testing job_set_running
 $result = OpenQA::Scheduler::Scheduler::job_set_running($job_id);
 $job    = job_get($job_id);
-ok($result == 1 && $job->{state} eq "running", "job_set_running");
+ok($result == 1 && $job->state eq "running", "job_set_running");
 $result = OpenQA::Scheduler::Scheduler::job_set_running($job_id);
 $job    = job_get($job_id);
-ok($result == 0 && $job->{state} eq "running", "Retry job_set_running");
+ok($result == 0 && $job->state eq "running", "Retry job_set_running");
 
 
 sleep 1;
 # Testing job_set_done
-%args = (
-    jobid  => $job_id,
-    result => 'passed',
-);
-$result = OpenQA::Scheduler::Scheduler::job_set_done(%args);
+$job = job_get($job_id);
+$result = $job->done(result => 'passed');
 is($result, 'passed', "job_set_done");
 $job = job_get($job_id);
-is($job->{state},  "done",   "job_set_done changed state");
-is($job->{result}, "passed", "job_set_done changed result");
-ok($job->{t_finished} =~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "job end timestamp updated");
-ok(!$job->{settings}->{JOBTOKEN},                               "job token not present after job done");
+is($job->state,  "done",   "job_set_done changed state");
+is($job->result, "passed", "job_set_done changed result");
+ok($job->t_finished =~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "job end timestamp updated");
+ok(!$job->settings_hash->{JOBTOKEN},                          "job token not present after job done");
 
 %args = (result => "passed");
 $current_jobs = list_jobs(%args);
@@ -342,18 +345,18 @@ is(scalar @{$current_jobs}, 1, "there is one passed job listed");
 # Testing job_set_waiting on job not in running state
 $result = OpenQA::Scheduler::Scheduler::job_set_waiting($job_id);
 $job    = job_get($job_id);
-ok($result == 0 && $job->{state} eq "done", "job_set_waiting on done job");
+ok($result == 0 && $job->state eq "done", "job_set_waiting on done job");
 
 
 # Testing job_set_running on done job
 $result = OpenQA::Scheduler::Scheduler::job_set_running($job_id);
 $job    = job_get($job_id);
-ok($result == 0 && $job->{state} eq "done", "job_set_running on done job");
+ok($result == 0 && $job->state eq "done", "job_set_running on done job");
 
 # Testing set_prio
 $schema->resultset('Jobs')->find($job_id)->set_prio(100);
 $job = job_get($job_id);
-is($job->{priority}, 100, "job->set_prio");
+is($job->priority, 100, "job->set_prio");
 
 # Testing job_restart
 # TBD

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -76,7 +76,7 @@ is($job->state, 'cancelled', "new job is cancelled");
 ok($job->t_finished, "There is a finish time");
 
 $job = job_get(99963);
-is($job->state, 'running', "old job still running");
+is($job->state, 'cancelled', "old job cancelled as well");
 
 $job = job_get(99928);
 is($job->state, 'scheduled', "unrelated job 99928 still scheduled");

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -174,7 +174,7 @@ is($job->{settings}->{NICVLAN}, 1,         "same vlan for whole group");
 
 # jobA failed
 my $result = OpenQA::Scheduler::Scheduler::job_set_done(jobid => $jobA->id, result => 'failed');
-ok($result, "job_set_done");
+is($result, 'failed', 'job_set_done');
 
 # then jobD and jobE, workers 5 and 6 must be canceled
 #$ws5->message_ok;
@@ -184,10 +184,10 @@ ok($result, "job_set_done");
 #$ws6->message_is('cancel');
 
 $result = OpenQA::Scheduler::Scheduler::job_set_done(jobid => $jobD->id, result => 'incomplete');
-ok($result, "job_set_done");
+is($result, 'incomplete', 'job_set_done');
 
 $result = OpenQA::Scheduler::Scheduler::job_set_done(jobid => $jobE->id, result => 'incomplete');
-ok($result, "job_set_done");
+is($result, 'incomplete', 'job_set_done');
 
 
 $job = job_get_deps($jobA->id);

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -42,11 +42,19 @@ sub list_jobs {
     [map { $_->to_hash(assets => 1) } $schema->resultset('Jobs')->complex_query(%args)->all];
 }
 
-sub job_get_deps {
+sub job_get {
     my ($id) = @_;
+    return $schema->resultset('Jobs')->find($id);
+}
 
+sub job_get_deps_rs {
+    my ($id) = @_;
     my $job = $schema->resultset("Jobs")->search({'me.id' => $id}, {prefetch => ['settings', 'parents', 'children']})->first;
-    return $job->to_hash(deps => 1);
+    return $job;
+}
+
+sub job_get_deps {
+    return job_get_deps_rs(@_)->to_hash(deps => 1);
 }
 
 my $current_jobs = list_jobs();
@@ -97,7 +105,10 @@ $settingsE{TEST} = 'E';
 $settingsF{TEST} = 'F';
 
 sub _job_create {
-    return $schema->resultset('Jobs')->create_from_settings(@_);
+    my $job = $schema->resultset('Jobs')->create_from_settings(@_);
+    # reload all values from database so we can check against default values
+    $job->discard_changes;
+    return $job;
 }
 
 my $jobA = _job_create(\%settingsA);
@@ -173,7 +184,7 @@ is($job->{id},                  $jobE->id, "jobE");                        # C a
 is($job->{settings}->{NICVLAN}, 1,         "same vlan for whole group");
 
 # jobA failed
-my $result = OpenQA::Scheduler::Scheduler::job_set_done(jobid => $jobA->id, result => 'failed');
+my $result = $jobA->done(result => 'failed');
 is($result, 'failed', 'job_set_done');
 
 # then jobD and jobE, workers 5 and 6 must be canceled
@@ -183,12 +194,14 @@ is($result, 'failed', 'job_set_done');
 #$ws6->message_ok;
 #$ws6->message_is('cancel');
 
-$result = OpenQA::Scheduler::Scheduler::job_set_done(jobid => $jobD->id, result => 'incomplete');
+# reload changes from DB - jobs should be cancelled by failed jobA
+$jobD->discard_changes;
+$jobE->discard_changes;
+# this should not change the result which is parallel_failed due to failed jobA
+$result = $jobD->done(result => 'incomplete');
 is($result, 'incomplete', 'job_set_done');
-
-$result = OpenQA::Scheduler::Scheduler::job_set_done(jobid => $jobE->id, result => 'incomplete');
+$result = $jobE->done(result => 'incomplete');
 is($result, 'incomplete', 'job_set_done');
-
 
 $job = job_get_deps($jobA->id);
 is($job->{state},  "done",   "job_set_done changed state");
@@ -401,7 +414,7 @@ $settingsY{TEST}              = 'Y';
 $settingsY{_START_AFTER_JOBS} = [$jobX->id];
 my $jobY = _job_create(\%settingsY);
 
-ok(job_set_done(jobid => $jobX->id, result => 'passed'), 'jobX set to done');
+is($jobX->done(result => 'passed'), 'passed', 'jobX set to done');
 # since we are skipping job_grab, reload missing columns from DB
 $jobX->discard_changes;
 
@@ -414,9 +427,9 @@ $jobX->discard_changes;
 my $jobX2_id = OpenQA::Scheduler::Scheduler::job_duplicate(jobid => $jobX->id);
 $jobY->discard_changes;
 is($jobX2_id, $jobY->parents->single->parent_job_id, 'jobY parent is now jobX clone');
-my $jobX2 = job_get_deps($jobX2_id);
-is($jobX2->{clone_id}, undef, "no clone");
-is($jobY->{clone_id},  undef, "no clone");
+my $jobX2 = job_get_deps_rs($jobX2_id);
+is($jobX2->clone, undef, "no clone");
+is($jobY->clone,  undef, "no clone");
 
 # current state:
 #
@@ -426,9 +439,8 @@ is($jobY->{clone_id},  undef, "no clone");
 # X2 <---- Y
 # sch.    sch.
 
-
-ok(job_set_done(jobid => $jobX2_id, result => 'passed'), 'jobX2 set to done');
-ok(job_set_done(jobid => $jobY->id, result => 'passed'), 'jobY set to done');
+ok($jobX2->done(result => 'passed'), 'jobX2 set to done');
+ok($jobY->done(result => 'passed'), 'jobY set to done');
 
 # current state:
 #
@@ -456,7 +468,7 @@ is_deeply($jobY2->{parents}, {Chained => [$jobX2_id], Parallel => []}, 'jobY2 pa
 is($jobX2->{clone_id}, undef, "no clone");
 is($jobY2->{clone_id}, undef, "no clone");
 
-ok(job_set_done(jobid => $jobY2_id, result => 'passed'), 'jobY2 set to done');
+ok(job_get($jobY2_id)->done(result => 'passed'), 'jobY2 set to done');
 
 # current state:
 #

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -25,7 +25,7 @@ use Data::Dump qw/pp dd/;
 use File::Path qw/remove_tree/;
 use Test::More;
 use Test::Warnings;
-use OpenQA::Scheduler::Scheduler qw/job_grab job_restart job_set_done/;
+use OpenQA::Scheduler::Scheduler qw/job_grab job_restart/;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::IPC;
 use OpenQA::WebSockets;
@@ -102,8 +102,9 @@ my $jobB = $schema->resultset('Jobs')->create_from_settings(\%settings);
 is(scalar @assets, 1, 'one asset assigned before grabbing');
 # set jobA (normally this is done by worker after abort) and cloneA to done
 # needed for job grab to fulfill dependencies
-ok(job_set_done(jobid => $jobA->id,   result => 'passed'), 'jobA job set to done');
-ok(job_set_done(jobid => $cloneA->id, result => 'passed'), 'cloneA job set to done');
+$jobA->discard_changes;
+is($jobA->done(result => 'passed'), 'passed', 'jobA job set to done');
+is($cloneA->done(result => 'passed'), 'passed', 'cloneA job set to done');
 
 # register asset and mark as created by cloneA
 my $ja = sprintf('%08d-%s', $cloneA->id, 'jobasset.raw');

--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -89,7 +89,7 @@ is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.creat
 # set the job as done via API
 $post = $t->post_ok("/api/v1/jobs/" . $job . "/set_done")->status_is(200);
 # check plugin called fedmsg-logger correctly
-is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.done --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":' . $job . ',"newbuild":null,"remaining":0,"result":null}', "job done triggers fedmsg");
+is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.done --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":' . $job . ',"newbuild":null,"remaining":0,"result":"failed"}', "job done triggers fedmsg");
 
 # we don't test update_results as comment indicates it's obsolete
 


### PR DESCRIPTION
- job_set_done recomputes overall job result, return this new value
back so correct job result is used in event
- moved job_set_done to OpenQA::Schema::Result::Jobs::done, to do so I needed also to move cancel and supporting subroutines
- OpenQA::Schema::Result::Jobs::cancel is pretty simple, the complexity of cancel by settings is now in OpenQA::Schema::ResultSet::Jobs::cancel_by_settings which is usually called from ISO controller
- command_enqueue moved to OpenQA::Schema::Result::Worker::send_command and added proper auditing
- added some more auditing places and enabled job_cancel_by_settings event
- important change which wasn't really needed but I did it anyway is when interactive mode and/or wait for needle requested, previously worker property was set immediately by websockets server. Now this property is only set when worker acknowledges request for interactive mode.
- for this I introduced new websocket message 'property_change'  with data about acknowledging requested property change (currently only 'interactive_mode', 'waitforneedle')