### PR TITLE
All your badge are belong to us!

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -97,3 +97,9 @@ function renderDataSize(sizeInByte) {
     });
     return sizeWithUnit;
 }
+
+function alignBuildLabels() {
+  var values = $.map($('.build-label'), function(el, index) { return parseInt($(el).css('width')); });
+  var max = Math.max.apply(null, values);
+  $('.build-label').css('min-width', max + 'px');
+}

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,8 +1,8 @@
 % for my $build_res (@$build_results) {
     % my $build = $build_res->{build};
     % my $group_id;
-    <div class="row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
-        <div class="col-xl-4 text-nowrap">
+    <div class="d-flex flex-row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
+        <div class="px-2 build-label text-nowrap">
             <span class="h4">
                 % if ($children) {
                     % $group_id = "group$group->{id}_build$build_res->{escaped_id}";
@@ -24,7 +24,7 @@
                 % }
             </span>
         </div>
-        <div class="col-xl-8">
+        <div class="px-2 align-self-end flex-grow-1">
             % if ($max_jobs) {
                 %= include 'main/build_progressbar', max_jobs => $max_jobs, result => $build_res
             % }
@@ -36,14 +36,14 @@
                 % my $child_res = $build_res->{children}->{$child->{id}};
                 % my $jobs = $child_res->{passed} + $child_res->{unfinished} + $child_res->{softfailed} + $child_res->{failed} + $child_res->{skipped};
                 % if ($jobs) {
-                    <div class="row build-row">
-                        <div class="col-lg-4 text-nowrap">
+                    <div class="d-flex flex-row build-row">
+                        <div class="px-2 build-label text-nowrap">
                             <span class="h4">
                                 %= link_to $child->{name} => url_for('tests_overview')->query(distri => [sort keys %{$child_res->{distris}}], version => $child_res->{version}, build => $build, groupid => $child->{id})
                                 %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $child_res, id_prefix => 'child-'
                             </span>
                         </div>
-                        <div class="col-lg-8">
+                        <div class="px-2 align-self-end flex-grow-1">
                             %= include 'main/build_progressbar', max_jobs => $jobs, result => $child_res
                         </div>
                     </div>

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -6,6 +6,7 @@
 % content_for 'ready_function' => begin
     setupIndexPage();
     hideNavbar();
+    alignBuildLabels();
 % end
 
 <div class="jumbotron">

--- a/templates/main/parent_group_overview.html.ep
+++ b/templates/main/parent_group_overview.html.ep
@@ -5,6 +5,7 @@
 
 % content_for 'ready_function' => begin
     $('.timeago').timeago();
+    alignBuildLabels();
 % end
 
 % if (is_admin) {


### PR DESCRIPTION
Instead of using fixed size grid columns, we use flexible columns and
set the width to the largest build column using javascript (possibly there
is a css way, but I don't know of any)

See https://progress.opensuse.org/issues/35697