### PR TITLE
Fix invalid HTML

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -4,7 +4,7 @@ function showCommentEditor(form) {
     jform.find('[name="applyChanges"]').show();
     jform.find('[name="discardChanges"]').show();
     jform.find('[name="editComment"]').hide();
-    jform.find('[name="markdown"]').hide();
+    jform.find('.markdown').hide();
     jform.find('[name="removeComment"]').hide();
 }
 
@@ -14,7 +14,7 @@ function hideCommentEditor(form) {
     jform.find('[name="applyChanges"]').hide();
     jform.find('[name="discardChanges"]').hide();
     jform.find('[name="editComment"]').show();
-    jform.find('[name="markdown"]').show();
+    jform.find('.markdown').show();
     jform.find('[name="removeComment"]').show();
 }
 
@@ -65,9 +65,9 @@ function updateComment(form) {
     var editorForm = $(form);
     var url = editorForm.data('put-url');
     var headingElement = editorForm.find('h4');
-    var markdownElement = editorForm.find('[name="markdown"]');
+    var markdownElement = editorForm.find('.markdown');
     var textElement = editorForm.find('[name="text"]');
-    var markdown = editorForm.find('[name="markdown"]').html();
+    var markdown = markdownElement.html();
     var text = textElement.val();
     if(text.length) {
         textElement.hide();
@@ -129,7 +129,7 @@ function addComment(form, insertAtBottom) {
                         var commentRow = $($('#comment-row-template').html().replace(/@comment_id@/g, commentId));
                         commentRow.find('h4').replaceWith(renderCommentHeading(response, commentId));
                         commentRow.find('[name="text"]').val(response.text);
-                        commentRow.find('[name="markdown"]').html(response.renderedMarkdown);
+                        commentRow.find('.markdown').html(response.renderedMarkdown);
                         var nextElement;
                         if(!insertAtBottom) {
                             nextElement = $('.comment-row').first();

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -87,7 +87,7 @@ disable_bootstrap_animations();
 
 ok($driver->find_element('#group1_build13_1-0091 h4 a')->is_displayed(), 'link to child group displayed');
 my @links = $driver->find_elements('h4 a', 'css');
-is(scalar @links, 12, 'all links expanded in the first place');
+is(scalar @links, 11, 'all links expanded in the first place');
 $driver->find_element_by_link_text('Build0091')->click();
 ok($driver->find_element('#group1_build13_1-0091 h4 a')->is_hidden(), 'link to child group collapsed');
 

--- a/templates/branding/plain/docbox.html.ep
+++ b/templates/branding/plain/docbox.html.ep
@@ -1,4 +1,3 @@
 <h1>Welcome to <%= $appname %></h1>
 <p>Life is too short for manual testing!</p>
-
-<a class="btn btn-primary btn-lg" href="http://os-autoinst.github.io/openQA/" role="button">Learn more »</a></p>
+<p><a class="btn btn-primary btn-lg" href="http://os-autoinst.github.io/openQA/" role="button">Learn more »</a></p>

--- a/templates/comments/comment_row.html.ep
+++ b/templates/comments/comment_row.html.ep
@@ -31,7 +31,7 @@
                             % }
                         % }
                     </h4>
-                    <div class="media-comment" name="markdown">
+                    <div class="media-comment markdown">
                         % if($comment) {
                             %= $comment->rendered_markdown
                         % }

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -36,7 +36,7 @@
     </div>
 % }
 
-<a name="build-results"/>
+<div id="build-results"></div>
 %= include 'main/group_builds', build_results => $build_results, group => $group, children => undef, default_expanded => 1
 %= include 'main/more_builds', limit_builds => $limit_builds
 

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -19,7 +19,7 @@
     </div>
 </div>
 
-<a name="build-results"/>
+<div id="build-results"></div>
 % for my $groupresults (@$results) {
     % my $group              = $groupresults->{group};
     % my $build_results      = $groupresults->{build_results};
@@ -41,7 +41,7 @@
 <div class="panel panel-default filter-panel-bottom" id="filter-panel">
     <div class="panel-heading"><strong>Filter</strong> <span>no filter present, click to toggle filter form</span></div>
     <div class="panel-body">
-        <form action="#" type="get" id="filter-form">
+        <form action="#" method="get" id="filter-form">
             <div class="form-group">
                 <strong>Group</strong>
                 <input type="text" class="form-control" name="group" placeholder="all" id="filter-group">

--- a/templates/main/parent_group_overview.html.ep
+++ b/templates/main/parent_group_overview.html.ep
@@ -33,6 +33,6 @@
     </div>
 </div>
 
-<a name="build-results"/>
+<div id="build-results"></div>
 %= include 'main/group_builds', build_results => $build_results, group => $group, children => $children, default_expanded => 1
 %= include 'main/more_builds', limit_builds => $limit_builds


### PR DESCRIPTION
* Replace anchor links with an id attribute at the right place
* Fix minor mistakes
* Also note that
  * using `/>` is not allowed to close an empty link
  * we are using HTML and not XHTML anyways
  * the markdown renderer still produces bad HTML which is not fixed
    in this commit
    * implicitely closing `<p>` via `<hr>` and then adding a
      surplus `</p>`
    * using obsolete `<font ...` tag