### PR TITLE
Avoid skipping relationships when cloning jobs.

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -745,7 +745,20 @@ sub duplicate {
     while (my $cd = $children->next) {
         my $c = $cd->child;
         # ignore already cloned child, prevent loops in test definition
-        next if $duplicated_ids{$c->id};
+        # However we still need to add the relationship parent - kid
+
+        if ($duplicated_ids{$c->id}) {
+            if ($jobs_map->{$c->id}) {
+                if ($cd->dependency eq OpenQA::Schema::Result::JobDependencies->PARALLEL) {
+                    push @direct_deps_children_parallel, $jobs_map->{$c->id};
+                }
+                else {
+                    push @direct_deps_children_chained, $jobs_map->{$c->id};
+                }
+            }
+            next;
+        }
+
         # do not clone DONE children for PARALLEL deps
         next if ($c->state eq DONE and $cd->dependency eq OpenQA::Schema::Result::JobDependencies->PARALLEL);
 

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -790,7 +790,7 @@ $_->discard_changes for ($jobA, $jobB, $jobC, $jobD);
 for ($jobB, $jobC, $jobD) {
     ok($_->clone, 'job cloned');
     my $h = job_get_deps($_->clone->id);
-    is_deeply($h->{parents}{Chained}, [$jobA2->id], 'job has jobA2 as parent');
+    is_deeply($h->{parents}{Chained}, [$jobA2->id], 'job has jobA2 as parent') or explain($h->{parents}{Chained});
 }
 
 for ($jobC, $jobD) {
@@ -824,7 +824,7 @@ sub _job_cloned_and_related {
     }
     ok($rel, "jobA is $rel parent of jobB");
     my $res = grep { $_ eq $cloneB } @{$cloneA_hash->{children}{$rel}};
-    ok($res, "cloneA is $rel parent of cloneB");
+    ok($res, "cloneA is $rel parent of cloneB") or explain(@{$cloneA_hash->{children}{$rel}});
 }
 
 subtest 'slepos test workers' => sub {


### PR DESCRIPTION
This change will avoid skipping **relationships** when cloning jobs.