### PR TITLE
Remove all assets from DB that are gone

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -406,7 +406,7 @@ sub limit_assets {
     while (my $a = $assets->next) {
         next if $a->fixed;
         my $delta = $a->t_created->delta_days(DateTime->now)->in_units('days');
-        if ($delta >= 14) {
+        if ($delta >= 14 || $a->ensure_size == 0) {
             $a->remove_from_disk;
             $a->delete;
         }


### PR DESCRIPTION
We did this for assets in job groups, but the assets not assigned were filling
the DB. This was especially troublesome with the TEMP files from upload laying
in the database for 14 days