### PR TITLE
Add issue reporting links to needle preview screen

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -428,7 +428,7 @@ div.flags {
 .fa.result_user_restarted { color: $color-module-none; }
 
 .fa.comment, .fa.bookmark, .fa.bug, .fa.certificate, .fa.tag { color: $color-labels; }
-.fa-bolt { color: $color-bolt; }
+.label_bug.fa-bolt { color: $color-bolt; }
 
 .step_actions {
     .step_action { color: $color-step-actions; }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -232,6 +232,13 @@ sub scenario_hash {
     return \%scenario;
 }
 
+sub scenario {
+    my ($self) = @_;
+    my $scenario = join('-', map { $self->get_column($_) } SCENARIO_KEYS);
+    if (my $machine = $self->MACHINE) { $scenario .= "@" . $machine }
+    return $scenario;
+}
+
 # return 0 if we have no worker
 sub worker_id {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -257,7 +257,7 @@ sub _show {
 
     my $scenario = join('-', map { $job->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_KEYS);
 
-    $scenario .= "@" . $job->MACHINE;
+    $scenario .= "@" . $job->MACHINE if $job->MACHINE;
 
     $self->stash(testname => $job->name);
     $self->stash(distri   => $job->DISTRI);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -255,15 +255,11 @@ sub _show {
     my ($self, $job) = @_;
     return $self->reply->not_found unless $job;
 
-    my $scenario = join('-', map { $job->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_KEYS);
-
-    $scenario .= "@" . $job->MACHINE if $job->MACHINE;
-
     $self->stash(testname => $job->name);
     $self->stash(distri   => $job->DISTRI);
     $self->stash(version  => $job->VERSION);
     $self->stash(build    => $job->BUILD);
-    $self->stash(scenario => $scenario);
+    $self->stash(scenario => $job->scenario);
     $self->stash(worker   => $job->worker);
 
     my $clone_of = $self->db->resultset("Jobs")->find({clone_id => $job->id});

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -61,11 +61,18 @@ sub register {
         });
 
     $app->helper(
+        bug_report_actions => sub {
+            my ($c) = @_;
+            return $c->include_branding('external_reporting');
+        });
+
+    $app->helper(
         stepaction_for => sub {
-            my ($c, $title, $url, $icon) = @_;
+            my ($c, $title, $url, $icon, $class) = @_;
+            $class //= '';
             my $icons = $c->t(i => (class => "step_action fa $icon fa-lg fa-stack-1x")) . $c->t(i => (class => 'new fa fa-plus fa-stack-1x'));
             my $content = $c->t(span => (class => 'fa-stack') => sub { $icons });
-            return $c->link_to($url => (title => $title) => sub { $content });
+            return $c->link_to($url => (title => $title, class => $class) => sub { $content });
         });
 
     $app->helper(

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -76,7 +76,15 @@ like($driver->find_element('.step_actions .fa-info-circle', 'css')->get_attribut
 $driver->find_element('.step_actions .fa-info-circle', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax;
 ok($driver->find_element('.step_actions .popover', 'css')->is_displayed(), "needle info is a clickable popover");
-$driver->find_element('[href="#step/bootloader/1"]', 'css')->click();
+$driver->find_element('//a[@href="#step/installer_timezone/1"]')->click();
+t::ui::PhantomTest::wait_for_ajax;
+my @report_links = $driver->find_elements('#preview_container_in .report', 'css');
+my @title = map { $_->get_attribute('title') } @report_links;
+is($title[0], 'Report product bug', 'product bug report URL available');
+is($title[1], 'Report test issue',  'test issue report URL available');
+my @url = map { $_->get_attribute('href') } @report_links;
+like($url[0], qr{bugzilla.*enter_bug.*tests%2F99937}, 'bugzilla link referencing current test');
+like($url[1], qr{progress.*new}, 'progress/redmine link for reporting test issues');
 
 # test running view with Test::Mojo as phantomjs would get stuck on the
 # liveview/livelog forever

--- a/templates/branding/openSUSE/external_reporting.html.ep
+++ b/templates/branding/openSUSE/external_reporting.html.ep
@@ -1,0 +1,79 @@
+%# % my $job = stash('job');
+% my $build = $job->BUILD;
+% my $step_url = url_for('step')->to_abs;
+% my $module = stash('moduleid');
+% my %product_details = ();
+% $product_details{short_desc} = "[Build $build] openQA test fails in $module";
+
+<% my %distri_to_prod = (
+    sle => 'SUSE Linux Enterprise',
+    opensuse => 'openSUSE',
+);%>
+<% my %flavor_to_prod_sle = (
+    Server => 'Server',
+    Desktop => 'Desktop',
+    SAP => 'for SAP Applications',
+);
+%>
+% my $distri = $distri_to_prod{$job->DISTRI};
+% my $product = '';
+% if ($job->DISTRI eq 'sle') {
+%     my $subproduct = $job->FLAVOR =~ s/(\w*)(-\w*)?/$1/r;
+%     my $version = $job->VERSION =~ s/-/ /r;
+%     if ($subproduct eq 'Server' && $version eq '12') {
+%         $version = '12 (SLES 12)';
+%     }
+%     $product = join(' ', $distri, $flavor_to_prod_sle{$subproduct}, $version);
+% }
+% else {
+%     $product = $job->VERSION eq 'Tumbleweed' ? 'Tumbleweed' : 'Distribution';
+% }
+% $product_details{product} = "$distri $product";
+% $product_details{bug_file_loc} = $step_url;
+% sub build_link {
+%     my ($job) = @_;
+%     return '[' . $job->BUILD . '](' . url_for('test', testid => $job->id)->to_abs .  ')';
+% }
+% my $scenario = $job->scenario;
+% my $first_known_bad = build_link($job) . ' (current job)';
+% my $last_good = '(unknown)';
+% for my $prev ($job->_previous_scenario_jobs) {
+%     if ($prev->result =~ '(passed|softfailed)') {
+%         $last_good = build_link($prev);
+%         last;
+%     }
+%     $first_known_bad = build_link($prev);
+% }
+% my $latest = url_for('latest')->query($job->scenario_hash)->to_abs;
+<% my $description = "### Observation
+
+openQA test in scenario $scenario fails in
+[$module]($step_url)
+
+
+## Reproducible
+
+Fails since (at least) Build $first_known_bad
+
+
+## Expected result
+
+Last good: $last_good (or more recent)
+
+
+## Further details
+
+Always latest result in this scenario: [latest]($latest)
+";
+%>
+% $product_details{comment} = $description;
+% my $product_url_new = 'https://bugzilla.opensuse.org/enter_bug.cgi';
+%= stepaction_for('Report product bug' => url_for($product_url_new)->query(%product_details), 'fa-bug', 'report product_bug');
+<% my %test_issue_params = (
+    'issue[subject]' => "test fails in $module",
+    'issue[description]' => $description,
+    'issue[category_id]' => 152,
+);
+%>
+% my $test_url_new = 'https://progress.opensuse.org/projects/openqatests/issues/new';
+%= stepaction_for('Report test issue' => url_for($test_url_new)->query(%test_issue_params), 'fa-bolt', 'report test_issue');

--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -33,6 +33,7 @@
         % if (is_operator) {
             %= stepaction_for 'Create new needle' => url_for('edit_step'), 'fa-thumb-tack'
         % }
+        %= bug_report_actions
     </span>
 </div>
 <div id="needle_diff">


### PR DESCRIPTION
Using the available context of test results a URL for
corresponding issue tracker can be generated. The
fields in the to be opened issue can already be
prefilled. This can be extended later on even more.

The configuration in openqa.ini must accomodate the
corresponding issue tracker type and URL for creating
new tickets. For now bugzilla and redmine are
supported, more can be added. If no configuration is
set at all no links are generated.

As at least in bugzilla the product field is mandatory
to end up with a pre-filled bug the mapping from job
group to bugzilla product can be done in the config
file, too.

Example screenshot:
![openqa_report_bug_link](https://cloud.githubusercontent.com/assets/1693432/18614478/86b9b632-7d8f-11e6-8d32-ed8f15cdd634.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/os-autoinst/openqa/887)

<!-- Reviewable:end -->
