### PR TITLE
client script: Don't encode URL twice

### DIFF
--- a/script/client
+++ b/script/client
@@ -164,11 +164,7 @@ for my $arg (@ARGV) {
         $method = lc $arg;
     }
     elsif ($arg =~ /^([[:alnum:]_\[\]\.]+)=(.+)/) {
-        my $key   = $1;
-        my $value = $2;
-        # Mojo::URL no longer escapes / (https://github.com/kraih/mojo/commit/aab2f1f)
-        $value =~ s@/@%2F@g;
-        $params{$key} = $value;
+        $params{$1} = $2;
     }
 }
 

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -79,7 +79,7 @@ sub test_create_comment {
     return $post->tx->res->json->{id};
 }
 
-my $test_message         = 'This is a cool test ☠';
+my $test_message         = 'This is a cool test ☠ - http://open.qa';
 my $another_test_message = ' - this message will be\nappended if editing works ☠';
 my $edited_test_message  = $test_message . $another_test_message;
 
@@ -133,7 +133,7 @@ sub test_comments {
         is($comment->{text}, $edited_test_message, 'text correct');
         is(
             $comment->{renderedMarkdown},
-            "<p>This is a cool test \x{2620} - this message will be\\nappended if editing works \x{2620}</p>\n",
+"<p>This is a cool test \x{2620} - <a href=\"http://open.qa\">http://open.qa</a> - this message will be\\nappended if editing works \x{2620}</p>\n",
             'markdown correct'
         );
     };


### PR DESCRIPTION
This prevents the client script to encode URLs twice. Seems like Mojo::URL encodes (again) so doing this manually isn't required anymore. To test, just call the script like:

```
script/client --host http://localhost:9526 jobs/128/comments post text=http://open.qa
```

Automatic tests are still missing (the extension in the first commit does not test for the client issue). I could add them to the full stack test where the client script is already executed or create a new test only for the client script.