### PR TITLE
Document the 'norollback' flag in WritingTests

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -74,10 +74,10 @@ sub run {
 }
 
 sub test_flags {
-    # without anything - rollback to 'lastgood' snapshot if failed
     # 'fatal'          - abort whole test suite if this fails (and set overall state 'failed')
     # 'ignore_failure' - if this module fails, it will not affect the overall result at all
     # 'milestone'      - after this test succeeds, update 'lastgood'
+    # 'norollback'     - don't roll back to 'lastgood' snapshot if this fails
     return { fatal => 1 };
 }
 


### PR DESCRIPTION
This flag has existed for a long time, but this comment block
(which pops up both here and in os-autoinst) has never explained
it.