### PR TITLE
WIP/Feedback: Adjust media queries and progress bar width

### DIFF
--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -2,7 +2,7 @@
     % my $build = $build_res->{build};
     % my $group_id;
     <div class="row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
-        <div class="col-md-4 text-nowrap">
+        <div class="col-lg-4 text-nowrap">
             <h4>
                 % if ($children) {
                     % $group_id = "group$group->{id}_build$build_res->{escaped_id}";
@@ -25,7 +25,7 @@
                 %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $build_res, id_prefix => ''
             </h4>
         </div>
-        <div class="col-md-8">
+        <div class="col-lg-8">
             % if ($max_jobs) {
                 %= include 'main/build_progressbar', max_jobs => $max_jobs, result => $build_res
             % }


### PR DESCRIPTION
See https://progress.opensuse.org/issues/12942

This shows how the width of the progress bars is adjusted (the larger progress bar shows how it was before for comparison):
![spectacle n21689](https://cloud.githubusercontent.com/assets/10248953/24704345/8850e73a-1a07-11e7-90e0-100216e60e71.png)

Alternative would be wrapping. It would look like this (not part of the PR):

![spectacle b21689](https://cloud.githubusercontent.com/assets/10248953/24704413/dfbf985e-1a07-11e7-85b6-e6cbe4b981b2.png)

Advantage would be that it works with any text length. The problem with indentation could be solved. However, it doesn't look very nice.
