### PR TITLE
Add link to latest job in each scenario

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -64,6 +64,11 @@ use constant RESULTS => (NONE, PASSED, SOFTFAILED, FAILED, INCOMPLETE, SKIPPED, 
 use constant COMPLETE_RESULTS => (PASSED, SOFTFAILED, FAILED);
 use constant INCOMPLETE_RESULTS => (INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED);
 
+# scenario keys w/o MACHINE. Add MACHINE when desired, commonly joined on
+# other keys with the '@' character
+use constant SCENARIO_KEYS => (qw/DISTRI VERSION FLAVOR ARCH TEST/);
+use constant SCENARIO_WITH_MACHINE_KEYS => (SCENARIO_KEYS, 'MACHINE');
+
 __PACKAGE__->table('jobs');
 __PACKAGE__->load_components(qw/InflateColumn::DateTime FilterColumn Timestamps/);
 __PACKAGE__->add_columns(
@@ -218,6 +223,12 @@ sub name {
         $self->{_name} = $name;
     }
     return $self->{_name};
+}
+
+sub scenario_hash {
+    my ($self) = @_;
+    my %scenario = map { lc $_ => $self->get_column($_) } SCENARIO_WITH_MACHINE_KEYS;
+    return %scenario;
 }
 
 # return 0 if we have no worker
@@ -1161,10 +1172,9 @@ sub needle_dir() {
 sub _previous_scenario_jobs {
     my ($self, $rows) = @_;
 
-    my $schema        = $self->result_source->schema;
-    my $conds         = [{'me.state' => 'done'}, {'me.result' => [COMPLETE_RESULTS]}, {'me.id' => {'<', $self->id}}];
-    my @scenario_keys = qw/DISTRI VERSION FLAVOR ARCH TEST MACHINE/;
-    for my $key (@scenario_keys) {
+    my $schema = $self->result_source->schema;
+    my $conds = [{'me.state' => 'done'}, {'me.result' => [COMPLETE_RESULTS]}, {'me.id' => {'<', $self->id}}];
+    for my $key (SCENARIO_WITH_MACHINE_KEYS) {
         push(@$conds, {"me.$key" => $self->get_column($key)});
     }
     my %attrs = (

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -257,11 +257,8 @@ sub show {
 
     return $self->reply->not_found unless $job;
 
-    my @scenario_keys = qw/DISTRI VERSION FLAVOR ARCH TEST/;
-    my $scenario = join('-', map { $job->get_column($_) } @scenario_keys);
+    my $scenario = join('-', map { $job->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_KEYS);
 
-    # append the MACHINE
-    push(@scenario_keys, 'MACHINE');
     $scenario .= "@" . $job->MACHINE;
 
     $self->stash(testname => $job->name);
@@ -299,7 +296,7 @@ sub show {
     push(@conds, {'me.state'  => 'done'});
     push(@conds, {'me.result' => {-not_in => [OpenQA::Schema::Result::Jobs::INCOMPLETE_RESULTS]}});
     push(@conds, {id          => {'<', $job->id}});
-    for my $key (@scenario_keys) {
+    for my $key (OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS) {
         push(@conds, {"me.$key" => $job->get_column($key)});
     }
     my $limit_previous = $self->param('limit_previous') // 10;    # arbitrary limit of previous results to show
@@ -309,7 +306,7 @@ sub show {
     my $previous_jobs_rs = $self->db->resultset("Jobs")->search({-and => \@conds}, \%attrs);
     my @previous_jobs;
     while (my $prev = $previous_jobs_rs->next) {
-        $self->app->log->debug("Previous result job " . $prev->id . ": " . join('-', map { $prev->get_column($_) } @scenario_keys));
+        $self->app->log->debug("Previous result job " . $prev->id . ": " . join('-', map { $prev->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS));
         push(@previous_jobs, $prev);
     }
     my $job_labels = $self->_job_labels(\@previous_jobs);
@@ -506,8 +503,7 @@ sub overview {
 sub latest {
     my ($self) = @_;
     my %search_args;
-    my @scenario_keys = qw/DISTRI VERSION FLAVOR ARCH TEST/;
-    for my $arg (@scenario_keys) {
+    for my $arg (OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS) {
         my $key = lc $arg;
         next unless defined $self->param($key);
         $search_args{$key} = $self->param($key);

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -90,6 +90,10 @@ subtest 'route to latest' => sub {
     $get = $t->get_ok($baseurl . 'tests/latest?version=13.1')->status_is(302);
     is($t->tx->res->headers->location, '/tests/99981', 'returns highest job nr of ambiguous group');
     $get = $t->get_ok($baseurl . 'tests/latest?test=foobar')->status_is(404);
+
+    $get = $t->get_ok($baseurl . 'tests/99963')->status_is(200);
+    $get = $t->get_ok($t->tx->res->dom->find('#info_box .panel-body #relation a')->last->{href})->status_is(302);
+    is($t->tx->res->headers->location, '/tests/99963', 'latest link points to last in scenario');
 };
 
 #print $driver->get_page_source();

--- a/templates/test/infopanel.html.ep
+++ b/templates/test/infopanel.html.ep
@@ -13,7 +13,7 @@
                 Results for <%= $job->name %>
             </div>
             <div class="panel-body">
-                <div>
+                <div id="status">
                     %if ($job->state eq 'done') {
                         Result: <b><%= $job->result %></b>
                     % } else
@@ -50,7 +50,7 @@
                         % end
                     % }
                 </div>
-                <div>
+                <div id="relation">
                     % if ($clone_of) {
                         Clone of
                         %= link_to $clone_of->id => url_for ('test', testid => $clone_of->id)
@@ -59,6 +59,8 @@
                         Cloned as
                         %= link_to $job->clone_id => url_for ('test', testid => $job->clone_id)
                     % }
+                    %= link_to Latest => url_for ('latest')->query($job->scenario_hash)
+                    in same scenario
                 </div>
 
                 <% if ($job->state eq 'scheduled') {  %>


### PR DESCRIPTION
Based on 'latest' query route each job can now link to the
newest incarnation within in the same scenario.

Add 'latest' query route
    
Should always refer to most recent job for the specified scenario.
    
* have the same link for test development, i.e. if one retriggers tests, the
person has to always update the URL. If there would be a static URL even the
browser can be instructed to reload the page automatically
    
* for linking to the always current execution of the last job within one
scenario, e.g. to respond faster to the standard question in bug reports "does
this bug still happen?"

As suggested in #796

Example screenshot:
![openqa_link_to_latest](https://cloud.githubusercontent.com/assets/1693432/17368118/0f92b70e-5993-11e6-9afa-a04210492a31.png)
