### PR TITLE
Print project directory

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -66,7 +66,7 @@ sub main {
         if ($worker_settings->{CACHEDIRECTORY}) {
             $shared_cache = prepare_cache_directory($h, $worker_settings->{CACHEDIRECTORY});
         }
-
+        # this is being also duplicated by OpenQA::Test::Utils since 49c06362d
         my @dirs = ($host_settings->{$h}{SHARE_DIRECTORY}, catdir($OpenQA::Utils::prjdir, 'share'));
         ($dir) = grep { $_ && -d } @dirs;
         unless ($dir) {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -70,11 +70,12 @@ sub main {
         my @dirs = ($host_settings->{$h}{SHARE_DIRECTORY}, catdir($OpenQA::Utils::prjdir, 'share'));
         ($dir) = grep { $_ && -d } @dirs;
         unless ($dir) {
-            log_error("Can not find working directory for host $h. Ignoring host");
+            map { log_debug("Found possible working directory for $h: $_") if $_ } @dirs;
+            log_error("Ignoring host '$h': Working directory does not exist.");
             next;
         }
 
-        log_debug("Using dir $dir for host $h");
+        log_info("Project dir for host $h is $dir");
         Mojo::IOLoop->next_tick(
             sub {
                 OpenQA::Worker::Common::register_worker($h, $dir, $host_settings->{$h}{TESTPOOLSERVER}, $shared_cache);

--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -36,7 +36,7 @@ function update_docs {
         # 2 files changed, 2 insertions(+), 2 deletions(-)
         ANYTHING_CHANGED=3 #
         ANYTHING_CHANGED=$(git diff --shortstat | perl -ne 'my $n; print $n = () = m/(?: 2 \w+)/g')
-        if [ ${ANYTHING_CHANGED} -ne 3]; then
+        if [ ${ANYTHING_CHANGED} -ne 3 ]; then
             cd ..
             git add _includes/api.html
             git add docs/index.html docs/current.pdf docs/api/testapi.html

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -16,10 +16,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use Cwd qw(abs_path getcwd);
-
-use strict;
-
 BEGIN {
     unshift @INC, 'lib';
     use FindBin;
@@ -62,7 +58,7 @@ eval 'use Test::More::Color "foreground"';
 
 use File::Path qw(make_path remove_tree);
 use Module::Load::Conditional 'can_load';
-use OpenQA::Test::Utils qw(create_websocket_server create_resourceallocator start_resourceallocator);
+use OpenQA::Test::Utils qw(create_websocket_server create_resourceallocator start_resourceallocator setup_share_dir);
 
 plan skip_all => "set FULLSTACK=1 (be careful)" unless $ENV{FULLSTACK};
 
@@ -70,7 +66,7 @@ my $workerpid;
 my $wspid;
 my $schedulerpid;
 my $resourceallocatorpid;
-my $sharedir = path($ENV{OPENQA_BASEDIR}, 'openqa', 'share')->make_path;
+my $sharedir = setup_share_dir($ENV{OPENQA_BASEDIR});
 
 sub turn_down_stack {
     if ($workerpid) {
@@ -154,17 +150,6 @@ my $wsport = $mojoport + 1;
 $wspid = create_websocket_server($wsport);
 
 my $connect_args = "--apikey=1234567890ABCDEF --apisecret=1234567890ABCDEF --host=http://localhost:$mojoport";
-
-path($sharedir, 'factory', 'iso')->make_path;
-
-symlink(abs_path("../os-autoinst/t/data/Core-7.2.iso"),
-    path($sharedir, 'factory', 'iso')->child("Core-7.2.iso")->to_string)
-  || die "can't symlink";
-
-path($sharedir, 'tests')->make_path;
-
-symlink(abs_path('../os-autoinst/t/data/tests/'), path($sharedir, 'tests')->child("tinycore"))
-  || die "can't symlink";
 
 sub client_output {
     my ($args) = @_;


### PR DESCRIPTION
Ensure that upon failure to setup the worker's project dir (due to missing directory)
print what were the attempts via debug, and send to the error the reason for the failure.