### PR TITLE
Allow override of the usual setting precedence order

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -476,6 +476,30 @@ may be expanded to this job variable:
 PUBLISH_HDD_1 = opensuse-13.1-i586-kde.qcow2
 --------------------------------------------------------------------------------
 
+=== Variable precedence
+
+It's possible to define the same variable in multiple places that would all be
+used for a single job - for instance, you may have a variable defined in both
+a test suite and a product that appear in the same job template. The precedence
+order for variables is as follows (from lowest to highest):
+
+* Product
+* Machine
+* Test suite
+* API POST query parameters
+
+That is, variable values set as part of the API request that triggers the jobs will
+'win' over values set at any of the other locations.
+
+If you need to override this precedence - for example, you want the value set in
+one particular test suite to take precedence over a setting of the same value from
+the API request - you can add a leading + to the variable name. For instance, if
+you set ++VARIABLE = foo+ in a test suite, and passed +VARIABLE=bar+ in the API
+request, the test suite setting would 'win' and the value would be foo.
+
+If the same variable is set with a + prefix in multiple places, the same precedence
+order described above will apply to those settings.
+
 == Testing openSUSE or Fedora
 
 An easy way to start using openQA is to start testing openSUSE or Fedora as they

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -165,6 +165,17 @@ sub _generate_jobs {
             $settings{PRIO}     = $job_template->prio;
             $settings{GROUP_ID} = $job_template->group_id;
 
+            # allow some messing with the usual precedence order. If anything
+            # sets +VARIABLE, that setting will be used as VARIABLE regardless
+            # (so a product or template +VARIABLE beats a post'ed VARIABLE).
+            # if *multiple* things set +VARIABLE, whichever comes highest in
+            # the usual precedence order wins.
+            for (keys %settings) {
+                if (substr($_, 0, 1) eq '+') {
+                    $settings{substr($_, 1)} = delete $settings{$_};
+                }
+            }
+
             # variable expansion
             # replace %NAME% with $settings{NAME}
             my $expanded;

--- a/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
+++ b/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
@@ -24,7 +24,7 @@ sub register {
                     $val =~ s/\\/\\\\/g;
                     $val =~ s/\'/\\\'/g;
 
-                    $key =~ s/[^\]\[0-9a-zA-Z_]//g;
+                    $key =~ s/[^\]\[0-9a-zA-Z_\+]//g;
                     $key =~ s/\[{2,}/\[/g;
                     $key =~ s/\]{2,}/\]/g;
                     $key =~ s/\\//g;
@@ -35,7 +35,7 @@ sub register {
                         push @list, $n if length($n) > 0;
                     }
 
-                    map $array[$index] .= "{$list[$_]}", 0 .. $#list;
+                    map $array[$index] .= "{'$list[$_]'}", 0 .. $#list;
 
                     $array[$index] .= " = '$val';";
                     $index++;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -117,7 +117,15 @@ $t->app->db->resultset("Jobs")->find(99928)->comments->create({text => 'any text
 # schedule the iso, this should not actually be possible. Only isos
 # with different name should result in new tests...
 my $res = schedule_iso(
-    {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'});
+    {
+        ISO        => $iso,
+        DISTRI     => 'opensuse',
+        VERSION    => '13.1',
+        FLAVOR     => 'DVD',
+        ARCH       => 'i586',
+        BUILD      => '0091',
+        PRECEDENCE => 'original'
+    });
 
 is($res->json->{count}, 10, "10 new jobs created");
 my @newids = @{$res->json->{ids}};
@@ -184,6 +192,12 @@ is($server_64->{priority}, 40,   'server_64 has priority according to job templa
 
 is($advanced_kde_32->{settings}->{PUBLISH_HDD_1}, 'opensuse-13.1-i586-kde-qemu32.qcow2', "variable expansion");
 is($advanced_kde_64->{settings}->{PUBLISH_HDD_1}, 'opensuse-13.1-i586-kde-qemu64.qcow2', "variable expansion");
+
+# variable precedence
+is($client1_32->{settings}->{PRECEDENCE}, 'original', "default precedence (post PRECEDENCE beats suite PRECEDENCE)");
+is($client1_64->{settings}->{PRECEDENCE}, 'original', "default precedence (post PRECEDENCE beats suite PRECEDENCE)");
+is($server_32->{settings}->{PRECEDENCE}, 'overridden', "precedence override (suite +PRECEDENCE beats post PRECEDENCE)");
+is($server_64->{settings}->{PRECEDENCE}, 'overridden', "precedence override (suite +PRECEDENCE beats post PRECEDENCE)");
 
 lj;
 

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -101,12 +101,20 @@ is_deeply(
                     {
                         'key'   => 'PARALLEL_WITH',
                         'value' => 'server'
+                    },
+                    {
+                        'key'   => 'PRECEDENCE',
+                        'value' => 'wontoverride'
                     }]
             },
             {
                 'id'       => 1015,
                 'name'     => 'server',
                 'settings' => [
+                    {
+                        'key'   => '+PRECEDENCE',
+                        'value' => 'overridden'
+                    },
                     {
                         'key'   => 'DESKTOP',
                         'value' => 'textmode'

--- a/t/fixtures/04-products.pl
+++ b/t/fixtures/04-products.pl
@@ -41,13 +41,17 @@
     TestSuites => {
         id       => 1014,
         name     => "client1",
-        settings => [{key => "DESKTOP", value => "kde"}, {key => "PARALLEL_WITH", value => "server"}],
+        settings => [
+            {key => "DESKTOP",       value => "kde"},
+            {key => "PARALLEL_WITH", value => "server"},
+            {key => "PRECEDENCE",    value => "wontoverride"}
+        ],
     },
 
     TestSuites => {
         id       => 1015,
         name     => "server",
-        settings => [{key => "DESKTOP", value => "textmode"}],
+        settings => [{key => "+PRECEDENCE", value => "overridden"}, {key => "DESKTOP", value => "textmode"}],
     },
 
     TestSuites => {


### PR DESCRIPTION
As suggested by @aaannz in #684, allow specifying a variable
as `+VARIABLE` to signify that it should not be overridden by
another setting of `VARIABLE` later in the usual precedence
order. For instance, usually if the same variable is set in both
a product and a test suite, the test suite setting wins; with
this change, if the product specified `+VARIABLE` and the test
suite `VARIABLE`, the product setting would win. One major use
for this could be to prevent an `HDD_1` set from an ISO post
request overriding the value set in templates for a test which
uses a disk image uploaded by another test.

If multiple things specify `+VARIABLE`, I believe the one that
comes highest in the normal precedence order should win out. We
could, of course, extend this to give `++VARIABLE` even greater
precedence, and so on...:)