### PR TITLE
Add error message for missing webserver

### DIFF
--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -301,7 +301,9 @@ sub clone_job {
         }
     }
     else {
-        die "failed to create job: ", pp($tx->res->body);
+        die "Failed to create job, empty response. Make sure your HTTP proxy is running, e.g. apache, nginx, etc."
+          unless $tx->res->body;
+        die "Failed to create job: ", pp($tx->res->body);
     }
 }
 


### PR DESCRIPTION
I wasn't able to clone a job because the apache2 service was disabled on my machine, so i added a message at this place.