### PR TITLE
Fix list of needle tags in needle info popover

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -50,7 +50,7 @@ function previewSuccess(data, force) {
       checkPreviewVisible(a, pin);
     }
   });
-  $('[data-toggle="popover"]').popover();
+  $('[data-toggle="popover"]').popover({html: true});
 }
 
 function mapHash(hash) {

--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -20,7 +20,7 @@
         % my $content;
         % if ($tags && @$tags) {
             % $title = "Looking for needle tags";
-            % $content = '- ' . join("\n- ", @$tags);
+            % $content = '<ul>' . join("\n", map { "<li>$_</li>" } @$tags) . '</ul>';
         % }
         % else {
             % $title = "Saved screenshot";


### PR DESCRIPTION
Use a proper `<ul>` instead of manually adding
list entries.

Example screenshot:
![openqa_ul_needle_info](https://cloud.githubusercontent.com/assets/1693432/19995746/7e70955a-a25a-11e6-8f9e-fe55b1123bca.png)
