### PR TITLE
Use travis stages to reduce failing tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   matrix:
     - FULLSTACK=0 UITESTS=0
     - FULLSTACK=0 UITESTS=1 SELENIUM_CHROME=0
-    - GH_PUBLISH=true FULLSTACK=1 SELENIUM_CHROME=0
     - SCHEDULER_FULLSTACK=1
   global:
     - COMMIT_AUTHOR_EMAIL=skynet@open.qa
@@ -35,6 +34,14 @@ install:
 script:
   - bash script/generate-documentation $encrypted_e2c381aa6b8c_key $encrypted_e2c381aa6b8c_iv
   - make travis-codecov
+jobs:
+  include:
+    - stage: fullstack
+      env:
+        - FULLSTACK=1 SELENIUM_CHROME=0 GH_PUBLISH=true
+stages:
+  - test
+  - fullstack
 after_failure:
   - cat /tmp/openqa-debug.log
 cache:


### PR DESCRIPTION
While we benefit a lot by tests that are running in parallel, very
often, some of this tests (Mainly FULL_STACK and SCHEDULER_FULLSTACK)
tend to fail, a higher sucess rate can be seen when these are restarted
separately.

While it's a Travi's beta feature, looks robust enough and improved
since last time I tried this.