### PR TITLE
Provide 'API help' menu entry

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -298,6 +298,14 @@ sub startup {
 
     # Favicon
     $r->get('/favicon.ico' => sub { my $c = shift; $c->render_static('favicon.ico') });
+
+    $auth->get(
+        '/routes' => sub {
+            my $c = shift;
+            $c->stash(snapshot => '');
+            $c->render('mojo/debug');
+        })->name('api_help');
+
     # Default route
     $r->get('/')->name('index')->to('main#index');
 

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -65,7 +65,7 @@ is($res, 'Login', 'no-one logged in');
 # And log in as operator
 $test_case->login($t, 'percival');
 my $actions = OpenQA::Test::Case::trim_whitespace($t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
-like($actions, qr/Logged in as perci Operators Menu.*Manage API keys Logout/, 'perci has operator links');
+like($actions, qr/Logged in as perci Operators Menu.*Manage API keys API help Logout/, 'perci has operator links');
 unlike($actions, qr/Administrators Menu/, 'perci has no admin links');
 
 $t->get_ok('/api_keys')->status_is(200);

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -103,6 +103,7 @@
                                       <li role="separator" class="divider"></li>
                                       <li>
                                          %= link_to "Manage API keys" => url_for('api_keys')
+                                         %= link_to "API help" => url_for('api_help')
                                       </li>
                                   % }
                                   <li>


### PR DESCRIPTION
The menu entry shown for every operator links to '/routes' which shows
the standard 'debug' page as shown for '404'. This page is only available to
operators as it might leak server config in the log file snippet rendered on
the page.

The intention of providing the list of available routes is to have at least
some kind of help for users of the API without needing to ask them to read the
source code and understand the Mojolicious routing algorithms.

Example screenshot:
![openqa_api_help_link](https://cloud.githubusercontent.com/assets/1693432/17966273/01764304-6ac1-11e6-98b2-6d2309ba367c.png)

Related to https://github.com/os-autoinst/openQA/pull/831

Related progress issue: https://progress.opensuse.org/issues/13192