### PR TITLE
Add unzip-plain to AppArmor profile

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -22,6 +22,7 @@
   /tmp/** rw,
   /usr/bin/perl ix,
   /usr/bin/ssh rcx,
+  /usr/bin/unzip-plain rix,
   /usr/lib/git/git rix,
   /usr/share/openqa/dbicdh/** r,
   /usr/share/openqa/lib/** r,


### PR DESCRIPTION
Without it openQA fails in `use Archive::Extract;` which apparently probes for `/usr/bin/unzip-plain`.
