### PR TITLE
Unlink existing asset symlinks on syncing

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -73,6 +73,7 @@ sub cache_assets {
         log_debug("Found $this_asset, caching " . $vars->{$this_asset});
         my $asset = get_asset($job, $assetkeys->{$this_asset}, $vars->{$this_asset});
         return {error => "Can't download $vars->{$this_asset}"} unless $asset;
+        unlink basename($asset) if -l basename($asset);
         symlink($asset, basename($asset)) or die "cannot create link: $asset, $pooldir";
         $vars->{$this_asset} = catdir(getcwd, basename($asset));
     }


### PR DESCRIPTION
Prevents the syncing to abort e.g. for workers running with '--no-cleanup'.