### PR TITLE
Make 'TEST' the only proper mandatory test setting

### DIFF
--- a/dbicdh/PostgreSQL/deploy/54/001-auto-__VERSION.sql
+++ b/dbicdh/PostgreSQL/deploy/54/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+--
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Wed Apr 26 16:56:37 2017
+--
+;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id serial NOT NULL,
+  version character varying(50) NOT NULL,
+  ddl text,
+  upgrade_sql text,
+  PRIMARY KEY (id),
+  CONSTRAINT dbix_class_deploymenthandler_versions_version UNIQUE (version)
+);
+
+;

--- a/dbicdh/PostgreSQL/deploy/54/001-auto.sql
+++ b/dbicdh/PostgreSQL/deploy/54/001-auto.sql
@@ -1,0 +1,672 @@
+--
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Wed Apr 26 16:56:37 2017
+--
+;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id serial NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  size bigint,
+  checksum text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT assets_type_name UNIQUE (type, name)
+);
+
+;
+--
+-- Table: gru_tasks
+--
+CREATE TABLE gru_tasks (
+  id serial NOT NULL,
+  taskname text NOT NULL,
+  args text NOT NULL,
+  run_at timestamp NOT NULL,
+  priority integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX gru_tasks_run_at_reversed on gru_tasks (run_at DESC);
+
+;
+--
+-- Table: job_group_parents
+--
+CREATE TABLE job_group_parents (
+  id serial NOT NULL,
+  name text NOT NULL,
+  default_size_limit_gb integer,
+  default_keep_logs_in_days integer,
+  default_keep_important_logs_in_days integer,
+  default_keep_results_in_days integer,
+  default_keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_group_parents_name UNIQUE (name)
+);
+
+;
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id serial NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  milestone integer DEFAULT 0 NOT NULL,
+  important integer DEFAULT 0 NOT NULL,
+  fatal integer DEFAULT 0 NOT NULL,
+  result character varying DEFAULT 'none' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX job_modules_idx_job_id on job_modules (job_id);
+CREATE INDEX idx_job_modules_result on job_modules (result);
+
+;
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id serial NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX job_settings_idx_job_id on job_settings (job_id);
+CREATE INDEX idx_value_settings on job_settings (key, value);
+CREATE INDEX idx_job_id_value_settings on job_settings (job_id, key, value);
+
+;
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id serial NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT machine_settings_machine_id_key UNIQUE (machine_id, key)
+);
+CREATE INDEX machine_settings_idx_machine_id on machine_settings (machine_id);
+
+;
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id serial NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT machines_name UNIQUE (name)
+);
+
+;
+--
+-- Table: needle_dirs
+--
+CREATE TABLE needle_dirs (
+  id serial NOT NULL,
+  path text NOT NULL,
+  name text NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT needle_dirs_path UNIQUE (path)
+);
+
+;
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id serial NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT product_settings_product_id_key UNIQUE (product_id, key)
+);
+CREATE INDEX product_settings_idx_product_id on product_settings (product_id);
+
+;
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id serial NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text DEFAULT '' NOT NULL,
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT products_distri_version_arch_flavor UNIQUE (distri, version, arch, flavor)
+);
+
+;
+--
+-- Table: screenshots
+--
+CREATE TABLE screenshots (
+  id serial NOT NULL,
+  filename text NOT NULL,
+  t_created timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT screenshots_filename UNIQUE (filename)
+);
+
+;
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id serial NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT secrets_secret UNIQUE (secret)
+);
+
+;
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id serial NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT test_suite_settings_test_suite_id_key UNIQUE (test_suite_id, key)
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id on test_suite_settings (test_suite_id);
+
+;
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id serial NOT NULL,
+  name text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT test_suites_name UNIQUE (name)
+);
+
+;
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id serial NOT NULL,
+  username text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer DEFAULT 0 NOT NULL,
+  is_admin integer DEFAULT 0 NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT users_username UNIQUE (username)
+);
+
+;
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id serial NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX worker_properties_idx_worker_id on worker_properties (worker_id);
+
+;
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id serial NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT api_keys_key UNIQUE (key)
+);
+CREATE INDEX api_keys_idx_user_id on api_keys (user_id);
+
+;
+--
+-- Table: audit_events
+--
+CREATE TABLE audit_events (
+  id serial NOT NULL,
+  user_id integer,
+  connection_id text,
+  event text NOT NULL,
+  event_data text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX audit_events_idx_user_id on audit_events (user_id);
+
+;
+--
+-- Table: comments
+--
+CREATE TABLE comments (
+  id serial NOT NULL,
+  job_id integer,
+  group_id integer,
+  text text NOT NULL,
+  user_id integer NOT NULL,
+  flags integer DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX comments_idx_group_id on comments (group_id);
+CREATE INDEX comments_idx_job_id on comments (job_id);
+CREATE INDEX comments_idx_user_id on comments (user_id);
+
+;
+--
+-- Table: job_groups
+--
+CREATE TABLE job_groups (
+  id serial NOT NULL,
+  name text NOT NULL,
+  parent_id integer,
+  size_limit_gb integer,
+  keep_logs_in_days integer,
+  keep_important_logs_in_days integer,
+  keep_results_in_days integer,
+  keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  build_version_sort boolean DEFAULT '1' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_groups_name UNIQUE (name)
+);
+CREATE INDEX job_groups_idx_parent_id on job_groups (parent_id);
+
+;
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id serial NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  job_id integer,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT workers_host_instance UNIQUE (host, instance),
+  CONSTRAINT workers_job_id UNIQUE (job_id)
+);
+CREATE INDEX workers_idx_job_id on workers (job_id);
+
+;
+--
+-- Table: needles
+--
+CREATE TABLE needles (
+  id serial NOT NULL,
+  dir_id integer NOT NULL,
+  filename text NOT NULL,
+  first_seen_module_id integer NOT NULL,
+  last_seen_module_id integer NOT NULL,
+  last_matched_module_id integer,
+  file_present boolean DEFAULT '1' NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT needles_dir_id_filename UNIQUE (dir_id, filename)
+);
+CREATE INDEX needles_idx_dir_id on needles (dir_id);
+CREATE INDEX needles_idx_first_seen_module_id on needles (first_seen_module_id);
+CREATE INDEX needles_idx_last_matched_module_id on needles (last_matched_module_id);
+CREATE INDEX needles_idx_last_seen_module_id on needles (last_seen_module_id);
+
+;
+--
+-- Table: job_module_needles
+--
+CREATE TABLE job_module_needles (
+  needle_id integer NOT NULL,
+  job_module_id integer NOT NULL,
+  matched boolean DEFAULT '1' NOT NULL,
+  CONSTRAINT job_module_needles_needle_id_job_module_id UNIQUE (needle_id, job_module_id)
+);
+CREATE INDEX job_module_needles_idx_job_module_id on job_module_needles (job_module_id);
+CREATE INDEX job_module_needles_idx_needle_id on job_module_needles (needle_id);
+
+;
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id serial NOT NULL,
+  result_dir text,
+  state character varying DEFAULT 'scheduled' NOT NULL,
+  priority integer DEFAULT 50 NOT NULL,
+  result character varying DEFAULT 'none' NOT NULL,
+  clone_id integer,
+  retry_avbl integer DEFAULT 3 NOT NULL,
+  backend character varying,
+  backend_info text,
+  TEST text NOT NULL,
+  DISTRI text DEFAULT '' NOT NULL,
+  VERSION text DEFAULT '' NOT NULL,
+  FLAVOR text DEFAULT '' NOT NULL,
+  ARCH text DEFAULT '' NOT NULL,
+  BUILD text DEFAULT '' NOT NULL,
+  MACHINE text,
+  group_id integer,
+  assigned_worker_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  logs_present boolean DEFAULT '1' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX jobs_idx_assigned_worker_id on jobs (assigned_worker_id);
+CREATE INDEX jobs_idx_clone_id on jobs (clone_id);
+CREATE INDEX jobs_idx_group_id on jobs (group_id);
+CREATE INDEX idx_jobs_state on jobs (state);
+CREATE INDEX idx_jobs_result on jobs (result);
+CREATE INDEX idx_jobs_build_group on jobs (BUILD, group_id);
+CREATE INDEX idx_jobs_scenario on jobs (VERSION, DISTRI, FLAVOR, TEST, MACHINE, ARCH);
+
+;
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency)
+);
+CREATE INDEX job_dependencies_idx_child_job_id on job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id on job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency on job_dependencies (dependency);
+
+;
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by text,
+  count integer DEFAULT 1 NOT NULL,
+  PRIMARY KEY (name, owner)
+);
+CREATE INDEX job_locks_idx_owner on job_locks (owner);
+
+;
+--
+-- Table: job_networks
+--
+CREATE TABLE job_networks (
+  name text NOT NULL,
+  job_id integer NOT NULL,
+  vlan integer NOT NULL,
+  PRIMARY KEY (name, job_id)
+);
+CREATE INDEX job_networks_idx_job_id on job_networks (job_id);
+
+;
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id)
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id on gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id on gru_dependencies (job_id);
+
+;
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id serial NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  prio integer NOT NULL,
+  group_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_templates_product_id_machine_id_test_suite_id UNIQUE (product_id, machine_id, test_suite_id)
+);
+CREATE INDEX job_templates_idx_group_id on job_templates (group_id);
+CREATE INDEX job_templates_idx_machine_id on job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id on job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id on job_templates (test_suite_id);
+
+;
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  created_by boolean DEFAULT '0' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  CONSTRAINT jobs_assets_job_id_asset_id UNIQUE (job_id, asset_id)
+);
+CREATE INDEX jobs_assets_idx_asset_id on jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id on jobs_assets (job_id);
+
+;
+--
+-- Table: screenshot_links
+--
+CREATE TABLE screenshot_links (
+  screenshot_id integer NOT NULL,
+  job_id integer NOT NULL
+);
+CREATE INDEX screenshot_links_idx_job_id on screenshot_links (job_id);
+CREATE INDEX screenshot_links_idx_screenshot_id on screenshot_links (screenshot_id);
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE job_modules ADD CONSTRAINT job_modules_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_settings ADD CONSTRAINT job_settings_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE machine_settings ADD CONSTRAINT machine_settings_fk_machine_id FOREIGN KEY (machine_id)
+  REFERENCES machines (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE product_settings ADD CONSTRAINT product_settings_fk_product_id FOREIGN KEY (product_id)
+  REFERENCES products (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE test_suite_settings ADD CONSTRAINT test_suite_settings_fk_test_suite_id FOREIGN KEY (test_suite_id)
+  REFERENCES test_suites (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE worker_properties ADD CONSTRAINT worker_properties_fk_worker_id FOREIGN KEY (worker_id)
+  REFERENCES workers (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE api_keys ADD CONSTRAINT api_keys_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) DEFERRABLE;
+
+;
+ALTER TABLE job_groups ADD CONSTRAINT job_groups_fk_parent_id FOREIGN KEY (parent_id)
+  REFERENCES job_group_parents (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE workers ADD CONSTRAINT workers_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_dir_id FOREIGN KEY (dir_id)
+  REFERENCES needle_dirs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_first_seen_module_id FOREIGN KEY (first_seen_module_id)
+  REFERENCES job_modules (id) DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_last_matched_module_id FOREIGN KEY (last_matched_module_id)
+  REFERENCES job_modules (id) DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_last_seen_module_id FOREIGN KEY (last_seen_module_id)
+  REFERENCES job_modules (id) DEFERRABLE;
+
+;
+ALTER TABLE job_module_needles ADD CONSTRAINT job_module_needles_fk_job_module_id FOREIGN KEY (job_module_id)
+  REFERENCES job_modules (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_module_needles ADD CONSTRAINT job_module_needles_fk_needle_id FOREIGN KEY (needle_id)
+  REFERENCES needles (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_assigned_worker_id FOREIGN KEY (assigned_worker_id)
+  REFERENCES workers (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_clone_id FOREIGN KEY (clone_id)
+  REFERENCES jobs (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_dependencies ADD CONSTRAINT job_dependencies_fk_child_job_id FOREIGN KEY (child_job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_dependencies ADD CONSTRAINT job_dependencies_fk_parent_job_id FOREIGN KEY (parent_job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_locks ADD CONSTRAINT job_locks_fk_owner FOREIGN KEY (owner)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_networks ADD CONSTRAINT job_networks_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_gru_task_id FOREIGN KEY (gru_task_id)
+  REFERENCES gru_tasks (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_machine_id FOREIGN KEY (machine_id)
+  REFERENCES machines (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_product_id FOREIGN KEY (product_id)
+  REFERENCES products (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_test_suite_id FOREIGN KEY (test_suite_id)
+  REFERENCES test_suites (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs_assets ADD CONSTRAINT jobs_assets_fk_asset_id FOREIGN KEY (asset_id)
+  REFERENCES assets (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs_assets ADD CONSTRAINT jobs_assets_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE screenshot_links ADD CONSTRAINT screenshot_links_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE screenshot_links ADD CONSTRAINT screenshot_links_fk_screenshot_id FOREIGN KEY (screenshot_id)
+  REFERENCES screenshots (id) ON UPDATE CASCADE DEFERRABLE;
+
+;

--- a/dbicdh/PostgreSQL/upgrade/53-54/002-auto.sql
+++ b/dbicdh/PostgreSQL/upgrade/53-54/002-auto.sql
@@ -1,0 +1,41 @@
+-- Convert schema '/home/okurz/local/os-autoinst/openQA/script/../dbicdh/_source/deploy/53/001-auto.yml' to '/home/okurz/local/os-autoinst/openQA/script/../dbicdh/_source/deploy/54/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+ALTER TABLE jobs ALTER COLUMN TEST SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN DISTRI SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN DISTRI SET DEFAULT '';
+
+;
+ALTER TABLE jobs ALTER COLUMN VERSION SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN VERSION SET DEFAULT '';
+
+;
+ALTER TABLE jobs ALTER COLUMN FLAVOR SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN FLAVOR SET DEFAULT '';
+
+;
+ALTER TABLE jobs ALTER COLUMN ARCH SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN ARCH SET DEFAULT '';
+
+;
+ALTER TABLE jobs ALTER COLUMN BUILD SET NOT NULL;
+
+;
+ALTER TABLE jobs ALTER COLUMN BUILD SET DEFAULT '';
+
+;
+
+COMMIT;

--- a/dbicdh/SQLite/deploy/54/001-auto-__VERSION.sql
+++ b/dbicdh/SQLite/deploy/54/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+--
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Wed Apr 26 16:56:37 2017
+--
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id INTEGER PRIMARY KEY NOT NULL,
+  version varchar(50) NOT NULL,
+  ddl text,
+  upgrade_sql text
+);
+CREATE UNIQUE INDEX dbix_class_deploymenthandler_versions_version ON dbix_class_deploymenthandler_versions (version);
+COMMIT;

--- a/dbicdh/SQLite/deploy/54/001-auto.sql
+++ b/dbicdh/SQLite/deploy/54/001-auto.sql
@@ -1,0 +1,476 @@
+--
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Wed Apr 26 16:56:37 2017
+--
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  size bigint,
+  checksum text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX assets_type_name ON assets (type, name);
+--
+-- Table: gru_tasks
+--
+CREATE TABLE gru_tasks (
+  id INTEGER PRIMARY KEY NOT NULL,
+  taskname text NOT NULL,
+  args text NOT NULL,
+  run_at datetime NOT NULL,
+  priority integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE INDEX gru_tasks_run_at_reversed ON gru_tasks (run_at DESC);
+--
+-- Table: job_group_parents
+--
+CREATE TABLE job_group_parents (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  default_size_limit_gb integer,
+  default_keep_logs_in_days integer,
+  default_keep_important_logs_in_days integer,
+  default_keep_results_in_days integer,
+  default_keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX job_group_parents_name ON job_group_parents (name);
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  milestone integer NOT NULL DEFAULT 0,
+  important integer NOT NULL DEFAULT 0,
+  fatal integer NOT NULL DEFAULT 0,
+  result varchar NOT NULL DEFAULT 'none',
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON UPDATE CASCADE
+);
+CREATE INDEX job_modules_idx_job_id ON job_modules (job_id);
+CREATE INDEX idx_job_modules_result ON job_modules (result);
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_settings_idx_job_id ON job_settings (job_id);
+CREATE INDEX idx_value_settings ON job_settings (key, value);
+CREATE INDEX idx_job_id_value_settings ON job_settings (job_id, key, value);
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  machine_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX machine_settings_idx_machine_id ON machine_settings (machine_id);
+CREATE UNIQUE INDEX machine_settings_machine_id_key ON machine_settings (machine_id, key);
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX machines_name ON machines (name);
+--
+-- Table: needle_dirs
+--
+CREATE TABLE needle_dirs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  path text NOT NULL,
+  name text NOT NULL
+);
+CREATE UNIQUE INDEX needle_dirs_path ON needle_dirs (path);
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX product_settings_idx_product_id ON product_settings (product_id);
+CREATE UNIQUE INDEX product_settings_product_id_key ON product_settings (product_id, key);
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text NOT NULL DEFAULT '',
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX products_distri_version_arch_flavor ON products (distri, version, arch, flavor);
+--
+-- Table: screenshots
+--
+CREATE TABLE screenshots (
+  id INTEGER PRIMARY KEY NOT NULL,
+  filename text NOT NULL,
+  t_created timestamp NOT NULL
+);
+CREATE UNIQUE INDEX screenshots_filename ON screenshots (filename);
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id INTEGER PRIMARY KEY NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX secrets_secret ON secrets (secret);
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id INTEGER PRIMARY KEY NOT NULL,
+  test_suite_id integer NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id ON test_suite_settings (test_suite_id);
+CREATE UNIQUE INDEX test_suite_settings_test_suite_id_key ON test_suite_settings (test_suite_id, key);
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX test_suites_name ON test_suites (name);
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY NOT NULL,
+  username text NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer NOT NULL DEFAULT 0,
+  is_admin integer NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL
+);
+CREATE UNIQUE INDEX users_username ON users (username);
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX worker_properties_idx_worker_id ON worker_properties (worker_id);
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id integer NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX api_keys_idx_user_id ON api_keys (user_id);
+CREATE UNIQUE INDEX api_keys_key ON api_keys (key);
+--
+-- Table: audit_events
+--
+CREATE TABLE audit_events (
+  id INTEGER PRIMARY KEY NOT NULL,
+  user_id integer,
+  connection_id text,
+  event text NOT NULL,
+  event_data text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX audit_events_idx_user_id ON audit_events (user_id);
+--
+-- Table: comments
+--
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY NOT NULL,
+  job_id integer,
+  group_id integer,
+  text text NOT NULL,
+  user_id integer NOT NULL,
+  flags integer DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX comments_idx_group_id ON comments (group_id);
+CREATE INDEX comments_idx_job_id ON comments (job_id);
+CREATE INDEX comments_idx_user_id ON comments (user_id);
+--
+-- Table: job_groups
+--
+CREATE TABLE job_groups (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  parent_id integer,
+  size_limit_gb integer,
+  keep_logs_in_days integer,
+  keep_important_logs_in_days integer,
+  keep_results_in_days integer,
+  keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  build_version_sort boolean NOT NULL DEFAULT 1,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (parent_id) REFERENCES job_group_parents(id) ON DELETE SET NULL ON UPDATE CASCADE
+);
+CREATE INDEX job_groups_idx_parent_id ON job_groups (parent_id);
+CREATE UNIQUE INDEX job_groups_name ON job_groups (name);
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id INTEGER PRIMARY KEY NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  job_id integer,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+);
+CREATE INDEX workers_idx_job_id ON workers (job_id);
+CREATE UNIQUE INDEX workers_host_instance ON workers (host, instance);
+CREATE UNIQUE INDEX workers_job_id ON workers (job_id);
+--
+-- Table: needles
+--
+CREATE TABLE needles (
+  id INTEGER PRIMARY KEY NOT NULL,
+  dir_id integer NOT NULL,
+  filename text NOT NULL,
+  first_seen_module_id integer NOT NULL,
+  last_seen_module_id integer NOT NULL,
+  last_matched_module_id integer,
+  file_present boolean NOT NULL DEFAULT 1,
+  FOREIGN KEY (dir_id) REFERENCES needle_dirs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (first_seen_module_id) REFERENCES job_modules(id),
+  FOREIGN KEY (last_matched_module_id) REFERENCES job_modules(id),
+  FOREIGN KEY (last_seen_module_id) REFERENCES job_modules(id)
+);
+CREATE INDEX needles_idx_dir_id ON needles (dir_id);
+CREATE INDEX needles_idx_first_seen_module_id ON needles (first_seen_module_id);
+CREATE INDEX needles_idx_last_matched_module_id ON needles (last_matched_module_id);
+CREATE INDEX needles_idx_last_seen_module_id ON needles (last_seen_module_id);
+CREATE UNIQUE INDEX needles_dir_id_filename ON needles (dir_id, filename);
+--
+-- Table: job_module_needles
+--
+CREATE TABLE job_module_needles (
+  needle_id integer NOT NULL,
+  job_module_id integer NOT NULL,
+  matched boolean NOT NULL DEFAULT 1,
+  FOREIGN KEY (job_module_id) REFERENCES job_modules(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (needle_id) REFERENCES needles(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_module_needles_idx_job_module_id ON job_module_needles (job_module_id);
+CREATE INDEX job_module_needles_idx_needle_id ON job_module_needles (needle_id);
+CREATE UNIQUE INDEX job_module_needles_needle_id_job_module_id ON job_module_needles (needle_id, job_module_id);
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  result_dir text,
+  state varchar NOT NULL DEFAULT 'scheduled',
+  priority integer NOT NULL DEFAULT 50,
+  result varchar NOT NULL DEFAULT 'none',
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  backend varchar,
+  backend_info text,
+  TEST text NOT NULL,
+  DISTRI text NOT NULL DEFAULT '',
+  VERSION text NOT NULL DEFAULT '',
+  FLAVOR text NOT NULL DEFAULT '',
+  ARCH text NOT NULL DEFAULT '',
+  BUILD text NOT NULL DEFAULT '',
+  MACHINE text,
+  group_id integer,
+  assigned_worker_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  logs_present boolean NOT NULL DEFAULT 1,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (assigned_worker_id) REFERENCES workers(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE SET NULL ON UPDATE CASCADE
+);
+CREATE INDEX jobs_idx_assigned_worker_id ON jobs (assigned_worker_id);
+CREATE INDEX jobs_idx_clone_id ON jobs (clone_id);
+CREATE INDEX jobs_idx_group_id ON jobs (group_id);
+CREATE INDEX idx_jobs_state ON jobs (state);
+CREATE INDEX idx_jobs_result ON jobs (result);
+CREATE INDEX idx_jobs_build_group ON jobs (BUILD, group_id);
+CREATE INDEX idx_jobs_scenario ON jobs (VERSION, DISTRI, FLAVOR, TEST, MACHINE, ARCH);
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id integer NOT NULL,
+  parent_job_id integer NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency),
+  FOREIGN KEY (child_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (parent_job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_dependencies_idx_child_job_id ON job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id ON job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency ON job_dependencies (dependency);
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by text,
+  count integer NOT NULL DEFAULT 1,
+  PRIMARY KEY (name, owner),
+  FOREIGN KEY (owner) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_locks_idx_owner ON job_locks (owner);
+--
+-- Table: job_networks
+--
+CREATE TABLE job_networks (
+  name text NOT NULL,
+  job_id integer NOT NULL,
+  vlan integer NOT NULL,
+  PRIMARY KEY (name, job_id),
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_networks_idx_job_id ON job_networks (job_id);
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE gru_dependencies (
+  job_id integer NOT NULL,
+  gru_task_id integer NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id),
+  FOREIGN KEY (gru_task_id) REFERENCES gru_tasks(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id ON gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id ON gru_dependencies (job_id);
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id INTEGER PRIMARY KEY NOT NULL,
+  product_id integer NOT NULL,
+  machine_id integer NOT NULL,
+  test_suite_id integer NOT NULL,
+  prio integer NOT NULL,
+  group_id integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id),
+  FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (test_suite_id) REFERENCES test_suites(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX job_templates_idx_group_id ON job_templates (group_id);
+CREATE INDEX job_templates_idx_machine_id ON job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id ON job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id ON job_templates (test_suite_id);
+CREATE UNIQUE INDEX job_templates_product_id_machine_id_test_suite_id ON job_templates (product_id, machine_id, test_suite_id);
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id integer NOT NULL,
+  asset_id integer NOT NULL,
+  created_by boolean NOT NULL DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX jobs_assets_idx_asset_id ON jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id ON jobs_assets (job_id);
+CREATE UNIQUE INDEX jobs_assets_job_id_asset_id ON jobs_assets (job_id, asset_id);
+--
+-- Table: screenshot_links
+--
+CREATE TABLE screenshot_links (
+  screenshot_id integer NOT NULL,
+  job_id integer NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (screenshot_id) REFERENCES screenshots(id) ON UPDATE CASCADE
+);
+CREATE INDEX screenshot_links_idx_job_id ON screenshot_links (job_id);
+CREATE INDEX screenshot_links_idx_screenshot_id ON screenshot_links (screenshot_id);
+COMMIT;

--- a/dbicdh/SQLite/upgrade/53-54/002-auto.sql
+++ b/dbicdh/SQLite/upgrade/53-54/002-auto.sql
@@ -1,0 +1,101 @@
+-- Convert schema '/home/okurz/local/os-autoinst/openQA/script/../dbicdh/_source/deploy/53/001-auto.yml' to '/home/okurz/local/os-autoinst/openQA/script/../dbicdh/_source/deploy/54/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE TEMPORARY TABLE jobs_temp_alter (
+  id INTEGER PRIMARY KEY NOT NULL,
+  result_dir text,
+  state varchar NOT NULL DEFAULT 'scheduled',
+  priority integer NOT NULL DEFAULT 50,
+  result varchar NOT NULL DEFAULT 'none',
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  backend varchar,
+  backend_info text,
+  TEST text NOT NULL,
+  DISTRI text NOT NULL DEFAULT '',
+  VERSION text NOT NULL DEFAULT '',
+  FLAVOR text NOT NULL DEFAULT '',
+  ARCH text NOT NULL DEFAULT '',
+  BUILD text NOT NULL DEFAULT '',
+  MACHINE text,
+  group_id integer,
+  assigned_worker_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  logs_present boolean NOT NULL DEFAULT 1,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (assigned_worker_id) REFERENCES workers(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+;
+INSERT INTO jobs_temp_alter( id, result_dir, state, priority, result, clone_id, retry_avbl, backend, backend_info, TEST, DISTRI, VERSION, FLAVOR, ARCH, BUILD, MACHINE, group_id, assigned_worker_id, t_started, t_finished, logs_present, t_created, t_updated) SELECT id, result_dir, state, priority, result, clone_id, retry_avbl, backend, backend_info, TEST, DISTRI, VERSION, FLAVOR, ARCH, BUILD, MACHINE, group_id, assigned_worker_id, t_started, t_finished, logs_present, t_created, t_updated FROM jobs;
+
+;
+DROP TABLE jobs;
+
+;
+CREATE TABLE jobs (
+  id INTEGER PRIMARY KEY NOT NULL,
+  result_dir text,
+  state varchar NOT NULL DEFAULT 'scheduled',
+  priority integer NOT NULL DEFAULT 50,
+  result varchar NOT NULL DEFAULT 'none',
+  clone_id integer,
+  retry_avbl integer NOT NULL DEFAULT 3,
+  backend varchar,
+  backend_info text,
+  TEST text NOT NULL,
+  DISTRI text NOT NULL DEFAULT '',
+  VERSION text NOT NULL DEFAULT '',
+  FLAVOR text NOT NULL DEFAULT '',
+  ARCH text NOT NULL DEFAULT '',
+  BUILD text NOT NULL DEFAULT '',
+  MACHINE text,
+  group_id integer,
+  assigned_worker_id integer,
+  t_started timestamp,
+  t_finished timestamp,
+  logs_present boolean NOT NULL DEFAULT 1,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  FOREIGN KEY (assigned_worker_id) REFERENCES workers(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (clone_id) REFERENCES jobs(id) ON DELETE SET NULL,
+  FOREIGN KEY (group_id) REFERENCES job_groups(id) ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+;
+CREATE INDEX jobs_idx_assigned_worker_id02 ON jobs (assigned_worker_id);
+
+;
+CREATE INDEX jobs_idx_clone_id02 ON jobs (clone_id);
+
+;
+CREATE INDEX jobs_idx_group_id02 ON jobs (group_id);
+
+;
+CREATE INDEX idx_jobs_state02 ON jobs (state);
+
+;
+CREATE INDEX idx_jobs_result02 ON jobs (result);
+
+;
+CREATE INDEX idx_jobs_build_group02 ON jobs (BUILD, group_id);
+
+;
+CREATE INDEX idx_jobs_scenario02 ON jobs (VERSION, DISTRI, FLAVOR, TEST, MACHINE, ARCH);
+
+;
+INSERT INTO jobs SELECT id, result_dir, state, priority, result, clone_id, retry_avbl, backend, backend_info, TEST, DISTRI, VERSION, FLAVOR, ARCH, BUILD, MACHINE, group_id, assigned_worker_id, t_started, t_finished, logs_present, t_created, t_updated FROM jobs_temp_alter;
+
+;
+DROP TABLE jobs_temp_alter;
+
+;
+
+COMMIT;

--- a/dbicdh/_common/upgrade/53-54/001-migrate-jobs.pl
+++ b/dbicdh/_common/upgrade/53-54/001-migrate-jobs.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl -w
+
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use 5.018;
+use warnings;
+
+sub {
+    my ($schema) = @_;
+    for my $col (qw(TEST DISTRI VERSION FLAVOR ARCH BUILD)) {
+        $schema->resultset('Jobs')->search({$col => undef})->update({$col => ''});
+    }
+  }

--- a/dbicdh/_source/deploy/54/001-auto-__VERSION.yml
+++ b/dbicdh/_source/deploy/54/001-auto-__VERSION.yml
@@ -1,0 +1,92 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/dbicdh/_source/deploy/54/001-auto.yml
+++ b/dbicdh/_source/deploy/54/001-auto.yml
@@ -1,0 +1,3667 @@
+---
+schema:
+  procedures: {}
+  tables:
+    api_keys:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - key
+          match_type: ''
+          name: api_keys_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: api_keys_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 2
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: secret
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_expiration:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_expiration
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: api_keys_idx_user_id
+          options: []
+          type: NORMAL
+      name: api_keys
+      options: []
+      order: 17
+    assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - type
+            - name
+          match_type: ''
+          name: assets_type_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        checksum:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: checksum
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        type:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: type
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: assets
+      options: []
+      order: 1
+    audit_events:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: audit_events_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        connection_id:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: connection_id
+          order: 3
+          size:
+            - 0
+        event:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: event
+          order: 4
+          size:
+            - 0
+        event_data:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: event_data
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: audit_events_idx_user_id
+          options: []
+          type: NORMAL
+      name: audit_events
+      options: []
+      order: 18
+    comments:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: comments_fk_group_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: comments_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: comments_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        flags:
+          data_type: integer
+          default_value: 0
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: flags
+          order: 6
+          size:
+            - 0
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        text:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: text
+          order: 4
+          size:
+            - 0
+        user_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: comments_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: comments_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - user_id
+          name: comments_idx_user_id
+          options: []
+          type: NORMAL
+      name: comments
+      options: []
+      order: 19
+    gru_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - gru_task_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - gru_task_id
+          match_type: ''
+          name: gru_dependencies_fk_gru_task_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: gru_tasks
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: gru_dependencies_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        gru_task_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: gru_task_id
+          order: 2
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - gru_task_id
+          name: gru_dependencies_idx_gru_task_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: gru_dependencies_idx_job_id
+          options: []
+          type: NORMAL
+      name: gru_dependencies
+      options: []
+      order: 28
+    gru_tasks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        args:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: args
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        run_at:
+          data_type: datetime
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: run_at
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        taskname:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: taskname
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - run_at DESC
+          name: gru_tasks_run_at_reversed
+          options: []
+          type: NORMAL
+      name: gru_tasks
+      options: []
+      order: 2
+    job_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+            - parent_job_id
+            - dependency
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+          match_type: ''
+          name: job_dependencies_fk_child_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_job_id
+          match_type: ''
+          name: job_dependencies_fk_parent_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        child_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: child_job_id
+          order: 1
+          size:
+            - 0
+        dependency:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: dependency
+          order: 3
+          size:
+            - 0
+        parent_job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: parent_job_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - child_job_id
+          name: job_dependencies_idx_child_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_job_id
+          name: job_dependencies_idx_parent_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - dependency
+          name: idx_job_dependencies_dependency
+          options: []
+          type: NORMAL
+      name: job_dependencies
+      options: []
+      order: 25
+    job_group_parents:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: job_group_parents_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        default_keep_important_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_important_logs_in_days
+          order: 5
+          size:
+            - 0
+        default_keep_important_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_important_results_in_days
+          order: 7
+          size:
+            - 0
+        default_keep_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_logs_in_days
+          order: 4
+          size:
+            - 0
+        default_keep_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_results_in_days
+          order: 6
+          size:
+            - 0
+        default_priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_priority
+          order: 8
+          size:
+            - 0
+        default_size_limit_gb:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_size_limit_gb
+          order: 3
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 10
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        sort_order:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: sort_order
+          order: 9
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 12
+          size:
+            - 0
+      indices: []
+      name: job_group_parents
+      options: []
+      order: 3
+    job_groups:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: job_groups_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_id
+          match_type: ''
+          name: job_groups_fk_parent_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_group_parents
+          type: FOREIGN KEY
+      fields:
+        build_version_sort:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: build_version_sort
+          order: 12
+          size:
+            - 0
+        default_priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_priority
+          order: 9
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 11
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        keep_important_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_important_logs_in_days
+          order: 6
+          size:
+            - 0
+        keep_important_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_important_results_in_days
+          order: 8
+          size:
+            - 0
+        keep_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_logs_in_days
+          order: 5
+          size:
+            - 0
+        keep_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_results_in_days
+          order: 7
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        parent_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: parent_id
+          order: 3
+          size:
+            - 0
+        size_limit_gb:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size_limit_gb
+          order: 4
+          size:
+            - 0
+        sort_order:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: sort_order
+          order: 10
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 13
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 14
+          size:
+            - 0
+      indices:
+        - fields:
+            - parent_id
+          name: job_groups_idx_parent_id
+          options: []
+          type: NORMAL
+      name: job_groups
+      options: []
+      order: 20
+    job_locks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - owner
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - owner
+          match_type: ''
+          name: job_locks_fk_owner
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        count:
+          data_type: integer
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: count
+          order: 4
+          size:
+            - 0
+        locked_by:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: locked_by
+          order: 3
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        owner:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: owner
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - owner
+          name: job_locks_idx_owner
+          options: []
+          type: NORMAL
+      name: job_locks
+      options: []
+      order: 26
+    job_module_needles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - needle_id
+            - job_module_id
+          match_type: ''
+          name: job_module_needles_needle_id_job_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_module_id
+          match_type: ''
+          name: job_module_needles_fk_job_module_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - needle_id
+          match_type: ''
+          name: job_module_needles_fk_needle_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: needles
+          type: FOREIGN KEY
+      fields:
+        job_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_module_id
+          order: 2
+          size:
+            - 0
+        matched:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: matched
+          order: 3
+          size:
+            - 0
+        needle_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: needle_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_module_id
+          name: job_module_needles_idx_job_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - needle_id
+          name: job_module_needles_idx_needle_id
+          options: []
+          type: NORMAL
+      name: job_module_needles
+      options: []
+      order: 23
+    job_modules:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_modules_fk_job_id
+          on_delete: ''
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        category:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: category
+          order: 5
+          size:
+            - 0
+        fatal:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: fatal
+          order: 8
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        important:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: important
+          order: 7
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        milestone:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: milestone
+          order: 6
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 9
+          size:
+            - 0
+        script:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: script
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 10
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 11
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_modules_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_job_modules_result
+          options: []
+          type: NORMAL
+      name: job_modules
+      options: []
+      order: 4
+    job_networks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - job_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_networks_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        vlan:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: vlan
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_networks_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_networks
+      options: []
+      order: 27
+    job_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_settings_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 4
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_settings_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - key
+            - value
+          name: idx_value_settings
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+            - key
+            - value
+          name: idx_job_id_value_settings
+          options: []
+          type: NORMAL
+      name: job_settings
+      options: []
+      order: 5
+    job_templates:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - machine_id
+            - test_suite_id
+          match_type: ''
+          name: job_templates_product_id_machine_id_test_suite_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: job_templates_fk_group_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: job_templates_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: job_templates_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: job_templates_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 3
+          size:
+            - 0
+        prio:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: prio
+          order: 5
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 7
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 8
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: job_templates_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - machine_id
+          name: job_templates_idx_machine_id
+          options: []
+          type: NORMAL
+        - fields:
+            - product_id
+          name: job_templates_idx_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - test_suite_id
+          name: job_templates_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: job_templates
+      options: []
+      order: 29
+    jobs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - assigned_worker_id
+          match_type: ''
+          name: jobs_fk_assigned_worker_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - clone_id
+          match_type: ''
+          name: jobs_fk_clone_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: jobs_fk_group_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+      fields:
+        ARCH:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: ARCH
+          order: 14
+          size:
+            - 0
+        BUILD:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: BUILD
+          order: 15
+          size:
+            - 0
+        DISTRI:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: DISTRI
+          order: 11
+          size:
+            - 0
+        FLAVOR:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: FLAVOR
+          order: 13
+          size:
+            - 0
+        MACHINE:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: MACHINE
+          order: 16
+          size:
+            - 0
+        TEST:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: TEST
+          order: 10
+          size:
+            - 0
+        VERSION:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: VERSION
+          order: 12
+          size:
+            - 0
+        assigned_worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: assigned_worker_id
+          order: 18
+          size:
+            - 0
+        backend:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 8
+          size:
+            - 0
+        backend_info:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend_info
+          order: 9
+          size:
+            - 0
+        clone_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: clone_id
+          order: 6
+          size:
+            - 0
+        group_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 17
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        logs_present:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: logs_present
+          order: 21
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: 50
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 4
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 5
+          size:
+            - 0
+        result_dir:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: result_dir
+          order: 2
+          size:
+            - 0
+        retry_avbl:
+          data_type: integer
+          default_value: 3
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: retry_avbl
+          order: 7
+          size:
+            - 0
+        state:
+          data_type: varchar
+          default_value: scheduled
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: state
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 22
+          size:
+            - 0
+        t_finished:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_finished
+          order: 20
+          size:
+            - 0
+        t_started:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_started
+          order: 19
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 23
+          size:
+            - 0
+      indices:
+        - fields:
+            - assigned_worker_id
+          name: jobs_idx_assigned_worker_id
+          options: []
+          type: NORMAL
+        - fields:
+            - clone_id
+          name: jobs_idx_clone_id
+          options: []
+          type: NORMAL
+        - fields:
+            - group_id
+          name: jobs_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - state
+          name: idx_jobs_state
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_jobs_result
+          options: []
+          type: NORMAL
+        - fields:
+            - BUILD
+            - group_id
+          name: idx_jobs_build_group
+          options: []
+          type: NORMAL
+        - fields:
+            - VERSION
+            - DISTRI
+            - FLAVOR
+            - TEST
+            - MACHINE
+            - ARCH
+          name: idx_jobs_scenario
+          options: []
+          type: NORMAL
+      name: jobs
+      options: []
+      order: 24
+    jobs_assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - asset_id
+          match_type: ''
+          name: jobs_assets_job_id_asset_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - asset_id
+          match_type: ''
+          name: jobs_assets_fk_asset_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: assets
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: jobs_assets_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        asset_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: asset_id
+          order: 2
+          size:
+            - 0
+        created_by:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: created_by
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - asset_id
+          name: jobs_assets_idx_asset_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: jobs_assets_idx_job_id
+          options: []
+          type: NORMAL
+      name: jobs_assets
+      options: []
+      order: 30
+    machine_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+            - key
+          match_type: ''
+          name: machine_settings_machine_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: machine_settings_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        machine_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: machine_settings_idx_machine_id
+          options: []
+          type: NORMAL
+      name: machine_settings
+      options: []
+      order: 6
+    machines:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: machines_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 3
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices: []
+      name: machines
+      options: []
+      order: 7
+    needle_dirs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - path
+          match_type: ''
+          name: needle_dirs_path
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        path:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: path
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: needle_dirs
+      options: []
+      order: 8
+    needles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+            - filename
+          match_type: ''
+          name: needles_dir_id_filename
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+          match_type: ''
+          name: needles_fk_dir_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: needle_dirs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - first_seen_module_id
+          match_type: ''
+          name: needles_fk_first_seen_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_matched_module_id
+          match_type: ''
+          name: needles_fk_last_matched_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_seen_module_id
+          match_type: ''
+          name: needles_fk_last_seen_module_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+      fields:
+        dir_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: dir_id
+          order: 2
+          size:
+            - 0
+        file_present:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: file_present
+          order: 7
+          size:
+            - 0
+        filename:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: filename
+          order: 3
+          size:
+            - 0
+        first_seen_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: first_seen_module_id
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        last_matched_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_matched_module_id
+          order: 6
+          size:
+            - 0
+        last_seen_module_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: last_seen_module_id
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - dir_id
+          name: needles_idx_dir_id
+          options: []
+          type: NORMAL
+        - fields:
+            - first_seen_module_id
+          name: needles_idx_first_seen_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_matched_module_id
+          name: needles_idx_last_matched_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_seen_module_id
+          name: needles_idx_last_seen_module_id
+          options: []
+          type: NORMAL
+      name: needles
+      options: []
+      order: 22
+    product_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - key
+          match_type: ''
+          name: product_settings_product_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: product_settings_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - product_id
+          name: product_settings_idx_product_id
+          options: []
+          type: NORMAL
+      name: product_settings
+      options: []
+      order: 9
+    products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - distri
+            - version
+            - arch
+            - flavor
+          match_type: ''
+          name: products_distri_version_arch_flavor
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        arch:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: arch
+          order: 5
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 7
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: distri
+          order: 3
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: flavor
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: products
+      options: []
+      order: 10
+    screenshot_links:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: screenshot_links_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - screenshot_id
+          match_type: ''
+          name: screenshot_links_fk_screenshot_id
+          on_delete: ''
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: screenshots
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        screenshot_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: screenshot_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: screenshot_links_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - screenshot_id
+          name: screenshot_links_idx_screenshot_id
+          options: []
+          type: NORMAL
+      name: screenshot_links
+      options: []
+      order: 31
+    screenshots:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - filename
+          match_type: ''
+          name: screenshots_filename
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        filename:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: filename
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: screenshots
+      options: []
+      order: 11
+    secrets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - secret
+          match_type: ''
+          name: secrets_secret
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: secret
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: secrets
+      options: []
+      order: 12
+    test_suite_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+            - key
+          match_type: ''
+          name: test_suite_settings_test_suite_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: test_suite_settings_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 2
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - test_suite_id
+          name: test_suite_settings_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: test_suite_settings
+      options: []
+      order: 13
+    test_suites:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: test_suites_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices: []
+      name: test_suites
+      options: []
+      order: 14
+    users:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - username
+          match_type: ''
+          name: users_username
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        email:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: email
+          order: 3
+          size:
+            - 0
+        fullname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: fullname
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        is_admin:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_admin
+          order: 7
+          size:
+            - 0
+        is_operator:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_operator
+          order: 6
+          size:
+            - 0
+        nickname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: nickname
+          order: 5
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        username:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: username
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: users
+      options: []
+      order: 15
+    worker_properties:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: worker_properties_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+        worker_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: worker_properties_idx_worker_id
+          options: []
+          type: NORMAL
+      name: worker_properties
+      options: []
+      order: 16
+    workers:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - host
+            - instance
+          match_type: ''
+          name: workers_host_instance
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: workers_job_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: workers_fk_job_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        host:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: host
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: integer
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        instance:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: instance
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: workers_idx_job_id
+          options: []
+          type: NORMAL
+      name: workers
+      options: []
+      order: 21
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - ApiKeys
+      - Assets
+      - AuditEvents
+      - Comments
+      - GruDependencies
+      - GruTasks
+      - JobDependencies
+      - JobGroupParents
+      - JobGroups
+      - JobLocks
+      - JobModuleNeedles
+      - JobModules
+      - JobNetworks
+      - JobSettings
+      - JobTemplates
+      - Jobs
+      - JobsAssets
+      - MachineSettings
+      - Machines
+      - NeedleDirs
+      - Needles
+      - ProductSettings
+      - Products
+      - ScreenshotLinks
+      - Screenshots
+      - Secrets
+      - TestSuiteSettings
+      - TestSuites
+      - Users
+      - WorkerProperties
+      - Workers
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args:
+    sqlite_version: 3.7
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -30,7 +30,7 @@ use OpenQA::Utils ();
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION   = 53;
+our $VERSION   = 54;
 our @databases = qw(SQLite PostgreSQL);
 
 __PACKAGE__->load_namespaces;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -117,28 +117,27 @@ __PACKAGE__->add_columns(
         is_nullable => 1,
     },
     TEST => {
-        data_type   => 'text',
-        is_nullable => 1
+        data_type => 'text'
     },
     DISTRI => {
-        data_type   => 'text',
-        is_nullable => 1
+        data_type     => 'text',
+        default_value => ''
     },
     VERSION => {
-        data_type   => 'text',
-        is_nullable => 1
+        data_type     => 'text',
+        default_value => ''
     },
     FLAVOR => {
-        data_type   => 'text',
-        is_nullable => 1
+        data_type     => 'text',
+        default_value => ''
     },
     ARCH => {
-        data_type   => 'text',
-        is_nullable => 1
+        data_type     => 'text',
+        default_value => ''
     },
     BUILD => {
-        data_type   => 'text',
-        is_nullable => 1
+        data_type     => 'text',
+        default_value => ''
     },
     MACHINE => {
         data_type   => 'text',

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -95,13 +95,13 @@ sub latest_jobs {
     my @latest;
     my %seen;
     foreach my $job (@jobs) {
+        my $test    = $job->TEST;
         my $distri  = $job->DISTRI;
         my $version = $job->VERSION;
         my $build   = $job->BUILD;
-        my $test    = $job->TEST;
-        my $flavor  = $job->FLAVOR || 'sweet';
-        my $arch    = $job->ARCH || 'noarch';
-        my $machine = $job->MACHINE || 'nomachine';
+        my $flavor  = $job->FLAVOR;
+        my $arch    = $job->ARCH;
+        my $machine = $job->MACHINE // '';
         my $key     = "$distri-$version-$build-$test-$flavor-$arch-$machine";
         next if $seen{$key}++;
         push(@latest, $job);
@@ -159,7 +159,9 @@ sub create_from_settings {
 
     # migrate the important keys
     for my $key (qw(DISTRI VERSION FLAVOR ARCH TEST MACHINE BUILD)) {
-        $new_job_args{$key} = delete $settings{$key};
+        my $value = delete $settings{$key};
+        next unless $value;
+        $new_job_args{$key} = $value;
     }
 
     my $job = $self->create(\%new_job_args);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -117,6 +117,9 @@ sub create {
     my %up_params = map { uc $_ => $params->{$_} } keys %$params;
     # restore URL encoded /
     my %params = map { $_ => $up_params{$_} =~ s@%2F@/@gr } keys %up_params;
+    if (!$params{TEST}) {
+        return $self->render(json => {error => 'TEST field mandatory'}, status => 400);
+    }
 
     my $json = {};
     my $status;
@@ -275,7 +278,7 @@ sub update {
     my @setting_cols = qw(TEST DISTRI VERSION FLAVOR ARCH BUILD MACHINE);
     if ($settings) {
         for my $setting_col (@setting_cols) {
-            $json->{$setting_col} = delete $settings->{$setting_col};
+            $json->{$setting_col} = delete $settings->{$setting_col} // '';
         }
     }
 

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -154,7 +154,7 @@ sub create_temp_job_log_file {
 
 subtest 'limit_results_and_logs gru task cleans up logs' => sub {
     my @jobs = $t->app->db->resultset('Jobs')->search({state => 'done'})->all;
-    my $job = $jobs[2];
+    my $job = $jobs[3];
     $job->update({t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600 * 24 * 12, 'UTC')});
     $job->group->update({"keep_logs_in_days" => 5});
     my $filename = create_temp_job_log_file($job->result_dir);
@@ -242,7 +242,7 @@ subtest 'scan_images' => sub {
 
 subtest 'labeled jobs considered important' => sub {
     my @jobs = $t->app->db->resultset('Jobs')->search({state => 'done'})->all;
-    my $job = $jobs[3];
+    my $job = $jobs[4];
     # but gets cleaned after important limit - change finished to 12 days ago
     $job->update({t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600 * 24 * 12, 'UTC')});
     $job->group->update({"keep_logs_in_days"           => 5});

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -31,6 +31,7 @@ use Test::Mojo;
 use Test::Warnings;
 
 my %settings = (
+    TEST    => 'test',
     DISTRI  => 'fedora',
     FLAVOR  => 'DVD',
     VERSION => '25',

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -84,7 +84,7 @@ $t->app->schema->resultset('Jobs')->find(99963)->update({assigned_worker_id => 1
 my $get        = $t->get_ok('/api/v1/jobs');
 my @jobs       = @{$get->tx->res->json->{jobs}};
 my $jobs_count = scalar @jobs;
-is($jobs_count, 16);
+is($jobs_count, 17);
 my %jobs = map { $_->{id} => $_ } @jobs;
 is($jobs{99981}->{state},              'cancelled');
 is($jobs{99981}->{origin_id},          undef, 'no original job');
@@ -98,9 +98,9 @@ is($jobs{99963}->{clone_id},           undef, 'no clone');
 
 # That means that only 9 are current and only 10 are relevant
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 13);
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
 is(scalar(@{$get->tx->res->json->{jobs}}), 14);
+$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
+is(scalar(@{$get->tx->res->json->{jobs}}), 15);
 
 # check limit quantity
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current', limit => 5});
@@ -149,7 +149,7 @@ $get = $t->get_ok('/api/v1/jobs?limit=1&page=2');
 is(scalar(@{$get->tx->res->json->{jobs}}), 1);
 is($get->tx->res->json->{jobs}->[0]->{id}, 99963);
 $get = $t->get_ok('/api/v1/jobs?before=99928');
-is(scalar(@{$get->tx->res->json->{jobs}}), 2);
+is(scalar(@{$get->tx->res->json->{jobs}}), 3);
 $get = $t->get_ok('/api/v1/jobs?after=99945');
 is(scalar(@{$get->tx->res->json->{jobs}}), 6);
 
@@ -177,7 +177,7 @@ my $cloned = $new_jobs{$new_jobs{99939}->{clone_id}};
 
 # The number of current jobs doesn't change
 $get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 13, 'job count stay the same');
+is(scalar(@{$get->tx->res->json->{jobs}}), 14, 'job count stay the same');
 
 # Test /jobs/X/restart and /jobs/X
 $get = $t->get_ok('/api/v1/jobs/99926')->status_is(200);
@@ -391,6 +391,15 @@ $get = $t->get_ok('/api/v1/jobs', form => $job_properties);
 is($get->tx->res->json->{jobs}->[1]->{group},    'opensuse test');
 is($get->tx->res->json->{jobs}->[1]->{priority}, 42);
 
+$job_properties = {TEST => 'pretty_empty'};
+$post = $t->post_ok('/api/v1/jobs', form => $job_properties)->status_is(200);
+$t->get_ok('/api/v1/jobs/' . $post->tx->res->json->{id})->status_is(200);
+$t->json_is('/job/settings/TEST'    => 'pretty_empty');
+$t->json_is('/job/settings/MACHINE' => undef, 'machine was not set and is therefore undef');
+$t->json_is('/job/settings/DISTRI'  => undef);
+
+$post = $t->post_ok('/api/v1/jobs', form => {})->status_is(400);
+
 subtest 'update job and job settings' => sub {
     # check defaults
     $t->get_ok('/api/v1/jobs/99926')->status_is(200);
@@ -421,6 +430,7 @@ subtest 'update job and job settings' => sub {
         json => {
             priority => 50,
             settings => {
+                TEST    => 'minimalx',
                 ARCH    => 'i686',
                 DESKTOP => 'kde',
                 NEW_KEY => 'new value',

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -41,6 +41,20 @@
         name => 'opensuse test'
     },
     Jobs => {
+        # job with empty value settings as default
+        id         => 80000,
+        priority   => 50,
+        result     => "passed",
+        retry_avbl => 3,
+        TEST       => 'minimalx',
+        state      => "done",
+        # Really old
+        t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 36000, 'UTC'),
+        # Really long ago
+        t_started => time2str('%Y-%m-%d %H:%M:%S', time - 72000, 'UTC'),
+        t_created => time2str('%Y-%m-%d %H:%M:%S', time - 72000, 'UTC'),
+    },
+    Jobs => {
         id         => 99926,
         group_id   => 1001,
         priority   => 56,

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -92,7 +92,7 @@ $time->text_like(qr/1[01] minutes ago/, 'right time for running');
 
 $get = $t->get_ok('/tests')->status_is(200);
 my @header = $t->tx->res->dom->find('h2')->map('text')->each;
-my @expected = ('2 jobs are running', '2 scheduled jobs', 'Last 10 finished jobs');
+my @expected = ('2 jobs are running', '2 scheduled jobs', 'Last 11 finished jobs');
 is_deeply(\@header, \@expected, 'all job summaries correct with defaults');
 
 $get      = $t->get_ok('/tests?limit=1')->status_is(200);
@@ -175,7 +175,7 @@ my @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tb
 
 is_deeply(
     \@jobs,
-    [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99937)],
+    [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_80000 job_99937)],
     '99945 is not displayed'
 );
 $driver->find_element_by_id('relevantfilter')->click();
@@ -197,7 +197,7 @@ wait_for_ajax();
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
 is_deeply(
     \@jobs,
-    [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_99937)],
+    [qw(job_99940 job_99939 job_99938 job_99926 job_99936 job_99947 job_99962 job_99946 job_80000 job_99937)],
     '99945 again hidden'
 );
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -261,5 +261,9 @@ $get         = $t->get_ok($baseurl . 'tests/99963')->status_is(200);
 @worker_text = $get->tx->res->dom->find('#info_box .panel-body div + div + div')->map('all_text')->each;
 like($worker_text[0], qr/[ \n]*Assigned worker:[ \n]*localhost:1[ \n]*/, 'worker still displayed when job set to done');
 
+# now test the details of a job with nearly no settings which should yield no
+# warnings
+$get = $t->get_ok('/tests/80000')->status_is(200);
+
 kill_phantom();
 done_testing();


### PR DESCRIPTION
In before there was no real check for most settings implicitly allowing
undefined settings but causing perl warnings. This commit now properly
tests job results where no setting is set besides the name composed of
'TEST' itself. It is not pretty in all cases when the individual
string components are empty but it works.

Related progress issue: https://progress.opensuse.org/issues/6762