### PR TITLE
Simplify asset definition for bootstrap

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -1,6 +1,4 @@
 ! bootstrap.css
-# download the fonts (plus some css we dont need)
-<< https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.css
 < https://cdn.datatables.net/1.10.12/css/dataTables.bootstrap.css
 < http://fontawesome.io/assets/font-awesome/css/font-awesome.css
 < stylesheets/overview.scss
@@ -8,7 +6,7 @@
 < stylesheets/openqa.scss
 < http://harvesthq.github.io/chosen/chosen.css
 < stylesheets/result_preview.scss
-<< https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/stylesheets/_bootstrap.scss
+< https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/stylesheets/_bootstrap.scss
 < sass/theme.scss
 
 ! codemirror.css


### PR DESCRIPTION
Newer assetpack has fixed the font fetching, so we no longer require the
workaround

See https://github.com/jhthorsen/mojolicious-plugin-assetpack/issues/92#issuecomment-247957583