### PR TITLE
More fixes to documentation formating

### DIFF
--- a/docs/Branding.asciidoc
+++ b/docs/Branding.asciidoc
@@ -4,29 +4,31 @@
 :toclevels: 6
 :author: Adam Williamson
 
-You can alter the appearance of the openQA web UI to some extent through the
-branding mechanism. The `branding` configuration setting in the `global` section
-of +/etc/openqa/openqa.ini+ specifies the branding to use. It defaults to
-'openSUSE', and openQA also includes the 'plain' branding, which is - as its
-name suggests - plain and generic.
 
-To create your own branding for openQA, you can create a subdirectory of
-`/usr/share/openqa/templates/branding` (or wherever openQA is installed). The
-subdirectory's name will be the name of your branding. You can copy the files
-from +branding/openSUSE+ or +branding/plain+ to use as starting points, and
-adjust as necessary.
+You can alter the appearance of the openQA web UI to some extent through
+the 'branding' mechanism. The 'branding' configuration setting in the
+'global' section of +/etc/openqa/openqa.ini+ specifies the branding to
+use. It defaults to 'openSUSE', and openQA also includes the 'plain'
+branding, which is - as its name suggests - plain and generic.
 
-== Mojolicious
+To create your own branding for openQA, you can create a subdirectory
+of +/usr/share/openqa/templates/branding+ (or wherever openQA is
+installed). The subdirectory's name will be the name of your branding.
+You can copy the files from +branding/openSUSE+ or +branding/plain+ to
+use as starting points, and adjust as necessary.
+
+== Web UI template
 
 :mojo-website: http://mojolicio.us/[Mojolicious]
 :mojo-docs: http://mojolicio.us/perldoc/Mojolicious/Guides/Rendering[Mojolicious Documentation]
 
-openQA uses the {mojo-website} framework's templating system; the branding files
-are included into the openQA templates at various points. To see where each
-branding file is actually included, you can search through the files in the
-+templates+ tree for the text +include_branding+. Anywhere that helper is
-called, the branding file with the matching name is being included.
+openQA uses the {mojo-website} framework's templating
+system; the branding files are included into the openQA templates at
+various points. To see where each branding file is actually included,
+you can search through the files in the +templates+ tree for the text
++include_branding+. Anywhere that helper is called, the branding file
+with the matching name is being included.
 
-The branding files themselves are Mojolicious _embedded perl_ templates just
+The branding files themselves are Mojolicious 'Embedded Perl' templates just
 like the main template files. You can read the {mojo-docs} for help with the
 format.

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -2,7 +2,7 @@
 = openQA developer guide
 :toc: left
 :toclevels: 6
-:author: OpenQA Team
+:author: openQA Team
 
 == Introduction
 
@@ -47,17 +47,23 @@ are the right way to contribute improvements and fixes.
 
 * Every commit is checked by https://travis-ci.org/travis[Travis CI] as soon as
 you create a pull request but you *should* run the openQA tests locally,
-i.e. before every commit call
+i.e. before every commit call:
+
+[source,sh]
 ----
 ./script/tidy
 ----
+
 to ensure your perl code changes are consistent with the style rules
 
 * You *may* also run local tests on your machine or in your own development
-environment to verify everything works as expected. Call
+environment to verify everything works as expected. Call:
+
+[source,sh]
 ----
 make test
 ----
+
 for unit and integration tests.
 
 * For git commit messages use the rules stated on
@@ -182,8 +188,8 @@ and upgrades include those changes.
 
 The above steps are executed in the developer's system. Once openQA is
 installed in a production server, you should run either
-+./script/initdb --init_database+ or +./script/upgradedb --upgrade_database+ to actually
-create or upgrade a database.
++./script/initdb --init_database+ or +./script/upgradedb --upgrade_database+
+to actually create or upgrade a database.
 
 === How to add fixtures to the database
 
@@ -202,9 +208,9 @@ Executed SQL statements can be traced by setting the +DBIC_TRACE+ environment
 variable.
 
 [source,sh]
---------------------------------------------------------------------------------
+----
 export DBIC_TRACE=1
---------------------------------------------------------------------------------
+----
 
 == How to overwrite config files
 
@@ -216,15 +222,18 @@ etc/openqa/openqa.ini.
 To avoid these changes getting in your git workflow, copy them to a new
 directory and set OPENQA_CONFIG in your shell setup files.
 
---------------------------------------------------------------------------------
+[source,sh]
+----
 cp -ar etc/openqa etc/mine
 export OPENQA_CONFIG=$PWD/etc/mine
---------------------------------------------------------------------------------
+----
+
 
 Note that OPENQA_CONFIG points to the directory containing openqa.ini, database.ini,
 client.conf and workers.ini.
 
 == How to setup PostgreSQL to test locally with production data
+:other-db-engines: link:Installing.asciidoc#other-database-engines[Other database engines]
 
 1. Install PosgreSQL - under openSUSE the following package are required:
    +postgresql-server postgresql-init+
@@ -242,13 +251,14 @@ client.conf and workers.ini.
 
 7. Import dump: +pg_restore -c -d openqa path/to/dump+
 
-8. Configure openQA to use PostgreSQL as described in +Installing.asciidoc+ under
-   'Other database engines'. User name and password are not required.
+8. Configure openQA to use PostgreSQL as described in the section {other-db-engines} of the installation guide.
+ User name and password are not required.
 
 == Adding new authentication module
+:user-authentication: link:Installing.asciidoc#user-authentication[User authentication]
 
 OpenQA comes with three authentication modules providing authentication methods:
-OpenID, iChain and Fake (see link:Installing.asciidoc[Installation - User authentication]).
+OpenID, iChain and Fake (see {user-authentication}).
 
 All authentication modules reside in +lib/OpenQA/Auth+ directory. During
 OpenQA start, +[auth]/method+ section of +/etc/openqa/openqa.ini+ is read and according
@@ -265,14 +275,15 @@ page or none.
 
 Authentication module is expected to return HASH:
 [source,perl]
---------------------------------------------------------------------------------
+----
+
 %res = (
     # error = 1 signals auth error
     error => 0|1
     # where to redirect the user
     redirect => ''
 );
---------------------------------------------------------------------------------
+----
 
 Authentication module is expected to create or update user entry in OpenQA database
 after user validation. See included modules for inspiration.

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -201,7 +201,7 @@ problem) and sqlite doesn't support nested transactions.
 Executed SQL statements can be traced by setting the +DBIC_TRACE+ environment
 variable.
 
-[source,bash]
+[source,sh]
 --------------------------------------------------------------------------------
 export DBIC_TRACE=1
 --------------------------------------------------------------------------------

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -2,7 +2,7 @@
 = openQA starter guide
 :toc: left
 :toclevels: 6
-:author: OpenQA Team
+:author: openQA Team
 
 == Introduction
 

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -201,7 +201,7 @@ of the openQA security model, refer to the
 http://lizards.opensuse.org/2014/02/28/about-openqa-and-authentication/[detailed
 blog post] about the subject by the openQA development team.
 
-==Using the client script
+== Using the client script
 :openqa-personal-configuration: ~/.config/openqa/client.conf
 
 Just as the worker uses an API key+secret every user of the +client script+

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -302,7 +302,7 @@ mount -t nfs openQA-webUI-host:/var/lib/openqa/share /var/lib/openqa/share
 === Needle Caching
 
 If your network is slow or you experience long time to load needles you
-might want to consider needle caching, to do this a directory
+might want to consider needle caching. To use needle caching a directory
 +/var/lib/openqa/cache+ must be created, and right permissions given to the
 'geekotest' user. If you install openQA through the repositories, said directory
 will be created for you.

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -288,13 +288,13 @@ storage for her specific needs.
 
 Example of NFS configuration:
 NFS server is where openQA WebUI is running. Content of +/etc/exports+
-[source]
+[source,sh]
 --------------------------------------------------------------------------------
 /var/lib/openqa/share *(fsid=0,rw,no_root_squash,sync,no_subtree_check)
 --------------------------------------------------------------------------------
 
 NFS clients are where openQA workers are running. Run following command:
-[source, sh]
+[source,sh]
 --------------------------------------------------------------------------------
 mount -t nfs openQA-webUI-host:/var/lib/openqa/share /var/lib/openqa/share
 --------------------------------------------------------------------------------
@@ -325,7 +325,7 @@ workers are tracked under user whose API keys are workers using.
 Audit log is directly accessible from +Admin menu+.
 
 Auditing, by default enabled, can be disabled by global configuration option in +/etc/openqa/openqa.ini+:
-[source, ini]
+[source,ini]
 --------------------------------------------------------------------------------
 [global]
 audit_enabled = 0
@@ -333,7 +333,7 @@ audit_enabled = 0
 
 The audit section of +/etc/openqa/openqa.ini+ allows to exclude some events from logging using
 a space separated blacklist:
-[source, ini]
+[source,ini]
 --------------------------------------------------------------------------------
 [audit]
 blacklist = job_grab job_done
@@ -436,7 +436,7 @@ and change the settings in the +[production]+ section.
 
 === Example for connecting to local PostgreSQL database
 
-[source, ini]
+[source,ini]
 --------------------------------------------------------------------------------
 [production]
 dsn = dbi:Pg:dbname=openqa
@@ -444,7 +444,7 @@ dsn = dbi:Pg:dbname=openqa
 
 === Example for connecting to remote PostgreSQL database
 
-[source, ini]
+[source,ini]
 --------------------------------------------------------------------------------
 [production]
 dsn = dbi:Pg:dbname=openqa;host=db.example.org

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -1,11 +1,10 @@
-openQA installation guide
-=========================
-:author: openQA developers
-:toc:
 
-Introduction
-------------
-[id="intro"]
+= openQA installation guide
+:toc: left
+:toclevels: 6
+:author: openQA developers
+
+== Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It's free software released
@@ -19,19 +18,21 @@ assumed that the reader is already familiar with openQA and has already read the
 Starter Guide, available at the
 https://github.com/os-autoinst/openQA[official repository].
 
-Installation
-------------
-[id="installation"]
+== Installation
 
 The easiest way to install openQA is from packages. You can find openSUSE
 packages in OBS in the
+https://build.opensuse.org/project/show/devel:openQA:stable[openQA:stable]
+repository.
+
+The latest development version can also be found in OBS in the
 https://build.opensuse.org/project/show/devel:openQA[openQA:devel] repository.
 
 For Fedora, packages are available in the official repositories for Fedora 23
 and later. Installation on these distributions is therefore pretty simple:
 
 [source,sh]
---------------------------------------------------------------------------------
+----
 # openSUSE Leap 42.2
 zypper ar -f obs://devel:openQA/openSUSE_Leap_42.2 openQA
 zypper ar -f obs://devel:openQA:Leap:42.2/openSUSE_Leap_42.2 openQA-perl-modules
@@ -44,20 +45,17 @@ zypper in openQA
 
 # Fedora 23+
 dnf install openqa openqa-httpd
---------------------------------------------------------------------------------
+----
 
-Basic configuration
--------------------
-[id="basic"]
+== Basic configuration
 
-Apache proxy
-~~~~~~~~~~~~
+=== Apache proxy
 
 It is required to run openQA behind an http proxy (apache, nginx, etc..). See the
 +openqa.conf.template+ config file in +/etc/apache2/vhosts.d+ (openSUSE) or
 +/etc/httpd/conf.d+ (Fedora). To make everything work correctly on openSUSE, you
 need to enable the 'headers', 'proxy', 'proxy_http' and 'proxy_wstunnel' modules
-using 'a2enmod'. This is not necessary on Fedora. For a basic setup, you can
+using the command 'a2enmod'. This is not necessary on Fedora. For a basic setup, you can
 copy +openqa.conf.template+ to +openqa.conf+ and modify the +ServerName+
 setting. This will direct all HTTP traffic to openQA.
 
@@ -71,8 +69,7 @@ a2enmod proxy_http
 a2enmod proxy_wstunnel
 --------------------------------------------------------------------------------
 
-TLS/SSL
-~~~~~~~
+=== TLS/SSL
 
 By default openQA expects to be run with HTTPS. The +openqa-ssl.conf.template+
 Apache config file is available as a base for creating the Apache config; you
@@ -88,8 +85,8 @@ your host you must turn HTTPS off. You can do that in +/etc/openqa/openqa.ini+:
 httpsonly = 0
 --------------------------------------------------------------------------------
 
-Run the web UI
-~~~~~~~~~~~~~~
+== Run the web UI
+
 [source,sh]
 --------------------------------------------------------------------------------
 systemctl start openqa-scheduler
@@ -115,8 +112,7 @@ systemctl enable openqa-websockets
 systemctl enable openqa-webui
 --------------------------------------------------------------------------------
 
-Run workers
-~~~~~~~~~~~
+== Run workers
 
 Workers are processes running virtual machines to perform the actual
 testing. They are distributed as a separate package and can be installed on
@@ -165,12 +161,15 @@ installed 'os-autoinst' from packages make sure to pass +--isotovideo+ option
 to point to the checkout dir where isotovideo is, not to +/usr/lib+! Otherwise
 it will have trouble finding its perl modules.
 
-Advanced configuration
-----------------------
+== Where to now?
+
+From this point on, you can refer to the link:GettingStarted.asciidoc#testing-opensuse-or-fedora[getting started] guide to
+fetch the tests cases and possibly take a look at link:WritingTests.asciidoc[Test Developer Guide]
+
+== Advanced configuration
 [id="advanced"]
 
-User authentication
-~~~~~~~~~~~~~~~~~~~
+=== User authentication
 
 OpenQA supports three different authentication methods - OpenID (default), iChain
 and Fake. See +auth+ section in +/etc/openqa/openqa.ini+.
@@ -185,8 +184,8 @@ method = OpenID|iChain|Fake
 Independently of method used, the first user that logs in (if there is no admin yet)
 will automatically get administrator rights!
 
-OpenID
-~~~~~~
+=== OpenID
+
 By default openQA uses OpenID with opensuse.org as OpenID provider.
 OpenID method has its own +openid+ section in +/etc/openqa/openqa.ini+:
 
@@ -202,12 +201,12 @@ httpsonly = 1
 OpenQA supports only OpenID version up to 2.0. Newer OpenID-Connect and OAuth is
 not supported currently.
 
-iChain
-~~~~~~
+=== iChain
+
 Use only if you use iChain (NetIQ Access Manager) proxy on your hosting server.
 
-Fake
-~~~~
+=== Fake
+
 For development purposes only! Fake authentication bypass any authentication and
 automatically allow any login requests as 'Demo user' with administrator privileges
 and without password. To ease worker testing, API key and secret is created (or updated)
@@ -224,8 +223,7 @@ secret = 1234567890ABCDEF
 If you switch authentication method from Fake to any other, review your API keys!
 You may be vulnerable for up to a day until Fake API key expires.
 
-Setting up git support
-~~~~~~~~~~~~~~~~~~~~~~
+=== Setting up git support
 
 Editing needles from web can optionally commit new or changed needles
 automatically to git. To do so, you need to enable git support by setting
@@ -243,6 +241,7 @@ from the web UI.
 You can do so by setting your configuration in the repository
 (+/var/lib/os-autoinst/needles/.git/config+) to some reasonable defaults such as:
 
+[source,ini]
 --------------------------------------------------------------------------------
 [user]
 	email = whatever@example.com
@@ -260,8 +259,7 @@ do_push = yes
 Depending on your setup, you might need to generate and propagate
 ssh keys for user 'geekotest' to be able to push.
 
-Worker settings
-~~~~~~~~~~~~~~~
+=== Worker settings
 
 Default behavior for all workers is to use the 'Qemu' backend and connect to
 'http://localhost'. If you want to change some of those options, you can do so
@@ -279,8 +277,7 @@ Once you got workers running they should show up in the admin section of openQA 
 the workers section as 'idle'. When you get so far, you have your own instance
 of openQA up and running and all that is left is to set up some tests.
 
-Configuring remote workers
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Configuring remote workers
 
 There are some additional requirements to get remote worker running. First is to
 ensure shared storage between openQA WebUI and workers.
@@ -302,11 +299,10 @@ NFS clients are where openQA workers are running. Run following command:
 mount -t nfs openQA-webUI-host:/var/lib/openqa/share /var/lib/openqa/share
 --------------------------------------------------------------------------------
 
-Needle Caching  
-~~~~~~~~~~~~~~~
+=== Needle Caching
 
 If your network is slow or you experience long time to load needles you
-might want to consider needle caching. To use needle caching a directory
+might want to consider needle caching, to do this a directory
 +/var/lib/openqa/cache+ must be created, and right permissions given to the
 'geekotest' user. If you install openQA through the repositories, said directory
 will be created for you.
@@ -319,8 +315,7 @@ In the +/etc/openqa/workers.ini+
 CACHEDIRECTORY = /var/lib/openqa/cache
 --------------------------------------------------------------------------------
 
-Auditing - tracking openQA changes
-----------------------------------
+== Auditing - tracking openQA changes
 [id="auditing"]
 
 Auditing plugin enables openQA administrators to maintain overview about what is happening with the system.
@@ -344,32 +339,31 @@ a space separated blacklist:
 blacklist = job_grab job_done
 --------------------------------------------------------------------------------
 
-List of events tracked by the auditing plugin:
-----
-Assets:
-  asset_register asset_delete
-Workers:
-  worker_register command_enqueue
-Jobs:
-  iso_create iso_delete iso_cancel
-  jobtemplate_create jobtemplate_delete
-  job_create job_grab job_delete job_update_result job_done jobs_restart job_restart job_cancel job_duplicate
-  jobgroup_create jobgroup_connect
-Tables:
-  table_create table_update table_delete
-Users:
-  user_new_comment user_update_comment user_delete_comment user_login
-Needles:
-  needle_delete needle_modify
-----
+=== List of events tracked by the auditing plugin:
+
+* Assets:
+** asset_register asset_delete
+* Workers:
+** worker_register command_enqueue
+* Jobs:
+** iso_create iso_delete iso_cancel
+** jobtemplate_create jobtemplate_delete
+** job_create job_grab job_delete job_update_result job_done jobs_restart job_restart job_cancel job_duplicate
+** jobgroup_create jobgroup_connect
+* Tables:
+** table_create table_update table_delete
+* Users:
+** user_new_comment user_update_comment user_delete_comment user_login
+* Needles:
+** needle_delete needle_modify
 
 Some of these events are very common and may clutter audit database. For this reason +job_grab+ and +job_done+
 events are blacklisted by default.
+
 [NOTE]
 Upgrading openQA does not automatically update +/etc/openqa/openqa.ini+. Review your configuration after upgrade.
 
-Filesystem Layout
------------------
+== Filesystem Layout
 [id="filesystem"]
 
 The openQA web interface can be started via +MOJO_REVERSE_PROXY=1 morbo script/openqa+ in
@@ -427,8 +421,7 @@ The worker needs to own +/var/lib/openqa/pool/$INSTANCE+, e.g.
 You can also give the whole pool directory to the +_openqa-worker+ user and let
 the workers create their own instance directories.
 
-Other database engines
-----------------------
+== Other database engines
 [id="otherdb"]
 
 By default, openQA will use an SQLite database: +/var/lib/openqa/db/db.sqlite+.
@@ -441,16 +434,16 @@ create a database and a dedicated user account with full access to it. To
 configure access to the chosen database in openQA, edit +/etc/openqa/database.ini+
 and change the settings in the +[production]+ section.
 
-Example for connecting to local PostgreSQL database
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Example for connecting to local PostgreSQL database
+
 [source, ini]
 --------------------------------------------------------------------------------
 [production]
 dsn = dbi:Pg:dbname=openqa
 --------------------------------------------------------------------------------
 
-Example for connecting to remote PostgreSQL database
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Example for connecting to remote PostgreSQL database
+
 [source, ini]
 --------------------------------------------------------------------------------
 [production]
@@ -459,14 +452,15 @@ user = openqa
 password = somepassword
 --------------------------------------------------------------------------------
 
-General notes
-~~~~~~~~~~~~~
+=== General notes
+:DBD-Pg-DBI_Class_Methods: https://metacpan.org/pod/DBD::Pg#DBI-Class-Methods[DBD::Pg]
+:DBD-mysql_Class_Methods: https://metacpan.org/pod/DBD::mysql#DBI-Class-Methods[DBD::mysql]
+
 The +dsn+ value format technically depends on the database type (though at
 time of writing it's in fact identical for both supported databases). For
-PostgreSQL it's documented at
-http://search.cpan.org/~rudy/DBD-Pg/Pg.pm#DBI_Class_Methods ,
-for MySQL / MariaDB it's documented at
-http://search.cpan.org/~capttofu/DBD-mysql/lib/DBD/mysql.pm#Class_Methods
+PostgreSQL it's documented at {DBD-Pg-DBI_Class_Methods},
+for MySQL / MariaDB it's documented at {DBD-mysql_Class_Methods}
+
 
 If you intend to use a different database, it is best to create the database
 and configuration file before starting the services and connecting to the
@@ -475,8 +469,7 @@ database and may get confused when you try to switch to a different one. See
 the following section if you want to migrate an existing openQA-on-SQLite
 deployment to a different database.
 
-Changing the database engine
-----------------------------
+=== Changing the database engine
 [id="dbengine"]
 
 openQA is compatible with several database engines and comes with all the needed
@@ -581,17 +574,15 @@ SELECT SETVAL('job_settings_id_seq', (SELECT MAX(id) FROM job_settings));
 SELECT SETVAL('job_modules_id_seq', (SELECT MAX(id) FROM job_modules));
 ---------------------------------------------------------------------------------------
 
-Troubleshooting
----------------
+== Troubleshooting
 [id="troubleshooting"]
 
-Tests fail quickly
-~~~~~~~~~~~~~~~~~~
+=== Tests fail quickly
+
 
 Check the log files in +/var/lib/openqa/testresults+
 
-KVM doesn't work
-~~~~~~~~~~~~~~~~
+=== KVM doesn't work
 
 * make sure you have a machine with kvm support
 * make sure +kvm_intel+ or +kvm_amd+ modules are loaded
@@ -600,16 +591,15 @@ KVM doesn't work
 * make sure you are not already running other hypervisors such as VirtualBox
 * when running inside a vm make sure nested virtualization is enabled (pass nested=1 to your kvm module)
 
-openid login times out
-~~~~~~~~~~~~~~~~~~~~~~
+=== openid login times out
 
-www.opensuse.org openid provider may have trouble with IPv6. openQA shows a message like this:
+www.opensuse.org's openid provider may have trouble with IPv6. openQA shows a message like this:
 
   no_identity_server: Could not determine ID provider from URL.
 
 To avoid that switch off IPv6 or add a special route that prevents the system
 from trying to use IPv6 with www.opensuse.org:
-
+[source,sh]
 --------------------------------------------------------------------------------
 ip -6 r a to unreachable 2620:113:8044:66:130:57:66:6/128
 --------------------------------------------------------------------------------

--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -4,7 +4,6 @@
 :toclevels: 6
 :author: OpenQA Team
 
-
 IMPORTANT: This overview is valid only when using QEMU backend!
 
 Which networking type to use is controlled by the `NICTYPE`
@@ -140,7 +139,7 @@ The VMs have unique MAC that differs in the last 16 bits (see /usr/lib/os-autoin
 `os-autoinst-openvswitch.service` sets up filtering rules for the following translation scheme which
 provide non-conflicting addresses visible from host:
 
-[source, bash]
+[source,sh]
 ----
 MAC 52:54:00:12:XX:YY -> IP 10.1.XX.YY
 ----

--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -33,7 +33,7 @@ worker1 uses tap0, worker 2 uses tap1 and so on.
 For multiple networks per job (see +NETWORKS+ variable), the following numbering
 scheme is used:
 
-[source, bash]
+[source,sh]
 ---------------
 worker1: tap0 tap64 tap128 ...
 worker2: tap1 tap65 tap129 ...
@@ -50,14 +50,14 @@ network, required internet access etc on the host manually.
 TAP devices need be owned by the +_openqa-worker+ user for openQA to
 be able to access them.
 
-[source, bash]
+[source,sh]
 ---------------
 tunctl -u _openqa-worker -p -t tap0
 ---------------
 
 or Wicked way:
 [caption="File: "]
-[source, bash]
+[source,sh]
 ./etc/sysconfig/network/ifcfg-tap0
 ---------------
 BOOTPROTO='none'
@@ -73,7 +73,7 @@ TUNNEL_SET_OWNER='_openqa-worker'
 If you want to use TAP device which doesn't exist on the system,
 you need to set CAP_NET_ADMIN capability on qemu binary file:
 
-[source, bash]
+[source,sh]
 ---------------
 zypper in libcap-progs
 setcap CAP_NET_ADMIN=ep /usr/bin/qemu-system-x86_64
@@ -83,7 +83,7 @@ Network setup can be changed after qemu is started using network configure scrip
 specified in TAPSCRIPT variable.
 
 Sample script to add TAP device to existing bridge br0:
-[source, bash]
+[source,sh]
 ---------------
 sudo brctl addif br0 $1
 sudo ip link set $1 up
@@ -102,7 +102,7 @@ Compared to VDE setup discussed later, Open vSwitch is more complicated to confi
 but provides more robust and scalable network.
 
 Start Open vSwitch and add TAP devices:
-[source, bash]
+[source,sh]
 ---------------
 
 # start openvswitch.service
@@ -125,7 +125,7 @@ If the workers with TAP capability are spread across multiple hosts, the network
 See Open vSwitch http://openvswitch.org/support/config-cookbooks/port-tunneling/[documentation] for details.
 
 Example configuration of GRE tunnel:
-[source, bash]
+[source,sh]
 ----
 ovs-vsctl add-port br0 gre0 -- set interface gre0 type=gre options:remote_ip=<IP address of other host>
 ----
@@ -147,7 +147,7 @@ MAC 52:54:00:12:XX:YY -> IP 10.1.XX.YY
 That means that the local port of the bridge must be configured to IP 10.0.2.2
 and netmask /15 that covers 10.0.0.0 and 10.1.0.0 ranges.
 
-[source, bash]
+[source,sh]
 ---------------
 ip addr add 10.0.2.2/15 dev br0
 ip route add 10.0.0.0/15 dev br0
@@ -155,7 +155,7 @@ ip link set br0 up
 ---------------
 
 and permanently in /etc/sysconfig/network
-[source, bash]
+[source,sh]
 ---------------
 # /etc/sysconfig/network/ifcfg-br0
 BOOTPROTO='static'
@@ -169,7 +169,7 @@ NOTE: In some cases (e.g. on Leap) can be needed to start the OpenvSwitch servic
 
 The permanent configuration for wicked 0.6.23 and later should look like this:
 
-[source, bash]
+[source,sh]
 ---------------
 # /etc/sysconfig/network/ifcfg-br0
 BOOTPROTO='static'
@@ -185,7 +185,7 @@ The IP 10.0.2.2 can also serve as a gateway to access outside
 network. For this, a NAT between br0 and eth0 must be configured
 with SuSEfirewall or iptables.
 
-[source, bash]
+[source,sh]
 ---------------
 # configuration options for NAT with SuSEfirewall
 # /etc/sysconfig/SuSEfirewall
@@ -199,13 +199,13 @@ Then it is possible to start the os-autoinst-openvswitch.service
 The service uses +br0+ by default. It can be configured for another
 bridge name by setting +/etc/sysconfig/os-autoinst-openvswitch+
 
-[source, bash]
+[source,sh]
 ---------------
 OS_AUTOINST_USE_BRIDGE=bridge_name
 ---------------
 
 Then, start the service:
-[source, bash]
+[source,sh]
 ---------------
 systemctl start os-autoinst-openvswitch.service
 systemctl enable os-autoinst-openvswitch.service
@@ -230,7 +230,7 @@ Boot sequence with wicked 0.6.23 and newer:
 
 The configuration and operation can be checked by the following commands:
 
-[source,bash]
+[source,sh]
 ----
 ovs-vsctl show # shows the bridge br0, the tap devices are assigned to it
 ovs-ofctl dump-flows br0 # shows the rules installed by os-autoinst-openvswitch in table=0
@@ -241,7 +241,10 @@ ovs-ofctl dump-flows br0 # shows the rules installed by os-autoinst-openvswitch 
 * empty output indicates a problem with os-autoinst-openvswitch service
 * zero packet count or missing rules in table=1 indicate problem with tap devices
 
+[source,sh]
+----
 ipables -L -v
+----
 
 As long as the SUT has access to external network, there should be
 nonzero packet count in the forward chain between br0 and external
@@ -267,7 +270,7 @@ create a machine with the following settings:
 
 Start switch and user mode networking:
 
-[source, bash]
+[source,sh]
 ---------------
 systemctl start openqa-vde_switch
 systemctl start openqa-slirpvde

--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -2,7 +2,7 @@
 = Networking in OpenQA
 :toc: left
 :toclevels: 6
-:author: OpenQA Team
+:author: openQA Team
 
 IMPORTANT: This overview is valid only when using QEMU backend!
 

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -1,11 +1,10 @@
-openQA pitfalls
-===============
-:author: openSUSE Team at SUSE
-:toc:
 
+= openQA pitfalls
+:toc: left
+:toclevels: 6
+:author: OpenQA Team
 
-Needle editing
-==============
+== Needle editing
 
 - If a new needle is created based on a failed test, the new needle
   will not be listed in old tests.
@@ -15,8 +14,7 @@ Needle editing
 - If a needle is deleted, old tests may display an error when viewing
   them in the web UI.
 
-Mixed production and development environment
-============================================
+== Mixed production and development environment
 
 There are few things to take into account when running a development version and
 a packaged version of openqa:

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -2,7 +2,7 @@
 = openQA pitfalls
 :toc: left
 :toclevels: 6
-:author: OpenQA Team
+:author: openQA Team
 
 == Needle editing
 

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -627,7 +627,6 @@ With a test-suites name +supportserver-opensuse-tftp+.
 
 The actual test 'child' job, will then have to set +PARALLEL_WITH=supportserver-opensuse-tftp+, and also other variables according to the test requirements. For convenience, we have also started a dhcp server on the supportserver, but even without it, network could be set up manually by assigning a free ip address (e.g. 10.0.2.15) on the system of the test job.
 
-
 [caption="Example of Support Server: "]
 .The code in the *.pm module doing the actual tftp test could then look something like the example below
 ====

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -2,7 +2,7 @@
 = openQA tests developer guide
 :toc: left
 :toclevels: 6
-:author: OpenQA Team
+:author: openQA Team
 
 == Introduction
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -6,7 +6,6 @@
 
 = openQA Documentation
 
-
 :sectnums:
 ifdef::basebackend-html[toc::[]]
 :sectnums!:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,6 @@
 :toc: left
 :toclevels: 6
-:author: OpenQA Team
+:author: openQA Team
 :listing-caption: Listing
 :source-highlighter: pygments
 


### PR DESCRIPTION
i'm adding some changes that were missing with my last rebase mess (Pitfalls and WritingTests), and also unified code blocks so there's only usage of sh instead of bash  which is basically the same coloring.

Results have been generated using [this script](https://github.com/foursixnine/openQA/blob/doc/generator_script/script/generate-documentation):
- https://w3.nue.suse.com/~szarate/openQA/docs/openqa-documentation-20161122_66e4f8c.html
- https://w3.nue.suse.com/~szarate/openQA/docs/openqa-documentation-20161122_66e4f8c.pdf