### PR TITLE
Add all job states to be monitored from /tests route

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -200,7 +200,12 @@ function setupResult(state, jobid, status_url, details_url) {
       }
     }
   }
-  if (state == "running" || state == "waiting" || state == "uploading" || state == "assigned") {
+  // This could be easily rewritten as $.inArray
+  if ( state == "running"   ||
+       state == "waiting"   ||
+       state == "uploading" ||
+       state == "assigned"  ||
+       state == "setup" ) {
     setupRunning(jobid, status_url, details_url);
   }
   else if (state == "scheduled") {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -48,8 +48,8 @@ use constant {
 use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, WAITING, DONE, CANCELLED);
 use constant PENDING_STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, WAITING, UPLOADING);
 use constant EXECUTION_STATES => (ASSIGNED, SETUP, WAITING, RUNNING, UPLOADING);
-use constant PRE_EXECUTION_STATES => (SCHEDULED); # Assigned belongs to pre execution, but makes no sense for now
-use constant FINAL_STATES         => (DONE,      CANCELLED);
+use constant PRE_EXECUTION_STATES => (SCHEDULED);    # Assigned belongs to pre execution, but makes no sense for now
+use constant FINAL_STATES => (DONE, CANCELLED);
 
 # Results
 use constant {
@@ -57,13 +57,13 @@ use constant {
     PASSED             => 'passed',
     SOFTFAILED         => 'softfailed',
     FAILED             => 'failed',
-    INCOMPLETE         => 'incomplete',            # worker died or reported some problem
-    SKIPPED            => 'skipped',               # dependencies failed before starting this job
-    OBSOLETED          => 'obsoleted',             # new iso was posted
-    PARALLEL_FAILED    => 'parallel_failed',       # parallel job failed, this job can't continue
-    PARALLEL_RESTARTED => 'parallel_restarted',    # parallel job was restarted, this job has to be restarted too
-    USER_CANCELLED     => 'user_cancelled',        # cancelled by user via job_cancel
-    USER_RESTARTED     => 'user_restarted',        # restarted by user via job_restart
+    INCOMPLETE         => 'incomplete',              # worker died or reported some problem
+    SKIPPED            => 'skipped',                 # dependencies failed before starting this job
+    OBSOLETED          => 'obsoleted',               # new iso was posted
+    PARALLEL_FAILED    => 'parallel_failed',         # parallel job failed, this job can't continue
+    PARALLEL_RESTARTED => 'parallel_restarted',      # parallel job was restarted, this job has to be restarted too
+    USER_CANCELLED     => 'user_cancelled',          # cancelled by user via job_cancel
+    USER_RESTARTED     => 'user_restarted',          # restarted by user via job_restart
 };
 use constant RESULTS => (NONE, PASSED, SOFTFAILED, FAILED, INCOMPLETE, SKIPPED,
     OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -43,12 +43,13 @@ use constant {
     DONE      => 'done',
     UPLOADING => 'uploading',
     ASSIGNED  => 'assigned'
-      #    OBSOLETED => 'obsoleted',
 };
-use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, CANCELLED, WAITING, DONE, UPLOADING);
+
+use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, WAITING, DONE, CANCELLED);
 use constant PENDING_STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, WAITING, UPLOADING);
-use constant EXECUTION_STATES => (ASSIGNED, RUNNING, WAITING, UPLOADING);
-use constant FINAL_STATES => (DONE, CANCELLED);
+use constant EXECUTION_STATES => (ASSIGNED, SETUP, WAITING, RUNNING, UPLOADING);
+use constant PRE_EXECUTION_STATES => (SCHEDULED); # Assigned belongs to pre execution, but makes no sense for now
+use constant FINAL_STATES         => (DONE,      CANCELLED);
 
 # Results
 use constant {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -77,7 +77,20 @@ sub list {
         };
         push @list, $data;
     }
-    @list = sort { $b->{job}->t_started <=> $a->{job}->t_started || $b->{job}->id <=> $a->{job}->id } @list;
+    @list = sort {
+        if ($b->{job} && $a->{job}) {
+            $b->{job}->t_started <=> $a->{job}->t_started || $b->{job}->id <=> $a->{job}->id;
+        }
+        elsif ($b->{job}) {
+            1;
+        }
+        elsif ($a->{job}) {
+            -1;
+        }
+        else {
+            0;
+        }
+    } @list;
     $self->stash(running => \@list);
 
     my @scheduled = $self->db->resultset("Jobs")->complex_query(
@@ -86,6 +99,20 @@ sub list {
         groupid => $groupid,
         assetid => $assetid
     )->all;
+    # @scheduled = sort {
+    #     if ($b->{job} && $a->{job}) {
+    #         $b->{job}->t_created <=> $a->{job}->t_created || $b->{job}->id <=> $a->{job}->id;
+    #     }
+    #     elsif ($b->{job}) {
+    #         1;
+    #     }
+    #     elsif ($a->{job}) {
+    #         -1;
+    #     }
+    #     else {
+    #         0;
+    #     }
+    # }
     @scheduled = sort { $b->t_created <=> $a->t_created || $b->id <=> $a->id } @scheduled;
     $self->stash(scheduled => \@scheduled);
 }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -51,7 +51,7 @@ sub list {
     my $limit   = $self->param('limit') // 500;
 
     my $jobs = $self->db->resultset("Jobs")->complex_query(
-        state   => 'done,cancelled',
+        state   => [OpenQA::Schema::Result::Jobs::FINAL_STATES],
         match   => $match,
         scope   => $scope,
         assetid => $assetid,
@@ -62,7 +62,7 @@ sub list {
     $self->stash(jobs => $jobs);
 
     my $running = $self->db->resultset("Jobs")->complex_query(
-        state   => 'running,waiting',
+        state   => [OpenQA::Schema::Result::Jobs::EXECUTION_STATES],
         match   => $match,
         groupid => $groupid,
         assetid => $assetid
@@ -81,7 +81,7 @@ sub list {
     $self->stash(running => \@list);
 
     my @scheduled = $self->db->resultset("Jobs")->complex_query(
-        state   => 'scheduled',
+        state   => [OpenQA::Schema::Result::Jobs::PRE_EXECUTION_STATES],
         match   => $match,
         groupid => $groupid,
         assetid => $assetid
@@ -120,7 +120,11 @@ sub list_ajax {
         {'me.id' => {in => \@ids}},
         {
             columns => [
-                qw(me.id MACHINE DISTRI VERSION FLAVOR ARCH BUILD TEST state clone_id test result group_id t_finished passed_module_count softfailed_module_count failed_module_count skipped_module_count)
+                qw(me.id MACHINE DISTRI VERSION FLAVOR ARCH BUILD TEST
+                  state clone_id test result group_id t_finished
+                  passed_module_count softfailed_module_count
+                  failed_module_count skipped_module_count
+                  )
             ],
             order_by => ['me.t_finished DESC, me.id DESC'],
             prefetch => [qw(children parents)],

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -35,7 +35,7 @@
             % my $distri = $job->DISTRI // '';
             % my $version = $job->VERSION // '';
             % my $flavor = $job->FLAVOR // '';
-	    % my $arch = $job->ARCH // '';
+        % my $arch = $job->ARCH // '';
             % my $start_time = $job->t_started ? $job->t_started->datetime() : 0;
             % my $query = { distri => $distri, version => $version, build => $build };
             % if ($job->group_id) {
@@ -48,12 +48,12 @@
                     of <%= "$distri-$version-$flavor.$arch" %>
                 </td>
                 <td class="test">
-		    % if (is_operator) {
-			%= link_to url_for('apiv1_cancel', jobid => $job->id) => (class => 'cancel') => begin
-                          <i class="action fa fa-fw fa-times-circle-o"></i>
-			% end
-		    % }
-		    %= link_to url_for('test', 'testid' => $job->id) => begin
+                    % if (is_operator) {
+                    %= link_to url_for('apiv1_cancel', jobid => $job->id) => (class => 'cancel') => begin
+                                  <i class="action fa fa-fw fa-times-circle-o"></i>
+                    % end
+                    % }
+                    %= link_to url_for('test', 'testid' => $job->id) => begin
                         <i class="status state_running fa fa-circle" title="Running"></i>
                     % end
                     %= link_to url_for('test', 'testid' => $job->id) => begin

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -35,7 +35,7 @@
             % my $distri = $job->DISTRI // '';
             % my $version = $job->VERSION // '';
             % my $flavor = $job->FLAVOR // '';
-        % my $arch = $job->ARCH // '';
+            % my $arch = $job->ARCH // '';
             % my $start_time = $job->t_started ? $job->t_started->datetime() : 0;
             % my $query = { distri => $distri, version => $version, build => $build };
             % if ($job->group_id) {
@@ -75,7 +75,7 @@
                             %   $ptext = $value."%";
                         % } else
                         % {
-                            %   $ptext = "pre-processing";
+                            %   $ptext = $job->state;
                             %   $classes = " progress-bar-striped active";
                         % }
                         <div class="progress-bar <%= $classes %>" role="progressbar" style="width: <%= $value %>%; min-width: 2em;" aria-valuemax="100" aria-valuemin="0" aria-valuenow="<%= $value %>">

--- a/templates/test/running_table.html.ep
+++ b/templates/test/running_table.html.ep
@@ -5,13 +5,13 @@
         "columnDefs": [
             { targets: 0,
               className: "name" },
-            { targets: 3,
-              className: "time",
+            { targets: 'time',
               "render": function ( data, type, row ) {
-                    if (type === 'display') {
+                    if (type === 'display' && data != '0Z') {
                       return jQuery.timeago(new Date(data));
-                  } else
-                      return data;
+                  } else {
+                      return 'Not yet';
+                  }
               }
             },
         ],
@@ -24,7 +24,7 @@
             <th class="name">Medium</th>
             <th class="test">Test</th>
             <th>Progress</th>
-            <th>Started</th>
+            <th class="time">Started</th>
         </tr>
     </thead>
     <tbody>
@@ -83,7 +83,7 @@
                         </div>
                     </div>
                 </td>
-                <td class="testtime" title="<%= $job->t_started %>Z"><%= $start_time %>Z</td>
+                <td class="time" title="<%= $job->t_started %>Z"><%= $start_time %>Z</td>
             </tr>
         % }
     </tbody>

--- a/templates/test/scheduled_table.html.ep
+++ b/templates/test/scheduled_table.html.ep
@@ -1,17 +1,16 @@
 % content_for 'ready_function' => begin
   $('#scheduled').DataTable( {
-        "pagingType" : 'simple',
-        "order": [],
-	"columnDefs": [
-	    { targets: 0,
+    "pagingType" : 'simple',
+    "order": [],
+    "columnDefs": [
+        { targets: 0,
               className: "name" },
-	    { targets: 3,
-              className: "time",
+        { targets: "time",
               "render": function ( data, type, row ) {
-                    if (type === 'display') {
+                    if (type === 'display' && data != '0Z') {
                       return jQuery.timeago(new Date(data));
                   } else
-                      return data;
+                      return 'Not yet';
               }
             },
         ],
@@ -21,57 +20,57 @@
 <table id="scheduled" class="display table table-striped" style="width: 100%">
     <thead>
         <tr>
-	    <th class="name">Medium</th>
-	    <th class="name">Test</th>
-            <th>Priority</th>
-            <th>Created</th>
+        <th class="name">Medium</th>
+        <th class="name">Test</th>
+        <th>Priority</th>
+        <th class="time">Created</th>
         </tr>
     </thead>
     <tbody>
-	% for my $job (@$scheduled) {
-	    % my $prio = $job->priority;
-	    % my $state = $job->state;
-	    % my $build = $job->BUILD;
-	    % my $distri = $job->DISTRI;
-	    % my $version = $job->VERSION;
-	    % my $flavor = $job->FLAVOR;
-	    % my $arch = $job->ARCH;
-	    % my $query = { distri => $distri, version => $version, build => $build };
-	    % if ($job->group_id) {
+    % for my $job (@$scheduled) {
+        % my $prio = $job->priority;
+        % my $state = $job->state;
+        % my $build = $job->BUILD;
+        % my $distri = $job->DISTRI;
+        % my $version = $job->VERSION;
+        % my $flavor = $job->FLAVOR;
+        % my $arch = $job->ARCH;
+        % my $query = { distri => $distri, version => $version, build => $build };
+        % if ($job->group_id) {
             % $query->{groupid} = $job->group_id;
-	    % }
-	    <tr id="job_<%= $job->id %>">
-		% my $test = $job->TEST . '@' . $job->MACHINE;
-                <td class="name">
-                    %= link_to "Build$build" => url_for('tests_overview')->query(%$query);
-                    of <%= "$distri-$version-$flavor.$arch" %>
-                </td>
-                <td class="test">
-		    % if (is_operator) {
-		      %= link_to url_for('apiv1_cancel', jobid => $job->id) => (class => 'cancel') => begin
-                         <i class="action fa fa-fw fa-times-circle-o"></i>
-		      % end
-		    % }
-		    %= link_to url_for('test', 'testid' => $job->id) => begin
+        % }
+        <tr id="job_<%= $job->id %>">
+        % my $test = $job->TEST . '@' . $job->MACHINE;
+            <td class="name">
+                %= link_to "Build$build" => url_for('tests_overview')->query(%$query);
+                of <%= "$distri-$version-$flavor.$arch" %>
+            </td>
+            <td class="test">
+                % if (is_operator) {
+                  %= link_to url_for('apiv1_cancel', jobid => $job->id) => (class => 'cancel') => begin
+                             <i class="action fa fa-fw fa-times-circle-o"></i>
+                  % end
+                % }
+                %= link_to url_for('test', 'testid' => $job->id) => begin
                        <i class="status state_scheduled fa fa-circle" title="Scheduled"></i>
                     % end
                     %= link_to url_for('test', 'testid' => $job->id) => begin
                        %= $test
                     % end
                     %= comment_icon($job->id, $job->comments->count);
-		</td>
+            </td>
                 % my $href = url_for('tests_overview')->query(build => $build, distri => $distri, version => $version);
-                <td class="actions">
-		    %= link_post url_for('apiv1_job_prio', 'jobid' => $job->id)->query(prio => $prio-10) => (class => 'prio-down') =>  ('data-remote' => 'true') => begin
-		    <i class="fa fa-minus-square-o"></i>
-		    % end
-		    <span data-prio="<%= $prio %>"><%= $prio %></span>
-		    %= link_post url_for('apiv1_job_prio', 'jobid' => $job->id)->query(prio => $prio+10) => (class => 'prio-up') => ('data-remote' => 'true') => begin
-		    <i class="fa fa-plus-square-o"></i>
-		    % end
-		</td>
-		<td class="testtime" title="<%= $job->t_created %>Z"><%= $job->t_created->datetime() %>Z</td>
-            </tr>
+             <td class="actions">
+                %= link_post url_for('apiv1_job_prio', 'jobid' => $job->id)->query(prio => $prio-10) => (class => 'prio-down') =>  ('data-remote' => 'true') => begin
+                <i class="fa fa-minus-square-o"></i>
+                % end
+                <span data-prio="<%= $prio %>"><%= $prio %></span>
+                %= link_post url_for('apiv1_job_prio', 'jobid' => $job->id)->query(prio => $prio+10) => (class => 'prio-up') => ('data-remote' => 'true') => begin
+                <i class="fa fa-plus-square-o"></i>
+                % end
+            </td>
+            <td class="time" title="<%= $job->t_created %>Z"><%= $job->t_created->datetime() %>Z</td>
+        </tr>
         % }
     </tbody>
 </table>


### PR DESCRIPTION
This is an approach of adding all the states to the /tests route, so that wen can see all tests that can be represented through any of `OpenQA::Schema::Result::Jobs::STATES`. 

While it seems to be feasible, there are few things that migh need to change (Including how we are representing the tests at all). Also not to do unnecesary queries thatspam the database every time someone is opening /tests. 

![2017-09-22-102458_1188x424_scrot](https://user-images.githubusercontent.com/229240/30735786-87eaa412-9f80-11e7-9570-a960d724aeb5.png)