### PR TITLE
Enforce t_updated incr for bugs

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
@@ -119,6 +119,7 @@ sub get_bug_values {
         status     => $self->param('status'),
         resolution => $self->param('resolution'),
         existing   => $self->param('existing') ? 1 : 0,
+        t_updated  => time2str('%Y-%m-%d %H:%M:%S', time, 'UTC'),
         refreshed  => 1
     };
 }


### PR DESCRIPTION
t_updated will be set to current time
even if the new values are identical to the old ones

This is necessary because `t_updated` is used to track when the update script updated the bug tha last time via the API to ensure that the bug isn't updated again, before some time intervall has passed.