### PR TITLE
Limit gru tasks

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -510,8 +510,8 @@ sub schedule_iso {
         @successful_job_ids = ();
     };
 
-    $self->gru->enqueue(limit_assets           => [] => {priority => 10});
-    $self->gru->enqueue(limit_results_and_logs => [] => {priority => 5});
+    $self->gru->enqueue(limit_assets           => [] => {priority => 10, ttl => 172800});
+    $self->gru->enqueue(limit_results_and_logs => [] => {priority => 5,  ttl => 172800});
 
     $self->emit_event('openqa_iso_create', $args);
     for my $succjob (@successful_job_ids) {


### PR DESCRIPTION
With this change, while enqueueing GRU tasks it can be supplied a ttl option to specify the task expiration time.

This is also setting the limit of 2 days for limit_assets and limit_results_and_logs since they can be accumulated pretty easily with subsequent iso posts.

[Staging tests](http://e122.suse.de/minion/jobs?state=failed)

See: https://progress.opensuse.org/issues/23318