### PR TITLE
Improve error if a worker cannot connect to a WebSocket

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -365,7 +365,9 @@ sub call_websocket {
                 else {
                     my $err = $tx->error;
                     if (defined $err) {
-                        warn "Unable to upgrade connection to WebSocket: "
+                        log_error "Unable to upgrade connection for host "
+                          . "\"$hosts->{$host}{url}{host}\""
+                          . " to WebSocket: "
                           . ($err->{code} ? $err->{code} : "[no code]")
                           . ". proxy_wstunnel enabled?";
                         if ($err->{code} && $err->{code} eq '404' && $hosts->{$host}{workerid}) {
@@ -409,7 +411,7 @@ sub register_worker {
     log_info("registering worker with openQA $host...");
 
     if (!$hosts->{$host}) {
-        warn "WebUI $host is unknown! - Should not happen but happened, exiting!";
+        log_error "WebUI $host is unknown! - Should not happen but happened, exiting!";
         Mojo::IOLoop->stop;
         return;
     }


### PR DESCRIPTION
Before:
```
Aug 04 13:57:53 monteverdi worker[34702]: [INFO] registering worker with openQA http://10.160.65.204...
Aug 04 13:57:53 monteverdi worker[34702]: [INFO] registering worker with openQA http://openqa.glados.qa.suse.de...
Aug 04 13:57:53 monteverdi worker[34702]: [INFO] registering worker with openQA http://10.160.66.147...
Aug 04 13:57:53 monteverdi worker[34702]: [INFO] registering worker with openQA http://e13.suse.de...
Aug 04 13:57:54 monteverdi worker[34702]: Unable to upgrade connection to WebSocket: 503. proxy_wstunnel enabled? at /usr/share/openqa/script/../lib/OpenQA/Worker/Common.pm line 368.
```

After:
```
Aug 04 14:34:33 monteverdi worker[37800]: [INFO] registering worker with openQA http://10.160.65.204...
Aug 04 14:34:33 monteverdi worker[37800]: [INFO] registering worker with openQA http://openqa.glados.qa.suse.de...
Aug 04 14:34:33 monteverdi worker[37800]: [INFO] registering worker with openQA http://10.160.66.147...
Aug 04 14:34:34 monteverdi worker[37800]: [INFO] registering worker with openQA http://e13.suse.de...
Aug 04 14:34:34 monteverdi worker[37800]: [ERROR] Unable to upgrade connection for host "10.160.65.204" to WebSocket: 503. proxy_wstunnel enabled?
```

Highly increases debug-ability especially on shared workers where a worker does not only connect to one single web UI.

Also uses proper logging facility now (therefore the change in line 414) and bumped up the log level on both occasions to an "error".

