### PR TITLE
Add web UI controls to filter only tagged or all builds

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -135,7 +135,8 @@ sub group_overview {
     my ($self) = @_;
 
     my $limit_builds = $self->param('limit_builds') // 10;
-    my $group = $self->db->resultset('JobGroups')->find($self->param('groupid'));
+    my $only_tagged  = $self->param('only_tagged')  // 0;
+    my $group        = $self->db->resultset('JobGroups')->find($self->param('groupid'));
     return $self->reply->not_found unless $group;
 
     my $res = $self->_group_result($group, $limit_builds);
@@ -159,9 +160,17 @@ sub group_overview {
             $res->{$build}->{tag} = {type => $tag[1], description => $tag[2]};
         }
     }
+    if ($only_tagged) {
+        for my $build (keys %$res) {
+            next if ($build eq '_max');
+            next unless $build;
+            delete $res->{$build} unless $res->{$build}->{tag};
+        }
+    }
     $self->stash('result',       $res);
     $self->stash('group',        $group);
     $self->stash('limit_builds', $limit_builds);
+    $self->stash('only_tagged',  $only_tagged);
     $self->stash('comments',     \@comments);
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -159,9 +159,10 @@ sub group_overview {
             $res->{$build}->{tag} = {type => $tag[1], description => $tag[2]};
         }
     }
-    $self->stash('result',   $res);
-    $self->stash('group',    $group);
-    $self->stash('comments', \@comments);
+    $self->stash('result',       $res);
+    $self->stash('group',        $group);
+    $self->stash('limit_builds', $limit_builds);
+    $self->stash('comments',     \@comments);
 }
 
 sub add_comment {

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -102,6 +102,13 @@ subtest 'builds first tagged important, then unimportant dissappear (poo#12028)'
     is($tags[0],     'Build0048', 'only youngest build present');
 };
 
+subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {
+    my $get = $t->get_ok('/group_overview/1001?only_tagged=1')->status_is(200);
+    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 1, 'only one tagged build is shown');
+    $get = $t->get_ok('/group_overview/1001?only_tagged=0')->status_is(200);
+    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 4, 'all builds shown again');
+};
+
 =pod
 Given a comment C<tag:<build_ref>:important> exists on a job group comments
 When GRU cleanup task is run

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -54,14 +54,15 @@ is(scalar @{$driver->find_elements('h4', 'css')}, 2, 'only one build per group s
 $driver->find_element('opensuse', 'link_text')->click();
 
 is(scalar @{$driver->find_elements('h4', 'css')}, 4, 'number of builds for opensuse');
-is($driver->get($baseurl . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
+is($driver->get($driver->get_current_url() . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
 
 my $more_builds = $t->get_ok($baseurl . 'group_overview/1001')->tx->res->dom->at('#more_builds');
 my $res         = OpenQA::Test::Case::trim_whitespace($more_builds->all_text);
-is($res, q{Limit to 10 / 20 / 50 / 100 / 400 builds}, 'more builds can be requested');
-my $get = $t->get_ok($more_builds->find('a[href]')->last->{href})->status_is(200);
-$res = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#more_builds b')->all_text);
-like($res, qr/400/, 'limited to the selected number');
+is($res, q{Limit to 10 / 20 / 50 / 100 / 400 builds, only tagged / all}, 'more builds can be requested');
+$driver->find_element('400', 'link_text')->click();
+is($driver->find_element('#more_builds b', 'css')->get_text(), 400, 'limited to the selected number');
+$driver->find_element('tagged', 'link_text')->click();
+is(scalar @{$driver->find_elements('h4', 'css')}, 0, 'no tagged builds exist');
 
 #t::ui::PhantomTest::make_screenshot('mojoResults.png');
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -56,6 +56,13 @@ $driver->find_element('opensuse', 'link_text')->click();
 is(scalar @{$driver->find_elements('h4', 'css')}, 4, 'number of builds for opensuse');
 is($driver->get($baseurl . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
 
+my $more_builds = $t->get_ok($baseurl . 'group_overview/1001')->tx->res->dom->at('#more_builds');
+my $res         = OpenQA::Test::Case::trim_whitespace($more_builds->all_text);
+is($res, q{Limit to 10 / 20 / 50 / 100 / 400 builds}, 'more builds can be requested');
+my $get = $t->get_ok($more_builds->find('a[href]')->last->{href})->status_is(200);
+$res = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#more_builds b')->all_text);
+like($res, qr/400/, 'limited to the selected number');
+
 #t::ui::PhantomTest::make_screenshot('mojoResults.png');
 
 t::ui::PhantomTest::kill_phantom();

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -10,6 +10,12 @@
 <h2>Last Builds for Group <%= $group->name %></h2>
 %= include 'main/group_builds', result => $result
 
+<div id="more_builds">
+    Limit to
+    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query(time_limit_days => 1000, limit_builds => $_)) } (10, 20, 50, 100, 400));
+    builds
+</div>
+
 <h2>Comments</h2>
 % for my $comment (reverse @$comments) {
     %= include 'comments/comment_row', comment_id => $comment->id, comment => $comment, user => $comment->user, context => {type => 'group', id => $group->id}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -12,8 +12,12 @@
 
 <div id="more_builds">
     Limit to
-    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query(time_limit_days => 1000, limit_builds => $_)) } (10, 20, 50, 100, 400));
-    builds
+    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query([time_limit_days => 1000, limit_builds => $_])) } (10, 20, 50, 100, 400));
+    builds, only
+    % my %tagged = (tagged => 1, all => 0);
+    % my %rtagged = reverse %tagged;
+    % my $selected = $rtagged{$only_tagged};
+    %= b join(' / ', map { $_ eq $selected ? "<b>$_</b>" : link_to($_ => url_with->query([only_tagged => $tagged{$_}])) } reverse sort keys %tagged);
 </div>
 
 <h2>Comments</h2>


### PR DESCRIPTION
Using a new query parameter 'only_tagged=[0|1]' the list can be filtered.

Example screenshot:
![openqa_limit_builds_current_bold_and_only_tagged](https://cloud.githubusercontent.com/assets/1693432/17464792/49bb6b18-5ce7-11e6-8053-7b74faf193a7.png)

Related progress issue: https://progress.opensuse.org/issues/11052

Obsoletes #804