### PR TITLE
Better support exclude areas

### DIFF
--- a/assets/javascripts/needlediff.js
+++ b/assets/javascripts/needlediff.js
@@ -128,7 +128,7 @@ NeedleDiff.prototype.draw = function() {
         width += 1;
       }
 
-      this.ctx.strokeStyle = "rgb(64,224,208)";
+      this.ctx.strokeStyle = NeedleDiff.strokecolor(a.type);
 
       orig = this.areas[idx];
       this.ctx.drawImage(this.needleImg, orig['xpos'], orig['ypos'],
@@ -171,6 +171,17 @@ NeedleDiff.prototype.draw = function() {
       this.ctx.lineTo(start, y_start);
       this.ctx.stroke();
     }
+  }.bind(this));
+
+  // Draw all exclude boxes
+  this.areas.forEach(function(a, idx) {
+    if(a.type !== 'exclude') {
+      return;
+    }
+    this.ctx.fillStyle = NeedleDiff.shapecolor(a.type);
+    this.ctx.strokeStyle = NeedleDiff.strokecolor(a.type);
+    this.ctx.fillRect(a.xpos, a.ypos, a.width, a.height);
+    this.ctx.strokeRect(a.xpos, a.ypos, a.width, a.height);
   }.bind(this));
 
   // Draw all match labels
@@ -253,9 +264,23 @@ NeedleDiff.prototype.mouseup = function(event) {
   this.dragstart = false;
 }
 
+NeedleDiff.strokecolors = {
+    ok:      'rgb( 64, 224, 208)',
+    fail:    'rgb( 64, 224, 208)',
+    exclude: 'rgb(100, 100, 100)',
+};
+
+NeedleDiff.strokecolor = function(type) {
+    if (type in NeedleDiff.strokecolors) {
+        return NeedleDiff.strokecolors[type];
+    }
+    return "pink";
+};
+
 NeedleDiff.shapecolors = {
-  'ok':      'rgba(  0, 255, 0, .9)',
-  'fail':    'rgba(255,   0, 0, .9)'
+  ok:      'rgba(  0, 255,   0, .9)',
+  fail:    'rgba(255,   0,   0, .9)',
+  exclude: 'rgba(225, 215, 215, .7)',
 };
 
 NeedleDiff.shapecolor = function(type) {

--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -294,9 +294,15 @@ function loadTagsAndName() {
 function loadAreas() {
   var needle = window.needles[$('#area_select option:selected').val()];
   if ($('#take_matches').prop('checked')) {
-    nEditor.LoadAreas(needle['matches']);
+    var matchesAndExcludes = needle.matches.slice();
+    $.each(needle.area, function(index, area) {
+      if (area.type === 'exclude') {
+        matchesAndExcludes.push(area);
+      }
+    });
+    nEditor.LoadAreas(matchesAndExcludes);
   } else {
-    nEditor.LoadAreas(needle['area']);
+    nEditor.LoadAreas(needle.area);
   }
 }
 

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -194,6 +194,24 @@ tags.
 }
 -------------------------------------------------------------------
 
+==== Areas ====
+There are three kinds of areas:
+
+* *Regular areas* define relevant parts of the screenshot. Those must match
+  with at least the specified similarity percentage. Regular areas are
+  displayed as green boxes in the needle editor and as green or red frames
+  in the needle view.
+* *OCR areas* also define relevant parts of the screenshot. However, an OCR
+  algorithm is used for matching. In the needle editor exclude areas are
+  displayed as orange boxes. To turn a regular area into an OCR area within
+  the needle editor, double click the concerning area twice. Note that such
+  needles are only rarely used.
+* *Exclude areas* can be used within regular areas to ignore parts of it.
+  In the needle editor exclude areas are displayed as red boxes. To turn a
+  regular area into an exclude area within the needle editor, double click
+  the concerning area.
+  In the needle view exclude areas are displayed as gray boxes.
+
 === Interactive mode
 
 There are several points in time during the execution of a job at which openQA

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -62,7 +62,7 @@ make_path($dir);
 
 # default needle JSON content
 my $default_json
-  = '{"area" : [{"height" : 217,"type" : "match","width" : 384,"xpos" : 0,"ypos" : 0}],"tags" : ["ENV-VIDEOMODE-text","inst-timezone"]}';
+  = '{"area" : [{"height" : 217,"type" : "match","width" : 384,"xpos" : 0,"ypos" : 0},{"height" : 60,"type" : "exclude","width" : 160,"xpos" : 175,"ypos" : 45}],"tags" : ["ENV-VIDEOMODE-text","inst-timezone"]}';
 
 # create a fake json
 my $filen = "$dir/inst-timezone-text.json";
@@ -114,7 +114,7 @@ sub editpage_layout_check() {
     is($driver->find_element_by_id('tags_select')->get_value(), 'inst-timezone-text', "inst-timezone tags selected");
     is($driver->find_element_by_id('image_select')->get_value(), 'screenshot', "Screenshot background selected");
     is($driver->find_element_by_id('area_select')->get_value(), 'inst-timezone-text', "inst-timezone areas selected");
-    is($driver->find_element_by_id('take_matches')->is_selected(), 1, "Matches selected");
+    is($driver->find_element_by_id('take_matches')->is_selected(), 1, '"take matches" selected by default');
 
     # check needle suggested name
     my $today = strftime("%Y%m%d", gmtime(time));
@@ -130,10 +130,22 @@ sub editpage_layout_check() {
     $elem            = $driver->find_element_by_id('needleeditor_textarea');
     $decode_textarea = decode_json($elem->get_value());
     # the value already defined in $default_json
-    is($decode_textarea->{area}[0]->{xpos},   0,   "xpos correct");
-    is($decode_textarea->{area}[0]->{ypos},   0,   "ypos correct");
-    is($decode_textarea->{area}[0]->{width},  384, "width correct");
-    is($decode_textarea->{area}[0]->{height}, 217, "height correct");
+    is(@{$decode_textarea->{area}},           1,       'exclude is not present when take matches selected');
+    is($decode_textarea->{area}[0]->{xpos},   0,       'xpos correct');
+    is($decode_textarea->{area}[0]->{ypos},   0,       'ypos correct');
+    is($decode_textarea->{area}[0]->{width},  384,     'width correct');
+    is($decode_textarea->{area}[0]->{height}, 217,     'height correct');
+    is($decode_textarea->{area}[0]->{type},   'match', 'type correct');
+
+    # unselect "take matches": exclude area should show up
+    $driver->find_element_by_id('take_matches')->click();
+    $decode_textarea = decode_json($elem->get_value());
+    is(@{$decode_textarea->{area}},           2,         'both areas present when take matches not selected');
+    is($decode_textarea->{area}[1]->{xpos},   175,       'xpos correct');
+    is($decode_textarea->{area}[1]->{ypos},   45,        'ypos correct');
+    is($decode_textarea->{area}[1]->{width},  160,       'width correct');
+    is($decode_textarea->{area}[1]->{height}, 60,        'height correct');
+    is($decode_textarea->{area}[1]->{type},   'exclude', 'type correct');
 }
 
 sub add_needle_tag(;$) {

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -130,22 +130,23 @@ sub editpage_layout_check() {
     $elem            = $driver->find_element_by_id('needleeditor_textarea');
     $decode_textarea = decode_json($elem->get_value());
     # the value already defined in $default_json
-    is(@{$decode_textarea->{area}},           1,       'exclude is not present when take matches selected');
-    is($decode_textarea->{area}[0]->{xpos},   0,       'xpos correct');
-    is($decode_textarea->{area}[0]->{ypos},   0,       'ypos correct');
-    is($decode_textarea->{area}[0]->{width},  384,     'width correct');
-    is($decode_textarea->{area}[0]->{height}, 217,     'height correct');
-    is($decode_textarea->{area}[0]->{type},   'match', 'type correct');
-
-    # unselect "take matches": exclude area should show up
-    $driver->find_element_by_id('take_matches')->click();
-    $decode_textarea = decode_json($elem->get_value());
-    is(@{$decode_textarea->{area}},           2,         'both areas present when take matches not selected');
+    is(@{$decode_textarea->{area}},           2,         'exclude areas always present');
+    is($decode_textarea->{area}[0]->{xpos},   0,         'xpos correct');
+    is($decode_textarea->{area}[0]->{ypos},   0,         'ypos correct');
+    is($decode_textarea->{area}[0]->{width},  384,       'width correct');
+    is($decode_textarea->{area}[0]->{height}, 217,       'height correct');
+    is($decode_textarea->{area}[0]->{type},   'match',   'type correct');
     is($decode_textarea->{area}[1]->{xpos},   175,       'xpos correct');
     is($decode_textarea->{area}[1]->{ypos},   45,        'ypos correct');
     is($decode_textarea->{area}[1]->{width},  160,       'width correct');
     is($decode_textarea->{area}[1]->{height}, 60,        'height correct');
     is($decode_textarea->{area}[1]->{type},   'exclude', 'type correct');
+
+    # toggling 'take matches' has no effect
+    $driver->find_element_by_xpath('//input[@value="inst-timezone"]')->click();
+    is(@{decode_json($elem->get_value())->{area}}, 2, 'exclude areas always present');
+    $driver->find_element_by_xpath('//input[@value="inst-timezone"]')->click();
+    is(@{decode_json($elem->get_value())->{area}}, 2, 'no duplicated exclude areas present');
 }
 
 sub add_needle_tag(;$) {

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -235,7 +235,8 @@
                                 </option>
                             % }
                         </select>
-                        <input type="checkbox" id="take_matches" checked>Take matches</input>
+                        <input type="checkbox" id="take_matches" checked>
+                        <label for="take_matches">Take matches</label>
                     </div>
                 </div>
 


### PR DESCRIPTION
* See particular commit messages and https://progress.opensuse.org/issues/16058
* Showing exclude areas in diff has been tested manually because it is hard to check whether the canvas elements are drawn correctly. The concerning JavaScript code is covered at least. Might be a test case for openQA in openQA test.

![spectacle hm9830](https://user-images.githubusercontent.com/10248953/27645218-dbf052f8-5c25-11e7-8107-606f108b4f95.png)