### PR TITLE
Worker: reset internal state if we fail contacting the WebUI

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -181,7 +181,7 @@ sub api_call {
     my $ignore_errors = $args{ignore_errors} // 0;
     my $tries         = $args{tries} // 3;
 
-    die 'No worker id or webui host set!' unless verify_workerid($host);
+    do { OpenQA::Worker::Jobs::_reset_state(); die 'No worker id or webui host set!'; } unless verify_workerid($host);
 
     $method = uc $method;
     my $ua_url = $hosts->{$host}{url}->clone;

--- a/lib/OpenQA/Worker/Pool.pm
+++ b/lib/OpenQA/Worker/Pool.pm
@@ -62,6 +62,7 @@ sub check_qemu_pid {
 
 sub clean_pool() {
     return if $nocleanup;
+    return unless $pooldir;
     check_qemu_pid();
     for my $file (glob "$pooldir/*") {
         if (-d $file) {


### PR DESCRIPTION
When we have Websocket disconnections the $host gets removed, resulting
in the impossibility to update the status of the job to the WebUI.

Previously we used just to let the worker loop die in this case, this lead
the worker to send messages of the previous job status, even if worker is not
working on it. In that case the WebUI would reap the job after the timeout expired.
Now we need to be sure from the worker that the status sent to the
server is consistent, and not leak previous jobs information: with this change we
 reset the state of worker instead of leaving the state unpredictable.

See related progress issue: https://progress.opensuse.org/issues/25124