### PR TITLE
Improve asset tables

### DIFF
--- a/assets/javascripts/assets.js
+++ b/assets/javascripts/assets.js
@@ -1,6 +1,5 @@
-function setup_asset_table()
-{
-    $('#assets').DataTable(
+function setup_asset_table() {
+    $('#assets, #untracked-assets').DataTable(
         {
             columnDefs: [
                 { targets: 3,

--- a/assets/javascripts/assets.js
+++ b/assets/javascripts/assets.js
@@ -14,15 +14,10 @@ function setup_asset_table()
                 { targets: 4,
                   render: function(data, type, row) {
                       if (type === 'display') {
-                          var unitFactor = 1073741824; // one GiB
-                          var dataWithUnit;
-                          $.each([' GiB', ' MiB', ' KiB', ' byte'], function(index, unit) {
-                              if (!unitFactor || data >= unitFactor) {
-                                  dataWithUnit = (data / unitFactor) + unit;
-                                  return false;
-                              }
-                              unitFactor >>= 10;
-                          });
+                          if (data === '') {
+                              return 'unknown';
+                          }
+                          var dataWithUnit = renderDataSize(data);
                           if (dataWithUnit) {
                             return dataWithUnit;
                           }

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -83,3 +83,16 @@ function updateQueryParams(params) {
     });
     history.replaceState({} , document.title, window.location.pathname + '?' + search.join('&'));
 }
+
+function renderDataSize(sizeInByte) {
+    var unitFactor = 1073741824; // one GiB
+    var sizeWithUnit = 0;
+    $.each([' GiB', ' MiB', ' KiB', ' byte'], function(index, unit) {
+        if (!unitFactor || sizeInByte >= unitFactor) {
+            sizeWithUnit = (Math.round(sizeInByte / unitFactor * 100) / 100) + unit;
+            return false;
+        }
+        unitFactor >>= 10;
+    });
+    return sizeWithUnit;
+}

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -491,8 +491,8 @@ subtest 'asset list' => sub {
 
     is_deeply(
         get_cell_contents('tr#asset_1'),
-        ['iso', 'openSUSE-13.1-DVD-i586-Build0091-Media.iso', '5', 'about 2 hours ago', '', 'unknown'],
-        'asset with unknown last use'
+        ['iso', 'openSUSE-13.1-DVD-i586-Build0091-Media.iso', '5', 'about 2 hours ago', 'unknown', 'unknown'],
+        'asset with unknown last use and size'
     );
     is_deeply(
         get_cell_contents('tr#asset_2'),

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -491,7 +491,7 @@ subtest 'asset list' => sub {
 
     is_deeply(
         get_cell_contents('tr#asset_1'),
-        ['iso', 'openSUSE-13.1-DVD-i586-Build0091-Media.iso', '5', 'about 2 hours ago', 'unknown', 'unknown'],
+        ['iso', 'openSUSE-13.1-DVD-i586-Build0091-Media.iso', '5', 'about 2 hours ago', 'unknown'],
         'asset with unknown last use and size'
     );
     is_deeply(
@@ -502,6 +502,14 @@ subtest 'asset list' => sub {
             '4 KiB', 'opensuse: opensuse-13.1-DVD-x86_64-Build0091-kde@64bit'
         ],
         'asset with last use'
+    );
+
+    my $used_assets      = $driver->find_element('#assets');
+    my $untracked_assets = $driver->find_element('#untracked-assets');
+    ok($driver->find_child_element($used_assets, 'tr#asset_2'), 'asset with last use part of used assets');
+    ok(
+        $driver->find_child_element($untracked_assets, 'tr#asset_1'),
+        'asset with unknown last use part of untracked assets'
     );
 };
 

--- a/templates/admin/asset/index.html.ep
+++ b/templates/admin/asset/index.html.ep
@@ -11,6 +11,8 @@
 
         %= include 'layouts/info'
 
+        <h3>Used assets</h3>
+        <p>The following assets are used by at least one job which is part of a group.</p>
         <table id="assets" class="display table table-striped">
             <thead>
                 <tr>
@@ -24,6 +26,7 @@
             </thead>
             <tbody>
             % while (my $asset = $assets->next()) {
+                % next unless ($asset->last_use_job_id);
             <tr id="asset_<%= $asset->id %>">
                 <td class="type"><%= $asset->type %></td>
                 <td class="name"><%= $asset->name %></td>
@@ -33,17 +36,43 @@
                 </td>
                 <td class="size"><%= $asset->size %></td>
                 <td class="last_use">
-                    % if (my $last_use_job = $asset->last_use_job) {
-                        % if (my $group = $last_use_job->group) {
-                            <%= link_to($group->name => url_for(is_admin() ? 'admin_job_templates' : 'group_overview', groupid => $group->id)); %>:
-                        % }
-                        %= link_to($last_use_job->name => url_for('test', testid => $last_use_job->id))
+                    % my $last_use_job = $asset->last_use_job;
+                    % if (my $group = $last_use_job->group) {
+                        <%= link_to($group->name => url_for(is_admin() ? 'admin_job_templates' : 'group_overview', groupid => $group->id)); %>:
                     % }
-                    % else {
-                        unknown
-                    % }
+                    %= link_to($last_use_job->name => url_for('test', testid => $last_use_job->id))
                 </td>
             </tr>
+            % }
+
+            </tbody>
+        </table>
+
+        <h3>Untracked assets</h3>
+        <p>The following assets are not used by any job or only by jobs which are not part of any group.</p>
+        <table id="untracked-assets" class="display table table-striped">
+            <thead>
+                <tr>
+                    <th>Type</th>
+                    <th>Name</th>
+                    <th>#Jobs</th>
+                    <th>Created</th>
+                    <th>Size</th>
+                </tr>
+            </thead>
+            <tbody>
+            % $assets->reset();
+            % while (my $asset = $assets->next()) {
+                % next if ($asset->last_use_job_id);
+                <tr id="asset_<%= $asset->id %>">
+                    <td class="type"><%= $asset->type %></td>
+                    <td class="name"><%= $asset->name %></td>
+                    <td class="nrjobs"><%= link_to($asset->jobs_assets->count => url_for('tests')->query(assetid => $asset->id)) %></td>
+                    <td class="t_created">
+                        %= $asset->t_created
+                    </td>
+                    <td class="size"><%= $asset->size %></td>
+                </tr>
             % }
             </tbody>
         </table>


### PR DESCRIPTION
* Reduce precision of sizes
* Split table in used and untracked assets

---

Not sure whether this is ok, but currently any job which has no 'last used job' is considered untracked. Or should that better depend on the list of jobs which have the asset (regardless of gru cleanup)?

---

The list of all job groups with their exclusively used assets is still [WIP](https://github.com/Martchus/openQA/commits/gru_log_to_webui_job_list).