### PR TITLE
Don't use config file as database lock file

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -67,7 +67,7 @@ unlink('t/full-stack.d/db/db.sqlite');
 open(my $conf, '>', 't/full-stack.d/config/database.ini');
 print $conf <<EOC;
 [production]
-dsn = dbi:SQLite:dbname=t/full-stack.d/db/db.sqlite
+dsn = dbi:SQLite:dbname=t/full-stack.d/openqa/db/db.sqlite
 on_connect_call = use_foreign_keys
 on_connect_do = PRAGMA synchronous = OFF
 sqlite_unicode = 1


### PR DESCRIPTION
Another tweak to the database deployment locking stuff. As
discussed in #1095, using the db config file for locking is not
a great idea; it requires the server be able to write to the
config file, which is denied by the AppArmor config on SUSE,
and that's probably a sensible precaution (it's never wise to
let webapps write to more stuff than is strictly needed).

So here's yet another try: let's rely on the fact that prjdir/db
(usually /var/lib/openqa/db) is made writeable by the server in
the install process and the SUSE/Fedora packages, and put the
lock file there, just assuming we are able to write to that
location.