### PR TITLE
Mention repos for Leap 42.3

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -33,6 +33,10 @@ and later. Installation on these distributions is therefore pretty simple:
 zypper ar -f obs://devel:openQA/openSUSE_Leap_42.2 openQA
 zypper ar -f obs://devel:openQA:Leap:42.2/openSUSE_Leap_42.2 openQA-perl-modules
 
+# openSUSE Leap 42.3
+zypper ar -f obs://devel:openQA/openSUSE_Leap_42.3 openQA
+zypper ar -f obs://devel:openQA:Leap:42.3/openSUSE_Leap_42.3 openQA-perl-modules
+
 # openSUSE Tumbleweed
 zypper ar -f obs://devel:openQA/openSUSE_Tumbleweed openQA
 


### PR DESCRIPTION
The documentation only shows info about Leap 42.2 and Tumbleweed.

Since the openQA version on official Leap 42.3 repositories is not compatible with the new versions and it will not be supported or maintain, I think it should be a good idea to promote installing openQA on Leap 42.3 from devel repos as on Tumbleweed.