### PR TITLE
Websocket: Do not kill connections due to inactivity (meant mostly for browsers)

### DIFF
--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -152,6 +152,7 @@ sub ws_create {
     # upgrade connection to websocket by subscribing to events
     $self->on(json   => \&_message);
     $self->on(finish => \&_finish);
+    $self->inactivity_timeout(0);    # Do not force connection close due to inactivity
     $worker->{socket} = $self->tx->max_websocket_size(10485760);
 }
 


### PR DESCRIPTION
Timeout inactivity in websockets are mostly meant for browsers and to close connection when we do not receive more data (e.g. the user leave the page open but it's AFK and such). With this change we disable the timeout from the websocket server.

Traces of frequent disconnections due to timeout are visible in websocket logs, e.g. : https://progress.opensuse.org/issues/25124