### PR TITLE
external_reporting: Fix differing header level in description

### DIFF
--- a/templates/branding/openSUSE/external_reporting.html.ep
+++ b/templates/branding/openSUSE/external_reporting.html.ep
@@ -45,7 +45,7 @@
 %     $first_known_bad = build_link($prev);
 % }
 % my $latest = url_for('latest')->query($job->scenario_hash)->to_abs;
-<% my $description = "### Observation
+<% my $description = "## Observation
 
 openQA test in scenario $scenario fails in
 [$module]($step_url)


### PR DESCRIPTION
Fixes https://progress.opensuse.org/issues/14836