### PR TITLE
Change the logs timestamp to ISO8601

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -90,6 +90,7 @@ requires 'diagnostics';
 requires 'namespace::clean';
 requires 'strict';
 requires 'warnings';
+requires 'POSIX';
 
 on 'test' => sub {
   requires 'Perl::Tidy';

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -411,8 +411,8 @@ subtest 'Worker logs' => sub {
     path($FindBin::Bin, "data")->child("workers.ini")->copy_to(path($ENV{OPENQA_CONFIG})->child("workers.ini"));
 
     my @re = (
-        '\[worker:debug\] Found possible working directory for .*?: .*',
-        '\[worker:error\] Ignoring host .*: Working directory does not exist'
+        '\[debug\] Found possible working directory for .*?: .*',
+        '\[error\] Ignoring host .*: Working directory does not exist'
     );
     my $c = join('\n', @re);
 
@@ -426,10 +426,10 @@ subtest 'Worker logs' => sub {
     $OpenQA::Utils::prjdir = path(tempdir(), 'openqa');
 
     @re = (
-        '\[worker:info\] Project dir for host .*? is .*',
-        '\[worker:info\] registering worker with .*',
-        '\[worker:error\] unable to connect to host .* retry in .*',
-        '\[worker:debug\] ## adding timer register_worker-.*'
+        '\[info\] Project dir for host .*? is .*',
+        '\[info\] registering worker with .*',
+        '\[error\] unable to connect to host .* retry in .*',
+        '\[debug\] ## adding timer register_worker-.*'
     );
 
     $c = join('\n', @re);

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -51,10 +51,10 @@ subtest 'Setup logging to file' => sub {
     $log->info('Works too');
 
     my $content = $tempfile->slurp;
-    like $content, qr/\[.*\] \[test:error\] Just works/,  'right error message';
-    like $content, qr/\[.*\] \[test:fatal\] Fatal error/, 'right fatal message';
-    like $content, qr/\[.*\] \[test:debug\] It works/,    'right debug message';
-    like $content, qr/\[.*\] \[test:info\] Works too/,    'right info message';
+    like $content, qr/\[.*\] \[error\] Just works/,  'right error message';
+    like $content, qr/\[.*\] \[fatal\] Fatal error/, 'right fatal message';
+    like $content, qr/\[.*\] \[debug\] It works/,    'right debug message';
+    like $content, qr/\[.*\] \[info\] Works too/,    'right info message';
 };
 
 subtest 'Setup logging to STDOUT' => sub {
@@ -72,10 +72,10 @@ subtest 'Setup logging to STDOUT' => sub {
         $log->debug('It works');
         $log->info('Works too');
     }
-    like $buffer, qr/\[test:error\] Just works\n/,  'right error message';
-    like $buffer, qr/\[test:fatal\] Fatal error\n/, 'right fatal message';
-    like $buffer, qr/\[test:debug\] It works\n/,    'right debug message';
-    like $buffer, qr/\[test:info\] Works too\n/,    'right info message';
+    like $buffer, qr/\[error\] Just works\n/,  'right error message';
+    like $buffer, qr/\[fatal\] Fatal error\n/, 'right fatal message';
+    like $buffer, qr/\[debug\] It works\n/,    'right debug message';
+    like $buffer, qr/\[info\] Works too\n/,    'right info message';
 };
 
 subtest 'Setup logging to file (ENV)' => sub {
@@ -91,10 +91,10 @@ subtest 'Setup logging to file (ENV)' => sub {
     $log->info('Works too');
 
     my $content = path($ENV{OPENQA_LOGFILE})->slurp;
-    like $content, qr/\[.*\] \[test:error\] Just works/,  'right error message';
-    like $content, qr/\[.*\] \[test:fatal\] Fatal error/, 'right fatal message';
-    like $content, qr/\[.*\] \[test:debug\] It works/,    'right debug message';
-    like $content, qr/\[.*\] \[test:info\] Works too/,    'right info message';
+    like $content, qr/\[.*\] \[error\] Just works/,  'right error message';
+    like $content, qr/\[.*\] \[fatal\] Fatal error/, 'right fatal message';
+    like $content, qr/\[.*\] \[debug\] It works/,    'right debug message';
+    like $content, qr/\[.*\] \[info\] Works too/,    'right info message';
     ok !-e "/tmp/ignored_foo_bar";
 
     $app = Mojolicious->new();
@@ -108,10 +108,10 @@ subtest 'Setup logging to file (ENV)' => sub {
     $log->info('Works too');
 
     $content = path($ENV{OPENQA_LOGFILE})->slurp;
-    like $content, qr/\[.*\] \[test:error\] Just works/,  'right error message';
-    like $content, qr/\[.*\] \[test:fatal\] Fatal error/, 'right fatal message';
-    like $content, qr/\[.*\] \[test:debug\] It works/,    'right debug message';
-    like $content, qr/\[.*\] \[test:info\] Works too/,    'right info message';
+    like $content, qr/\[.*\] \[error\] Just works/,  'right error message';
+    like $content, qr/\[.*\] \[fatal\] Fatal error/, 'right fatal message';
+    like $content, qr/\[.*\] \[debug\] It works/,    'right debug message';
+    like $content, qr/\[.*\] \[info\] Works too/,    'right info message';
 };
 
 subtest 'Update configuration from Plugin requirements' => sub {

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -26,8 +26,8 @@ use File::Path qw(make_path remove_tree);
 use Sys::Hostname;
 use File::Spec::Functions 'catfile';
 
-my $reFile    = qr/\[.*?\] \[worker:(.*?)\] (.*?) message/;
-my $reStdOut  = qr/(?:.*?)\[worker:(.*?)\] (.*?) message/;
+my $reFile    = qr/\[.*?\] \[(.*?)\] (.*?) message/;
+my $reStdOut  = qr/(?:.*?)\[(.*?)\] (.*?) message/;
 my $reChannel = qr/\[.*?\] \[(.*?)\] (.*?) message/;
 
 subtest 'load correct configs' => sub {


### PR DESCRIPTION
This change will make sure that all the logs (except when logging to stdout/stderr) will respect
ISO8601 date format.

This is achieved by overriding the Mojo::Log format callback.

poo#29304