### PR TITLE
AMQP: Declare exchange passive and durable

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -88,8 +88,12 @@ sub connect {
             $self->{channel}->on(
                 open => sub {
                     my ($channel) = @_;
-                    $channel->declare_exchange(exchange => $self->{config}->{amqp}{exchange}, type => 'topic')
-                      ->deliver();
+                    $channel->declare_exchange(
+                        exchange => $self->{config}->{amqp}{exchange},
+                        type     => 'topic',
+                        passive  => 1,
+                        durable  => 1
+                    )->deliver();
                 });
             $self->{channel}->on(
                 close => sub {


### PR DESCRIPTION
This will allow the rabbitmq user to use less privileges.
The exchange needs to be created by the rabbitmq admin.

See also: https://w3.suse.de/~dheidler/amqp.html