### PR TITLE
Add worker version check on the server.

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -49,7 +49,7 @@ sub init {
     $app->level($worker_settings->{LOG_LEVEL}) if $worker_settings->{LOG_LEVEL};
     $app->setup_log();
     OpenQA::Worker::Common::api_init($host_settings, $options);
-    OpenQA::Worker::Engines::isotovideo::set_engine_exec($options->{isotovideo}) if $options->{isotovideo};
+    OpenQA::Worker::Engines::isotovideo::set_engine_exec($options->{isotovideo});
 }
 
 sub main {

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -183,6 +183,10 @@ sub websocket_commands {
                 $check_job_running->{$host} = 0;
             }
         }
+        elsif ($type eq 'incompatible') {
+            log_error("The worker is running an incompatible version");
+            Mojo::IOLoop->singleton->stop_gracefully;
+        }
         else {
             log_error("got unknown command $type");
         }

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -43,7 +43,7 @@ our $pooldir;
 our $nocleanup = 0;
 our $testresults;
 our $worker_caps;
-
+our $isotovideo_interface_version = 0;
 # package global variables
 # HASHREF with structure
 # {hostname => {url => Mojo::URL, ua => OpenQA::Client, ws => Mojo::Transaction::WebSockets}, workerid => uint}
@@ -61,6 +61,7 @@ use constant {
     STATUS_UPDATES_FAST => 0.5,
     MAX_TIMER           => 100,    # It should never be more than OpenQA::WebSockets::Server::_workers_checker threshold
     MIN_TIMER           => 20,
+    INTERFACE_VERSION => 1,   # Which version the worker follows. Minimal version that will connect to the openqa server
 };
 
 # the template noted what architecture are known
@@ -337,7 +338,10 @@ sub send_status {
 
     my $status_message = {
         json => {
-            type => 'worker_status'
+            type                         => 'worker_status',
+            websocket_api_version        => INTERFACE_VERSION,
+            isotovideo_interface_version => $isotovideo_interface_version
+
         }};
 
     if (defined $job && ref($job) eq "HASH" && exists $job->{id}) {
@@ -467,7 +471,9 @@ sub register_worker {
         $worker_caps->{worker_class} = 'qemu_' . $worker_caps->{cpu_arch};
     }
 
-    log_info("registering worker with openQA $host...");
+    log_info(
+"registering worker $hostname version $isotovideo_interface_version with openQA $host using protocol version [@{[INTERFACE_VERSION]}]"
+    );
 
     if (!$hosts->{$host}) {
         log_error "WebUI $host is unknown! - Should not happen but happened, exiting!";

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -41,9 +41,13 @@ our (@ISA, @EXPORT);
 
 sub set_engine_exec {
     my ($path) = @_;
-    die "Path to isotovideo invalid: $path" unless -f $path;
-    # save the absolute path as we chdir later
-    $isotovideo = abs_path($path);
+    if ($path) {
+        die "Path to isotovideo invalid: $path" unless -f $path;
+        # save the absolute path as we chdir later
+        $isotovideo = abs_path($path);
+    }
+    $OpenQA::Worker::Common::isotovideo_interface_version = $1
+      if (-f $isotovideo && qx(perl $isotovideo --version) =~ /interface v(\d+)/);
 }
 
 sub _kill($) {

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -34,6 +34,7 @@ use Test::Output qw(stderr_like);
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
+use OpenQA::Test::Utils 'redirect_output';
 require OpenQA::Worker::Commands;
 
 my $schema = OpenQA::Test::Database->new->create();
@@ -113,6 +114,12 @@ subtest 'worker accepted ws commands' => sub {
     is($OpenQA::Worker::Jobs::do_livelog, 1, 'livelog is started');
     OpenQA::Worker::Commands::websocket_commands($ws, {type => 'livelog_stop'});
     is($OpenQA::Worker::Jobs::do_livelog, 0, 'livelog is stopped');
+
+    my $buf;
+    redirect_output(\$buf);
+    OpenQA::Worker::Commands::websocket_commands($ws, {type => 'incompatible'});
+    like($buf, qr/The worker is running an incompatible version/, 'The worker is running an incompatible version');
+
 };
 
 done_testing();

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -82,11 +82,30 @@ subtest "WebSocket Server _message()" => sub {
 
     monkey_patch "Mojo::Transaction::Websocket", send => sub { undef };
     $fake_tx->OpenQA::WebSockets::Server::_message({type => 'worker_status'});
+    like $buf, qr/Received a message from an incompatible worker/ or diag explain $buf;
+    $fake_tx->OpenQA::WebSockets::Server::_message(
+        {type => 'worker_status', websocket_api_version => OpenQA::WebSockets::Server->INTERFACE_VERSION});
     like $buf, qr/Could not be able to send population number to worker/ or diag explain $buf;
+    $fake_tx->OpenQA::WebSockets::Server::_message(
+        {
+            type                         => 'worker_status',
+            websocket_api_version        => 999999,
+            isotovideo_interface_version => 9999
+        });
+    like $buf, qr/Received a message from an incompatible worker/ or diag explain $buf;
 
     monkey_patch "OpenQA::WebAPI", schema => sub { undef };
     $fake_tx->OpenQA::WebSockets::Server::_message({type => 'worker_status'});
+    like $buf, qr/Received a message from an incompatible worker/ or diag explain $buf;
+    $fake_tx->OpenQA::WebSockets::Server::_message(
+        {
+            type                         => 'worker_status',
+            websocket_api_version        => OpenQA::WebSockets::Server->INTERFACE_VERSION,
+            isotovideo_interface_version => 9999
+        });
     like $buf, qr/Failed updating worker seen status/ or diag explain $buf;
+    $fake_tx->OpenQA::WebSockets::Server::_message({type => 'worker_status', websocket_api_version => 99999});
+    like $buf, qr/Received a message from an incompatible worker/ or diag explain $buf;
 };
 
 done_testing();

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -487,6 +487,25 @@ subtest 'Cache tests' => sub {
     kill_worker;
 };
 
+
+subtest 'Isotovideo version' => sub {
+    use OpenQA::Worker::Engines::isotovideo;
+    use OpenQA::Worker;
+
+    eval { OpenQA::Worker::Engines::isotovideo::set_engine_exec('/bogus/location'); };
+    like($@, qr/Path to isotovideo invalid/, 'isotovideo version path invalid');
+    OpenQA::Worker::init({}, {apikey => 123, apisecret => 456, instance => 1});
+    is($OpenQA::Worker::Common::isotovideo_interface_version, 0, 'isotovideo worker init not set');
+
+    OpenQA::Worker::Engines::isotovideo::set_engine_exec('../os-autoinst/isotovideo');
+    ok($OpenQA::Worker::Common::isotovideo_interface_version > 0, 'isotovideo update version');
+
+    $OpenQA::Worker::Common::isotovideo_interface_version = 0;
+    OpenQA::Worker::init({},
+        {apikey => 123, apisecret => 456, instance => 1, isotovideo => '../os-autoinst/isotovideo'});
+    ok($OpenQA::Worker::Common::isotovideo_interface_version > 0, 'isotovideo worker init');
+};
+
 kill_driver;
 turn_down_stack;
 done_testing;

--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -45,6 +45,8 @@
                     <th>Class</th>
                     <th>Arch</th>
                     <th>Status</th>
+                    <th>Websocket Api version</th>
+                    <th>os-autoinst version</th>
                 </tr>
             </thead>
             <tbody>
@@ -67,6 +69,12 @@
                             % stash(workername => $workername, worker => $worker);
                             %= include 'admin/workers/worker_status'
                         </td>
+                        <td class="version">
+                            <%= exists $worker->{properties} && $worker->{properties}->{WEBSOCKET_API_VERSION} ? $worker->{properties}->{WEBSOCKET_API_VERSION} : 'unknown' %>
+                        </td>
+                        <td class="version">
+                            <%= exists $worker->{properties} && $worker->{properties}->{ISOTOVIDEO_INTERFACE_VERSION} ? $worker->{properties}->{ISOTOVIDEO_INTERFACE_VERSION} : 'unknown' %>
+                        </td>                        
                     </tr>
                 % }
             </tbody>


### PR DESCRIPTION
If the worker have a lower version than the minimal version required by the
server the worker will disconnect and shutdown.

The worker's status message, now contains an extra parameter: The current
worker version.

This version is then updated in the database by the openqa server, and displayed
in the workers list.

Both versions (worker version, and the minimal required version) are
just a simple number and the version comparison number is just a simple
"different than" (!=).

Related: poo#7086, poo#26890, poo#10474
  