### PR TITLE
Subscribe start_job/stop_job events before we call send on websocket connection

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -359,7 +359,8 @@ sub call_websocket {
                 $tx->on(
                     finish => sub {
                         my (undef, $code, $reason) = @_;
-                        log_debug("Connection turned off from $host - $code : $reason");
+                        log_debug("Connection turned off from $host - $code : "
+                              . (defined $reason ? $reason : "Not specified"));
                         remove_timer("keepalive-$host");
                         remove_timer("workerstatus-$host");
 


### PR DESCRIPTION
Also, print the reason only when websocket server gives one.