### PR TITLE
Replace extra dots in the filenames

### DIFF
--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -100,8 +100,9 @@ sub parse {
             $result->{result} = 'fail' if $tc_result eq 'fail';
 
             my $details = {result => $tc_result};
-
-            my $text_fn = "$ts_category-$ts_name-$num.txt";
+            my $text_fn = "$ts_category-$ts_name-$num";
+            $text_fn =~ s/[\/.]/_/g;
+            $text_fn .= '.txt';
             my $content = "# $tc->{name}\n";
             for my $out ($tc->children('system-out, system-err, failure')->each) {
                 $content .= "# " . $out->tag . ": \n\n";

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -46,7 +46,7 @@ sub parse {
         # may be optional since format result_array:v2
         $result->{environment} = OpenQA::Parser::Result::LTP::Environment->new($result->{environment})
           if $res->{environment};
-
+        $t_name =~ s/[\/.]/_/g;    # dots in the filename confuse the web api routes
         $result->{name} = $t_name;
 
         my $details

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -83,7 +83,9 @@ sub parse {
                 $tc_result = 'fail'
                   if ($tc->{failures} && $tc->{failures} > 0) || ($tc->{errors} && $tc->{errors} > 0);
 
-                my $text_fn = "$ts_category-$ts_name-$num.txt";
+                my $text_fn = "$ts_category-$ts_name-$num";
+                $text_fn =~ s/[\/.]/_/g;
+                $text_fn .= '.txt';
                 my $content = "# Test messages ";
                 $content .= "# $tc->{name}\n" if $tc->{name};
 


### PR DESCRIPTION
If an element of text details points to a file with dots, the webapi will get confused and will not load the text.
[With dot](http://phobos.suse.de/tests/11062#step/LTP_net_stress.interface_if4-addr-change_ifconfig/1) vs [Without dot](http://phobos.suse.de/tests/11063#step/LTP_net_stress_interface_if4-addr-change_ifconfig/1)
