### PR TITLE
Allow '@' in asset name

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -28,7 +28,7 @@ sub register {
         log_warning "asset type '$type' invalid";
         return;
     }
-    unless ($name && $name =~ /^[0-9A-Za-z+-._]+$/) {
+    unless ($name && $name =~ /^[0-9A-Za-z+-._@]+$/) {
         log_warning "asset name '$name' invalid";
         return;
     }


### PR DESCRIPTION
This prevents warnings on assets with a '@' in name as is common for
SUSE/openSUSE. This has been made obvious just by a recent change baac24b
which introduced explicit checking for a "correct name" separated from the
existance of an asset on the filesystem.

Fixes https://progress.opensuse.org/issues/14650