### PR TITLE
Remove duplicate "current step"

### DIFF
--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -16,7 +16,6 @@
                 <tr>
                     <th>Worker</th>
                     <th>Status</th>
-                    <th>Current step</th>
                 </tr>
             </thead>
             <tbody>
@@ -29,11 +28,6 @@
                         <td class="status">
                             % stash(workername => $workername, worker => $worker);
                             %= include 'admin/workers/worker_status'
-                        </td>
-                        <td class="currentstep">
-                            % if(defined($worker->{currentstep}) && $worker->{status} eq 'running') {
-                                %= $worker->{currentstep}
-                            % }
                         </td>
                     </tr>
                 % }


### PR DESCRIPTION
"Current step" was shown along with the test status and also in the column status. The only reason why it was shown with the status is to be shown on the worker view, but I added it as a new point.

With these changes the status field, only shows the status.