### PR TITLE
Reuse a constant boundary to make debugging failed uploads a little easier

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -44,6 +44,8 @@ my $test_order;
 my $stop_job_running;
 my $update_status_running;
 
+my $boundary = '--a_sTrinG-thAt_wIll_n0t_apPEar_iN_openQA_uPloads-61020111';
+
 my $tosend_images = {};
 my $tosend_files  = [];
 
@@ -157,10 +159,8 @@ sub upload {
     my $tx = $OpenQA::Worker::Common::ua->build_tx(POST => $ua_url => form => $form);
     # override the default boundary calculation - it reads whole file
     # and it can cause various timeouts
-    my $ct = $tx->req->headers->content_type;
-    my $boundary = encode_base64 join('', map chr(rand 256), 1 .. 32);
-    $boundary =~ s/\W/X/g;
-    $tx->req->headers->content_type("$ct; boundary=$boundary");
+    my $headers = $tx->req->headers;
+    $headers->content_type($headers->content_type . "; boundary=$boundary");
 
     my $res = $OpenQA::Worker::Common::ua->start($tx);
 


### PR DESCRIPTION
While looking into a problem with corrupted uploads, i've noticed that the boundary workaround in `OpenQA::Worker::Jobs` uses a randomly generated string. This seems like a bad idea without actually checking the content of the file to be uploaded, and incredibly hard to debug should it ever fail. So, this patch replaces the random string with a constant one that is very unlikely to appear out in the wild.

Reasons against applying this patch might be security concerns, like the possibility of creating a DoS attack vector. Sadly i'm not familiar enough with the code base yet to find out. But should it be the case, i would recommend using a constant string as a base and combining it with a randomly generated salt.