### PR TITLE
Add API routes for job group parents

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -99,7 +99,7 @@ around 'keep_results_in_days' => sub {
 
 around 'keep_important_results_in_days' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('keep_important_results_in_days') // ($self->parent ? $self->parent->default_keep_results_in_days : OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS);
+    return $self->get_column('keep_important_results_in_days') // ($self->parent ? $self->parent->default_keep_important_results_in_days : OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS);
 };
 
 around 'default_priority' => sub {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -302,6 +302,13 @@ sub startup {
     $api_ra->put('/job_groups/:group_id')->name('apiv1_put_job_group')->to('job_group#update');
     $api_ra->delete('/job_groups/:group_id')->name('apiv1_delete_job_group')->to('job_group#delete');
 
+    # api/v1/parent_groups
+    $api_public_r->get('/parent_groups')->name('apiv1_list_parent_groups')->to('job_group#list');
+    $api_public_r->get('/parent_groups/:group_id')->name('apiv1_get_parent_group')->to('job_group#list');
+    $api_ra->post('/parent_groups')->name('apiv1_post_parent_group')->to('job_group#create');
+    $api_ra->put('/parent_groups/:group_id')->name('apiv1_put_parent_group')->to('job_group#update');
+    $api_ra->delete('/parent_groups/:group_id')->name('apiv1_delete_job_group')->to('parent_group#delete');
+
     # api/v1/jobs
     $api_public_r->get('/jobs')->name('apiv1_jobs')->to('job#list');
     $api_ro->post('/jobs')->name('apiv1_create_job')->to('job#create');

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -35,69 +35,71 @@ my $app = $t->app;
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-subtest 'list' => sub() {
+subtest 'list job groups' => sub() {
     my $get = $t->get_ok('/api/v1/job_groups')->status_is(200);
     is_deeply(
         $get->tx->res->json,
         [
             {
-                'name'                           => 'opensuse',
-                'parent_id'                      => undef,
-                'sort_order'                     => undef,
-                'keep_logs_in_days'              => 30,
-                'keep_important_logs_in_days'    => 120,
-                'default_priority'               => 50,
-                'description'                    => '##Test description\n\nwith bugref bsc#1234',
-                'keep_results_in_days'           => 365,
-                'keep_important_results_in_days' => 0,
-                'size_limit_gb'                  => 100,
-                'id'                             => 1001
+                name                           => 'opensuse',
+                parent_id                      => undef,
+                sort_order                     => undef,
+                keep_logs_in_days              => 30,
+                keep_important_logs_in_days    => 120,
+                default_priority               => 50,
+                description                    => '##Test description\n\nwith bugref bsc#1234',
+                keep_results_in_days           => 365,
+                keep_important_results_in_days => 0,
+                size_limit_gb                  => 100,
+                id                             => 1001
             },
             {
-                'description'                    => undef,
-                'keep_results_in_days'           => 365,
-                'keep_important_results_in_days' => 0,
-                'size_limit_gb'                  => 100,
-                'id'                             => 1002,
-                'name'                           => 'opensuse test',
-                'parent_id'                      => undef,
-                'keep_important_logs_in_days'    => 120,
-                'sort_order'                     => undef,
-                'keep_logs_in_days'              => 30,
-                'default_priority'               => 50
+                description                    => undef,
+                keep_results_in_days           => 365,
+                keep_important_results_in_days => 0,
+                size_limit_gb                  => 100,
+                id                             => 1002,
+                name                           => 'opensuse test',
+                parent_id                      => undef,
+                keep_important_logs_in_days    => 120,
+                sort_order                     => undef,
+                keep_logs_in_days              => 30,
+                default_priority               => 50
             }]);
 };
 
-subtest 'update' => sub() {
-    my $put = $t->put_ok(
-        '/api/v1/job_groups/1001',
+subtest 'create parent group' => sub() {
+    my $post = $t->post_ok(
+        '/api/v1/parent_groups',
         form => {
-            size_limit_gb               => 101,
-            description                 => 'Test',
-            keep_important_logs_in_days => 45
-        });
+            name                                => 'Cool parent group',
+            default_size_limit_gb               => 200,
+            default_keep_important_logs_in_days => 45
+        })->status_is(200);
+    my $new_id = $post->tx->res->json->{id};
 
-    my $get = $t->get_ok('/api/v1/job_groups/1001')->status_is(200);
+    my $get = $t->get_ok('/api/v1/parent_groups/' . $new_id)->status_is(200);
     is_deeply(
         $get->tx->res->json,
         [
             {
-                'name'                           => 'opensuse',
-                'parent_id'                      => undef,
-                'sort_order'                     => undef,
-                'keep_logs_in_days'              => 30,
-                'keep_important_logs_in_days'    => 45,
-                'default_priority'               => 50,
-                'description'                    => 'Test',
-                'keep_results_in_days'           => 365,
-                'keep_important_results_in_days' => 0,
-                'size_limit_gb'                  => 101,
-                'id'                             => 1001
+                name                                   => 'Cool parent group',
+                sort_order                             => undef,
+                default_keep_logs_in_days              => 30,
+                default_keep_important_logs_in_days    => 45,
+                default_priority                       => 50,
+                default_keep_results_in_days           => 365,
+                default_keep_important_results_in_days => 0,
+                default_size_limit_gb                  => 200,
+                id                                     => $new_id,
+                description                            => undef,
             },
-        ]);
+        ],
+        'list created parent group'
+    );
 };
 
-subtest 'create' => sub() {
+subtest 'create job group' => sub() {
     my $post = $t->post_ok(
         '/api/v1/job_groups',
         form => {
@@ -113,27 +115,70 @@ subtest 'create' => sub() {
         $get->tx->res->json,
         [
             {
-                'name'                           => 'Cool group',
-                'parent_id'                      => undef,
-                'sort_order'                     => undef,
-                'keep_logs_in_days'              => 30,
-                'keep_important_logs_in_days'    => 45,
-                'default_priority'               => 50,
-                'description'                    => 'Test2',
-                'keep_results_in_days'           => 365,
-                'keep_important_results_in_days' => 0,
-                'size_limit_gb'                  => 200,
-                'id'                             => $new_id
+                name                           => 'Cool group',
+                parent_id                      => undef,
+                sort_order                     => undef,
+                keep_logs_in_days              => 30,
+                keep_important_logs_in_days    => 45,
+                default_priority               => 50,
+                description                    => 'Test2',
+                keep_results_in_days           => 365,
+                keep_important_results_in_days => 0,
+                size_limit_gb                  => 200,
+                id                             => $new_id
             },
-        ]);
+        ],
+        'list created job group'
+    );
 };
 
-subtest 'delete and error when listing non-existing group' => sub() {
+subtest 'update job group' => sub() {
+    my $new_id = $t->post_ok(
+        '/api/v1/parent_groups',
+        form => {
+            name                                   => 'Update parent',
+            default_keep_important_logs_in_days    => 100,
+            default_keep_important_results_in_days => 366
+        })->tx->res->json->{id};
+
+    my $put = $t->put_ok(
+        '/api/v1/job_groups/1001',
+        form => {
+            size_limit_gb               => 101,
+            description                 => 'Test',
+            keep_important_logs_in_days => 45,
+            parent_id                   => $new_id,
+        });
+
+    my $get = $t->get_ok('/api/v1/job_groups/1001')->status_is(200);
+    is_deeply(
+        $get->tx->res->json,
+        [
+            {
+                name                           => 'opensuse',
+                parent_id                      => $new_id,
+                sort_order                     => undef,
+                keep_logs_in_days              => 30,
+                keep_important_logs_in_days    => 45,           # inherited value overridden
+                default_priority               => 50,
+                description                    => 'Test',
+                keep_results_in_days           => 365,
+                keep_important_results_in_days => 366,          # changed through inheritance
+                size_limit_gb                  => 101,
+                id                             => 1001,
+            },
+        ],
+        'list updated job group'
+    );
+};
+
+subtest 'delete job group and error when listing non-existing group' => sub() {
     $t->delete_ok('/api/v1/job_groups/3498371')->status_is(400);
     my $new_id = $t->post_ok('/api/v1/job_groups', form => {name => 'To delete'})->tx->res->json->{id};
-    $t->delete_ok('/api/v1/job_groups/' . $new_id)->status_is(200);
+    my $delete = $t->delete_ok('/api/v1/job_groups/' . $new_id)->status_is(200);
+    is($delete->tx->res->json->{id}, $new_id, 'correct ID returned');
     my $get = $t->get_ok('/api/v1/job_groups/' . $new_id)->status_is(400);
-    is_deeply($get->tx->res->json, {error => 'Job group 1004 does not exist'});
+    is_deeply($get->tx->res->json, {error => 'Group 1004 does not exist'}, 'error about non-existing group');
 };
 
 subtest 'prevent deleting non-empty job group' => sub() {


### PR DESCRIPTION
* Works in the same way as the API for
  regular groups and shares the same code
* When deleting a parent group, all groups
  inside remain parentless
* Still TODO
  * List all job groups inside a parent
  * List all jobs inside a group