### PR TITLE
Prevent needle editor flickering (progress #12984)

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -14,6 +14,11 @@ function NeedleEditor(needle) {
 NeedleEditor.prototype.init = function() {
   var editor = this;
 
+  if (this.cv) {
+    this.cv.set_bgImage(this.bgImage);
+    return;
+  }
+
   var cv = this.cv = new CanvasState(this.canvas);
 
   cv.set_bgImage(this.bgImage);


### PR DESCRIPTION
- Every time when a new base image was selected, a new CanvasState
  object was created by the editor.init() method.
- Each cs object would register its own event handlers on the `<canvas>`
- Now the init() method will only update the base image and return,
  as soon as an instance of CanvasState has been created by the first init() call

https://progress.opensuse.org/issues/12984