### PR TITLE
Enable wrapping cells in overview table

### DIFF
--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -12,10 +12,6 @@
 
 .table.overview {
     table-layout: fixed;
-
-    td {
-        white-space: nowrap;
-    }
 }
 
 #summary .badge {


### PR DESCRIPTION
Disabled wrapping looks nice, but can hide bug icons.