### PR TITLE
[WIP]Stop showing thumbnails on test result page

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -226,3 +226,63 @@ function setupResult(state, jobid, status_url, details_url) {
     setResultHash(tabshown);
   });
 }
+
+$(document).ready(function() {
+    $.ajax({
+        url: sessionStorage.getItem('openQA.requestURL'),
+        type: 'GET',
+        dataType: 'json',
+        success: function(resp) {
+            for (var i = 0; i < resp.modules.length; i++) {
+                if (resp.modules[i].result != 'passed') {
+                    showThumbnailsForModule(i, resp.modules[i]);
+                }
+            }
+        }
+    });
+});
+
+function setupUrls(audio_icon_url, terminal_icon_url, request_url) {
+    sessionStorage.setItem('openQA.audioIconURL', audio_icon_url);
+    sessionStorage.setItem('openQA.terminalIconURL', terminal_icon_url);
+    sessionStorage.setItem('openQA.requestURL', request_url);
+}
+
+function onClickShowThumbnails(moduleNumber) {
+    $.ajax({
+        url: sessionStorage.getItem('openQA.requestURL'),
+        type: 'GET',
+        dataType: 'json',
+        success: function(resp) {
+            showThumbnailsForModule(moduleNumber, resp.modules[moduleNumber]);
+        }
+    });
+}
+
+function showThumbnailsForModule(moduleNumber, moduleObj) {
+    var stepBegin = "<div class=\"links_a\"><div class=\"fa fa-caret-down\"></div><a class=\"no_hover\" data-url=\"";
+    var moduleHTML = " ";
+    var audio_icon_url = sessionStorage.getItem('openQA.audioIconURL');
+    var terminal_icon_url = sessionStorage.getItem('openQA.terminalIconURL');
+    for (var i = 0; i < moduleObj.details.length; i++) {
+        var step = moduleObj.details[i];
+        var href = "#step/" + moduleObj.name + "/" + step.num;
+        var title = step.text ? step.title : step.name;
+        moduleHTML += stepBegin + step.dataurl + "\"href=\"" + href + "\">";
+        if (step.screenshot) {
+            moduleHTML += step.thumbnail;
+        } else if (step.audio) {
+            moduleHTML += "<img src=\"" + audio_icon_url + "\" width=\"60\" height=\"45\" alt=\"" + step.name + "\" class=\"resborder resborder_" + step.result + "\"/>";
+        } else if (step.text) {
+            if (step.title == "wait_serial") {
+                moduleHTML += "<img src=\"" + terminal_icon_url + "\" width=\"60\" height=\"45\" alt=\"" + step.name + "\" class=\"resborder resborder_" + step.result + "\/>";
+            } else {
+                moduleHTML += "<span class=\"resborder resborder_" + step.result + "\"";
+                moduleHTML += step.title ? step.title : 'Text';
+                moduleHTML += "</span>";
+            }
+        }
+        moduleHTML += "</a></div>";
+    }
+    document.getElementById("module" + moduleNumber).innerHTML = moduleHTML;
+}

--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -250,6 +250,7 @@ sub job_module {
     return $schema->resultset("JobModules")->search({job_id => $job->id, name => $name})->first;
 }
 
+# TODO replace $job by $job_id because it is simpler
 sub job_modules {
     my ($job) = @_;
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -336,6 +336,7 @@ sub startup {
 
     my $job_r = $api_ro->route('/jobs/:jobid', jobid => qr/\d+/);
     $api_public_r->route('/jobs/:jobid', jobid => qr/\d+/)->get('/')->name('apiv1_job')->to('job#show');
+    $api_public_r->route('/jobmodules/:jobid', jobid => qr/\d+/)->get('/')->name('apiv1_jobmodule')->to('job#showmodules');
     $job_r->put('/')->name('apiv1_put_job')->to('job#update');
     $job_r->delete('/')->name('apiv1_delete_job')->to('job#destroy');
     $job_r->post('/prio')->name('apiv1_job_prio')->to('job#prio');

--- a/templates/test/details.html.ep
+++ b/templates/test/details.html.ep
@@ -8,7 +8,7 @@
             </tr>
         </thead>
         <tbody>
-            % for my $module (@$modlist) {
+            % while ( my ($i,$module) = each(@$modlist)) {
                 % if ($module->{category}) {
                     <tr>
                         <td colspan="3">
@@ -21,6 +21,7 @@
                     <td class="component">
                         <div>
                             %= link_to $module->{name} => url_for('src_step', stepid => 1, moduleid => $module->{name}, testid => $testid)
+                            <button onclick="showThumbnails('<%== $i %>')">+/-</button>
                         </div>
                         <div class="flags">
                             % if ($module->{fatal}) {
@@ -37,29 +38,7 @@
                     <td class="result <%= css_for($module) %>">
                         %= format_result($module)
                     </td>
-                    <td class="links">
-                        % for my $step (@{$module->{details}}) {
-                            <div class="links_a">
-                                <div class="fa fa-caret-down"></div>
-                                % my $url   = url_for('step', moduleid => $module->{name}, stepid => $step->{num}, testid => $testid);
-                                % my $href  = "#step/$module->{name}/$step->{num}";
-                                % my $title = $step->{text} ? $step->{title} : $step->{name};
-                                %= link_to $href => (class => 'no_hover') => (data => { url => $url }) => (title => $title) => begin
-                                    % if ($step->{screenshot}) {
-                                        %= step_thumbnail($step, 60, $testid, $module->{name}, $step->{num})
-                                    % } elsif ($step->{audio}) {
-                                        <img src="<%= icon_url 'audio.svg' %>" width="60" height="45" alt="<%= $step->{name} %>" class="resborder <%= "resborder_\L$step->{result}" %>"/>
-                                    % } elsif ($step->{text}) {
-                                       % if($step->{title} eq "wait_serial") {
-                                           <img src="<%= icon_url 'terminal.svg' %>" width="60" height="45" alt="<%= $step->{name} %>" class="resborder <%= "resborder_\L$step->{result}" %>"/>
-                                       % } else {
-                                           <span class="resborder <%= "resborder_\L$step->{result}" %>" ><%= $step->{title} || 'Text' %></span>
-                                       % }
-                                   % }
-                                % end
-                          </div>
-                     % }
-                   </td>
+                    <td class="links" id="module<%== $i %>"></td>
                 </tr>
              % }
         </tbody>

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -9,6 +9,7 @@
     $('.timeago').timeago();
     setupResultButtons();
     setupResult('<%= $job->state %>', <%= $job->id %>, '<%= url_for('status', testid => $job->id) %>', '<%= url_for('details', testid => $job->id) %>');
+    setupUrls('<%== icon_url 'audio.svg' %>','<%= icon_url 'terminal.svg' %>','<%== url_for('apiv1_jobmodule',jobid => $job->id) %>');
 % end
 
 <div class="row">


### PR DESCRIPTION
Two goals are behind this change :
   - Performance - stop wasting time on generating previews not used in most cases
   - Usability - dramatically decrease page length by hiding thumbnails which not used in most cases
From now on we will show only thumbnails for not passed modules, so test reviewer can concentrate on
his/her main goal. But we leave ability to expand thumnails for all/certain module(s) in case user need it.