### PR TITLE
Avoid DBUS dead locks

### DIFF
--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -208,7 +208,7 @@ sub _dispatch {
     catch {
         confess "error getting ipc service: $_";
     };
-    my $object = $service->get_object('/' . $services{$target}, join('.', $openqa_prefix, $services{$target}));
+    my $object = $service->get_object('/' . $services{$target}, $service_name);
     log_debug("dispatching IPC $command to $target: " . pp(\@data));
     my $ret = $object->$command(@data);
     log_debug("IPC finished");

--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -198,8 +198,8 @@ sub _get_fh_from_fd {
     return $fh;
 }
 
-sub _dispatch {
-    my ($self, $target, $command, @data) = @_;
+sub service {
+    my ($self, $target) = @_;
     my $service_name = join('.', $openqa_prefix, $services{$target});
     my $service;
     try {
@@ -208,7 +208,13 @@ sub _dispatch {
     catch {
         confess "error getting ipc service: $_";
     };
-    my $object = $service->get_object('/' . $services{$target}, $service_name);
+    return $service->get_object('/' . $services{$target}, $service_name);
+
+}
+
+sub _dispatch {
+    my ($self, $target, $command, @data) = @_;
+    my $object = $self->service($target);
     log_debug("dispatching IPC $command to $target: " . pp(\@data));
     my $ret = $object->$command(@data);
     log_debug("IPC finished");

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -184,4 +184,12 @@ sub barrier_destroy {
     return 1;
 }
 
+dbus_signal('JobsAvailable');
+dbus_method('emit_jobs_available');
+sub emit_jobs_available {
+    my ($self) = @_;
+    $self->emit_signal("JobsAvailable");
+    return;
+}
+
 1;

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -40,7 +40,7 @@ use OpenQA::Schema::Result::JobDependencies;
 use FindBin;
 use lib $FindBin::Bin;
 #use lib $FindBin::Bin.'Schema';
-use OpenQA::Utils qw/log_debug log_warning parse_assets_from_settings asset_type_from_setting/;
+use OpenQA::Utils qw/log_debug log_warning parse_assets_from_settings asset_type_from_setting notify_workers/;
 use db_helpers qw/rndstr/;
 
 use OpenQA::IPC;
@@ -286,8 +286,7 @@ sub job_grab {
 
     # starting one job from parallel group can unblock
     # other jobs from the group
-    my $ipc = OpenQA::IPC->ipc;
-    $ipc->websockets('ws_notify_workers');
+    notify_workers;
 
     return $job_hashref;
 }
@@ -386,8 +385,7 @@ sub job_restart {
 
     # if we got new jobs, notify workers
     if (@duplicated) {
-        my $ipc = OpenQA::IPC->ipc;
-        $ipc->websockets('ws_notify_workers');
+        notify_workers;
     }
     return @duplicated;
 }

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -146,7 +146,7 @@ sub download_asset {
         # we're not going to die because this is a gru task and we don't
         # want to cause the Endless Gru Loop Of Despair, just return and
         # let the jobs fail
-        $ipc->websockets('ws_notify_workers');
+        notify_workers;
         return;
     }
 
@@ -164,7 +164,7 @@ sub download_asset {
             OpenQA::Utils::log_error("download_asset: URL $url host $host is blacklisted!");
         }
         OpenQA::Utils::log_error("**API MAY HAVE BEEN BYPASSED TO CREATE THIS TASK!**");
-        $ipc->websockets('ws_notify_workers');
+        notify_workers;
         return;
     }
 
@@ -182,7 +182,7 @@ sub download_asset {
         catch {
             # again, we're trying not to die here, but log and return on fail
             OpenQA::Utils::log_error("Error renaming temporary file to $dlpath: $_");
-            $ipc->websockets('ws_notify_workers');
+            notify_workers;
             return;
         };
     }
@@ -190,7 +190,7 @@ sub download_asset {
         # Clean up after ourselves. Probably won't exist, but just in case
         OpenQA::Utils::log_error("Downloading failed! Deleting files");
         unlink($dlpath);
-        $ipc->websockets('ws_notify_workers');
+        notify_workers;
         return;
     }
 
@@ -213,7 +213,7 @@ sub download_asset {
 
     # We want to notify workers either way: if we failed to download the ISO,
     # we want the jobs to run and fail.
-    $ipc->websockets('ws_notify_workers');
+    notify_workers;
 }
 
 # this is a GRU task - abusing the namespace

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -648,8 +648,7 @@ the caller is responsible to notify the workers about the new job - the model is
 
 I.e.
     $job->auto_duplicate;
-    my $ipc = OpenQA::IPC->ipc;
-    $ipc->websockets('ws_notify_workers');
+    notify_workers;
 
 =cut
 sub auto_duplicate {

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -35,6 +35,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &asset_type_from_setting
   &check_download_url
   &check_download_whitelist
+  &notify_workers
 );
 
 
@@ -397,6 +398,16 @@ sub check_download_whitelist {
     }
     # empty list signals caller that check passed
     return ();
+}
+
+sub notify_workers {
+    my $ipc = OpenQA::IPC->ipc;
+
+    my $con = $ipc->{bus}->get_connection;
+    my $msg = $con->make_method_call_message("org.opensuse.openqa.Scheduler", "/Scheduler", "org.opensuse.openqa.Scheduler", "emit_jobs_available");
+    # do not wait for a reply - avoid deadlocks. this way we can even call it
+    # from within the scheduler without having to worry about reentering
+    $con->send($msg);
 }
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -404,6 +404,10 @@ sub notify_workers {
     my $ipc = OpenQA::IPC->ipc;
 
     my $con = $ipc->{bus}->get_connection;
+
+    # ugly work around for Net::DBus::Test not being able to handle us using low level API
+    return if ref($con) eq 'Net::DBus::Test::MockConnection';
+
     my $msg = $con->make_method_call_message("org.opensuse.openqa.Scheduler", "/Scheduler", "org.opensuse.openqa.Scheduler", "emit_jobs_available");
     # do not wait for a reply - avoid deadlocks. this way we can even call it
     # from within the scheduler without having to worry about reentering

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -420,15 +420,7 @@ sub schedule_iso {
             run_at   => now(),
         });
 
-    # if the notification fails
-    try {
-        #notify workers new jobs are available
-        my $ipc = OpenQA::IPC->ipc;
-        $ipc->websockets('ws_notify_workers');
-    }
-    catch {
-        $self->app->log->warn("Failed to notify workers");
-    };
+    notify_workers;
     $self->emit_event('openqa_iso_create', $args);
     return @ids;
 }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -65,8 +65,7 @@ sub _register {
     if (my $job = $worker->job) {
         $job->set_property('JOBTOKEN');
         $job->auto_duplicate;
-        my $ipc = OpenQA::IPC->ipc;
-        $ipc->websockets('ws_notify_workers');
+        notify_workers;
 
         # .. set it incomplete
         $job->update(

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -56,6 +56,7 @@ sub new {
     bless $self, $class;
     # hook DBus to Mojo reactor
     $ipc->manage_events($reactor, $self);
+
     return $self;
 }
 
@@ -76,12 +77,6 @@ dbus_method('ws_send_all', ['string']);
 sub ws_send_all {
     my ($self, @args) = @_;
     return OpenQA::WebSockets::Server::ws_send_all(@args);
-}
-
-dbus_method('ws_notify_workers');
-sub ws_notify_workers {
-    my ($self) = @_;
-    return OpenQA::WebSockets::Server::ws_send_all(('job_available'));
 }
 
 1;


### PR DESCRIPTION
Instead of calling blocking DBUS methods into websockets when notifying the worker,
we do a non blocking call into the scheduler, which then emits a signal.

This signal is then listened from websockets (whenever it has time :) to notify
the workers. None of that blocks and as such can't deadlock