### PR TITLE
Remove IDs from fixtures if they are in sequence

### DIFF
--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -1,33 +1,27 @@
 [
     Assets => {
-        id   => 1,
         type => 'iso',
         name => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso',
         # Two hours ago
         t_created => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),
     },
     Assets => {
-        id   => 2,
         type => 'iso',
         name => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'
     },
     Assets => {
-        id   => 3,
         type => 'iso',
         name => 'openSUSE-13.1-GNOME-Live-i686-Build0091-Media.iso'
     },
     Assets => {
-        id   => 4,
         type => 'iso',
         name => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso',
     },
     Assets => {
-        id   => 5,
         type => 'hdd',
         name => 'openSUSE-13.1-x86_64.hda',
     },
     Assets => {
-        id   => 6,
         type => 'repo',
         name => 'testrepo',
     },

--- a/t/fixtures/05-job_modules.pl
+++ b/t/fixtures/05-job_modules.pl
@@ -7,7 +7,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 2,
         script   => 'tests/installation/bootloader.pm',
         job_id   => 99937,
         category => 'installation',
@@ -15,7 +14,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id        => 3,
         t_created => time2str('%Y-%m-%d %H:%M:%S', time - 10000, 'UTC'),
         script    => 'tests/installation/welcome.pm',
         job_id    => 99937,
@@ -24,7 +22,6 @@
         result    => 'passed',
     },
     JobModules => {
-        id       => 4,
         script   => 'tests/installation/installation_mode.pm',
         job_id   => 99937,
         category => 'installation',
@@ -32,7 +29,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 5,
         script   => 'tests/installation/installation_mode.pm',
         job_id   => 99939,
         category => 'installation',
@@ -40,7 +36,6 @@
         result   => 'softfailed'
     },
     JobModules => {
-        id       => 6,
         script   => 'tests/installation/installer_timezone.pm',
         job_id   => 99937,
         category => 'installation',
@@ -48,7 +43,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 7,
         script   => 'tests/installation/logpackages.pm',
         job_id   => 99937,
         category => 'installation',
@@ -56,7 +50,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 8,
         script   => 'tests/installation/installer_desktopselection.pm',
         job_id   => 99937,
         category => 'installation',
@@ -64,7 +57,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id        => 9,
         t_created => time2str('%Y-%m-%d %H:%M:%S', time - 50000, 'UTC'),
         script    => 'tests/installation/partitioning.pm',
         job_id    => 99937,
@@ -73,7 +65,6 @@
         result    => 'passed',
     },
     JobModules => {
-        id        => 10,
         t_created => time2str('%Y-%m-%d %H:%M:%S', time - 100000, 'UTC'),
 
         script   => 'tests/installation/partitioning_finish.pm',
@@ -83,7 +74,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 11,
         script   => 'tests/installation/user_settings.pm',
         job_id   => 99937,
         category => 'installation',
@@ -91,7 +81,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 12,
         script   => 'tests/installation/installation_overview.pm',
         job_id   => 99937,
         category => 'installation',
@@ -99,7 +88,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 13,
         script   => 'tests/installation/start_install.pm',
         job_id   => 99937,
         category => 'installation',
@@ -107,7 +95,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 14,
         script   => 'tests/installation/livecdreboot.pm',
         job_id   => 99937,
         category => 'installation',
@@ -115,7 +102,6 @@
         result   => 'passed',
     },
     JobModules => {
-        id       => 15,
         script   => 'tests/installation/second_stage.pm',
         job_id   => 99937,
         category => 'installation',


### PR DESCRIPTION
Postgresql has a different logic than Sqlite has for how to assign IDs