### PR TITLE
WIP: Add bootstrap tour to project with example

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -17,6 +17,7 @@
 << https://raw.githubusercontent.com/twbs/bootstrap-sass/a73cc0f0e5c794206e9a70bc0b67e67cf37c1bca/assets/stylesheets/_bootstrap.scss
 < sass/theme.scss
 < https://raw.githubusercontent.com/vsn4ik/bootstrap-submenu/v2.0.4/dist/css/bootstrap-submenu.css
+< https://raw.githubusercontent.com/sorich87/bootstrap-tour/v0.11.0/build/css/bootstrap-tour.css
 
 ! codemirror.css
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/lib/codemirror.css
@@ -50,6 +51,7 @@
 < javascripts/filter_form.js
 < javascripts/comments.js
 < javascripts/keyevent.js
+< javascripts/tours.js
 < https://raw.githubusercontent.com/vsn4ik/bootstrap-submenu/v2.0.4/dist/js/bootstrap-submenu.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/5d6b2ebba0c2a5885ce2f0e01e9218db3d3b5e47/assets/javascripts/bootstrap/collapse.js
 < https://raw.githubusercontent.com/twbs/bootstrap-sass/5d6b2ebba0c2a5885ce2f0e01e9218db3d3b5e47/assets/javascripts/bootstrap/tooltip.js
@@ -60,6 +62,7 @@
 < http://harvesthq.github.io/chosen/chosen.jquery.js
 < https://cdnjs.cloudflare.com/ajax/libs/jquery-ujs/1.2.1/rails.js
 < javascripts/disable_animations.js [mode==test]
+< https://raw.githubusercontent.com/sorich87/bootstrap-tour/v0.11.0/build/js/bootstrap-tour.js
 
 ! test_result.js
 < javascripts/test_result.js
@@ -80,4 +83,3 @@
 
 ! audio.svg
 < images/audio.svg
-

--- a/assets/javascripts/tours.js
+++ b/assets/javascripts/tours.js
@@ -1,0 +1,38 @@
+// Example
+
+function startTour() {
+    //Create a new tour
+    var tour = new Tour({
+    storage : false //Disabled for test purposes
+  });
+
+//Add your steps
+    tour.addSteps([
+        {
+          element: ".jumbotron",
+          title: "Welcome to my example tour!",
+          content: "We're going to make this quick and useful.",
+          placement: "bottom"
+        },
+        {
+          element: ".navbar",
+          title: "Navigation bar",
+          content: "Use me to navigate through openQA!",
+          placement: "bottom",
+          backdrop: true
+        },
+        {
+          element: "#filter-panel",
+          title: "It's me the filter panel!",
+          content: "I'm able to filter everything!",
+          placement: "top",
+          backdrop: true
+        },
+      ]);
+
+    // Initialize the tour
+    tour.init();
+
+    // Start the tour
+    tour.start();
+};

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -5,6 +5,7 @@
 
 % content_for 'ready_function' => begin
     setupIndexPage();
+    startTour();
 % end
 
 <div class="jumbotron">


### PR DESCRIPTION
Related to https://progress.opensuse.org/issues/16376

http://bootstraptour.com/

Added a quick example tour with bootstrap tour.  It is easy to use, just have to add a few lines of javascript to introduce a new feature. By default it stores the state (already seen etc.) locally. Its possible to navigate through sub domains (wasn't able to accomplish this yet).

![screenshot_tour01](https://cloud.githubusercontent.com/assets/22001671/26834413/946d8b28-4ad5-11e7-9c2d-e0833cdab2fa.png)
