### PR TITLE
Avoid appening multile runs with --nocleanup

### DIFF
--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -166,13 +166,16 @@ With the attribute C<include_result()> set to true, it will include inside the
 results the respective test that generated it (inside the C<test()> attribute).
 See also L<OpenQA::Parser::Result::OpenQA>.
 
+JUnit format is specific for slenkins tests. If you wish to use generic JUnit format,
+use XUnit format instead.
+
 =head1 ATTRIBUTES
 
 OpenQA::Parser::Format::JUnit inherits all attributes from L<OpenQA::Parser::Format::Base>.
 
 =head1 METHODS
 
-OpenQA::Parser::Format::Base inherits all methods from L<OpenQA::Parser::Format::Base>, it only overrides
+OpenQA::Parser::Format::JUnit inherits all methods from L<OpenQA::Parser::Format::Base>, it only overrides
 C<parse()> to generate a tree of results.
 
 =cut

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -834,6 +834,9 @@ sub read_test_modules {
                     log_debug("Reading information from " . encode_json($step));
                     $step->{text_data} = $file->slurp;
                 }
+                else {
+                    log_debug("Cannot read file: $file");
+                }
             }
             push(@details, $step);
         }

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -524,7 +524,13 @@ sub start_job {
 
     # update settings with worker-specific stuff
     copy_job_settings($job, $worker_settings);
-
+    if ($pooldir) {
+        my $fd;
+        print $fd, "" if open($fd, '>', "$pooldir/worker-log.txt") or log_error "could not open worker log $!";
+        foreach my $file (qw(serial0.txt autoinst-log.txt serial_terminal.txt)) {
+            unlink("$pooldir/$file") or log_error "Could not unlink '$file': $!";
+        }
+    }
     my $name = $job->{settings}->{NAME};
     log_info(sprintf('got job %d: %s', $job->{id}, $name));
 


### PR DESCRIPTION
When the worker is invoked with --nocleanup, it will append previus runs
making it a bit difficult to debug or read the logs, ensure this doesn't
happen anymore, but keep other result files.