### PR TITLE
Scheduler: low aggressivity on slow workers

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,7 @@ coverage:
         branches: null
     project:
       default:
-        target: 85.0
+        target: 86.5
         threshold: 0.1
     patch:
       default:

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -41,11 +41,11 @@ use constant SHUFFLE_WORKERS => $ENV{OPENQA_SCHEDULER_SHUFFLE_WORKERS} // 1;
 
 # When enabled scheduler will keep a table of seen workers and periodically clean it up.
 # Jobs will be allocated also to those workers, even if we see them as dead from the DB state.
-use constant KEEPALIVE_DEAD_WORKERS => $ENV{KEEPALIVE_DEAD_WORKERS} // 0;
+use constant KEEPALIVE_DEAD_WORKERS => $ENV{OPENQA_SCHEDULER_KEEPALIVE_DEAD_WORKERS} // 0;
 
 # Max attempts to performs before seeing the worker that didn't accepted the job.
 # Defaults to 3
-use constant RETRY_JOB_ALLOCATION_ATTEMPTS => $ENV{RETRY_JOB_ALLOCATION_ATTEMPTS} // 3;
+use constant RETRY_JOB_ALLOCATION_ATTEMPTS => $ENV{OPENQA_SCHEDULER_RETRY_JOB_ALLOCATION_ATTEMPTS} // 3;
 
 # Scheduler default clock. Defaults to 8s
 # Optimization rule of thumb is:
@@ -60,6 +60,9 @@ use constant SCHEDULE_TICK_MS => $ENV{OPENQA_SCHEDULER_SCHEDULE_TICK_MS} // 8000
 # backoff to avoid congestion.
 # Enable it with 1, disable with 0. Following options depends on it.
 use constant CONGESTION_CONTROL => $ENV{OPENQA_SCHEDULER_CONGESTION_CONTROL} // 1;
+
+# Wakes up the scheduler on request
+use constant WAKEUP_ON_REQUEST => $ENV{OPENQA_SCHEDULER_WAKEUP_ON_REQUEST} // 0;
 
 # Timeslot. Defaults to SCHEDULE_TICK_MS
 use constant TIMESLOT => $ENV{OPENQA_SCHEDULER_TIMESLOT} // 1000;
@@ -98,7 +101,9 @@ sub run {
     log_debug("Scheduler started");
     log_debug("\t Scheduler default interval(ms) : " . SCHEDULE_TICK_MS);
     log_debug("\t Max job allocation: " . MAX_JOB_ALLOCATION);
+    log_debug("\t Job allocation retries: " . RETRY_JOB_ALLOCATION_ATTEMPTS);
     log_debug("\t Timeslot(ms) : " . TIMESLOT);
+    log_debug("\t Wakeup on request : " .     (WAKEUP_ON_REQUEST      ? "enabled" : "disabled"));
     log_debug("\t Internal worker cache : " . (KEEPALIVE_DEAD_WORKERS ? "enabled" : "disabled"));
     log_debug("\t Find job retries : " . FIND_JOB_ATTEMPTS);
     log_debug("\t Congestion control : " .                  (CONGESTION_CONTROL ? "enabled" : "disabled"));
@@ -145,6 +150,12 @@ dbus_method('job_grab', [['dict', 'string', ['variant']]], [['dict', 'string', [
 sub job_grab {
     my ($self, $args) = @_;
     return OpenQA::Scheduler::Scheduler::job_grab(%$args);
+}
+
+dbus_method('wakeup_scheduler');
+sub wakeup_scheduler {
+    my ($self, $args) = @_;
+    return OpenQA::Scheduler::Scheduler::wakeup_scheduler();
 }
 
 dbus_method('job_restart', [['array', 'uint32']], [['array', 'uint32']]);

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -39,6 +39,10 @@ use constant FIND_JOB_ATTEMPTS => $ENV{OPENQA_SCHEDULER_FIND_JOB_ATTEMPTS} // 1;
 # Setting it to 0 may lead to worker starvation
 use constant SHUFFLE_WORKERS => $ENV{OPENQA_SCHEDULER_SHUFFLE_WORKERS} // 1;
 
+# When enabled scheduler will keep a table of seen workers and periodically clean it up.
+# Jobs will be allocated also to those workers, even if we see them as dead from the DB state.
+use constant KEEPALIVE_DEAD_WORKERS => $ENV{KEEPALIVE_DEAD_WORKERS} // 1;
+
 # Scheduler default clock. Defaults to 8s
 # Optimization rule of thumb is:
 # if we see a enough big number of messages while in debug mode stating "Congestion control"
@@ -90,11 +94,12 @@ sub run {
     log_debug("Scheduler started");
     log_debug("\t Scheduler default interval(ms) : " . SCHEDULE_TICK_MS);
     log_debug("\t Max job allocation: " . MAX_JOB_ALLOCATION);
+    log_debug("\t Timeslot(ms) : " . TIMESLOT);
+    log_debug("\t Internal worker cache : " . (KEEPALIVE_DEAD_WORKERS ? "enabled" : "disabled"));
     log_debug("\t Find job retries : " . FIND_JOB_ATTEMPTS);
     log_debug("\t Congestion control : " .                  (CONGESTION_CONTROL ? "enabled" : "disabled"));
     log_debug("\t Backoff when we can't schedule jobs : " . (BUSY_BACKOFF       ? "enabled" : "disabled"));
     log_debug("\t Capture loop avoidance(ms) : " . CAPTURE_LOOP_AVOIDANCE);
-    log_debug("\t Timeslot(ms) : " . TIMESLOT);
     log_debug("\t Max backoff(ms) : " . MAX_BACKOFF);
     log_debug("\t Exp backoff : " . EXPBACKOFF);
 

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -41,7 +41,11 @@ use constant SHUFFLE_WORKERS => $ENV{OPENQA_SCHEDULER_SHUFFLE_WORKERS} // 1;
 
 # When enabled scheduler will keep a table of seen workers and periodically clean it up.
 # Jobs will be allocated also to those workers, even if we see them as dead from the DB state.
-use constant KEEPALIVE_DEAD_WORKERS => $ENV{KEEPALIVE_DEAD_WORKERS} // 1;
+use constant KEEPALIVE_DEAD_WORKERS => $ENV{KEEPALIVE_DEAD_WORKERS} // 0;
+
+# Max attempts to performs before seeing the worker that didn't accepted the job.
+# Defaults to 3
+use constant RETRY_JOB_ALLOCATION_ATTEMPTS => $ENV{RETRY_JOB_ALLOCATION_ATTEMPTS} // 3;
 
 # Scheduler default clock. Defaults to 8s
 # Optimization rule of thumb is:
@@ -58,16 +62,16 @@ use constant SCHEDULE_TICK_MS => $ENV{OPENQA_SCHEDULER_SCHEDULE_TICK_MS} // 8000
 use constant CONGESTION_CONTROL => $ENV{OPENQA_SCHEDULER_CONGESTION_CONTROL} // 1;
 
 # Timeslot. Defaults to SCHEDULE_TICK_MS
-use constant TIMESLOT => $ENV{OPENQA_SCHEDULER_TIMESLOT} // SCHEDULE_TICK_MS;
+use constant TIMESLOT => $ENV{OPENQA_SCHEDULER_TIMESLOT} // 1000;
 
-# Maximum backoff. Defaults to 560s
-use constant MAX_BACKOFF => $ENV{OPENQA_SCHEDULER_MAX_BACKOFF} // 560000;
+# Maximum backoff. Defaults to 60s
+use constant MAX_BACKOFF => $ENV{OPENQA_SCHEDULER_MAX_BACKOFF} // 60000;
 
 # Our exponent, used to calculate backoff. Defaults to 2 (Binary)
 use constant EXPBACKOFF => $ENV{OPENQA_SCHEDULER_EXP_BACKOFF} // 2;
 
-# Timer reset to avoid starvation caused by CONGESTION_CONTROL/BUSY_BACKOFF. Defaults to 660s
-use constant CAPTURE_LOOP_AVOIDANCE => $ENV{OPENQA_SCHEDULER_CAPTURE_LOOP_AVOIDANCE} // 660000;
+# Timer reset to avoid starvation caused by CONGESTION_CONTROL/BUSY_BACKOFF. Defaults to 120s
+use constant CAPTURE_LOOP_AVOIDANCE => $ENV{OPENQA_SCHEDULER_CAPTURE_LOOP_AVOIDANCE} // 120000;
 
 # set it to 1 if you want to backoff when no jobs can be assigned or we are really busy
 # Default is enabled as CONGESTION_CONTROL.

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -20,6 +20,7 @@ use base 'DBIx::Class::ResultSet';
 use DBIx::Class::Timestamps 'now';
 use Date::Format 'time2str';
 use OpenQA::Schema::Result::JobDependencies;
+use OpenQA::Utils 'wakeup_scheduler';
 use JSON;
 
 =head2 latest_build
@@ -189,6 +190,7 @@ sub create_from_settings {
             'Ignoring invalid group ' . to_json(\%group_args) . ' when creating new job ' . $job->id);
     }
     $txn_guard->commit;
+    wakeup_scheduler;
     return $job;
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -219,6 +219,20 @@ sub update_status {
         return;
     }
 
+    if (!exists $status->{worker_id}) {
+        OpenQA::Utils::log_info(
+            'Got status update for job ' . $self->stash('jobid') . ' but does not contain a worker id! ');
+        return;
+    }
+
+    if (!$job->worker || $job->worker->id != $status->{worker_id}) {
+        OpenQA::Utils::log_info('Got status update for job '
+              . $self->stash('jobid')
+              . ' that does not belong to Worker '
+              . $status->{worker_id});
+        return;
+    }
+
     my $ret = $job->update_status($status);
     if (!$ret || $ret->{error} || $ret->{error_status}) {
         $ret = {} unless $ret;

--- a/systemd/openqa-scheduler.service
+++ b/systemd/openqa-scheduler.service
@@ -8,6 +8,7 @@ User=geekotest
 Environment="DBUS_STARTER_BUS_TYPE=system"
 ExecStart=/usr/share/openqa/script/openqa-scheduler
 BusName=org.opensuse.openqa.Scheduler
+TimeoutStopSec=120
 Type=dbus
 
 [Install]

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -26,10 +26,14 @@ BEGIN {
     $ENV{OPENQA_BASEDIR} = path(tempdir, 't', 'full-stack.d');
     $ENV{OPENQA_CONFIG} = path($ENV{OPENQA_BASEDIR}, 'config')->make_path;
     # Since tests depends on timing, we require the scheduler to be fixed in its actions.
-    $ENV{OPENQA_SCHEDULER_TIMESLOT}           = 3000;
-    $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} = 1;
-    $ENV{OPENQA_SCHEDULER_FIND_JOB_ATTEMPTS}  = 1;
-    $ENV{OPENQA_SCHEDULER_CONGESTION_CONTROL} = 0;
+    $ENV{OPENQA_SCHEDULER_TIMESLOT}               = 1000;
+    $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION}     = 1;
+    $ENV{OPENQA_SCHEDULER_FIND_JOB_ATTEMPTS}      = 1;
+    $ENV{OPENQA_SCHEDULER_CONGESTION_CONTROL}     = 1;
+    $ENV{OPENQA_SCHEDULER_SCHEDULE_TICK_MS}       = 3000;
+    $ENV{OPENQA_SCHEDULER_MAX_BACKOFF}            = 8000;
+    $ENV{OPENQA_SCHEDULER_WAKEUP_ON_REQUEST}      = 1;
+    $ENV{OPENQA_SCHEDULER_KEEPALIVE_DEAD_WORKERS} = 1;
     path($FindBin::Bin, "data")->child("openqa.ini")->copy_to(path($ENV{OPENQA_CONFIG})->child("openqa.ini"));
     path($FindBin::Bin, "data")->child("database.ini")->copy_to(path($ENV{OPENQA_CONFIG})->child("database.ini"));
     path($FindBin::Bin, "data")->child("workers.ini")->copy_to(path($ENV{OPENQA_CONFIG})->child("workers.ini"));


### PR DESCRIPTION
- Before considering that the worker haven't accepted the job (can be optionally enabled), attempt by retrial mechanism
- Build a run-time cache of seen workers, periodically reset (can be optionally enabled) to try to allocate jobs even if workers are slow and thought dead
- Adds the ability to wake up the scheduler when we receive new jobs or restarts (optionally enabled)
- Handle gracefully quit/restarts

Let's see also if we get some coverage back