### PR TITLE
Use $FindBin::RealBin to resolve links for client script

### DIFF
--- a/script/client
+++ b/script/client
@@ -71,7 +71,7 @@ lorem ipsum ...
 
 use strict;
 use FindBin;
-BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
+BEGIN { unshift @INC, "$FindBin::RealBin/../lib" }
 
 use Data::Dump;
 use Mojo::URL;


### PR DESCRIPTION
Recently I added openqa-client link to openqa-client package pointing
to /usr/share/openqa/script/client. Without resolving this link
calling openqa-client fails due to missing OpenQA::Client module.