### PR TITLE
Fix sporadic problem of systemd service start (poo#21004)

### DIFF
--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=The openQA WebSockets server
-Wants=apache2.service
+Wants=apache2.service network.target
 Before=apache2.service openqa-webui.service
-After=openqa-scheduler.service postgresql.service mariadb.service
+After=openqa-scheduler.service postgresql.service mariadb.service network.target
 Requires=openqa-scheduler.service
 
 [Service]


### PR DESCRIPTION
openqa-websockets/openqa-webui sometimes don't start
during boot.
See https://progress.opensuse.org/issues/21004 for
more information.

Simply add a dependency to network.target in
openqa-websockets.service.

Note: the same dependency exists in openqa-worker.service, so I used network.target like openqa-worker instead of  network.service.