### PR TITLE
Add JSON representation of index and group overview

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -111,7 +111,10 @@ sub compute_build_results {
     }
     if (%builds) {
         $builds{_max}   = $max_jobs;
-        $builds{_group} = $group;
+        $builds{_group} = {
+            id   => $group->id,
+            name => $group->name
+        };
         return \%builds;
     }
     return;

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -39,6 +39,9 @@ sub index {
         push(@results, $build_results) if $build_results;
     }
     $self->stash('results', \@results);
+    $self->respond_to(
+        json => {json     => {results => \@results}},
+        html => {template => 'main/index'});
 }
 
 sub group_overview {
@@ -89,11 +92,13 @@ sub group_overview {
         }
     }
     $self->stash('result',          $res);
-    $self->stash('group',           $group);
     $self->stash('limit_builds',    $limit_builds);
     $self->stash('only_tagged',     $only_tagged);
     $self->stash('comments',        \@comments);
     $self->stash('pinned_comments', \@pinned_comments);
+    $self->respond_to(
+        json => {json     => {result => $res}},
+        html => {template => 'main/group_overview'});
 }
 
 1;

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,33 +1,32 @@
 % my $max = delete $result->{_max};
-% delete $result->{_group};
 % for my $build (reverse sort keys %$result) {
     % my $build_res = $result->{$build};
     <div class="row">
         <div class="col-md-4 text-nowrap">
             <h4>
-                <%= link_to "Build$build" => url_for('tests_overview')->query(distri => $build_res->{distri}, version => $build_res->{version}, build => $build, groupid => $group->id ) %>
+                <%= link_to "Build$build" => url_for('tests_overview')->query(distri => $build_res->{distri}, version => $build_res->{version}, build => $build, groupid => $group->{id} ) %>
                 (<abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">
                 %= delete $build_res->{oldest}
                 </abbr>)
-            % my $group_build_id = $group->id . '-' . $build;
-            % my $tag = $build_res->{tag};
-            % if ($tag) {
-                <span id="tag-<%= $group_build_id %>">
-                    <i class="tag fa fa-tag" title="<%= $tag->{type}; %>"><%= $tag->{description} %></i>
-                </span>
-            % }
-            % my $reviewed = $build_res->{reviewed};
-            % if ($reviewed) {
-                <span id="review-<%= $group_build_id %>">
-                    <i class="review fa fa-certificate" title="Reviewed (<%= $build_res->{labeled}; %> comments)"></i>
-                </span>
-            % }
-            % my $reviewed_all_passed = $build_res->{reviewed_all_passed};
-            % if ($reviewed_all_passed) {
-                <span id="review-all-passed-<%= $group_build_id %>">
-                    <i class="review-all-passed fa fa-certificate" title="Reviewed (all passed)"></i>
-                </span>
-            % }
+                % my $group_build_id = $group->{id} . '-' . $build;
+                % my $tag = $build_res->{tag};
+                % if ($tag) {
+                    <span id="tag-<%= $group_build_id %>">
+                        <i class="tag fa fa-tag" title="<%= $tag->{type}; %>"><%= $tag->{description} %></i>
+                    </span>
+                % }
+                % my $reviewed = $build_res->{reviewed};
+                % if ($reviewed) {
+                    <span id="review-<%= $group_build_id %>">
+                        <i class="review fa fa-certificate" title="Reviewed (<%= $build_res->{labeled}; %> comments)"></i>
+                    </span>
+                % }
+                % my $reviewed_all_passed = $build_res->{reviewed_all_passed};
+                % if ($reviewed_all_passed) {
+                    <span id="review-all-passed-<%= $group_build_id %>">
+                        <i class="review-all-passed fa fa-certificate" title="Reviewed (all passed)"></i>
+                    </span>
+                % }
             </h4>
         </div>
         <div class="col-md-8">

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -7,17 +7,19 @@
     $('.timeago').timeago();
 % end
 
-<h2>Last Builds for Group <%= $group->name %></h2>
+% my $group = delete $result->{_group};
+
+<h2>Last Builds for Group <%= $group->{name} %></h2>
 
 % if ($pinned_comments) {
     <div id="group_descriptions">
     % for my $comment (@$pinned_comments) {
-        %= include 'comments/comment_row', comment_id => $comment->id, comment => $comment, user => $comment->user, context => {type => 'group', id => $group->id, pinned => 1}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'
+        %= include 'comments/comment_row', comment_id => $comment->id, comment => $comment, user => $comment->user, context => {type => 'group', id => $group->{id}, pinned => 1}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'
     % }
     </div>
 % }
 
-%= include 'main/group_builds', result => $result
+%= include 'main/group_builds', result => $result, group => $group
 
 <div id="more_builds">
     Limit to
@@ -31,14 +33,14 @@
 
 <h2>Comments</h2>
 % for my $comment (reverse @$comments) {
-    %= include 'comments/comment_row', comment_id => $comment->id, comment => $comment, user => $comment->user, context => {type => 'group', id => $group->id}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'
+    %= include 'comments/comment_row', comment_id => $comment->id, comment => $comment, user => $comment->user, context => {type => 'group', id => $group->{id}}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'
 % }
 
 % if (current_user) {
     <script id="comment-row-template" type="text/template">
-        %= include 'comments/comment_row', comment_id => '@comment_id@', comment => 0, user => current_user, context => {type => 'group', id => $group->id}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'
+        %= include 'comments/comment_row', comment_id => '@comment_id@', comment => 0, user => current_user, context => {type => 'group', id => $group->{id}}, put_action => 'apiv1_put_group_comment', delete_action => 'apiv1_delete_group_comment'
     </script>
-    %= form_for url_for('apiv1_post_group_comment', group_id => $group->id) => (method => "post", class => "form-horizontal", id => "commentForm", role => "form", onsubmit => "addComment(this, false); return false;") => begin
+    %= form_for url_for('apiv1_post_group_comment', group_id => $group->{id}) => (method => "post", class => "form-horizontal", id => "commentForm", role => "form", onsubmit => "addComment(this, false); return false;") => begin
         %= include 'comments/add_comment_form_groups'
     % end
 % }

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -22,7 +22,7 @@
 % for my $groupresults (@$results) {
     % my $group = delete $groupresults->{_group};
     <h2>
-        %= link_to $group->name => url_for('group_overview', groupid => $group->id)
+        %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})
     </h2>
     %= include 'main/group_builds', result => $groupresults, group => $group
 % }


### PR DESCRIPTION
JSON response can be triggered by adding HTTP header 'Accept: application/json'

Eg.:
```
curl -H 'Accept: application/json' http://localhost:9526?time_limit_days=48 | json_pp
curl -H 'Accept: application/json' http://localhost:9526/group_overview/25?time_limit_days=48 | json_pp
```

Like the former approach, this is meant for the openQA review script.

I don't know how to add the magic for `.json` routes but this variant (proposed by @coolo) looks good as well in my opinion.

Note that this can not be done generically for each page because currently database objects are stashed and those are not rendered as JSON automatically.