### PR TITLE
Do not enforce any asset name at all

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -28,10 +28,6 @@ sub register {
         log_warning "asset type '$type' invalid";
         return;
     }
-    unless ($name && $name =~ /^[0-9A-Za-z+-._@]+$/) {
-        log_warning "asset name '$name' invalid";
-        return;
-    }
     unless (locate_asset $type, $name, mustexist => 1) {
         if (!$missingok) {
             log_warning "no file found for asset '$name' type '$type'";


### PR DESCRIPTION
We just do not see a reason why we should limit the names. And as we have
assets which are considered 'invalid' we just have a lot of warnings but do
not plan to do anything about it.

Related progress issue: https://progress.opensuse.org/issues/14650