### PR TITLE
Force a restart when the children or grandchildren processes die

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -48,6 +48,7 @@ requires 'Module::Runtime';
 requires 'Mojo::Base';
 requires 'Mojo::ByteStream';
 requires 'Mojo::IOLoop';
+requires 'Mojo::IOLoop::ReadWriteProcess';
 requires 'Mojo::JSON';
 requires 'Mojo::RabbitMQ::Client';
 requires 'Mojo::URL';

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -242,20 +242,9 @@ sub engine_workit {
         max_kill_attempts    => 1,
         _default_kill_signal => -POSIX::SIGTERM());
 
-    $child->on(
-        collect_status => sub {
-            my ($self, $status) = (@_, $?);
-            if ($status != 0) {
-                # kill all the processes
-            }
-            # TODO:
-            # stop_job();
-
-        });
-
     $child->start();
     $workerpid = $child->pid();
-    return $child;
+    return {child => $child};
 }
 
 sub locate_local_assets {

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -30,6 +30,7 @@ use Cwd qw(abs_path getcwd);
 use OpenQA::Worker::Cache;
 use Time::HiRes 'sleep';
 use IO::Handle;
+use Mojo::IOLoop::ReadWriteProcess;
 
 my $isotovideo = "/usr/bin/isotovideo";
 my $workerpid;
@@ -215,31 +216,46 @@ sub engine_workit {
     my $tmpdir = "$pooldir/tmp";
     mkdir($tmpdir) unless (-d $tmpdir);
 
-    my $child = fork();
-    die "failed to fork: $!\n" unless defined $child;
+    my $child = Mojo::IOLoop::ReadWriteProcess->new(
+        code => sub {
 
-    unless ($child) {
-        # create new process group
-        setpgrp(0, 0);
-        $ENV{TMPDIR} = $tmpdir;
-        log_info("$$: WORKING " . $job->{id});
-        log_debug('+++ worker notes +++', channels => 'autoinst');
-        log_debug(sprintf("start time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
+            setpgrp(0, 0);
+            $ENV{TMPDIR} = $tmpdir;
+            log_info("$$: WORKING " . $job->{id});
+            log_debug('+++ worker notes +++', channels => 'autoinst');
+            log_debug(sprintf("start time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
 
-        my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
-        log_debug(sprintf("running on $hostname:%d ($sysname $release $version $machine)", $instance),
-            channels => 'autoinst');
-        my $handle = get_channel_handle('autoinst');
-        STDOUT->fdopen($handle, 'w');
-        STDERR->fdopen($handle, 'w');
-        exec "perl", "$isotovideo", '-d';
-        die "exec failed: $!\n";
-    }
-    else {
-        $workerpid = $child;
-        return {pid => $child};
-    }
+            my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
+            log_debug(sprintf("running on $hostname:%d ($sysname $release $version $machine)", $instance),
+                channels => 'autoinst');
+            my $handle = get_channel_handle('autoinst');
+            STDOUT->fdopen($handle, 'w');
+            STDERR->fdopen($handle, 'w');
 
+            exec "perl", "$isotovideo", '-d';
+            die "exec failed: $!\n";
+
+        },
+        set_pipes            => 0,
+        internal_pipes       => 0,
+        blocking_stop        => 1,
+        max_kill_attempts    => 1,
+        _default_kill_signal => -POSIX::SIGTERM());
+
+    $child->on(
+        collect_status => sub {
+            my ($self, $status) = (@_, $?);
+            if ($status != 0) {
+                # kill all the processes
+            }
+            # TODO:
+            # stop_job();
+
+        });
+
+    $child->start();
+    $workerpid = $child->pid();
+    return $child;
 }
 
 sub locate_local_assets {
@@ -256,49 +272,3 @@ sub locate_local_assets {
     return undef;
 }
 
-sub engine_check {
-    # abort job if backend crashed and reschedule it
-    if (-e "$pooldir/backend.crashed") {
-        unlink("$pooldir/backend.crashed");
-        log_error('backend crashed ...');
-        if (open(my $fh, '<', "$pooldir/os-autoinst.pid")) {
-            local $/;
-            my $pid = <$fh>;
-            close $fh;
-            if ($pid =~ /(\d+)/) {
-                log_info("killing os-autoinst $1");
-                _kill($1);
-            }
-        }
-        if (open(my $fh, '<', "$pooldir/qemu.pid")) {
-            local $/;
-            my $pid = <$fh>;
-            close $fh;
-            if ($pid =~ /(\d+)/) {
-                log_error("killing qemu $1");
-                _kill($1);
-            }
-        }
-        return 'crashed';
-    }
-
-    # check if the worker is still running
-    my $pid = waitpid($workerpid, WNOHANG);
-    log_debug("waitpid $workerpid returned $pid with status $?");
-
-    if ($pid == -1 && $!{ECHILD}) {
-        warn "we lost our child\n";
-        return 'died';
-    }
-
-    if ($pid == $workerpid) {
-        if ($?) {
-            warn "child $pid died with exit status $?\n";
-            return 'died';
-        }
-        else {
-            return 'done';
-        }
-    }
-    return;
-}

--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -15,6 +15,7 @@ ExecStartPre=/usr/bin/install -d -m 0755 -o _openqa-worker /var/lib/openqa/pool/
 ExecStart=/usr/share/openqa/script/worker --instance %i
 User=_openqa-worker
 KillMode=mixed
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change will compare the exit code and if it's not a clean exit the worker will die, so the systemd can collect all the grandchildren.

Please be aware that this change makes systemd as a dependency.