### PR TITLE
Switch to Selenium::Remote::Driver > 1, which starts phantomjs itself

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,7 +21,7 @@ coverage:
         branches: null
     project:
       default:
-        target: auto
+        target: 82.8
         threshold: 0.1
     patch:
       default:

--- a/cpanfile
+++ b/cpanfile
@@ -68,7 +68,7 @@ requires 'Regexp::Common';
 requires 'SQL::SplitStatement';
 requires 'SQL::Translator';
 requires 'Scalar::Util';
-requires 'Selenium::Remote::Driver';
+requires 'Selenium::Remote::Driver', '>= 1.0';
 requires 'Sub::Install';
 requires 'Sub::Name';
 requires 'Test::Compile';

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -30,7 +30,6 @@ seq:
      - ./t/23-amqp.t
      - ./t/24-worker.t
      - ./t/api/02-assets.t
-     - ./t/api/02-iso.t
      - ./t/api/04-jobs.t
      - ./t/api/05-machines.t
      - ./t/api/08-jobtemplates.t


### PR DESCRIPTION
The main benefit is that we can switch drivers easily.