### PR TITLE
Use OPENQA_TEST_IPC in more tests due to scheduler changes

### DIFF
--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -17,6 +17,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use strict;


### PR DESCRIPTION
More tests now need to use the dummy IPC stuff due to the recent
scheduler changes (these tests fail in Fedora's package build
environment without this change).