### PR TITLE
Vertically align progress bar with build number

### DIFF
--- a/assets/sass/theme.scss
+++ b/assets/sass/theme.scss
@@ -9,3 +9,8 @@ table a:not(.btn),
 .table a:not(.btn) {
 	  text-decoration: inherit;
 }
+
+div.progress {
+    margin-top: $line-height-computed / 2;
+    margin-bottom: $line-height-computed / 2;
+}


### PR DESCRIPTION
Change 18px bottom margin (bootstrap default) into 8 top 8 bottom.