### PR TITLE
Use default priority of job groups

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -355,8 +355,8 @@ sub schedule_iso {
         my %testsuite_ids;    # key: "suite:machine", value: array of job ids
 
         for my $settings (@{$jobs || []}) {
-            my $prio     = delete $settings->{PRIO};
-            my $group_id = delete $settings->{GROUP_ID};
+            my $prio = delete $settings->{PRIO};
+            $settings->{_GROUP_ID} = delete $settings->{GROUP_ID};
 
             # create a new job with these parameters and count if successful, do not send job notifies yet
             my $job = $self->db->resultset('Jobs')->create_from_settings($settings);
@@ -367,11 +367,10 @@ sub schedule_iso {
                 $testsuite_ids{_settings_key($settings)} //= [];
                 push @{$testsuite_ids{_settings_key($settings)}}, $job->id;
 
-                # change prio only if other than default prio
-                if (defined($prio) && $prio != 50) {
+                # set prio if defined explicitely (otherwise default prio is used)
+                if (defined($prio)) {
                     $job->priority($prio);
                 }
-                $job->group_id($group_id);
                 $job->update;
             }
         }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -89,16 +89,15 @@ sub create {
     my $id;
     my $validation = $self->validation;
 
-    $validation->required('prio')->like(qr/^[0-9]+$/);
-
     if ($validation->optional('product_id')->like(qr/^[0-9]+$/)->is_valid) {
         $validation->required('machine_id')->like(qr/^[0-9]+$/);
         $validation->required('group_id')->like(qr/^[0-9]+$/);
         $validation->required('test_suite_id')->like(qr/^[0-9]+$/);
+        $validation->optional('prio')->like(qr/^[0-9]+$/);
 
         if ($validation->has_error) {
             $error = "wrong parameter: ";
-            for my $k (qw/product_id machine_id test_suite_id group_id/) {
+            for my $k (qw(product_id machine_id test_suite_id group_id)) {
                 $error .= $k if $validation->has_error($k);
             }
         }
@@ -121,10 +120,11 @@ sub create {
         $validation->required('distri');
         $validation->required('flavor');
         $validation->required('version');
+        $validation->required('prio')->like(qr/^[0-9]+$/);
 
         if ($validation->has_error) {
             $error = "wrong parameter: ";
-            for my $k (qw/group_name machine_name test_suite_name arch distri flavor version/) {
+            for my $k (qw(group_name machine_name test_suite_name arch distri flavor version)) {
                 $error .= $k if $validation->has_error($k);
             }
         }

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -84,9 +84,13 @@ sub save_connect {
 
     $self->validation->required('groupid')->like(qr/^[0-9]+$/);
     my $group = $self->db->resultset("JobGroups")->find($self->param('groupid'));
+    if (!$group) {
+        $self->flash(error => 'Specified group ID ' . $self->param('groupid') . 'doesn\'t exist.');
+        $self->redirect_to('admin_groups');
+    }
 
     my $values = {
-        prio => $self->param('prio') // 50,
+        prio => $self->param('prio') // $group->default_priority,
         product_id    => $self->param('medium'),
         machine_id    => $self->param('machine'),
         group_id      => $group->id,

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -185,7 +185,9 @@ is_deeply(
 );    # textmode is not defined for 64bit machine
 
 is($server_32->{group_id}, 1001, 'server_32 part of opensuse group');
+is($server_32->{priority}, 40,   'server_32 has priority according to job template');
 is($server_64->{group_id}, 1001, 'server_64 part of opensuse group');
+is($server_64->{priority}, 40,   'server_64 has priority according to job template');
 
 is($advanced_kde_32->{settings}->{PUBLISH_HDD_1}, 'opensuse-13.1-i586-kde-qemu32.qcow2', "variable expansion");
 is($advanced_kde_64->{settings}->{PUBLISH_HDD_1}, 'opensuse-13.1-i586-kde-qemu64.qcow2', "variable expansion");

--- a/templates/admin/group/group_property_editor.html.ep
+++ b/templates/admin/group/group_property_editor.html.ep
@@ -17,31 +17,31 @@
             </div>
             % if (!$is_parent) {
                 <div class="form-group">
-                    <label for="editor-size-limit" class="col-sm-2 control-label" title="Size limit for assets">Size limit</label>
+                    <label for="editor-size-limit" class="col-sm-2 control-label" data-toggle="tooltip" title="Size limit for assets">Size limit</label>
                     <div class="col-sm-10">
                         <input type="number" min="1" class="form-control" id="editor-size-limit" name="size_limit_gb" value="<%= $group->size_limit_gb %>"> GiB
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-logs-in-days" class="col-sm-2 control-label" title="Number of days to keep logs of jobs">Keep logs for</label>
+                    <label for="editor-keep-logs-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep logs of jobs">Keep logs for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-logs-in-days" name="keep_logs_in_days" value="<%= $group->keep_logs_in_days %>"> days
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-important-logs-in-days" class="col-sm-2 control-label" title="Number of days to keep logs of important jobs" title="currently not used">Keep important logs for</label>
+                    <label for="editor-keep-important-logs-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep logs of important jobs" title="currently not used">Keep important logs for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-important-logs-in-days" name="keep_important_logs_in_days" value="<%= $group->keep_important_logs_in_days %>"> days
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-results-in-days" class="col-sm-2 control-label" title="Number of days to keep results of jobs">Keep results for</label>
+                    <label for="editor-keep-results-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep results of jobs">Keep results for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-results-in-days" name="keep_results_in_days" value="<%= $group->keep_results_in_days %>"> days
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-important-results-in-days" class="col-sm-2 control-label" title="Number of days to keep results of important jobs">Keep important results for</label>
+                    <label for="editor-keep-important-results-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep results of important jobs">Keep important results for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-important-results-in-days" name="keep_important_results_in_days" value="<%= $group->keep_important_results_in_days %>"> days
                     </div>
@@ -49,44 +49,51 @@
             % }
             % else {
                 <div class="form-group">
-                    <label for="editor-size-limit" class="col-sm-2 control-label" title="Size limit for assets">Size limit</label>
+                    <label for="editor-size-limit" class="col-sm-2 control-label" data-toggle="tooltip" title="Size limit for assets">Size limit</label>
                     <div class="col-sm-10">
                         <input type="number" min="1" class="form-control" id="editor-size-limit" name="default_size_limit_gb" value="<%= $group->default_size_limit_gb %>"> GiB
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-logs-in-days" class="col-sm-2 control-label" title="Number of days to keep logs of jobs">Keep logs for</label>
+                    <label for="editor-keep-logs-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep logs of jobs">Keep logs for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-logs-in-days" name="default_keep_logs_in_days" value="<%= $group->default_keep_logs_in_days %>"> days
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-important-logs-in-days" class="col-sm-2 control-label" title="Number of days to keep logs of important jobs">Keep important logs for</label>
+                    <label for="editor-keep-important-logs-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep logs of important jobs">Keep important logs for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-important-logs-in-days" name="default_keep_important_logs_in_days" value="<%= $group->default_keep_important_logs_in_days %>"> days
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-results-in-days" class="col-sm-2 control-label" title="Number of days to keep results of jobs">Keep results for</label>
+                    <label for="editor-keep-results-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep results of jobs">Keep results for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-results-in-days" name="default_keep_results_in_days" value="<%= $group->default_keep_results_in_days %>"> days
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="editor-keep-important-results-in-days" class="col-sm-2 control-label" title="Number of days to keep results of important jobs">Keep important results for</label>
+                    <label for="editor-keep-important-results-in-days" class="col-sm-2 control-label" data-toggle="tooltip" title="Number of days to keep results of important jobs">Keep important results for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-important-results-in-days" name="default_keep_important_results_in_days" value="<%= $group->default_keep_important_results_in_days %>"> days
                     </div>
                 </div>
             % }
             <div class="form-group">
-                <label for="editor-default-priority" class="col-sm-2 control-label" title="Currently not used">Default priority for jobs</label>
+                <label for="editor-default-priority" class="col-sm-2 control-label" data-toggle="tooltip" title="Default priority for jobs and job templates created in the group">Default priority</label>
                 <div class="col-sm-10">
                     <input type="number" class="form-control" id="editor-default-priority" name="default_priority" value="<%= $group->default_priority %>">
+                    <%= help_popover 'Default priority' =>
+                        '<p>Specifies the default priority for jobs and job templates created in the group</p>
+                        <ul>
+                            <li>Does not affect existing jobs</li>
+                            <li>When scheduling a new ISO the priority from the job template is taken, so this settings does not affect this directly</li>
+                        </ul>';
+                %>
                 </div>
             </div>
             <div class="form-group">
-                <label for="editor-description" class="col-sm-2 control-label" title="Shown on top of the group overview">Description</label>
+                <label for="editor-description" class="col-sm-2 control-label" data-toggle="tooltip" title="Shown on top of the group overview">Description</label>
                 <div class="col-sm-10">
                     <textarea class="form-control" id="editor-description" name="description" ><%= $group->description %></textarea>
                 </div>


### PR DESCRIPTION
* When creating a new job in a job group, priority is set to the default of the job group
* Does not affect
   * existing jobs
   * new jobs without a job group
   * new jobs added when a new ISO is scheduled (then still the priority from the job template is taken)

Because of the last point I guess this is not too useful actually. But it was on the TODO list because we decided to add the `default_priority` column for job/parent groups.