### PR TITLE
Prevent use of non-existing route in upload_status

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -410,6 +410,7 @@ sub upload_status(;$) {
 
     return unless verify_workerid;
     return unless $job;
+    defined $job->{URL} || die 'need $job->{URL}';
     my $status = {};
 
     my $ua        = Mojo::UserAgent->new;


### PR DESCRIPTION
Die early, die often to get to the root of problems.

Prevents warning as seen from worker output:

```
Use of uninitialized value in concatenation (.) or string at /usr/share/openqa/script/../lib/OpenQA/Worker/Jobs.pm line 408.
[debug] GET "/isotovideo/status"
[debug] Template "not_found.development.html.ep" not found
[debug] Template "not_found.html.ep" not found
[debug] Rendering cached inline template "fd403ab55a4c875e35b42428816134c7"
[debug] Rendering cached inline template "5c56e02d3f6bef1b561eb2fd795ceacc"
[debug] 404 Not Found (0.009919s, 100.817/s)
```

This *will* make workers crash but lead us to the root cause more easily.