### PR TITLE
Fix appearance of popover arrow

### DIFF
--- a/assets/sass/theme_overwrites.scss
+++ b/assets/sass/theme_overwrites.scss
@@ -266,8 +266,27 @@ abbr[title], acronym[title] {
 }
     
 .popover {
-  border: none;
+  border: 1px solid #ddd;
   @include box-shadow(0 1px 4px rgba(0,0,0,.3));
+
+  &.top .arrow:after {
+      bottom: 2px;
+  }
+
+  &.bottom .arrow:after {
+      top: 2px;
+      border-bottom-color: #f7f7f7;
+  }
+
+  &.left .arrow:after {
+      right: 2px;
+      bottom: -10px;
+  }
+
+  &.right .arrow:after {
+      left: 2px;
+      bottom: -10px;
+  }
 }
 
 .carousel {

--- a/assets/sass/theme_variables.scss
+++ b/assets/sass/theme_variables.scss
@@ -548,14 +548,14 @@ $popover-fallback-border-color:       transparent !default;
 $popover-title-bg:                    darken($popover-bg, 3%) !default;
 
 //** Popover arrow width
-$popover-arrow-width:                 10px !default;
+$popover-arrow-width:                 11px !default;
 //** Popover arrow color
 $popover-arrow-color:                 $popover-bg !default;
 
 //** Popover outer arrow width
 $popover-arrow-outer-width:           ($popover-arrow-width + 1) !default;
 //** Popover outer arrow color
-$popover-arrow-outer-color:           fadein($popover-border-color, 7.5%) !default;
+$popover-arrow-outer-color:           #ddd !default;
 //** Popover outer arrow fallback color
 $popover-arrow-outer-fallback-color:  darken($popover-fallback-border-color, 20%) !default;
 


### PR DESCRIPTION
So it looks like this
![spectacle z28439](https://cloud.githubusercontent.com/assets/10248953/21591164/d7f2ec6a-d101-11e6-9861-c89513a9acff.png)

instead of
![spectacle q28439](https://cloud.githubusercontent.com/assets/10248953/21591177/f1ae4668-d101-11e6-969c-f0e11b0aed1c.png)

