### PR TITLE
Workaround for Mojolicious 7.11

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -249,7 +249,7 @@ sub api_call {
 
     # This ugly. we need to "block" here so enter ioloop recursively
     while (!$done && Mojo::IOLoop->is_running) {
-        Mojo::IOLoop->one_tick;
+        Mojo::IOLoop->singleton->reactor->one_tick;
     }
 
     $call_running = 0;


### PR DESCRIPTION
The method `Mojo::IOLoop->one_tick` is no longer allowed to be called
recursively in Mojolicious 7.11. For now we can use
`Mojo::IOLoop->singleton->reactor->one_tick` as a workaround, even though
long term we should just get rid of event loop recursion, which is
considered an anti-pattern that can make Perl explode in very funny ways.