### PR TITLE
Check qemu pid before starting job

### DIFF
--- a/lib/OpenQA/Worker/Pool.pm
+++ b/lib/OpenQA/Worker/Pool.pm
@@ -43,6 +43,7 @@ sub lockit() {
 }
 
 sub check_qemu_pid {
+    return unless $pooldir;
     my $pidfile = "$pooldir/qemu.pid";
     return unless open(my $fh, '<', $pidfile);
 
@@ -61,9 +62,9 @@ sub check_qemu_pid {
 
 
 sub clean_pool() {
+    check_qemu_pid();
     return if $nocleanup;
     return unless $pooldir;
-    check_qemu_pid();
     for my $file (glob "$pooldir/*") {
         if (-d $file) {
             remove_tree($file);


### PR DESCRIPTION
If the worker was started with --no-cleanup and the isotovideo died, leaving a qemu running in the background all the jobs would get errored and the worker would continue like everything is ok.

The verification for a running qemu was not being done if the --no-cleanup
was being used.

Before the changes: https://openqa.suse.de/tests/1389513/file/autoinst-log.txt

After the changes: 
When the worker starts doing the next job, it will check the qemu and the job will be cancelled, and the worker will die with the error:
> [error] QEMU (4109 -> /usr/bin/qemu-system-x86_64) should be dead - WASUP?

The same error will happen if the admin tries to start the worker again.
