### PR TITLE
Add help text using popovers, title and placeholder

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -17,6 +17,7 @@ function getCookie(cname) {
 
 function setupForAll() {
     $('[data-toggle="tooltip"]').tooltip({html: true});
+    $('[data-toggle="popover"]').popover({html: true});
 
     $.ajaxSetup({
         headers:

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -207,6 +207,10 @@ ul.modcategory {
     margin-right: 1em;
 }
 
+.help_popover  {
+    margin-left: 1em;
+}
+
 /* special table stuff */
 
 .infotbl {

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -243,6 +243,21 @@ sub register {
         });
 
     $app->helper(
+        # generate popover help button with title, content and optional details_url
+        # Examples:
+        #   help_popover 'Help for me' => 'This is me'
+        #   help_popover 'Help for button' => 'Do not press this button!', 'http://nuke.me'
+        help_popover => sub {
+            my ($c, $title, $content, $details_url) = @_;
+            my $class = 'help_popover fa fa-question-circle';
+            if ($details_url) {
+                $content .= '<br/><br/>See ' . $c->link_to(here => $details_url) . ' for details';
+            }
+            my $data = {toggle => 'popover', trigger => 'focus', title => $title, content => $content};
+            return $c->t(a => (tabindex => 0, class => $class, role => 'button', (data => $data)));
+        });
+
+    $app->helper(
         # emit_event helper, adds user, connection to events
         emit_event => sub {
             my ($self, $event, $data) = @_;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -101,5 +101,6 @@ subtest 'filter form' => sub {
 $driver->get($baseurl . 'index.json');
 like($driver->get_page_source(), qr({"results":\[.*{"0048":), 'page rendered as JSON');
 
+like($t->get_ok($baseurl)->tx->res->dom->at('#filter-panel .help_popover')->{'data-title'}, qr/Help/, 'help popover is shown');
 t::ui::PhantomTest::kill_phantom();
 done_testing();

--- a/templates/comments/add_comment_form_groups.html.ep
+++ b/templates/comments/add_comment_form_groups.html.ep
@@ -11,5 +11,9 @@
         <button class="btn btn-success btn-circle" type="submit" id="submitComment">
             <span class="glyphicon glyphicon-send"></span>
             Submit comment</button>
+        % my $title = 'Help for comments';
+        % my $content = 'The comment field supports Markdown, automatic detection of URLs and special tags to record bug references, \'labels\' as well as \'build tagging\'. For bugreferences write <i>bugtracker_shortname</i>#<i>bug_nr</i> in a comment, e.g. "bsc#1234", for generic labels use label:<i>keyword</i> where <i>keyword</i> can be any valid character up to the next whitespace, e.g. "false_positive". The keywords are not defined within openQA itself. A valid list of keywords should be decided upon within each project or environment of one openQA instance. Also github pull requests and issues can be linked using the generic format <i>marker</i>[#<i>project/repo</i>]#<i>id</i>, e.g. gh#os-autoinst/openQA#1234. You can also write (or copy-paste) full links to bugs and issues. The links are automatically changed to the shortlinks (e.g. https://progress.opensuse.org/issues/11110 turns into poo#11110).';
+        %= help_popover $title => $content, 'https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Advanced-features-in-openQA'
     </div>
+
 </div>

--- a/templates/comments/add_comment_form_groups.html.ep
+++ b/templates/comments/add_comment_form_groups.html.ep
@@ -3,7 +3,7 @@
         <img class="img-circle" src="<%= current_user->gravatar(60) %>" alt="Own avatar" title="<%= current_user->name %>">
     </label>
     <div class="col-sm-11">
-        <textarea class="form-control" name="text" id="text" rows="5"></textarea>
+        <textarea class="form-control" name="text" id="text" placeholder="Write your comments here (Markdown and special tags supported)…" rows="5"></textarea>
     </div>
 </div>
 <div class="form-group">

--- a/templates/comments/add_comment_form_groups.html.ep
+++ b/templates/comments/add_comment_form_groups.html.ep
@@ -1,6 +1,6 @@
 <div class="form-group">
     <label for="text" class="col-sm-1 control-label">Comment
-        <img class="img-circle" src="<%= current_user->gravatar(60) %>" alt="Own avatar">
+        <img class="img-circle" src="<%= current_user->gravatar(60) %>" alt="Own avatar" title="<%= current_user->name %>">
     </label>
     <div class="col-sm-11">
         <textarea class="form-control" name="text" id="text" rows="5"></textarea>

--- a/templates/comments/comment_row.html.ep
+++ b/templates/comments/comment_row.html.ep
@@ -1,7 +1,7 @@
 % if (!$context->{pinned}) {
     <div class="row comment-row">
         <div class="col-sm-1">
-            <img class="media-object img-circle" src="<%= $user->gravatar(60) %>" alt="profile">
+            <img class="media-object img-circle" src="<%= $user->gravatar(60) %>" alt="profile" title="<%= $user->name %>">
         </div>
     <div class="col-sm-11">
 % }

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -46,11 +46,8 @@
                 <strong>Misc</strong>
                 <label><input value="1" name="only_tagged" type="checkbox" id="filter-only-tagged"> Only tagged</label>
                 % my $title = 'Help for \'Only tagged\'';
-                % my $content = 'Show only builds that have been tagged in the corresponding group overview comments<br/><br/>See <a href="https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Build-tagging-and-keeping-important-builds-gh591">here</a> for details';
-                <a tabindex="0" class="help_popover fa fa-question-circle" role="button"
-                    data-toggle="popover" data-trigger="focus"
-                    data-title="<%= $title %>"
-                    data-content="<%= $content %>"></a>
+                % my $content = 'Show only builds that have been tagged in the corresponding group overview comments';
+                %= help_popover $title => $content, 'https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Build-tagging-and-keeping-important-builds-gh591'
             </div>
             <button type="submit" class="btn btn-default">Apply</button>
         </form>

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -45,6 +45,12 @@
             <div class="form-group">
                 <strong>Misc</strong>
                 <label><input value="1" name="only_tagged" type="checkbox" id="filter-only-tagged"> Only tagged</label>
+                % my $title = 'Help for \'Only tagged\'';
+                % my $content = 'Show only builds that have been tagged in the corresponding group overview comments<br/><br/>See <a href="https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Build-tagging-and-keeping-important-builds-gh591">here</a> for details';
+                <a tabindex="0" class="help_popover fa fa-question-circle" role="button"
+                    data-toggle="popover" data-trigger="focus"
+                    data-title="<%= $title %>"
+                    data-content="<%= $content %>"></a>
             </div>
             <button type="submit" class="btn btn-default">Apply</button>
         </form>

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -184,7 +184,7 @@
                         % if (is_operator) {
                             <div class="form-group row">
                                 <div class="col-sm-10">
-                                    <input type="text" class="form-control" id="newtag">
+                                    <input type="text" class="form-control" id="newtag" placeholder="Add new tags here">
                                 </div>
                                 <div class="col-sm-2">
                                     <button type="button" class="btn btn-default form-control" id="tag_add_button">Add</button>

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -152,6 +152,7 @@
                                         %= 'checked' if $properties->{workaround}
                                         >
                                 <label for="property_workaround">workaround</label>
+                                %= help_popover 'Help for the workaround property' => 'If a needle with the workaround property matches the match result is recorded as a \'soft-fail\'. It is suggested to mark the reason for this choice in either the name of the needle (e.g. my-name-bsc1234-20161224) or with special tags'
                             </div>
                         </div>
                         <button type="button" class="btn btn-default" id="review_json" title="Review JSON">Review JSON</button>
@@ -213,6 +214,7 @@
                                 </option>
                             % }
                         </select>
+                        %= help_popover 'Select which image the needle should be based on' => 'Select either \'Screenshot\' to take the image as can be seen in the current test or one of the images from the existing needle candidates'
                     </div>
 
                     <div>


### PR DESCRIPTION
* edit: Add help popovers
* edit: Add placeholder help text for new tags
* Add help popover for comment writing
* Show placeholder text for comment textedit
* Also show name/nickname for existing comments gravatar hover
* Show name/nickname on hover over own gravatar
* Extract help popover into helper function
* Add help popover for 'only_tagged' checkbox