### PR TITLE
Add SUSE internal branding with more links

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -2,7 +2,7 @@
 ## Web site name for tab titles and bookmarks
 #appname = openQA
 
-## type of branding - [ openSUSE,  plain ]
+## type of branding - [ openSUSE, plain, openqa.suse.de ]
 #branding = plain
 
 ## type and location of needle repo

--- a/templates/branding/openSUSE/docbox.html.ep
+++ b/templates/branding/openSUSE/docbox.html.ep
@@ -1,0 +1,1 @@
+%=include 'branding/plain/docbox'

--- a/templates/branding/openqa.suse.de/docbox.html.ep
+++ b/templates/branding/openqa.suse.de/docbox.html.ep
@@ -1,0 +1,6 @@
+<h2>Welcome to <%= $appname %> at SUSE</h2>
+
+<p><a href="http://os-autoinst.github.io/openQA/">» More information regarding openQA</a></p>
+<p><a href="https://wiki.microfocus.net/index.php/OpenQA">» Description of internal setup and administration</a></p>
+<p><a href="irc://irc.suse.de/testing">» IRC channel</a></p>
+<p><a href="https://build.suse.de/project/staging_projects/SUSE:SLE-12-SP2:GA">» SLE staging dashboard</a></p>

--- a/templates/branding/openqa.suse.de/sponsorbox.html.ep
+++ b/templates/branding/openqa.suse.de/sponsorbox.html.ep
@@ -1,0 +1,5 @@
+<div class="text-right" id="sponsorbox">
+    <a href="http://www.suse.com" title="SUSE">
+        <img alt="sponsor_suse" class="icons-sponsor_suse" src="<%= icon_url 'suse.png' %>" />
+    </a>
+</div>

--- a/templates/branding/plain/docbox.html.ep
+++ b/templates/branding/plain/docbox.html.ep
@@ -1,0 +1,4 @@
+<h1>Welcome to <%= $appname %></h1>
+<p>Life is too short for manual testing!</p>
+
+<a class="btn btn-primary btn-lg" href="http://os-autoinst.github.io/openQA/" role="button">Learn more »</a></p>

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -10,10 +10,7 @@
 <div class="jumbotron">
     <div class="container">
         <div class="col-md-10">
-             <h1>Welcome to <%= $appname %></h1>
-             <p>Life is too short for manual testing!</p>
-
-            <a class="btn btn-primary btn-lg" href="http://os-autoinst.github.io/openQA/" role="button">Learn more »</a></p>
+            %= include_branding 'docbox'
         </div>
 
         <div class="col-md-2 hidden-sm hidden-xs">


### PR DESCRIPTION
Related issue: [bsc#973842](https://bugzilla.suse.com/show_bug.cgi?id=973842)

screenshot:
![openqa_osd_branding](https://cloud.githubusercontent.com/assets/1693432/17048728/76c54a36-4fe8-11e6-82c0-0d45194ac5c4.png)
