### PR TITLE
Add web UI controls to select more builds in group_overview

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -159,9 +159,10 @@ sub group_overview {
             $res->{$build}->{tag} = {type => $tag[1], description => $tag[2]};
         }
     }
-    $self->stash('result',   $res);
-    $self->stash('group',    $group);
-    $self->stash('comments', \@comments);
+    $self->stash('result',       $res);
+    $self->stash('group',        $group);
+    $self->stash('limit_builds', $limit_builds);
+    $self->stash('comments',     \@comments);
 }
 
 sub add_comment {

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -56,6 +56,13 @@ $driver->find_element('opensuse', 'link_text')->click();
 is(scalar @{$driver->find_elements('h4', 'css')}, 4, 'number of builds for opensuse');
 is($driver->get($baseurl . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
 
+my $more_builds = $t->get_ok($baseurl . 'group_overview/1001')->tx->res->dom->at('#more_builds');
+my $res         = OpenQA::Test::Case::trim_whitespace($more_builds->all_text);
+is($res, q{Limit to 10 / 20 / 50 / 100 / 400 builds}, 'more builds can be requested');
+my $get = $t->get_ok($more_builds->find('a[href]')->last->{href})->status_is(200);
+$res = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#more_builds b')->all_text);
+like($res, qr/400/, 'limited to the selected number');
+
 #t::ui::PhantomTest::make_screenshot('mojoResults.png');
 
 t::ui::PhantomTest::kill_phantom();

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -10,6 +10,12 @@
 <h2>Last Builds for Group <%= $group->name %></h2>
 %= include 'main/group_builds', result => $result
 
+<div id="more_builds">
+    Limit to
+    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query(time_limit_days => 1000, limit_builds => $_)) } (10, 20, 50, 100, 400));
+    builds
+</div>
+
 <h2>Comments</h2>
 % for my $comment (reverse @$comments) {
     %= include 'comments/comment_row', comment_id => $comment->id, comment => $comment, user => $comment->user, context => {type => 'group', id => $group->id}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'


### PR DESCRIPTION
The query parameter 'limit_builds' allows to show more than the default 10
builds on demand. Just like we have for configuring previous results, the
current commit adds web UI selections to reload the same page with
higher number of builds on demand. For this, the limit of days is increased
to show more builds but still limited by the selected number.

Example screenshot:
![openqa_limit_builds_current_bold](https://cloud.githubusercontent.com/assets/1693432/17462279/59e344e6-5ca8-11e6-8350-42a0fbb5267d.png)
