### PR TITLE
Fix print() on closed filehandle $log

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -253,7 +253,6 @@ sub upload {
         }
         open(my $log, '>>', "autoinst-log.txt");
         print $log "Checksum comparison (actual:expected) $csum1:$csum2 with size (actual:expected) $size1:$size2\n";
-        close $log;
         if ($csum1 eq $csum2 && $size1 eq $size2) {
             my $ua_url = $hosts->{$current_host}{url}->clone;
             $ua_url->path("jobs/$job_id/ack_temporary");


### PR DESCRIPTION
I sometimes see something like this when asset upload of ISO image with
svirt backend fails:
```
[DEBUG] uploading my.iso
[WARN] Upload attempts remaining: 5/5 for my.iso, in 5 seconds
.....
print() on closed filehandle $log at /usr/share/openqa/script/../lib/OpenQA/Worker/Jobs.pm line 263.
```