### PR TITLE
[WIP] Sort parent group overview also by date

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -1,3 +1,5 @@
+var ajax_set_cookie_url;
+var session_parentoverview_order;
 function setupOverview() {
     setupAsyncFailedResult();
     $('.cancel')
@@ -75,4 +77,37 @@ function setupOverview() {
             element.checked = states[element.id.substr(7)];
         });
     }
+}
+
+function toggleParentOverviewOrdering(current) {
+    var cookie_data;
+    if(current === 't_created'){
+      cookie_data = { key: "favorite_parent_group_ordering" };
+    } else {
+      cookie_data = { key: "favorite_parent_group_ordering", value: "t_created" };
+    }
+    if(cookie_data != null){
+      $.ajax({
+          url: ajax_set_cookie_url,
+          data: cookie_data,
+          method: 'GET',
+          success: function(response) {
+              if(response.favorite_parent_group_ordering === "t_created") {
+                session_parentoverview_order = "t_created";
+                //addFlash("info", "Now parent group overview will be ordered by date");
+                location.reload();
+              } else if(response.favorite_parent_group_ordering == null) {
+                session_parentoverview_order = null;
+                //addFlash("info", "Now parent group overview will be ordered by default");
+                location.reload();
+              }
+              //} else {
+              //  addFlash("error", "An error occurred when setting up cookies. You should not see me. ");
+              //}
+          },
+          error: function(xhr, ajaxOptions, thrownError) {
+              showError(thrownError + ' (requesting entry HTML, group probably added though! - reload page to find out)');
+          }
+      });
+  }
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -167,6 +167,7 @@ sub startup {
     $r->delete('/logout')->name('logout')->to('session#destroy');
     $r->get('/response')->to('session#response');
     $auth->get('/session/test')->to('session#test');
+    $logged_in->get('/session/set_cookie')->to('session#set_cookie')->name("set_cookie");
 
     my $apik_auth = $auth->route('/api_keys');
     $apik_auth->get('/')->name('api_keys')->to('api_key#index');

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -85,6 +85,8 @@ sub group_overview {
     $limit_builds = 10 unless looks_like_number($limit_builds);
     my $time_limit_days = $self->param('time_limit_days');
     $time_limit_days = 0 unless looks_like_number($time_limit_days);
+    my $order_by = $self->param('order_by');
+    $order_by = undef unless $order_by and $order_by eq 't_created';  # strict checking but open to other ordering types
 
     $self->app->log->debug("Retrieving results for up to $limit_builds builds up to $time_limit_days days old");
     my $only_tagged = $self->param('only_tagged') // 0;
@@ -108,7 +110,7 @@ sub group_overview {
     $tags = $group->tags;
 
     my $cbr = OpenQA::BuildResults::compute_build_results($group, $limit_builds, $time_limit_days,
-        $only_tagged ? $tags : undef);
+        $only_tagged ? $tags : undef, $order_by);
     my $build_results = $cbr->{build_results};
     my $max_jobs      = $cbr->{max_jobs};
     $self->stash(children => $cbr->{children});

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -86,6 +86,7 @@ sub group_overview {
     my $time_limit_days = $self->param('time_limit_days');
     $time_limit_days = 0 unless looks_like_number($time_limit_days);
     my $order_by = $self->param('order_by');
+
     if (   exists $self->session->{user}
         && exists $self->session->{favorite_parent_group_ordering}
         && $resultset eq 'JobGroupParents')

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -86,6 +86,12 @@ sub group_overview {
     my $time_limit_days = $self->param('time_limit_days');
     $time_limit_days = 0 unless looks_like_number($time_limit_days);
     my $order_by = $self->param('order_by');
+    if (   exists $self->session->{user}
+        && exists $self->session->{favorite_parent_group_ordering}
+        && $resultset eq 'JobGroupParents')
+    {
+        $order_by = $self->session->{favorite_parent_group_ordering};
+    }
     $order_by = undef unless $order_by and $order_by eq 't_created';  # strict checking but open to other ordering types
 
     $self->app->log->debug("Retrieving results for up to $limit_builds builds up to $time_limit_days days old");

--- a/lib/OpenQA/WebAPI/Controller/Session.pm
+++ b/lib/OpenQA/WebAPI/Controller/Session.pm
@@ -133,6 +133,22 @@ sub response {
     return $self->render(text => 'Forbidden', status => 403);
 }
 
+sub set_cookie {
+    my ($self) = @_;
+    my $key    = $self->param('key');
+    my $value  = $self->param('value');
+    return $self->render(text => 'Forbidden', status => 403) if !$key;
+
+    if ($value) {
+        $self->session->{$key} = $value;
+        return $self->render(json => {$key => $value});
+    }
+    else {
+        delete $self->session->{$key};
+        return $self->render(json => {$key => undef});
+    }
+}
+
 sub test {
     my $self = shift;
     $self->render(text => "You can see this because you are " . $self->current_user->username);

--- a/templates/main/parent_group_overview.html.ep
+++ b/templates/main/parent_group_overview.html.ep
@@ -5,6 +5,8 @@
 
 % content_for 'ready_function' => begin
     $('.timeago').timeago();
+    ajax_set_cookie_url    = "<%= url_for('set_cookie') %>";
+    session_parentoverview_order = "<%= session('favorite_parent_group_ordering') || 'none' %>";
 % end
 
 % if (is_admin) {
@@ -32,7 +34,16 @@
         </ul>
     </div>
 </div>
-
+% if(session('user')) {
+% my $display_order = (session('favorite_parent_group_ordering') and session('favorite_parent_group_ordering') eq "t_created") ? "build" : "date";
+  <div class="pull-right">
+    <a title="Order by <%= $display_order; %>" href="#" onclick="return toggleParentOverviewOrdering(session_parentoverview_order);">
+      <span id="parent_group_order_by_date">
+        <i id="parent_group_overview_order" class="fa fa-sort-amount-desc" aria-hidden="true"></i>Order by <%= $display_order; %>
+      </span>
+    </a>
+  </div>
+% }
 <div id="build-results"></div>
 %= include 'main/group_builds', build_results => $build_results, group => $group, children => $children, default_expanded => 1
 %= include 'main/more_builds', limit_builds => $limit_builds


### PR DESCRIPTION
This is still a WIP, local tests will be added later.

I need some feedbacks on the visual side and on saving preferences implementations:

![2017-06-05-093757_3840x1200_scrot](https://cloud.githubusercontent.com/assets/2420543/26775061/82cba952-49d3-11e7-9af6-381da57a0ec2.png)
![2017-06-05-093820_3840x1200_scrot](https://cloud.githubusercontent.com/assets/2420543/26775062/82d2a306-49d3-11e7-8fd5-d08101f702a3.png)

Considering that the issue regards more specific products, made sense to me to have a special button to choose the ordering preference.
The last two commits, makes the sorting ordering preference saved into user session instead of the database, that because i suppose (correct me if i'm wrong) we don't want to store user visual preferences at all. That required a new route to store session data from user since Mojolicious encrypts the cookie.

If the above approach is good, should we also save preferencies per-product, or globally? 

Anyway bear in mind that javascript / UI design is not really my cup of tea, open to suggestion also on visual improvements.

Related progress issue: https://progress.opensuse.org/issues/18082