### PR TITLE
Make heartbeat timeout for rabbitmq configurable

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -78,8 +78,9 @@ blacklist = job_grab job_done
 
 ## Configuration for AMQP plugin
 [amqp]
-# guest/guest is the default anonymous user/pass for RabbitMQ
+#heartbeat_timeout = 60
 #reconnect_timeout = 5
+# guest/guest is the default anonymous user/pass for RabbitMQ
 #url = amqp://guest:guest@localhost:5672/
 #exchange = pubsub
 #topic_prefix = suse

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -77,6 +77,7 @@ sub connect {
 
     OpenQA::Utils::log_info("Connecting to AMQP server");
     $self->{client} = Mojo::RabbitMQ::Client->new(url => $self->{config}->{amqp}{url});
+    $self->{client}->heartbeat_timeout($self->{config}->{amqp}{heartbeat_timeout} // 60);
     $self->{client}->on(
         open => sub {
             OpenQA::Utils::log_info("AMQP connection established");

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -50,8 +50,9 @@ $client_mock->fake_module(
 
         return $self;
     },
-    catch => sub { },
-    on    => sub {
+    heartbeat_timeout => sub { },
+    catch             => sub { },
+    on                => sub {
         my $self  = shift;
         my $event = shift;
         my $sub   = shift;


### PR DESCRIPTION
The default is 60 seconds in Mojo::Client::RabbitMQ, but this is too
long for our HA proxy's ssl tunnel