### PR TITLE
Checks if failure status file exists before trying to slurp it

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -817,8 +817,11 @@ sub read_test_modules {
         for my $step (@{$module->details}) {
             $step->{num} = $num++;
             if ($step->{text}) {
-                log_debug("Reading information from " . encode_json($step));
-                $step->{text_data} = path($job->result_dir(), $step->{text})->slurp;
+                my $file = path($job->result_dir(), $step->{text});
+                if (-e $file) {
+                    log_debug("Reading information from " . encode_json($step));
+                    $step->{text_data} = $file->slurp;
+                }
             }
             push(@details, $step);
         }


### PR DESCRIPTION
The status file that is created when an exception is launched isn't
immediatly available and the display of the details page doesn't
take that into consideration, creating a race condition when someone
is following the test in the live tab, and then suddenly the test
have a hard failure.

The race condition is created, because the web interface will change
immediatly to the details page, and the exception information might
not be available.

This creates an exception and the interface is redirected to the
exception.html.ep template.