### PR TITLE
Disable auto-duplication of jobs (poo#13042)

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -410,6 +410,7 @@ sub upload_status(;$) {
 
     return unless verify_workerid;
     return unless $job;
+    return unless $job->{URL};
     my $status = {};
 
     my $ua        = Mojo::UserAgent->new;

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -286,13 +286,7 @@ sub _stop_job($;$) {
     }
     unless ($job_done || $aborted eq 'api-failure') {
         upload_status(1);
-        # set job to done. if priority is less than threshold duplicate it
-        # with worse priority so it can be picked up again.
-        my %args;
-        $args{dup_type_auto} = 1;
-        printf "duplicating job %d\n", $job->{id};
-        # make it less attractive so we don't get it again
-        api_call('post', 'jobs/' . $job->{id} . '/duplicate', \%args);
+        printf "job %d incomplete\n", $job->{id};
         api_call('post', 'jobs/' . $job->{id} . '/set_done', {result => 'incomplete'});
     }
     warn sprintf("cleaning up %s...\n", $job->{settings}->{NAME});


### PR DESCRIPTION
Auto-duplication of jobs just hides errors which we want to learn and improve
on. A worker might be right to retry when any web API call fails temporarily
so we might want to add back some auto-duplication unless we can handle a
retry even at a lower level to not discard the whole job which is another
story.