### PR TITLE
Ensure parallel jobs get assigned in one round

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -28,7 +28,7 @@ use OpenQA::Setup;
 use OpenQA::Utils 'log_debug';
 
 # How many jobs to allocate in one tick. Defaults to 50 ( set it to 0 for as much as possible)
-use constant MAX_JOB_ALLOCATION => $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} // 50;
+use constant MAX_JOB_ALLOCATION => $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} // 80;
 
 # How many attempts have to be performed to find a job before assuming there is nothing to be scheduled. Defaults to 1
 use constant FIND_JOB_ATTEMPTS => $ENV{OPENQA_SCHEDULER_FIND_JOB_ATTEMPTS} // 1;

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -125,8 +125,10 @@ sub _prefer_parallel {
 
     my $available_children = $children->search(
         {
-            child_job_id => $available_cond
-        });
+            -and => [
+                child_job_id => $available_cond,
+                child_job_id => {-not_in => $allocating},
+            ]});
 
     # we have scheduled children that are not blocked
     return ({'-in' => $available_children->get_column('child_job_id')->as_query})
@@ -138,6 +140,7 @@ sub _prefer_parallel {
             dependency   => OpenQA::Schema::Result::JobDependencies::PARALLEL,
             child_job_id => {-in => $children->get_column('child_job_id')->as_query},
             state        => OpenQA::Schema::Result::Jobs::SCHEDULED,
+            child_job_id => {-not_in => $allocating},
         },
         {
             join => 'parent',

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -594,8 +594,8 @@ sub filter_jobs {
 
         foreach my $j (@jobs) {
 
-            #Filter by PARALLEL_CLUSTER
-            next unless exists $j->{settings}->{PARALLEL_CLUSTER};
+            # Filter by PARALLEL_CLUSTER
+            # next unless exists $j->{settings}->{PARALLEL_CLUSTER};
 
             my $dep = schema->resultset("Jobs")->search({id => $j->{id},})->first->dependencies;
 

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -506,6 +506,7 @@ sub _build_search_query {
             -not_in => $blocked->get_column('child_job_id')->as_query
         },
     );
+    push @available_cond, {-not_in => $allocating} if @$allocating > 0;
 
     # Don't kick off jobs if GRU task they depend on is running
     my $waiting_jobs = schema->resultset("GruDependencies")->get_column('job_id')->as_query;

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -480,10 +480,8 @@ sub _reschedule {
 }
 
 sub _build_search_query {
-    my $worker     = shift;
-    my $allocating = shift;
-    my $allocate   = shift;
-    my $blocked    = schema->resultset("JobDependencies")->search(
+    my ($worker, $allocating, $allocate) = @_;
+    my $blocked = schema->resultset("JobDependencies")->search(
         {
             -or => [
                 -and => {
@@ -613,7 +611,6 @@ sub filter_jobs {
     catch {
         log_debug("Failed job filtering, error: " . $_);
         @filtered_jobs = @jobs;
-
     };
 
     return @filtered_jobs;

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -488,10 +488,9 @@ sub _build_search_query {
                     state      => {-not_in => [OpenQA::Schema::Result::Jobs::FINAL_STATES]},
                 },
                 -and => {
-                    dependency    => OpenQA::Schema::Result::JobDependencies::PARALLEL,
-                    state         => OpenQA::Schema::Result::Jobs::SCHEDULED,
-                    parent_job_id => {-not_in => $allocating},
-
+                    dependency => OpenQA::Schema::Result::JobDependencies::PARALLEL,
+                    state      => OpenQA::Schema::Result::Jobs::SCHEDULED,
+                    (parent_job_id => {-not_in => $allocating}) x !!(@$allocating > 0),
                 }
             ],
         },

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -658,6 +658,12 @@ subtest 'job PARALLEL_WITH' => sub {
     $_settings{PARALLEL_WITH} = 'A,B,C';
     my $jobE = _job_create(\%_settings);
 
+    %_settings                   = %settings;
+    $_settings{TEST}             = 'H';
+    $_settings{PARALLEL_WITH}    = 'B,C,D';
+    $_settings{PARALLEL_CLUSTER} = '1';
+    my $jobH = _job_create(\%_settings);
+
     $jobA->children->create(
         {
             child_job_id => $jobB->id,
@@ -730,6 +736,28 @@ subtest 'job PARALLEL_WITH' => sub {
     # just few that requires cluster are going, but since they want to be together, they are not
     @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobA->to_hash, $jobB->to_hash, $jobC->to_hash);
     is @res, 0;
+
+    # just few that requires cluster are going, but since they want to be together, they are not
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobH->to_hash, $jobC->to_hash);
+    is @res, 0;
+
+    # just few that requires cluster are going, but since they want to be together, they are not
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobH->to_hash, $jobC->to_hash, $jobB->to_hash);
+    is @res, 0;
+
+    # just few that requires cluster are going, but since they want to be together, they are not
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobH->to_hash, $jobB->to_hash, $jobD->to_hash);
+    is @res, 0;
+
+    # A requires E, so it is not going
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobH->to_hash, $jobC->to_hash, $jobB->to_hash, $jobA->to_hash,
+        $jobD->to_hash);
+    is @res, 4 or die diag explain \@res;
+
+
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobH->to_hash, $jobC->to_hash, $jobE->to_hash, $jobB->to_hash,
+        $jobA->to_hash, $jobD->to_hash);
+    is @res, 6 or die diag explain \@res;
 };
 
 done_testing();

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -752,6 +752,10 @@ subtest 'job PARALLEL_WITH' => sub {
     @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobH->to_hash, $jobC->to_hash, $jobE->to_hash, $jobB->to_hash,
         $jobA->to_hash, $jobD->to_hash);
     is @res, 6 or die diag explain \@res;
+
+    my @e = ([], [qw(a b c)], [qw(d e f)]);
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs(@e);
+    is_deeply \@res, \@e or die diag explain \@res;
 };
 
 done_testing();

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -632,25 +632,21 @@ subtest 'job PARALLEL_WITH' => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'A';
     #  $_settings{PARALLEL_WITH}    = 'B,C,D';
-    $_settings{PARALLEL_CLUSTER} = '1';
     my $jobA = _job_create(\%_settings);
 
-    %_settings                   = %settings;
-    $_settings{TEST}             = 'B';
-    $_settings{PARALLEL_WITH}    = 'A,C,D';
-    $_settings{PARALLEL_CLUSTER} = '1';
+    %_settings                = %settings;
+    $_settings{TEST}          = 'B';
+    $_settings{PARALLEL_WITH} = 'A,C,D';
     my $jobB = _job_create(\%_settings);
 
-    %_settings                   = %settings;
-    $_settings{TEST}             = 'C';
-    $_settings{PARALLEL_WITH}    = 'A,B,D';
-    $_settings{PARALLEL_CLUSTER} = '1';
+    %_settings                = %settings;
+    $_settings{TEST}          = 'C';
+    $_settings{PARALLEL_WITH} = 'A,B,D';
     my $jobC = _job_create(\%_settings);
 
-    %_settings                   = %settings;
-    $_settings{TEST}             = 'D';
-    $_settings{PARALLEL_WITH}    = 'A,B, C ';    # Let's commit an error on purpose :)
-    $_settings{PARALLEL_CLUSTER} = '1';
+    %_settings                = %settings;
+    $_settings{TEST}          = 'D';
+    $_settings{PARALLEL_WITH} = 'A,B, C ';    # Let's commit an error on purpose :)
     my $jobD = _job_create(\%_settings);
 
     %_settings                = %settings;
@@ -688,9 +684,8 @@ subtest 'job PARALLEL_WITH' => sub {
     $_settings{TEST} = 'F';
     my $jobF = _job_create(\%_settings);
 
-    %_settings                   = %settings;
-    $_settings{TEST}             = 'G';
-    $_settings{PARALLEL_CLUSTER} = '1';
+    %_settings = %settings;
+    $_settings{TEST} = 'G';
     my $jobG = _job_create(\%_settings);
 
     # A wants to be in the cluster while being assigned!
@@ -703,12 +698,11 @@ subtest 'job PARALLEL_WITH' => sub {
         $jobE->to_hash, $jobF->to_hash);
     is @res, 6;
 
-    # Only E and F doesn't care about clusters, and we are not about to start B
+    # Only F doesn't belong to any cluster
     @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobA->to_hash, $jobC->to_hash, $jobD->to_hash, $jobE->to_hash,
         $jobF->to_hash);
-    is @res, 2;
-    is $res[0]->{id}, $jobE->id();
-    is $res[1]->{id}, $jobF->id();
+    is @res, 1;
+    is $res[0]->{id}, $jobF->id();
 
     # Only E and F doesn't care about clusters, and we are not about to start D
     @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobA->to_hash, $jobC->to_hash, $jobB->to_hash, $jobE->to_hash,

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -649,7 +649,7 @@ subtest 'job PARALLEL_WITH' => sub {
 
     %_settings                   = %settings;
     $_settings{TEST}             = 'D';
-    $_settings{PARALLEL_WITH}    = 'A,B,C';
+    $_settings{PARALLEL_WITH}    = 'A,B, C ';    # Let's commit an error on purpose :)
     $_settings{PARALLEL_CLUSTER} = '1';
     my $jobD = _job_create(\%_settings);
 


### PR DESCRIPTION
This PR is addressing the race condition in _prefer_parallel.
~~To guarantee the cluster execution in one scheduling round it is also introducing a new variable ```PARALLEL_CLUSTER``` - when this is defined in the job settings, it will ensure the job to be assigned ONLY if the child/parents are going in the same scheduling round.~~ will be default

This has been already tested ( and still deployed ) on staging: http://e122.suse.de/tests

See related progress issue: https://progress.opensuse.org/issues/25892

Created https://progress.opensuse.org/issues/32725 for refactoring, since now that area calls for it