### PR TITLE
Add link for docs, show changelog

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -862,3 +862,18 @@ h2 + * {
         margin-right: 15px;
     }
 }
+
+.changelog {
+    ul {
+        font-weight: bold;
+
+        p {
+            margin-top: 10px;
+            margin-bottom: 0px;
+        }
+
+        ul, span {
+            font-weight: normal;
+        }
+    }
+}

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -138,7 +138,8 @@ sub read_config {
             profiling_enabled   => 0,
             plugins             => undef,
             hide_asset_types    => 'repo',
-            recognized_referers => ''
+            recognized_referers => '',
+            changelog_file      => '/usr/share/openqa/public/Changelog',
         },
         auth => {
             method => 'OpenID',

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -234,6 +234,7 @@ sub startup {
 
     # Default route
     $r->get('/')->name('index')->to('main#index');
+    $r->get('/changelog')->name('changelog')->to('main#changelog');
 
     # shorter version of route to individual job results
     $r->get('/t:testid' => sub { shift->redirect_to('test') });

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 SUSE LLC
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -162,6 +162,20 @@ sub job_group_overview {
 sub parent_group_overview {
     my ($self) = @_;
     $self->group_overview('JobGroupParents', 'main/parent_group_overview');
+}
+
+sub changelog {
+    my ($self) = @_;
+
+    my $changelog;
+    if (open(my $changelog_file, '<', '/usr/share/openqa/public/Changelog')) {
+        read($changelog_file, $changelog, -s $changelog_file);
+        close($changelog_file);
+    }
+    else {
+        $changelog = 'No changelog available.';
+    }
+    $self->stash(changelog => $changelog);
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -168,7 +168,7 @@ sub changelog {
     my ($self) = @_;
 
     my $changelog;
-    if (open(my $changelog_file, '<', '/usr/share/openqa/public/Changelog')) {
+    if (open(my $changelog_file, '<', $self->app->config->{global}->{changelog_file})) {
         read($changelog_file, $changelog, -s $changelog_file);
         close($changelog_file);
     }

--- a/t/config.t
+++ b/t/config.t
@@ -42,7 +42,8 @@ subtest 'Test configuration default modes' => sub {
             max_rss_limit       => 0,
             profiling_enabled   => 0,
             hide_asset_types    => 'repo',
-            recognized_referers => []
+            recognized_referers => [],
+            changelog_file      => '/usr/share/openqa/public/Changelog',
         },
         auth => {
             method => 'Fake',

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -58,7 +58,7 @@ $test_case->login($t, 'morgana');
 # ...who should see a logout option but no link to API keys
 $res = OpenQA::Test::Case::trim_whitespace(
     $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
-like($res, qr/Logged in as morgana Operators Menu.*API help Logout/, 'morgana as no api keys');
+like($res, qr/Logged in as morgana Operators Menu.*API help Changelog Logout/, 'morgana as no api keys');
 $t->get_ok('/api_keys')->status_is(403);
 
 #
@@ -73,7 +73,11 @@ is($res, 'Login', 'no-one logged in');
 $test_case->login($t, 'percival');
 my $actions = OpenQA::Test::Case::trim_whitespace(
     $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
-like($actions, qr/Logged in as perci Operators Menu.*Manage API keys API help Logout/, 'perci has operator links');
+like(
+    $actions,
+    qr/Logged in as perci Operators Menu.*Manage API keys API help Changelog Logout/,
+    'perci has operator links'
+);
 unlike($actions, qr/Administrators Menu/, 'perci has no admin links');
 $t->get_ok('/api_keys')->status_is(200);
 

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -106,7 +106,6 @@
                                 <!-- Sure this is not the proper place for the workers view,
                                 but the previous one was even more annoying -->
                                 <li><%= link_to('Workers' => url_for('admin_workers')) %></li>
-
                                 % if (is_admin) {
                                     <li role="separator" class="divider"></li>
                                     <li class="dropdown-header">Administrators Menu</li>
@@ -119,6 +118,7 @@
                                     <li><%= link_to "Manage API keys" => url_for('api_keys') %></li>
                                 % }
                                 <li><%= link_to "API help" => url_for('api_help') %></li>
+                                <li><%= link_to(Changelog => url_for('changelog')) %></li>
                                 <li><%= link_to('Logout' => url_for('logout') => 'data-method' => 'delete') %></li>
                               </ul>
                           </li>

--- a/templates/main/changelog.html.ep
+++ b/templates/main/changelog.html.ep
@@ -1,0 +1,9 @@
+% layout 'bootstrap';
+% title 'Changelog';
+
+%= include 'layouts/info'
+
+<h2>Changelog for web UI</h2>
+<div class="changelog">
+    <pre><%= $changelog %></pre>
+</div>


### PR DESCRIPTION
See https://progress.opensuse.org/issues/16062

![spectacle t25241](https://cloud.githubusercontent.com/assets/10248953/22063567/c5c69818-dd7f-11e6-97c8-b9f7d7fb90c1.png)

Still to improve:
* formatting
* more generic approach for getting change logs or at least handle case where logs can not be queried via `rpm`
* maybe some caching
* also show os-autoinst log for worker
