### PR TITLE
Merge 'Status' and 'Connected' columns in workers overview

### DIFF
--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 BEGIN {
     unshift @INC, 'lib';
@@ -61,7 +60,7 @@ $driver->find_element_by_link_text('Login')->click();
 $driver->title_is("openQA", "back on main page");
 # but ...
 
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 # Demo is admin, so go there
 $driver->find_element('#user-action a')->click();

--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -16,7 +16,6 @@
                 <tr>
                     <th>Worker</th>
                     <th>Status</th>
-                    <th>Connected</th>
                     <th>Current step</th>
                 </tr>
             </thead>
@@ -30,13 +29,6 @@
                         <td class="status">
                             % stash(workername => $workername, worker => $worker);
                             %= include 'admin/workers/worker_status'
-                        </td>
-                        <td class="ws_connected">
-                            % if($worker->{connected}) {
-                                online
-                            % } else {
-                                offline
-                            % }
                         </td>
                         <td class="currentstep">
                             % if(defined($worker->{currentstep}) && $worker->{status} eq 'running') {

--- a/templates/admin/workers/worker_status.html.ep
+++ b/templates/admin/workers/worker_status.html.ep
@@ -1,14 +1,12 @@
-% if($worker->{status} eq 'idle') {
-    Idle
-% } elsif ($worker->{status} eq 'running')
-% {
+% if($worker->{status} eq 'running') {
     Working on job <%= link_to $worker->{jobid}, url_for('test', testid => $worker->{jobid}) %>
 % } elsif ($worker->{status} eq 'dead' && $worker->{job} )
 % {
     Dead with job <%= link_to $worker->{jobid}, url_for('test', testid => $worker->{jobid}) %>
-% } else
-% {
-    Dead
+% } elsif ($worker->{connected}) {
+    Online
+% } else {
+    Offline
 % }
 % if($worker->{status} eq 'running' && defined($worker->{currentstep}) ) {
     - <%= $worker->{currentstep} %>


### PR DESCRIPTION
Status column was mistakenly printing Dead even for live workers
due to quering database instead of websocket connection as
Connected status was.
This PR merge information of both into the Status. When worker
is idle, websockets connection is queried and Online/Offline is
displayed, else information about job is available.