### PR TITLE
clone_job.pl: Print URL of generated job for easy access

### DIFF
--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -287,7 +287,8 @@ sub clone_job {
     if ($tx->success) {
         my $r = $tx->success->json->{id};
         if ($r) {
-            print "Created job #$r: $job->{name}\n";
+            my $url = $remote_url->scheme . '://' . $remote_url->host . '/t' . $r;
+            print "Created job #$r: $job->{name} -> $url\n";
             $clone_map->{$jobid} = $r;
             return $r;
         }


### PR DESCRIPTION
Example output:

```
$ clone_job.pl …
Created job #123456: openSUSE-Tumbleweed-DVD-Build1234-gnome -> https://openqa.opensuse.org/t123456
```