### PR TITLE
Use locking for db check, run check on most db connections

### DIFF
--- a/lib/OpenQA/Test/Database.pm
+++ b/lib/OpenQA/Test/Database.pm
@@ -24,7 +24,7 @@ sub create {
     );
 
     # New db
-    my $schema = OpenQA::Schema::connect_db('test');
+    my $schema = OpenQA::Schema::connect_db(mode => 'test', check => 0);
     OpenQA::Schema::deployment_check($schema);
     $self->insert_fixtures($schema) unless $options{skip_fixtures};
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -90,7 +90,6 @@ sub startup {
 
     # take care of DB deployment or migration before starting the main app
     my $schema = OpenQA::Schema::connect_db;
-    OpenQA::Schema::deployment_check($schema);
 
     unshift @{$self->renderer->paths}, '/etc/openqa/templates';
 

--- a/script/initdb
+++ b/script/initdb
@@ -78,7 +78,7 @@ umask 027;
 
 my $script_directory = "$FindBin::Bin/../dbicdh";
 my @databases        = qw( SQLite PostgreSQL );
-my $schema           = OpenQA::Schema::connect_db;
+my $schema           = OpenQA::Schema::connect_db(check => 0);
 
 if ($schema->dsn =~ /:SQLite:dbname=(.*)/) {
     my $dbdir = dirname($1);

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -73,7 +73,7 @@ if ($user) {
     setuid($uid) || die "can't suid to $user";
 }
 
-my $schema = OpenQA::Schema::connect_db;
+my $schema = OpenQA::Schema::connect_db(check => 0);
 
 my $script_directory = "$FindBin::Bin/../dbicdh";
 my @databases        = qw( SQLite PostgreSQL );

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -42,7 +42,7 @@ sub ws_send {
 
 package main;
 
-my $schema = OpenQA::Schema::connect_db('test');
+my $schema = OpenQA::Schema::connect_db(mode => 'test', check => 0);
 #issue valid commands for worker 1
 my @valid_commands = qw(quit abort cancel obsolete
   stop_waitforneedle reload_needles_and_retry continue_waitforneedle

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -27,8 +27,8 @@ use SQL::Translator;
 use OpenQA::Schema;
 use Try::Tiny;
 
-my $schema = OpenQA::Schema::connect_db('test');
-my $dh     = DBIx::Class::DeploymentHandler->new(
+my $schema = OpenQA::Schema::connect_db(mode => 'test', check => 0);
+my $dh = DBIx::Class::DeploymentHandler->new(
     {
         schema              => $schema,
         script_directory    => 'dbicdh',
@@ -40,7 +40,7 @@ my $deployed_version;
 try {
     $deployed_version = $dh->version_storage->database_version;
 };
-ok(!$deployed_version, 'DB not deployed by plain schema connection');
+ok(!$deployed_version, 'DB not deployed by plain schema connection with check => 0');
 
 my $ret = OpenQA::Schema::deployment_check($schema);
 ok($dh->version_storage->database_version, 'DB deployed');
@@ -57,7 +57,7 @@ $schema->storage->with_deferred_fk_checks(
     });
 
 OpenQA::Schema::disconnect_db;
-$schema = OpenQA::Schema::connect_db('test');
+$schema = OpenQA::Schema::connect_db(mode => 'test', check => 0);
 # redeploy DB to older version and check if deployment_check upgrades the DB
 $dh = DBIx::Class::DeploymentHandler->new(
     {


### PR DESCRIPTION
This is an attempt to address POO #15540. There are two major
changes.

First, we `flock` the db config file (chosen as we must be
able to read it, and the code to find it was already present)
to try and ensure that only one openQA process (one of the
server processes, gru, or any of the admin scripts that handle
the database) can run the deployment check at a time; this is
to ensure multiple processes don't try to deploy or upgrade the
db schema at once.

Second, we have the first call to `connect_db` for any given
process run the deployment check (because `connect_db` caches
the schema, subsequent calls won't run the check). This should
ensure that the db is always checked, and deployed or upgraded
if needed, when *any* openQA server process tries to use it.
Previously, only the webui process ran the deployment check,
which wasn't really sufficient.

We allow passing `check => 0` to `connect_db` to disable this,
so `initdb`, `upgradedb`, and some tests which actually want
to get a schema without doing the deployment check can do so.