### PR TITLE
check_job: check if we really got a job hash, not an error

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -112,7 +112,7 @@ sub check_job {
             my ($res) = @_;
             return unless ($res);
             $job = $res->{job};
-            if ($job && $job->{id}) {
+            if ($job && ref($job) eq "HASH" && $job->{id}) {
                 Mojo::IOLoop->next_tick(sub { start_job($host) });
             }
             else {


### PR DESCRIPTION
After updating an openQA instance to current git, I noticed that
many workers stopped picking up jobs. Looking at their logs, I
see a bunch of errors indicating that first the line modified
in this commit (the `$job->{id}` part) and then a line in
`websocket_commands` (where it does `$job->{URL}`) are trying to
use a string as a hash ref. In most cases the string was some
sort of DBus error, but in one case the string was *itself* an
error about trying to use a string as a hash ref (holy recursion,
batman).

It seems like what's going on is that, occasionally, when
`check_job` tries to grab a job, it gets back a response that is
 not a proper job hash ref, but some kind of error string. We
can also look at the `grab_job` end of this problem and see if
we can stop it from doing this, but making this check more
robust should also help (it should cause the `else` clause to
kick in properly and make the worker ignore the response and
keep polling for a job on the next tick).