### PR TITLE
Disable carry-over for job 'labels' to support new use cases

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1348,13 +1348,13 @@ sub _carry_over_candidate {
     return;
 }
 
-=head2 carry_over_labels
+=head2 carry_over_bugrefs
 
-carry over labels (i.e. special comments) from previous jobs to current result
-in the same scenario.
+carry over bugrefs (i.e. special comments) from previous jobs to current
+result in the same scenario.
 
 =cut
-sub carry_over_labels {
+sub carry_over_bugrefs {
     my ($self) = @_;
 
     # the carry over makes only sense for some jobs
@@ -1366,7 +1366,7 @@ sub carry_over_labels {
     my $comments = $prev->comments->search({}, {order_by => {-desc => 'me.id'}});
 
     while (my $comment = $comments->next) {
-        next if !($comment->bugref or $comment->label);
+        next if !($comment->bugref);
 
         my $text = $comment->text;
         if ($text !~ "Automatic takeover") {
@@ -1496,8 +1496,8 @@ sub done {
         $self->_job_skip_children;
         $self->_job_stop_children;
     }
-    # labels are there to mark reasons of failure - the function checks itself though
-    $self->carry_over_labels;
+    # bugrefs are there to mark reasons of failure - the function checks itself though
+    $self->carry_over_bugrefs;
 
     return $result;
 }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -354,9 +354,7 @@ sub _job_labels {
     my %labels;
     my $c
       = $self->db->resultset("Comments")->search({job_id => {in => [map { $_->id } @$jobs]}}, {order_by => 'me.id'});
-    # previous occurences of bug or label are overwritten here so the
-    # behaviour for multiple bugs or label references within one job is
-    # undefined.
+    # previous occurences of bug or label are overwritten here.
     while (my $comment = $c->next()) {
         if (my $bugref = $comment->bugref) {
             $self->app->log->debug('found bug ticket reference ' . $bugref . ' for job ' . $comment->job_id);

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -279,7 +279,7 @@ $t->app->db->resultset('JobModules')->create(
 # softfailed with failing modules:    not reviewed
 check_badge(0, 0, 'no badge for completely unreviewed build');
 
-my $softfailed_without_failing_modules_label
+my $softfailed_without_failing_modules_issueref
   = $opensuse_group->jobs->find({id => 99939})->comments->create({text => 'poo#4322', user_id => 99901});
 
 # failed:                             not reviewed
@@ -287,7 +287,7 @@ my $softfailed_without_failing_modules_label
 # softfailed with failing modules:    not reviewed
 check_badge(0, 0, 'no badge as long as not all failed reviewed');
 
-my $softfail_with_failing_modules_label
+my $softfail_with_failing_modules_issueref
   = $opensuse_group->jobs->find({id => 99936})->comments->create({text => 'poo#4322', user_id => 99901});
 
 # failed:                             not reviewed
@@ -295,16 +295,17 @@ my $softfail_with_failing_modules_label
 # softfailed with failing modules:    reviewed
 check_badge(0, 0, 'no badge as long as not all failed reviewed');
 
-$softfail_with_failing_modules_label->delete;
+$softfail_with_failing_modules_issueref->delete;
 # add review for job 99938 (so now all failed jobs are reviewed but one softfailed is missing)
-my $failed_label = $opensuse_group->jobs->find({id => 99938})->comments->create({text => 'poo#4321', user_id => 99901});
+my $failed_issueref
+  = $opensuse_group->jobs->find({id => 99938})->comments->create({text => 'poo#4321', user_id => 99901});
 
 # failed:                             reviewed
 # softfailed without failing modules: reviewed
 # softfailed with failing modules:    not reviewed
 check_badge(1, 0, 'regular badge when all failed reviewed but softfailed with failing modules still unreviewed');
 
-$softfail_with_failing_modules_label
+$softfail_with_failing_modules_issueref
   = $opensuse_group->jobs->find({id => 99936})->comments->create({text => 'poo#4322', user_id => 99901});
 
 # failed:                             reviewed
@@ -312,7 +313,7 @@ $softfail_with_failing_modules_label
 # softfailed with failing modules:    reviewed
 check_badge(0, 1, 'review badge for all failed and all softfailed with failed modules when everything reviewed');
 
-$softfailed_without_failing_modules_label->delete;
+$softfailed_without_failing_modules_issueref->delete;
 
 # failed:                             reviewed
 # softfailed without failing modules: not reviewed
@@ -321,7 +322,7 @@ check_badge(0, 1,
 'review badge for all failed and all softfailed with failed modules though there is an unreviewed softfailure without failing modules'
 );
 
-$softfail_with_failing_modules_label->delete;
+$softfail_with_failing_modules_issueref->delete;
 
 # failed:                             reviewed
 # softfailed without failing modules: not reviewed

--- a/templates/comments/add_comment_form_groups.html.ep
+++ b/templates/comments/add_comment_form_groups.html.ep
@@ -13,7 +13,7 @@
             Submit comment</button>
             <% my $content = '
                 <p>
-                    The comment field supports Markdown, automatic detection of URLs and special tags to record bug references, \'labels\'
+                    The comment field supports Markdown, automatic detection of URLs and special tags to record issue references, \'labels\'
                     as well as \'build tagging\'.
                 </p>
                 <ul>
@@ -35,6 +35,10 @@
                 <p>
                     The links are automatically changed to the shortlinks (e.g. <code>https://progress.opensuse.org/issues/11110</code> turns
                     into <code>poo#11110</code>).
+                </p>
+                <p>
+                    Issue references are automatically carried over to the next jobs in the same scenario when the corresponding job fails in
+                    the same module or the failed modules did not change.
                 </p>';
             %>
             %= help_popover 'Help for comments' => $content, 'https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Advanced-features-in-openQA' => 'Wiki'


### PR DESCRIPTION
Labels - in contrast to normal comments or issue references - did not find a
very common use case when used by us. With d806699 we now add a `label:linked`
to jobs to mark them as important when referenced from outside. To make this
approach sensible a carry-over does not make sense not to regard all following
jobs as important. This commit changes the behaviour to disable the carry-over
on job labels. So now only issue references, or "bugrefs" are carried over.
However job 'labels' still retain their other properties, for example they
infuence the appearence of a certificate icon, unlike simple comments.

Related progress issue: https://progress.opensuse.org/issues/14926