### PR TITLE
Support multiple version per job group

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -97,8 +97,6 @@ sub add_review_badge {
 sub compute_build_results {
     my ($group, $limit, $time_limit_days, $tags) = @_;
 
-    my %builds;
-    my $jobs_resultset = $group->result_source->schema->resultset('Jobs');
     my $group_ids;
     my @children;
     if ($group->can('children')) {
@@ -109,36 +107,57 @@ sub compute_build_results {
         $group_ids = [$group->id];
     }
 
+    my %builds;
+    my %result = (
+        result   => \%builds,
+        max_jobs => 0,
+        children => [map { {id => $_->id, name => $_->name} } @children],
+        group    => {
+            id   => $group->id,
+            name => $group->name
+        });
+
+    if (defined($limit) && int($limit) <= 0) {
+        return \%result;
+    }
+
     # split the statement - give in to perltidy
     my $search_opts = {
-        select => ['BUILD', {min => 't_created', -as => 'first_hit'}],
-        as     => [qw(BUILD first_hit)],
+        select => ['VERSION', 'BUILD', {min => 't_created', -as => 'first_hit'}],
+        as     => [qw(VERSION BUILD first_hit)],
         # order-by is required here despite it is not relevant when iterating results
         # because the ordering must be applied before the row limit is applied
         order_by => {-desc => 'first_hit'},
-        group_by => [qw(BUILD)]};
+        group_by => [qw(VERSION BUILD)]};
+    $search_opts->{rows} = $limit if defined($limit);
     my $search_filter = {group_id => {in => $group_ids}};
     if ($time_limit_days) {
         $search_filter->{t_created}
           = {'>' => time2str('%Y-%m-%d %H:%M:%S', time - 24 * 3600 * $time_limit_days, 'UTC')};
     }
     if ($tags) {
+        # caveat: A tag that references only a build, not including a version, might be ambiguous
         $search_filter->{BUILD} = {-in => [keys %$tags]};
     }
-    my $builds   = $jobs_resultset->search($search_filter, $search_opts);
-    my $max_jobs = 0;
-    my $buildnr  = 0;
-    for my $b (map { $_->BUILD } $builds->all) {
-        last if (defined($limit) && ++$buildnr > $limit);
 
+    my $jobs_resultset = $group->result_source->schema->resultset('Jobs');
+    my $builds         = $jobs_resultset->search($search_filter, $search_opts);
+    my $max_jobs       = 0;
+    my $buildnr        = 0;
+    for my $b ($builds->all) {
         my $jobs = $jobs_resultset->search(
             {
-                BUILD    => $b,
+                VERSION  => $b->VERSION,
+                BUILD    => $b->BUILD,
                 group_id => {in => $group_ids},
                 clone_id => undef,
             },
             {order_by => 'me.id DESC'});
-        my %jr = (oldest => DateTime->now);
+        my %jr = (
+            build   => $b->BUILD,
+            version => $b->VERSION,
+            oldest  => DateTime->now
+        );
         init_job_figures(\%jr);
         for my $child (@children) {
             init_job_figures($jr{children}->{$child->id} = {});
@@ -158,8 +177,7 @@ sub compute_build_results {
         $jobs->reset;
 
         while (my $job = $jobs->next) {
-            $jr{distri}  //= $job->DISTRI;
-            $jr{version} //= $job->VERSION;
+            $jr{distri} //= $job->DISTRI;
             my $key = $job->TEST . "-" . $job->ARCH . "-" . $job->FLAVOR . "-" . $job->MACHINE;
             next if $seen{$key}++;
 
@@ -169,24 +187,22 @@ sub compute_build_results {
                 my $child = $jr{children}->{$job->group_id};
                 $child->{distri}  //= $job->DISTRI;
                 $child->{version} //= $job->VERSION;
+                $child->{build}   //= $job->BUILD;
                 count_job($job, $child, \%labels);
                 add_review_badge($child);
             }
         }
-        $jr{escaped_id} = $b;
-        $jr{escaped_id} =~ s/\W/_/g;
+        $jr{escaped_version} = $jr{version};
+        $jr{escaped_version} =~ s/\W/_/g;
+        $jr{escaped_build} = $jr{build};
+        $jr{escaped_build} =~ s/\W/_/g;
+        $jr{escaped_id} = join('-', $jr{escaped_version}, $jr{escaped_build});
         add_review_badge(\%jr);
-        $builds{$b} = \%jr;
+        $builds{join('-', $jr{version}, $jr{build})} = \%jr;
         $max_jobs = $jr{total} if ($jr{total} > $max_jobs);
     }
-    return {
-        result => (%builds) ? \%builds : {},
-        max_jobs => $max_jobs,
-        children => [map { {id => $_->id, name => $_->name} } @children],
-        group    => {
-            id   => $group->id,
-            name => $group->name
-        }};
+    $result{max_jobs} = $max_jobs;
+    return \%result;
 }
 
 1;

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -113,6 +113,8 @@ sub compute_build_results {
     my $search_opts = {
         select => ['BUILD', {min => 't_created', -as => 'first_hit'}],
         as     => [qw(BUILD first_hit)],
+        # order-by is required here despite it is not relevant when iterating results
+        # because the ordering must be applied before the row limit is applied
         order_by => {-desc => 'first_hit'},
         group_by => [qw(BUILD)]};
     my $search_filter = {group_id => {in => $group_ids}};

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -27,9 +27,16 @@ use Scalar::Util 'looks_like_number';
 sub _map_tags_into_build {
     my ($res, $tags) = @_;
 
-    for my $build (keys %$res) {
-        if ($tags->{$build}) {
-            $res->{$build}->{tag} = $tags->{$build};
+    for my $key (keys %$res) {
+        my $build = $res->{$key}->{build};
+        if ($tags->{$key}) {
+            $res->{$key}->{tag} = $tags->{$key};
+        }
+        # as fallback we are looking for build and not other criteria we can end
+        # up with multiple tags if the build appears more than once, e.g.
+        # for each version
+        elsif ($tags->{$build}) {
+            $res->{$key}->{tag} = $tags->{$build};
         }
     }
     return;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -289,7 +289,7 @@ $t->get_ok('/api/v1/jobs/99937')->status_is(404);
 $get = $t->get_ok('/group_overview/1001.json')->status_is(200);
 $get = $get->tx->res->json;
 is_deeply({id => 1001, name => 'opensuse'}, $get->{group});
-my $b48 = $get->{result}->{'0048'};
+my $b48 = $get->{result}->{'Factory-0048'};
 delete $b48->{oldest};
 is_deeply(
     $b48,
@@ -310,7 +310,10 @@ is_deeply(
         distri                            => 'opensuse',
         unfinished                        => 1,
         version                           => 'Factory',
-        escaped_id                        => '0048',
+        escaped_version                   => 'Factory',
+        build                             => '0048',
+        escaped_build                     => '0048',
+        escaped_id                        => 'Factory-0048',
     },
     'Build 0048 exported'
 );
@@ -320,7 +323,7 @@ $get = $get->tx->res->json;
 is(@{$get->{results}}, 2);
 my $g1 = (shift @{$get->{results}});
 is($g1->{group}->{name}, 'opensuse', 'First group is opensuse');
-my $b1 = $g1->{result}->{'0092'};
+my $b1 = $g1->{result}->{'13.1-0092'};
 delete $b1->{oldest};
 is_deeply(
     $b1,
@@ -341,7 +344,11 @@ is_deeply(
         softfailed_without_failed_modules => 0,
         all_passed                        => 1,
         reviewed_also_softfailed          => '1',
-        escaped_id                        => '0092',
+        version                           => '13.1',
+        escaped_version                   => '13_1',
+        build                             => '0092',
+        escaped_build                     => '0092',
+        escaped_id                        => '13_1-0092',
     },
     'Build 92 of opensuse'
 );

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -74,19 +74,19 @@ ok($element->is_displayed(), 'link to child group expanded');
 # first try of click does not work for unknown reasons
 for (0 .. 10) {
     $driver->find_element('Build0091', 'link_text')->click();
-    last if $driver->find_element('#group1_build0091 h4 a', 'css')->is_hidden();
+    last if $driver->find_element('#group1_build13_1-0091 h4 a', 'css')->is_hidden();
 }
-ok($driver->find_element('#group1_build0091 h4 a', 'css')->is_hidden(), 'link to child group collapsed');
+ok($driver->find_element('#group1_build13_1-0091 h4 a', 'css')->is_hidden(), 'link to child group collapsed');
 
 # go to parent group overview
 $driver->find_element('Test parent', 'link_text')->click();
 disable_bootstrap_animations();
 
-ok($driver->find_element('#group1_build0091 h4 a', 'css')->is_displayed(), 'link to child group displayed');
+ok($driver->find_element('#group1_build13_1-0091 h4 a', 'css')->is_displayed(), 'link to child group displayed');
 my @links = $driver->find_elements('h4 a', 'css');
 is(scalar @links, 11, 'all links expanded in the first place');
 $driver->find_element('Build0091', 'link_text')->click();
-ok($driver->find_element('#group1_build0091 h4 a', 'css')->is_hidden(), 'link to child group collapsed');
+ok($driver->find_element('#group1_build13_1-0091 h4 a', 'css')->is_hidden(), 'link to child group collapsed');
 
 t::ui::PhantomTest::kill_phantom();
 done_testing();

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -42,9 +42,11 @@ unless ($driver) {
 is($driver->get_title(), "openQA", "on main page");
 my $baseurl = $driver->get_current_url();
 
-is(scalar @{$driver->find_elements('h4', 'css')}, 4, '4 builds shown');
+my @build_headings = $driver->find_elements('h4', 'css');
+is(scalar @build_headings, 4, '4 builds shown');
 
-$driver->find_element('Build0091', 'link_text')->click();
+# click on last build which should be Build0091
+$driver->find_child_element($build_headings[-1], 'a', 'css')->click();
 like(
     $driver->find_element('#summary', 'css')->get_text(),
     qr/Overall Summary of opensuse test build 0091/,
@@ -126,7 +128,7 @@ subtest 'filter form' => sub {
 
 # JSON representation of index page
 $driver->get($baseurl . 'index.json');
-like($driver->get_page_source(), qr({"results":\[.*{"0048":), 'page rendered as JSON');
+like($driver->get_page_source(), qr({"results":\[.*"Factory-0048":), 'page rendered as JSON');
 
 like($t->get_ok($baseurl)->tx->res->dom->at('#filter-panel .help_popover')->{'data-title'},
     qr/Help/, 'help popover is shown');

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,5 +1,6 @@
-% for my $build (reverse sort keys %$result) {
-    % my $build_res = $result->{$build};
+% for my $key (reverse sort keys %$result) {
+    % my $build_res = $result->{$key};
+    % my $build = $build_res->{build};
     % my $group_id;
     <div class="row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
         <div class="col-md-4 text-nowrap">
@@ -15,7 +16,7 @@
                     %= $build_res->{oldest}
                 </abbr>)
 
-                % my $group_build_id = $group->{id} . '-' . $build;
+                % my $group_build_id = $group->{id} . '-' . $build_res->{escaped_id};
                 % my $tag = $build_res->{tag};
                 % if ($tag) {
                     <span id="tag-<%= $group_build_id %>">


### PR DESCRIPTION
* Distinguish builds also by version
* Consider version for sorting
* Improve escaping build IDs when used in HTML-IDs