### PR TITLE
Create jobs from settings within a transaction

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -116,6 +116,8 @@ sub create_from_settings {
     my %new_job_args = (TEST => $settings{TEST});
     my $group;
     my %group_args;
+    my $txn_guard = $self->result_source->storage->txn_scope_guard;
+
     if ($settings{_GROUP_ID}) {
         $group_args{id} = delete $settings{_GROUP_ID};
     }
@@ -156,7 +158,6 @@ sub create_from_settings {
         }
         delete $settings{_PARALLEL_JOBS};
     }
-
     # migrate the important keys
     for my $key (qw(DISTRI VERSION FLAVOR ARCH TEST MACHINE BUILD)) {
         my $value = delete $settings{$key};
@@ -187,7 +188,7 @@ sub create_from_settings {
         OpenQA::Utils::log_warning(
             'Ignoring invalid group ' . to_json(\%group_args) . ' when creating new job ' . $job->id);
     }
-
+    $txn_guard->commit;
     return $job;
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -137,12 +137,14 @@ sub create {
                 run_at   => now(),
             });
 
-        notify_workers;
     }
     catch {
         $status = 400;
         $json->{error} = "$_";
     };
+
+    notify_workers unless $json->{error};
+
     $self->render(json => $json, status => $status);
 }
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -135,7 +135,6 @@ is($res->json->{count}, 10, '10 new jobs created');
 my @newids = @{$res->json->{ids}};
 my $newid  = $newids[0];
 
-
 $ret = $t->get_ok('/api/v1/jobs');
 my @jobs = @{$ret->tx->res->json->{jobs}};
 


### PR DESCRIPTION
Currently when clone_jobs is being spammed to the web ui
there might be some jobs that go Entrepreneurial, and end
up in the wrong worker.

This is caused most likely by notify_workers being called
by another clone_job call, while the current one is being
still created, this definitely solves poo#18684 but would
need some validation for poo#20002