### PR TITLE
Websocket: terminate worker connection when it's not registered

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -32,6 +32,7 @@ requires 'File::Path';
 requires 'File::Spec';
 requires 'FindBin';
 requires 'Getopt::Long';
+requires 'IO::Handle';
 requires 'IO::Socket::SSL';
 requires 'IPC::Cmd';
 requires 'IPC::Run';

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -22,6 +22,7 @@ use Mojo::URL;
 use Regexp::Common 'URI';
 use Try::Tiny;
 use Mojo::File 'path';
+use IO::Handle;
 
 require Exporter;
 our ($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
@@ -212,7 +213,7 @@ sub log_debug {
         $app->log->debug($msg);
     }
     else {
-        print "[DEBUG] $msg\n";
+        STDOUT->printflush("[DEBUG] $msg\n");
     }
 }
 
@@ -222,7 +223,7 @@ sub log_info {
         $app->log->info($msg);
     }
     else {
-        print "[INFO] $msg\n";
+        STDOUT->printflush("[INFO] $msg\n");
     }
 }
 
@@ -232,7 +233,7 @@ sub log_warning {
         $app->log->warn($msg);
     }
     else {
-        print STDERR "[WARN] $msg\n";
+        STDERR->printflush("[WARN] $msg\n");
     }
 }
 
@@ -242,7 +243,7 @@ sub log_error {
         $app->log->error($msg);
     }
     else {
-        print STDERR "[ERROR] $msg\n";
+        STDERR->printflush("[ERROR] $msg\n");
     }
 }
 

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -188,11 +188,13 @@ sub _message {
     my $worker = _get_worker($ws->tx);
     unless ($worker) {
         $ws->app->log->warn("A message received from unknown worker connection");
-        log_debug(sprintf('A message received from unknown worker connection: %s', Dumper($json)));
+        log_debug(sprintf('A message received from unknown worker connection (terminating ws): %s', Dumper($json)));
+        $ws->finish("1008", "Connection terminated from WebSocket server - thought dead");
         return;
     }
     unless (ref($json) eq 'HASH') {
         log_error(sprintf('Received unexpected WS message "%s from worker %u', Dumper($json), $worker->id));
+        $ws->finish("1003", "Received unexpected data from worker, forcing close");
         return;
     }
 

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -358,6 +358,8 @@ sub call_websocket {
                 $tx->on(json => \&OpenQA::Worker::Commands::websocket_commands);
                 $tx->on(
                     finish => sub {
+                        my (undef, $code, $reason) = @_;
+                        log_debug("Connection turned off from $host - $code : $reason");
                         remove_timer("keepalive-$host");
                         remove_timer("workerstatus-$host");
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -486,6 +486,22 @@ subtest 'job is not marked as linked if accessed from unrecognized referal' => s
     is($linked, 0, 'job not linked after accessed from unknown referer');
 };
 
+subtest 'job set_running()' => sub {
+    my %_settings = %settings;
+    $_settings{TEST} = 'L';
+    my $job = _job_create(\%_settings);
+    $job->update({state => OpenQA::Schema::Result::Jobs::ASSIGNED});
+    is($job->set_running, 1, 'job was set to running');
+    is($job->state, OpenQA::Schema::Result::Jobs::RUNNING, 'job state is now on running');
+    $job->update({state => OpenQA::Schema::Result::Jobs::RUNNING});
+    is($job->set_running, 1, 'job already running');
+    is($job->state, OpenQA::Schema::Result::Jobs::RUNNING, 'job state is now on running');
+    $job->update({state => 'foobar'});
+    is($job->set_running, 0,        'job not set to running');
+    is($job->state,       'foobar', 'job state is foobar');
+};
+
+
 use OpenQA::Worker::Common 'get_timer';
 use OpenQA::Worker::Jobs;
 no warnings 'redefine';

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -59,10 +59,10 @@ my $host    = "http://localhost:$port";
 remove_tree($cachedir);
 make_path($ENV{LOGDIR});
 
-#redirect stdout
-open(my $FD, '>>', $logfile);
-select $FD;
-$| = 1;
+# reassign STDOUT, STDERR
+open my $FD, '>>', $logfile;
+*STDOUT = $FD;
+*STDERR = $FD;
 
 sub truncate_log {
     my ($new_log) = @_;
@@ -164,7 +164,6 @@ sub stop_server {
 }
 
 OpenQA::Worker::Cache::init($host, $cachedir);
-
 $openqalogs = read_log($logfile);
 like $openqalogs, qr/Creating cache directory tree for/, "Cache directory tree created.";
 like $openqalogs, qr/Deploying DB/,                      "Cache deploys the database.";


### PR DESCRIPTION
When we receive worker connections without prior registration, a message is displayed but no action is performed. This happens mostly when WebUI have been restarted, but not the workers associated with it. 

This is a big issue related to scheduler, since latest changes dispatch jobs completely over ws, and  if no connection between worker and WebUI is present, dispatching of jobs will stop with regard to those workers, even if we see them as online. With the changes in this PR we close the connection gracefully - so the worker is forced to re-register to the WebUI.

As a side change of this PR - prints to STDERR/STDOUT from `log_*` calls inside `OpenQA::Utils` are flushed to avoid misleading messages (see https://progress.opensuse.org/issues/23334).

See (main) related progress issue: https://progress.opensuse.org/issues/21836

Still in WIP also because i want to get rid of the sleep inside the (new) test to cover this case