### PR TITLE
Disable livelog autoscroll by default

### DIFF
--- a/templates/test/live.html.ep
+++ b/templates/test/live.html.ep
@@ -42,7 +42,7 @@
 <div class="panel panel-default">
     <pre id="livelog" data-url='<%= url_for("livelog", testid => $testid) %>'></pre>
 </div>
-<input type="checkbox" id="scrolldown" checked="checked" />
+<input type="checkbox" id="scrolldown" />
 <label for="scrolldown">Autoscroll log</label>
 <div class="h5">Serial Output (serial0.txt and serial_terminal.txt)</div>
 <div class="panel panel-default">


### PR DESCRIPTION
As discussed, to help reduce the load on a heavy instance, require the user to explicitly enable the livelog