### PR TITLE
ignore .pc directory

### DIFF
--- a/script/tidy
+++ b/script/tidy
@@ -22,6 +22,8 @@ test -e script/openqa || exit 1
 
 find -name '*.tdy' -delete
 
+# .pc directory is used for "quilt" patch system (in Debian/Ubuntu)
+# it contains pre-patched files and should be ignored
 find . ! -path '*/.pc/*' \( -name '*.p[lm]' -o -name '*.t' \) -print0 | xargs -0 perltidy --pro=.../.perltidyrc
 
 find script/{check_dependencies,client,initdb,openqa,worker,upgradedb,load_templates,dump_templates,clean_needles,openqa-scheduler,openqa-websockets} -print0 | xargs -0 perltidy $TIDY_ARGS

--- a/script/tidy
+++ b/script/tidy
@@ -22,7 +22,7 @@ test -e script/openqa || exit 1
 
 find -name '*.tdy' -delete
 
-find . \( -name '*.p[lm]' -o -name '*.t' \) -print0 | xargs -0 perltidy --pro=.../.perltidyrc
+find . ! -path '*/.pc/*' \( -name '*.p[lm]' -o -name '*.t' \) -print0 | xargs -0 perltidy --pro=.../.perltidyrc
 
 find script/{check_dependencies,client,initdb,openqa,worker,upgradedb,load_templates,dump_templates,clean_needles,openqa-scheduler,openqa-websockets} -print0 | xargs -0 perltidy $TIDY_ARGS
 


### PR DESCRIPTION
Debian patches use "quilt" patch system and it saves files pre-patched
files under .pc directory. Accidentaly prove works for directory and
tidy check fails, so ignore this .pc directory.