### PR TITLE
Show parent groups in navbar

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -10,6 +10,7 @@
 < stylesheets/result_preview.scss
 << https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/stylesheets/_bootstrap.scss
 < sass/theme.scss
+< https://raw.githubusercontent.com/Martchus/bootstrap-submenu/openqa/dist/css/bootstrap-submenu.css
 
 ! codemirror.css
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/lib/codemirror.css
@@ -42,6 +43,7 @@
 < javascripts/filter_form.js
 < javascripts/comments.js
 < javascripts/keyevent.js
+< https://raw.githubusercontent.com/Martchus/bootstrap-submenu/openqa/dist/js/bootstrap-submenu.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap/collapse.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap/tooltip.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap/popover.js

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -18,6 +18,7 @@ function getCookie(cname) {
 function setupForAll() {
     $('[data-toggle="tooltip"]').tooltip({html: true});
     $('[data-toggle="popover"]').popover({html: true});
+    $('[data-submenu]').submenupicker();
 
     $.ajaxSetup({
         headers:

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -61,13 +61,30 @@
                       </li>
 
                       <li class="dropdown">
-                          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Job Groups<span class="caret"></span></a>
+                          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" data-submenu>Job Groups<span class="caret"></span></a>
                           <ul class="dropdown-menu">
                               %= current_job_group
-                              % for my $jg ($self->db->resultset('JobGroups')->search({}, {order_by => 'name'})->all) {
-                                  <li>
-                                      %= link_to $jg->name => url_for('group_overview', groupid => $jg->id)
-                                  </li>
+                              % for my $parent_group ($self->db->resultset('JobGroupParents')->search({}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})->all) {
+                                  % my @children = $parent_group->children;
+                                  % if(scalar(@children)) {
+                                    <li class="dropdown-submenu">
+                                        %= link_to $parent_group->name => url_for('admin_edit_parent_group', groupid => $parent_group->id)
+                                        % if(scalar(@children)) {
+                                            <ul  class="dropdown-menu">
+                                                % for my $group (@children) {
+                                                    <li>
+                                                        %= link_to $group->name => url_for('group_overview', groupid => $group->id)
+                                                    </li>
+                                                % }
+                                            </ul>
+                                        % }
+                                    </li>
+                                  % }
+                              % }
+                              % for my $group ($self->db->resultset('JobGroups')->search({parent_id => undef}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})->all) {
+                                    <li>
+                                        %= link_to $group->name => url_for('group_overview', groupid => $group->id)
+                                    </li>
                               % }
                           </ul>
                       </li>


### PR DESCRIPTION
* Since there is currently no parent group overview
  the link just leads to the editor.
* Parentless groups are still displayed (at the top).