### PR TITLE
Fix bugzilla links for CaaSP

### DIFF
--- a/templates/branding/openSUSE/external_reporting.html.ep
+++ b/templates/branding/openSUSE/external_reporting.html.ep
@@ -12,8 +12,7 @@
 <% my %distri_to_prod = (
     sle => 'SUSE Linux Enterprise',
     opensuse => 'openSUSE',
-    # sic!
-    casp => 'SUSE Container as a  Service Platform',
+    casp => 'SUSE Container as a Service Platform',
 ); %>
 <% my %flavor_to_prod_sle = (
     Server => 'Server',
@@ -45,8 +44,7 @@
 %     $product = $job->VERSION eq 'Tumbleweed' ? 'Tumbleweed' : 'Distribution';
 % }
 % elsif ($job->DISTRI eq 'casp') {
-%     # sic!
-%     $product = "1 .0\x{00A0}(CaaSP/MicroOS)";
+%     $product = $job->VERSION;
 % }
 % $product_details{product} = "$distri $product";
 % $product_details{bug_file_loc} = $step_url;


### PR DESCRIPTION
Old name: SUSE Container as a  Service Platform 1 .0 (CaaSP/MicroOS)
New name: SUSE Container as a Service Platform 1.0 