### PR TITLE
Prevent tags from getting cut by long build numbers

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -1,3 +1,4 @@
+@import "../sass/theme_variables.scss";
 $color-softfailed: #EEB560;
 $color-ok: #CDFFB9;
 $color-warning: #ff9;
@@ -64,6 +65,16 @@ $color-step-actions: #666;
     overflow: hidden;
 }
 
+.col-lg-4.text-nowrap {
+    display: flex;
+    align-items: baseline;
+}
+
+.col-lg-4.text-nowrap span {
+    font-size: $font-size-h4;
+    margin-left: 2px;
+    margin-right: 2px;
+}
 
 .build_group_children, .build-row {
     h4:before {

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -163,15 +163,15 @@ my $tag_for_0092_comment = $opensuse_group->comments->create({text => 'tag:0092:
 
 sub check_tags {
     $get = $t->get_ok('/?limit_builds=20&show_tags=1')->status_is(200);
-    my @tags = $get->tx->res->dom->find('div.children-collapsed h4 span i.tag')->map('text')->each;
+    my @tags = $get->tx->res->dom->find('div.children-collapsed span i.tag')->map('text')->each;
     is_deeply(\@tags, ['some_tag'], 'tag is shown on parent-level');
 
     $get  = $t->get_ok('/parent_group_overview/' . $test_parent->id . '?limit_builds=20&show_tags=1')->status_is(200);
-    @tags = $get->tx->res->dom->find('div.children-expanded h4 span i.tag')->map('text')->each;
+    @tags = $get->tx->res->dom->find('div.children-expanded span i.tag')->map('text')->each;
     is_deeply(\@tags, ['some_tag'], 'tag is shown on parent-level');
 
     $get  = $t->get_ok('/?limit_builds=20&only_tagged=1')->status_is(200);
-    @tags = $get->tx->res->dom->find('div.children-collapsed h4 span i.tag')->map('text')->each;
+    @tags = $get->tx->res->dom->find('div.children-collapsed span i.tag')->map('text')->each;
     is_deeply(\@tags, ['some_tag'], 'tag is shown on parent-level (only tagged)');
     @h4 = $get->tx->res->dom->find("div.children-collapsed h4 a")->map('text')->each;
     is_deeply(\@h4, ['Build0092'], 'only tagged builds on parent-level shown');

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -17,13 +17,13 @@
 
                 % my $group_build_id = $group->{id} . '-' . $build_res->{escaped_id};
                 % my $tag = $build_res->{tag};
-                % if ($tag) {
-                    <span id="tag-<%= $group_build_id %>">
-                        <i class="tag fa fa-tag" title="<%= $tag->{type}; %>"><%= $tag->{description} %></i>
-                    </span>
-                % }
-                %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $build_res, id_prefix => ''
             </h4>
+            %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $build_res, id_prefix => ''
+            % if ($tag) {
+                <span id="tag-<%= $group_build_id %>">
+                    <i class="tag fa fa-tag" title="<%= $tag->{type}; %>"><%= $tag->{description} %></i>
+                </span>
+            % }
         </div>
         <div class="col-lg-8">
             % if ($max_jobs) {


### PR DESCRIPTION
Related to https://progress.opensuse.org/issues/12942

Already fixed the issue with those long build numbers by shorten them with dots. But then the tags got cut aswell. Now the tags are always visible and just the text and timeago part gets shortend. 

![screenshot_2017-05-11_15-50-23](https://cloud.githubusercontent.com/assets/22001671/25953047/87178a00-3662-11e7-9da1-aedfcebb3ac4.png)

