### PR TITLE
Fix registration of downloaded assets (broken by 0905559b)

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -20,7 +20,8 @@ use base qw/DBIx::Class::ResultSet/;
 use OpenQA::Utils qw/log_warning locate_asset/;
 
 sub register {
-    my ($self, $type, $name) = @_;
+    my ($self, $type, $name, $missingok) = @_;
+    $missingok //= 0;
 
     our %types = map { $_ => 1 } qw/iso repo hdd other/;
     unless ($types{$type}) {
@@ -32,7 +33,9 @@ sub register {
         return;
     }
     unless (locate_asset $type, $name, 1) {
-        log_warning "no file found for asset '$name' type '$type'";
+        if (!$missingok) {
+            log_warning "no file found for asset '$name' type '$type'";
+        }
         return;
     }
     my $asset = $self->find_or_create(

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -323,7 +323,6 @@ sub parse_assets_from_settings {
     my $assets = {};
 
     for my $k (keys %$settings) {
-        next if exists $settings->{$k . '_URL'};    # don't register assets that also have _URL variant defined
         my $type = asset_type_from_setting($k);
         if ($type) {
             $assets->{$k} = {type => $type, name => $settings->{$k}};

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -263,7 +263,7 @@ sub schedule_iso {
     # register assets posted here right away, in case no job
     # templates produce jobs.
     for my $a (values %{parse_assets_from_settings($args)}) {
-        $self->app->schema->resultset("Assets")->register($a->{type}, $a->{name});
+        $self->app->schema->resultset("Assets")->register($a->{type}, $a->{name}, 1);
     }
     my $noobsolete = delete $args->{_NOOBSOLETEBUILD};
     $noobsolete //= 0;


### PR DESCRIPTION
The change in 0905559b which made `parse_assets_from_settings`
skip any setting with a `_URL` partner was a bad idea. It was
an attempt to fix a real problem, but it went too far.

When `schedule_iso` is run, it calls `parse_assets_from_settings`
and attempts to register all the discovered assets. The problem
is that when an ISO is POSTed with, say, both `KERNEL` and
`KERNEL_URL` specified, `parse_assets_from_settings` will find
the `KERNEL` asset and so `schedule_iso` will try to register
it, but because the download has not run yet, the asset does not
exist yet. The `Schema::ResultSet::Assets->register()` method
which `schedule_iso` calls checks whether the asset file exists
and logs a warning if it doesn't.

The problem with fixing it this way is that every subsequent
effort to register the assets associated with a job runs through
`Schema::Result::Jobs->register_assets_from_settings()` - and
that runs through `parse_assets_from_settings`. Because that now
ignores any asset setting with a `_URL` partner, we *never*
register downloaded assets.

Say we post an ISO with just an `ISO_URL` setting. On the first
registration attempt, at the start of `schedule_iso`, there is
no `ISO` setting at all, so `parse_assets_from_settings` will
not find an ISO asset. So we don't register it there. Next,
`schedule_iso` parses the `ISO_URL` setting and generates a
`ISO` setting from it...but it does not remove the `ISO_URL`
setting when it does this (this is intentional and I believe
correct, I don't think we should change that). So from then on,
the job has both `ISO` and `ISO_URL` settings, so the asset will
never be registered because `parse_assets_from_settings` will
always skip the `ISO` setting because of the existence of the
`ISO_URL` setting.

Note that `register_assets_from_settings` actually includes its
own check for the asset file's existence, which doesn't log on
failure. So calling `register_assets_from_settings` for assets
which may not actually exist is safe (it won't fail or generate
any logs). It's only calling `parse_assets_from_settings` and
registering the discovered assets directly, as `schedule_iso`
does, that causes the log messages.

So I think we should leave `parse_assets_from_settings` as it
was and instead address the `schedule_iso` case more precisely.
This fix just lets us tell `ResultSet::Assets->register()` to
silently ignore assets that don't exist, instead of logging a
warning for them, and has `schedule_iso` do that. We could also
have `schedule_iso` check for the asset file's existence before
registering, but I don't like that, we should avoid duplicating
that work in too many places.