### PR TITLE
Remove assets from disk when deleting database entry

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -91,7 +91,7 @@ sub delete {
 
     my $asset = $self->app->schema->resultset("Assets")->search(\%cond, \%attrs);
     return unless $asset;
-    my $rs = $asset->delete;
+    my $rs = $asset->delete_all;
     $self->emit_event('openqa_asset_delete', \%args);
 
     $self->render(json => {count => $rs});

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -47,6 +47,7 @@ my @deleted;
 # @deleted array
 sub mock_delete {
     my ($self) = @_;
+    $self->remove_from_disk;
     push @deleted, $self->name;
 }
 

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -24,6 +24,8 @@ BEGIN {
 use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
+use File::Path qw(remove_tree);
+use File::Spec::Functions 'catfile';
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;
@@ -531,6 +533,14 @@ subtest 'asset list' => sub {
         'assets of "assets by group"'
     );
 
+    # add the file for asset 4 actually in the file system to check deletion
+    my $asset_path
+      = catfile($OpenQA::Utils::assetdir, 'iso', 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso');
+    open(my $fh, '>', $asset_path);
+    print $fh "ISO\n";
+    close($fh);
+    ok(-e $asset_path, 'dummy asset present at ' . $asset_path);
+
     # delete one of the assets
     $driver->find_element('#asset_4 .name a')->click();
     wait_for_ajax;
@@ -538,6 +548,9 @@ subtest 'asset list' => sub {
     $driver->get($driver->get_current_url());
     wait_for_ajax;
     is(scalar @{$driver->find_elements('#asset_4')}, 0, 'asset gone forever');
+
+    ok(!-e $asset_path, 'dummy asset should have been removed');
+    unlink($asset_path);
 };
 
 kill_driver();


### PR DESCRIPTION
See https://github.com/os-autoinst/openQA/pull/1551#issuecomment-353311600

Note: This changes the meaning of the DELETE route as it now actually deletes
the files on the file system. In don't think that this is a bad thing because
this way we can not forget to actually delete the file.

It also simplifies the GRU task code a little bit, because it
currently always removes the file from disk and then deletes the database
entry.