### PR TITLE
Fix overriden shared $dir worker registration

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -52,15 +52,14 @@ sub main {
         # if caching is not enabled
 
         if ($worker_settings->{CACHEDIRECTORY}) {
-            $dir = prepare_cache_directory($h, $worker_settings->{CACHEDIRECTORY});
+            prepare_cache_directory($h, $worker_settings->{CACHEDIRECTORY});
         }
-        else {
-            my @dirs = ($host_settings->{$h}{SHARE_DIRECTORY}, catdir($OpenQA::Utils::prjdir, 'share'));
-            ($dir) = grep { $_ && -d } @dirs;
-            unless ($dir) {
-                log_error("Can not find working directory for host $h. Ignoring host");
-                next;
-            }
+
+        my @dirs = ($host_settings->{$h}{SHARE_DIRECTORY}, catdir($OpenQA::Utils::prjdir, 'share'));
+        ($dir) = grep { $_ && -d } @dirs;
+        unless ($dir) {
+            log_error("Can not find working directory for host $h. Ignoring host");
+            next;
         }
 
         log_debug("Using dir $dir for host $h") if $verbose;


### PR DESCRIPTION
Fix poo#17812 introduced by 00108e5813187e9616612130d4174b1947df59b0
so now thests are able to find assets in the share/factory asset dir.

http://deimos.suse.de/tests/550 has a sucessful run.