### PR TITLE
[WIP] Add first approach to have asset syncing on the worker side

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -23,3 +23,8 @@
 
 #[openqa.example.host]
 # SHARE_DIRECTORY = /var/lib/openqa/example
+# In case caching of assets and tests needs to be enabled
+# CACHEDIRECTORY and TESTPOOLSERVER need to be enabled
+# CACHEDIRECTORY = /var/lib/openqa/cache
+# TESTPOOLSERVER = rsync://deimos.suse.de/openqa-tests
+

--- a/lib/OpenQA/Cache.pm
+++ b/lib/OpenQA/Cache.pm
@@ -104,7 +104,7 @@ sub get_asset {
     # repo, kernel, and initrd should be also accepted here.
     $asset_type = (split /^(ISO|HDD)/, $asset_type)[1];
     while () {
-    read_db();
+        read_db();
         log_debug "CACHE: Aquiring lock";
         open(my $asset_fd, ">", $asset . ".lock");
 
@@ -115,7 +115,7 @@ sub get_asset {
             next;
         }
 
-        if ( -s $asset ) {
+        if (-s $asset) {
             $type = "Cache Hit";
             get($asset);
         }
@@ -166,7 +166,7 @@ sub read_db {
 
     local $/;    # use slurp mode to read the whole file at once.
     $cache = {};
-    if ( -e $db_file ){
+    if (-e $db_file) {
         open(my $fh, "<", $db_file) or die "$db_file could not be created";
         flock($fh, LOCK_EX);
         eval { $cache = JSON->new->relaxed->decode(<$fh>) };
@@ -176,7 +176,8 @@ sub read_db {
         log_debug(Dumper($cache));
         close($fh);
         log_debug("Read cache db file");
-    } else {
+    }
+    else {
         log_debug "Creating empty cache";
         write_db;
     }

--- a/lib/OpenQA/Cache.pm
+++ b/lib/OpenQA/Cache.pm
@@ -1,0 +1,183 @@
+package OpenQA::Cache;
+use strict;
+use warnings;
+
+
+use File::Basename;
+use Fcntl qw(:flock);
+use Mojo::UserAgent;
+use OpenQA::Utils qw(log_error log_info log_debug);
+use OpenQA::Worker::Common;
+use List::MoreUtils;
+use Data::Dumper;
+use Mojo::JSON qw(to_json from_json);
+
+require Exporter;
+our (@ISA, @EXPORT);
+@ISA    = qw(Exporter);
+@EXPORT = qw(get_asset);
+
+my %cache;
+my $host;
+my $limit   = 5;
+my $delete  = 0;
+my $db_file = "../cache.db";
+
+sub get {
+    my ($asset) = @_;
+    my $index = List::MoreUtils::first_index { $_ eq $asset } @{$cache{$host}};
+    splice @{$cache{$host}}, $index, 1;
+    unshift @{$cache{$host}}, $asset;
+    expire_asset();
+}
+
+sub set {
+    my ($asset) = @_;
+    unshift @{$cache{$host}}, $asset;
+    expire_asset();
+}
+
+sub init {
+    my $class;
+    $host = shift;
+    @{$cache{$host}} = read_db();
+    log_debug(__PACKAGE__ . ": Initialized with $host");
+    log_debug(Dumper(\%cache));
+}
+
+sub update_setup_status {
+    my $id = @_;
+    my $status = {setup => 1};
+    api_call(
+        'post',
+        'jobs/' . $job->{id} . '/status',
+        json     => {status => $status},
+        callback => "no",
+    );
+    log_debug("Update status so job is not considered dead.");
+}
+
+sub download_asset {
+    my ($id, $type, $asset) = @_;
+    # $asset =~ s/share\///;
+    log_debug "Attemping to download: $host $asset, $type, $id";
+    my $ua = Mojo::UserAgent->new(max_redirects => 5);
+    $ua->max_response_size(0);    #set initial filesize of 20GB
+    my $tx = $ua->build_tx(GET => sprintf '%s/tests/%d/asset/%s/%s', $host, $id, $type, basename($asset));
+
+    log_debug "Set up the transaction";
+    open(my $log, '>>', "autoinst-log.txt") or die("Cannot open autoinst-log.txt");
+    local $| = 1;
+    print $log "CACHE: Locking $asset";
+
+    $ua->on(
+        start => sub {
+            my ($ua, $tx) = @_;
+            my $progress     = 0;
+            my $last_updated = time;
+            $tx->res->on(
+                progress => sub {
+                    my $msg = shift;
+                    return unless my $len = $msg->headers->content_length;
+                    my $size = $msg->content->progress;
+                    my $current = int($size / ($len / 100));
+                    local $| = 1;
+                    # Don't spam the webui, update only every 5 seconds
+                    if (time - $last_updated > 5) {
+                        update_setup_status $id;
+                        log_debug($progress . " < " . $current);
+                        $last_updated = time;
+                        if ($progress < $current) {
+                            $progress = $current;
+                            print $log "Downloading $asset :", $size == $len ? 100 : $progress, "\n";
+                        }
+                    }
+                });
+        });
+
+    $tx = $ua->start($tx);
+    log_debug("saving to $asset");
+    print $log "CACHE: " . basename($asset) . " download sucessful";
+    close($log);
+    $tx->res->content->asset->move_to($asset);
+
+}
+
+sub get_asset {
+    my ($job, $asset_type, $asset) = @_;
+    my $type;
+    $asset =~ s/share\///;
+    # repo, kernel, and initrd should be also accepted here.
+    $asset_type = (split /^(ISO|HDD)/, $asset_type)[1];
+
+    while () {
+        log_debug "Trying to aquire lock";
+        open(my $asset_fd, ">", $asset . ".lock");
+
+        if (!flock($asset_fd, LOCK_EX | LOCK_NB)) {
+            update_setup_status $job->{id};
+            log_debug("Asked to wait for lock, sleeping 10 secs");
+            sleep 10;
+            next;
+        }
+
+        if (-e $asset) {
+            $type = "Cache Hit";
+            get($asset);
+        }
+        else {
+            $type = "Cache Miss";
+            download_asset($job->{id}, lc($asset_type), $asset);
+            set($asset);
+        }
+        write_db();
+        flock($asset_fd, LOCK_UN);
+        last;
+
+    }
+
+    unlink($asset . ".lock") or log_debug("Lock file for " . basename($asset) . " is not present");
+    log_debug "got $type " . basename($asset);
+
+}
+
+sub purge_cache {
+    log_debug("Expiring all the assets");
+    map { expire_asset($_) } @{$cache{$host}};
+}
+
+sub expire_asset {
+    if (@{$cache{$host}} > $limit) {
+        my $asset = pop(@{$cache{$host}});
+        unlink($asset) if $delete;
+        log_debug("Purged $asset");
+    }
+}
+
+sub write_db {
+    open(my $file, ">", $db_file);
+    flock($file, LOCK_EX);
+    print $file to_json(\%cache);
+    close($file);
+    flock($file, LOCK_UN);
+    log_debug("Wrote db file");
+}
+
+sub read_db {
+    open(my $file, "<", $db_file);
+
+    flock($file, LOCK_EX);
+    my $data;
+    while (<$file>) {
+        $data .= $_;
+    }
+
+    %cache = \from_json($data);
+    log_debug(Dumper(\%cache));
+
+    close($file);
+    flock($file, LOCK_UN);
+    log_debug("Wrote db file");
+}
+
+1;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -35,6 +35,7 @@ use DBIx::Class::Timestamps 'now';
 # States
 use constant {
     SCHEDULED => 'scheduled',
+    SETUP     => 'setup',
     RUNNING   => 'running',
     CANCELLED => 'cancelled',
     WAITING   => 'waiting',
@@ -42,8 +43,8 @@ use constant {
     UPLOADING => 'uploading',
     #    OBSOLETED => 'obsoleted',
 };
-use constant STATES => (SCHEDULED, RUNNING, CANCELLED, WAITING, DONE, UPLOADING);
-use constant PENDING_STATES => (SCHEDULED, RUNNING, WAITING, UPLOADING);
+use constant STATES => (SCHEDULED, SETUP, RUNNING, CANCELLED, WAITING, DONE, UPLOADING);
+use constant PENDING_STATES => (SCHEDULED, SETUP, RUNNING, WAITING, UPLOADING);
 use constant EXECUTION_STATES => (RUNNING, WAITING, UPLOADING);
 use constant FINAL_STATES => (DONE, CANCELLED);
 
@@ -1115,7 +1116,6 @@ sub update_status {
     my ($self, $status) = @_;
 
     my $ret = {result => 1};
-
     if (!$self->worker) {
         OpenQA::Utils::log_info(
             'Got status update for job with no worker assigned (maybe running job already considered dead): '

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -92,23 +92,22 @@ our $app;
 # testrepository name" and "old/new folder structure" within the
 # testrepository.
 sub productdir {
-    my ($distri, $version) = @_;
+    my ($distri, $version, $rootfortests) = @_;
 
-    my $dir = testcasedir($distri, $version);
+    my $dir = testcasedir($distri, $version, $rootfortests);
     return $dir . "/products/$distri" if -e "$dir/products/$distri";
     return $dir;
 }
 
 sub testcasedir {
-    my ($distri, $version) = @_;
-
-    my @dirs = (catdir($prjdir, 'share', 'tests', $distri), catdir($prjdir, 'tests', $distri));
-    if ($version) {
-        unshift @dirs, catdir($prjdir, 'share', 'tests', "$distri-$version");
+    my ($distri, $version, $rootfortests) = @_;
+    for my $dir (catdir($prjdir, 'share', 'tests'), catdir($prjdir, 'tests')) {
+        $rootfortests ||= $dir if -d $dir;
     }
     # TODO actually "distri" is misused here. It should rather be something
     # like the name of the repository with all tests
-    my ($dir) = grep { -d } @dirs;
+    my $dir = catdir($rootfortests, $distri);
+    $dir .= "-$version" if $version && -e "$dir-$version";
     return $dir;
 }
 

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -31,42 +31,56 @@ use OpenQA::Worker::Pool qw(lockit clean_pool);
 use OpenQA::Worker::Jobs;
 
 sub init {
-    my ($worker_options, $host_settings, %options) = @_;
-    $worker_settings = $worker_options;
-    $instance        = $options{instance} if defined $options{instance};
-    $pooldir         = $OpenQA::Utils::prjdir . '/pool/' . $instance;
-    $nocleanup       = $options{"no-cleanup"};
-    $verbose         = $options{verbose} if defined $options{verbose};
+    my ($host_settings, $options) = @_;
+    $instance  = $options->{instance} if defined $options->{instance};
+    $pooldir   = $OpenQA::Utils::prjdir . '/pool/' . $instance;
+    $nocleanup = $options->{"no-cleanup"};
+    $verbose   = $options->{verbose} if defined $options->{verbose};
 
-    OpenQA::Worker::Common::api_init($host_settings, \%options);
-    OpenQA::Worker::Engines::isotovideo::set_engine_exec($options{isotovideo}) if $options{isotovideo};
+    OpenQA::Worker::Common::api_init($host_settings, $options);
+    OpenQA::Worker::Engines::isotovideo::set_engine_exec($options->{isotovideo}) if $options->{isotovideo};
 }
 
 sub main {
     my ($host_settings) = @_;
     my $lockfd = lockit();
-
+    my $dir;
     clean_pool();
     ## register worker at startup to all webuis
     for my $h (@{$host_settings->{HOSTS}}) {
         # check if host`s working directory exists
-        my @dirs = (
-            $host_settings->{$h}{SHARE_DIRECTORY},
-            catdir($OpenQA::Utils::prjdir, $h),
-            catdir($OpenQA::Utils::prjdir, 'share'));
-        my ($dir) = grep { $_ && -d } @dirs;
-        unless ($dir) {
-            log_error("Can not find working directory for host $h. Ignoring host");
-            next;
+        # if caching is not enabled
+
+        if ($host_settings->{$h}{TESTPOOLSERVER}) {
+            $dir = prepare_cache_directory($h, $worker_settings->{CACHEDIRECTORY});
         }
+        else {
+            my @dirs = ($host_settings->{$h}{SHARE_DIRECTORY}, catdir($OpenQA::Utils::prjdir, 'share'));
+            ($dir) = grep { $_ && -d } @dirs;
+            unless ($dir) {
+                log_error("Can not find working directory for host $h. Ignoring host");
+                next;
+            }
+        }
+
         log_debug("Using dir $dir for host $h") if $verbose;
-        Mojo::IOLoop->next_tick(sub { OpenQA::Worker::Common::register_worker($h, $dir) });
+        Mojo::IOLoop->next_tick(
+            sub { OpenQA::Worker::Common::register_worker($h, $dir, $host_settings->{$h}{TESTPOOLSERVER}) });
     }
 
     # start event loop - this will block until stop is called
     Mojo::IOLoop->start;
 
     return 0;
+}
+
+sub prepare_cache_directory {
+    my ($current_host, $cachedirectory) = @_;
+    my $host_to_cache = Mojo::URL->new($current_host)->host;
+    my $shared_cache = File::Spec->catdir($cachedirectory, $host_to_cache);
+    File::Path::make_path($shared_cache) if (!-e $shared_cache);
+    log_info("CACHE: caching is enabled, setting up $shared_cache");
+    return $shared_cache;
 }
 
 sub catch_exit {

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -139,9 +139,7 @@ sub get_timer {
 ## prepare UA and URL for OpenQA-scheduler connection
 sub api_init {
     my ($host_settings, $options) = @_;
-    my @hosts = @{$host_settings->{HOSTS}};
-
-    for my $host (@hosts) {
+    for my $host (@{$host_settings->{HOSTS}}) {
         my ($ua, $url);
         if ($host !~ '/') {
             $url = Mojo::URL->new->scheme('http')->host($host);
@@ -391,7 +389,7 @@ sub call_websocket {
 }
 
 sub register_worker {
-    my ($host, $dir) = @_;
+    my ($host, $dir, $testpoolserver) = @_;
     die unless $host;
 
     $worker_caps             = _get_capabilities;
@@ -437,6 +435,7 @@ sub register_worker {
         }
         return;
     }
+    $hosts->{$host}{testpoolserver} = $testpoolserver;
     my $newid    = $tx->success->json->{id};
     my $workerid = $hosts->{$host}{workerid};
     my $ws       = $hosts->{$host}{ws};

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -263,7 +263,6 @@ sub api_call {
     }
 }
 
-
 sub ws_call {
     my ($type, $data) = @_;
     die 'Current host not set!' unless $current_host;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -68,6 +68,7 @@ sub cache_assets {
     #cache ISO and HDD
     foreach my $this_asset (sort grep { /^(ISO|HDD)[_]*\d?$/ } keys %{$job->{settings}}) {
         log_debug("Found $this_asset, caching " . $job->{settings}->{$this_asset});
+        $job->{settings}{$this_asset} =~ s/share\///;
         get_asset($job, $this_asset, $job->{settings}{$this_asset});
     }
 }
@@ -132,7 +133,8 @@ sub engine_workit($) {
         }
     }
 
-    if (!-e '/var/lib/openqa/share/') {
+    # for now the only condition to enable syncing is $hosts->{$current_host}{dir}
+    if (!-e $hosts->{$current_host}{dir}) {
         OpenQA::Cache::init($current_host);
         cache_assets($job);
     }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -68,7 +68,7 @@ sub cache_assets {
     #cache ISO and HDD
     foreach my $this_asset (sort grep { /^(ISO|HDD)[_]*\d?$/ } keys %{$job->{settings}}) {
         log_debug("Found $this_asset, caching " . $job->{settings}->{$this_asset});
-        OpenQA::Cache::get_asset($job, $this_asset, $job->{settings}{$this_asset});
+        get_asset($job, $this_asset, $job->{settings}{$this_asset});
     }
 }
 
@@ -132,10 +132,11 @@ sub engine_workit($) {
         }
     }
 
-    if ( ! -e '/var/lib/openqa/share/'){
+    if (!-e '/var/lib/openqa/share/') {
         OpenQA::Cache::init($current_host);
         cache_assets($job);
-    } else {
+    }
+    else {
         log_info("CACHE: share directory found, asset caching is not enabled");
     }
 

--- a/script/worker
+++ b/script/worker
@@ -86,7 +86,6 @@ L<OpenQA::Client>
 use strict;
 use warnings;
 
-
 BEGIN {
     #prepare for large files
     $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
@@ -106,6 +105,7 @@ use Getopt::Long;
 Getopt::Long::Configure("no_ignore_case");
 
 use OpenQA::Worker;
+use OpenQA::Worker::Common;
 
 my %options;
 
@@ -161,12 +161,12 @@ sub read_worker_config {
 $options{instance} ||= 1;
 
 my ($worker_settings, $host_settings) = read_worker_config($options{instance}, $options{host});
-
+$OpenQA::Worker::Common::worker_settings = $worker_settings;
 # XXX: this should be sent to the scheduler to be included in the worker's table
 $ENV{QEMUPORT} = ($options{instance}) * 10 + 20002;
 $ENV{VNC}      = ($options{instance}) + 90;
 
-OpenQA::Worker::init($worker_settings, $host_settings, %options);
+OpenQA::Worker::init($host_settings, \%options);
 OpenQA::Worker::main($host_settings);
 
 # vim: set sw=4 sts=4 et:


### PR DESCRIPTION
With this PR the caching is enabled on the worker, it will sync
assets to /var/lib/openqa/factory if the share directory does not exists
locally.

Currently the cache is very dumb, it will only treat limits as number of files and not size. 

To allow the caching to work correctly, the timers need to be avoided
when using api_call, since they are added to the event loop and by the
nature of how the caching is working (blocking), the event loop will
only keep running after the cache has finished downloading the assets.

