### PR TITLE
Fix /index.json route to pass the format

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -216,9 +216,9 @@ sub startup {
 
     # Favicon
     $r->get('/favicon.ico' => sub { my $c = shift; $c->render_static('favicon.ico') });
+    $r->get('/index' => [format => ['html', 'json']])->to('main#index');
     # Default route
     $r->get('/')->name('index')->to('main#index');
-    $r->get('/index.json')->to('main#index');
 
     # Redirection for old links to openQAv1
     $r->get(

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -88,5 +88,8 @@ subtest 'filter form' => sub {
     is($driver->get_current_url(), $baseurl . '?group=SLE+12+SP2&limit_builds=38&time_limit_days=142#', 'URL parameters for filter are correct');
 };
 
+$driver->get($baseurl . 'index.json');
+like($driver->get_page_source(), qr({"results":\[.*{"0048":), 'page rendered as JSON');
+
 t::ui::PhantomTest::kill_phantom();
 done_testing();


### PR DESCRIPTION
/index.json matches the route but doesn't know it has to reply with json.
So just use /index with given formats