### PR TITLE
Enable INTEGRATION_TESTS

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -184,7 +184,7 @@ sub client_call {
 
 my $JOB_SETUP
   = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 QEMU_NO_KVM=1 '
-  . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 '
+  . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1'
   . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2';
 
 # schedule job


### PR DESCRIPTION
By adding the control variable `INTEGRATION_TESTS=1` we allow now openQA to control the test plan generated by isotovideo, and therefore allowing the enhancement of both, without affecting eachoter.

This requires https://github.com/os-autoinst/os-autoinst/pull/826