### PR TITLE
Load step and needles for failedmodules link async

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -1,4 +1,5 @@
 function setupOverview() {
+    setupAsyncFailedResult();
     $('.cancel')
     	.bind("ajax:success", function(event, xhr, status) {
             $(this).text(''); // hide the icon

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -154,6 +154,7 @@ function checkResultHash() {
 }
 
 function setupResult(state, jobid) {
+  setupAsyncFailedResult();
   $(".current_preview").removeClass("current_preview");
 
   $(window).keydown(function(e) {

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -235,3 +235,36 @@ function setupResultButtons() {
    
 }
 
+function getFailedSteps(failed_module) {
+    if (failed_module.has_failed_steps) {
+        return;
+    }
+    failed_module.has_failed_steps = true;
+    var m = $(failed_module);
+    var a = m.children('a');
+    $.getJSON(m.data('async'), function(fails) {
+        var new_href = a.attr('href').replace(/\/1$/, '/'+fails.first_failed_step);
+        a.replaceWith('<a href="'+new_href+'">'+a.text()+'</a>');
+        if (fails.failed_needles.length) {
+            var new_title = '<p>Failed needles:</p><ul>';
+            $.each(fails.failed_needles, function(i, needle) {
+                new_title += '<li>'+needle+'</li>';
+            });
+            new_title += '</ul>'
+            m.attr('data-original-title', new_title);
+            if (m.next('.tooltip:visible').length) {
+                m.tooltip('show');
+            }
+        }
+        else {
+            m.attr('data-original-title', "");
+            m.tooltip('hide');
+        }
+    }).fail(function() {
+        failed_module.has_failed_steps = false;
+    });
+}
+
+function setupAsyncFailedResult() {
+    $(document).on('show.bs.tooltip', '.failedmodule', function() { getFailedSteps(this) });
+}

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1016,29 +1016,14 @@ sub create_asset {
     return $abs;
 }
 
-sub failed_modules_with_needles {
-
+sub failed_modules {
     my ($self) = @_;
 
     my $fails = $self->modules->search({result => 'failed'});
-    my $failedmodules = {};
+    my $failedmodules = [];
 
     while (my $module = $fails->next) {
-
-        my @needles;
-
-        my $counter = 0;
-        for my $detail (@{$module->details}) {
-            $counter++;
-            next unless $detail->{result} eq 'fail';
-            for my $needle (@{$detail->{needles}}) {
-                push @needles, [$needle->{name}, $counter];
-            }
-        }
-        if (!@needles) {
-            push @needles, [undef, $counter];
-        }
-        $failedmodules->{$module->name} = \@needles;
+        push @$failedmodules, $module->name;
     }
     return $failedmodules;
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -179,6 +179,7 @@ sub startup {
     my $test_r = $r->route('/tests/:testid', testid => qr/\d+/);
     my $test_auth = $auth->route('/tests/:testid', testid => qr/\d+/, format => 0);
     $test_r->get('/')->name('test')->to('test#show');
+    $test_r->get('/modules/:moduleid/fails')->name('test_module_fails')->to('test#module_fails');
 
     $test_r->get('/details')->name('details')->to('test#details');
     $test_r->get('/status')->name('status')->to('running#status');

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -173,6 +173,16 @@ $driver->find_element('#filter-panel .panel-heading', 'css')->click();
 $driver->find_element('#filter-form button',          'css')->click();
 is($driver->get_current_url(), $url_with_escaped_parameters . '#', 'escaped URL parameters are passed correctly');
 
+# Test failed module info async update
+$driver->get($baseurl . 'tests/overview?distri=opensuse&version=13.1&build=0091&groupid=1001');
+my $fmod = $driver->find_elements('.failedmodule', 'css')->[1];
+$driver->mouse_move_to_location(element => $fmod, xoffset => 8, yoffset => 8);
+t::ui::PhantomTest::wait_for_ajax;
+like($driver->find_elements('.failedmodule a', 'css')->[1]->get_attribute('href'), qr/\/3$/, 'ajax update failed module step');
+
+$t->get_ok('/tests/99937/modules/kate/fails')->json_is('/failed_needles' => ["test-kate-1"], 'correct failed needles');
+$t->get_ok('/tests/99937/modules/zypper_up/fails')->json_is('/first_failed_step' => 1, 'failed module: fallback to first step');
+
 t::ui::PhantomTest::kill_phantom();
 
 done_testing();

--- a/templates/test/previous.html.ep
+++ b/templates/test/previous.html.ep
@@ -24,7 +24,7 @@
                         <i class="status fa fa-circle<%=  $css %>" title="Done: <%= $res %>"></i>
                     </a>
                 </span>
-                %= include 'test/tr_job_result_failedmodules', jobid => $prev->id, failedmodules => $prev->failed_modules_with_needles()
+                %= include 'test/tr_job_result_failedmodules', jobid => $prev->id, failedmodules => $prev->failed_modules()
                 %= include 'test/tr_job_result_details', jobid => $prev->id, res => $previous_labels->{$prev->id}
             </td>
             % my $query = {build => $prev->BUILD, distri => $distri, version => $version};

--- a/templates/test/tr_job_result_failedmodules.html.ep
+++ b/templates/test/tr_job_result_failedmodules.html.ep
@@ -1,27 +1,18 @@
 % my $count = 0;
 % my $limit = 25;
 
-% for my $failedmodule (sort keys %$failedmodules) {
+% for my $failedmodule (sort @$failedmodules) {
     % if ($count++) {
-      % my $more = (scalar(keys %$failedmodules)) - $count + 1;
+      % my $more = (scalar(@$failedmodules)) - $count + 1;
       % if ($more > 0 && $limit < 12) {
          +<%= $more %>
          % last;
       % }
     % }
-    % my $failedneedles = $failedmodules->{$failedmodule};
-    % my $step = 1;
-    % my $tooltip = '';
-    % if (@$failedneedles) {
-        % $step = $failedneedles->[0]->[1];
-        % if ($failedneedles->[0]->[0]) {
-            % $tooltip = "title='<p>Failed needles:</p><ul><li>" . join('</li><li>',
-            % sort map { $_->[0] } @$failedneedles) . "</li></ul>' data-toggle='tooltip'";
-        % }
-    % }
+    % my $async_url = url_for('test_module_fails', 'testid' => $jobid, 'moduleid' => $failedmodule);
 
-    <span <%= Mojo::ByteStream->new($tooltip) %> class="failedmodule" >
-        %= link_to trim_text($failedmodule, $limit) => url_for('test', 'testid' => $jobid) . "#step/$failedmodule/$step"
+    <span title="<i class='fa fa-refresh fa-spin fa-2x fa-fw'></i><span class='sr-only'>Loading...</span>" data-toggle="tooltip" class="failedmodule" data-async="<%= $async_url %>">
+        %= link_to trim_text($failedmodule, $limit) => url_for('test', 'testid' => $jobid) . "#step/$failedmodule/1"
 	% $limit -= length($failedmodule) > $limit ? $limit : length($failedmodule) + 2;
     </span>
 % }


### PR DESCRIPTION
This change shall reduce filesystem accesses.

- Load on first mouseover
- Update step index in link url
- Insert failed needles into tooltip

See: https://progress.opensuse.org/issues/13986