### PR TITLE
Make group_overview behave as expected

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/Result/JobGroupParents.pm
@@ -122,4 +122,11 @@ sub rendered_description {
     return Mojo::ByteStream->new($m->markdown($self->description));
 }
 
+sub tags {
+    my ($self) = @_;
+
+    # for now
+    return {};
+}
+
 1;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -59,7 +59,7 @@ $driver->find_element('opensuse', 'link_text')->click();
 my $build_url = $driver->get_current_url();
 $build_url =~ s/\?.*//;
 OpenQA::Utils::log_debug('build_url: ' . $build_url);
-is(scalar @{$driver->find_elements('h4', 'css')}, 2, 'number of builds for opensuse');
+is(scalar @{$driver->find_elements('h4', 'css')}, 5, 'number of builds for opensuse');
 is($driver->find_element('#group_description',   'css')->get_text(),            'Test description\n\nwith bugref bsc#1234',       'description shown');
 is($driver->find_element('#group_description a', 'css')->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bugref in description rendered as link');
 $driver->get($baseurl . '/group_overview/1002');

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -26,12 +26,12 @@
 
     % if (@{$groupresults->{children}}) {
         <h2>
-            %= link_to $group->{name} => url_for('parent_group_overview', groupid => $group->{id})->query(limit_builds => $limit_builds, time_limit_days => $time_limit_days)
+            %= link_to $group->{name} => url_for('parent_group_overview', groupid => $group->{id})
         </h2>
         %= include 'main/group_builds', result => $result, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => 0
     % } else {
         <h2>
-            %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})->query(limit_builds => $limit_builds, time_limit_days => $time_limit_days)
+            %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})
         </h2>
         %= include 'main/group_builds', result => $result, group => $group, max_jobs => $max_jobs, children => undef, default_expanded => 0
     % }

--- a/templates/main/more_builds.html.ep
+++ b/templates/main/more_builds.html.ep
@@ -1,6 +1,6 @@
 <div id="more_builds">
     Limit to
-    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query([time_limit_days => 1000, limit_builds => $_])) } (10, 20, 50, 100, 400));
+    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query([limit_builds => $_])) } (10, 20, 50, 100, 400));
     builds, only
     % my %tagged = (tagged => 1, all => 0);
     % my %rtagged = reverse %tagged;


### PR DESCRIPTION
- by default show 10 builds, no matter how old they are
- if 'only tagged' is requested, show 10 tagged builds. no matter how old they are