### PR TITLE
Label builds where all tests passed as reviewed

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -477,3 +477,8 @@ a.restart-link {
 .table-nonfluid {
     width: auto;
 }
+
+.review-all-passed {
+    color: $color-module-passed;
+}
+

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -104,8 +104,9 @@ sub _group_result {
             }
             $self->app->log->error("MISSING S:" . $job->state . " R:" . $job->result);
         }
-        $jr{reviewed} = $jr{failed} > 0 && $jr{labeled} == $jr{failed};
-        $res{$b} = \%jr;
+        $jr{reviewed_all_passed} = $jr{passed} == $count;
+        $jr{reviewed}            = $jr{failed} > 0 && $jr{labeled} == $jr{failed};
+        $res{$b}                 = \%jr;
         $max_jobs = $count if ($count > $max_jobs);
         last if (++$buildnr >= $limit);
     }

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -106,7 +106,7 @@ subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {
     my $get = $t->get_ok('/group_overview/1001?only_tagged=1')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 1, 'only one tagged build is shown');
     $get = $t->get_ok('/group_overview/1001?only_tagged=0')->status_is(200);
-    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 4, 'all builds shown again');
+    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 5, 'all builds shown again');
 };
 
 =pod

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -72,7 +72,7 @@ $t->app($app);
 my $get        = $t->get_ok('/api/v1/jobs');
 my @jobs       = @{$get->tx->res->json->{jobs}};
 my $jobs_count = scalar @jobs;
-is($jobs_count, 14);
+is($jobs_count, 15);
 my %jobs = map { $_->{id} => $_ } @jobs;
 is($jobs{99981}->{state},    'cancelled');
 is($jobs{99963}->{state},    'running');
@@ -82,9 +82,9 @@ is($jobs{99963}->{clone_id}, undef);
 
 # That means that only 9 are current and only 10 are relevant
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 11);
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
 is(scalar(@{$get->tx->res->json->{jobs}}), 12);
+$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
+is(scalar(@{$get->tx->res->json->{jobs}}), 13);
 
 # check limit quantity
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current', limit => 5});
@@ -140,7 +140,7 @@ my $cloned = $new_jobs{$new_jobs{99939}->{clone_id}};
 
 # The number of current jobs doesn't change
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 11, 'job count stay the same');
+is(scalar(@{$get->tx->res->json->{jobs}}), 12, 'job count stay the same');
 
 # Test /jobs/X/restart and /jobs/X
 $get = $t->get_ok('/api/v1/jobs/99926')->status_is(200);

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -230,7 +230,7 @@
         result     => "softfailed",
         state      => "done",
         backend    => 'qemu',
-        t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 14400, 'UTC'),    # Four hour ago
+        t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 14400, 'UTC'),    # Four hours ago
         t_started  => time2str('%Y-%m-%d %H:%M:%S', time - 18000, 'UTC'),    # Five hours ago
         t_created  => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),     # Two hours ago
         TEST       => "textmode",
@@ -243,6 +243,27 @@
         jobs_assets => [{asset_id => 1},],
         retry_avbl  => 3,
         settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}]
+    },
+    Jobs => {
+        id         => 99947,
+        group_id   => 1001,
+        priority   => 35,
+        result     => "passed",
+        state      => "done",
+        backend    => 'qemu',
+        t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),     # Two hours ago
+        t_started  => time2str('%Y-%m-%d %H:%M:%S', time - 14300, 'UTC'),    # Three hours ago
+        t_created  => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),     # One hour ago
+        TEST       => "textmode",
+        FLAVOR     => 'DVD',
+        DISTRI     => 'opensuse',
+        BUILD      => '0092',
+        VERSION    => '13.1',
+        MACHINE    => '32bit',
+        ARCH       => 'i586',
+        jobs_assets => [{asset_id => 1},],
+        retry_avbl  => 3,
+        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0092-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}]
     },
     Jobs => {
         id         => 99963,

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -77,7 +77,7 @@ like($driver->find_element('#running #job_99963 td.time', 'css')->get_text(), qr
 
 $get = $t->get_ok('/tests')->status_is(200);
 my @header = $t->tx->res->dom->find('h2')->map('text')->each;
-my @expected = ('2 jobs are running', '2 scheduled jobs', 'Last 8 finished jobs');
+my @expected = ('2 jobs are running', '2 scheduled jobs', 'Last 9 finished jobs');
 is_deeply(\@header, \@expected, 'all job summaries correct with defaults');
 
 $get      = $t->get_ok('/tests?limit=1')->status_is(200);
@@ -135,13 +135,13 @@ is($parent_e->get_attribute('data-parents'),  "[]",              "no parents");
 # first check the relevant jobs
 my @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
 
-is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99962 job_99946 job_99937 job_99981)], '99945 is not displayed');
+is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99947 job_99962 job_99946 job_99937 job_99981)], '99945 is not displayed');
 $driver->find_element('#relevantfilter', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax();
 
 # Test 99945 is not longer relevant (replaced by 99946) - but displayed for all
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99962 job_99946 job_99945 job_99944 job_99937 job_99981)], 'all rows displayed');
+is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99947 job_99962 job_99946 job_99945 job_99944 job_99937)], 'first 10 rows displayed');
 
 # now toggle back
 #print $driver->get_page_source();
@@ -149,7 +149,7 @@ $driver->find_element('#relevantfilter', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax();
 
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99962 job_99946 job_99937 job_99981)], '99945 again hidden');
+is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99947 job_99962 job_99946 job_99937 job_99981)], '99945 again hidden');
 
 $driver->get($baseurl . "tests?match=staging_e");
 t::ui::PhantomTest::wait_for_ajax();

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -45,15 +45,14 @@ my $baseurl = $driver->get_current_url();
 is(scalar @{$driver->find_elements('h4', 'css')}, 4);
 
 $driver->find_element('Build0091', 'link_text')->click();
-
-like($driver->find_element('#summary', 'css')->get_text(), qr/Overall Summary of opensuse build 0091/, 'we are on build 91');
+like($driver->find_element('#summary', 'css')->get_text(), qr/Overall Summary of opensuse test build 0091/, 'we are on build 91');
 
 is($driver->get($baseurl . '?time_limit_days=1&limit_builds=1'), 1, 'index page accepts query parameters');
 is(scalar @{$driver->find_elements('h4', 'css')}, 2, 'only one build per group shown');
 
 $driver->find_element('opensuse', 'link_text')->click();
 
-is(scalar @{$driver->find_elements('h4', 'css')}, 4, 'number of builds for opensuse');
+is(scalar @{$driver->find_elements('h4', 'css')}, 5, 'number of builds for opensuse');
 is($driver->get($driver->get_current_url() . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
 
 my $more_builds = $t->get_ok($baseurl . 'group_overview/1001')->tx->res->dom->at('#more_builds');

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -48,9 +48,10 @@ $driver->find_element('Login', 'link_text')->click();
 # we are back on the main page
 is($driver->get_title(), "openQA", "back on main page");
 
-# make sure no build is marked as 'reviewed' as there are no comments yet
+# check 'reviewed' labels
 my $get = $t->get_ok($driver->get_current_url())->status_is(200);
-$get->element_exists_not('.fa-certificate');
+$get->element_exists_not('.review', 'no build is marked as \'reviewed\' as there are no comments yet');
+$get->element_exists('.review-all-passed', 'exactly one build is marked as \'reviewed\' because all tests passed');
 
 $driver->find_element('opensuse', 'link_text')->click();
 
@@ -248,7 +249,8 @@ subtest 'commenting in test results including labels' => sub {
         $get = $t->get_ok($driver->get_current_url())->status_is(200);
         is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href}, 'https://bugzilla.suse.com/show_bug.cgi?id=1234');
         $driver->find_element('opensuse', 'link_text')->click();
-        is($driver->find_element('.fa-certificate', 'css')->get_attribute('title'), 'Reviewed (1 comments)', 'build should be marked as labeled');
+        is($driver->find_element('.review-all-passed', 'css')->get_attribute('title'), 'Reviewed (all passed)', 'build should be marked because all tests passed');
+        is($driver->find_element('.review',            'css')->get_attribute('title'), 'Reviewed (1 comments)', 'build should be marked as labeled');
         $driver->get($baseurl . 'tests/99926#comments');
         $driver->find_element('#text',          'css')->send_keys('poo#9876');
         $driver->find_element('#submitComment', 'css')->click();

--- a/t/ui/16-tests_previous_results.t
+++ b/t/ui/16-tests_previous_results.t
@@ -42,7 +42,7 @@ like($t->tx->res->dom->at('#res_99944 ~ .build a')->{href}, qr{/tests/overview?}
 my $build = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#previous_results .build')->all_text);
 is($build, '0091', 'build of previous job is shown');
 $get = $t->get_ok($previous_results_header->at('a')->{href})->status_is(200);
-is($t->tx->res->dom->at('#info_box .panel-heading a')->{href}, '/tests/99946', 'latest link points to last in scenario');
+is($t->tx->res->dom->at('#info_box .panel-heading a')->{href}, '/tests/99947', 'latest link points to last in scenario');
 $get = $t->get_ok('/tests/99946?limit_previous=1#previous')->status_is(200);
 my $table_rows = $t->tx->res->dom->find('#previous tbody tr');
 is($table_rows->size, 1, 'can be limited with query parameter');

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -21,7 +21,12 @@
                     <i class="review fa fa-certificate" title="Reviewed (<%= $build_res->{labeled}; %> comments)"></i>
                 </span>
             % }
-
+            % my $reviewed_all_passed = $build_res->{reviewed_all_passed};
+            % if ($reviewed_all_passed) {
+                <span id="review-all-passed-<%= $group_build_id %>">
+                    <i class="review-all-passed fa fa-certificate" title="Reviewed (all passed)"></i>
+                </span>
+            % }
             </h4>
         </div>
         <div class="col-md-8">


### PR DESCRIPTION
As proposed by @okurz

For better distinction review icons for such builds are green and have an appropriate tool tip.

For testing I had to insert another job to the fixtures. That's the reason for all the adjustments in all the tests.