### PR TITLE
Sort needles by RMSE instead of MIN

### DIFF
--- a/t/testresults/00099/00099946-opensuse-13.1-DVD-i586-Build0091-textmode/details-yast2_lan.json
+++ b/t/testresults/00099/00099946-opensuse-13.1-DVD-i586-Build0091-textmode/details-yast2_lan.json
@@ -1,1 +1,94 @@
-[{"result":"unk","tags":["sudo-passwordprompt","ENV-VIDEOMODE-text","ENV-DESKTOP-textmode","ENV-DISTRI-opensuse","ENV-INSTLANG-en_US","ENV-FLAVOR-DVD"],"screenshot":"yast2_lan-1.png","needles":[{"error":0.228645558501967,"name":"sudo-passwordprompt","area":[{"x":"872","diff":"yast2_lan-1-sudo-passwordprompt-diff0.png","result":"fail","w":137,"similarity":52,"y":"660","h":29}]},{"area":[{"result":"fail","diff":"yast2_lan-1-sudo-passwordprompt-lxde-diff0.png","w":224,"x":"197","h":33,"similarity":62,"y":"575"}],"name":"sudo-passwordprompt-lxde","error":0.139486480876258}]},{"result":"unk","screenshot":"yast2_lan-2.png"},{"area":[{"h":131,"similarity":100,"y":"29","w":999,"result":"ok","x":"7"}],"needle":"yast2_lan-1370608095","screenshot":"yast2_lan-3.png","result":"ok","tags":["test-yast2_lan-1"]},{"tags":["test-yast2_lan-2"],"result":"ok","screenshot":"yast2_lan-4.png","needle":"yast2_lan-2-1-good-diff","area":[{"diff":"yast2_lan-4-yast2_lan-2-1-good-diff-diff0.png","w":64,"result":"ok","x":"0","h":71,"y":"2","similarity":99}]}]
+[
+   {
+      "result" : "unk",
+      "screenshot" : "yast2_lan-1.png",
+      "tags" : [
+         "sudo-passwordprompt",
+         "ENV-VIDEOMODE-text",
+         "ENV-DESKTOP-textmode",
+         "ENV-DISTRI-opensuse",
+         "ENV-INSTLANG-en_US",
+         "ENV-FLAVOR-DVD"
+      ],
+      "needles" : [
+         {
+            "error" : 0.228645558501967,
+            "area" : [
+               {
+                  "y" : "660",
+                  "result" : "fail",
+                  "w" : 137,
+                  "x" : "872",
+                  "similarity" : 52,
+                  "h" : 29
+               },
+               {
+                  "y" : "660",
+                  "w" : 137,
+                  "result" : "fail",
+                  "x" : "872",
+                  "similarity" : 0,
+                  "h" : 29
+               }
+            ],
+            "name" : "sudo-passwordprompt"
+         },
+         {
+            "area" : [
+               {
+                  "result" : "fail",
+                  "y" : "575",
+                  "w" : 224,
+                  "x" : "197",
+                  "similarity" : 62,
+                  "diff" : "yast2_lan-1-sudo-passwordprompt-lxde-diff0.png",
+                  "h" : 33
+               }
+            ],
+            "name" : "sudo-passwordprompt-lxde",
+            "error" : 0.139486480876258
+         }
+      ]
+   },
+   {
+      "result" : "unk",
+      "screenshot" : "yast2_lan-2.png"
+   },
+   {
+      "tags" : [
+         "test-yast2_lan-1"
+      ],
+      "screenshot" : "yast2_lan-3.png",
+      "result" : "ok",
+      "needle" : "yast2_lan-1370608095",
+      "area" : [
+         {
+            "h" : 131,
+            "similarity" : 100,
+            "x" : "7",
+            "y" : "29",
+            "result" : "ok",
+            "w" : 999
+         }
+      ]
+   },
+   {
+      "tags" : [
+         "test-yast2_lan-2"
+      ],
+      "screenshot" : "yast2_lan-4.png",
+      "result" : "ok",
+      "needle" : "yast2_lan-2-1-good-diff",
+      "area" : [
+         {
+            "h" : 71,
+            "similarity" : 99,
+            "diff" : "yast2_lan-4-yast2_lan-2-1-good-diff-diff0.png",
+            "x" : "0",
+            "result" : "ok",
+            "w" : 64,
+            "y" : "2"
+         }
+      ]
+   }
+]

--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -4,7 +4,7 @@
         <select id="needlediff_selector">
             <option data-areas="[]" data-matches="[]">-None-</option>
             % for my $needle (@$needles) {
-                % my $title = $needle->{min_similarity} . "%: " . $needle->{name};
+                % my $title = $needle->{avg_similarity} . "%: " . $needle->{name};
                 <option data-image="<%= $needle->{image} %>"
                         data-areas="<%= JSON::to_json($needle->{areas})%>"
                         % if ($needle->{selected}) {


### PR DESCRIPTION
So far we sorted the needles while displaying them by the minimum of the
similiarity of the match areas. The problem is that this makes needles
more equal than they are. In case if you have 2 needles that both mismatch

Needle A:
  Area 1 matches 0%

Needle B:
  Area 1 matches 100%
  Area 2 matches 0%

Both needles have a minimum of 0% and so they would display as:

0%: A
0%: B

With this change, we display the needles by their root mean square error,
which results in:
71%: B
0%: A

See https://progress.opensuse.org/issues/14886