### PR TITLE
Add defaults for all job attributes used for sorting

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -95,12 +95,12 @@ sub latest_jobs {
     my @latest;
     my %seen;
     foreach my $job (@jobs) {
-        my $distri  = $job->DISTRI;
-        my $version = $job->VERSION;
-        my $build   = $job->BUILD;
-        my $test    = $job->TEST;
-        my $flavor  = $job->FLAVOR || 'sweet';
-        my $arch    = $job->ARCH || 'noarch';
+        my $distri  = $job->DISTRI  || 'nodistri';
+        my $version = $job->VERSION || 'noversion';
+        my $build   = $job->BUILD   || 'nobuild';
+        my $test    = $job->TEST    || 'notest';
+        my $flavor  = $job->FLAVOR  || 'sweet';
+        my $arch    = $job->ARCH    || 'noarch';
         my $machine = $job->MACHINE || 'nomachine';
         my $key     = "$distri-$version-$build-$test-$flavor-$arch-$machine";
         next if $seen{$key}++;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -395,9 +395,11 @@ sub prepare_job_results {
     my %descriptions = map { $_->name => $_->description } @descriptions;
 
     foreach my $job (@$jobs) {
-        my $test   = $job->TEST;
-        my $flavor = $job->FLAVOR || 'sweet';
-        my $arch   = $job->ARCH || 'noarch';
+        my $test    = $job->TEST;
+        my $distri  = $job->DISTRI || 'nodistri';
+        my $version = $job->VERSION || 'noversion';
+        my $flavor  = $job->FLAVOR || 'sweet';
+        my $arch    = $job->ARCH || 'noarch';
 
         my $result;
         if ($job->state eq 'done') {


### PR DESCRIPTION
One can consider all these variables to be mandatory but so far they are not
really and just output a messy perl warning on use. So we can go ahead and
just offer a sane default. The alternative is to make every entry point into
the database more restrictive, e.g. api calls.

Related progress issue: https://progress.opensuse.org/issues/6762