### PR TITLE
WebAPI: Add API description from Controller's POD

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -79,6 +79,7 @@ requires 'URI::Heuristic';
 requires 'URI::URL';
 requires 'URI::WithBase';
 requires 'URI::data';
+requires 'Pod::Tree';
 requires 'base';
 requires 'constant';
 requires 'diagnostics';

--- a/cpanfile
+++ b/cpanfile
@@ -79,7 +79,7 @@ requires 'URI::Heuristic';
 requires 'URI::URL';
 requires 'URI::WithBase';
 requires 'URI::data';
-requires 'Pod::Tree';
+requires 'Pod::POM';
 requires 'base';
 requires 'constant';
 requires 'diagnostics';

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -487,6 +487,7 @@ sub startup {
     # Parse API controller modules for POD
     get_pod_from_controllers(@api_routes);
     # Set API descriptions
+    $api_description{apiv1} = 'Root API V1 path';
     foreach my $api_rt (@api_routes) {
         set_api_desc(\%api_description, $api_rt);
     }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -304,14 +304,14 @@ sub startup {
     ## JSON API starts here
     ###
     # Array to store new API routes' references, so they can all be checked to get API description from POD
-    my @api_routes = ();
+    my @api_routes        = ();
     my $api_auth_any_user = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth');
     my $api_auth_operator = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_operator');
     my $api_auth_admin    = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_admin');
-    my $api_ru = $api_auth_any_user->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
-    my $api_ro = $api_auth_operator->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
-    my $api_ra = $api_auth_admin->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
-    my $api_public_r = $r->route('/api/v1')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_ru            = $api_auth_any_user->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_ro            = $api_auth_operator->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_ra            = $api_auth_admin->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_public_r      = $r->route('/api/v1')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     push @api_routes, $api_ru, $api_ro, $api_ra, $api_public_r;
     # this is fallback redirect if one does not use apache
     $api_public_r->websocket(

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -18,6 +18,32 @@ use Mojo::Base 'Mojolicious::Controller';
 use OpenQA::Utils;
 use OpenQA::IPC;
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Asset
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Asset;
+
+=head1 DESCRIPTION
+
+OpenQA API implementation for assets handling methods.
+
+=head1 METHODS
+
+=over 4
+
+=item register()
+
+Register an asset given its name and type. Returns a code of 200 on success and of 400 on error.
+
+=back
+
+=cut
+
 sub register {
     my ($self) = @_;
 
@@ -38,6 +64,17 @@ sub register {
     $self->render(json => $json, status => $status);
 }
 
+=over 4
+
+=item list()
+
+Returns a list of all assets present in the system. For each asset relevant information such
+as its id, name, timestamp of creation and type is included.
+
+=back
+
+=cut
+
 sub list {
     my $self   = shift;
     my $schema = $self->app->schema;
@@ -46,6 +83,18 @@ sub list {
     $rs->result_class('DBIx::Class::ResultClass::HashRefInflator');
     $self->render(json => {assets => [$rs->all]});
 }
+
+=over 4
+
+=item get()
+
+Returns information for a specific asset given its id or its type and name. Information
+returned the asset id, name, timestamp of creation and type. Returns a code of 200
+on success and of 404 on error.
+
+=back
+
+=cut
 
 sub get {
     my $self   = shift;
@@ -71,6 +120,17 @@ sub get {
         $self->render(json => {}, status => 404);
     }
 }
+
+=over 4
+
+=item delete()
+
+Removes an asset from the system given its id or its type and name. Returns the
+number of assets removed. 
+
+=back
+
+=cut
 
 sub delete {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
@@ -22,9 +22,34 @@ use DBIx::Class::Timestamps 'now';
 use Date::Format 'time2str';
 use Try::Tiny;
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Bug
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Bug;
+
+=head1 DESCRIPTION
+
+OpenQA API implementation for bug handling methods.
+
+=head1 METHODS
+
+=over 4
+
+=item list()
+
+Returns list of bugs reported in the system with its id and text.
+
+=back
+
+=cut
+
 sub list {
     my ($self) = @_;
-
 
     my $bugs;
     if ($self->param('refreshable')) {
@@ -46,6 +71,18 @@ sub list {
     $self->render(json => {bugs => \%ret});
 }
 
+=over 4
+
+=item show()
+
+Returns information for a bug given its id in the system. Information includes the internal
+(openQA-specific) and the external bug id. Also shows the bug's title, priority, whether its
+assigned or not and its assignee, whether its open or not, status, resolution, whether its an
+existing bug or not, and the date when the bug was last updated in the system.
+
+=back
+
+=cut
 
 sub show {
     my ($self) = @_;
@@ -62,6 +99,18 @@ sub show {
     $self->render(json => \%json);
 }
 
+=over 4
+
+=item create()
+
+Creates a new bug in the system. This method will check for the existence of a bug with the same
+external bug id, in which case the method fails with an error code of 1. Otherwise, the new bug
+is created with the bug values passed as arguments.
+
+=back
+
+=cut
+
 sub create {
     my ($self) = @_;
 
@@ -76,6 +125,17 @@ sub create {
     $self->emit_event('openqa_bug_create', {id => $bug->id, bugid => $bug->bugid, fromapi => 1});
     $self->render(json => {id => $bug->id});
 }
+
+=over 4
+
+=item update()
+
+Updates the information of a bug given its id and a set of bug values to update. Returns
+the id of the bug, or an error if the bug id is not found in the system.
+
+=back
+
+=cut
 
 sub update {
     my ($self) = @_;
@@ -92,6 +152,16 @@ sub update {
     $self->render(json => {id => $bug->id});
 }
 
+=over 4
+
+=item destroy()
+
+Removes a bug from the system given its bug id. Return 1 on success or not found on error.
+
+=back
+
+=cut
+
 sub destroy {
     my ($self) = @_;
 
@@ -106,6 +176,20 @@ sub destroy {
     $bug->delete;
     $self->render(json => {result => 1});
 }
+
+=over 4
+
+=item get_bug_values()
+
+Internal method to extract from the query string the named arguments for values that can be
+set for a bug: title, priority, whether its assigned or not (assigned), assignee, whether its
+an open bug or not (open), status, resolution, whether its an existing bug or not (existing),
+and the timestamp of the update operation (t_updated). This method is used by B<create()> and
+B<update()>.
+
+=back
+
+=cut
 
 sub get_bug_values {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
@@ -19,6 +19,34 @@ use OpenQA::Utils;
 use OpenQA::IPC;
 use Try::Tiny;
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Command
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Command;
+
+=head1 DESCRIPTION
+
+Implements API methods for openQA commands.
+
+=head1 METHODS
+
+=over 4
+
+=item create()
+
+Sends a command to a worker. Receives the worker id and the command as arguments. Returns not
+found if the worker cannot be found or a 200 status code and a JSON with an OK status of 1 on
+success.
+
+=back
+
+=cut
+
 sub create {
     my $self     = shift;
     my $workerid = $self->stash('workerid');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -20,6 +20,34 @@ use OpenQA::Utils;
 use OpenQA::IPC;
 use OpenQA::Utils 'href_to_bugref';
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Comment
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Comment;
+
+=head1 DESCRIPTION
+
+Implements openQA API methods for comments handling.
+
+=head1 METHODS
+
+=over 4
+
+=item obj_comments()
+
+Internal method to extract the comments from a job or job group. Returns an object containing
+the comments or a 404 error status if an unexistent job or job group was referenced. Used by
+the B<comments()> method.
+
+=back
+
+=cut
+
 sub obj_comments {
     my ($self, $param, $table, $label) = @_;
     my $id  = int($self->param($param));
@@ -31,6 +59,19 @@ sub obj_comments {
     return $obj->comments;
 }
 
+=over 4
+
+=item comments()
+
+Returns a list of comments for a job or a job group given its id. For each comment the
+list includes its bug references, date of creation, comment id, rendered markdown text,
+text, date of update and the user name that created the comment. Internal method used
+by B<list()>.
+
+=back
+
+=cut
+
 sub comments {
     my ($self) = @_;
     if ($self->param('job_id')) {
@@ -40,6 +81,18 @@ sub comments {
         return $self->obj_comments('group_id', 'JobGroups', 'Job group');
     }
 }
+
+=over 4
+
+=item list()
+
+Returns a list of comments for a job or a job group given its id. For each comment the
+list includes its bug references, date of creation, comment id, rendered markdown text,
+text, date of update and the user name that created the comment.
+
+=back
+
+=cut
 
 sub list {
     my ($self) = @_;
@@ -53,8 +106,18 @@ sub list {
     $self->render(json => \@comments);
 }
 
-# Renders text and properties for a comment specified by job/group id and comment id
-# including rendered markdown and bugrefs
+=over 4
+
+=item text()
+
+Renders text and properties for a comment specified by job/group id and comment id
+including rendered markdown and bug references. Returns a 404 code if the specified
+comment does not exist, or 200 on success.
+
+=back
+
+=cut
+
 sub text {
     my ($self) = @_;
     my $comments = $self->comments();
@@ -66,7 +129,17 @@ sub text {
     $self->render(json => $comment->extended_hash);
 }
 
-# Adds a new comment to the specified job/group.
+=over 4
+
+=item create()
+
+Adds a new comment to the specified job/group. Returns a 200 code with a JSON containing the
+new comment id or 400 if no text is specified for the comment.
+
+=back
+
+=cut
+
 sub create {
     my ($self) = @_;
     my $comments = $self->comments();
@@ -84,7 +157,19 @@ sub create {
     $self->render(json => {id => $res->id});
 }
 
-# Updates an existing comment specified by job/group id and comment id
+=over 4
+
+=item update()
+
+Updates an existing comment specified by job/group id and comment id. An update text argument
+is required. Returns a 200 code and a JSON on success and 400 if no text was specified, 404 if
+the comment to update does not exist and 403 if the update is not requested by the original
+author of the comment.
+
+=back
+
+=cut
+
 sub update {
     my ($self) = @_;
     my $comments = $self->comments();
@@ -103,7 +188,16 @@ sub update {
     $self->render(json => {id => $res->id});
 }
 
-# Deletes an existing comment specified by job/group id and comment id
+=over 4
+
+=item delete()
+
+Deletes an existing comment specified by job/group id and comment id.
+
+=back
+
+=cut
+
 sub delete {
     my ($self) = @_;
     my $comments = $self->comments();

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Feature.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Feature.pm
@@ -17,6 +17,8 @@ OpenQA::WebAPI::Controller::API::V1::Feature
 
 Implements feature API.
 
+=head1 METHODS
+
 =over 4
 
 =item informed()

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Feature.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Feature.pm
@@ -3,6 +3,30 @@ use strict;
 use warnings;
 use Mojo::Base 'Mojolicious::Controller';
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Feature
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Feature;
+
+=head1 DESCRIPTION
+
+Implements feature API.
+
+=over 4
+
+=item informed()
+
+Post integer value to save feature tour progress of current user in the database
+
+=back
+
+=cut
+
 sub informed {
     my ($self)  = @_;
     my $user    = $self->current_user;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -22,6 +22,34 @@ use OpenQA::Utils 'find_job';
 use Try::Tiny;
 use DBIx::Class::Timestamps 'now';
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Job
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Job;
+
+=head1 DESCRIPTION
+
+Implements API methods to access jobs.
+
+=cut
+
+=over 4
+
+=item list()
+
+List jobs in the system, including related information for each job such as the assets
+associated, assigned worker id, children and parents, job id, group id, name, priority,
+result, settings, state and times of startup and finish of the job.
+
+=back
+
+=cut
+
 sub list {
     my $self = shift;
 
@@ -109,6 +137,17 @@ sub list {
     $self->render(json => {jobs => \@results});
 }
 
+=over 4
+
+=item create()
+
+Creates a job given a list of settings passed as parameters. TEST setting/parameter
+is mandatory and should be the name of the test.
+
+=back
+
+=cut
+
 sub create {
     my $self   = shift;
     my $params = $self->req->params->to_hash;
@@ -146,6 +185,18 @@ sub create {
     $self->render(json => $json, status => $status);
 }
 
+=over 4
+
+=item show()
+
+Shows details for a specific job, such as the assets associated, assigned worker id,
+children and parents, job id, group id, name, priority, result, settings, state and times
+of startup and finish of the job.
+
+=back
+
+=cut
+
 sub show {
     my $self    = shift;
     my $job_id  = int($self->stash('jobid'));
@@ -158,6 +209,16 @@ sub show {
         $self->reply->not_found;
     }
 }
+
+=over 4
+
+=item set_command()
+
+Sets a job as waiting or running.
+
+=back
+
+=cut
 
 # set_waiting and set_running
 sub set_command {
@@ -172,6 +233,16 @@ sub set_command {
     $self->render(json => {result => \$res});
 }
 
+=over 4
+
+=item destroy()
+
+Deletes a job from the system.
+
+=back
+
+=cut
+
 sub destroy {
     my $self = shift;
 
@@ -180,6 +251,16 @@ sub destroy {
     $job->delete;
     $self->render(json => {result => 1});
 }
+
+=over 4
+
+=item prio()
+
+Sets priority for a given job.
+
+=back
+
+=cut
 
 sub prio {
     my ($self) = @_;
@@ -190,7 +271,16 @@ sub prio {
     $self->render(json => {result => \$res});
 }
 
-# replaced in favor of done
+=over 4
+
+=item result()
+
+Updates result of a job in the system. Replaced in favor of done.
+
+=back
+
+=cut
+
 sub result {
     my ($self) = @_;
     my $job    = find_job($self, $self->stash('jobid')) or return;
@@ -202,6 +292,18 @@ sub result {
     # See comment in set_command
     $self->render(json => {result => \$res});
 }
+
+=over 4
+
+=item update_status()
+
+Updates status of a job. Requires a new status, the id of the job and of the
+worker assigned to the job. In order to update the status, the submitted worker
+id must match the id of the worker assigned to the job identified by the job id.
+
+=back
+
+=cut
 
 # this is the general worker update call
 sub update_status {
@@ -250,6 +352,17 @@ sub update_status {
     $self->render(json => $ret);
 }
 
+=over 4
+
+=item update()
+
+Updates the settings of a job with information specified in a passed JSON argument.
+Columns group_id, priority and retry_avbl cannot be set.
+
+=back
+
+=cut
+
 sub update {
     my ($self) = @_;
 
@@ -296,7 +409,16 @@ sub update {
     $self->render(json => {job_id => $job->id});
 }
 
-# used by the worker to upload files to the test
+=over 4
+
+=item create_artefact()
+
+Used by the worker to upload files to the test.
+
+=back
+
+=cut
+
 sub create_artefact {
     my ($self) = @_;
 
@@ -338,6 +460,18 @@ sub create_artefact {
     }
 }
 
+=over 4
+
+=item ack_temporary()
+
+Verifies existence of a temporary file passed as the param "temporary" to the method,
+and logs a message if the file is present. Also renames the temporary file to its
+corresponding asset name if possible.
+
+=back
+
+=cut
+
 sub ack_temporary {
     my ($self) = @_;
 
@@ -352,6 +486,16 @@ sub ack_temporary {
     }
     $self->render(text => "OK");
 }
+
+=over 4
+
+=item done()
+
+Updates result of a job in the system.
+
+=back
+
+=cut
 
 sub done {
     my ($self) = @_;
@@ -376,7 +520,16 @@ sub done {
     $self->render(json => {result => \$res});
 }
 
-# Used for both apiv1_restart and apiv1_restart_jobs
+=over 4
+
+=item restart()
+
+Restart job or jobs. Used for both apiv1_restart and apiv1_restart_jobs
+
+=back
+
+=cut
+
 sub restart {
     my ($self) = @_;
     my $jobs = $self->param('jobid');
@@ -398,7 +551,16 @@ sub restart {
     $self->render(json => {result => $res, test_url => \@urls});
 }
 
-# Used for both apiv1_cancel and apiv1_cancel_jobs
+=over 4
+
+=item cancel()
+
+Cancel job or jobs. Used for both apiv1_cancel and apiv1_cancel_jobs
+
+=back
+
+=cut
+
 sub cancel {
     my ($self) = @_;
     my $jobid = $self->param('jobid');
@@ -418,6 +580,16 @@ sub cancel {
 
     $self->render(json => {result => $res});
 }
+
+=over 4
+
+=item duplicate()
+
+Creates a new job as a duplicate of an existing one given its job id.
+
+=back
+
+=cut
 
 sub duplicate {
     my ($self) = @_;
@@ -447,6 +619,16 @@ sub duplicate {
         $self->render(json => {});
     }
 }
+
+=over 4
+
+=item whoami()
+
+Returns the job id of the current job.
+
+=back
+
+=cut
 
 sub whoami {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -36,7 +36,7 @@ OpenQA::WebAPI::Controller::API::V1::Job
 
 Implements API methods to access jobs.
 
-=cut
+=head1 METHODS
 
 =over 4
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -31,6 +31,8 @@ OpenQA::WebAPI::Controller::API::V1::JobGroup
 
 Implements API methods to access group of jobs.
 
+=head1 METHODS
+
 =cut
 
 # Helper methods

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -17,17 +17,63 @@ package OpenQA::WebAPI::Controller::API::V1::JobGroup;
 use Mojo::Base 'Mojolicious::Controller';
 use OpenQA::Schema::Result::JobGroups;
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::JobGroup
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::JobGroup;
+
+=head1 DESCRIPTION
+
+Implements API methods to access group of jobs.
+
+=cut
+
 # Helper methods
+
+=over 4
+
+=item is_parent()
+
+Reports true if the job group given to the method is a parent group.
+
+=back
+
+=cut
 
 sub is_parent {
     my ($self) = @_;
     return $self->req->url->path =~ qr/.*\/parent_groups/;
 }
 
+=over 4
+
+=item resultset()
+
+Returns results for a set of groups.
+
+=back
+
+=cut
+
 sub resultset {
     my ($self) = @_;
     return $self->db->resultset($self->is_parent ? 'JobGroupParents' : 'JobGroups');
 }
+
+=over 4
+
+=item find_group()
+
+Returns information from a job group given its ID.
+
+=back
+
+=cut
 
 sub find_group {
     my ($self) = @_;
@@ -46,6 +92,16 @@ sub find_group {
 
     return $group;
 }
+
+=over 4
+
+=item load_properties()
+
+Returns an indexed list of properties for a job group.
+
+=back
+
+=cut
 
 sub load_properties {
     my ($self) = @_;
@@ -66,6 +122,18 @@ sub load_properties {
 }
 
 # Actual API entry points
+
+=over 4
+
+=item list()
+
+Shows a list jobs belonging to a job group given its ID, or a list of all jobs.
+For each job in the list, all relevant information - with the exception of
+timestamps - is also returned as a list of indexed lists.
+
+=back
+
+=cut
 
 sub list {
     my ($self) = @_;
@@ -93,7 +161,16 @@ sub list {
     $self->render(json => \@results);
 }
 
-# check existing job group on top level to prevent create/update duplicate
+=over 4
+
+=item check_top_level_group()
+
+Check existing job group on top level to prevent create/update duplicate.
+
+=back
+
+=cut
+
 sub check_top_level_group {
     my ($self, $group_id) = @_;
 
@@ -103,6 +180,16 @@ sub check_top_level_group {
     $conditions->{id} = {'!=', $group_id} if $group_id;
     return $self->resultset->search($conditions);
 }
+
+=over 4
+
+=item create()
+
+Creates a new job group given a name. Prevents the creation of job groups with the same name.
+
+=back
+
+=cut
 
 sub create {
     my ($self) = @_;
@@ -125,6 +212,16 @@ sub create {
     $self->render(json => {id => $group->id});
 }
 
+=over 4
+
+=item update()
+
+Updates the properties of a job group.
+
+=back
+
+=cut
+
 sub update {
     my ($self) = @_;
 
@@ -145,6 +242,16 @@ sub update {
     $self->render(json => {id => $res->id});
 }
 
+=over 4
+
+=item list_jobs()
+
+List jobs belonging to a job group.
+
+=back
+
+=cut
+
 sub list_jobs {
     my ($self) = @_;
 
@@ -160,6 +267,16 @@ sub list_jobs {
     }
     return $self->render(json => {ids => [sort map { $_->id } @jobs]});
 }
+
+=over 4
+
+=item delete()
+
+Deletes a job group. Verifies that it is not empty before attempting to remove.
+
+=back
+
+=cut
 
 sub delete {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -17,6 +17,40 @@
 package OpenQA::WebAPI::Controller::API::V1::JobTemplate;
 use Mojo::Base 'Mojolicious::Controller';
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::JobTemplate
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::JobTemplate;
+
+=head1 DESCRIPTION
+
+Implements API method for handling job templates in openQA.
+
+=head1 METHODS
+
+=over 4
+
+=item list()
+
+Shows information for the job templates defined in the system. If given a job template id, only the
+information for that template is shown, otherwise will attempt to fetch job templates based on any
+of the following parameters: machine name or id, test suite name or id, distri, arch, version, flavor,
+product id or group id. If none of those arguments are passed to the method, will attempt to list
+all job templates defined in the system.
+
+Returns a list of job templates containing the following information for each template: template id,
+priority, group name, product (id, arch, distri, flavor, group and version), machine (id and name)
+and test suite (id and name).
+
+=back
+
+=cut
+
 sub list {
     my $self = shift;
 
@@ -82,6 +116,21 @@ sub list {
 
     $self->render(json => {JobTemplates => \@templates});
 }
+
+=over 4
+
+=item create()
+
+Creates a new job template. If the method receives a valid product id as argument, it will
+also check for the following arguments: machine id, group id, test suite id and priority. If
+no valid product id is received as argument, the method will instead check for the following
+arguments: product name, machine name, test suite name, arch, distri, flavor, version and
+priority. Returns a 400 code on error, or a 303 code and the job template id within a JSON
+block on success.
+
+=back
+
+=cut
 
 sub create {
     my $self = shift;
@@ -171,6 +220,17 @@ sub create {
             $self->redirect_to($self->req->headers->referrer);
         });
 }
+
+=over 4
+
+=item destroy()
+
+Deletes a job template given its id. Returns a 404 error code if the template is not found,
+a 400 code on other errors or a 303 code on success.
+
+=back
+
+=cut
 
 sub destroy {
     my $self          = shift;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
@@ -18,6 +18,31 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use OpenQA::IPC;
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Locks
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Locks;
+
+=head1 DESCRIPTION
+
+OpenQA API implementation for locking and mutex mechanisms.
+
+=over 4
+
+=item mutex_action()
+
+Perform the mutex operations of "lock" or "unlock" as requested. Renders a return
+code of 200 on success, 410 on error and 409 on mutex unavailable.
+
+=back
+
+=cut
+
 sub mutex_action {
     my ($self)     = @_;
     my $name       = $self->stash('name');
@@ -44,8 +69,20 @@ sub mutex_action {
     return $self->render(text => 'nack', status => 409);
 }
 
+=over 4
+
+=item mutex_create()
+
+Creates a named mutex resource associated with the current job. Renders a return code
+of 200 on success and 409 on error.
+
+=back
+
+=cut
+
 sub mutex_create {
     my ($self) = @_;
+
     my $jobid = $self->stash('job_id');
 
     my $validation = $self->validation;
@@ -61,6 +98,18 @@ sub mutex_create {
     return $self->render(text => 'nack', status => 409);
 }
 
+=over 4
+
+=item barrier_wait()
+
+Blocks execution of the calling job until the method is called by all tasks
+using the barrier referenced by "name". Renders a 200 code on success, 410
+on error on 409 when the referenced barrier does not exist.
+
+=back
+
+=cut
+
 sub barrier_wait {
     my ($self) = @_;
     my $jobid  = $self->stash('job_id');
@@ -71,7 +120,7 @@ sub barrier_wait {
     $validation->optional('check_dead_job')->like(qr/^[0-9]+$/);
 
     return $self->render(text => 'Bad request', status => 400) if ($validation->has_error);
-    my $where          = $validation->param('where') // '';
+    my $where          = $validation->param('where')          // '';
     my $check_dead_job = $validation->param('check_dead_job') // 0;
 
     my $ipc = OpenQA::IPC->ipc;
@@ -81,6 +130,17 @@ sub barrier_wait {
     return $self->render(text => 'nack', status => 410) if $res < 0;
     return $self->render(text => 'nack', status => 409);
 }
+
+=over 4
+
+=item barrier_create()
+
+Creates a new barrier resource for a group of tasks referenced by the argument "task."
+Renders a return code of 200 on success or of 409 on error.
+
+=back
+
+=cut
 
 sub barrier_create {
     my ($self) = @_;
@@ -98,6 +158,16 @@ sub barrier_create {
     return $self->render(text => 'ack', status => 200) if $res;
     return $self->render(text => 'nack', status => 409);
 }
+
+=over 4
+
+=item barrier_destroy()
+
+Removes a barrier given its name.
+
+=back
+
+=cut
 
 sub barrier_destroy {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
@@ -120,7 +120,7 @@ sub barrier_wait {
     $validation->optional('check_dead_job')->like(qr/^[0-9]+$/);
 
     return $self->render(text => 'Bad request', status => 400) if ($validation->has_error);
-    my $where          = $validation->param('where')          // '';
+    my $where          = $validation->param('where') // '';
     my $check_dead_job = $validation->param('check_dead_job') // 0;
 
     my $ipc = OpenQA::IPC->ipc;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
@@ -32,11 +32,13 @@ OpenQA::WebAPI::Controller::API::V1::Locks
 
 OpenQA API implementation for locking and mutex mechanisms.
 
+=head1 METHODS
+
 =over 4
 
 =item mutex_action()
 
-Perform the mutex operations of "lock" or "unlock" as requested. Renders a return
+Perform the mutex operations of "lock" or "unlock" as requested. Returns a
 code of 200 on success, 410 on error and 409 on mutex unavailable.
 
 =back
@@ -73,7 +75,7 @@ sub mutex_action {
 
 =item mutex_create()
 
-Creates a named mutex resource associated with the current job. Renders a return code
+Creates a named mutex resource associated with the current job. Returns a code
 of 200 on success and 409 on error.
 
 =back
@@ -103,7 +105,7 @@ sub mutex_create {
 =item barrier_wait()
 
 Blocks execution of the calling job until the method is called by all tasks
-using the barrier referenced by "name". Renders a 200 code on success, 410
+using the barrier referenced by "name". Returns a 200 code on success, 410
 on error on 409 when the referenced barrier does not exist.
 
 =back
@@ -136,7 +138,7 @@ sub barrier_wait {
 =item barrier_create()
 
 Creates a new barrier resource for a group of tasks referenced by the argument "task."
-Renders a return code of 200 on success or of 409 on error.
+Returns a code of 200 on success or of 409 on error.
 
 =back
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
@@ -19,6 +19,34 @@ use Mojo::Base 'Mojolicious::Controller';
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Schema::Result::JobDependencies;
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Mm
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Mm;
+
+=head1 DESCRIPTION
+
+OpenQA API implementation for multi machine methods.
+
+=head1 METHODS
+
+=over 4
+
+=item get_children_status()
+
+Given a job id and a status text (running, scheduled or done), this method returns a list of
+children jobs' job ids that have the same status as the parent job. Return a 200 code and a
+JSON block with the list.
+
+=back
+
+=cut
+
 # this needs 2 calls to do anything useful
 # IMHO it should be replaced with get_children and removed
 sub get_children_status {
@@ -41,6 +69,17 @@ sub get_children_status {
     return $self->render(json => {jobs => \@res_ids}, status => 200);
 }
 
+=over 4
+
+=item get_children()
+
+Returns a list of jobs that are configured as children of a given job identified by job_id. For the
+children jobs, their id and state is returned in a JSON block.
+
+=back
+
+=cut
+
 sub get_children {
     my ($self) = @_;
     my $jobid = $self->stash('job_id');
@@ -51,6 +90,17 @@ sub get_children {
     my %res_ids = map { ($_->id, $_->state) } @res;
     return $self->render(json => {jobs => \%res_ids}, status => 200);
 }
+
+=over 4
+
+=item get_parents()
+
+Returns a list of jobs that are configured as parents of a given job identified by job_id. For the
+parents jobs, their id is returned in a JSON block.
+
+=back
+
+=cut
 
 sub get_parents {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -20,6 +20,44 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use Try::Tiny;
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Table
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Table;
+
+=head1 DESCRIPTION
+
+OpenQA API implementation for table handling.
+
+Within this package, three types of tables are handled:
+
+=over 4
+
+=item Machines
+
+Machines are defined by id, name, a backend and a description. Only the id and the backend are
+always required.
+
+=item Test Suites
+
+Test Suites are defined by id, name and description. Only the name is always required.
+
+=item Products
+
+Products are defined by id, distri, version, arch, flavor and description. The distri,
+version, arch and flavor parameters are always required.
+
+=back
+
+=head1 METHODS
+
+=cut
+
 my %tables = (
     Machines => {
         keys => [['id'], ['name'],],
@@ -41,6 +79,20 @@ my %tables = (
     },
 );
 
+=over 4
+
+=item list()
+
+List the parameters of tables given its type (machine, test suite or product). If an
+id is passed as an argument to the method, only information for the passed id is
+returned, otherwise all structures of the same type defined in the system are
+returned. For further information on the type of parameters associated to each
+of the type of tables, check the OpenQA::WebAPI::Controller::API::V1::Table package
+documentation.
+
+=back
+
+=cut
 
 sub list {
     my ($self) = @_;
@@ -89,6 +141,20 @@ sub list {
             ]});
 }
 
+=over 4
+
+=item create()
+
+Creates a new table given its type (machine, test suite or product). Returns the
+table id in a JSON block on success or a 400 code on error. For information on the
+type of parameters associated to each of the type of tables, as well as which of those
+parameters are required and validated when calling this method, check the
+OpenQA::WebAPI::Controller::API::V1::Table package documentation.
+
+=back
+
+=cut
+
 sub create {
     my ($self)     = @_;
     my $table      = $self->param("table");
@@ -126,6 +192,22 @@ sub create {
     $self->emit_event('openqa_table_create', {table => $table, %entry});
     $self->render(json => {id => $id});
 }
+
+=over 4
+
+=item update()
+
+Updates the parameters of a table given its type (machine, test suite or product). This
+method will check the required parameters for the type of structure before updating. 
+For information on the type of parameters associated to each of the type of tables, as
+well as which of those parameters are required and validated when calling this method, check
+the OpenQA::WebAPI::Controller::API::V1::Table package documentation. Returns a 404 error
+code if the table is not found, 400 on other errors or a JSON block containing the number
+of tables updated by the method on success.
+
+=back
+
+=cut
 
 sub update {
     my ($self) = @_;
@@ -191,6 +273,17 @@ sub update {
     $self->render(json => {result => int($ret)});
 }
 
+=over 4
+
+=item destroy()
+
+Deletes a table given its type (machine, test suite or product) and its id. Returns
+a 404 error code when the table is not found, 400 on other errors or a JSON block
+with the number of deleted tables on success.
+
+=back
+
+=cut
 
 sub destroy {
     my ($self)   = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -23,6 +23,32 @@ use DBIx::Class::Timestamps 'now';
 use Try::Tiny;
 use Scalar::Util 'looks_like_number';
 
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Worker
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Worker;
+
+=head1 DESCRIPTION
+
+Implements API methods relating to OpenQA Workers.
+
+=over 4
+
+=item list()
+
+Returns a list of workers with useful information for each including its ID, the host
+where the worker is located, the worker instance, the worker status and the worker's
+websocket status.
+
+=back
+
+=cut
+
 sub list {
     my ($self) = @_;
     my $live    = !looks_like_number($self->param('live')) ? 0 : !!$self->param('live');
@@ -36,9 +62,22 @@ sub list {
     $self->render(json => {workers => $ret});
 }
 
-# TODO: this function exists purely for unit tests to be able to register
-# workers without fixtures so usage elsewhere should be avoided
-# NOTE: currently this function is used in create (API entry point)
+=over 4
+
+=item _register()
+
+Register a worker instance on the database or update its information if it
+was already registered.
+
+B<TODO>: this function exists purely for unit tests to be able to register
+workers without fixtures so usage elsewhere should be avoided
+
+B<NOTE>: currently this function is used in create (API entry point)
+
+=back
+
+=cut
+
 sub _register {
     my ($self, $schema, $host, $instance, $caps) = @_;
 
@@ -85,6 +124,16 @@ sub _register {
     return $worker->id;
 }
 
+=over 4
+
+=item create()
+
+Initializes and registers a worker.
+
+=back
+
+=cut
+
 sub create {
     my ($self) = @_;
 
@@ -118,6 +167,19 @@ sub create {
     $self->render(json => {id => $id});
 
 }
+
+=over 4
+
+=item show()
+
+Prints information from a worker given its ID. Each entry contains the "hostname",
+the boolean flag "connected" which can be 0 or 1 depending on the connection to
+the websockets server and the field "status" which can be "dead", "idle", "running".
+A worker can be considered "up" when "connected=1" and "status!=dead"'
+
+=back
+
+=cut
 
 sub show {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -37,6 +37,8 @@ OpenQA::WebAPI::Controller::API::V1::Worker
 
 Implements API methods relating to OpenQA Workers.
 
+=head1 METHODS
+
 =over 4
 
 =item list()

--- a/lib/OpenQA/WebAPI/Description.pm
+++ b/lib/OpenQA/WebAPI/Description.pm
@@ -33,7 +33,7 @@ my %methods_description;
 
 # Determine the controller modules being used by the API routes and parse the POD from the files.
 # Extract the description of the methods and store them in the global HASH %methods_description
-# by ->walk()ing the POD tree from each controller module file
+# by walking the POD tree from each controller module file
 
 sub get_pod_from_controllers {
     # Object to get API descriptions from POD

--- a/lib/OpenQA/WebAPI/Description.pm
+++ b/lib/OpenQA/WebAPI/Description.pm
@@ -1,0 +1,157 @@
+# Copyright (C) 2012-2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+package OpenQA::WebAPI::Description;
+use strict;
+
+use OpenQA::Utils 'log_warning';
+use Mojo::File 'path';
+use Pod::Tree;
+
+require Exporter;
+our ($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
+$VERSION = sprintf "%d.%03d", q$Revision: 0.01 $ =~ /(\d+)/g;
+@ISA     = qw(Exporter);
+@EXPORT  = qw(
+  get_pod_from_controllers
+  set_api_desc
+);
+
+# Global hash to store method's description
+my %methods_description;
+# Path where openQA is installed
+my $OPENQA_CODEBASE = '/usr/share/openqa';
+
+# Determine the controller modules being used by the API routes and parse the POD from the files.
+# Extract the description of the methods and store them in the global HASH %methods_description
+# by ->walk()ing the POD tree from each controller module file
+
+sub get_pod_from_controllers {
+    # Object to get API descriptions from POD
+    my $tree = Pod::Tree->new or die "cannot create object: $!\n";
+    my %controllers;
+    my $ctrlrpath = path($OPENQA_CODEBASE)->child('lib', 'OpenQA', 'WebAPI', 'Controller', 'API', 'V1');
+
+    # Review all routes to get controllers, and from there get the .pm filename to parse for POD
+    foreach my $api_rt (@_) {
+        next if (ref($api_rt) ne 'Mojolicious::Routes::Route');
+        foreach my $rt (@{$api_rt->children}) {
+            next unless ($rt->to->{controller});
+            my $filename = ucfirst($rt->to->{controller});
+            if ($filename =~ /_/) {
+                $filename = join('', map(ucfirst, split(/_/, $filename)));
+            }
+            $filename .= '.pm';
+            $controllers{$rt->to->{controller}} = $filename;
+        }
+    }
+
+    # Parse API controller files for POD
+    foreach my $ctrl (keys %controllers) {
+        # Only attempt to load files that exist
+        next unless (-e -f $ctrlrpath->child($controllers{$ctrl})->to_string);
+        $tree->load_file($ctrlrpath->child($controllers{$ctrl})->to_string);
+        if ($tree->loaded() and $tree->has_pod()) {
+            $tree->get_root->set_filename($ctrl);
+            $tree->walk(\&_itemize);
+        }
+    }
+}
+
+# Assign API description in a HASH passed as a hashref for the controller#action's found in the
+# passed API route. The API descriptions were collected in get_pod_from_controllers()
+
+sub set_api_desc {
+    my $api_description = shift;
+    my $api_route       = shift;
+
+    if (ref($api_description) ne 'HASH') {
+        log_warning("set_api_desc: expected HASH ref for api_descriptions. Got: " . ref($api_description));
+        return;
+    }
+
+    if (ref($api_route) ne 'Mojolicious::Routes::Route') {
+        log_warning("set_api_desc: expected Mojolicious::Routes::Route for api_routes. Got: " . ref($api_route));
+        return;
+    }
+
+    foreach my $r (@{$api_route->children}) {
+        next unless ($r->to->{controller} and $r->to->{action});
+        my $key = $r->to->{controller} . '#' . $r->to->{action};
+        $api_description->{$r->name} = $methods_description{$key} if (defined $methods_description{$key});
+    }
+}
+
+# Support method to ->walk() a POD tree and extract the documentation for each =item
+
+sub _itemize {
+    my ($node) = @_;
+    if (ref($node) ne 'Pod::Tree::Node') {
+        log_warning("_itemize() expected Pod::Tree::Node arg. Got " . ref($node));
+        return 0;    # Stop walking the tree
+    }
+    my $methodname = '';
+    my $desc       = '';
+    my $controller = $node->get_filename;
+    if ($node->is_item()) {
+        $methodname = _get_pod_text($node);
+        $methodname =~ s/\s+//g;
+        $methodname =~ s/\(\)//;
+        my $siblings = $node->get_siblings();
+        foreach my $i (@$siblings) {
+            unless ($desc) {    # Only take first paragraph for the description
+                $desc = $i->get_text()    if $i->is_text();
+                $desc = _get_pod_text($i) if $i->is_ordinary();
+            }
+        }
+        my $key = $controller . '#' . $methodname;
+        $methods_description{$key} = $desc;
+    }
+    else {
+        return 1;               # Keep walking the tree
+    }
+}
+
+# Extract POD text for children's of item and ordinary nodes
+
+sub _get_pod_text {
+    my $node   = shift;
+    my $retval = '';
+    if (ref($node) ne 'Pod::Tree::Node') {
+        log_warning("_get_pod_text() expected Pod::Tree::Node arg. Got " . ref($node));
+    }
+    else {
+        my $argtype = $node->get_type();
+        unless ($argtype eq 'item' or $argtype eq 'ordinary') {
+            log_warning("_get_pod_test() Pod::Tree::Node arg should be of type item or ordinary. Got [$argtype]");
+        }
+        my $children = $node->get_children();
+        if (defined $children->[0] and ref($children->[0]) eq 'Pod::Tree::Node') {
+            if ($children->[0]->is_text) {
+                $retval = $children->[0]->get_text();
+                $retval =~ s/[\r\n]/ /g;
+            }
+            if ($children->[0]->is_sequence) {
+                my $seqs = $children->[0]->get_children();
+                if (defined $seqs->[0] and ref($seqs->[0]) eq 'Pod::Tree::Node' and $seqs->[0]->is_text) {
+                    $retval = $seqs->[0]->get_text();
+                }
+            }
+        }
+    }
+    return $retval;
+}
+
+1;
+# vim: set sw=4 et:

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -35,9 +35,6 @@ my $get = $t->get_ok('/unavailable_page')->status_is(404);
 my $dom = $get->tx->res->dom;
 is_deeply([$dom->find('h1')->map('text')->each], ['Page not found'],   'correct page');
 is_deeply([$dom->find('h2')->map('text')->each], ['Available routes'], 'available routes shown');
-ok(
-    index($get->tx->res->text, 'Post integer value to save feature tour progress of current user in the database') >= 0,
-    'description shown'
-);
+ok(index($get->tx->res->text, 'Each entry contains the') >= 0, 'description shown');
 
 done_testing;

--- a/t/31-api_descriptions.t
+++ b/t/31-api_descriptions.t
@@ -1,0 +1,30 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use Test::Warnings;
+
+use_ok('OpenQA::WebAPI::Description', qw(get_pod_from_controllers set_api_desc));
+$ENV{OPENQA_CODEBASE} = ".";
+get_pod_from_controllers();
+
+done_testing;

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -31,6 +31,7 @@ seq:
      - ./t/25-cache.t
      - ./t/27-errorpages.t
      - ./t/30-test_parser.t
+     - ./t/31-api_descriptions.t
      - ./t/basic.t
      - ./t/deploy.t
      - ./t/full-stack.t


### PR DESCRIPTION
This PR adds the package OpenQA::WebAPI::Description which contains methods to be used on lib/OpenQA/WebAPI.pm to parse the Controller/API/V1 module files for POD documentation, and extract from there API descriptions to be shown in the GUI's help page.

In order to parse POD, the module Pod::POM was also added to the required modules for the project.

POD documentation was added to three API controller modules:

lib/OpenQA/WebAPI/Controller/API/V1/Feature.pm
lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm

Adding POD documentation to the remaining modules, should populate API descriptions in the help page automatically.