### PR TITLE
Add openqa-setup-db service that will create postgresql database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ install:
 	install -m 644 systemd/openqa-websockets.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-scheduler.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-resource-allocator.service "$(DESTDIR)"/usr/lib/systemd/system
+	install -m 644 systemd/openqa-setup-db.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf
 	install -D -m 644 etc/dbus-1/system.d/org.opensuse.openqa.conf "$(DESTDIR)"/etc/dbus-1/system.d/org.opensuse.openqa.conf

--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=The openQA gru daemon
-After=postgresql.service
-Requires=postgresql.service
+After=postgresql.service openqa-setup-db.service
+Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest

--- a/systemd/openqa-resource-allocator.service
+++ b/systemd/openqa-resource-allocator.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=The openQA ResourceAllocator
 Before=openqa-webui.service openqa-websockets.service openqa-scheduler.service
-After=postgresql.service
-Requires=postgresql.service
+After=postgresql.service openqa-setup-db.service
+Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest

--- a/systemd/openqa-scheduler.service
+++ b/systemd/openqa-scheduler.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=The openQA Scheduler
 Before=openqa-webui.service openqa-websockets.service
-After=postgresql.service
-Requires=postgresql.service
+After=postgresql.service openqa-setup-db.service
+Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest

--- a/systemd/openqa-setup-db.service
+++ b/systemd/openqa-setup-db.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Setup local PostgreSQL database for openQA
+Requires=postgresql.service
+After=postgresql.service
+
+[Service]
+User=postgres
+Type=oneshot
+ExecStart=-/usr/bin/createuser -D geekotest
+ExecStart=-/usr/bin/createdb -O geekotest openqa
+
+[Install]
+WantedBy=multi-user.target
+

--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=The openQA WebSockets server
-Wants=apache2.service network.target
+Wants=apache2.service network.target openqa-setup-db.service
 Before=apache2.service openqa-webui.service
-After=openqa-resource-allocator.service openqa-scheduler.service postgresql.service network.target
-Requires=openqa-resource-allocator.service openqa-scheduler.service postgresql.service
+After=openqa-resource-allocator.service openqa-scheduler.service postgresql.service network.target openqa-setup-db.service
+Requires=openqa-resource-allocator.service openqa-scheduler.service
 
 [Service]
 # TODO: define whether we want to run the websockets with the same user

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=The openQA web UI
-Wants=apache2.service
+Wants=apache2.service openqa-setup-db.service
 Before=apache2.service
-After=postgresql.service
-Requires=openqa-resource-allocator.service openqa-scheduler.service openqa-websockets.service postgresql.service
+After=postgresql.service openqa-setup-db.service
+Requires=openqa-resource-allocator.service openqa-scheduler.service openqa-websockets.service
 
 [Service]
 # TODO: define whether we want to run the web ui with the same user


### PR DESCRIPTION
and make the other service 'want' it. So if's there (packaged in an extra package)
it will start postgresql and add the database for openqa. This way all
the user has to do is: zypper in openQA (and tons of apache mocking)

Verification run: https://tortuga.suse.de/tests/15#live

Idea: @lnussel 