### PR TITLE
Show review badges also on group-level

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -61,6 +61,13 @@ sub count_job {
     return;
 }
 
+sub add_review_badge {
+    my ($build_res) = @_;
+
+    $build_res->{reviewed_all_passed} = $build_res->{passed} == $build_res->{total};
+    $build_res->{reviewed} = $build_res->{failed} > 0 && $build_res->{labeled} == $build_res->{failed};
+}
+
 sub compute_build_results {
     my ($group, $limit, $time_limit_days, $tags) = @_;
 
@@ -144,13 +151,13 @@ sub compute_build_results {
                 $child->{distri}  //= $job->DISTRI;
                 $child->{version} //= $job->VERSION;
                 count_job($job, $child, \%labels);
+                add_review_badge($child);
             }
         }
         $jr{escaped_id} = $b;
         $jr{escaped_id} =~ s/\W/_/g;
-        $jr{reviewed_all_passed} = $jr{passed} == $jr{total};
-        $jr{reviewed}            = $jr{failed} > 0 && $jr{labeled} == $jr{failed};
-        $builds{$b}              = \%jr;
+        add_review_badge(\%jr);
+        $builds{$b} = \%jr;
         $max_jobs = $jr{total} if ($jr{total} > $max_jobs);
     }
     return {

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -94,6 +94,8 @@ sub check_test_parent {
         1, 'review badge for build 0048@0815 shown');
     is($get->tx->res->dom->find('#review-' . $test_parent->id . '-0048')->size,
         0, 'review badge for build 0048 NOT shown yet');
+    is($get->tx->res->dom->find('#child-review-' . $test_parent->id . '-0048')->size,
+        0, 'review badge for build 0048 also on child-level NOT shown yet');
 
     my @progress_bars
       = $get->tx->res->dom->find("div.children-$default_expanded .progress")->map('attr', 'title')->each;
@@ -193,6 +195,8 @@ my $not_reviewed_job = $jobs->create(
 $get = $t->get_ok('/?limit_builds=20&show_tags=1')->status_is(200);
 is($get->tx->res->dom->find('#review-' . $test_parent->id . '-0048@0815')->size,
     0, 'review badge NOT shown for build 0048@0815 anymore');
+is($get->tx->res->dom->find('#child-review-' . $test_parent->id . '-0048@0815')->size,
+    1, 'review badge for build 0048@0815 still shown on child-level');
 $not_reviewed_job->delete();
 
 # add review for job 99938 so build 0048 is reviewed, despite the unreviewed softfails
@@ -200,6 +204,8 @@ $opensuse_group->jobs->find({id => 99938})->comments->create({text => 'poo#4321'
 $get = $t->get_ok('/?limit_builds=20')->status_is(200);
 is($get->tx->res->dom->find('#review-' . $test_parent->id . '-0048')->size,
     1, 'review badge for build 0048 shown, despite unreviewed softfails');
+is($get->tx->res->dom->find('#child-review-' . $test_parent->id . '-0048')->size,
+    1, 'review badge for build 0048 shown on child-level, despite unreviewed softfails');
 
 # change DISTRI/VERSION of test in opensuse group to test whether links are still correct then
 $opensuse_group->jobs->update({VERSION => '14.2', DISTRI => 'suse'});

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -22,18 +22,7 @@
                         <i class="tag fa fa-tag" title="<%= $tag->{type}; %>"><%= $tag->{description} %></i>
                     </span>
                 % }
-                % my $reviewed = $build_res->{reviewed};
-                % if ($reviewed) {
-                    <span id="review-<%= $group_build_id %>">
-                        <i class="review fa fa-certificate" title="Reviewed (<%= $build_res->{labeled}; %> comments)"></i>
-                    </span>
-                % }
-                % my $reviewed_all_passed = $build_res->{reviewed_all_passed};
-                % if ($reviewed_all_passed) {
-                    <span id="review-all-passed-<%= $group_build_id %>">
-                        <i class="review-all-passed fa fa-certificate" title="Reviewed (all passed)"></i>
-                    </span>
-                % }
+                %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $build_res, id_prefix => ''
             </h4>
         </div>
         <div class="col-md-8">
@@ -52,6 +41,7 @@
                         <div class="col-md-4 text-nowrap">
                             <h4>
                                 %= link_to $child->{name} => url_for('tests_overview')->query(distri => $child_res->{distri}, version => $child_res->{version}, build => $build, groupid => $child->{id})
+                                %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $child_res, id_prefix => 'child-'
                             </h4>
                         </div>
                         <div class="col-md-8">

--- a/templates/main/review_badge.html.ep
+++ b/templates/main/review_badge.html.ep
@@ -1,0 +1,12 @@
+% my $reviewed = $build_res->{reviewed};
+% if ($reviewed) {
+    <span id="<%= $id_prefix %>review-<%= $group_build_id %>">
+        <i class="review fa fa-certificate" title="Reviewed (<%= $build_res->{labeled}; %> <%= $build_res->{labeled} == 1 ? 'comment' : 'comments' %>)"></i>
+    </span>
+% }
+% my $reviewed_all_passed = $build_res->{reviewed_all_passed};
+% if ($reviewed_all_passed) {
+    <span id="<%= $id_prefix %>review-all-passed-<%= $group_build_id %>">
+        <i class="review-all-passed fa fa-certificate" title="Reviewed (all passed)"></i>
+    </span>
+% }


### PR DESCRIPTION
Show review badges also in the foldable job group entries on index page and parent group overview

After this all TODOs regarding parent groups should be done: https://progress.opensuse.org/issues/14814