### PR TITLE
Add support for multiple distri/version/group on /tests/overview

### DIFF
--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -36,14 +36,6 @@ sub get_summary {
 }
 
 #
-# Overview with incorrect parameters
-#
-$t->get_ok('/tests/overview')->status_is(404);
-$t->get_ok('/tests/overview' => form => {build => '0091'})->status_is(404);
-$t->get_ok('/tests/overview' => form => {build => '0091', distri => 'opensuse'})->status_is(404);
-$t->get_ok('/tests/overview' => form => {build => '0091', version => '13.1'})->status_is(404);
-
-#
 # Overview of build 0091
 #
 my $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', build => '0091'});
@@ -208,6 +200,22 @@ like(
     'multiple groups with no build specified yield latest build of first group'
 );
 like($summary, qr/Passed: 2 Failed: 0 Scheduled: 1 Running: 2 None: 1/i);
+
+# overview page searches for all available data with less specified parameters
+$t->get_ok('/tests/overview' => form => {build => '0091', version => '13.1'})->status_is(200);
+$t->get_ok('/tests/overview' => form => {build => '0091', distri  => 'opensuse'})->status_is(200);
+$t->get_ok('/tests/overview' => form => {build => '0091'})->status_is(200);
+$get     = $t->get_ok('/tests/overview')->status_is(200);
+$summary = get_summary;
+like($summary, qr/Summary of opensuse/i, 'shows all available latest jobs for the only present distri');
+like(
+    $summary,
+    qr/Passed: 2 Failed: 0 Scheduled: 2 Running: 2 None: 1/i,
+    'shows latest jobs from all distri, version, build, flavor, arch'
+);
+$get->element_exists('#res_DVD_i586_kde');
+$get->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled');
+$get->element_exists('#res_NET_x86_64_kde .state_running');
 
 #
 # Test filter form

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -6,6 +6,14 @@
   setupOverview();
 % end
 
+% my $only_distri = scalar keys $results == 1;
+% if (!defined $distri and $only_distri) {
+    % $distri = (keys $results)[0];
+    % if (!defined $version and scalar keys $results->{$distri} == 1) {
+        % $version = (keys $results->{$distri})[0];
+    % }
+% }
+
 <div>
     <h2>Test result overview</h2>
     <div id="summary" class="panel <%= ($aggregated->{failed} + $aggregated->{incomplete}) ? 'panel-danger' : 'panel-success' %>">
@@ -14,10 +22,15 @@
             % if (@$groups) {
                 <b><%= b join(', ', map { link_to $_->name => url_for('group_overview', groupid => $_->id) } @$groups) %></b>
             % }
-            % else {
+            % elsif ($distri or $version) {
                 <b><%= $distri %> <%= $version %></b>
             % }
-            build <%= $build %>
+            % else {
+                multiple distri/version
+            % }
+            % if ($build) {
+                build <%= $build %>
+            % }
         </div>
         <div class="panel-body">
             Passed: <span class="badge"><%= $aggregated->{passed} %></span>
@@ -106,47 +119,18 @@
             </form>
         </div>
     </div>
-    % for my $type (@$types) {
-        <h3>Flavor: <%= $type %></h3>
-        <table id="results_<%= $type %>" class="overview table table-striped table-hover">
-            <thead>
-                <tr id="flavors">
-                    <th>Test</th>
-                    % for my $arch (@{$archs->{$type}}) {
-                        <th id="flavor_<%= $type %>_arch_<%= $arch %>"><%= $arch %></th>
-                    % }
-                </tr>
-            </thead>
-            <tbody>
-                % for my $config (sort keys %$results) {
-                    % next unless $results->{$config}{flavors}{$type};
-                    <tr>
-                        <td class="name">
-                            % my $test_label = trim_text($config, 30);
-                            % if (my $description = $results->{$config}{description}) {
-                                <a data-content="<p><%= rendered_refs $description %></p>"
-                                data-title="<%= $config %>" data-toggle="popover" data-trigger="focus" role="button" tabindex="0"><%= $test_label %></a>
-                            % }
-                            % else {
-                                <%= $test_label %>
-                            % }
-                        </td>
-
-                        % for my $arch (@{$archs->{$type}}) {
-                            % my $res = $results->{$config}{flavors}{$type}{$arch};
-                            % my $jobid = $res->{jobid};
-                            % my $state = $res->{state};
-
-                            % if (!$state) {
-                                <td>-</td>
-                                % next;
-                            % }
-                            % my $resultid = join('_', $type, $arch, $config);
-                            %= include 'test/tr_job_result', resultid => $resultid, res => $res, state => $state, jobid => $jobid
-                        % }
-                    </tr>
-                % }
-            </tbody>
-        </table>
+    % for my $distri (sort keys $results) {
+        % my $type_prefix_distri = $only_distri ? '' : "Distri: $distri / ";
+        % my $version_results = $results->{$distri};
+        % my $only_version = scalar keys $version_results == 1;
+        % for my $version (sort keys $version_results) {
+            % my $type_prefix = $type_prefix_distri . ($only_version ? '' : " Version: $version / ");
+            % my $type_archs = $archs->{$distri}{$version};
+            % for my $type (sort keys $type_archs) {
+                % my $type_result = $version_results->{$version}{$type};
+                <h3><%= $type_prefix %>Flavor: <%= $type %></h3>
+                %= include 'test/overview_result_table', type => $type, type_results => $type_result, type_archs => $type_archs->{$type}
+            % }
+        % }
     % }
 </div>

--- a/templates/test/overview_result_table.html.ep
+++ b/templates/test/overview_result_table.html.ep
@@ -1,0 +1,42 @@
+% use OpenQA::Utils;
+<table id="results_<%= $type %>" class="overview table table-striped table-hover">
+    <thead>
+        <tr>
+            <th>Test</th>
+            % my @archs = sort @$type_archs;
+            % for my $arch (@archs) {
+                <th id="flavor_<%= $type %>_arch_<%= $arch %>"><%= $arch %></th>
+            % }
+        </tr>
+    </thead>
+    <tbody>
+        % for my $config (sort keys %$type_results) {
+            % next unless $type_results->{$config};
+            <tr>
+                <td class="name">
+                    % my $test_label = trim_text($config, 30);
+                    % if (my $description = $type_results->{$config}{description}) {
+                        <a data-content="<p><%= href_to_bugref(render_escaped_refs($description)) %></p>"
+                        data-title="<%= $config %>" data-toggle="popover" data-trigger="focus" role="button" tabindex="0"><%= $test_label %></a>
+                    % }
+                    % else {
+                        <%= $test_label %>
+                    % }
+                </td>
+
+                % for my $arch (@archs) {
+                    % my $res = $type_results->{$config}{$arch};
+                    % my $jobid = $res->{jobid};
+                    % my $state = $res->{state};
+
+                    % if (!$state) {
+                        <td>-</td>
+                        % next;
+                    % }
+                    % my $resultid = join('_', $type, $arch, $config);
+                    %= include 'test/tr_job_result', resultid => $resultid, res => $res, state => $state, jobid => $jobid
+                % }
+            </tr>
+        % }
+    </tbody>
+</table>


### PR DESCRIPTION
Add support for multiple distri/version/group on /tests/overview

This adds support to specify zero to multiple of distri/version/group
parameters to show multiple ones as well as look up corresponding entries from
the job results table. Every group of results will be displayed just as before
as a table on the tests overview page. Previously the title for each table was
just the "flavor" where now the "distri" as well as "version" is also
specified. For the special case of having just one "distri" and/or "version"
it is displayed just as before, i.e. only the "flavor" is shown. This also
works if "distri" and/or "version" have not been specified as query parameters
but the search in the job results based on the other parameters resolved to
just one value of these.

With this change also no query parameter for the /tests/overview route is
mandatory anymore.

This alters previous behaviour where additional 'groupid' parameters would
overwrite previous ones. Now a logical 'or' operation is done on the job
group ids as well as names to show jobs from all job groups. Jobs are still
filtered to show only the latest ones over all job groups. Still this should
allow to show more jobs of one build when multiple job groups are involved.

Also extracting a partial template for the result table itself.

Screenshot of showing multiple versions and groups for one distri:
![openqa_multiple_version_groups_in_overview](https://cloud.githubusercontent.com/assets/1693432/21434654/ff694134-c875-11e6-99bd-683cb1c5ee56.png)


Related progress issue: https://progress.opensuse.org/issues/13712