### PR TITLE
WIP: Kill all the children and grand children.

### DIFF
--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -15,6 +15,7 @@ ExecStartPre=/usr/bin/install -d -m 0755 -o _openqa-worker /var/lib/openqa/pool/
 ExecStart=/usr/share/openqa/script/worker --instance %i
 User=_openqa-worker
 KillMode=mixed
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When a job finishes we need to be sure that we don't leave processes
running behind.

Since all the grandchildren process will belong to the process group
of the children (worker), when the job finishes we need to loop through
/proc to find the grandchildrens process by checking their group.

Example of a process tree:

```
 worker(6288)───perl(6311)─┬─/usr/bin/isotov(6313)
                           ├─/usr/bin/isotov(6315)
                           └─/usr/bin/isotov(6317)─┬─qemu-system-x86(6321)─┬─{qemu-system-x86}(6324)
                                                   │                       ├─{qemu-system-x86}(6325)
                                                   │                       ├─{qemu-system-x86}(6326)
                                                   │                       └─{qemu-system-x86}(6328)
```

pgroups:
6288 - 6288
6311 - 6311
6313 - 6311
6315 - 6311
6317 - 6311
6321 - 6311
6318 - 6311
...

These changes will make sure that any process belonging to 6311 will be sent an SIGTERM