### PR TITLE
Improve documentation for contributors

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -152,25 +152,47 @@ package, one of the tests consists of a call to
 http://perltidy.sourceforge.net/[Perltidy] to ensure that the contributed code
 follows the most common Perl style conventions.
 
+== Starting the webserver from local Git checkout
+* To start the webserver for development, use the +scripts/openqa daemon+.
+* openQA will pull the required asssets on the first run.
+* openQA uses SASS, so Ruby development files are required. Under openSUSE,
+  installing the packages +devel_C_C+++ and +ruby-devel+ should be sufficient.
+  openQA will install the required files automatically under +.gem+. Add
+  +.gem/ruby/2.4.0/bin+ to the +PATH+ variable to let it find the sass/scss
+  binaries. I also had to create symlinks of those binaries without +.ruby2.4+
+  suffix so openQA could find them.
+* It is also useful to start openQA with morbo which allows applying changes
+  without restarting the server:
+  +morbo -m development -w assets -w lib -w templates
+    -l http://localhost:9526 script/openqa daemon+
+
+
 == Managing the database
 
-=== How to change the database schema
-
 During the development process there are cases in which the database schema
-needs to be changed. After modifying files in +lib/OpenQA/Schema/Result+
+needs to be changed.
 there are some steps that have to be followed so that new database instances
 and upgrades include those changes.
 
-.  First, you need to increase the database version number in the `$VERSION`
+=== When is it required to update the database schema?
+After modifying files in +lib/OpenQA/Schema/Result+. However, not all changes
+require to update the schema. Adding just another method or altering/adding
+functions like +has_many+ doesn't require an update. However, adding new
+columns, modifying or removing existing ones requires to follow the steps
+mentioned above.
+
+=== How to update the database schema
+
+1. First, you need to increase the database version number in the `$VERSION`
    variable in the +lib/OpenQA/Schema.pm+ file.
    Note that it's recommended to notify the other developers before doing so,
    to synchronize in case there are more developers wanting to increase the
    version number at the same time.
 
-.  Then you need to generate the deployment files for new installations,
+2. Then you need to generate the deployment files for new installations,
    this is done by running +./script/initdb --prepare_init+.
 
-.  Afterwards you need to generate the deployment files for existing installations,
+3. Afterwards you need to generate the deployment files for existing installations,
    this is done by running +./script/upgradedb --prepare_upgrade+.
    After doing so, the directories +dbicdh/$ENGINE/deploy/<new version>+ and
    +dbicdh/$ENGINE/upgrade/<prev version>-<new version>+ for SQLite and PosgreSQL
@@ -178,20 +200,33 @@ and upgrades include those changes.
    initialize the schema and to upgrade from one version
    to the next in the corresponding database engine.
 
-.  And finally, you need to create the fixtures files. Under
-   +dbicdh/_common/deploy+, rename the directory of the (previous) latest version
-   to the new version and do the necessary changes (if any). Then, under
-   +dbicdh/_common/upgrade+ create a +<prev_version>-<new_version>+ directory and
-   put some files there with SQL statements that upgrade the fixtures. Usually a
-   diff from the previous version to the new one helps to see what has to be in
-   the upgrade file.
+4. Migration scripts to upgrade from previous versions can be added under
+   +dbicdh/_common/upgrade+. Create a +<prev_version>-<new_version>+ directory and
+   put some files there with DBIx commands for the migration. For examples just
+   have a look at the migrations which are already there.
 
-The above steps are executed in the developer's system. Once openQA is
-installed in a production server, you should run either
-+./script/initdb --init_database+ or +./script/upgradedb --upgrade_database+
-to actually create or upgrade a database.
+The above steps are only for preparing the required SQL statements, but do not
+actually alter the database. Before doing so, it is recommended *to backup your
+database* to be able to downgrade again if something goes wrong or you just need
+to continue working on another branch. To do so, just copy your SQLite file.
+If you are using PostgreSQL, the following command can be used to create a copy:
+[source,sh]
+----
+createdb -O ownername -T originaldb newdb
+----
+
+To actually create or update the database (after creating a backup as described),
+you should run either +./script/initdb --init_database+ or
++./script/upgradedb --upgrade_database+. This is also required when the changes
+are installed in a production server.
 
 === How to add fixtures to the database
+
+Note: This section is not about the fixtures for the testsuite. Those are located
+under t/fixtures.
+
+Note: This section might not be relevant anymore. At least there are currently
+none of the mentioned directories with files containing SQL statements present.
 
 Fixtures (initial data stored in tables at installation time) are stored
 in files into the +dbicdh/_common/deploy/_any/<version>+ and


### PR DESCRIPTION
* Add "Starting the webserver from local Git checkout"
* Update "Managing the database"

---

I'm not sure whether the provided info is correct, but when starting the web server from local Git checkout I noticed some time ago that there are now some extra steps are required. The openQA in openQA tests also contains similar commands for that purpose.

I also updated the steps for database migration because some of the mentioned steps seem to be irrelevant/outdated and some other useful hints like creating a backup were missing. But I'm not sure whether the info is correct, especially concerning the notes at the end.