### PR TITLE
Improve bug references in comments

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -30,6 +30,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &parse_assets_from_settings
   &bugurl
   &bugref_to_href
+  &href_to_bugref
   &asset_type_from_setting
   &check_download_url
   &check_download_whitelist
@@ -302,6 +303,8 @@ my %bugrefs = (
     boo => 'https://bugzilla.opensuse.org/show_bug.cgi?id=',
     poo => 'https://progress.opensuse.org/issues/',
 );
+my %bugurls = reverse %bugrefs;
+
 sub bugurl {
     my ($bugref) = @_;
     return $bugrefs{$bugref};
@@ -312,8 +315,15 @@ sub bugref_to_href {
     my $regex = join('|', keys %bugrefs);
     $regex = qr/(($regex)#(\d+))(?=\s|$)/;
     $text =~ s{$regex}{<a href="@{[$bugrefs{$2}]}$3">$1</a>}gi;
+    return $text;
+}
 
+sub href_to_bugref {
+    my ($text) = @_;
 
+    my $regex = join('|', values %bugrefs) =~ s/\?/\\\?/gr;
+    $regex = qr/($regex)(\d+)(?=\s|$)/;
+    $text =~ s{$regex}{@{[$bugurls{$1}]}#$2}gi;
     return $text;
 }
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -296,21 +296,23 @@ sub parse_assets_from_settings {
     return $assets;
 }
 
+my %bugrefs = (
+    bnc => 'https://bugzilla.novell.com/show_bug.cgi?id=',
+    bsc => 'https://bugzilla.suse.com/show_bug.cgi?id=',
+    boo => 'https://bugzilla.opensuse.org/show_bug.cgi?id=',
+    poo => 'https://progress.opensuse.org/issues/',
+);
 sub bugurl {
     my ($bugref) = @_;
-    my %bugrefs = (
-        bnc => 'https://bugzilla.novell.com/show_bug.cgi?id=',
-        bsc => 'https://bugzilla.suse.com/show_bug.cgi?id=',
-        boo => 'https://bugzilla.opensuse.org/show_bug.cgi?id=',
-        poo => 'https://progress.opensuse.org/issues/',
-    );
     return $bugrefs{$bugref};
 }
 
 sub bugref_to_href {
     my ($text) = @_;
+    my $regex = join('|', keys %bugrefs);
+    $regex = qr/(($regex)#(\d+))(?=\s|$)/;
+    $text =~ s{$regex}{<a href="@{[$bugrefs{$2}]}$3">$1</a>}gi;
 
-    $text =~ s{((bnc|bsc|boo|poo)#(\d+))}{<a href="@{[bugurl($2)]}$3">$1</a>}gi;
 
     return $text;
 }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -18,6 +18,7 @@ use Date::Format;
 use Mojo::Base 'Mojolicious::Controller';
 use OpenQA::Utils;
 use OpenQA::IPC;
+use OpenQA::Utils qw/href_to_bugref/;
 
 sub obj_comments {
     my ($self, $param, $table, $label) = @_;
@@ -70,7 +71,7 @@ sub create {
 
     my $res = $comments->create(
         {
-            text    => $text,
+            text    => href_to_bugref($text),
             user_id => $self->current_user->id
         });
     $self->emit_event('openqa_user_new_comment', {id => $res->id});
@@ -90,7 +91,7 @@ sub update {
     my $comment    = $comments->find($self->param('comment_id'));
     return $self->render(json => {error => "Comment $comment_id does not exist"}, status => 404) unless $comment;
     return $self->render(json => {error => "Forbidden (must be author)"},         status => 403) unless ($comment->user_id == $self->current_user->id);
-    my $res = $comment->update({text => $text});
+    my $res = $comment->update({text => href_to_bugref($text)});
     $self->emit_event('openqa_user_update_comment', {id => $comment->id});
     $self->render(json => {id => $res->id});
 }

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -174,7 +174,9 @@ subtest 'URL auto-replace' => sub {
         <a href="https://openqa.example.com/foo/bar">https://openqa.example.com/foo/bar</a>: http://localhost:9562
         https://openqa.example.com/tests/181148 (reference http://localhost/foo/bar )
         bsc#1234 boo#2345 poo#3456 t#4567
-        t#5678/modules/welcome/steps/1'
+        t#5678/modules/welcome/steps/1
+        https://progress.opensuse.org/issues/6789
+        https://bugzilla.novell.com/show_bug.cgi?id=1234'
     );
     $driver->find_element('#submitComment', 'css')->click();
     t::ui::PhantomTest::wait_for_ajax;
@@ -183,8 +185,9 @@ subtest 'URL auto-replace' => sub {
     my @comments = $driver->find_elements('div.media-comment p', 'css');
     is($comments[1]->get_text(), $test_message, "body of first comment after adding another");
 
-    like($comments[0]->get_text(), qr/bsc#1234 boo#2345 poo#3456 t#4567/);
+    like($comments[0]->get_text(), qr/bsc#1234 boo#2345 poo#3456 t#4567 .*poo#6789 bnc#1234/);
     my @urls = $driver->find_elements('div.media-comment a', 'css');
+    is(scalar @urls, 11);
     is((shift @urls)->get_text(), 'https://openqa.example.com/foo/bar',      "url1");
     is((shift @urls)->get_text(), 'http://localhost:9562',                   "url2");
     is((shift @urls)->get_text(), 'https://openqa.example.com/tests/181148', "url3");
@@ -194,6 +197,8 @@ subtest 'URL auto-replace' => sub {
     is((shift @urls)->get_text(), 'poo#3456',                                "url7");
     is((shift @urls)->get_text(), 't#4567',                                  "url8");
     is((shift @urls)->get_text(), 't#5678/modules/welcome/steps/1',          "url9");
+    is((shift @urls)->get_text(), 'poo#6789',                                "url10");
+    is((shift @urls)->get_text(), 'bnc#1234',                                "url11");
 
     my @urls2 = $driver->find_elements('div.media-comment a', 'css');
     is((shift @urls2)->get_attribute('href'), 'https://openqa.example.com/foo/bar',                 "url1-href");
@@ -205,6 +210,8 @@ subtest 'URL auto-replace' => sub {
     is((shift @urls2)->get_attribute('href'), 'https://progress.opensuse.org/issues/3456',          "url7-href");
     like((shift @urls2)->get_attribute('href'), qr{/tests/4567}, "url8-href");
     like((shift @urls2)->get_attribute('href'), qr{/tests/5678/modules/welcome/steps}, "url9-href");
+    is((shift @urls2)->get_attribute('href'), 'https://progress.opensuse.org/issues/6789',        "url10-href");
+    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.novell.com/show_bug.cgi?id=1234', "url11-href");
 };
 
 subtest 'commenting in test results including labels' => sub {

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -168,7 +168,9 @@ subtest 'commenting in the group overview' => sub {
 
 subtest 'URL auto-replace' => sub {
     $driver->find_element('#text', 'css')->send_keys('
-        foo@bar foo#bar
+        foo@bar foo#bar should not be detected as bugref
+        bsc#2436346bla should not be detected, too
+        bsc#2436346bla2
         <a href="https://openqa.example.com/foo/bar">https://openqa.example.com/foo/bar</a>: http://localhost:9562
         https://openqa.example.com/tests/181148 (reference http://localhost/foo/bar )
         bsc#1234 boo#2345 poo#3456 t#4567
@@ -181,6 +183,7 @@ subtest 'URL auto-replace' => sub {
     my @comments = $driver->find_elements('div.media-comment p', 'css');
     is($comments[1]->get_text(), $test_message, "body of first comment after adding another");
 
+    like($comments[0]->get_text(), qr/bsc#1234 boo#2345 poo#3456 t#4567/);
     my @urls = $driver->find_elements('div.media-comment a', 'css');
     is((shift @urls)->get_text(), 'https://openqa.example.com/foo/bar',      "url1");
     is((shift @urls)->get_text(), 'http://localhost:9562',                   "url2");


### PR DESCRIPTION
- Prevent detecting occurrences like bsc#2436346bla as bugref
- Replace URLs with the appropriate bugref pattern (fixes https://progress.opensuse.org/issues/11110)