### PR TITLE
Fix missing images in documentation

### DIFF
--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -27,6 +27,8 @@ function update_docs {
         mkdir -p docs
         cp -r ${tmpwd}/output/* docs
         cd docs
+        ls -l 
+        git add images
         update_api
         ln -f openqa-documentation-${verbose_doc_name}.html index.html
         ln -f openqa-documentation-${verbose_doc_name}.pdf current.pdf


### PR DESCRIPTION
The images were just not being added to the git branch, but were being
used correctly by the pdf-generator.

This commit will fix that problem. (fixes #1179)