### PR TITLE
Fix synchronization of TODO with badges

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -402,8 +402,8 @@ sub prepare_job_results {
                   if $job->result eq OpenQA::Schema::Result::Jobs::PASSED
                   || $job_labels->{$jobid}{bugs}
                   || $job_labels->{$jobid}{label}
-                  || ( $job->result eq OpenQA::Schema::Result::Jobs::SOFTFAILED
-                    && $job->has_failed_modules);
+                  || ($job->result eq OpenQA::Schema::Result::Jobs::SOFTFAILED
+                    && ($job_labels->{$jobid}{label} || !$job->has_failed_modules));
             }
 
             $result = {


### PR DESCRIPTION
* First introduced with fe2fa2b
* All softfails except ones with unreviewed failed modules
  are filtered out

See https://progress.opensuse.org/issues/17172

But we should discuss how to improve this in general, because that there are 2 different softfails is too confusing. Actually, I'm hoping to do the right thing this time.