### PR TITLE
Better error msg for openqa client

### DIFF
--- a/script/client
+++ b/script/client
@@ -217,7 +217,7 @@ if ($res->code == 200) {
     }
 }
 else {
-    printf STDERR "ERROR: %s - %s\n", $res->code, $res->message;
+    printf STDERR "ERROR: %s - %s\n", $res->code, $res->{error}->{message};
     if ($res->body) {
         if ($options{json}) {
             print JSON->new->pretty->encode($res->json);


### PR DESCRIPTION
Fixes [poo#18494](https://progress.opensuse.org/issues/18494)

Error for missing module:

```
ERROR:  - IO::Socket::SSL 1.94+ required for TLS support
```

Server error:

```
ERROR: 403 - Forbidden
{ error => "no api key", error_status => 403 }
```