### PR TITLE
Fix test directory to share/tests Remove unnecesary calls to Mojo::Asset::File Improve server_start and port handling Improve cache tests Improve handling of logs and directories Refactor server handling to avoid race conditions Remove unnecesary code from cache tests Set sleep_time to 5 again Add 25-cache.t to testrules.yml Add unit test for cache Unlock the asset before the next download retry Allow the cache to use a configurable sleep time Changing from using pure perl to Mojo::Asset::File Check when asset has been removed by hand Fix perl structure printed in the logs Retrigger download retry for incomplete downloads

### DIFF
--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -154,7 +154,7 @@ sub download_asset {
               . $headers->content_length
               . " / Downloaded: "
               . $size . "\n";
-            $asset = undef;
+            $asset = 598;    # 598 (Informal convention) Network read timeout error
         }
     }
     else {

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -95,7 +95,9 @@ sub download_asset {
             my ($ua, $tx) = @_;
             my $progress     = 0;
             my $last_updated = time;
-            $tx->req->headers->header('If-None-Match' => qq{$etag}) if $etag;
+            if (-e $asset) {    # Assets might be deleted by a sysadmin
+                $tx->req->headers->header('If-None-Match' => qq{$etag}) if $etag;
+            }
             $tx->res->on(
                 progress => sub {
                     my $msg = shift;

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -43,6 +43,7 @@ my $db_file;
 my $dsn;
 my $dbh;
 my $cache_real_size;
+my $sleep_time = 1;
 
 END {
     $dbh->disconnect() if $dbh;
@@ -186,8 +187,8 @@ sub get_asset {
         $result = try_lock_asset($asset);
         if (!$result) {
             update_setup_status;
-            log_debug "CACHE: Waiting 5 seconds for the lock.";
-            sleep 5;
+            log_debug "CACHE: Waiting $sleep_time seconds for the lock.";
+            sleep $sleep_time;
             next;
         }
         $ret = download_asset($job->{id}, lc($asset_type), $asset, ($result->{etag}) ? $result->{etag} : undef);
@@ -197,8 +198,8 @@ sub get_asset {
         }
         elsif ($ret =~ /^5[0-9]{2}$/ && --$n) {
             log_debug "CACHE: Error $ret, retrying download for $n more tries";
-            log_debug "CACHE: Waiting 5 seconds for the next retry";
-            sleep 5;
+            log_debug "CACHE: Waiting $sleep_time seconds for the next retry";
+            sleep $sleep_time;
             next;
         }
         elsif (!$n) {

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -153,7 +153,8 @@ sub download_asset {
             print $log "CACHE: Size of $asset differs, Expected: "
               . $headers->content_length
               . " / Downloaded: "
-              . $size . "\n";
+              . $asset->size
+              . "\n";    # At this point, trust the contents of Mojo::Asset
             $asset = 598;    # 598 (Informal convention) Network read timeout error
         }
     }

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -146,17 +146,13 @@ sub download_asset {
     elsif ($tx->res->is_success) {
         $etag = $headers->etag;
         unlink($asset);
-        $tx->res->content->asset->move_to($asset);
-        my $file = Mojo::Asset::File->new(path => $asset);
-        my $size = $file->size;
-
+        my $size = $tx->res->content->asset->move_to($asset)->size;
         if ($size == $headers->content_length) {
             check_limits($size);
             update_asset($asset, $etag, $size);
             print $log "CACHE: Asset download successful to $asset, Cache size is: $cache_real_size\n";
         }
         else {
-            $size = ($size) ? $size : "Unknown";
             print $log "CACHE: Size of $asset differs, Expected: "
               . $headers->content_length
               . " / Downloaded: "

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -43,7 +43,7 @@ my $db_file;
 my $dsn;
 my $dbh;
 my $cache_real_size;
-my $sleep_time = 1;
+our $sleep_time = 5;
 
 END {
     $dbh->disconnect() if $dbh;
@@ -312,7 +312,6 @@ sub update_asset {
         log_info "CACHE: updating the $asset with $etag and $size";
         return 1;
     }
-
 }
 
 sub purge_asset {

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -199,6 +199,7 @@ sub get_asset {
         elsif ($ret =~ /^5[0-9]{2}$/ && --$n) {
             log_debug "CACHE: Error $ret, retrying download for $n more tries";
             log_debug "CACHE: Waiting $sleep_time seconds for the next retry";
+            toggle_asset_lock($asset, 0);
             sleep $sleep_time;
             next;
         }

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -13,7 +13,7 @@ set -e
 
 : ${updateall:="0"}
 
-dir="/var/lib/openqa/tests"
+dir="/var/lib/openqa/share/tests"
 if [ -w / ]; then
 	if [ ! -e "$dir/$dist" ]; then
 		mkdir -p "$dir/$dist"

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -1,0 +1,247 @@
+#! /usr/bin/perl
+
+# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+BEGIN {
+    unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
+}
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Warnings;
+use Test::MockModule;
+use OpenQA::Utils;
+use OpenQA::Worker::Cache;
+use DBI;
+use File::Path qw(remove_tree make_path);
+use File::Spec::Functions qw(catdir catfile);
+use Digest::MD5 qw(md5);
+use Cwd qw(abs_path getcwd);
+
+use Mojo::IOLoop;
+use Mojolicious;
+use Mojo::Server::Daemon;
+use Mojolicious::Lite;
+
+
+
+# create Test DBus bus and service for fake WebSockets call
+# my $ws = OpenQA::WebSockets->new;
+
+my $sql;
+my $sth;
+my $result;
+my $dbh;
+my $filename;
+
+my $cachedir = catdir(getcwd(), 't/cache.d/cache');
+my $db_file = "$cachedir/cache.sqlite";
+$ENV{LOGDIR} = catdir(getcwd(), 't/cache.d', 'logs');
+my $logfile = catdir($ENV{LOGDIR}, 'cache.log');
+my $host = 'http://localhost:8080';
+
+remove_tree($cachedir);
+make_path($ENV{LOGDIR});
+
+#redirect stdout
+open(my $FD, '>>', $logfile);
+select $FD;
+$| = 1;
+truncate_log();
+# Mock of log_* methods used by Cache:
+
+my $openqa_utils = new Test::MockModule('OpenQA::Utils');
+#log_error log_info log_debug
+
+$openqa_utils->mock(log_info  => \&mock_log_info);
+$openqa_utils->mock(log_error => \&mock_log_error);
+$openqa_utils->mock(log_debug => \&mock_log_debug);
+$openqa_utils->mock(delete    => \&mock_delete);
+
+# logging helpers
+sub mock_log_debug {
+    my ($msg) = @_;
+    print "[DEBUG] $msg\n";
+}
+
+sub mock_log_info {
+    my ($msg) = @_;
+    print "[INFO] $msg\n";
+}
+
+sub mock_log_error {
+    my ($msg) = @_;
+    print "[ERROR] $msg\n";
+}
+
+sub truncate_log {
+    truncate $FD, 0;
+}
+
+
+sub read_log {
+    my ($new_log) = @_;
+    my $logfile_ = ($new_log) ? $new_log : $logfile;
+    open(my $f, '<', $logfile_) or die "OPENING $logfile_: $!\n";
+    my $log = do { local ($/); <$f> };
+    close($f);
+    truncate $f, 0;
+    return $log;
+}
+
+sub db_handle_connection {
+    my $disconnect = @_;
+    if ($dbh) {
+        $dbh->disconnect;
+        return if $disconnect;
+    }
+
+    $dbh
+      = DBI->connect("dbi:SQLite:dbname=$db_file", undef, undef, {RaiseError => 1, PrintError => 1, AutoCommit => 1});
+
+}
+
+OpenQA::Worker::Cache::init($host, $cachedir);
+
+like read_log, qr/Creating cache directory tree for/, "Cache directory tree created.";
+like read_log, qr/Deploying DB/,                      "Cache deploys the database.";
+like read_log, qr/Configured limit: 53687091200/,     "Cache limit is default (50GB).";
+ok(-e $db_file, "cache.sqlite is present");
+
+
+truncate_log;
+
+db_handle_connection;
+
+for (1 .. 3) {
+    $filename = "$cachedir/$_.qcow2";
+    open(my $tmpfd, '>:raw', $filename);
+    print $tmpfd "\0" x 84 or die($filename);
+    close $tmpfd;
+
+    if ($_ % 2) {
+        log_info "Inserting $_";
+        $sql = "INSERT INTO assets (downloading,filename,size, etag,last_use)
+                VALUES (0, ?, ?, 'Not valid', strftime('%s','now'));";
+        $sth = $dbh->prepare($sql);
+        $sth->bind_param(1, $filename);
+        $sth->bind_param(2, 84);
+        $sth->execute();
+    }
+
+}
+
+OpenQA::Worker::Cache::init($host, $cachedir);
+
+unlike read_log, qr/Deploying DB/, "Cache deploys the database.";
+like read_log, qr/CACHE: Health: Real size: 168, Configured limit: 53687091200/,
+  "Cache limit/size match the expected 100GB/168)";
+unlike read_log, qr/CACHE: Purging non registered.*[13].qcow2/, "Registered assets 1 and 3 were kept";
+like read_log,   qr/CACHE: Purging non registered.*2.qcow2/,    "Asset 2 was removed";
+truncate_log;
+
+$OpenQA::Worker::Cache::limit = 100;
+OpenQA::Worker::Cache::init($host, $cachedir);
+
+like read_log, qr/CACHE: Health: Real size: 84, Configured limit: 100/, "Cache limit/size match the expected 100/84)";
+like read_log, qr/CACHE: removed.*1.qcow2/, "Oldest asset (1.qcow2) removal was logged";
+ok(!-e "$cachedir/1.qcow2", "Oldest asset (1.qcow2) was sucessfully removed");
+truncate_log;
+my $daemon;
+my $mock = Mojolicious->new;
+
+sub start_server {
+    my $serverpid = fork();
+    if ($serverpid == 0) {
+        # setup mock
+
+        $mock->routes->get(
+            '/tests/:job/asset/:type/:filename' => sub {
+                my $c        = shift;
+                my $id       = $c->stash('job');
+                my $type     = $c->stash('type');
+                my $filename = $c->stash('filename');
+                return $c->render(status => 404, text => "Move along, nothing to see here")
+                  if $filename =~ /sle-12-SP3-x86_64-0368-404/;
+                return $c->render(status => 400, text => "Move along, nothing to see here")
+                  if $filename =~ /sle-12-SP3-x86_64-0368-400/;
+                return $c->render(status => 500, text => "Move along, nothing to see here")
+                  if $filename =~ /sle-12-SP3-x86_64-0368-589/;
+                if ($filename =~ /sle-12-SP3-x86_64-0368-589/) {
+                    $c->res->headers->content_length(10);
+                    $c->write(
+                        'Hel' => sub {
+                            my $c = shift;
+                            $c->write('lo!');
+                        });
+                }
+            });
+
+        $mock->routes->get(
+            '/' => sub {
+                my $c = shift;
+                return $c->render(status => 200, text => "server is running");
+            });
+
+        # Connect application with web server and start accepting connections
+
+        $daemon = Mojo::Server::Daemon->new(app => $mock, listen => [$host]);
+        $daemon->start;
+    }
+}
+
+start_server;
+Mojo::IOLoop->start if !Mojo::IOLoop->is_running;
+
+chdir $ENV{LOGDIR};
+get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-textmode@64bit.qcow2');
+
+my $autoinst_log = read_log('autoinst-log.txt');
+
+like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2 from/, "Asset download attempt";
+like $autoinst_log, qr/failed with: 521/, "Asset download fails with connection refused";
+truncate_log;
+
+get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-404@64bit.qcow2');
+$autoinst_log = read_log('autoinst-log.txt');
+like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-404\@64bit.qcow2 from/, "Asset download attempt";
+like $autoinst_log, qr/failed with: 404/, "Asset download fails with connection refused 404";
+truncate_log;
+
+get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-400@64bit.qcow2');
+$autoinst_log = read_log('autoinst-log.txt');
+like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-400\@64bit.qcow2 from/, "Asset download attempt";
+like $autoinst_log, qr/failed with: 400/, "Asset download fails with connection refused 400";
+truncate_log;
+
+get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-500@64bit.qcow2');
+$autoinst_log = read_log('autoinst-log.txt');
+like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-500\@64bit.qcow2 from/, "Asset download attempt";
+like $autoinst_log, qr/failed with: 500/, "Asset download fails with connection refused 500";
+truncate_log;
+
+get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-589@64bit.qcow2');
+$autoinst_log = read_log('autoinst-log.txt');
+like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-589\@64bit.qcow2 from/, "Asset download attempt";
+like $autoinst_log, qr/failed with: 589/, "Asset download fails with connection refused 589";
+truncate_log;
+
+Mojo::IOLoop->stop;
+
+done_testing();

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -34,15 +34,8 @@ use File::Spec::Functions qw(catdir catfile);
 use Digest::MD5 qw(md5);
 use Cwd qw(abs_path getcwd);
 
-use Mojo::IOLoop;
 use Mojolicious;
 use Mojo::Server::Daemon;
-use Mojolicious::Lite;
-
-
-
-# create Test DBus bus and service for fake WebSockets call
-# my $ws = OpenQA::WebSockets->new;
 
 my $sql;
 my $sth;
@@ -63,32 +56,6 @@ make_path($ENV{LOGDIR});
 open(my $FD, '>>', $logfile);
 select $FD;
 $| = 1;
-truncate_log();
-# Mock of log_* methods used by Cache:
-
-my $openqa_utils = new Test::MockModule('OpenQA::Utils');
-#log_error log_info log_debug
-
-$openqa_utils->mock(log_info  => \&mock_log_info);
-$openqa_utils->mock(log_error => \&mock_log_error);
-$openqa_utils->mock(log_debug => \&mock_log_debug);
-$openqa_utils->mock(delete    => \&mock_delete);
-
-# logging helpers
-sub mock_log_debug {
-    my ($msg) = @_;
-    print "[DEBUG] $msg\n";
-}
-
-sub mock_log_info {
-    my ($msg) = @_;
-    print "[INFO] $msg\n";
-}
-
-sub mock_log_error {
-    my ($msg) = @_;
-    print "[ERROR] $msg\n";
-}
 
 sub truncate_log {
     truncate $FD, 0;

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -28,6 +28,7 @@ seq:
      - ./t/22-dashboard.t
      - ./t/23-amqp.t
      - ./t/24-worker.t
+     - ./t/25-cache.t
      - ./t/basic.t
      - ./t/deploy.t
      - ./t/full-stack.t


### PR DESCRIPTION
Sync the fetch needles script with commit
 c7c37edc2f63b96bedfb68d83c6da603b1435bf2 where shared workers have
been introduced, and moved all the contents from /var/lib/openqa/tests
to /var/lib/openqa/share/tests

* Add test to check when the file is under 256K
   (https://progress.opensuse.org/issues/19436#note-9)


With the previous changes, the way to tests things inside
the cache is a bit easier.

The following conditions are being tested, while they are not
all of them, it is good enough to cover most cases:
  When the asset has been downloaded
  When the size of the downloaded asset mismaches
  Proper asset download (Properly tested in the full-stack test too)







To reduce the probability of poo#19564 happening, unlocking
the asset, will allow other workers to try to download, but
also keep the current worker busy waiting, removing it from
the round robin for the next lock.

In order to help with unit testing, adding $sleep_time comes in
handy for those situations where the developer wants the tests
to run faster. And the default of 5 seconds can be a bit too high
in those conditions

This will handle the problem with poo#19436