### PR TITLE
Add support for multiple group, no build on /tests/overview

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -39,6 +39,9 @@ see <<overview_multiple_groups,the following example>>.
 .The openQA test overview page showing multiple groups at once. The URL query parameters specify the groupid parameter two times to resolve both the "opensuse" and "opensuse test" group.
 image::images/tests-overview_multiple_groups.png[test overview page showing multiple groups]
 
+Specifying multiple groups with no build will yield the latest build of the
+first group. This can be useful to have a static URL for bookmarking.
+
 
 === Description of test suites
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -493,10 +493,8 @@ sub overview {
     }
 
     if (!$search_args{build}) {
-        if (@groups > 1) {
-            return $self->render(text => 'Specify a build when you want to lookup multiple groups', status => 404);
-        }
-        elsif (@groups == 1) {
+        if (@groups >= 1) {
+            $self->app->log->info('More than one group but no build specified, selecting build of first group');
             $search_args{groupid} = $groups[0]->id;
         }
         $search_args{build} = $self->db->resultset("Jobs")->latest_build(%search_args);

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -206,8 +206,14 @@ $get->element_exists('#res_DVD_i586_kde',                           'job from gr
 $get->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled', 'another job from group 1001');
 $get->element_exists('#res_NET_x86_64_kde .state_running',          'job from group 1002 is shown');
 
-$get = $t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002')->status_is(404);
-like($get->tx->res->dom->content, qr/Specify.*build.*multiple groups/, 'multiple groups and no build is not supported');
+$get     = $t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002')->status_is(200);
+$summary = get_summary;
+like(
+    $summary,
+    qr/Summary of opensuse, opensuse test/i,
+    'multiple groups with no build specified yield latest build of first group'
+);
+like($summary, qr/Passed: 2 Failed: 0 Scheduled: 1 Running: 2 None: 1/i);
 
 #
 # Test filter form


### PR DESCRIPTION
Just lookup the latest build from the first group so that we have useful URLs
e.g. for bookmarking.

Related progress issue: https://progress.opensuse.org/issues/13712