### PR TITLE
Do not upload empty serial_terminal.txt

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -167,13 +167,20 @@ sub test_resultfile_list($) {
     # get a list of existing resultfiles
     my ($testresdir) = @_;
 
-    my @filelist = qw(video.ogv vars.json backend.json serial0.txt autoinst-log.txt serial_terminal.txt);
+    my @filelist = qw(video.ogv vars.json backend.json serial0.txt autoinst-log.txt);
     my @filelist_existing;
     for my $f (@filelist) {
         if (-e "$testresdir/$f") {
             push(@filelist_existing, $f);
         }
     }
+
+    for my $f (qw(serial_terminal.txt)) {
+        if (-s "$testresdir/$f") {
+            push(@filelist_existing, $f);
+        }
+    }
+
     return @filelist_existing;
 }
 


### PR DESCRIPTION
Generally we enable the virtio terminal through the Machine settings which
means it is enabled for many tests which don't use it. QEMU creates a log file
for the virtio serial device whether it is used or not, so we have a lot of
empty log files. This was reported to be confusing so this commit only
uploads the file if it has data in it.

The behavior for other files is deliberately left unchanged so as to avoid
hiding the existence of an empty file when it might be used to diagnose a
problem.

https://progress.opensuse.org/issues/17962