### PR TITLE
Emit openqa_job_create events when an ISO is posted

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -533,6 +533,9 @@ sub schedule_iso {
         });
 
     $self->emit_event('openqa_iso_create', $args);
+    for my $succjob (@successful_job_ids) {
+        $self->emit_event('openqa_job_create', {id => $succjob});
+    }
     return {
         successful_job_ids => \@successful_job_ids,
         failed_job_info    => \@failed_job_info,


### PR DESCRIPTION
We currently don't actually emit any openqa_job_create events
when posting an ISO - only a batch openqa_iso_create event. It
is easy to also emit an openqa_job_create event for each of the
newly-created jobs, so let's do that.

Signed-off-by: Adam Williamson <awilliam@redhat.com>