### PR TITLE
[WIP] Worker registration tests

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -310,7 +310,7 @@ sub startup {
                 $port = $1 + 1;
             }
             $c->redirect_to("http://localhost:$port/ws/$workerid");
-        });
+        })->name('worker_websockets');
     my $api_job_auth = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_jobtoken');
     my $api_r_job = $api_job_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     $api_r_job->get('/whoami')->name('apiv1_jobauth_whoami')->to('job#whoami');    # primarily for tests

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -29,13 +29,13 @@ our @EXPORT = qw($job $verbose $instance $worker_settings $pooldir $nocleanup
   $hosts $ws_to_host $current_host
   $worker_caps $testresults update_setup_status
   STATUS_UPDATES_SLOW STATUS_UPDATES_FAST
-  add_timer remove_timer change_timer get_timer
+  add_timer remove_timer change_timer get_timer get_timers
   api_call verify_workerid register_worker ws_call);
 
 # Exported variables
 our $job;
 our $verbose  = 0;
-our $instance = 'manual';
+our $instance = 99;
 our $worker_settings;
 our $pooldir;
 our $nocleanup = 0;
@@ -129,6 +129,10 @@ sub change_timer {
     $callback = $timers->{$timer}->[1] unless $callback;
     remove_timer($timer);
     add_timer($timer, $newtimeout, $callback);
+}
+
+sub get_timers {
+    return keys(%$timers);
 }
 
 sub get_timer {


### PR DESCRIPTION
After various tries of mocking and hacking various Mojo parts I found out I can use Test::Mojo and it's Mojo::UserAgent::Server to simulate WebUI and use `before_dispatch` hook to easily control desired response.

This is still WIP as api_call tests are not yet adapted to this framework, only registration tests are in. Even they are not complete since I do not test websocket setup failure yet.