### PR TITLE
Sort builds by version before applying limit

### DIFF
--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -95,8 +95,8 @@ subtest 'builds first tagged important, then unimportant dissappear (poo#12028)'
     post_comment_1001 'tag:0091:-important';
     my $get  = $t->get_ok('/group_overview/1001?limit_builds=1')->status_is(200);
     my @tags = $t->tx->res->dom->find('a[href^=/tests/]')->map('text')->each;
-    is(scalar @tags, 1,           'only one build');
-    is($tags[0],     'Build0092', 'only youngest build present');
+    is(scalar @tags, 1, 'only one build');
+    is($tags[0], 'Build87.5011', 'only newest build present');
 };
 
 subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -66,14 +66,14 @@ $get = $t->get_ok('/')->status_is(200);
 is_deeply(\@h2, ['opensuse test', 'Test parent'], 'parent group shown and opensuse is no more on top-level');
 
 my @h4 = $get->tx->res->dom->find('div.children-collapsed h4 a')->map('text')->each;
-is_deeply(\@h4, [qw(Build0048@0815 Build0048 Build0092)], 'builds on parent-level shown, sorted first by version');
+is_deeply(\@h4, [qw(Build87.5011 Build0048@0815 Build0048)], 'builds on parent-level shown, sorted first by version');
 @h4 = $get->tx->res->dom->find('div.collapse h4 a')->map('text')->each;
 is_deeply(\@h4, ['opensuse', 'opensuse', 'opensuse'], 'opensuse now shown as child group (for each build)');
 
 # check build limit
 $get = $t->get_ok('/?limit_builds=2')->status_is(200);
 @h4  = $get->tx->res->dom->find('div.children-collapsed h4 a')->map('text')->each;
-is_deeply(\@h4, [qw(Build0048 Build0092)], 'builds on parent-level shown (limit builds)');
+is_deeply(\@h4, [qw(Build87.5011 Build0048@0815)], 'builds on parent-level shown (limit builds)');
 @h4 = $get->tx->res->dom->find('div.collapse h4 a')->map('text')->each;
 is_deeply(\@h4, ['opensuse', 'opensuse'], 'opensuse now shown as child group (limit builds)');
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -125,7 +125,7 @@ subtest 'filter form' => sub {
 
 # JSON representation of index page
 $driver->get('/index.json');
-like($driver->get_page_source(), qr({"results":\[.*"Factory-0048":), 'page rendered as JSON');
+like($driver->get_page_source(), qr("key":"Factory-0048"), 'page rendered as JSON');
 
 like($t->get_ok('/')->tx->res->dom->at('#filter-panel .help_popover')->{'data-title'},
     qr/Help/, 'help popover is shown');

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -47,8 +47,10 @@ $driver->find_element_by_link_text('Login')->click();
 is($driver->get_title(), "openQA", "back on main page");
 
 # check 'reviewed' labels
-my $get = $t->get_ok($driver->get_current_url())->status_is(200);
+
+my $get = $t->get_ok('/?limit_builds=10')->status_is(200);
 $get->element_exists_not('.review', 'no build is marked as \'reviewed\' as there are no comments yet');
+$get->element_count_is('.review-also-softfailed', 2, 'exactly two builds wrongly marked as \'reviewed\'');
 $get->element_exists('.badge-all-passed', 'exactly one build is marked as \'reviewed\' because all tests passed');
 
 $driver->find_element_by_link_text('opensuse')->click();

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,5 +1,4 @@
-% for my $key (@{$sorted_result_keys}) {
-    % my $build_res = $result->{$key};
+% for my $build_res (@$build_results) {
     % my $build = $build_res->{build};
     % my $group_id;
     <div class="row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -36,7 +36,7 @@
     </div>
 % }
 
-%= include 'main/group_builds', result => $result, sorted_result_keys => $sorted_result_keys, group => $group, children => undef, default_expanded => 1
+%= include 'main/group_builds', build_results => $build_results, group => $group, children => undef, default_expanded => 1
 %= include 'main/more_builds', limit_builds => $limit_builds
 
 <h2>Comments</h2>

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -21,7 +21,7 @@
 
 % for my $groupresults (@$results) {
     % my $group              = $groupresults->{group};
-    % my $result             = $groupresults->{result};
+    % my $build_results      = $groupresults->{build_results};
     % my $sorted_result_keys = $groupresults->{sorted_result_keys};
     % my $max_jobs           = $groupresults->{max_jobs};
 
@@ -29,12 +29,12 @@
         <h2>
             %= link_to $group->{name} => url_for('parent_group_overview', groupid => $group->{id})
         </h2>
-        %= include 'main/group_builds', result => $result, sorted_result_keys => $sorted_result_keys, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => 0
+        %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => 0
     % } else {
         <h2>
             %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})
         </h2>
-        %= include 'main/group_builds', result => $result, sorted_result_keys => $sorted_result_keys, group => $group, max_jobs => $max_jobs, children => undef, default_expanded => 0
+        %= include 'main/group_builds', build_results => $build_results, sorted_result_keys => $sorted_result_keys, group => $group, max_jobs => $max_jobs, children => undef, default_expanded => 0
     % }
 % }
 

--- a/templates/main/parent_group_overview.html.ep
+++ b/templates/main/parent_group_overview.html.ep
@@ -33,5 +33,5 @@
     </div>
 </div>
 
-%= include 'main/group_builds', result => $result, sorted_result_keys => $sorted_result_keys, group => $group, children => $children, default_expanded => 1
+%= include 'main/group_builds', build_results => $build_results, group => $group, children => $children, default_expanded => 1
 %= include 'main/more_builds', limit_builds => $limit_builds


### PR DESCRIPTION
Previously builds where sorted by creation time before applying limit

BTW: Likely to break review script if it used `.json` routes.