### PR TITLE
Have initdb exit 4 when no init or upgrade is done

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -82,7 +82,9 @@ sub deployment_check {
             sql_translator_args => {add_drop_table => 0},
             force_overwrite     => $force_overwrite
         });
-    _try_deploy_db($dh) or _try_upgrade_db($dh);
+    return 2 if _try_deploy_db($dh);
+    return 1 if _try_upgrade_db($dh);
+    return 0;
 }
 
 sub _db_tweaks {
@@ -133,7 +135,7 @@ sub _try_upgrade_db {
         $dh->upgrade;
         return 1;
     }
-    return;
+    return 0;
 }
 
 1;

--- a/script/initdb
+++ b/script/initdb
@@ -55,7 +55,9 @@ if ($help) {
     print "                    Don't forget to increase the version before using this\n";
     print "                    and note those files should be commited to the source repo.\n";
     print "  --init_database : Use the generated deployment files created with --prepare_init\n";
-    print "                    to actually initialize a database.\n";
+    print "                    to actually initialize a database (or upgrade an outdated one).\n";
+    print "                    Exit code 4 indicates database already exists and is updated and\n";
+    print "                    --force was not used.\n";
     print "  --force         : Force overwriting existing data.\n";
     print "  --user=login    : Change uid before connecting the DB.\n";
     print "  --help          : This help message.\n";
@@ -129,7 +131,23 @@ if ($prepare_init) {
 }
 if ($init_database) {
     # Create the schema
-    OpenQA::Schema::deployment_check($schema, $force);
+    my $ret = OpenQA::Schema::deployment_check($schema, $force);
+    if ($ret == 0) {
+        print "Database already exists and schema is up to date.\n";
+        exit 4;
+    }
+    elsif ($ret == 2) {
+        print "Database initialized.\n";
+        exit 0;
+    }
+    elsif ($ret == 1) {
+        print "Database already exists, but schema was upgraded.\n";
+        exit 0;
+    }
+    else {
+        print "Unexpected result from deployment_check!\n";
+        exit 1;
+    }
 }
 
 # vim: set sw=4 sts=4 et:

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -42,9 +42,10 @@ try {
 };
 ok(!$deployed_version, 'DB not deployed by plain schema connection');
 
-OpenQA::Schema::deployment_check($schema);
+my $ret = OpenQA::Schema::deployment_check($schema);
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
+is($ret, 2, 'Expected return value (2) for a deployment');
 
 $schema->storage->with_deferred_fk_checks(
     sub {
@@ -69,14 +70,16 @@ $dh = DBIx::Class::DeploymentHandler->new(
 $dh->install({version => $dh->schema_version - 2});
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version - 2, 'Schema at correct, old, version');
-OpenQA::Schema::deployment_check($schema);
+$ret = OpenQA::Schema::deployment_check($schema);
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
+is($ret, 1, 'Expected return value (1) for an upgrade');
 
 # check another deployment_check call doesn't do a thing
-OpenQA::Schema::deployment_check($schema);
+$ret = OpenQA::Schema::deployment_check($schema);
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
+is($ret, 0, 'Expected return value (0) for no action needed');
 
 # check systemuser exists after upgrade
 my $user = $schema->resultset('Users')->find({username => 'system'});


### PR DESCRIPTION
022553fd made `initdb --init_database` silently return 0,
instead of crashing with an uncaught exception, when the db
is already initialized. The exception was bad, of course, but
the new behaviour is a bit of a problem for things like ansible
or puppet or salt, where it's Good Practice for actions to be
aware of whether they changed anything. It's not longer possible
to know whether a run of `initdb` a) initialized the database, b)
upgraded the database or c) did nothing because the database was
fine.

So, this makes it print an informative message about what it did
and exit 0 if it actually did anything; if the db was already
initialized and up to date, it exits 4 (a distinctive code that
ansible plays etc. can recognize).