### PR TITLE
Fix 'Use of uninitialized value $realpath in index'

### DIFF
--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -89,7 +89,7 @@ sub update_needle {
         my $needledir_path = realpath($module->job->needle_dir());
         my $dir;
         my $basename;
-        if (index($realpath, $needledir_path) != 0) {    # leave old behaviour as it is
+        if ($realpath && (index($realpath, $needledir_path) != 0)) {    # leave old behaviour as it is
             $dir = $schema->resultset('NeedleDirs')->find_or_new({path => dirname($realpath)});
             $basename = basename($realpath);
         }


### PR DESCRIPTION
Observed in logs on openqa.opensuse.org after the recent deployment.