### PR TITLE
Disable live log by default

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -191,14 +191,8 @@ function setupResult(state, jobid, status_url, details_url) {
   });
 
   // don't overwrite the tab if coming from the URL (ignore '#')
-  if (location.hash.length < 2) {
-    if (state == "scheduled") {
-      setResultHash("#settings", true);
-    } else if (state == "running" || state == "waiting") {
-      if (window.location.href.substr(-1) != "#") {
-        setResultHash("#live", true);
-      }
-    }
+  if (location.hash.length < 2 && state === "scheduled") {
+    setResultHash("#settings", true);
   }
   if (state == "running" || state == "waiting" || state == "uploading" || state == "assigned") {
     setupRunning(jobid, status_url, details_url);

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -146,8 +146,7 @@ function checkResultHash() {
       setCurrentPreview(null);
     }
   } else if (hash.search("#comment-") == 0) {
-    var commentstab = $("[href='#comments']");
-    commentstab.tab("show");
+    $("[href='#comments']").tab("show");
   } else {
     // reset
     setCurrentPreview(null);
@@ -218,5 +217,15 @@ function setupResult(state, jobid, status_url, details_url) {
       return;
     }
     setResultHash(tabshown);
+  });
+
+  // define handler for tab switch to resume/pause live view depending on whether it is the
+  // current tab
+  $('#result-row a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+    if (e.target.hash === '#live') {
+      resumeLiveView();
+    } else {
+      pauseLiveView();
+    }
   });
 }

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -316,12 +316,15 @@ ul.modcategory {
     width: calc(73% + (23% - 280px));
 }
 
-#livelog {
+#liveterminal, #livelog {
     padding: 0;
     margin: 0;
     border: none;
     background: none;
     width: 100%;
+}
+
+#livelog {
     height: 30em;
     overflow-x: hidden;
     overflow-y: scroll;

--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -22,7 +22,7 @@
     margin-right: 8px;
 }
 
-#filter-panel {
+#filter-panel, #live-log-panel, #live-terminal-panel {
     .panel-heading {
         cursor: pointer;
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -190,7 +190,7 @@ my $job_name = 'tinycore-1-flavor-i386-Build1-core@coolone';
 $driver->find_element_by_link_text('core@coolone')->click();
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');
 like($driver->find_element('#result-row .panel-body')->get_text(), qr/State: scheduled/, 'test 1 is scheduled');
-javascript_console_is_empty;
+javascript_console_has_no_warnings_or_errors;
 
 sub start_worker {
     $workerpid = fork();
@@ -209,7 +209,7 @@ sub wait_for_result_panel {
         last if $driver->find_element('#result-row .panel-body')->get_text() =~ $result_panel;
         sleep 1;
     }
-    javascript_console_is_empty;
+    javascript_console_has_no_warnings_or_errors;
     $driver->refresh();
     like($driver->find_element('#result-row .panel-body')->get_text(), $result_panel, $desc);
 }
@@ -265,7 +265,7 @@ $job_name = 'tinycore-1-flavor-i386-Build1-core@noassets';
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');
 like($driver->find_element('#result-row .panel-body')->get_text(), qr/State: scheduled/, 'test 4 is scheduled');
 
-javascript_console_is_empty;
+javascript_console_has_no_warnings_or_errors;
 start_worker;
 
 wait_for_result_panel qr/Result: incomplete/, 'Test 4 crashed as expected';

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -216,6 +216,7 @@ sub wait_for_result_panel {
 
 sub wait_for_job_running {
     wait_for_result_panel qr/State: running/, 'job is running';
+    $driver->find_element_by_link_text('Live View')->click();
 }
 wait_for_job_running;
 wait_for_result_panel qr/Result: passed/, 'test 1 is passed';

--- a/templates/test/live.html.ep
+++ b/templates/test/live.html.ep
@@ -38,13 +38,29 @@
     <canvas id="livestream" width="1024" height="768" data-url='<%= url_for("streaming", testid => $testid) %>'>
     </canvas>
 </div>
-<div class="h5">Live Log</div>
-<div class="panel panel-default">
-    <pre id="livelog" data-url='<%= url_for("livelog", testid => $testid) %>'></pre>
+
+<div class="panel panel-default filter-panel-bottom" id="live-log-panel">
+    <div class="panel-heading">
+        <strong>Live log</strong>
+        <span>click to toggle</span>
+    </div>
+    <div class="panel-body">
+        <pre id="livelog" data-url='<%= url_for("livelog", testid => $testid) %>'></pre>
+        <form action="#">
+            <div>
+                <input type="checkbox" id="scrolldown" checked="checked" />
+                <label for="scrolldown">Autoscroll log</label>
+            </div>
+        </form>
+    </div>
 </div>
-<input type="checkbox" id="scrolldown" checked="checked" />
-<label for="scrolldown">Autoscroll log</label>
-<div class="h5">Serial Output (serial0.txt and serial_terminal.txt)</div>
-<div class="panel panel-default">
-    <pre id="liveterminal" data-url='<%= url_for("liveterminal", testid => $testid) %>'></pre>
+
+<div class="panel panel-default filter-panel-bottom" id="live-terminal-panel">
+    <div class="panel-heading">
+        <strong>Serial output</strong> (serial0.txt and serial_terminal.txt)
+        <span>click to toggle</span>
+    </div>
+    <div class="panel-body">
+        <pre id="liveterminal" data-url='<%= url_for("liveterminal", testid => $testid) %>'></pre>
+    </div>
 </div>


### PR DESCRIPTION
See https://progress.opensuse.org/issues/20606

This disables the live log and the live terminal by default. The user can expand it similar to the filter boxes.

Since currently the live stream is not available unless the live log is consumed as well, this prevents the live stream to work. The 2nd commit should to fix that.

Additionally, this ensures that the streams for the live view are only consumed when the 'Live view' tab is shown.

Tested manually:
* If entering the 'Live view' tab the last message in openQA web UI
  log is `Telling worker to start providing livestream`
* If leaving the 'Live view' tab the last message in openQA web UI
  log is `Telling worker to stop providing livestream`
* Developer console in browser shows requests for stream/livelog
  accordingly
* If there are two viewers and only one quits, the live stream
  is still provided (the counting itself hasn't changed by this
  PR anyways)