### PR TITLE
Fix group overview page when job group has no description

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -114,7 +114,7 @@ sub rendered_description {
         my $m = CommentsMarkdownParser->new;
         return Mojo::ByteStream->new($m->markdown($self->description));
     }
-    return;
+    return '';
 }
 
 1;


### PR DESCRIPTION
The return value of `rendered_description` is passed to the
group_overview template as `$description`. If there is no
description text for the group, it winds up as undefined, and
that causes Mojo to barf when rendering the template and you
get an error when you visit the group overview page. So let's
have `rendered_description` return the empty string rather than
nothing at all when there's no description text, and now the
template behaves as intended.