### PR TITLE
Add use Mojo::DOM in JUnit and XUnit Parser

### DIFF
--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -18,6 +18,7 @@ package OpenQA::Parser::Format::JUnit;
 use Mojo::Base 'OpenQA::Parser::Format::Base';
 use Carp qw(croak confess);
 use OpenQA::Parser::Result::OpenQA;
+use Mojo::DOM;
 
 has include_results => 0;
 has [qw(_dom)];

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -17,6 +17,7 @@ package OpenQA::Parser::Format::XUnit;
 
 use Mojo::Base 'OpenQA::Parser::Format::JUnit';
 use Carp qw(croak confess);
+use Mojo::DOM;
 
 sub _add_single_result { shift->results->add(OpenQA::Parser::Result::XUnit->new(@_)) }
 


### PR DESCRIPTION
Not needed while in openQA, but otherwise makes parser fail loading
 when using it separately.

```perl
use lib '/usr/share/openqa/lib';
 
use OpenQA::Parser qw(parser);
 
my $file = "slenkins_control-junit-results.xml";
 
my $data = parser( JUnit => $file );
 
use Data::Dumper;
 
print Dumper($data->results);
```