### PR TITLE
Don't show configure button for untracked assets

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -154,7 +154,7 @@ END_SQL
     # We collect data required for /admin/assets *and* the limit_assets task
     my $groups = $schema->resultset('JobGroups');
     my %group_infos;
-    $group_infos{0} = {size_limit_gb => 0, size => 0, group => 'Untracked', id => 0};
+    $group_infos{0} = {size_limit_gb => 0, size => 0, group => 'Untracked', id => undef};
 
     # find relevant assets which belong to a job group
     while (my $g = $groups->next) {

--- a/templates/admin/asset/index.html.ep
+++ b/templates/admin/asset/index.html.ep
@@ -69,7 +69,7 @@
                     <label for="group-<%= $group->{id} %>-checkbox">
                         %= $group->{group}
                     </label>
-                    % if (is_admin) {
+                    % if (is_admin && defined($group->{id})) {
                         <a href="<%= $c->url_for('admin_job_templates', groupid => $group->{id}) %>">
                             <i class="fa fa-wrench" title="Configure"></i>
                         </a>


### PR DESCRIPTION
Since this link would not work without job group ID