### PR TITLE
Add tests to scheduler to cover OpenQA::Scheduler::FakeApp

### DIFF
--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -424,4 +424,15 @@ is_deeply(
 my $asset = $schema->resultset('Assets')->register('iso', $settings{ISO});
 is($asset->name, $settings{ISO}, "asset register returns same");
 
+subtest 'OpenQA::Scheduler::FakeApp object test' => sub {
+    use OpenQA::Scheduler::FakeApp;
+    use OpenQA::ServerStartup;
+    my $fakeapp = OpenQA::Scheduler::FakeApp->new;
+    OpenQA::ServerStartup::read_config($fakeapp);
+    OpenQA::ServerStartup::setup_logging($fakeapp);
+    isa_ok($fakeapp->home,   'Mojo::Home');
+    isa_ok($fakeapp->schema, 'OpenQA::Schema');
+    isa_ok($fakeapp->log,    'Mojo::Log');
+};
+
 done_testing;


### PR DESCRIPTION
ensure with tests that OpenQA::Scheduler::FakeApp is strictly mimicking a Mojolicious application (was about to add them in the other PR, sorry for the noise ). 

Also if this test is not full, it's a start to avoid future breakages