### PR TITLE
Not everything is debug information

### DIFF
--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -94,7 +94,7 @@ sub download_asset {
     my $ua = Mojo::UserAgent->new(max_redirects => 2);
     $ua->max_response_size(0);
     my $url = sprintf '%s/tests/%d/asset/%s/%s', $host, $id, $type, basename($asset);
-    log_debug("Downloading " . basename($asset) . " from $url");
+    log_info("Downloading " . basename($asset) . " from $url");
     my $tx = $ua->build_tx(GET => $url);
     my $headers;
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -121,9 +121,9 @@ sub engine_workit {
     my ($job) = @_;
 
     my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
-    log_debug('+++ setup notes +++', channels => 'autoinst');
-    log_debug(sprintf("start time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
-    log_debug(sprintf("running on $hostname:%d ($sysname $release $version $machine)", $instance),
+    log_info('+++ setup notes +++', channels => 'autoinst');
+    log_info(sprintf("start time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
+    log_info(sprintf("running on $hostname:%d ($sysname $release $version $machine)", $instance),
         channels => 'autoinst');
 
     # set base dir to the one assigned with webui

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -193,7 +193,7 @@ sub upload {
 
     # we need to open and close the log here as one of the files
     # might actually be autoinst-log.txt
-    log_debug("uploading $filename", channels => ['worker', 'autoinst'], default => 1);
+    log_info("uploading $filename", channels => ['worker', 'autoinst'], default => 1);
 
     my $regular_upload_failed = 0;
     my $retry_counter         = 5;
@@ -311,9 +311,9 @@ sub _stop_job_2 {
     $aborted ||= 'done';
 
     my $job_done;    # undef
-    log_debug("+++ worker notes +++", channels => 'autoinst');
-    log_debug(sprintf("end time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
-    log_debug("result: $aborted", channels => 'autoinst');
+    log_info("+++ worker notes +++", channels => 'autoinst');
+    log_info(sprintf("end time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
+    log_info("result: $aborted", channels => 'autoinst');
     if ($aborted ne 'quit' && $aborted ne 'abort' && $aborted ne 'api-failure') {
         # collect uploaded logs
         my @uploaded_logfiles = glob "$pooldir/ulogs/*";

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -279,19 +279,24 @@ for (my $i = 0; $i < 5; $i++) {
     last if -s $filename;
     sleep 1;
 }
-ok(-s $filename, 'Test 4 autoinst-log.txt file created');
-open(my $f, '<', $filename) or die "OPENING $filename: $!\n";
-my $autoinst_log = do { local ($/); <$f> };
-close($f);
+#  The worker is launched with --verbose, so by default in this test the level is always debug
+if (!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i) {
+    ok(-s $filename, 'Test 4 autoinst-log.txt file created');
+    open(my $f, '<', $filename) or die "OPENING $filename: $!\n";
+    my $autoinst_log = do { local ($/); <$f> };
+    close($f);
 
-like($autoinst_log, qr/result: setup failure/, 'Test 4 state correct: setup failure');
+    like($autoinst_log, qr/result: setup failure/, 'Test 4 state correct: setup failure');
 
-like((split(/\n/, $autoinst_log))[0], qr/\[debug\] \+\+\+ setup notes \+\+\+/, 'Test 4 correct autoinst setup notes');
-like(
-    (split(/\n/, $autoinst_log))[-1],
-    qr/\[debug\] uploading autoinst-log.txt/,
-    'Test 4 correct autoinst uploading autoinst'
-);
+    like((split(/\n/, $autoinst_log))[0], qr/\[info\] \+\+\+ setup notes \+\+\+/,
+        'Test 4 correct autoinst setup notes');
+    like(
+        (split(/\n/, $autoinst_log))[-1],
+        qr/\[info\] uploading autoinst-log.txt/,
+        'Test 4 correct autoinst uploading autoinst'
+    );
+}
+
 kill_worker;    # Ensure that the worker can be killed with TERM signal
 
 my $cache_location = path($ENV{OPENQA_BASEDIR}, 'cache')->make_path;
@@ -342,25 +347,27 @@ subtest 'Cache tests' => sub {
     wait_for_result_panel qr/Result: passed/, 'test 5 is passed';
     kill_worker;
 
-    $filename = path($resultdir, '00000', "00000005-$job_name")->child("autoinst-log.txt");
-    open(my $f, '<', $filename) or die "OPENING $filename: $!\n";
-    $autoinst_log = do { local ($/); <$f> };
-    close($f);
+    #  The worker is launched with --verbose, so by default in this test the level is always debug
+    if (!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i) {
+        $filename = path($resultdir, '00000', "00000005-$job_name")->child("autoinst-log.txt");
+        open(my $f, '<', $filename) or die "OPENING $filename: $!\n";
+        my $autoinst_log = do { local ($/); <$f> };
+        close($f);
 
-    like($autoinst_log, qr/Downloading Core-7.2.iso/, 'Test 5, downloaded the right iso.');
-    like($autoinst_log, qr/11116544/,                 'Test 5 Core-7.2.iso size is correct.');
-    like($autoinst_log, qr/\[debug\] result: done/,   'Test 5 result done');
-    like(
-        (split(/\n/, $autoinst_log))[0],
-        qr/\[debug\] \+\+\+ setup notes \+\+\+/,
-        'Test 5 correct autoinst setup notes'
-    );
-    like(
-        (split(/\n/, $autoinst_log))[-1],
-        qr/\[debug\] uploading autoinst-log.txt/,
-        'Test 5 correct autoinst uploading autoinst'
-    );
-
+        like($autoinst_log, qr/Downloading Core-7.2.iso/, 'Test 5, downloaded the right iso.');
+        like($autoinst_log, qr/11116544/,                 'Test 5 Core-7.2.iso size is correct.');
+        like($autoinst_log, qr/\[info\] result: done/,    'Test 5 result done');
+        like(
+            (split(/\n/, $autoinst_log))[0],
+            qr/\[info\] \+\+\+ setup notes \+\+\+/,
+            'Test 5 correct autoinst setup notes'
+        );
+        like(
+            (split(/\n/, $autoinst_log))[-1],
+            qr/\[info\] uploading autoinst-log.txt/,
+            'Test 5 correct autoinst uploading autoinst'
+        );
+    }
     my $dbh
       = DBI->connect("dbi:SQLite:dbname=$db_file", undef, undef, {RaiseError => 1, PrintError => 1, AutoCommit => 1});
     my $sql    = "SELECT * from assets order by last_use asc";
@@ -418,50 +425,57 @@ subtest 'Cache tests' => sub {
     start_worker;
     wait_for_result_panel qr/Result: passed/, 'test 7 is passed';
 
-    $filename = path($resultdir, '00000', "00000007-$job_name")->child("autoinst-log.txt");
-    ok(-s $filename, 'Test 7 autoinst-log.txt file created');
+    #  The worker is launched with --verbose, so by default in this test the level is always debug
+    if (!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i) {
+        $filename = path($resultdir, '00000', "00000007-$job_name")->child("autoinst-log.txt");
+        ok(-s $filename, 'Test 7 autoinst-log.txt file created');
 
-    open($f, '<', $filename) or die "OPENING $filename: $!\n";
-    $autoinst_log = do { local ($/); <$f> };
-    close($f);
+        open(my $f, '<', $filename) or die "OPENING $filename: $!\n";
+        my $autoinst_log = do { local ($/); <$f> };
+        close($f);
 
-    like($autoinst_log, qr/Content has not changed/, 'Test 7 Core-7.2.iso has not changed.');
-    like($autoinst_log, qr/\[debug\] \+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
-    like(
-        (split(/\n/, $autoinst_log))[0],
-        qr/\[debug\] \+\+\+ setup notes \+\+\+/,
-        'Test 7 correct autoinst setup notes'
-    );
-    like(
-        (split(/\n/, $autoinst_log))[-1],
-        qr/\[debug\] uploading autoinst-log.txt/,
-        'Test 7 correct autoinst uploading autoinst'
-    );
-
+        like($autoinst_log, qr/Content has not changed/, 'Test 7 Core-7.2.iso has not changed.');
+        like($autoinst_log, qr/\[info\] \+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
+        like(
+            (split(/\n/, $autoinst_log))[0],
+            qr/\[info\] \+\+\+ setup notes \+\+\+/,
+            'Test 7 correct autoinst setup notes'
+        );
+        like(
+            (split(/\n/, $autoinst_log))[-1],
+            qr/\[info\] uploading autoinst-log.txt/,
+            'Test 7 correct autoinst uploading autoinst'
+        );
+    }
     client_call("jobs post $JOB_SETUP HDD_1=non-existent.qcow2");
     $driver->get('/tests/8');
     wait_for_result_panel qr/Result: incomplete/, 'test 8 is incomplete';
-    $filename = path($resultdir, '00000', "00000008-$job_name")->child("autoinst-log.txt");
-    ok(-s $filename, 'Test 8 autoinst-log.txt file created');
 
-    open($f, '<', $filename) or die "OPENING $filename: $!\n";
-    $autoinst_log = do { local ($/); <$f> };
-    close($f);
+    #  The worker is launched with --verbose, so by default in this test the level is always debug
+    if (!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i) {
+        $filename = path($resultdir, '00000', "00000008-$job_name")->child("autoinst-log.txt");
+        ok(-s $filename, 'Test 8 autoinst-log.txt file created');
 
-    like($autoinst_log, qr/\[debug\] \+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
-    like(
-        (split(/\n/, $autoinst_log))[0],
-        qr/\[debug\] \+\+\+ setup notes \+\+\+/,
-        'Test 8 correct autoinst setup notes'
-    );
-    like(
-        (split(/\n/, $autoinst_log))[-1],
-        qr/\[debug\] uploading autoinst-log.txt/,
-        'Test 8 correct autoinst uploading autoinst'
-    );
+        open(my $f, '<', $filename) or die "OPENING $filename: $!\n";
+        my $autoinst_log = do { local ($/); <$f> };
+        close($f);
 
-    like($autoinst_log, qr/non-existent.qcow2 failed with: 404 - Not Found/, 'Test 8 failure message found in log.');
-    like($autoinst_log, qr/result: setup failure/, 'Test 8 state correct: setup failure');
+        like($autoinst_log, qr/\[info\] \+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
+        like(
+            (split(/\n/, $autoinst_log))[0],
+            qr/\[info\] \+\+\+ setup notes \+\+\+/,
+            'Test 8 correct autoinst setup notes'
+        );
+        like(
+            (split(/\n/, $autoinst_log))[-1],
+            qr/\[info\] uploading autoinst-log.txt/,
+            'Test 8 correct autoinst uploading autoinst'
+        );
+
+        like($autoinst_log, qr/non-existent.qcow2 failed with: 404 - Not Found/,
+            'Test 8 failure message found in log.');
+        like($autoinst_log, qr/result: setup failure/, 'Test 8 state correct: setup failure');
+    }
 
     kill_worker;
 };


### PR DESCRIPTION
There are some activities that are better suited as info than as debug.
Such activities include: starting worker, worker downloading/uploading files

All of these information is usefull although we don't care most of the time.

It also addresses the bug in which we if we override the default verbosity level with MOJO_LOG_LEVEL, the fullstack.t test will fail, because the autoinst-log.tx file won't be created (as there is nothing to be written).