### PR TITLE
Register job assets even if one of the assets need to be skipped

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2016 SUSE LLC
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
the function used to return from the function even if only one out of 3 assets
was not to be registered. Now moved the check to the loop

See https://progress.opensuse.org/issues/18862