### PR TITLE
limit_assets: Remove assets that exceed the remaining limit

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -308,7 +308,7 @@ sub limit_assets {
 
             # check whether the asset has a size and whether we haven't exceeded the reduce limit
             my $size = $asset->ensure_size;
-            if ($size > 0 && $reduceto > 0) {
+            if ($size > 0 && $reduceto > 0 && $sizelimit >= $size) {
                 # keep asset
 
                 # determine whether the asset is kept exclusively by this group


### PR DESCRIPTION
@Martchus noted yesterday that the Tumbleweed PowerPC group is configured to 80GB limit but has 118GB of assets.

The reason for this is that the last asset considered is the old repo of 56GB, so if the sizelimit is down to 10 bytes and the next asset is 56GB, it's kept.

I think this breaks user's expectations - as a limit of 0 in my book means 0 assets and not one asset, no matter what size it is.