### PR TITLE
Return 0 by default on worker's try_lock_asset()

### DIFF
--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -258,15 +258,11 @@ sub try_lock_asset {
         log_error "try_lock_asset: Rolling back $@";
         $dbh->rollback;
     }
-    else {
-        if ($lock_granted) {
-            return $result;
-        }
-        else {
-            return 0;
-        }
+    elsif ($lock_granted) {
+        return $result;
     }
 
+    return 0;
 }
 
 sub add_asset {


### PR DESCRIPTION
In case of database locks, we attempt to rollback, but we are returning
the` $dbh->rollback()` result, which leads to unexpected results. In this
way we return 0 by default, and result otherwise. This is still far from
a correct solution since it can still go into deep loop.

Besides, toggle_asset_lock() can be potentially subject to the same
issue.

See related Progress issue: https://progress.opensuse.org/issues/26088