### PR TITLE
Do not do any jsonfile path processing

### DIFF
--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -84,6 +84,10 @@ sub update_needle {
 
     if (!-f $filename) {
         $filename = catdir($OpenQA::Utils::prjdir, $filename);
+        if (!-f $filename) {
+            log_error(
+                "Needle file $filename not found where expected. Check $OpenQA::Utils::prjdir for distri symlinks");
+        }
     }
     my $needle;
     if ($needle_cache) {

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -352,7 +352,7 @@ sub call_websocket {
                 $ws_to_host->{$hosts->{$host}{ws}} = $host;
             }
             else {
-                delete $ws_to_host->{$hosts->{$host}{ws}};
+                delete $ws_to_host->{$hosts->{$host}{ws}} if ($hosts->{$host}{ws});
                 $hosts->{$host}{ws} = undef;
                 if (my $location_header = ($tx->completed ? $tx->res->headers->location : undef)) {
                     log_info("Following ws redirection to: $location_header");

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -126,6 +126,7 @@ sub engine_workit($) {
     }
 
     $vars{ASSETDIR}   = $OpenQA::Utils::assetdir;
+    $vars{PRJDIR}     = $OpenQA::Utils::prjdir;
     $vars{CASEDIR}    = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION});
     $vars{PRODUCTDIR} = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION});
     _save_vars(\%vars);

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -717,14 +717,11 @@ sub read_module_result($) {
     return unless $result;
     for my $d (@{$result->{details}}) {
         if ($d->{json}) {
-            my $jsonfile = $d->{json};
-            $jsonfile = substr $jsonfile, length($OpenQA::Utils::prjdir) + 1, length($jsonfile);
-            $d->{json} = $jsonfile;
+            $d->{json} = $d->{json};
         }
         for my $n (@{$d->{needles}}) {
-            my $jsonfile = $n->{json};
-            $jsonfile = substr $jsonfile, length($OpenQA::Utils::prjdir) + 1, length($jsonfile);
-            $n->{json} = $jsonfile;
+            $n->{json} = $n->{json};
+
         }
         for my $type (qw(screenshot audio text)) {
             my $file = $d->{$type};


### PR DESCRIPTION
- new isotovideo will store jsonfile path already relative to
  $prjdir, no need to process further.
- add an error log if needle can not be found even after adding
  $prjdir prefix

- fixes https://progress.opensuse.org/issues/1609
- expects os-autoinst/os-autoinst#703