### PR TITLE
Do not manually render anything on websocket creation

### DIFF
--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -120,7 +120,6 @@ sub ws_create {
     $self->on(json   => \&_message);
     $self->on(finish => \&_finish);
     ws_add_worker($workerid, $self->tx->max_websocket_size(10485760));
-    return $self->render(text => 'ack', status => 101);
 }
 
 sub ws_is_worker_connected {


### PR DESCRIPTION
This extra content actually confused the websocket parser on the
clients. It's unclear why this worked before, but the documentation
clearly indicates that this is not necessary to do any render