### PR TITLE
fix downloading assets to different filename

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -292,6 +292,7 @@ sub parse_assets_from_settings {
     my $assets = {};
 
     for my $k (keys %$settings) {
+        next if exists $settings->{$k . '_URL'};    # don't register assets that also have _URL variant defined
         my $type = asset_type_from_setting($k);
         if ($type) {
             $assets->{$k} = {type => $type, name => $settings->{$k}};

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -313,6 +313,9 @@ sub schedule_iso {
                 next;
             }
         }
+        else {
+            $filename = $args->{$short};
+        }
         # full path to download target location. We need to guess
         # the asset type to know where to put it, using the same
         # subroutine as parse_assets_from_settings


### PR DESCRIPTION
I've deleted fork from which I've created #673 and it looks like I cannot update that pull request anymore, so I have created new pull request. It's rebased on top of master and with updated tests. You can find discussion in #673.

Basically, this code fixes problem with functionality that should enable you to specify both `ASSET` and `ASSET_URL` with intention of downloading from `ASSET_URL`, but then saving it into `ASSET` filename. We need it to be able to download from https://kojipkgs.fedoraproject.org/compose/branched/Fedora-25-20161004.n.0/compose/Everything/armhfp/os/images/pxeboot/vmlinuz but then save it as `vmlinuz.Fedora-25-20161004.n.0`.

This code works, but shows `asset name 'vmlinuz.Fedora-25-20161004.n.0' invalid or does not exist` during scheduling. @aaannz suggested to adapt `OpenQA::Utils::asset_type_from_setting` not to register assets if both asset name and asset _URL is set.