### PR TITLE
Add a 120 column limit to .perltidyrc

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,4 +1,4 @@
--l=0     # don't force line length
+-l=120   # 120 characters per line
 -fbl     # don't change blank lines
 -nsfs    # no spaces before semicolons
 -baao    # space after operators

--- a/dbicdh/_common/upgrade/18-19/01-convert.pl
+++ b/dbicdh/_common/upgrade/18-19/01-convert.pl
@@ -39,8 +39,12 @@ sub {
 
     # JobModules->result
     $schema->resultset('JobModules')->search({result_id => 0})->update({result => OpenQA::Schema::Result::Jobs::NONE});
-    $schema->resultset('JobModules')->search({result_id => 1})->update({result => OpenQA::Schema::Result::Jobs::PASSED});
-    $schema->resultset('JobModules')->search({result_id => 2})->update({result => OpenQA::Schema::Result::Jobs::FAILED});
-    $schema->resultset('JobModules')->search({result_id => 3})->update({result => OpenQA::Schema::Result::Jobs::INCOMPLETE});
-    $schema->resultset('JobModules')->search({result_id => 4})->update({result => OpenQA::Schema::Result::Jobs::SKIPPED});
+    $schema->resultset('JobModules')->search({result_id => 1})
+      ->update({result => OpenQA::Schema::Result::Jobs::PASSED});
+    $schema->resultset('JobModules')->search({result_id => 2})
+      ->update({result => OpenQA::Schema::Result::Jobs::FAILED});
+    $schema->resultset('JobModules')->search({result_id => 3})
+      ->update({result => OpenQA::Schema::Result::Jobs::INCOMPLETE});
+    $schema->resultset('JobModules')->search({result_id => 4})
+      ->update({result => OpenQA::Schema::Result::Jobs::SKIPPED});
   }

--- a/dbicdh/_common/upgrade/26-27/007-migrate-jobs.pl
+++ b/dbicdh/_common/upgrade/26-27/007-migrate-jobs.pl
@@ -52,7 +52,6 @@ sub {
             $searches->{"$where.key"}   = $key;
             $searches->{"$where.value"} = $value;
         }
-        #print $jt->machine->name, " ", $jt->product->name, " ", $jt->test_suite->name, " ", join(',', map { $_->id } $schema->resultset("Jobs")->search($searches, { join => \@joins })->all), " ", $jt->group_id, "\n";
         $schema->resultset("Jobs")->search($searches, {join => \@joins})->update_all({group_id => $jt->group_id});
     }
   }

--- a/dbicdh/_common/upgrade/28-29/10-add-worker-class.pl
+++ b/dbicdh/_common/upgrade/28-29/10-add-worker-class.pl
@@ -40,7 +40,8 @@ sub {
         "smp_32"     => 'qemu_i586',
         "smp_64"     => 'qemu_x86_64',
     );
-    my $workers_with_class = $schema->resultset('Machines')->search({'settings.key' => 'WORKER_CLASS'}, {columns => ['id'], join => ['settings']})->as_query;
+    my $workers_with_class = $schema->resultset('Machines')
+      ->search({'settings.key' => 'WORKER_CLASS'}, {columns => ['id'], join => ['settings']})->as_query;
     my $rs = $schema->resultset('Machines')->search({id => {-not_in => $workers_with_class}},);
     while (my $r = $rs->next()) {
         my $class;
@@ -59,13 +60,15 @@ sub {
 
     # set a worker class on all scheduled jobs so they won't suddely get
     # dispatched to any worker.
-    my $jobs_with_class = $schema->resultset('Jobs')->search({'settings.key' => 'WORKER_CLASS'}, {columns => ['id'], join => ['settings']})->as_query;
+    my $jobs_with_class = $schema->resultset('Jobs')
+      ->search({'settings.key' => 'WORKER_CLASS'}, {columns => ['id'], join => ['settings']})->as_query;
     $rs = $schema->resultset('Jobs')->search({id => {-not_in => $jobs_with_class}, state => 'scheduled'},);
     while (my $r = $rs->next()) {
         my $arch = $r->settings->find({key => 'ARCH'});
         next unless $arch;
         $arch = $arch->value;
-        my $result = $schema->resultset('JobSettings')->create({job_id => $r->id, key => 'WORKER_CLASS', value => 'qemu_' . $arch});
+        my $result = $schema->resultset('JobSettings')
+          ->create({job_id => $r->id, key => 'WORKER_CLASS', value => 'qemu_' . $arch});
         unless ($result) {
             warn "failed to set WORKER_CLASS on job $r->id";
             next;

--- a/dbicdh/_common/upgrade/38-39/004-drop-settings.pl
+++ b/dbicdh/_common/upgrade/38-39/004-drop-settings.pl
@@ -24,5 +24,6 @@ sub {
     my $schema = shift;
 
     # now we're done
-    $schema->resultset("JobSettings")->search({key => {-in => [qw/DISTRI VERSION FLAVOR ARCH MACHINE BUILD TEST/]}})->delete;
+    $schema->resultset("JobSettings")->search({key => {-in => [qw/DISTRI VERSION FLAVOR ARCH MACHINE BUILD TEST/]}})
+      ->delete;
   }

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -84,7 +84,8 @@ sub compute_build_results {
         group_by => [qw(BUILD)]};
     my $search_filter = {group_id => {in => $group_ids}};
     if ($time_limit_days) {
-        $search_filter->{t_created} = {'>' => time2str('%Y-%m-%d %H:%M:%S', time - 24 * 3600 * $time_limit_days, 'UTC')};
+        $search_filter->{t_created}
+          = {'>' => time2str('%Y-%m-%d %H:%M:%S', time - 24 * 3600 * $time_limit_days, 'UTC')};
     }
     if ($tags) {
         $search_filter->{BUILD} = {-in => [keys %$tags]};
@@ -102,9 +103,19 @@ sub compute_build_results {
                 clone_id => undef,
             },
             {order_by => 'me.id DESC'});
-        my %jr = (oldest => DateTime->now, passed => 0, failed => 0, unfinished => 0, labeled => 0, softfailed => 0, skipped => 0, total => 0);
+        my %jr = (
+            oldest     => DateTime->now,
+            passed     => 0,
+            failed     => 0,
+            unfinished => 0,
+            labeled    => 0,
+            softfailed => 0,
+            skipped    => 0,
+            total      => 0
+        );
         for my $child (@children) {
-            $jr{children}->{$child->id} = {passed => 0, failed => 0, unfinished => 0, labeled => 0, softfailed => 0, skipped => 0, total => 0};
+            $jr{children}->{$child->id}
+              = {passed => 0, failed => 0, unfinished => 0, labeled => 0, softfailed => 0, skipped => 0, total => 0};
         }
 
         my %seen;

--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -119,15 +119,21 @@ sub _manage_watch_on {
 
     if ($flags & &Net::DBus::Binding::Watch::READABLE) {
         my $fh = $self->_get_fh_from_fd($watch->get_fileno);
-        my $cb = Net::DBus::Callback->new(object => $watch, method => "handle", args => [&Net::DBus::Binding::Watch::READABLE]);
+        my $cb = Net::DBus::Callback->new(
+            object => $watch,
+            method => "handle",
+            args   => [&Net::DBus::Binding::Watch::READABLE]);
         # Net::DBus calls dispatch each time some event wakes it up, Mojo::Reactor does not support this kind of hooks
         $reactor->io($fh => sub { my ($self, $writable) = @_; $cb->invoke; $self->emit('dbus-dispatch') });
         $reactor->watch($fh, $watch->is_enabled, 0);
     }
     if ($flags & &Net::DBus::Binding::Watch::WRITABLE) {
         my $fh = $self->_get_fh_from_fd($watch->get_fileno, 1);
-        my $cb = Net::DBus::Callback->new(object => $watch, method => "handle", args => [&Net::DBus::Binding::Watch::WRITABLE]);
-        # Net::DBus calls flush event each time some event wakes it up, Mojo::Reactor does not support this kind of hooks
+        my $cb = Net::DBus::Callback->new(
+            object => $watch,
+            method => "handle",
+            args   => [&Net::DBus::Binding::Watch::WRITABLE]);
+       # Net::DBus calls flush event each time some event wakes it up, Mojo::Reactor does not support this kind of hooks
         $reactor->io($fh => sub { my ($self, $writable) = @_; $cb->invoke; $self->emit('dbus-flush') });
         $reactor->watch($fh, 0, $watch->is_enabled);
     }

--- a/lib/OpenQA/Scheduler/Locks.pm
+++ b/lib/OpenQA/Scheduler/Locks.pm
@@ -64,7 +64,8 @@ sub lock {
     if (!$lock and $where =~ /^\d+$/) {
         my $schema = OpenQA::Scheduler::Scheduler::schema();
         # prevent deadlock - job that is supposed to create the lock already finished
-        return -1 if $schema->resultset("Jobs")->count({id => $where, state => [OpenQA::Schema::Result::Jobs::FINAL_STATES]});
+        return -1
+          if $schema->resultset("Jobs")->count({id => $where, state => [OpenQA::Schema::Result::Jobs::FINAL_STATES]});
     }
 
     # if no lock so far, there is no lock, return as locked

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -99,7 +99,9 @@ sub _prefer_parallel {
             child_job_id => $available_cond
         });
 
-    return ({'-in' => $available_children->get_column('child_job_id')->as_query}) if ($available_children->count() > 0);    # we have scheduled children that are not blocked
+    # we have scheduled children that are not blocked
+    return ({'-in' => $available_children->get_column('child_job_id')->as_query})
+      if ($available_children->count() > 0);
 
     # children are blocked, we have to find and start their parents first
     my $parents = schema->resultset("JobDependencies")->search(
@@ -119,7 +121,8 @@ sub _prefer_parallel {
                 parent_job_id => $available_cond
             });
 
-        return ({'-in' => $available_parents->get_column('parent_job_id')->as_query}) if ($available_parents->count() > 0);
+        return ({'-in' => $available_parents->get_column('parent_job_id')->as_query})
+          if ($available_parents->count() > 0);
 
         # parents are blocked, lets check grandparents
         $parents = schema->resultset("JobDependencies")->search(

--- a/lib/OpenQA/Schema/Result/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/Result/JobGroupParents.pm
@@ -69,7 +69,9 @@ __PACKAGE__->add_unique_constraint([qw/name/]);
 
 __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
-__PACKAGE__->has_many(children => 'OpenQA::Schema::Result::JobGroups', 'parent_id', {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
+__PACKAGE__->has_many(
+    children => 'OpenQA::Schema::Result::JobGroups',
+    'parent_id', {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
 
 around 'default_size_limit_gb' => sub {
     my ($orig, $self) = @_;
@@ -83,7 +85,8 @@ around 'default_keep_logs_in_days' => sub {
 
 around 'default_keep_important_logs_in_days' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('default_keep_important_logs_in_days') // OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_LOGS_IN_DAYS;
+    return $self->get_column('default_keep_important_logs_in_days')
+      // OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_LOGS_IN_DAYS;
 };
 
 around 'default_keep_results_in_days' => sub {
@@ -93,7 +96,8 @@ around 'default_keep_results_in_days' => sub {
 
 around 'default_keep_important_results_in_days' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('default_keep_important_results_in_days') // OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS;
+    return $self->get_column('default_keep_important_results_in_days')
+      // OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS;
 };
 
 around 'default_priority' => sub {

--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -77,36 +77,54 @@ __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->has_many(jobs => 'OpenQA::Schema::Result::Jobs', 'group_id');
 __PACKAGE__->has_many(comments => 'OpenQA::Schema::Result::Comments', 'group_id', {order_by => 'id'});
-__PACKAGE__->belongs_to(parent => 'OpenQA::Schema::Result::JobGroupParents', 'parent_id', {join_type => 'left', on_delete => 'SET NULL'});
+__PACKAGE__->belongs_to(
+    parent => 'OpenQA::Schema::Result::JobGroupParents',
+    'parent_id', {join_type => 'left', on_delete => 'SET NULL'});
 
 around 'size_limit_gb' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('size_limit_gb') // ($self->parent ? $self->parent->default_size_limit_gb : OpenQA::Schema::JobGroupDefaults::SIZE_LIMIT_GB);
+    return $self->get_column('size_limit_gb')
+      // ($self->parent ? $self->parent->default_size_limit_gb : OpenQA::Schema::JobGroupDefaults::SIZE_LIMIT_GB);
 };
 
 around 'keep_logs_in_days' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('keep_logs_in_days') // ($self->parent ? $self->parent->default_keep_logs_in_days : OpenQA::Schema::JobGroupDefaults::KEEP_LOGS_IN_DAYS);
+    return $self->get_column('keep_logs_in_days')
+      // (
+        $self->parent ? $self->parent->default_keep_logs_in_days : OpenQA::Schema::JobGroupDefaults::KEEP_LOGS_IN_DAYS);
 };
 
 around 'keep_important_logs_in_days' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('keep_important_logs_in_days') // ($self->parent ? $self->parent->default_keep_important_logs_in_days : OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_LOGS_IN_DAYS);
+    return $self->get_column('keep_important_logs_in_days') // (
+        $self->parent ?
+          $self->parent->default_keep_important_logs_in_days
+        : OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_LOGS_IN_DAYS
+    );
 };
 
 around 'keep_results_in_days' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('keep_results_in_days') // ($self->parent ? $self->parent->default_keep_results_in_days : OpenQA::Schema::JobGroupDefaults::KEEP_RESULTS_IN_DAYS);
+    return $self->get_column('keep_results_in_days') // (
+        $self->parent ?
+          $self->parent->default_keep_results_in_days
+        : OpenQA::Schema::JobGroupDefaults::KEEP_RESULTS_IN_DAYS
+    );
 };
 
 around 'keep_important_results_in_days' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('keep_important_results_in_days') // ($self->parent ? $self->parent->default_keep_important_results_in_days : OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS);
+    return $self->get_column('keep_important_results_in_days') // (
+        $self->parent ?
+          $self->parent->default_keep_important_results_in_days
+        : OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS
+    );
 };
 
 around 'default_priority' => sub {
     my ($orig, $self) = @_;
-    return $self->get_column('default_priority') // ($self->parent ? $self->parent->default_priority : OpenQA::Schema::JobGroupDefaults::PRIORITY);
+    return $self->get_column('default_priority')
+      // ($self->parent ? $self->parent->default_priority : OpenQA::Schema::JobGroupDefaults::PRIORITY);
 };
 
 sub rendered_description {
@@ -154,7 +172,8 @@ sub expired_jobs {
 
     if ($self->keep_important_results_in_days) {
         # expired jobs in important builds
-        my $timecond = {'<' => time2str('%Y-%m-%d %H:%M:%S', time - 24 * 3600 * $self->keep_important_results_in_days, 'UTC')};
+        my $timecond
+          = {'<' => time2str('%Y-%m-%d %H:%M:%S', time - 24 * 3600 * $self->keep_important_results_in_days, 'UTC')};
         push(@ors, {BUILD => {-in => $important_builds}, t_finished => $timecond});
     }
     my $jobs = $self->jobs->search({-or => \@ors}, {order_by => qw/id/});

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -60,10 +60,13 @@ use constant {
     USER_CANCELLED     => 'user_cancelled',        # cancelled by user via job_cancel
     USER_RESTARTED     => 'user_restarted',        # restarted by user via job_restart
 };
-use constant RESULTS => (NONE, PASSED, SOFTFAILED, FAILED, INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED);
+use constant RESULTS => (NONE, PASSED, SOFTFAILED, FAILED, INCOMPLETE, SKIPPED,
+    OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED
+);
 use constant COMPLETE_RESULTS => (PASSED, SOFTFAILED, FAILED);
 use constant OK_RESULTS => (PASSED, SOFTFAILED);
-use constant INCOMPLETE_RESULTS => (INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED);
+use constant INCOMPLETE_RESULTS =>
+  (INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED);
 
 # scenario keys w/o MACHINE. Add MACHINE when desired, commonly joined on
 # other keys with the '@' character
@@ -162,8 +165,12 @@ __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->has_many(settings => 'OpenQA::Schema::Result::JobSettings', 'job_id');
 __PACKAGE__->has_one(worker => 'OpenQA::Schema::Result::Workers', 'job_id');
-__PACKAGE__->belongs_to(clone => 'OpenQA::Schema::Result::Jobs',      'clone_id', {join_type => 'left', on_delete => 'SET NULL'});
-__PACKAGE__->belongs_to(group => 'OpenQA::Schema::Result::JobGroups', 'group_id', {join_type => 'left', on_delete => 'SET NULL'});
+__PACKAGE__->belongs_to(
+    clone => 'OpenQA::Schema::Result::Jobs',
+    'clone_id', {join_type => 'left', on_delete => 'SET NULL'});
+__PACKAGE__->belongs_to(
+    group => 'OpenQA::Schema::Result::JobGroups',
+    'group_id', {join_type => 'left', on_delete => 'SET NULL'});
 __PACKAGE__->might_have(origin => 'OpenQA::Schema::Result::Jobs', 'clone_id', {cascade_delete => 0});
 __PACKAGE__->has_many(jobs_assets => 'OpenQA::Schema::Result::JobsAssets', 'job_id');
 __PACKAGE__->many_to_many(assets => 'jobs_assets', 'asset');
@@ -445,7 +452,10 @@ sub duplicate {
     ## now go and clone and recreate test dependencies - parents first
     my $parents = $self->parents->search(
         {
-            dependency => {-in => [OpenQA::Schema::Result::JobDependencies->PARALLEL, OpenQA::Schema::Result::JobDependencies->CHAINED]},
+            dependency => {
+                -in =>
+                  [OpenQA::Schema::Result::JobDependencies->PARALLEL, OpenQA::Schema::Result::JobDependencies->CHAINED]
+            },
         },
         {
             join => 'parent',
@@ -499,7 +509,10 @@ sub duplicate {
     ## go and clone and recreate test dependencies - running children tests, this cover also asset dependencies (use CHAINED dep)
     my $children = $self->children->search(
         {
-            dependency => {-in => [OpenQA::Schema::Result::JobDependencies->PARALLEL, OpenQA::Schema::Result::JobDependencies->CHAINED]},
+            dependency => {
+                -in =>
+                  [OpenQA::Schema::Result::JobDependencies->PARALLEL, OpenQA::Schema::Result::JobDependencies->CHAINED]
+            },
         },
         {
             join => 'child',
@@ -675,7 +688,9 @@ sub auto_duplicate {
             $args->{retry_avbl} = int($self->retry_avbl) - 1;
         }
         else {
-            log_warning("Could not auto-duplicated! The job are auto-duplicated too many times. Please restart the job manually.");
+            log_warning(
+"Could not auto-duplicated! The job are auto-duplicated too many times. Please restart the job manually."
+            );
             return;
         }
     }

--- a/lib/OpenQA/Schema/Result/Machines.pm
+++ b/lib/OpenQA/Schema/Result/Machines.pm
@@ -41,6 +41,8 @@ __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/name/]);
 __PACKAGE__->has_many(job_templates => 'OpenQA::Schema::Result::JobTemplates', 'machine_id');
-__PACKAGE__->has_many(settings => 'OpenQA::Schema::Result::MachineSettings', 'machine_id', {order_by => {-asc => 'key'}});
+__PACKAGE__->has_many(
+    settings => 'OpenQA::Schema::Result::MachineSettings',
+    'machine_id', {order_by => {-asc => 'key'}});
 
 1;

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -104,7 +104,8 @@ sub update_needle {
             $dir->name($name);
             $dir->insert;
         }
-        $needle ||= $dir->needles->find_or_new({filename => $basename, first_seen_module_id => $module->id}, {key => 'needles_dir_id_filename'});
+        $needle ||= $dir->needles->find_or_new({filename => $basename, first_seen_module_id => $module->id},
+            {key => 'needles_dir_id_filename'});
     }
 
     # normally we would not need that, but the migration is working on the jobs from past backward
@@ -149,16 +150,19 @@ sub scan_old_jobs() {
 
     my $guard = $app->db->txn_scope_guard;
 
-    my $jobs = $app->db->resultset("Jobs")->search({-and => [{id => {'>', $minid}}, {id => {'<=', $maxid}}]}, {order_by => 'me.id ASC'});
+    my $jobs = $app->db->resultset("Jobs")
+      ->search({-and => [{id => {'>', $minid}}, {id => {'<=', $maxid}}]}, {order_by => 'me.id ASC'});
 
-    my $job_modules = $app->db->resultset('JobModules')->search({job_id => {-in => $jobs->get_column('id')->as_query}})->get_column('id')->as_query;
+    my $job_modules = $app->db->resultset('JobModules')->search({job_id => {-in => $jobs->get_column('id')->as_query}})
+      ->get_column('id')->as_query;
 
     # make sure we're not duplicating any previous data
     $app->db->resultset('JobModuleNeedles')->search({job_module_id => {-in => $job_modules}})->delete;
     my %needle_cache;
 
     while (my $job = $jobs->next) {
-        my $modules = $job->modules->search({"me.result" => {'!=', OpenQA::Schema::Result::Jobs::NONE}}, {order_by => 'me.id ASC'});
+        my $modules = $job->modules->search({"me.result" => {'!=', OpenQA::Schema::Result::Jobs::NONE}},
+            {order_by => 'me.id ASC'});
         while (my $module = $modules->next) {
 
             $module->job($job);

--- a/lib/OpenQA/Schema/Result/Products.pm
+++ b/lib/OpenQA/Schema/Result/Products.pm
@@ -52,7 +52,9 @@ __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->has_many(job_templates => 'OpenQA::Schema::Result::JobTemplates', 'product_id');
 __PACKAGE__->add_unique_constraint([qw/distri version arch flavor/]);
-__PACKAGE__->has_many(settings => 'OpenQA::Schema::Result::ProductSettings', 'product_id', {order_by => {-asc => 'key'}});
+__PACKAGE__->has_many(
+    settings => 'OpenQA::Schema::Result::ProductSettings',
+    'product_id', {order_by => {-asc => 'key'}});
 
 sub name {
     my ($self) = @_;

--- a/lib/OpenQA/Schema/Result/TestSuites.pm
+++ b/lib/OpenQA/Schema/Result/TestSuites.pm
@@ -38,6 +38,8 @@ __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw/name/]);
 __PACKAGE__->has_many(job_templates => 'OpenQA::Schema::Result::JobTemplates', 'test_suite_id');
-__PACKAGE__->has_many(settings => 'OpenQA::Schema::Result::TestSuiteSettings', 'test_suite_id', {order_by => {-asc => 'key'}});
+__PACKAGE__->has_many(
+    settings => 'OpenQA::Schema::Result::TestSuiteSettings',
+    'test_suite_id', {order_by => {-asc => 'key'}});
 
 1;

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -172,7 +172,11 @@ sub send_command {
     return if (!defined $args{command});
 
     if (!grep { /^$args{command}$/ } COMMANDS) {
-        log_error(sprintf('Trying to issue unknown command "%s" for worker "%s:%n"', $args{command}, $self->host, $self->instance));
+        log_error(
+            sprintf(
+                'Trying to issue unknown command "%s" for worker "%s:%n"',
+                $args{command}, $self->host, $self->instance
+            ));
         return;
     }
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -233,7 +233,7 @@ sub complex_query {
                 'me.result' => {    # these results should be hidden by default
                     -not_in => [
                         OpenQA::Schema::Result::Jobs::OBSOLETED,
-                        # OpenQA::Schema::Result::Jobs::USER_CANCELLED  I think USER_CANCELLED jobs should be available for restart
+             # OpenQA::Schema::Result::Jobs::USER_CANCELLED  I think USER_CANCELLED jobs should be available for restart
                     ]}});
     }
     if ($scope eq 'current') {
@@ -340,8 +340,9 @@ sub cancel_by_settings {
         # ... or belong to a tagged build, i.e. is considered important
         # this might be even the tag 'not important' but not much is lost if
         # we still not cancel these builds
-        my $groups_query = $jobs->get_column('group_id')->as_query;
-        my @important_builds = grep defined, map { ($_->tag)[0] } $schema->resultset('Comments')->search({'me.group_id' => {-in => $groups_query}});
+        my $groups_query     = $jobs->get_column('group_id')->as_query;
+        my @important_builds = grep defined,
+          map { ($_->tag)[0] } $schema->resultset('Comments')->search({'me.group_id' => {-in => $groups_query}});
         my @unimportant_jobs;
         while (my $j = $jobs_to_cancel->next) {
             next if grep ($j->BUILD eq $_, @important_builds);

--- a/lib/OpenQA/ServerStartup.pm
+++ b/lib/OpenQA/ServerStartup.pm
@@ -93,7 +93,10 @@ sub read_config {
     for my $section (sort keys %defaults) {
         for my $k (sort keys %{$defaults{$section}}) {
             my $v = $cfg && $cfg->val($section, $k);
-            $v //= exists $mode_defaults{$app->mode}{$section}->{$k} ? $mode_defaults{$app->mode}{$section}->{$k} : $defaults{$section}->{$k};
+            $v //=
+              exists $mode_defaults{$app->mode}{$section}->{$k} ?
+              $mode_defaults{$app->mode}{$section}->{$k}
+              : $defaults{$section}->{$k};
             $app->config->{$section}->{$k} = $v if defined $v;
         }
     }

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -479,7 +479,11 @@ sub notify_workers {
     # ugly work around for Net::DBus::Test not being able to handle us using low level API
     return if ref($con) eq 'Net::DBus::Test::MockConnection';
 
-    my $msg = $con->make_method_call_message("org.opensuse.openqa.Scheduler", "/Scheduler", "org.opensuse.openqa.Scheduler", "emit_jobs_available");
+    my $msg = $con->make_method_call_message(
+        "org.opensuse.openqa.Scheduler",
+        "/Scheduler", "org.opensuse.openqa.Scheduler",
+        "emit_jobs_available"
+    );
     # do not wait for a reply - avoid deadlocks. this way we can even call it
     # from within the scheduler without having to worry about reentering
     $con->send($msg);
@@ -516,13 +520,17 @@ sub human_readable_size {
 
 # query group parents and job groups and let the database sort it for us - and merge it afterwards
 sub job_groups_and_parents {
-    my @parents = $app->db->resultset('JobGroupParents')->search({}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})->all;
-    my @groups_without_parent = $app->db->resultset('JobGroups')->search({parent_id => undef}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})->all;
+    my @parents
+      = $app->db->resultset('JobGroupParents')->search({}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})
+      ->all;
+    my @groups_without_parent = $app->db->resultset('JobGroups')
+      ->search({parent_id => undef}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})->all;
     my @res;
     my $first_parent = shift @parents;
     my $first_group  = shift @groups_without_parent;
     while ($first_parent || $first_group) {
-        my $pick_parent = $first_parent && (!$first_group || ($first_group->sort_order // 0) > ($first_parent->sort_order // 0));
+        my $pick_parent
+          = $first_parent && (!$first_group || ($first_group->sort_order // 0) > ($first_parent->sort_order // 0));
         if ($pick_parent) {
             push(@res, $first_parent);
             $first_parent = shift @parents;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -129,7 +129,11 @@ sub startup {
                 $c->app->sessions->secure(1);
             }
             if (my $days = $c->app->config->{global}->{hsts}) {
-                $c->res->headers->header('Strict-Transport-Security', sprintf 'max-age=%d; includeSubDomains', $days * 24 * 60 * 60);
+                $c->res->headers->header(
+                    'Strict-Transport-Security',
+                    sprintf 'max-age=%d; includeSubDomains',
+                    $days * 24 * 60 * 60
+                );
             }
             $c->stash('job_groups_and_parents', job_groups_and_parents);
         });
@@ -368,12 +372,15 @@ sub startup {
     $api_r_job->post('/mutex/:name')->name('apiv1_mutex_action')->to('locks#mutex_action');
     # api/v1/barriers/
     $api_r_job->post('/barrier')->name('apiv1_barrier_create')->to('locks#barrier_create');
-    $api_r_job->post('/barrier/:name', [name => qr/[0-9a-zA-Z_]+/])->name('apiv1_barrier_wait')->to('locks#barrier_wait');
-    $api_r_job->delete('/barrier/:name', [name => qr/[0-9a-zA-Z_]+/])->name('apiv1_barrier_destroy')->to('locks#barrier_destroy');
+    $api_r_job->post('/barrier/:name', [name => qr/[0-9a-zA-Z_]+/])->name('apiv1_barrier_wait')
+      ->to('locks#barrier_wait');
+    $api_r_job->delete('/barrier/:name', [name => qr/[0-9a-zA-Z_]+/])->name('apiv1_barrier_destroy')
+      ->to('locks#barrier_destroy');
 
     # api/v1/mm
     my $mm_api = $api_r_job->route('/mm');
-    $mm_api->get('/children/:status' => [status => [qw/running scheduled done/]])->name('apiv1_mm_running_children')->to('mm#get_children_status');
+    $mm_api->get('/children/:status' => [status => [qw/running scheduled done/]])->name('apiv1_mm_running_children')
+      ->to('mm#get_children_status');
     $mm_api->get('/children')->name('apiv1_mm_children')->to('mm#get_children');
     $mm_api->get('/parents')->name('apiv1_mm_parents')->to('mm#get_parents');
 

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -37,14 +37,20 @@ sub auth_login {
     my $headers = $self->req->headers;
 
     my %users;
-    $users{Demo}   = {fullname => 'Demo User', email => 'demo@user.org',      admin => 1, operator => 1, key => '1234567890ABCDEF'};
-    $users{nobody} = {fullname => 'Nobody',    email => 'nobody@example.com', admin => 0, operator => 0, key => '1111111111111111'};
+    $users{Demo}
+      = {fullname => 'Demo User', email => 'demo@user.org', admin => 1, operator => 1, key => '1234567890ABCDEF'};
+    $users{nobody}
+      = {fullname => 'Nobody', email => 'nobody@example.com', admin => 0, operator => 0, key => '1111111111111111'};
 
     my $user     = $self->req->param('user') || 'Demo';
     my $userinfo = $users{$user}             || die "No such user";
     $userinfo->{username} = $user;
 
-    $user = OpenQA::Schema::Result::Users->create_user($userinfo->{username}, $self->db, email => $userinfo->{email}, nickname => $userinfo->{username}, fullname => $userinfo->{fullname});
+    $user = OpenQA::Schema::Result::Users->create_user(
+        $userinfo->{username}, $self->db,
+        email    => $userinfo->{email},
+        nickname => $userinfo->{username},
+        fullname => $userinfo->{fullname});
     $user->is_admin($userinfo->{admin});
     $user->is_operator($userinfo->{operator});
     $user->update;

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -102,9 +102,9 @@ sub auth_response {
     }
 
     my $csr = Net::OpenID::Consumer->new(
-        debug           => sub { $self->app->log->debug("Net::OpenID::Consumer: " . join(' ', @_)); },
-        ua              => LWP::UserAgent->new,
-        required_root   => $url,
+        debug         => sub { $self->app->log->debug("Net::OpenID::Consumer: " . join(' ', @_)); },
+        ua            => LWP::UserAgent->new,
+        required_root => $url,
         consumer_secret => $self->app->config->{_openid_secret},
         args            => \%params,
     );
@@ -155,7 +155,12 @@ sub auth_response {
                 }
             }
 
-            my $user = OpenQA::Schema::Result::Users->create_user($vident->{identity}, $self->db, email => $email, nickname => $nickname, fullname => $fullname);
+            my $user = OpenQA::Schema::Result::Users->create_user(
+                $vident->{identity}, $self->db,
+                email    => $email,
+                nickname => $nickname,
+                fullname => $fullname
+            );
 
             $msg = 'verified';
             $self->session->{user} = $vident->{identity};

--- a/lib/OpenQA/WebAPI/Auth/iChain.pm
+++ b/lib/OpenQA/WebAPI/Auth/iChain.pm
@@ -41,7 +41,12 @@ sub auth_login {
 
     if ($username) {
         # iChain login
-        OpenQA::Schema::Result::Users->create_user($username, $self->db, email => $email, nickname => $username, fullname => $fullname);
+        OpenQA::Schema::Result::Users->create_user(
+            $username, $self->db,
+            email    => $email,
+            nickname => $username,
+            fullname => $fullname
+        );
         $self->session->{user} = $username;
         return (error => 0);
     }

--- a/lib/OpenQA/WebAPI/Controller/API/V1.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1.pm
@@ -102,7 +102,9 @@ sub auth_jobtoken {
 
     if ($token) {
         $self->app->log->debug("Received JobToken: $token");
-        my $job = $self->db->resultset('Jobs')->search({'properties.key' => 'JOBTOKEN', 'properties.value' => $token}, {columns => ['id'], join => {worker => 'properties'}})->single;
+        my $job = $self->db->resultset('Jobs')->search(
+            {'properties.key' => 'JOBTOKEN', 'properties.value' => $token},
+            {columns => ['id'], join => {worker => 'properties'}})->single;
         if ($job) {
             $self->stash('job_id', $job->id);
             $self->app->log->debug(sprintf('Found associated job %u', $job->id));

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -90,7 +90,8 @@ sub update {
     my $comment_id = $self->param('comment_id');
     my $comment    = $comments->find($self->param('comment_id'));
     return $self->render(json => {error => "Comment $comment_id does not exist"}, status => 404) unless $comment;
-    return $self->render(json => {error => "Forbidden (must be author)"},         status => 403) unless ($comment->user_id == $self->current_user->id);
+    return $self->render(json => {error => "Forbidden (must be author)"}, status => 403)
+      unless ($comment->user_id == $self->current_user->id);
     my $res = $comment->update({text => href_to_bugref($text)});
     $self->emit_event('openqa_user_update_comment', {id => $comment->id});
     $self->render(json => {id => $res->id});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -477,7 +477,8 @@ sub destroy {
     $self->emit_event('openqa_iso_delete', {iso => $iso});
 
     my $subquery = $self->db->resultset("JobSettings")->query_for_settings({ISO => $iso});
-    my @jobs = $self->db->resultset("Jobs")->search({'me.id' => {-in => $subquery->get_column('job_id')->as_query}})->all;
+    my @jobs
+      = $self->db->resultset("Jobs")->search({'me.id' => {-in => $subquery->get_column('job_id')->as_query}})->all;
 
     for my $job (@jobs) {
         $self->emit_event('openqa_job_delete', {id => $job->id});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -25,7 +25,9 @@ sub list {
     my $self = shift;
 
     my %args;
-    for my $arg (qw/build iso distri version flavor maxage scope group groupid limit page before after arch hdd_1 test machine/) {
+    for my $arg (
+        qw/build iso distri version flavor maxage scope group groupid limit page before after arch hdd_1 test machine/)
+    {
         next unless defined $self->param($arg);
         $args{$arg} = $self->param($arg);
     }
@@ -154,8 +156,10 @@ sub grab {
     $caps->{cpu_opmode}    = $self->param('cpu_opmode');
     $caps->{mem_max}       = $self->param('mem_max');
 
-    my $res = $ipc->scheduler('job_grab', {workerid => $workerid, blocking => $blocking, workerip => $workerip, workercaps => $caps});
-    $self->emit_event('openqa_job_grab', {workerid => $workerid, blocking => $blocking, workerip => $workerip, id => $res->{id}});
+    my $res = $ipc->scheduler('job_grab',
+        {workerid => $workerid, blocking => $blocking, workerip => $workerip, workercaps => $caps});
+    $self->emit_event('openqa_job_grab',
+        {workerid => $workerid, blocking => $blocking, workerip => $workerip, id => $res->{id}});
     $self->render(json => {job => $res});
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -100,7 +100,8 @@ sub create {
     return $self->render(json => {error => 'No group name specified'}, status => 400) unless $group_name;
 
     my $group = $self->resultset->create($self->load_properties);
-    return $self->render(json => {error => 'Unable to create group with specified properties'}, status => 400) unless $group;
+    return $self->render(json => {error => 'Unable to create group with specified properties'}, status => 400)
+      unless $group;
 
     $self->render(json => {id => $group->id});
 }
@@ -112,7 +113,8 @@ sub update {
     return unless $group;
 
     my $res = $group->update($self->load_properties);
-    return $self->render(json => {error => 'Specified job group ' . $group->id . ' exist but unable to update, though'}) unless $res;
+    return $self->render(json => {error => 'Specified job group ' . $group->id . ' exist but unable to update, though'})
+      unless $res;
     $self->render(json => {id => $res->id});
 }
 
@@ -143,7 +145,9 @@ sub delete {
     }
 
     my $res = $group->delete;
-    return $self->render(json => {error => 'Specified job group ' . $group->id . ' exist but can not be deleted, though'}) unless $res;
+    return $self->render(
+        json => {error => 'Specified job group ' . $group->id . ' exist but can not be deleted, though'})
+      unless $res;
     $self->render(json => {id => $res->id});
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -45,10 +45,14 @@ sub list {
             for my $id (qw/machine_id test_suite_id product_id group_id/) {
                 $params{$id} = $self->param($id) if $self->param($id);
             }
-            @templates = $self->db->resultset("JobTemplates")->search(\%params, {join => ['machine', 'test_suite', 'product'], prefetch => [qw/machine test_suite product/]});
+            @templates
+              = $self->db->resultset("JobTemplates")
+              ->search(\%params,
+                {join => ['machine', 'test_suite', 'product'], prefetch => [qw/machine test_suite product/]});
         }
         else {
-            @templates = $self->db->resultset("JobTemplates")->search({}, {prefetch => [qw/machine test_suite product/]});
+            @templates
+              = $self->db->resultset("JobTemplates")->search({}, {prefetch => [qw/machine test_suite product/]});
         }
     };
     my $error = $@;
@@ -58,26 +62,32 @@ sub list {
         return;
     }
 
-    #<<< do not let perltidy touch this
-    $self->render(json =>
-                 { JobTemplates =>
-                     [map { { id => $_->id,
-                              prio => $_->prio,
-                              group_name => $_->group ? $_->group->name : '',
-                              product => {id => $_->product_id,
-                                          arch => $_->product->arch,
-                                          distri => $_->product->distri,
-                                          flavor => $_->product->flavor,
-                                          group => $_->product->mediagroup,
-                                          version => $_->product->version},
-                              machine => {id => $_->machine_id,
-                                          name => $_->machine ? $_->machine->name : ''},
-                              test_suite => {id => $_->test_suite_id,
-                                             name => $_->test_suite->name}}
-             } @templates
-            ]
-          });
-    #>>>
+    $self->render(
+        json => {
+            JobTemplates => [
+                map {
+                    {
+                        id         => $_->id,
+                        prio       => $_->prio,
+                        group_name => $_->group ? $_->group->name : '',
+                        product    => {
+                            id      => $_->product_id,
+                            arch    => $_->product->arch,
+                            distri  => $_->product->distri,
+                            flavor  => $_->product->flavor,
+                            group   => $_->product->mediagroup,
+                            version => $_->product->version
+                        },
+                        machine => {
+                            id   => $_->machine_id,
+                            name => $_->machine ? $_->machine->name : ''
+                        },
+                        test_suite => {
+                            id   => $_->test_suite_id,
+                            name => $_->test_suite->name
+                        }}
+                } @templates
+            ]});
 }
 
 sub create {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
@@ -35,7 +35,8 @@ sub get_children_status {
     }
     my $jobid = $self->stash('job_id');
 
-    my @res = $self->db->resultset('Jobs')->search({'parents.parent_job_id' => $jobid, state => $status}, {columns => ['id'], join => 'parents'});
+    my @res = $self->db->resultset('Jobs')
+      ->search({'parents.parent_job_id' => $jobid, state => $status}, {columns => ['id'], join => 'parents'});
     my @res_ids = map { $_->id } @res;
     return $self->render(json => {jobs => \@res_ids}, status => 200);
 }
@@ -44,7 +45,9 @@ sub get_children {
     my ($self) = @_;
     my $jobid = $self->stash('job_id');
 
-    my @res = $self->db->resultset('Jobs')->search({'parents.parent_job_id' => $jobid, 'parents.dependency' => OpenQA::Schema::Result::JobDependencies::PARALLEL}, {columns => ['id', 'state'], join => 'parents'});
+    my @res = $self->db->resultset('Jobs')->search(
+        {'parents.parent_job_id' => $jobid, 'parents.dependency' => OpenQA::Schema::Result::JobDependencies::PARALLEL},
+        {columns => ['id', 'state'], join => 'parents'});
     my %res_ids = map { ($_->id, $_->state) } @res;
     return $self->render(json => {jobs => \%res_ids}, status => 200);
 }
@@ -53,7 +56,9 @@ sub get_parents {
     my ($self) = @_;
     my $jobid = $self->stash('job_id');
 
-    my @res = $self->db->resultset('Jobs')->search({'children.child_job_id' => $jobid, 'children.dependency' => OpenQA::Schema::Result::JobDependencies::PARALLEL}, {columns => ['id'], join => 'children'});
+    my @res = $self->db->resultset('Jobs')->search(
+        {'children.child_job_id' => $jobid, 'children.dependency' => OpenQA::Schema::Result::JobDependencies::PARALLEL},
+        {columns                 => ['id'], join                  => 'children'});
     my @res_ids = map { $_->id } @res;
     return $self->render(json => {jobs => \@res_ids}, status => 200);
 }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -80,8 +80,10 @@ sub list {
         json => {
             $table => [
                 map {
-                    my $row = $_;
-                    my %hash = ((map { ($_ => $row->get_column($_)) } @{$tables{$table}->{cols}}), settings => [map { {key => $_->key, value => $_->value} } $row->settings]);
+                    my $row  = $_;
+                    my %hash = (
+                        (map { ($_ => $row->get_column($_)) } @{$tables{$table}->{cols}}),
+                        settings => [map { {key => $_->key, value => $_->value} } $row->settings]);
                     \%hash;
                 } @result
             ]});

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -29,7 +29,8 @@ sub index {
 sub productlog {
     my ($self) = @_;
     $self->stash(audit_enabled => $self->app->config->{global}{audit_enabled});
-    my $events_rs = $self->db->resultset("AuditEvents")->search({event => 'iso_create'}, {order_by => {-desc => 'me.id'}, prefetch => 'owner', rows => 100});
+    my $events_rs = $self->db->resultset("AuditEvents")
+      ->search({event => 'iso_create'}, {order_by => {-desc => 'me.id'}, prefetch => 'owner', rows => 100});
     my @events;
     my $json = JSON->new();
     $json->allow_nonref(1);
@@ -53,7 +54,8 @@ sub ajax {
     if ($event_type_filter) {
         $query = {event => $event_type_filter};
     }
-    my $events_rs = $self->db->resultset("AuditEvents")->search($query, {order_by => {-desc => 'me.id'}, prefetch => 'owner', rows => 300});
+    my $events_rs = $self->db->resultset("AuditEvents")
+      ->search($query, {order_by => {-desc => 'me.id'}, prefetch => 'owner', rows => 300});
     my @events;
     while (my $event = $events_rs->next) {
         my $data = {

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -22,8 +22,10 @@ use Mojo::Base 'Mojolicious::Controller';
 sub index {
     my ($self) = @_;
 
-    my $parent_groups = $self->db->resultset('JobGroupParents')->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
-    my $groups = $self->db->resultset('JobGroups')->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
+    my $parent_groups = $self->db->resultset('JobGroupParents')
+      ->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
+    my $groups
+      = $self->db->resultset('JobGroups')->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
 
     $self->stash('job_groups_and_parents_for_editor', job_groups_and_parents);
     $self->stash('parent_groups',                     $parent_groups);

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -65,7 +65,12 @@ sub ajax {
     while (1) {
         my $column_index = $self->param("order[$index][column]");
         my $column_order = $self->param("order[$index][dir]");
-        if (!(defined($column_index) && $column_index < scalar(@columns) && ($column_order eq 'asc' || $column_order eq 'desc'))) {
+        if (
+            !(
+                   defined($column_index)
+                && $column_index < scalar(@columns)
+                && ($column_order eq 'asc' || $column_order eq 'desc')))
+        {
             last;
         }
         push(@order_by_params, {'-' . $column_order => $columns[$column_index]});

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -100,7 +100,10 @@ sub test_asset {
     }
 
     my %asset;
-    my $res = $self->db->resultset('Jobs')->search(\%cond, {join => {jobs_assets => 'asset'}, +select => [qw(asset.name asset.type)], +as => [qw(name type)]});
+    my $res
+      = $self->db->resultset('Jobs')
+      ->search(\%cond,
+        {join => {jobs_assets => 'asset'}, +select => [qw(asset.name asset.type)], +as => [qw(name type)]});
     if ($res and $res->first) {
         %asset = $res->first->get_columns;
     }
@@ -111,7 +114,8 @@ sub test_asset {
     # find the asset path
     my $path = locate_asset($asset{type}, $asset{name}, relative => 1);
     $path = catfile($path, $self->param('subpath')) if $self->param('subpath');
-    return $self->render(text => 'invalid character in path', status => 400) if ($path =~ /\/\.\./ || $path =~ /\.\.\//);
+    return $self->render(text => 'invalid character in path', status => 400)
+      if ($path =~ /\/\.\./ || $path =~ /\.\.\//);
 
     # map to URL - mojo will canonalize
     $path = $self->url_for('download_asset', assetpath => $path);

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -56,7 +56,8 @@ sub index {
             next unless grep { $_ eq '' || $group->name =~ /$_/ } @$group_params;
         }
         my $tags = $show_tags || $only_tagged ? $group->tags : undef;
-        my $build_results = OpenQA::BuildResults::compute_build_results($group, $limit_builds, $time_limit_days, $only_tagged ? $tags : undef);
+        my $build_results = OpenQA::BuildResults::compute_build_results($group, $limit_builds, $time_limit_days,
+            $only_tagged ? $tags : undef);
 
         my $res = $build_results->{result};
         if ($show_tags) {
@@ -101,7 +102,8 @@ sub group_overview {
     }
     $tags = $group->tags;
 
-    my $cbr      = OpenQA::BuildResults::compute_build_results($group, $limit_builds, $time_limit_days, $only_tagged ? $tags : undef);
+    my $cbr = OpenQA::BuildResults::compute_build_results($group, $limit_builds, $time_limit_days,
+        $only_tagged ? $tags : undef);
     my $res      = $cbr->{result};
     my $max_jobs = $cbr->{max_jobs};
     $self->stash(children => $cbr->{children});

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -80,7 +80,8 @@ sub needle_url {
 
     if (defined($jsonfile) && $jsonfile) {
         if (defined($version) && $version) {
-            $self->url_for('needle_file', distri => $distri, name => $name)->query(version => $version, jsonfile => $jsonfile);
+            $self->url_for('needle_file', distri => $distri, name => $name)
+              ->query(version => $version, jsonfile => $jsonfile);
         }
         else {
             $self->url_for('needle_file', distri => $distri, name => $name)->query(jsonfile => $jsonfile);
@@ -176,7 +177,8 @@ sub edit {
         my $needle = needle_info($module_detail->{needle}, $distribution, $dversion, $module_detail->{json});
 
         if (!$needle) {
-            my $error_message = sprintf("Could not find needle: %s for %s %s", $module_detail->{needle}, $distribution, $dversion);
+            my $error_message
+              = sprintf("Could not find needle: %s for %s %s", $module_detail->{needle}, $distribution, $dversion);
             $self->app->log->error($error_message);
             push(@error_messages, $error_message);
         }
@@ -184,16 +186,18 @@ sub edit {
             my $matched = {
                 name           => $module_detail->{needle},
                 suggested_name => $self->_timestamp($module_detail->{needle}),
-                imageurl       => $self->needle_url($distribution, $module_detail->{needle} . '.png', $dversion, $needle->{json})->to_string,
-                imagename      => basename($needle->{image}),
-                imagedir       => dirname($needle->{image}),
-                imagedistri    => $needle->{distri},
-                imageversion   => $needle->{version},
-                area           => $needle->{area},
-                tags           => $needle->{tags},
-                json       => $needle->{json}       || "",
-                properties => $needle->{properties} || [],
-                matches    => $screenshot->{matches}};
+                imageurl =>
+                  $self->needle_url($distribution, $module_detail->{needle} . '.png', $dversion, $needle->{json})
+                  ->to_string,
+                imagename    => basename($needle->{image}),
+                imagedir     => dirname($needle->{image}),
+                imagedistri  => $needle->{distri},
+                imageversion => $needle->{version},
+                area         => $needle->{area},
+                tags         => $needle->{tags},
+                json         => $needle->{json} || "",
+                properties   => $needle->{properties} || [],
+                matches      => $screenshot->{matches}};
             calc_min_similarity($matched, $module_detail->{area});
             $matched->{title} = $matched->{min_similarity} . "%: " . $matched->{name};
             push(@needles, $matched);
@@ -234,7 +238,8 @@ sub edit {
             $needleinfo = needle_info($needlename, $distribution, $dversion || '', $needle->{json});
 
             if (!defined $needleinfo) {
-                my $error_message = sprintf("Could not parse needle: %s for %s %s", $needlename, $distribution, $dversion || '');
+                my $error_message
+                  = sprintf("Could not parse needle: %s for %s %s", $needlename, $distribution, $dversion || '');
                 $self->app->log->error($error_message);
                 push(@error_messages, $error_message);
 
@@ -248,17 +253,18 @@ sub edit {
                 name           => $needlename,
                 title          => $needlename,
                 suggested_name => $self->_timestamp($needlename),
-                imageurl       => $self->needle_url($distribution, "$needlename.png", $dversion, $needleinfo->{json})->to_string,
-                imagename      => basename($needleinfo->{image}),
-                imagedir       => dirname($needleinfo->{image}),
-                imagedistri    => $needleinfo->{distri},
-                imageversion   => $needleinfo->{version},
-                tags           => $needleinfo->{tags},
-                area           => $needleinfo->{area},
-                json       => $needleinfo->{json}       || "",
-                properties => $needleinfo->{properties} || [],
-                matches    => [],
-                broken     => $needleinfo->{broken}};
+                imageurl =>
+                  $self->needle_url($distribution, "$needlename.png", $dversion, $needleinfo->{json})->to_string,
+                imagename    => basename($needleinfo->{image}),
+                imagedir     => dirname($needleinfo->{image}),
+                imagedistri  => $needleinfo->{distri},
+                imageversion => $needleinfo->{version},
+                tags         => $needleinfo->{tags},
+                area         => $needleinfo->{area},
+                json         => $needleinfo->{json} || "",
+                properties   => $needleinfo->{properties} || [],
+                matches      => [],
+                broken       => $needleinfo->{broken}};
             push(@needles, $needlehash) unless $needlehash->{broken};
             for my $match (@{$needle->{area}}) {
                 $area = {
@@ -525,7 +531,8 @@ sub save_needle_ajax {
                 return $self->render(json => {error => "$needledir is not a git repo"});
             }
         }
-        $self->emit_event('openqa_needle_modify', {needle => "$baseneedle.png", tags => $json_data->{tags}, update => 0});
+        $self->emit_event('openqa_needle_modify',
+            {needle => "$baseneedle.png", tags => $json_data->{tags}, update => 0});
         my $info = {info => "Needle $needlename created/updated."};
         if ($job->can_be_duplicated) {
             $info->{restart} = $self->url_for('apiv1_restart', jobid => $job->id);
@@ -587,8 +594,9 @@ sub viewimg {
         my $needle = needle_info($module_detail->{needle}, $distribution, $dversion, $module_detail->{json});
         if ($needle) {    # possibly missing/broken file
             my $info = {
-                name    => $module_detail->{needle},
-                image   => $self->needle_url($distribution, $module_detail->{needle} . '.png', $dversion, $needle->{json}),
+                name => $module_detail->{needle},
+                image =>
+                  $self->needle_url($distribution, $module_detail->{needle} . '.png', $dversion, $needle->{json}),
                 areas   => $needle->{area},
                 matches => []};
             calc_matches($info, $module_detail->{area});

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -112,7 +112,8 @@ sub list_ajax {
     my @jobs = $self->db->resultset("Jobs")->search(
         {'me.id' => {in => \@ids}},
         {
-            columns  => [qw/me.id MACHINE DISTRI VERSION FLAVOR ARCH BUILD TEST state clone_id test result group_id t_finished/],
+            columns =>
+              [qw/me.id MACHINE DISTRI VERSION FLAVOR ARCH BUILD TEST state clone_id test result group_id t_finished/],
             order_by => ['me.t_finished DESC, me.id DESC'],
             prefetch => [qw/children parents/],
         })->all;
@@ -301,7 +302,9 @@ sub _show {
     my $previous_jobs_rs = $self->db->resultset("Jobs")->search({-and => \@conds}, \%attrs);
     my @previous_jobs;
     while (my $prev = $previous_jobs_rs->next) {
-        $self->app->log->debug("Previous result job " . $prev->id . ": " . join('-', map { $prev->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS));
+        $self->app->log->debug("Previous result job "
+              . $prev->id . ": "
+              . join('-', map { $prev->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS));
         push(@previous_jobs, $prev);
     }
     my $job_labels = $self->_job_labels(\@previous_jobs);
@@ -339,7 +342,8 @@ sub _job_labels {
     my ($self, $jobs) = @_;
 
     my %labels;
-    my $c = $self->db->resultset("Comments")->search({job_id => {in => [map { $_->id } @$jobs]}}, {order_by => 'me.id'});
+    my $c
+      = $self->db->resultset("Comments")->search({job_id => {in => [map { $_->id } @$jobs]}}, {order_by => 'me.id'});
     # previous occurences of bug or label are overwritten here so the
     # behaviour for multiple bugs or label references within one job is
     # undefined.

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -22,8 +22,9 @@ use parent qw/Mojolicious::Plugin/;
 use Mojo::IOLoop;
 use JSON ();
 
-my @table_events       = qw/table_create table_update table_delete/;
-my @job_events         = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_set_waiting job_set_running job_done job_grab job_cancel_by_settings/;
+my @table_events = qw/table_create table_update table_delete/;
+my @job_events
+  = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_set_waiting job_set_running job_done job_grab job_cancel_by_settings/;
 my @jobgroup_events    = qw/jobgroup_create jobgroup_connect/;
 my @jobtemplate_events = qw/jobtemplate_create jobtemplate_delete/;
 my @user_events        = qw/user_update user_login user_new_comment user_update_comment user_delete_comment/;
@@ -39,7 +40,10 @@ sub register {
     my ($self, $app, $reactor) = @_;
 
     # register for events
-    my @events = (@table_events, @job_events, @jobgroup_events, @jobtemplate_events, @user_events, @asset_events, @iso_events, @worker_events, @needle_events);
+    my @events = (
+        @table_events, @job_events, @jobgroup_events, @jobtemplate_events, @user_events,
+        @asset_events, @iso_events, @worker_events,   @needle_events
+    );
     # filter out blacklisted events
     my @blacklist = split / /, $app->config->{audit}{blacklist};
     for my $e (@blacklist) {
@@ -49,7 +53,8 @@ sub register {
         $reactor->on("openqa_$e" => sub { shift; $self->on_event($app, @_) });
     }
 
-    $app->db->resultset('AuditEvents')->create({user_id => undef, connection_id => 0, event => 'startup', event_data => 'openQA restarted'});
+    $app->db->resultset('AuditEvents')
+      ->create({user_id => undef, connection_id => 0, event => 'startup', event_data => 'openQA restarted'});
 }
 
 # table events
@@ -60,7 +65,12 @@ sub on_event {
     $event =~ s/^openqa_//;
     my $json = JSON->new();
     $json->allow_nonref(1);
-    $app->db->resultset('AuditEvents')->create({user_id => $user_id, connection_id => $connection_id, event => $event, event_data => $json->encode($event_data)});
+    $app->db->resultset('AuditEvents')->create(
+        {
+            user_id       => $user_id,
+            connection_id => $connection_id,
+            event         => $event,
+            event_data    => $json->encode($event_data)});
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -24,7 +24,7 @@ use JSON;
 use Mojo::IOLoop;
 use OpenQA::Schema::Result::Jobs;
 
-my @job_events     = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_done/;
+my @job_events = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_done/;
 my @comment_events = qw/user_new_comment user_update_comment user_delete_comment/;
 
 sub register {
@@ -52,7 +52,10 @@ sub log_event {
     # FIXME: should be some way for plugins to have configuration and then
     # cert-prefix could be configurable, for now we hard code it
     # we use IPC::Run rather than system() as it's easier to mock for testing
-    my @command = ("fedmsg-logger", "--cert-prefix=openqa", "--modname=openqa", "--topic=$event", "--json-input", "--message=$event_data");
+    my @command = (
+        "fedmsg-logger", "--cert-prefix=openqa", "--modname=openqa", "--topic=$event",
+        "--json-input",  "--message=$event_data"
+    );
     my ($stdin, $stderr, $output) = (undef, undef, undef);
     IPC::Run::run(\@command, \$stdin, \$output, \$stderr);
 }

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -90,7 +90,8 @@ sub run_first {
 
     my $dtf   = $self->app->schema->storage->datetime_parser;
     my $where = {run_at => {'<=', $dtf->format_datetime(DBIx::Class::Timestamps::now())}};
-    my $first = $self->app->schema->resultset('GruTasks')->search($where, {order_by => [{-desc => 'priority'}, 'id'], rows => 1})->first;
+    my $first = $self->app->schema->resultset('GruTasks')
+      ->search($where, {order_by => [{-desc => 'priority'}, 'id'], rows => 1})->first;
 
     if ($first) {
         $self->app->log->debug(sprintf("Running Gru task %d(%s)", $first->id, $first->taskname));

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -70,7 +70,8 @@ sub register {
         stepaction_for => sub {
             my ($c, $title, $url, $icon, $class) = @_;
             $class //= '';
-            my $icons = $c->t(i => (class => "step_action fa $icon fa-lg fa-stack-1x")) . $c->t(i => (class => 'new fa fa-plus fa-stack-1x'));
+            my $icons = $c->t(i => (class => "step_action fa $icon fa-lg fa-stack-1x"))
+              . $c->t(i => (class => 'new fa fa-plus fa-stack-1x'));
             my $content = $c->t(span => (class => 'fa-stack') => sub { $icons });
             return $c->link_to($url => (title => $title, class => $class) => sub { $content });
         });
@@ -94,7 +95,8 @@ sub register {
                 if ($job->group_id) {
                     $query->{groupid} = $job->group_id;
                     $crumbs .= "\n<li id='current-group-overview'>";
-                    $crumbs .= $c->link_to(($job->group->name . ' (current)') => $c->url_for('group_overview', groupid => $job->group_id));
+                    $crumbs .= $c->link_to(
+                        ($job->group->name . ' (current)') => $c->url_for('group_overview', groupid => $job->group_id));
                     $crumbs .= "</li>";
                     $overview_text = "Build " . $job->BUILD;
                 }
@@ -104,7 +106,8 @@ sub register {
                 my $overview_url = $c->url_for('tests_overview')->query(%$query);
 
                 $crumbs .= "\n<li id='current-build-overview'>";
-                $crumbs .= $c->link_to($overview_url => sub { '<i class="glyphicon glyphicon-arrow-right"></i> ' . $overview_text });
+                $crumbs .= $c->link_to(
+                    $overview_url => sub { '<i class="glyphicon glyphicon-arrow-right"></i> ' . $overview_text });
                 $crumbs .= "</li>";
                 $crumbs .= "\n<li role='separator' class='divider'></li>\n";
                 return Mojo::ByteStream->new($crumbs);
@@ -123,7 +126,11 @@ sub register {
             my $c = shift;
 
             # If the value is not in the stash
-            if (!(defined($c->stash('current_user')) && ($c->stash('current_user')->{no_user} || defined($c->stash('current_user')->{user})))) {
+            if (
+                !(
+                    defined($c->stash('current_user'))
+                    && ($c->stash('current_user')->{no_user} || defined($c->stash('current_user')->{user}))))
+            {
 
                 my $user = undef;
                 if (my $id = $c->session->{user}) {
@@ -258,7 +265,8 @@ sub register {
             my ($c, $title, $content, $details_url, $details_text) = @_;
             my $class = 'help_popover fa fa-question-circle';
             if ($details_url) {
-                $content .= '<p>See ' . $c->link_to($details_text ? $details_text : here => $details_url) . ' for details</p>';
+                $content
+                  .= '<p>See ' . $c->link_to($details_text ? $details_text : here => $details_url) . ' for details</p>';
             }
             my $data = {toggle => 'popover', trigger => 'focus', title => $title, content => $content};
             return $c->t(a => (tabindex => 0, class => $class, role => 'button', (data => $data)));

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -99,7 +99,8 @@ sub check_authorized {
                 if (my $secret = $api_key->secret) {
                     my $sum = hmac_sha1_sum($self->req->url->to_string . $timestamp, $secret);
                     $user = $api_key->user;
-                    $self->app->log->debug(sprintf "API auth by user: %s, operator: %d", $user->username, $user->is_operator);
+                    $self->app->log->debug(sprintf "API auth by user: %s, operator: %d",
+                        $user->username, $user->is_operator);
                 }
             }
         }

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -43,11 +43,13 @@ sub websocket_commands {
         my $ua = Mojo::UserAgent->new;
         if ($jobid) {
             if (!$job) {
-                printf STDERR 'Received command %s for job %u, but we do not have any assigned. Ignoring!%s', $type, $jobid, "\n";
+                printf STDERR 'Received command %s for job %u, but we do not have any assigned. Ignoring!%s', $type,
+                  $jobid, "\n";
                 return;
             }
             elsif ($jobid ne $job->{id}) {
-                printf STDERR 'Received command %s for different job id %u (our %u). Ignoring!%s', $type, $jobid, $job->{id}, "\n";
+                printf STDERR 'Received command %s for different job id %u (our %u). Ignoring!%s', $type, $jobid,
+                  $job->{id}, "\n";
                 return;
             }
         }

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -22,7 +22,8 @@ use Carp;
 use POSIX qw/uname/;
 
 use base qw/Exporter/;
-our @EXPORT = qw/$job $workerid $verbose $instance $worker_settings $pooldir $nocleanup $worker_caps $testresults $openqa_url
+our @EXPORT
+  = qw/$job $workerid $verbose $instance $worker_settings $pooldir $nocleanup $worker_caps $testresults $openqa_url
   STATUS_UPDATES_SLOW STATUS_UPDATES_FAST
   add_timer remove_timer change_timer
   api_call verify_workerid register_worker ws_call/;
@@ -220,7 +221,10 @@ sub api_call {
         }
         --$tries;
         my $err = $tx->error;
-        my $msg = $err->{code} ? "$tries: $err->{code} response: $err->{message}" : "$tries: Connection error: $err->{message}";
+        my $msg
+          = $err->{code} ?
+          "$tries: $err->{code} response: $err->{message}"
+          : "$tries: Connection error: $err->{message}";
         Carp::carp $msg;
         if (!$tries) {
             # abort the current job, we're in trouble - but keep running to grab the next

--- a/script/client
+++ b/script/client
@@ -90,7 +90,8 @@ sub usage($) {
     }
 }
 
-GetOptions(\%options, "host=s", "apibase=s", "json", "verbose|v", "apikey:s", "apisecret:s", "params=s", "help|h|?",) or usage(1);
+GetOptions(\%options, "host=s", "apibase=s", "json", "verbose|v", "apikey:s", "apisecret:s", "params=s", "help|h|?",)
+  or usage(1);
 
 usage(1) unless @ARGV;
 $options{host}    ||= 'localhost';

--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -125,7 +125,11 @@ sub usage($) {
     }
 }
 
-GetOptions(\%options, "from=s", "host=s", "dir=s", "apikey:s", "apisecret:s", "verbose|v", "skip-deps", "skip-chained-deps", "skip-download", "parental-inheritance", "help|h",) or usage(1);
+GetOptions(
+    \%options,           "from=s",        "host=s",               "dir=s",
+    "apikey:s",          "apisecret:s",   "verbose|v",            "skip-deps",
+    "skip-chained-deps", "skip-download", "parental-inheritance", "help|h",
+) or usage(1);
 
 usage(1) unless @ARGV;
 usage(1) unless exists $options{'from'};

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -129,7 +129,11 @@ sub usage($) {
     exit $_[0];
 }
 
-GetOptions(\%options, "json", "host=s", "apibase=s", "apikey:s", "apisecret:s", "group=s@", "name=s@", "test=s@", "product=s@", "machine=s@", "full", "help|h",) or usage(1);
+GetOptions(
+    \%options,  "json",    "host=s",  "apibase=s",  "apikey:s",   "apisecret:s",
+    "group=s@", "name=s@", "test=s@", "product=s@", "machine=s@", "full",
+    "help|h",
+) or usage(1);
 
 usage(0) if $options{help};
 

--- a/script/initdb
+++ b/script/initdb
@@ -101,11 +101,12 @@ if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
 
 my $dh = DBIx::Class::DeploymentHandler->new(
     {
-        schema              => $schema,
-        script_directory    => $script_directory,
-        databases           => \@databases,
-        sql_translator_args => {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
-        force_overwrite     => $force,
+        schema           => $schema,
+        script_directory => $script_directory,
+        databases        => \@databases,
+        sql_translator_args =>
+          {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
+        force_overwrite => $force,
     });
 
 my $version = $dh->schema_version;
@@ -117,7 +118,8 @@ if ($prepare_init) {
 
         if (exists $deploy_dir{$version} and not $force) {
             print "The deploy directory already contains the schema for the current version.\n";
-            print "Use the --force option if you want to overwrite the contents of the $script_directory/$db/deploy/$version directory\n";
+            print
+"Use the --force option if you want to overwrite the contents of the $script_directory/$db/deploy/$version directory\n";
             exit 1;
         }
     }

--- a/script/load_templates
+++ b/script/load_templates
@@ -186,9 +186,12 @@ sub post_entry {
     if (!$options{'clean'}) {    # with --clean the entry should not exist at this point, no need to check
         my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table))->query(%param))->res;
         if ($res->code == 200 && @{$res->json->{$table}} == 1 && $res->json->{$table}[0]{id}) {
-            if ($options{'update'} && $table ne 'JobTemplates') {    # there is nothing to update in JobTemplates, the entry just exists or not
-                my $id  = $res->json->{$table}[0]{id};
-                my $res = $client->put($url->path($options{'apibase'} . '/' . decamelize($table) . "/$id")->query(%param))->res;
+            if ($options{'update'} && $table ne 'JobTemplates')
+            {                    # there is nothing to update in JobTemplates, the entry just exists or not
+                my $id = $res->json->{$table}[0]{id};
+                my $res
+                  = $client->put($url->path($options{'apibase'} . '/' . decamelize($table) . "/$id")->query(%param))
+                  ->res;
                 if ($res->code != 200) {
                     print_error($res);
                     return 0;
@@ -196,7 +199,7 @@ sub post_entry {
                 return 1;
             }
             else {
-                return 0;                                            # already exists
+                return 0;        # already exists
             }
         }
     }

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -92,11 +92,12 @@ if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
 
 my $dh = DH->new(
     {
-        schema              => $schema,
-        script_directory    => $script_directory,
-        databases           => \@databases,
-        sql_translator_args => {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
-        force_overwrite     => $force,
+        schema           => $schema,
+        script_directory => $script_directory,
+        databases        => \@databases,
+        sql_translator_args =>
+          {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
+        force_overwrite => $force,
     });
 
 
@@ -116,7 +117,8 @@ if ($prepare_upgrades) {
 
         if (exists $upgrade_dir{$upgrade_directory} and not $force) {
             print "The upgrade directory already contains files to upgrade to the current version ($version)\n";
-            print "Use the --force option if you want to overwrite the contents of the $script_directory/$db/upgrade/$upgrade_directory directory\n";
+            print "Use the --force option if you want to overwrite the contents of the\n";
+            print "$script_directory/$db/upgrade/$upgrade_directory directory\n";
             exit 1;
         }
     }

--- a/script/worker
+++ b/script/worker
@@ -118,7 +118,10 @@ sub usage($) {
     }
 }
 
-GetOptions(\%options, "no-cleanup", "instance=i", "isotovideo=s", "host=s", "apikey:s", "apisecret:s", "verbose|v", "help|h",) or usage(1);
+GetOptions(
+    \%options,     "no-cleanup", "instance=i", "isotovideo=s", "host=s", "apikey:s",
+    "apisecret:s", "verbose|v",  "help|h",
+) or usage(1);
 
 usage(0) if ($options{help});
 

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -406,7 +406,11 @@ is_deeply($current_jobs, [], "no jobs listed");
 
 my $rs = OpenQA::Scheduler::Scheduler::asset_list();
 $rs->result_class('DBIx::Class::ResultClass::HashRefInflator');
-is_deeply(nots($rs->all()), {id => 1, name => "whatever.iso", type => "iso", size => undef, checksum => undef}, "asset list");
+is_deeply(
+    nots($rs->all()),
+    {id => 1, name => "whatever.iso", type => "iso", size => undef, checksum => undef},
+    "asset list"
+);
 
 my $asset = $schema->resultset('Assets')->register('iso', $settings{ISO});
 is($asset->name, $settings{ISO}, "asset register returns same");

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -63,7 +63,8 @@ sub lj {
 
 lj;
 
-my $ret = $schema->resultset('Jobs')->cancel_by_settings({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'x86_64'});
+my $ret = $schema->resultset('Jobs')
+  ->cancel_by_settings({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'x86_64'});
 is($ret, 2, "two jobs cancelled by hash");
 
 $job = $new_job;

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -186,7 +186,9 @@ $job = OpenQA::Scheduler::Scheduler::job_grab(workerid => $w7_id);
 is($job->{id}, $jobH->id, "next job by prio, parent - server");
 
 $job = OpenQA::Scheduler::Scheduler::job_grab(workerid => $w8_id);
-is($job->{id}, $jobJ->id, "I is a scheduled child of running H so it should have the highest prio, but this worker can't do it because of class -> take next job by prio instead");
+is($job->{id}, $jobJ->id,
+"I is a scheduled child of running H so it should have the highest prio, but this worker can't do it because of class -> take next job by prio instead"
+);
 
 $job = OpenQA::Scheduler::Scheduler::job_grab(workerid => $w9_id);
 is($job->{id}, $jobI->id, "this worker can do jobI, child - client");

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -49,7 +49,8 @@ sub job_get {
 
 sub job_get_deps_rs {
     my ($id) = @_;
-    my $job = $schema->resultset("Jobs")->search({'me.id' => $id}, {prefetch => ['settings', 'parents', 'children']})->first;
+    my $job
+      = $schema->resultset("Jobs")->search({'me.id' => $id}, {prefetch => ['settings', 'parents', 'children']})->first;
     return $job;
 }
 
@@ -172,8 +173,8 @@ is($job->{id},                  $jobF->id, "jobF");                        #dire
 is($job->{settings}->{NICVLAN}, 1,         "same vlan for whole group");
 
 $job = OpenQA::Scheduler::Scheduler::job_grab(workerid => $w4_id);
-is($job->{id},                  $jobA->id, "jobA");                        # E is direct child of C, but A and D must be started first
-is($job->{settings}->{NICVLAN}, 1,         "same vlan for whole group");
+is($job->{id}, $jobA->id, "jobA");    # E is direct child of C, but A and D must be started first
+is($job->{settings}->{NICVLAN}, 1, "same vlan for whole group");
 
 $job = OpenQA::Scheduler::Scheduler::job_grab(workerid => $w5_id);
 is($job->{id},                  $jobD->id, "jobD");                        # direct child of A
@@ -462,7 +463,8 @@ my $jobY2 = $jobY->auto_duplicate;
 # X2 <---- Y2
 # done    sch.
 
-is_deeply($jobY2->to_hash(deps => 1)->{parents}, {Chained => [$jobX2->id], Parallel => []}, 'jobY2 parent is now jobX2');
+is_deeply($jobY2->to_hash(deps => 1)->{parents}, {Chained => [$jobX2->id], Parallel => []},
+    'jobY2 parent is now jobX2');
 is($jobX2->{clone_id}, undef, "X no clone");
 is($jobY2->clone_id,   undef, "Y no clone");
 
@@ -646,7 +648,8 @@ my $jobR2 = job_get_deps($jobR->clone->id);
 my $jobT2 = job_get_deps($jobT->clone->id);
 
 my @sorted_got = sort(@{$jobQ->{children}->{Chained}});
-my @sorted_exp = sort(($jobW2->{id}, $jobU2->id, $jobR2->{id}, $jobT2->{id}, $jobW->id, $jobU->id, $jobR->id, $jobT->id));
+my @sorted_exp
+  = sort(($jobW2->{id}, $jobU2->id, $jobR2->{id}, $jobT2->{id}, $jobW->id, $jobU->id, $jobR->id, $jobT->id));
 is_deeply(\@sorted_got, \@sorted_exp, 'jobQ is chained parent to all jobs');
 
 @sorted_got = sort(@{$jobT2->{parents}->{Parallel}});
@@ -654,11 +657,19 @@ is_deeply(\@sorted_got, \@sorted_exp, 'jobQ is chained parent to all jobs');
 is_deeply(\@sorted_got, \@sorted_exp, 'jobT is parallel child of all jobs except jobQ');
 
 is_deeply($jobW2->{children}, {Chained => [], Parallel => [$jobT2->{id}]}, 'jobW2 has no child dependency to sibling');
-is_deeply($jobU2->to_hash(deps => 1)->{children}, {Chained => [], Parallel => [$jobT2->{id}]}, 'jobU2 has no child dependency to sibling');
+is_deeply(
+    $jobU2->to_hash(deps => 1)->{children},
+    {Chained => [], Parallel => [$jobT2->{id}]},
+    'jobU2 has no child dependency to sibling'
+);
 is_deeply($jobR2->{children}, {Chained => [], Parallel => [$jobT2->{id}]}, 'jobR2 has no child dependency to sibling');
 
 is_deeply($jobW2->{parents}, {Chained => [$jobQ->{id}], Parallel => []}, 'jobW2 has no parent dependency to sibling');
-is_deeply($jobU2->to_hash(deps => 1)->{parents}, {Chained => [$jobQ->{id}], Parallel => []}, 'jobU2 has no parent dependency to sibling');
+is_deeply(
+    $jobU2->to_hash(deps => 1)->{parents},
+    {Chained => [$jobQ->{id}], Parallel => []},
+    'jobU2 has no parent dependency to sibling'
+);
 is_deeply($jobR2->{parents}, {Chained => [$jobQ->{id}], Parallel => []}, 'jobR2 has no parent dependency to sibling');
 
 # check cloning of clones
@@ -848,7 +859,11 @@ is_deeply($jobD2_h->{parents}->{Chained}, [$jobA2->id], 'jobD2 has jobA2 as chai
 is($jobD2_h->{settings}{TEST}, $jobD->TEST, 'jobD2 test and jobD test are equal');
 
 my $jobA2_h = job_get_deps($jobA2->id);
-is_deeply($jobA2_h->{children}->{Chained}, [$jobB2_h->{id}, $jobC2_h->{id}, $jobD2_h->{id}], 'jobA2 has jobB2, jobC2 and jobD2 as children');
+is_deeply(
+    $jobA2_h->{children}->{Chained},
+    [$jobB2_h->{id}, $jobC2_h->{id}, $jobD2_h->{id}],
+    'jobA2 has jobB2, jobC2 and jobD2 as children'
+);
 
 # situation parent is done, children running -> parent is cloned -> parent is running -> parent is cloned. Check all children has new parent
 # A <- B

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -148,7 +148,9 @@ subtest 'job with all important modules passed and at least one unimportant fail
     is($job->result, OpenQA::Schema::Result::Jobs::SOFTFAILED, 'job result is softfailed');
 };
 
-subtest 'job with important modules passed and at least one softfailed and at least one unimportant failed => overall softfailed' => sub {
+subtest
+'job with important modules passed and at least one softfailed and at least one unimportant failed => overall softfailed'
+  => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'F';
     my $job = _job_create(\%_settings);
@@ -166,7 +168,7 @@ subtest 'job with important modules passed and at least one softfailed and at le
     $job->done;
     $job->discard_changes;
     is($job->result, OpenQA::Schema::Result::Jobs::SOFTFAILED, 'job result is softfailed');
-};
+  };
 
 subtest 'job with one important module failed and at least one unimportant passed => overall failed' => sub {
     my %_settings = %settings;

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -57,7 +57,8 @@ for my $cmd (@valid_commands) {
 }
 
 #issue invalid commands
-stderr_like { $worker->send_command(command => 'foo', job_id => 0); } qr/\[ERROR\] Trying to issue unknown command "foo" for worker "localhost:"/;
+stderr_like { $worker->send_command(command => 'foo', job_id => 0); }
+qr/\[ERROR\] Trying to issue unknown command "foo" for worker "localhost:"/;
 isnt($OpenQA::WebSockets::Server::last_command, 'foo', 'refuse invalid commands');
 
 done_testing();

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -160,8 +160,14 @@ subtest 'reduce_result gru task cleans up logs' => sub {
 subtest 'migrate_images' => sub {
     File::Path::remove_tree('t/images/aa7/');
     File::Path::make_path('t/data/openqa/images/aa/.thumbs');
-    copy('t/images/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png', 't/data/openqa/images/aa/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png');
-    copy('t/images/347/da6/61d0c3faf37d49d33b6fc308f2.png',         't/data/openqa/images/aa//7da661d0c3faf37d49d33b6fc308f2.png');
+    copy(
+        't/images/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png',
+        't/data/openqa/images/aa/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png'
+    );
+    copy(
+        't/images/347/da6/61d0c3faf37d49d33b6fc308f2.png',
+        't/data/openqa/images/aa//7da661d0c3faf37d49d33b6fc308f2.png'
+    );
     ok(!-l 't/data/openqa/images/aa/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png', 'no link yet');
 
     run_gru('migrate_images' => {prefix => 'aa'});
@@ -173,21 +179,33 @@ subtest 'migrate_images' => sub {
 
 subtest 'relink_testresults' => sub {
     File::Path::make_path('t/data/openqa/images/34/.thumbs');
-    symlink('../../../images/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png', 't/data/openqa/images/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png');
+    symlink(
+        '../../../images/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png',
+        't/data/openqa/images/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png'
+    );
 
     # setup
     unlink('t/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/zypper_up-3.png');
     File::Path::make_path('t/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/');
-    symlink('../../../images/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png', 't/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/zypper_up-3.png');
-    like(readlink('t/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/zypper_up-3.png'), qr{\Q/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png\E}, 'link correct');
+    symlink('../../../images/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png',
+        't/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/zypper_up-3.png');
+    like(
+        readlink('t/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/zypper_up-3.png'),
+        qr{\Q/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png\E},
+        'link correct'
+    );
 
     run_gru('relink_testresults' => {max_job => 1000000, min_job => 0});
-    like(readlink('t/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/zypper_up-3.png'), qr{\Qimages/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png\E}, 'relinked');
+    like(readlink('t/data/openqa/testresults/00099937-opensuse-13.1-DVD-i586-Build0091-kde/.thumbs/zypper_up-3.png'),
+        qr{\Qimages/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png\E}, 'relinked');
 };
 
 subtest 'rm_compat_symlinks' => sub {
     File::Path::make_path(join('/', $OpenQA::Utils::imagesdir, '34', '.thumbs'));
-    symlink('../../../images/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png', 't/data/openqa/images/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png');
+    symlink(
+        '../../../images/347/da6/.thumbs/61d0c3faf37d49d33b6fc308f2.png',
+        't/data/openqa/images/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png'
+    );
 
     ok(-e 't/data/openqa/images/34/.thumbs/7da661d0c3faf37d49d33b6fc308f2.png', 'thumb is there');
     run_gru('rm_compat_symlinks' => {});

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -185,10 +185,12 @@ ok($fixed->is_fixed(), 'fixed should be considered a fixed asset');
 # test Utils::locate_asset
 # fixed HDD asset
 my $expected = catfile($OpenQA::Utils::assetdir, 'hdd', 'fixed', 'fixed.img');
-is(locate_asset('hdd', 'fixed.img', mustexist => 1), $expected, 'locate_asset should find fixed asset in fixed location');
+is(locate_asset('hdd', 'fixed.img', mustexist => 1),
+    $expected, 'locate_asset should find fixed asset in fixed location');
 # relative
 $expected = catfile('hdd', 'fixed', 'fixed.img');
-is(locate_asset('hdd', 'fixed.img', mustexist => 1, relative => 1), $expected, 'locate_asset should return fixed path as relative');
+is(locate_asset('hdd', 'fixed.img', mustexist => 1, relative => 1),
+    $expected, 'locate_asset should return fixed path as relative');
 
 # transient repo asset
 $expected = catfile($OpenQA::Utils::assetdir, 'repo', 'tmprepo');

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -25,15 +25,20 @@ use OpenQA::Utils;
 use Test::More;
 
 is bugurl('bsc#1234'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bug url is properly expanded';
-ok find_bugref('gh#os-autoinst/openQA#1234'),                             'github bugref is recognized';
-is bugurl('gh#os-autoinst/openQA#1234'),                                  'https://github.com/os-autoinst/openQA/issues/1234';
-is bugurl('poo#1234'),                                                    'https://progress.opensuse.org/issues/1234';
-is href_to_bugref('https://progress.opensuse.org/issues/1234'),           'poo#1234';
-is bugref_to_href('boo#9876'),                                            '<a href="https://bugzilla.opensuse.org/show_bug.cgi?id=9876">boo#9876</a>';
+ok find_bugref('gh#os-autoinst/openQA#1234'),                   'github bugref is recognized';
+is bugurl('gh#os-autoinst/openQA#1234'),                        'https://github.com/os-autoinst/openQA/issues/1234';
+is bugurl('poo#1234'),                                          'https://progress.opensuse.org/issues/1234';
+is href_to_bugref('https://progress.opensuse.org/issues/1234'), 'poo#1234';
+is bugref_to_href('boo#9876'), '<a href="https://bugzilla.opensuse.org/show_bug.cgi?id=9876">boo#9876</a>';
 is href_to_bugref('https://github.com/foo/bar/issues/1234'),              'gh#foo/bar#1234';
-is href_to_bugref('https://github.com/os-autoinst/os-autoinst/pull/960'), 'gh#os-autoinst/os-autoinst#960', 'github pull are also transformed same as issues';
-is bugref_to_href('gh#foo/bar#1234'),                                     '<a href="https://github.com/foo/bar/issues/1234">gh#foo/bar#1234</a>';
-like bugref_to_href('bsc#2345 poo#3456 and more'),                        qr{a href="https://bugzilla.suse.com/show_bug.cgi\?id=2345">bsc\#2345</a> <a href=.*3456.*> and more}, 'bugrefs in text get replaced';
-like bugref_to_href('boo#2345,poo#3456'),                                 qr{a href="https://bugzilla.opensuse.org/show_bug.cgi\?id=2345">boo\#2345</a>,<a href=.*3456.*}, 'interpunctation is not consumed by href';
+is href_to_bugref('https://github.com/os-autoinst/os-autoinst/pull/960'), 'gh#os-autoinst/os-autoinst#960',
+  'github pull are also transformed same as issues';
+is bugref_to_href('gh#foo/bar#1234'), '<a href="https://github.com/foo/bar/issues/1234">gh#foo/bar#1234</a>';
+like bugref_to_href('bsc#2345 poo#3456 and more'),
+  qr{a href="https://bugzilla.suse.com/show_bug.cgi\?id=2345">bsc\#2345</a> <a href=.*3456.*> and more},
+  'bugrefs in text get replaced';
+like bugref_to_href('boo#2345,poo#3456'),
+  qr{a href="https://bugzilla.opensuse.org/show_bug.cgi\?id=2345">boo\#2345</a>,<a href=.*3456.*},
+  'interpunctation is not consumed by href';
 
 done_testing();

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -120,8 +120,10 @@ subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {
 subtest 'show_tags query parameter enables/disables tags on index page' => sub {
     for my $enabled (0, 1) {
         my $get = $t->get_ok('/?show_tags=' . $enabled)->status_is(200);
-        is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')},     4,        "all builds shown on index page (show_tags=$enabled)");
-        is(scalar @{$t->tx->res->dom->find("i[title='important']")}, $enabled, "tag (not) shown on index page (show_tags=$enabled)");
+        is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')},
+            4, "all builds shown on index page (show_tags=$enabled)");
+        is(scalar @{$t->tx->res->dom->find("i[title='important']")},
+            $enabled, "tag (not) shown on index page (show_tags=$enabled)");
     }
 };
 
@@ -158,7 +160,8 @@ sub _map_expired {
 subtest 'expired_jobs' => sub {
     my $jg = $t->app->db->resultset('JobGroups')->find(1001);
     is_deeply($jg->expired_jobs, [], 'no jobs expired');
-    $t->app->db->resultset('Jobs')->find(99938)->update({t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600 * 24 * 12, 'UTC')});
+    $t->app->db->resultset('Jobs')->find(99938)
+      ->update({t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600 * 24 * 12, 'UTC')});
     is_deeply($jg->expired_jobs, [], 'still no jobs expired');
     $jg->update({keep_results_in_days => 5});
     # now the unimportant jobs are expired

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -73,7 +73,8 @@ subtest '"happy path": failed->failed carries over last label' => sub {
     is($comments_previous[2],     $simple_comment, 'another comment present');
     $t->post_ok('/api/v1/jobs/99963/set_done', $auth => form => {result => 'failed'})->status_is(200);
     my @comments_current = @{comments('/tests/99963')};
-    my $comment_must     = '<a href="https://bugzilla.suse.com/show_bug.cgi?id=1234">bsc#1234</a>(Automatic takeover from <a href="/tests/99962">t#99962</a>)';
+    my $comment_must
+      = '<a href="https://bugzilla.suse.com/show_bug.cgi?id=1234">bsc#1234</a>(Automatic takeover from <a href="/tests/99962">t#99962</a>)';
     is(join('', @comments_current), $comment_must, 'only one label is carried over');
     like($comments_current[0], qr/\Q$second_label/, 'last entered label found, it is expanded');
 };

--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -57,7 +57,8 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses its app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 # create Test DBus bus and service for fake WebSockets
@@ -82,14 +83,26 @@ my $settings = {
 # create a job via API
 my $post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
 my $job = $post->tx->res->json->{id};
-is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.create --json-input --message={"ARCH":"x86_64","BUILD":"666","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink","ISO":"whatever.iso","ISO_MAXSIZE":"1","KVM":"KVM","MACHINE":"RainbowPC","TEST":"rainbow","VERSION":"42","id":' . $job . ',"remaining":1}', "job create triggers fedmsg");
+is(
+    $args,
+'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.create --json-input --message={"ARCH":"x86_64","BUILD":"666","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink","ISO":"whatever.iso","ISO_MAXSIZE":"1","KVM":"KVM","MACHINE":"RainbowPC","TEST":"rainbow","VERSION":"42","id":'
+      . $job
+      . ',"remaining":1}',
+    "job create triggers fedmsg"
+);
 
 # FIXME: restarting job via API emits an event in real use, but not if we do it here
 
 # set the job as done via API
 $post = $t->post_ok("/api/v1/jobs/" . $job . "/set_done")->status_is(200);
 # check plugin called fedmsg-logger correctly
-is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.done --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":' . $job . ',"newbuild":null,"remaining":0,"result":"failed"}', "job done triggers fedmsg");
+is(
+    $args,
+'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.done --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":'
+      . $job
+      . ',"newbuild":null,"remaining":0,"result":"failed"}',
+    "job done triggers fedmsg"
+);
 
 # we don't test update_results as comment indicates it's obsolete
 
@@ -97,12 +110,25 @@ is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.done 
 $post = $t->post_ok("/api/v1/jobs/" . $job . "/duplicate")->status_is(200);
 my $newjob = $post->tx->res->json->{id};
 # check plugin called fedmsg-logger correctly
-is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.duplicate --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","auto":0,"id":' . $job . ',"remaining":1,"result":' . $newjob . '}', "job duplicate triggers fedmsg");
+is(
+    $args,
+'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.duplicate --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","auto":0,"id":'
+      . $job
+      . ',"remaining":1,"result":'
+      . $newjob . '}',
+    "job duplicate triggers fedmsg"
+);
 
 # cancel the new job via API
 $post = $t->post_ok("/api/v1/jobs/" . $newjob . "/cancel")->status_is(200);
 # check plugin called fedmsg-logger correctly
-is($args, 'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.cancel --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":' . $newjob . ',"remaining":0}', "job cancel triggers fedmsg");
+is(
+    $args,
+'fedmsg-logger --cert-prefix=openqa --modname=openqa --topic=job.cancel --json-input --message={"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC","TEST":"rainbow","id":'
+      . $newjob
+      . ',"remaining":0}',
+    "job cancel triggers fedmsg"
+);
 
 # FIXME: deleting job via DELETE call to api/v1/jobs/$newjob fails with 500?
 

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -64,14 +64,34 @@ my $drs = $schema->resultset('NeedleDirs');
 # there should be two files called test-rootneedle, that shouldn't be problem, because they have different needledir
 is($rs->count({filename => "test-rootneedle.json"}), 2);
 # there should be one test-rootneedle needle in fedora/needles needledir
-is($rs->search({filename => "test-rootneedle.json"})->search_related('directory', {path => {like => '%fedora/needles'}})->count(), 1);
+is(
+    $rs->search({filename => "test-rootneedle.json"})
+      ->search_related('directory', {path => {like => '%fedora/needles'}})->count(),
+    1
+);
 # there should be one needle that has fedora/needles needledir and it has relative path in its filename
-is($rs->search({filename => "gnome/browser/test-nestedneedle-2.json"})->search_related('directory', {path => {like => '%fedora/needles'}})->count(), 1);
+is(
+    $rs->search({filename => "gnome/browser/test-nestedneedle-2.json"})
+      ->search_related('directory', {path => {like => '%fedora/needles'}})->count(),
+    1
+);
 # this tests that there can be two needles with the same names in different directories
-is($rs->search({filename => "test-duplicate-needle.json"})->search_related('directory', {path => {like => '%fedora/needles'}})->count(), 1);
-is($rs->search({filename => "installer/test-duplicate-needle.json"})->search_related('directory', {path => {like => '%fedora/needles'}})->count(), 1);
+is(
+    $rs->search({filename => "test-duplicate-needle.json"})
+      ->search_related('directory', {path => {like => '%fedora/needles'}})->count(),
+    1
+);
+is(
+    $rs->search({filename => "installer/test-duplicate-needle.json"})
+      ->search_related('directory', {path => {like => '%fedora/needles'}})->count(),
+    1
+);
 # this tests needledir for nested needles placed under non-project needledir
-is($rs->search({filename => "test-kdeneedle.json"})->search_related('directory', {path => {like => '%archlinux/needles/kde'}})->count(), 1);
+is(
+    $rs->search({filename => "test-kdeneedle.json"})
+      ->search_related('directory', {path => {like => '%archlinux/needles/kde'}})->count(),
+    1
+);
 # all those needles should have file_present set to 1
 if (my $needle = $rs->next) {
     is($needle->file_present, 1);

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -80,17 +80,38 @@ sub check_test_parent {
     my ($default_expanded) = @_;
 
     @h4 = $get->tx->res->dom->find("div.children-$default_expanded h4 a")->map('text')->each;
-    is_deeply(\@h4, ['Build87.5011', 'Build0092', 'Build0091', 'Build0048@0815', 'Build0048'], 'builds on parent-level shown');
+    is_deeply(
+        \@h4,
+        ['Build87.5011', 'Build0092', 'Build0091', 'Build0048@0815', 'Build0048'],
+        'builds on parent-level shown'
+    );
 
-    my @progress_bars = $get->tx->res->dom->find("div.children-$default_expanded .progress")->map('attr', 'title')->each;
-    is_deeply(\@progress_bars, ["failed: 1\ntotal: 1", "passed: 1\ntotal: 1", "passed: 2\nunfinished: 3\nskipped: 1\ntotal: 6", "failed: 1\ntotal: 1", "softfailed: 2\nfailed: 1\ntotal: 3",], 'parent-level progress bars are accumulated');
+    my @progress_bars
+      = $get->tx->res->dom->find("div.children-$default_expanded .progress")->map('attr', 'title')->each;
+    is_deeply(
+        \@progress_bars,
+        [
+            "failed: 1\ntotal: 1",
+            "passed: 1\ntotal: 1",
+            "passed: 2\nunfinished: 3\nskipped: 1\ntotal: 6",
+            "failed: 1\ntotal: 1",
+            "softfailed: 2\nfailed: 1\ntotal: 3",
+        ],
+        'parent-level progress bars are accumulated'
+    );
 
     @h4 = $get->tx->res->dom->find('div#group' . $test_parent->id . '_build0091 h4 a')->map('text')->each;
     is_deeply(\@h4, ['opensuse', 'opensuse test'], 'both child groups shown under common build');
-    @progress_bars = $get->tx->res->dom->find('div#group' . $test_parent->id . '_build0091 .progress')->map('attr', 'title')->each;
-    is_deeply(\@progress_bars, ["passed: 2\nunfinished: 2\nskipped: 1\ntotal: 5", "unfinished: 1\ntotal: 1"], 'progress bars for child groups shown correctly');
+    @progress_bars
+      = $get->tx->res->dom->find('div#group' . $test_parent->id . '_build0091 .progress')->map('attr', 'title')->each;
+    is_deeply(
+        \@progress_bars,
+        ["passed: 2\nunfinished: 2\nskipped: 1\ntotal: 5", "unfinished: 1\ntotal: 1"],
+        'progress bars for child groups shown correctly'
+    );
 
-    is($get->tx->res->dom->find("div.children-$default_expanded .review-all-passed")->size, 1, 'badge shown on parent-level');
+    is($get->tx->res->dom->find("div.children-$default_expanded .review-all-passed")->size,
+        1, 'badge shown on parent-level');
 
     is($get->tx->res->dom->find("div.children-$default_expanded h4 span i.tag")->size, 0, 'no tags shown yet');
 }

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -45,7 +45,10 @@ $t->app($app);
 
 my $ret;
 
-like(warning { $ret = $t->post_ok('/api/v1/workers', form => {host => 'localhost', instance => 1, backend => 'qemu'}) }, qr/missing apisecret/);
+like(
+    warning { $ret = $t->post_ok('/api/v1/workers', form => {host => 'localhost', instance => 1, backend => 'qemu'}) },
+    qr/missing apisecret/
+);
 is($ret->tx->res->code, 403, "register worker without API key fails");
 
 $t->ua(OpenQA::Client->new(api => 'testapi')->ioloop(Mojo::IOLoop->singleton));

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -163,11 +163,13 @@ $ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})
 
 # switch to operator (percival) and try some modifications
 $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 # test delete operation
-$ret = $t->delete_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(403, 'asset deletion forbidden for operator');
+$ret = $t->delete_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))
+  ->status_is(403, 'asset deletion forbidden for operator');
 # delete by name
 $ret = $t->delete_ok('/api/v1/assets/iso/' . $iso1)->status_is(403, 'asset deletion forbidden for operator');
 # asset must be still there

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -40,7 +40,8 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 sub lj {
@@ -118,7 +119,10 @@ $t->app->db->resultset("Jobs")->find(99928)->comments->create({text => 'any text
 # with different name should result in new tests...
 my $expected = qr/START_AFTER_TEST=.* not found - check for typos and dependency cycles/;
 my $res;
-my @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'}) };
+my @warnings = warnings {
+    $res = schedule_iso(
+        {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})
+};
 is(scalar @warnings, 2, 'two warnings expected');
 map { like($_, $expected) } @warnings;
 
@@ -137,11 +141,23 @@ my $advanced_kde_32 = find_job(\@jobs, \@newids, 'advanced_kde', '32bit');
 my $kde_32          = find_job(\@jobs, \@newids, 'kde',          '32bit');
 my $textmode_32     = find_job(\@jobs, \@newids, 'textmode',     '32bit');
 
-is_deeply($client1_32->{parents}, {Parallel => [$server_32->{id}], Chained => []}, "server_32 is only parent of client1_32");
-is_deeply($client2_32->{parents}, {Parallel => [$server_32->{id}], Chained => []}, "server_32 is only parent of client2_32");
-is_deeply($server_32->{parents},  {Parallel => [],                 Chained => []}, "server_32 has no parents");
+is_deeply(
+    $client1_32->{parents},
+    {Parallel => [$server_32->{id}], Chained => []},
+    "server_32 is only parent of client1_32"
+);
+is_deeply(
+    $client2_32->{parents},
+    {Parallel => [$server_32->{id}], Chained => []},
+    "server_32 is only parent of client2_32"
+);
+is_deeply($server_32->{parents}, {Parallel => [], Chained => []}, "server_32 has no parents");
 is($kde_32, undef, "kde is not created for 32bit machine");
-is_deeply($advanced_kde_32->{parents}, {Parallel => [], Chained => [$textmode_32->{id}]}, "textmode_32 is only parent of advanced_kde_32");    # kde is not defined for 32bit machine
+is_deeply(
+    $advanced_kde_32->{parents},
+    {Parallel => [], Chained => [$textmode_32->{id}]},
+    "textmode_32 is only parent of advanced_kde_32"
+);    # kde is not defined for 32bit machine
 
 my $server_64       = find_job(\@jobs, \@newids, 'server',       '64bit');
 my $client1_64      = find_job(\@jobs, \@newids, 'client1',      '64bit');
@@ -150,11 +166,23 @@ my $advanced_kde_64 = find_job(\@jobs, \@newids, 'advanced_kde', '64bit');
 my $kde_64          = find_job(\@jobs, \@newids, 'kde',          '64bit');
 my $textmode_64     = find_job(\@jobs, \@newids, 'textmode',     '64bit');
 
-is_deeply($client1_64->{parents}, {Parallel => [$server_64->{id}], Chained => []}, "server_64 is only parent of client1_64");
-is_deeply($client2_64->{parents}, {Parallel => [$server_64->{id}], Chained => []}, "server_64 is only parent of client2_64");
-is_deeply($server_64->{parents},  {Parallel => [],                 Chained => []}, "server_64 has no parents");
+is_deeply(
+    $client1_64->{parents},
+    {Parallel => [$server_64->{id}], Chained => []},
+    "server_64 is only parent of client1_64"
+);
+is_deeply(
+    $client2_64->{parents},
+    {Parallel => [$server_64->{id}], Chained => []},
+    "server_64 is only parent of client2_64"
+);
+is_deeply($server_64->{parents}, {Parallel => [], Chained => []}, "server_64 has no parents");
 is($textmode_64, undef, "textmode is not created for 64bit machine");
-is_deeply($advanced_kde_64->{parents}, {Parallel => [], Chained => [$kde_64->{id}]}, "kde_64 is only parent of advanced_kde_64");    # textmode is not defined for 64bit machine
+is_deeply(
+    $advanced_kde_64->{parents},
+    {Parallel => [], Chained => [$kde_64->{id}]},
+    "kde_64 is only parent of advanced_kde_64"
+);    # textmode is not defined for 64bit machine
 
 is($server_32->{group_id}, 1001, 'server_32 part of opensuse group');
 is($server_64->{group_id}, 1001, 'server_64 part of opensuse group');
@@ -222,16 +250,25 @@ subtest 'jobs belonging to important builds are not cancelled by new iso post' =
     is($ret->tx->res->json->{job}->{state}, 'running', 'job in build 0091 running');
     my $tag = 'tag:0091:important';
     $t->app->db->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
-    @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'}) };
+    @warnings = warnings {
+        $res = schedule_iso(
+            {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})
+    };
     is(scalar @warnings,    2,  'two warnings expected');
     is($res->json->{count}, 10, '10 jobs created');
     $ret = $t->get_ok('/api/v1/jobs/99992')->status_is(200);
     is($ret->tx->res->json->{job}->{state}, 'scheduled');
-    @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0092'}) };
+    @warnings = warnings {
+        $res = schedule_iso(
+            {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0092'})
+    };
     is(scalar @warnings, 2, 'two warnings expected');
     $ret = $t->get_ok('/api/v1/jobs/99992')->status_is(200);
     is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job in old important build still scheduled');
-    @warnings = warnings { $res = schedule_iso({ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0093'}) };
+    @warnings = warnings {
+        $res = schedule_iso(
+            {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0093'})
+    };
     is(scalar @warnings, 2, 'two warnings expected');
     $ret = $t->get_ok('/api/v1/jobs?state=scheduled');
     my @jobs = @{$ret->tx->res->json->{jobs}};
@@ -275,62 +312,157 @@ sub check_job_setting {
 }
 
 # Schedule download of an existing ISO
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://localhost/openSUSE-13.1-DVD-i586-Build0091-Media.iso'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI  => 'opensuse',
+            VERSION => '13.1',
+            FLAVOR  => 'DVD',
+            ARCH    => 'i586',
+            ISO_URL => 'http://localhost/openSUSE-13.1-DVD-i586-Build0091-Media.iso'
+        })
+};
 map { like($_, $expected, 'expected warning') } @warnings;
 check_download_asset('existing ISO');
 
 # Schedule download of an existing HDD for extraction
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', HDD_1_DECOMPRESS_URL => 'http://localhost/openSUSE-13.1-x86_64.hda.xz'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI               => 'opensuse',
+            VERSION              => '13.1',
+            FLAVOR               => 'DVD',
+            ARCH                 => 'i586',
+            HDD_1_DECOMPRESS_URL => 'http://localhost/openSUSE-13.1-x86_64.hda.xz'
+        })
+};
 map { like($_, $expected, 'expected warning') } @warnings;
 check_download_asset('existing HDD');
 
 # Schedule download of a non-existing ISO
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://localhost/nonexistent.iso'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI  => 'opensuse',
+            VERSION => '13.1',
+            FLAVOR  => 'DVD',
+            ARCH    => 'i586',
+            ISO_URL => 'http://localhost/nonexistent.iso'
+        })
+};
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent ISO', ['http://localhost/nonexistent.iso', locate_asset('iso', 'nonexistent.iso', mustexist => 0), 0]);
+check_download_asset('non-existent ISO',
+    ['http://localhost/nonexistent.iso', locate_asset('iso', 'nonexistent.iso', mustexist => 0), 0]);
 check_job_setting($t, $rsp, 'ISO', 'nonexistent.iso', 'parameter ISO is correctly set from ISO_URL');
 
 # Schedule download and uncompression of a non-existing HDD
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', HDD_1_DECOMPRESS_URL => 'http://localhost/nonexistent.hda.xz'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI               => 'opensuse',
+            VERSION              => '13.1',
+            FLAVOR               => 'DVD',
+            ARCH                 => 'i586',
+            HDD_1_DECOMPRESS_URL => 'http://localhost/nonexistent.hda.xz'
+        })
+};
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent HDD (with uncompression)', ['http://localhost/nonexistent.hda.xz', locate_asset('hdd', 'nonexistent.hda', mustexist => 0), 1]);
+check_download_asset('non-existent HDD (with uncompression)',
+    ['http://localhost/nonexistent.hda.xz', locate_asset('hdd', 'nonexistent.hda', mustexist => 0), 1]);
 check_job_setting($t, $rsp, 'HDD_1', 'nonexistent.hda', 'parameter HDD_1 is correctly set from HDD_1_DECOMPRESS_URL');
 
 # Schedule download of a non-existing ISO with a custom target name
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://localhost/nonexistent2.iso', ISO => 'callitthis.iso'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI  => 'opensuse',
+            VERSION => '13.1',
+            FLAVOR  => 'DVD',
+            ARCH    => 'i586',
+            ISO_URL => 'http://localhost/nonexistent2.iso',
+            ISO     => 'callitthis.iso'
+        })
+};
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent ISO (with custom name)', ['http://localhost/nonexistent2.iso', locate_asset('iso', 'callitthis.iso', mustexist => 0), 0]);
+check_download_asset('non-existent ISO (with custom name)',
+    ['http://localhost/nonexistent2.iso', locate_asset('iso', 'callitthis.iso', mustexist => 0), 0]);
 check_job_setting($t, $rsp, 'ISO', 'callitthis.iso', 'parameter ISO is not overwritten when ISO_URL is set');
 
 # Schedule download and uncompression of a non-existing kernel with a custom target name
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', KERNEL_DECOMPRESS_URL => 'http://localhost/nonexistvmlinuz', KERNEL => 'callitvmlinuz'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI                => 'opensuse',
+            VERSION               => '13.1',
+            FLAVOR                => 'DVD',
+            ARCH                  => 'i586',
+            KERNEL_DECOMPRESS_URL => 'http://localhost/nonexistvmlinuz',
+            KERNEL                => 'callitvmlinuz'
+        })
+};
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 map { like($_, $expected, 'expected warning') } @warnings;
-check_download_asset('non-existent kernel (with uncompression, custom name', ['http://localhost/nonexistvmlinuz', locate_asset('other', 'callitvmlinuz', mustexist => 0), 1]);
-check_job_setting($t, $rsp, 'KERNEL', 'callitvmlinuz', 'parameter KERNEL is not overwritten when KERNEL_DECOMPRESS_URL is set');
+check_download_asset('non-existent kernel (with uncompression, custom name',
+    ['http://localhost/nonexistvmlinuz', locate_asset('other', 'callitvmlinuz', mustexist => 0), 1]);
+check_job_setting($t, $rsp, 'KERNEL', 'callitvmlinuz',
+    'parameter KERNEL is not overwritten when KERNEL_DECOMPRESS_URL is set');
 
 # Using non-asset _URL does not create gru job and schedule jobs
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', NO_ASSET_URL => 'http://localhost/nonexistent.iso'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI       => 'opensuse',
+            VERSION      => '13.1',
+            FLAVOR       => 'DVD',
+            ARCH         => 'i586',
+            NO_ASSET_URL => 'http://localhost/nonexistent.iso'
+        })
+};
 map { like($_, $expected, 'expected warning') } @warnings;
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 check_download_asset('non-asset _URL');
 
 # Using asset _URL but without filename extractable from URL create warning in log file, jobs, but no gru job
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://localhost'}) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://localhost'})
+};
 map { like($_, $expected, 'expected warning') } @warnings;
 is($rsp->json->{count}, 10, 'a regular ISO post creates the expected number of jobs');
 check_download_asset('asset _URL without valid filename');
 
 # Using asset _URL outside of whitelist will yield 403
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', ISO_URL => 'http://adamshost/nonexistent.iso'}, 403) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI  => 'opensuse',
+            VERSION => '13.1',
+            FLAVOR  => 'DVD',
+            ARCH    => 'i586',
+            ISO_URL => 'http://adamshost/nonexistent.iso'
+        },
+        403
+      )
+};
 map { like($_, $expected, 'expected warning') } @warnings;
 is($rsp->message, 'Asset download requested from non-whitelisted host adamshost');
 check_download_asset('asset _URL not in whitelist');
 
 # Using asset _DECOMPRESS_URL outside of whitelist will yield 403
-@warnings = warnings { $rsp = schedule_iso({DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', HDD_1_DECOMPRESS_URL => 'http://adamshost/nonexistent.hda.xz'}, 403) };
+@warnings = warnings {
+    $rsp = schedule_iso(
+        {
+            DISTRI               => 'opensuse',
+            VERSION              => '13.1',
+            FLAVOR               => 'DVD',
+            ARCH                 => 'i586',
+            HDD_1_DECOMPRESS_URL => 'http://adamshost/nonexistent.hda.xz'
+        },
+        403
+      )
+};
 map { like($_, $expected, 'expected warning') } @warnings;
 is($rsp->message, 'Asset download requested from non-whitelisted host adamshost');
 check_download_asset('asset _DECOMPRESS_URL not in whitelist');

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -53,7 +53,8 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 # INITIAL JOB LIST (from fixtures)
@@ -150,7 +151,8 @@ $get = $t->get_ok('/api/v1/jobs?ids=99981&ids=99963&ids=99926');
 is(scalar(@{$get->tx->res->json->{jobs}}), 3);
 
 # Test /jobs/restart
-my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})->status_is(200);
+my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})
+  ->status_is(200);
 
 $get = $t->get_ok('/api/v1/jobs');
 my @new_jobs = @{$get->tx->res->json->{jobs}};
@@ -183,13 +185,17 @@ close($fh);
 
 my $rp = "t/data/openqa/testresults/00099963-opensuse-13.1-DVD-x86_64-Build0091-kde/video.ogv";
 unlink($rp);                       # make sure previous tests don't fool us
-$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'video.ogv'}})->status_is(200);
+$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'video.ogv'}})
+  ->status_is(200);
 
 ok(-e $rp, 'video exist after');
 is(calculate_file_md5($rp), "feeebd34e507d3a1641c774da135be77", "md5sum matches");
 
 $rp = "t/data/openqa/testresults/00099963-opensuse-13.1-DVD-x86_64-Build0091-kde/ulogs/y2logs.tar.bz2";
-$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'y2logs.tar.bz2'}, ulog => 1})->status_is(200);
+$post
+  = $t->post_ok(
+    '/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'y2logs.tar.bz2'}, ulog => 1})
+  ->status_is(200);
 $post->content_is('OK');
 ok(-e $rp, 'logs exist after');
 is(calculate_file_md5($rp), "feeebd34e507d3a1641c774da135be77", "md5sum matches");
@@ -197,7 +203,8 @@ is(calculate_file_md5($rp), "feeebd34e507d3a1641c774da135be77", "md5sum matches"
 
 $rp = "t/data/openqa/factory/hdd/hdd_image.qcow2";
 unlink($rp);
-$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'hdd_image.qcow2'}, asset => 'public'})->status_is(200);
+$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+      {file => {file => $filename, filename => 'hdd_image.qcow2'}, asset => 'public'})->status_is(200);
 my $temp = $post->tx->res->json->{temporary};
 like($temp, qr,t/data/openqa/factory/hdd/hdd_image\.qcow2\.TEMP.*,);
 ok(-e $temp, "temporary exists");
@@ -210,7 +217,8 @@ is($ret->tx->res->json->{name}, 'hdd_image.qcow2');
 
 $rp = "t/data/openqa/factory/hdd/00099963-hdd_image2.qcow2";
 unlink($rp);
-$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'hdd_image2.qcow2'}, asset => 'private'})->status_is(200);
+$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+      {file => {file => $filename, filename => 'hdd_image2.qcow2'}, asset => 'private'})->status_is(200);
 $temp = $post->tx->res->json->{temporary};
 like($temp, qr,t/data/openqa/factory/hdd/00099963-hdd_image2\.qcow2\.TEMP.*,);
 $t->post_ok('/api/v1/jobs/99963/ack_temporary' => form => {temporary => $temp});

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -92,23 +92,31 @@ is_deeply(
 my $res = $t->post_ok('/api/v1/machines', form => {name => "testmachine"})->status_is(400);    # missing backend
 $res = $t->post_ok('/api/v1/machines', form => {backend => "kde/usb"})->status_is(400);        #missing name
 
-$res = $t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu", "settings[TEST]" => "val1", "settings[TEST2]" => "val1"})->status_is(200);
+$res
+  = $t->post_ok('/api/v1/machines',
+    form => {name => "testmachine", backend => "qemu", "settings[TEST]" => "val1", "settings[TEST2]" => "val1"})
+  ->status_is(200);
 my $machine_id = $res->tx->res->json->{id};
 
 $res = $t->get_ok('/api/v1/machines', form => {name => "testmachine"})->status_is(200);
 is($res->tx->res->json->{Machines}->[0]->{id}, $machine_id);
 
-$res = $t->post_ok('/api/v1/machines', form => {name => "testmachineQ", backend => "qemu", "settings[TEST]" => "'v'al1", "settings[TEST2]" => "va'l\'1"})->status_is(200);
+$res
+  = $t->post_ok('/api/v1/machines',
+    form => {name => "testmachineQ", backend => "qemu", "settings[TEST]" => "'v'al1", "settings[TEST2]" => "va'l\'1"})
+  ->status_is(200);
 $res = $t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
 is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
 is($res->tx->res->json->{Machines}->[0]->{settings}->[1]->{value}, "va'l\'1");
 
-$t->post_ok('/api/v1/machines', form => {name => "testmachineZ", backend => "qemu", "settings[TE'S\'T]" => "'v'al1"})->status_is(200);
+$t->post_ok('/api/v1/machines', form => {name => "testmachineZ", backend => "qemu", "settings[TE'S\'T]" => "'v'al1"})
+  ->status_is(200);
 $res = $t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
 is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{key},   "TEST");
 is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
 
-$res = $t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu"})->status_is(400);    #already exists
+$res
+  = $t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu"})->status_is(400); #already exists
 
 $get = $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
 is_deeply(
@@ -132,7 +140,8 @@ is_deeply(
     "Add machine"
 ) || diag explain $get->tx->res->json;
 
-$res = $t->put_ok("/api/v1/machines/$machine_id", form => {name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1"})->status_is(200);
+$res = $t->put_ok("/api/v1/machines/$machine_id",
+    form => {name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1"})->status_is(200);
 
 $get = $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
 is_deeply(
@@ -157,10 +166,14 @@ $res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(404);    #not fo
 
 # switch to operator (percival) and try some modifications
 $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
-$t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu", "settings[TEST]" => "val1", "settings[TEST2]" => "val1"})->status_is(403);
-$t->put_ok("/api/v1/machines/$machine_id", form => {name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1"})->status_is(403);
+$t->post_ok('/api/v1/machines',
+    form => {name => "testmachine", backend => "qemu", "settings[TEST]" => "val1", "settings[TEST2]" => "val1"})
+  ->status_is(403);
+$t->put_ok("/api/v1/machines/$machine_id",
+    form => {name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1"})->status_is(403);
 $t->delete_ok("/api/v1/machines/$machine_id")->status_is(403);
 
 done_testing();

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -180,7 +180,8 @@ is_deeply(
     "Add test_suite"
 ) || diag explain $get->tx->res->json;
 
-$t->put_ok("/api/v1/test_suites/$test_suite_id", form => {name => "testsuite", "settings[TEST2]" => "val1"})->status_is(200);
+$t->put_ok("/api/v1/test_suites/$test_suite_id", form => {name => "testsuite", "settings[TEST2]" => "val1"})
+  ->status_is(200);
 
 $get = $t->get_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
 is_deeply(
@@ -204,10 +205,12 @@ $res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(404);    #
 
 # switch to operator (percival) and try some modifications
 $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 $t->post_ok('/api/v1/test_suites', form => {name => "testsuite"})->status_is(403);
-$t->put_ok("/api/v1/test_suites/$test_suite_id", form => {name => "testsuite", "settings[TEST2]" => "val1"})->status_is(403);
+$t->put_ok("/api/v1/test_suites/$test_suite_id", form => {name => "testsuite", "settings[TEST2]" => "val1"})
+  ->status_is(403);
 $res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(403);
 
 done_testing();

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -341,7 +341,16 @@ is_deeply(
 ) || diag explain $get->tx->res->json;
 
 # search by name
-$get = $t->get_ok("/api/v1/job_templates", form => {machine_name => '64bit', test_suite_name => 'RAID0', 'arch' => 'i586', 'distri' => 'opensuse', 'flavor' => 'DVD', 'version' => '13.1'})->status_is(200);
+$get = $t->get_ok(
+    "/api/v1/job_templates",
+    form => {
+        machine_name    => '64bit',
+        test_suite_name => 'RAID0',
+        'arch'          => 'i586',
+        'distri'        => 'opensuse',
+        'flavor'        => 'DVD',
+        'version'       => '13.1'
+    })->status_is(200);
 is_deeply(
     $get->tx->res->json,
     {
@@ -430,7 +439,8 @@ $res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(404);
 
 # switch to operator (percival) and try some modifications
 $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 $t->post_ok(
     '/api/v1/job_templates',

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -32,7 +32,8 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 sub test_get_comment {
@@ -57,7 +58,11 @@ sub test_get_comment_groups_json {
 sub test_get_comment_invalid_job_or_group {
     my ($in, $id, $comment_id) = @_;
     my $get = $t->get_ok("/api/v1/$in/$id/comments/$comment_id")->status_is(404, 'comment not found');
-    like($get->tx->res->json->{error}, qr/$id does not exist/, $in eq 'jobs' ? "Job $id does not exist" : "Job group $id does not exist");
+    like(
+        $get->tx->res->json->{error},
+        qr/$id does not exist/,
+        $in eq 'jobs' ? "Job $id does not exist" : "Job group $id does not exist"
+    );
 }
 
 sub test_get_comment_invalid_comment {
@@ -68,7 +73,8 @@ sub test_get_comment_invalid_comment {
 
 sub test_create_comment {
     my ($in, $id, $text) = @_;
-    my $post = $t->post_ok("/api/v1/$in/$id/comments" => form => {text => $text})->status_is(200, 'comment can be created');
+    my $post
+      = $t->post_ok("/api/v1/$in/$id/comments" => form => {text => $text})->status_is(200, 'comment can be created');
     return $post->tx->res->json->{id};
 }
 
@@ -87,36 +93,43 @@ sub test_comments {
     };
 
     subtest 'create comment without text' => sub {
-        my $post = $t->post_ok("/api/v1/$in/$id/comments" => form => {text => ''})->status_is(400, 'comment can not be created without text');
+        my $post = $t->post_ok("/api/v1/$in/$id/comments" => form => {text => ''})
+          ->status_is(400, 'comment can not be created without text');
         is($post->tx->res->json->{error}, 'No/invalid text specified');
     };
 
     subtest 'create comment with invalid job or group' => sub {
-        my $post = $t->post_ok("/api/v1/$in/1234/comments" => form => {text => $test_message})->status_is(404, 'comment can not be created for invalid job/group');
+        my $post = $t->post_ok("/api/v1/$in/1234/comments" => form => {text => $test_message})
+          ->status_is(404, 'comment can not be created for invalid job/group');
         is($post->tx->res->json->{error}, $in eq 'jobs' ? 'Job 1234 does not exist' : 'Job group 1234 does not exist');
         test_get_comment_invalid_job_or_group($in, 1234, 35);
     };
 
     subtest 'update comment' => sub {
-        my $put = $t->put_ok("/api/v1/$in/$id/comments/$new_comment_id" => form => {text => $edited_test_message})->status_is(200, 'comment can be updated');
+        my $put = $t->put_ok("/api/v1/$in/$id/comments/$new_comment_id" => form => {text => $edited_test_message})
+          ->status_is(200, 'comment can be updated');
         test_get_comment($in, $id, $new_comment_id, $edited_test_message);
     };
 
     subtest 'update comment with invalid job or group' => sub {
-        my $put = $t->put_ok("/api/v1/$in/1234/comments/$new_comment_id" => form => {text => $edited_test_message})->status_is(404, 'comment can not be updated for invalid job/group');
+        my $put = $t->put_ok("/api/v1/$in/1234/comments/$new_comment_id" => form => {text => $edited_test_message})
+          ->status_is(404, 'comment can not be updated for invalid job/group');
         is($put->tx->res->json->{error}, $in eq 'jobs' ? 'Job 1234 does not exist' : 'Job group 1234 does not exist');
         test_get_comment_invalid_job_or_group('jobs', 1234, 35);
     };
 
     subtest 'update comment with invalid comment id' => sub {
-        my $put = $t->put_ok("/api/v1/$in/$id/comments/33546345" => form => {text => $edited_test_message})->status_is(404, 'comment can not be update for invalid comment ID');
+        my $put = $t->put_ok("/api/v1/$in/$id/comments/33546345" => form => {text => $edited_test_message})
+          ->status_is(404, 'comment can not be update for invalid comment ID');
         test_get_comment_invalid_job_or_group('jobs', 1234, 35);
     };
 
-    my $put = $t->put_ok("/api/v1/$in/$id/comments/$new_comment_id" => form => {text => ''})->status_is(400, 'comment can not be updated without text');
+    my $put = $t->put_ok("/api/v1/$in/$id/comments/$new_comment_id" => form => {text => ''})
+      ->status_is(400, 'comment can not be updated without text');
     test_get_comment($in, $id, $new_comment_id, $edited_test_message);
 
-    my $delete = $t->delete_ok("/api/v1/$in/$id/comments/$new_comment_id")->status_is(403, 'comment can not be deleted by unauthorized user');
+    my $delete = $t->delete_ok("/api/v1/$in/$id/comments/$new_comment_id")
+      ->status_is(403, 'comment can not be deleted by unauthorized user');
 }
 
 subtest 'job comments' => sub {
@@ -133,24 +146,29 @@ subtest 'admin can delete comments' => sub {
     $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
     $t->app($app);
     my $new_comment_id = test_create_comment(jobs => 99981, $test_message);
-    my $delete = $t->delete_ok("/api/v1/jobs/99981/comments/$new_comment_id")->status_is(200, 'comment can be deleted by admin');
+    my $delete
+      = $t->delete_ok("/api/v1/jobs/99981/comments/$new_comment_id")->status_is(200, 'comment can be deleted by admin');
     is($delete->tx->res->json->{id}, $new_comment_id, 'deleted comment was the requested one');
     test_get_comment_invalid_comment(jobs => 99981, $new_comment_id);
 
     subtest 'delete comment with invalid job or group' => sub {
-        my $delete = $t->delete_ok("/api/v1/jobs/1234/comments/$new_comment_id")->status_is(404, 'comment can be deleted for invalid job/group');
+        my $delete = $t->delete_ok("/api/v1/jobs/1234/comments/$new_comment_id")
+          ->status_is(404, 'comment can be deleted for invalid job/group');
         is($delete->tx->res->json->{error}, 'Job 1234 does not exist');
         test_get_comment_invalid_job_or_group('jobs', 1234, 35);
     };
 
     subtest 'delete comment with invalid comment id' => sub {
-        my $put = $t->put_ok("/api/v1/jobs/1234/comments/33546345" => form => {text => $edited_test_message})->status_is(404, 'comment can not be deleted for invalid comment ID');
+        my $put = $t->put_ok("/api/v1/jobs/1234/comments/33546345" => form => {text => $edited_test_message})
+          ->status_is(404, 'comment can not be deleted for invalid comment ID');
         test_get_comment_invalid_job_or_group('jobs', 1234, 35);
     };
 };
 
 subtest 'can not edit comment by other user' => sub {
-    my $put = $t->put_ok("/api/v1/jobs/99981/comments/1" => form => {text => $edited_test_message . $another_test_message})->status_is(403, 'editing comments by other users is forbidden');
+    my $put
+      = $t->put_ok("/api/v1/jobs/99981/comments/1" => form => {text => $edited_test_message . $another_test_message})
+      ->status_is(403, 'editing comments by other users is forbidden');
     test_get_comment(jobs => 99981, 1, $edited_test_message);
 };
 

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -46,15 +46,20 @@
         priority   => 56,
         result     => "incomplete",
         retry_avbl => 3,
-        settings   => [{key => 'DESKTOP', value => 'minimalx'}, {key => 'ISO', value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'}, {key => 'ISO_MAXSIZE', value => 737280000}, {key => 'ISO_1', value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'}],
-        ARCH       => 'x86_64',
-        BUILD      => '87.5011',
-        DISTRI     => 'opensuse',
-        FLAVOR     => 'staging_e',
-        TEST       => 'minimalx',
-        VERSION    => 'Factory',
-        MACHINE    => '32bit',
-        state      => "done",
+        settings   => [
+            {key => 'DESKTOP',     value => 'minimalx'},
+            {key => 'ISO',         value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'},
+            {key => 'ISO_MAXSIZE', value => 737280000},
+            {key => 'ISO_1',       value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'}
+        ],
+        ARCH    => 'x86_64',
+        BUILD   => '87.5011',
+        DISTRI  => 'opensuse',
+        FLAVOR  => 'staging_e',
+        TEST    => 'minimalx',
+        VERSION => 'Factory',
+        MACHINE => '32bit',
+        state   => "done",
         # One hour ago
         t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),
         # Two hours ago
@@ -82,7 +87,16 @@
         MACHINE    => '32bit',
         BUILD      => '0091',
         VERSION    => '13.1',
-        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'INSTALLONLY', value => '1'}, {key => 'RAIDLEVEL', value => '0'}, {key => 'DVD', value => '1'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'LIVETEST', value => '1'},]
+        settings   => [
+            {key => 'QEMUCPU',     value => 'qemu32'},
+            {key => 'INSTALLONLY', value => '1'},
+            {key => 'RAIDLEVEL',   value => '0'},
+            {key => 'DVD',         value => '1'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'LIVETEST',    value => '1'},
+        ]
     },
     Jobs => {
         id       => 99928,
@@ -102,7 +116,15 @@
         ARCH       => 'i586',
         VERSION    => '13.1',
         MACHINE    => '32bit',
-        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'INSTALLONLY', value => '1'}, {key => 'RAIDLEVEL', value => '1'}, {key => 'DVD', value => '1'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},]
+        settings   => [
+            {key => 'QEMUCPU',     value => 'qemu32'},
+            {key => 'INSTALLONLY', value => '1'},
+            {key => 'RAIDLEVEL',   value => '1'},
+            {key => 'DVD',         value => '1'},
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},
+        ]
     },
     Jobs => {
         id         => 99937,
@@ -123,7 +145,12 @@
         DISTRI      => 'opensuse',
         MACHINE     => '32bit',
         result_dir  => '00099937-opensuse-13.1-DVD-i586-Build0091-kde',
-        settings => [{key => 'DVD', value => '1'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'QEMUCPU', value => 'qemu32'}]
+        settings    => [
+            {key => 'DVD',         value => '1'},
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},
+            {key => 'QEMUCPU',     value => 'qemu32'}]
     },
     Jobs => {
         id       => 99938,
@@ -147,7 +174,12 @@
         backend    => 'qemu',
         retry_avbl => 3,
         result_dir => '00099938-opensuse-Factory-DVD-x86_64-Build0048-doc',
-        settings => [{key => 'DVD', value => '1'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}]
+        settings   => [
+            {key => 'DVD',         value => '1'},
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'},
+            {key => 'QEMUCPU',     value => 'qemu64'}]
     },
     Jobs => {
         id       => 99936,
@@ -168,7 +200,14 @@
         DISTRI     => 'opensuse',
         MACHINE    => '64bit-uefi',
         retry_avbl => 3,
-        settings => [{key => 'DVD', value => '1'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}, {key => 'HDD_1', value => 'openSUSE-13.1-x86_64.hda'},]
+        settings   => [
+            {key => 'DVD',         value => '1'},
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'},
+            {key => 'QEMUCPU',     value => 'qemu64'},
+            {key => 'HDD_1',       value => 'openSUSE-13.1-x86_64.hda'},
+        ]
     },
     Jobs => {
         id       => 99939,
@@ -193,7 +232,14 @@
         retry_avbl => 3,
         # no result dir, let us assume that this is an old test that has
         # already be pruned
-        settings => [{key => 'DVD', value => '1'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}, {key => 'HDD_1', value => 'openSUSE-13.1-x86_64.hda'},]
+        settings => [
+            {key => 'DVD',         value => '1'},
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'},
+            {key => 'QEMUCPU',     value => 'qemu64'},
+            {key => 'HDD_1',       value => 'openSUSE-13.1-x86_64.hda'},
+        ]
     },
     Jobs => {
         id       => 99940,
@@ -217,7 +263,12 @@
         backend    => 'qemu',
         retry_avbl => 3,
         result_dir => '00099938-opensuse-Factory-DVD-x86_64-Build0048-doc',
-        settings => [{key => 'DVD', value => '1'}, {key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'}, {key => 'QEMUCPU', value => 'qemu64'}]
+        settings   => [
+            {key => 'DVD',         value => '1'},
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'},
+            {key => 'QEMUCPU',     value => 'qemu64'}]
     },
     Jobs => {
         id       => 99946,
@@ -242,7 +293,15 @@
         jobs_assets => [{asset_id => 1}, {asset_id => 5}],
         retry_avbl  => 3,
         result_dir  => '00099946-opensuse-13.1-DVD-i586-Build0091-textmode',
-        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'HDD_1', value => 'openSUSE-13.1-x86_64.hda'},]
+        settings    => [
+            {key => 'QEMUCPU',     value => 'qemu32'},
+            {key => 'DVD',         value => '1'},
+            {key => 'VIDEOMODE',   value => 'text'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},
+            {key => 'DESKTOP',     value => 'textmode'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'HDD_1',       value => 'openSUSE-13.1-x86_64.hda'},
+        ]
     },
     Jobs => {
         id         => 99945,
@@ -264,7 +323,13 @@
         ARCH       => 'i586',
         jobs_assets => [{asset_id => 1},],
         retry_avbl  => 3,
-        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}]
+        settings    => [
+            {key => 'QEMUCPU',     value => 'qemu32'},
+            {key => 'DVD',         value => '1'},
+            {key => 'VIDEOMODE',   value => 'text'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},
+            {key => 'DESKTOP',     value => 'textmode'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'}]
     },
     Jobs => {
         id         => 99944,
@@ -286,7 +351,13 @@
         ARCH       => 'i586',
         jobs_assets => [{asset_id => 1},],
         retry_avbl  => 3,
-        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}]
+        settings    => [
+            {key => 'QEMUCPU',     value => 'qemu32'},
+            {key => 'DVD',         value => '1'},
+            {key => 'VIDEOMODE',   value => 'text'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},
+            {key => 'DESKTOP',     value => 'textmode'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'}]
     },
     Jobs => {
         id         => 99947,
@@ -307,7 +378,13 @@
         ARCH       => 'i586',
         jobs_assets => [{asset_id => 1},],
         retry_avbl  => 3,
-        settings => [{key => 'QEMUCPU', value => 'qemu32'}, {key => 'DVD', value => '1'}, {key => 'VIDEOMODE', value => 'text'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0092-Media.iso'}, {key => 'DESKTOP', value => 'textmode'}, {key => 'ISO_MAXSIZE', value => '4700372992'}]
+        settings    => [
+            {key => 'QEMUCPU',     value => 'qemu32'},
+            {key => 'DVD',         value => '1'},
+            {key => 'VIDEOMODE',   value => 'text'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-i586-Build0092-Media.iso'},
+            {key => 'DESKTOP',     value => 'textmode'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'}]
     },
     Jobs => {
         id         => 99963,
@@ -328,7 +405,12 @@
         jobs_assets => [{asset_id => 2},],
         retry_avbl  => 3,
         ARCH        => 'x86_64',
-        settings   => [{key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'}, {key => 'DVD', value => '1'}],
+        settings    => [
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},
+            {key => 'DVD',         value => '1'}
+        ],
         result_dir => '00099963-opensuse-13.1-DVD-x86_64-Build0091-kde',
     },
     Jobs => {
@@ -352,7 +434,12 @@
         retry_avbl  => 3,
         ARCH        => 'x86_64',
         result_dir  => '00099962-opensuse-13.1-DVD-x86_64-Build0091-kde',
-        settings => [{key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'}, {key => 'DVD', value => '1'},]
+        settings    => [
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},
+            {key => 'DVD',         value => '1'},
+        ]
     },
     Jobs => {
         id         => 99981,
@@ -373,7 +460,16 @@
         DISTRI    => 'opensuse',
         jobs_assets => [{asset_id => 3},],
         retry_avbl  => 3,
-        settings => [{key => 'DESKTOP', value => 'gnome'}, {key => 'ISO_MAXSIZE', value => '999999999'}, {key => 'LIVECD', value => '1'}, {key => 'ISO', value => 'openSUSE-13.1-GNOME-Live-i686-Build0091-Media.iso'}, {key => 'RAIDLEVEL', value => '0'}, {key => 'INSTALLONLY', value => '1'}, {key => 'GNOME', value => '1'}, {key => 'QEMUCPU', value => 'qemu32'},]
+        settings    => [
+            {key => 'DESKTOP',     value => 'gnome'},
+            {key => 'ISO_MAXSIZE', value => '999999999'},
+            {key => 'LIVECD',      value => '1'},
+            {key => 'ISO',         value => 'openSUSE-13.1-GNOME-Live-i686-Build0091-Media.iso'},
+            {key => 'RAIDLEVEL',   value => '0'},
+            {key => 'INSTALLONLY', value => '1'},
+            {key => 'GNOME',       value => '1'},
+            {key => 'QEMUCPU',     value => 'qemu32'},
+        ]
     },
     Jobs => {
         id         => 99961,
@@ -397,7 +493,12 @@
         jobs_assets => [{asset_id => 2}, {asset_id => 6},],
         retry_avbl  => 3,
         result_dir  => '00099961-opensuse-13.1-DVD-x86_64-Build0091-kde',
-        settings => [{key => 'DESKTOP', value => 'kde'}, {key => 'ISO_MAXSIZE', value => '4700372992'}, {key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'}, {key => 'DVD', value => '1'},]
+        settings    => [
+            {key => 'DESKTOP',     value => 'kde'},
+            {key => 'ISO_MAXSIZE', value => '4700372992'},
+            {key => 'ISO',         value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},
+            {key => 'DVD',         value => '1'},
+        ]
     },
 ]
 # vim: set sw=4 et:

--- a/t/fixtures/04-products.pl
+++ b/t/fixtures/04-products.pl
@@ -1,100 +1,108 @@
-#<<< do not let perltidy touch this
 [
     Machines => {
-        id => 1001,
-        name => '32bit',
-        backend => 'qemu',
+        id        => 1001,
+        name      => '32bit',
+        backend   => 'qemu',
         variables => '',
-        settings => [{ key => "QEMUCPU", value => "qemu32" },],
+        settings  => [{key => "QEMUCPU", value => "qemu32"},],
     },
     Machines => {
-        id => 1002,
-        name => '64bit',
-        backend => 'qemu',
+        id        => 1002,
+        name      => '64bit',
+        backend   => 'qemu',
         variables => '',
-        settings => [{ key => "QEMUCPU", value => "qemu64" },],
+        settings  => [{key => "QEMUCPU", value => "qemu64"},],
     },
     Machines => {
-        id => 1008,
-        name => 'Laptop_64',
-        backend => 'qemu',
+        id        => 1008,
+        name      => 'Laptop_64',
+        backend   => 'qemu',
         variables => '',
-        settings => [{ key => "QEMUCPU", value => "qemu64" },{ key => "LAPTOP", value => "1" },],
+        settings  => [{key => "QEMUCPU", value => "qemu64"}, {key => "LAPTOP", value => "1"},],
     },
 
     TestSuites => {
-        id => 1001,
-        name => "textmode",
+        id        => 1001,
+        name      => "textmode",
         variables => '',
-        settings => [{ key => "DESKTOP", value => "textmode" },{ key => "VIDEOMODE", value => "text" },],
+        settings  => [{key => "DESKTOP", value => "textmode"}, {key => "VIDEOMODE", value => "text"},],
     },
 
     TestSuites => {
-        id => 1002,
-        name => "kde",
+        id        => 1002,
+        name      => "kde",
         variables => '',
-        settings => [{ key => "DESKTOP", value => "kde" }],
+        settings  => [{key => "DESKTOP", value => "kde"}],
     },
 
     TestSuites => {
-        id => 1013,
-        name => "RAID0",
+        id        => 1013,
+        name      => "RAID0",
         variables => '',
-        settings => [{ key => "RAIDLEVEL", value => 0 },{ key => "INSTALLONLY", value => 1 },{ key => "DESKTOP", value => "kde" },],
+        settings =>
+          [{key => "RAIDLEVEL", value => 0}, {key => "INSTALLONLY", value => 1}, {key => "DESKTOP", value => "kde"},],
     },
 
     TestSuites => {
-        id => 1014,
-        name => "client1",
+        id        => 1014,
+        name      => "client1",
         variables => '',
-        settings => [{ key => "DESKTOP", value => "kde" }, { key => "PARALLEL_WITH", value => "server" }],
+        settings  => [{key => "DESKTOP", value => "kde"}, {key => "PARALLEL_WITH", value => "server"}],
     },
 
     TestSuites => {
-        id => 1015,
-        name => "server",
+        id        => 1015,
+        name      => "server",
         variables => '',
-        settings => [{ key => "DESKTOP", value => "textmode" }],
+        settings  => [{key => "DESKTOP", value => "textmode"}],
     },
 
     TestSuites => {
-        id => 1016,
-        name => "client2",
+        id        => 1016,
+        name      => "client2",
         variables => '',
-        settings => [{ key => "DESKTOP", value => "textmode" }, { key => "PARALLEL_WITH", value => "server" }],
+        settings  => [{key => "DESKTOP", value => "textmode"}, {key => "PARALLEL_WITH", value => "server"}],
     },
 
     TestSuites => {
-        id => 1017,
-        name => "advanced_kde",
+        id        => 1017,
+        name      => "advanced_kde",
         variables => '',
-        settings => [{ key => "DESKTOP", value => "kde" }, { key => "START_AFTER_TEST", value => "kde,textmode" }, { key => "PUBLISH_HDD_1", value => "%DISTRI%-%VERSION%-%ARCH%-%DESKTOP%-%QEMUCPU%.qcow2" }],
+        settings  => [
+            {key => "DESKTOP",          value => "kde"},
+            {key => "START_AFTER_TEST", value => "kde,textmode"},
+            {key => "PUBLISH_HDD_1",    value => "%DISTRI%-%VERSION%-%ARCH%-%DESKTOP%-%QEMUCPU%.qcow2"}
+        ],
     },
     Products => {
-		 name => '',
-		 distri => 'opensuse',
-		 version => '13.1',
-		 flavor => 'DVD',
-		 arch => 'i586',
-		 variables => '',
-		 settings => [
-			      { key => "ISO_MAXSIZE",
-			        value => 4_700_372_992 },
-			      { key => "DVD",
-			        value => "1" },
-			     ],
-		 job_templates => [
-				   { machine => { name => '32bit' }, test_suite => { name => 'textmode' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '64bit' }, test_suite => { name => 'kde' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '32bit' }, test_suite => { name => 'client1' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '32bit' }, test_suite => { name => 'client2' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '32bit' }, test_suite => { name => 'server' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '32bit' }, test_suite => { name => 'advanced_kde' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '64bit' }, test_suite => { name => 'client1' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '64bit' }, test_suite => { name => 'client2' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '64bit' }, test_suite => { name => 'server' }, prio => 40, group_id => 1001 },
-				   { machine => { name => '64bit' }, test_suite => { name => 'advanced_kde' }, prio => 40, group_id => 1001 },],
+        name      => '',
+        distri    => 'opensuse',
+        version   => '13.1',
+        flavor    => 'DVD',
+        arch      => 'i586',
+        variables => '',
+        settings  => [
+            {
+                key   => "ISO_MAXSIZE",
+                value => 4_700_372_992
+            },
+            {
+                key   => "DVD",
+                value => "1"
+            },
+        ],
+        job_templates => [
+            {machine => {name => '32bit'}, test_suite => {name => 'textmode'},     prio => 40, group_id => 1001},
+            {machine => {name => '64bit'}, test_suite => {name => 'kde'},          prio => 40, group_id => 1001},
+            {machine => {name => '32bit'}, test_suite => {name => 'client1'},      prio => 40, group_id => 1001},
+            {machine => {name => '32bit'}, test_suite => {name => 'client2'},      prio => 40, group_id => 1001},
+            {machine => {name => '32bit'}, test_suite => {name => 'server'},       prio => 40, group_id => 1001},
+            {machine => {name => '32bit'}, test_suite => {name => 'advanced_kde'}, prio => 40, group_id => 1001},
+            {machine => {name => '64bit'}, test_suite => {name => 'client1'},      prio => 40, group_id => 1001},
+            {machine => {name => '64bit'}, test_suite => {name => 'client2'},      prio => 40, group_id => 1001},
+            {machine => {name => '64bit'}, test_suite => {name => 'server'},       prio => 40, group_id => 1001},
+            {machine => {name => '64bit'}, test_suite => {name => 'advanced_kde'}, prio => 40, group_id => 1001},
+        ],
     },
 ]
-#>>>
 # vim: set sw=4 et:

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -72,8 +72,16 @@ like((shift @tds)->get_text(), qr/about 3 hours ago/, "finish time of 99946");
 
 # Test 99963 is still running
 isnt($driver->find_element('#running #job_99963', 'css'), undef, '99963 still running');
-is($driver->find_element('#running #job_99963 td.test a', 'css')->get_attribute('href'), "$baseurl" . "tests/99963", 'right link');
-like($driver->find_element('#running #job_99963 td.time', 'css')->get_text(), qr/1[01] minutes ago/, 'right time for running');
+is(
+    $driver->find_element('#running #job_99963 td.test a', 'css')->get_attribute('href'),
+    "$baseurl" . "tests/99963",
+    'right link'
+);
+like(
+    $driver->find_element('#running #job_99963 td.time', 'css')->get_text(),
+    qr/1[01] minutes ago/,
+    'right time for running'
+);
 
 $get = $t->get_ok('/tests')->status_is(200);
 my @header = $t->tx->res->dom->find('h2')->map('text')->each;
@@ -89,14 +97,22 @@ $get = $t->get_ok('/tests/99963')->status_is(200);
 $t->content_like(qr/State.*running/, "Running jobs are marked");
 
 $driver->find_element('Build0091', 'link_text')->click();
-like($driver->find_element('#summary', 'css')->get_text(), qr/Overall Summary of opensuse build 0091/, 'we are on build 91');
+like(
+    $driver->find_element('#summary', 'css')->get_text(),
+    qr/Overall Summary of opensuse build 0091/,
+    'we are on build 91'
+);
 
 # return
 is($driver->get($baseurl . "tests"), 1, "/tests gets");
 
 # Test 99928 is scheduled
 isnt($driver->find_element('#scheduled #job_99928', 'css'), undef, '99928 scheduled');
-is($driver->find_element('#scheduled #job_99928 td.test a', 'css')->get_attribute('href'), "$baseurl" . "tests/99928", 'right link');
+is(
+    $driver->find_element('#scheduled #job_99928 td.test a', 'css')->get_attribute('href'),
+    "$baseurl" . "tests/99928",
+    'right link'
+);
 $driver->find_element('#scheduled #job_99928 td.test a', 'css')->click();
 is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-RAID1@32bit test results', 'tests/99928 followed');
 
@@ -107,9 +123,14 @@ is($driver->get($baseurl . "tests"), 1, "/tests gets");
 my $job99938 = $driver->find_element('#results #job_99946', 'css');
 
 is($driver->find_element('#results #job_99938 .test .status.result_failed', 'css')->get_text(), '', '99938 failed');
-is($driver->find_element('#results #job_99938 td.test a', 'css')->get_attribute('href'), "$baseurl" . "tests/99938", 'right link');
+is(
+    $driver->find_element('#results #job_99938 td.test a', 'css')->get_attribute('href'),
+    "$baseurl" . "tests/99938",
+    'right link'
+);
 $driver->find_element('#results #job_99938 td.test a', 'css')->click();
-is($driver->get_title(), 'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results', 'tests/99938 followed');
+is($driver->get_title(), 'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results',
+    'tests/99938 followed');
 
 # return
 is($driver->get($baseurl . "tests"), 1, "/tests gets");
@@ -119,7 +140,8 @@ my @links = $driver->find_elements('#results #job_99946 td.test a', 'css');
 is(@links, 2, 'only two links (icon, name, no restart)');
 
 # Test 99926 is displayed
-is($driver->find_element('#results #job_99926 .test .status.result_incomplete', 'css')->get_text(), '', '99926 incomplete');
+is($driver->find_element('#results #job_99926 .test .status.result_incomplete', 'css')->get_text(),
+    '', '99926 incomplete');
 
 # parent-child
 my $child_e = $driver->find_element('#results #job_99938 .parent_child', 'css');
@@ -135,13 +157,21 @@ is($parent_e->get_attribute('data-parents'),  "[]",              "no parents");
 # first check the relevant jobs
 my @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
 
-is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99937 job_99981)], '99945 is not displayed');
+is_deeply(
+    \@jobs,
+    [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99937 job_99981)],
+    '99945 is not displayed'
+);
 $driver->find_element('#relevantfilter', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax();
 
 # Test 99945 is not longer relevant (replaced by 99946) - but displayed for all
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99945 job_99944)], 'all rows displayed');
+is_deeply(
+    \@jobs,
+    [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99945 job_99944)],
+    'all rows displayed'
+);
 
 # now toggle back
 #print $driver->get_page_source();
@@ -149,7 +179,11 @@ $driver->find_element('#relevantfilter', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax();
 
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
-is_deeply(\@jobs, [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99937 job_99981)], '99945 again hidden');
+is_deeply(
+    \@jobs,
+    [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99937 job_99981)],
+    '99945 again hidden'
+);
 
 $driver->get($baseurl . "tests?match=staging_e");
 t::ui::PhantomTest::wait_for_ajax();

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -84,7 +84,8 @@ $req = $t->get_ok('/api_keys')->status_is(200);
 $req->content_like(qr/API key not found/, 'error is displayed');
 
 # Try to create an API key for Lancelot
-$req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {user_id => 99902, user => 99902})->status_is(302);
+$req
+  = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {user_id => 99902, user => 99902})->status_is(302);
 $req = $t->get_ok('/api_keys')->status_is(200);
 $req->element_exists('#api_key_99902', 'Percival keys are there');
 $req->element_exists('#api_key_99908', 'and the new one belongs to Percival, not Lancelot');

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -30,41 +30,47 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 #
 # No login, no user-info and no api_keys
-my $res = OpenQA::Test::Case::trim_whitespace($t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
+my $res = OpenQA::Test::Case::trim_whitespace(
+    $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
 is($res, 'Login', 'no-one logged in');
 $t->get_ok('/api_keys')->status_is(302);
 
 # So let's log in as an unpriviledged user
 $test_case->login($t, 'https://openid.camelot.uk/lancelot');
 # ...who should see a logout option but no link to API keys
-$res = OpenQA::Test::Case::trim_whitespace($t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
+$res = OpenQA::Test::Case::trim_whitespace(
+    $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
 is($res, 'Logged in as lance Logout', 'lance is logged in');
 $t->get_ok('/api_keys')->status_is(403);
 
 #
 # Then logout
 $t->delete_ok('/logout')->status_is(302);
-$res = OpenQA::Test::Case::trim_whitespace($t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
+$res = OpenQA::Test::Case::trim_whitespace(
+    $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
 is($res, 'Login', 'no-one logged in');
 
 #
 # Try creating new user by logging in
 $test_case->login($t, 'morgana');
 # ...who should see a logout option but no link to API keys
-$res = OpenQA::Test::Case::trim_whitespace($t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
+$res = OpenQA::Test::Case::trim_whitespace(
+    $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
 is($res, 'Logged in as morgana Logout', 'morgana as no api keys');
 $t->get_ok('/api_keys')->status_is(403);
 
 #
 # Then logout
 $t->delete_ok('/logout')->status_is(302);
-$res = OpenQA::Test::Case::trim_whitespace($t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
+$res = OpenQA::Test::Case::trim_whitespace(
+    $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
 is($res, 'Login', 'no-one logged in');
 
 #
 # And log in as operator
 $test_case->login($t, 'percival');
-my $actions = OpenQA::Test::Case::trim_whitespace($t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
+my $actions = OpenQA::Test::Case::trim_whitespace(
+    $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
 like($actions, qr/Logged in as perci Operators Menu.*Manage API keys Logout/, 'perci has operator links');
 unlike($actions, qr/Administrators Menu/, 'perci has no admin links');
 

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -81,7 +81,8 @@ is($driver->find_element('#user-action', 'css')->get_text(), 'Logged in as Demo'
 $driver->find_element('#user-action a', 'css')->click();
 $driver->find_element('Users',          'link_text')->click;
 $driver->execute_script('$("#users").off("change")');
-$driver->execute_script('$("#users").on("change", "input[name=\"role\"]:radio", function() {$(this).parent("form").submit();})');
+$driver->execute_script(
+    '$("#users").on("change", "input[name=\"role\"]:radio", function() {$(this).parent("form").submit();})');
 $driver->find_element('//tr[./td[@class="nick" and text()="Demo"]]/td[@class="role"]//label[2]')->click;
 
 # refresh and return to admin pages

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -39,11 +39,13 @@ $test_case->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # Exact size of logpackages-1.png
-$t->get_ok('/tests/99938/images/logpackages-1.png')->status_is(200)->content_type_is('image/png')->header_is('Content-Length' => '48019');
+$t->get_ok('/tests/99938/images/logpackages-1.png')->status_is(200)->content_type_is('image/png')
+  ->header_is('Content-Length' => '48019');
 
 $t->get_ok('/tests/99937/../99938/images/logpackages-1.png')->status_is(404);
 
-$t->get_ok('/tests/99938/images/thumb/logpackages-1.png')->status_is(200)->content_type_is('image/png')->header_is('Content-Length' => '6769');
+$t->get_ok('/tests/99938/images/thumb/logpackages-1.png')->status_is(200)->content_type_is('image/png')
+  ->header_is('Content-Length' => '6769');
 
 # Not the same logpackages-1.png
 $t->get_ok('/tests/99946/images/logpackages-1.png')->header_is('Content-Length' => '211');
@@ -60,30 +62,37 @@ $t->get_ok('/tests/99938/file/y2logs.tar.bz2')->status_is(200);
 
 $t->get_ok('/tests/99938/file/ulogs/y2logs.tar.bz2')->status_is(404);
 
-$t->get_ok('/tests/99946/iso')->status_is(200)->header_is('Content-Disposition' => "attatchment; filename=openSUSE-13.1-DVD-i586-Build0091-Media.iso;");
+$t->get_ok('/tests/99946/iso')->status_is(200)
+  ->header_is('Content-Disposition' => "attatchment; filename=openSUSE-13.1-DVD-i586-Build0091-Media.iso;");
 
 # check the download links
 my $req = $t->get_ok('/tests/99946')->status_is(200);
 $req->element_exists('#downloads #asset_1');
 $req->element_exists('#downloads #asset_5');
 my $res = OpenQA::Test::Case::trim_whitespace($req->tx->res->dom->at('#downloads #asset_1')->text);
-is($res,                                                  "openSUSE-13.1-DVD-i586-Build0091-Media.iso");
-is($req->tx->res->dom->at('#downloads #asset_1')->{href}, '/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso');
+is($res, "openSUSE-13.1-DVD-i586-Build0091-Media.iso");
+is($req->tx->res->dom->at('#downloads #asset_1')->{href},
+    '/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso');
 $res = OpenQA::Test::Case::trim_whitespace($req->tx->res->dom->at('#downloads #asset_5')->text);
 is($res,                                                  "openSUSE-13.1-x86_64.hda");
 is($req->tx->res->dom->at('#downloads #asset_5')->{href}, '/tests/99946/asset/hdd/openSUSE-13.1-x86_64.hda');
 
 # downloads are currently redirects
-$req = $t->get_ok('/tests/99946/asset/1')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
-$req = $t->get_ok('/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
+$req = $t->get_ok('/tests/99946/asset/1')->status_is(302)
+  ->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
+$req = $t->get_ok('/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(302)
+  ->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
 
-$req = $t->get_ok('/tests/99946/asset/5')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/hdd\/fixed\/openSUSE-13.1-x86_64.hda/);
+$req = $t->get_ok('/tests/99946/asset/5')->status_is(302)
+  ->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/hdd\/fixed\/openSUSE-13.1-x86_64.hda/);
 
 # verify error on invalid downloads
 $t->get_ok('/tests/99946/asset/iso/foobar.iso')->status_is(404);
 
-$t->get_ok('/tests/99961/asset/repo/testrepo/README')->status_is(302)->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/repo\/testrepo\/README/);
-$t->get_ok('/tests/99961/asset/repo/testrepo/README/../README')->status_is(400)->content_is('invalid character in path');
+$t->get_ok('/tests/99961/asset/repo/testrepo/README')->status_is(302)
+  ->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/repo\/testrepo\/README/);
+$t->get_ok('/tests/99961/asset/repo/testrepo/README/../README')->status_is(400)
+  ->content_is('invalid character in path');
 
 # verify 404 on download_assets - to be handled by apache (for now at least)
 $t->get_ok('/assets/repo/testrepo/README')->status_is(404);

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -87,7 +87,8 @@ $get->element_exists('#res_DVD_x86_64_kde .result_softfailed');
 $get->element_exists_not('#res_DVD_i586_doc');
 $get->element_exists_not('#res_DVD_i686_doc');
 
-my $failedmodules = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#res_DVD_x86_64_doc .failedmodule a')->all_text);
+my $failedmodules
+  = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#res_DVD_x86_64_doc .failedmodule a')->all_text);
 like($failedmodules, qr/logpackages/i, "failed modules are listed");
 
 #
@@ -119,7 +120,8 @@ like($summary, qr/Summary of opensuse Factory build 87.5011/);
 like($summary, qr/Passed: 0 Incomplete: 1 Failed: 0/);
 
 # Advanced query parameters can be forwarded
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', result => 'passed'})->status_is(200);
+$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', result => 'passed'})
+  ->status_is(200);
 $summary = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#summary')->all_text);
 like($summary, qr/Summary of opensuse 13\.1 build 0091/i, "Still references the last build");
 like($summary, qr/Passed: 2 Failed: 0/i, "Only passed are shown");
@@ -132,13 +134,17 @@ $get->element_exists_not('.result_failed');
 $get->element_exists_not('.state_cancelled');
 
 # This time show only failed
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', result => 'failed'})->status_is(200);
+$get
+  = $t->get_ok(
+    '/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', result => 'failed'})
+  ->status_is(200);
 $summary = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#summary')->all_text);
 like($summary, qr/Passed: 0 Failed: 1/i);
 $get->element_exists('#res_DVD_x86_64_doc .result_failed');
 $get->element_exists_not('#res_DVD_x86_64_kde .result_passed');
 
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', todo => 1})->status_is(200);
+$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', todo => 1})
+  ->status_is(200);
 $summary = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#summary')->all_text);
 like($summary, qr/Passed: 0 Soft Failure: 2 Failed: 1/i, 'todo=1 shows all unlabeled failed');
 
@@ -148,7 +154,10 @@ like($summary, qr/Passed: 0 Soft Failure: 2 Failed: 1/i, 'todo=1 shows all unlab
 #
 
 # Test initial state of architecture text box
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', result => 'passed', arch => 'i686'})->status_is(200);
+$get
+  = $t->get_ok(
+    '/tests/overview' => form => {distri => 'opensuse', version => 'Factory', result => 'passed', arch => 'i686'})
+  ->status_is(200);
 # FIXME: works when testing manually, but accessing the value via Mojo doesn't work
 #is($t->tx->res->dom->at('#filter-arch')->val, 'i686', 'default state of architecture');
 
@@ -167,7 +176,8 @@ my @filtered_out = $driver->find_elements('#res_DVD_x86_64_kde', 'css');
 is(scalar @filtered_out, 0, 'result filter correctly applied');
 
 # Test whether all URL parameter are passed correctly
-my $url_with_escaped_parameters = $baseurl . 'tests/overview?arch=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001';
+my $url_with_escaped_parameters
+  = $baseurl . 'tests/overview?arch=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001';
 $driver->get($url_with_escaped_parameters);
 $driver->find_element('#filter-panel .panel-heading', 'css')->click();
 $driver->find_element('#filter-form button',          'css')->click();
@@ -178,10 +188,12 @@ $driver->get($baseurl . 'tests/overview?distri=opensuse&version=13.1&build=0091&
 my $fmod = $driver->find_elements('.failedmodule', 'css')->[1];
 $driver->mouse_move_to_location(element => $fmod, xoffset => 8, yoffset => 8);
 t::ui::PhantomTest::wait_for_ajax;
-like($driver->find_elements('.failedmodule a', 'css')->[1]->get_attribute('href'), qr/\/3$/, 'ajax update failed module step');
+like($driver->find_elements('.failedmodule a', 'css')->[1]->get_attribute('href'),
+    qr/\/3$/, 'ajax update failed module step');
 
 $t->get_ok('/tests/99937/modules/kate/fails')->json_is('/failed_needles' => ["test-kate-1"], 'correct failed needles');
-$t->get_ok('/tests/99937/modules/zypper_up/fails')->json_is('/first_failed_step' => 1, 'failed module: fallback to first step');
+$t->get_ok('/tests/99937/modules/zypper_up/fails')
+  ->json_is('/first_failed_step' => 1, 'failed module: fallback to first step');
 
 t::ui::PhantomTest::kill_phantom();
 

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -58,7 +58,8 @@ remove_tree($dir);
 make_path($dir);
 
 # default needle JSON content
-my $default_json = '{"area" : [{"height" : 217,"type" : "match","width" : 384,"xpos" : 0,"ypos" : 0}],"tags" : ["ENV-VIDEOMODE-text","inst-timezone"]}';
+my $default_json
+  = '{"area" : [{"height" : 217,"type" : "match","width" : 384,"xpos" : 0,"ypos" : 0}],"tags" : ["ENV-VIDEOMODE-text","inst-timezone"]}';
 
 # create a fake json
 my $filen = "$dir/inst-timezone-text.json";
@@ -91,7 +92,11 @@ sub goto_editpage() {
     is($driver->find_element('#user-action', 'css')->get_text(), 'Logged in as Demo', "logged in as demo");
 
     $driver->get($baseurl . "tests/99946");
-    is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results', 'tests/99946 followed');
+    is(
+        $driver->get_title(),
+        'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results',
+        'tests/99946 followed'
+    );
 
     open_needle_editor;
 
@@ -104,14 +109,15 @@ sub editpage_layout_check() {
     t::ui::PhantomTest::wait_for_ajax;
 
     # layout check
-    is($driver->find_element('#tags_select',  'css')->get_value(),   'inst-timezone-text', "inst-timezone tags selected");
-    is($driver->find_element('#image_select', 'css')->get_value(),   'screenshot',         "Screenshot background selected");
-    is($driver->find_element('#area_select',  'css')->get_value(),   'inst-timezone-text', "inst-timezone areas selected");
-    is($driver->find_element('#take_matches', 'css')->is_selected(), 1,                    "Matches selected");
+    is($driver->find_element('#tags_select', 'css')->get_value(), 'inst-timezone-text', "inst-timezone tags selected");
+    is($driver->find_element('#image_select', 'css')->get_value(), 'screenshot', "Screenshot background selected");
+    is($driver->find_element('#area_select', 'css')->get_value(), 'inst-timezone-text', "inst-timezone areas selected");
+    is($driver->find_element('#take_matches', 'css')->is_selected(), 1, "Matches selected");
 
     # check needle suggested name
     my $today = strftime("%Y%m%d", gmtime(time));
-    is($driver->find_element('#needleeditor_name', 'css')->get_value(), "inst-timezone-text-$today", "has correct needle name");
+    is($driver->find_element('#needleeditor_name', 'css')->get_value(),
+        "inst-timezone-text-$today", "has correct needle name");
 
     # ENV-VIDEOMODE-text and inst-timezone tag are selected
     is($driver->find_element('//input[@value="inst-timezone"]')->is_selected(), 1, "tag selected");
@@ -153,9 +159,17 @@ sub change_needle_value($$) {
     $decode_textarea = decode_json($elem->get_value());
 
     $elem = $driver->find_element('#needleeditor_canvas', 'css');
-    $driver->mouse_move_to_location(element => $elem, xoffset => $decode_textarea->{area}[0]->{xpos} + $pre_offset, yoffset => $decode_textarea->{area}[0]->{ypos} + $pre_offset);
+    $driver->mouse_move_to_location(
+        element => $elem,
+        xoffset => $decode_textarea->{area}[0]->{xpos} + $pre_offset,
+        yoffset => $decode_textarea->{area}[0]->{ypos} + $pre_offset
+    );
     $driver->button_down();
-    $driver->mouse_move_to_location(element => $elem, xoffset => $decode_textarea->{area}[0]->{xpos} + $xoffset + $pre_offset, yoffset => $decode_textarea->{area}[0]->{ypos} + $yoffset + $pre_offset);
+    $driver->mouse_move_to_location(
+        element => $elem,
+        xoffset => $decode_textarea->{area}[0]->{xpos} + $xoffset + $pre_offset,
+        yoffset => $decode_textarea->{area}[0]->{ypos} + $yoffset + $pre_offset
+    );
     $driver->button_up();
     t::ui::PhantomTest::wait_for_ajax;
     $elem = $driver->find_element('#needleeditor_textarea', 'css');
@@ -175,7 +189,8 @@ sub change_needle_value($$) {
     is($decode_new_textarea->{area}[0]->{type}, "ocr", "type is ocr");
     $driver->double_click;    # the match type change back to match
 
-    unlike($driver->find_element('#change-match', 'css')->get_attribute('class'), qr/disabled/, "match level now enabled");
+    unlike($driver->find_element('#change-match', 'css')->get_attribute('class'),
+        qr/disabled/, "match level now enabled");
 
     # test match level
     $driver->find_element('#change-match', 'css')->click();
@@ -210,18 +225,30 @@ sub overwrite_needle($) {
     my $diag;
     $diag = $driver->find_element('#modal-overwrite', 'css');
     is($driver->find_child_element($diag, '.modal-title', 'css')->is_displayed(), 1, "We can see the overwrite dialog");
-    is($driver->find_child_element($diag, '.modal-title', 'css')->get_text(), "Sure to overwrite test-newneedle?", "Needle part of the title");
+    is(
+        $driver->find_child_element($diag, '.modal-title', 'css')->get_text(),
+        "Sure to overwrite test-newneedle?",
+        "Needle part of the title"
+    );
 
     $driver->find_element('#modal-overwrite-confirm', 'css')->click();
 
     t::ui::PhantomTest::wait_for_ajax;
-    is($driver->find_element('#flash-messages span', 'css')->get_text(), "Needle test-newneedle created/updated. (restart job)", "highlight appears correct");
+    is(
+        $driver->find_element('#flash-messages span', 'css')->get_text(),
+        "Needle test-newneedle created/updated. (restart job)",
+        "highlight appears correct"
+    );
     ok(-f "$dir/$needlename.json", "$needlename.json overwritten");
 
     $driver->find_element('#flash-messages span a', 'css')->click();
     # restart is an ajax call, for some reason the check/sleep interval must be at least 1 sec for this call
     t::ui::PhantomTest::wait_for_ajax(1);
-    is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results', "no longer on needle editor");
+    is(
+        $driver->get_title(),
+        'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results',
+        "no longer on needle editor"
+    );
 }
 
 # start testing
@@ -244,7 +271,11 @@ $driver->find_element('#save', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax;
 
 # check state highlight appears with valid content
-is($driver->find_element('#flash-messages span', 'css')->get_text(), "Needle test-newneedle created/updated. (restart job)", "highlight appears correct");
+is(
+    $driver->find_element('#flash-messages span', 'css')->get_text(),
+    "Needle test-newneedle created/updated. (restart job)",
+    "highlight appears correct"
+);
 # check files are exists
 ok(-f "$dir/$needlename.json", "$needlename.json created");
 ok(-f "$dir/$needlename.png",  "$needlename.png created");
@@ -277,18 +308,28 @@ my $match = 0;
 for my $tag (@$new_tags) {
     $match = 1 if ($tag eq 'test-overwritetag');
 }
-is($match,                            1,                                                "found new tag in new needle");
-is($decode_json->{'area'}[0]->{xpos}, $decode_textarea->{'area'}[0]->{xpos} + $xoffset, "new xpos stored to new needle");
-is($decode_json->{'area'}[0]->{ypos}, $decode_textarea->{'area'}[0]->{ypos} + $yoffset, "new ypos stored to new needle");
+is($match, 1, "found new tag in new needle");
+is($decode_json->{'area'}[0]->{xpos}, $decode_textarea->{'area'}[0]->{xpos} + $xoffset,
+    "new xpos stored to new needle");
+is($decode_json->{'area'}[0]->{ypos}, $decode_textarea->{'area'}[0]->{ypos} + $yoffset,
+    "new ypos stored to new needle");
 
 subtest 'Deletion of needle is handled gracefully' => sub {
     # re-open the needle editor after deleting needle
     unlink $filen;
     $driver->get($baseurl . "tests/99946");
-    is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results', 'tests/99946 followed');
+    is(
+        $driver->get_title(),
+        'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results',
+        'tests/99946 followed'
+    );
     open_needle_editor;
     is($driver->get_title(), 'openQA: Needle Editor', 'needle editor still shows up');
-    is($driver->find_element('#editor_warnings span', 'css')->get_text(), 'Could not find needle: inst-timezone-text for opensuse 13.1', 'warning about deleted needle is displayed');
+    is(
+        $driver->find_element('#editor_warnings span', 'css')->get_text(),
+        'Could not find needle: inst-timezone-text for opensuse 13.1',
+        'warning about deleted needle is displayed'
+    );
 };
 
 t::ui::PhantomTest::kill_phantom();
@@ -299,8 +340,11 @@ subtest '(created) needles can be accessed over API' => sub {
     my @warnings = warnings { $t->get_ok('/needles/opensuse/doesntexist.png')->status_is(404) };
     map { like($_, qr/No such file or directory/, 'expected warning') } @warnings;
 
-    $t->get_ok('/needles/opensuse/test-newneedle.png?jsonfile=t/data/openqa/share/tests/opensuse/needles/test-newneedle.json')->status_is(200)->content_type_is('image/png');
-    @warnings = warnings { $t->get_ok('/needles/opensuse/test-newneedle.png?jsonfile=/try/to/break_out.json')->status_is(403) };
+    $t->get_ok(
+        '/needles/opensuse/test-newneedle.png?jsonfile=t/data/openqa/share/tests/opensuse/needles/test-newneedle.json')
+      ->status_is(200)->content_type_is('image/png');
+    @warnings
+      = warnings { $t->get_ok('/needles/opensuse/test-newneedle.png?jsonfile=/try/to/break_out.json')->status_is(403) };
     map { like($_, qr/is not in a subdir of/, 'expected warning') } @warnings;
 };
 

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -228,7 +228,7 @@ subtest 'add test suite' => sub() {
     is($driver->find_element('//button[@title="Add"]')->click(), 1, 'added');
     # leave the ajax some time
     t::ui::PhantomTest::wait_for_ajax;
-    # now read data back and compare to original, name and value shall be the same, key sanitized by removing all special chars
+# now read data back and compare to original, name and value shall be the same, key sanitized by removing all special chars
     $elem = $driver->find_element('.admintable tbody tr:last-child', 'css');
     is($elem->get_text(), "$suiteName testKey=$suiteValue", 'stored text is the same except key');
     # try to edit and save
@@ -273,7 +273,11 @@ subtest 'add job group' => sub() {
     is((shift @parent_group_entries)->get_text(), 'opensuse',      'first parentless group present');
     is((shift @parent_group_entries)->get_text(), 'opensuse test', 'second parentless group present');
     is(@parent_group_entries,                     0,               'and also no more parent groups');
-    like($driver->find_element('#new_group_name_group ', 'css')->get_text(), qr/The group name must not be empty/, 'refuse creating group with empty name');
+    like(
+        $driver->find_element('#new_group_name_group ', 'css')->get_text(),
+        qr/The group name must not be empty/,
+        'refuse creating group with empty name'
+    );
 
     # add new parentless group (dialog should still be open), this time enter a name
     $driver->find_element('#new_group_name',      'css')->send_keys('Cool Group');
@@ -297,7 +301,8 @@ subtest 'add job group' => sub() {
     # check whether parent is present
     $list_element = $driver->find_element('#job_group_list', 'css');
     @parent_group_entries = $driver->find_child_elements($list_element, 'li');
-    is(@parent_group_entries, 4, 'now 4 top-level groups present (one is new parent, remaining are parentless job groups)');
+    is(@parent_group_entries, 4,
+        'now 4 top-level groups present (one is new parent, remaining are parentless job groups)');
     my $new_groups_entry = shift @parent_group_entries;
     is($new_groups_entry->get_text(), 'New parent group', 'new group present');
 
@@ -309,7 +314,8 @@ subtest 'add job group' => sub() {
 
     $list_element = $driver->find_element('#job_group_list', 'css');
     @parent_group_entries = $driver->find_child_elements($list_element, 'li');
-    is(@parent_group_entries,                     4,                  'now 4 top-level groups present (one is new parent, remaining are parentless job groups)');
+    is(@parent_group_entries, 4,
+        'now 4 top-level groups present (one is new parent, remaining are parentless job groups)');
     is((shift @parent_group_entries)->get_text(), 'Cool Group',       'new parentless group present');
     is((shift @parent_group_entries)->get_text(), 'opensuse',         'first parentless group from fixtures present');
     is((shift @parent_group_entries)->get_text(), 'opensuse test',    'second parentless group from fixtures present');
@@ -324,14 +330,16 @@ subtest 'job property editor' => sub() {
     $driver->find_element('#job-group-name + form button', 'css')->click();
 
     subtest 'current/default values present' => sub() {
-        is($driver->find_element('#editor-name',                           'css')->get_value(), 'Cool Group', 'name');
-        is($driver->find_element('#editor-size-limit',                     'css')->get_value(), '100',        'size limit');
-        is($driver->find_element('#editor-keep-logs-in-days',              'css')->get_value(), '30',         'keep logs in days');
-        is($driver->find_element('#editor-keep-important-logs-in-days',    'css')->get_value(), '120',        'keep important logs in days');
-        is($driver->find_element('#editor-keep-results-in-days',           'css')->get_value(), '365',        'keep results in days');
-        is($driver->find_element('#editor-keep-important-results-in-days', 'css')->get_value(), '0',          'keep important results in days');
-        is($driver->find_element('#editor-default-priority',               'css')->get_value(), '50',         'default priority');
-        is($driver->find_element('#editor-description',                    'css')->get_value(), '',           'no description yet');
+        is($driver->find_element('#editor-name',              'css')->get_value(), 'Cool Group', 'name');
+        is($driver->find_element('#editor-size-limit',        'css')->get_value(), '100',        'size limit');
+        is($driver->find_element('#editor-keep-logs-in-days', 'css')->get_value(), '30',         'keep logs in days');
+        is($driver->find_element('#editor-keep-important-logs-in-days', 'css')->get_value(),
+            '120', 'keep important logs in days');
+        is($driver->find_element('#editor-keep-results-in-days', 'css')->get_value(), '365', 'keep results in days');
+        is($driver->find_element('#editor-keep-important-results-in-days', 'css')->get_value(),
+            '0', 'keep important results in days');
+        is($driver->find_element('#editor-default-priority', 'css')->get_value(), '50', 'default priority');
+        is($driver->find_element('#editor-description',      'css')->get_value(), '',   'no description yet');
     };
 
     subtest 'edit some properties' => sub() {
@@ -348,11 +356,13 @@ subtest 'job property editor' => sub() {
         $driver->get($driver->get_current_url());
         is($driver->get_title(), 'openQA: Jobs for Cool Group has been edited!', 'new name on title');
         $driver->find_element('#job-group-name + form button', 'css')->click();
-        is($driver->find_element('#editor-name',                           'css')->get_value(), 'Cool Group has been edited!', 'name edited');
-        is($driver->find_element('#editor-size-limit',                     'css')->get_value(), '1000',                        'size edited');
-        is($driver->find_element('#editor-keep-important-results-in-days', 'css')->get_value(), '500',                         'keep important results in days edited');
-        is($driver->find_element('#editor-default-priority',               'css')->get_value(), '50',                          'default priority should be the same');
-        is($driver->find_element('#editor-description',                    'css')->get_value(), 'Test group',                  'description added');
+        is($driver->find_element('#editor-name', 'css')->get_value(), 'Cool Group has been edited!', 'name edited');
+        is($driver->find_element('#editor-size-limit', 'css')->get_value(), '1000', 'size edited');
+        is($driver->find_element('#editor-keep-important-results-in-days', 'css')->get_value(),
+            '500', 'keep important results in days edited');
+        is($driver->find_element('#editor-default-priority', 'css')->get_value(),
+            '50', 'default priority should be the same');
+        is($driver->find_element('#editor-description', 'css')->get_value(), 'Test group', 'description added');
     };
 };
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -45,13 +45,19 @@ my $baseurl = $driver->get_current_url();
 is(scalar @{$driver->find_elements('h4', 'css')}, 4, '4 builds shown');
 
 $driver->find_element('Build0091', 'link_text')->click();
-like($driver->find_element('#summary', 'css')->get_text(), qr/Overall Summary of opensuse test build 0091/, 'we are on build 91');
+like(
+    $driver->find_element('#summary', 'css')->get_text(),
+    qr/Overall Summary of opensuse test build 0091/,
+    'we are on build 91'
+);
 
 is($driver->get($baseurl . '?limit_builds=1'), 1, 'index page accepts limit_builds parameter');
 is(scalar @{$driver->find_elements('h4', 'css')}, 2, 'only one build per group shown');
-is($driver->get($baseurl . '?time_limit_days=0.02&limit_builds=100000'), 1, 'index page accepts time_limit_days parameter');
+is($driver->get($baseurl . '?time_limit_days=0.02&limit_builds=100000'),
+    1, 'index page accepts time_limit_days parameter');
 is(scalar @{$driver->find_elements('h4', 'css')}, 0, 'no builds shown');
-is($driver->get($baseurl . '?time_limit_days=0.05&limit_builds=100000'), 1, 'index page accepts time_limit_days parameter');
+is($driver->get($baseurl . '?time_limit_days=0.05&limit_builds=100000'),
+    1, 'index page accepts time_limit_days parameter');
 is(scalar @{$driver->find_elements('h4', 'css')}, 2, 'only the one hour old builds is shown');
 
 # group overview
@@ -60,14 +66,27 @@ my $build_url = $driver->get_current_url();
 $build_url =~ s/\?.*//;
 OpenQA::Utils::log_debug('build_url: ' . $build_url);
 is(scalar @{$driver->find_elements('h4', 'css')}, 5, 'number of builds for opensuse');
-is($driver->find_element('#group_description',   'css')->get_text(),            'Test description\n\nwith bugref bsc#1234',       'description shown');
-is($driver->find_element('#group_description a', 'css')->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bugref in description rendered as link');
+is(
+    $driver->find_element('#group_description', 'css')->get_text(),
+    'Test description\n\nwith bugref bsc#1234',
+    'description shown'
+);
+is(
+    $driver->find_element('#group_description a', 'css')->get_attribute('href'),
+    'https://bugzilla.suse.com/show_bug.cgi?id=1234',
+    'bugref in description rendered as link'
+);
 $driver->get($baseurl . '/group_overview/1002');
-is(scalar @{$driver->find_elements('#group_description', 'css')}, 0, 'no well for group description shown if none present');
+is(scalar @{$driver->find_elements('#group_description', 'css')},
+    0, 'no well for group description shown if none present');
 is($driver->get($build_url . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
 $driver->get($build_url . '?limit_builds=0');
 is(scalar @{$driver->find_elements('div.build-row h4', 'css')}, 0, 'all builds filtered out');
-is($driver->find_element('h2', 'css')->get_text(), 'Last Builds for Group opensuse', 'group name shown correctly when all builds filtered out');
+is(
+    $driver->find_element('h2', 'css')->get_text(),
+    'Last Builds for Group opensuse',
+    'group name shown correctly when all builds filtered out'
+);
 
 my $more_builds = $t->get_ok($baseurl . 'group_overview/1001')->tx->res->dom->at('#more_builds');
 my $res         = OpenQA::Test::Case::trim_whitespace($more_builds->all_text);
@@ -85,7 +104,8 @@ is($driver->find_element('opensuse test', 'link_text')->get_text, 'opensuse test
 is($driver->get($baseurl . '?group=opensuse$'), 1, 'group parameter can be used for exact matching, though');
 is(scalar @{$driver->find_elements('h2', 'css')}, 1, 'only one job group shown');
 is($driver->find_element('opensuse', 'link_text')->get_text, 'opensuse');
-is($driver->get($baseurl . '?group=opensuse$&group=test'), 1, 'multiple group parameter can be use to ease building queries');
+is($driver->get($baseurl . '?group=opensuse$&group=test'),
+    1, 'multiple group parameter can be use to ease building queries');
 is(scalar @{$driver->find_elements('h2', 'css')}, 2, 'both job groups shown');
 $driver->get($baseurl . '?group=');
 is(scalar @{$driver->find_elements('h2', 'css')}, 2, 'a single, empty group parameter has no affect');
@@ -97,14 +117,19 @@ subtest 'filter form' => sub {
     $driver->find_element('#filter-limit-builds',         'css')->send_keys('8');            # appended to default '3'
     $driver->find_element('#filter-time-limit-days',      'css')->send_keys('2');            # appended to default '14'
     $driver->find_element('#filter-form button',          'css')->click();
-    is($driver->get_current_url(), $baseurl . '?group=SLE+12+SP2&limit_builds=38&time_limit_days=142#', 'URL parameters for filter are correct');
+    is(
+        $driver->get_current_url(),
+        $baseurl . '?group=SLE+12+SP2&limit_builds=38&time_limit_days=142#',
+        'URL parameters for filter are correct'
+    );
 };
 
 # JSON representation of index page
 $driver->get($baseurl . 'index.json');
 like($driver->get_page_source(), qr({"results":\[.*{"0048":), 'page rendered as JSON');
 
-like($t->get_ok($baseurl)->tx->res->dom->at('#filter-panel .help_popover')->{'data-title'}, qr/Help/, 'help popover is shown');
+like($t->get_ok($baseurl)->tx->res->dom->at('#filter-panel .help_popover')->{'data-title'},
+    qr/Help/, 'help popover is shown');
 
 # parent group overview: tested in t/22-dashboard.t
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -55,7 +55,11 @@ $get->element_exists('.review-all-passed', 'exactly one build is marked as \'rev
 
 $driver->find_element('opensuse', 'link_text')->click();
 
-is($driver->find_element('h2:first-of-type', 'css')->get_text(), "Last Builds for Group opensuse\nEDIT JOB GROUP", 'on group overview');
+is(
+    $driver->find_element('h2:first-of-type', 'css')->get_text(),
+    "Last Builds for Group opensuse\nEDIT JOB GROUP",
+    'on group overview'
+);
 
 # define test message
 my $test_message             = "This is a cool test ☠";
@@ -76,10 +80,12 @@ sub check_comment {
     my ($supposed_text, $edited) = @_;
 
     if ($edited) {
-        is($driver->find_element('h4.media-heading', 'css')->get_text(), "$user_name wrote less than a minute ago (last edited less than a minute ago)", "heading");
+        is($driver->find_element('h4.media-heading', 'css')->get_text(),
+            "$user_name wrote less than a minute ago (last edited less than a minute ago)", "heading");
     }
     else {
-        is($driver->find_element('h4.media-heading', 'css')->get_text(), "$user_name wrote less than a minute ago", "heading");
+        is($driver->find_element('h4.media-heading', 'css')->get_text(),
+            "$user_name wrote less than a minute ago", "heading");
     }
     is($driver->find_element('div.media-comment', 'css')->get_text(), $supposed_text, "body");
     my $anchor = $driver->find_element('h4.media-heading .comment-anchor', 'css')->get_attribute('href');
@@ -133,7 +139,8 @@ sub test_comment_editing {
         $driver->execute_script("window.confirm = function() { return false; }");
 
         # the comment musn't be deleted yet
-        is($driver->find_element('div.media-comment', 'css')->get_text(), $edited_test_message, "comment is still there after dismissing removal");
+        is($driver->find_element('div.media-comment', 'css')->get_text(),
+            $edited_test_message, "comment is still there after dismissing removal");
 
         # try to remove the first displayed comment again (and accept this time);
         $driver->execute_script("window.confirm = function() { return true; };");
@@ -235,7 +242,11 @@ subtest 'commenting in test results including labels' => sub {
     $driver->find_element('Job Groups', 'link_text')->click();
     $driver->find_element('Build0048',  'link_text')->click();
     $driver->find_element('.status',    'css')->click();
-    is($driver->get_title(), 'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results', "on test result page");
+    is(
+        $driver->get_title(),
+        'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results',
+        "on test result page"
+    );
     switch_to_comments_tab(0);
 
     # do the same tests for comments as in the group overview
@@ -247,11 +258,19 @@ subtest 'commenting in test results including labels' => sub {
 
     subtest 'check comment availability sign on test result overview' => sub {
         $driver->find_element('Job Groups', 'link_text')->click();
-        like($driver->find_element('#current-build-overview', 'css')->get_text(), qr/\QBuild 0048\E/, 'on the right build');
+        like(
+            $driver->find_element('#current-build-overview', 'css')->get_text(),
+            qr/\QBuild 0048\E/,
+            'on the right build'
+        );
         $driver->find_element('#current-build-overview a', 'css')->click();
 
         is($driver->get_title(), "openQA: Test summary", "back on test group overview");
-        is($driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'), '2 comments available', "test results show available comment(s)");
+        is(
+            $driver->find_element('#res_DVD_x86_64_doc .fa-comment', 'css')->get_attribute('title'),
+            '2 comments available',
+            "test results show available comment(s)"
+        );
     };
 
     subtest 'add label and bug and check availability sign' => sub {
@@ -261,20 +280,30 @@ subtest 'commenting in test results including labels' => sub {
         t::ui::PhantomTest::wait_for_ajax;
         $driver->find_element('Job Groups',                'link_text')->click();
         $driver->find_element('#current-build-overview a', 'css')->click();
-        is($driver->find_element('#res_DVD_x86_64_doc .fa-bookmark', 'css')->get_attribute('title'), 'true_positive', 'label icon shown');
+        is($driver->find_element('#res_DVD_x86_64_doc .fa-bookmark', 'css')->get_attribute('title'),
+            'true_positive', 'label icon shown');
         $driver->get($baseurl . 'tests/99938#comments');
         $driver->find_element('#text',          'css')->send_keys('bsc#1234');
         $driver->find_element('#submitComment', 'css')->click();
         t::ui::PhantomTest::wait_for_ajax;
         $driver->find_element('Job Groups',                'link_text')->click();
         $driver->find_element('#current-build-overview a', 'css')->click();
-        is($driver->find_element('#res_DVD_x86_64_doc .fa-bug', 'css')->get_attribute('title'), 'Bug(s) referenced: bsc#1234', 'bug icon shown');
+        is(
+            $driver->find_element('#res_DVD_x86_64_doc .fa-bug', 'css')->get_attribute('title'),
+            'Bug(s) referenced: bsc#1234',
+            'bug icon shown'
+        );
         my @labels = $driver->find_elements('#res_DVD_x86_64_doc .test-label', 'css');
         is(scalar @labels, 1, 'Only one label is shown at a time');
         $get = $t->get_ok($driver->get_current_url())->status_is(200);
-        is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href}, 'https://bugzilla.suse.com/show_bug.cgi?id=1234');
+        is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href},
+            'https://bugzilla.suse.com/show_bug.cgi?id=1234');
         $driver->find_element('opensuse', 'link_text')->click();
-        is($driver->find_element('.review-all-passed', 'css')->get_attribute('title'), 'Reviewed (all passed)', 'build should be marked because all tests passed');
+        is(
+            $driver->find_element('.review-all-passed', 'css')->get_attribute('title'),
+            'Reviewed (all passed)',
+            'build should be marked because all tests passed'
+        );
 
         subtest 'progress items work, too' => sub {
             $driver->get($baseurl . 'tests/99926#comments');
@@ -282,9 +311,17 @@ subtest 'commenting in test results including labels' => sub {
             $driver->find_element('#submitComment', 'css')->click();
             t::ui::PhantomTest::wait_for_ajax;
             $driver->find_element('Job Groups', 'link_text')->click();
-            like($driver->find_element('#current-build-overview', 'css')->get_text(), qr/\QBuild 87.5011\E/, 'on the right build');
+            like(
+                $driver->find_element('#current-build-overview', 'css')->get_text(),
+                qr/\QBuild 87.5011\E/,
+                'on the right build'
+            );
             $driver->find_element('#current-build-overview a', 'css')->click();
-            is($driver->find_element('#res_staging_e_x86_64_minimalx .fa-bolt', 'css')->get_attribute('title'), 'Bug(s) referenced: poo#9876', 'bolt icon shown for progress issues');
+            is(
+                $driver->find_element('#res_staging_e_x86_64_minimalx .fa-bolt', 'css')->get_attribute('title'),
+                'Bug(s) referenced: poo#9876',
+                'bolt icon shown for progress issues'
+            );
         };
 
         subtest 'latest bugref but first in each comment' => sub {
@@ -293,12 +330,17 @@ subtest 'commenting in test results including labels' => sub {
             $driver->find_element('#submitComment', 'css')->click();
             t::ui::PhantomTest::wait_for_ajax;
             $driver->find_element('Job Groups', 'link_text')->click();
-            like($driver->find_element('#current-build-overview', 'css')->get_text(), qr/\QBuild 87.5011\E/, 'on the right build');
+            like(
+                $driver->find_element('#current-build-overview', 'css')->get_text(),
+                qr/\QBuild 87.5011\E/,
+                'on the right build'
+            );
             $driver->find_element('#current-build-overview a', 'css')->click();
             my $bugref = $driver->find_element('#res_staging_e_x86_64_minimalx .fa-bolt', 'css');
             is($bugref->get_attribute('title'), 'Bug(s) referenced: poo#9875', 'first bugref in latest comment wins');
             $get = $t->get_ok($driver->get_current_url())->status_is(200);
-            is($get->tx->res->dom->at('#res_staging_e_x86_64_minimalx .fa-bolt')->parent->{href}, 'https://progress.opensuse.org/issues/9875');
+            is($get->tx->res->dom->at('#res_staging_e_x86_64_minimalx .fa-bolt')->parent->{href},
+                'https://progress.opensuse.org/issues/9875');
         };
 
         $driver->find_element('opensuse', 'link_text')->click();
@@ -307,12 +349,14 @@ subtest 'commenting in test results including labels' => sub {
 
 subtest 'editing when logged in as regular user' => sub {
     sub no_edit_no_remove_on_other_comments_expected {
-        is(@{$driver->find_elements('button.trigger-edit-button', 'css')}, 0, "edit not displayed for other users comments");
-        is(@{$driver->find_elements('button.remove-edit-button',  'css')}, 0, "removal not displayed for regular user");
+        is(@{$driver->find_elements('button.trigger-edit-button', 'css')},
+            0, "edit not displayed for other users comments");
+        is(@{$driver->find_elements('button.remove-edit-button', 'css')}, 0, "removal not displayed for regular user");
     }
     sub only_edit_for_own_comments_expected {
         is(@{$driver->find_elements('button.trigger-edit-button', 'css')}, 1, "own comments can be edited");
-        is(@{$driver->find_elements('button.remove-edit-button',  'css')}, 0, "no comments can be removed, even not own");
+        is(@{$driver->find_elements('button.remove-edit-button', 'css')}, 0,
+            "no comments can be removed, even not own");
     }
 
     subtest 'test pinned comments' => sub {
@@ -323,7 +367,8 @@ subtest 'editing when logged in as regular user' => sub {
         # waiting for AJAX is required though to eliminate race condition
         t::ui::PhantomTest::wait_for_ajax;
         $driver->get($baseurl . 'group_overview/1001');
-        is($driver->find_element('#group_descriptions .media-comment', 'css')->get_text(), $description_test_message, 'comment is pinned');
+        is($driver->find_element('#group_descriptions .media-comment', 'css')->get_text(),
+            $description_test_message, 'comment is pinned');
     };
 
     $driver->get($baseurl . 'login?user=nobody');

--- a/t/ui/16-tests_previous_results.t
+++ b/t/ui/16-tests_previous_results.t
@@ -32,7 +32,11 @@ my $get       = $t->get_ok('/tests/99946#previous')->status_is(200);
 my $tab_label = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('li a[href=#previous]')->all_text);
 is($tab_label, q/Previous results (2)/, 'previous results with number is shown');
 my $previous_results_header = $t->tx->res->dom->at('#previous #scenario .h5');
-like(OpenQA::Test::Case::trim_whitespace($previous_results_header->all_text), qr/Results for opensuse-13.1-DVD-i586-textmode/, 'header for previous results with scenario');
+like(
+    OpenQA::Test::Case::trim_whitespace($previous_results_header->all_text),
+    qr/Results for opensuse-13.1-DVD-i586-textmode/,
+    'header for previous results with scenario'
+);
 $get->element_exists('#res_99945',                    'result from previous job');
 $get->element_exists('#res_99945 .result_passed',     'previous job was passed');
 $get->element_exists('#res_99944 .result_softfailed', 'previous job was passed (softfailed)');
@@ -40,7 +44,8 @@ like($t->tx->res->dom->at('#res_99944 ~ .build a')->{href}, qr{/tests/overview?}
 my $build = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#previous_results .build')->all_text);
 is($build, '0091', 'build of previous job is shown');
 $get = $t->get_ok($previous_results_header->at('a')->{href})->status_is(200);
-is($t->tx->res->dom->at('#info_box .panel-heading a')->{href}, '/tests/99947', 'latest link points to last in scenario');
+is($t->tx->res->dom->at('#info_box .panel-heading a')->{href}, '/tests/99947',
+    'latest link points to last in scenario');
 $get = $t->get_ok('/tests/99946?limit_previous=1#previous')->status_is(200);
 my $table_rows = $t->tx->res->dom->find('#previous tbody tr');
 is($table_rows->size, 1, 'can be limited with query parameter');

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -48,10 +48,20 @@ $t->get_ok($url . '/admin/productlog')->status_is(200);
 # XXX: Test::Mojo loses it's app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
-$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $ret = $t->post_ok($url . '/api/v1/isos', form => {ISO => 'whatever.iso', DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'})->status_is(200);
+my $ret = $t->post_ok(
+    $url . '/api/v1/isos',
+    form => {
+        ISO     => 'whatever.iso',
+        DISTRI  => 'opensuse',
+        VERSION => '13.1',
+        FLAVOR  => 'DVD',
+        ARCH    => 'i586',
+        BUILD   => '0091'
+    })->status_is(200);
 is($ret->tx->res->json->{count}, 10, '10 new jobs created');
 
 # Log in as Demo in phantomjs webui

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -44,10 +44,15 @@ is($driver->get_title(), "openQA", "back on main page");
 is($driver->find_element('#user-action', 'css')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 $driver->get($baseurl . "tests/99946");
-is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results', 'tests/99946 followed');
+is($driver->get_title(), 'openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results',
+    'tests/99946 followed');
 
 $driver->find_element('installer_timezone', 'link_text')->click();
-is($driver->get_current_url(), $baseurl . "tests/99946/modules/installer_timezone/steps/1/src", "on src page for installer_timezone test");
+is(
+    $driver->get_current_url(),
+    $baseurl . "tests/99946/modules/installer_timezone/steps/1/src",
+    "on src page for installer_timezone test"
+);
 
 is($driver->find_element('.cm-comment', 'css')->get_text(), '#!/usr/bin/perl -w', "we have a perl comment");
 
@@ -64,7 +69,11 @@ is(current_tab, 'Details', 'back to details tab');
 $driver->find_element('[title="wait_serial"]', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax;
 ok($driver->find_element('#preview_container_out', 'css')->is_displayed(), "preview window opens on click");
-like($driver->find_element('#preview_container_in', 'css')->get_text(), qr/wait_serial expected/, "Preview text with wait_serial output shown");
+like(
+    $driver->find_element('#preview_container_in', 'css')->get_text(),
+    qr/wait_serial expected/,
+    "Preview text with wait_serial output shown"
+);
 like($driver->get_current_url(), qr/#step/, "current url contains #step hash");
 $driver->find_element('[title="wait_serial"]', 'css')->click();
 ok($driver->find_element('#preview_container_out', 'css')->is_hidden(), "preview window closed after clicking again");
@@ -72,7 +81,8 @@ unlike($driver->get_current_url(), qr/#step/, "current url doesn't contain #step
 
 $driver->find_element('[href="#step/bootloader/1"]', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax;
-like($driver->find_element('.step_actions .fa-info-circle', 'css')->get_attribute('data-content'), qr/inst-bootmenu/, "show searched needle tags");
+like($driver->find_element('.step_actions .fa-info-circle', 'css')->get_attribute('data-content'),
+    qr/inst-bootmenu/, "show searched needle tags");
 $driver->find_element('.step_actions .fa-info-circle', 'css')->click();
 t::ui::PhantomTest::wait_for_ajax;
 ok($driver->find_element('.step_actions .popover', 'css')->is_displayed(), "needle info is a clickable popover");
@@ -102,18 +112,25 @@ subtest 'render bugref links in thumbnail text windows' => sub {
     $driver->get($baseurl . 'tests/99946');
     $driver->find_element('[title="Soft Failed"]', 'css')->click();
     t::ui::PhantomTest::wait_for_ajax;
-    is($driver->find_element('#preview_container_in', 'css')->get_text(), 'Test bugref bsc#1234', 'bugref text correct');
-    is($driver->find_element('#preview_container_in a', 'css')->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bugref href correct');
+    is($driver->find_element('#preview_container_in', 'css')->get_text(), 'Test bugref bsc#1234',
+        'bugref text correct');
+    is(
+        $driver->find_element('#preview_container_in a', 'css')->get_attribute('href'),
+        'https://bugzilla.suse.com/show_bug.cgi?id=1234',
+        'bugref href correct'
+    );
 };
 
 subtest 'route to latest' => sub {
-    $get = $t->get_ok($baseurl . 'tests/latest?distri=opensuse&version=13.1&flavor=DVD&arch=x86_64&test=kde&machine=64bit')->status_is(200);
+    $get
+      = $t->get_ok($baseurl . 'tests/latest?distri=opensuse&version=13.1&flavor=DVD&arch=x86_64&test=kde&machine=64bit')
+      ->status_is(200);
     my $header = $t->tx->res->dom->at('#info_box .panel-heading a');
     is($header->text,   '99963',        'link shows correct test');
     is($header->{href}, '/tests/99963', 'latest link shows tests/99963');
     my $first_detail = $get->tx->res->dom->at('#details tbody > tr ~ tr');
-    is($first_detail->at('.component a')->{href},     '/tests/99963/modules/isosize/steps/1/src', 'correct src link');
-    is($first_detail->at('.links_a a')->{'data-url'}, '/tests/99963/modules/isosize/steps/1',     'correct needle link');
+    is($first_detail->at('.component a')->{href}, '/tests/99963/modules/isosize/steps/1/src', 'correct src link');
+    is($first_detail->at('.links_a a')->{'data-url'}, '/tests/99963/modules/isosize/steps/1', 'correct needle link');
     $get    = $t->get_ok($baseurl . 'tests/latest?flavor=DVD&arch=x86_64&test=kde')->status_is(200);
     $header = $t->tx->res->dom->at('#info_box .panel-heading a');
     is($header->{href}, '/tests/99963', '... as long as it is unique');
@@ -129,7 +146,11 @@ subtest 'route to latest' => sub {
 # test /details route
 $driver->get($baseurl . "tests/99946/details");
 $driver->find_element('installer_timezone', 'link_text')->click();
-is($driver->get_current_url(), $baseurl . "tests/99946/modules/installer_timezone/steps/1/src", "on src page from details route");
+is(
+    $driver->get_current_url(),
+    $baseurl . "tests/99946/modules/installer_timezone/steps/1/src",
+    "on src page from details route"
+);
 
 t::ui::PhantomTest::kill_phantom();
 done_testing();

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -56,7 +56,11 @@ $driver->find_element('logpackages', 'link_text')->click();
 is($driver->get_title(), 'openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results', 'on test page');
 
 # expect the failure to be displayed
-is($driver->find_element('#step_view', 'css')->get_attribute('data-image'), '/tests/99938/images/logpackages-1.png', 'Failure displayed');
+is(
+    $driver->find_element('#step_view', 'css')->get_attribute('data-image'),
+    '/tests/99938/images/logpackages-1.png',
+    'Failure displayed'
+);
 
 # now navigate back
 $driver->find_element('.navbar-brand', 'css')->click();

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -77,7 +77,11 @@ is((shift @tds)->get_text(), 'a day ago',          "last use is right");
 is((shift @tds)->get_text(), 'about 14 hours ago', "last match is right");
 
 $driver->find_element('a day ago', 'link_text')->click();
-like($driver->execute_script("return window.location.href"), qr(\Q/tests/99937#step/partitioning_finish/1\E), "redirected to right module");
+like(
+    $driver->execute_script("return window.location.href"),
+    qr(\Q/tests/99937#step/partitioning_finish/1\E),
+    "redirected to right module"
+);
 
 # go back to needles
 $driver->find_element('#user-action a', 'css')->click();
@@ -85,7 +89,11 @@ $driver->find_element('Needles',        'link_text')->click();
 t::ui::PhantomTest::wait_for_ajax;
 
 $driver->find_element('about 14 hours ago', 'link_text')->click();
-like($driver->execute_script("return window.location.href"), qr(\Q/tests/99937#step/partitioning/1\E), "redirected to right module too");
+like(
+    $driver->execute_script("return window.location.href"),
+    qr(\Q/tests/99937#step/partitioning/1\E),
+    "redirected to right module too"
+);
 
 # go back to needles
 $driver->find_element('#user-action a', 'css')->click();
@@ -105,7 +113,8 @@ subtest 'delete needle' => sub {
     is($driver->find_element('#confirm_delete .modal-title', 'css')->get_text(), 'Needle deletion', 'title matches');
     is(scalar @{$driver->find_elements('#outstanding-needles li', 'css')}, 1, 'one needle outstanding for deletion');
     is(scalar @{$driver->find_elements('#failed-needles li',      'css')}, 0, 'no failed needles so far');
-    is($driver->find_element('#outstanding-needles li', 'css')->get_text(), 'inst-timezone-text.json', 'right needle name displayed');
+    is($driver->find_element('#outstanding-needles li', 'css')->get_text(),
+        'inst-timezone-text.json', 'right needle name displayed');
 
     subtest 'error case' => sub {
         chmod(0444, $needle_dir);
@@ -113,7 +122,11 @@ subtest 'delete needle' => sub {
         t::ui::PhantomTest::wait_for_ajax;
         is(scalar @{$driver->find_elements('#outstanding-needles li', 'css')}, 0, 'no outstanding needles');
         is(scalar @{$driver->find_elements('#failed-needles li',      'css')}, 1, 'but failed needle');
-        is($driver->find_element('#failed-needles li', 'css')->get_text(), "inst-timezone-text.json\nUnable to delete t/data/openqa/share/tests/opensuse/needles/inst-timezone-text.json and t/data/openqa/share/tests/opensuse/needles/inst-timezone-text.png", 'right needle name and error message displayed');
+        is(
+            $driver->find_element('#failed-needles li', 'css')->get_text(),
+"inst-timezone-text.json\nUnable to delete t/data/openqa/share/tests/opensuse/needles/inst-timezone-text.json and t/data/openqa/share/tests/opensuse/needles/inst-timezone-text.png",
+            'right needle name and error message displayed'
+        );
         $driver->find_element('#close_delete', 'css')->click();
     };
 
@@ -121,9 +134,12 @@ subtest 'delete needle' => sub {
     t::ui::PhantomTest::wait_for_ajax;    # required due to server-side datatable
     $driver->find_element('td input',    'css')->click();
     $driver->find_element('#delete_all', 'css')->click();
-    is(scalar @{$driver->find_elements('#outstanding-needles li', 'css')}, 1, 'still one needle outstanding for deletion');
-    is(scalar @{$driver->find_elements('#failed-needles li',      'css')}, 0, 'failed needles from last time shouldn\'t appear again when reopening deletion dialog');
-    is($driver->find_element('#outstanding-needles li', 'css')->get_text(), 'inst-timezone-text.json', 'still right needle name displayed');
+    is(scalar @{$driver->find_elements('#outstanding-needles li', 'css')},
+        1, 'still one needle outstanding for deletion');
+    is(scalar @{$driver->find_elements('#failed-needles li', 'css')},
+        0, 'failed needles from last time shouldn\'t appear again when reopening deletion dialog');
+    is($driver->find_element('#outstanding-needles li', 'css')->get_text(),
+        'inst-timezone-text.json', 'still right needle name displayed');
 
     subtest 'successful deletion' => sub {
         chmod(0755, $needle_dir);
@@ -135,7 +151,11 @@ subtest 'delete needle' => sub {
         t::ui::PhantomTest::wait_for_ajax;    # required due to server-side datatable
         is(-f $needle_json_file, undef, 'JSON file is gone');
         is(-f $needle_png_file,  undef, 'png file is gone');
-        is($driver->find_element('#needles tbody tr', 'css')->get_text(), 'No data available in table', 'no needles left');
+        is(
+            $driver->find_element('#needles tbody tr', 'css')->get_text(),
+            'No data available in table',
+            'no needles left'
+        );
     };
 };
 


### PR DESCRIPTION
It used to be necessary to hide code like this from perltidy, because it would get folded into unreadable 500 column lines.
```perl
   #<<< do not let perltidy touch this
   $self->render(json =>
                { JobTemplates =>
                    [map { { id => $_->id,
                             prio => $_->prio,
                             group_name => $_->group ? $_->group->name : '',
                             product => {id => $_->product_id,
                                         arch => $_->product->arch,
                                         distri => $_->product->distri,
                                         flavor => $_->product->flavor,
                                         group => $_->product->mediagroup,
                                         version => $_->product->version},
                             machine => {id => $_->machine_id,
                                         name => $_->machine ? $_->machine->name : ''},
                             test_suite => {id => $_->test_suite_id,
                                            name => $_->test_suite->name}}
            } @templates
           ]
         });
   #>>>
```
That could be avoided by adding a 120 column limit to the `.perltidyrc`.