### PR TITLE
Detect jobs linked from other sources and regard as important

### DIFF
--- a/dbicdh/PostgreSQL/deploy/50/001-auto-__VERSION.sql
+++ b/dbicdh/PostgreSQL/deploy/50/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Mon Dec  5 14:31:49 2016
+-- 
+;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id serial NOT NULL,
+  version character varying(50) NOT NULL,
+  ddl text,
+  upgrade_sql text,
+  PRIMARY KEY (id),
+  CONSTRAINT dbix_class_deploymenthandler_versions_version UNIQUE (version)
+);
+
+;

--- a/dbicdh/PostgreSQL/deploy/50/001-auto.sql
+++ b/dbicdh/PostgreSQL/deploy/50/001-auto.sql
@@ -1,0 +1,667 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Mon Dec  5 14:31:49 2016
+-- 
+;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id serial NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  size bigint,
+  checksum text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT assets_type_name UNIQUE (type, name)
+);
+
+;
+--
+-- Table: gru_tasks
+--
+CREATE TABLE gru_tasks (
+  id serial NOT NULL,
+  taskname text NOT NULL,
+  args text NOT NULL,
+  run_at timestamp NOT NULL,
+  priority integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX gru_tasks_run_at_reversed on gru_tasks (run_at DESC);
+
+;
+--
+-- Table: job_group_parents
+--
+CREATE TABLE job_group_parents (
+  id serial NOT NULL,
+  name text NOT NULL,
+  default_size_limit_gb integer,
+  default_keep_logs_in_days integer,
+  default_keep_important_logs_in_days integer,
+  default_keep_results_in_days integer,
+  default_keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_group_parents_name UNIQUE (name)
+);
+
+;
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id serial NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  milestone integer DEFAULT 0 NOT NULL,
+  important integer DEFAULT 0 NOT NULL,
+  fatal integer DEFAULT 0 NOT NULL,
+  result character varying DEFAULT 'none' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX job_modules_idx_job_id on job_modules (job_id);
+CREATE INDEX idx_job_modules_result on job_modules (result);
+
+;
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id serial NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX job_settings_idx_job_id on job_settings (job_id);
+CREATE INDEX idx_value_settings on job_settings (key, value);
+CREATE INDEX idx_job_id_value_settings on job_settings (job_id, key, value);
+
+;
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id serial NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT machine_settings_machine_id_key UNIQUE (machine_id, key)
+);
+CREATE INDEX machine_settings_idx_machine_id on machine_settings (machine_id);
+
+;
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id serial NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT machines_name UNIQUE (name)
+);
+
+;
+--
+-- Table: needle_dirs
+--
+CREATE TABLE needle_dirs (
+  id serial NOT NULL,
+  path text NOT NULL,
+  name text NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT needle_dirs_path UNIQUE (path)
+);
+
+;
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id serial NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT product_settings_product_id_key UNIQUE (product_id, key)
+);
+CREATE INDEX product_settings_idx_product_id on product_settings (product_id);
+
+;
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id serial NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text DEFAULT '' NOT NULL,
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT products_distri_version_arch_flavor UNIQUE (distri, version, arch, flavor)
+);
+
+;
+--
+-- Table: screenshots
+--
+CREATE TABLE screenshots (
+  id serial NOT NULL,
+  filename text NOT NULL,
+  t_created timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT screenshots_filename UNIQUE (filename)
+);
+
+;
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id serial NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT secrets_secret UNIQUE (secret)
+);
+
+;
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id serial NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT test_suite_settings_test_suite_id_key UNIQUE (test_suite_id, key)
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id on test_suite_settings (test_suite_id);
+
+;
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id serial NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT test_suites_name UNIQUE (name)
+);
+
+;
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id serial NOT NULL,
+  username text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer DEFAULT 0 NOT NULL,
+  is_admin integer DEFAULT 0 NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT users_username UNIQUE (username)
+);
+
+;
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id serial NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX worker_properties_idx_worker_id on worker_properties (worker_id);
+
+;
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id serial NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT api_keys_key UNIQUE (key)
+);
+CREATE INDEX api_keys_idx_user_id on api_keys (user_id);
+
+;
+--
+-- Table: audit_events
+--
+CREATE TABLE audit_events (
+  id serial NOT NULL,
+  user_id integer,
+  connection_id text,
+  event text NOT NULL,
+  event_data text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX audit_events_idx_user_id on audit_events (user_id);
+
+;
+--
+-- Table: comments
+--
+CREATE TABLE comments (
+  id serial NOT NULL,
+  job_id integer,
+  group_id integer,
+  text text NOT NULL,
+  user_id integer NOT NULL,
+  flags integer DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX comments_idx_group_id on comments (group_id);
+CREATE INDEX comments_idx_job_id on comments (job_id);
+CREATE INDEX comments_idx_user_id on comments (user_id);
+
+;
+--
+-- Table: job_groups
+--
+CREATE TABLE job_groups (
+  id serial NOT NULL,
+  name text NOT NULL,
+  parent_id integer,
+  size_limit_gb integer,
+  keep_logs_in_days integer,
+  keep_important_logs_in_days integer,
+  keep_results_in_days integer,
+  keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_groups_name UNIQUE (name)
+);
+CREATE INDEX job_groups_idx_parent_id on job_groups (parent_id);
+
+;
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id serial NOT NULL,
+  slug text,
+  result_dir text,
+  state character varying DEFAULT 'scheduled' NOT NULL,
+  priority integer DEFAULT 50 NOT NULL,
+  result character varying DEFAULT 'none' NOT NULL,
+  clone_id integer,
+  retry_avbl integer DEFAULT 3 NOT NULL,
+  backend character varying,
+  backend_info text,
+  TEST text,
+  DISTRI text,
+  VERSION text,
+  FLAVOR text,
+  ARCH text,
+  BUILD text,
+  MACHINE text,
+  group_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  logs_present boolean DEFAULT '1' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT jobs_slug UNIQUE (slug)
+);
+CREATE INDEX jobs_idx_clone_id on jobs (clone_id);
+CREATE INDEX jobs_idx_group_id on jobs (group_id);
+CREATE INDEX idx_jobs_state on jobs (state);
+CREATE INDEX idx_jobs_result on jobs (result);
+CREATE INDEX idx_jobs_build_group on jobs (BUILD, group_id);
+CREATE INDEX idx_jobs_scenario on jobs (VERSION, DISTRI, FLAVOR, TEST, MACHINE, ARCH);
+
+;
+--
+-- Table: needles
+--
+CREATE TABLE needles (
+  id serial NOT NULL,
+  dir_id integer NOT NULL,
+  filename text NOT NULL,
+  first_seen_module_id integer NOT NULL,
+  last_seen_module_id integer NOT NULL,
+  last_matched_module_id integer,
+  file_present boolean DEFAULT '1' NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT needles_dir_id_filename UNIQUE (dir_id, filename)
+);
+CREATE INDEX needles_idx_dir_id on needles (dir_id);
+CREATE INDEX needles_idx_first_seen_module_id on needles (first_seen_module_id);
+CREATE INDEX needles_idx_last_matched_module_id on needles (last_matched_module_id);
+CREATE INDEX needles_idx_last_seen_module_id on needles (last_seen_module_id);
+
+;
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency)
+);
+CREATE INDEX job_dependencies_idx_child_job_id on job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id on job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency on job_dependencies (dependency);
+
+;
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by text,
+  count integer DEFAULT 1 NOT NULL,
+  PRIMARY KEY (name, owner)
+);
+CREATE INDEX job_locks_idx_owner on job_locks (owner);
+
+;
+--
+-- Table: job_module_needles
+--
+CREATE TABLE job_module_needles (
+  needle_id integer NOT NULL,
+  job_module_id integer NOT NULL,
+  matched boolean DEFAULT '1' NOT NULL,
+  CONSTRAINT job_module_needles_needle_id_job_module_id UNIQUE (needle_id, job_module_id)
+);
+CREATE INDEX job_module_needles_idx_job_module_id on job_module_needles (job_module_id);
+CREATE INDEX job_module_needles_idx_needle_id on job_module_needles (needle_id);
+
+;
+--
+-- Table: job_networks
+--
+CREATE TABLE job_networks (
+  name text NOT NULL,
+  job_id integer NOT NULL,
+  vlan integer NOT NULL,
+  PRIMARY KEY (name, job_id)
+);
+CREATE INDEX job_networks_idx_job_id on job_networks (job_id);
+
+;
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id serial NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  job_id integer,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT workers_host_instance UNIQUE (host, instance),
+  CONSTRAINT workers_job_id UNIQUE (job_id)
+);
+CREATE INDEX workers_idx_job_id on workers (job_id);
+
+;
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id)
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id on gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id on gru_dependencies (job_id);
+
+;
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  created_by boolean DEFAULT '0' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  CONSTRAINT jobs_assets_job_id_asset_id UNIQUE (job_id, asset_id)
+);
+CREATE INDEX jobs_assets_idx_asset_id on jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id on jobs_assets (job_id);
+
+;
+--
+-- Table: screenshot_links
+--
+CREATE TABLE screenshot_links (
+  screenshot_id integer NOT NULL,
+  job_id integer NOT NULL
+);
+CREATE INDEX screenshot_links_idx_job_id on screenshot_links (job_id);
+CREATE INDEX screenshot_links_idx_screenshot_id on screenshot_links (screenshot_id);
+
+;
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id serial NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  prio integer NOT NULL,
+  group_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_templates_product_id_machine_id_test_suite_id UNIQUE (product_id, machine_id, test_suite_id)
+);
+CREATE INDEX job_templates_idx_group_id on job_templates (group_id);
+CREATE INDEX job_templates_idx_machine_id on job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id on job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id on job_templates (test_suite_id);
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE job_modules ADD CONSTRAINT job_modules_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_settings ADD CONSTRAINT job_settings_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE machine_settings ADD CONSTRAINT machine_settings_fk_machine_id FOREIGN KEY (machine_id)
+  REFERENCES machines (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE product_settings ADD CONSTRAINT product_settings_fk_product_id FOREIGN KEY (product_id)
+  REFERENCES products (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE test_suite_settings ADD CONSTRAINT test_suite_settings_fk_test_suite_id FOREIGN KEY (test_suite_id)
+  REFERENCES test_suites (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE worker_properties ADD CONSTRAINT worker_properties_fk_worker_id FOREIGN KEY (worker_id)
+  REFERENCES workers (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE api_keys ADD CONSTRAINT api_keys_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) DEFERRABLE;
+
+;
+ALTER TABLE job_groups ADD CONSTRAINT job_groups_fk_parent_id FOREIGN KEY (parent_id)
+  REFERENCES job_group_parents (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_clone_id FOREIGN KEY (clone_id)
+  REFERENCES jobs (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_dir_id FOREIGN KEY (dir_id)
+  REFERENCES needle_dirs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_first_seen_module_id FOREIGN KEY (first_seen_module_id)
+  REFERENCES job_modules (id) DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_last_matched_module_id FOREIGN KEY (last_matched_module_id)
+  REFERENCES job_modules (id) DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_last_seen_module_id FOREIGN KEY (last_seen_module_id)
+  REFERENCES job_modules (id) DEFERRABLE;
+
+;
+ALTER TABLE job_dependencies ADD CONSTRAINT job_dependencies_fk_child_job_id FOREIGN KEY (child_job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_dependencies ADD CONSTRAINT job_dependencies_fk_parent_job_id FOREIGN KEY (parent_job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_locks ADD CONSTRAINT job_locks_fk_owner FOREIGN KEY (owner)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_module_needles ADD CONSTRAINT job_module_needles_fk_job_module_id FOREIGN KEY (job_module_id)
+  REFERENCES job_modules (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_module_needles ADD CONSTRAINT job_module_needles_fk_needle_id FOREIGN KEY (needle_id)
+  REFERENCES needles (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_networks ADD CONSTRAINT job_networks_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE workers ADD CONSTRAINT workers_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_gru_task_id FOREIGN KEY (gru_task_id)
+  REFERENCES gru_tasks (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs_assets ADD CONSTRAINT jobs_assets_fk_asset_id FOREIGN KEY (asset_id)
+  REFERENCES assets (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs_assets ADD CONSTRAINT jobs_assets_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE screenshot_links ADD CONSTRAINT screenshot_links_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE screenshot_links ADD CONSTRAINT screenshot_links_fk_screenshot_id FOREIGN KEY (screenshot_id)
+  REFERENCES screenshots (id) ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_machine_id FOREIGN KEY (machine_id)
+  REFERENCES machines (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_product_id FOREIGN KEY (product_id)
+  REFERENCES products (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_test_suite_id FOREIGN KEY (test_suite_id)
+  REFERENCES test_suites (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;

--- a/dbicdh/PostgreSQL/upgrade/49-50/001-auto.sql
+++ b/dbicdh/PostgreSQL/upgrade/49-50/001-auto.sql
@@ -1,0 +1,5 @@
+-- Convert schema '/home/openQA/openQA/script/../dbicdh/_source/deploy/49/001-auto.yml' to '/home/openQA/openQA/script/../dbicdh/_source/deploy/50/001-auto.yml':;
+
+;
+-- No differences found;
+

--- a/dbicdh/SQLite/deploy/50/001-auto-__VERSION.sql
+++ b/dbicdh/SQLite/deploy/50/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Mon Dec  5 14:31:49 2016
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id INTEGER PRIMARY KEY NOT NULL,
+  version varchar(50) NOT NULL,
+  ddl text,
+  upgrade_sql text
+);
+CREATE UNIQUE INDEX dbix_class_deploymenthandler_versions_version ON dbix_class_deploymenthandler_versions (version);
+COMMIT;

--- a/dbicdh/SQLite/deploy/50/001-auto.sql
+++ b/dbicdh/SQLite/deploy/50/001-auto.sql
@@ -1,0 +1,474 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Mon Dec  5 14:31:49 2016
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  size bigint,
+  checksum text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX assets_type_name ON assets (type, name);
+--
+-- Table: gru_tasks
+--
+CREATE TABLE gru_tasks (
+  id INTEGER PRIMARY KEY NOT NULL,
+  taskname text NOT NULL,
+  args text NOT NULL,
+  run_at datetime NOT NULL,
+  priority integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE INDEX gru_tasks_run_at_reversed ON gru_tasks (run_at DESC);
+--
+-- Table: job_group_parents
+--
+CREATE TABLE job_group_parents (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  default_size_limit_gb integer,
+  default_keep_logs_in_days integer,
+  default_keep_important_logs_in_days integer,
+  default_keep_results_in_days integer,
+  default_keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX job_group_parents_name ON job_group_parents (name);
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  milestone integer NOT NULL DEFAULT 0,
+  important integer NOT NULL DEFAULT 0,
+  fatal integer NOT NULL DEFAULT 0,
+  result varchar NOT NULL DEFAULT 'none',
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON UPDATE CASCADE
+);
+CREATE INDEX job_modules_idx_job_id ON job_modules (job_id);
+CREATE INDEX idx_job_modules_result ON job_modules (result);
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_settings_idx_job_id ON job_settings (job_id);
+CREATE INDEX idx_value_settings ON job_settings (key, value);
+CREATE INDEX idx_job_id_value_settings ON job_settings (job_id, key, value);
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX machine_settings_idx_machine_id ON machine_settings (machine_id);
+CREATE UNIQUE INDEX machine_settings_machine_id_key ON machine_settings (machine_id, key);
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX machines_name ON machines (name);
+--
+-- Table: needle_dirs
+--
+CREATE TABLE needle_dirs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  path text NOT NULL,
+  name text NOT NULL
+);
+CREATE UNIQUE INDEX needle_dirs_path ON needle_dirs (path);
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX product_settings_idx_product_id ON product_settings (product_id);
+CREATE UNIQUE INDEX product_settings_product_id_key ON product_settings (product_id, key);
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX products_distri_version_arch_flavor ON products (distri, version, arch, flavor);
+--
+-- Table: screenshots
+--
+CREATE TABLE screenshots (
+  id INTEGER PRIMARY KEY NOT NULL,
+  filename text NOT NULL,
+  t_created timestamp NOT NULL
+);
+CREATE UNIQUE INDEX screenshots_filename ON screenshots (filename);
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX secrets_secret ON secrets (secret);
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id ON test_suite_settings (test_suite_id);
+CREATE UNIQUE INDEX test_suite_settings_test_suite_id_key ON test_suite_settings (test_suite_id, key);
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  variables text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX test_suites_name ON test_suites (name);
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY NOT NULL,
+  username text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX users_username ON users (username);
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX worker_properties_idx_worker_id ON worker_properties (worker_id);
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX api_keys_idx_user_id ON api_keys (user_id);
+CREATE UNIQUE INDEX api_keys_key ON api_keys (key);
+--
+-- Table: audit_events
+--
+CREATE TABLE audit_events (
+  id INTEGER PRIMARY KEY NOT NULL,
+  user_id integer,
+  connection_id text,
+  event text NOT NULL,
+  event_data text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX audit_events_idx_user_id ON audit_events (user_id);
+--
+-- Table: comments
+--
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer,
+  group_id integer,
+  text text NOT NULL,
+  user_id integer NOT NULL,
+  flags integer DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX comments_idx_group_id ON comments (group_id);
+CREATE INDEX comments_idx_job_id ON comments (job_id);
+CREATE INDEX comments_idx_user_id ON comments (user_id);
+--
+-- Table: job_groups
+--
+CREATE TABLE job_groups (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  parent_id integer,
+  size_limit_gb integer,
+  keep_logs_in_days integer,
+  keep_important_logs_in_days integer,
+  keep_results_in_days integer,
+  keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (parent_id) REFERENCES job_group_parents(id) ON DELETE SET NULL ON UPDATE CASCADE
+);
+CREATE INDEX job_groups_idx_parent_id ON job_groups (parent_id);
+CREATE UNIQUE INDEX job_groups_name ON job_groups (name);
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  slug text,
+  result_dir text,
+  state varchar NOT NULL DEFAULT 'scheduled',
+  priority integer NOT NULL DEFAULT 50,
+  result varchar NOT NULL DEFAULT 'none',
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  backend varchar,
+  backend_info text,
+  TEST text,
+  DISTRI text,
+  VERSION text,
+  FLAVOR text,
+  ARCH text,
+  BUILD text,
+  MACHINE text,
+  group_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  logs_present boolean NOT NULL DEFAULT 1,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE SET NULL ON UPDATE CASCADE
+);
+CREATE INDEX jobs_idx_clone_id ON jobs (clone_id);
+CREATE INDEX jobs_idx_group_id ON jobs (group_id);
+CREATE INDEX idx_jobs_state ON jobs (state);
+CREATE INDEX idx_jobs_result ON jobs (result);
+CREATE INDEX idx_jobs_build_group ON jobs (BUILD, group_id);
+CREATE INDEX idx_jobs_scenario ON jobs (VERSION, DISTRI, FLAVOR, TEST, MACHINE, ARCH);
+CREATE UNIQUE INDEX jobs_slug ON jobs (slug);
+--
+-- Table: needles
+--
+CREATE TABLE needles (
+  id INTEGER PRIMARY KEY NOT NULL,
+  dir_id integer NOT NULL,
+  filename text NOT NULL,
+  first_seen_module_id integer NOT NULL,
+  last_seen_module_id integer NOT NULL,
+  last_matched_module_id integer,
+  file_present boolean NOT NULL DEFAULT 1,
+  FOREIGN KEY (dir_id) REFERENCES needle_dirs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (first_seen_module_id) REFERENCES job_modules(id),
+  FOREIGN KEY (last_matched_module_id) REFERENCES job_modules(id),
+  FOREIGN KEY (last_seen_module_id) REFERENCES job_modules(id)
+);
+CREATE INDEX needles_idx_dir_id ON needles (dir_id);
+CREATE INDEX needles_idx_first_seen_module_id ON needles (first_seen_module_id);
+CREATE INDEX needles_idx_last_matched_module_id ON needles (last_matched_module_id);
+CREATE INDEX needles_idx_last_seen_module_id ON needles (last_seen_module_id);
+CREATE UNIQUE INDEX needles_dir_id_filename ON needles (dir_id, filename);
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency),
+  FOREIGN KEY (child_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (parent_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_dependencies_idx_child_job_id ON job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id ON job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency ON job_dependencies (dependency);
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by text,
+  count integer NOT NULL DEFAULT 1,
+  PRIMARY KEY (name, owner),
+  FOREIGN KEY (owner) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_locks_idx_owner ON job_locks (owner);
+--
+-- Table: job_module_needles
+--
+CREATE TABLE job_module_needles (
+  needle_id integer NOT NULL,
+  job_module_id integer NOT NULL,
+  matched boolean NOT NULL DEFAULT 1,
+  FOREIGN KEY (job_module_id) REFERENCES job_modules(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (needle_id) REFERENCES needles(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_module_needles_idx_job_module_id ON job_module_needles (job_module_id);
+CREATE INDEX job_module_needles_idx_needle_id ON job_module_needles (needle_id);
+CREATE UNIQUE INDEX job_module_needles_needle_id_job_module_id ON job_module_needles (needle_id, job_module_id);
+--
+-- Table: job_networks
+--
+CREATE TABLE job_networks (
+  name text NOT NULL,
+  job_id integer NOT NULL,
+  vlan integer NOT NULL,
+  PRIMARY KEY (name, job_id),
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_networks_idx_job_id ON job_networks (job_id);
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  job_id integer,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+);
+CREATE INDEX workers_idx_job_id ON workers (job_id);
+CREATE UNIQUE INDEX workers_host_instance ON workers (host, instance);
+CREATE UNIQUE INDEX workers_job_id ON workers (job_id);
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id),
+  FOREIGN KEY (gru_task_id) REFERENCES gru_tasks(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id ON gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id ON gru_dependencies (job_id);
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  created_by boolean NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_assets_idx_asset_id ON jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id ON jobs_assets (job_id);
+CREATE UNIQUE INDEX jobs_assets_job_id_asset_id ON jobs_assets (job_id, asset_id);
+--
+-- Table: screenshot_links
+--
+CREATE TABLE screenshot_links (
+  screenshot_id integer NOT NULL,
+  job_id integer NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (screenshot_id) REFERENCES screenshots(id) ON UPDATE CASCADE
+);
+CREATE INDEX screenshot_links_idx_job_id ON screenshot_links (job_id);
+CREATE INDEX screenshot_links_idx_screenshot_id ON screenshot_links (screenshot_id);
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  prio integer NOT NULL,
+  group_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id),
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_templates_idx_group_id ON job_templates (group_id);
+CREATE INDEX job_templates_idx_machine_id ON job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id ON job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id ON job_templates (test_suite_id);
+CREATE UNIQUE INDEX job_templates_product_id_machine_id_test_suite_id ON job_templates (product_id, machine_id, test_suite_id);
+COMMIT;

--- a/dbicdh/SQLite/upgrade/49-50/001-auto.sql
+++ b/dbicdh/SQLite/upgrade/49-50/001-auto.sql
@@ -1,0 +1,5 @@
+-- Convert schema '/home/openQA/openQA/script/../dbicdh/_source/deploy/49/001-auto.yml' to '/home/openQA/openQA/script/../dbicdh/_source/deploy/50/001-auto.yml':;
+
+;
+-- No differences found;
+

--- a/dbicdh/_common/upgrade/49-50/01-add-system-user.pl
+++ b/dbicdh/_common/upgrade/49-50/01-add-system-user.pl
@@ -1,0 +1,30 @@
+#!/usr/bin/perl -w
+
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use 5.018;
+use warnings;
+
+sub {
+    my ($schema) = @_;
+    $schema->resultset('Users')->find_or_new(
+        {
+            username => 'system',
+            email    => 'noemail@open.qa',
+            fullname => 'openQA system user',
+            nickname => 'system'
+        });
+  }

--- a/dbicdh/_source/deploy/50/001-auto-__VERSION.yml
+++ b/dbicdh/_source/deploy/50/001-auto-__VERSION.yml
@@ -1,0 +1,92 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/dbicdh/_source/deploy/50/001-auto.yml
+++ b/dbicdh/_source/deploy/50/001-auto.yml
@@ -1,0 +1,3651 @@
+---
+schema:
+  procedures: {}
+  tables:
+    api_keys:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - key
+          match_type: ''
+          name: api_keys_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: api_keys_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 2
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: secret
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_expiration:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_expiration
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: api_keys_idx_user_id
+          options: []
+          type: NORMAL
+      name: api_keys
+      options: []
+      order: 17
+    assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - type
+            - name
+          match_type: ''
+          name: assets_type_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        checksum:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: checksum
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        type:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: type
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: assets
+      options: []
+      order: 1
+    audit_events:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: audit_events_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        connection_id:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: connection_id
+          order: 3
+          size:
+            - 0
+        event:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: event
+          order: 4
+          size:
+            - 0
+        event_data:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: event_data
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: audit_events_idx_user_id
+          options: []
+          type: NORMAL
+      name: audit_events
+      options: []
+      order: 18
+    comments:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: comments_fk_group_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: comments_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: comments_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        flags:
+          data_type: integer
+          default_value: 0
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: flags
+          order: 6
+          size:
+            - 0
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        text:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: text
+          order: 4
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: comments_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: comments_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - user_id
+          name: comments_idx_user_id
+          options: []
+          type: NORMAL
+      name: comments
+      options: []
+      order: 19
+    gru_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - gru_task_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - gru_task_id
+          match_type: ''
+          name: gru_dependencies_fk_gru_task_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: gru_tasks
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: gru_dependencies_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        gru_task_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: gru_task_id
+          order: 2
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - gru_task_id
+          name: gru_dependencies_idx_gru_task_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: gru_dependencies_idx_job_id
+          options: []
+          type: NORMAL
+      name: gru_dependencies
+      options: []
+      order: 28
+    gru_tasks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        args:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: args
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        run_at:
+          data_type: datetime
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: run_at
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        taskname:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: taskname
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - run_at DESC
+          name: gru_tasks_run_at_reversed
+          options: []
+          type: NORMAL
+      name: gru_tasks
+      options: []
+      order: 2
+    job_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+            - parent_job_id
+            - dependency
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+          match_type: ''
+          name: job_dependencies_fk_child_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_job_id
+          match_type: ''
+          name: job_dependencies_fk_parent_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        child_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: child_job_id
+          order: 1
+          size:
+            - 0
+        dependency:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: dependency
+          order: 3
+          size:
+            - 0
+        parent_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: parent_job_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - child_job_id
+          name: job_dependencies_idx_child_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_job_id
+          name: job_dependencies_idx_parent_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - dependency
+          name: idx_job_dependencies_dependency
+          options: []
+          type: NORMAL
+      name: job_dependencies
+      options: []
+      order: 23
+    job_group_parents:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: job_group_parents_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        default_keep_important_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_important_logs_in_days
+          order: 5
+          size:
+            - 0
+        default_keep_important_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_important_results_in_days
+          order: 7
+          size:
+            - 0
+        default_keep_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_logs_in_days
+          order: 4
+          size:
+            - 0
+        default_keep_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_results_in_days
+          order: 6
+          size:
+            - 0
+        default_priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_priority
+          order: 8
+          size:
+            - 0
+        default_size_limit_gb:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_size_limit_gb
+          order: 3
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 10
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        sort_order:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: sort_order
+          order: 9
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 12
+          size:
+            - 0
+      indices: []
+      name: job_group_parents
+      options: []
+      order: 3
+    job_groups:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: job_groups_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_id
+          match_type: ''
+          name: job_groups_fk_parent_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_group_parents
+          type: FOREIGN KEY
+      fields:
+        default_priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_priority
+          order: 9
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 11
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        keep_important_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_important_logs_in_days
+          order: 6
+          size:
+            - 0
+        keep_important_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_important_results_in_days
+          order: 8
+          size:
+            - 0
+        keep_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_logs_in_days
+          order: 5
+          size:
+            - 0
+        keep_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_results_in_days
+          order: 7
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        parent_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: parent_id
+          order: 3
+          size:
+            - 0
+        size_limit_gb:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size_limit_gb
+          order: 4
+          size:
+            - 0
+        sort_order:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: sort_order
+          order: 10
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 12
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 13
+          size:
+            - 0
+      indices:
+        - fields:
+            - parent_id
+          name: job_groups_idx_parent_id
+          options: []
+          type: NORMAL
+      name: job_groups
+      options: []
+      order: 20
+    job_locks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - owner
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - owner
+          match_type: ''
+          name: job_locks_fk_owner
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        count:
+          data_type: integer
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: count
+          order: 4
+          size:
+            - 0
+        locked_by:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: locked_by
+          order: 3
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        owner:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: owner
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - owner
+          name: job_locks_idx_owner
+          options: []
+          type: NORMAL
+      name: job_locks
+      options: []
+      order: 24
+    job_module_needles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - needle_id
+            - job_module_id
+          match_type: ''
+          name: job_module_needles_needle_id_job_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_module_id
+          match_type: ''
+          name: job_module_needles_fk_job_module_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - needle_id
+          match_type: ''
+          name: job_module_needles_fk_needle_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: needles
+          type: FOREIGN KEY
+      fields:
+        job_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_module_id
+          order: 2
+          size:
+            - 0
+        matched:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: matched
+          order: 3
+          size:
+            - 0
+        needle_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: needle_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_module_id
+          name: job_module_needles_idx_job_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - needle_id
+          name: job_module_needles_idx_needle_id
+          options: []
+          type: NORMAL
+      name: job_module_needles
+      options: []
+      order: 25
+    job_modules:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_modules_fk_job_id
+          on_delete: ''
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        category:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: category
+          order: 5
+          size:
+            - 0
+        fatal:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: fatal
+          order: 8
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        important:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: important
+          order: 7
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        milestone:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: milestone
+          order: 6
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 9
+          size:
+            - 0
+        script:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: script
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 10
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 11
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_modules_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_job_modules_result
+          options: []
+          type: NORMAL
+      name: job_modules
+      options: []
+      order: 4
+    job_networks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - job_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_networks_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        vlan:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: vlan
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_networks_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_networks
+      options: []
+      order: 26
+    job_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_settings_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 4
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_settings_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - key
+            - value
+          name: idx_value_settings
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+            - key
+            - value
+          name: idx_job_id_value_settings
+          options: []
+          type: NORMAL
+      name: job_settings
+      options: []
+      order: 5
+    job_templates:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - machine_id
+            - test_suite_id
+          match_type: ''
+          name: job_templates_product_id_machine_id_test_suite_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: job_templates_fk_group_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: job_templates_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: job_templates_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: job_templates_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 3
+          size:
+            - 0
+        prio:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: prio
+          order: 5
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: job_templates_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - machine_id
+          name: job_templates_idx_machine_id
+          options: []
+          type: NORMAL
+        - fields:
+            - product_id
+          name: job_templates_idx_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - test_suite_id
+          name: job_templates_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: job_templates
+      options: []
+      order: 31
+    jobs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - slug
+          match_type: ''
+          name: jobs_slug
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - clone_id
+          match_type: ''
+          name: jobs_fk_clone_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: jobs_fk_group_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+      fields:
+        ARCH:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ARCH
+          order: 15
+          size:
+            - 0
+        BUILD:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: BUILD
+          order: 16
+          size:
+            - 0
+        DISTRI:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: DISTRI
+          order: 12
+          size:
+            - 0
+        FLAVOR:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: FLAVOR
+          order: 14
+          size:
+            - 0
+        MACHINE:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: MACHINE
+          order: 17
+          size:
+            - 0
+        TEST:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: TEST
+          order: 11
+          size:
+            - 0
+        VERSION:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: VERSION
+          order: 13
+          size:
+            - 0
+        backend:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 9
+          size:
+            - 0
+        backend_info:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend_info
+          order: 10
+          size:
+            - 0
+        clone_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: clone_id
+          order: 7
+          size:
+            - 0
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 18
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        logs_present:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: logs_present
+          order: 21
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: 50
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 6
+          size:
+            - 0
+        result_dir:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: result_dir
+          order: 3
+          size:
+            - 0
+        retry_avbl:
+          data_type: integer
+          default_value: 3
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: retry_avbl
+          order: 8
+          size:
+            - 0
+        slug:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: slug
+          order: 2
+          size:
+            - 0
+        state:
+          data_type: varchar
+          default_value: scheduled
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: state
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 22
+          size:
+            - 0
+        t_finished:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_finished
+          order: 20
+          size:
+            - 0
+        t_started:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_started
+          order: 19
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 23
+          size:
+            - 0
+      indices:
+        - fields:
+            - clone_id
+          name: jobs_idx_clone_id
+          options: []
+          type: NORMAL
+        - fields:
+            - group_id
+          name: jobs_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - state
+          name: idx_jobs_state
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_jobs_result
+          options: []
+          type: NORMAL
+        - fields:
+            - BUILD
+            - group_id
+          name: idx_jobs_build_group
+          options: []
+          type: NORMAL
+        - fields:
+            - VERSION
+            - DISTRI
+            - FLAVOR
+            - TEST
+            - MACHINE
+            - ARCH
+          name: idx_jobs_scenario
+          options: []
+          type: NORMAL
+      name: jobs
+      options: []
+      order: 21
+    jobs_assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - asset_id
+          match_type: ''
+          name: jobs_assets_job_id_asset_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - asset_id
+          match_type: ''
+          name: jobs_assets_fk_asset_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: assets
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: jobs_assets_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        asset_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: asset_id
+          order: 2
+          size:
+            - 0
+        created_by:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: created_by
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - asset_id
+          name: jobs_assets_idx_asset_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: jobs_assets_idx_job_id
+          options: []
+          type: NORMAL
+      name: jobs_assets
+      options: []
+      order: 29
+    machine_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+            - key
+          match_type: ''
+          name: machine_settings_machine_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: machine_settings_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: machine_settings_idx_machine_id
+          options: []
+          type: NORMAL
+      name: machine_settings
+      options: []
+      order: 6
+    machines:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: machines_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: machines
+      options: []
+      order: 7
+    needle_dirs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - path
+          match_type: ''
+          name: needle_dirs_path
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        path:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: path
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: needle_dirs
+      options: []
+      order: 8
+    needles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+            - filename
+          match_type: ''
+          name: needles_dir_id_filename
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+          match_type: ''
+          name: needles_fk_dir_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: needle_dirs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - first_seen_module_id
+          match_type: ''
+          name: needles_fk_first_seen_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_matched_module_id
+          match_type: ''
+          name: needles_fk_last_matched_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_seen_module_id
+          match_type: ''
+          name: needles_fk_last_seen_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+      fields:
+        dir_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: dir_id
+          order: 2
+          size:
+            - 0
+        file_present:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: file_present
+          order: 7
+          size:
+            - 0
+        filename:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: filename
+          order: 3
+          size:
+            - 0
+        first_seen_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: first_seen_module_id
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        last_matched_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_matched_module_id
+          order: 6
+          size:
+            - 0
+        last_seen_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: last_seen_module_id
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - dir_id
+          name: needles_idx_dir_id
+          options: []
+          type: NORMAL
+        - fields:
+            - first_seen_module_id
+          name: needles_idx_first_seen_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_matched_module_id
+          name: needles_idx_last_matched_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_seen_module_id
+          name: needles_idx_last_seen_module_id
+          options: []
+          type: NORMAL
+      name: needles
+      options: []
+      order: 22
+    product_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - key
+          match_type: ''
+          name: product_settings_product_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: product_settings_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - product_id
+          name: product_settings_idx_product_id
+          options: []
+          type: NORMAL
+      name: product_settings
+      options: []
+      order: 9
+    products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - distri
+            - version
+            - arch
+            - flavor
+          match_type: ''
+          name: products_distri_version_arch_flavor
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        arch:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: arch
+          order: 5
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: distri
+          order: 3
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: flavor
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 7
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: products
+      options: []
+      order: 10
+    screenshot_links:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: screenshot_links_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - screenshot_id
+          match_type: ''
+          name: screenshot_links_fk_screenshot_id
+          on_delete: ''
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: screenshots
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        screenshot_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: screenshot_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: screenshot_links_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - screenshot_id
+          name: screenshot_links_idx_screenshot_id
+          options: []
+          type: NORMAL
+      name: screenshot_links
+      options: []
+      order: 30
+    screenshots:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - filename
+          match_type: ''
+          name: screenshots_filename
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        filename:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: filename
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: screenshots
+      options: []
+      order: 11
+    secrets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - secret
+          match_type: ''
+          name: secrets_secret
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: secret
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: secrets
+      options: []
+      order: 12
+    test_suite_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+            - key
+          match_type: ''
+          name: test_suite_settings_test_suite_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: test_suite_settings_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 2
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - test_suite_id
+          name: test_suite_settings_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: test_suite_settings
+      options: []
+      order: 13
+    test_suites:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: test_suites_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+        variables:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: variables
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: test_suites
+      options: []
+      order: 14
+    users:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - username
+          match_type: ''
+          name: users_username
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        email:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: email
+          order: 3
+          size:
+            - 0
+        fullname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: fullname
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        is_admin:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_admin
+          order: 7
+          size:
+            - 0
+        is_operator:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_operator
+          order: 6
+          size:
+            - 0
+        nickname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: nickname
+          order: 5
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        username:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: username
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: users
+      options: []
+      order: 15
+    worker_properties:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: worker_properties_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: worker_properties_idx_worker_id
+          options: []
+          type: NORMAL
+      name: worker_properties
+      options: []
+      order: 16
+    workers:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - host
+            - instance
+          match_type: ''
+          name: workers_host_instance
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: workers_job_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: workers_fk_job_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        host:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: host
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        instance:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: instance
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: workers_idx_job_id
+          options: []
+          type: NORMAL
+      name: workers
+      options: []
+      order: 27
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - ApiKeys
+      - Assets
+      - AuditEvents
+      - Comments
+      - GruDependencies
+      - GruTasks
+      - JobDependencies
+      - JobGroupParents
+      - JobGroups
+      - JobLocks
+      - JobModuleNeedles
+      - JobModules
+      - JobNetworks
+      - JobSettings
+      - JobTemplates
+      - Jobs
+      - JobsAssets
+      - MachineSettings
+      - Machines
+      - NeedleDirs
+      - Needles
+      - ProductSettings
+      - Products
+      - ScreenshotLinks
+      - Screenshots
+      - Secrets
+      - TestSuiteSettings
+      - TestSuites
+      - Users
+      - WorkerProperties
+      - Workers
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -42,6 +42,11 @@
 # web UI. Default is 'repo'
 #hide_asset_types = repo iso
 
+## Recognized referers contains list of hostnames separated by space. When
+# openQA detects (via 'Referer' header) that test job was accessed from
+# this domain, this job is labeled as linked and considered as important
+# recognized_referers = bugzilla.suse.com bugzilla.opensuse.org bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com
+
 #[scm git]
 #do_push = no
 

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -26,7 +26,7 @@ use FindBin qw($Bin);
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION   = 49;
+our $VERSION   = 50;
 our @databases = qw(SQLite PostgreSQL);
 
 __PACKAGE__->load_namespaces;
@@ -108,6 +108,14 @@ sub _try_deploy_db {
             _db_tweaks($schema, 'PRAGMA synchronous = OFF;');
         }
         $dh->install;
+        # create system user right away
+        $schema->resultset('Users')->create(
+            {
+                username => 'system',
+                email    => 'noemail@open.qa',
+                fullname => 'openQA system user',
+                nickname => 'system'
+            });
     };
     umask $mask;
     return !$version;

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -64,7 +64,8 @@ sub dsn {
 }
 
 sub deployment_check {
-    my ($schema) = @_;
+    my ($schema, $force_overwrite) = @_;
+    $force_overwrite //= 0;
     my $dir = $FindBin::Bin;
     while (abs_path($dir) ne '/') {
         last if (-d "$dir/dbicdh");
@@ -79,7 +80,7 @@ sub deployment_check {
             script_directory    => $dir,
             databases           => \@databases,
             sql_translator_args => {add_drop_table => 0},
-            force_overwrite     => 0
+            force_overwrite     => $force_overwrite
         });
     _try_deploy_db($dh) or _try_upgrade_db($dh);
 }

--- a/lib/OpenQA/ServerStartup.pm
+++ b/lib/OpenQA/ServerStartup.pm
@@ -28,17 +28,18 @@ sub read_config {
 
     my %defaults = (
         global => {
-            appname          => 'openQA',
-            base_url         => undef,
-            branding         => 'openSUSE',
-            allowed_hosts    => undef,
-            download_domains => undef,
-            suse_mirror      => undef,
-            scm              => undef,
-            hsts             => 365,
-            audit_enabled    => 1,
-            plugins          => undef,
-            hide_asset_types => 'repo',
+            appname             => 'openQA',
+            base_url            => undef,
+            branding            => 'openSUSE',
+            allowed_hosts       => undef,
+            download_domains    => undef,
+            suse_mirror         => undef,
+            scm                 => undef,
+            hsts                => 365,
+            audit_enabled       => 1,
+            plugins             => undef,
+            hide_asset_types    => 'repo',
+            recognized_referers => ''
         },
         auth => {
             method => 'OpenID',
@@ -106,6 +107,7 @@ sub read_config {
             $app->config->{$section}->{$k} = $v if defined $v;
         }
     }
+    $app->config->{global}->{recognized_referers} = [split(/ /, $app->config->{global}->{recognized_referers})];
     $app->config->{_openid_secret} = db_helpers::rndstr(16);
 }
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -182,6 +182,7 @@ sub startup {
     $r->get('/assets/*assetpath')->name('download_asset')->to('file#download_asset');
 
     my $test_r = $r->route('/tests/:testid', testid => qr/\d+/);
+    $test_r = $test_r->under('/')->to('test#referer_check');
     my $test_auth = $auth->route('/tests/:testid', testid => qr/\d+/, format => 0);
     $test_r->get('/')->name('test')->to('test#show');
     $test_r->get('/modules/:moduleid/fails')->name('test_module_fails')->to('test#module_fails');

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -243,12 +243,32 @@ sub show {
     my ($self) = @_;
 
     return $self->reply->not_found if (!defined $self->param('testid'));
+    my $referer = $self->req->headers->header('Referer') // '';
 
     my $job = $self->app->schema->resultset("Jobs")->search(
         {
             id => $self->param('testid')
         },
         {prefetch => qw(jobs_assets)})->first;
+    $referer = Mojo::URL->new($referer)->host;
+    if ($referer && grep { $referer eq $_ } @{$self->config->{global}->{recognized_referers}}) {
+        my $found    = 0;
+        my $comments = $job->comments;
+        while (my $comment = $comments->next) {
+            if ($comment->label eq 'linked') {
+                $found = 1;
+                last;
+            }
+        }
+        unless ($found) {
+            my $user = $self->app->schema->resultset('Users')->search({username => 'system'})->first;
+            $comments->create(
+                {
+                    text    => 'label:linked',
+                    user_id => $user->id
+                });
+        }
+    }
     return $self->_show($job);
 }
 
@@ -464,7 +484,10 @@ sub overview {
         }
 
         # Populate @configs and %archs
-        if ($job->MACHINE && $preferred_machines->{$job->ARCH} && $preferred_machines->{$job->ARCH} ne $job->MACHINE) {
+        if (   $job->MACHINE
+            && $preferred_machines->{$job->ARCH}
+            && $preferred_machines->{$job->ARCH} ne $job->MACHINE)
+        {
             $test .= "@" . $job->MACHINE;
         }
         push(@configs, $test) unless (grep { $test eq $_ } @configs);

--- a/script/initdb
+++ b/script/initdb
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 # Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -99,20 +100,20 @@ if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
         });
 }
 
-my $dh = DBIx::Class::DeploymentHandler->new(
-    {
-        schema           => $schema,
-        script_directory => $script_directory,
-        databases        => \@databases,
-        sql_translator_args =>
-          {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
-        force_overwrite => $force,
-    });
-
-my $version = $dh->schema_version;
-
-my %deploy_dir;
 if ($prepare_init) {
+    my $dh = DBIx::Class::DeploymentHandler->new(
+        {
+            schema           => $schema,
+            script_directory => $script_directory,
+            databases        => \@databases,
+            sql_translator_args =>
+              {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
+            force_overwrite => $force,
+        });
+
+    my $version = $dh->schema_version;
+
+    my %deploy_dir;
     foreach my $db (@databases) {
         tie %deploy_dir, 'IO::Dir', "$script_directory/$db/deploy";
 
@@ -128,7 +129,7 @@ if ($prepare_init) {
 }
 if ($init_database) {
     # Create the schema
-    $dh->install;
+    OpenQA::Schema::deployment_check($schema, $force);
 }
 
 # vim: set sw=4 sts=4 et:

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 # Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,20 +33,18 @@ use IO::Dir;
 use Fcntl ':mode';
 use POSIX qw(setuid setgid);
 
-my $prepare_upgrades            = 0;
-my $upgrade_database            = 0;
-my $help                        = 0;
-my $from_uninitialized_database = 0;
-my $force                       = 0;
+my $prepare_upgrades = 0;
+my $upgrade_database = 0;
+my $help             = 0;
+my $force            = 0;
 my $user;
 
 my $result = GetOptions(
-    "help"                        => \$help,
-    "from_uninitialized_database" => \$from_uninitialized_database,
-    "prepare_upgrades"            => \$prepare_upgrades,
-    "upgrade_database"            => \$upgrade_database,
-    "user=s"                      => \$user,
-    "force"                       => \$force
+    "help"             => \$help,
+    "prepare_upgrades" => \$prepare_upgrades,
+    "upgrade_database" => \$upgrade_database,
+    "user=s"           => \$user,
+    "force"            => \$force
 );
 
 if (!$prepare_upgrades and !$upgrade_database) {
@@ -59,8 +58,6 @@ if ($help) {
     print "                       and note those files should be commited to the source repo.\n";
     print "  --upgrade_database : Use the generated deployment files created with --prepare_upgrades\n";
     print "                       to actually upgrade a database.\n";
-    print "  --from_uninitialized_database : Create and populate an existing database as if it was\n";
-    print "                       initialized with the initdb script.\n";
     print "  --force            : Force overwriting existing data.\n";
     print "  --user=login       : Change uid before connecting the DB.\n";
     print "  --help             : This help message.\n";
@@ -90,28 +87,24 @@ if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
         });
 }
 
-my $dh = DH->new(
-    {
-        schema           => $schema,
-        script_directory => $script_directory,
-        databases        => \@databases,
-        sql_translator_args =>
-          {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
-        force_overwrite => $force,
-    });
-
-
-my $version = $dh->schema_version;
-
-#print "Schema version: $version\n";
-#print "Current DB version: $db_version\n";
-
-my $prev_version      = $version - 1;
-my $upgrade_directory = "$prev_version-$version";
-
-my %upgrade_dir;
-
 if ($prepare_upgrades) {
+    my $dh = DH->new(
+        {
+            schema           => $schema,
+            script_directory => $script_directory,
+            databases        => \@databases,
+            sql_translator_args =>
+              {add_drop_table => 0, producer_args => {sqlite_version => '3.7'}, quote_identifiers => 0},
+            force_overwrite => $force,
+        });
+
+
+    my $version = $dh->schema_version;
+
+    my $prev_version      = $version - 1;
+    my $upgrade_directory = "$prev_version-$version";
+
+    my %upgrade_dir;
     foreach my $db (@databases) {
         tie %upgrade_dir, 'IO::Dir', "$script_directory/$db/upgrade";
 
@@ -127,17 +120,7 @@ if ($prepare_upgrades) {
 }
 
 if ($upgrade_database) {
-    if ($from_uninitialized_database) {
-        print "'--from_uninitialized_database' not implemented yet\n";
-    }
-    my $db_version = $dh->version_storage->database_version;
-
-    if ($db_version == $version) {
-        print "Database already at version $version . No need to upgrade\n";
-    }
-    else {
-        $dh->upgrade;
-    }
+    OpenQA::Schema::deployment_check($schema, $force);
 }
 
 # vim: set sw=4 sts=4 et:

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -30,9 +30,31 @@ use Test::Warnings;
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-my $mordred_id = 'https://openid.badguys.uk/mordred';
-my $user = $t->app->db->resultset("Users")->create({username => $mordred_id});
-ok(!$user->is_admin,    'new users are not admin by default');
-ok(!$user->is_operator, 'new users are not operator by default');
+subtest 'new users are not ops and admins' => sub {
+    my $mordred_id = 'https://openid.badguys.uk/mordred';
+    my $user = $t->app->db->resultset('Users')->create({username => $mordred_id});
+    ok(!$user->is_admin,    'new users are not admin by default');
+    ok(!$user->is_operator, 'new users are not operator by default');
+};
+
+subtest 'system user presence' => sub {
+    my $system_user = $t->app->db->resultset("Users")->search({username => 'system'})->first;
+    ok($system_user,               'system user exists');
+    ok(!$system_user->is_admin,    'system user is not an admin');
+    ok(!$system_user->is_operator, 'system user is not an operator');
+    is($system_user->email, 'noemail@open.qa', 'system user`s email uses open.qa domain');
+};
+
+subtest 'new user is admin if no admin is present' => sub {
+    my $admins = $t->app->db->resultset('Users')->search({is_admin => 1});
+    while (my $u = $admins->next) {
+        $u->update({is_admin => 0});
+    }
+    ok(!$t->app->db->resultset('Users')->search({is_admin => 1})->all, 'no admin is present');
+    require OpenQA::Schema::Result::Users;
+    my $user = OpenQA::Schema::Result::Users->create_user('test_user', $t->app->db);
+    ok($user->is_admin,    'new user is admin by default if there was no admin');
+    ok($user->is_operator, 'new user is operator by default if there was no admin');
+};
 
 done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -36,11 +36,12 @@ is_deeply(
     $cfg,
     {
         global => {
-            appname          => 'openQA',
-            branding         => 'openSUSE',
-            hsts             => 365,
-            audit_enabled    => 1,
-            hide_asset_types => 'repo',
+            appname             => 'openQA',
+            branding            => 'openSUSE',
+            hsts                => 365,
+            audit_enabled       => 1,
+            hide_asset_types    => 'repo',
+            recognized_referers => []
         },
         auth => {
             method => 'Fake',
@@ -74,11 +75,20 @@ open(my $fd, '>', $ENV{OPENQA_CONFIG} . '/openqa.ini');
 print $fd "[global]\n";
 print $fd "allowed_hosts=foo bar\n";
 print $fd "suse_mirror=http://blah/\n";
+print $fd
+"recognized_referers = bugzilla.suse.com bugzilla.opensuse.org bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com\n";
 close $fd;
 
 $t = Test::Mojo->new('OpenQA::WebAPI');
 ok($t->app->config->{global}->{allowed_hosts} eq 'foo bar',    'allowed hosts');
 ok($t->app->config->{global}->{suse_mirror} eq 'http://blah/', 'suse mirror');
+is_deeply(
+    $t->app->config->{global}->{recognized_referers},
+    [
+        qw(bugzilla.suse.com bugzilla.opensuse.org bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com)
+    ],
+    'referers parsed correctly'
+);
 
 unlink($ENV{OPENQA_CONFIG} . '/openqa.ini');
 


### PR DESCRIPTION
First commit adds `system` openqa user. This user is meant to be used for actions which requires some user, but at that time cannot use real one - startup/shutdown events in audit, and for jobs labeling introduced in second commit.

Then new config file entry `recognized_referers` is added (open for discussion about naming ;) ). When GET request to show test job comes from one of these referers, job is automatically labeled as linked. So far no other message is added, but I'll add back url.

Last commit tend to cleanup routing where linked jobs are meant to be regarded as important. (*missing tests*)

[issue#14926](https://progress.opensuse.org/issues/14926)