### PR TITLE
Fix softfail logic for no-TODO flag

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -76,6 +76,7 @@ sub compute_build_results {
                 }
                 if ($job->result eq OpenQA::Schema::Result::Jobs::SOFTFAILED) {
                     $jr{softfailed}++;
+                    $jr{labeled}++ if $labels{$job->id};
                     next;
                 }
 
@@ -106,8 +107,9 @@ sub compute_build_results {
         }
         $jr{reviewed_all_passed} = $jr{passed} == $count;
         $jr{total}               = $count;
-        $jr{reviewed}            = $jr{failed} > 0 && $jr{labeled} == $jr{failed};
-        $builds{$b}              = \%jr;
+        my $failed = $jr{failed} + $jr{softfailed};
+        $jr{reviewed} = $failed > 0 && $jr{labeled} == $failed;
+        $builds{$b} = \%jr;
         $max_jobs = $count if ($count > $max_jobs);
     }
     return {

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -275,7 +275,6 @@ subtest 'commenting in test results including labels' => sub {
         is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href}, 'https://bugzilla.suse.com/show_bug.cgi?id=1234');
         $driver->find_element('opensuse', 'link_text')->click();
         is($driver->find_element('.review-all-passed', 'css')->get_attribute('title'), 'Reviewed (all passed)', 'build should be marked because all tests passed');
-        is($driver->find_element('.review',            'css')->get_attribute('title'), 'Reviewed (1 comments)', 'build should be marked as labeled');
 
         subtest 'progress items work, too' => sub {
             $driver->get($baseurl . 'tests/99926#comments');


### PR DESCRIPTION
softfails are listed as TODO, so their presence should require a label
to receive a no-TODO icon

This fixes https://progress.opensuse.org/issues/14362 documenting user expectations. Back in the days we only cared for failures, but meanwhile softfailures are considered bugs worth labeling
