### PR TITLE
Add basic http-only config for nginx

### DIFF
--- a/etc/nginx/vhosts.d/openqa.conf
+++ b/etc/nginx/vhosts.d/openqa.conf
@@ -1,0 +1,23 @@
+server {
+    listen       80;
+    server_name  openqa.example.com;
+    root /usr/share/openqa/public;
+    client_max_body_size 0;
+
+    location /api/v1/ws/ {
+        proxy_pass http://[::1]:9527;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+
+        rewrite /api/v1/ws/(.*) /ws/$1 break;
+    }
+
+    location / {
+        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass "http://[::1]:9526";
+    }
+}


### PR DESCRIPTION
I use this config on my local development instance.

What works right now:
- Navigation in the webui (Login, overview page and so on)
- Register remote worker
- Cloning jobs

What does not work yet:
- ~Cloning jobs~

My instance can be seen here: http://openqa.glados.qa.suse.de