### PR TITLE
needle editor: Distinguish tag/area selection in check

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -352,13 +352,14 @@ function reactToSaveNeedle(data) {
 function saveNeedle(e) {
   var form = $("#save_needle_form");
   var errors = [];
-  var selection = window.needles[$('#tags_select').val()];
-  var takeMatches = $('#take_matches').prop('checked');
-  if(!selection.tags.length) {
+  var tagSelection = window.needles[$('#tags_select').val()];
+  if(!tagSelection.tags.length) {
       errors.push('No tags specified.');
   }
-  if((!takeMatches && !selection.area.length)
-      || (takeMatches && !selection.matches.length)) {
+  var areaSelection = window.needles[$('#area_select').val()];
+  var takeMatches = $('#take_matches').prop('checked');
+  if((!takeMatches && !areaSelection.area.length)
+      || (takeMatches && !areaSelection.matches.length)) {
       errors.push('No areas defined.');
   }
   if(errors.length) {

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -269,6 +269,21 @@ is($driver->find_element_by_id('needleeditor_name')->get_value(), "", "needle na
 $driver->find_element_by_id('needleeditor_name')->send_keys($needlename);
 is($driver->find_element_by_id('needleeditor_name')->get_value(), "$needlename", "new needle name inputed");
 
+# select 'Copy areas from: None'
+$driver->execute_script('$("#area_select option").eq(0).prop("selected", true)');
+$driver->find_element_by_id('save')->click();
+wait_for_ajax;
+is(
+    $driver->find_element('.alert-danger span')->get_text(),
+    "Unable to save needle:\nNo areas defined.",
+    'areas verified via JavaScript when "Copy areas from: None" selected'
+);
+# dismiss the alert (can't use click because of fade effect)
+$driver->execute_script('$(".alert-danger").remove()');
+
+# select 'Copy areas from: 100%: inst-timezone-text' again
+$driver->execute_script('$("#area_select option").eq(1).prop("selected", true)');
+
 # create new needle by clicked save button
 $driver->find_element_by_id('save')->click();
 wait_for_ajax;


### PR DESCRIPTION
Fixes the verification in the needle editor when not copying areas.
Might also fix https://progress.opensuse.org/issues/16596