### PR TITLE
.perltidyrc file for use in 3rd party tools

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,9 @@
+-l=0     # don't force line length
+-fbl     # don't change blank lines
+-nsfs    # no spaces before semicolons
+-baao    # space after operators
+-bbao    # space before operators
+-pt=2    # no spaces around ()
+-bt=2    # no spaces around []
+-sbt=2   # no spaces around {}
+-sct     # stack closing tokens )}

--- a/script/tidy
+++ b/script/tidy
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-# don't force line length -l=0
-# don't change blank lines -fbl
-# no spaces before semicolons -nsfs
-# space before and after operators -bbao -baao
-# no spaces around () [] {} -pt=2 -bt=2 -sbt=2
-# stack closing tokens )} -sct
-TIDY_ARGS="-l=0 -fbl -nsfs -baao -bbao -pt=2 -bt=2 -sbt=2 -sct"
-check=
+#
+# perltidy rules can be found in ../.perltidyrc
+#
 
+check=
 if test "$1"  = '--check'; then
     shift
     check=1
@@ -26,7 +22,7 @@ test -e script/openqa || exit 1
 
 find -name '*.tdy' -delete
 
-find . \( -name '*.p[lm]' -o -name '*.t' \) -print0 | xargs -0 perltidy $TIDY_ARGS
+find . \( -name '*.p[lm]' -o -name '*.t' \) -print0 | xargs -0 perltidy --pro=.../.perltidyrc
 
 find script/{check_dependencies,client,initdb,openqa,worker,upgradedb,load_templates,dump_templates,clean_needles,openqa-scheduler,openqa-websockets} -print0 | xargs -0 perltidy $TIDY_ARGS
 


### PR DESCRIPTION
Personally, i like to perltidy files while working on them in my editor of choice. Having a separate `.perltidyrc` file makes that a lot easier. Additionally, Perl developers working on their first contribution to openQA can read the `.perltidyrc` file to get up to speed on formatting rules used by the project.

One of the 3rd party tools benefitting from this change would be my [perltidy package for the Atom text editor](https://atom.io/packages/perltidy).