### PR TITLE
Try harder to avoid long running pre-processing

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -145,9 +145,10 @@ sub job_grab {
 
     my $worker = _validate_workerid($workerid);
     if ($worker->job) {
-        # TROUBLE ahead - do not call seen, to get into dead worker detection first
-        log_warning($worker->name . " still has a job, but wants to grab new one: " . $worker->job->id);
-        return {};
+        my $job = $worker->job;
+        log_warning($worker->name . " wants to grab a new job - killing the old one: " . $job->id);
+        $job->done(result => 'incomplete');
+        $job->auto_duplicate;
     }
     $worker->seen($workercaps);
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1416,25 +1416,16 @@ test modules
 =cut
 sub done {
     my ($self, %args) = @_;
-    my $newbuild = 0;
-    $newbuild = int($args{newbuild}) if defined $args{newbuild};
+    my $newbuild = int($args{newbuild} // 0);
     $args{result} = OBSOLETED if $newbuild;
-
-    # cleanup
-    $self->set_property('JOBTOKEN');
-    $self->release_networks();
-    $self->owned_locks->delete;
-    $self->locked_locks->update({locked_by => undef});
-    if ($self->worker) {
-        # free the worker
-        $self->worker->update({job_id => undef});
-    }
 
     # update result if not provided
     my $result = $args{result} || $self->calculate_result();
     my %new_val = (state => DONE);
     # for cancelled jobs the result is already known
     $new_val{result} = $result if $self->result eq NONE;
+
+    $self->_cleanup;
 
     $self->update(\%new_val);
 
@@ -1446,6 +1437,20 @@ sub done {
     $self->carry_over_labels;
 
     return $result;
+}
+
+# free the worker and remove token and locks
+sub _cleanup {
+    my ($self) = @_;
+
+    $self->set_property('JOBTOKEN');
+    $self->release_networks();
+    $self->owned_locks->delete;
+    $self->locked_locks->update({locked_by => undef});
+    if ($self->worker) {
+        # free the worker
+        $self->worker->update({job_id => undef});
+    }
 }
 
 sub cancel {
@@ -1466,6 +1471,8 @@ sub cancel {
         $count += $self->_job_skip_children;
         $count += $self->_job_stop_children;
     }
+
+    $self->_cleanup;
     return $count;
 }
 1;


### PR DESCRIPTION
If many workers grab a job at the same time, they all go through the
scheduler bottleneck, wo will assign every worker a job one by one.
But the last couple of job_grab requests will actually get a timeout
and the worker will believe it didn't get a job.

if it then later grabs another job, we need to do something with the
previously assigned job. Just saying no is a problem as both the worker
keeps being unused and the job stays in running (pre-processing).

So now I set the previous job to incomplete and duplicate it. Beside
that I also made sure that cancelling a job kills the worker reference,
so it can grab another one.