### PR TITLE
Avoid 404 errors on scheduled jobs

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -14,15 +14,15 @@ var testStatus = {
 
 // Update global variable testStatus
 function updateTestStatus(newStatus) {
+    if (newStatus.state != 'running' && newStatus.state != 'waiting') {
+        setTimeout(function() {location.reload();}, 2000);
+        return;
+    }
     testStatus.workerid = newStatus.workerid;
     testStatus.interactive = newStatus.interactive == true;
     testStatus.needinput = newStatus.needinput == true;
     testStatus.stop_waitforneedle_requested = newStatus.stop_waitforneedle_requested == true;
     updateInteractiveIndicator();
-    if (newStatus.state != 'running' && newStatus.state != 'waiting') {
-          setTimeout(function() {location.reload();}, 2000);
-          return;
-    }
     $('#running_module').text(newStatus.running);
 
     // Reload broken thumbnails (that didn't exist yet when being requested) every 7 sec

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
   branch: master
+  notify:
+    after_n_builds: 4
 comment:
   behavior: default
   require_changes: true
@@ -9,19 +11,13 @@ coverage:
   - 60.0
   - 95.0
   round: down
-  notify:
-    irc:
-      default:
-        server: chat.freenode.net
-        channel: '##opensuse-factory'
-        threshold: 0.01
   status:
     changes:
       default:
         branches: null
     project:
       default:
-        target: 83.2
+        target: 85.3
         threshold: 0.1
     patch:
       default:

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -29,8 +29,12 @@ sub init {
 
     my $job = $self->app->schema->resultset("Jobs")->find($self->param('testid'));
 
-    unless (defined $job && $job->worker) {
+    unless (defined $job) {
         $self->reply->not_found;
+        return 0;
+    }
+    if (!$job->worker) {
+        $self->render(json => {state => $job->state});
         return 0;
     }
     $self->stash('job', $job);

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -24,7 +24,7 @@ use Mojo::IOLoop;
 use File::Spec::Functions 'catdir';
 
 use OpenQA::Client;
-use OpenQA::Utils qw(log_error log_debug);
+use OpenQA::Utils qw(log_error log_info log_debug);
 use OpenQA::Worker::Common;
 use OpenQA::Worker::Commands;
 use OpenQA::Worker::Pool qw(lockit clean_pool);

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -140,6 +140,7 @@ else {
 my $connect_args = "--apikey=1234567890ABCDEF --apisecret=1234567890ABCDEF --host=http://localhost:$mojoport";
 
 make_path('t/full-stack.d/openqa/share/factory/iso');
+unlink('t/full-stack.d/openqa/share/factory/iso/pitux-0.3.2.iso');
 symlink(abs_path("../os-autoinst/t/data/pitux-0.3.2.iso"), "t/full-stack.d/openqa/share/factory/iso/pitux-0.3.2.iso")
   || die "can't symlink";
 
@@ -195,8 +196,7 @@ for ($count = 0; $count < 130; $count++) {
     sleep 1;
 }
 
-# TODO: there can be console logs if the /status returns 404
-# is(pp($driver->get_log('browser')), "[]", "no console logs");
+is(pp($driver->get_log('browser')), "[]", "no console logs");
 
 print "PASSED after $count seconds\n";
 system("cat t/full-stack.d/openqa/testresults/00000/00000001-$job_name/autoinst-log.txt");


### PR DESCRIPTION
There is nothing running, but we still know the job, so 404 is incorrect