### PR TITLE
Description for test suites

### DIFF
--- a/assets/javascripts/admintable.js
+++ b/assets/javascripts/admintable.js
@@ -87,6 +87,18 @@ function table_row (data, table, edit, is_admin)
                 html += '</textarea>';
             }
             html += '</td>';
+        } else if (th.hasClass("col_description")) {
+            var description = '';
+            if (data[name]) description = htmlEscape(data[name]);
+            if (edit) {
+                html +=
+                '<td class="editable">' +
+                     '<textarea class="description">' + description + '</textarea>' +
+                 '</td>';
+            }
+            else {
+                html += '<td>' + description + '</td>';
+            }
         } else if (th.hasClass("col_action")) {
             html += '<td>';
             if (edit) {
@@ -190,6 +202,11 @@ function submit_table_row(tr, id)
                     });
                 });
             }
+            else if (th.hasClass("col_description")) {
+                var value = $(this).find('.description').val();
+                data[name] = value;
+            }
+
         });
 
         var url = $("#admintable_api_url").val();

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -258,6 +258,10 @@ ul.modcategory {
     word-break: break-all;
 }
 
+.popover .popover-title {
+    word-break: break-all;
+}
+
 /* special table stuff */
 
 .infotbl {

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -381,6 +381,10 @@ table.dataTable {
         }
 }
 table.admintable {
+        td {
+                max-width: 10em;
+                word-wrap: break-word;
+        }
         td.editable {
                 text-align: right;
         }
@@ -401,6 +405,7 @@ table.admintable {
         }
         textarea {
             height: 100%;
+            min-width: 10em;
         }
 }
 table.overview {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -378,7 +378,6 @@ sub _job_labels {
 # Take an job objects arrayref and prepare data structures for 'overview'
 sub prepare_job_results {
     my ($self, $jobs) = @_;
-    my @configs;
     my %archs;
     my %results;
     my $aggregated = {none => 0, passed => 0, failed => 0, incomplete => 0, scheduled => 0, running => 0, unknown => 0};
@@ -441,15 +440,15 @@ sub prepare_job_results {
             }
         }
 
-        # Populate @configs and %archs
+        # Populate %archs
         if (   $job->MACHINE
             && $preferred_machines->{$job->ARCH}
             && $preferred_machines->{$job->ARCH} ne $job->MACHINE)
         {
             $test .= "@" . $job->MACHINE;
         }
-        push(@configs, $test) unless (grep { $test eq $_ } @configs);
-        $archs{$flavor} = [] unless $archs{$flavor};
+        # poor mans set
+        $archs{$flavor} //= [];
         push(@{$archs{$flavor}}, $arch) unless (grep { $arch eq $_ } @{$archs{$flavor}});
 
         # Populate %results
@@ -457,7 +456,7 @@ sub prepare_job_results {
         $results{$test}{$flavor} = {} unless $results{$test}{$flavor};
         $results{$test}{$flavor}{$arch} = $result;
     }
-    return (\@configs, \%archs, \%results, $aggregated);
+    return (\%archs, \%results, $aggregated);
 }
 
 # A generic query page showing test results in a configurable matrix
@@ -495,11 +494,10 @@ sub overview {
     my $req_params = $self->req->params->to_hash;
     %search_args = (%search_args, %$req_params);
     my @latest_jobs = $self->db->resultset("Jobs")->complex_query(%search_args)->latest_jobs;
-    my ($configs, $archs, $results, $aggregated) = $self->prepare_job_results(\@latest_jobs);
+    my ($archs, $results, $aggregated) = $self->prepare_job_results(\@latest_jobs);
     # Sorting everything
     my @types = keys %$archs;
     @types = sort @types;
-    my @configs = sort @$configs;
     for my $flavor (@types) {
         my @sorted = sort(@{$archs->{$flavor}});
         $archs->{$flavor} = \@sorted;
@@ -510,7 +508,6 @@ sub overview {
         version    => $search_args{version},
         distri     => $search_args{distri},
         group      => $group,
-        configs    => \@configs,
         types      => \@types,
         archs      => $archs,
         results    => $results,

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -65,9 +65,10 @@ is_deeply(
                     }]
             },
             {
-                'id'       => 1002,
-                'name'     => 'kde',
-                'settings' => [
+                'id'          => 1002,
+                'name'        => 'kde',
+                'description' => 'Simple kde test, before advanced_kde',
+                'settings'    => [
                     {
                         'key'   => 'DESKTOP',
                         'value' => 'kde'

--- a/t/fixtures/04-products.pl
+++ b/t/fixtures/04-products.pl
@@ -25,9 +25,10 @@
     },
 
     TestSuites => {
-        id       => 1002,
-        name     => "kde",
-        settings => [{key => "DESKTOP", value => "kde"}],
+        id          => 1002,
+        name        => "kde",
+        description => 'Simple kde test, before advanced_kde',
+        settings    => [{key => "DESKTOP", value => "kde"}],
     },
 
     TestSuites => {

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -65,6 +65,11 @@ t::ui::PhantomTest::wait_for_ajax;
 like($driver->find_elements('.failedmodule a', 'css')->[1]->get_attribute('href'),
     qr/\/3$/, 'ajax update failed module step');
 
+my @descriptions = $driver->find_elements('td.name a', 'css');
+is(scalar @descriptions, 1, 'only test suites with description content are shown as links');
+$descriptions[0]->click();
+is($driver->find_element('.popover-title', 'css')->get_text, 'kde', 'description popover shows content');
+
 t::ui::PhantomTest::kill_phantom();
 
 done_testing();

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -184,12 +184,13 @@ subtest 'add test suite' => sub() {
     t::ui::PhantomTest::wait_for_ajax;
     my $elem = $driver->find_element('.admintable thead tr', 'css');
     my @headers = $driver->find_child_elements($elem, 'th');
-    is(@headers, 3, "3 columns");
+    is(@headers, 4, 'all columns');
 
     # the headers are specific to our fixtures - if they change, we have to adapt
-    is((shift @headers)->get_text(), "Name",     "1st column");
-    is((shift @headers)->get_text(), "Settings", "2th column");
-    is((shift @headers)->get_text(), "Actions",  "3th column");
+    is((shift @headers)->get_text(), "Name",        "1st column");
+    is((shift @headers)->get_text(), "Settings",    "2th column");
+    is((shift @headers)->get_text(), "Description", "3rd column");
+    is((shift @headers)->get_text(), "Actions",     "4th column");
 
     # now check one row by example
     $elem = $driver->find_element('.admintable tbody tr:nth-child(3)', 'css');
@@ -209,7 +210,7 @@ subtest 'add test suite' => sub() {
     is(@fields, 1, '1 input field');
     (shift @fields)->send_keys('xfce');    # name
     @fields = $driver->find_child_elements($elem, '//textarea');
-    is(@fields, 1, '1 textarea');
+    is(@fields, 2, '2 textareas');
 
     is($driver->find_element('//button[@title="Add"]')->click(), 1, 'added');
     t::ui::PhantomTest::wait_for_ajax;

--- a/templates/admin/test_suite/index.html.ep
+++ b/templates/admin/test_suite/index.html.ep
@@ -16,6 +16,7 @@
                 <tr>
                     <th class="col_value">Name</th>
                     <th class="col_settings_list">Settings</th>
+                    <th class="col_description">Description</th>
                     <th class="col_action">Actions</th>
                 </tr>
             </thead>

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -1,6 +1,7 @@
 % layout 'bootstrap';
 % title 'Test summary';
 % use OpenQA::Schema::Result::Jobs;
+% use OpenQA::Utils;
 
 % content_for 'ready_function' => begin
   setupOverview();
@@ -94,9 +95,19 @@
                 % for my $config (sort keys %$results) {
                     % next unless $results->{$config}{flavors}{$type};
                     <tr>
-                        <td class="name"><%= trim_text($config, 30) %></td>
+                        <td class="name">
+                            % my $test_label = trim_text($config, 30);
+                            % if (my $description = $results->{$config}{description}) {
+                                <a data-content="<p><%= href_to_bugref(render_escaped_refs($results->{$config}{description})) %></p>"
+                                data-title="<%= $config %>" data-toggle="popover" data-trigger="click" role="button" tabindex="0"><%= $test_label %></a>
+                            % }
+                            % else {
+                                <%= $test_label %>
+                            % }
+                        </td>
+
                         % for my $arch (@{$archs->{$type}}) {
-                            % my $res = $results->{$config}{$type}{$arch};
+                            % my $res = $results->{$config}{flavors}{$type}{$arch};
                             % my $jobid = $res->{jobid};
                             % my $state = $res->{state};
 

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -91,8 +91,8 @@
                 </tr>
             </thead>
             <tbody>
-                % for my $config (@$configs) {
-                    % next unless $results->{$config}{$type};
+                % for my $config (sort keys %$results) {
+                    % next unless $results->{$config}{flavors}{$type};
                     <tr>
                         <td class="name"><%= trim_text($config, 30) %></td>
                         % for my $arch (@{$archs->{$type}}) {


### PR DESCRIPTION
Add API CRUD operations for a description field for test suites, machines, products.

Also deletes 'variables' field which has not been in use for test suites,
machines, products for quite some time now.

Add UI elements for CRUD on test suite description.

Show description as popover on each test row.

Screenshot how the test suite description shows up in the admin table:
![openqa_wrapped_test_suite_table_and_description](https://cloud.githubusercontent.com/assets/1693432/21359513/c6841b40-c6dc-11e6-8dbd-9b85e8de3cc4.png)

Screenshot of edit:
![openqa_wrapped_test_suite_table_and_description_edit](https://cloud.githubusercontent.com/assets/1693432/21359512/c66bd04e-c6dc-11e6-8ee3-d6eec6850425.png)

Screenshot of popover in test overview with content as configured in the test suites database (i.e. over admin view):
![openqa_test_suite_description_hover_on_overview2](https://cloud.githubusercontent.com/assets/1693432/21397904/bf8ba80c-c7a5-11e6-8f9c-823323464dfc.png)