### PR TITLE
Add description part for api routes at not_found page

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -164,6 +164,7 @@ sub startup {
     my $r         = $self->routes;
     my $logged_in = $r->under('/')->to("session#ensure_user");
     my $auth      = $r->under('/')->to("session#ensure_operator");
+    my %api_description;
 
     $r->post('/session')->to('session#create');
     $r->delete('/session')->to('session#destroy');
@@ -467,6 +468,8 @@ sub startup {
 
     # api/v1/feature
     $api_ru->post('/feature')->name('apiv1_post_informed_about')->to('feature#informed');
+    $api_description{'apiv1_post_informed_about'}
+      = 'Post integer value to save feature tour progress of current user in the database';
 
     # reduce_result is obsolete (replaced by limit_results_and_logs)
     $self->gru->add_task(reduce_result          => \&OpenQA::Schema::Result::Jobs::reduce_result);
@@ -512,6 +515,7 @@ sub startup {
                 # the JSON API might already provide JSON in some error cases which must be preserved
                 (($args->{json} //= {})->{error_status}) = $args->{status};
             }
+            $c->stash('api_description', \%api_description);
         });
 }
 

--- a/templates/not_found.html.ep
+++ b/templates/not_found.html.ep
@@ -28,6 +28,9 @@ table pre {
             % my $name = $route->name;
             <%= $route->has_custom_name ? qq{"$name"} : $name %>
         </td>
+        <td>
+            <%= $api_description->{$route->name} %>
+        </td>
     </tr>
     % $depth++;
     %= $walk->($walk, $_, $depth) for @{$route->children};
@@ -35,7 +38,7 @@ table pre {
     % end
     <table class="table">
         <thead>
-            <tr><th>Pattern</th><th>Methods</th><th>Name</th></tr>
+            <tr><th>Pattern</th><th>Methods</th><th>Name</th><th>Description</th></tr>
         </thead>
         %= $walk->($walk, $_, 0) for @{app->routes->children};
     </table>


### PR DESCRIPTION
Related to https://progress.opensuse.org/issues/16282

The thought was to make a first step relating this ticket and add a description part to the already existing api routes table on the not_found page. 