### PR TITLE
Avoid HMAC timestamp mismatch during large file upload

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -131,6 +131,14 @@ sub startup {
             }
         });
 
+    # Mark build_tx time in the header for HMAC time stamp check
+    # to avoid large timeouts on uploads
+    $self->hook(
+        after_build_tx => sub {
+            my ($tx, $app) = @_;
+            $tx->req->headers->header('X-Build-Tx-Time' => time);
+        });
+
     # load auth module
     my $auth_method = $self->config->{auth}->{method};
     my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";


### PR DESCRIPTION
By using the build_tx hook to register an additional header to compare
against that time in HMAC check. The auth check only runs after the request
is completely uploaded