### PR TITLE
Trim less text in overview tables by using CSS instead of custom code

### DIFF
--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -438,6 +438,7 @@ table.overview {
         td.name {
                 padding-top: .5em;
                 padding-bottom: .5em;
+                text-overflow: ellipsis;
         }
         .failedmodule {
                 background-color: #E9F7C9;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -284,12 +284,9 @@ sub register {
         });
 
     $app->helper(
-        trim_text => sub {
-            my ($c, $text, $length) = @_;
-            $length //= 10;
-            return $text if (length($text) < $length);
-
-            return $c->tag('span', title => $text, sub { substr($text, 0, $length - 4) . " ..." });
+        text_with_title => sub {
+            my ($c, $text) = @_;
+            return $c->tag('span', title => $text, $text);
         });
 
     $app->helper(

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -277,7 +277,7 @@ $get = $t->get_ok(
     })->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 2/i, 'expected job failures matches');
 $failedmodules = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#res_DVD_x86_64_doc')->all_text);
-is($failedmodules, 'logpackages failing_ ...', 'failing_module module failed');
+is($failedmodules, 'logpackages failing_module', 'failing_module module failed');
 
 # Check if failed_modules hides successful jobs even if a (fake) module failure is there
 $failing_module = $t->app->db->resultset('JobModules')->create(

--- a/templates/test/overview_result_table.html.ep
+++ b/templates/test/overview_result_table.html.ep
@@ -14,7 +14,7 @@
             % next unless $type_results->{$config};
             <tr>
                 <td class="name">
-                    % my $test_label = trim_text($config, 30);
+                    % my $test_label = text_with_title($config);
                     % if (my $description = $type_results->{$config}{description}) {
                         <a data-content="<p><%= href_to_bugref(render_escaped_refs($description)) %></p>"
                         data-title="<%= $config %>" data-toggle="popover" data-trigger="focus" role="button" tabindex="0"><%= $test_label %></a>

--- a/templates/test/tr_job_result_failedmodules.html.ep
+++ b/templates/test/tr_job_result_failedmodules.html.ep
@@ -12,7 +12,7 @@
     % my $async_url = url_for('test_module_fails', 'testid' => $jobid, 'moduleid' => $failedmodule);
 
     <span title="<i class='fa fa-refresh fa-spin fa-2x fa-fw'></i><span class='sr-only'>Loading...</span>" data-toggle="tooltip" class="failedmodule" data-async="<%= $async_url %>">
-        %= link_to trim_text($failedmodule, $limit) => url_for('test', 'testid' => $jobid) . "#step/$failedmodule/1"
+        %= link_to text_with_title($failedmodule) => url_for('test', 'testid' => $jobid) . "#step/$failedmodule/1"
 	% $limit -= length($failedmodule) > $limit ? $limit : length($failedmodule) + 2;
     </span>
 % }


### PR DESCRIPTION
Alternative to https://github.com/os-autoinst/openQA/pull/1090