### PR TITLE
Fix test directory to share/tests

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -13,7 +13,7 @@ set -e
 
 : ${updateall:="0"}
 
-dir="/var/lib/openqa/tests"
+dir="/var/lib/openqa/share/tests"
 if [ -w / ]; then
 	if [ ! -e "$dir/$dist" ]; then
 		mkdir -p "$dir/$dist"


### PR DESCRIPTION
Sync the fetch needles script with commit
 c7c37edc2f63b96bedfb68d83c6da603b1435bf2 where shared workers have
been introduced, and moved all the contents from /var/lib/openqa/tests
to /var/lib/openqa/share/tests