### PR TITLE
Add Database setup to Installing.asciidoc

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -141,6 +141,24 @@ httpsonly = 0
 Since version _4.5.1512500474.437cc1c7_ of openQA, PostgreSQL is used as the
 database.
 
+Install Postgres if not yet installed:
+[source,sh]
+--------------------------------------------------------------------------------
+# openSUSE
+zypper in postgresql postgresql-server
+# Fedora
+dnf install postgresql-server postgresql-contrib
+--------------------------------------------------------------------------------
+
+If you don't have a database yet, create one:
+[source,sh]
+--------------------------------------------------------------------------------
+systemctl start postgresql
+su - postgres
+createuser geekotest
+createdb -O geekotest openqa
+--------------------------------------------------------------------------------
+
 To configure access to the database in openQA, edit +/etc/openqa/database.ini+
 and change the settings in the +[production]+ section.
 


### PR DESCRIPTION
The manual in Installing.asciidoc was lacking some basic instruction on installing and running postgresql, as well as setting up a database. Added a few lines on how to do this. 