### PR TITLE
Fix softfailed results not showing in tests list

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -102,8 +102,8 @@ function renderTestResult( data, type, row ) {
         var html = '';
         if (row['state'] === 'done') {
             html += data['passed'] + "<i class='fa module_passed fa-star' title='modules passed'></i>";
-            if (data['dents']) {
-                html +=  " " + data['dents'] + "<i class='fa module_softfail fa-star-half-empty' title='modules with warnings'></i> ";
+            if (data['softfailed']) {
+                html +=  " " + data['softfailed'] + "<i class='fa module_softfail fa-star-half-empty' title='modules with warnings'></i> ";
             }
             if (data['failed']) {
                 html +=  " " + data['failed'] + "<i class='fa module_failed fa-star-o' title='modules failed'></i> ";
@@ -126,7 +126,7 @@ function renderTestResult( data, type, row ) {
         }
         return '<a href="/tests/' + row['id'] + '">' + html + '</a>';
     } else {
-        return (parseInt(data['passed']) * 10000) + (parseInt(data['dents']) * 100) + parseInt(data['failed']);
+        return (parseInt(data['passed']) * 10000) + (parseInt(data['softfailed']) * 100) + parseInt(data['failed']);
     }
 }
 

--- a/t/fixtures/05-job_modules.pl
+++ b/t/fixtures/05-job_modules.pl
@@ -764,7 +764,7 @@
         job_id   => 99946,
         category => 'installation',
         name     => 'logpackages',
-        result   => 'passed',
+        result   => 'softfailed',
     },
     JobModules => {
         script   => 'tests/installation/installer_desktopselection.pm',

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -67,7 +67,7 @@ my $job99946 = $driver->find_element('#results #job_99946', 'css');
 my @tds = $driver->find_child_elements($job99946, "td");
 is((shift @tds)->get_text(), 'Build0091 of opensuse-13.1-DVD.i586', "medium of 99946");
 is((shift @tds)->get_text(), 'textmode@32bit',                      "test of 99946");
-is((shift @tds)->get_text(), '29 1',                                "result of 99946");
+is((shift @tds)->get_text(), '28 1 1',                              "result of 99946 (passed, softfailed, failed)");
 like((shift @tds)->get_text(), qr/about 3 hours ago/, "finish time of 99946");
 
 # Test 99963 is still running


### PR DESCRIPTION
Fixes a regression introduced by commit 37d549e "Make softfailed a proper
final result". As there was no test for softfailed modules this was not
catched. Fixtures changed accordingly.

Fixes https://progress.opensuse.org/issues/14132