### PR TITLE
[WIP] Render links on 'latest' route directly instead of redirect

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -254,7 +254,11 @@ sub show {
             id => $self->param('testid')
         },
         {prefetch => qw/jobs_assets/})->first;
+    return $self->_show($job);
+}
 
+sub _show {
+    my ($self, $job) = @_;
     return $self->reply->not_found unless $job;
 
     my @scenario_keys = qw/DISTRI VERSION FLAVOR ARCH TEST/;
@@ -514,7 +518,8 @@ sub latest {
     }
     my $job = $self->db->resultset("Jobs")->complex_query(%search_args)->first;
     return $self->render(text => 'No matching job found', status => 404) unless $job;
-    return $self->redirect_to('test', testid => $job->id);
+    $self->stash(testid => $job->id);
+    return $self->_show($job);
 }
 
 sub add_comment {

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -83,12 +83,19 @@ my $href_to_isosize = $t->tx->res->dom->at('.component a[href*=installer_timezon
 $t->get_ok($baseurl . ($href_to_isosize =~ s@^/@@r))->status_is(200);
 
 subtest 'route to latest' => sub {
-    $get = $t->get_ok($baseurl . 'tests/latest?distri=opensuse&version=13.1&flavor=DVD&arch=x86_64&test=kde&machine=64bit')->status_is(302);
-    is($t->tx->res->headers->location, '/tests/99963', 'latest link shows tests/99963');
-    $get = $t->get_ok($baseurl . 'tests/latest?flavor=DVD&arch=x86_64&test=kde')->status_is(302);
-    is($t->tx->res->headers->location, '/tests/99963', '... as long as it is unique');
-    $get = $t->get_ok($baseurl . 'tests/latest?version=13.1')->status_is(302);
-    is($t->tx->res->headers->location, '/tests/99981', 'returns highest job nr of ambiguous group');
+    $get = $t->get_ok($baseurl . 'tests/latest?distri=opensuse&version=13.1&flavor=DVD&arch=x86_64&test=kde&machine=64bit')->status_is(200);
+    my $header = $t->tx->res->dom->at('#info_box .panel-heading a');
+    is($header->text,   '99963',        'link shows correct test');
+    is($header->{href}, '/tests/99963', 'latest link shows tests/99963');
+    my $first_detail = $get->tx->res->dom->at('#details tbody > tr ~ tr');
+    is($first_detail->at('.component a')->{href},     '/tests/99963/modules/isosize/steps/1/src', 'correct src link');
+    is($first_detail->at('.links_a a')->{'data-url'}, '/tests/99963/modules/isosize/steps/1',     'correct needle link');
+    $get    = $t->get_ok($baseurl . 'tests/latest?flavor=DVD&arch=x86_64&test=kde')->status_is(200);
+    $header = $t->tx->res->dom->at('#info_box .panel-heading a');
+    is($header->{href}, '/tests/99963', '... as long as it is unique');
+    $get    = $t->get_ok($baseurl . 'tests/latest?version=13.1')->status_is(200);
+    $header = $t->tx->res->dom->at('#info_box .panel-heading a');
+    is($header->{href}, '/tests/99981', 'returns highest job nr of ambiguous group');
     $get = $t->get_ok($baseurl . 'tests/latest?test=foobar')->status_is(404);
 };
 

--- a/templates/test/details.html.ep
+++ b/templates/test/details.html.ep
@@ -20,7 +20,7 @@
                 <tr>
                     <td class="component">
                         <div>
-                            %= link_to $module->{name} => url_for('src_step', stepid => 1, moduleid => $module->{name})
+                            %= link_to $module->{name} => url_for('src_step', stepid => 1, moduleid => $module->{name}, testid => $testid)
                         </div>
                         <div class="flags">
                             % if ($module->{fatal}) {
@@ -41,7 +41,7 @@
                         % for my $step (@{$module->{details}}) {
                             <div class="links_a">
                                 <div class="fa fa-caret-down"></div>
-                                % my $url   = url_for('step', moduleid => $module->{name}, stepid => $step->{num});
+                                % my $url   = url_for('step', moduleid => $module->{name}, stepid => $step->{num}, testid => $testid);
                                 % my $href  = "#step/$module->{name}/$step->{num}";
                                 % my $title = $step->{text} ? $step->{title} : $step->{name};
                                 %= link_to $href => (class => 'no_hover') => (data => { url => $url }) => (title => $title) => begin

--- a/templates/test/infopanel.html.ep
+++ b/templates/test/infopanel.html.ep
@@ -10,7 +10,11 @@
         % }
         <div class="panel <%= $panelclass %>" id="info_box">
             <div class="panel-heading">
-                Results for <%= $job->name %>
+                Results for
+                % if (current_route 'latest') {
+                    <%= link_to $job->id => url_for ('test', testid => $job->id) %>:
+                % }
+                <%= $job->name %>
             </div>
             <div class="panel-body">
                 <div>


### PR DESCRIPTION
This allows a '/latest' link also used as a permalink to the always latest job, especially for local machines. http://<openqa>/tests/latest w/o query parameters already gave just the job with highest id but as a temporary redirect, i.e. reloading the page does not update the job. This way for example the browser can be configured to always reload the same page to have the always recent job displayed for local test development.

To still provide a link to the specific job the infobox now has a link to the '/tests/[:jobid:]' route. We could also put this link somewhere else, however, if it is preferred.

Example screenshot:
![openqa_latest_render_directly_with_link_no_redirect](https://cloud.githubusercontent.com/assets/1693432/17409232/9cdc635e-5a6e-11e6-9df7-cea6f7792bdd.png)