### PR TITLE
Fix undefined value

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -773,7 +773,7 @@ sub part_of_important_build {
 
 # gru job
 sub reduce_result {
-    my ($app, $args) = @_;
+    my ($self, $app, $args) = @_;
 
     if (!ref($args)) {
         $args = {resultdir => $args};


### PR DESCRIPTION
Can't call method part_of_important_build on an undefined value at /usr/share/openqa/script/../lib/OpenQA/Schema/Result/Jobs.pm line 784.