### PR TITLE
Fix broken links in openQA documents

### DIFF
--- a/docs/Branding.asciidoc
+++ b/docs/Branding.asciidoc
@@ -1,4 +1,5 @@
 
+[[branding]]
 = openQA branding
 :toc: left
 :toclevels: 6

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -1,4 +1,5 @@
 
+[[contributing]]
 = openQA developer guide
 :toc: left
 :toclevels: 6
@@ -273,8 +274,8 @@ export OPENQA_CONFIG=$PWD/etc/mine
 Note that OPENQA_CONFIG points to the directory containing openqa.ini, database.ini,
 client.conf and workers.ini.
 
+[[setup-postgresql]]
 == How to setup PostgreSQL to test locally with production data
-:other-db-engines: link:Installing.asciidoc#other-database-engines[Other database engines]
 
 1. Install PosgreSQL - under openSUSE the following package are required:
    +postgresql-server postgresql-init+
@@ -292,14 +293,13 @@ client.conf and workers.ini.
 
 7. Import dump: +pg_restore -c -d openqa path/to/dump+
 
-8. Configure openQA to use PostgreSQL as described in the section {other-db-engines} of the installation guide.
+8. Configure openQA to use PostgreSQL as described in the section <<Installing.asciidoc#database,Database>> of the installation guide.
  User name and password are not required.
 
 == Adding new authentication module
-:user-authentication: link:Installing.asciidoc#user-authentication[User authentication]
 
 OpenQA comes with three authentication modules providing authentication methods:
-OpenID, iChain and Fake (see {user-authentication}).
+OpenID, iChain and Fake (see <<Installing.asciidoc#authentication,User authentication>>).
 
 All authentication modules reside in +lib/OpenQA/Auth+ directory. During
 OpenQA start, +[auth]/method+ section of +/etc/openqa/openqa.ini+ is read and according

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -1,4 +1,5 @@
 
+[[gettingstarted]]
 = openQA starter guide
 :toc: left
 :toclevels: 6
@@ -521,6 +522,7 @@ request, the test suite setting would 'win' and the value would be foo.
 If the same variable is set with a + prefix in multiple places, the same precedence
 order described above will apply to those settings.
 
+[[get-testing]]
 == Testing openSUSE or Fedora
 
 An easy way to start using openQA is to start testing openSUSE or Fedora as they
@@ -627,9 +629,9 @@ For Fedora, a sample run might be:
 --------------------------------------------------------------------------------
 
 More details on triggering tests can also be found in the
-link:UsersGuide.asciidoc[Users Guide].
+<<UsersGuide.asciidoc#usersguide,Users Guide>>.
 
 
 == Pitfalls
 
-Take a look at link:Pitfalls.asciidoc[Documented Pitfalls].
+Take a look at <<Pitfalls.asciidoc#pitfalls,Documented Pitfalls>>.

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -1,4 +1,5 @@
 
+[[installing]]
 = openQA installation guide
 :toc: left
 :toclevels: 6
@@ -134,6 +135,7 @@ You can do that in +/etc/openqa/openqa.ini+:
 httpsonly = 0
 --------------------------------------------------------------------------------
 
+[[database]]
 === Database
 
 Since version _4.5.1512500474.437cc1c7_ of openQA, PostgreSQL is used as the
@@ -166,7 +168,7 @@ password = somepassword
 
 For older versions of openQA, you can migrate from SQLite to PostgreSQL
 according to
-link:Pitfalls.asciidoc#db-migration-from-sqlite-to-postgresql[DB migration from SQLite to PostgreSQL]
+<<Pitfalls.asciidoc#db-migration,DB migration from SQLite to PostgreSQL>>
 
 
 == Run the web UI
@@ -244,6 +246,7 @@ installed 'os-autoinst' from packages make sure to pass +--isotovideo+ option
 to point to the checkout dir where isotovideo is, not to +/usr/lib+! Otherwise
 it will have trouble finding its perl modules.
 
+[[authentication]]
 === User authentication
 
 OpenQA supports three different authentication methods - OpenID (default), iChain
@@ -300,8 +303,8 @@ You may be vulnerable for up to a day until Fake API key expires.
 
 == Where to now?
 
-From this point on, you can refer to the link:GettingStarted.asciidoc#testing-opensuse-or-fedora[getting started] guide to
-fetch the tests cases and possibly take a look at link:WritingTests.asciidoc[Test Developer Guide]
+From this point on, you can refer to the <<GettingStarted.asciidoc#get-testing,Getting Started>> guide to
+fetch the tests cases and possibly take a look at <<WritingTests.asciidoc#writingtests,Test Developer Guide>>
 
 == Advanced configuration
 [id="advanced"]

--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -1,4 +1,5 @@
 
+[[networking]]
 = Networking in OpenQA
 :toc: left
 :toclevels: 6

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -1,4 +1,5 @@
 
+[[pitfalls]]
 = openQA pitfalls
 :toc: left
 :toclevels: 6
@@ -54,10 +55,11 @@ SUT behavior as the execution of the first step after loading a snapshot might
 be delayed. This can lead to problems if the executed tests do not foresee an
 appropriate timeout margin.
 
+[[db-migration]]
 == DB migration from SQlite to postgreSQL
 As a first step to start using postgreSQL, please, configure postgreSQL database
 according to the
-link:Contributing.asciidoc#how-to-setup-postgresql-to-test-locally-with-production-data[postgreSQL setup guide]
+<<Contributing.asciidoc#setup-postgresql,postgreSQL setup guide>>
 
 To migrate api keys run following commands:
 

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1,4 +1,5 @@
 
+[[usersguide]]
 = openQA users guide
 :toc: left
 :toclevels: 6
@@ -9,7 +10,7 @@
 This document provides additional information for use of the web interface or
 the REST API as well as administration information.
 For administrators it is recommend to have read the
-link:Installing.asciidoc[installation guide] first to understand the structure
+<<Installing.asciidoc#installing,Installation Guide>> first to understand the structure
 of components as well as the configuration of an installed instance.
 
 == Use of the web interface
@@ -164,7 +165,7 @@ instance without needing to install the full package. Call
 --help`).
 
 Basics are described in the
-link:GettingStarted.asciidoc[Getting Started] guide.
+<<GettingStarted.asciidoc#gettingstarted,Getting Started>> guide.
 
 
 === Triggering tests
@@ -181,7 +182,7 @@ instance the script `clone_job.pl` can be used to copy the necessary settings
 and assets to another instance and schedule the test. For the test to be
 executed it has to be ensured that matching ressources can be found, for
 example a worker with matching `WORKER_CLASS` must be registered. More details
-on `clone_job.pl` can be found in link:WritingTests.asciidoc[Writing Tests].
+on `clone_job.pl` can be found in <<WritingTests.asciidoc#writingtests,Writing Tests>>.
 
 
 ==== Spawning single new jobs - jobs post ====
@@ -196,7 +197,7 @@ examples for this.
 The most common way of spawning jobs on production instances is using the
 `isos post` API route. Based on previously defined settings for media, job
 groups, machines and test suites jobs are triggered based on template
-matching. The link:GettingStarted.asciidoc[Getting Started] guide already
+matching. The <<GettingStarted.asciidoc#gettingstarted,Getting Started>> guide already
 mentioned examples. Additionally to the necessary template matching parameters
 more parameters can be specified which are forwarded to all triggered jobs.
 There are also special parameters which only have an influence on the way the
@@ -236,4 +237,4 @@ openqa-client isos post ISO=my_iso.iso DISTRI=my_distri FLAVOR=sweet \
 == Where to now?
 
 For test developers it is recommended to continue with the
-link:WritingTests.asciidoc[Test Developer Guide].
+<<WritingTests.asciidoc#writingtests,Test Developer Guide>>.

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1,4 +1,5 @@
 
+[[writingtests]]
 = openQA tests developer guide
 :toc: left
 :toclevels: 6
@@ -305,7 +306,7 @@ In short, writing multi-machine tests adds a few more layers of complexity:
 
 1. documenting the dependencies and order between individual tests
 2. synchronization between individual tests
-3. actual technical realization (i.e. link:Networking.asciidoc[custom networking])
+3. actual technical realization (i.e. <<Networking.asciidoc#networking,custom networking>>)
 
 ==== Job dependencies
 


### PR DESCRIPTION
Some relative links didn't work in single HTML/PDF file
unless put asciidocs to the same directory, but it is
duplicate and is not a good behaviour to link asciidocs
which their content are already in the single HTML/PDF
document.
Using cross references to reach location within HTML/PDF
document as well as across asciidocs.

See: https://progress.opensuse.org/issues/19790