### PR TITLE
Avoid unit test to write on source code directory

### DIFF
--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -36,6 +36,7 @@ use Test::MockModule;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;
+use Mojo::File qw(tempdir path);
 
 my $args;
 
@@ -52,11 +53,9 @@ $module->mock('run', \&mock_ipc_run);
 my $schema = OpenQA::Test::Database->new->create();
 
 # this test also serves to test plugin loading via config file
-$ENV{OPENQA_CONFIG} = 't';
-open(my $fd, '>', $ENV{OPENQA_CONFIG} . '/openqa.ini');
-print $fd "[global]\n";
-print $fd "plugins=Fedmsg\n";
-close $fd;
+my @conf = ("[global]\n", "plugins=Fedmsg\n");
+$ENV{OPENQA_CONFIG} = tempdir;
+path($ENV{OPENQA_CONFIG})->make_path->child("openqa.ini")->spurt(@conf);
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -36,6 +36,7 @@ use Test::MockObject;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;
+use Mojo::File qw(tempdir path);
 
 my %client_context;
 
@@ -115,11 +116,9 @@ $channel_mock->fake_module(
 my $schema = OpenQA::Test::Database->new->create();
 
 # this test also serves to test plugin loading via config file
-$ENV{OPENQA_CONFIG} = 't';
-open(my $fd, '>', $ENV{OPENQA_CONFIG} . '/openqa.ini');
-print $fd "[global]\n";
-print $fd "plugins=AMQP\n";
-close $fd;
+my @conf = ("[global]\n", "plugins=AMQP\n");
+$ENV{OPENQA_CONFIG} = tempdir;
+path($ENV{OPENQA_CONFIG})->make_path->child("openqa.ini")->spurt(@conf);
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -29,6 +29,7 @@ use Test::Mojo;
 use Test::Warnings;
 use Test::Output qw(stdout_like stderr_like);
 use Test::Fatal;
+use Mojo::File qw(tempdir path);
 #use Scalar::Utils 'refaddr';
 
 use OpenQA::Worker::Common;
@@ -112,8 +113,12 @@ test_via_io_loop sub {
     Mojo::IOLoop->stop;
 };
 
-$ENV{OPENQA_CONFIG} = 't';
-open(my $fh, '>>', $ENV{OPENQA_CONFIG} . '/client.conf') or die 'can not open client.conf for appending';
+my @conf = ("[global]\n", "plugins=AMQP\n");
+$ENV{OPENQA_CONFIG} = tempdir;
+path($FindBin::Bin, "data")->child("client.conf")->copy_to(path($ENV{OPENQA_CONFIG})->make_path->child("client.conf"));
+ok -e path($ENV{OPENQA_CONFIG})->child('client.conf')->to_string;
+open(my $fh, '>>', path($ENV{OPENQA_CONFIG})->child('client.conf')->to_string)
+  or die 'can not open client.conf for appending';
 print $fh "[host1]\nkey=1234\nsecret=1234\n";
 print $fh "[host2]\nkey=1234\nsecret=1234\n";
 print $fh "[host3]\nkey=1234\nsecret=1234\n";

--- a/t/basic.t
+++ b/t/basic.t
@@ -22,6 +22,7 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Database;
+use Mojo::File qw(tempdir path);
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
@@ -31,16 +32,13 @@ $t->get_ok('/')->status_is(200)->content_like(qr/Welcome to openQA/i);
 sub test_auth_method_startup {
     my $auth = shift;
 
-    $ENV{OPENQA_CONFIG} = 't';
-    open(my $fd, '>', $ENV{OPENQA_CONFIG} . '/openqa.ini');
-    print $fd "[auth]\n";
-    print $fd "method = \t  $auth \t\n";
-    close $fd;
+    my @conf = ("[auth]\n", "method = \t  $auth \t\n");
+    $ENV{OPENQA_CONFIG} = tempdir;
+    path($ENV{OPENQA_CONFIG})->make_path->child("openqa.ini")->spurt(@conf);
 
     no warnings 'redefine';
     my $t = Test::Mojo->new('OpenQA::WebAPI');
     ok($t->app->config->{auth}->{method} eq $auth, "started successfully with auth $auth");
-    unlink($ENV{OPENQA_CONFIG} . '/openqa.ini');
 }
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);


### PR DESCRIPTION
Utilize Mojo::File to create specific sandboxes folders to avoid polluting source code directory with data needed for unit testing generated by local tests.

Related Progress issue: [Poo#15138](https://progress.opensuse.org/issues/15138)