### PR TITLE
Hardcode mojo requirement to < 7.14 for now

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -53,7 +53,7 @@ requires 'Mojo::JSON';
 requires 'Mojo::RabbitMQ::Client';
 requires 'Mojo::URL';
 requires 'Mojo::Util';
-requires 'Mojolicious';
+requires 'Mojolicious', '< 7.14';
 requires 'Mojolicious::Commands';
 requires 'Mojolicious::Plugin';
 requires 'Mojolicious::Plugin::AssetPack', '>= 1.1';


### PR DESCRIPTION
7.14 deprecates a function that Mojo::Plugin::AssetPack uses and this
leads to tons of warnings all over our code base - which breaks
tests using Test::Warnings.

So we need to stay with 7.13 until this is resolved