### PR TITLE
use /var/lib/openqa/share/factory/iso path

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -469,7 +469,7 @@ If your openQA is not running on port 80 on 'localhost', you can add option
 +--host=http://otherhost:9526+ to specify a different port or host.
 
 WARNING: Use only the ISO filename in the 'client' command. You must place the
-file in +/var/lib/openqa/factory/iso+. You cannot place the file elsewhere and
+file in +/var/lib/openqa/share/factory/iso+. You cannot place the file elsewhere and
 specify its path in the command.
 
 For Fedora, a sample run might be:


### PR DESCRIPTION
to use same canonical location as before (not the symlink)

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>