### PR TITLE
Improve web editor

### DIFF
--- a/templates/step/src.html.ep
+++ b/templates/step/src.html.ep
@@ -21,7 +21,8 @@
         <script type="text/javascript">
          var editor = CodeMirror.fromTextArea(document.getElementById("script"), {
              lineNumbers: true,
-             readOnly: true
+             readOnly: true,
+             lineWrapping: true
          });
         </script>
 </div>

--- a/templates/step/src.html.ep
+++ b/templates/step/src.html.ep
@@ -20,7 +20,8 @@
 
         <script type="text/javascript">
          var editor = CodeMirror.fromTextArea(document.getElementById("script"), {
-             lineNumbers: true
+             lineNumbers: true,
+             readOnly: true
          });
         </script>
 </div>


### PR DESCRIPTION
We don't save changes to the source code anyway so there is no real reason to not be read-only.
Line wrapping was also enabled because, in the current implementation, it is barely visible if a line is cut off by the maximum width of the editor if the horizontal scroll bar gets pushed off the screen (due to many lines of source code).

There is a second solution for this problem: limiting the size of the editor field to the height of the screen so that the horizontal scrollbar is always visible. 
I've split up the line wrapping into a separate commit for easy cherry-picking of not desired.