### PR TITLE
Worker worker_status timer optimizations

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -78,6 +78,10 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   read_test_modules
   exists_worker
   safe_call
+  feature_scaling
+  logistic_map_steps
+  logistic_map
+  rand_range
 );
 
 if ($0 =~ /\.t$/) {
@@ -838,6 +842,21 @@ sub safe_call {
     log_error("Safe call error: $@") and return [] if $@;
     return $ret;
 }
+
+# Args:
+# First is i-th element, Second is maximum element number, Third and Fourth are the range limit (lower and upper)
+# $i, $imax, MIN, MAX
+sub feature_scaling { $_[2] + ((($_[0] - 1) * ($_[3] - $_[2])) / (($_[1] - 1) || 1)) }
+# $r, $xn
+sub logistic_map { $_[0] * $_[1] * (1 - $_[1]) }
+# $steps, $r, $xn
+sub logistic_map_steps {
+    $_[2] = 0.1 if $_[2] <= 0;    # do not let population die. - with this change we get more "chaos"
+    $_[2] = logistic_map($_[1], $_[2]) for (1 .. $_[0]);
+    $_[2];
+}
+sub rand_range { $_[0] + rand($_[1] - $_[0]) }
+
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -82,6 +82,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   logistic_map_steps
   logistic_map
   rand_range
+  in_range
 );
 
 if ($0 =~ /\.t$/) {
@@ -856,6 +857,7 @@ sub logistic_map_steps {
     $_[2];
 }
 sub rand_range { $_[0] + rand($_[1] - $_[0]) }
+sub in_range { $_[0] >= $_[1] && $_[0] <= $_[2] ? 1 : 0 }
 
 
 1;

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -200,19 +200,7 @@ sub _message {
     }
 
     $worker->{last_seen} = time();
-    if ($json->{type} eq 'ok') {
-        $ws->tx->send({json => {type => 'ok'}});
-        # NOTE: Update the worker state from keepalives.
-        # We could check if the worker is dead before updating seen state
-        # the downside of it will be that we will have more timewindows
-        # where the worker is seen as dead.
-        #
-        #    if ($w and $w->dead())  # It's still one query, at this point let's just update the seen status
-        #        log_debug("Keepalive from worker $worker->{id} received, and worker thought dead. updating the DB");
-        app->schema->txn_do(sub { my $w = app->schema->resultset("Workers")->find($worker->{id}); $w->seen; })
-          if $worker && exists $worker->{id};
-    }
-    elsif ($json->{type} eq 'accepted') {
+    if ($json->{type} eq 'accepted') {
         my $jobid = $json->{jobid};
         log_debug("Worker: $worker->{id} accepted job $jobid");
     }
@@ -248,13 +236,18 @@ sub _message {
         log_debug(sprintf('Received from worker "%u" worker_status message "%s"', $wid, Dumper($json)));
 
         # XXX: This would make keepalive useless.
-        # app->schema->txn_do(
-        #     sub {
-        #         my $w = app->schema->resultset("Workers")->find($wid);
-        #         return unless $w;
-        #         log_debug("Updated worker seen from worker_status");
-        #         $w->seen;
-        #     });
+        try {
+            app->schema->txn_do(
+                sub {
+                    my $w = app->schema->resultset("Workers")->find($wid);
+                    return unless $w;
+                    log_debug("Updated worker seen from worker_status");
+                    $w->seen;
+                });
+        }
+        catch {
+            log_error("Failed updating worker seen status: $_");
+        };
 
         my $registered_job_id;
         my $registered_job_token;
@@ -384,7 +377,7 @@ sub _workers_checker {
     try {
         $schema->txn_do(
             sub {
-                my $threshold  = 40;
+                my $threshold  = 120;
                 my $stale_jobs = _get_stale_worker_jobs($threshold);
                 for my $job ($stale_jobs->all) {
                     next unless _is_job_considered_dead($job);

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -26,6 +26,8 @@ use Data::Dumper;
 use Data::Dump 'pp';
 use db_profiler;
 
+use constant WORKERS_CHECKER_THRESHOLD => 120;
+
 require Exporter;
 our (@ISA, @EXPORT, @EXPORT_OK);
 
@@ -386,8 +388,7 @@ sub _workers_checker {
     try {
         $schema->txn_do(
             sub {
-                my $threshold  = 120;
-                my $stale_jobs = _get_stale_worker_jobs($threshold);
+                my $stale_jobs = _get_stale_worker_jobs(WORKERS_CHECKER_THRESHOLD);
                 for my $job ($stale_jobs->all) {
                     next unless _is_job_considered_dead($job);
 

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -129,9 +129,6 @@ sub websocket_commands {
                 }
             }
         }
-        elsif ($type eq 'ok') {
-            # ignore keepalives, but dont' report as unknown
-        }
         elsif ($type eq 'grab_job') {
             state $check_job_running;
             state $job_in_progress;

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -355,7 +355,13 @@ sub calculate_status_timer {
     my ($hosts, $host) = @_;
     my $i = $hosts->{$host}{workerid} ? $hosts->{$host}{workerid} : looks_like_number($instance) ? $instance : 1;
     my $imax = $hosts->{$host}{population} ? $hosts->{$host}{population} : 1;
-    my $scale_factor = 300;
+    my $scale_factor = $imax;
+    my $steps        = 215;
+    my $r            = 3.81199961;
+
+    # my $scale_factor = 4;
+    # my $scale_factor =  (MAX_TIMER - MIN_TIMER)/MIN_TIMER;
+    # log_debug("I: $i population: $imax scale_factor: $scale_factor");
 
     # XXX: we are using now fixed values, to stick with a
     #      predictable behavior but random intervals
@@ -363,13 +369,11 @@ sub calculate_status_timer {
     # my $steps = int(rand_range(2, 120));
     # my $r = rand_range(3.20, 3.88);
 
-    my $steps      = 215;
-    my $r          = 3.81199961;
-    my $population = feature_scaling($i, $imax, 0.1, 1);
+    my $population = feature_scaling($i, $imax, 0, 1);
     my $status_timer
-      = abs(feature_scaling(logistic_map_steps($steps, $r, $population), $imax, MIN_TIMER, MAX_TIMER) * $scale_factor);
-
-    $status_timer = $status_timer > MIN_TIMER && $status_timer < MAX_TIMER ? $status_timer : MIN_TIMER;
+      = abs(feature_scaling(logistic_map_steps($steps, $r, $population) * $scale_factor, $imax, MIN_TIMER, MAX_TIMER));
+    $status_timer = $status_timer > MIN_TIMER
+      && $status_timer < MAX_TIMER ? $status_timer : $status_timer > MAX_TIMER ? MAX_TIMER : MIN_TIMER;
     return int($status_timer);
 }
 

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -354,12 +354,8 @@ sub send_status {
 sub calculate_status_timer {
     my ($hosts, $host) = @_;
     my $i = $hosts->{$host}{workerid} ? $hosts->{$host}{workerid} : looks_like_number($instance) ? $instance : 1;
-    my $imax
-      = $hosts->{$host}{population}                     ? $hosts->{$host}{population}
-      : !$worker_settings->{TOTAL_INSTANCES}            ? 1
-      : $worker_settings->{TOTAL_INSTANCES} > MAX_TIMER ? MAX_TIMER - 1
-      :                                                   $worker_settings->{TOTAL_INSTANCES} + 1;
-    my $scale_factor = 4;
+    my $imax = $hosts->{$host}{population} ? $hosts->{$host}{population} : 1;
+    my $scale_factor = 300;
 
     # XXX: we are using now fixed values, to stick with a
     #      predictable behavior but random intervals
@@ -367,8 +363,8 @@ sub calculate_status_timer {
     # my $steps = int(rand_range(2, 120));
     # my $r = rand_range(3.20, 3.88);
 
-    my $steps      = 88;
-    my $r          = 3.88;
+    my $steps      = 215;
+    my $r          = 3.81199961;
     my $population = feature_scaling($i, $imax, 0.1, 1);
     my $status_timer
       = abs(feature_scaling(logistic_map_steps($steps, $r, $population), $imax, MIN_TIMER, MAX_TIMER) * $scale_factor);
@@ -580,7 +576,6 @@ sub read_worker_config {
             $host_settings->{$section} = {};
         }
     }
-    $sets->{TOTAL_INSTANCES} ||= $cfg ? max(grep { looks_like_number($_) } $cfg->Sections) || 1 : 1;
     $host_settings->{HOSTS} = \@hosts;
 
     return $sets, $host_settings;

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -22,7 +22,8 @@ use Carp;
 use POSIX 'uname';
 use Mojo::URL;
 use OpenQA::Client;
-use OpenQA::Utils qw(log_error log_debug log_warning log_info);
+use OpenQA::Utils qw(log_error log_debug log_warning log_info), qw(feature_scaling rand_range logistic_map_steps);
+use Scalar::Util 'looks_like_number';
 
 use base 'Exporter';
 our @EXPORT = qw($job $instance $worker_settings $pooldir $nocleanup
@@ -56,6 +57,8 @@ my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
 use constant {
     STATUS_UPDATES_SLOW => 10,
     STATUS_UPDATES_FAST => 0.5,
+    MAX_TIMER           => 100,    # It should never be more than OpenQA::WebSockets::Server::_workers_checker threshold
+    MIN_TIMER           => 20,
 };
 
 # the template noted what architecture are known
@@ -350,17 +353,39 @@ sub call_websocket {
     my ($host, $ua_url) = @_;
     my $ua = $hosts->{$host}{ua};
 
+    my $i = looks_like_number($instance) ? $instance : 1;
+    my $imax
+      = !$worker_settings->{TOTAL_INSTANCES}            ? 1
+      : $worker_settings->{TOTAL_INSTANCES} > MAX_TIMER ? MAX_TIMER - 1
+      :                                                   $worker_settings->{TOTAL_INSTANCES} + 1;
+    my $scale_factor = 4;
+
+    # XXX: we are using now fixed values, to stick with a
+    #      predictable behavior but random intervals
+    #      seems to work as well.
+    # my $steps = int(rand_range(2, 120));
+    # my $r = rand_range(3.20, 3.88);
+
+    my $steps      = 88;
+    my $r          = 3.88;
+    my $population = feature_scaling($i, $imax, 0.1, 1);
+    my $status_timer
+      = abs(feature_scaling(logistic_map_steps($steps, $r, $population), $imax, MIN_TIMER, MAX_TIMER) * $scale_factor);
+
+    $status_timer = $status_timer > MIN_TIMER && $status_timer < MAX_TIMER ? $status_timer : MIN_TIMER;
+
+    log_debug("worker_status timer time window: $status_timer");
     $ua->websocket(
         $ua_url => {'Sec-WebSocket-Extensions' => 'permessage-deflate'} => sub {
             my ($ua, $tx) = @_;
             if ($tx->is_websocket) {
-                # keep websocket connection busy
-                $tx->send({json => {type => 'ok'}});    # Send keepalive immediately
-                $hosts->{$host}{timers}{keepalive}
-                  = add_timer("keepalive-$host", 10, sub { $tx->send({json => {type => 'ok'}}); });
-
-                $hosts->{$host}{timers}{status} = add_timer("workerstatus-$host", 15,
-                    sub { send_status($tx); log_debug("Sending worker status to $host (workerstatus timer)"); });
+                $hosts->{$host}{timers}{status} = add_timer(
+                    "workerstatus-$host",
+                    $status_timer,
+                    sub {
+                        send_status($tx);
+                        log_debug("Sending worker status to $host (workerstatus timer)");
+                    });
 
                 $tx->on(json => \&OpenQA::Worker::Commands::websocket_commands);
                 $tx->on(
@@ -368,7 +393,6 @@ sub call_websocket {
                         my (undef, $code, $reason) = @_;
                         log_debug("Connection turned off from $host - $code : "
                               . (defined $reason ? $reason : "Not specified"));
-                        remove_timer("keepalive-$host");
                         remove_timer("workerstatus-$host");
 
                         $hosts->{$host}{timers}{setup_websocket}

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -35,8 +35,7 @@ BEGIN {
 $ENV{MOJO_LISTEN} ||= 'http://localhost:9527/';
 
 # allow up to 20GB - hdd images
-$ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
-$ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
+$ENV{MOJO_MAX_MESSAGE_SIZE} = 1024 * 1024 * 1024 * 20;
 
 use OpenQA::WebSockets;
 

--- a/script/worker
+++ b/script/worker
@@ -100,7 +100,6 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Scalar::Util 'looks_like_number';
 use Getopt::Long;
 Getopt::Long::Configure("no_ignore_case");
 

--- a/script/worker
+++ b/script/worker
@@ -101,6 +101,8 @@ BEGIN {
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Config::IniFiles;
+use Scalar::Util 'looks_like_number';
+use List::Util 'max';
 use Getopt::Long;
 Getopt::Long::Configure("no_ignore_case");
 
@@ -152,6 +154,7 @@ sub read_worker_config {
             $host_settings->{$section} = {};
         }
     }
+    $sets->{TOTAL_INSTANCES} ||= $cfg ? max(grep { looks_like_number($_) } $cfg->Sections) || 1 : 1;
     $host_settings->{HOSTS} = \@hosts;
 
     return $sets, $host_settings;

--- a/script/worker
+++ b/script/worker
@@ -100,9 +100,7 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Config::IniFiles;
 use Scalar::Util 'looks_like_number';
-use List::Util 'max';
 use Getopt::Long;
 Getopt::Long::Configure("no_ignore_case");
 
@@ -126,44 +124,10 @@ GetOptions(
 
 usage(0) if ($options{help});
 
-sub read_worker_config {
-    my ($instance, $host) = @_;
-    my $worker_dir = $ENV{OPENQA_CONFIG} || '/etc/openqa';
-    my $cfg = Config::IniFiles->new(-file => $worker_dir . '/workers.ini');
-
-    my $sets = {};
-    for my $section ('global', $instance) {
-        if ($cfg && $cfg->SectionExists($section)) {
-            for my $set ($cfg->Parameters($section)) {
-                $sets->{uc $set} = $cfg->val($section, $set);
-            }
-        }
-    }
-    # use separate set as we may not want to advertise other host confiuration to the world in job settings
-    my $host_settings;
-    $host ||= $sets->{HOST} ||= 'localhost';
-    delete $sets->{HOST};
-    my @hosts = split / /, $host;
-    for my $section (@hosts) {
-        if ($cfg && $cfg->SectionExists($section)) {
-            for my $set ($cfg->Parameters($section)) {
-                $host_settings->{$section}{uc $set} = $cfg->val($section, $set);
-            }
-        }
-        else {
-            $host_settings->{$section} = {};
-        }
-    }
-    $sets->{TOTAL_INSTANCES} ||= $cfg ? max(grep { looks_like_number($_) } $cfg->Sections) || 1 : 1;
-    $host_settings->{HOSTS} = \@hosts;
-
-    return $sets, $host_settings;
-}
-
 # count workers from 1 if not set - if tap devices are used worker would try to use tap -1
 $options{instance} ||= 1;
 
-my ($worker_settings, $host_settings) = read_worker_config($options{instance}, $options{host});
+my ($worker_settings, $host_settings) = OpenQA::Worker::Common::read_worker_config($options{instance}, $options{host});
 $worker_settings->{LOG_LEVEL} = 'debug' if $options{verbose};
 $OpenQA::Worker::Common::worker_settings = $worker_settings;
 # XXX: this should be sent to the scheduler to be included in the worker's table

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -44,6 +44,7 @@ use lib "$FindBin::Bin/lib";
 use Data::Dump qw(pp dd);
 use OpenQA::Scheduler;
 use OpenQA::Scheduler::Scheduler;
+use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::More;
 use Net::DBus qw(:typing);
@@ -390,7 +391,7 @@ sub range_ok {
     my $low_limit  = $tick - $step;
     my $high_limit = $tick + $step;
     my $delta      = $fired - $started;
-    ok($delta > $low_limit && $delta < $high_limit,
+    ok(in_range($delta, $low_limit, $high_limit),
         "timeout in range $low_limit->$high_limit (setted tick $tick, real tick occurred at $delta)");
 }
 

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -55,11 +55,11 @@ sub _check_job_incomplete {
     return $job;
 }
 
-subtest 'worker with job and not updated in last 50s is considered dead' => sub {
+subtest 'worker with job and not updated in last 120s is considered dead' => sub {
     _check_job_running($_) for (99961, 99963);
     # move the updated timestamp of the workers to avoid sleeping
     my $dtf = $schema->storage->datetime_parser;
-    my $dt = DateTime->from_epoch(epoch => time() - 50, time_zone => 'UTC');
+    my $dt = DateTime->from_epoch(epoch => time() - 121, time_zone => 'UTC');
 
     $schema->resultset('Workers')->update_all({t_updated => $dtf->format_datetime($dt)});
     stderr_like {

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -75,6 +75,20 @@ sub test_via_io_loop {
     Mojo::IOLoop->start;
 }
 
+sub test_timer {
+    my ($i, $population) = @_;
+    $OpenQA::Worker::Common::instance = $i;
+    OpenQA::Worker::Common::calculate_status_timer({localhost => {population => $population}}, 'localhost');
+}
+
+sub compare_timers {
+    my ($instance1, $instance2, $population) = @_;
+    my $t  = test_timer($instance1, $population);
+    my $t1 = test_timer($instance2, $population);
+    ok $t != $t1,
+      "timer between instances $instance1 and $instance2 is different in a population of $population ( $t != $t1 )";
+}
+
 test_via_io_loop sub {
     OpenQA::Worker::Common::api_call(
         'post', 'jobs/500/status',
@@ -249,17 +263,37 @@ subtest 'worker status timer calculation' => sub {
         (OpenQA::WebSockets::Server::WORKERS_CHECKER_THRESHOLD - OpenQA::Worker::Common::MAX_TIMER) >= 20,
 "OpenQA::WebSockets::Server::WORKERS_CHECKER_THRESHOLD is bigger than OpenQA::Worker::Common::MAX_TIMER at least by 20s"
     );
-
-    my $pop = 1;
+    my $instance = 1;
+    my $pop      = $instance;
     do {
-        $OpenQA::Worker::Common::instance = int(rand_range(1, $pop));
-        ok in_range(
-            OpenQA::Worker::Common::calculate_status_timer({localhost => {population => ++$pop}}, 'localhost'),
-            OpenQA::Worker::Common::MIN_TIMER,
-            OpenQA::Worker::Common::MAX_TIMER
-          ),
-          "timer in range with worker population of $pop";
+        $pop++;
+        my $t = test_timer($instance, $pop);
+        ok in_range($t, 70, 90), "timer $t for instance $instance in range with worker population of $pop";
       }
+      for $instance .. 10;
+
+    $instance = 25;
+    $pop      = $instance;
+         compare_timers(7, 9, ++$pop)
+      && compare_timers(5, 10,        $pop)
+      && compare_timers(4, $instance, $pop)
+      && compare_timers(9, 10,        $pop)
+      for $instance .. 30;
+
+    $instance = 205;
+    $pop      = $instance;
+    compare_timers(40, 190, ++$pop)
+      && compare_timers(30, 200, $pop)
+      && compare_timers(70, 254, $pop)
+      for $instance .. 300;
+
+    $pop = 1;
+    ok in_range(
+        test_timer(int(rand_range(1, $pop)), ++$pop),
+        OpenQA::Worker::Common::MIN_TIMER,
+        OpenQA::Worker::Common::MAX_TIMER
+      ),
+      "timer in range with worker population of $pop"
       for 1 .. 999;
 };
 
@@ -295,6 +329,19 @@ subtest 'mock test send_status' => sub {
     OpenQA::Worker::Common::send_status($faketx);
     is($faketx->get(4)->{status}, "free");
     ok(!exists $faketx->get(4)->{job}->{state});
+};
+
+subtest 'Worker websocket messages' => sub {
+    use OpenQA::Worker::Commands;
+    my $buf;
+    open my $FD, '>', \$buf;
+    *STDOUT = $FD;
+    *STDERR = $FD;
+    OpenQA::Worker::Commands::websocket_commands(undef, {fooo => undef});
+    like $buf, qr/Received WS message without type!/ or diag explain $buf;
+
+    OpenQA::Worker::Commands::websocket_commands(FakeTx->new, {type => 'foo'});
+    like $buf, qr/got unknown command/ or diag explain $buf;
 };
 
 done_testing();

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -268,6 +268,21 @@ EOF
     is $w_setting->{TOTAL_INSTANCES}, 1 or diag explain $w_setting;
 };
 
+subtest 'worker status timer calculation' => sub {
+    $OpenQA::Worker::Common::worker_settings = {};
+    my $pop = 1;
+    do {
+        $OpenQA::Worker::Common::instance = int(rand_range(1, $pop));
+        ok in_range(
+            OpenQA::Worker::Common::calculate_status_timer({localhost => {population => ++$pop}}, 'localhost'),
+            OpenQA::Worker::Common::MIN_TIMER,
+            OpenQA::Worker::Common::MAX_TIMER
+          ),
+          "timer in range with worker population of $pop";
+      }
+      for 1 .. 999;
+};
+
 subtest 'mock test send_status' => sub {
     $OpenQA::Worker::Common::job = {id => 9999, state => "scheduled"};
 

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -78,6 +78,14 @@ subtest "WebSocket Server _message()" => sub {
 
     $fake_tx->OpenQA::WebSockets::Server::_message({type => "FOOBAR"});
     like $buf, qr/Received unknown message type "FOOBAR" from worker/, "log_error on unknown message";
+
+    monkey_patch "Mojo::Transaction::Websocket", send => sub { undef };
+    $fake_tx->OpenQA::WebSockets::Server::_message({type => 'worker_status'});
+    like $buf, qr/Could not be able to send population number to worker/ or diag explain $buf;
+
+    monkey_patch "OpenQA::WebAPI", schema => sub { undef };
+    $fake_tx->OpenQA::WebSockets::Server::_message({type => 'worker_status'});
+    like $buf, qr/Failed updating worker seen status/ or diag explain $buf;
 };
 
 done_testing();


### PR DESCRIPTION
Having a fixed timer to send messages generates load on WebSockets server side when we have a large number of worker, this proposal tries to partially avoid this introducing dynamic timers allocations (as in slots) and enlarging the time window in which an instance can be detected as dead.

See [Poo](https://progress.opensuse.org/issues/25960) for more informations.

This PR is not introducing any form of clock syncronizations yet, but makes easier to introduce them in a second time. 

Giving as assumption that most likely workers are started all together (hence, **no form of worker clock sync yet**, but this method would be still more performant than having a fixed value)  this PR is creating the possibility to modify on-demand and with relatively small changes the behavior of all workers worker_status timeout in a determined cluster, depending on the population size and two numeric variables (with fixed values as for now). 
It is also removing the keepalive message (currently used to update worker's seen status), leaving that responsability to the worker_status message, hence the timespan was increased (since if we have delay of 1-2 minutes to detect the worker as offline, should not create any form of regression or problem).

It's still in WIP because i'd like to add more tests, squash commits a bit and try the whole in our staging infrastructure (now currently used for testing other bunch of changes).

The method picked up is based on [Logistic maps](https://en.wikipedia.org/wiki/Logistic_map) and it's a simple and slight retake - which in Complex Systems can be used to represent the reproduction and starvation rate of a population (so can be also seen as 'growth' or 'adaptation') . 
![Logistic map](https://upload.wikimedia.org/wikipedia/commons/1/1f/Logistic_map_animation.gif)
To note, with different fixed values, it's possible to reach similarity with other models like: Gaussian, sin(x), and so on, so leaves a lot of room further changes and optimizations. 


The current fixed values (plotted for 300 worker instances) will make (mostly, it's not taking account of possible latencies) workers timer's hit dinamically on osd as workers number grows(or shrinks):
![worker_timers](https://user-images.githubusercontent.com/2420543/32053710-6c67ba62-ba5c-11e7-8498-61469aeceaad.png)

This supersedes #1436


