### PR TITLE
[WIP] Add support for federated webUI

### DIFF
--- a/lib/OpenQA/Client.pm
+++ b/lib/OpenQA/Client.pm
@@ -55,6 +55,7 @@ sub new {
     # Scheduling a couple of hundred jobs takes quite some time - so we better wait a couple of minutes
     # (default is 20 seconds)
     $self->inactivity_timeout(600);
+    $self->max_redirects(3);
 
     $self->on(
         start => sub {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -39,15 +39,16 @@ use constant {
     SCHEDULED => 'scheduled',
     SETUP     => 'setup',
     RUNNING   => 'running',
+    PROXIED   => 'proxied',
     CANCELLED => 'cancelled',
     WAITING   => 'waiting',
     DONE      => 'done',
     UPLOADING => 'uploading',
     #    OBSOLETED => 'obsoleted',
 };
-use constant STATES => (SCHEDULED, SETUP, RUNNING, CANCELLED, WAITING, DONE, UPLOADING);
-use constant PENDING_STATES => (SCHEDULED, SETUP, RUNNING, WAITING, UPLOADING);
-use constant EXECUTION_STATES => (RUNNING, WAITING, UPLOADING);
+use constant STATES => (SCHEDULED, SETUP, RUNNING, PROXIED, CANCELLED, WAITING, DONE, UPLOADING);
+use constant PENDING_STATES => (SCHEDULED, SETUP, PROXIED, RUNNING, WAITING, UPLOADING);
+use constant EXECUTION_STATES => (RUNNING, WAITING, PROXIED, UPLOADING);
 use constant FINAL_STATES => (DONE, CANCELLED);
 
 # Results

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1302,6 +1302,11 @@ sub update_status {
         return $ret;
     }
 
+    if ($status->{setup}) {
+        $self->update({state => SETUP});
+        return $ret;
+    }
+
     $self->append_log($status->{log},             "autoinst-log-live.txt");
     $self->append_log($status->{serial_log},      "serial-terminal-live.txt");
     $self->append_log($status->{serial_terminal}, "serial-terminal-live.txt");

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1279,6 +1279,11 @@ sub update_status {
     my ($self, $status) = @_;
 
     my $ret = {result => 1};
+    if ($status->{proxied}) {
+        $self->update({state => PROXIED});
+        return $ret;
+    }
+
     if (!$self->worker) {
         OpenQA::Utils::log_info(
             'Got status update for job with no worker assigned (maybe running job already considered dead): '

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -23,7 +23,8 @@ use JSON;
 use Fcntl;
 use DateTime;
 use db_helpers;
-use OpenQA::Utils qw(log_debug log_info log_warning parse_assets_from_settings locate_asset send_job_to_worker);
+use OpenQA::Utils
+  qw(log_debug log_info log_warning parse_assets_from_settings locate_asset send_job_to_worker read_test_modules);
 use File::Basename qw(basename dirname);
 use File::Spec::Functions 'catfile';
 use File::Path ();
@@ -546,6 +547,10 @@ sub to_hash {
     }
     if ($args{deps}) {
         $j = {%$j, %{$job->deps_hash}};
+    }
+    if ($args{details}) {
+        my $testresults = read_test_modules($job);
+        $j = {%$j, testresults => $testresults};
     }
     return $j;
 }

--- a/lib/OpenQA/Schema/ResultSet/JobSettings.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobSettings.pm
@@ -17,6 +17,7 @@
 package OpenQA::Schema::ResultSet::JobSettings;
 use strict;
 use base 'DBIx::Class::ResultSet';
+use OpenQA::Utils;
 
 =head2 query_for_settings
 
@@ -47,11 +48,24 @@ sub query_for_settings {
                 }
                 push(@joins, 'siblings');
             }
-            push(
-                @conds,
-                {
-                    "$tname.key"   => $setting,
-                    "$tname.value" => $args->{$setting}});
+            if ($args->{$setting} =~ /^:\w+:/) {
+                my $worker_class = $&;
+                log_error($');
+                push(
+                    @conds,
+                    {
+                        "$tname.key"   => $setting,
+                        "$tname.value" => {'like', "$worker_class%"},
+                    });
+                print $worker_class;
+            }
+            else {
+                push(
+                    @conds,
+                    {
+                        "$tname.key"   => $setting,
+                        "$tname.value" => $args->{$setting}});
+            }
         }
     }
     return $self->search({-and => \@conds}, {join => \@joins});

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -315,7 +315,9 @@ sub complex_query {
     }
     else {
         my %js_settings;
-        for my $key (qw(ISO HDD_1)) {
+        # Check if the settings are between the arguments passed via query url
+        # they come in lowercase, so mace sure $key is lc'ed
+        for my $key (qw(ISO HDD_1 WORKER_CLASS)) {
             $js_settings{$key} = $args{lc $key} if defined $args{lc $key};
         }
         if (%js_settings) {

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -317,7 +317,7 @@ sub complex_query {
         my %js_settings;
         # Check if the settings are between the arguments passed via query url
         # they come in lowercase, so mace sure $key is lc'ed
-        for my $key (qw(ISO HDD_1 WORKER_CLASS CLUSTER)) {
+        for my $key (qw(ISO HDD_1 WORKER_CLASS PROXIED)) {
             $js_settings{$key} = $args{lc $key} if defined $args{lc $key};
         }
         if (%js_settings) {

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -317,7 +317,7 @@ sub complex_query {
         my %js_settings;
         # Check if the settings are between the arguments passed via query url
         # they come in lowercase, so mace sure $key is lc'ed
-        for my $key (qw(ISO HDD_1 WORKER_CLASS)) {
+        for my $key (qw(ISO HDD_1 WORKER_CLASS CLUSTER)) {
             $js_settings{$key} = $args{lc $key} if defined $args{lc $key};
         }
         if (%js_settings) {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -352,6 +352,9 @@ sub startup {
     $job_r->post('/artefact')->name('apiv1_create_artefact')->to('job#create_artefact');
     $job_r->post('/ack_temporary')->to('job#ack_temporary');
 
+    # api/v1/federation
+    # mimic for now the behaviour in job#list
+    $api_public_r->get('/federation')->name('apiv1_jobs')->to('job#list');
 
     # job_set_waiting, job_set_continue
     my $command_r = $job_r->route('/set_:command', command => [qw(waiting running)]);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -27,7 +27,7 @@ sub list {
 
     my %args;
     my @args = qw(build iso distri version flavor maxage scope group
-      groupid limit page before after arch hdd_1 test machine worker_class);
+      groupid limit page before after arch hdd_1 test machine worker_class cluster);
     for my $arg (@args) {
         next unless defined(my $value = $self->param($arg));
         $args{$arg} = $value;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -27,7 +27,7 @@ sub list {
 
     my %args;
     my @args = qw(build iso distri version flavor maxage scope group
-      groupid limit page before after arch hdd_1 test machine);
+      groupid limit page before after arch hdd_1 test machine worker_class);
     for my $arg (@args) {
         next unless defined(my $value = $self->param($arg));
         $args{$arg} = $value;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -151,7 +151,8 @@ sub show {
     my $job_id = int($self->stash('jobid'));
     my $job    = $self->db->resultset("Jobs")->search({'me.id' => $job_id}, {prefetch => 'settings'})->first;
     if ($job) {
-        $self->render(json => {job => $job->to_hash(assets => 1, deps => 1)});
+        my $details = $self->req->params->to_hash->{details} || 0;
+        $self->render(json => {job => $job->to_hash(assets => 1, deps => 1, details => $details)});
     }
     else {
         $self->reply->not_found;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -150,6 +150,7 @@ sub show {
     my $self   = shift;
     my $job_id = int($self->stash('jobid'));
     my $job    = $self->db->resultset("Jobs")->search({'me.id' => $job_id}, {prefetch => 'settings'})->first;
+
     if ($job) {
         my $details = $self->req->params->to_hash->{details} || 0;
         $self->render(json => {job => $job->to_hash(assets => 1, deps => 1, details => $details)});
@@ -261,7 +262,7 @@ sub update {
     my $settings = delete $json->{settings};
 
     # validate specified columns (print error if at least one specified column does not exist)
-    my @allowed_cols = qw(group_id priority retry_avbl);
+    my @allowed_cols = qw(group_id priority retry_avbl backend backend_info);
     for my $key (keys %$json) {
         if (!grep $_ eq $key, @allowed_cols) {
             return $self->render(json => {error => "Column $key can not be set"}, status => 400);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -27,7 +27,7 @@ sub list {
 
     my %args;
     my @args = qw(build iso distri version flavor maxage scope group
-      groupid limit page before after arch hdd_1 test machine worker_class cluster);
+      groupid limit page before after arch hdd_1 test machine worker_class proxied);
     for my $arg (@args) {
         next unless defined(my $value = $self->param($arg));
         $args{$arg} = $value;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -188,48 +188,6 @@ sub test_resultfile_list($) {
     return @filelist_existing;
 }
 
-sub read_test_modules {
-    my ($job) = @_;
-
-    my $testresultdir = $job->result_dir();
-    return [] unless $testresultdir;
-
-    my $category;
-    my @modlist;
-
-    for my $module (OpenQA::Schema::Result::JobModules::job_modules($job)) {
-        my $name = $module->name();
-        # add link to $testresultdir/$name*.png via png CGI
-        my @details;
-
-        my $num = 1;
-
-        for my $step (@{$module->details}) {
-            $step->{num} = $num++;
-            push(@details, $step);
-        }
-
-        push(
-            @modlist,
-            {
-                name      => $module->name,
-                result    => $module->result,
-                details   => \@details,
-                milestone => $module->milestone,
-                important => $module->important,
-                fatal     => $module->fatal
-            });
-
-        if (!$category || $category ne $module->category) {
-            $category = $module->category;
-            $modlist[-1]->{category} = $category;
-        }
-
-    }
-
-    return \@modlist;
-}
-
 sub details {
     my ($self) = @_;
 

--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -180,7 +180,7 @@ sub get_job {
     my $job;
     my $url = $remote_url->clone;
     $url->path("jobs/$jobid");
-    my $tx = $remote->max_redirects(3)->get($url);
+    my $tx = $remote->get($url);
     if ($tx->success) {
         if ($tx->success->code == 200) {
             $job = $tx->success->json->{job};
@@ -287,7 +287,7 @@ sub clone_job {
     }
     print JSON->new->pretty->encode(\%settings) if ($options{verbose});
     $url->query(%settings);
-    my $tx = $local->max_redirects(3)->post($url);
+    my $tx = $local->post($url);
     if ($tx->success) {
         my $r = $tx->success->json->{id};
         if ($r) {

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -111,8 +111,9 @@ $options{limit} ||= 1000;
 $options{worker_class} ||= ":provo:qemu_aarch64";
 
 #"/api/v1/jobs.json?&worker_class=aarch64_seattle9&limit=1000";
-my $master_url = Mojo::URL->new($options{master})->path("/api/v1/jobs.json")->query({
+my $master_url = Mojo::URL->new($options{master})->path("/api/v1/federation")->query({
         limit => $options{limt},
+        state => 'scheduled',
         worker_class => $options{worker_class}
     });
 
@@ -180,7 +181,7 @@ sub move_job {
 sub fetch_jobs {
     my @crop;
     my $UI = $masterUI->get($master_url->clone);
-    $log->debug("fetching jobs from".$master_url->clone);
+    $log->debug("fetching jobs from ".$master_url->clone);
     if($UI->res->is_success){
         my $job_count = scalar @{$UI->res->json->{jobs}};
         $log->info("Found: $job_count at ". $master_url->to_abs);

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -69,7 +69,7 @@ BEGIN {
     $ENV{MOJO_CONNECT_TIMEOUT}    = 300;
     # the default is EV, and this heavily screws with our children handling
     $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
-    #$ENV{MOJO_LOG_LEVEL} = 'debug';
+    $ENV{MOJO_LOG_LEVEL} = 'debug';
     #$ENV{MOJO_USERAGENT_DEBUG} = 1;
     #$ENV{MOJO_IOLOOP_DEBUG} = 1;
 }
@@ -81,6 +81,9 @@ use Getopt::Long;
 use Mojo::Base -strict;
 use Mojo::UserAgent;
 use Mojo::URL;
+use Mojo::Log;
+use OpenQA::Client;
+use JSON;
 
 Getopt::Long::Configure("no_ignore_case");
 
@@ -100,19 +103,40 @@ GetOptions(
 
 usage(0) if ($options{help});
 
-$options{master} ||= "http://deimos.suse.de";
-$options{slave}  ||= "http://lanner.arch.suse.de";
+my $log = Mojo::Log->new;
+$options{master} ||= 'http://0DCD0E0C65A6822A:59D8C0D855F2AABD@deimos.suse.de';
+$options{slave}  ||= 'http://0DCD0E0C65A6822A:59D8C0D855F2AABD@lanner.arch.suse.de';
 $options{limit} ||= 1000;
 $options{worker_class} ||= "cluster_job";
 
-
-
 #"/api/v1/jobs.json?&worker_class=aarch64_seattle9&limit=1000";
-my $url = Mojo::URL->new($options{master})->path("/api/v1/jobs.json")->query({
+my $master_url = Mojo::URL->new($options{master})->path("/api/v1/jobs.json")->query({
         limit => $options{limt},
         worker_class => $options{worker_class}
     });
 
-say $url->to_abs;
+my $master = OpenQA::Client->new(
+        api    => $master_url->host,
+        apikey => $master_url->username,
+        apisecret => $master_url->password,
+    );
+
+
+my $slave_url = Mojo::URL->new($options{slave})->path("/api/v1/jobs");
+my $slave = OpenQA::Client->new(
+        api    => $slave_url->host,
+        apikey => $slave_url->username,
+        apisecret => $slave_url->password,
+    );
+
+$log->info("Master: ". $master_url->to_abs);
+$log->info("Slave: ". $slave_url->to_abs);
+my $jobs;
+if($jobs = $master->get($master_url->clone)->res->is_success && ($slave->get($slave_url->clone)->res->is_success)){
+    $log->info("Works");
+}
+
+# $log->error();
+# $log->error($slave->get($slave_url->clone)->res->is_sucess);
 
 # vim: set sw=4 sts=4 et:

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -135,6 +135,7 @@ $log->info("Slave: ". $slave_url->to_abs);
 my $masterUI = $master;
 my $slaveUI = $slave;
 my $main_loop = Mojo::IOLoop->singleton;
+my $proxy_job_monitor_lock = 0;
 
 
 sub get_asset_list {
@@ -196,9 +197,8 @@ sub fetch_jobs {
 sub update_proxied_job {
     my ($job, $url, $status) = @_;
     $url->path("jobs/".$job->{id}."/status");
-    my $js = {status => $status};
-    # $url->query($js);
-    $log->info("Updating job: ".$job->{id}." at the MasterUI");
+    my $js = {status => $status, backend => 'UFP', backend_info => 'United Federation of Planets'};
+    $log->info("Updating job: ".$job->{id}." at ".$url->host);
     my $tx = $master->post($url => json => $js);
     if ($tx->success) {
         my $req = $tx->success->json;
@@ -206,52 +206,68 @@ sub update_proxied_job {
             $log->debug("Job #".$job->{id}." sucessully updated in the MasterUI");
             return 1;
         } else {
-            die "job not created. duplicate? ", Dumper($tx->res->body);
+            $log->error( "job not created. duplicate? ", Dumper($tx->res->json));
+            return $tx->res->json;
         }
     }
     else {
-        die "Failed to create job, empty response. Make sure your HTTP proxy is running, e.g. apache, nginx, etc."
-          unless $tx->res->body;
-        die "Failed to create job: ", Dumper($tx->res->body);
+        $log->error("Failed to create job, empty response. Make sure your HTTP proxy is running, e.g. apache, nginx, etc.")
+          unless $tx->res->json;
+        return $tx->res->json;
     }
 }
 
 sub proxy_job_monitor {
-    my ($result) = @_;
-    $log->debug("proxy_job_monitor: ".$result->{jobid});
-    $main_loop->recurring(2 => sub {
-        my $loop = shift;
-        # Add a timer
-        $log->error("Adding a monitor for #".$result->{jobid}, Dumper($result));
 
-        Mojo::IOLoop->subprocess(
-            sub {
-                    $log->info("Checking for job #".$result->{jobid}, Dumper($result));
-                    my $url = $slave_url->clone;
-                    $url->path("jobs/".$result->{jobid});
-                    my $UI = $slaveUI->get($url);
-                    $log->info("Job #". $result->{jobid} ." reported ".$UI->res->json->{job}{state});
-                    if($UI->res->is_success){
-                        my $job_status = $UI->res->json->{state};
-                        $log->info("Job #". $result->{jobid} ." reported ".$UI->res->json->{job}{state});
-                        $log->info(Dumper($result));
-                        $log->info(Dumper($UI->res->json));
-                        update_proxied_job(id => $result->{jobid}, $master_url->clone, passed => 1) if $UI->res->json->{job}{state} eq 'done' ;
-                        update_proxied_job(id => $result->{jobid}, $master_url->clone, incomplete => 1) if $UI->res->json->{job}{state} eq 'scheduled' ;
-                    }
-            },
-            sub {
-            my ($subprocess, $err, @results) = @_;
-            $subprocess->ioloop->emit('job_progress', @results);
-        });
-    });
+    $log->debug("Monitoring SlaveUI for jobs that are either DONE or CANCELLED");
+    $log->debug("setting up subprocess");
+    my @jobs;
+    my $url = $slave_url->clone->query({
+                # limit => $options{limt},
+                state => 'cancelled,incomplete,scheduled',
+                proxied => 1
+            });
+    my $UI = $slaveUI->get($url);
+    if($UI->res->is_success){
+        $log->info("Transaction executed");
+    } else {
+        $log->error($UI->res);
+    }
 
+    foreach my $job (@{$UI->res->json->{jobs}}) { 
+        my $progress_updated = process_job_progress($job);
+        if ($progress_updated eq 1){
+            push @jobs, $job;
+        } else {
+            $log->debug($progress_updated->{error});
+        }
+    };
+
+    $proxy_job_monitor_lock = 0;
+    $log->info("Lock released", $url->to_abs);
+    return @jobs;
+}
+
+sub process_job_progress {
+    my ($job) = @_;
+    return 0 unless $job->{settings}{FEDERATED_REPORT};
+    my $id = Mojo::URL->new($job->{settings}{FEDERATED_REPORT});
+    my $status;
+    $job->{id} = $id->path->parts->[1];
+    $status = {passed => 1} if $job->{state} eq 'done';
+    $status = {incomplete => 1} if $job->{state} eq 'incomplete';
+    my $result = update_proxied_job($job, $master_url->clone, $status);
+    if ($result){
+        return $result;
+    } else {
+        return 0;
+    }
 }
 
 $main_loop->on(new_jobs => sub {
     my ($loop, @report_args) = @_;
     $log->info("Job progress on the SlaveUI", Dumper(\@report_args));
-    map { proxy_job_monitor($_) } @report_args;
+    #map { proxy_job_monitor($_) } @report_args;
     });
 
 $main_loop->on(job_progress => sub {
@@ -280,6 +296,37 @@ $main_loop->recurring(5 => sub {
             $subprocess->ioloop->emit('new_jobs', @results);
         }
     });
+});
+
+# Check the slaveUI and check for jobs that are in a final state DONE or CANCELLED
+$main_loop->recurring(0.5 => sub {
+    my $loop = shift;
+    # Add a timer
+    unless($proxy_job_monitor_lock){
+    $log->info("Checking for job progress on the slaveUI");
+    $log->info("Locking");
+    $proxy_job_monitor_lock = 1;
+    # Mojo::IOLoop->subprocess(
+        # sub {
+            # my $subprocess = shift;
+            $log->debug("Calling proxy job monitor");
+            my @jobs = proxy_job_monitor();
+            $log->info("Got ${@jobs} to update") if @jobs;
+            $log->info("Jobs have been updated");
+            # return @jobs;
+        # },
+        # sub {
+        # my ($subprocess, $err, @results) = @_;
+        # if (@results){
+            map { $log->debug("Job ".$_->{jobid}." created at ". $_->{slave_url}) } @jobs;
+            $log->info("Jobs available on the MasterUI");
+            # $subprocess->ioloop->emit('job_progress', @results);
+        # }
+    # });
+    } else {
+        $log->debug("Still locked");
+    }
+    $log->debug("Hello?");
 });
 
 Mojo::IOLoop->start;

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -108,7 +108,7 @@ usage(0) if ($options{help});
 
 my $log = Mojo::Log->new;
 $options{master} ||= 'http://0DCD0E0C65A6822A:59D8C0D855F2AABD@deimos.suse.de';
-$options{slave}  ||= 'http://0DCD0E0C65A6822A:59D8C0D855F2AABD@lanner.arch.suse.de';
+$options{slave}  ||= 'http://6468159B01623A43:FA7B6B37353EDD4F@lanner.arch.suse.de';
 $options{limit} ||= 1000;
 $options{worker_class} ||= "cluster_job";
 
@@ -135,30 +135,87 @@ my $slave = OpenQA::Client->new(
 $log->info("Master: ". $master_url->to_abs);
 $log->info("Slave: ". $slave_url->to_abs);
 
+my $masterUI = $master->get($master_url->clone);
+my $slaveUI = $slave;
+
 sub get_asset_list {
     return {a => 1};
 }
 
-sub monitor_jobs {
-
-my $masterUI = $master->get($master_url->clone);
-my $slaveUI = $slave->get($slave_url->clone);
-
-    if($masterUI->res->is_success){
-        $log->info("Works: ". $master_url->to_abs);
-        #Get a list of assets to download:
-        my $asset_list = get_asset_list($masterUI->res->json);
-
+sub move_job {
+    my ($job) = @_;
+    my %settings = %{$job->{settings}};
+    if ($job->{group}) {
+        $settings{_GROUP} = $job->{group};
+    }
+    delete $settings{NAME};
+    # print JSON->new->pretty->encode(\%settings) if ($options{verbose});
+    my $url = $slave_url->clone;
+    $settings{federated_report} = $master_url->scheme . '://' . $master_url->host().'/tests/'.$job->{id};
+    $url->query(%settings);
+    $log->info("Posting to: $url");
+    my $tx = $slaveUI->post($url);
+    if ($tx->success) {
+        my $remote_id = $tx->success->json->{id};
+        if ($remote_id) {
+            my $url = $slave_url->scheme . '://' . $slave_url->host . '/tests/' . $remote_id;
+            $log->info( "Created job #$remote_id: ".$job->{name}." -> $url\n");
+                update_job($job);
+            return {jobid => $remote_id, url => $url};
+        }
+        else {
+            die "job not created. duplicate? ", pp($tx->res->body);
+        }
+    }
+    else {
+        die "Failed to create job, empty response. Make sure your HTTP proxy is running, e.g. apache, nginx, etc."
+          unless $tx->res->body;
+        die "Failed to create job: ", pp($tx->res->body);
     }
 }
+
+sub fetch_jobs {
+    my @crop;
+    if($masterUI->res->is_success){
+        my $job_count = scalar @{$masterUI->res->json->{jobs}};
+        $log->info("Found: $job_count at ". $master_url->to_abs);
+        foreach my $job (@{$masterUI->res->json->{jobs}}){
+            push @crop, move_job($job);
+        }
+        #my $asset_list = get_asset_list($masterUI->res->json);
+    }
+}
+
+sub update_job {
+    my ($job) = @_;
+
+    my $url = $master_url->clone;
+    $url->path("jobs/".$job->{id}."/status");
+    my $js = {status => {proxied => 1}};
+    # $url->query($js);
+    $log->info("Posting to: $url");
+    my $tx = $master->post($url => json => $js);
+    if ($tx->success) {
+        my $req = $tx->success->json;
+        if ($req) {
+            $log->debug(Dumper($req));
+        } else {
+            die "job not created. duplicate? ", Dumper($tx->res->body);
+        }
+    }
+    else {
+        die "Failed to create job, empty response. Make sure your HTTP proxy is running, e.g. apache, nginx, etc."
+          unless $tx->res->body;
+        die "Failed to create job: ", Dumper($tx->res->body);
+    }
+}
+
 my $main_loop = Mojo::IOLoop->singleton;
 
 $main_loop->on(new_jobs => sub {
     my $loop = shift;
     $log->info("New Jobs available on master webui");
-        for (1..80){
-            print '.';
-        }
+
     });
 
 $main_loop->on(job_progress => sub {
@@ -173,27 +230,28 @@ $main_loop->recurring(0.2 => sub {
     $log->debug("job progress event");
 });
 
-#Add a timer
+#Check for new jobs on the master webUI
 $main_loop->recurring(5 => sub {
     my $loop = shift;
     # Add a timer
+    $log->info("Checking for new jobs on the masterUI");
     Mojo::IOLoop->subprocess(
         sub {
             my $subprocess = shift;
-            # $loop->remove($id);
             $log->debug("Executing every 10 and will check for new jobs");
-            monitor_jobs();
+            return fetch_jobs();
         },
         sub {
         my ($subprocess, $err, @results) = @_;
         $subprocess->ioloop->emit('new_jobs');
-        # $->emit('newjobs');
     });
+
+    $log->info("New jobs monitoring finished");
 
 });
 
-Mojo::IOLoop->start;
+#Mojo::IOLoop->start;
 
-return 0;
+fetch_jobs();
 
 # vim: set sw=4 sts=4 et:

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -83,7 +83,10 @@ use Mojo::UserAgent;
 use Mojo::URL;
 use Mojo::Log;
 use OpenQA::Client;
+use Mojo::IOLoop;
 use JSON;
+
+use Data::Dumper;
 
 Getopt::Long::Configure("no_ignore_case");
 
@@ -131,12 +134,66 @@ my $slave = OpenQA::Client->new(
 
 $log->info("Master: ". $master_url->to_abs);
 $log->info("Slave: ". $slave_url->to_abs);
-my $jobs;
-if($jobs = $master->get($master_url->clone)->res->is_success && ($slave->get($slave_url->clone)->res->is_success)){
-    $log->info("Works");
+
+sub get_asset_list {
+    return {a => 1};
 }
 
-# $log->error();
-# $log->error($slave->get($slave_url->clone)->res->is_sucess);
+sub monitor_jobs {
+
+my $masterUI = $master->get($master_url->clone);
+my $slaveUI = $slave->get($slave_url->clone);
+
+    if($masterUI->res->is_success){
+        $log->info("Works: ". $master_url->to_abs);
+        #Get a list of assets to download:
+        my $asset_list = get_asset_list($masterUI->res->json);
+
+    }
+}
+my $main_loop = Mojo::IOLoop->singleton;
+
+$main_loop->on(new_jobs => sub {
+    my $loop = shift;
+    $log->info("New Jobs available on master webui");
+        for (1..80){
+            print '.';
+        }
+    });
+
+$main_loop->on(job_progress => sub {
+    my $loop = shift;
+    $log->info("New job progress available on the webui");
+    });
+
+#$Add a timer
+$main_loop->recurring(0.2 => sub {
+    my $loop = shift;
+    $loop->emit('job_progress');
+    $log->debug("job progress event");
+});
+
+#Add a timer
+$main_loop->recurring(5 => sub {
+    my $loop = shift;
+    # Add a timer
+    Mojo::IOLoop->subprocess(
+        sub {
+            my $subprocess = shift;
+            # $loop->remove($id);
+            $log->debug("Executing every 10 and will check for new jobs");
+            monitor_jobs();
+        },
+        sub {
+        my ($subprocess, $err, @results) = @_;
+        $subprocess->ioloop->emit('new_jobs');
+        # $->emit('newjobs');
+    });
+
+});
+
+Mojo::IOLoop->start;
+
+return 0;
 
 # vim: set sw=4 sts=4 et:

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -110,7 +110,7 @@ my $log = Mojo::Log->new;
 $options{master} ||= 'http://0DCD0E0C65A6822A:59D8C0D855F2AABD@deimos.suse.de';
 $options{slave}  ||= 'http://6468159B01623A43:FA7B6B37353EDD4F@lanner.arch.suse.de';
 $options{limit} ||= 1000;
-$options{worker_class} ||= "cluster_job";
+$options{worker_class} ||= ":provo:qemu_aarch64";
 
 #"/api/v1/jobs.json?&worker_class=aarch64_seattle9&limit=1000";
 my $master_url = Mojo::URL->new($options{master})->path("/api/v1/jobs.json")->query({
@@ -123,7 +123,6 @@ my $master = OpenQA::Client->new(
         apikey => $master_url->username,
         apisecret => $master_url->password,
     );
-
 
 my $slave_url = Mojo::URL->new($options{slave})->path("/api/v1/jobs");
 my $slave = OpenQA::Client->new(
@@ -149,19 +148,22 @@ sub move_job {
         $settings{_GROUP} = $job->{group};
     }
     delete $settings{NAME};
+    $settings{WORKER_CLASS} =~ s/:provo://;
+    $settings{PROXIED} = 1;
+
     # print JSON->new->pretty->encode(\%settings) if ($options{verbose});
     my $url = $slave_url->clone;
     $settings{federated_report} = $master_url->scheme . '://' . $master_url->host().'/tests/'.$job->{id};
+    $log->info("Posting to: ".$url->to_abs);
     $url->query(%settings);
-    $log->info("Posting to: $url");
     my $tx = $slaveUI->post($url);
     if ($tx->success) {
         my $remote_id = $tx->success->json->{id};
         if ($remote_id) {
-            my $url = $slave_url->scheme . '://' . $slave_url->host . '/tests/' . $remote_id;
-            $log->info( "Created job #$remote_id: ".$job->{name}." -> $url\n");
-                update_job($job);
-            return {jobid => $remote_id, url => $url};
+            my $new_url = $slave_url->scheme . '://' . $slave_url->host . '/tests/' . $remote_id;
+            $log->info( "Created job #$remote_id: ".$job->{name}." -> $new_url\n");
+            update_job($job);
+            return {jobid => $remote_id, url => $new_url};
         }
         else {
             die "job not created. duplicate? ", pp($tx->res->body);
@@ -180,10 +182,12 @@ sub fetch_jobs {
         my $job_count = scalar @{$masterUI->res->json->{jobs}};
         $log->info("Found: $job_count at ". $master_url->to_abs);
         foreach my $job (@{$masterUI->res->json->{jobs}}){
-            push @crop, move_job($job);
+            my $seed = move_job($job);
+            push @crop, $seed if $seed;
         }
         #my $asset_list = get_asset_list($masterUI->res->json);
     }
+    return @crop;
 }
 
 sub update_job {
@@ -193,12 +197,13 @@ sub update_job {
     $url->path("jobs/".$job->{id}."/status");
     my $js = {status => {proxied => 1}};
     # $url->query($js);
-    $log->info("Posting to: $url");
+    $log->info("Updating job: ".$job->{id}." at the MasterUI");
     my $tx = $master->post($url => json => $js);
     if ($tx->success) {
         my $req = $tx->success->json;
         if ($req) {
-            $log->debug(Dumper($req));
+            $log->debug("Job #".$job->{id}." sucessully updated in the MasterUI");
+            return 1;
         } else {
             die "job not created. duplicate? ", Dumper($tx->res->body);
         }
@@ -210,48 +215,49 @@ sub update_job {
     }
 }
 
+sub proxy_job_monitor {
+    ...
+}
+
 my $main_loop = Mojo::IOLoop->singleton;
 
 $main_loop->on(new_jobs => sub {
     my $loop = shift;
-    $log->info("New Jobs available on master webui");
-
+    $log->info("Jobs available on the MasterUI");
+    proxy_job_monitor();
     });
 
 $main_loop->on(job_progress => sub {
-    my $loop = shift;
-    $log->info("New job progress available on the webui");
+    my ($loop, @report_agrs) = shift;
+    $log->info("Job progress on the SlaveUI");
     });
 
 #$Add a timer
-$main_loop->recurring(0.2 => sub {
-    my $loop = shift;
-    $loop->emit('job_progress');
-    $log->debug("job progress event");
-});
+#$main_loop->recurring(0.2 => sub {
+#    my $loop = shift;
+#    $loop->emit('job_progress');
+#    $log->debug("job progress event");
+#});
 
 #Check for new jobs on the master webUI
 $main_loop->recurring(5 => sub {
     my $loop = shift;
     # Add a timer
-    $log->info("Checking for new jobs on the masterUI");
+    $log->info("Checking for new jobs on the MasterUI");
     Mojo::IOLoop->subprocess(
         sub {
             my $subprocess = shift;
-            $log->debug("Executing every 10 and will check for new jobs");
+            $log->debug("Checking for new jobs");
             return fetch_jobs();
         },
         sub {
         my ($subprocess, $err, @results) = @_;
-        $subprocess->ioloop->emit('new_jobs');
+        $subprocess->ioloop->emit('new_jobs', @results);
+        map { $log->info("Job ".$_->{jobid}." created at ". $_->{url}) } @results;
     });
-
     $log->info("New jobs monitoring finished");
-
 });
 
-#Mojo::IOLoop->start;
-
-fetch_jobs();
+Mojo::IOLoop->start;
 
 # vim: set sw=4 sts=4 et:

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -134,13 +134,42 @@ $log->info("Master: ". $master_url->to_abs);
 $log->info("Slave: ". $slave_url->to_abs);
 
 my $masterUI = $master;
+my $masterUI_workerid=register_worker($masterUI, $master_url->clone);
 my $slaveUI = $slave;
+my $slaveUI_workerid=register_worker($slaveUI, $slave_url->clone);
 my $main_loop = Mojo::IOLoop->singleton;
 my $proxy_job_monitor_lock = 0;
 
 
 sub get_asset_list {
     return {a => 1};
+}
+
+sub register_worker {
+    my ($webui, $url) = @_;
+    $url->path("/api/v1/workers")->query(Mojo::Parameters->new);
+    $url->query(
+        host => ':bridge:'.$url->host,
+        instance => 1,
+        cpu_arch => 'bridge',
+        mem_max => 0,
+        worker_class => 'FEDERATION_BRIDGE_WORKER'
+        );
+    $log->info("Registering bridge at ".$url->to_abs);
+    my $tx = $webui->post($url);
+    if ($tx->success) {
+        my $req = $tx->success->json;
+        if ($req) {
+            return $tx->success->json->{id};
+        } else {
+            die "job not created. duplicate? ", Dumper($tx->res->body);
+        }
+    }
+    else {
+        die "Failed to create job, empty response. Make sure your HTTP proxy is running, e.g. apache, nginx, etc."
+          unless $tx->res->body;
+        die "Failed to create job: ", Dumper($tx->res->body);
+    }
 }
 
 sub move_job {
@@ -235,7 +264,7 @@ sub proxy_job_monitor {
         $log->error($UI->res);
     }
 
-    foreach my $job (@{$UI->res->json->{jobs}}) { 
+    foreach my $job (@{$UI->res->json->{jobs}}) {
         my $progress_updated = process_job_progress($job);
         if ($progress_updated eq 1){
             push @jobs, $job;

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -107,8 +107,6 @@ GetOptions(
 usage(0) if ($options{help});
 
 my $log = Mojo::Log->new;
-$options{master} ||= 'http://0DCD0E0C65A6822A:59D8C0D855F2AABD@deimos.suse.de';
-$options{slave}  ||= 'http://6468159B01623A43:FA7B6B37353EDD4F@lanner.arch.suse.de';
 $options{limit} ||= 1000;
 $options{worker_class} ||= ":provo:qemu_aarch64";
 
@@ -134,8 +132,10 @@ my $slave = OpenQA::Client->new(
 $log->info("Master: ". $master_url->to_abs);
 $log->info("Slave: ". $slave_url->to_abs);
 
-my $masterUI = $master->get($master_url->clone);
+my $masterUI = $master;
 my $slaveUI = $slave;
+my $main_loop = Mojo::IOLoop->singleton;
+
 
 sub get_asset_list {
     return {a => 1};
@@ -162,8 +162,8 @@ sub move_job {
         if ($remote_id) {
             my $new_url = $slave_url->scheme . '://' . $slave_url->host . '/tests/' . $remote_id;
             $log->info( "Created job #$remote_id: ".$job->{name}." -> $new_url\n");
-            update_job($job);
-            return {jobid => $remote_id, url => $new_url};
+            update_proxied_job($job, $master_url->clone, {proxied => 1});
+            return { jobid => $remote_id, remote_url => $settings{federated_report}, slave_url => $new_url };
         }
         else {
             die "job not created. duplicate? ", pp($tx->res->body);
@@ -178,24 +178,25 @@ sub move_job {
 
 sub fetch_jobs {
     my @crop;
-    if($masterUI->res->is_success){
-        my $job_count = scalar @{$masterUI->res->json->{jobs}};
+    my $UI = $masterUI->get($master_url->clone);
+    $log->debug("fetching jobs from".$master_url->clone);
+    if($UI->res->is_success){
+        my $job_count = scalar @{$UI->res->json->{jobs}};
         $log->info("Found: $job_count at ". $master_url->to_abs);
-        foreach my $job (@{$masterUI->res->json->{jobs}}){
+        foreach my $job (@{$UI->res->json->{jobs}}){
             my $seed = move_job($job);
             push @crop, $seed if $seed;
         }
-        #my $asset_list = get_asset_list($masterUI->res->json);
+    } else {
+        $log->info("Nothing found?". $master_url->to_abs);
     }
     return @crop;
 }
 
-sub update_job {
-    my ($job) = @_;
-
-    my $url = $master_url->clone;
+sub update_proxied_job {
+    my ($job, $url, $status) = @_;
     $url->path("jobs/".$job->{id}."/status");
-    my $js = {status => {proxied => 1}};
+    my $js = {status => $status};
     # $url->query($js);
     $log->info("Updating job: ".$job->{id}." at the MasterUI");
     my $tx = $master->post($url => json => $js);
@@ -216,28 +217,47 @@ sub update_job {
 }
 
 sub proxy_job_monitor {
-    ...
+    my ($result) = @_;
+    $log->debug("proxy_job_monitor: ".$result->{jobid});
+    $main_loop->recurring(2 => sub {
+        my $loop = shift;
+        # Add a timer
+        $log->error("Adding a monitor for #".$result->{jobid}, Dumper($result));
+
+        Mojo::IOLoop->subprocess(
+            sub {
+                    $log->info("Checking for job #".$result->{jobid}, Dumper($result));
+                    my $url = $slave_url->clone;
+                    $url->path("jobs/".$result->{jobid});
+                    my $UI = $slaveUI->get($url);
+                    $log->info("Job #". $result->{jobid} ." reported ".$UI->res->json->{job}{state});
+                    if($UI->res->is_success){
+                        my $job_status = $UI->res->json->{state};
+                        $log->info("Job #". $result->{jobid} ." reported ".$UI->res->json->{job}{state});
+                        $log->info(Dumper($result));
+                        $log->info(Dumper($UI->res->json));
+                        update_proxied_job(id => $result->{jobid}, $master_url->clone, passed => 1) if $UI->res->json->{job}{state} eq 'done' ;
+                        update_proxied_job(id => $result->{jobid}, $master_url->clone, incomplete => 1) if $UI->res->json->{job}{state} eq 'scheduled' ;
+                    }
+            },
+            sub {
+            my ($subprocess, $err, @results) = @_;
+            $subprocess->ioloop->emit('job_progress', @results);
+        });
+    });
+
 }
 
-my $main_loop = Mojo::IOLoop->singleton;
-
 $main_loop->on(new_jobs => sub {
-    my $loop = shift;
-    $log->info("Jobs available on the MasterUI");
-    proxy_job_monitor();
+    my ($loop, @report_args) = @_;
+    $log->info("Job progress on the SlaveUI", Dumper(\@report_args));
+    map { proxy_job_monitor($_) } @report_args;
     });
 
 $main_loop->on(job_progress => sub {
-    my ($loop, @report_agrs) = shift;
+    my ($loop, @report_args) = @_;
     $log->info("Job progress on the SlaveUI");
     });
-
-#$Add a timer
-#$main_loop->recurring(0.2 => sub {
-#    my $loop = shift;
-#    $loop->emit('job_progress');
-#    $log->debug("job progress event");
-#});
 
 #Check for new jobs on the master webUI
 $main_loop->recurring(5 => sub {
@@ -248,14 +268,18 @@ $main_loop->recurring(5 => sub {
         sub {
             my $subprocess = shift;
             $log->debug("Checking for new jobs");
-            return fetch_jobs();
+            my @jobs = fetch_jobs();
+            $log->info("New jobs monitoring finished");
+            return @jobs;
         },
         sub {
         my ($subprocess, $err, @results) = @_;
-        $subprocess->ioloop->emit('new_jobs', @results);
-        map { $log->info("Job ".$_->{jobid}." created at ". $_->{url}) } @results;
+        if (@results){
+            map { $log->debug("Job ".$_->{jobid}." created at ". $_->{slave_url}) } @results;
+            $log->info("Jobs available on the MasterUI");
+            $subprocess->ioloop->emit('new_jobs', @results);
+        }
     });
-    $log->info("New jobs monitoring finished");
 });
 
 Mojo::IOLoop->start;

--- a/script/worker_bridge
+++ b/script/worker_bridge
@@ -1,0 +1,118 @@
+#!/usr/bin/env perl
+# Copyright (C) 2017 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+=head1 slave_bridge
+
+slave_bridge - openQA slave bridge
+
+=head1 SYNOPSIS
+
+worker [OPTIONS]
+
+=head2OPTIONS
+
+=over 4
+
+=item B<--master> https://s.ky.net.openqa.opensuse.org
+
+=item B<--master> https://openqa.opensuse.org
+
+=item B<--help, -h>
+
+print help
+
+=back
+
+=head2 DESCRIPTION
+
+(no content)
+
+=head1 CONFIG FILE
+
+L<worker> relies on credentials provided by L<OpenQA::Client>, i.e. tries to
+find a config file C<client.conf> resolving C<$OPENQA_CONFIG> or
+C<~/.config/openqa> or C</etc/openqa/> in this order of preference.
+Additionally L<worker> uses a config file C<workers.ini> to configure worker
+settings.
+
+Example:
+  [global]
+  BACKEND = qemu
+  HOST = http://openqa.example.com
+
+
+=head1 SEE ALSO
+L<OpenQA::Client>
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    #prepare for large files
+    $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
+    $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
+    $ENV{MOJO_CONNECT_TIMEOUT}    = 300;
+    # the default is EV, and this heavily screws with our children handling
+    $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
+    #$ENV{MOJO_LOG_LEVEL} = 'debug';
+    #$ENV{MOJO_USERAGENT_DEBUG} = 1;
+    #$ENV{MOJO_IOLOOP_DEBUG} = 1;
+}
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Config::IniFiles;
+use Getopt::Long;
+use Mojo::Base -strict;
+use Mojo::UserAgent;
+use Mojo::URL;
+
+Getopt::Long::Configure("no_ignore_case");
+
+my %options;
+
+sub usage($) {
+    my $r = shift;
+    eval "use Pod::Usage; pod2usage($r);";
+    if ($@) {
+        die "cannot display help, install perl(Pod::Usage)\n";
+    }
+}
+
+GetOptions(
+    \%options, "master=s", "slave=s", "verbose|v", "help|h",
+) or usage(1);
+
+usage(0) if ($options{help});
+
+$options{master} ||= "http://deimos.suse.de";
+$options{slave}  ||= "http://lanner.arch.suse.de";
+$options{limit} ||= 1000;
+$options{worker_class} ||= "cluster_job";
+
+
+
+#"/api/v1/jobs.json?&worker_class=aarch64_seattle9&limit=1000";
+my $url = Mojo::URL->new($options{master})->path("/api/v1/jobs.json")->query({
+        limit => $options{limt},
+        worker_class => $options{worker_class}
+    });
+
+say $url->to_abs;
+
+# vim: set sw=4 sts=4 et:

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -401,6 +401,18 @@ $t->json_is('/job/settings/DISTRI'  => undef);
 
 $post = $t->post_ok('/api/v1/jobs', form => {})->status_is(400);
 
+subtest 'job details' => sub {
+
+    $t->get_ok('/api/v1/jobs/99926')->status_is(200);
+    $t->json_is('/job/testresults' => undef, 'Test details are not present');
+
+    $t->get_ok('/api/v1/jobs/99926?details=1')->status_is(200);
+    $t->json_hasnt('/job/testresults/0', 'Test details are empty');
+
+    $t->get_ok('/api/v1/jobs/99963?details=1')->status_is(200);
+    $t->json_has('/job/testresults/0', 'Test details are there');
+};
+
 subtest 'update job and job settings' => sub {
     # check defaults
     $t->get_ok('/api/v1/jobs/99926')->status_is(200);


### PR DESCRIPTION
So, after some digging I've got to a point where I can say that the federation could work. 

The approach is simple, have a separate script/app that will check a master webUI for jobs available under a certain worker class, if there are, create the respective jobs on the slave webUI and monitor them. 

For this mode, we require an explicit setting that will allow openQA to know what jobs must run on a separate instance. This allows to use WORKER_CLASS=:my_location:our_worker_class

To improve and isolate the federation support, a new dedicated api route is needed, given the latest changes to the API and grab job, thus I added /federation, for now this is just mimicking the behavior of job#list

Add proxy_job_monitor as a stub to spawn a new ioloop timer that will monitor the state of a job, but I'm not 100% sure that this could be efficient, but another idea is to simply have a timer every N seconds and query all jobs's status that have PROXIED=1 in their job settings on the slaveUI

Status PROXIED has also been added, so these jobs can be tagged properly on the masterUI 