### PR TITLE
Include '.' in INC for 24-feature-tour.t

### DIFF
--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    push @INC, '.';
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 


### PR DESCRIPTION
This test was recently added, and uses the PhantomTest module,
but didn't include the workaround for loading it with Perl 5.26
that we recently committed to all the other tests (see #1406).