### PR TITLE
Add hour-suffix to rotated logs

### DIFF
--- a/etc/logrotate.d/openqa
+++ b/etc/logrotate.d/openqa
@@ -7,5 +7,6 @@
     notifempty
     missingok
     copytruncate
+    hourly
 }
 


### PR DESCRIPTION
Since we rotate our log hourly we need to add an hour suffix to the compressed logs.
Right now logrotate complains after the first rotation with:

> 2017-08-24T23:15:02.607168+02:00 openqa logrotate: ALERT exited abnormally with [1]
> 2017-08-24T23:15:02.609679+02:00 openqa logrotate: error: destination /var/log/openqa-20170824.gz already exists, skipping rotation

and refuses the compression. This can result in high disk space usage - especially if you let openQA run on debug log level.
This PR changes the filename from e.g.:
openqa-20170825.gz
to:
openqa-2017082508.gz