### PR TITLE
Big rework of the GRU limit_asset task

### DIFF
--- a/assets/javascripts/assets.js
+++ b/assets/javascripts/assets.js
@@ -1,16 +1,8 @@
 function setup_asset_table() {
-    $('#assets, #untracked-assets').DataTable(
+    $('#assets').DataTable(
         {
             columnDefs: [
-                { targets: 3,
-                  render: function(data, type, row) {
-                      if (type === 'display') {
-                          return jQuery.timeago(data + "Z");
-                      }
-                      return data;
-                  }
-                },
-                { targets: 4,
+                { targets: 2,
                   render: function(data, type, row) {
                       if (type === 'display') {
                           if (data === '') {
@@ -25,7 +17,7 @@ function setup_asset_table() {
                   }
                 }
             ],
-            order: [[3, 'desc']]
+            order: [[1, 'desc']]
         }
     );
 }

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -918,3 +918,15 @@ h2 + * {
         }
     }
 }
+
+table#assets {
+  a.picked-group {
+    text-decoration: underline !important;
+  }
+  a.to-be-removed {
+    text-decoration: line-through !important;
+  }
+  td {
+    overflow:hidden; white-space: nowrap; text-overflow: ellipsis;
+  }
+}

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -65,7 +65,10 @@ __PACKAGE__->add_columns(
 __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw(type name)]);
-__PACKAGE__->has_many(jobs_assets => 'OpenQA::Schema::Result::JobsAssets', 'asset_id');
+__PACKAGE__->has_many(
+    jobs_assets => 'OpenQA::Schema::Result::JobsAssets',
+    'asset_id'
+);
 __PACKAGE__->many_to_many(jobs => 'jobs_assets', 'job');
 __PACKAGE__->belongs_to(
     last_use_job => 'OpenQA::Schema::Result::Jobs',
@@ -139,14 +142,16 @@ sub ensure_size {
         }
         else {
             $size = $st[7];
-            return $self->size if defined($self->size) && $size == $self->size;
+            return $self->size
+              if defined($self->size) && $size == $self->size;
         }
     }
-    $self->update({size => $size}) if $size;
+    $self->update({size => $size});
     return $size;
 }
 
 sub hidden {
+
     # 1 if asset should not be linked from the web UI (as set by
     # 'hide_asset_types' config setting), otherwise 0
     my ($self) = @_;
@@ -160,6 +165,7 @@ sub download_asset {
     my ($app, $args) = @_;
     my ($url, $assetpath, $do_extract) = @{$args};
     my $ipc = OpenQA::IPC->ipc;
+
     # Bail if the dest file exists (in case multiple downloads of same ISO
     # are scheduled)
     return if (-e $assetpath);
@@ -167,6 +173,7 @@ sub download_asset {
     my $assetdir = (splitpath($assetpath))[1];
     unless (-w $assetdir) {
         OpenQA::Utils::log_error("download_asset: cannot write to $assetdir");
+
         # we're not going to die because this is a gru task and we don't
         # want to cause the Endless Gru Loop Of Despair, just return and
         # let the jobs fail
@@ -197,6 +204,7 @@ sub download_asset {
     }
     my $ua = Mojo::UserAgent->new(max_redirects => 5);
     my $tx = $ua->build_tx(GET => $url);
+
     # Allow >16MiB downloads
     # http://mojolicio.us/perldoc/Mojolicious/Guides/Cookbook#Large-file-downloads
     $tx->res->max_message_size(0);
@@ -204,6 +212,7 @@ sub download_asset {
     if ($tx->success) {
         try {
             if ($do_extract) {
+
                 # Rename the downloaded data to the original file name, in
                 # MOJO_TMPDIR
                 my $tempfile = catfile($ENV{MOJO_TMPDIR}, Mojo::URL->new($url)->path->parts->[-1]);
@@ -237,245 +246,60 @@ sub download_asset {
         unlink($assetpath);
         return;
     }
+
     # set proper permissions for downloaded asset
     chmod 0644, $assetpath;
 
 }
 
+sub _remove_if {
+    my ($db, $asset) = @_;
+    return if $asset->{fixed} || $asset->{pending};
+    $db->resultset('Assets')->single({id => $asset->{id}})->delete;
+}
+
 # this is a GRU task - abusing the namespace
 sub limit_assets {
     my ($app) = @_;
-    my $groups = $app->db->resultset('JobGroups')->search(undef, {order_by => 'id'});
-    my $asset_resultset = $app->db->resultset('Assets');
 
-    # to avoid perpetually being on the very edge of the size limit and prone
-    # to edge cases while multiple jobs that may upload images are running,
-    # we take a number 80% of the size limit. we go through the group and keep
-    # all assets that fit within that number in %keep and the others in
-    # toremove. Once we exceed the actual size limit, we set doremove to 1 to
-    # indicate that removal should occur (so we don't do any removal if total
-    # size is between reduceto and sizelimit).
-    # If $doremove is 1 we remove all in %toremove that no other group put in
-    # %keep (assets can easily be in 2 groups - and both have different update
-    # ratios, it's up to the admin to configure the size limit)
+    my $asset_status = $app->db->resultset('Assets')->status();
+    my $assets       = $asset_status->{assets};
 
-    # define variables to keep track of all assets related to jobs
-    my %seen_asset;       # group ID by asset ID, just to find assets having no group
-    my %toremove;         # assets to be removed when $doremove
-    my %keep;             # assets needed to be kept
-    my %size_by_group;    # the size of assets which are exclusively kept by a certain group
-    my $doremove   = 0;   # whether we actually want to remove something
-    my $debug_keep = 0;   # enables debug output
-
-    # these queries are just too much for dbix. note the sort order here:
-    # we sort the assets in descending order by highest related job ID,
-    # so assets for recent jobs are considered first (and most likely to be kept)
-    my $dbh = $app->schema->storage->dbh;
-    my $job_assets_sth
-      = $dbh->prepare(
-"select a.*,max(j.id) from jobs_assets ja join jobs j on j.id=ja.job_id join assets a on a.id=ja.asset_id where j.group_id=? group by a.id order by max desc;"
-      );
-
-    # prefetch all assets
-    my %assets;
-    while (my $a = $asset_resultset->next) {
-        $assets{$a->id} = $a;
-        if ($a->is_fixed) {
-            $a->update({fixed => 1});
-            $keep{$a->id} = {log_msg => "fixed"};
-        }
-        else {
-            $a->update({fixed => 0});
-        }
-    }
-
-    # find relevant assets which belong to a job group
-    while (my $g = $groups->next) {
-        my $group_id  = $g->id;
-        my $sizelimit = $g->size_limit_gb * 1024 * 1024 * 1024;
-        my $reduceto  = $sizelimit * 0.8;
-
-        # initialize %size_by_group for the current group
-        $size_by_group{$group_id} = 0;
-
-        $job_assets_sth->execute($group_id);
-
-        # define variable to keep track of all the jobs which have been kept
-        my @kept_by_jobgroup;
-
-        while (my $a = $job_assets_sth->fetchrow_hashref) {
-            my $asset = $assets{$a->{id}};
-
-            # ignore fixed assets
-            next if $asset->fixed;
-
-            OpenQA::Utils::log_debug(
-                sprintf "Group %d: %s/%s %s->%s",
-                $group_id, $asset->type, $asset->name,
-                human_readable_size($asset->size // 0),
-                human_readable_size($sizelimit));
-
-            # add asset to mapping of seen assets by group
-            $seen_asset{$asset->id} = $group_id;
-
-            # check whether the asset has a size and whether we haven't exceeded the reduce limit
-            my $size = $asset->ensure_size;
-            # count the current asset's size against the limits
-            $sizelimit -= $size;
-            $reduceto  -= $size;
-            if ($size > 0 && $reduceto > 0) {
-                # keep asset
-
-                # determine whether the asset is kept exclusively by this group
-                my $asset_id       = $a->{id};
-                my $existing_entry = $keep{$asset_id};
-                my $is_exclusive   = not defined($existing_entry)
-                  || ($existing_entry->{exclusive} && $existing_entry->{group_id} == $group_id);
-
-                # add entry for kept asset
-                my $kept_asset = $keep{$asset_id} = {
-                    group_id  => $group_id,
-                    job_id    => $a->{max},
-                    log_msg   => sprintf("%s: %s/%s", $g->name, $asset->type, $asset->name),
-                    size      => $size,
-                    exclusive => $is_exclusive,
-                };
-                # NOTE: this might override the group/job information about the kept asset
-                # in case the asset is kept because of multiple jobs
-
-                # add asset to list by assets kept by the current job group (used for debugging purposes only)
-                push(@kept_by_jobgroup, $kept_asset) if $debug_keep;
-            }
-            else {
-                # add assets to removal list
-                $toremove{$asset->id} = sprintf "%s/%s", $asset->type, $asset->name;
-                # set flag for removal if we have exceeded the actual size limit
-                $doremove = 1 if ($sizelimit <= 0);
-            }
-        }
-
-        # print messages
-        if ($debug_keep && @kept_by_jobgroup) {
-            OpenQA::Utils::log_debug('the following assets are kept by job group: ' . $g->name);
-            for my $kept_asset (@kept_by_jobgroup) {
-                OpenQA::Utils::log_debug($kept_asset->{log_msg} . '; referencing job: ' . $kept_asset->{job_id});
-            }
+    # first remove grouped assets
+    for my $asset (@$assets) {
+        if (keys %{$asset->{groups}} && !$asset->{picked_into}) {
+            _remove_if($app->db, $asset);
         }
     }
 
     # use DBD::Pg as dbix doesn't seem to have a direct update call - find()->update are 2 queries
+    my $dbh        = $app->schema->storage->dbh;
     my $update_sth = $dbh->prepare('UPDATE assets SET last_use_job_id = ? WHERE id = ?');
 
-    # remove all kept assets from the removal list and propagate last update to asset table
-    # and accumulate size of exclusively kept assets per job group
-    for my $id (sort keys %keep) {
-        my $asset = $keep{$id};
-
-        OpenQA::Utils::log_debug("KEEP $asset->{log_msg}") if $debug_keep;
-        delete $toremove{$id};
-
-        # set the time of the last use and the related job group
-        $update_sth->execute($asset->{job_id}, $id);
-
-        $size_by_group{$asset->{group_id}} += $asset->{size} if $asset->{exclusive};
-    }
-
-    # remove assets in removal list (from db and disk)
-    if ($doremove) {
-        # skip assets for pending jobs
-        my $pending = $app->db->resultset('Jobs')->search({state => [OpenQA::Schema::Result::Jobs::PENDING_STATES]})
-          ->get_column('id')->as_query;
-        my @pendassets
-          = $app->db->resultset('JobsAssets')->search({job_id => {-in => $pending}})->get_column('asset_id')->all;
-        $app->db->resultset('Assets')->search(
-            {
-                -and => [
-                    id => {in        => [sort keys %toremove]},
-                    id => {'-not in' => \@pendassets},
-                ],
-            },
-            {
-                order_by => qw(t_created)
-            })->delete_all;
-    }
-
-    # update accumulated sizes in the data base
-    $update_sth = $dbh->prepare('UPDATE job_groups SET exclusively_kept_asset_size = ? WHERE id = ?');
-    for my $group_id (keys %size_by_group) {
-        $update_sth->execute($size_by_group{$group_id}, $group_id);
-    }
-
-    # find assets which do not belong to a job group
-    my $timecond = {"<" => time2str('%Y-%m-%d %H:%M:%S', time - 24 * 3600, 'UTC')};
-    my $search = {t_created => $timecond, type => [qw(iso hdd repo)], id => {-not_in => [sort keys %seen_asset]}};
-    my $assets = $app->db->resultset('Assets')->search($search, {order_by => [qw(t_created)]});
-
     # remove all assets older than 14 days which do not belong to a job group
-    while (my $a = $assets->next) {
-        next if $a->fixed;
-        my $delta = $a->t_created->delta_days(DateTime->now)->in_units('days');
-        if ($delta >= 14 || $a->ensure_size == 0) {
-            $a->delete;
+    for my $asset (@$assets) {
+        $update_sth->execute($asset->{max_job} ? $asset->{max_job} : undef, $asset->{id});
+
+        next if $asset->{fixed} || scalar(keys %{$asset->{groups}}) > 0;
+
+        # age is in minutes
+        my $delta = int($asset->{age} / 60 / 24);
+        if ($delta >= 14 || $asset->{size} == 0) {
+            _remove_if($app->db, $asset);
         }
         else {
-            OpenQA::Utils::log_warning("Asset "
-                  . $a->type . "/"
-                  . $a->name
-                  . " is not in any job group, will delete in "
-                  . (14 - $delta)
-                  . " days");
+            OpenQA::Utils::log_warning(
+                "Asset " . $asset->{name} . " is not in any job group, will delete in " . (14 - $delta) . " days");
         }
     }
 
-    # search for new assets and register them
-    for my $type (qw(iso repo hdd)) {
-        my $dh;
-        if (opendir($dh, $OpenQA::Utils::assetdir . "/$type")) {
-            my %assets;
-            my @paths;
-            while (readdir($dh)) {
-                unless ($_ eq 'fixed' or $_ eq '.' or $_ eq '..') {
-                    push(@paths, "$OpenQA::Utils::assetdir/$type/$_");
-                }
-            }
-            closedir($dh);
-            if (opendir($dh, $OpenQA::Utils::assetdir . "/$type" . "/fixed")) {
-                while (readdir($dh)) {
-                    unless ($_ eq 'fixed' or $_ eq '.' or $_ eq '..') {
-                        push(@paths, "$OpenQA::Utils::assetdir/$type/fixed/$_");
-                    }
-                }
-                closedir($dh);
-            }
-            for my $path (@paths) {
-                # very specific to our external syncing
-                next if basename($path) =~ m/CURRENT/;
-                next if -l $path;
-                # ignore files not owned by us
-                next unless -o $path;
-                if ($type eq 'repo') {
-                    next unless -d $path;
-                }
-                else {
-                    next unless -f $path;
-                    if ($type eq 'iso') {
-                        next unless $path =~ m/\.iso$/;
-                    }
-                }
-                $assets{basename($path)} = 0;
-            }
-            $assets = $app->db->resultset('Assets')->search({type => $type, name => {in => [keys %assets]}});
-            while (my $a = $assets->next) {
-                $assets{$a->name} = $a->id;
-            }
-            for my $asset (keys %assets) {
-                if ($assets{$asset} == 0) {
-                    OpenQA::Utils::log_info "Registering asset $type/$asset";
-                    $app->db->resultset('Assets')->register($type, $asset);
-                }
-            }
-        }
+    # store the exclusively_kept_asset_size in the DB - for the job group edit field
+    $update_sth = $dbh->prepare('UPDATE job_groups SET exclusively_kept_asset_size = ? WHERE id = ?');
+
+    for my $group (values %{$asset_status->{groups}}) {
+        $update_sth->execute($group->{picked}, $group->{id});
     }
+
 }
 
 1;

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -17,8 +17,11 @@
 package OpenQA::Schema::ResultSet::Assets;
 use strict;
 use base 'DBIx::Class::ResultSet';
-use OpenQA::Utils qw(log_warning locate_asset);
+use OpenQA::Utils qw(log_warning locate_asset human_readable_size);
+use OpenQA::Schema::Result::Jobs;
+use File::Basename;
 
+# called when uploading an asset or finding one in scanning
 sub register {
     my ($self, $type, $name, $missingok) = @_;
     $missingok //= 0;
@@ -45,5 +48,172 @@ sub register {
     return $asset;
 }
 
+sub scan_for_untracked_assets {
+    my ($self) = @_;
+
+    # search for new assets and register them
+    for my $type (qw(iso repo hdd)) {
+        my $dh;
+        next unless opendir($dh, $OpenQA::Utils::assetdir . "/$type");
+        my %assets;
+        my @paths;
+        while (readdir($dh)) {
+            unless ($_ eq 'fixed' or $_ eq '.' or $_ eq '..') {
+                push(@paths, "$OpenQA::Utils::assetdir/$type/$_");
+            }
+        }
+        closedir($dh);
+        if (opendir($dh, $OpenQA::Utils::assetdir . "/$type" . "/fixed")) {
+            while (readdir($dh)) {
+                unless ($_ eq 'fixed' or $_ eq '.' or $_ eq '..') {
+                    push(@paths, "$OpenQA::Utils::assetdir/$type/fixed/$_");
+                }
+            }
+            closedir($dh);
+        }
+        my %paths;
+        for my $path (@paths) {
+
+            my $basepath = basename($path);
+            # very specific to our external syncing
+            next if $basepath =~ m/CURRENT/;
+            next if -l $path;
+
+            # ignore files not owned by us
+            next unless -o $path;
+            if ($type eq 'repo') {
+                next unless -d $path;
+            }
+            else {
+                next unless -f $path;
+                if ($type eq 'iso') {
+                    next unless $path =~ m/\.iso$/;
+                }
+            }
+            $paths{$basepath} = 0;
+        }
+        my $assets = $self->search({type => $type});
+        while (my $as = $assets->next) {
+            $paths{$as->name} = $as->id;
+        }
+        for my $asset (keys %paths) {
+            if ($paths{$asset} == 0) {
+                OpenQA::Utils::log_info "Registering asset $type/$asset";
+                $self->register($type, $asset);
+            }
+        }
+    }
+}
+
+sub status {
+    my ($self) = @_;
+
+    $self->scan_for_untracked_assets();
+
+    my $rsource = $self->result_source;
+    my $schema  = $rsource->schema;
+
+    # prefetch all assets
+    my %asset_info;
+    while (my $as = $self->next) {
+        if ($as->is_fixed) {
+            $as->update({fixed => 1});
+        }
+        else {
+            $as->update({fixed => 0});
+        }
+        my $age     = $as->t_created->delta_ms(DateTime->now)->in_units('minutes');
+        my $dirname = $as->type . '/';
+        if ($as->fixed) { $dirname .= 'fixed/'; }
+        $asset_info{$as->id} = {
+            id      => $as->id,
+            fixed   => $as->fixed,
+            pending => 0,
+            size    => $as->ensure_size,
+            name    => $dirname . $as->name,
+            age     => $age,
+            max_job => 0,
+            groups  => {}};
+    }
+
+    # these queries are just too much for dbix. note the sort order here:
+    # we sort the assets in descending order by highest related job ID,
+    # so assets for recent jobs are considered first (and most likely to be kept)
+    my $stm = <<'END_SQL';
+         select a.*,max(j.id) from jobs_assets ja
+              join jobs j on j.id=ja.job_id
+              join assets a on a.id=ja.asset_id
+           where j.group_id=?
+           group by a.id
+           order by max desc;
+END_SQL
+    my $dbh            = $schema->storage->dbh;
+    my $job_assets_sth = $dbh->prepare($stm);
+
+    # query list of job groups to show assets by job group
+    # We collect data required for /admin/assets *and* the limit_assets task
+    my $groups = $schema->resultset('JobGroups');
+    my %group_infos;
+    $group_infos{0} = {size_limit_gb => 0, size => 0, group => 'Untracked', id => 0};
+
+    # find relevant assets which belong to a job group
+    while (my $g = $groups->next) {
+        my $group_id = $g->id;
+
+        $group_infos{$g->id}->{size_limit_gb} = $g->size_limit_gb;
+        $group_infos{$g->id}->{size}          = $g->size_limit_gb * 1024 * 1024 * 1024;
+        $group_infos{$g->id}->{picked}        = 0;
+        $group_infos{$g->id}->{id}            = $g->id;
+        $group_infos{$g->id}->{group}         = $g->full_name;
+
+        $job_assets_sth->execute($group_id);
+
+        while (my $a = $job_assets_sth->fetchrow_hashref) {
+            my $ai = $asset_info{$a->{id}};
+
+            # ignore assets arriving in between - API can register new ones
+            next unless $ai;
+
+            $ai->{groups}->{$group_id} = $a->{max};
+            if ($a->{max} > $ai->{max_job}) {
+                $ai->{max_job} = $a->{max};
+            }
+        }
+    }
+
+    my $pending
+      = $schema->resultset('Jobs')->search({state => [OpenQA::Schema::Result::Jobs::PENDING_STATES]})->get_column('id')
+      ->as_query;
+    my @pendassets
+      = $schema->resultset('JobsAssets')->search({job_id => {-in => $pending}})->get_column('asset_id')->all;
+    for my $id (@pendassets) {
+        my $ai = $asset_info{$id};
+
+        # ignore assets arriving in between - API can register new ones
+        next unless $ai;
+        $ai->{pending} = 1;
+    }
+
+    # sort the assets by importance
+    my @assets = values(%asset_info);
+    @assets = sort { $b->{max_job} <=> $a->{max_job} || $a->{age} <=> $b->{age} } @assets;
+
+    for my $asset (@assets) {
+        my $largest_group = 0;
+        my $largest_size  = 0;
+        my @groups        = sort { $a <=> $b } keys %{$asset->{groups}};
+        for my $g (@groups) {
+            if ($largest_size < $group_infos{$g}->{size} && $group_infos{$g}->{size} >= $asset->{size}) {
+                $largest_size  = $group_infos{$g}->{size};
+                $largest_group = $g;
+            }
+        }
+        $asset->{picked_into} = $largest_group;
+        $group_infos{$largest_group}->{size} -= $asset->{size};
+        $group_infos{$largest_group}->{picked} += $asset->{size};
+    }
+
+    return {assets => \@assets, groups => \%group_infos};
+}
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -743,7 +743,11 @@ sub human_readable_size {
     my ($size) = @_;
 
     my $p = ($size < 0) ? '-' : '';
-    $size = abs($size) / 1024.;
+    $size = abs($size);
+    if ($size < 3000) {
+        return "$p$size Byte";
+    }
+    $size = $size / 1024.;
     if ($size < 1024) {
         return $p . _round_a_bit($size) . "KiB";
     }

--- a/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
@@ -16,39 +16,19 @@
 
 package OpenQA::WebAPI::Controller::Admin::Asset;
 use Mojo::Base 'Mojolicious::Controller';
+use List::Util qw(sum);
 
 sub index {
     my $self = shift;
 
-    # query assets
-    my $assets = $self->db->resultset('Assets');
-    my $assets_ordered_by_id = $assets->search(undef, {order_by => 'id', prefetch => 'jobs_assets'});
+    my $status = $self->db->resultset('Assets')->status();
 
-    # query list of job groups to show assets by job group
-    my @assets_by_group;
-    my $groups
-      = $self->db->resultset('JobGroups')->search(undef, {order_by => {-desc => 'exclusively_kept_asset_size'}});
-    my $dbh                = $self->db->storage->dbh;
-    my $query_group_assets = $dbh->prepare(
-        'select a.* from assets a join jobs j on j.id = a.last_use_job_id where j.group_id = ? order by a.size desc;');
-    while (my $group = $groups->next) {
-        my @group_assets;
-        $query_group_assets->execute($group->id);
-        while (my $asset = $query_group_assets->fetchrow_hashref) {
-            push(@group_assets, $asset);
-        }
-        push(
-            @assets_by_group,
-            {
-                id     => $group->id,
-                name   => $group->name,
-                size   => $group->exclusively_kept_asset_size,
-                assets => \@group_assets,
-            });
-    }
+    my $total_size = sum(map { $_->{picked} } values(%{$status->{groups}}));
 
-    $self->stash('assets',          $assets_ordered_by_id);
-    $self->stash('assets_by_group', \@assets_by_group);
+    $self->stash('assets',     $status->{assets});
+    $self->stash('groups',     $status->{groups});
+    $self->stash('total_size', $total_size);
+
     $self->render('admin/asset/index');
 }
 

--- a/templates/admin/asset/index.html.ep
+++ b/templates/admin/asset/index.html.ep
@@ -16,85 +16,58 @@
         <table id="assets" class="display table table-striped">
             <thead>
                 <tr>
-                    <th>Type</th>
-                    <th>Name</th>
-                    <th>#Jobs</th>
-                    <th>Created</th>
+                    <th>Asset</th>
+                    <th>Latest Job</th>
                     <th>Size</th>
-                    <th>Last use</th>
+                    <th>Groups</th>
                 </tr>
             </thead>
             <tbody>
-            % while (my $asset = $assets->next()) {
-                % next unless ($asset->last_use_job_id);
-            <tr id="asset_<%= $asset->id %>">
-                <td class="type"><%= $asset->type %></td>
+            % for my $asset (@$assets) {
+            % next unless $asset->{size};
+
+            <tr id="asset_<%= $asset->{id} %>">
                 <td class="name">
-                    %= $asset->name
-                    <a href="#" onclick="deleteAsset(<%= $asset->id %>);">
+                    %= $asset->{name}
+                    <a href="#" onclick="deleteAsset(<%= $asset->{id} %>);">
                         <i class="action far fa-fw fa-times-circle" title="Delete asset"></i>
                     </a>
                 </td>
-                <td class="nrjobs"><%= link_to($asset->jobs_assets->count => url_for('tests')->query(assetid => $asset->id)) %></td>
                 <td class="t_created">
-                    %= $asset->t_created
-                </td>
-                <td class="size"><%= $asset->size %></td>
-                <td class="last_use">
-                    % my $last_use_job = $asset->last_use_job;
-                    % if (my $group = $last_use_job->group) {
-                        <%= link_to($group->name => url_for(is_admin() ? 'admin_job_templates' : 'group_overview', groupid => $group->id)); %>:
+                    % if ($asset->{max_job}) {
+                       %= link_to($asset->{max_job} => url_for('test', testid => $asset->{max_job}))
+                    % } else {
+                      0
                     % }
-                    %= link_to($last_use_job->name => url_for('test', testid => $last_use_job->id))
+                </td>
+                <td class="size"><%= $asset->{size} %></td>
+                <td class="last_use">
+                   % for my $group (sort { $a <=> $b } keys(%{$asset->{groups}})) {
+                     % my $class = 'not-picked';
+                     % if ($asset->{picked_into} == $group) {
+                       % $class = 'picked-group';
+                     % }
+                     % if ($asset->{picked_into} == 0) {
+                       % $class = 'to-be-removed';
+                     % }
+                     %=  link_to $group => url_for('test', testid => $asset->{groups}->{$group}) => (class => $class)
+                   % }
                 </td>
             </tr>
             % }
-
             </tbody>
         </table>
 
-        <h3>Untracked assets</h3>
-        <p>The following assets are not used by any job or only by jobs which are not part of any group.</p>
-        <table id="untracked-assets" class="display table table-striped">
-            <thead>
-                <tr>
-                    <th>Type</th>
-                    <th>Name</th>
-                    <th>#Jobs</th>
-                    <th>Created</th>
-                    <th>Size</th>
-                </tr>
-            </thead>
-            <tbody>
-            % $assets->reset();
-            % while (my $asset = $assets->next()) {
-                % next if ($asset->last_use_job_id);
-                <tr id="asset_<%= $asset->id %>">
-                    <td class="type"><%= $asset->type %></td>
-                    <td class="name">
-                        %= $asset->name
-                        <a href="#" onclick="deleteAsset(<%= $asset->id %>);">
-                            <i class="action far fa-fw fa-times-circle" title="Delete asset"></i>
-                        </a>
-                    </td>
-                    <td class="nrjobs"><%= link_to($asset->jobs_assets->count => url_for('tests')->query(assetid => $asset->id)) %></td>
-                    <td class="t_created">
-                        %= $asset->t_created
-                    </td>
-                    <td class="size"><%= $asset->size %></td>
-                </tr>
-            % }
-            </tbody>
-        </table>
+        <h3>Assets by group (Total <%= OpenQA::Utils::human_readable_size($total_size) %>) </h3>
 
-        <h3>Assets by group</h3>
-        <p>The following list shows the <em>exclusively</em> kept assets for each group. Untracked assets will never be shown here.</p>
         <ul id="assets-by-group">
-            % for my $group (@$assets_by_group) {
+            % for my $group (sort { $b->{picked} <=> $a->{picked} || $a->{group} cmp $b->{group} } values(%$groups)) {
+                % # ignore those groups without picked assets
+                % next unless $group->{picked};
                 <li>
                     <input id="group-<%= $group->{id} %>-checkbox" type="checkbox">
                     <label for="group-<%= $group->{id} %>-checkbox">
-                        %= $group->{name}
+                        %= $group->{group}
                     </label>
                     % if (is_admin) {
                         <a href="<%= $c->url_for('admin_job_templates', groupid => $group->{id}) %>">
@@ -102,10 +75,14 @@
                         </a>
                     % }
                     <span>
-                        %= ($group->{size} ? OpenQA::Utils::human_readable_size($group->{size}) : 'unknown')
+                        %= OpenQA::Utils::human_readable_size($group->{picked})
+                        /
+                        %= $group->{size_limit_gb}
+                        GiB
                     </span>
                     <ul>
-                        % for my $asset (@{$group->{assets}}) {
+                        % for my $asset (sort { $b->{name} cmp $a->{name} } @$assets) {
+                            % next unless $asset->{size} && $asset->{picked_into} == $group->{id};
                             <li>
                                 %= $asset->{name}
                                 <span>
@@ -117,5 +94,6 @@
                 </li>
             % }
         </ul>
+
     </div>
 </div>


### PR DESCRIPTION
Instead of querying the groups one by one and decide what to delete, we
now collect all assets, sort them by how important they are overall and
then assign groups to them before deleting.

This allows to use the same infos also to display in the admin/assets
page and to apply the size limit exclusively. Finally it's possible to
explain what GRU deletes exactly as the web page displays the same
infos that GRU sees.

I dropped the 80% logic though - the admin will have to adjust the
job group sizes to match his file system anyway and can't have all
disk space eaten up by job groups to account for uploads and overcommits
due to pending jobs.

One additional change I did was take fixed/ assets into the calculcation
to give a better overview what is taking up the disk space, they won't
be deleted though even if they fall out of the sum

The two last changes affect 14-grutasks quite heavily - and the last_job_id
field is actually no longer needed, but I left it in case we want to show
it somewhere