### PR TITLE
Relax the regex for build values in tag: comments again, handle `VERSION-BUILD` format tags when exempting jobs for important builds from obsoletion

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -118,7 +118,10 @@ e.g. 'tag:0123:important:GM' returns a list of '0123', 'important' and 'GM'.
 =cut
 sub tag {
     my ($self) = @_;
-    $self->text =~ /\btag:(?<build>([-.@\d\w]+-)?[@\d\w]+):(?<type>[-@\d\w]+)(:(?<description>[@\d\w]+))?\b/;
+    $self->text =~ /\btag:(?<build>[-.@\d\w]+):(?<type>[-@\d\w]+)(:(?<description>[@\d\w]+))?\b/;
+    # note: calling this 'build' is a slight lie, because it may be
+    # either VERSION-BUILD or just BUILD. Things that consume it must
+    # be aware of this
     return $+{build}, $+{type}, $+{description};
 }
 

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -119,9 +119,10 @@ e.g. 'tag:0123:important:GM' returns a list of '0123', 'important' and 'GM'.
 sub tag {
     my ($self) = @_;
     $self->text =~ /\btag:(?<build>[-.@\d\w]+):(?<type>[-@\d\w]+)(:(?<description>[@\d\w]+))?\b/;
-    # note: calling this 'build' is a slight lie, because it may be
-    # either VERSION-BUILD or just BUILD. Things that consume it must
-    # be aware of this
+    # note: 'build' here may be either VERSION-BUILD or just BUILD.
+    # If the tag is in VERSION-BUILD form it will return the entire
+    # value, it does not isolate the BUILD component. Things that
+    # consume it must be aware of this
     return $+{build}, $+{type}, $+{description};
 }
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -358,7 +358,10 @@ sub cancel_by_settings {
           map { ($_->tag)[0] } $schema->resultset('Comments')->search({'me.group_id' => {-in => $groups_query}});
         my @unimportant_jobs;
         while (my $j = $jobs_to_cancel->next) {
+            # the value we get from that @important_builds search above
+            # could be just BUILD or VERSION-BUILD
             next if grep ($j->BUILD eq $_, @important_builds);
+            next if grep (join('-', $j->VERSION, $j->BUILD) eq $_, @important_builds);
             push @unimportant_jobs, $j->id;
         }
         # if there are only important jobs there is nothing left for us to do


### PR DESCRIPTION
This regex was still too restrictive, even after the last time
it was loosened. It rejects BUILD values with a period after
the final dash, which all Fedora BUILDs have, because they look
like this:

Fedora-25-20170327.n.0

I don't see any value to this restriction, so I think we can
just simplify the regex to allow any string consisting only of
dashes, periods, @s, digits and word characters.

This was preventing tagging builds as 'important' working for
Fedora.