### PR TITLE
Makefile: Allow to skip checkstyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,12 @@ checkstyle:
 	PERL5LIB=lib/perlcritic:$$PERL5LIB perlcritic --gentle lib
 
 .PHONY: test
-test:
-	if test "$$TRAVIS" = "true"; then \
-	  $(MAKE) travis ;\
-	else \
-	   $(MAKE) checkstyle ;\
-	   OPENQA_CONFIG= prove ${PROVE_ARGS} ;\
-	fi
+ifeq ($(TRAVIS),true)
+test: travis
+else
+test: checkstyle
+	OPENQA_CONFIG= prove ${PROVE_ARGS}
+endif
 
 .PHONY: travis
 travis:

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,9 @@ install:
 
 .PHONY: checkstyle
 checkstyle:
+ifneq ($(CHECKSTYLE),0)
 	PERL5LIB=lib/perlcritic:$$PERL5LIB perlcritic --gentle lib
+endif
 
 .PHONY: test
 ifeq ($(TRAVIS),true)


### PR DESCRIPTION
As the 'checkstyle' test can take some time provide a switch to skip it on
demand which can be useful when for example one wants to collect coverage from
a single test and execute this in a faster manner.

Example use: `make CHECKSTYLE=0 PROVE_ARGS=t/full-stack.t coverage-html` to
execute the full stack test and collect coverage without needing to conduct
the long-running style check every time.