### PR TITLE
Worker support for multiple webUIs

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -1,17 +1,25 @@
 # Configuration of the workers and their backends.
 #
+# Global section to enter webui hosts and optionaly cache dir
+
+#[global]
+# space separated list of webuis to connect to (empty defaults to localhost)
+#HOST = http://openqa.example.host
+# if your /var/lib/openqa/share is slow, enable it
+#CACHEDIRECTORY = /var/lib/openqa/cache
+
 # The section ids are the instance of the workers.
 # The key/value pairs will be added to $job->{settings}
 # and will appear in vars.json in the jobs.
-#
-#[global]
-# where the webui is hosted (if not localhost)
-#HOST = http://openqa.example.com
-# if your /var/lib/openqa/share is slow, enable it
-#CACHEDIRECTORY = /var/lib/openqa/cache
 
 #[1]
 #WORKER_CLASS = 64bit-ipmi
 
 #[2]
 #WORKER_CLASS = qemu_x86_64_staging,qemu_x86_64
+
+#[localhost]
+# SHARE_DIRECTORY = /var/lib/openqa/share
+
+#[openqa.example.host]
+# SHARE_DIRECTORY = /var/lib/openqa/example

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,10 +15,13 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Needles;
+use 5.018;
+use warnings;
 use base 'DBIx::Class::Core';
 use File::Basename;
 use Cwd 'realpath';
-use strict;
+use File::Spec::Functions 'catdir';
+
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Utils 'commit_git_return_error';
 
@@ -79,6 +82,9 @@ sub update_needle {
     my $schema = OpenQA::Scheduler::Scheduler::schema();
     my $guard  = $schema->txn_scope_guard;
 
+    if (!-f $filename) {
+        $filename = catdir($OpenQA::Utils::prjdir, $filename);
+    }
     my $needle;
     if ($needle_cache) {
         $needle = $needle_cache->{$filename};

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -60,21 +60,20 @@ if ($0 =~ /\.t$/) {
 
 #use lib "/usr/share/openqa/cgi-bin/modules";
 use File::Basename;
-use File::Spec::Functions 'catfile';
+use File::Spec::Functions qw(catfile catdir);
 use Fcntl;
 use JSON "decode_json";
 use Mojo::Util 'xml_escape';
-our $basedir     = $ENV{OPENQA_BASEDIR} || "/var/lib";
-our $prj         = "openqa";
-our $prjdir      = "$basedir/$prj";
-our $resultdir   = "$prjdir/testresults";
-our $assetdir    = "$prjdir/factory";
-our $isodir      = "$assetdir/iso";
-our $hdddir      = "$assetdir/hdd";
-our $otherdir    = "$assetdir/other";
-our $imagesdir   = "$prjdir/images";
-our $hostname    = $ENV{SERVER_NAME};
-our $testcasedir = "$prjdir/share/tests";
+our $basedir   = $ENV{OPENQA_BASEDIR} || "/var/lib";
+our $prj       = "openqa";
+our $prjdir    = "$basedir/$prj";
+our $resultdir = "$prjdir/testresults";
+our $assetdir  = "$prjdir/factory";
+our $isodir    = "$assetdir/iso";
+our $hdddir    = "$assetdir/hdd";
+our $otherdir  = "$assetdir/other";
+our $imagesdir = "$prjdir/images";
+our $hostname  = $ENV{SERVER_NAME};
 our $app;
 
 # the desired new folder structure is
@@ -101,10 +100,27 @@ sub testcasedir($$) {
     my $version = shift;
     # TODO actually "distri" is misused here. It should rather be something
     # like the name of the repository with all tests
-    my $dir = "$testcasedir/$distri";
+    my @dirs = (catdir($prjdir, 'share', 'tests', $distri), catdir($prjdir, 'tests', $distri));
+    my $dir;
+    for my $d (@dirs) {
+        if (-d $d) {
+            $dir = $d;
+        }
+    }
     $dir .= "-$version" if $version && -e "$dir-$version";
 
     return $dir;
+}
+
+# Call this when $prjdir is changed to reevalue all dependent directories
+sub change_prjdir {
+    $prjdir    = shift;
+    $resultdir = "$prjdir/testresults";
+    $assetdir  = "$prjdir/factory";
+    $isodir    = "$assetdir/iso";
+    $hdddir    = "$assetdir/hdd";
+    $otherdir  = "$assetdir/other";
+    $imagesdir = "$prjdir/images";
 }
 
 sub needledir {

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -25,6 +25,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &file_content
   &log_debug
   &log_warning
+  &log_info
   &log_error
   &save_base64_png
   &run_cmd_with_log
@@ -112,7 +113,7 @@ sub testcasedir($$) {
     return $dir;
 }
 
-# Call this when $prjdir is changed to reevalue all dependent directories
+# Call this when $prjdir is changed to re-evaluate all dependent directories
 sub change_prjdir {
     $prjdir    = shift;
     $resultdir = "$prjdir/testresults";

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -101,13 +101,7 @@ sub testcasedir($$) {
     my $version = shift;
     # TODO actually "distri" is misused here. It should rather be something
     # like the name of the repository with all tests
-    my @dirs = (catdir($prjdir, 'share', 'tests', $distri), catdir($prjdir, 'tests', $distri));
-    my $dir;
-    for my $d (@dirs) {
-        if (-d $d) {
-            $dir = $d;
-        }
-    }
+    my ($dir) = grep { -d } (catdir($prjdir, 'share', 'tests', $distri), catdir($prjdir, 'tests', $distri));
     $dir .= "-$version" if $version && -e "$dir-$version";
 
     return $dir;

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -40,8 +40,11 @@ sub needle {
     # make sure the directory of the file parameter is a real subdir of
     # testcasedir before applying it as needledir to prevent access
     # outside of the zoo
-    if ($jsonfile && index(File::Spec->rel2abs($jsonfile), File::Spec->rel2abs($OpenQA::Utils::testcasedir)) != 0) {
-        warn "$jsonfile is not in a subdir of $OpenQA::Utils::testcasedir";
+    if ($jsonfile
+        && index(File::Spec->rel2abs($jsonfile), File::Spec->rel2abs(OpenQA::Utils::testcasedir($distri, $version)))
+        != 0)
+    {
+        warn "$jsonfile is not in a subdir of " . OpenQA::Utils::testcasedir($distri, $version);
         return $self->render(text => "Forbidden", status => 403);
     }
     my $needle = OpenQA::Utils::needle_info($name, $distri, $version, $jsonfile);

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -54,14 +54,7 @@ sub main {
             $host_settings->{$h}{SHARE_DIRECTORY},
             catdir($OpenQA::Utils::prjdir, $h),
             catdir($OpenQA::Utils::prjdir, 'share'));
-        my $dir;
-        for my $d (@dirs) {
-            next unless $d;
-            if (-d $d) {
-                $dir = $d;
-                last;
-            }
-        }
+        my ($dir) = grep { $_ && -d } @dirs;
         unless ($dir) {
             log_error("Can not find working directory for host $h. Ignoring host");
             next;

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -24,7 +24,7 @@ use Mojo::IOLoop;
 use File::Spec::Functions 'catdir';
 
 use OpenQA::Client;
-use OpenQA::Utils ();
+use OpenQA::Utils qw(log_error log_debug);
 use OpenQA::Worker::Common;
 use OpenQA::Worker::Commands;
 use OpenQA::Worker::Pool qw(lockit clean_pool);
@@ -63,10 +63,10 @@ sub main {
             }
         }
         unless ($dir) {
-            print STDERR "Can not find working directory for host $h. Ignoring host\n";
+            log_error("Can not find working directory for host $h. Ignoring host");
             next;
         }
-        print "Using dir $dir for host $h\n" if $verbose;
+        log_debug("Using dir $dir for host $h") if $verbose;
         Mojo::IOLoop->next_tick(sub { OpenQA::Worker::Common::register_worker($h, $dir) });
     }
 
@@ -78,7 +78,7 @@ sub main {
 
 sub catch_exit {
     my ($sig) = @_;
-    print STDERR "quit due to signal $sig\n";
+    log_info("quit due to signal $sig");
     if ($job && !$OpenQA::Worker::Jobs::stop_job_running) {
         Mojo::IOLoop->next_tick(
             sub {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE Linux Products GmbH
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,12 +14,14 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker;
-use strict;
+use 5.018;
 use warnings;
 
 use Mojolicious::Lite;
 use Mojo::Server::Daemon;
 use Mojo::IOLoop;
+
+use File::Spec::Functions 'catdir';
 
 use OpenQA::Client;
 use OpenQA::Utils ();
@@ -29,24 +31,44 @@ use OpenQA::Worker::Pool qw(lockit clean_pool);
 use OpenQA::Worker::Jobs;
 
 sub init {
-    my ($worker_options, %options) = @_;
+    my ($worker_options, $host_settings, %options) = @_;
     $worker_settings = $worker_options;
     $instance        = $options{instance} if defined $options{instance};
     $pooldir         = $OpenQA::Utils::prjdir . '/pool/' . $instance;
     $nocleanup       = $options{"no-cleanup"};
     $verbose         = $options{verbose} if defined $options{verbose};
 
-    OpenQA::Worker::Common::api_init(\%options);
+    OpenQA::Worker::Common::api_init($host_settings, \%options);
     OpenQA::Worker::Engines::isotovideo::set_engine_exec($options{isotovideo}) if $options{isotovideo};
 }
 
 sub main {
+    my ($host_settings) = @_;
     my $lockfd = lockit();
 
     clean_pool();
-
-    ## register worker at startup
-    add_timer('register_worker', 0, \&OpenQA::Worker::Common::register_worker, 1);
+    ## register worker at startup to all webuis
+    for my $h (@{$host_settings->{HOSTS}}) {
+        # check if host`s working directory exists
+        my @dirs = (
+            $host_settings->{$h}{SHARE_DIRECTORY},
+            catdir($OpenQA::Utils::prjdir, $h),
+            catdir($OpenQA::Utils::prjdir, 'share'));
+        my $dir;
+        for my $d (@dirs) {
+            next unless $d;
+            if (-d $d) {
+                $dir = $d;
+                last;
+            }
+        }
+        unless ($dir) {
+            print STDERR "Can not find working directory for host $h. Ignoring host\n";
+            next;
+        }
+        print "Using dir $dir for host $h\n" if $verbose;
+        Mojo::IOLoop->next_tick(sub { OpenQA::Worker::Common::register_worker($h, $dir) });
+    }
 
     # start event loop - this will block until stop is called
     Mojo::IOLoop->start;

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -17,6 +17,7 @@ package OpenQA::Worker::Commands;
 use 5.012;
 use warnings;
 
+use OpenQA::Utils qw(log_error log_warning log_debug);
 use OpenQA::Worker::Common;
 use OpenQA::Worker::Jobs;
 
@@ -35,7 +36,7 @@ sub websocket_commands {
         # requests
         my $type = $json->{type};
         if (!$type) {
-            printf STDERR 'Received WS message without type!';
+            log_warning('Received WS message without type!');
             return;
         }
         my $jobid = $json->{jobid} // '';
@@ -44,61 +45,59 @@ sub websocket_commands {
         my $ua   = Mojo::UserAgent->new;
         if ($jobid) {
             if (!$job) {
-                printf STDERR 'Received command %s for job %u, but we do not have any assigned. Ignoring!%s', $type,
-                  $jobid, "\n";
+                log_warning("Received command $type for job $jobid, but we do not have any assigned. Ignoring!");
                 return;
             }
             elsif ($jobid ne $job->{id}) {
-                printf STDERR 'Received command %s for different job id %u (our %u). Ignoring!%s', $type, $jobid,
-                  $job->{id}, "\n";
+                log_warning("Received command $type for different job id $jobid (our " . $job->{id} . '). Ignoring!');
                 return;
             }
             elsif (!$current_host) {
                 die 'Job ids match but current host not set';
             }
             elsif ($current_host ne $host) {
-                print STDERR 'Received message from different host (%s) than we are working with (%s). Ignoring',
-                  $host, $current_host;
+                log_warning(
+                    "Received message from different host ($host) than we are working with ($current_host). Ignoring");
             }
         }
         if ($job) {
             $joburl = $job->{URL};
         }
         if ($type =~ m/quit|abort|cancel|obsolete/) {
-            print "received command: $type" if $verbose;
+            log_debug("received command: $type") if $verbose;
             stop_job($type);
         }
         elsif ($type eq 'stop_waitforneedle') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/stop_waitforneedle");
-                print "stop_waitforneedle triggered\n" if $verbose;
+                log_debug('stop_waitforneedle triggered') if $verbose;
                 ws_call('property_change', {waitforneedle => 1});
             }
         }
         elsif ($type eq 'reload_needles_and_retry') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/reload_needles");
-                print "needles will be reloaded\n" if $verbose;
+                log_debug('needles will be reloaded') if $verbose;
             }
         }
         elsif ($type eq 'enable_interactive_mode') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=1");
-                print "interactive mode enabled\n" if $verbose;
+                log_debug('interactive mode enabled') if $verbose;
                 ws_call('property_change', {interactive_mode => 1});
             }
         }
         elsif ($type eq 'disable_interactive_mode') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=0");
-                print "interactive mode disabled\n" if $verbose;
+                log_debug('interactive mode disabled') if $verbose;
                 ws_call('property_change', {interactive_mode => 0});
             }
         }
         elsif ($type eq 'continue_waitforneedle') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/continue_waitforneedle");
-                print "waitforneedle will continue\n" if $verbose;
+                log_debug('waitforneedle will continue') if $verbose;
                 ws_call('property_change', {waitforneedle => 0});
             }
         }
@@ -106,14 +105,14 @@ sub websocket_commands {
             # change update_status timer if $job running
             if (backend_running) {
                 OpenQA::Worker::Jobs::start_livelog();
-                print "Starting livelog\n" if $verbose;
+                log_debug('Starting livelog') if $verbose;
                 change_timer('update_status', STATUS_UPDATES_FAST);
             }
         }
         elsif ($type eq 'livelog_stop') {
             # change update_status timer
             if (backend_running) {
-                print "Stopping livelog\n" if $verbose;
+                log_debug('Stopping livelog') if $verbose;
                 OpenQA::Worker::Jobs::stop_livelog();
                 unless (OpenQA::Worker::Jobs::has_logviewers()) {
                     change_timer('update_status', STATUS_UPDATES_SLOW);
@@ -124,13 +123,13 @@ sub websocket_commands {
             # ignore keepalives, but dont' report as unknown
         }
         elsif ($type eq 'job_available') {
-            print "received job notification\n" if $verbose;
+            log_debug('received job notification') if $verbose;
             if (!$job) {
                 Mojo::IOLoop->next_tick(sub { check_job($host) });
             }
         }
         else {
-            print STDERR "got unknown command $type\n";
+            log_error("got unknown command $type");
         }
 
     }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -65,6 +65,9 @@ sub _save_vars($) {
 sub engine_workit($) {
     my ($job) = @_;
 
+    # set base dir to the one assigned with webui
+    OpenQA::Utils::change_prjdir($hosts->{$current_host}{dir});
+
     # XXX: this should come from the worker table. Only included
     # here for convenience when looking at the pool of
     # debugging.
@@ -114,11 +117,14 @@ sub engine_workit($) {
     # pass worker instance and worker id to isotovideo
     # both used to create unique MAC and TAP devices if needed
     # workerid is also used by libvirt backend to identify VMs
-    my %vars = (OPENQA_URL => $openqa_url, WORKER_INSTANCE => $instance, WORKER_ID => $workerid);
+    my $openqa_url = $current_host;
+    my $workerid   = $hosts->{$current_host}{workerid};
+    my %vars       = (OPENQA_URL => $openqa_url, WORKER_INSTANCE => $instance, WORKER_ID => $workerid);
     while (my ($k, $v) = each %{$job->{settings}}) {
         print "setting $k=$v\n" if $verbose;
         $vars{$k} = $v;
     }
+
     $vars{ASSETDIR}   = $OpenQA::Utils::assetdir;
     $vars{CASEDIR}    = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION});
     $vars{PRODUCTDIR} = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION});

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 
 use OpenQA::Worker::Common;
-use OpenQA::Utils 'locate_asset';
+use OpenQA::Utils qw(locate_asset log_error log_info log_debug);
 
 use POSIX qw(:sys_wait_h strftime uname);
 use JSON 'to_json';
@@ -121,7 +121,7 @@ sub engine_workit($) {
     my $workerid   = $hosts->{$current_host}{workerid};
     my %vars       = (OPENQA_URL => $openqa_url, WORKER_INSTANCE => $instance, WORKER_ID => $workerid);
     while (my ($k, $v) = each %{$job->{settings}}) {
-        print "setting $k=$v\n" if $verbose;
+        log_debug("setting $k=$v") if $verbose;
         $vars{$k} = $v;
     }
 
@@ -144,7 +144,7 @@ sub engine_workit($) {
         # create new process group
         setpgrp(0, 0);
         $ENV{TMPDIR} = $tmpdir;
-        printf "$$: WORKING %d\n", $job->{id};
+        log_info("$$: WORKING " . $job->{id});
         if (open(my $log, '>', "autoinst-log.txt")) {
             print $log "+++ worker notes +++\n";
             printf $log "start time: %s\n", strftime("%F %T", gmtime);
@@ -168,13 +168,13 @@ sub engine_check {
     # abort job if backend crashed and reschedule it
     if (-e "$pooldir/backend.crashed") {
         unlink("$pooldir/backend.crashed");
-        print STDERR "backend crashed ...\n";
+        log_error('backend crashed ...');
         if (open(my $fh, '<', "$pooldir/os-autoinst.pid")) {
             local $/;
             my $pid = <$fh>;
             close $fh;
             if ($pid =~ /(\d+)/) {
-                print STDERR "killing os-autoinst $1\n";
+                log_info("killing os-autoinst $1");
                 _kill($1);
             }
         }
@@ -183,7 +183,7 @@ sub engine_check {
             my $pid = <$fh>;
             close $fh;
             if ($pid =~ /(\d+)/) {
-                print STDERR "killing qemu $1\n";
+                log_info("killing qemu $1");
                 _kill($1);
             }
         }
@@ -193,7 +193,7 @@ sub engine_check {
     # check if the worker is still running
     my $pid = waitpid($workerpid, WNOHANG);
     if ($verbose) {
-        printf "waitpid %d returned %d with status $?\n", $workerpid, $pid;
+        log_debug("waitpid $workerpid returned $pid with status $?");
     }
     if ($pid == -1 && $!{ECHILD}) {
         warn "we lost our child\n";

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -94,10 +94,12 @@ sub check_job {
     my (@todo) = @_;
     state $check_job_running;
     return unless @todo;
+
     my $host = shift @todo;
     return if $check_job_running->{$host};
     return unless my $workerid = $hosts->{$host}{workerid};
     return if $job;
+
     $check_job_running->{$host} = 1;
     log_debug("checking for job with webui $host") if $verbose;
     api_call(
@@ -107,7 +109,7 @@ sub check_job {
         host     => $host,
         callback => sub {
             my ($res) = @_;
-            return unless ($res && $res->{job});
+            return unless ($res);
             $job = $res->{job};
             if ($job && $job->{id}) {
                 Mojo::IOLoop->next_tick(sub { start_job($host) });
@@ -120,7 +122,6 @@ sub check_job {
         });
 }
 
-sub _stop_job;
 sub stop_job {
     my ($aborted, $job_id) = @_;
 

--- a/lib/OpenQA/Worker/Pool.pm
+++ b/lib/OpenQA/Worker/Pool.pm
@@ -21,6 +21,7 @@ use Fcntl;
 use File::Path qw(make_path remove_tree);
 
 use OpenQA::Worker::Common qw($nocleanup $pooldir);
+use OpenQA::Utils 'log_error';
 
 use base 'Exporter';
 our (@EXPORT_OK);
@@ -54,7 +55,7 @@ sub check_qemu_pid {
     return unless $link;
     return unless $link =~ /\/qemu-[^\/]+$/;
 
-    print "QEMU ($pid -> $link) should be dead - WASUP?\n";
+    log_error("QEMU ($pid -> $link) should be dead - WASUP?");
     exit(1);
 }
 

--- a/script/worker
+++ b/script/worker
@@ -108,7 +108,6 @@ Getopt::Long::Configure("no_ignore_case");
 use OpenQA::Worker;
 
 my %options;
-my $worker_settings;
 
 sub usage($) {
     my $r = shift;
@@ -125,35 +124,49 @@ GetOptions(
 
 usage(0) if ($options{help});
 
-sub read_worker_config($) {
-    my $instance   = shift;
+sub read_worker_config {
+    my ($instance, $host) = @_;
     my $worker_dir = $ENV{OPENQA_CONFIG} || '/etc/openqa';
-    my $cfg        = Config::IniFiles->new(-file => $worker_dir . '/workers.ini');
+    my $cfg = Config::IniFiles->new(-file => $worker_dir . '/workers.ini');
 
     my $sets = {};
-    foreach my $section ('global', $instance) {
+    for my $section ('global', $instance) {
         if ($cfg && $cfg->SectionExists($section)) {
-            foreach my $set ($cfg->Parameters($section)) {
+            for my $set ($cfg->Parameters($section)) {
                 $sets->{uc $set} = $cfg->val($section, $set);
             }
         }
     }
-    $sets->{'HOST'} ||= "localhost";
+    # use separate set as we may not want to advertise other host confiuration to the world in job settings
+    my $host_settings;
+    $host ||= $sets->{'HOST'} ||= 'localhost';
+    delete $sets->{'HOST'};
+    my @hosts = split / /, $host;
+    for my $section (@hosts) {
+        if ($cfg && $cfg->SectionExists($section)) {
+            for my $set ($cfg->Parameters($section)) {
+                $host_settings->{$section}{uc $set} = $cfg->val($section, $set);
+            }
+        }
+        else {
+            $host_settings->{$section} = {};
+        }
+    }
+    $host_settings->{'HOSTS'} = \@hosts;
 
-    return $sets;
+    return $sets, $host_settings;
 }
 
-$worker_settings = read_worker_config($options{instance});
+# count workers from 1 if not set - if tap devices are used worker would try to use tap -1
+$options{instance} ||= 1;
 
-$options{instance} ||= 0;
-$options{host} ||= $worker_settings->{'HOST'};
+my ($worker_settings, $host_settings) = read_worker_config($options{instance}, $options{host});
 
 # XXX: this should be sent to the scheduler to be included in the worker's table
 $ENV{QEMUPORT} = ($options{instance}) * 10 + 20002;
 $ENV{VNC}      = ($options{instance}) + 90;
-($ENV{OPENQA_HOSTNAME}) = $options{host} =~ m|([^/]+:?\d*)/?$|;
 
-OpenQA::Worker::init($worker_settings, %options);
-OpenQA::Worker::main();
+OpenQA::Worker::init($worker_settings, $host_settings, %options);
+OpenQA::Worker::main($host_settings);
 
 # vim: set sw=4 sts=4 et:

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -139,8 +139,8 @@ else {
 
 my $connect_args = "--apikey=1234567890ABCDEF --apisecret=1234567890ABCDEF --host=http://localhost:$mojoport";
 
-unlink("t/full-stack.d/openqa/factory/iso/pitux-0.3.2.iso");
-symlink(abs_path("../os-autoinst/t/data/pitux-0.3.2.iso"), "t/full-stack.d/openqa/factory/iso/pitux-0.3.2.iso")
+make_path('t/full-stack.d/openqa/share/factory/iso');
+symlink(abs_path("../os-autoinst/t/data/pitux-0.3.2.iso"), "t/full-stack.d/openqa/share/factory/iso/pitux-0.3.2.iso")
   || die "can't symlink";
 
 make_path('t/full-stack.d/openqa/share/tests');


### PR DESCRIPTION
Allows worker to register and work on jobs from multiple openQA servers.

Hosts to register with are configured in `workers.ini` in global section `HOST` key. Accepts space separated hostnames. Optionally specific share directory can be configured in respective host sections. See example in `workers.ini`. If share directory is not configured, worker will check if `/var/lib/openqa/$hostname` does not exist or use default `/var/lib/openqa/share`.

There are also changes in `api_call` method, now accepts named options `json, params, callback`. Callback is used to queue actions dependent on result of api call.