### PR TITLE
Fix restarting jobs from worker page

### DIFF
--- a/assets/javascripts/admin_worker.js
+++ b/assets/javascripts/admin_worker.js
@@ -17,6 +17,6 @@ function setupWorkerNeedles() {
                 {targets: 2, render: renderTimeAgo}
             ]
         });
-
+    table.on('draw.dt', setupTestButtons);
     $('#previous_jobs_filter').hide();
 }

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -185,24 +185,28 @@ function renderTestsList(jobs) {
     $(document).on('focusin', '.parent_child', highlightJobs);
     $(document).on('focusout', '.parent_child', unhighlightJobs);
 
+    setupTestButtons();
+}
+
+function setupTestButtons() {
     $(document).on("click", '.restart', function(event) {
-	event.preventDefault();
+        event.preventDefault();
         var restart_link = $(this);
         var link = $(this).parent('td');
         $.post(restart_link.attr("href")).done( function( data, res, xhr ) {
-	    link.append(' <a href="' + xhr.responseJSON.test_url + '" title="new test">(restarted)</a>');
-	});
+            link.append(' <a href="' + xhr.responseJSON.test_url + '" title="new test">(restarted)</a>');
+        });
         var i = $(this).find('i').removeClass('fa-repeat');
-	$(this).replaceWith(i);
+        $(this).replaceWith(i);
     });
 
     $(document).on('click', '.cancel', function(event) {
-	event.preventDefault();
+        event.preventDefault();
         var cancel_link = $(this);
         var test = $(this).parent('td');
         $.post(cancel_link.attr("href")).done( function( data ) { $(test).append(' (cancelled)'); });
-	var i = $(this).find('i').removeClass('fa-times-circle-o');
-	$(this).replaceWith(i);
+        var i = $(this).find('i').removeClass('fa-times-circle-o');
+        $(this).replaceWith(i);
     });
 }
 

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -102,5 +102,23 @@ is_deeply(
     'correct entries shown'
 );
 
+# restart job
+$driver->find_child_element($table, 'a.restart', 'css')->click();
+wait_for_ajax;
+$table = $driver->find_element_by_id('previous_jobs');
+ok($table, 'still on same page (with table)');
+@entries = map { $_->get_text() } $driver->find_child_elements($table, 'tbody/tr/td', 'xpath');
+is_deeply(
+    \@entries,
+    [
+        'opensuse-Factory-staging_e-x86_64-Build87.5011-minimalx@32bit (restarted)',
+        '0',
+        'about an hour ago',
+        'opensuse-13.1-DVD-i586-Build0091-RAID1@32bit',
+        '', 'not finished yet',
+    ],
+    'the first job has been restarted'
+);
+
 kill_phantom();
 done_testing();


### PR DESCRIPTION
Since the table is server-side, the buttons must be
initialized again when the table is redrawn.

See https://progress.opensuse.org/issues/17830