### PR TITLE
Update current test module details when cancelling running job

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -395,7 +395,7 @@ sub _stop_job_2 {
             }
         }
 
-        if ($aborted eq 'done') {
+        if ($aborted eq 'done' || $aborted eq 'cancel') {
             # job succeeded, upload assets created by the job
 
           ASSET_UPLOAD: for my $dir (qw(private public)) {

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -718,13 +718,6 @@ sub upload_status {
         $status->{screen} = $screen if $screen;
     }
 
-    # if there is nothing to say, don't say it (said my mother)
-    unless (%$status) {
-        $update_status_running = 0;
-        return $callback->() if $callback;
-        return;
-    }
-
     if ($os_status->{running}) {
         $status->{result}->{$os_status->{running}}->{result} = 'running';
     }


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/13524
* Only one half of the implementation. The other half is done
  in os-autoinst (see https://github.com/os-autoinst/os-autoinst/pull/941).

---

<s>When canceling a job locally it actually works. But it can't be that easy :-)  
So let's see what tests this breaks on travis.</s>
Ok, the previous approach wasn't really working. The module must have just finished regularly when I canceled.