### PR TITLE
[WIP] Use special style for boo#0

### DIFF
--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -99,6 +99,10 @@ div.flags {
     color: $color-bug-closed;
     transform: rotate(180deg);
 }
+.label_bug.bug_0 {
+    color: $color-bolt;
+    transform: rotate(90deg);
+}
 
 // misc
 .component {

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -61,6 +61,9 @@ sub register {
             if ($bug && !$bug->open) {
                 $css_class .= " bug_closed";
             }
+            elsif ($text =~ /(boo|bsc)#0/) {
+                $css_class .= " bug_0";
+            }
             return $css_class;
         });
 

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -56,6 +56,13 @@ sub schema_hook {
             job_id  => 99946,
         });
 
+    $comments->create(
+        {
+            text    => 'boo#0 (trick ttm)',
+            user_id => 1,
+            job_id  => 99937,
+        });
+
     $bugs->create(
         {
             bugid     => 'bsc#111111',
@@ -126,6 +133,9 @@ my @open_bugs = $driver->find_elements('#bug-99946 .label_bug', 'css');
 @closed_bugs = $driver->find_elements('#bug-99946 .bug_closed', 'css');
 is(scalar @open_bugs,   1, 'open bug correctly shown, and only once despite the 2 comments');
 is(scalar @closed_bugs, 0, 'open bug not shown as closed bug');
+
+my @special_bugs = $driver->find_elements('#bug-99937 .bug_0', 'css');
+is(scalar @special_bugs, 1, 'bug with reference id #0 is correctly shown');
 
 kill_driver();
 


### PR DESCRIPTION
In openSUSE openQA instance we see the invalid boo#0 bug references
to fool ttm which demands a ticket reference for each failure.
Those are not easily visible during review as are labeled, hence require
openning every single one to identify such a case.

This commit introduces another styling for boo#0 bug references, so
those can be easily identified and reviewed.

See [poo#35758](https://progress.opensuse.org/issues/35758).

![image](https://user-images.githubusercontent.com/28305643/39933655-dfb7ca0c-5543-11e8-9e67-43d3a81cdd67.png)
