### PR TITLE
Only store md5_dirname if the image is in /images

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -138,9 +138,12 @@ sub details {
         next unless $link;
         my $base = basename($link);
         my $dir  = dirname($link);
-        $dir =~ s,^.*/images/,,;
-        $img->{md5_dirname}  = $dir;
-        $img->{md5_basename} = $base;
+        # if linking into images, translate it into md5 lookup
+        if ($dir =~ m,/images/,) {
+            $dir =~ s,^.*/images/,,;
+            $img->{md5_dirname}  = $dir;
+            $img->{md5_basename} = $base;
+        }
     }
 
     return $ret;


### PR DESCRIPTION
This might not be typical, but if you rsync a testresult from one
instance to another, it's easier to just detach the symlinks.

The helper already made a difference between link to /image and
file in testresults, but at some refactoring this was lost