### PR TITLE
Conflict no-cleanup worker with normal worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ install:
 	sed -e 's_^\(ExecStart=/usr/share/openqa/script/worker\) \(--instance %i\)$$_\1 --no-cleanup \2_' \
 		systemd/openqa-worker@.service \
 		> "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
+	sed -i '/Wants/aConflicts=openqa-worker@.service' \
+		"$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
 	install -m 644 systemd/openqa-worker.target "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-webui.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-gru.service "$(DESTDIR)"/usr/lib/systemd/system


### PR DESCRIPTION
Right now the service files for "--no-cleanup" worker and "normal" worker are totally independent of each other. This results in errors if you try to start a normal worker instance while a no-cleanup worker runs with the same instance name.
The "Conflicts" directive takes care of stopping one of them if you try to start the other and vice versa.
I've chosen another sed-call to continue the "don't repeat yourself thought" from one line above and will always add the directive under "Wants=" - this hopefully ensures independence of the main service in the future.