### PR TITLE
Fix job_timeout timer not being removed after stop_job

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -101,10 +101,11 @@ sub add_timer {
     }
     else {
         $timerid = Mojo::IOLoop->recurring($timeout => $callback);
-        # store timerid for recurring global timers so we can stop them later
-        $timers->{$timer} = [$timerid, $callback] if $timer;
-  # there are still non-global host related timers, their $timerid is stored in respective $hosts->{$host}{timers} field
     }
+  # store timerid for global timers so we can stop them later
+  # there are still non-global host related timers, their $timerid is stored in respective $hosts->{$host}{timers} field
+    $timers->{$timer} = [$timerid, $callback] if $timer;
+
     return $timerid;
 }
 

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -450,9 +450,10 @@ sub start_job {
 
     $worker = engine_workit($job);
     if ($worker->{error}) {
-        warn "job is missing files, releasing job\n";
+        log_warning('job is missing files, releasing job');
         return stop_job("setup failure: $worker->{error}");
     }
+    my $jobid = $job->{id};
 
     # start updating status - slow updates if livelog is not running
     add_timer('update_status', STATUS_UPDATES_SLOW, \&update_status);
@@ -464,8 +465,8 @@ sub start_job {
         $job->{settings}->{MAX_JOB_TIME} || $max_job_time,
         sub {
             # abort job if it takes too long
-            if ($job) {
-                warn sprintf("max job time exceeded, aborting %s ...\n", $name);
+            if ($job && $job->{id} eq $jobid) {
+                log_warning("max job time exceeded, aborting $name");
                 stop_job('timeout');
             }
         },


### PR DESCRIPTION
- job_timeout was registered as one shot timer and after
recent changes, one shot timers are no longer stored in
internal mapping. Stop job then was not able to find
proper timer id for removal
- this commit stores even non-recurrent timer mapping
- job_timeout now also checks if the job id matches the
  expected one