### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -152,7 +152,7 @@ virtual machine or one of the existing needles. Once the needles are adjusted,
 the user can command the job to reload the list of needles and continue with the
 execution.
 
-* *enable interactive mode* Get into waiting for input automatically(ie. waitforneedle)
+* *enable interactive mode* Get into waiting for input automatically (ie. waitforneedle)
   in case it can not find the matched needle and timeout.
 * *stop waiting for needle* Stop the waitforneedle call immediately without timeout.
 * *continue waiting for needle* Continue testing but will get into waitforneedle

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -703,7 +703,7 @@ and the rest is done automatically, using already prepared test modules in +test
 === Using text consoles and the serial terminal
 
 Typically the OS you are testing will boot into a graphical shell e.g. The
-Gnome dekstop environment. This is fine if you wish to test a program with a
+Gnome desktop environment. This is fine if you wish to test a program with a
 GUI, but lets say you want to run some shell scripts then it is not so
 convenient.
 


### PR DESCRIPTION
Signed-off-by: Petr Vorel <pvorel@suse.cz>

Just a tiny typo fix.