### PR TITLE
WIP: Allow filtering test details

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -290,4 +290,50 @@ function setupResult(state, jobid, status_url, details_url) {
       pauseLiveView();
     }
   });
+
+  // setup result filter, define function to apply filter changes
+  var detailsFilter = $('.details-filter');
+  var detailsNameFilter = $('#details-name-filter');
+  var detailsFailedOnlyFilter = $('#details-only-failed-filter');
+  var resultsTable = $('#results');
+  var anyFilterEnabled = false;
+  var applyFilterChanges = function(event) {
+      // determine enabled filter
+      anyFilterEnabled = !detailsFilter.hasClass('hidden');
+      if (anyFilterEnabled) {
+          var nameFilter = detailsNameFilter.val();
+          var nameFilterEnabled = nameFilter.length !== 0;
+          var failedOnlyFilterEnabled = detailsFailedOnlyFilter.prop('checked');
+          anyFilterEnabled = nameFilterEnabled || failedOnlyFilterEnabled;
+      }
+
+      // show everything if no filter present
+      if (!anyFilterEnabled) {
+          resultsTable.find('tbody tr').show();
+          return;
+      }
+
+      // show/hide table rows considering filter
+      $.each(resultsTable.find('tbody .result'), function(index, td) {
+          var tdElement = $(td);
+          var trElement = tdElement.parent('tr');
+          var stepMaches = (
+              (!nameFilterEnabled
+              || trElement.find('td.component').text().indexOf(nameFilter) >= 0)
+              && (!failedOnlyFilterEnabled
+              || tdElement.hasClass('resultfailed')
+              || tdElement.hasClass('resultsoftfailed'))
+          );
+          trElement[stepMaches ? 'show' : 'hide']();
+      });
+  };
+  detailsNameFilter.keyup(applyFilterChanges);
+  detailsFailedOnlyFilter.change(applyFilterChanges);
+
+  // setup filter toggle
+  $('.details-filter-toggle').on('click', function(event) {
+      event.preventDefault();
+      detailsFilter.toggleClass('hidden');
+      applyFilterChanges();
+  });
 }

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -198,3 +198,29 @@ ul.modcategory {
         color: green;
     }
 }
+
+// filter for test details
+.details-filter {
+    &.hidden {
+        display: none;
+    }
+    & > div {
+        margin-top: auto;
+        margin-bottom: auto;
+    }
+    .form-control {
+        display: inline-block !important;
+        width: auto !important;
+    }
+    label {
+        margin-bottom: 0px;
+    }
+    .result-filter-container {
+        text-align: right;
+    }
+}
+.details-filter-toggle {
+    display: inline-block;
+    float: right;
+    margin-top: -50px;
+}

--- a/templates/test/details.html.ep
+++ b/templates/test/details.html.ep
@@ -1,4 +1,19 @@
 % if (@$modlist) {
+    <div class="details-filter-toggle">
+        <a href="#" aria-controls="previous" class="nav-link" title="Filter">
+            <i class="fas fa-filter"></i>
+        </a>
+    </div>
+    <form class="row details-filter hidden">
+        <div class="col-sm-12 col-md-6">
+            Name:
+            <input type="search" class="form-control form-control-sm" placeholder="Filter by name" aria-controls="results" id="details-name-filter">
+        </div>
+        <div class="col-sm-12 col-md-6 result-filter-container">
+            <input id="details-only-failed-filter" name="relevant" type="checkbox" value="1">
+            <label for="details-only-failed-filter">Show only failures</label>
+        </div>
+    </form>
     <table id="results" class="table table-striped">
         <thead>
             <tr>


### PR DESCRIPTION
* User can filter by step name
* User can filter for failed steps
* See also https://progress.opensuse.org/issues/35380

---

Works, only selenium tests are still WIP:

![screenshot_20180424_171150](https://user-images.githubusercontent.com/10248953/39196499-94cf871e-47e2-11e8-8c6a-9d76f9cb17a2.png)
