### PR TITLE
templates: Simplify single line statements

### DIFF
--- a/templates/admin/asset/index.html.ep
+++ b/templates/admin/asset/index.html.ep
@@ -27,7 +27,7 @@
                 <td class="name"><%= $asset->name %></td>
                 <td class="nrjobs"><%= link_to scalar($asset->jobs_assets->all) => url_for('tests')->query(assetid => $asset->id ) %></td>
                 <td class="t_created">
-                    <%= $asset->t_created %>
+                    %= $asset->t_created
                 </td>
             </tr>
             % }

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -34,7 +34,7 @@
                 <option value="">Select...</option>
                 % for my $test (@$tests) {
                     <option value="<%= $test->name %>" data-test-id="<%= $test->id %>">
-                        <%= $test->name %>
+                        %= $test->name
                     </option>
                 % }
             </select>

--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -22,7 +22,7 @@
             </thead>
             <tbody>
                 % for my $workername (sort keys %$workers) {
-                    %   my $worker = $workers->{$workername};
+                    % my $worker = $workers->{$workername};
                     <tr id="worker_<%= $worker->{id} %>" >
                         <td class="worker">
                             %= link_to( $workername => url_for('admin_worker_show', worker_id => $worker->{id}) )
@@ -48,5 +48,4 @@
             </tbody>
         </table>
     </div>
-
 </div>

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -112,7 +112,7 @@
                           </li>
                       % } else {
                           <li id="user-action">
-                              %= link_to('Login' => url_for('login'));
+                              %= link_to('Login' => url_for('login'))
                           </li>
                       % }
                   </ul>

--- a/templates/layouts/dependencies.html.ep
+++ b/templates/layouts/dependencies.html.ep
@@ -11,7 +11,7 @@
                         text-align: center;"
                         class="<%= css_for({'result' => $dep->parent->result}) %>"><%= $dep->parent->result %></span>
                 % } else {
-                    <%= $dep->parent->state %>
+                    %= $dep->parent->state
                 % }
             </td>
         </tr>
@@ -32,7 +32,7 @@
                         text-align: center;"
                         class="<%= css_for({'result' => $dep->child->result}) %>"><%= $dep->child->result %></span>
                 % } else {
-                    <%= $dep->child->state %>
+                    %= $dep->child->state
                 % }
             </td>
         </tr>

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -6,7 +6,7 @@
             <h4>
                 <%= link_to "Build$build" => url_for('tests_overview')->query(distri => $build_res->{distri}, version => $build_res->{version}, build => $build, groupid => $group->id ) %>
                 (<abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">
-                <%= delete $build_res->{oldest} %>
+                %= delete $build_res->{oldest}
                 </abbr>)
             % my $group_build_id = $group->id . '-' . $build;
             % my $tag = $build_res->{tag};

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -203,7 +203,7 @@
                         <select id="image_select">
                             % for my $needle (@$needles) {
                                 <option value="<%= $needle->{name} %>">
-                                    <%= $needle->{title} %>
+                                    %= $needle->{title}
                                 </option>
                             % }
                         </select>
@@ -216,7 +216,7 @@
                             % for my $needle (@$needles) {
                                 % next if $needle->{name} eq 'screenshot';
                                 <option value="<%= $needle->{name} %>">
-                                    <%= $needle->{title} %>
+                                    %= $needle->{title}
                                 </option>
                             % }
                         </select>

--- a/templates/test/infopanel.html.ep
+++ b/templates/test/infopanel.html.ep
@@ -14,7 +14,7 @@
                 % if (current_route 'latest') {
                     <%= link_to $job->id => url_for ('test', testid => $job->id) %>:
                 % }
-                <%= $job->name %>
+                %= $job->name
             </div>
             <div class="panel-body">
                 <div>
@@ -36,7 +36,7 @@
                         finished
                         <abbr class="timeago" title="<%= $job->t_finished->datetime() %>Z"><%= format_time($job->t_finished) %></abbr>
                         (
-                        <%= $job->t_started ? format_time_duration($job->t_finished - $job->t_started) : 0 %>
+                        %= $job->t_started ? format_time_duration($job->t_finished - $job->t_started) : 0
                         )
                     % } elsif ($job->t_started)
                     % {

--- a/templates/test/previous.html.ep
+++ b/templates/test/previous.html.ep
@@ -31,7 +31,7 @@
             <td class="t_finished">
                 <abbr class="timeago" title="<%= $prev->t_finished->datetime() %>Z"><%= format_time($prev->t_finished) %></abbr>
                 (
-                <%= $job->t_started ? format_time_duration($prev->t_finished - $prev->t_started) : 0 %>
+                %= $job->t_started ? format_time_duration($prev->t_finished - $prev->t_started) : 0
                 )
             </td>
         </tr>
@@ -42,6 +42,6 @@
 </div>
 <div id="more_results">
     Show
-    %= b join(' / ', map { link_to($_ => url_with->query(limit_previous => $_) . '#previous') } (20, 50, 100, 400));
+    %= b join(' / ', map { link_to($_ => url_with->query(limit_previous => $_) . '#previous') } (20, 50, 100, 400))
     previous results
 </div>

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -43,7 +43,7 @@
             <tr id="job_<%= $job->id %>">
                 % my $testname = $job->TEST . '@' . $job->MACHINE;
                 <td class="name">
-                    %= link_to "Build$build" => url_for('tests_overview')->query(%$query);
+                    %= link_to "Build$build" => url_for('tests_overview')->query(%$query)
                     of <%= "$distri-$version-$flavor.$arch" %>
                 </td>
                 <td class="test">
@@ -77,7 +77,7 @@
                             %   $classes = " progress-bar-striped active";
                         % }
                         <div class="progress-bar <%= $classes %>" role="progressbar" style="width: <%= $value %>%; min-width: 2em;" aria-valuemax="100" aria-valuemin="0" aria-valuenow="<%= $value %>">
-                            <%= $ptext %>
+                            %= $ptext
                         </div>
                     </div>
                 </td>


### PR DESCRIPTION
* Using '%=' instead of '<%= ... %>' where feasible
* Deleting redundant ';' on single line 'url_for, link_to'