### PR TITLE
Apparently the only version available on cpan is 1.12

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -90,7 +90,7 @@ requires 'POSIX';
 on 'test' => sub {
   requires 'Perl::Critic';
   requires 'Perl::Tidy', '>= 20171214';
-  requires 'Selenium::Remote::Driver', '< 1.20';
+  requires 'Selenium::Remote::Driver', '< 1.21';
   requires 'Test::Compile';
   requires 'Test::Fatal';
   requires 'Test::MockModule';


### PR DESCRIPTION
Which break our tests as well

I was wrong with https://github.com/os-autoinst/openQA/pull/1566#issuecomment-360817342 , it selected 1.12 instead of 1.20 (wanted) which resulted in skip of the UI tests (it's friday 🎉 )

This should also bring back codecov to normal as well