### PR TITLE
Group candidate needles by tag

### DIFF
--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -2,34 +2,29 @@
     <span class="candidate_needles">
         Candidate needle:
         <select id="needlediff_selector">
-            <option data-areas="[]" data-matches="[]">-None-</option>
-            % for my $needle (@$needles) {
-                % my $title = $needle->{avg_similarity} . "%: " . $needle->{name};
-                <option data-image="<%= $needle->{image} %>"
-                        data-areas="<%= Cpanel::JSON::XS::encode_json($needle->{areas})%>"
-                        % if ($needle->{selected}) {
-                        selected="selected"
-                        % }
-                        data-matches="<%= Cpanel::JSON::XS::encode_json($needle->{matches}) %>">
-                    <%= $title %></option>
+            <option data-areas="[]" data-matches="[]">None</option>
+            % for my $tag (sort keys %$needles_by_tag) {
+                <optgroup label="<%= $tag %>">
+                    % for my $needle (@{$needles_by_tag->{$tag}}) {
+                        % my $title = $needle->{avg_similarity} . "%: " . $needle->{name};
+                        <option data-image="<%= $needle->{image} %>"
+                                data-areas="<%= Cpanel::JSON::XS::encode_json($needle->{areas})%>"
+                                data-matches="<%= Cpanel::JSON::XS::encode_json($needle->{matches}) %>"
+                            % if ($needle->{selected}) {
+                                selected="selected"
+                            % }
+                            % if ($needle->{primary_match}) {
+                                style="font-style: italic;"
+                            % }
+                            >
+                            %= $title
+                        </option>
+                    % }
+                </optgroup>
             % }
         </select>
     </span>
     <span class="step_actions">
-        % my $title;
-        % my $content;
-        % if ($tags && @$tags) {
-            % $title = "Looking for needle tags";
-            % $content = '<ul>' . join("\n", map { "<li>$_</li>" } @$tags) . '</ul>';
-        % }
-        % else {
-            % $title = "Saved screenshot";
-            % $content = "No tags";
-        % }
-        <a tabindex="0" class="step_action fa fa-info-circle fa-lg" role="button"
-            data-toggle="popover" data-trigger="focus"
-            data-placement="bottom" data-title="<%= $title %>"
-            data-content="<%= $content %>"></a>
         % if (is_operator) {
             %= stepaction_for 'Create new needle' => url_for('edit_step'), 'fa-thumbtack', 'create_new_needle'
         % }


### PR DESCRIPTION
It currently looks like this: ![candidates grouped by tags](https://user-images.githubusercontent.com/10248953/37907892-b2ff44ec-3106-11e8-9caf-d7b25a25efe5.png)

I haven't implemented/adjusted tests so far, but I'll do as soon as I have feedback.

See https://progress.opensuse.org/issues/15030