### PR TITLE
Add 'fixed' asset subdirectories for fixed assets (#928)

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -442,7 +442,7 @@ For Fedora, similarly, you can call:
 --------------------------------------------------------------------------------
 
 Some Fedora tests require special hard disk images to be present in
-+/var/lib/openqa/share/factory/hdd+. The +createhdds.py+ script in the
++/var/lib/openqa/share/factory/hdd/fixed+. The +createhdds.py+ script in the
 https://bitbucket.org/rajcze/openqa_fedora_tools.git[openqa_fedora_tools]
 repository can be used to create these. See the documentation in that repo
 for more information.

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -375,13 +375,21 @@ directories, most of which must be owned by the user that runs openQA
 * +images+ is where the server stores test screenshots and thumbnails
 * +share+ contains shared directories for remote workers, can be owned by root
 * +share/factory+ contains test assets and temp directory, can be owned by root but sysadmin must create subdirs
-* +share/factory/iso+ contains ISOs for tests
-* +share/factory/hdd+ contains hard disk images for tests
-* +share/factory/repo+ contains repositories for tests
-* +share/factory/other+ contains miscellaneous test assets (e.g. kernels and initrds)
+* +share/factory/iso+ and +share/factory/iso/fixed+ contain ISOs for tests
+* +share/factory/hdd+ and +share/factory/hdd/fixed+ contain hard disk images for tests
+* +share/factory/repo+ and +share/factory/repo/fixed+ contain repositories for tests
+* +share/factory/other+ and +share/factory/other/fixed+ contain miscellaneous test assets (e.g. kernels and initrds)
 * +share/factory/tmp+ is used as a temporary directory (openQA will create it if it owns +share/factory+)
 * +share/tests+ contains the tests themselves
 * +testresults+ is where the server stores test logs and test-generated assets
+
+Each of the asset directories (+factory/iso+, +factory/hdd+, +factory/repo+ and
++factory/other+) may contain a +fixed/+ subdirectory, and assets of the same
+type may be placed in that directory. Placing an asset in the +fixed/+
+subdirectory indicates that it should not be deleted to save space: the GRU
+task which removes old assets when the size of all assets for a given job
+group is above a specified size will ignore assets in the +fixed/+
+subdirectories.
 
 It also contains several symlinks which are necessary due to various things
 moving around over the course of openQA's development. All the symlinks

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -30,7 +30,6 @@ use Data::Dump qw/dd pp/;
 use Date::Format qw/time2str/;
 use DBIx::Class::Timestamps qw/now/;
 use DateTime;
-use File::Spec::Functions qw/catfile catdir/;
 use File::Temp qw/tempdir/;
 use Mojo::URL;
 use Try::Tiny;

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -17,7 +17,7 @@
 package OpenQA::Schema::ResultSet::Assets;
 use strict;
 use base qw/DBIx::Class::ResultSet/;
-use OpenQA::Utils qw/log_warning/;
+use OpenQA::Utils qw/log_warning locate_asset/;
 
 sub register {
     my ($self, $type, $name) = @_;
@@ -27,8 +27,12 @@ sub register {
         log_warning "asset type '$type' invalid";
         return;
     }
-    unless ($name && $name =~ /^[0-9A-Za-z+-._]+$/ && -e join('/', $OpenQA::Utils::assetdir, $type, $name)) {
-        log_warning "asset name '$name' invalid or does not exist";
+    unless ($name && $name =~ /^[0-9A-Za-z+-._]+$/) {
+        log_warning "asset name '$name' invalid";
+        return;
+    }
+    unless (locate_asset $type, $name, 1) {
+        log_warning "no file found for asset '$name' type '$type'";
         return;
     }
     my $asset = $self->find_or_create(

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -28,7 +28,6 @@ use Mojolicious::Commands;
 use DateTime;
 use Cwd qw/abs_path/;
 use File::Path qw/make_path/;
-use OpenQA::Worker::Common qw/ASSET_DIR/;
 
 # reinit pseudo random number generator in every child to avoid
 # starting off with the same state.
@@ -78,7 +77,7 @@ sub startup {
     OpenQA::ServerStartup::setup_logging($self);
 
     unless ($ENV{MOJO_TMPDIR}) {
-        $ENV{MOJO_TMPDIR} = ASSET_DIR . '/tmp';
+        $ENV{MOJO_TMPDIR} = $OpenQA::Utils::assetdir . '/tmp';
         # Try to create tmpdir if it doesn't exist but don't die if failed to create
         if (!-e $ENV{MOJO_TMPDIR}) {
             eval { make_path($ENV{MOJO_TMPDIR}); };

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -22,6 +22,7 @@ use Mojo::Server::Daemon;
 use Mojo::IOLoop;
 
 use OpenQA::Client;
+use OpenQA::Utils qw//;
 use OpenQA::Worker::Common;
 use OpenQA::Worker::Commands;
 use OpenQA::Worker::Pool qw/lockit clean_pool/;
@@ -31,7 +32,7 @@ sub init {
     my ($worker_options, %options) = @_;
     $worker_settings = $worker_options;
     $instance        = $options{instance} if defined $options{instance};
-    $pooldir         = OPENQA_BASE . '/pool/' . $instance;
+    $pooldir         = $OpenQA::Utils::prjdir . '/pool/' . $instance;
     $nocleanup       = $options{"no-cleanup"};
     $verbose         = $options{verbose} if defined $options{verbose};
 

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -23,7 +23,7 @@ use POSIX qw/uname/;
 
 use base qw/Exporter/;
 our @EXPORT = qw/$job $workerid $verbose $instance $worker_settings $pooldir $nocleanup $worker_caps $testresults $openqa_url
-  OPENQA_BASE OPENQA_SHARE ISO_DIR HDD_DIR OTHER_DIR ASSET_DIR STATUS_UPDATES_SLOW STATUS_UPDATES_FAST
+  STATUS_UPDATES_SLOW STATUS_UPDATES_FAST
   add_timer remove_timer change_timer
   api_call verify_workerid register_worker ws_call/;
 
@@ -46,14 +46,6 @@ my $ws;
 my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
 
 # global constants
-use constant OPENQA_BASE  => '/var/lib/openqa';
-use constant OPENQA_SHARE => OPENQA_BASE . '/share';
-use constant ASSET_DIR    => OPENQA_SHARE . '/factory';
-use constant {
-    ISO_DIR   => ASSET_DIR . '/iso',
-    HDD_DIR   => ASSET_DIR . '/hdd',
-    OTHER_DIR => ASSET_DIR . '/other',
-};
 use constant {
     STATUS_UPDATES_SLOW => 10,
     STATUS_UPDATES_FAST => 0.5,

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 
 use OpenQA::Worker::Common;
-use OpenQA::Utils qw//;
+use OpenQA::Utils qw/locate_asset/;
 
 use POSIX qw/:sys_wait_h strftime uname/;
 use JSON qw/to_json/;
@@ -75,8 +75,8 @@ sub engine_workit($) {
 
     for my $isokey (qw/ISO/, map { "ISO_$_" } (1 .. 9)) {
         if (my $iso = $job->{settings}->{$isokey}) {
-            $iso = join('/', ISO_DIR, $iso);
-            unless (-e $iso) {
+            $iso = locate_asset('iso', $iso, 1);
+            unless ($iso) {
                 my $error = "$iso does not exist!";
                 return {error => $error};
             }
@@ -86,8 +86,8 @@ sub engine_workit($) {
 
     for my $otherkey (qw/KERNEL INITRD/) {
         if (my $file = $job->{settings}->{$otherkey}) {
-            $file = join('/', OTHER_DIR, $file);
-            unless (-e $file) {
+            $file = locate_asset('other', $file, 1);
+            unless ($file) {
                 my $error = "$file does not exist!";
                 return {error => $error};
             }
@@ -99,8 +99,8 @@ sub engine_workit($) {
     for my $i (1 .. $nd) {
         my $hdd = $job->{settings}->{"HDD_$i"} || undef;
         if ($hdd) {
-            $hdd = join('/', HDD_DIR, $hdd);
-            unless (-e $hdd) {
+            $hdd = locate_asset('hdd', $hdd, 1);
+            unless ($hdd) {
                 my $error = "$hdd does not exist!";
                 return {error => $error};
             }
@@ -116,7 +116,7 @@ sub engine_workit($) {
         print "setting $k=$v\n" if $verbose;
         $vars{$k} = $v;
     }
-    $vars{ASSETDIR}   = ASSET_DIR;
+    $vars{ASSETDIR}   = $OpenQA::Utils::assetdir;
     $vars{CASEDIR}    = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION});
     $vars{PRODUCTDIR} = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION});
     _save_vars(\%vars);


### PR DESCRIPTION
This adjusts all the places that look for asset files to check
both in the current location and in a new possible location,
which is in a 'fixed/' subdirectory of the normal asset folder
for that asset type. It also adjusts the `limit_assets` gru
task to ignore files in the 'fixed' subdirectories. This
replaces the current special-casing of disk image assets created
by user '0'. That approach has become problematic now both SUSE
and Fedora are testing disk images that come from the distro
composes; these disk images are never getting cleaned up and
that causes disk space exhaustion. This also allows for 'fixed'
ISO and other assets, which the current approach does not.

Note: this is kind of a rough first cut, I haven't tested it manually or extended the tests to cover it yet. I wanted to throw it up for discussion before I spend too much time on it, to see if this is really the way we want to go. I agree with @okurz in #928 that this approach is more obvious to the administrator than just having it be a property of the asset that I guess you'd have to look in the web UI to see, but the code implementation - at least the one I came up with - is kinda ugly, I'm not totally in love with this. The way things are set up, making the asset location on disk ambiguous does introduce some awkward corner cases at least in theory, like which location should `disk_file` return if neither location actually exists? What happens if the appropriate file exists in *both* directories?

So...@okurz @coolo wdyt? Should I push on with this approach or go for something else?

Oh, also, there's a minor unrelated bug fix snuck in here: the current `limit_assets` code for registering assets that exist on disk but not in the database registers `/asset_dir/repo/.` and `/asset_dir/repo/..` as `repo`-type assets, which it probably shouldn't.