### PR TITLE
comment events: drop unneeded fedmsg conditional, include id

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -178,7 +178,8 @@ sub on_comment_event {
 
     # just send the hash already used for JSON representation
     my $hash = $comment->hash;
-    # also include job_id/group_id
+    # also include comment id, job_id, and group_id
+    $hash->{id}       = $comment->id;
     $hash->{job_id}   = $comment->job_id;
     $hash->{group_id} = $comment->group_id;
 

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -96,22 +96,18 @@ sub on_comment_event {
     my ($user_id, $connection_id, $event, $event_data) = @$args;
     my $hash;
 
-    # if event was a deletion, we'll have to create the hash, and we
-    # don't really know very much
-    if ($event eq 'openqa_user_delete_comment') {
-        $hash = {id => $event_data->{id}};
-    }
-    else {
-        # find comment in database
-        my $comment = $app->db->resultset('Comments')->find($event_data->{id});
-        return unless $comment;
+    # find comment in database. on comment deletion, the mojo event
+    # is emitted *before* the comment is actually deleted, so this
+    # should still work
+    my $comment = $app->db->resultset('Comments')->find($event_data->{id});
+    return unless $comment;
 
-        # just send the hash already used for JSON representation
-        $hash = $comment->hash;
-        # also include job_id/group_id
-        $hash->{job_id}   = $comment->job_id;
-        $hash->{group_id} = $comment->group_id;
-    }
+    # just send the hash already used for JSON representation
+    $hash = $comment->hash;
+    # also include comment id, job_id, and group_id
+    $hash->{id}       = $comment->id;
+    $hash->{job_id}   = $comment->job_id;
+    $hash->{group_id} = $comment->group_id;
 
     log_event($event, $hash);
 }

--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -150,25 +150,25 @@ $args = '';
 
 # add a job comment via API
 $post = $t->post_ok("/api/v1/jobs/$job/comments" => form => {text => "test comment"})->status_is(200);
+# stash the comment ID
+my $comment = $post->tx->res->json->{id};
 # check plugin called fedmsg-logger correctly
 my $commonexpr = 'fedmsg-logger --cert-prefix=openqa --modname=openqa';
 my $dateexpr   = '\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}Z';
 like(
     $args,
-qr/$commonexpr --topic=comment.create --json-input --message=\{"created":"$dateexpr","group_id":null,"job_id":$job,"text":"test comment","updated":"$dateexpr","user":"perci"\}/,
+qr/$commonexpr --topic=comment.create --json-input --message=\{"created":"$dateexpr","group_id":null,"id":$comment,"job_id":$job,"text":"test comment","updated":"$dateexpr","user":"perci"\}/,
     'comment post triggers fedmsg'
 );
 # reset $args
 $args = '';
-# stash the comment ID
-my $comment = $post->tx->res->json->{id};
 
 # update job comment via API
 my $put = $t->put_ok("/api/v1/jobs/$job/comments/$comment" => form => {text => "updated comment"})->status_is(200);
 # check plugin called fedmsg-logger correctly
 like(
     $args,
-qr/$commonexpr --topic=comment.update --json-input --message=\{"created":"$dateexpr","group_id":null,"job_id":$job,"text":"updated comment","updated":"$dateexpr","user":"perci"\}/,
+qr/$commonexpr --topic=comment.update --json-input --message=\{"created":"$dateexpr","group_id":null,"id":$comment,"job_id":$job,"text":"updated comment","updated":"$dateexpr","user":"perci"\}/,
     'comment update triggers fedmsg'
 );
 # reset $args
@@ -181,7 +181,7 @@ $t->app($app);
 my $delete = $t->delete_ok("/api/v1/jobs/$job/comments/$comment")->status_is(200);
 like(
     $args,
-qr/$commonexpr --topic=comment.delete --json-input --message=\{"created":"$dateexpr","group_id":null,"job_id":$job,"text":"updated comment","updated":"$dateexpr","user":"perci"\}/,
+qr/$commonexpr --topic=comment.delete --json-input --message=\{"created":"$dateexpr","group_id":null,"id":$comment,"job_id":$job,"text":"updated comment","updated":"$dateexpr","user":"perci"\}/,
     'comment delete triggers fedmsg'
 );
 # reset $args


### PR DESCRIPTION
This touches both Fedmsg and AMQP comment event emitters. We
no longer need the conditional in the Fedmsg plugin to produce
a different hash in the case of comment deletion, as the API
code was changed to event the mojo event *before* rather than
after deleting the comment. Also include the comment ID in the
emitted events, since it doesn't hurt anything and could be
useful (seems odd to emit an event with lots of info on the
subject of the event, but not its actual ID).