### PR TITLE
Replace old 'important' behaviour with 'ignore_failure'

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -75,8 +75,9 @@ sub run {
 
 sub test_flags {
     # without anything - rollback to 'lastgood' snapshot if failed
-    # 'fatal' - abort whole test suite if this fails
-    # 'milestone' - after this test succeeds, update 'lastgood'
+    # 'fatal'          - abort whole test suite if this fails (and set overall state 'failed')
+    # 'ignore_failure' - if this module fails, it will not affect the overall result at all
+    # 'milestone'      - after this test succeeds, update 'lastgood'
     return { fatal => 1 };
 }
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -130,52 +130,54 @@ subtest 'job with at least one failed module and one softfailed => overall is fa
     is($job->result, OpenQA::Schema::Result::Jobs::FAILED, 'job result is failed');
 };
 
-subtest 'job with all important modules passed and at least one unimportant failed => overall failed' => sub {
+subtest 'job with all modules passed and at least one ignore_failure failed => overall passed' => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'E';
     my $job = _job_create(\%_settings);
     for my $i (qw(a b c)) {
-        $job->insert_module({name => $i, category => $i, script => $i, flags => {important => 1}});
+        $job->insert_module({name => $i, category => $i, script => $i, flags => {}});
         $job->update_module($i, {result => 'ok', details => []});
     }
-    $job->insert_module({name => 'd', category => 'd', script => 'd', flags => {}});
+    $job->insert_module({name => 'd', category => 'd', script => 'd', flags => {ignore_failure => 1}});
     $job->update_module('d', {result => 'fail', details => []});
     $job->update;
     $job->discard_changes;
     is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
     $job->done;
     $job->discard_changes;
-    is($job->result, OpenQA::Schema::Result::Jobs::FAILED, 'job result is failed');
+    is($job->result, OpenQA::Schema::Result::Jobs::PASSED, 'job result is passed');
 };
 
 subtest
-  'job with important modules passed and at least one softfailed and at least one unimportant failed => overall failed'
+'job with important modules passed and at least one softfailed and at least one ignore_failure failed => overall softfailed'
   => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'F';
     my $job = _job_create(\%_settings);
     for my $i (qw(a b)) {
-        $job->insert_module({name => $i, category => $i, script => $i, flags => {important => 1}});
+        $job->insert_module({name => $i, category => $i, script => $i, flags => {}});
         $job->update_module($i, {result => 'ok', details => []});
     }
-    $job->insert_module({name => 'c', category => 'c', script => 'c', flags => {important => 1}});
+    $job->insert_module({name => 'c', category => 'c', script => 'c', flags => {}});
     $job->update_module('c', {result => 'ok', details => [], dents => 1});
-    $job->insert_module({name => 'd', category => 'd', script => 'd', flags => {}});
+    $job->insert_module({name => 'd', category => 'd', script => 'd', flags => {ignore_failure => 1}});
     $job->update_module('d', {result => 'fail', details => []});
     $job->update;
     $job->discard_changes;
     is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
     $job->done;
     $job->discard_changes;
-    is($job->result, OpenQA::Schema::Result::Jobs::FAILED, 'job result is failed');
+    is($job->result, OpenQA::Schema::Result::Jobs::SOFTFAILED, 'job result is softfailed');
   };
 
-subtest 'job with one important module failed and at least one unimportant passed => overall failed' => sub {
+subtest
+'job with one "important" (old flag we now ignore) module failed and at least one ignore_failure passed => overall failed'
+  => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'G';
     my $job = _job_create(\%_settings);
     for my $i (qw(a b c)) {
-        $job->insert_module({name => $i, category => $i, script => $i, flags => {important => 0}});
+        $job->insert_module({name => $i, category => $i, script => $i, flags => {ignore_failure => 1}});
         $job->update_module($i, {result => 'ok', details => []});
     }
     $job->insert_module({name => 'd', category => 'd', script => 'd', flags => {important => 1}});
@@ -186,22 +188,50 @@ subtest 'job with one important module failed and at least one unimportant passe
     $job->done;
     $job->discard_changes;
     is($job->result, OpenQA::Schema::Result::Jobs::FAILED, 'job result is failed');
-};
+  };
 
-subtest 'job with first unimportant and rest softfails => overall is failed' => sub {
+subtest 'job with first ignore_failure failed and rest softfails => overall is softfailed' => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'H';
     my $job = _job_create(\%_settings);
-    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {ignore_failure => 1}});
     $job->update_module('a', {result => 'fail', details => []});
     $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {important => 1}});
-    $job->update_module('b', {result => 'ok', details => []});
+    $job->update_module('b', {result => 'ok', details => [], dents => 1});
     $job->update;
     $job->discard_changes;
     is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
     $job->done;
     $job->discard_changes;
-    is($job->result, OpenQA::Schema::Result::Jobs::FAILED, 'job result is failed');
+    is($job->result, OpenQA::Schema::Result::Jobs::SOFTFAILED, 'job result is softfailed');
+};
+
+subtest 'job with one ignore_failure pass => overall is passed' => sub {
+    my %_settings = %settings;
+    $_settings{TEST} = 'H';
+    my $job = _job_create(\%_settings);
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {ignore_failure => 1}});
+    $job->update_module('a', {result => 'ok', details => []});
+    $job->update;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
+    $job->done;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::PASSED, 'job result is passed');
+};
+
+subtest 'job with one ignore_failure fail => overall is passed' => sub {
+    my %_settings = %settings;
+    $_settings{TEST} = 'H';
+    my $job = _job_create(\%_settings);
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {ignore_failure => 1}});
+    $job->update_module('a', {result => 'fail', details => []});
+    $job->update;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
+    $job->done;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::PASSED, 'job result is passed');
 };
 
 subtest 'job with at least one softfailed => overall is softfailed' => sub {
@@ -238,13 +268,13 @@ subtest 'job with no modules => overall is failed' => sub {
     is($job->result, OpenQA::Schema::Result::Jobs::FAILED, 'job result is failed');
 };
 
-subtest 'carry over for soft fails' => sub {
+subtest 'carry over for soft-fails' => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'K';
     my $job = _job_create(\%_settings);
     $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
     $job->update_module('a', {result => 'ok', details => [], dents => 1});
-    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {important => 1}});
+    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {}});
     $job->update_module('b', {result => 'ok', details => []});
     $job->update;
     $job->discard_changes;
@@ -258,7 +288,7 @@ subtest 'carry over for soft fails' => sub {
     $job = _job_create(\%_settings);
     $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
     $job->update_module('a', {result => 'ok', details => [], dents => 1});
-    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {important => 1}});
+    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {}});
     $job->update_module('b', {result => 'ok', details => []});
     $job->update;
     $job->discard_changes;
@@ -273,9 +303,59 @@ subtest 'carry over for soft fails' => sub {
     $_settings{BUILD} = '668';
     $job = _job_create(\%_settings);
     $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
+    $job->update_module('a', {result => 'ok', details => [], dents => 1});
+    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {}});
+    $job->update_module('b', {result => 'fail', details => []});
+    $job->update;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
+    is(0, $job->comments, 'no comment');
+    $job->done;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::FAILED, 'job result is failed');
+    is(0, $job->comments, 'no takeover');
+
+};
+
+subtest 'carry over for ignore_failure modules' => sub {
+    my %_settings = %settings;
+    $_settings{TEST}  = 'K';
+    $_settings{BUILD} = '669';
+    my $job = _job_create(\%_settings);
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {ignore_failure => 1}});
     $job->update_module('a', {result => 'fail', details => []});
-    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {important => 1}});
+    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {}});
     $job->update_module('b', {result => 'ok', details => []});
+    $job->update;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
+    $job->done;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::PASSED, 'job result is passed');
+    $job->comments->create({text => 'bsc#101', user_id => 99901});
+
+    $_settings{BUILD} = '670';
+    $job = _job_create(\%_settings);
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {ignore_failure => 1}});
+    $job->update_module('a', {result => 'fail', details => []});
+    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {}});
+    $job->update_module('b', {result => 'ok', details => []});
+    $job->update;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');
+    is(0, $job->comments, 'no comment');
+    $job->done;
+    $job->discard_changes;
+    is($job->result, OpenQA::Schema::Result::Jobs::PASSED, 'job result is passed');
+    is(1, $job->comments, 'one comment');
+    like($job->comments->first->text, qr/\Qbsc#101\E/, 'right take over');
+
+    $_settings{BUILD} = '671';
+    $job = _job_create(\%_settings);
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {ignore_failure => 1}});
+    $job->update_module('a', {result => 'fail', details => []});
+    $job->insert_module({name => 'b', category => 'b', script => 'b', flags => {}});
+    $job->update_module('b', {result => 'fail', details => []});
     $job->update;
     $job->discard_changes;
     is($job->result, OpenQA::Schema::Result::Jobs::NONE, 'result is not yet set');


### PR DESCRIPTION
This partly reverts commit
487fcdbd56f5e46bd569a5ffcbbbb0e90da5744a, which made openQA's
result calculation ignore the 'important' test flag entirely.

This is really inconvenient to Fedora, we found the ability to
have 'unimportant' tests quite handy and have used it in a few
different ways. Adapting to its removal has proved very hard.
So this partly restores the 'important' behaviour, but with an
'ignore_failure' flag instead of 'important'. This both inverts
the default from before, and behaves slightly differently: no
soft failure mode is involved. 'ignore_failure' does exactly
what it sounds like - a failure or soft failure of the module
will never result in failure of the overall test. If a test is
made up entirely of 'ignore_failure' modules, it will always
have 'PASSED' as its overall result. This behaviour is fine for
the cases Fedora cares about, while still allowing the removal
of the logic to handle different soft failure cases (#1293).

There will be a corresponding PR for os-autoinst, but as it
doesn't actually use the flag directly, the changes there are
quite small.