### PR TITLE
Allow pinning comments as group description

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -47,6 +47,7 @@ function deleteComment(deleteButton) {
             method: 'DELETE',
             success: function() {
                 deleteButton.parents('.comment-row').remove();
+                deleteButton.parents('.pinned-comment-row').remove();
                 $('a[href="#comments"]').html('Comments (' + $('.comment-row').length + ')');
             },
             error: function(xhr, ajaxOptions, thrownError) {

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -140,8 +140,17 @@ sub group_overview {
     return $self->reply->not_found unless $group;
 
     my $res = $self->_group_result($group, $limit_builds);
-    my @comments = $group->comments->all;
-    for my $comment (@comments) {
+    my @comments;
+    my @pinned_comments;
+    for my $comment ($group->comments->all) {
+        # find pinned comments
+        if ($comment->user->is_operator && CORE::index($comment->text, 'pinned-description') >= 0) {
+            push(@pinned_comments, $comment);
+        }
+        else {
+            push(@comments, $comment);
+        }
+
         my @tag   = $comment->tag;
         my $build = $tag[0];
         next unless $build;
@@ -167,11 +176,12 @@ sub group_overview {
             delete $res->{$build} unless $res->{$build}->{tag};
         }
     }
-    $self->stash('result',       $res);
-    $self->stash('group',        $group);
-    $self->stash('limit_builds', $limit_builds);
-    $self->stash('only_tagged',  $only_tagged);
-    $self->stash('comments',     \@comments);
+    $self->stash('result',          $res);
+    $self->stash('group',           $group);
+    $self->stash('limit_builds',    $limit_builds);
+    $self->stash('only_tagged',     $only_tagged);
+    $self->stash('comments',        \@comments);
+    $self->stash('pinned_comments', \@pinned_comments);
 }
 
 sub add_comment {

--- a/templates/comments/comment_row.html.ep
+++ b/templates/comments/comment_row.html.ep
@@ -1,8 +1,14 @@
-<div class="row comment-row">
-    <div class="col-sm-1">
-        <img class="media-object img-circle" src="<%= $user->gravatar(60) %>" alt="profile">
-    </div>
+% if (!$context->{pinned}) {
+    <div class="row comment-row">
+        <div class="col-sm-1">
+            <img class="media-object img-circle" src="<%= $user->gravatar(60) %>" alt="profile">
+        </div>
     <div class="col-sm-11">
+% }
+% else {
+    <div class="row pinned-comment-row">
+        <div class="col-sm-12">
+% }
         <div class="media-body comment-body">
             <div class="well well-lg">
                 <form onsubmit="updateComment(this); return false;" onreset="hideCommentEditor(this); return true;" data-put-url="<%= url_for($put_action => ($context->{type}.'_id' => $context->{id}, comment_id => $comment_id)) %>">

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -8,6 +8,15 @@
 % end
 
 <h2>Last Builds for Group <%= $group->name %></h2>
+
+% if ($pinned_comments) {
+    <div id="group_descriptions">
+    % for my $comment (@$pinned_comments) {
+        %= include 'comments/comment_row', comment_id => $comment->id, comment => $comment, user => $comment->user, context => {type => 'group', id => $group->id, pinned => 1}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'
+    % }
+    </div>
+% }
+
 %= include 'main/group_builds', result => $result
 
 <div id="more_builds">


### PR DESCRIPTION
Implements the feature requested here: https://progress.opensuse.org/issues/12400