### PR TITLE
Consider running jobs in filter_jobs

### DIFF
--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -587,11 +587,13 @@ sub filter_jobs {
     # so we stripped down to what we needed
 
     try {
+        my @running = map { $_->to_hash(assets => 1) }
+          schema->resultset("Jobs")->search({state => OpenQA::Schema::Result::Jobs::RUNNING})->all;
+
         # Build adjacent list with the tests that would have been assigned
-        $allocated_tests->{$_->{test} . join(".", @{$_->{settings}}{@k})}++ for @jobs;
+        $allocated_tests->{$_->{test} . join(".", @{$_->{settings}}{@k})}++ for (@jobs, @running);
 
         foreach my $j (@jobs) {
-
             # Filter by PARALLEL_CLUSTER
             # next unless exists $j->{settings}->{PARALLEL_CLUSTER};
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -654,10 +654,9 @@ subtest 'job PARALLEL_WITH' => sub {
     $_settings{PARALLEL_WITH} = 'A,B,C';
     my $jobE = _job_create(\%_settings);
 
-    %_settings                   = %settings;
-    $_settings{TEST}             = 'H';
-    $_settings{PARALLEL_WITH}    = 'B,C,D';
-    $_settings{PARALLEL_CLUSTER} = '1';
+    %_settings                = %settings;
+    $_settings{TEST}          = 'H';
+    $_settings{PARALLEL_WITH} = 'B,C,D';
     my $jobH = _job_create(\%_settings);
 
     $jobA->children->create(
@@ -752,6 +751,29 @@ subtest 'job PARALLEL_WITH' => sub {
     @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobH->to_hash, $jobC->to_hash, $jobE->to_hash, $jobB->to_hash,
         $jobA->to_hash, $jobD->to_hash);
     is @res, 6 or die diag explain \@res;
+
+    %_settings                = %settings;
+    $_settings{TEST}          = 'J';
+    $_settings{PARALLEL_WITH} = 'K,L';
+    my $jobJ = _job_create(\%_settings);
+
+    %_settings                = %settings;
+    $_settings{TEST}          = 'K';
+    $_settings{PARALLEL_WITH} = 'J,L';
+    my $jobK = _job_create(\%_settings);
+
+    %_settings                = %settings;
+    $_settings{TEST}          = 'L';
+    $_settings{PARALLEL_WITH} = 'J,K';
+    my $jobL = _job_create(\%_settings);
+
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobJ->to_hash, $jobK->to_hash);
+    is @res, 0 or die diag explain \@res;
+
+    $jobL->update({state => OpenQA::Schema::Result::Jobs::RUNNING});
+
+    @res = OpenQA::Scheduler::Scheduler::filter_jobs($jobJ->to_hash, $jobK->to_hash);
+    is @res, 2 or die diag explain \@res;
 
     my @e = ([], [qw(a b c)], [qw(d e f)]);
     @res = OpenQA::Scheduler::Scheduler::filter_jobs(@e);


### PR DESCRIPTION
This would not make the scheduler behave exactly as proposed in
https://progress.opensuse.org/issues/25892, but should avoid cluster
jobs to get stuck.

When there are not enough workers available, it would still not allocate the whole cluster, but if some part of it is already running,  it will start allocate them as long as there is capacity (without going 'stuck')

Seems to work here but needs still tests, changes are deployed in staging (e212).