### PR TITLE
Ensure use of symlinked applications for clone_job/dump_templates/load_templates

### DIFF
--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -111,10 +111,8 @@ use LWP::UserAgent;
 Getopt::Long::Configure("no_ignore_case");
 use Mojo::URL;
 use JSON;
-
 use FindBin;
-use lib "$FindBin::Bin/../lib";
-use OpenQA::Client;
+use lib "$FindBin::RealBin/../lib";
 
 my %options;
 

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -102,10 +102,8 @@ JobTemplates e.g. to load them on another instance.
 
 =cut
 
-BEGIN {
-    use FindBin qw($Bin);
-    use lib "$Bin/../lib";
-}
+use FindBin;
+use lib "$FindBin::RealBin/../lib";
 
 use strict;
 use Data::Dump;

--- a/script/load_templates
+++ b/script/load_templates
@@ -61,11 +61,8 @@ lorem ipsum ...
 
 =cut
 
-BEGIN {
-    use FindBin qw($Bin);
-    use lib "$Bin/../lib";
-}
-
+use FindBin;
+use lib "$FindBin::RealBin/../lib";
 use strict;
 use File::Basename qw(dirname);
 use Try::Tiny;


### PR DESCRIPTION
Using the same approach as in client we can symlink clone_job.pl and others to
somewhere else which allows easier packaging of the according tools as
applications within a standalone client package.