### PR TITLE
Shorten build-numbers with dots to prevent overlapping

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -59,6 +59,12 @@ $color-step-actions: #666;
     }
 }
 
+.build-row h4 {
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+
 .build_group_children, .build-row {
     h4:before {
         display: inline-box;


### PR DESCRIPTION
Related to https://progress.opensuse.org/issues/12942

Now the text gets shortend by dots before overlapping. 
![screenshot_2017-04-21_15-31-07](https://cloud.githubusercontent.com/assets/22001671/25279761/ce0c72f6-26a7-11e7-9bd3-9132f706b540.png)
