### PR TITLE
Avoid OpenQA::IPC::ipc being called premetaure

### DIFF
--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -36,26 +36,25 @@ sub _is_method_allowed {
 
 sub run {
     # config Mojo to get reactor
-    my $server = OpenQA::WebSockets::Server->setup();
+    my $server = OpenQA::WebSockets::Server->setup;
     # start DBus
-    my $self = OpenQA::WebSockets->new($server->ioloop->reactor);
+    my $self = OpenQA::WebSockets->new;
     $self->{server} = $server;
     # start IOLoop
     $server->run;
 }
 
 sub new {
-    my ($class, $reactor) = @_;
+    my ($class) = @_;
     $class = ref $class || $class;
-    # register @ IPC - we use DBus reactor here for symplicity
-    my $ipc = OpenQA::IPC->ipc($reactor);
+    my $ipc = OpenQA::IPC->ipc(1);
     return unless $ipc;
     my $service = $ipc->register_service('websockets');
     my $self = $class->SUPER::new($service, '/WebSockets');
     $self->{ipc} = $ipc;
     bless $self, $class;
     # hook DBus to Mojo reactor
-    $ipc->manage_events($reactor, $self);
+    $ipc->manage_events(Mojo::IOLoop->singleton->reactor, $self);
 
     return $self;
 }

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -285,14 +285,15 @@ sub setup {
     $connect_signal = sub {
         try {
             log_debug "connecting scheduler signal";
-            OpenQA::IPC->ipc->service('scheduler')->connect_to_signal(JobsAvailable => \&jobs_available);
+            OpenQA::IPC->ipc(1)->service('scheduler')->connect_to_signal(JobsAvailable => \&jobs_available);
         }
         catch {
             log_debug "scheduler connect failed, retrying in 2 seconds";
             Mojo::IOLoop->timer(2 => $connect_signal);
         };
     };
-    $connect_signal->();
+    # delay that until the ioloop is up
+    Mojo::IOLoop->next_tick($connect_signal);
 
     return Mojo::Server::Daemon->new(app => app, listen => ["$listen"]);
 }

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -18,10 +18,10 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;
-use OpenQA::IPC;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
@@ -68,9 +68,8 @@ sub nots {
 }
 
 # create Test DBus bus and service for fake WebSockets
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new();
-my $sh  = OpenQA::Scheduler->new();
+my $ws = OpenQA::WebSockets->new();
+my $sh = OpenQA::Scheduler->new();
 
 my $current_jobs = list_jobs();
 is_deeply($current_jobs, [], "assert database has no jobs to start with")

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -18,11 +18,11 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;
 use Data::Dump qw(pp dd);
-use OpenQA::IPC;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
@@ -33,7 +33,6 @@ use Test::Warnings;
 
 my $schema = OpenQA::Test::Database->new->create();
 # create Test DBus bus and service for fake WebSockets call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $ws = OpenQA::WebSockets->new;
 
 sub job_get {

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -18,11 +18,11 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;
 use Data::Dump qw(pp dd);
-use OpenQA::IPC;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
@@ -35,7 +35,6 @@ my $schema = OpenQA::Test::Database->new->create;    #(skip_fixtures => 1);
 #my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # create Test DBus bus and service for fake WebSockets call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $ws = OpenQA::WebSockets->new;
 
 sub list_jobs {

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;
@@ -32,7 +33,6 @@ use Test::Warnings;
 my $schema = OpenQA::Test::Database->new->create();
 
 # create Test DBus bus and service for fake WebSockets call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $ws = OpenQA::WebSockets->new;
 
 #my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;
@@ -32,7 +33,6 @@ use Test::Warnings;
 use Test::Output qw(stderr_like);
 
 # create Test DBus bus and service for fake WebSockets call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $ws = OpenQA::WebSockets->new;
 
 my $schema = OpenQA::Test::Database->new->create();

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE Linux Products GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Test::More;
@@ -28,7 +31,6 @@ use OpenQA::WebSockets;
 OpenQA::Test::Case->new->init_data;
 
 # create Test DBus bus and service for fake WebSockets call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $ws = OpenQA::WebSockets->new;
 
 # monkey patch ws_send of OpenQA::WebSockets::Server to store received command

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -17,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;
@@ -28,7 +29,6 @@ use Test::Mojo;
 use Test::Warnings;
 
 # create Test DBus bus and service for fake WebSockets call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $sh = OpenQA::Scheduler->new;
 
 my $schema = OpenQA::Test::Database->new->create();

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -1,4 +1,4 @@
-#!/bin/perl
+#! /usr/bin/perl
 
 # Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
 #
@@ -17,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;
@@ -28,13 +29,11 @@ use Test::More;
 use Test::Warnings;
 use OpenQA::Scheduler::Scheduler qw(job_grab job_restart);
 use OpenQA::WebAPI::Controller::API::V1::Worker;
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 use OpenQA::Utils;
 
 # create Test DBus bus and service for fake WebSockets call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $ws = OpenQA::WebSockets->new;
 
 my $schema;

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2016-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -23,14 +26,12 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
-use OpenQA::IPC;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use JSON qw(decode_json);
 
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $sh  = OpenQA::Scheduler->new;
-my $ws  = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
 
 my $test_case;
 my $t;

--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -1,4 +1,4 @@
-BEGIN { unshift @INC, 'lib'; }
+#! /usr/bin/perl
 
 # Copyright (C) 2016 Red Hat
 #
@@ -16,11 +16,15 @@ BEGIN { unshift @INC, 'lib'; }
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+BEGIN {
+    unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
+}
+
 use Mojo::Base;
 use Mojo::IOLoop;
 
 use OpenQA::Client;
-use OpenQA::IPC;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
@@ -62,9 +66,8 @@ $t->ua(
 $t->app($app);
 
 # create Test DBus bus and service for fake WebSockets
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new();
-my $sh  = OpenQA::Scheduler->new();
+my $ws = OpenQA::WebSockets->new();
+my $sh = OpenQA::Scheduler->new();
 
 my $settings = {
     DISTRI      => 'Unicorn',

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2016-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +17,8 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
+
 }
 
 use strict;
@@ -23,13 +27,11 @@ use DateTime;
 use Test::More;
 use Test::Warnings;
 use Test::Output qw(stderr_like);
-use OpenQA::IPC;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 
 my $schema = OpenQA::Test::Database->new->create();
-my $ipc = OpenQA::IPC->ipc('', 1);
 OpenQA::Scheduler->new;
 OpenQA::WebSockets->new;
 

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -1,6 +1,6 @@
-BEGIN { unshift @INC, 'lib'; }
+#! /usr/bin/perl
 
-# Copyright (C) 2016 SUSE Linux LLC
+# Copyright (C) 2016-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +16,15 @@ BEGIN { unshift @INC, 'lib'; }
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+BEGIN {
+    unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
+}
+
 use Mojo::Base;
 use Mojo::IOLoop;
 
 use OpenQA::Client;
-use OpenQA::IPC;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
@@ -125,9 +129,8 @@ $t->ua(
 $t->app($app);
 
 # create Test DBus bus and service for fake WebSockets
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new();
-my $sh  = OpenQA::Scheduler->new();
+my $ws = OpenQA::WebSockets->new();
+my $sh = OpenQA::Scheduler->new();
 
 my $settings = {
     DISTRI      => 'Unicorn',

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -25,14 +28,12 @@ use Test::Warnings ':all';
 use Mojo::URL;
 use OpenQA::Test::Case;
 use OpenQA::Client;
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 OpenQA::Test::Case->new->init_data;
 

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -27,14 +30,12 @@ use OpenQA::Client;
 use Mojo::IOLoop;
 use Data::Dump;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 sub nots {
     my $h  = shift;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -17,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -28,7 +29,6 @@ use OpenQA::Client;
 use Mojo::IOLoop;
 use Data::Dump;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 use OpenQA::Utils 'locate_asset';
@@ -79,9 +79,8 @@ sub schedule_iso {
 }
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 my $ret;
 

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -26,7 +29,6 @@ use Mojo::URL;
 use Mojo::Util qw(encode hmac_sha1_sum);
 use OpenQA::Test::Case;
 use OpenQA::Client;
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 
 OpenQA::Test::Case->new->init_data;
@@ -64,7 +66,6 @@ $t->ua(OpenQA::Client->new()->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
 my $ws = OpenQA::WebSockets->new;
 
 my $ret;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2015 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -25,15 +28,13 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
 use Digest::MD5;
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 require OpenQA::Schema::Result::Jobs;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 sub calculate_file_md5($) {
     my ($file) = @_;

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -27,14 +30,12 @@ use OpenQA::Client;
 use Mojo::IOLoop;
 use Data::Dump;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 OpenQA::Test::Case->new->init_data;
 

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -27,14 +30,12 @@ use OpenQA::Client;
 use Mojo::IOLoop;
 use Data::Dump;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 OpenQA::Test::Case->new->init_data;
 

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -15,6 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 BEGIN {
+    $ENV{OPENQA_TEST_IPC} = 1;
     unshift @INC, 'lib';
 }
 
@@ -27,14 +28,12 @@ use OpenQA::Client;
 use Mojo::IOLoop;
 use Data::Dump;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 OpenQA::Test::Case->new->init_data;
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -22,6 +22,7 @@ BEGIN {
     unshift @INC, 'lib';
     $ENV{OPENQA_CONFIG}  = 't/full-stack.d/config';
     $ENV{OPENQA_BASEDIR} = abs_path('t/full-stack.d');
+    # DO NOT SET OPENQA_IPC_TEST HERE
 }
 
 use Mojo::Base -strict;
@@ -194,9 +195,7 @@ for ($count = 0; $count < 130; $count++) {
     sleep 1;
 }
 
-# TODO: this creates a deadlock we need to sort. The loading of /livelog triggers a ws_send from the webui
-# to the worker but the worker is trying to upload the status so it won't reply to the websocket and so
-# all stalls. Until dbus times out
+# TODO: there can be console logs if the /status returns 404
 # is(pp($driver->get_log('browser')), "[]", "no console logs");
 
 print "PASSED after $count seconds\n";

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -1,5 +1,6 @@
+#! /usr/bin/perl
 
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -26,14 +28,12 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Test::Database;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 OpenQA::Test::Case->new->init_data;
 

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -16,6 +16,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -25,14 +26,12 @@ use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use Data::Dumper;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data;

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -16,6 +16,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -15,6 +15,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -16,6 +16,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -24,14 +25,12 @@ use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -16,6 +16,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -28,14 +31,12 @@ use File::Path qw(make_path remove_tree);
 use POSIX qw(strftime);
 use JSON;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data;

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright (C) 2015-2016 SUSE LLC
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2016-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -1,3 +1,5 @@
+#! /usr/bin/perl
+
 # Copyright (C) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;
@@ -25,14 +28,12 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use Data::Dumper;
 
-use OpenQA::IPC;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 
 # create Test DBus bus and service for fake WebSockets and Scheduler call
-my $ipc = OpenQA::IPC->ipc('', 1);
-my $ws  = OpenQA::WebSockets->new;
-my $sh  = OpenQA::Scheduler->new;
+my $ws = OpenQA::WebSockets->new;
+my $sh = OpenQA::Scheduler->new;
 
 # optional but very useful
 eval 'use Test::More::Color';

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2015 SUSE Linux GmbH
+#! /usr/bin/perl
+
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2016-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base;

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base -strict;

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +18,8 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
+
 }
 
 use Mojo::Base -strict;

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 SUSE LLC
+#! /usr/bin/perl
+
+# Copyright (C) 2016-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use Mojo::Base;


### PR DESCRIPTION
This singleton is very dangerous as if you call it wrong the first time,
it will stick to that. And that's what happened in the full-stack test.
The websocket server was calling the scheduler with ipc->scheduler during
its startup phase - and this set the singleton to its own event loop.
Just that we never called that event loop - and so the dbus service was
stuck on the bus and caused everything else to lockup.

I overreacted a bit and now expect the fake tests to set an environment
variable if they want the testing event loop and the websocket service
to always call ipc with 1 - which will use the mojo loop