### PR TITLE
Changes the log level

### DIFF
--- a/lib/OpenQA/FakeApp.pm
+++ b/lib/OpenQA/FakeApp.pm
@@ -33,7 +33,7 @@ has mode => 'production';
 
 has log_name => 'scheduler';
 
-has level => 'debug';
+has level => 'info';
 
 has instance => undef;
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -43,6 +43,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   &log_warning
   &log_info
   &log_error
+  &log_fatal
   &save_base64_png
   &run_cmd_with_log
   &run_cmd_with_log_return_error
@@ -245,6 +246,17 @@ sub log_error {
     else {
         STDERR->printflush("[ERROR] $msg\n");
     }
+}
+
+sub log_fatal {
+    my ($msg) = @_;
+    if ($app && $app->log) {
+        $app->log->fatal($msg);
+    }
+    else {
+        STDERR->printflush("[FATAL] $msg\n");
+    }
+    die $msg;
 }
 
 sub save_base64_png($$$) {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -37,17 +37,16 @@ sub init {
     $instance  = $options->{instance} if defined $options->{instance};
     $pooldir   = $OpenQA::Utils::prjdir . '/pool/' . $instance;
     $nocleanup = $options->{"no-cleanup"};
-    $verbose   = $options->{verbose} if defined $options->{verbose};
 
     my $logdir = $ENV{OPENQA_WORKER_LOGDIR} // $worker_settings->{LOG_DIR};
     my $app = OpenQA::FakeApp->new(
         mode     => 'production',
         log_name => 'worker',
         instance => $instance,
-        log_dir  => $logdir,
-        level    => $worker_settings->{LOG_LEVEL} // 'debug'
+        log_dir  => $logdir
     );
 
+    $app->level($worker_settings->{LOG_LEVEL}) if $worker_settings->{LOG_LEVEL};
     $app->setup_log();
     $OpenQA::Utils::app = $app;
     OpenQA::Worker::Common::api_init($host_settings, $options);
@@ -75,7 +74,7 @@ sub main {
             next;
         }
 
-        log_debug("Using dir $dir for host $h") if $verbose;
+        log_debug("Using dir $dir for host $h");
         Mojo::IOLoop->next_tick(
             sub { OpenQA::Worker::Common::register_worker($h, $dir, $host_settings->{$h}{TESTPOOLSERVER}) });
     }

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -65,40 +65,40 @@ sub websocket_commands {
             $joburl = $job->{URL};
         }
         if ($type =~ m/quit|abort|cancel|obsolete/) {
-            log_debug("received command: $type") if $verbose;
+            log_debug("received command: $type");
             stop_job($type);
         }
         elsif ($type eq 'stop_waitforneedle') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/stop_waitforneedle");
-                log_debug('stop_waitforneedle triggered') if $verbose;
+                log_debug('stop_waitforneedle triggered');
                 ws_call('property_change', {waitforneedle => 1});
             }
         }
         elsif ($type eq 'reload_needles_and_retry') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/reload_needles");
-                log_debug('needles will be reloaded') if $verbose;
+                log_debug('needles will be reloaded');
             }
         }
         elsif ($type eq 'enable_interactive_mode') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=1");
-                log_debug('interactive mode enabled') if $verbose;
+                log_debug('interactive mode enabled');
                 ws_call('property_change', {interactive_mode => 1});
             }
         }
         elsif ($type eq 'disable_interactive_mode') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/interactive?state=0");
-                log_debug('interactive mode disabled') if $verbose;
+                log_debug('interactive mode disabled');
                 ws_call('property_change', {interactive_mode => 0});
             }
         }
         elsif ($type eq 'continue_waitforneedle') {
             if (backend_running) {
                 $ua->post("$joburl/isotovideo/continue_waitforneedle");
-                log_debug('waitforneedle will continue') if $verbose;
+                log_debug('waitforneedle will continue');
                 ws_call('property_change', {waitforneedle => 0});
             }
         }
@@ -106,14 +106,14 @@ sub websocket_commands {
             # change update_status timer if $job running
             if (backend_running) {
                 OpenQA::Worker::Jobs::start_livelog();
-                log_debug('Starting livelog') if $verbose;
+                log_debug('Starting livelog');
                 change_timer('update_status', STATUS_UPDATES_FAST);
             }
         }
         elsif ($type eq 'livelog_stop') {
             # change update_status timer
             if (backend_running) {
-                log_debug('Stopping livelog') if $verbose;
+                log_debug('Stopping livelog');
                 OpenQA::Worker::Jobs::stop_livelog();
                 unless (OpenQA::Worker::Jobs::has_logviewers()) {
                     change_timer('update_status', STATUS_UPDATES_SLOW);

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -25,7 +25,7 @@ use OpenQA::Client;
 use OpenQA::Utils qw(log_error log_debug log_warning log_info);
 
 use base 'Exporter';
-our @EXPORT = qw($job $verbose $instance $worker_settings $pooldir $nocleanup
+our @EXPORT = qw($job $instance $worker_settings $pooldir $nocleanup
   $hosts $ws_to_host $current_host
   $worker_caps $testresults update_setup_status
   STATUS_UPDATES_SLOW STATUS_UPDATES_FAST
@@ -34,7 +34,6 @@ our @EXPORT = qw($job $verbose $instance $worker_settings $pooldir $nocleanup
 
 # Exported variables
 our $job;
-our $verbose  = 0;
 our $instance = 'manual';
 our $worker_settings;
 our $pooldir;
@@ -94,7 +93,7 @@ sub add_timer {
     die "must specify callback\n" unless $callback && ref $callback eq 'CODE';
     # skip if timer already defined, but not if one shot timer (avoid the need to call remove_timer for nonrecurring)
     return if ($timer && $timers->{$timer} && !$nonrecurring);
-    log_debug("## adding timer $timer $timeout") if $verbose;
+    log_debug("## adding timer $timer $timeout");
     my $timerid;
     if ($nonrecurring) {
         $timerid = Mojo::IOLoop->timer($timeout => $callback);
@@ -112,7 +111,7 @@ sub add_timer {
 sub remove_timer {
     my ($timer) = @_;
     return unless $timer;
-    log_debug("## removing timer $timer") if $verbose;
+    log_debug("## removing timer $timer");
     my $timerid = $timer;
     if ($timers->{$timer}) {
         # global timers needs translation to actual timerid
@@ -125,7 +124,7 @@ sub remove_timer {
 sub change_timer {
     my ($timer, $newtimeout, $callback) = @_;
     return unless ($timer && $timers->{$timer});
-    log_debug("## changing timer $timer") if $verbose;
+    log_debug("## changing timer $timer");
     $callback = $timers->{$timer}->[1] unless $callback;
     remove_timer($timer);
     add_timer($timer, $newtimeout, $callback);
@@ -190,7 +189,7 @@ sub api_call {
     $ua_url->path($path =~ s/^\///r);
     $ua_url->query($params) if $params;
 
-    log_debug("$method $ua_url") if $verbose;
+    log_debug("$method $ua_url");
 
     my @args = ($method, $ua_url);
 
@@ -265,7 +264,7 @@ sub ws_call {
     die 'Current host not set!' unless $current_host;
 
     # this call is also non blocking, result and image upload is handled by json handles
-    log_debug("WEBSOCKET: $type") if $verbose;
+    log_debug("WEBSOCKET: $type");
     my $ws = $hosts->{$current_host}{ws};
     $ws->send({json => {type => $type, jobid => $job->{id} || '', data => $data}});
 }
@@ -323,7 +322,7 @@ sub setup_websocket {
         $ua_url->scheme('wss');
     }
     $ua_url->path("ws/$workerid");
-    log_debug("WEBSOCKET $ua_url") if $verbose;
+    log_debug("WEBSOCKET $ua_url");
 
     call_websocket($host, $ua_url);
 }
@@ -495,7 +494,7 @@ sub register_worker {
     }
     my $newid = $tx->res->json->{id};
 
-    log_debug("new worker id within WebUI $host is $newid") if $verbose;
+    log_debug("new worker id within WebUI $host is $newid");
     $hosts->{$host}{workerid} = $newid;
 
     setup_websocket($host);

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -148,7 +148,7 @@ sub engine_workit {
     my $workerid   = $hosts->{$current_host}{workerid};
     my %vars       = (OPENQA_URL => $openqa_url, WORKER_INSTANCE => $instance, WORKER_ID => $workerid);
     while (my ($k, $v) = each %{$job->{settings}}) {
-        log_debug("setting $k=$v") if $verbose;
+        log_debug("setting $k=$v");
         $vars{$k} = $v;
     }
 
@@ -274,9 +274,8 @@ sub engine_check {
 
     # check if the worker is still running
     my $pid = waitpid($workerpid, WNOHANG);
-    if ($verbose) {
-        log_debug("waitpid $workerpid returned $pid with status $?");
-    }
+    log_debug("waitpid $workerpid returned $pid with status $?");
+
     if ($pid == -1 && $!{ECHILD}) {
         warn "we lost our child\n";
         return 'died';

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -103,7 +103,7 @@ sub check_job {
     return if $job;
 
     $check_job_running->{$host} = 1;
-    log_debug("checking for job with webui $host") if $verbose;
+    log_debug("checking for job with webui $host");
     api_call(
         'post',
         "workers/$workerid/grab_job",
@@ -143,7 +143,7 @@ sub stop_job {
 
     $job_id = $job->{id};
 
-    log_debug("stop_job $aborted") if $verbose;
+    log_debug("stop_job $aborted");
     $stop_job_running = 1;
 
     # stop all job related timers
@@ -156,7 +156,7 @@ sub stop_job {
     my $stop_job_check_status;
     $stop_job_check_status = sub {
         if ($update_status_running) {
-            log_debug("waiting for update_status to finish") if $verbose;
+            log_debug("waiting for update_status to finish");
             Mojo::IOLoop->timer(1 => $stop_job_check_status);
         }
         else {
@@ -178,7 +178,7 @@ sub upload {
     open(my $log, '>>', "autoinst-log.txt");
     printf $log "uploading %s\n", $filename;
     close $log;
-    log_debug("uploading $filename") if $verbose;
+    log_debug("uploading $filename");
 
     my $regular_upload_failed = 0;
     my $retry_counter         = 5;
@@ -286,7 +286,7 @@ sub _stop_job {
     # now tell the webui that we're about to finish, but the following
     # process of killing the backend process and checksums uploads and
     # checksums again can take a long while, so the webui needs to know
-    log_debug('stop_job 2nd part') if $verbose;
+    log_debug('stop_job 2nd part');
 
     if ($aborted eq "scheduler_abort") {
         log_debug('stop_job called by the scheduler. do not send logs');
@@ -309,7 +309,7 @@ sub _stop_job_2 {
     my ($aborted, $job_id) = @_;
     _kill_worker($worker);
 
-    log_debug('stop_job 3rd part') if $verbose;
+    log_debug('stop_job 3rd part');
 
     my $name = $job->{settings}->{NAME};
     $aborted ||= 'done';
@@ -383,13 +383,13 @@ sub _stop_job_2 {
         }
 
         if ($aborted eq 'obsolete') {
-            log_debug('setting job ' . $job->{id} . ' to incomplete (obsolete)') if $verbose;
+            log_debug('setting job ' . $job->{id} . ' to incomplete (obsolete)');
             upload_status(1, sub { _stop_job_finish({result => 'incomplete', newbuild => 1}) });
             $job_done = 1;
         }
         elsif ($aborted eq 'cancel') {
             # not using job_incomplete here to avoid duplicate
-            log_debug('setting job ' . $job->{id} . ' to incomplete (cancel)') if $verbose;
+            log_debug('setting job ' . $job->{id} . ' to incomplete (cancel)');
             upload_status(1, sub { _stop_job_finish({result => 'incomplete'}) });
             $job_done = 1;
         }
@@ -397,13 +397,13 @@ sub _stop_job_2 {
             log_warning('job ' . $job->{id} . ' spent more time than MAX_JOB_TIME');
         }
         elsif ($aborted eq 'done') {    # not aborted
-            log_debug('setting job ' . $job->{id} . ' to done') if $verbose;
+            log_debug('setting job ' . $job->{id} . ' to done');
             upload_status(1, \&_stop_job_finish);
             $job_done = 1;
         }
     }
     unless ($job_done || $aborted eq 'api-failure') {
-        log_debug(sprintf 'job %d incomplete', $job->{id}) if $verbose;
+        log_debug(sprintf 'job %d incomplete', $job->{id});
         if ($aborted eq 'quit') {
             log_debug(sprintf "duplicating job %d\n", $job->{id});
             api_call(
@@ -425,7 +425,7 @@ sub _stop_job_2 {
 
 sub _stop_job_finish {
     my ($params, $quit) = @_;
-    log_debug("update status running $update_status_running") if $verbose && $update_status_running;
+    log_debug("update status running $update_status_running") if $update_status_running;
     if ($update_status_running) {
         add_timer('', 1, sub { _stop_job_finish($params, $quit) }, 1);
         return;
@@ -541,7 +541,7 @@ sub read_last_screen {
 sub update_status {
     return if $update_status_running;
     $update_status_running = 1;
-    log_debug('updating status') if $verbose;
+    log_debug('updating status');
     upload_status();
     return;
 }
@@ -550,7 +550,7 @@ sub stop_livelog {
     # We can have multiple viewers at the same time
     $do_livelog--;
     if ($do_livelog eq 0) {
-        log_debug('Removing live_log mark, live views active') if $verbose;
+        log_debug('Removing live_log mark, live views active');
         unlink "$pooldir/live_log";
     }
 }
@@ -682,7 +682,7 @@ sub optimize_image {
     my ($image) = @_;
 
     if (which('optipng')) {
-        log_debug("optipng $image") if $verbose;
+        log_debug("optipng $image");
         # be careful not to be too eager optimizing, this needs to be quick
         # or we will be considered a dead worker
         system('optipng', '-quiet', '-o2', $image);
@@ -702,7 +702,7 @@ sub upload_images {
 
     my $fileprefix = "$pooldir/testresults";
     while (my ($md5, $file) = each %$tosend_images) {
-        log_debug("upload $file as $md5") if $verbose;
+        log_debug("upload $file as $md5");
 
         optimize_image("$fileprefix/$file");
         my $form = {
@@ -729,7 +729,7 @@ sub upload_images {
     $tosend_images = {};
 
     for my $file (@$tosend_files) {
-        log_debug("upload $file") if $verbose;
+        log_debug("upload $file");
 
         my $form = {
             file => {
@@ -829,7 +829,7 @@ sub backend_running {
 }
 
 sub check_backend {
-    log_debug("checking backend state") if $verbose;
+    log_debug("checking backend state");
     my $res = engine_check;
     if ($res && $res ne 'ok') {
         stop_job($res);

--- a/script/worker
+++ b/script/worker
@@ -118,8 +118,8 @@ sub usage($) {
 }
 
 GetOptions(
-    \%options,     "no-cleanup", "instance=i", "isotovideo=s", "host=s", "apikey:s",
-    "apisecret:s", "verbose|v",  "help|h",
+    \%options,     "no-cleanup",        "instance=i", "isotovideo=s", "host=s", "apikey:s",
+    "apisecret:s", "verbose|v|debug|d", "help|h",
 ) or usage(1);
 
 usage(0) if ($options{help});
@@ -161,6 +161,7 @@ sub read_worker_config {
 $options{instance} ||= 1;
 
 my ($worker_settings, $host_settings) = read_worker_config($options{instance}, $options{host});
+$worker_settings->{LOG_LEVEL} = 'debug' if $options{verbose};
 $OpenQA::Worker::Common::worker_settings = $worker_settings;
 # XXX: this should be sent to the scheduler to be included in the worker's table
 $ENV{QEMUPORT} = ($options{instance}) * 10 + 20002;

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -194,7 +194,6 @@ subtest 'test timer helpers' => sub {
 subtest 'mock test stop_job' => sub {
     use Mojo::Util 'monkey_patch';
     $OpenQA::Worker::Common::job = {id => 9999};
-    $OpenQA::Worker::Common::verbose = 1;
 
     my $stop_job = 0;
     monkey_patch 'Mojo::IOLoop', timer => sub {

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -99,14 +99,50 @@ subtest 'Logging to file' => sub {
     delete $ENV{OPENQA_WORKER_LOGDIR};
 };
 
+subtest 'log fatal to stderr' => sub {
+    delete $ENV{OPENQA_WORKER_LOGDIR};
+    # Capture STDERR:
+    # 1- dups the current STDERR to $oldSTDERR. This is used to restore the STDERR later
+    # 2- Closes the current STDERR
+    # 2- Links the STDERR to the variable
+    open(my $oldSTDERR, ">&", STDERR) or die "Can't preserve STDERR\n$!\n";
+    close STDERR;
+    my $output;
+    open STDERR, '>', \$output;
+    ### Testing code here ###
+
+    my $app = OpenQA::FakeApp->new(
+        mode     => 'production',
+        log_name => 'worker',
+        instance => 1,
+        log_dir  => undef,
+        level    => 'debug'
+    );
+
+    $app->setup_log();
+    $OpenQA::Utils::app = undef;    # To make sure we don't are setting it in other tests
+    eval { log_fatal('fatal message'); };
+    my $exception_raised = 0;
+    $exception_raised++ if $@;
+    ### End of the Testing code ###
+    # Close the capture (current stdout) and restore STDOUT (by dupping the old STDOUT);
+    close STDERR;
+    open(STDERR, '>&', $oldSTDERR) or die "Can't dup \$oldSTDERR: $!";
+    ok($exception_raised == 1, 'Fatal raised exception');
+    like($output, qr/\[FATAL\] fatal message/, 'OK fatal');
+
+};
+
 subtest 'Checking log level' => sub {
     $ENV{OPENQA_WORKER_LOGDIR} = tempdir;
+    delete $ENV{MOJO_LOG_LEVEL};    # The Makefile is overriding this variable
     make_path $ENV{OPENQA_WORKER_LOGDIR};
 
     my $output_logfile = catfile($ENV{OPENQA_WORKER_LOGDIR}, hostname() . '-1.log');
 
-    my @loglevels = qw(debug info warn error fatal);
-    my $counter   = @loglevels;
+    my @loglevels    = qw(debug info warn error fatal);
+    my $deathcounter = 0;
+    my $counter      = @loglevels;
     for (@loglevels) {
         my $app = OpenQA::FakeApp->new(
             mode     => 'production',
@@ -123,12 +159,17 @@ subtest 'Checking log level' => sub {
         log_info('info message');
         log_warning('warn message');
         log_error('error message');
-        log_fatal('fatal message');
+
+        my $exception = 0;
+        eval { log_fatal('fatal message'); };
+
+        $deathcounter++ if $@;
 
         my %matches = map { $_ => 1 } (Mojo::File->new($output_logfile)->slurp =~ m/$re/gm);
         ok(keys(%matches) == $counter--, "Worker log level $_ entry");
         truncate $output_logfile, 0;
     }
+    ok($deathcounter == @loglevels, "Worker dies when logs fatal");
 
     # clear the system
     remove_tree $ENV{OPENQA_WORKER_LOGDIR};


### PR DESCRIPTION
Changes the log level to debug if --debug or --verbose is applied. Default is info level.

The command line switches have precedence over workers.ini settings.

In the case no value is set in the workers.ini:
* if no --verbose or no --debug  is set then the default log level is info.

* if --verbose of --debug is set then the log level is set to debug

In the case a value is set in the workers.ini:
* if no --verbose or no --debug  is set then the default log level will be
what's specified in the workers.ini file

* if --verbose of --debug is set then the log level is set to debug