### PR TITLE
Ensure preview is visible

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -35,6 +35,7 @@ function previewSuccess(data, force) {
   var pout = $("#preview_container_out");
   // make it visible so jquery gets the props right
   pout.insertAfter(td.children(".links_a").eq(preview_offset));
+  pout.show();
 
   var pin = $("#preview_container_in");
   if (!(pin.find("pre").length || pin.find("audio").length)) {


### PR DESCRIPTION
Might prevent https://progress.opensuse.org/issues/13484

I actually can not reproduce the issue myself so I'm not sure. From the error log I think `a.offset()` is undefined because `a` isn't visible because its parent `#preview_container_out` isn't visible. Hence this might fix the issue. What do you think?