### PR TITLE
Add RabbitMQ support

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -50,6 +50,7 @@ requires 'Mojo::Base';
 requires 'Mojo::ByteStream';
 requires 'Mojo::IOLoop';
 requires 'Mojo::JSON';
+requires 'Mojo::RabbitMQ::Client';
 requires 'Mojo::URL';
 requires 'Mojo::Util';
 requires 'Mojolicious';
@@ -94,6 +95,7 @@ on 'test' => sub {
   requires 'Test::Pod';
   requires 'Test::Warnings';
   requires 'Test::MockModule';
+  requires 'Test::MockObject';
 };
 
 feature 'coverage', 'coverage for travis' => sub {

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -67,3 +67,11 @@
 [audit]
 # disable auditing of chatty events by default
 blacklist = job_grab job_done
+
+## Configuration for AMQP plugin
+[amqp]
+# guest/guest is the default anonymous user/pass for RabbitMQ
+#reconnect_timeout = 5
+#url = amqp://guest:guest@localhost:5672/
+#exchange = pubsub
+#topic_prefix = suse

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -125,7 +125,8 @@ sub hash {
     return {
         user    => $self->user->name,
         text    => $self->text,
-        created => $self->t_created
+        created => $self->t_created->datetime() . 'Z',
+        updated => $self->t_updated->datetime() . 'Z',
     };
 }
 

--- a/lib/OpenQA/ServerStartup.pm
+++ b/lib/OpenQA/ServerStartup.pm
@@ -62,6 +62,12 @@ sub read_config {
         audit => {
             blacklist => '',
         },
+        amqp => {
+            reconnect_timeout => 5,
+            url               => 'amqp://guest:guest@localhost:5672/',
+            exchange          => 'pubsub',
+            topic_prefix      => 'suse',
+        },
     );
 
     # in development mode we use fake auth and log to stderr

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -74,7 +74,7 @@ sub create {
             text    => href_to_bugref($text),
             user_id => $self->current_user->id
         });
-    $self->emit_event('openqa_user_new_comment', {id => $res->id});
+    $self->emit_event('openqa_comment_create', {id => $res->id});
     $self->render(json => {id => $res->id});
 }
 
@@ -93,7 +93,7 @@ sub update {
     return $self->render(json => {error => "Forbidden (must be author)"}, status => 403)
       unless ($comment->user_id == $self->current_user->id);
     my $res = $comment->update({text => href_to_bugref($text)});
-    $self->emit_event('openqa_user_update_comment', {id => $comment->id});
+    $self->emit_event('openqa_comment_update', {id => $comment->id});
     $self->render(json => {id => $res->id});
 }
 
@@ -106,8 +106,8 @@ sub delete {
     my $comment_id = $self->param('comment_id');
     my $comment    = $comments->find($self->param('comment_id'));
     return $self->render(json => {error => "Comment $comment_id does not exist"}, status => 404) unless $comment;
+    $self->emit_event('openqa_comment_delete', {id => $comment_id});
     my $res = $comment->delete();
-    $self->emit_event('openqa_user_delete_comment', {id => $res->id});
     $self->render(json => {id => $res->id});
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -336,11 +336,8 @@ sub restart {
 
     my $ipc = OpenQA::IPC->ipc;
     my $res = $ipc->scheduler('job_restart', $jobs);
-    if (@$res > 1) {
-        $self->emit_event('openqa_jobs_restart', {ids => $jobs, results => $res});
-    }
-    elsif (@$res == 1) {
-        $self->emit_event('openqa_job_restart', {id => $jobs->[0], result => $res->[0]});
+    for (my $i = 0; $i < @$res; $i++) {
+        $self->emit_event('openqa_job_restart', {id => $jobs->[$i], result => $res->[$i]});
     }
     my @urls = map { $self->url_for('test', testid => $_) } @$res;
     $self->render(json => {result => $res, test_url => \@urls});

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -1,0 +1,188 @@
+# Copyright (C) 2016 SUSE Linux LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Plugin::AMQP;
+
+use strict;
+use warnings;
+
+use parent qw/Mojolicious::Plugin/;
+use JSON;
+use Mojo::IOLoop;
+use OpenQA::Utils;
+use OpenQA::Schema::Result::Jobs;
+use Mojo::RabbitMQ::Client;
+
+my @job_events     = qw(job_create job_delete job_cancel job_duplicate job_restart job_update_result job_done);
+my @comment_events = qw(comment_create comment_update comment_delete);
+
+sub new {
+    my $class = shift;
+    my $self  = $class->SUPER::new(@_);
+    $self->{app}          = undef;
+    $self->{config}       = undef;
+    $self->{client}       = undef;
+    $self->{channel}      = undef;
+    $self->{reconnecting} = 0;
+    return $self;
+}
+
+sub register {
+    my $self = shift;
+    $self->{app}    = shift;
+    $self->{config} = $self->{app}->config;
+    my $ioloop = Mojo::IOLoop->singleton;
+
+    $self->connect();
+
+    # register for events
+    for my $e (@job_events) {
+        $ioloop->on("openqa_$e" => sub { shift; $self->on_job_event(@_) });
+    }
+    for my $e (@comment_events) {
+        $ioloop->on("openqa_$e" => sub { shift; $self->on_comment_event(@_) });
+    }
+}
+
+sub reconnect {
+    my $self = shift;
+
+    return if $self->{reconnecting};
+    $self->{reconnecting} = 1;
+    Mojo::IOLoop->timer(
+        $self->{config}->{reconnect_timeout} => sub {
+            $self->{reconnecting} = 0;
+            $self->connect();
+        });
+}
+
+sub connect {
+    my $self = shift;
+
+    OpenQA::Utils::log_debug("Connecting to AMQP server");
+    $self->{client} = Mojo::RabbitMQ::Client->new(url => $self->{config}->{amqp}{url});
+    $self->{client}
+      ->catch(sub { OpenQA::Utils::log_warning("Failed to connect to AMQP server: " . $self->{config}->{amqp}{url}); });
+    $self->{client}->on(
+        open => sub {
+            my ($client) = @_;
+
+            $self->{channel} = Mojo::RabbitMQ::Client::Channel->new();
+            $self->{channel}->catch(sub { OpenQA::Utils::log_warning("Error on AMQP channel received"); });
+
+            $self->{channel}->on(
+                open => sub {
+                    my ($channel) = @_;
+                    $channel->declare_exchange(exchange => $self->{config}->{amqp}{exchange}, type => 'topic')
+                      ->deliver();
+                });
+            $self->{channel}->on(
+                close => sub {
+                    OpenQA::Utils::log_warning("AMQP channel closed");
+                });
+            $client->open_channel($self->{channel});
+        });
+    $self->{client}->on(
+        close => sub {
+            OpenQA::Utils::log_warning("AMQP connection closed");
+            $self->reconnect();
+        });
+    $self->{client}->on(
+        error => sub {
+            OpenQA::Utils::log_warning("AMQP connection error");
+            $self->reconnect();
+        });
+    $self->{client}->on(
+        disconnect => sub {
+            OpenQA::Utils::log_warning("AMQP connection closed");
+            $self->reconnect();
+        });
+    $self->{client}->on(
+        timeout => sub {
+            OpenQA::Utils::log_warning("AMQP connection closed");
+            $self->reconnect();
+        });
+    $self->{client}->connect();
+}
+
+sub log_event {
+    my ($self, $event, $event_data) = @_;
+
+    unless ($self->{channel} && $self->{channel}->is_open) {
+        OpenQA::Utils::log_warning("Error sending AMQP event: Channel is not open");
+        return;
+    }
+
+    # use dot separators
+    $event =~ s/_/\./;
+    $event =~ s/_/\./;
+
+    my $topic = $self->{config}->{amqp}{topic_prefix} . '.' . $event;
+
+    # convert data to JSON, with reliable key ordering (helps the tests)
+    $event_data = to_json($event_data, {canonical => 1, allow_blessed => 1});
+
+    OpenQA::Utils::log_debug("Sending AMQP event: $topic");
+
+    $self->{channel}->publish(
+        exchange    => $self->{config}->{amqp}{exchange},
+        routing_key => $topic,
+        body        => $event_data
+    )->deliver();
+}
+
+sub on_job_event {
+    my ($self, $args) = @_;
+    my ($user_id, $connection_id, $event, $event_data) = @$args;
+
+    # find count of pending jobs for the same build
+    # this is so we can tell when all tests for a build are done
+    my $job = $self->{app}->db->resultset('Jobs')->find({id => $event_data->{id}});
+    my $build = $job->BUILD;
+    $event_data->{group_id}  = $job->group_id;
+    $event_data->{remaining} = $self->{app}->db->resultset('Jobs')->search(
+        {
+            'me.BUILD' => $build,
+            state      => [OpenQA::Schema::Result::Jobs::PENDING_STATES],
+        })->count;
+    # add various useful properties for consumers if not there already
+    for my $detail (qw(BUILD TEST ARCH MACHINE FLAVOR)) {
+        $event_data->{$detail} //= $job->$detail;
+    }
+    for my $detail (qw(ISO HDD_1)) {
+        $event_data->{$detail} //= $job->settings_hash->{$detail} if ($job->settings_hash->{$detail});
+    }
+
+    $self->log_event($event, $event_data);
+}
+
+sub on_comment_event {
+    my ($self, $args) = @_;
+    my ($comment_id, $connection_id, $event, $event_data) = @$args;
+
+    # find comment in database
+    my $comment = $self->{app}->db->resultset('Comments')->find($event_data->{id});
+    return unless $comment;
+
+    # just send the hash already used for JSON representation
+    my $hash = $comment->hash;
+    # also include job_id/group_id
+    $hash->{job_id}   = $comment->job_id;
+    $hash->{group_id} = $comment->group_id;
+
+    $self->log_event($event, $hash);
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -24,7 +24,7 @@ use JSON;
 use Mojo::IOLoop;
 use OpenQA::Schema::Result::Jobs;
 
-my @job_events = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_done/;
+my @job_events     = qw/job_create job_delete job_cancel job_duplicate job_restart job_update_result job_done/;
 my @comment_events = qw/comment_create comment_update comment_delete/;
 
 sub register {

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -25,7 +25,7 @@ use Mojo::IOLoop;
 use OpenQA::Schema::Result::Jobs;
 
 my @job_events = qw/job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result job_done/;
-my @comment_events = qw/user_new_comment user_update_comment user_delete_comment/;
+my @comment_events = qw/comment_create comment_update comment_delete/;
 
 sub register {
     my ($self, $app) = @_;

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -1,0 +1,193 @@
+BEGIN { unshift @INC, 'lib'; }
+
+# Copyright (C) 2016 SUSE Linux LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Mojo::Base;
+use Mojo::IOLoop;
+
+use OpenQA::Client;
+use OpenQA::IPC;
+use OpenQA::Scheduler;
+use OpenQA::WebSockets;
+use OpenQA::Test::Database;
+use Net::DBus;
+use Net::DBus::Test::MockObject;
+use Test::MockObject;
+use Test::More;
+use Test::Mojo;
+use Test::Warnings;
+
+my %client_context;
+
+my $client_mock = Test::MockObject->new();
+$client_mock->fake_module(
+    'Mojo::RabbitMQ::Client',
+    new => sub {
+        my $self = shift;
+        my %args = @_;
+        $client_context{url} = $args{url};
+
+        return $self;
+    },
+    catch => sub { },
+    on    => sub {
+        my $self  = shift;
+        my $event = shift;
+        my $sub   = shift;
+        $client_context{on}{$event} = $sub;
+    },
+    connect => sub {
+        my $self = shift;
+        $client_context{on}{open}($self);
+    },
+    open_channel => sub {
+        my $self    = shift;
+        my $channel = shift;
+        $channel->connect();
+    });
+
+my %channel_context;
+my $channel_mock = Test::MockObject->new();
+$channel_mock->fake_module(
+    'Mojo::RabbitMQ::Client::Channel',
+    new => sub {
+        my $self = shift;
+        $channel_context{is_open} = 0;
+        return $self;
+    },
+    catch => sub { },
+    on    => sub {
+        my $self  = shift;
+        my $event = shift;
+        my $sub   = shift;
+        $channel_context{on}{$event} = $sub;
+    },
+    connect => sub {
+        my $self = shift;
+        $channel_context{on}{open}($self);
+    },
+    declare_exchange => sub {
+        my $self = shift;
+        my %args = @_;
+        is($args{exchange}, 'pubsub', 'declare the right exchange');
+        is($args{type},     'topic',  'declare the right exchange type');
+        $channel_context{is_open}   = 1;
+        $channel_context{delivered} = 0;
+        return $self;
+    },
+    publish => sub {
+        my $self = shift;
+        my %args = @_;
+        ok($channel_context{delivered}, 'previous command was delivered');
+        $channel_context{delivered} = 0;
+        $channel_context{last}{$args{routing_key}} = $args{body};
+        return $self;
+    },
+    deliver => sub {
+        my $self = shift;
+        $channel_context{delivered} = 1;
+    },
+    is_open => sub {
+        my $self = shift;
+        return $channel_context{is_open};
+    });
+
+my $schema = OpenQA::Test::Database->new->create();
+
+# this test also serves to test plugin loading via config file
+$ENV{OPENQA_CONFIG} = 't';
+open(my $fd, '>', $ENV{OPENQA_CONFIG} . '/openqa.ini');
+print $fd "[global]\n";
+print $fd "plugins=AMQP\n";
+close $fd;
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+# XXX: Test::Mojo loses its app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+my $app = $t->app;
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+# create Test DBus bus and service for fake WebSockets
+my $ipc = OpenQA::IPC->ipc('', 1);
+my $ws  = OpenQA::WebSockets->new();
+my $sh  = OpenQA::Scheduler->new();
+
+my $settings = {
+    DISTRI      => 'Unicorn',
+    FLAVOR      => 'pink',
+    VERSION     => '42',
+    BUILD       => '666',
+    TEST        => 'rainbow',
+    ISO         => 'whatever.iso',
+    DESKTOP     => 'DESKTOP',
+    KVM         => 'KVM',
+    ISO_MAXSIZE => 1,
+    MACHINE     => "RainbowPC",
+    ARCH        => 'x86_64'
+};
+
+# create a job via API
+my $post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+my $job = $post->tx->res->json->{id};
+is(
+    $channel_context{last}{'suse.openqa.job.create'},
+    '{"ARCH":"x86_64","BUILD":"666","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink","ISO":"whatever.iso",'
+      . '"ISO_MAXSIZE":"1","KVM":"KVM","MACHINE":"RainbowPC","TEST":"rainbow","VERSION":"42","group_id":null,"id":'
+      . $job
+      . ',"remaining":1}',
+    "job create triggers amqp"
+);
+
+# set the job as done via API
+$post = $t->post_ok("/api/v1/jobs/" . $job . "/set_done")->status_is(200);
+is(
+    $channel_context{last}{'suse.openqa.job.done'},
+    '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
+      . '"TEST":"rainbow","group_id":null,"id":'
+      . $job
+      . ',"newbuild":null,"remaining":0,"result":"failed"}',
+    "job done triggers amqp"
+);
+
+# duplicate the job via API
+$post = $t->post_ok("/api/v1/jobs/" . $job . "/duplicate")->status_is(200);
+my $newjob = $post->tx->res->json->{id};
+is(
+    $channel_context{last}{'suse.openqa.job.duplicate'},
+    '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
+      . '"TEST":"rainbow","auto":0,"group_id":null,"id":'
+      . $job
+      . ',"remaining":1,"result":'
+      . $newjob . '}',
+    "job duplicate triggers amqp"
+);
+
+# cancel the new job via API
+$post = $t->post_ok("/api/v1/jobs/" . $newjob . "/cancel")->status_is(200);
+is(
+    $channel_context{last}{'suse.openqa.job.cancel'},
+    '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
+      . '"TEST":"rainbow","group_id":null,"id":'
+      . $newjob
+      . ',"remaining":0}',
+    "job cancel triggers amqp"
+);
+
+done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -61,6 +61,12 @@ is_deeply(
         },
         audit => {
             blacklist => 'job_grab job_done',
+        },
+        amqp => {
+            reconnect_timeout => 5,
+            url               => 'amqp://guest:guest@localhost:5672/',
+            exchange          => 'pubsub',
+            topic_prefix      => 'suse',
         }});
 
 $ENV{OPENQA_CONFIG} = 't';


### PR DESCRIPTION
This will add a plugin to send the events via AMQP (RabbitMQ).
The plugin depends on `Mojo::RabbitMQ::Client`.

@AdamWill: We did some changes on the comment event names.

The PR also has some fixes for problems with `comment->hash` that were hidden by the too friendly mojo internal json encoder.
Also the `jobs_reset` event was removed (it was broken in the Fedmsg plugin anyway) and replaced by multiple `job_reset` events. This removes some edge cases that violated the `object.action` event name pattern. Sticking to that pattern allows easy rabbitmq serverside event filtering.