### PR TITLE
audit log: Fix filtering event data by default

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -111,7 +111,7 @@ sub _get_search_query {
     # construct query only from allowed columns
     my $query       = {};
     my @subsearch   = split(/ /, $raw_search);
-    my $current_key = 'event_data';
+    my $current_key = 'data';
     my @current_search;
     for my $s (@subsearch) {
         if (CORE::index($s, ':') == -1) {


### PR DESCRIPTION
* and finally add a test for this simple use case
* however, sleeps in the test are still present

I'm unable to find a way to get rid of the sleeps so far.

I tried:

```
while ($driver->execute_script('return $($("#audit_log_table").dataTable().fnSettings().aanFeatures.r).is(":visible")')) {
    sleep 0.1;
}
```

It actually waits (one iteration) till the 'processing' indication is hidden. However, this is not sufficient as the table isn't updated at this time.