### PR TITLE
Fix group overview when no builds shown

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -36,6 +36,8 @@ sub compute_build_results {
     my $max_jobs = 0;
     my $buildnr  = 0;
     for my $b (map { $_->BUILD } $builds->all) {
+        last if (defined($limit) && ++$buildnr > $limit);
+
         my $jobs = $group->result_source->schema->resultset('Jobs')->search(
             {
                 'me.BUILD'    => $b,
@@ -107,7 +109,6 @@ sub compute_build_results {
         $jr{reviewed}            = $jr{failed} > 0 && $jr{labeled} == $jr{failed};
         $builds{$b}              = \%jr;
         $max_jobs = $count if ($count > $max_jobs);
-        last if (++$buildnr >= $limit);
     }
     if (%builds) {
         $builds{_max}   = $max_jobs;

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -91,7 +91,13 @@ sub group_overview {
             delete $res->{$build} unless $res->{$build}->{tag};
         }
     }
-    $self->stash('result',          $res);
+    $self->stash('result', $res);
+    $self->stash(
+        'group',
+        {
+            id   => $group->id,
+            name => $group->name
+        });
     $self->stash('limit_builds',    $limit_builds);
     $self->stash('only_tagged',     $only_tagged);
     $self->stash('comments',        \@comments);

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -21,6 +21,7 @@ BEGIN {
 use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
+use Test::Warnings;
 use OpenQA::Test::Case;
 
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -56,8 +56,12 @@ is(scalar @{$driver->find_elements('h4', 'css')}, 2, 'only the one hour old buil
 
 $driver->find_element('opensuse', 'link_text')->click();
 
+my $build_url = $driver->get_current_url();
 is(scalar @{$driver->find_elements('h4', 'css')}, 5, 'number of builds for opensuse');
-is($driver->get($driver->get_current_url() . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
+is($driver->get($build_url . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
+$driver->get($build_url . '?limit_builds=0');
+is(scalar @{$driver->find_elements('div.build-row h4', 'css')}, 0, 'all builds filtered out');
+is($driver->find_element('h2', 'css')->get_text(), 'Last Builds for Group opensuse', 'group name shown correctly when all builds filtered out');
 
 my $more_builds = $t->get_ok($baseurl . 'group_overview/1001')->tx->res->dom->at('#more_builds');
 my $res         = OpenQA::Test::Case::trim_whitespace($more_builds->all_text);

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,7 +1,7 @@
 % my $max = delete $result->{_max};
 % for my $build (reverse sort keys %$result) {
     % my $build_res = $result->{$build};
-    <div class="row">
+    <div class="row build-row">
         <div class="col-md-4 text-nowrap">
             <h4>
                 <%= link_to "Build$build" => url_for('tests_overview')->query(distri => $build_res->{distri}, version => $build_res->{version}, build => $build, groupid => $group->{id} ) %>

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -7,7 +7,7 @@
     $('.timeago').timeago();
 % end
 
-% my $group = delete $result->{_group};
+% delete $result->{_group};
 
 <h2>Last Builds for Group <%= $group->{name} %></h2>
 


### PR DESCRIPTION
* Fix https://progress.opensuse.org/issues/14136
* Also group name was missing in heading