### PR TITLE
Avoid OpenID login to clutter log files

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -105,7 +105,7 @@ sub auth_response {
 
     my $err_handler = sub {
         my ($err, $txt) = @_;
-        $self->app->log->error($err, $txt);
+        $self->app->log->error("$err: $txt");
         $self->flash(error => "$err: $txt");
         return (error => 0);
     };


### PR DESCRIPTION
Supply error text in one argument to `Mojo::Log error()`, avoids to
clutter log file with multi-lines.

A change in https://github.com/os-autoinst/openqa-logwarn will follow to ignore login error reports
