### PR TITLE
build tagging: Allow digits, word chars and @ in each section

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -118,7 +118,7 @@ e.g. 'tag:0123:important:GM' returns a list of '0123', 'important' and 'GM'.
 =cut
 sub tag {
     my ($self) = @_;
-    $self->text =~ /\btag:(?<build>([-.\d\w]+-)?[@\d]+):(?<type>[-\w]+)(:(?<description>\w+))?\b/;
+    $self->text =~ /\btag:(?<build>([-.@\d\w]+-)?[@\d\w]+):(?<type>[-@\d\w]+)(:(?<description>[@\d\w]+))?\b/;
     return $+{build}, $+{type}, $+{description};
 }
 


### PR DESCRIPTION
So builds like GMC can be tagged