### PR TITLE
Draw needle match labels after match boxes

### DIFF
--- a/assets/javascripts/needlediff.js
+++ b/assets/javascripts/needlediff.js
@@ -99,7 +99,7 @@ NeedleDiff.prototype.draw = function() {
     split = 1;
   }
 
-  // Draw all matches
+  // Draw all match boxes
   this.matches.forEach(function(a, idx) {
 
     // If some part of the match is at the left of the handle...
@@ -162,7 +162,10 @@ NeedleDiff.prototype.draw = function() {
       this.ctx.lineTo(start, a['ypos'] - lineWidth);
       this.ctx.stroke();
     }
+  }.bind(this));
 
+  // Draw all match labels
+  this.matches.forEach(function(a, idx) {
     // And the similarity, if needed
     if (split > a['xpos'] && split < a['xpos'] + a['width']) {
       this.ctx.strokeStyle = "rgb(0, 0, 0)";

--- a/assets/javascripts/needlediff.js
+++ b/assets/javascripts/needlediff.js
@@ -109,6 +109,15 @@ NeedleDiff.prototype.draw = function() {
     var orig;
     var lineWidth = 1;
 
+    var y_start = a['ypos'] - lineWidth;
+    var y_end = a['ypos'] + a['height'] + lineWidth;
+    if (y_start < 0) {
+      y_start = 0;
+    }
+    if (y_end > this.height) {
+      y_end = this.height;
+    }
+
     if (split > x) {
 
       // ...fill that left part with the original needle's area
@@ -127,11 +136,11 @@ NeedleDiff.prototype.draw = function() {
 
       this.ctx.lineWidth = lineWidth;
       this.ctx.beginPath();
-      this.ctx.moveTo(x + width, a['ypos'] - lineWidth);
-      this.ctx.lineTo(x, a['ypos'] - lineWidth);
-      this.ctx.lineTo(x, a['ypos'] + a['height'] + lineWidth);
-      this.ctx.lineTo(x + width, a['ypos'] + a['height'] + lineWidth);
-      this.ctx.lineTo(x + width, a['ypos'] - lineWidth);
+      this.ctx.moveTo(x + width, y_start);
+      this.ctx.lineTo(x, y_start);
+      this.ctx.lineTo(x, y_end);
+      this.ctx.lineTo(x + width, y_end);
+      this.ctx.lineTo(x + width, y_start);
       this.ctx.stroke();
     }
 
@@ -155,11 +164,11 @@ NeedleDiff.prototype.draw = function() {
 
       this.ctx.lineWidth = lineWidth;
       this.ctx.beginPath();
-      this.ctx.moveTo(start, a['ypos'] - lineWidth);
-      this.ctx.lineTo(a['xpos'] + a['width'] + lineWidth, a['ypos'] - lineWidth);
-      this.ctx.lineTo(a['xpos'] + a['width'] + lineWidth, a['ypos'] + a['height'] + lineWidth);
-      this.ctx.lineTo(start, a['ypos'] + a['height'] + lineWidth);
-      this.ctx.lineTo(start, a['ypos'] - lineWidth);
+      this.ctx.moveTo(start, y_start);
+      this.ctx.lineTo(a['xpos'] + a['width'] + lineWidth, y_start);
+      this.ctx.lineTo(a['xpos'] + a['width'] + lineWidth, y_end);
+      this.ctx.lineTo(start, y_end);
+      this.ctx.lineTo(start, y_start);
       this.ctx.stroke();
     }
   }.bind(this));

--- a/assets/javascripts/needlediff.js
+++ b/assets/javascripts/needlediff.js
@@ -184,8 +184,13 @@ NeedleDiff.prototype.draw = function() {
       var textSize = this.ctx.measureText(text);
       var tx;
       var ty = a['ypos'] + a['height'] + 19;
-      if (ty > this.screenshotImg.height) {
-        ty = a['ypos'] - 4;
+      if (ty > this.height) {
+        // Place text above match box
+        ty = a['ypos'] - 10;
+      }
+      if (ty < 14) {
+        // Place text in match box (text is 14px large)
+        ty = a['ypos'] + a['height'] - 10;
       }
       if (split + textSize.width < a['xpos'] + a['width']) {
         tx = a['xpos'] + a['width'] - textSize.width - 1;


### PR DESCRIPTION
This prevents match boxes from covering up labels of other boxes.

https://progress.opensuse.org/issues/12296