### PR TITLE
Add id to comments over API to allow referencing

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -142,6 +142,7 @@ sub hash {
 sub extended_hash {
     my ($self) = @_;
     return {
+        id               => $self->id,
         text             => $self->text,
         renderedMarkdown => $self->rendered_markdown,
         bugrefs          => $self->bugrefs,

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -39,6 +39,7 @@ $t->app($app);
 sub test_get_comment {
     my ($in, $id, $comment_id, $supposed_text) = @_;
     my $get = $t->get_ok("/api/v1/$in/$id/comments/$comment_id");
+    is($get->tx->res->json->{id},   $comment_id,    'comment id is correct');
     is($get->tx->res->json->{text}, $supposed_text, 'comment text is correct');
 }
 


### PR DESCRIPTION
For example for deleting comments over API it makes sense if they identify
themselves on retrieval. Let's say we retrieve comments on a job and we want
to delete a comment on the job. For that we need the id of the comment.