### PR TITLE
Alternative to #1040 based on #1094

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -18,6 +18,11 @@ function getCookie(cname) {
 function setupForAll() {
     $('[data-toggle="tooltip"]').tooltip({html: true});
     $('[data-toggle="popover"]').popover({html: true});
+    // workaround for popover with hover on text for firefox
+    $('[data-toggle="popover"]').on('click', function (e) {
+        e.target.closest('a').focus();
+    });
+
     $('[data-submenu]').submenupicker();
 
     $.ajaxSetup({

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -19,7 +19,7 @@ package OpenQA::WebAPI::Plugin::Helpers;
 use strict;
 use warnings;
 use Mojo::ByteStream;
-use OpenQA::Utils 'bugurl';
+use OpenQA::Utils qw(bugurl render_escaped_refs href_to_bugref);
 use db_helpers;
 
 use base 'Mojolicious::Plugin';
@@ -70,6 +70,18 @@ sub register {
               . $c->t(i => (class => 'new fa fa-plus fa-stack-1x'));
             my $content = $c->t(span => (class => 'fa-stack') => sub { $icons });
             return $c->link_to($url => (title => $title, class => $class) => sub { $content });
+        });
+
+    $app->helper(
+        rendered_refs_no_shortening => sub {
+            my ($c, $text) = @_;
+            return render_escaped_refs($text);
+        });
+
+    $app->helper(
+        rendered_refs => sub {
+            my ($c, $text) = @_;
+            return href_to_bugref(render_escaped_refs($text));
         });
 
     $app->helper(

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -141,6 +141,16 @@ $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version =>
   ->status_is(200);
 like(get_summary, qr/Passed: 0 Soft Failure: 2 Failed: 1/i, 'todo=1 shows all unlabeled failed');
 
+# multiple groups can be shown at the same time
+$get     = $t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002')->status_is(200);
+$summary = get_summary;
+like($summary, qr/Summary of opensuse, opensuse test/i, 'references both groups selected by query');
+like($summary, qr/Passed: 2 Failed: 0 Scheduled: 1 Running: 2 None: 1/i,
+    'shows latest jobs from both groups 1001/1002');
+$get->element_exists('#res_DVD_i586_kde',                           'job from group 1001 is shown');
+$get->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled', 'another job from group 1001');
+$get->element_exists('#res_NET_x86_64_kde .state_running',          'job from group 1002 is shown');
+
 #
 # Test filter form
 #

--- a/templates/admin/test_suite/index.html.ep
+++ b/templates/admin/test_suite/index.html.ep
@@ -16,7 +16,16 @@
                 <tr>
                     <th class="col_value">Name</th>
                     <th class="col_settings_list">Settings</th>
-                    <th class="col_description">Description</th>
+                    <th class="col_description">
+                        Description
+                        <%= help_popover('Help for description' =>
+                            'An optional description can be entered for each
+                            test suite which is displayed as description on
+                            each test row on the test overview page
+                            <i>/tests/overview</i>',
+                            'https://github.com/os-autoinst/openQA/pull/1094' => 'pull request')
+                        %>
+                    </th>
                     <th class="col_action">Actions</th>
                 </tr>
             </thead>

--- a/templates/step/viewtext.html.ep
+++ b/templates/step/viewtext.html.ep
@@ -1,2 +1,1 @@
-% use OpenQA::Utils;
-<pre><%== render_escaped_refs($textresult) %></pre>
+<pre><%== rendered_refs_no_shortening $textresult %></pre>

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -52,7 +52,25 @@
         </div>
     </div>
     <div class="panel panel-default" id="filter-panel">
-        <div class="panel-heading"><strong>Filter</strong> <span>no filter present, click to toggle filter form</span></div>
+        <div class="panel-heading"><strong>Filter</strong>
+            <%= help_popover('Help for the <i>test overview</i>' => '
+                    <p>This page shows an overview of job results in a matrix
+                    view. Only the latest job for each scenario is shown. The
+                    view can be configured based on query parameters which can
+                    be set within this filter box.</p>
+                    <p><b>Caveat:</b> Based on the parameters the resulting
+                    job query might consider jobs as latest which do not
+                    represent the complete picture for a corresponding
+                    "latest" build so be careful with a more advanced
+                    selection of checkboxes with the interpretation of the
+                    results.</p>
+                    <p>Additional tweaking of the query is possible by leaving
+                    out query parameters completely or specifying them
+                    multiple times equivalent to an logical "or" search.</p>',
+                    'https://progress.opensuse.org/projects/openqav3/wiki/Wiki#Allow-group-overview-query-by-result-gh531' => 'Wiki')
+                %>
+            <span>no filter present, click to toggle filter form</span>
+        </div>
         <div class="panel-body">
             <form action="#" type="get" id="filter-form">
                 <div class="form-group" id="filter-results">

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -12,10 +12,10 @@
     <div id="summary" class="panel <%= ($aggregated->{failed} + $aggregated->{incomplete}) ? 'panel-danger' : 'panel-success' %>">
         <div class="panel-heading">
             Overall Summary of
-            % if ($group) {
-                <b><%= link_to $group->name => url_for('group_overview', groupid => $group->id) %></b>
-            % } else
-            % {
+            % if (@$groups) {
+                <b><%= b join(', ', map { link_to $_->name => url_for('group_overview', groupid => $_->id) } @$groups) %></b>
+            % }
+            % else {
                 <b><%= $distri %> <%= $version %></b>
             % }
             build <%= $build %>

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -1,7 +1,6 @@
 % layout 'bootstrap';
 % title 'Test summary';
 % use OpenQA::Schema::Result::Jobs;
-% use OpenQA::Utils;
 
 % content_for 'ready_function' => begin
   setupOverview();
@@ -115,7 +114,7 @@
                         <td class="name">
                             % my $test_label = trim_text($config, 30);
                             % if (my $description = $results->{$config}{description}) {
-                                <a data-content="<p><%= href_to_bugref(render_escaped_refs($results->{$config}{description})) %></p>"
+                                <a data-content="<p><%= rendered_refs $description %></p>"
                                 data-title="<%= $config %>" data-toggle="popover" data-trigger="focus" role="button" tabindex="0"><%= $test_label %></a>
                             % }
                             % else {

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -79,7 +79,6 @@
             </form>
         </div>
     </div>
-    % my $failedid;
     % for my $type (@$types) {
         <h3>Flavor: <%= $type %></h3>
         <table id="results_<%= $type %>" class="overview table table-striped table-hover">

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -99,7 +99,7 @@
                             % my $test_label = trim_text($config, 30);
                             % if (my $description = $results->{$config}{description}) {
                                 <a data-content="<p><%= href_to_bugref(render_escaped_refs($results->{$config}{description})) %></p>"
-                                data-title="<%= $config %>" data-toggle="popover" data-trigger="click" role="button" tabindex="0"><%= $test_label %></a>
+                                data-title="<%= $config %>" data-toggle="popover" data-trigger="focus" role="button" tabindex="0"><%= $test_label %></a>
                             % }
                             % else {
                                 <%= $test_label %>


### PR DESCRIPTION
* Add help popover for '/tests/overview'
* Add defaults for all job attributes used for sorting
* Allow selecting multiple job groups in overview query
* Delete unused variable '$failedid' from overview template
* Use word wrap for title in test suite popover
* Add test suite description to overview page
* Get rid of redundant @configs array in favor of keys