### PR TITLE
Fix showing long needle name in hover popup

### DIFF
--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -1,11 +1,11 @@
 .overview {
     .tooltip ul {
         text-align: left;
-        white-space: nowrap;
+        word-break: break-word;
     }
     
     .tooltip-inner {
-        /* we need smoe more space for all the needles */
+        /* we need some more space for all the needles */
         max-width: 400px;
     }
 }

--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -1,12 +1,12 @@
 .overview {
     .tooltip ul {
-	text-align: left;
-	white-space: nowrap;
+        text-align: left;
+        white-space: nowrap;
     }
     
     .tooltip-inner {
-	/* we need smoe more space for all the needles */
-	max-width: 400px;
+        /* we need smoe more space for all the needles */
+        max-width: 400px;
     }
 }
 
@@ -14,7 +14,7 @@
     table-layout: fixed;
 
     td {
-	white-space: nowrap;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
Wrapping looks much better than spilling the text over the popup border:

![spectacle k23484](https://cloud.githubusercontent.com/assets/10248953/25901103/f8a3e722-3595-11e7-951d-0362b872dfad.png)

See https://progress.opensuse.org/issues/14732