### PR TITLE
Treat uploading jobs like running

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -200,7 +200,7 @@ function setupResult(state, jobid, status_url, details_url) {
       }
     }
   }
-  if (state == "running" || state == "waiting") {
+  if (state == "running" || state == "waiting" || state == "uploading") {
     setupRunning(jobid, status_url, details_url);
   }
   else if (state == "scheduled") {


### PR DESCRIPTION
An uploading job is like a running one, just not updating. So show
the live tab for the log - and more importantely wait for the state
to change to passed/failed

There is unfortunately no test coverage for this :(