### PR TITLE
Add _ONLYOBSOLETESAME parameter, obsolete only same BUILD jobs

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -207,15 +207,21 @@ parameters.
 [horizontal]
 .The following scheduling parameters exist
 
-_NOOBSOLETEBUILD:: Do not obsolete jobs in older builds which would be
-default. With this option jobs which are currently in execution, for example
-scheduled or running, are not cancelled when a new medium is triggered.
+_NO_OBSOLETE:: Do not obsolete jobs in older builds with same DISTRI and VERSION
+(as is the default behavior). With this option jobs which are currently pending,
+for example scheduled or running, are not cancelled when a new medium is triggered.
 
 _DEPRIORITIZEBUILD:: Setting this switch '1' will not immediately obsolete jobs of old
 builds but rather deprioritize them up to a configurable limit of priority.
 
 _DEPRIORITIZE_LIMIT:: The configurable limit of priority up to which jobs
 should be deprioritized. Needs `_DEPRIORITIZEBUILD`. Default 100.
+
+_ONLY_OBSOLETE_SAME_BUILD:: Only obsolete (or deprioritize) jobs for the same BUILD.
+This is useful for cases where a new build appearing doesn't necessarily
+mean existing jobs for earlier builds with the same DISTRI and VERSION are
+no longer interesting, but you still want to be able to re-submit jobs for a
+build and have existing jobs for the exact same build obsoleted.
 
 Example for `_DEPRIORITIZEBUILD` and `_DEPRIORITIZE_LIMIT`.
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -275,7 +275,8 @@ sub schedule_iso {
     }
     my $deprioritize       = delete $args->{_DEPRIORITIZEBUILD} // 0;
     my $deprioritize_limit = delete $args->{_DEPRIORITIZE_LIMIT};
-    my $obsolete           = !(delete $args->{_NOOBSOLETEBUILD} // $deprioritize);
+    my $obsolete           = !(delete $args->{_NO_OBSOLETE} // delete $args->{_NOOBSOLETEBUILD} // $deprioritize);
+    my $onlysame           = delete $args->{_ONLY_OBSOLETE_SAME_BUILD} // 0;
 
     # Any arg name ending in _URL is special: it tells us to download
     # the file at that URL before running the job
@@ -344,7 +345,9 @@ sub schedule_iso {
         OpenQA::Utils::log_debug(
             "Triggering new iso with build \'$build\', obsolete: $obsolete, deprioritize: $deprioritize");
         my %cond;
-        for my $k (qw(DISTRI VERSION FLAVOR ARCH)) {
+        my @attrs = qw(DISTRI VERSION FLAVOR ARCH);
+        push @attrs, 'BUILD' if ($onlysame);
+        for my $k (@attrs) {
             next unless $jobs->[0]->{$k};
             $cond{$k} = $jobs->[0]->{$k};
         }


### PR DESCRIPTION
By default, whenever openQA receives an ISO POST request and
schedules a set of jobs for the posted image, any pending jobs
with the same DISTRI, VERSION, FLAVOR and ARCH are canceled.
This can be too aggressive, so a _NOOBSOLETEBUILD parameter is
available which disables this behaviour entirely. However, there
may be a need for a happy medium.

For instance, in Fedora, it's too aggressive to cancel any job
with the same DISTRI, VERSION, FLAVOR and ARCH as a newly-POSTed
ISO, especially at present, since we are currently producing two
streams of composes for the same release (VERSION), modular and
non-modular; we don't want pending jobs for a non-modular
compose to be canceled when a modular compose with the same
VERSION lands, and vice versa. However, there's also a problem
with _NOOBSOLETEBUILD. Sometimes it happens that a build lands,
100+ jobs are created, but we realize something's wrong - we
need to tweak something and re-run all the jobs. The normal way
to do this is just to re-POST the images from the same build and
rely on the obsoletion behaviour to cancel the existing jobs.
But if we do this with _NOOBSOLETEBUILD set, the existing jobs
for the same build will not be canceled.

So this commit adds _ONLYOBSOLETESAME, which restricts this
obsoletion (or, if _DEPRIORITIZEBUILD is used, deprioritization)
behaviour to only apply to jobs with the exact same BUILD. So
any pending jobs with the same DISTRI, VERSION, FLAVOR, ARCH and
BUILD get obsoleted or deprioritized, but no other jobs do.