### PR TITLE
Add help popover for 'only_tagged' checkbox

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -17,6 +17,7 @@ function getCookie(cname) {
 
 function setupForAll() {
     $('[data-toggle="tooltip"]').tooltip({html: true});
+    $('[data-toggle="popover"]').popover({html: true});
 
     $.ajaxSetup({
         headers:

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -207,6 +207,10 @@ ul.modcategory {
     margin-right: 1em;
 }
 
+.help_popover  {
+    margin-left: 1em;
+}
+
 /* special table stuff */
 
 .infotbl {

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -243,6 +243,21 @@ sub register {
         });
 
     $app->helper(
+        # generate popover help button with title, content and optional details_url
+        # Examples:
+        #   help_popover 'Help for me' => 'This is me'
+        #   help_popover 'Help for button' => 'Do not press this button!', 'http://nuke.me'
+        help_popover => sub {
+            my ($c, $title, $content, $details_url) = @_;
+            my $class = 'help_popover fa fa-question-circle';
+            if ($details_url) {
+                $content .= '<br/><br/>See ' . $c->link_to(here => $details_url) . ' for details';
+            }
+            my $data = {toggle => 'popover', trigger => 'focus', title => $title, content => $content};
+            return $c->t(a => (tabindex => 0, class => $class, role => 'button', (data => $data)));
+        });
+
+    $app->helper(
         # emit_event helper, adds user, connection to events
         emit_event => sub {
             my ($self, $event, $data) = @_;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -101,5 +101,6 @@ subtest 'filter form' => sub {
 $driver->get($baseurl . 'index.json');
 like($driver->get_page_source(), qr({"results":\[.*{"0048":), 'page rendered as JSON');
 
+like($t->get_ok($baseurl)->tx->res->dom->at('#filter-panel .help_popover')->{'data-title'}, qr/Help/, 'help popover is shown');
 t::ui::PhantomTest::kill_phantom();
 done_testing();

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -46,11 +46,8 @@
                 <strong>Misc</strong>
                 <label><input value="1" name="only_tagged" type="checkbox" id="filter-only-tagged"> Only tagged</label>
                 % my $title = 'Help for \'Only tagged\'';
-                % my $content = 'Show only builds that have been tagged in the corresponding group overview comments<br/><br/>See <a href="https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Build-tagging-and-keeping-important-builds-gh591">here</a> for details';
-                <a tabindex="0" class="help_popover fa fa-question-circle" role="button"
-                    data-toggle="popover" data-trigger="focus"
-                    data-title="<%= $title %>"
-                    data-content="<%= $content %>"></a>
+                % my $content = 'Show only builds that have been tagged in the corresponding group overview comments';
+                %= help_popover $title => $content, 'https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Build-tagging-and-keeping-important-builds-gh591'
             </div>
             <button type="submit" class="btn btn-default">Apply</button>
         </form>

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -45,6 +45,12 @@
             <div class="form-group">
                 <strong>Misc</strong>
                 <label><input value="1" name="only_tagged" type="checkbox" id="filter-only-tagged"> Only tagged</label>
+                % my $title = 'Help for \'Only tagged\'';
+                % my $content = 'Show only builds that have been tagged in the corresponding group overview comments<br/><br/>See <a href="https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Build-tagging-and-keeping-important-builds-gh591">here</a> for details';
+                <a tabindex="0" class="help_popover fa fa-question-circle" role="button"
+                    data-toggle="popover" data-trigger="focus"
+                    data-title="<%= $title %>"
+                    data-content="<%= $content %>"></a>
             </div>
             <button type="submit" class="btn btn-default">Apply</button>
         </form>


### PR DESCRIPTION
The popover code can later be extracted into a helper
function if more help popover icons should be added.

The help content includes a link to the wiki with
the feature description including examples and
screenshots.

Example screenshot:
![openqa_help_popover](https://cloud.githubusercontent.com/assets/1693432/19995736/6b75702e-a25a-11e6-959c-912f5a67568b.png)
