### PR TITLE
Trying to make peace with adamw over locate_asset

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -23,10 +23,9 @@ use OpenQA::IPC;
 use Date::Format;
 use Archive::Extract;
 use File::Basename;
-use File::Spec::Functions 'catfile';
+use File::Spec::Functions qw(catfile splitpath);
 use Mojo::UserAgent;
 use Mojo::URL;
-use File::Spec::Functions 'splitpath';
 use Try::Tiny;
 
 use db_helpers;
@@ -82,7 +81,7 @@ sub _getDirSize {
 
 sub disk_file {
     my ($self) = @_;
-    return locate_asset($self->type, $self->name, 0);
+    return locate_asset($self->type, $self->name);
 }
 
 sub is_fixed {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1136,7 +1136,7 @@ sub _asset_find {
     # add undef to parents so that we check regular assets too
     for my $parent (@$parents, undef) {
         my $fname = $parent ? sprintf("%08d-%s", $parent, $name) : $name;
-        return $fname if (locate_asset($type, $fname, 1));
+        return $fname if (locate_asset($type, $fname, mustexist => 1));
     }
     return;
 }

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -32,7 +32,7 @@ sub register {
         log_warning "asset name '$name' invalid";
         return;
     }
-    unless (locate_asset $type, $name, 1) {
+    unless (locate_asset $type, $name, mustexist => 1) {
         if (!$missingok) {
             log_warning "no file found for asset '$name' type '$type'";
         }

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -332,18 +332,26 @@ sub parse_assets_from_settings {
     return $assets;
 }
 
-# find the actual disk location of a given asset.
+sub _relative_or_absolute {
+    my ($path, $relative) = @_;
+
+    return $path if $relative;
+    return catfile($assetdir, $path);
+}
+
+# find the actual disk location of a given asset. Supported arguments are
+# mustexist => 1 - return undef if the asset is not present
+# relative => 1 - return path below assetdir, otherwise absolute path
 sub locate_asset {
-    my ($type, $name, $mustexist) = @_;
-    $mustexist //= 0;
+    my ($type, $name, %args) = @_;
 
-    my $trans = catfile($assetdir, $type, $name);
-    return $trans if (-e $trans);
+    my $trans = catfile($type, $name);
+    return _relative_or_absolute($trans, $args{relative}) if -e _relative_or_absolute($trans);
 
-    my $fixed = catfile($assetdir, $type, 'fixed', $name);
-    return $fixed if (-e $fixed);
+    my $fixed = catfile($type, 'fixed', $name);
+    return _relative_or_absolute($fixed, $args{relative}) if -e _relative_or_absolute($fixed);
 
-    return $mustexist ? undef : $trans;
+    return $args{mustexist} ? undef : _relative_or_absolute($trans, $args{relative});
 }
 
 my %bugrefs = (

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -177,8 +177,7 @@ sub startup {
     $r->post('/tests/list_ajax')->name('tests_ajax')->to('test#list_ajax');
 
     # only provide a URL helper - this is overtaken by apache
-    $r->get('/assets/#assettype/#assetname')->name('download_asset')->to('file#download_asset');
-    $r->get('/assets/#assettype/fixed/#assetname')->name('download_fixed_asset')->to('file#download_asset');
+    $r->get('/assets/*assetpath')->name('download_asset')->to('file#download_asset');
 
     my $test_r = $r->route('/tests/:testid', testid => qr/\d+/);
     my $test_auth = $auth->route('/tests/:testid', testid => qr/\d+/, format => 0);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -315,7 +315,7 @@ sub schedule_iso {
             $filename = $args->{$short};
         }
         # Find where we should download the file to
-        my $fullpath = locate_asset($assettype, $filename, 0);
+        my $fullpath = locate_asset($assettype, $filename, mustexist => 0);
 
         unless (-s $fullpath) {
             # if the file doesn't exist, add the url/target path and extraction

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -75,7 +75,7 @@ sub engine_workit($) {
 
     for my $isokey (qw/ISO/, map { "ISO_$_" } (1 .. 9)) {
         if (my $isoname = $job->{settings}->{$isokey}) {
-            my $iso = locate_asset('iso', $isoname, 1);
+            my $iso = locate_asset('iso', $isoname, mustexist => 1);
             unless ($iso) {
                 my $error = "Cannot find ISO asset $isoname!";
                 return {error => $error};
@@ -86,7 +86,7 @@ sub engine_workit($) {
 
     for my $otherkey (qw/KERNEL INITRD/) {
         if (my $filename = $job->{settings}->{$otherkey}) {
-            my $file = locate_asset('other', $filename, 1);
+            my $file = locate_asset('other', $filename, mustexist => 1);
             unless ($file) {
                 my $error = "Cannot find OTHER asset $filename!";
                 return {error => $error};
@@ -99,7 +99,7 @@ sub engine_workit($) {
     for my $i (1 .. $nd) {
         my $hddname = $job->{settings}->{"HDD_$i"} || undef;
         if ($hddname) {
-            my $hdd = locate_asset('hdd', $hddname, 1);
+            my $hdd = locate_asset('hdd', $hddname, mustexist => 1);
             unless ($hdd) {
                 my $error = "Cannot find HDD asset $hddname!";
                 return {error => $error};

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -84,14 +84,14 @@ for my $i ($iso1, $iso2) {
 
 my $listing = [
     {
-        id       => 6,
+        id       => 7,
         name     => $iso1,
         type     => "iso",
         size     => undef,
         checksum => undef,
     },
     {
-        id       => 7,
+        id       => 8,
         name     => $iso2,
         type     => "iso",
         size     => undef,
@@ -130,7 +130,7 @@ is_deeply(nots($ret->tx->res->json), $listing->[1], "asset correctly entered by 
 
 # check listing
 $ret = $t->get_ok('/api/v1/assets')->status_is(200);
-is_deeply(nots($ret->tx->res->json->{assets}->[5]), $listing->[0], "listing ok");
+is_deeply(nots($ret->tx->res->json->{assets}->[6]), $listing->[0], "listing ok");
 
 la;
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -288,27 +288,27 @@ check_download_asset('existing HDD');
 @warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://localhost/nonexistent.iso'}) };
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent ISO', ['http://localhost/nonexistent.iso', locate_asset('iso', 'nonexistent.iso', 0), 0]);
+check_download_asset('non-existent ISO', ['http://localhost/nonexistent.iso', locate_asset('iso', 'nonexistent.iso', mustexist => 0), 0]);
 check_job_setting($t, $rsp, 'ISO', 'nonexistent.iso', 'parameter ISO is correctly set from ISO_URL');
 
 # Schedule download and uncompression of a non-existing HDD
 @warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', HDD_1_DECOMPRESS_URL => 'http://localhost/nonexistent.hda.xz'}) };
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent HDD (with uncompression)', ['http://localhost/nonexistent.hda.xz', locate_asset('hdd', 'nonexistent.hda', 0), 1]);
+check_download_asset('non-existent HDD (with uncompression)', ['http://localhost/nonexistent.hda.xz', locate_asset('hdd', 'nonexistent.hda', mustexist => 0), 1]);
 check_job_setting($t, $rsp, 'HDD_1', 'nonexistent.hda', 'parameter HDD_1 is correctly set from HDD_1_DECOMPRESS_URL');
 
 # Schedule download of a non-existing ISO with a custom target name
 @warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://localhost/nonexistent2.iso', ISO => 'callitthis.iso'}) };
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent ISO (with custom name)', ['http://localhost/nonexistent2.iso', locate_asset('iso', 'callitthis.iso', 0), 0]);
+check_download_asset('non-existent ISO (with custom name)', ['http://localhost/nonexistent2.iso', locate_asset('iso', 'callitthis.iso', mustexist => 0), 0]);
 check_job_setting($t, $rsp, 'ISO', 'callitthis.iso', 'parameter ISO is not overwritten when ISO_URL is set');
 
 # Schedule download and uncompression of a non-existing kernel with a custom target name
 @warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', KERNEL_DECOMPRESS_URL => 'http://localhost/nonexistvmlinuz', KERNEL => 'callitvmlinuz'}) };
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent kernel (with uncompression, custom name', ['http://localhost/nonexistvmlinuz', locate_asset('other', 'callitvmlinuz', 0), 1]);
+check_download_asset('non-existent kernel (with uncompression, custom name', ['http://localhost/nonexistvmlinuz', locate_asset('other', 'callitvmlinuz', mustexist => 0), 1]);
 check_job_setting($t, $rsp, 'KERNEL', 'callitvmlinuz', 'parameter KERNEL is not overwritten when KERNEL_DECOMPRESS_URL is set');
 
 # Using non-asset _URL does not create gru job and schedule jobs

--- a/t/data/openqa/factory/repo/.gitignore
+++ b/t/data/openqa/factory/repo/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/t/data/openqa/factory/repo/testrepo/README
+++ b/t/data/openqa/factory/repo/testrepo/README
@@ -1,0 +1,1 @@
+Hello world

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -26,6 +26,11 @@
         type => 'hdd',
         name => 'openSUSE-13.1-x86_64.hda',
     },
+    Assets => {
+        id   => 6,
+        type => 'repo',
+        name => 'testrepo',
+    },
     JobGroups => {
         id          => 1001,
         name        => 'opensuse',
@@ -378,16 +383,18 @@
         state      => "running",
         t_finished => undef,
         backend    => 'qemu',
-        t_started  => time2str('%Y-%m-%d %H:%M:%S', time - 600, 'UTC'),     # 10 minutes ago
-        t_created  => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),    # Two hours ago
-        TEST       => "kde",
-        ARCH       => 'x86_64',
-        BUILD      => '0091',
-        DISTRI     => 'opensuse',
-        FLAVOR     => 'NET',
-        MACHINE    => '64bit',
-        VERSION    => '13.1',
-        jobs_assets => [{asset_id => 2},],
+        # 10 minutes ago
+        t_started => time2str('%Y-%m-%d %H:%M:%S', time - 600, 'UTC'),
+        # Two hours ago
+        t_created => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),
+        TEST      => "kde",
+        ARCH      => 'x86_64',
+        BUILD     => '0091',
+        DISTRI    => 'opensuse',
+        FLAVOR    => 'NET',
+        MACHINE   => '64bit',
+        VERSION   => '13.1',
+        jobs_assets => [{asset_id => 2}, {asset_id => 6},],
         retry_avbl  => 3,
         settings => [{key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'}, {key => 'DVD', value => '1'},]
     },

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -78,12 +78,20 @@ $req = $t->get_ok('/tests/99946/asset/1')->status_is(302)->header_like(Location 
 $req = $t->get_ok('/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
 
 $req = $t->get_ok('/tests/99946/asset/5')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/hdd\/fixed\/openSUSE-13.1-x86_64.hda/);
-$req = $t->get_ok('/tests/99946/asset/hdd/openSUSE-13.1-x86_64.hda')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/hdd\/fixed\/openSUSE-13.1-x86_64.hda/);
 
 # verify error on invalid downloads
-$req = $t->get_ok('/tests/99946/asset/iso/foobar.iso')->status_is(404);
+$t->get_ok('/tests/99946/asset/iso/foobar.iso')->status_is(404);
+
+$t->get_ok('/tests/99961/asset/repo/testrepo/README')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/repo\/testrepo\/README/);
+$t->get_ok('/tests/99961/asset/repo/testrepo/README/../README')->status_is(400)->content_is('invalid character in path');
+
+# verify 404 on download_assets - to be handled by apache (for now at least)
+$t->get_ok('/assets/repo/testrepo/README')->status_is(404);
+$t->get_ok('/assets/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(404);
+
 
 # TODO: also test repos
+
 
 SKIP: {
     skip "FIXME: allow to download only assets related to a test", 1;


### PR DESCRIPTION
Instead of returning self constructed URLs from helper functions, return
a relative path passed to URL helpers in the controller.

This way we don't hard code the /fixed/ part anywhere but the utility
function and still use URL helpers