### PR TITLE
fix perlcritic warning

### DIFF
--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -20,7 +20,7 @@ use warnings;
 use OpenQA::Utils qw(log_error log_warning log_debug);
 use OpenQA::Worker::Common;
 use OpenQA::Worker::Jobs;
-use POSIX qw(:sys_wait_h);
+use POSIX q(:sys_wait_h);
 use OpenQA::Worker::Engines::isotovideo;
 
 ## WEBSOCKET commands


### PR DESCRIPTION
"$ make checkstyle" results warning as below
> lib/OpenQA/Worker/Commands.pm: qw should be used as function at line 23, column 11.  use MODULE 'func' for single imports.  (Severity: 5)

Just use 'q' seems to be enough for single item.