### PR TITLE
Add . to INC for tests that use local modules (perl 5.26 doesn't)

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -20,6 +20,7 @@ use Cwd qw(abs_path getcwd);
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     use FindBin;
     use Mojo::File qw(path tempdir);
     $ENV{OPENQA_BASEDIR} = path(tempdir, 't', 'full-stack.d');

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -16,6 +16,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -15,6 +15,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -15,6 +15,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -17,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -17,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 
 }

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -17,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 


### PR DESCRIPTION
As with https://github.com/os-autoinst/os-autoinst/pull/820 ,
Perl 5.26 not including the current working directory in INC
breaks loading of modules in some tests.