### PR TITLE
Show custom error pages

### DIFF
--- a/templates/exception.html.ep
+++ b/templates/exception.html.ep
@@ -1,0 +1,7 @@
+% layout 'error';
+% title 'Error';
+
+<div class="container" id="content">
+    <h1>Internal server error</h1>
+    <p>If you believe this is a bug you can <a href="https://progress.opensuse.org/projects/openqav3/issues/new" target="blank">open an issue</a>.</p>
+</div>

--- a/templates/layouts/error.html.ep
+++ b/templates/layouts/error.html.ep
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+      <!-- Meta, title, CSS, favicons, etc. -->
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <meta name="description" content="openQA is a testing framework mainly for distributions">
+      <meta name="keywords" content="Testing, Linux, Qemu">
+      <meta name="author" content="openQA contributors">
+
+      % if ($title) {
+      <title><%= $appname . ": " . title %></title>
+      % } else
+      % {
+      <title><%= $appname %></title>
+      % }
+
+      <!-- Bootstrap core CSS -->
+      %= asset 'bootstrap.css'
+      %= asset 'bootstrap.js'
+
+      %= content_for 'head'
+
+      %= javascript begin
+          %= content_for 'head_javascript'
+          $(function() {
+          setupForAll();
+          %= content_for 'ready_function'
+          } );
+      % end
+
+      <link rel="icon"
+            type="image/png" sizes="16x16"
+            href="<%= icon_url 'logo-16.png' %>">
+      <link rel="icon" href="<%= icon_url 'logo.svg'%>" sizes="any" type="image/svg+xml">
+
+  </head>
+  <body>
+      <nav class="navbar navbar-static-top navbar-default">
+          <div class="container">
+              <!-- Brand and toggle get grouped for better mobile display -->
+              <div class="navbar-header">
+                  <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-1" aria-expanded="false">
+                      <span class="sr-only">Toggle navigation</span>
+                      <span class="icon-bar"></span>
+                      <span class="icon-bar"></span>
+                      <span class="icon-bar"></span>
+                  </button>
+                  <a class="navbar-brand" href="/"><img src="<%= icon_url 'logo.svg'%>" alt="openQA"></a>
+              </div>
+          </div>
+      </nav>
+      <div class="container" id="content">
+          %= content
+      </div>
+      <footer class='footer'>
+        <div class='container'>
+          <div id='footer-legal' class="text-center">
+              openQA is licensed
+              %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
+          </div>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/templates/not_found.html.ep
+++ b/templates/not_found.html.ep
@@ -1,0 +1,8 @@
+% layout 'error';
+% title 'Page not found';
+
+<div class="container" id="content">
+    <h1>Page not found</h1>
+    <p>If you believe this is a bug you can <a href="https://progress.opensuse.org/projects/openqav3/issues/new" target="blank">open an issue</a>.</p>
+    <p>If the URL is self-crafted, ensure it is correct and properly encoded.</p>
+</div>

--- a/templates/not_found.html.ep
+++ b/templates/not_found.html.ep
@@ -1,8 +1,42 @@
 % layout 'error';
 % title 'Page not found';
 
+<style type="text/css">
+table pre {
+    border: none;
+    background-color: transparent;
+    margin: 0px;
+    padding: 0px;
+}
+</style>
 <div class="container" id="content">
     <h1>Page not found</h1>
     <p>If you believe this is a bug you can <a href="https://progress.opensuse.org/projects/openqav3/issues/new" target="blank">open an issue</a>.</p>
     <p>If the URL is self-crafted, ensure it is correct and properly encoded.</p>
+
+    <h2>Available routes</h2>
+    % my $walk = begin
+    % my ($walk, $route, $depth) = @_;
+    <tr>
+        <td>
+            % my $pattern = $route->pattern->unparsed || '/';
+            % $pattern = "+$pattern" if $depth;
+            <pre><%= '  ' x $depth %><%= $pattern %></pre>
+        </td>
+        <td><%= uc(join ',', @{$route->via || []}) || '*' %></td>
+        <td>
+            % my $name = $route->name;
+            <%= $route->has_custom_name ? qq{"$name"} : $name %>
+        </td>
+    </tr>
+    % $depth++;
+    %= $walk->($walk, $_, $depth) for @{$route->children};
+    % $depth--;
+    % end
+    <table class="table">
+        <thead>
+            <tr><th>Pattern</th><th>Methods</th><th>Name</th></tr>
+        </thead>
+        %= $walk->($walk, $_, 0) for @{app->routes->children};
+    </table>
 </div>


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/13192

The content of the pages could still be improved. Currently there is (beside the error message) just a link to 'New ticket' form under progress.opensuse.org.

Not sure how I would implement the last point mentioned in the issue. Just inserting the message via JavaScript is not possible due to cross-site security.