### PR TITLE
Allow saving needles for OS with dots in the version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - cpanm local::lib
   - eval "$(perl -Mlocal::lib=${HOME}/perl_modules)"
   - mkdir -p $HOME/chrome
-  - if ! test -f $HOME/chrome/chromedriver; then curl -s https://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip | funzip - > $HOME/chrome/chromedriver; fi
+  - if ! test -f $HOME/chrome/chromedriver; then curl -s https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip | funzip - > $HOME/chrome/chromedriver; fi
   - chmod a+x $HOME/chrome/chromedriver
   - export PATH=$PATH:$HOME/chrome
 install:

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -453,7 +453,8 @@ sub save_needle_ajax {
     $validation->required('json');
     $validation->required('imagename')->like(qr/^[^.\/][^\/]{3,}\.png$/);
     $validation->optional('imagedistri')->like(qr/^[^.\/]+$/);
-    $validation->optional('imageversion')->like(qr/^[^.\/]+$/);
+    $validation->optional('imageversion')->like(qr/^(?!.*([.])\1+).*$/);
+    $validation->optional('imageversion')->like(qr/^[^\/]+$/);
     $validation->required('needlename')->like(qr/^[^.\/][^\/]{3,}$/);
 
     if ($validation->has_error) {


### PR DESCRIPTION
related poo#17706

The validation didn't allowed to save a needle for an OS
with a dot (.) in the name (for example: Opensuse leap 42.3)
if the VERSION was set.

This new change in the validation allows for 1 dot, but not consecutive
dots.

The version is only used to find the location in the FS to save the
needle.

