### PR TITLE
Refactor Cache.pm to use SQLite instead of json

### DIFF
--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -315,7 +315,7 @@ sub asset_lookup {
     my $lock_granted;
     my $result;
 
-    $sql    = "SELECT filename, etag, last_use, size from assets where filename = ? and downloading = 0";
+    $sql    = "SELECT filename, etag, last_use, size from assets where filename = ?";
     $sth    = $dbh->prepare($sql);
     $result = $dbh->selectrow_hashref($sql, undef, $asset);
     if (!$result) {

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -26,6 +26,8 @@ use List::MoreUtils;
 use File::Spec::Functions 'catdir';
 use Data::Dumper;
 use JSON;
+use DBI;
+
 
 require Exporter;
 our (@ISA, @EXPORT);
@@ -35,173 +37,324 @@ our (@ISA, @EXPORT);
 my $cache;
 my $host;
 my $location;
-my $limit = 50;
-my $db_file;
+our $limit = 50 * 1024 * 1024 * 1024;
+my $db_file = "cache.db";
+my $dsn     = "";
+my $dbh;
+my $cache_real_size;
 
-sub get {
-    my ($asset) = @_;
-    my $index = List::MoreUtils::first_index { $_ eq $asset } @{$cache->{$host}};
-    splice @{$cache->{$host}}, $index, 1 if @{$cache->{$host}} > 0;
-    unshift @{$cache->{$host}}, $asset;
-    expire_asset();
+END {
+    $dbh->disconnect() if $dbh;
 }
 
-sub set {
-    my ($asset) = @_;
-    unshift @{$cache->{$host}}, $asset;
-    get($asset);
+sub deploy_db {
+    local $/;
+    my $sql = <DATA>;
+    log_info "Deploying DB: $sql";
+    $dbh = DBI->connect($dsn, undef, undef, {RaiseError => 1, PrintError => 1, AutoCommit => 0})
+      or die("Could not connect to the dbfile.");
+    $dbh->do($sql);
+    $dbh->commit;
+    $dbh->disconnect;
 }
 
 sub init {
-    my $class;
     ($host, $location) = @_;
     $db_file = catdir($location, 'cache.db');
-    @{$cache->{$host}} = read_db();
-    log_debug(__PACKAGE__ . ": Initialized with $host at $location");
+    $dsn = "dbi:SQLite:dbname=$db_file";
+    deploy_db unless (-e $db_file);
+    $dbh = DBI->connect($dsn, undef, undef, {RaiseError => 1, PrintError => 1, AutoCommit => 1})
+      or die("Could not connect to the dbfile.");
+    $cache_real_size = 0;
+    cache_cleanup();
+    #Ideally we only need $limit, and $need no extra space
+    check_limits(0);
+    log_info(__PACKAGE__ . ": Initialized with $host at $location, current size is $cache_real_size");
 }
 
 sub download_asset {
-    my ($id, $type, $asset) = @_;
+    my ($id, $type, $asset, $etag) = @_;
 
     open(my $log, '>>', "autoinst-log.txt") or die("Cannot open autoinst-log.txt");
     local $| = 1;
-    print $log "CACHE: Locking $asset\n";
-
-    print $log "Attemping to download: $host $asset, $type, $id\n";
     my $ua = Mojo::UserAgent->new(max_redirects => 2);
     $ua->max_response_size(0);
-    my $tx = $ua->build_tx(GET => sprintf '%s/tests/%d/asset/%s/%s', $host, $id, $type, basename($asset));
+    my $url = sprintf '%s/tests/%d/asset/%s/%s', $host, $id, $type, basename($asset);
+    print $log "Downloading " . basename($asset) . " from $url\n";
+    my $tx = $ua->build_tx(GET => $url);
+    my $headers;
 
     $ua->on(
         start => sub {
             my ($ua, $tx) = @_;
             my $progress     = 0;
             my $last_updated = time;
+            $tx->req->headers->header('If-None-Match' => qq{$etag}) if $etag;
             $tx->res->on(
                 progress => sub {
                     my $msg = shift;
+                    $msg->finish if $msg->code == 304;
                     return unless my $len = $msg->headers->content_length;
+
                     my $size = $msg->content->progress;
+                    $headers = $msg->headers if !$headers;
                     my $current = int($size / ($len / 100));
-                    local $| = 1;
                     # Don't spam the webui, update only every 5 seconds
                     if (time - $last_updated > 5) {
                         update_setup_status;
+                        toggle_asset_lock($asset, 1);
                         $last_updated = time;
                         if ($progress < $current) {
                             $progress = $current;
-                            print $log "Downloading $asset :", $size == $len ? 100 : $progress, "\n";
+                            print $log "CACHE: Downloading $asset :", $size == $len ? 100 : $progress . "\n";
                         }
                     }
                 });
         });
 
     $tx = $ua->start($tx);
-    if (!$tx->res->is_success) {
-        printf $log "CACHE: download of %s failed with %d: %s\n", basename($asset), $tx->res->code, $tx->res->message;
-        return undef;
+
+    if ($tx->res->code == 304) {
+        if (toggle_asset_lock($asset, 0)) {
+            print $log "CACHE: Content has not changed, not downloading the $asset but updating last use\n";
+        }
+        else {
+            print $log "CACHE: Abnormal situation, bailing out\n";
+            $asset = undef;
+        }
+    }
+    elsif ($tx->res->is_success) {
+        $etag = $headers->etag;
+        unlink($asset);
+        $asset = $tx->res->content->asset->move_to($asset)->path;
+        my $size = (stat $asset)[7];
+        if ($size == $headers->content_length) {
+            check_limits($size);
+            update_asset($asset, $etag, $size);
+            print $log "CACHE: Asset download sucessful to $asset, Cache size is: $cache_real_size\n";
+        }
+        else {
+            print $log "CACHE: Size of $asset differs, Expected: "
+              . $headers->content_length
+              . " / Downloaded: "
+              . $size . "\n";
+            $asset = undef;
+        }
     }
     else {
-        print $log "CACHE: " . basename($asset) . " download sucessful\n";
-        $asset = $tx->res->content->asset->move_to($asset);
+        print $log "CACHE: Download of $asset failed with: " . $tx->res->error->{message} . "\n";
+        purge_asset($asset);
+        $asset = undef;
     }
-    close($log);
+
     return $asset;
 }
 
 sub get_asset {
     my ($job, $asset_type, $asset) = @_;
     my $type;
-
-    $asset = catdir($location, $asset);
+    my $result;
+    my $ret;
+    $asset = catdir($location, basename($asset));
 
     while () {
-        read_db();
-        log_debug "CACHE: Aquiring lock";
-        open(my $asset_fd, ">", $asset . ".lock");
 
-        if (!flock($asset_fd, LOCK_EX | LOCK_NB)) {
+        log_debug "CACHE: Aquiring lock for $asset in the database";
+        $result = try_lock_asset($asset);
+        if (!$result) {
             update_setup_status;
-            log_debug("CACHE: Asked to wait for lock, sleeping 10 secs");
-            sleep 10;
+            log_debug "CACHE: waiting 5 seconds for the lock.";
+            sleep 5;
             next;
         }
+        $ret = download_asset($job->{id}, lc($asset_type), $asset, ($result->{etag}) ? $result->{etag} : undef);
 
-        if (-s $asset) {
-            $type = "Cache Hit";
-            get($asset);
-        }
-        else {
-            $type = "Cache Miss";
-            my $ret = download_asset($job->{id}, lc($asset_type), $asset);
-            if (!$ret) {
-                unlink($asset . ".lock");
-                return undef;
-            }
-            set($asset);
+        if (!$ret) {
+            return undef;
         }
 
-        write_db();
-        close($asset_fd);
         last;
     }
 
-    unlink($asset . ".lock") or log_debug("Lock file for " . basename($asset) . " is not present");
-    log_debug "$type for: " . basename($asset);
     return $asset;
 }
 
-sub expire_asset {
-    # currently only
-    while (@{$cache->{$host}} > $limit) {
-        my $count = @{$cache->{$host}};
-        my $asset = pop(@{$cache->{$host}});
-        if (-e $asset) {
-            unlink($asset);
-            if ($@) {
-                log_error("Cannot purge $asset: $@");
-            }
-            else {
-                log_debug("Purged $asset due to assets in cache ($count) being over $limit");
-            }
-        }
-        else {
-            log_debug("$asset does not exist, reference has been removed from the cache");
-        }
-    }
-    write_db();
-}
+sub toggle_asset_lock {
+    my ($asset, $toggle) = @_;
+    my $sql = "UPDATE assets set downloading = ?, filename = ?, last_use = strftime('%s','now') where filename = ?";
 
-sub write_db {
-    open(my $fh, ">", $db_file);
-    flock($fh, LOCK_EX);
-    truncate($fh, 0) or die "cannot truncate $db_file: $!\n";
-    my $json = JSON->new->pretty->canonical;
-    print $fh $json->encode($cache);
-    close($fh);
-    log_debug("Saving cache db file");
-    read_db();
-}
+    eval { $dbh->prepare($sql)->execute($toggle, $asset, $asset) or die $dbh->errstr; };
 
-sub read_db {
-
-    local $/;    # use slurp mode to read the whole file at once.
-    $cache = {};
-    if (-e $db_file) {
-        open(my $fh, "<", $db_file) or die "$db_file could not be created";
-        flock($fh, LOCK_EX);
-        eval { $cache = JSON->new->relaxed->decode(<$fh>) };
-
-        log_debug "parse error in $db_file:\n$@" if $@;
-        log_debug("Objects in the cache: ");
-        log_debug(Dumper($cache));
-        close($fh);
-        log_debug("Read cache db file");
+    if ($@) {
+        $dbh->rollback;
+        die "Rolling back $@";
     }
     else {
-        log_debug "Creating empty cache";
-        write_db;
+        return 1;
     }
+
+}
+
+sub try_lock_asset {
+    my ($asset) = @_;
+    my $sth;
+    my $sql;
+    my $lock_granted;
+    my $result;
+
+    eval {
+        $sql
+          = "SELECT (last_use > strftime('%s','now') - 60 and downloading = 1) as is_fresh, etag from assets where filename = ?";
+        $sth = $dbh->prepare($sql);
+        $result = $dbh->selectrow_hashref($sql, undef, $asset);
+        if (!$result) {
+            add_asset($asset);
+            $lock_granted = 1;
+            $result       = {};
+        }
+        elsif (!$result->{is_fresh}) {
+            $lock_granted = toggle_asset_lock($asset, 1);
+        }
+        elsif ($result->{is_fresh} == 1) {
+            log_info "CACHE: Being downloaded by another worker, sleeping.";
+            $lock_granted = 0;
+        }
+        else {
+            die "CACHE: Abnormal situation.";
+        }
+    };
+
+    if ($@) {
+        $dbh->rollback;
+        die "Rolling back $@";
+    }
+    else {
+        if ($lock_granted) {
+            return $result;
+        }
+        else {
+            return 0;
+        }
+    }
+
+}
+
+sub add_asset {
+    my ($asset, $toggle) = @_;
+    my $sql = "INSERT INTO assets (downloading,filename,last_use) VALUES (1, ?, strftime('%s','now'));";
+    eval { $dbh->prepare($sql)->execute($asset) or die $dbh->errstr; };
+
+    if ($@) {
+        $dbh->rollback;
+        die "Rolling back $@";
+    }
+    else {
+        return 1;
+    }
+
+}
+
+sub update_asset {
+    my ($asset, $etag, $size) = @_;
+    my $sql
+      = "UPDATE assets set downloading = 0, filename =?, etag =? , size = ?, last_use = strftime('%s','now') where filename = ?;";
+    eval {
+        my $sth = $dbh->prepare($sql);
+        $sth->bind_param(1, $asset);
+        $sth->bind_param(2, $etag);
+        $sth->bind_param(3, $size);
+        $sth->bind_param(4, $asset);
+
+        $sth->execute;
+    };
+
+    $cache_real_size += $size;
+
+    if ($@) {
+        $dbh->rollback;
+        die "Rolling back $@";
+    }
+    else {
+        log_info "CACHE: updating the $asset with $etag and $size";
+        return 1;
+    }
+
+}
+
+sub purge_asset {
+    my ($asset) = @_;
+    my $sql = "DELETE FROM assets WHERE filename = ?";
+
+    eval {
+        $dbh->prepare($sql)->execute($asset) or die $dbh->errstr;
+        unlink($asset) or eval { log_error "CACHE: Could not remove $asset" if -e $asset };
+        log_debug "CACHE: removed $asset";
+    };
+
+    if ($@) {
+        $dbh->rollback;
+        die "Rolling back $@";
+    }
+    return 1;
+}
+
+sub cache_cleanup {
+    my @assets = `find $location -maxdepth 1 -type f -name '*.img' -o -name '*.qcow2' -o -name '*.iso'`;
+    foreach my $file (@assets) {
+        my $asset_size;
+        chomp $file;
+        $asset_size = (stat $file)[7];
+        $cache_real_size += $asset_size if asset_lookup($file);
+    }
+}
+
+sub asset_lookup {
+    my ($asset) = @_;
+    my $sth;
+    my $sql;
+    my $lock_granted;
+    my $result;
+
+    $sql    = "SELECT filename, etag, last_use, size from assets where filename = ? and downloading = 0";
+    $sth    = $dbh->prepare($sql);
+    $result = $dbh->selectrow_hashref($sql, undef, $asset);
+    if (!$result) {
+        log_info "CACHE: Purging non registered $asset";
+        purge_asset($asset);
+        return 0;
+    }
+    else {
+        return $result;
+    }
+
+}
+
+sub check_limits {
+    # Trust the filesystem.
+    my ($needed) = @_;
+    my $sql;
+    my $sth;
+    my $result;
+
+    my $wanted_size = $cache_real_size + $needed;
+
+    while ($cache_real_size + $needed > $limit) {
+        $sql    = "SELECT size, filename FROM assets WHERE downloading = 0 ORDER BY last_use asc";
+        $sth    = $dbh->prepare($sql);
+        $result = $dbh->selectrow_hashref($sql);
+
+        foreach my $asset ($result) {
+            if (purge_asset($asset->{filename})) {
+                $cache_real_size -= $asset->{size};
+                log_debug "Reclaiming " . $asset->{size} . " from $cache_real_size to make space for $limit";
+            }    # purge asset will die anyway in case of failure.
+            last if ($cache_real_size < $limit);
+        }
+    }
+    log_debug "CACHE: Health: Real size: $cache_real_size, Configured limit: $limit";
 }
 
 1;
+
+__DATA__
+CREATE TABLE "assets" ( `etag` TEXT, `size` INTEGER, `last_use` DATETIME NOT NULL, `downloading` boolean NOT NULL, `filename` TEXT NOT NULL UNIQUE, PRIMARY KEY(`filename`) );


### PR DESCRIPTION
This changes in the Cache.pm attempt to solve the race condition where
more than two workers downloading one file, could try to remove the
same lockfile.

This refactor attempts to solve the situation, by using sqlite, since
it is able to handle on it's own database locking and atomic
transactions (With AutoCommit), so once a DDL is issued, sqlite handles
automatically the persistance of those bits.

In case the cache.db file is not present, it will be deployed from
scratch.

Since we are saving now size and etag, we can now easily know if an
asset has been changed, by sending the etag during the first request
and bailing out if there are no changes.

The limiting of assets is done in two stages: at the init of the cache
and after the download of an asset (304 for now are ignored).

Once this is deployed, the cache.db file present in the cache directory
needs to be removed as they are not compatible.