### PR TITLE
Do correct DISTRI-VERSION case dir lookup

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -102,10 +102,13 @@ sub productdir {
 sub testcasedir {
     my ($distri, $version) = @_;
 
+    my @dirs = (catdir($prjdir, 'share', 'tests', $distri), catdir($prjdir, 'tests', $distri));
+    if ($version) {
+        unshift @dirs, catdir($prjdir, 'share', 'tests', "$distri-$version");
+    }
     # TODO actually "distri" is misused here. It should rather be something
     # like the name of the repository with all tests
-    my ($dir) = grep { -d } (catdir($prjdir, 'share', 'tests', $distri), catdir($prjdir, 'tests', $distri));
-    $dir .= "-$version" if $version && -e "$dir-$version";
+    my ($dir) = grep { -d } @dirs;
     return $dir;
 }
 


### PR DESCRIPTION
- when DISTRI test directory didn't exist, $dir variable was not set
and following DISTRI-VERSION directory lookup was not successful
- this patch adds DISTRI-VERSION dir as the first one to try if
VERSION is set