### PR TITLE
Show submenus on click

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -10,7 +10,7 @@
 < stylesheets/result_preview.scss
 << https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/stylesheets/_bootstrap.scss
 < sass/theme.scss
-< https://raw.githubusercontent.com/Martchus/bootstrap-submenu/openqa/dist/css/bootstrap-submenu.css
+< https://raw.githubusercontent.com/vsn4ik/bootstrap-submenu/v2.0.4/dist/css/bootstrap-submenu.css
 
 ! codemirror.css
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/lib/codemirror.css
@@ -43,7 +43,7 @@
 < javascripts/filter_form.js
 < javascripts/comments.js
 < javascripts/keyevent.js
-< https://raw.githubusercontent.com/Martchus/bootstrap-submenu/openqa/dist/js/bootstrap-submenu.js
+< https://raw.githubusercontent.com/vsn4ik/bootstrap-submenu/v2.0.4/dist/js/bootstrap-submenu.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap/collapse.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap/tooltip.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/javascripts/bootstrap/popover.js

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -69,7 +69,7 @@
                                       % my @children = $parent_or_group->children;
                                       % if (scalar(@children)) {
                                           <li class="dropdown-submenu">
-                                              %= link_to $parent_or_group->name => url_for('admin_edit_parent_group', groupid => $parent_or_group->id)
+                                              %= link_to $parent_or_group->name => url_for('parent_group_overview', groupid => $parent_or_group->id)
                                               <ul class="dropdown-menu">
                                                   % for my $group (@children) {
                                                       %= group_link_menu_entry $group;


### PR DESCRIPTION
Also change link to parent group overview, which has effect when opening in new tab via context menu or copying the link