### PR TITLE
API jobs list: add params 'before' and 'after'

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -243,6 +243,12 @@ sub complex_query {
         $attrs{rows} = $args{limit};
     }
     $attrs{page} = $args{page} || 0;
+    if ($args{before}) {
+        push(@conds, {'me.id' => {'<', $args{before}}});
+    }
+    if ($args{after}) {
+        push(@conds, {'me.id' => {'>', $args{after}}});
+    }
     if ($args{assetid}) {
         push(@joins, 'jobs_assets');
         push(

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -25,7 +25,7 @@ sub list {
     my $self = shift;
 
     my %args;
-    for my $arg (qw/build iso distri version flavor maxage scope group groupid limit arch hdd_1 test machine/) {
+    for my $arg (qw/build iso distri version flavor maxage scope group groupid limit page before after arch hdd_1 test machine/) {
         next unless defined $self->param($arg);
         $args{$arg} = $self->param($arg);
     }

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -60,10 +60,16 @@ $t->app($app);
 # 99981 cancelled  no clone
 # 99963 running    no clone
 # 99962 done       clone_id: 99963 (running)
+# 99961 running    no clone
+# 99947 done       no clone
 # 99946 done       no clone
 # 99945 done       clone_id: 99946 (also done)
+# 99944 done       clone_id: 99945 (also done)
+# 99940 done       no clone
+# 99939 done       no clone
 # 99938 done       no clone
 # 99937 done       no clone
+# 99936 done       no clone
 # 99928 scheduled  no clone
 # 99927 scheduled  no clone
 # 99926 done       no clone
@@ -122,6 +128,26 @@ $get = $t->get_ok('/api/v1/jobs?test=kde&result=softfailed&machine=64bit');
 is(scalar(@{$get->tx->res->json->{jobs}}), 1);
 $get = $t->get_ok('/api/v1/jobs?test=kde&result=passed&machine=64bit');
 is(scalar(@{$get->tx->res->json->{jobs}}), 0);
+
+# test limiting options
+$get = $t->get_ok('/api/v1/jobs?limit=5');
+is(scalar(@{$get->tx->res->json->{jobs}}), 5);
+$get = $t->get_ok('/api/v1/jobs?limit=1');
+is(scalar(@{$get->tx->res->json->{jobs}}), 1);
+is($get->tx->res->json->{jobs}->[0]->{id}, 99981);
+$get = $t->get_ok('/api/v1/jobs?limit=1&page=2');
+is(scalar(@{$get->tx->res->json->{jobs}}), 1);
+is($get->tx->res->json->{jobs}->[0]->{id}, 99963);
+$get = $t->get_ok('/api/v1/jobs?before=99928');
+is(scalar(@{$get->tx->res->json->{jobs}}), 2);
+$get = $t->get_ok('/api/v1/jobs?after=99945');
+is(scalar(@{$get->tx->res->json->{jobs}}), 6);
+
+# test multiple arg forms
+$get = $t->get_ok('/api/v1/jobs?ids=99981,99963,99926');
+is(scalar(@{$get->tx->res->json->{jobs}}), 3);
+$get = $t->get_ok('/api/v1/jobs?ids=99981&ids=99963&ids=99926');
+is(scalar(@{$get->tx->res->json->{jobs}}), 3);
 
 # Test /jobs/restart
 my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})->status_is(200);


### PR DESCRIPTION
I want to do something like 'find the job before job X that has
the same scenario' - this is something we do internally in a
few places, e.g. the 'previous results' page in the web UI. But
it's very difficult to do via the API, because you really can't
say "I only want jobs with IDs lower than X".

It's easy enough to add, though! So add 'before' and 'after'
params for the API method and also for the `complex_query`
method which backs it. While I'm at it, add `page` to the args
for the API method too (it's pretty useless to support `limit`
without `page`, and `complex_query` already handles it) and
cover all these bits in the tests, plus test the variant forms
for specifying multiple `ids` args (since I wrote that a while
back but it's not tested yet).