### PR TITLE
Apply openqa.ini log level correctly

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -38,7 +38,7 @@ has mode => 'production';
 
 has 'log_name';
 
-has level => 'info';
+has 'level';
 
 has 'instance';
 
@@ -62,8 +62,8 @@ sub setup_log {
     }
     else {
         $log = $self->log;
-        $level = $self->config->{logging}->{level} || 'debug';
     }
+    $level //= $self->config->{logging}->{level} // 'info';
     $logfile = $ENV{OPENQA_LOGFILE} || $self->config->{logging}->{file};
 
     if ($logfile && $logdir) {

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -29,6 +29,38 @@ use File::Spec::Functions 'catfile';
 my $reFile    = qr/\[.*?\] \[worker:(.*?)\] (.*?) message/;
 my $reStdOut  = qr/(?:.*?)\[worker:(.*?)\] (.*?) message/;
 my $reChannel = qr/\[.*?\] \[(.*?)\] (.*?) message/;
+
+subtest 'load correct configs' => sub {
+    local $ENV{OPENQA_CONFIG} = 't/data/logging/';
+    my $app = OpenQA::Setup->new(
+        mode     => 'production',
+        log_name => 'worker',
+        instance => 1,
+        log_dir  => undef,
+        level    => 'debug'
+    );
+
+    OpenQA::Setup::read_config($app);
+    is($app->level,                    'debug');
+    is($app->mode,                     'production');
+    is($app->config->{logging}{level}, 'warning');
+    is($app->log->level,               'info');
+    OpenQA::Setup::setup_log($app);
+    is($app->level,      'debug');
+    is($app->log->level, 'debug');
+
+    $app = OpenQA::Setup->new();
+    OpenQA::Setup::read_config($app);
+    is($app->level,                    undef);
+    is($app->mode,                     'production');
+    is($app->config->{logging}{level}, 'warning');
+    is($app->log->level,               'info');
+    OpenQA::Setup::setup_log($app);
+    is($app->level,      undef);
+    is($app->log->level, 'warning');
+
+};
+
 subtest 'Logging to stdout' => sub {
     local $ENV{OPENQA_WORKER_LOGDIR};
     local $ENV{OPENQA_LOGFILE};

--- a/t/data/logging/openqa.ini
+++ b/t/data/logging/openqa.ini
@@ -1,0 +1,17 @@
+[global]
+
+[auth]
+
+[logging]
+#logging is to stderr (so systemd journal) by default
+#if you use a file, remember the apparmor profile!
+file = /tmp/openqa_log_file
+level = warning
+#sql_debug = true
+
+## Configuration for OpenID auth method
+[openid]
+
+[audit]
+
+[amqp]


### PR DESCRIPTION
The openqa.ini log level wasn't being set correctly.
This caused for the server components (resource allocator, scheduler...) to ignore the level defined in the openqa.ini file. Only when the level was set on the constructor it was being set correctly.

No issues for the worker.ini