### PR TITLE
Add retry for failed uploads on server errors (5xx)

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -44,6 +44,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &human_readable_size
   &locate_asset
   &job_groups_and_parents
+  wait_with_progress
 );
 
 
@@ -556,6 +557,20 @@ sub job_groups_and_parents {
         }
     }
     return \@res;
+}
+
+sub wait_with_progress {
+    my ($interval) = @_;
+    my $tics;
+    local $| = 1;
+
+    do {
+        $tics++;
+        sleep(1);
+        print ".";
+    } while ($interval > $tics);
+
+    print "\n";
 }
 
 1;


### PR DESCRIPTION
Ensure that if the upload failed due to server being unavailable (status 5xx) that will be executed
up to $retry_limit times for $tics of 1 second each.

This one in particular is related to: [poo#13876](https://progress.opensuse.org/issues/13876). The missing autoinst.log is a bit unrelated. 

