### PR TITLE
Allow filtering nested groups on the dashboard

### DIFF
--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -25,6 +25,9 @@ function setupIndexPage() {
         } else if (key === 'group') {
             $('#filter-group').prop('value', val);
             return "group '" + val + "'";
+        } else if (key === 'subgroup') {
+            $('#filter-subgroup').prop('value', val);
+            return "nested group '" + val + "'";
         } else if (key === 'limit_builds') {
             $('#filter-limit-builds').prop('value', val);
             return val + ' builds per group';

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -85,13 +85,27 @@ sub add_review_badge {
 }
 
 sub compute_build_results {
-    my ($group, $limit, $time_limit_days, $tags) = @_;
+    my ($group, $limit, $time_limit_days, $tags, $subgroups) = @_;
 
+    # find child groups
     my $group_ids;
     my @children;
     if ($group->can('children')) {
-        @children  = $group->children;
-        $group_ids = $group->child_group_ids;
+        if (@$subgroups) {
+            # filter subgroups
+            $group_ids = [];
+            for my $child ($group->children) {
+                if (grep { $_ eq '' || $child->name =~ /$_/ } @$subgroups) {
+                    push(@$group_ids, $child->id);
+                    push(@children,   $child);
+                }
+            }
+
+        }
+        else {
+            $group_ids = $group->child_group_ids;
+            @children  = $group->children;
+        }
     }
     else {
         $group_ids = [$group->id];

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -126,7 +126,8 @@ subtest 'filter form' => sub {
     $driver->find_element('#filter-panel .panel-heading')->click();
     $driver->find_element_by_id('filter-group')->send_keys('SLE 12 SP2');
     my $ele = $driver->find_element_by_id('filter-limit-builds');
-    $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{end}, '8');    # append to 3
+    $ele->click();
+    $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{end}, '8');    # appended to default '3'
     $ele = $driver->find_element_by_id('filter-time-limit-days');
     $ele->click();
     $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{end}, '2');    # appended to default '14'

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -131,7 +131,7 @@ subtest 'filter form' => sub {
     $ele->click();
     $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{end}, '2');    # appended to default '14'
     $driver->find_element('#filter-form button')->click();
-    $url .= '?group=SLE+12+SP2&limit_builds=38&time_limit_days=142#';
+    $url .= '?group=SLE+12+SP2&subgroup=&limit_builds=38&time_limit_days=142#';
     is($driver->get_current_url, $url, 'URL parameters for filter are correct');
 };
 

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -30,7 +30,7 @@
         <h2>
             %= link_to $group->{name} => url_for('parent_group_overview', groupid => $group->{id})
         </h2>
-        %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => 0
+        %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => $has_subgroup_filter
     % } else {
         <h2>
             %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -47,6 +47,10 @@
                 <strong>Group</strong>
                 <input type="text" class="form-control" name="group" placeholder="all" id="filter-group">
             </div>
+            <div class="form-group">
+                <strong>Nested group</strong>
+                <input type="text" class="form-control" name="subgroup" placeholder="all" id="filter-subgroup">
+            </div>
             <div class="form-group form-inline">
                 <strong>Limit builds</strong>
                 Maximum number of builds per group <input type="number" class="form-control" name="limit_builds" value="3" id="filter-limit-builds"><br>


### PR DESCRIPTION
@okurz It looks like this. Is that ok?

`?group=SLE+15&group=SLE+12&limit_builds=4&time_limit_days=60&subgroup=Functional&subgroup=Autoyast`

![screenshot_20180116_143217](https://user-images.githubusercontent.com/10248953/34991494-18b8dbcc-faca-11e7-8318-0ace8ea84c6a.png)

Note that if a filter for nested groups is present, the groups are expanded by default.