### PR TITLE
Kill worker process group when not reactive on shutdown

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -132,6 +132,7 @@ sub engine_workit($) {
     die "failed to fork: $!\n" unless defined $child;
 
     unless ($child) {
+        setpgrp(0, 0);
         $ENV{TMPDIR} = $tmpdir;
         printf "$$: WORKING %d\n", $job->{id};
         if (open(my $log, '>', "autoinst-log.txt")) {


### PR DESCRIPTION
Fixes issues e.g. when cancelling s390x jobs from the WebUI. The root cause is
probably within the backend depending on the subprocesses that are needed
there but this is a working remedy from one level higher. Killing the
subprocess group is safe as all processes are torn down and the worker even
uploads logs in this case.

Example log output:

```
received command: cancelstop_job cancel
killing 28395
(waiting for 40 seconds)
sending KILL signal to everyone in the child process group
stop_job 2nd half
uploading video.ogv
uploading vars.json
uploading serial0.txt
uploading autoinst-log.txt
setting job 2333 to incomplete (cancel)
```

Related progress issue: https://progress.opensuse.org/issues/12178