### PR TITLE
Add support for colons on worker class

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/JobSettings.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobSettings.pm
@@ -47,11 +47,13 @@ sub query_for_settings {
                 }
                 push(@joins, 'siblings');
             }
+            my $setting_value = ($args->{$setting} =~ /^:\w+:/) ? {'like', "$&%"} : $args->{$setting};
             push(
                 @conds,
                 {
                     "$tname.key"   => $setting,
-                    "$tname.value" => $args->{$setting}});
+                    "$tname.value" => $setting_value
+                });
         }
     }
     return $self->search({-and => \@conds}, {join => \@joins});

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -315,7 +315,9 @@ sub complex_query {
     }
     else {
         my %js_settings;
-        for my $key (qw(ISO HDD_1)) {
+        # Check if the settings are between the arguments passed via query url
+        # they come in lowercase, so mace sure $key is lc'ed
+        for my $key (qw(ISO HDD_1 WORKER_CLASS)) {
             $js_settings{$key} = $args{lc $key} if defined $args{lc $key};
         }
         if (%js_settings) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -27,7 +27,7 @@ sub list {
 
     my %args;
     my @args = qw(build iso distri version flavor maxage scope group
-      groupid limit page before after arch hdd_1 test machine);
+      groupid limit page before after arch hdd_1 test machine worker_class);
     for my $arg (@args) {
         next unless defined(my $value = $self->param($arg));
         $args{$arg} = $value;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -158,6 +158,7 @@ sub engine_workit {
     # do asset caching if CACHEDIRECTORY is set
     if ($worker_settings->{CACHEDIRECTORY}) {
         my $host_to_cache = Mojo::URL->new($current_host)->host;
+        $shared_cache = catdir($worker_settings->{CACHEDIRECTORY}, $host_to_cache);
         OpenQA::Worker::Cache::init($current_host, $worker_settings->{CACHEDIRECTORY});
         my $error = cache_assets(\%vars, $assetkeys);
         return $error if $error;
@@ -191,6 +192,7 @@ sub engine_workit {
         }
     }
     else {
+        $vars{PRJDIR} = $OpenQA::Utils::sharedir;
         my $error = locate_local_assets(\%vars, $assetkeys);
         return $error if $error;
     }


### PR DESCRIPTION
In order to allow better filtering and proper grouping of jobs when
they belong to an instance in another location, so that bridged
worker can query all the jobs available to be "proxied", without
extra need for more worker settings and redefinition of worker
classes. This allows to use :my_location:our_worker_class


Ends up being something like this: http://deimos.suse.de/api/v1/jobs.json?limit=100&worker_class=:provo:qemu_aarch64