### PR TITLE
Url tab cleanups for result details

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -187,7 +187,9 @@ function setupResult(state, jobid) {
     if (state == "scheduled") {
       setResultHash("#settings", true);
     } else if (state == "running" || state == "waiting") {
-      setResultHash("#live", true);
+      if (!window.location.href.endsWith("#")) {
+        setResultHash("#live", true);
+      }
     }
   }
   if (state == "running" || state == "waiting") {

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -91,6 +91,7 @@ function setCurrentPreview(a, replace, force) {
     // hide
     $("#preview_container_out").fadeOut(150);
     $(".current_preview").removeClass("current_preview");
+    setResultHash("", replace);
   }
 }
 

--- a/t/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/details-partitioning.json
+++ b/t/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/details-partitioning.json
@@ -1,1 +1,1 @@
-[{"area":[{"result":"ok","similarity":100,"w":392,"y":"296","x":"429","h":365}],"needle":"partitioning-13B1","result":"ok","tags":["partitioning"],"screenshot":"partitioning-1.png"}]
+[{"area":[{"result":"ok","similarity":100,"w":392,"y":"296","x":"429","h":365}],"needle":"inst-timezone-text","result":"ok","tags":["partitioning"],"screenshot":"partitioning-1.png"}]

--- a/t/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/details-partitioning_finish.json
+++ b/t/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/details-partitioning_finish.json
@@ -1,1 +1,1 @@
-[{"area":[{"h":762,"similarity":96,"result":"ok","w":775,"x":"249","diff":"partitioning_finish-1-inst-usersetup-131M1-diff0.png","y":"5"}],"needle":"inst-usersetup-131M1","result":"ok","tags":["after-paritioning"],"screenshot":"partitioning_finish-1.png"}]
+[{"area":[{"h":762,"similarity":96,"result":"ok","w":775,"x":"249","diff":"partitioning_finish-1-inst-usersetup-131M1-diff0.png","y":"5"}],"needle":"inst-timezone-text","result":"ok","tags":["after-paritioning"],"screenshot":"partitioning_finish-1.png"}]

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -65,8 +65,10 @@ $driver->find_element('[title="wait_serial"]', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax;
 ok($driver->find_element('#preview_container_out', 'css')->is_displayed(), "preview window opens on click");
 like($driver->find_element('#preview_container_in', 'css')->get_text(), qr/wait_serial expected/, "Preview text with wait_serial output shown");
+like($driver->get_current_url(), qr/#step/, "current url contains #step hash");
 $driver->find_element('[title="wait_serial"]', 'css')->click();
 ok($driver->find_element('#preview_container_out', 'css')->is_hidden(), "preview window closed after clicking again");
+unlike($driver->get_current_url(), qr/#step/, "current url doesn't contain #step hash anymore");
 
 # test running view with Test::Mojo as phantomjs would get stuck on the
 # liveview/livelog forever

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -66,7 +66,7 @@ is((shift @tds)->get_text(), 'a day ago',          "last use is right");
 is((shift @tds)->get_text(), 'about 14 hours ago', "last match is right");
 
 $driver->find_element('a day ago', 'link_text')->click();
-like($driver->execute_script("return window.location.href"), qr(\Q/tests/99937#step/partitioning_finish/2\E), "redirected to right module");
+like($driver->execute_script("return window.location.href"), qr(\Q/tests/99937#step/partitioning_finish/1\E), "redirected to right module");
 
 # go back to needles
 $driver->find_element('#user-action a', 'css')->click();
@@ -74,7 +74,7 @@ $driver->find_element('Needles',        'link_text')->click();
 t::ui::PhantomTest::wait_for_ajax;
 
 $driver->find_element('about 14 hours ago', 'link_text')->click();
-like($driver->execute_script("return window.location.href"), qr(\Q/tests/99937#step/partitioning/2\E), "redirected to right module too");
+like($driver->execute_script("return window.location.href"), qr(\Q/tests/99937#step/partitioning/1\E), "redirected to right module too");
 
 # go back to needles
 $driver->find_element('#user-action a', 'css')->click();


### PR DESCRIPTION
- Only redirect to running tab when no `#` is in the url
- Clear url hash on test step result preview close
- Test for url hash cleanup after preview close