### PR TITLE
Replace file_content() with Mojo::File

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -38,7 +38,6 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &productdir
   &testcasedir
   &is_in_tests
-  &file_content
   &log_debug
   &log_warning
   &log_info
@@ -200,19 +199,6 @@ sub needle_info {
     $needle->{distri}    = $distri;
     $needle->{version}   = $version;
     return $needle;
-}
-
-sub file_content($;$) {
-    my ($fn, $enc) = @_;
-    my $mode = "<";
-    if ($enc) {
-        $mode = "$mode:encoding($enc)";
-    }
-    open(my $FCONTENT, $mode, $fn) or return;
-    local $/;
-    my $result = <$FCONTENT>;
-    close($FCONTENT);
-    return $result;
 }
 
 # logging helpers

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use Mojo::Base 'Mojolicious::Controller';
 use Mojo::Util 'b64_encode';
+use Mojo::File 'path';
 use JSON qw(encode_json decode_json);
 use OpenQA::Utils;
 use OpenQA::IPC;
@@ -217,13 +218,13 @@ sub streaming {
             my $newfile = readlink("$basepath/last.png") || '';
             if ($lastfile ne $newfile) {
                 if (!-l $newfile || !$lastfile) {
-                    my $data = file_content("$basepath/$newfile");
+                    my $data = path($basepath, $newfile)->slurp;
                     $self->write("data: data:image/png;base64," . b64_encode($data, '') . "\n\n");
                     $lastfile = $newfile;
                 }
                 elsif (!-e $basepath . 'backend.run') {
                     # Some browsers can't handle mpng (at least after reciving jpeg all the time)
-                    my $data = file_content($self->app->static->file('images/suse-tested.png')->path);
+                    my $data = $self->app->static->file('images/suse-tested.png')->slurp;
                     $self->write("data: data:image/png;base64," . b64_encode($data, '') . "\n\n");
                     $doclose->();
                 }

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::Step;
 use Mojo::Base 'Mojolicious::Controller';
+use Mojo::File 'path';
 use OpenQA::Utils;
 use File::Basename;
 use File::Copy;
@@ -64,7 +65,12 @@ sub check_tabmode {
             $tabmode = 'audio';
         }
         elsif ($module_detail->{text}) {
-            $self->stash('textresult', file_content(join('/', $job->result_dir(), $module_detail->{text}), "UTF-8"));
+            my $file = path($job->result_dir(), $module_detail->{text})->open('<:encoding(UTF-8)');
+            my @file_content;
+            if (defined $file) {
+                @file_content = <$file>;
+            }
+            $self->stash('textresult', "@file_content");
             $tabmode = 'text';
         }
         $self->stash('module_detail', $module_detail);
@@ -369,8 +375,12 @@ sub src {
         $scriptpath ||= "";
         return $self->reply->not_found;
     }
-
-    my $script = file_content($scriptpath, "UTF-8");
+    my $script_h = path($scriptpath)->open('<:encoding(UTF-8)');
+    my @script_content;
+    if (defined $script_h) {
+        @script_content = <$script_h>;
+    }
+    my $script = "@script_content";
 
     $self->stash('script',     $script);
     $self->stash('scriptpath', $scriptpath);

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -31,6 +31,7 @@ use Fcntl;
 use MIME::Base64;
 use File::Basename 'basename';
 use File::Which 'which';
+use Mojo::File 'path';
 
 use POSIX ':sys_wait_h';
 
@@ -504,15 +505,15 @@ my $lastscreenshot = '';
 # reads the base64 encoded content of a file below pooldir
 sub read_base64_file($) {
     my ($file) = @_;
-    my $c = OpenQA::Utils::file_content("$pooldir/$file");
+    my $c = path($pooldir, $file)->slurp;
     return encode_base64($c);
 }
 
 # reads the content of a file below pooldir and returns its md5
 sub calculate_file_md5($) {
     my ($file) = @_;
-    my $c      = OpenQA::Utils::file_content("$pooldir/$file");
-    my $md5    = Digest::MD5->new;
+    my $c = path($pooldir, $file)->slurp;
+    my $md5 = Digest::MD5->new;
     $md5->add($c);
     return $md5->clone->hexdigest;
 }

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -29,6 +29,7 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
+use Mojo::File 'path';
 use Digest::MD5;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
@@ -40,7 +41,7 @@ my $sh = OpenQA::Scheduler->new;
 
 sub calculate_file_md5($) {
     my ($file) = @_;
-    my $c      = OpenQA::Utils::file_content($file);
+    my $c      = path($file)->slurp;
     my $md5    = Digest::MD5->new;
     $md5->add($c);
     return $md5->hexdigest;

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -14,6 +14,7 @@ use Cwd qw( abs_path getcwd );
 use OpenQA::Schema;
 use OpenQA::Utils;
 use Mojo::Base -base;
+use Mojo::File 'path';
 has fixture_path => 't/fixtures';
 
 sub create {
@@ -42,7 +43,7 @@ sub insert_fixtures {
 
     foreach my $fixture (glob "*.pl") {
 
-        my $info = eval file_content $fixture;    ## no critic
+        my $info = eval path($fixture)->slurp;    ## no critic
         chdir $cwd, croak "Could not insert fixture $fixture: $@" if $@;
 
         # Arrayrefs of rows, (dbic syntax) table defined by fixture filename


### PR DESCRIPTION
As discussed in https://github.com/os-autoinst/openQA/pull/1316 OpenQA::Utils contains `file_content()` , that can be replaced with Mojo::File pretty straightforward.
Aside from that, `file_content()` it's not tested while Mojo::File is.