### PR TITLE
Fix asciidoctor call and changes to documents

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,5 +1,9 @@
-openQA image:https://api.travis-ci.org/os-autoinst/openQA.svg?branch=master[link=https://travis-ci.org/os-autoinst/openQA] image:https://codecov.io/gh/os-autoinst/openQA/branch/master/graph/badge.svg[link=https://codecov.io/gh/os-autoinst/openQA]
-================================================================================================================================================================================================================================================================================
+:travis-ci: image:https://api.travis-ci.org/os-autoinst/openQA.svg?branch=master[link=https://travis-ci.org/os-autoinst/openQA]
+:codecov: image:https://codecov.io/gh/os-autoinst/openQA/branch/master/graph/badge.svg[link=https://codecov.io/gh/os-autoinst/openQA]
+
+= openQA
+
+{codecov} {travis-ci}
 
 openQA is a testing framework that allows you to test GUI applications on one
 hand and bootloader and kernel on the other. In both cases, it is difficult to
@@ -10,20 +14,19 @@ Therefore openQA runs virtual machines and closely monitors their state and
 runs tests on them.
 
 The testing framework can be divided in two parts. The one that is hosted in
-this repository contains the web frontend and management logic (test 
+this repository contains the web frontend and management logic (test
 scheduling, management, high-level API, ...)
 
 The other part that you need to run openQA is the OS-autoinst test engine that
 is hosted in a separate https://github.com/os-autoinst/os-autoinst[repository].
 
-Getting started
----------------
+== Getting started
 
 The project's information is organized into four basic documents. As a first
 step, read the link:docs/GettingStarted.asciidoc[Starter Guide] and then, if
 needed, proceed to the link:docs/Installing.asciidoc[Installation Guide].
 
-If you are interested in development, check the 
+If you are interested in development, check the
 link:docs/Contributing.asciidoc[Developer Guide] or the
 link:docs/WritingTests.asciidoc[Tests Developer Guide], write your code and
 send a pull request ;-)

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -28,38 +28,10 @@ is already familiar with Perl.
 
 == API
 [id="api"]
+:testapi: https://github.com/os-autoinst/os-autoinst/blob/master/testapi.pm[os-autoinst]
 
-https://github.com/os-autoinst/os-autoinst[os-autoinst] provides the
-API for the tests. The most commonly used functions are:
-
-* +get_var NAME[, DEFAULT]+ Returns the content of a variable if available; otherwise returns the specified default value or undef.
-* +check_var NAME, CONTENT+ Check content of a variable, treating undef as empty.
-* +send_key KEY[, WAITIDLE]+ Send key to openQA instance. Call +wait_idle+ at the end if WAITIDLE is set. (e.g. +send_key "alt-o", 1+)
-* +type_string STRING+ Typing the given string. (e.g. +type_string "yes\n"+)
-* +save_screenshot+ Capture and save a screenshot in the test results.
-* +check_screen NEEDLE[, TIMEOUT]+ Wait until NEEDLE is seen on the screen. Return undef if not found within TIMEOUT (default 30s).
-* +assert_screen NEEDLE[, TIMEOUT]+ Wait until NEEDLE is seen on the screen. Abort test and mark as failed if not found within TIMEOUT (default 30s).
-* +record_soft_failure+ Record a workaround applied in the test.
-* +wait_idle TIMEOUT+  Wait for max TIMEOUT seconds until system is idle.
-* +select_console STRING+ Switch to another TTY (text based or graphical), console names are defined by the distribution.
-* +wait_serial REGEX[, TIMEOUT]+ Wait until REGEX is seen on serial port. Return 0 if not found after TIMEOUT (default 90s)
-* +upload_logs FILE+ Type in necessary shell commands to save FILE in the test results
-* +assert_and_click NEEDLE[, BUTTON]+ Wait until NEEDLE is seen on the screen and click it in the middle of the smallest defined area
-* +wait_still_screen [TIME]+ Wait for the screen to stop changing for TIME seconds
-* +mouse_hide+ Moves the mouse cursor into the edge of the screen to hide it within needles
-* +script_output SCRIPT[, TIMEOUT]+ Returns the text output of the given bash script. The script is called with bash -xe and STDOUT is returned
-* +validate_script_output SCRIPT, CODE+ Checks the text output of the bash script using the given callback (e.g. +validate_script_output "ls -la $HOME", sub { m/.xsession-errors/ }+)
-* +assert_shutdown [TIMEOUT]+ Wait for max TIMEOUT seconds for system to shut down (default 30s)
-
-The following API is distribution specific and subject to change
-
-* +ensure_installed PACKAGES...+ Check that the specific application was installed in the system, if not then it will try to install it from download repositories.
-* +x11_start_program NAME+ Execute the graphical application NAME. How exactly depends on the desktop environment.
-* +become_root+ Become root (in a shell)
-* +script_run COMMAND[, TIMEOUT]+ Wrapper for type_string meant to type in shell commands. Waits TIMEOUT until idle (default 30s)
-* +assert_script_run COMMAND [, timeout => TIMEOUT] [, fail_message => FAIL_MESSAGE]+ Same as script_run but verifies that execution of the script was successful, ended with exit code 0.
-* +script_sudo COMMAND+ Use sudo to execute COMMAND, handling the optional password prompt.
-* +type_password+ Type default password (used for root and user)
+{testapi} provides the API for the tests using the os-autoinst backend, you can
+take a look to the published documentation at http://open.qa/api/testapi/.
 
 == How to write tests
 

--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -17,12 +17,7 @@
 
 function update_docs {
 
-        # install dependencies
-        gem install asciidoctor pygments.rb
-        gem install asciidoctor-pdf --pre
-        cpanm --install Pod::AsciiDoctor
-
-	call_asciidoctor
+        call_asciidoctor
 
         git clone $REPO out
         cd out
@@ -84,7 +79,7 @@ APIFILE
 
 green="\e[23m\e[1m"
 
-asciidoctor_bin=$(which asciidoctor)
+asciidoctor_bin="/bin/not/set"
 shortref=$(git rev-parse --short HEAD)
 verbose_doc_name=$(date +%Y%m%d)"_"${shortref} #we are not intending to run this off a git repository
 tmpwd=$(mktemp -d -t openqa-doc-XXXX)
@@ -96,12 +91,36 @@ REPO_DIRECTORY=$PWD
 SSH_KEY=$1
 SSH_IV=$2
 
-function call_asciidoctor {
+
+function check_asciidoctor {
+
+    asciidoctor_bin=$(which asciidoctor)
 
     if [ -z "${asciidoctor_bin}" -o ! -f "${asciidoctor_bin}" ]; then
         echo "Could not find asciidoctor binary in your path, please install it and run this command again"
+        echo "gem install asciidoctor pygments.rb"
+        echo "gem install asciidoctor-pdf --pre"
         exit 1
     fi
+
+}
+
+function set_sshkey {
+    openssl aes-256-cbc -K $SSH_KEY -iv $SSH_IV -in .openqa-travis.enc -out .openqa-travis -d
+    chmod 600 .openqa-travis
+    ssh-add .openqa-travis
+}
+
+function install_asciidoctor {
+    # install dependencies
+    gem install asciidoctor pygments.rb
+    gem install asciidoctor-pdf --pre
+    cpanm --install Pod::AsciiDoctor
+}
+
+function call_asciidoctor {
+
+    check_asciidoctor
 
     cd docs
     mkdir ${tmpwd}/output 2>/dev/null || true # we don't care if the directory already exists
@@ -132,12 +151,12 @@ if [ ${GH_PUBLISH} ] && [ ${CONTINUOUS_INTEGRATION} ]; then
     fi
 
     echo "Requirements met, generating documentation"
-    openssl aes-256-cbc -K $SSH_KEY -iv $SSH_IV -in .openqa-travis.enc -out .openqa-travis -d
-    eval "$(ssh-agent -s)"
-    chmod 600 .openqa-travis
-    ssh-add .openqa-travis
 
+    set_sshkey
+    eval "$(ssh-agent -s)"
+    install_asciidoctor
     update_docs
+
 else
     call_asciidoctor
 fi


### PR DESCRIPTION
Changes on the `generate-documentation` script should fix the problems we've found regarding documentation publishing. 

Changes to the Readme and WritingTests.asciidoc are just an update to links. 