### PR TITLE
Make sure worker updates status throughout asset upload and checksum

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -100,8 +100,7 @@ sub stop_job($;$) {
     print "stop_job $aborted\n" if $verbose;
     $stop_job_running = 1;
 
-    # stop all job related timers
-    remove_timer('update_status');
+    # stop all job related timers except update_status
     remove_timer('check_backend');
     remove_timer('job_timeout');
 
@@ -298,6 +297,10 @@ sub _stop_job($;$) {
         api_call('post', 'jobs/' . $job->{id} . '/set_done', {result => 'incomplete'});
     }
     warn sprintf("cleaning up %s...\n", $job->{settings}->{NAME});
+    # now we're actually done, remove the update_status timer (we have
+    # to do this as late as possible to prevent the dead job checker
+    # from deciding we're dead)
+    remove_timer('update_status');
     clean_pool();
     $job              = undef;
     $worker           = undef;


### PR DESCRIPTION
Combined with https://github.com/os-autoinst/os-autoinst/pull/574 , this should address poo#13526. The aim here is to make sure the worker process continues to update status throughout the teardown process, while it's uploading files and doing checksums. https://github.com/os-autoinst/os-autoinst/pull/574 removes the checksum operation in os-autoinst, which blocks the worker process for ~1-2 mins on large files.

In this PR, we go back to a non-blocking post for file upload, allowing timers to fire while the upload is in progress. We move the `remove_timer` call for the `update_status` timer to *after* the file upload is done. Together, these changes make the worker keep updating status through file upload.

Finally, we change the way we do the post-upload checksum to read in 100MB of data at a time, and update status every five seconds. I did try finding a way to let the timer keep firing while the checksum is running; you can *kinda* do it by hitting `Mojo::IOLoop->one_tick` before each `add()`, but it's clearly not really 'right' - it makes the checksum significantly slower, and when I played with it in a test script, it seems like it could get completely stuck, depending on how fast the disk reads were and how long the timers take to fire. It seems simpler and more robust to simply accept that the timer is going to be blocked and have the checksum function itself update the status every five seconds while it's running.

I've tested these changes on Fedora's staging instance, by watching the HTTP server logs for `POST . /api/v1/jobs/36100/status` events. Before these changes, in a typical 'run an install and upload the disk image' test, there's about a 4-5 minute period after the VM shuts down during which there is only 0 or 1 status update POST. With all commits from this patch *and* https://github.com/os-autoinst/os-autoinst/pull/574 applied, this phase takes only 2-3 minutes, and there are status update POSTs throughout.

There is an extremely new addition to Mojo which looks interesting and could potentially help us make all this cleaner: http://mojolicious.org/perldoc/Mojo/IOLoop#subprocess . This was literally added three days ago, in Mojo 7.04, and is labelled experimental; we should probably wait a bit for it to mature before using it.