### PR TITLE
Enable Travis cache for perl dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,14 @@ env:
     - FULLSTACK=1
   global:
     - COMMIT_AUTHOR_EMAIL: "skynet@open.qa"
+addons:
+  apt:
+    packages:
+      - libgmp3-dev
+      - libdbus-1-dev
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install libgmp3-dev libdbus-1-dev
+  - cpanm local::lib
+  - eval "$(perl -Mlocal::lib=${HOME}/perl_modules)"
 install:
   - gem install sass
   - cpanm -nq --installdeps --with-feature=coverage .
@@ -24,3 +29,6 @@ script:
   - make coverage-codecov
 after_failure:
   - cat /tmp/openqa-debug.log
+cache:
+  directories:
+  - $HOME/perl_modules


### PR DESCRIPTION
we spend 2 minutes on each run installing cpan modules. So safe this time and cache them. 

The downside is that our dependencies get old - so travis will no longer test with latest mojolicious, but with a rather random one that was latest when the cache was created. IMO the benefit outweights that.

Before:
 https://travis-ci.org/coolo/openQA/builds/188818032 - Elapsed time 13 min 38 sec

After:
  https://travis-ci.org/coolo/openQA/builds/188827391 - Elapsed time 11 min 34 sec

