### PR TITLE
Restart the mojo worker every 2000 requests

### DIFF
--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -10,7 +10,8 @@ Requires=openqa-scheduler.service openqa-websockets.service
 User=geekotest
 Environment="DBUS_STARTER_BUS_TYPE=system"
 # Our API commands are very expensive, so the default timeouts are too tight
-ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 10
+# for the meaning of -a -G and -r, check https://progress.opensuse.org/issues/13876
+ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 10 -a 100 -G 1000 -r 20
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To avoid the worker growing memory usage we restart it after 200*10
requests and give it a lot of time to finish requests. Mojolocious 7.10
has a bug, that during restart it will still accept more requests from
apache, so we need to limit the number of requests accepted (-r)
and give the restart enough time to finish all of them (-G).

This bug caused several sudden deaths in uploads, e.g. see
https://progress.opensuse.org/issues/13876