### PR TITLE
Show parent name in group overview heading

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -110,12 +110,10 @@ sub group_overview {
     _map_tags_into_build($res, $tags);
     $self->stash('result',   $res);
     $self->stash('max_jobs', $max_jobs);
-    $self->stash(
-        'group',
-        {
-            id   => $group->id,
-            name => $group->name
-        });
+    my $group_hash = {
+        id   => $group->id,
+        name => $group->name,
+    };
     $self->stash('limit_builds',    $limit_builds);
     $self->stash('only_tagged',     $only_tagged);
     $self->stash('comments',        \@comments);
@@ -124,6 +122,11 @@ sub group_overview {
         my @child_groups = $group->children->all;
         $self->stash('child_groups', \@child_groups);
     }
+    elsif ($group->parent_id) {
+        $group_hash->{parent_id}   = $group->parent_id;
+        $group_hash->{parent_name} = $group->parent->name;
+    }
+    $self->stash('group', $group_hash);
     my $desc = $group->rendered_description;
     $self->stash('description', $desc);
     $self->respond_to(
@@ -132,7 +135,7 @@ sub group_overview {
             @pinned_comments = map($_->hash, @pinned_comments);
             $self->render(
                 json => {
-                    group           => $self->stash('group'),
+                    group           => $group_hash,
                     result          => $self->stash('result'),
                     max_jobs        => $self->stash('max_jobs'),
                     description     => $group->description,

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -53,6 +53,14 @@ is_deeply(\@h2, ['opensuse', 'opensuse test'], 'empty parent group not shown');
 my $opensuse_group = $job_groups->find({name => 'opensuse'});
 $opensuse_group->update({parent_id => $test_parent->id});
 
+$get = $t->get_ok('/group_overview/' . $opensuse_group->id)->status_is(200);
+@h2  = $get->tx->res->dom->find('h2')->map('all_text')->each;
+like(
+    $h2[0],
+    qr/[ \n]*Last Builds for[ \n]*Test parent[ \n]*\/[ \n]*opensuse[ \n]*/,
+    'parent name also shown on group overview'
+);
+
 $get = $t->get_ok('/')->status_is(200);
 @h2  = $get->tx->res->dom->find('h2 a')->map('text')->each;
 is_deeply(\@h2, ['opensuse test', 'Test parent'], 'parent group shown and opensuse is no more on top-level');

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -72,7 +72,7 @@ my $element = $driver->find_element('opensuse', 'link_text');
 ok($element->is_displayed(), 'link to child group expanded');
 
 # first try of click does not work for unknown reasons
-for (0 .. 7) {
+for (0 .. 10) {
     $driver->find_element('Build0091', 'link_text')->click();
     last if $driver->find_element('#group1_build0091 h4 a', 'css')->is_hidden();
 }

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -84,7 +84,7 @@ $driver->get($build_url . '?limit_builds=0');
 is(scalar @{$driver->find_elements('div.build-row h4', 'css')}, 0, 'all builds filtered out');
 is(
     $driver->find_element('h2', 'css')->get_text(),
-    'Last Builds for Group opensuse',
+    'Last Builds for opensuse',
     'group name shown correctly when all builds filtered out'
 );
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -57,7 +57,7 @@ $driver->find_element('opensuse', 'link_text')->click();
 
 is(
     $driver->find_element('h2:first-of-type', 'css')->get_text(),
-    "Last Builds for Group opensuse\nEDIT JOB GROUP",
+    "Last Builds for opensuse\nEDIT JOB GROUP",
     'on group overview'
 );
 

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -8,7 +8,11 @@
 % end
 
 <h2>
-    Last Builds for Group
+    Last Builds for
+    % if ($group->{parent_id}) {
+        %= link_to $group->{parent_name} => url_for('parent_group_overview', groupid => $group->{parent_id})
+        /
+    % }
     %= $group->{name}
     % if (is_admin) {
         <form action="<%= url_for('admin_job_templates', groupid => $group->{id}) %>" class="corner-buttons">


### PR DESCRIPTION
So it shows now, eg.
	`Last Builds for SLE Server 12 SP3 / Acceptance: Server`
instead of just
	`Last Builds for Group Acceptance: Server`
to make it more clear which group overview page is actually shown