### PR TITLE
Allow selecting multiple job groups in overview query

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -95,12 +95,12 @@ sub latest_jobs {
     my @latest;
     my %seen;
     foreach my $job (@jobs) {
-        my $distri  = $job->DISTRI;
-        my $version = $job->VERSION;
-        my $build   = $job->BUILD;
-        my $test    = $job->TEST;
-        my $flavor  = $job->FLAVOR || 'sweet';
-        my $arch    = $job->ARCH || 'noarch';
+        my $distri  = $job->DISTRI  || 'nodistri';
+        my $version = $job->VERSION || 'noversion';
+        my $build   = $job->BUILD   || 'nobuild';
+        my $test    = $job->TEST    || 'notest';
+        my $flavor  = $job->FLAVOR  || 'sweet';
+        my $arch    = $job->ARCH    || 'noarch';
         my $machine = $job->MACHINE || 'nomachine';
         my $key     = "$distri-$version-$build-$test-$flavor-$arch-$machine";
         next if $seen{$key}++;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -395,9 +395,11 @@ sub prepare_job_results {
     my %descriptions = map { $_->name => $_->description } @descriptions;
 
     foreach my $job (@$jobs) {
-        my $test   = $job->TEST;
-        my $flavor = $job->FLAVOR || 'sweet';
-        my $arch   = $job->ARCH || 'noarch';
+        my $test    = $job->TEST;
+        my $distri  = $job->DISTRI || 'nodistri';
+        my $version = $job->VERSION || 'noversion';
+        my $flavor  = $job->FLAVOR || 'sweet';
+        my $arch    = $job->ARCH || 'noarch';
 
         my $result;
         if ($job->state eq 'done') {

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -141,6 +141,16 @@ $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version =>
   ->status_is(200);
 like(get_summary, qr/Passed: 0 Soft Failure: 2 Failed: 1/i, 'todo=1 shows all unlabeled failed');
 
+# multiple groups can be shown at the same time
+$get     = $t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002')->status_is(200);
+$summary = get_summary;
+like($summary, qr/Summary of opensuse, opensuse test/i, 'references both groups selected by query');
+like($summary, qr/Passed: 2 Failed: 0 Scheduled: 1 Running: 2 None: 1/i,
+    'shows latest jobs from both groups 1001/1002');
+$get->element_exists('#res_DVD_i586_kde',                           'job from group 1001 is shown');
+$get->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled', 'another job from group 1001');
+$get->element_exists('#res_NET_x86_64_kde .state_running',          'job from group 1002 is shown');
+
 #
 # Test filter form
 #

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -52,7 +52,25 @@
         </div>
     </div>
     <div class="panel panel-default" id="filter-panel">
-        <div class="panel-heading"><strong>Filter</strong> <span>no filter present, click to toggle filter form</span></div>
+        <div class="panel-heading"><strong>Filter</strong>
+            <%= help_popover('Help for the <i>test overview</i>' => '
+                    <p>This page shows an overview of job results in a matrix
+                    view. Only the latest job for each scenario is shown. The
+                    view can be configured based on query parameters which can
+                    be set within this filter box.</p>
+                    <p><b>Caveat:</b> Based on the parameters the resulting
+                    job query might consider jobs as latest which do not
+                    represent the complete picture for a corresponding
+                    "latest" build so be careful with a more advanced
+                    selection of checkboxes with the interpretation of the
+                    results.</p>
+                    <p>Additional tweaking of the query is possible by leaving
+                    out query parameters completely or specifying them
+                    multiple times equivalent to an logical "or" search.</p>',
+                    'https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Allow-group-overview-query-by-result-gh531' => 'Wiki')
+                %>
+            <span>no filter present, click to toggle filter form</span>
+        </div>
         <div class="panel-body">
             <form action="#" type="get" id="filter-form">
                 <div class="form-group" id="filter-results">

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -12,10 +12,10 @@
     <div id="summary" class="panel <%= ($aggregated->{failed} + $aggregated->{incomplete}) ? 'panel-danger' : 'panel-success' %>">
         <div class="panel-heading">
             Overall Summary of
-            % if ($group) {
-                <b><%= link_to $group->name => url_for('group_overview', groupid => $group->id) %></b>
-            % } else
-            % {
+            % if (@$groups) {
+                <b><%= b join(', ', map { link_to $_->name => url_for('group_overview', groupid => $_->id) } @$groups) %></b>
+            % }
+            % else {
                 <b><%= $distri %> <%= $version %></b>
             % }
             build <%= $build %>

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -79,7 +79,6 @@
             </form>
         </div>
     </div>
-    % my $failedid;
     % for my $type (@$types) {
         <h3>Flavor: <%= $type %></h3>
         <table id="results_<%= $type %>" class="overview table table-striped table-hover">


### PR DESCRIPTION
This alters previous behaviour where additional 'groupid' parameters would
overwrite previous ones. Now a logical 'or' operation is done on the job
group ids as well as names to show jobs from all job groups. Jobs are still
filtered to show only the latest ones over all job groups. Still this should
allow to show more jobs of one build when multiple job groups are involved.

Screenshot showing the overview page for multiple job groups at once:

![openqa_multiple_groups_in_overview](https://cloud.githubusercontent.com/assets/1693432/21398081/6146e1d4-c7a6-11e6-8d8f-e9bdd93732e1.png)


Related progress issue: https://progress.opensuse.org/issues/13712