### PR TITLE
Make apache follow symlinks for assets directory

### DIFF
--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -15,6 +15,7 @@ DocumentRoot /usr/share/openqa/public
 Alias /assets "/var/lib/openqa/share/factory"
 
 <Directory "/var/lib/openqa/images">
+  Options SymLinksIfOwnerMatch
   AllowOverride None
   Require all granted
 


### PR DESCRIPTION
Required to avoid stuff like https://openqa.suse.de/tests/523246#step/zypper_migration/6

Already hotfixed on openqa.suse.de and resolved the issue - https://openqa.suse.de/tests/523871