### PR TITLE
Major changes on the documentation's formatting

### DIFF
--- a/docs/Branding.asciidoc
+++ b/docs/Branding.asciidoc
@@ -1,25 +1,32 @@
-openQA branding
-===============
+
+= openQA branding
+:toc: left
+:toclevels: 6
 :author: Adam Williamson
 
-You can alter the appearance of the openQA web UI to some extent through
-the 'branding' mechanism. The 'branding' configuration setting in the
-'global' section of +/etc/openqa/openqa.ini+ specifies the branding to
-use. It defaults to 'openSUSE', and openQA also includes the 'plain'
-branding, which is - as its name suggests - plain and generic.
+You can alter the appearance of the openQA web UI to some extent through the
+branding mechanism. The `branding` configuration setting in the `global` section
+of +/etc/openqa/openqa.ini+ specifies the branding to use. It defaults to
+'openSUSE', and openQA also includes the 'plain' branding, which is - as its
+name suggests - plain and generic.
 
-To create your own branding for openQA, you can create a subdirectory
-of +/usr/share/openqa/templates/branding+ (or wherever openQA is
-installed). The subdirectory's name will be the name of your branding.
-You can copy the files from +branding/openSUSE+ or +branding/plain+ to
-use as starting points, and adjust as necessary.
+To create your own branding for openQA, you can create a subdirectory of
+`/usr/share/openqa/templates/branding` (or wherever openQA is installed). The
+subdirectory's name will be the name of your branding. You can copy the files
+from +branding/openSUSE+ or +branding/plain+ to use as starting points, and
+adjust as necessary.
 
-openQA uses the http://mojolicio.us/[Mojolicious] framework's templating
-system; the branding files are included into the openQA templates at
-various points. To see where each branding file is actually included,
-you can search through the files in the +templates+ tree for the text
-+include_branding+. Anywhere that helper is called, the branding file
-with the matching name is being included. The branding files themselves
-are Mojolicious 'Embedded Perl' templates just like the main template
-files. You can read the http://mojolicio.us/perldoc/Mojolicious/Guides/Rendering[Mojolicious documentation] for
-help with the format.
+== Mojolicious
+
+:mojo-website: http://mojolicio.us/[Mojolicious]
+:mojo-docs: http://mojolicio.us/perldoc/Mojolicious/Guides/Rendering[Mojolicious Documentation]
+
+openQA uses the {mojo-website} framework's templating system; the branding files
+are included into the openQA templates at various points. To see where each
+branding file is actually included, you can search through the files in the
++templates+ tree for the text +include_branding+. Anywhere that helper is
+called, the branding file with the matching name is being included.
+
+The branding files themselves are Mojolicious _embedded perl_ templates just
+like the main template files. You can read the {mojo-docs} for help with the
+format.

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -1,11 +1,10 @@
-openQA developer guide
-======================
-:author: openSUSE Team at SUSE
-:toc:
 
-Introduction
-------------
-[id="intro"]
+= openQA developer guide
+:toc: left
+:toclevels: 6
+:author: OpenQA Team
+
+== Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It's free software released
@@ -18,11 +17,10 @@ openQA development improving the tool, fixing bugs and implementing new
 features. For information about writing or improving openQA tests, refer to the
 Tests Developer Guide. In both documents it's assumed that the reader is already
 familiar with openQA and has already read the Starter Guide. All those documents
-are available at the 
+are available at the
 https://github.com/os-autoinst/openQA[official repository].
 
-Development guidelines
-----------------------
+== Development guidelines
 [id="guidelines"]
 
 As mentioned, the central point of development is the
@@ -44,8 +42,7 @@ repositories can be found:
 As in most projects hosted on GitHub, pull request are always welcome and
 are the right way to contribute improvements and fixes.
 
-Rules for commits
-~~~~~~~~~~~~~~~~~
+=== Rules for commits
 [id="rules_for_commits"]
 
 * Every commit is checked by https://travis-ci.org/travis[Travis CI] as soon as
@@ -73,8 +70,7 @@ implications and how we can help each other to improve
 If this is too much hassle for you feel free to provide incomplete pull
 requests for consideration or create an issue with a code change proposal.
 
-Getting involved into development
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+== Getting involved into development
 [id="getting_involved"]
 
 But developers willing to get really involved into the development of openQA or
@@ -82,7 +78,7 @@ people interested in following the always-changing roadmap should take a look
 at the https://progress.opensuse.org/projects/openqav3[openQAv3 project] in
 openSUSE's project management tool. This Redmine instance is used to coordinate
 the main development effort organizing the existing issues (bugs and desired
-features) into `target versions'.
+features) into 'target versions'.
 
 Currently developers meet in IRC channel
 irc://chat.freenode.net/opensuse-factory[#opensuse-factory] and in a daily
@@ -104,8 +100,7 @@ configured in the repositories to encourage contributors to raise the tests
 coverage with every commit and pull request. New features and bug fixes are
 expected to be backed with the corresponding tests.
 
-Technologies
-------------
+== Technologies
 [id="technologies"]
 
 Everything in openQA, from +os-autoinst+ to the web frontend and from the tests
@@ -151,11 +146,9 @@ package, one of the tests consists of a call to
 http://perltidy.sourceforge.net/[Perltidy] to ensure that the contributed code
 follows the most common Perl style conventions.
 
-Managing the database
----------------------
+== Managing the database
 
-How to change the database schema
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== How to change the database schema
 
 During the development process there are cases in which the database schema
 needs to be changed. After modifying files in +lib/OpenQA/Schema/Result+
@@ -192,8 +185,7 @@ installed in a production server, you should run either
 +./script/initdb --init_database+ or +./script/upgradedb --upgrade_database+ to actually
 create or upgrade a database.
 
-How to add fixtures to the database
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== How to add fixtures to the database
 
 Fixtures (initial data stored in tables at installation time) are stored
 in files into the +dbicdh/_common/deploy/_any/<version>+ and
@@ -209,12 +201,12 @@ problem) and sqlite doesn't support nested transactions.
 Executed SQL statements can be traced by setting the +DBIC_TRACE+ environment
 variable.
 
+[source,bash]
 --------------------------------------------------------------------------------
 export DBIC_TRACE=1
 --------------------------------------------------------------------------------
 
-How to overwrite config files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+== How to overwrite config files
 
 It can be necessary during development to change the config files in +etc/+.
 For example you have to edit etc/openqa/database.ini to use another database.
@@ -232,8 +224,7 @@ export OPENQA_CONFIG=$PWD/etc/mine
 Note that OPENQA_CONFIG points to the directory containing openqa.ini, database.ini,
 client.conf and workers.ini.
 
-How to setup PostgreSQL to test locally with production data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+== How to setup PostgreSQL to test locally with production data
 
 1. Install PosgreSQL - under openSUSE the following package are required:
    +postgresql-server postgresql-init+
@@ -254,8 +245,7 @@ How to setup PostgreSQL to test locally with production data
 8. Configure openQA to use PostgreSQL as described in +Installing.asciidoc+ under
    'Other database engines'. User name and password are not required.
 
-Adding new authentication module
---------------------------------
+== Adding new authentication module
 
 OpenQA comes with three authentication modules providing authentication methods:
 OpenID, iChain and Fake (see link:Installing.asciidoc[Installation - User authentication]).
@@ -267,7 +257,7 @@ If successful, module for given method is imported or the OpenQA ends with error
 
 
 Each authentication module is expected to export +auth_config+,
-+auth_login+ and +auth_logout+ functions. In case of request-response mechanism (as in 
++auth_login+ and +auth_logout+ functions. In case of request-response mechanism (as in
 OpenID), +auth_response+ is imported on demand.
 
 Currently there is no login page because all implemented methods use either 3rd party

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -1,18 +1,17 @@
-openQA starter guide
-====================
-:author: openSUSE Team at SUSE
-:toc:
 
-Introduction
-------------
-[id="intro"]
+= openQA starter guide
+:toc: left
+:toclevels: 6
+:author: OpenQA Team
+
+== Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It uses virtual machines to
 reproduce the process, check the output (both serial console and
 screen) in every step and send the necessary keystrokes and commands to
 proceed to the next. openQA can check whether the system can be installed,
-whether it works properly in `live' mode, whether applications work
+whether it works properly in 'live' mode, whether applications work
 or whether the system responds as expected to different installation options and
 commands.
 
@@ -32,8 +31,7 @@ become a happy user. More advanced topics like installation, administration or
 development of new tests are covered by further documents available in the
 https://github.com/os-autoinst/openQA[official repository].
 
-Architecture
-------------
+== Architecture
 [id="architecture"]
 
 Although the project as a whole is referred to as openQA, there are in fact
@@ -60,12 +58,10 @@ application takes care of distributing test jobs among workers. Web
 application and workers don't have to run on the same machine but
 can be connected via network instead.
 
-Basic concepts
---------------
+== Basic concepts
 [id="concepts"]
 
-Jobs
-~~~~
+=== Jobs
 
 One of the most important features of openQA is that it can be used to test
 several combinations of actions and configurations. For every one of those
@@ -81,7 +77,7 @@ A job goes through several states:
 * *running* In progress.
 * *cancelled* The job was explicitly cancelled by the user or was replaced by a
   clone (see below).
-* *waiting* The job is in `interactive mode' (see below) and waiting for input.
+* *waiting* The job is in 'interactive mode' (see below) and waiting for input.
 * *done* Execution finished.
 
 Jobs in state 'done' have typically gone through a whole sequence of steps
@@ -90,7 +86,7 @@ partial results, a finished job also provides an overall result from the
 following list.
 
 * *none* For jobs that have not reached the 'done' state.
-* *passed* No critical check failed during the process. It doesn't necessarily 
+* *passed* No critical check failed during the process. It doesn't necessarily
   mean that all testmodules where successful or that no single assertion failed.
 * *failed* At least one assertion considered to be critical was not satisfied at some
   point.
@@ -108,11 +104,10 @@ From that point in time, the clone becomes the current version and the original
 job is considered outdated (and can be filtered in the listing) but its
 information and results (if any) are kept for future reference.
 
-Needles
-~~~~~~~
+=== Needles
 
 One of the main mechanisms for openQA to know the state of the virtual machine
-is checking the presence of some elements in the machine's `screen'.
+is checking the presence of some elements in the machine's 'screen'.
 This is performed using fuzzy image matching between the screen and the so
 called 'needles'. A needle specifies both the elements to search for and a
 list of tags used to decide which needles should be used at any moment.
@@ -142,8 +137,7 @@ tags.
 }
 -------------------------------------------------------------------
 
-Interactive mode
-~~~~~~~~~~~~~~~~
+=== Interactive mode
 
 There are several points in time during the execution of a job at which openQA
 tries to match the screen with the available needles, reacting to the result of
@@ -170,9 +164,7 @@ operating system or when the look & feel have changed and several needles need
 to be adjusted accordingly.
 
 
-Access management
------------------
-[id="auth"]
+=== Access management
 
 Some actions in openQA require special privileges. openQA provides
 authentication through http://en.wikipedia.org/wiki/OpenID[openID]. By default,
@@ -209,29 +201,26 @@ of the openQA security model, refer to the
 http://lizards.opensuse.org/2014/02/28/about-openqa-and-authentication/[detailed
 blog post] about the subject by the openQA development team.
 
-Using the client script
-~~~~~~~~~~~~~~~~~~~~~~~
+==Using the client script
+:openqa-personal-configuration: ~/.config/openqa/client.conf
 
 Just as the worker uses an API key+secret every user of the +client script+
 must do the same. The same API key+secret as previously created can be used or
 a new one created over the webUI.
 
 The personal configuration should be stored in a file
-+~/.config/openqa/client.conf+ in the same format as previously described for
+`{openqa-personal-configuration}` in the same format as previously described for
 the +client.conf+, i.e. sections for each machine, e.g. `localhost`.
 
-
-Using job templates to automate jobs creation
----------------------------------------------
+== Using job templates to automate jobs creation
 [id="job_templates"]
 
-The problem
-~~~~~~~~~~~
+=== The problem
 
 When testing an operating system, especially when doing continuous testing,
 there is always a certain combination of jobs, each one with its own
 settings, that needs to be run for every revision. Those combinations can be
-different for different `flavors' of the same revision, like running a different
+different for different 'flavors' of the same revision, like running a different
 set of jobs for each architecture or for the Full and the Lite versions. This
 combinational problem can go one step further if openQA is being used for
 different kinds of tests, like running some simple pre-integration tests
@@ -268,21 +257,20 @@ can be tested in x86-64 and i586 machines. If we write this as a
 triples, we can create a list like this to characterize KDE tests:
 
   (Product,             Test Suite, Machine)
-  (openSUSE-DVD-x86_64, KDE,        64bit) 
+  (openSUSE-DVD-x86_64, KDE,        64bit)
   (openSUSE-DVD-x86_64, KDE,        Laptop-64bit)
   (openSUSE-DVD-x86_64, KDE,        USBBoot-64bit)
-  (openSUSE-DVD-i586,   KDE,        32bit) 
-  (openSUSE-DVD-i586,   KDE,        Laptop-32bit) 
+  (openSUSE-DVD-i586,   KDE,        32bit)
+  (openSUSE-DVD-i586,   KDE,        Laptop-32bit)
   (openSUSE-DVD-x86_64, KDE,        USBBoot-32bit)
-  (openSUSE-DVD-i586,   KDE,        64bit) 
-  (openSUSE-DVD-i586,   KDE,        Laptop-64bit) 
+  (openSUSE-DVD-i586,   KDE,        64bit)
+  (openSUSE-DVD-i586,   KDE,        Laptop-64bit)
   (openSUSE-DVD-x86_64, KDE,        USBBoot-64bit)
 
 For every triplet, we need to configure a different instance of
 os-autoinst with a different set of parameters.
 
-Medium Types (products)
-~~~~~~~~~~~~~~~~~~~~~~~
+=== Medium Types (products)
 
 A medium type (product) in openQA is a simple description without any concrete
 meaning. It basically consists of a name and a set of variables that
@@ -301,8 +289,7 @@ Some example variables used by openSUSE are:
 * +PROMO+ marks the promotional product.
 * +RESCUECD+ is set to 1 for rescue CD images.
 
-Test Suites
-~~~~~~~~~~~
+=== Test Suites
 
 This is the form where we define the different tests that we created
 for openQA. A test consists of a name, a priority (used in the
@@ -346,8 +333,7 @@ and/or os-autoinst's own behavior are:
 * +RAIDLEVEL+ RAID configuration variable
 * +QEMUVGA+ parameter to declare the video hardware configuration in QEMU
 
-Machines
-~~~~~~~~
+=== Machines
 
 You need to have at least one machine set up to be able to run any
 tests. Those machines represent virtual machine types that you want to
@@ -370,8 +356,8 @@ of how the test machine is set up. A few important examples:
 ** +USBBOOT+ when set to 1, the image will be loaded through an
    emulated USB stick.
 
-Variable expansion
-~~~~~~~~~~~~~~~~~~
+=== Variable expansion
+
 Any variable defined in Test Suite, Machine or Product table can refer to another
 variable using this syntax: +%NAME%+. When the test job is created, the string
 will be substituted with the value of the specified variable at that time.
@@ -390,19 +376,17 @@ may be expanded to this job variable:
 PUBLISH_HDD_1 = opensuse-13.1-i586-kde.qcow2
 --------------------------------------------------------------------------------
 
-Testing openSUSE or Fedora
---------------------------
+== Testing openSUSE or Fedora
 
 An easy way to start using openQA is to start testing openSUSE or Fedora as they
 have everything setup and prepared to ease the initial deployment. If you want
 to play deeper, you can configure the whole openQA manually from scratch, but
 this document should help you to get started faster.
 
-Getting tests
-~~~~~~~~~~~~~
+=== Getting tests
 
 First you need to get actual tests. You can get openSUSE tests and needles (the
-expected results) from 
+expected results) from
 https://github.com/os-autoinst/os-autoinst-distri-opensuse[GitHub]. It belongs
 into the +/var/lib/openqa/tests/opensuse+ directory. To make it easier, you can just
 run
@@ -428,8 +412,7 @@ cd ..
 chown -R geekotest fedora/
 --------------------------------------------------------------------------------
 
-Getting openQA configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Getting openQA configuration
 
 To get everything configured to actually run the tests, there are plenty of
 options to set in the admin interface. If you plan to test openSUSE Factory, using
@@ -443,7 +426,7 @@ following command:
 
 This will load some default settings that were used at some point of time in
 openSUSE production openQA. Therefore those should work reasonably well with
-openSUSE tests and needles. This script uses +/usr/share/openqa/script/load_templates+, 
+openSUSE tests and needles. This script uses +/usr/share/openqa/script/load_templates+,
 consider reading its help page (+--help+) for documentation on possible extra arguments.
 
 For Fedora, similarly, you can call:
@@ -459,8 +442,7 @@ https://bitbucket.org/rajcze/openqa_fedora_tools.git[openqa_fedora_tools]
 repository can be used to create these. See the documentation in that repo
 for more information.
 
-Adding a new ISO to test
-~~~~~~~~~~~~~~~~~~~~~~~~
+=== Adding a new ISO to test
 
 To start testing a new ISO put it in +/var/lib/openqa/share/factory/iso+ and call
 the following commands:
@@ -498,6 +480,6 @@ For Fedora, a sample run might be:
          BUILD=Rawhide-20160308.n.0
 --------------------------------------------------------------------------------
 
-Pitfalls
---------
-Take a look at link:Pitfalls.asciidoc[Documented Pitfalls]
+== Pitfalls
+
+Take a look at link:Pitfalls.asciidoc[Documented Pitfalls].

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -16,7 +16,7 @@ https://github.com/os-autoinst[os-autoinst organization on GitHub].
 This document provides the information needed to install and setup the tool, as
 well as information useful for everyday administration of the system. It's
 assumed that the reader is already familiar with openQA and has already read the
-Starter Guide, available at the 
+Starter Guide, available at the
 https://github.com/os-autoinst/openQA[official repository].
 
 Installation
@@ -177,7 +177,6 @@ Advanced configuration
 ----------------------
 [id="advanced"]
 
-
 User authentication
 ~~~~~~~~~~~~~~~~~~~
 
@@ -311,6 +310,23 @@ NFS clients are where openQA workers are running. Run following command:
 mount -t nfs openQA-webUI-host:/var/lib/openqa/share /var/lib/openqa/share
 --------------------------------------------------------------------------------
 
+Needle Caching  
+~~~~~~~~~~~~~~~
+
+If your network is slow or you experience long time to load needles you
+might want to consider needle caching. To use needle caching a directory
++/var/lib/openqa/cache+ must be created, and right permissions given to the
+'geekotest' user. If you install openQA through the repositories, said directory
+will be created for you.
+
+In the +/etc/openqa/workers.ini+
+
+[source,ini]
+--------------------------------------------------------------------------------
+[global]
+CACHEDIRECTORY = /var/lib/openqa/cache
+--------------------------------------------------------------------------------
+
 Auditing - tracking openQA changes
 ----------------------------------
 [id="auditing"]
@@ -346,7 +362,7 @@ Jobs:
   iso_create iso_delete iso_cancel
   jobtemplate_create jobtemplate_delete
   job_create job_grab job_delete job_update_result job_done jobs_restart job_restart job_cancel job_duplicate
-  jobgroup_create jobgroup_connect 
+  jobgroup_create jobgroup_connect
 Tables:
   table_create table_update table_delete
 Users:
@@ -528,7 +544,7 @@ SELECT * FROM jobs;
 .output job_dependencies.csv
 SELECT * FROM job_dependencies;
 .output jobs_assets.csv
-SELECT * FROM jobs_assets;     
+SELECT * FROM jobs_assets;
 --------------------------------------------------------------------------------
 
 Then, initialize the PostgreSQL database using the standard procedure and

--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -1,24 +1,28 @@
-# Networking in OpenQA
 
-*This overview is valid only when using QEMU backend!*
+= Networking in OpenQA
+:toc: left
+:toclevels: 6
+:author: OpenQA Team
 
-Which networking type to use is controlled by the +NICTYPE+
-variable. If unset or empty +NICTYPE+ defaults to +user+, ie qemu
+
+IMPORTANT: This overview is valid only when using QEMU backend!
+
+Which networking type to use is controlled by the `NICTYPE`
+variable. If unset or empty `NICTYPE` defaults to +user+, ie qemu
 user networking which requires no further configuration.
 
 For more advanced setups or tests that require multiple jobs to be
-in the same networking the TAP or VDE based modes can be used.
+in the same networking the <<TAP based network,TAP>> or <<VDE Based Network,VDE>> based modes can be used.
 
-## Qemu user networking
+== Qemu user networking
+:qemu-user-networking: http://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29[user networking]
 
-With Qemu [user
-networking](http://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29)
-each jobs gets it's own isolated network with TCP and UDP routed to
-the outside. DHCP is provided by qemu. The MAC address of the
-machine can be controlled with the +NICMAC+ variable. If not set,
-it's +52:54:00:12:34:56+.
+With Qemu {qemu-user-networking} each jobs gets it's own isolated network with
+TCP and UDP routed to the outside. DHCP is provided by qemu. The MAC address of
+the machine can be controlled with the +NICMAC+ variable. If not set, it's
++52:54:00:12:34:56+.
 
-## TAP based network
+== TAP based network
 
 os-autoinst can connect qemu to TAP devices of the host system to
 leverage advanced network setups provided by the host by setting +NICTYPE=tap+.
@@ -51,10 +55,12 @@ be able to access them.
 ---------------
 tunctl -u _openqa-worker -p -t tap0
 ---------------
+
 or Wicked way:
+[caption="File: "]
 [source, bash]
+./etc/sysconfig/network/ifcfg-tap0
 ---------------
-#/etc/sysconfig/network/ifcfg-tap0
 BOOTPROTO='none'
 IPADDR=''
 NETMASK=''
@@ -80,13 +86,11 @@ specified in TAPSCRIPT variable.
 Sample script to add TAP device to existing bridge br0:
 [source, bash]
 ---------------
-#!/bin/sh
-
 sudo brctl addif br0 $1
 sudo ip link set $1 up
 ---------------
 
-## TAP with Open vSwitch
+== TAP with Open vSwitch
 
 The recomended way to configure the network for TAP devices is using Open vSwitch.
 There is a support service +os-autoinst-openvswitch.service+ which sets vlan number
@@ -106,7 +110,7 @@ Start Open vSwitch and add TAP devices:
 systemctl start openvswitch.service
 systemctl enable openvswitch.service
 
-#create bridge
+# create bridge
 ovs-vsctl add-br br0
 
 # add tap devices, use vlan 999 by default, the vlan number is supposed to be changed when the vm starts
@@ -123,19 +127,23 @@ See Open vSwitch http://openvswitch.org/support/config-cookbooks/port-tunneling/
 
 Example configuration of GRE tunnel:
 [source, bash]
----------------
+----
 ovs-vsctl add-port br0 gre0 -- set interface gre0 type=gre options:remote_ip=<IP address of other host>
----------------
+----
 
 The virtual machines need access to os-autoinst webserver acessible
 via IP 10.0.2.2. The IP addresses of VMs are controlled by tests
 and are likely to conflict if more independent tests runs in parallel.
 
 The VMs have unique MAC that differs in the last 16 bits (see /usr/lib/os-autoinst/backend/qemu.pm).
-os-autoinst-openvswitch.service sets up filtering rules for the following translation scheme which
+
+`os-autoinst-openvswitch.service` sets up filtering rules for the following translation scheme which
 provide non-conflicting addresses visible from host:
 
-  MAC 52:54:00:12:XX:YY -> IP 10.1.XX.YY
+[source, bash]
+----
+MAC 52:54:00:12:XX:YY -> IP 10.1.XX.YY
+----
 
 That means that the local port of the bridge must be configured to IP 10.0.2.2
 and netmask /15 that covers 10.0.0.0 and 10.1.0.0 ranges.
@@ -150,22 +158,21 @@ ip link set br0 up
 and permanently in /etc/sysconfig/network
 [source, bash]
 ---------------
-#/etc/sysconfig/network/ifcfg-br0
+# /etc/sysconfig/network/ifcfg-br0
 BOOTPROTO='static'
 IPADDR='10.0.2.2/15'
 STARTMODE='auto'
 ---------------
 
-wicked 0.6.23 and later has enhanced support for the creation and configuration of OpenvSwitch bridges. 
+wicked 0.6.23 and later has enhanced support for the creation and configuration of OpenvSwitch bridges.
 
-[NOTE]
-In some cases (e.g. on Leap) can be needed to start the OpenvSwitch service before the Network service by modifying the OpenvSwitch service. For reference see https://en.opensuse.org/Portal:Wicked/OpenvSwitch#Wicked_0.6.23.2B[this].
+NOTE: In some cases (e.g. on Leap) can be needed to start the OpenvSwitch service before the Network service by modifying the OpenvSwitch service. For reference see https://en.opensuse.org/Portal:Wicked/OpenvSwitch#Wicked_0.6.23.2B[this].
 
 The permanent configuration for wicked 0.6.23 and later should look like this:
 
 [source, bash]
 ---------------
-#/etc/sysconfig/network/ifcfg-br0
+# /etc/sysconfig/network/ifcfg-br0
 BOOTPROTO='static'
 IPADDR='10.0.2.2/15'
 STARTMODE='auto'
@@ -189,7 +196,6 @@ FW_MASQUERADE="yes"
 FW_DEV_INT="br0"
 ---------------
 
-
 Then it is possible to start the os-autoinst-openvswitch.service
 The service uses +br0+ by default. It can be configured for another
 bridge name by setting +/etc/sysconfig/os-autoinst-openvswitch+
@@ -206,7 +212,7 @@ systemctl start os-autoinst-openvswitch.service
 systemctl enable os-autoinst-openvswitch.service
 ---------------
 
-### Debugging Open vSwitch configuration
+== Debugging Open vSwitch configuration
 
 Boot sequence with wicked < 0.6.23:
 
@@ -225,14 +231,11 @@ Boot sequence with wicked 0.6.23 and newer:
 
 The configuration and operation can be checked by the following commands:
 
-ovs-vsctl show
-
-shows the bridge br0, the tap devices are assigned to it
-
-
-ovs-ofctl dump-flows br0
-
-shows the rules installed by os-autoinst-openvswitch in table=0
+[source,bash]
+----
+ovs-vsctl show # shows the bridge br0, the tap devices are assigned to it
+ovs-ofctl dump-flows br0 # shows the rules installed by os-autoinst-openvswitch in table=0
+----
 
 * packets from tapX to br0 create additional rules in table=1
 * packets from br0 to tapX increase packet counts in table=1
@@ -245,8 +248,7 @@ As long as the SUT has access to external network, there should be
 nonzero packet count in the forward chain between br0 and external
 interface.
 
-
-## VDE based network
+== VDE Based Network
 
 Virtual Distributed Ethernet provides a software switch that runs in
 user space. It allows to connect several qemu instances without
@@ -255,7 +257,7 @@ affecting the system's network configuration.
 The openQA workers need a vde_switch instance running. The workers
 reconfigure the switch as needed by the job.
 
-### Basic, single machine tests
+=== Basic, single machine tests
 
 To start with a basic configuration like qemu user mode networking,
 create a machine with the following settings:
@@ -275,12 +277,12 @@ systemctl start openqa-slirpvde
 With this setting all jobs on the same host would be in the same
 network share the same SLIRP instance though.
 
-### Multi machine tests
+=== Multi machine tests
 
-Create a machine like above but don't set +NICVLAN+. openQA will
+Create a machine like above but don't set NICVLAN. openQA will
 dynamically allocate a VLAN number for all jobs that have
 dependencies between each other. By default this VLAN is private and
 has no internet access. To enable user mode networking set
-+VDE_USE_SLIRP=1+ on one of the machines. The worker running the job
+`VDE_USE_SLIRP=1` on one of the machines. The worker running the job
 on such a machine will start slirpvde and put it in the correct VLAN
 then.

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -7,10 +7,25 @@ openQA pitfalls
 Needle editing
 ==============
 
-- if a new needle is created based on a failed test, the new needle
+- If a new needle is created based on a failed test, the new needle
   will not be listed in old tests.
-- if an existing needle is updated with a new image or different
+- If an existing needle is updated with a new image or different
   areas, the old test will display the new needle which might be
   confusing
-- if a needle is deleted, old tests may display an error when viewing
+- If a needle is deleted, old tests may display an error when viewing
   them in the web UI.
+
+Mixed production and development environment
+============================================
+
+There are few things to take into account when running a development version and
+a packaged version of openqa:
+
+If the setup for the development scenario involves sharing +/var/lib/openqa+,
+it would be wise to have a shared group _openqa_, that will have write and execute
+permissions over said directory, so that _geekotest_ user and the normal development
+user can share the environment without problems.
+
+This approach will lead to a problem when the openqa package is updated, since the
+directory permissions will be changed again, nothing a `chmod -R g+rwx /var/lib/openqa/`
+and `chgrp -R openqa /var/lib/openqa` can not fix.

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1,11 +1,10 @@
-openQA tests developer guide
-============================
-:author: openSUSE Team at SUSE
-:toc:
 
-Introduction
-------------
-[id="intro"]
+= openQA tests developer guide
+:toc: left
+:toclevels: 6
+:author: OpenQA Team
+
+== Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It's free software released
@@ -16,11 +15,10 @@ https://github.com/os-autoinst[os-autoinst organization on GitHub].
 This document provides the information needed to start developing new tests for
 openQA or to improve the existing ones. It's
 assumed that the reader is already familiar with openQA and has already read the
-Starter Guide, available at the 
+Starter Guide, available at the
 https://github.com/os-autoinst/openQA[official repository].
 
-Basic
------
+== Basic
 [id="basic"]
 
 This section explains the basic layout of openQA tests and the API available in tests.
@@ -28,8 +26,8 @@ openQA tests are written in the *Perl* programming language. Some basic but no
 in-depth knowledge of Perl is needed. This document assumes that the reader
 is already familiar with Perl.
 
-API
-~~~
+== API
+[id="api"]
 
 https://github.com/os-autoinst/os-autoinst[os-autoinst] provides the
 API for the tests. The most commonly used functions are:
@@ -62,8 +60,7 @@ The following API is distribution specific and subject to change
 * +script_sudo COMMAND+ Use sudo to execute COMMAND, handling the optional password prompt.
 * +type_password+ Type default password (used for root and user)
 
-How to write tests
-~~~~~~~~~~~~~~~~~~
+== How to write tests
 
 openQA tests need to implement at least the *run* subroutine to
 contain the actual test code and the test needs to be loaded in the distribution's
@@ -88,7 +85,7 @@ that boots into the desktop when pressing enter at the boot loader:
 -------------------------------------------------------------------
 use base "basetest";
 use strict;
-use testapi; 
+use testapi;
 
 sub run {
     # wait for bootloader to appear
@@ -112,11 +109,11 @@ sub test_flags {
 1;
 -------------------------------------------------------------------
 
-Test Case Examples
-~~~~~~~~~~~~~~~~~~
+=== Test Case Examples
+[id="testcase_examples"]
 
-* Console test that installs software from remote repository via zypper command
-
+[caption="Example: "]
+.Console test that installs software from remote repository via zypper command
 [source,perl]
 ----------------------------------------------------------------------------------------------------------
 sub run() {
@@ -138,8 +135,8 @@ sub run() {
 }
 ----------------------------------------------------------------------------------------------------------
 
-* Typical X11 test testing kate
-
+[caption="Example: "]
+.Typical X11 test testing kate
 [source,perl]
 --------------------------------------------------------------
 sub run() {
@@ -152,7 +149,7 @@ sub run() {
     x11_start_program "kate";
 
     # check that kate execution succeeded
-    assert_screen 'test-kate-1', 10; 
+    assert_screen 'test-kate-1', 10;
 
     # close kate's welcome window and wait for system becoming idle
     send_key 'alt-c', 1;
@@ -171,8 +168,7 @@ sub run() {
 }
 --------------------------------------------------------------
 
-Variables
-~~~~~~~~~
+== Variables
 
 Test case behavior can be controlled via variables. Some basic
 variables like +DISTRI+, +VERSION+, +ARCH+ are always set.
@@ -184,8 +180,9 @@ on GitHub] for examples.
 
 Variables are accessible via the *get_var* and *check_var* functions.
 
-Modifying setting of an existing test
--------------------------------------
+== Test Development tricks
+
+=== Modifying setting of an existing test
 
 There is no interface to modify existing tests but the clone script
 can be used to create a new job that adds, removes or changes
@@ -214,8 +211,7 @@ and the job will not appear as a job in any job group, e.g.:
 /usr/share/openqa/script/clone_job.pl --from localhost 42 _GROUP=0
 -------------
 
-Using snapshots to speed up development of tests
-------------------------------------------------
+=== Using snapshots to speed up development of tests
 [id="snapshots"]
 
 Sometimes it's annoying to run the full installation to adjust some
@@ -226,19 +222,19 @@ help in this situation.
 Depending on the use case, there are two options to help:
 
 * create and *preserve* snapshots for *every test* module run (+MAKETESTSNAPSHOTS+)
-- offers more flexibility as test can be resumed almost at any point, however
-  disk space requirements are high (expect more than 30GB for one job)
-- this mode is useful for fixing non fatal issues in tests and debugging SUT
+  - offers more flexibility as test can be resumed almost at any point, however
+    disk space requirements are high (expect more than 30GB for one job)
+  - this mode is useful for fixing non fatal issues in tests and debugging SUT
 
 * create snapshot *after every successful* test module, *always overwrite* to preserve only latest (+TESTDEBUG+)
-- allows to skip just before the start of first failed test module, which can be limiting, but there are
+  - allows to skip just before the start of first failed test module, which can be limiting, but there are
   no additional hardware requirements.
-- this mode is useful for iterative test development
+  - this mode is useful for iterative test development
 
 In both modes there is no need to modify tests (i.e. adding +milestone+ test flag, it is implied).
 In later mode, every test module is also considered +fatal+. This means the job is aborted after first failed test module.
 
-
+[caption="Example: "]
 .Steps to enable snapshots for each test module (former mode):
 ----
 1. run the worker with --no-cleanup parameter. This will preserve the hard
@@ -259,6 +255,7 @@ Use qemu-img snapshot -l something.img to find out what snapshots
 are in the image. Snapshots are named `"test module category"-"test module name"` (e.g. `installation-start_install`)
 ----
 
+[caption="Example: "]
 .Steps to enable storing only last successful snapshot (latter mode):
 ----
 1. run the worker with --no-cleanup parameter. This will preserve the hard
@@ -276,8 +273,7 @@ variable must be also included:
 $ /usr/share/openqa/script/clone_job.pl --from https://openqa.opensuse.org  --host localhost 24 TESTDEBUG=1 SKIPTO=consoletest-yast2_i
 ----
 
-Assigning jobs to workers
--------------------------
+=== Assigning jobs to workers
 
 By default, any worker can get any job with the matching architecture.
 
@@ -288,7 +284,9 @@ assigned only to workers, which have the same variable in the configuration file
 For example, the following configuration ensures, that jobs with WORKER_CLASS=desktop
 can be assigned _only_ to worker instances 1 and 2.
 
-[workers.ini]
+[caption="File: "]
+.workers.ini
+[source=ini]
 --------------------------------------------------------------------------------
 [1]
 WORKER_CLASS = desktop
@@ -300,8 +298,7 @@ WORKER_CLASS = desktop
 # WORKER_CLASS is not set
 --------------------------------------------------------------------------------
 
-Writing multi-machine tests
----------------------------
+=== Writing multi-machine tests
 [id="mm-tests"]
 
 Scenarios requiring more than one system under test (SUT), like High Availability testing, are covered as multi-machine tests (MM tests) in this section.
@@ -313,7 +310,7 @@ etc. if required), which in principle is not part of the actual testing, must ha
 * OpenQA scheduler makes sure _tests are started as a group_ and in right order, _cancelled as a group_ if some dependencies are violated and _cloned as
 a group_ if requested.
 * OpenQA _does not synchronize_ individual steps of the tests.
-* OpenQA provides _locking server for basic synchronization_ of tests (e.g. wait until services are ready for failover), but the _correct usage of locks is 
+* OpenQA provides _locking server for basic synchronization_ of tests (e.g. wait until services are ready for failover), but the _correct usage of locks is
 test designer job_ (beware deadlocks).
 
 In short, writing multi-machine tests adds a few more layers of complexity:
@@ -322,8 +319,7 @@ In short, writing multi-machine tests adds a few more layers of complexity:
 2. synchronization between individual tests
 3. actual technical realization (i.e. link:Networking.asciidoc[custom networking])
 
-Job dependencies
-~~~~~~~~~~~~~~~~
+==== Job dependencies
 
 There are 2 types of dependencies: +CHAINED+ and +PARALLEL+:
 
@@ -347,13 +343,12 @@ won't work.
 Job dependencies are currently only possible between tests that are
 scheduled for the same machine.
 
-OpenQA worker requirements
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== OpenQA worker requirements
+
 +CHAINED+ dependency requires only one worker, since dependent jobs will run only after the first one finish.
 On the other hand +PARALLEL+ dependency requires at _least 2 workers_ for simple scenarios.
 
-Examples:
-^^^^^^^^^
+===== Examples:
 
 .+CHAINED+ - i.e. test basic functionality before going advanced - requires 1 worker
 ----
@@ -402,8 +397,8 @@ and then define B,C,D with PARALLEL_WITH=A
 A is parent test suite for B, C, D (all can run in parallel).
 Children B, C, D can run and finish anytime, but A must run until all B, C, D finishes.
 ----
-Test synchronization and locking API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+=== Test synchronization and locking API
 
 OpenQA provides locking server through lock API. To use lock API import +lockapi+ package (_use lockapi;_) in your test file.
 Lock API provides three functions: +mutex_create+, +mutex_lock+, +mutex_unlock+. Each of these functions take one parameter: name of the lock.
@@ -422,10 +417,9 @@ same time and the same lock name is used, these locks are independent of each ot
 
 The +mmapi+ package provides +wait_for_children+, which the parent can use to wait for the children to complete.
 
-Example:
-^^^^^^^^
-
-parent job - wait until login prompt appear, assume services are started
+[caption="Example of mmapi: Parent Job"]
+.Wait until login prompt appear, assume services are started
+====
 [source,perl]
 --------------------------------------------------------------------------------
 use base "basetest";
@@ -449,8 +443,11 @@ sub run {
     wait_for_children;
 }
 --------------------------------------------------------------------------------
+====
 
-child job - check until parent is ready, then start testing services
+[caption="Example of mmapi: Child job"]
+.Check until parent is ready, then start testing services
+====
 [source,perl]
 --------------------------------------------------------------------------------
 use base "basetest";
@@ -475,7 +472,7 @@ sub run {
     type_string("secret\n");
 }
 --------------------------------------------------------------------------------
-
+====
 
 Sometimes it is useful to let a parent wait for certain action on a child, for example to verify
 server state after completed request. In this scenario the child creates
@@ -485,7 +482,9 @@ The child can however die at any time. To prevent parent deadlock in this situat
 parent has to pass child ID as a second parameter to mutex_lock(). If a child job
 with given ID already finished, mutex_lock() calls die.
 
-parent job - wait until the child reaches given point
+[caption="Example of mmapi: Parent Job"]
+.Wait until the child reaches given point
+====
 [source,perl]
 --------------------------------------------------------------------------------
 use base "basetest";
@@ -506,10 +505,13 @@ sub run {
     # continue with the test
 }
 --------------------------------------------------------------------------------
+====
 
-Getting info about parents / children
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Getting information about parents and children
 
+[caption="Example of mmapi: "]
+.Getting info about parents / children
+====
 [source,perl]
 --------------------------------------------------------------------------------
 use base "basetest";
@@ -547,16 +549,16 @@ sub run {
     # my $parent_vnc = $parent_info->{settings}->{VNC}
 }
 --------------------------------------------------------------------------------
+====
 
-Support Server based tests
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Support Server based tests
 
-The idea is to have a dedicated "helper server" to allow advanced network based testing. 
+The idea is to have a dedicated "helper server" to allow advanced network based testing.
 
 Support server takes advantage of the basic parallel setup as described in the previous section, with the support server being the parent test 'A' and the test needing it being the child test 'B'. This ensures that the test 'B' always have the support server available.
 
-Preparing the supportserver:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Preparing the supportserver:
+
 
 The support server image is created by calling a special test, based on the autoyast test:
 
@@ -565,7 +567,7 @@ The support server image is created by calling a special test, based on the auto
 /usr/share/openqa/script/client jobs post DISTRI=opensuse VERSION=13.2 \
     ISO=openSUSE-13.2-DVD-x86_64.iso  ARCH=x86_64 FLAVOR=Server-DVD \
     TEST=supportserver_generator MACHINE=64bit DESKTOP=textmode  INSTALLONLY=1 \
-    AUTOYAST=supportserver/autoyast_supportserver.xml SUPPORT_SERVER_GENERATOR=1 \    
+    AUTOYAST=supportserver/autoyast_supportserver.xml SUPPORT_SERVER_GENERATOR=1 \
     PUBLISH_HDD_1=supportserver.qcow2
 --------------------------------------------------------------------------------
 
@@ -574,8 +576,8 @@ should define correct user and password, as well as packages and the common conf
 
 More specific role the supportserver should take is then selected when the server is run in the actual test scenario.
 
-Using the supportserver:
-^^^^^^^^^^^^^^^^^^^^^^^^
+==== Using the supportserver:
+
 
 In the Test suites, the supportserver is defined by setting:
 
@@ -588,12 +590,13 @@ WORKER_CLASS=server,qemu_autoyast_tap_64
 --------------------------------------------------------------------------------
 
 where the +SUPPORT_SERVER_ROLES+ defines the specific role (see code in 'tests/support_server/setup.pm' for available roles and their definition), and
- +HDD_1+ variable must be the name of the supportserver image as defined via +PUBLISH_HDD_1+ variable during supportserver generation. If the support server is based on older SUSE versions (opensuse 11.x, SLE11SP4..) it may also be needed to add +HDDMODEL=virtio-blk+. In case of qemu backend, one can also use +BOOTFROM=c+, for faster boot directly from the +HDD_1+ image.
- 
+ +HDD_1+ variable must be the name of the supportserver image as defined via +PUBLISH_HDD_1+ variable during supportserver generation. If the support
+server is based on older SUSE versions (opensuse 11.x, SLE11SP4..) it may also be needed to add +HDDMODEL=virtio-blk+. In case of qemu backend, one can
+also use +BOOTFROM=c+, for faster boot directly from the +HDD_1+ image.
 
 Then for the 'child' test using this supportserver, the following additional variable must be set:
 +PARALLEL_WITH=supportserver-pxe-tftp+
-where 'supportserver-pxe-tftp' is the name given to the supportserver in the test suites screen. 
+where 'supportserver-pxe-tftp' is the name given to the supportserver in the test suites screen.
 Once the tests are defined, they can be added to openQA in the usual way:
 
 [source,sh]
@@ -606,8 +609,9 @@ where the +DISTRI+, +VERSION+, +FLAVOR+ and +ARCH+ correspond to the job group c
 Note that the networking is provided by tap devices, so both jobs should run on machines defined by (apart from others) having +NICTYPE=tap+, +WORKER_CLASS=qemu_autoyast_tap_64+.
 
 
-Example - a simple tftp test:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[caption="Example of Support Server: "]
+.a simple tftp test
+====
 
 Let's assume that we want to test tftp client operation. For this, we setup the supportserver as a tftp server:
 [source,ini]
@@ -617,13 +621,16 @@ SUPPORT_SERVER=1
 SUPPORT_SERVER_ROLES=dhcp,tftp
 WORKER_CLASS=server,qemu_autoyast_tap_64
 --------------------------------------------------------------------------------
+====
 
-with a test-suites name +supportserver-opensuse-tftp+.
+With a test-suites name +supportserver-opensuse-tftp+.
 
 The actual test 'child' job, will then have to set +PARALLEL_WITH=supportserver-opensuse-tftp+, and also other variables according to the test requirements. For convenience, we have also started a dhcp server on the supportserver, but even without it, network could be set up manually by assigning a free ip address (e.g. 10.0.2.15) on the system of the test job.
 
-The code in the *.pm module doing the actual tftp test could then look something like this:
 
+[caption="Example of Support Server: "]
+.The code in the *.pm module doing the actual tftp test could then look something like the example below
+====
 [source,perl]
 --------------------------------------------------------------------------------
 use strict;
@@ -640,14 +647,15 @@ sub run {
   script_output($script);
 
 }
-
 --------------------------------------------------------------------------------
+====
 
 assuming of course, that the tested machine was already set up with necessary infrastructure for tftp, e.g. network was set up, tftp rpm installed and tftp service started, etc. All of this could be conveniently achieved using the autoyast installation, as shown in the next section.
 
 
-Example - autoyast based tftp test:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[caption="Example of Support Server: "]
+.autoyast based tftp test
+====
 
 Here we will use autoyast to setup the system of the test job and the os-autoinst autoyast testing infrastructure. For supportserver, this means using proxy to access qemu provided data, for dowloading autoyast profile and tftp verify script:
 
@@ -659,7 +667,6 @@ SUPPORT_SERVER_ROLES=pxe,qemuproxy
 WORKER_CLASS=server,qemu_autoyast_tap_64
 --------------------------------------------------------------------------------
 
-
 The actual test 'child' job, will then be defined as :
 
 [source,ini]
@@ -670,11 +677,13 @@ DESKTOP=textmode
 INSTALLONLY=1
 PARALLEL_WITH=supportserver-opensuse-tftp
 --------------------------------------------------------------------------------
+====
 
 again assuming the support server's name being +supportserver-opensuse-tftp+. Note that the +pxe+ role already contains +tftp+ and +dhcp+ server role, since they are needed for the pxe boot to work.
 
-The tftp test defined in the +autoyast_opensuse/opensuse_autoyast_tftp.sh+ file could be something like:
-
+[caption="Example of Support Server: "]
+.The tftp test defined in the +autoyast_opensuse/opensuse_autoyast_tftp.sh+ file could be something like:
+====
 [source,sh]
 --------------------------------------------------------------------------------
 set -e -x
@@ -685,3 +694,4 @@ diff -u test.txt test2.txt && echo "AUTOYAST OK"
 --------------------------------------------------------------------------------
 
 and the rest is done automatically, using already prepared test modules in +tests/autoyast+ subdirectory.
+====

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,19 @@
+:toc: left
+:toclevels: 6
+:author: OpenQA Team
+:listing-caption: Listing
+:source-highlighter: pygments
+
+= openQA Documentation
+
+
+:sectnums:
+ifdef::basebackend-html[toc::[]]
+:sectnums!:
+include::GettingStarted.asciidoc[]
+include::Installing.asciidoc[]
+include::WritingTests.asciidoc[]
+include::Pitfalls.asciidoc[]
+include::Networking.asciidoc[]
+include::Contributing.asciidoc[]
+include::Branding.asciidoc[]


### PR DESCRIPTION
I updated a bit the documentation's formatting, the main idea behind this is to be able to generate a full document from the index, that can be published or distributed through the open.qa website. 

I kept in most cases the same structure as it was before, so looking individually at the documentation directly on the repo should render in most cases almost the same content as before. 

One thing to note is that not everything is perfect, still a lot of formatting to do (And this is just in the openQA documentation... backend is still in progress)... But a html single page can be generated now, with better navigation, and also a single pdf file.

One idea I have is to move the documentation to os-autoinst/documentation, but I guess we're too early in time for this. 

In future changes (i.e another PR), the +api+ section would be replaced by something generated by the `Pod::AsciiDoctor` module.

Examples of the generated single book is here in [Pdf](https://w3.nue.suse.com/~szarate/openQA/docs/openqa-documentation-20161111.pdf) and [html](https://w3.nue.suse.com/~szarate/openQA/docs/openqa-documentation-20161111.html)