### PR TITLE
Add environmental variable to skip online tests

### DIFF
--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -256,15 +256,18 @@ subtest 'labeled jobs considered important' => sub {
     ok(!-e $filename, 'file got cleaned');
 };
 
-subtest 'download assets with correct permissions' => sub {
-    # need to whitelist github
-    $t->app->config->{global}->{download_domains} = 'github.com';
+SKIP: {
+    skip 'no network available', 1 if $ENV{OBS_RUN};
+    subtest 'download assets with correct permissions' => sub {
+        # need to whitelist github
+        $t->app->config->{global}->{download_domains} = 'github.com';
 
-    my $assetsource = 'https://github.com/os-autoinst/os-autoinst/blob/master/t/data/Core-7.2.iso';
-    my $assetpath   = 't/data/openqa/share/factory/iso/Core-7.2.iso';
-    run_gru('download_asset' => [$assetsource, $assetpath, 0]);
-    ok(-f $assetpath, 'asset downloaded');
-    is(S_IMODE((stat($assetpath))[2]), 0644, 'asset downloaded with correct permissions');
-};
+        my $assetsource = 'https://github.com/os-autoinst/os-autoinst/blob/master/t/data/Core-7.2.iso';
+        my $assetpath   = 't/data/openqa/share/factory/iso/Core-7.2.iso';
+        run_gru('download_asset' => [$assetsource, $assetpath, 0]);
+        ok(-f $assetpath, 'asset downloaded');
+        is(S_IMODE((stat($assetpath))[2]), 0644, 'asset downloaded with correct permissions');
+    };
+}
 
 done_testing();

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -113,7 +113,7 @@ ok(make_path($resultdir));
 remove_tree('t/full-stack.d/openqa/images/');
 
 $driver->title_is("openQA", "on main page");
-is($driver->find_element_by_id('user-action')->get_text(), 'Login', "noone logged in");
+is($driver->find_element('#user-action a')->get_text(), 'Login', "noone logged in");
 $driver->find_element_by_link_text('Login')->click();
 # we're back on the main page
 $driver->title_is("openQA", "back on main page");

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -76,7 +76,7 @@ $driver->find_element_by_link_text('Login')->click();
 $driver->title_is("openQA", "back on main page");
 # but ...
 
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 # now hack ourselves to be just operator - this is stupid procedure, but we don't have API for user management
 $driver->find_element('#user-action a')->click();

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -89,7 +89,7 @@ sub goto_editpage() {
     # we're back on the main page
     $driver->title_is("openQA", "back on main page");
 
-    is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+    is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
     $driver->get("/tests/99946");
     is(

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -55,13 +55,13 @@ unless (can_load(modules => {'Selenium::Remote::WDKeys' => undef,})) {
 }
 
 $driver->title_is("openQA");
-is($driver->find_element_by_id('user-action')->get_text(), 'Login', "noone logged in");
+is($driver->find_element('#user-action a')->get_text(), 'Login', "noone logged in");
 $driver->find_element_by_link_text('Login')->click();
 # we're back on the main page
 $driver->title_is("openQA", "back on main page");
 # but ...
 
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 # expand user menu
 $driver->find_element('#user-action a')->click();

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -74,7 +74,7 @@ is(scalar @restart_buttons, 0, 'no restart buttons present when not logged in');
 
 # Log in as Demo in phantomjs webui
 $driver->find_element_by_link_text('Login')->click();
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', 'logged in as demo');
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', 'logged in as demo');
 
 # Test Scheduled isos are displayed
 $driver->find_element('#user-action a')->click();

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -62,7 +62,7 @@ $driver->find_element_by_link_text('Login')->click();
 # we're back on the main page
 $driver->title_is("openQA", "back on main page");
 
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 $driver->get("/tests/99946");
 $driver->title_is('openQA: opensuse-13.1-DVD-i586-Build0091-textmode@32bit test results', 'tests/99946 followed');

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -46,7 +46,7 @@ $driver->title_is("openQA", "back on main page");
 my @texts = map { $_->get_text() } $driver->find_elements('.progress-bar-softfailed', 'css');
 is_deeply(\@texts, ['2 softfailed'], 'Progress bars show soft fails');
 
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 # follow a build to overview page
 $driver->find_element_by_link_text('Build0048')->click();

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -63,7 +63,7 @@ $driver->find_element_by_link_text('Login')->click();
 # we're back on the main page
 $driver->title_is("openQA", "back on main page");
 
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 # Demo is admin, so go there
 $driver->find_element('#user-action a')->click();

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -58,7 +58,7 @@ $driver->title_is("openQA", "on main page");
 $driver->find_element_by_link_text('Login')->click();
 # we're back on the main page
 $driver->title_is("openQA", "back on main page");
-is($driver->find_element_by_id('user-action')->get_text(), 'Logged in as Demo', "logged in as demo");
+is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 $driver->find_element('#user-action a')->click();
 $driver->find_element_by_link_text('Audit log')->click();


### PR DESCRIPTION
OBS does not allow network access to build hosts, we must skip tests requiring network access to succeed.

Also for some reason my branch tests are frequently failing on matching text of complete dropdown menu instead of logged in line. I added one more commit that makes it specific we are interested only in logged in line.