### PR TITLE
Show softfails in previous results

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -297,8 +297,20 @@ sub show {
     }
     my $job_labels = $self->_job_labels(\@previous_jobs);
 
+    # find softfailures
+    my @previous_job_ids = map { $_->id } @previous_jobs;
+    my $dents = $self->db->resultset('JobModules')->search(
+        {
+            job_id       => {-in  => \@previous_job_ids},
+            soft_failure => {'!=' => 0}});
+    my %soft_fails;
+    while (my $jm = $dents->next) {
+        $soft_fails{$jm->job_id}++;
+    }
+
     $self->stash(previous        => \@previous_jobs);
     $self->stash(previous_labels => $job_labels);
+    $self->stash(soft_fails      => \%soft_fails);
     $self->stash(limit_previous  => $limit_previous);
 
     $self->render('test/result');

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -72,7 +72,7 @@ $t->app($app);
 my $get        = $t->get_ok('/api/v1/jobs');
 my @jobs       = @{$get->tx->res->json->{jobs}};
 my $jobs_count = scalar @jobs;
-is($jobs_count, 12);
+is($jobs_count, 13);
 my %jobs = map { $_->{id} => $_ } @jobs;
 is($jobs{99981}->{state},    'cancelled');
 is($jobs{99963}->{state},    'running');
@@ -101,11 +101,11 @@ is(scalar(@{$get->tx->res->json->{jobs}}), 0);
 
 # query for existing jobs by iso
 $get = $t->get_ok('/api/v1/jobs?iso=openSUSE-13.1-DVD-i586-Build0091-Media.iso');
-is(scalar(@{$get->tx->res->json->{jobs}}), 5);
+is(scalar(@{$get->tx->res->json->{jobs}}), 6);
 
 # query for existing jobs by build
 $get = $t->get_ok('/api/v1/jobs?build=0091');
-is(scalar(@{$get->tx->res->json->{jobs}}), 9);
+is(scalar(@{$get->tx->res->json->{jobs}}), 10);
 
 # query for existing jobs by hdd_1
 $get = $t->get_ok('/api/v1/jobs?hdd_1=openSUSE-13.1-x86_64.hda');

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -194,6 +194,27 @@
         settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}]
     },
     Jobs => {
+        id         => 99944,
+        group_id   => 1001,
+        clone_id   => 99945,
+        priority   => 35,
+        result     => "passed",
+        state      => "done",
+        backend    => 'qemu',
+        t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 14400, 'UTC'),    # Four hour ago
+        t_started  => time2str('%Y-%m-%d %H:%M:%S', time - 18000, 'UTC'),    # Five hours ago
+        TEST       => "textmode",
+        FLAVOR     => 'DVD',
+        DISTRI     => 'opensuse',
+        BUILD      => '0091',
+        VERSION    => '13.1',
+        MACHINE    => '32bit',
+        ARCH       => 'i586',
+        jobs_assets => [{asset_id => 1},],
+        retry_avbl  => 3,
+        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}]
+    },
+    Jobs => {
         id         => 99963,
         group_id   => 1001,
         priority   => 35,

--- a/t/fixtures/05-job_modules.pl
+++ b/t/fixtures/05-job_modules.pl
@@ -936,6 +936,14 @@
         result   => 'passed',
     },
     JobModules => {
+        script       => 'tests/console/consoletest_finish.pm',
+        job_id       => 99944,
+        category     => 'console',
+        name         => 'consoletest_finish',
+        result       => 'passed',
+        soft_failure => 1,
+    },
+    JobModules => {
         script   => 'tests/installation/isosize.pm',
         job_id   => 99963,
         category => 'installation',

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -141,7 +141,7 @@ t::ui::PhantomTest::wait_for_ajax();
 
 # Test 99945 is not longer relevant (replaced by 99946) - but displayed for all
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply(\@jobs, [qw(job_99939 job_99938 job_99926 job_99962 job_99946 job_99945 job_99937 job_99981)], 'all rows displayed');
+is_deeply(\@jobs, [qw(job_99939 job_99938 job_99926 job_99962 job_99946 job_99945 job_99944 job_99937 job_99981)], 'all rows displayed');
 
 # now toggle back
 #print $driver->get_page_source();

--- a/t/ui/16-tests_previous_results.t
+++ b/t/ui/16-tests_previous_results.t
@@ -32,11 +32,12 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $get       = $t->get_ok('/tests/99946#previous')->status_is(200);
 my $tab_label = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('li a[href=#previous]')->all_text);
-is($tab_label, q/Previous results (1)/, 'previous results with number is shown');
+is($tab_label, q/Previous results (2)/, 'previous results with number is shown');
 my $previous_results_header = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#previous #scenario')->all_text);
 is($previous_results_header, q/Results for opensuse-13.1-DVD-i586-textmode@32bit, limited to 10/, 'header for previous results with scenario');
-$get->element_exists('#res_99945',                'result from previous job');
-$get->element_exists('#res_99945 .result_passed', 'previous job was passed');
+$get->element_exists('#res_99945',                  'result from previous job');
+$get->element_exists('#res_99945 .result_passed',   'previous job was passed');
+$get->element_exists('#res_99944 .result_softfail', 'previous job was passed (softfail)');
 my $build = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#previous_results .build')->all_text);
 is($build, '0091', 'build of previous job is shown');
 $get                     = $t->get_ok('/tests/99946?limit_previous=1#previous')->status_is(200);

--- a/templates/test/previous.html.ep
+++ b/templates/test/previous.html.ep
@@ -15,9 +15,12 @@
             % my $res = $prev->result;
             %# partially recreate the 'res' hash as used in 'overview' route
             <td id="res_<%= $prev->id %>">
-                % my $css = "";
-                % next unless ($prev->state eq "done");
-                % $css .= " result_" . $res;
+                % my $css = '';
+                % next unless ($prev->state eq OpenQA::Schema::Result::Jobs::DONE);
+                % if($res eq OpenQA::Schema::Result::Jobs::PASSED && $soft_fails->{$prev->id}) {
+                %    $res = 'softfail';
+                % }
+                % $css .= ' result_' . $res;
                 <span id="res-<%= $prev->id %>">
                     <a href="<%= url_for('test', 'testid' => $prev->id) %>">
                         <i class="status fa fa-circle<%=  $css %>" title="Done: <%= $res %>"></i>


### PR DESCRIPTION
This fixes https://progress.opensuse.org/issues/12126

These commits will conflict with "Fix build tagging when '@' is used". I'll fix the conflict as soon as one of the pull requests is merged.

I'm not sure whether the behavior is correct now, I've just tried to apply the same logic as in the group overview.