### PR TITLE
Use proper die message on duplicate job name

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -100,6 +100,7 @@ on 'test' => sub {
   requires 'Test::MockModule';
   requires 'Test::MockObject';
   requires 'Test::Fatal';
+  requires 'Test::Exception';
 };
 
 feature 'coverage', 'coverage for travis' => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -100,7 +100,6 @@ on 'test' => sub {
   requires 'Test::MockModule';
   requires 'Test::MockObject';
   requires 'Test::Fatal';
-  requires 'Test::Exception';
 };
 
 feature 'coverage', 'coverage for travis' => sub {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -268,7 +268,7 @@ sub delete {
 }
 
 sub name {
-    my $self = shift;
+    my ($self) = @_;
     return $self->slug if $self->slug;
 
     if (!$self->{_name}) {

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -115,11 +115,11 @@ sub create_from_settings {
 
     my %new_job_args = (TEST => $settings{TEST});
 
-    if ($settings{NAME}) {
-        my $njobs = $self->search({slug => $settings{NAME}})->count;
-        return 0 if $njobs;
 
-        $new_job_args{slug} = $settings{NAME};
+    if (my $name = $settings{NAME}) {
+        my $njobs = $self->search({slug => $name})->count;
+        !$njobs or die "job with name \'$name\' already exists in database";
+        $new_job_args{slug} = $name;
         delete $settings{NAME};
     }
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -114,15 +114,6 @@ sub create_from_settings {
     my %settings = %$settings;
 
     my %new_job_args = (TEST => $settings{TEST});
-
-
-    if (my $name = $settings{NAME}) {
-        my $njobs = $self->search({slug => $name})->count;
-        !$njobs or die "job with name \'$name\' already exists in database";
-        $new_job_args{slug} = $name;
-        delete $settings{NAME};
-    }
-
     my $group;
     my %group_args;
     if ($settings{_GROUP_ID}) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -360,19 +360,16 @@ sub schedule_iso {
 
             # create a new job with these parameters and count if successful, do not send job notifies yet
             my $job = $self->db->resultset('Jobs')->create_from_settings($settings);
+            push @jobs, $job;
 
-            if ($job) {
-                push @jobs, $job;
+            $testsuite_ids{_settings_key($settings)} //= [];
+            push @{$testsuite_ids{_settings_key($settings)}}, $job->id;
 
-                $testsuite_ids{_settings_key($settings)} //= [];
-                push @{$testsuite_ids{_settings_key($settings)}}, $job->id;
-
-                # set prio if defined explicitely (otherwise default prio is used)
-                if (defined($prio)) {
-                    $job->priority($prio);
-                }
-                $job->update;
+            # set prio if defined explicitely (otherwise default prio is used)
+            if (defined($prio)) {
+                $job->priority($prio);
             }
+            $job->update;
         }
 
         # jobs are created, now recreate dependencies and extract ids

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -31,6 +31,7 @@ use Net::DBus::Test::MockObject;
 use Test::More;
 use Test::Warnings;
 use Test::Output qw(stderr_like);
+use Test::Exception;
 
 my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
@@ -157,6 +158,10 @@ my %settings2 = %settings;
 $settings2{NAME}  = "OTHER NAME";
 $settings2{BUILD} = "44";
 my $job2 = $schema->resultset('Jobs')->create_from_settings(\%settings2);
+
+# try to call again with same settings
+throws_ok { $schema->resultset('Jobs')->create_from_settings(\%settings2) }
+qr/job with name 'OTHER NAME' already exists in database/, 'No two jobs with same name accepted';
 
 $job->set_prio(40);
 my $new_job = job_get_hash($job->id);

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -31,7 +31,6 @@ use Net::DBus::Test::MockObject;
 use Test::More;
 use Test::Warnings;
 use Test::Output qw(stderr_like);
-use Test::Exception;
 
 my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
@@ -158,10 +157,13 @@ my %settings2 = %settings;
 $settings2{NAME}  = "OTHER NAME";
 $settings2{BUILD} = "44";
 my $job2 = $schema->resultset('Jobs')->create_from_settings(\%settings2);
+is($job2->id, 2);
 
-# try to call again with same settings
-throws_ok { $schema->resultset('Jobs')->create_from_settings(\%settings2) }
-qr/job with name 'OTHER NAME' already exists in database/, 'No two jobs with same name accepted';
+subtest 'calling again with same settings' => sub {
+    my $job3 = $schema->resultset('Jobs')->create_from_settings(\%settings2);
+    is($job3->id, 3, 'calling again with same settings yields new job');
+    $schema->resultset('Jobs')->find($job3->id)->delete;
+};
 
 $job->set_prio(40);
 my $new_job = job_get_hash($job->id);
@@ -172,7 +174,7 @@ my $jobs = [
     {
         t_finished => undef,
         id         => 2,
-        name       => "OTHER NAME",
+        name       => 'Unicorn-42-pink-x86_64-Build44-rainbow@RainbowPC',
         priority   => 50,
         result     => 'none',
         t_started  => undef,
@@ -193,7 +195,7 @@ my $jobs = [
             KVM         => "KVM",
             MACHINE     => "RainbowPC",
             ARCH        => 'x86_64',
-            NAME        => '00000002-OTHER NAME',
+            NAME        => '00000002-Unicorn-42-pink-x86_64-Build44-rainbow@RainbowPC',
         },
         assets => {
             iso => ['whatever.iso'],
@@ -301,10 +303,10 @@ ok(!$grabbed->settings_hash->{JOBTOKEN}, "job token no longer present");
 $grabbed = OpenQA::Scheduler::Scheduler::job_grab(%args);
 isnt($job->id, $grabbed->{id}, "new job grabbed");
 isnt($grabbed->{settings}->{JOBTOKEN}, $job_ref->{settings}->{JOBTOKEN}, "job token differs");
-$job_ref->{settings}->{NAME} = '00000003-Unicorn-42-pink-x86_64-Build666-rainbow@RainbowPC';
 
-## update JOBTOKEN for isdeeply compare
+## update refs for isdeeply compare
 $job_ref->{settings}->{JOBTOKEN} = $grabbed->{settings}->{JOBTOKEN};
+$job_ref->{settings}->{NAME} = $grabbed->{settings}->{NAME};
 
 is_deeply($grabbed->{settings}, $job_ref->{settings}, "settings correct");
 my $job3_id = $job->id;


### PR DESCRIPTION
The 'NAME' field is checked to be unique for jobs and can fail but the value
'0' is not a good choice for that cause. Triggering a single job was plain
wrong assuming the job return value to always be a valid argument which was
then catched and forwarded to the API caller in a totally misleading error
message. For the iso the job creation failure was just ignored in before. Now
the code would just die on the iso post request which should be much more
helpful.