### PR TITLE
notify workers when job with chained children done (POO #13746)

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -114,12 +114,6 @@ sub job_grab {
     return OpenQA::Scheduler::Scheduler::job_grab(%$args);
 }
 
-dbus_method('job_notify_workers');
-sub job_notify_workers {
-    my ($self) = @_;
-    OpenQA::Scheduler::Scheduler::job_notify_workers;
-}
-
 dbus_method('job_restart', [['array', 'uint32']], [['array', 'uint32']]);
 sub job_restart {
     my ($self, $args) = @_;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -62,6 +62,7 @@ use constant {
 };
 use constant RESULTS => (NONE, PASSED, SOFTFAILED, FAILED, INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED);
 use constant COMPLETE_RESULTS => (PASSED, SOFTFAILED, FAILED);
+use constant OK_RESULTS => (PASSED, SOFTFAILED);
 use constant INCOMPLETE_RESULTS => (INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED);
 
 # scenario keys w/o MACHINE. Add MACHINE when desired, commonly joined on
@@ -1378,7 +1379,7 @@ sub done {
 
     $self->update(\%new_val);
 
-    if (!grep { $result eq $_ } (PASSED, SOFTFAILED)) {
+    if (!grep { $result eq $_ } OK_RESULTS) {
         $self->_job_skip_children;
         $self->_job_stop_children;
     }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -26,7 +26,7 @@ use DBIx::Class::Timestamps qw/now/;
 
 use Carp;
 
-use OpenQA::Scheduler::Scheduler 'job_notify_workers';
+use OpenQA::Scheduler::Scheduler qw/asset_register/;
 
 # return settings key for given job settings
 sub _settings_key {
@@ -423,7 +423,8 @@ sub schedule_iso {
     # if the notification fails
     try {
         #notify workers new jobs are available
-        job_notify_workers;
+        my $ipc = OpenQA::IPC->ipc;
+        $ipc->websockets('ws_notify_workers');
     }
     catch {
         $self->app->log->warn("Failed to notify workers");

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -131,7 +131,7 @@ sub create {
                 run_at   => now(),
             });
 
-        OpenQA::Scheduler::Scheduler::job_notify_workers();
+        $ipc->websockets('ws_notify_workers');
     }
     catch {
         $status = 400;

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -66,4 +66,10 @@ sub ws_send_all {
     return OpenQA::WebSockets::Server::ws_send_all(@args);
 }
 
+dbus_method('ws_notify_workers');
+sub ws_notify_workers {
+    my ($self) = @_;
+    return OpenQA::WebSockets::Server::ws_send_all(('job_available'));
+}
+
 1;


### PR DESCRIPTION
This should resolve POO #13746. When a job with chained
children passes (or soft fails) we should notify workers to
ensure the child jobs are picked up promptly. Since we're now
using this 'passed or softfailed is OK' logic in two places,
make it another result array constant.