### PR TITLE
Fix documentation generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - FULLSTACK=0 UITESTS=1 SELENIUM_CHROME=0
     - FULLSTACK=1 SELENIUM_CHROME=0
     - FULLSTACK=1 SELENIUM_CHROME=1
+    - GH_PUBLISH=true
   global:
     - COMMIT_AUTHOR_EMAIL=skynet@open.qa
 before_install:
@@ -32,7 +33,7 @@ install:
   - gem install sass
   - cpanm -nq --installdeps --with-feature=coverage .
 script:
-  - GH_PUBLISH=true bash script/generate-documentation $encrypted_e2c381aa6b8c_key $encrypted_e2c381aa6b8c_iv
+  - bash script/generate-documentation $encrypted_e2c381aa6b8c_key $encrypted_e2c381aa6b8c_iv
   # 'coverage-codecov' calls checkstyle, tests and coverage analysis
   - make coverage-codecov
 after_failure:

--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -87,7 +87,6 @@ REPO=$(git config remote.origin.url)
 SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
 TARGET_BRANCH="gh-pages"
 REPO_DIRECTORY=$PWD
-: ${GH_PUBLISH:=0}
 SSH_KEY=$1
 SSH_IV=$2
 
@@ -135,20 +134,25 @@ function call_asciidoctor {
     cd ..
 }
 
-if [ ${GH_PUBLISH} ] && [ ${CONTINUOUS_INTEGRATION} ]; then
+if [ ${CONTINUOUS_INTEGRATION} ]; then
     if [ "${TRAVIS_BRANCH}" != "master" ]; then
-	echo "Branch is: ${TRAVIS_BRANCH}, not generating any documentation"
-	exit 0
+        echo "Branch is: ${TRAVIS_BRANCH}, not generating any documentation"
+        exit 0
     fi
 
     if [ "${TRAVIS_PULL_REQUEST}" != false ]; then
-	echo "Build is a pull request, not generating any documentation"
-	exit 0
+        echo "Build is a pull request, not generating any documentation"
+        exit 0
     fi
 
     if [ -z "${SSH_KEY}" -o -z "${SSH_IV}" ]; then
-	echo "Build is a pull request, not generating any documentation"
-	exit 0
+        echo "Build is a pull request, not generating any documentation"
+        exit 0
+    fi
+
+    if [ -z ${GH_PUBLISH} ]; then
+        echo "There's no need to generate the documentation"
+        exit 0
     fi
 
     echo "Requirements met, generating documentation"


### PR DESCRIPTION
The generate documentation script and .travis.yml have now been fix to
only run on a separate travis job.

The generate-documentation script can be still called on demand.