### PR TITLE
 Implement a config option to restart workers that grew too big

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 requires 'Archive::Extract';
+requires 'BSD::Resource';
 requires 'CSS::Minifier::XS', '>= 0.01';
 requires 'Carp';
 requires 'Clone';

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -47,6 +47,9 @@
 # this domain, this job is labeled as linked and considered as important
 # recognized_referers = bugzilla.suse.com bugzilla.opensuse.org bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com
 
+## Gracefully restart the prefork workers if they reach a certain memory limit (in kB)
+#max_rss_limit = 180000
+
 #[scm git]
 #do_push = no
 

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -10,8 +10,7 @@ Requires=openqa-scheduler.service openqa-websockets.service
 User=geekotest
 Environment="DBUS_STARTER_BUS_TYPE=system"
 # Our API commands are very expensive, so the default timeouts are too tight
-# for the meaning of -a -G and -r, check https://progress.opensuse.org/issues/13876
-ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 10 -a 100 -G 1000 -r 20
+ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 20
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Actual code is from @kraih for cavil - I adopted it only to openQA.