### PR TITLE
Replace HOSTS with HOST on the installing docs Enforce spaces as separator for HOST string

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -335,7 +335,7 @@ configure where the shared storage is mounted. Example:
 [source,ini]
 --------------------------------------------------------------------------------
 [global]
-HOSTS = openqa.opensuse.org openqa.fedora.fedoraproject.org
+HOST = openqa.opensuse.org openqa.fedora.fedoraproject.org
 
 [openqa.opensuse.org]
 SHARE_DIRECTORY = /var/lib/openqa/opensuse

--- a/script/worker
+++ b/script/worker
@@ -77,7 +77,6 @@ Example:
   BACKEND = qemu
   HOST = http://openqa.example.com
 
-
 =head1 SEE ALSO
 L<OpenQA::Client>
 
@@ -141,6 +140,7 @@ sub read_worker_config {
     my $host_settings;
     $host ||= $sets->{'HOST'} ||= 'localhost';
     delete $sets->{'HOST'};
+    die "Hosts in workers.ini is malformed, use space as separators ($host)" if grep /,/, $host;
     my @hosts = split / /, $host;
     for my $section (@hosts) {
         if ($cfg && $cfg->SectionExists($section)) {


### PR DESCRIPTION
The documentation for shared workers specifies using spaces for HOST
when multiple openQA instances will share a worker. This makes it more
obvious (Instead of reporting that API keys are not present)