### PR TITLE
More prominent color for closed bug references, old ones for open bugs

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -19,8 +19,8 @@ $color-resborder-unk: $color-module-none;
 $color-highlight-parent: #ffe0e0;
 $color-highlight-child: #d0f0ff;
 $color-labels: gray;
-$color-bug: #f2b500; /* amber */
-$color-bug-closed: #6d6d6d; /* gray */
+$color-bolt: #f2b500; /* amber */
+$color-bug-closed: $color-failed;
 $color-state-scheduled: #67A2B7;
 $color-state-cancelled: $color-module-none;
 $color-state-running: #8BDFFF;
@@ -503,8 +503,7 @@ div.flags {
 .fa.result_user_restarted { color: $color-module-none; }
 
 .fa.comment, .fa.bookmark, .fa.bug, .fa.certificate, .fa.tag { color: $color-labels; }
-.label_bug.fa-bolt { padding: 0 3px; }
-.label_bug { color: $color-bug; }
+.label_bug.fa-bolt { padding: 0 3px; color: $color-bolt; }
 .label_bug.bug_closed {
     color: $color-bug-closed;
     transform: rotate(180deg);


### PR DESCRIPTION
![openqa_new_bug_icons](https://user-images.githubusercontent.com/1693432/28848374-ff62acc4-7712-11e7-82bc-70895027033a.png)

Followup to https://github.com/os-autoinst/openQA/pull/1376/files#r130724832