### PR TITLE
Make .json easier to use and include more data

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -110,15 +110,13 @@ sub compute_build_results {
         $builds{$b}              = \%jr;
         $max_jobs = $count if ($count > $max_jobs);
     }
-    if (%builds) {
-        $builds{_max}   = $max_jobs;
-        $builds{_group} = {
+    return {
+        result => (%builds) ? \%builds : {},
+        max_jobs => $max_jobs,
+        group    => {
             id   => $group->id,
             name => $group->name
-        };
-        return \%builds;
-    }
-    return;
+        }};
 }
 
 1;

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -120,6 +120,15 @@ sub rendered_markdown {
     return Mojo::ByteStream->new($m->markdown($self->text));
 }
 
+sub hash {
+    my ($self) = @_;
+    return {
+        user    => $self->user->name,
+        text    => $self->text,
+        created => $self->t_created
+    };
+}
+
 package CommentsMarkdownParser;
 require Text::Markdown;
 our @ISA = qw/Text::Markdown/;

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -109,7 +109,19 @@ sub group_overview {
     my $desc = $group->rendered_description;
     $self->stash('description', $desc);
     $self->respond_to(
-        json => {json     => {result => $res, group => $self->stash('group'), max_jobs => $max_jobs}},
+        json => sub {
+            @comments        = map($_->hash, @comments);
+            @pinned_comments = map($_->hash, @pinned_comments);
+            $self->render(
+                json => {
+                    group           => $self->stash('group'),
+                    result          => $self->stash('result'),
+                    max_jobs        => $self->stash('max_jobs'),
+                    description     => $group->description,
+                    comments        => \@comments,
+                    pinned_comments => \@pinned_comments
+                });
+        },
         html => {template => 'main/group_overview'});
 }
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -253,9 +253,9 @@ my $delete = $t->delete_ok('/api/v1/jobs/99937')->status_is(200);
 $t->get_ok('/api/v1/jobs/99937')->status_is(404);
 
 $get = $t->get_ok('/group_overview/1001.json')->status_is(200);
-$get = $get->tx->res->json->{result};
-is_deeply({id => 1001, name => 'opensuse'}, $get->{_group});
-my $b48 = $get->{'0048'};
+$get = $get->tx->res->json;
+is_deeply({id => 1001, name => 'opensuse'}, $get->{group});
+my $b48 = $get->{result}->{'0048'};
 delete $b48->{oldest};
 is_deeply(
     {
@@ -278,8 +278,8 @@ $get = $t->get_ok('/index.json')->status_is(200);
 $get = $get->tx->res->json;
 is(@{$get->{results}}, 2);
 my $g1 = (shift @{$get->{results}});
-is($g1->{_group}->{name}, 'opensuse', 'First group is opensuse');
-my $b1 = $g1->{'0092'};
+is($g1->{group}->{name}, 'opensuse', 'First group is opensuse');
+my $b1 = $g1->{result}->{'0092'};
 delete $b1->{oldest};
 is_deeply(
     $b1,

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -41,6 +41,19 @@ sub test_get_comment {
     is($get->tx->res->json->{text}, $supposed_text, 'comment text is correct');
 }
 
+sub test_get_comment_groups_json {
+    my ($id, $supposed_text) = @_;
+    my $get           = $t->get_ok("/group_overview/$id.json");
+    my $found_comment = 0;
+    for my $comment (@{$get->tx->res->json->{comments}}) {
+        if ($comment->{text} eq $supposed_text) {
+            $found_comment = 1;
+            last;
+        }
+    }
+    ok($found_comment, 'comment found in .json');
+}
+
 sub test_get_comment_invalid_job_or_group {
     my ($in, $id, $comment_id) = @_;
     my $get = $t->get_ok("/api/v1/$in/$id/comments/$comment_id")->status_is(404, 'comment not found');
@@ -112,6 +125,7 @@ subtest 'job comments' => sub {
 
 subtest 'group comments' => sub {
     test_comments(groups => 1001);
+    test_get_comment_groups_json(1001, $edited_test_message);
 };
 
 subtest 'admin can delete comments' => sub {

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,4 +1,3 @@
-% my $max = delete $result->{_max};
 % for my $build (reverse sort keys %$result) {
     % my $build_res = $result->{$build};
     <div class="row build-row">
@@ -30,13 +29,13 @@
             </h4>
         </div>
         <div class="col-md-8">
-            % if ($max) {
+            % if ($max_jobs) {
                 <div class="progress build-dashboard" title="<%= build_progress_bar_title($build_res) %>">
-                    %= build_progress_bar_section(passed => $build_res->{passed}, $max)
-                    %= build_progress_bar_section(unfinished => $build_res->{unfinished}, $max, 'progress-bar-striped')
-                    %= build_progress_bar_section(softfailed => $build_res->{softfailed}, $max)
-                    %= build_progress_bar_section(failed => $build_res->{failed}, $max)
-                    %= build_progress_bar_section(skipped => $build_res->{skipped}, $max)
+                    %= build_progress_bar_section(passed => $build_res->{passed}, $max_jobs)
+                    %= build_progress_bar_section(unfinished => $build_res->{unfinished}, $max_jobs, 'progress-bar-striped')
+                    %= build_progress_bar_section(softfailed => $build_res->{softfailed}, $max_jobs)
+                    %= build_progress_bar_section(failed => $build_res->{failed}, $max_jobs)
+                    %= build_progress_bar_section(skipped => $build_res->{skipped}, $max_jobs)
                 </div>
             % }
         </div>

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -7,8 +7,6 @@
     $('.timeago').timeago();
 % end
 
-% delete $result->{_group};
-
 <h2>Last Builds for Group <%= $group->{name} %></h2>
 
 % if($description) {

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -20,11 +20,13 @@
 </div>
 
 % for my $groupresults (@$results) {
-    % my $group = delete $groupresults->{_group};
+    % my $group    = delete $groupresults->{group};
+    % my $result   = delete $groupresults->{result};
+    % my $max_jobs = delete $groupresults->{max_jobs};
     <h2>
         %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})
     </h2>
-    %= include 'main/group_builds', result => $groupresults, group => $group
+    %= include 'main/group_builds', result => $result, group => $group, max_jobs => $max_jobs
 % }
 
 <div class="panel panel-default filter-panel-bottom" id="filter-panel">


### PR DESCRIPTION
The current json output is painful to parse as it violates the hierarchical principle of json.

- Don't keep data structures of different types in the same hash (move `_group` and `_max` one level up)
- Expose comments via job_group .json