### PR TITLE
Take latest version of Selenium::Remote::Driver

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -90,7 +90,7 @@ requires 'POSIX';
 on 'test' => sub {
   requires 'Perl::Critic';
   requires 'Perl::Tidy', '>= 20171214';
-  requires 'Selenium::Remote::Driver', '< 1.21';
+  requires 'Selenium::Remote::Driver', '>= 1.23';
   requires 'Test::Compile';
   requires 'Test::Fatal';
   requires 'Test::MockModule';

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -109,7 +109,8 @@ like($elem->get_attribute('data-content'), qr/inst-bootmenu/, "show searched nee
 $elem->click();
 wait_for_ajax;
 ok($driver->find_element('.step_actions .popover')->is_displayed(), "needle info is a clickable popover");
-$driver->find_element_by_xpath('//a[@href="#step/installer_timezone/1"]')->click();
+# hide again
+$elem->click();
 wait_for_ajax;
 
 my @report_links = $driver->find_elements('#preview_container_in .report', 'css');


### PR DESCRIPTION
Selenium::Remote::Driver 1.23 fixed our issue, so take the latest version
1.21 introduced the regresion, so technically we forbid 1.21 and 1.22,
but testing with the latest sounds more reasonable - especially as Tumbleweed
is already at the broken 1.21 version