### PR TITLE
Allow download of a full job data from the client

### DIFF
--- a/lib/OpenQA/Client.pm
+++ b/lib/OpenQA/Client.pm
@@ -18,12 +18,19 @@ package OpenQA::Client;
 use Mojo::Base 'OpenQA::UserAgent';
 
 use OpenQA::Client::Upload;
+use OpenQA::Client::Archive;
 use Scalar::Util ();
 
 has upload => sub {
     my $upload = OpenQA::Client::Upload->new(client => shift);
     Scalar::Util::weaken $upload->{client};
     return $upload;
+};
+
+has archive => sub {
+    my $archive = OpenQA::Client::Archive->new(client => shift);
+    Scalar::Util::weaken $archive->{client};
+    return $archive;
 };
 
 1;

--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -26,7 +26,6 @@ sub run {
         $job = $res->json->{job} || die("No job could be retrieved");
         #We have a job now, make a directory in $pwd by default
         $path = path($options{archive})->make_path->to_abs;
-        chdir($path);
         #we can't backup repos, so don't even try
         delete($job->{assets}->{repos});
         download_assets() unless $options{'skip-download'};

--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -1,46 +1,65 @@
+# Copyright (C) 2018 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 package OpenQA::Client::Archive;
-use strict;
-use warnings;
+use Mojo::Base 'OpenQA::Client::Handler';
+
+use Mojo::Exception;
+use Mojo::File 'path';
+use Mojo::URL;
+use Carp 'croak';
+use JSON;
+
 use Data::Dump;
 
-use JSON;
-use Mojo::URL;
-use Mojo::File 'path';
-
-our $client;
-our %options;
-our $job;
-our $path;
+my $job;
+my $path;
+my $url;
+my $options;
 
 sub run {
-    #We're only taking one argument
-    ($client, %options) = @_;
-    my $method = 'get';
 
-    my $url = $options{url}->clone;
-    $url->path->merge('details');
-    my $req = $client->$method($url);
+    #We'he only taking one argument
+    my ($self, $options) = @_;
+
+    croak 'Options must be a HASH ref' unless ref $options eq 'HASH';
+    croak 'Need a file to upload in the options!' unless $options->{url};
+
+    $url = Mojo::URL->new($options->{url});
+    my $req = $self->client->get($url);
     my $res = $req->res;
 
     if ($res->code eq 200) {
         $job = $res->json->{job} || die("No job could be retrieved");
         #We have a job now, make a directory in $pwd by default
-        $path = path($options{archive})->make_path->to_abs;
+        $path = path($options->{archive})->make_path;
         #we can't backup repos, so don't even try
         delete($job->{assets}->{repos});
-        download_assets() unless $options{'skip-download'};
-        download_test_results(@{$job->{testresults}});
-        print "Files have been downloaded to " . $path->realpath . "\n";
+        $path->path('testresults/thumbnails')->make_path if $options->{'with-thumbnails'};
+        $self->download_assets unless $options->{'skip-download'};
+        $self->download_test_results;
     }
     else {
-        die "There's an error openQA client returned ". $res->code;
+        die "There's an error openQA client returned " . $res->code;
     }
 }
 
 sub _download_test_result_details {
-    my $module = shift;
-    my $url    = $options{url}->clone;
-    my $ua     = $client;
+    my ($self, $module) = @_;
+    my $ua = $self->client;
     if ($module->{screenshot}) {
         #same structure is used for thumbnails and screenshots
         my @dirnames = map { /md5_[^basename]/ ? $_ : () } keys %{$module};
@@ -50,27 +69,27 @@ sub _download_test_result_details {
         my $dir = $module->{'md5_dirname'} || ($module->{'md5_1'} . '/' . $module->{'md5_2'});
 
         $url->path("/image/$dir/" . $module->{md5_basename});
-        my $tx = $ua->get($url)->res->content->asset->move_to('testresults/' . $module->{screenshot});
 
-        if ($options{'with-thumbnails'}) {
-            path('testresults/thumbnails')->make_path;
+        my $destination = $path->path('testresults/', $module->{screenshot});
+        my $tx = $ua->get($url)->res->content->asset->move_to($destination);
+
+        if ($options->{'with-thumbnails'}) {
             $url->path('/image/', $dir, '/.thumbs/', $module->{md5_basename});
-            $ua->get($url)->res->content->asset->move_to('testresults/thumbnails/' . $module->{md5_basename});
+            $ua->get($url)
+              ->res->content->asset->move_to($path->path('testresults/thumbnails/', $module->{md5_basename}));
         }
 
     }
     elsif ($module->{text}) {
-        my $file = Mojo::File->new('testresults', $module->{text});
+        my $file = Mojo::File->new($path->path('testresults/' . $module->{text}));
         $file->spurt($module->{text_data} // "No data\n");
     }
 }
 
 sub _download_file_at {
 
-    my ($file, $location) = @_;
-    my $url = $options{url}->clone;
-    my $ua  = $client;
-
+    my ($self, $file, $location) = @_;
+    my $ua = $self->client;
 
     my $jobid = $job->{id};
     $url->path("/tests/$jobid/file/$file");
@@ -78,67 +97,77 @@ sub _download_file_at {
     $ua->{filename} = $file;
 
     my $tx = $ua->build_tx(GET => $url);
-    $ua->start($tx);
+    $tx = $ua->start($tx);
 
     # fix the \r :)
     print "\n";
-    if ($tx->res->is_server_error) {
-        print("Could not download the file $file.\n");
+    my $destination = $location->path($file);
+    _download_handler($tx, $destination);
+}
+
+sub _download_handler {
+    my ($tx, $file) = @_;
+
+    print("Unexpected error while downloading $file.\n") unless $tx;
+
+    if ($tx->res->is_success && $tx->res->content->asset->move_to($file)) {
+        print "File download successful to $file\n";
+        return 1;
     }
-    elsif ($tx->res->is_success) {
-        $tx->res->content->asset->move_to($location->merge($file));
-        print("File download successful to $file.\n");
+    elsif ($tx->res->is_server_error) {
+        print "Could not download the file $file.\n";
     }
-    else {
-        print("Unexpected error while downloading $file from $url.\n");
+    elsif ($tx->res->code == 404) {
+        print "file not found.\n";
     }
+
+    print "Unexpected error while moving $file.\n";
 
 }
 
 sub download_test_results {
 
-    my $resultdir       = path('testresults')->make_path;
+    my ($self) = shift;
+    my $resultdir = path($path, 'testresults')->make_path;
     my $resultdir_ulogs = $resultdir->path('ulogs')->make_path;
 
-    print "Downloading test details and screenshots\n";
+    print "Downloading test details and screenshots to $resultdir\n";
     for my $test (@{$job->{testresults}}) {
         my $filename = $resultdir->path . "/details-" . $test->{name} . ".json";
         open(my $fh, ">", $filename);
         $fh->print(encode_json($test));
         close($fh);
-        map { _download_test_result_details($_) } @{$test->{details}};
+        print "Saved details for " . $filename . "\n";
+        map { $self->_download_test_result_details($_) } @{$test->{details}};
     }
 
     print "Downloading logs\n";
     for my $test_log (@{$job->{logs}}) {
-        _download_file_at($test_log, $resultdir);
+        $self->_download_file_at($test_log, $resultdir);
     }
 
     print "Downloading ulogs\n";
     for my $test_log (@{$job->{ulogs}}) {
-        _download_file_at($test_log->{filename}, $resultdir_ulogs);
+        $self->_download_file_at($test_log, $resultdir_ulogs);
     }
 
 }
 
 sub download_asset {
-    # local $/;
-    # $client->clone;
-    my ($jobid, $type, $file) = @_;
-    my $url = $options{url}->clone;
-    my $ua  = $client;
+
+    my ($self, $jobid, $type, $file) = @_;
+    my $ua = $self->client;
     local $| = 1;
 
     # Override waitting time as big assets can take quite some time
-    $ua->max_response_size(0);
     $url->path("/tests/$jobid/asset/$type/$file");
     my $tx = $ua->build_tx(GET => $url);
     my $headers;
 
     #assume that we're in the working directory.
-    path("$type")->make_path;
-    die "can't write in $path/$type directory" unless -w "$type";
-    $file = path("$type/$file");
+    my $destination_directory = $path->path("$type")->make_path;
+    die "can't write in $path/$type directory" unless -w "$destination_directory";
+    $file = $destination_directory->path($file);
 
     #Download progress monitor
     $ua->on(start => \&_progress_monitior);
@@ -149,20 +178,12 @@ sub download_asset {
     $| = 0;
     # fix the \r :)
     print "\n";
-    if ($tx->res->is_server_error) {
-        print("Could not download the file $file.\n");
-    }
-    elsif ($tx->res->is_success) {
-        $tx->res->content->asset->move_to($file)->size;
-        print("File download successful to $file.\n");
-    }
-    else {
-        print("Unexpected error while downloading $file.\n");
-    }
+    _download_handler($tx, $file);
 
 }
 
 sub download_assets {
+    my $self = shift;
     my $asset_group;
     for my $asset_group (keys %{$job->{assets}}) {
         print "Attempt $asset_group download:\n";

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -588,7 +588,7 @@ sub to_hash {
     }
     if ($args{details}) {
         $j->{testresults} = read_test_modules($job);
-        @{$j->{logs}} = $job->test_resultfile_list;
+        @{$j->{logs}}  = $job->test_resultfile_list;
         @{$j->{ulogs}} = $job->test_uploadlog_list;
     }
     return $j;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -588,8 +588,8 @@ sub to_hash {
     }
     if ($args{details}) {
         $j->{testresults} = read_test_modules($job);
-        @{$j->{logs}}  = $job->test_resultfile_list;
-        @{$j->{ulogs}} = $job->test_uploadlog_list;
+        $j->{logs}        = $job->test_resultfile_list;
+        $j->{ulogs}       = $job->test_uploadlog_list;
     }
     return $j;
 }
@@ -1785,7 +1785,7 @@ sub test_uploadlog_list {
         $f =~ s#.*/##;
         push(@filelist, $f);
     }
-    return @filelist;
+    return \@filelist;
 }
 
 sub test_resultfile_list {
@@ -1807,7 +1807,7 @@ sub test_resultfile_list {
         }
     }
 
-    return @filelist_existing;
+    return \@filelist_existing;
 }
 
 =head2 done

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -588,6 +588,8 @@ sub to_hash {
     }
     if ($args{details}) {
         $j->{testresults} = read_test_modules($job);
+        @{$j->{logs}} = $job->test_resultfile_list;
+        @{$j->{ulogs}} = $job->test_uploadlog_list;
     }
     return $j;
 }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1773,6 +1773,41 @@ sub _job_stop_children {
     return $count;
 }
 
+sub test_uploadlog_list {
+    # get a list of uploaded logs
+    my ($self) = @_;
+    my $testresdir = $self->result_dir();
+
+    my @filelist;
+    for my $f (glob "$testresdir/ulogs/*") {
+        $f =~ s#.*/##;
+        push(@filelist, $f);
+    }
+    return @filelist;
+}
+
+sub test_resultfile_list {
+    # get a list of existing resultfiles
+    my ($self) = @_;
+    my $testresdir = $self->result_dir();
+
+    my @filelist = qw(video.ogv vars.json backend.json serial0.txt autoinst-log.txt worker-log.txt);
+    my @filelist_existing;
+    for my $f (@filelist) {
+        if (-e "$testresdir/$f") {
+            push(@filelist_existing, $f);
+        }
+    }
+
+    for my $f (qw(serial_terminal.txt)) {
+        if (-s "$testresdir/$f") {
+            push(@filelist_existing, $f);
+        }
+    }
+
+    return @filelist_existing;
+}
+
 =head2 done
 
 Finalize job by setting it as DONE.

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -54,6 +54,9 @@ sub new {
     # (default is 20 seconds)
     $self->inactivity_timeout(600);
 
+    # Some urls might redirect to https and then there are internal redirects for assets
+    $self->max_redirects(3);
+
     $self->on(
         start => sub {
             $self->_add_auth_headers(@_);

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -816,10 +816,9 @@ sub read_test_modules {
 
         for my $step (@{$module->details}) {
             $step->{num} = $num++;
-            if($step->{text}){
-                log_error("Should read information in ");
-                log_error("Reading information from ".encode_json($step));
-                $step->{text_data} = path($job->result_dir(),$step->{text})->slurp; #;"$text_data";
+            if ($step->{text}) {
+                log_debug("Reading information from " . encode_json($step));
+                $step->{text_data} = path($job->result_dir(), $step->{text})->slurp;
             }
             push(@details, $step);
         }

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -107,7 +107,7 @@ use File::Basename;
 use File::Spec;
 use File::Spec::Functions qw(catfile catdir);
 use Fcntl;
-use Cpanel::JSON::XS "decode_json";
+use Cpanel::JSON::XS qw(encode_json decode_json);
 use Mojo::Util 'xml_escape';
 our $basedir   = $ENV{OPENQA_BASEDIR} || "/var/lib";
 our $prj       = "openqa";
@@ -816,6 +816,11 @@ sub read_test_modules {
 
         for my $step (@{$module->details}) {
             $step->{num} = $num++;
+            if($step->{text}){
+                log_error("Should read information in ");
+                log_error("Reading information from ".encode_json($step));
+                $step->{text_data} = path($job->result_dir(),$step->{text})->slurp; #;"$text_data";
+            }
             push(@details, $step);
         }
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -180,38 +180,6 @@ sub list_ajax {
     $self->render(json => {data => \@list});
 }
 
-sub test_uploadlog_list($) {
-    # get a list of uploaded logs
-    my $testresdir = shift;
-    my @filelist;
-    for my $f (glob "$testresdir/ulogs/*") {
-        $f =~ s#.*/##;
-        push(@filelist, $f);
-    }
-    return @filelist;
-}
-
-sub test_resultfile_list($) {
-    # get a list of existing resultfiles
-    my ($testresdir) = @_;
-
-    my @filelist = qw(video.ogv vars.json backend.json serial0.txt autoinst-log.txt worker-log.txt);
-    my @filelist_existing;
-    for my $f (@filelist) {
-        if (-e "$testresdir/$f") {
-            push(@filelist_existing, $f);
-        }
-    }
-
-    for my $f (qw(serial_terminal.txt)) {
-        if (-s "$testresdir/$f") {
-            push(@filelist_existing, $f);
-        }
-    }
-
-    return @filelist_existing;
-}
-
 sub details {
     my ($self) = @_;
 
@@ -268,10 +236,10 @@ sub _show {
     my $rd = $job->result_dir();
     if ($rd) {    # saved anything
                   # result files box
-        my @resultfiles = test_resultfile_list($job->result_dir());
+        my @resultfiles = $job->test_resultfile_list;
 
         # uploaded logs box
-        my @ulogs = test_uploadlog_list($job->result_dir());
+        my @ulogs =  $job->test_uploadlog_list;
 
         $self->stash(resultfiles => \@resultfiles);
         $self->stash(ulogs       => \@ulogs);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -236,13 +236,13 @@ sub _show {
     my $rd = $job->result_dir();
     if ($rd) {    # saved anything
                   # result files box
-        my @resultfiles = $job->test_resultfile_list;
+        my $resultfiles = $job->test_resultfile_list;
 
         # uploaded logs box
-        my @ulogs = $job->test_uploadlog_list;
+        my $ulogs = $job->test_uploadlog_list;
 
-        $self->stash(resultfiles => \@resultfiles);
-        $self->stash(ulogs       => \@ulogs);
+        $self->stash(resultfiles => $resultfiles);
+        $self->stash(ulogs       => $ulogs);
     }
     else {
         $self->stash(resultfiles => []);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -239,7 +239,7 @@ sub _show {
         my @resultfiles = $job->test_resultfile_list;
 
         # uploaded logs box
-        my @ulogs =  $job->test_uploadlog_list;
+        my @ulogs = $job->test_uploadlog_list;
 
         $self->stash(resultfiles => \@resultfiles);
         $self->stash(ulogs       => \@ulogs);

--- a/script/client
+++ b/script/client
@@ -243,7 +243,6 @@ else {
         $res = $client->$method($url)->res;
         #exit(0);
     }
-
 }
 if ($res->code == 200) {
     if ($options{'json-output'}) {

--- a/script/client
+++ b/script/client
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2016 SUSE LLC
+# Copyright (C) 2014-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -106,6 +106,7 @@ Trigger jobs on iso B<bar.iso> matching test suite B<blah>.
 # client jobs/1/artefact post file.file=bar file.filename=bar.log
 
 use strict;
+use warnings;
 use FindBin;
 BEGIN { unshift @INC, "$FindBin::RealBin/../lib" }
 
@@ -114,6 +115,8 @@ use Data::Dump;
 use Mojo::URL;
 use OpenQA::Client;
 use Getopt::Long;
+use OpenQA::Client::Archive;
+
 Getopt::Long::Configure("no_ignore_case");
 
 my %options;
@@ -128,7 +131,8 @@ sub usage($) {
 
 GetOptions(
     \%options,     'host=s',   'apibase=s', 'json-output', 'verbose|v', 'apikey:s',
-    'apisecret:s', 'params=s', 'form',      'json-data:s', 'help|h|?'
+    'apisecret:s', 'params=s', 'form',      'json-data:s', 'help|h|?',  'archive|a:s',
+    'skip-download'
 ) or usage(1);
 
 usage(1) unless @ARGV;
@@ -168,6 +172,7 @@ for my $arg (@ARGV) {
 }
 
 my $url;
+
 if ($options{host} !~ '/') {
     $url = Mojo::URL->new();
     $url->host($options{host});
@@ -205,7 +210,22 @@ elsif ($options{'json-data'}) {
     $res = $client->$method($url, {'Content-Type' => 'application/json'} => $options{'json-data'})->res;
 }
 else {
-    $res = $client->$method($url)->res;
+    dd(%options);
+    $options{path}    = $path;
+    $options{url}     = $url;
+    $options{params}  = \%params;
+    $options{params2} = @ARGV;
+    #treat it as a command if there is no form parameter
+    if ($options{archive}) {
+        print("Going to archive something!\n");
+        OpenQA::Client::Archive::run($client, %options);
+        exit;
+    }
+    else {
+        $res = $client->$method($url)->res;
+        #exit(0);
+    }
+
 }
 if ($res->code == 200) {
     if ($options{'json-output'}) {

--- a/script/client
+++ b/script/client
@@ -66,7 +66,20 @@ jobs/639172 put --json-data '{"group_id": 1}'
 
 print help
 
-=back
+=head2 Archive mode
+
+=item B<--archive, -a> DIRECTORY
+
+Archive mode: Download assets and test results from a job to DIRECTORY.
+
+=item B<--with-thumbnails>
+
+Archive mode: Include thumbnails
+
+=item B<--asset-size-limit> LIMIT
+
+Archive mode: Download assets that do not exceed the specified limit in bytes
+The default limit is 200 MB.
 
 =head1 SYNOPSIS
 
@@ -93,6 +106,10 @@ Delete job nr. B<1> (permissions read from config file).
 =item client --host openqa.example.com isos post iso=bar.iso tests=blah
 
 Trigger jobs on iso B<bar.iso> matching test suite B<blah>.
+
+=item client --archive /path/to/directory --asset-size-limit 1048576000 --with-thumbnails --host openqa.opensuse.org jobs/42
+
+Download all assets and test logs and images from job B<42> with asset limit of B<1GB> to B</path/to/directory>.
 
 =cut
 
@@ -123,16 +140,17 @@ my %options;
 
 sub usage($) {
     my $r = shift;
-    eval "use Pod::Usage; pod2usage(1);";
+    eval { use Pod::Usage; pod2usage(1); };
     if ($@) {
         die "cannot display help, install perl(Pod::Usage)\n";
     }
 }
 
 GetOptions(
-    \%options,       'host=s',   'apibase=s', 'json-output', 'verbose|v', 'apikey:s',
-    'apisecret:s',   'params=s', 'form',      'json-data:s', 'help|h|?',  'archive|a:s',
-    'skip-download', 'with-thumbnails'
+    \%options,            'host=s',      'apibase=s',   'json-output',
+    'verbose|v',          'apikey:s',    'apisecret:s', 'params=s',
+    'form',               'json-data:s', 'help|h|?',    'archive|a:s',
+    'asset-size-limit:i', 'with-thumbnails'
 ) or usage(1);
 
 usage(1) unless @ARGV;
@@ -217,7 +235,9 @@ else {
         $options{url}     = $url;
         $options{params}  = \%params;
         $options{params2} = @ARGV;
-        my $call = $client->archive->run(%options);
+        eval { $res = $client->archive->run(\%options) };
+        die "ERROR: $@ \n", $@ if $@;
+        exit(0);
     }
     else {
         $res = $client->$method($url)->res;

--- a/script/client
+++ b/script/client
@@ -130,9 +130,9 @@ sub usage($) {
 }
 
 GetOptions(
-    \%options,     'host=s',   'apibase=s', 'json-output', 'verbose|v', 'apikey:s',
-    'apisecret:s', 'params=s', 'form',      'json-data:s', 'help|h|?',  'archive|a:s',
-    'skip-download'
+    \%options,       'host=s',   'apibase=s', 'json-output', 'verbose|v', 'apikey:s',
+    'apisecret:s',   'params=s', 'form',      'json-data:s', 'help|h|?',  'archive|a:s',
+    'skip-download', 'with-thumbnails'
 ) or usage(1);
 
 usage(1) unless @ARGV;
@@ -210,16 +210,14 @@ elsif ($options{'json-data'}) {
     $res = $client->$method($url, {'Content-Type' => 'application/json'} => $options{'json-data'})->res;
 }
 else {
-    dd(%options);
-    $options{path}    = $path;
-    $options{url}     = $url;
-    $options{params}  = \%params;
-    $options{params2} = @ARGV;
-    #treat it as a command if there is no form parameter
+    # Either the user wants to call a command or wants to interact with
+    # the rest api directly.
     if ($options{archive}) {
-        print("Going to archive something!\n");
-        OpenQA::Client::Archive::run($client, %options);
-        exit;
+        $options{path}    = $path;
+        $options{url}     = $url;
+        $options{params}  = \%params;
+        $options{params2} = @ARGV;
+        my $call = $client->archive->run(%options);
     }
     else {
         $res = $client->$method($url)->res;

--- a/t/31-client.t
+++ b/t/31-client.t
@@ -52,7 +52,7 @@ subtest 'OpenQA::Client:Archive tests' => sub {
     ok(-e $file, 'details-zypper_up.json file exists') or diag $file;
     $file = path($destination, 'testresults', 'video.ogv');
     ok(-e $file, 'Test video file exists') or diag $file;
-    $file = path($destination, 'testresults','ulogs', 'y2logs.tar.bz2');
+    $file = path($destination, 'testresults', 'ulogs', 'y2logs.tar.bz2');
     ok(-e $file, 'Test uploaded logs file exists') or diag $file;
 
 };

--- a/t/31-client.t
+++ b/t/31-client.t
@@ -1,0 +1,71 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/lib", "lib";
+
+use Test::More;
+use Test::Mojo;
+use Mojo::URL;
+use Test::Warnings;
+use OpenQA::Client;
+use OpenQA::Client::Archive;
+use OpenQA::WebAPI;
+use Mojo::File qw(tempfile tempdir path);
+use OpenQA::Test::Case;
+
+
+# allow up to 200MB - videos mostly
+$ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
+
+# init test case
+OpenQA::Test::Case->new->init_data;
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+my $app = $t->app;
+
+
+path('t', 'client_tests.d')->remove_tree;
+my $dir = path('t', 'client_tests.d', tempdir)->make_path;
+
+
+# XXX: Test::Mojo loses it's app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+$t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+# $client->max_redirects(3);
+
+$t->app($app);
+$t->app->log->level('debug');
+$t->ua->max_redirects(3);
+
+my $base_url = $t->ua->server->url->to_string;
+
+use Data::Dump;
+
+subtest 'OpenQA::Client:Archive tests' => sub {
+    my $jobid = 99938;
+    diag $t->ua->server->url->path("/api/v1/jobs/$jobid");
+    diag $dir->to_abs;
+
+    my %options = (archive => $dir, url => "/api/v1/jobs/$jobid/details");
+    $t->get_ok('/tests/99938/file/video.ogv');
+    $t->ua->OpenQA::Client::Archive::run(%options);
+    $t->get_ok('/tests/99938/file/video.ogv');
+
+    is($@, '', '--archive 1234 would perform correctly' . $@);
+
+};
+
+done_testing();

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -624,14 +624,24 @@ subtest 'job details' => sub {
 
     $t->get_ok('/api/v1/jobs/99926')->status_is(200);
     $t->json_is('/job/testresults' => undef, 'Test details are not present');
-
-    $t->get_ok('/api/v1/jobs/99926/details')->status_is(200);
-    $t->json_hasnt('/job/testresults/0', 'Test details are empty');
+    $t->json_hasnt('/job/logs/0' => undef, 'Test result logs are empty');
 
     $t->get_ok('/api/v1/jobs/99963/details')->status_is(200);
     $t->json_has('/job/testresults/0', 'Test details are there');
     $t->json_is('/job/assets/hdd/0',           => 'hdd_image.qcow2', 'Job has hdd_image.qcow2 as asset');
     $t->json_is('/job/testresults/0/category', => 'installation',    'Job category is "installation"');
+
+    $post = $t->get_ok('/api/v1/jobs/99946/details')->status_is(200);
+    $t->json_has('/job/testresults/0', 'Test details are there');
+    $t->json_is('/job/assets/hdd/0',           => 'openSUSE-13.1-x86_64.hda', 'Job has openSUSE-13.1-x86_64.hda as asset');
+    $t->json_is('/job/testresults/0/category', => 'installation',    'Job category is "installation"');
+
+    $t->json_is('/job/testresults/5/name', 'logpackages', 'logpackages test is present');
+    $t->json_like('/job/testresults/5/details/5/text_data', qr/fate/, 'logpackages has fate');
+
+    $t->json_has('/job/logs', 'Test result logs are present');
+    $t->json_has('/job/ulogs', 'Test result uploaded logs are present');
+
 };
 
 subtest 'update job and job settings' => sub {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -633,14 +633,16 @@ subtest 'job details' => sub {
 
     $post = $t->get_ok('/api/v1/jobs/99946/details')->status_is(200);
     $t->json_has('/job/testresults/0', 'Test details are there');
-    $t->json_is('/job/assets/hdd/0',           => 'openSUSE-13.1-x86_64.hda', 'Job has openSUSE-13.1-x86_64.hda as asset');
-    $t->json_is('/job/testresults/0/category', => 'installation',    'Job category is "installation"');
+    $t->json_is('/job/assets/hdd/0', => 'openSUSE-13.1-x86_64.hda', 'Job has openSUSE-13.1-x86_64.hda as asset');
+    $t->json_is('/job/testresults/0/category', => 'installation', 'Job category is "installation"');
 
     $t->json_is('/job/testresults/5/name', 'logpackages', 'logpackages test is present');
     $t->json_like('/job/testresults/5/details/5/text_data', qr/fate/, 'logpackages has fate');
 
-    $t->json_has('/job/logs', 'Test result logs are present');
-    $t->json_has('/job/ulogs', 'Test result uploaded logs are present');
+    $t->get_ok('/api/v1/jobs/99938/details')->status_is(200);
+
+    $t->json_is('/job/logs/0',  'video.ogv',      'Test result logs are present');
+    $t->json_is('/job/ulogs/0', 'y2logs.tar.bz2', 'Test result uploaded logs are present');
 
 };
 


### PR DESCRIPTION
This is meant to add support for the openQA::Client to support download of all the assets and generated data from a job. 

In theory this is another stepping stone for the worker_bridge/federation

https://progress.opensuse.org/issues/14580