### PR TITLE
Add helper to get current version of openQA and display it in the footer

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -20,7 +20,7 @@ use Mojo::Base 'Mojolicious';
 use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
 use OpenQA::IPC;
-use OpenQA::Utils qw(log_warning job_groups_and_parents);
+use OpenQA::Utils qw(log_warning job_groups_and_parents detect_current_version);
 use OpenQA::ServerStartup;
 
 use Mojo::IOLoop;
@@ -70,11 +70,11 @@ sub startup {
     my $self = shift;
 
     OpenQA::ServerStartup::read_config($self);
+    OpenQA::ServerStartup::setup_logging($self);
 
     # Set some application defaults
-    $self->defaults(appname => $self->app->config->{global}->{appname});
-
-    OpenQA::ServerStartup::setup_logging($self);
+    $self->defaults(appname         => $self->app->config->{global}->{appname});
+    $self->defaults(current_version => detect_current_version($self->app->home));
 
     unless ($ENV{MOJO_TMPDIR}) {
         $ENV{MOJO_TMPDIR} = $OpenQA::Utils::assetdir . '/tmp';

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -137,6 +137,10 @@
           <div id='footer-legal' class="text-center">
               openQA is licensed
               %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
+              % if ($current_version) {
+                  - Version
+                  %= $current_version
+              % }
           </div>
         </div>
       </footer>


### PR DESCRIPTION
Adding helper to cache and return the current running version.

Currently:
![no-version](https://cloud.githubusercontent.com/assets/2420543/25892838/f3b3a1fa-3575-11e7-8921-e2842db8256a.png)

Git:
![git-version](https://cloud.githubusercontent.com/assets/2420543/25892833/f17ceff4-3575-11e7-91f9-d77e33f4c6f0.png)

Installed from rpm:
![rpm-version](https://cloud.githubusercontent.com/assets/2420543/25892841/f58f93c6-3575-11e7-88d9-dbe735921a81.png)

Related progress issue: [Poo#16232](https://progress.opensuse.org/issues/16232)
