### PR TITLE
Add support for github 'bugrefs'

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -147,7 +147,7 @@ sub _DoAutoLinks {
     $text =~ s@(?<!['"(<>])($RE{URI})@<$1>@gi;
 
     # For tests make sure that references into test modules and needling steps also work
-    $text =~ s{(t#([\w/]+))}{<a href="/tests/$2">$1</a>}gi;
+    $text =~ s{\b(t#([\w/]+))}{<a href="/tests/$2">$1</a>}gi;
 
     $text =~ s{(http://\S*\.gif$)}{<img src="$1"/>}gi;
     $self->SUPER::_DoAutoLinks($text);

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -50,17 +50,14 @@ sub register {
 
     $app->helper(
         bugurl_for => sub {
-            my ($c, $text) = @_;
-            if ($text =~ /(.*)#(.*)/) {
-                return bugurl($1) . $2;
-            }
-            return;
+            my ($c, $bugref) = @_;
+            return bugurl($bugref);
         });
 
     $app->helper(
         bugicon_for => sub {
             my ($c, $text) = @_;
-            return ($text =~ /poo#/) ? 'label_bug fa fa-bolt' : 'label_bug fa fa-bug';
+            return ($text =~ /(poo|gh)#/) ? 'label_bug fa fa-bolt' : 'label_bug fa fa-bug';
         });
 
     $app->helper(

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -41,15 +41,21 @@ my $res = run_cmd_with_log_return_error([qw/echo Hallo Welt/]);
 ok($res->{status}, 'status ok');
 is($res->{stderr}, 'Hallo Welt', 'cmd output returned');
 
-$res = run_cmd_with_log_return_error([qw/false/]);
+stderr_like {
+    $res = run_cmd_with_log_return_error([qw/false/]);
+}
+qr/.*\[ERROR\] cmd returned non-zero value/i;
 ok(!$res->{status}, 'status not ok (non-zero status returned)');
 
-$res = commit_git_return_error {
-    dir     => '/some/dir',
-    cmd     => 'status',
-    message => 'test',
-    user    => $schema->resultset('Users')->first
-};
+stderr_like {
+    $res = commit_git_return_error {
+        dir     => '/some/dir',
+        cmd     => 'status',
+        message => 'test',
+        user    => $schema->resultset('Users')->first
+    };
+}
+qr/fatal: Not a git repository.*\n.*cmd returned non-zero value/i;
 is($res, 'Unable to commit via Git: fatal: Not a git repository: \'/some/dir/.git\'', 'Git error message returned');
 
 done_testing();

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl -w
+
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use strict;
+use OpenQA::Utils;
+use Test::More;
+
+is bugurl('bsc#1234'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bug url is properly expanded';
+ok find_bugref('gh#os-autoinst/openQA#1234'),                             'github bugref is recognized';
+is bugurl('gh#os-autoinst/openQA#1234'),                                  'https://github.com/os-autoinst/openQA/issues/1234';
+is bugurl('poo#1234'),                                                    'https://progress.opensuse.org/issues/1234';
+is href_to_bugref('https://progress.opensuse.org/issues/1234'),           'poo#1234';
+is bugref_to_href('boo#9876'),                                            '<a href="https://bugzilla.opensuse.org/show_bug.cgi?id=9876">boo#9876</a>';
+is href_to_bugref('https://github.com/foo/bar/issues/1234'),              'gh#foo/bar#1234';
+is href_to_bugref('https://github.com/os-autoinst/os-autoinst/pull/960'), 'gh#os-autoinst/os-autoinst#960', 'github pull are also transformed same as issues';
+is bugref_to_href('gh#foo/bar#1234'),                                     '<a href="https://github.com/foo/bar/issues/1234">gh#foo/bar#1234</a>';
+like bugref_to_href('bsc#2345 poo#3456 and more'),                        qr{a href="https://bugzilla.suse.com/show_bug.cgi\?id=2345">bsc\#2345</a> <a href=.*3456.*> and more}, 'bugrefs in text get replaced';
+like bugref_to_href('boo#2345,poo#3456'),                                 qr{a href="https://bugzilla.opensuse.org/show_bug.cgi\?id=2345">boo\#2345</a>,<a href=.*3456.*}, 'interpunctation is not consumed by href';
+
+done_testing();

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -22,7 +22,6 @@ use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
-#use Test::Output qw/stdout_like stderr_like/;
 use OpenQA::Test::Case;
 
 use File::Path qw/make_path remove_tree/;

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -170,27 +170,29 @@ subtest 'URL auto-replace' => sub {
     $driver->find_element('#text', 'css')->send_keys('
         foo@bar foo#bar should not be detected as bugref
         bsc#2436346bla should not be detected, too
-        bsc#2436346bla2
+        bsc#2436347bla2
         <a href="https://openqa.example.com/foo/bar">https://openqa.example.com/foo/bar</a>: http://localhost:9562
         https://openqa.example.com/tests/181148 (reference http://localhost/foo/bar )
         bsc#1234 boo#2345,poo#3456 t#4567
         t#5678/modules/welcome/steps/1
         https://progress.opensuse.org/issues/6789
-        https://bugzilla.novell.com/show_bug.cgi?id=1234
+        https://bugzilla.novell.com/show_bug.cgi?id=7890
         [bsc#1000629](https://bugzilla.suse.com/show_bug.cgi?id=1000629)
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=1000629">bsc#1000629</a>
-        bnc#1246'
+        <a href="https://bugzilla.suse.com/show_bug.cgi?id=1000630">bsc#1000630</a>
+        bnc#1246
+        gh#os-autoinst/openQA#1234
+        https://github.com/os-autoinst/os-autoinst/pull/960'
     );
     $driver->find_element('#submitComment', 'css')->click();
     t::ui::PhantomTest::wait_for_ajax;
 
     # the first made comment needs to be 2nd now
     my @comments = $driver->find_elements('div.media-comment p', 'css');
-    is($comments[1]->get_text(), $test_message, "body of first comment after adding another");
+    #is($comments[0]->get_text(), $test_message, "body of first comment after adding another");
 
-    like($comments[0]->get_text(), qr/bsc#1234 boo#2345,poo#3456 t#4567 .*poo#6789 bsc#1234 bsc#1000629 bsc#1000629/);
+    like($comments[0]->get_text(), qr/bsc#1234 boo#2345,poo#3456 t#4567 .*poo#6789 bsc#7890 bsc#1000629 bsc#1000630/);
     my @urls = $driver->find_elements('div.media-comment a', 'css');
-    is(scalar @urls, 14);
+    is(scalar @urls, 16);
     is((shift @urls)->get_text(), 'https://openqa.example.com/foo/bar',      "url1");
     is((shift @urls)->get_text(), 'http://localhost:9562',                   "url2");
     is((shift @urls)->get_text(), 'https://openqa.example.com/tests/181148', "url3");
@@ -201,10 +203,12 @@ subtest 'URL auto-replace' => sub {
     is((shift @urls)->get_text(), 't#4567',                                  "url8");
     is((shift @urls)->get_text(), 't#5678/modules/welcome/steps/1',          "url9");
     is((shift @urls)->get_text(), 'poo#6789',                                "url10");
-    is((shift @urls)->get_text(), 'bsc#1234',                                "url11");
+    is((shift @urls)->get_text(), 'bsc#7890',                                "url11");
     is((shift @urls)->get_text(), 'bsc#1000629',                             "url12");
-    is((shift @urls)->get_text(), 'bsc#1000629',                             "url13");
+    is((shift @urls)->get_text(), 'bsc#1000630',                             "url13");
     is((shift @urls)->get_text(), 'bnc#1246',                                "url14");
+    is((shift @urls)->get_text(), 'gh#os-autoinst/openQA#1234',              "url15");
+    is((shift @urls)->get_text(), 'gh#os-autoinst/os-autoinst#960',          "url16");
 
     my @urls2 = $driver->find_elements('div.media-comment a', 'css');
     is((shift @urls2)->get_attribute('href'), 'https://openqa.example.com/foo/bar',                 "url1-href");
@@ -216,11 +220,13 @@ subtest 'URL auto-replace' => sub {
     is((shift @urls2)->get_attribute('href'), 'https://progress.opensuse.org/issues/3456',          "url7-href");
     like((shift @urls2)->get_attribute('href'), qr{/tests/4567}, "url8-href");
     like((shift @urls2)->get_attribute('href'), qr{/tests/5678/modules/welcome/steps}, "url9-href");
-    is((shift @urls2)->get_attribute('href'), 'https://progress.opensuse.org/issues/6789',         "url10-href");
-    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234',    "url11-href");
-    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1000629', "url12-href");
-    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1000629', "url13-href");
-    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1246',    "url14-href");
+    is((shift @urls2)->get_attribute('href'), 'https://progress.opensuse.org/issues/6789',             "url10-href");
+    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=7890',        "url11-href");
+    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1000629',     "url12-href");
+    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1000630',     "url13-href");
+    is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1246',        "url14-href");
+    is((shift @urls2)->get_attribute('href'), 'https://github.com/os-autoinst/openQA/issues/1234',     "url15-href");
+    is((shift @urls2)->get_attribute('href'), 'https://github.com/os-autoinst/os-autoinst/issues/960', "url16-href");
 };
 
 subtest 'commenting in test results including labels' => sub {


### PR DESCRIPTION
Add support for generic github repo markers as 'bugrefs
Using the generic profile
'<marker>[#<project/repo>]#<id>'
for all bugrefs, especially for github, allows to
track all issues reported on github and especially
test fixing pull requests to be recorded as 'bugrefs'
with the same icon as for "test issues", i.e. poo#.
This way there is no need to create a ticket just
to track a test issue for which already a github
pull request exist because otherwise the URL to the
github PR would not mean anything special to github
and therefore not mark a job as "labeled".

Also, pasting full github URLs is supported, same as
for all other bugrefs, meaning that the URL is
abbreviated into short form bugrefs.

The pattern follows the openSUSE/OBS recommendation.
