### PR TITLE
fix loch ness monster bug in 14-grutasks.t

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -245,7 +245,7 @@ sub limit_assets {
                 job_id => {-in => $g->jobs->get_column('id')->as_query},
             },
             {
-                select   => ['asset_id', 'created_by', {max => 't_created', -as => 'latest'},],
+                select   => ['asset_id', 'created_by', {max => 'job_id', -as => 'latest'},],
                 group_by => 'asset_id,created_by',
                 order_by => {-desc => 'latest'}})->all;
         my %assets;


### PR DESCRIPTION
This is a fix for https://progress.opensuse.org/issues/13846. The problem was that the test fixtures had no timestamps, and timestamps generated automatically by the database can overlap, which in very very rare cases will result in assets being retrieved in a different order. By itself that's not a problem, but in the current "keep bucket" code order matters, assets retrieved first will be preserved, while at the same time different groups can prevent certain assets from being deleted. Making the number of assets being removed random.

I see two solutions here, add timestamps to fixtures and mask the problem, or order assets by id to avoid race conditions like this more broadly. My preference in general would be to avoid ordering by timestamps, so that's what i went with here.