### PR TITLE
Inspect failed modules in /tests/overview

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -60,6 +60,9 @@ function setupOverview() {
         } else if (key === 'arch') {
             $('#filter-arch').prop('value', val);
             return val;
+        } else if (key === 'failed_modules') {
+            $('#filter-failed_modules').prop('value', val);
+            return val;
         }
     });
 
@@ -73,4 +76,3 @@ function setupOverview() {
         });
     }
 }
-

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -194,7 +194,7 @@ sub complex_query {
 
     # For args where we accept a list of values, allow passing either an
     # array ref or a comma-separated list
-    for my $arg (qw(state ids result)) {
+    for my $arg (qw(state ids result failed_modules)) {
         next unless $args{$arg};
         $args{$arg} = [split(',', $args{$arg})] unless (ref($args{$arg}) eq 'ARRAY');
     }
@@ -207,6 +207,16 @@ sub complex_query {
         push @{$attrs{prefetch}}, 'settings';
         push @{$attrs{prefetch}}, 'parents';
         push @{$attrs{prefetch}}, 'children';
+    }
+
+    if ($args{failed_modules}) {
+        push @joins, "modules";
+        push(
+            @conds,
+            {
+                'modules.name'   => {-in => $args{failed_modules}},
+                'modules.result' => OpenQA::Schema::Result::Jobs::FAILED,
+            });
     }
 
     if ($args{state}) {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -399,6 +399,11 @@ sub prepare_job_results {
         my $arch   = $job->ARCH || 'noarch';
 
         my $result;
+
+        next
+          if $self->param("failed_modules")
+          && $job->result ne OpenQA::Schema::Result::Jobs::FAILED;
+
         if ($job->state eq OpenQA::Schema::Result::Jobs::DONE) {
             my $result_stats = $all_result_stats->{$jobid};
             my $overall      = $job->result;
@@ -412,6 +417,7 @@ sub prepare_job_results {
                   || ($job->result eq OpenQA::Schema::Result::Jobs::SOFTFAILED
                     && ($job_labels->{$jobid}{label} || !$job->has_failed_modules));
             }
+
 
             $result = {
                 passed   => $result_stats->{passed},
@@ -497,6 +503,10 @@ sub overview {
         my @group_name_search = map { {name => $_} } @{$self->every_param('group')};
         my @search_terms = (@group_id_search, @group_name_search);
         @groups = $self->db->resultset("JobGroups")->search(\@search_terms)->all;
+    }
+
+    if ($self->param('failed_modules')) {
+        $search_args{failed_modules} = $self->every_param('failed_modules');
     }
 
     if (!$search_args{build}) {

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -225,4 +225,69 @@ $t->get_ok('/tests/99937/modules/kate/fails')->json_is('/failed_needles' => ["te
 $t->get_ok('/tests/99937/modules/zypper_up/fails')
   ->json_is('/first_failed_step' => 1, 'failed module: fallback to first step');
 
+# Check if logpackages has failed, filtering with failed_modules
+$form = {distri => 'opensuse', version => 'Factory', failed_modules => 'logpackages'};
+$get = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+like(get_summary, qr/Passed: 0 Failed: 1/i);
+$get->element_exists('#res_DVD_x86_64_doc .result_failed');
+$get->element_exists_not('#res_DVD_x86_64_kde .result_passed');
+
+# Check if another random module haz failed
+$failing_module = $t->app->db->resultset('JobModules')->create(
+    {
+        script   => 'tests/x11/failing_module.pm',
+        job_id   => 99940,
+        category => 'x11',
+        name     => 'failing_module',
+        result   => 'failed'
+    });
+$get = $t->get_ok(
+    '/tests/overview' => form => {
+        distri         => 'opensuse',
+        version        => 'Factory',
+        failed_modules => 'failing_module'
+    })->status_is(200);
+
+like(get_summary, qr/Passed: 0 Failed: 1/i, 'failed_modules shows failed jobs');
+$get->element_exists('#res-99940',                         'foo_bar_failed_module failed');
+$get->element_exists('#res_DVD_x86_64_doc .result_failed', 'foo_bar_failed_module module failed');
+
+# Check if another random module haz failed
+$t->app->db->resultset('JobModules')->create(
+    {
+        script   => 'tests/x11/failing_module.pm',
+        job_id   => 99938,
+        category => 'x11',
+        name     => 'failing_module',
+        result   => 'failed'
+    });
+$get = $t->get_ok(
+    '/tests/overview' => form => {
+        distri         => 'opensuse',
+        version        => 'Factory',
+        failed_modules => 'failing_module,logpackages',
+    })->status_is(200);
+like(get_summary, qr/Passed: 0 Failed: 2/i, 'expected job failures matches');
+$failedmodules
+  = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#res_DVD_x86_64_doc .failedmodule a')->all_text);
+like($failedmodules, qr/failing_module/i, 'failing_module module failed');
+
+# Check if failed_modules hides successful jobs even if a (fake) module failure is there
+$failing_module = $t->app->db->resultset('JobModules')->create(
+    {
+        script   => 'tests/x11/failing_module.pm',
+        job_id   => 99946,
+        category => 'x11',
+        name     => 'failing_module',
+        result   => 'failed'
+    });
+$get = $t->get_ok(
+    '/tests/overview' => form => {
+        distri         => 'opensuse',
+        version        => '13.1',
+        failed_modules => 'failing_module',
+    })->status_is(200);
+like(get_summary, qr/Passed: 0 Failed: 0/i, 'Job was successful, so failed_modules does not show it');
+$get->element_exists_not('#res-99946', 'no module has failed');
+
 done_testing();

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -54,7 +54,7 @@ is(scalar @filtered_out, 0, 'result filter correctly applied');
 
 # Test whether all URL parameter are passed correctly
 my $url_with_escaped_parameters
-  = $baseurl . 'tests/overview?arch=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001';
+  = $baseurl . 'tests/overview?arch=&failed_modules=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001';
 $driver->get($url_with_escaped_parameters);
 $driver->find_element('#filter-panel .panel-heading')->click();
 $driver->find_element('#filter-form button')->click();

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -89,6 +89,12 @@
                     <input type="text" class="form-control" name="arch" placeholder="any" id="filter-arch">
                 </div>
                 <div class="form-group">
+                    <strong>Failed modules</strong>
+                    <input name="failed_modules" type="text" id="filter-failed_modules" placeholder="failed modules, comma separated, e.g. mod1,mod2">
+                    <%= help_popover('Help for the <em>Failed Modules</em> filter' => '
+                        <p>Shows only the jobs that failed in the specified modules</p>') %>
+                </div>
+                <div class="form-group">
                     <strong>Misc</strong>
                     <label><input value="1" name="todo" type="checkbox" id="filter-todo"> TODO</label>
                     <%= help_popover('Help for the <em>TODO</em>-filter' => '


### PR DESCRIPTION
Add query parameter 'failed_modules' on /tests/overview yielding only jobs where the supplied modules have failures (including soft failures)
![failed_modules](https://cloud.githubusercontent.com/assets/2420543/26307726/518c298a-3ef6-11e7-8f67-536c2ff5fc68.png)
The parameter can be set in the UI, or directly from the url:
`/tests/overview?distri=sle&version=12-SP2&build=1629&groupid=25&arch=aarch64&result=failed&failed_modules=install_and_reboot,shutdown`
(in the image there was only a failure with shutdown and not with install_and_reboot)

Not sure if soft-failures should be listed as well, so in this implementation are showed.
@okurz can you also shed some light on AC3? (not very sure what's the suggested behavior) aside from that i think i've covered the other ACs

Would be also maybe a good idea to be able to filter also with different states per-module?
Progress related issue: [Poo#12448](https://progress.opensuse.org/issues/12448)