### PR TITLE
Make the layout use 100% width (aka 'fluid')

### DIFF
--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -24,7 +24,6 @@ body {
     #content {
         padding-left: 40px;
         padding-right: 40px;
-        max-width: 1220px;
     }
 }
 

--- a/templates/layouts/bootstrap.html.ep
+++ b/templates/layouts/bootstrap.html.ep
@@ -44,12 +44,12 @@
   </head>
   <body>
       %= include 'layouts/navbar'
-      <div class="container" id="content">
+      <div class="container-fluid" id="content">
           %= content
       </div>
 
       <footer class='footer'>
-          <div class='container'>
+          <div class='container-fluid'>
               <div id="footer-links">
                   <span id="footer-links" class="left">
                       %= include_branding 'links_footer_left'

--- a/templates/layouts/navbar.html.ep
+++ b/templates/layouts/navbar.html.ep
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light">
-  <div class="container">
+  <div class="container-fluid">
      <a class="navbar-brand" href="/"><img src="<%= icon_url 'logo.svg'%>" alt="openQA"></a>
      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
        <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
This makes better usage of the screen space, but can look displaced on
very wide screens. But especially in /tests and /tests/X it looks better
IMO

Before:
![fixed](https://user-images.githubusercontent.com/1067203/39740431-dbecc6bc-5295-11e8-8a5a-d7b6578440ca.png)

After:
![fluid](https://user-images.githubusercontent.com/1067203/39740440-e285269a-5295-11e8-999e-9ae4ab527705.png)
