### PR TITLE
Add support for custom links in footer

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -810,3 +810,19 @@ h2 + * {
   margin-right: 10px;
   width: auto;
 }
+
+#footer-links {
+    &.left {
+        float: left;
+    }
+
+    &.right {
+        float: right;
+    }
+
+    a {
+        display: inline-table;
+        margin-left: 15px;
+        margin-right: 15px;
+    }
+}

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -821,7 +821,7 @@ h2 + * {
     }
 
     a {
-        display: inline-table;
+        display: inline;
         margin-left: 15px;
         margin-right: 15px;
     }

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -137,16 +137,21 @@
 
       <footer class='footer'>
           <div class='container'>
-              <div id='footer-legal'>
-                  <div class="text-center !important">
-                      openQA is licensed
-                      %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
-                      % if ($current_version) {
-                          - Version
-                          %= $current_version
-                      % }
-                      %= include_branding 'links_footer'
-                  </div>
+              <div id="footer-links">
+                  <span id="footer-links" class="left">
+                      %= include_branding 'links_footer_left'
+                  </span>
+                  <span id="footer-links" class="right">
+                      %= include_branding 'links_footer_right'
+                  </span>
+              </div>
+              <div id='footer-legal' class="text-center">
+                  openQA is licensed
+                  %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
+                  % if ($current_version) {
+                      - Version
+                      %= $current_version
+                  % }
               </div>
             </div>
       </footer>

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -136,16 +136,19 @@
       </div>
 
       <footer class='footer'>
-        <div class='container'>
-          <div id='footer-legal' class="text-center">
-              openQA is licensed
-              %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
-              % if ($current_version) {
-                  - Version
-                  %= $current_version
-              % }
-          </div>
-        </div>
+          <div class='container'>
+              <div id='footer-legal'>
+                  <div class="text-center !important">
+                      openQA is licensed
+                      %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
+                      % if ($current_version) {
+                          - Version
+                          %= $current_version
+                      % }
+                      %= include_branding 'links_footer'
+                  </div>
+              </div>
+            </div>
       </footer>
   </body>
 </html>


### PR DESCRIPTION
Related to https://progress.opensuse.org/issues/13954

Added the possibility to show links in the footer section by adding a file to the brandings folder.

It would look like the following screenshot:
![footer_screenshot](https://user-images.githubusercontent.com/22001671/29178667-8e6a02d8-7df2-11e7-990a-233137adbcfe.png)

Please checkout out  https://gitlab.suse.de/openqa/salt-states-openqa/merge_requests/19 since it is related to this pull request.
