### PR TITLE
Fix use of a deprecated method in OpenQA::Worker::Jobs

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -182,7 +182,7 @@ sub upload {
         $res = $OpenQA::Worker::Common::ua->start($tx);
 
         # Upload known server failures (Instead of anything that's not 200)
-        if ($res->res->is_status_class(500)) {
+        if ($res->res->is_server_error) {
             $regular_upload_failed = 1;
             next if $retry_counter;
 


### PR DESCRIPTION
The method `Mojo::Message::Response::is_status_class` has been deprecated in Mojolicious 7.13. Its replacement is `Mojo::Message::Response::is_server_error`, which has been added in the same release.