### PR TITLE
Fix build lookup for single groups (poo#15988)

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -498,6 +498,12 @@ sub overview {
     }
 
     if (!$search_args{build}) {
+        if (@groups > 1) {
+            return $self->render(text => 'Specify a build when you want to lookup multiple groups', status => 404);
+        }
+        elsif (@groups == 1) {
+            $search_args{groupid} = $groups[0]->id;
+        }
         $search_args{build} = $self->db->resultset("Jobs")->latest_build(%search_args);
     }
     $search_args{scope} = 'current';


### PR DESCRIPTION
Fixes a problem for '/tests/overview' when no build is specified, for example
to show the most recent build. Problem was that an 'unrelated' build could
show up as the groupid was not forwarded to the database query.

Also introduces a check for multiple groups and no build which is currently
not supported.

Probably introduced by dce250d.

Related progress issue: https://progress.opensuse.org/issues/15988