### PR TITLE
Allow filtering by result on 'All tests' page

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -46,3 +46,40 @@ function toggleChildGroups(link) {
     buildRow.toggleClass('children-expanded');
     return false;
 }
+
+function parseQueryParams() {
+    var params = {};
+    $.each(window.location.search.substr(1).split('&'), function(index, param) {
+        var equationSignIndex = param.indexOf('=');
+        if (equationSignIndex < 0) {
+            var key = decodeURIComponent(param);
+            var value = undefined;
+        } else {
+            var key = decodeURIComponent(param.substr(0, equationSignIndex));
+            var value = decodeURIComponent(param.substr(equationSignIndex + 1));
+        }
+        if (Array.isArray(params[key])) {
+            params[key].push(value);
+        } else {
+            params[key] = [value];
+        }
+    });
+    return params;
+}
+
+function updateQueryParams(params) {
+    if (!history.replaceState) {
+        return; // skip if not supported
+    }
+    var search = [];
+    $.each(params, function(key, values) {
+        $.each(values, function(index, value) {
+            if (value === undefined) {
+                search.push(encodeURIComponent(key));
+            } else {
+                search.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+            }
+        });
+    });
+    history.replaceState({} , document.title, window.location.pathname + '?' + search.join('&'));
+}

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -195,7 +195,12 @@ function renderTestsList(jobs) {
     finishedJobsResultFilter.chosen();
     // ensure the table is re-drawn when a filter is added/removed
     finishedJobsResultFilter.change(function(event) {
+        // update data table
         table.draw();
+        // update query params
+        var params = parseQueryParams();
+        params.resultfilter = finishedJobsResultFilter.val();
+        updateQueryParams(params);
     });
     // add a handler for the actual filtering
     $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
@@ -220,6 +225,11 @@ function renderTestsList(jobs) {
         }
         return false;
     });
+    // apply filter from query params
+    var filter = parseQueryParams().resultfilter;
+    if (filter) {
+        finishedJobsResultFilter.val(filter).trigger('chosen:updated').trigger('change');
+    }
 
     $(document).on('mouseover', '.parent_child', highlightJobs);
     $(document).on('mouseout', '.parent_child', unhighlightJobs);

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -453,6 +453,38 @@ table.overview {
         }
 }
 
+#finished_jobs_result_filter_chosen {
+    margin-left: 3px;
+
+    .chosen-results {
+        text-align: left;
+        float: none;
+    }
+}
+
+
+#results {
+    clear: both;
+}
+
+#results_filter label {
+    vertical-align: top;
+}
+
+@media (min-width: $screen-sm) {
+    #toolbar {
+        &> div {
+            padding-right: 0px !important;
+            width: 20%;
+        }
+
+        &+ div {
+            padding-left: 0px !important;
+            width: 55%;
+        }
+    }
+}
+
 span.status .fa {
     font-size: 120%;
 }

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -217,6 +217,17 @@ is_deeply(
     'all rows displayed'
 );
 
+# test filtering finished jobs by result
+my $filter_input = $driver->find_element('#finished_jobs_result_filter_chosen input', 'css');
+$filter_input->click();
+$filter_input->send_keys('Passed');
+$driver->find_element('#finished_jobs_result_filter_chosen .active-result', 'css')->click();
+# actually this does not use AJAX, but be sure all JavaScript processing is done anyways
+wait_for_ajax();
+@jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
+is_deeply(\@jobs, [qw(job_99947 job_99946 job_99945 job_80000 job_99937)], 'only passed jobs displayed');
+$driver->find_element('#finished_jobs_result_filter_chosen .search-choice-close', 'css')->click();
+
 # now toggle back
 #print $driver->get_page_source();
 $driver->find_element_by_id('relevantfilter')->click();

--- a/templates/test/list.html.ep
+++ b/templates/test/list.html.ep
@@ -25,11 +25,25 @@
 <div>
 
   <h2>Last <%= $jobs->all %> finished jobs</h2>
-    <div class="col-sm-5" id="relevantbox" style="display: none">
-	%= check_box relevant => '1', 'checked' => 'checked' => (id => 'relevantfilter')
-	%= label_for 'relevantfilter' => 'Show only relevant jobs'
-    </div>
-    
+    <form action="#">
+        <div class="col-sm-3" id="relevantbox" style="display: none;">
+            %= check_box relevant => '1', 'checked' => 'checked' => (id => 'relevantfilter')
+            %= label_for 'relevantfilter' => 'Show only relevant jobs'
+            <select style="min-width: 250px;" id="finished-jobs-result-filter" data-placeholder="Filter by result" class="chosen-select" multiple>
+                <option>Passed</option>
+                <option>Softfailed</option>
+                <option>Failed</option>
+                <option>Incomplete</option>
+                <option>Skipped</option>
+                <option>Obsoleted</option>
+                <option>Parallel failed</option>
+                <option>Parallel restarted</option>
+                <option>User cancelled</option>
+                <option>User restarted</option>
+            </select>
+        </div>
+    </form>
+
     <table id="results" class="display table table-striped no-wrap" style="width: 100%">
         <thead>
             <tr>


### PR DESCRIPTION
See https://progress.opensuse.org/issues/19388

I could not use the approach from the job results overview page. The
structure of the pages are just too different.

However, this implementation using the filtering of the data table
is quite simple and will not cause any performance regressions.

WIP because tests are missing. But maybe it is better to get some feedback before anyways.

![spectacle bw7714](https://user-images.githubusercontent.com/10248953/31185995-b07281be-a92d-11e7-90cd-1234d07726a6.png)
