### PR TITLE
Do not remove forwarded-for=https headers

### DIFF
--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -59,10 +59,6 @@ ProxyPassReverse / http://localhost:9526/
 RequestHeader set X-Forwarded-HTTPS "1"
 RequestHeader set X-Forwarded-Proto "https"
 </If>
-<Else>
-RequestHeader set X-Forwarded-HTTPS "0"
-RequestHeader set X-Forwarded-Proto "http"
-</Else>
 
 HostnameLookups Off
 UseCanonicalName Off


### PR DESCRIPTION
When I explained Ludwig how to avoid jobs expiring through mentioning in
bugzilla (and following the link), we noticed that it does not work for us.
Only after some experiments we realized that the 'report bug' template
puts http:// urls into bugzilla.opensuse.org. So most people's browsers
won't send refererrs (TLS default policy) and as such we have no linked
labels on opensuse.org

The reason is that we overwrite the forward-for=https header the login proxy
sends - as the apache on our openqa vm is not running on http, but gets
http requests from the login proxy.