### PR TITLE
notify workers on job restart

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -468,6 +468,7 @@ sub job_restart {
         $j->worker->send_command(command => 'abort', job_id => $j->id);
     }
 
+    job_notify_workers();
     return @duplicated;
 }
 


### PR DESCRIPTION
Without this, when you restart a completed job, it doesn't get
picked up until job_notify_workers() or job_grab() get run for
some other reason.

It's pretty easy to reproduce the problem: just try and restart a completed job when no other jobs are running. It'll sit there in 'scheduled' state until you restart a worker service, or trigger a `job_grab` some other way.