### PR TITLE
Fix scheduler comment - now default MAX_JOB_ALLOCATION is 80

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -27,7 +27,7 @@ use OpenQA::Setup;
 
 use OpenQA::Utils 'log_debug';
 
-# How many jobs to allocate in one tick. Defaults to 50 ( set it to 0 for as much as possible)
+# How many jobs to allocate in one tick. Defaults to 80 ( set it to 0 for as much as possible)
 use constant MAX_JOB_ALLOCATION => $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} // 80;
 
 # How many attempts have to be performed to find a job before assuming there is nothing to be scheduled. Defaults to 1


### PR DESCRIPTION
Thanks to @ldevulder for noticing this

See: https://github.com/os-autoinst/openQA/pull/1592#discussion_r172836272