### PR TITLE
Sync needles when caching is enabled

### DIFF
--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -17,12 +17,11 @@ package OpenQA::Worker::Commands;
 use 5.018;
 use warnings;
 
-use OpenQA::Utils qw(log_error log_warning log_debug log_info);
+use OpenQA::Utils qw(log_error log_warning log_debug);
 use OpenQA::Worker::Common;
 use OpenQA::Worker::Jobs;
 use POSIX qw(:sys_wait_h);
-use File::Spec::Functions 'catdir';
-use Mojo::URL;
+use OpenQA::Worker::Engines::isotovideo;
 
 ## WEBSOCKET commands
 sub websocket_commands {
@@ -80,28 +79,13 @@ sub websocket_commands {
         }
         elsif ($type eq 'reload_needles_and_retry') {
             if (backend_running) {
-
-                if ($hosts->{$current_host}{testpoolserver} && $worker_settings->{CACHEDIRECTORY}) {
-                    # my attempts to use ioloop::subprocess failed, so go back to blocking
-                    my $shared_cache = catdir($worker_settings->{CACHEDIRECTORY}, Mojo::URL->new($current_host)->host);
+                if ($hosts->{$current_host}{testpoolserver} && $hosts->{$host}{shared_cache}) {
                     my $sync_child = fork();
                     if (!$sync_child) {
-                        OpenQA::Worker::Engines::isotovideo::cache_tests($shared_cache,
+                        OpenQA::Worker::Engines::isotovideo::cache_tests($hosts->{$host}{shared_cache},
                             $hosts->{$current_host}{testpoolserver});
                     }
-                    else {
-                        my $last_update = time;
-                        while (waitpid($sync_child, WNOHANG) == 0) {
-                            log_info "Waiting for subprocess";
-                            if (time - $last_update > 5) {    # do not spam the webui
-                                update_setup_status;
-                                $last_update = time;
-                            }
-                            sleep .5;
-                        }
-                    }
                 }
-
                 $ua->post("$joburl/isotovideo/reload_needles");
                 log_debug('needles will be reloaded') if $verbose;
             }

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -417,7 +417,7 @@ sub call_websocket {
 }
 
 sub register_worker {
-    my ($host, $dir, $testpoolserver) = @_;
+    my ($host, $dir, $testpoolserver, $shared_cache) = @_;
     die unless $host;
     $hosts->{$host}{accepting_jobs} = 0;
 
@@ -447,6 +447,7 @@ sub register_worker {
 
     # test pool is from config, so it doesn't change
     $hosts->{$host}{testpoolserver} = $testpoolserver if $testpoolserver;
+    $hosts->{$host}{shared_cache}   = $shared_cache   if $shared_cache;
 
     # reset workerid
     $hosts->{$host}{workerid} = undef;


### PR DESCRIPTION
This is a quick try to solve poo#19408

A verification run: http://deimos.suse.de/tests/6104#step/bootloader/6 that's showing just the needle that was created in interactive mode. 