### PR TITLE
Use a smaller font for the 'ago time' to fix chromium rendering

### DIFF
--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -10,6 +10,11 @@
     background-color: #bbb;
 }
 
+/* dotted underline looks strange with default font size */
+.h4 {
+    .smaller-font { font-size: 90%; }
+}
+
 #filter-panel, #live-log-panel, #live-terminal-panel {
     .card-header {
         cursor: pointer;

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -11,9 +11,9 @@
                     %= link_to "Build$build" => url_for('tests_overview')->query(distri => [sort keys %{$build_res->{distris}}], version => $build_res->{version}, build => $build, groupid => $group->{id} )
                 % }
 
-                (<abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">
+                <span class="smaller-font">(<abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">
                     %= $build_res->{oldest}
-                </abbr>)
+                </abbr>)</span>
 
                 % my $group_build_id = $group->{id} . '-' . $build_res->{escaped_id};
                 %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $build_res, id_prefix => ''


### PR DESCRIPTION
The smaller font doesn't really make a difference, but the dotted line looks better in chromium - firefox doesn't seem to have this problem.

Before:
![](https://i.imgur.com/9ZrrIJl.png)

After:
![](https://i.imgur.com/DHQOVJ5.png)