### PR TITLE
Fix apparmor rule for 'svirt' backend

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -68,6 +68,7 @@
   /usr/bin/flock rix,
   /usr/bin/git rix,
   /usr/bin/gzip rix,
+  /usr/bin/icewm rix,
   /usr/bin/ionice rix,
   /usr/bin/ipmitool rix,
   /usr/bin/isotovideo rix,


### PR DESCRIPTION
The problem appeared when running a job for s390x with apparmor enabled.

- https://progress.opensuse.org/issues/34990