### PR TITLE
Respect log level configuration even when no log file is set

### DIFF
--- a/lib/OpenQA/ServerStartup.pm
+++ b/lib/OpenQA/ServerStartup.pm
@@ -145,7 +145,7 @@ sub setup_logging {
             });
     }
 
-    if ($logfile && $config->{logging}->{level}) {
+    if ($config->{logging}->{level}) {
         $app->log->level($config->{logging}->{level});
     }
     if ($ENV{OPENQA_SQL_DEBUG} // $config->{logging}->{sql_debug} // 'false' eq 'true') {


### PR DESCRIPTION
If you set a log level but not a log file in your openqa.ini
(or environment variables), because of this conditional, the
log level is not respected by at least openqa-scheduler and
openqa-websockets; they will log at debug level. I can't see
any justification for this, and it's a problem for my usage.
Intentionally setting no log file means that messages wind up
in the system journal when started as systemd services, but I
still want to be able to set the log *level* so the journal
isn't stuffed with debug messages.