### PR TITLE
Fix testsuite descriptions if default config not present

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -468,12 +468,14 @@ sub prepare_job_results {
         # if there is only one member on each level, do not output the key of
         # that level to resemble previous behaviour or maybe better, show it
         # in aggregation only
-        $results{$distri}                                        //= {};
-        $results{$distri}{$version}                              //= {};
-        $results{$distri}{$version}{$flavor}                     //= {};
-        $results{$distri}{$version}{$flavor}{$test}              //= {};
-        $results{$distri}{$version}{$flavor}{$test}{description} //= $descriptions{$test};
+        $results{$distri}                           //= {};
+        $results{$distri}{$version}                 //= {};
+        $results{$distri}{$version}{$flavor}        //= {};
+        $results{$distri}{$version}{$flavor}{$test} //= {};
         $results{$distri}{$version}{$flavor}{$test}{$arch} = $result;
+
+        # add description
+        $results{$distri}{$version}{$flavor}{$test}{description} //= $descriptions{$test =~ s/@.*//r};
     }
     return (\%archs, \%results, $aggregated);
 }

--- a/templates/test/overview_result_table.html.ep
+++ b/templates/test/overview_result_table.html.ep
@@ -12,11 +12,12 @@
     <tbody>
         % my @configs = sort { $a =~ s/@/ /r cmp $b =~ s/@/ /r } keys %$type_results;
         % for my $config (@configs) {
-            % next unless $type_results->{$config};
+            % my $config_results = $type_results->{$config};
+            % next unless $config_results;
             <tr>
                 <td class="name">
                     % my $test_label = text_with_title($config);
-                    % if (my $description = $type_results->{$config =~ s/@.*//r}{description}) {
+                    % if (my $description = $config_results->{description}) {
                         <a data-content="<p><%= href_to_bugref(render_escaped_refs($description)) %></p>"
                         data-title="<%= $config %>" data-toggle="popover" data-trigger="focus" role="button" tabindex="0"><%= $test_label %></a>
                     % }
@@ -26,7 +27,7 @@
                 </td>
 
                 % for my $arch (@archs) {
-                    % my $res = $type_results->{$config}{$arch};
+                    % my $res = $config_results->{$arch};
                     % my $jobid = $res->{jobid};
                     % my $state = $res->{state};
 


### PR DESCRIPTION
This fixes displaying the testsuite descriptions in the overview
page for configurations with '@' in the case the 'general config'
(without @) is not present as well.

I tested this manually, but I can also add a PhantomJS test if wanted.