### PR TITLE
Fix UI test skipping when modules not available

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -73,11 +73,10 @@ sub kill_worker {
 
 use t::ui::PhantomTest;
 
-# skip if phantomjs or Selenium::Remote::WDKeys isn't available
-use IPC::Cmd 'can_run';
-if (!can_run('phantomjs') || !can_load(modules => {'Selenium::PhantomJS' => undef,})) {
-    diag("Make sure that phantomjs binary is installed") unless (can_run('phantomjs'));
-    return undef;
+# skip if appropriate modules aren't available
+unless (check_phantom_modules) {
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
+    exit(0);
 }
 
 unlink('t/full-stack.d/openqa/db/db.sqlite');
@@ -103,10 +102,8 @@ if ($schedulerpid == 0) {
 }
 
 # we don't want no fixtures
-my $mojoport = t::ui::PhantomTest::start_app(sub { });
-ok($mojoport);
-my $driver = t::ui::PhantomTest::start_phantomjs($mojoport);
-ok($driver);
+my $driver = call_phantom(sub { });
+my $mojoport = t::ui::PhantomTest::get_mojoport;
 
 my $resultdir = 't/full-stack.d/openqa/testresults/';
 # remove_tree dies on error

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -51,7 +51,7 @@ sub schema_hook {
 
 my $driver = call_phantom(\&schema_hook);
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -33,7 +33,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $driver = call_phantom();
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -31,7 +31,7 @@ my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data;
 my $driver = call_phantom();
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -32,7 +32,7 @@ $test_case->init_data;
 my $driver = call_phantom();
 
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -46,7 +46,7 @@ use t::ui::PhantomTest;
 
 my $driver = call_phantom();
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -40,11 +40,17 @@ my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data;
 
 use t::ui::PhantomTest;
-use Selenium::Remote::WDKeys;
 
 my $driver = call_phantom();
 unless ($driver) {
-    plan skip_all => 'Install phantomjs to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
+    exit(0);
+}
+
+# DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
+# to crash if the module is unavailable
+unless (can_load(modules => {'Selenium::Remote::WDKeys' => undef,})) {
+    plan skip_all => 'Install Selenium::Remote::WDKeys to run this test';
     exit(0);
 }
 
@@ -350,10 +356,10 @@ subtest 'job property editor' => sub() {
         # those keys will be appended
         $driver->find_element_by_id('editor-name')->send_keys(' has been edited!');
         my $ele = $driver->find_element_by_id('editor-size-limit');
-        $ele->send_keys(KEYS->{control}, 'a');
+        $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $ele->send_keys('1000');
         $ele = $driver->find_element_by_id('editor-keep-important-results-in-days');
-        $ele->send_keys(KEYS->{control}, 'a');
+        $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $ele->send_keys('500');
         $driver->find_element_by_id('editor-description')->send_keys('Test group');
         $driver->find_element('p.buttons button.btn-primary')->click();

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -50,7 +50,7 @@ sub schema_hook {
 
 my $driver = call_phantom(\&schema_hook);
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -51,7 +51,7 @@ sub schema_hook {
 
 my $driver = call_phantom(\&schema_hook);
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -36,7 +36,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 my $driver = call_phantom();
 
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -34,7 +34,7 @@ OpenQA::Test::Case->new->init_data;
 
 my $driver = call_phantom();
 if (!$driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -44,12 +44,12 @@ sub schema_hook {
     $jobs->find(99963)->update({assigned_worker_id => 1});
 }
 
-my $driver  = call_phantom(\&schema_hook);
-my $baseurl = $driver->get_current_url;
+my $driver = call_phantom(\&schema_hook);
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
+my $baseurl = $driver->get_current_url;
 
 sub disable_bootstrap_fade_animation {
     $driver->execute_script(

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -34,7 +34,7 @@ use t::ui::PhantomTest;
 
 my $driver = call_phantom();
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -52,7 +52,7 @@ use t::ui::PhantomTest;
 
 my $driver = call_phantom();
 unless ($driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -34,7 +34,7 @@ OpenQA::Test::Case->new->init_data;
 
 my $driver = call_phantom();
 if (!$driver) {
-    plan skip_all => 'Install phantomjs and Selenium::Remote::Driver to run these tests';
+    plan skip_all => $t::ui::PhantomTest::phantommissing;
     exit(0);
 }
 


### PR DESCRIPTION
Also don't require Chrome when testing with PhantomJS, and vice
versa. @coolo broke this pretty bad recently; please be careful
not to just throw `use` around in this stuff, it breaks the
case where Selenium is unavailable entirely.

I also took the chance to clean up the implementation and the
message a bit.