### PR TITLE
Allow client to restart a build for a jobgroup

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -350,6 +350,7 @@ sub startup {
 
     # api/v1/jobs
     $api_public_r->get('/jobs')->name('apiv1_jobs')->to('job#list');
+    $api_public_r->get('/jobs/overview')->name('apiv1_jobs_overview')->to('job#overview');
     $api_ro->post('/jobs')->name('apiv1_create_job')->to('job#create');
     $api_ro->post('/jobs/cancel')->name('apiv1_cancel_jobs')->to('job#cancel');
     $api_ro->post('/jobs/restart')->name('apiv1_restart_jobs')->to('job#restart');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -141,6 +141,25 @@ sub list {
 
 =over 4
 
+=item overview()
+
+Returns the latest jobs matching the specified arch, build, distri, version, flavor and groupid.
+So this works in the same way as the test results overview in the GUI.
+
+=back
+
+=cut
+
+sub overview {
+    my $self = shift;
+    my ($search_args, $groups) = OpenQA::Utils::compose_job_overview_search_args($self);
+    my @jobs = map { {id => $_->id, name => $_->name} }
+      $self->db->resultset('Jobs')->complex_query(%$search_args)->latest_jobs;
+    $self->render(json => \@jobs);
+}
+
+=over 4
+
 =item create()
 
 Creates a job given a list of settings passed as parameters. TEST setting/parameter

--- a/script/client
+++ b/script/client
@@ -103,7 +103,7 @@ Show details of job nr. B<1>.
 
 Delete job nr. B<1> (permissions read from config file).
 
-=item client --host openqa.example.com isos post iso=bar.iso tests=blah
+=item client --host openqa.example.com isos post ISO=bar.iso DISTRI=my-distri FLAVOR=my-flavor ARCH=my-arch VERSION=42 BUILD=1234
 
 Trigger jobs on iso B<bar.iso> matching test suite B<blah>.
 

--- a/script/client
+++ b/script/client
@@ -95,6 +95,16 @@ Common top level entry points: jobs, workers, isos.
 List all jobs. Caution: this will take a very long time or even timeout on big
 productive instances.
 
+=item client --host openqa.example.com jobs groupid=135 distri=caasp version=3.0 latest=1
+
+List all jobs matching the specified search criteria.
+
+=item client --host openqa.example.com jobs/overview groupid=135 distri=caasp version=3.0
+
+List the latest jobs for the latest build in the given scenario.
+In contrast to the route above, this will limit the results to the latest build in the same
+way the test result overview in the web UI does.
+
 =item client --host openqa.example.com jobs/1
 
 Show details of job nr. B<1>.
@@ -146,6 +156,42 @@ sub usage($) {
     }
 }
 
+sub handle_result {
+    my $res = shift;
+
+    if ($res->code == 200) {
+        my $json = $res->json;
+        if ($options{'json-output'}) {
+            print JSON->new->pretty->encode($json);
+        }
+        else {
+            dd($json || $res->body);
+        }
+        return $json;
+    }
+
+    printf(STDERR "ERROR: %s - %s\n", $res->code, $res->{error}->{message});
+    if ($res->body) {
+        if ($options{json}) {
+            print JSON->new->pretty->encode($res->json);
+        }
+        else {
+            dd($res->json || $res->body);
+        }
+    }
+    exit(1);
+}
+
+# prepend the API-base if the specified path is relative
+sub prepend_api_base {
+    my $path = shift;
+
+    if ($path !~ m/^\//) {
+        $path = join('/', $options{apibase}, $path);
+    }
+    return $path;
+}
+
 GetOptions(
     \%options,            'host=s',      'apibase=s',   'json-output',
     'verbose|v',          'apikey:s',    'apisecret:s', 'params=s',
@@ -163,11 +209,9 @@ if ($options{form} && $options{'json-data'}) {
 $options{host}    ||= 'localhost';
 $options{apibase} ||= '/api/v1';
 
-my $path = shift @ARGV;
-# Relative paths are routed to v1
-if ($path !~ m/^\//) {
-    $path = join('/', $options{apibase}, $path);
-}
+# determine operation and path
+my $operation = shift @ARGV;
+my $path      = prepend_api_base($operation);
 
 my $method = 'get';
 my %params;
@@ -220,17 +264,17 @@ else {
 
 my $client = OpenQA::Client->new(apikey => $options{apikey}, apisecret => $options{apisecret}, api => $url->host);
 
-my $res;
 if ($options{form}) {
-    $res = $client->$method($url, form => \%params)->res;
+    handle_result($client->$method($url, form => \%params)->res);
 }
 elsif ($options{'json-data'}) {
-    $res = $client->$method($url, {'Content-Type' => 'application/json'} => $options{'json-data'})->res;
+    handle_result($client->$method($url, {'Content-Type' => 'application/json'} => $options{'json-data'})->res);
 }
 else {
     # Either the user wants to call a command or wants to interact with
     # the rest api directly.
     if ($options{archive}) {
+        my $res;
         $options{path}    = $path;
         $options{url}     = $url;
         $options{params}  = \%params;
@@ -239,30 +283,19 @@ else {
         die "ERROR: $@ \n", $@ if $@;
         exit(0);
     }
+    elsif ($operation eq 'jobs/overview/restart') {
+        $url->path(prepend_api_base('jobs/overview'));
+        my $relevant_jobs = handle_result($client->get($url)->res);
+        my @job_ids = map { $_->{id} } @$relevant_jobs;
+        $url->path(prepend_api_base('jobs/restart'));
+        $url->query(Mojo::Parameters->new);
+        $url->query(jobs => \@job_ids);
+        print("$url\n");
+        handle_result($client->post($url)->res);
+    }
     else {
-        $res = $client->$method($url)->res;
-        #exit(0);
+        handle_result($client->$method($url)->res);
     }
-}
-if ($res->code == 200) {
-    if ($options{'json-output'}) {
-        print JSON->new->pretty->encode($res->json);
-    }
-    else {
-        dd($res->json || $res->body);
-    }
-}
-else {
-    printf STDERR "ERROR: %s - %s\n", $res->code, $res->{error}->{message};
-    if ($res->body) {
-        if ($options{json}) {
-            print JSON->new->pretty->encode($res->json);
-        }
-        else {
-            dd($res->json || $res->body);
-        }
-    }
-    exit(1);
 }
 
 1;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -167,6 +167,50 @@ is(scalar(@{$get->tx->res->json->{jobs}}), 3);
 $get = $t->get_ok('/api/v1/jobs?ids=99981&ids=99963&ids=99926');
 is(scalar(@{$get->tx->res->json->{jobs}}), 3);
 
+subtest 'job overview' => sub {
+    my $query = Mojo::URL->new('/api/v1/jobs/overview');
+
+    # overview for latest build in group 1001
+    $query->query(
+        distri  => 'opensuse',
+        version => 'Factory',
+        groupid => '1001',
+    );
+    $get = $t->get_ok($query->path_query)->status_is(200);
+    is_deeply(
+        $get->tx->res->json,
+        [
+            {
+                id   => 99940,
+                name => 'opensuse-Factory-DVD-x86_64-Build0048@0815-doc@64bit',
+            }
+        ],
+        'latest build present'
+    );
+
+    # overview for build 0048
+    $query->query(build => '0048',);
+    $get = $t->get_ok($query->path_query)->status_is(200);
+    is_deeply(
+        $get->tx->res->json,
+        [
+            {
+                id   => 99939,
+                name => 'opensuse-Factory-DVD-x86_64-Build0048-kde@64bit',
+            },
+            {
+                id   => 99938,
+                name => 'opensuse-Factory-DVD-x86_64-Build0048-doc@64bit',
+            },
+            {
+                id   => 99936,
+                name => 'opensuse-Factory-DVD-x86_64-Build0048-kde@64bit-uefi',
+            },
+        ],
+        'latest build present'
+    );
+};
+
 # Test /jobs/restart
 my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})
   ->status_is(200);


### PR DESCRIPTION
See https://progress.opensuse.org/issues/33892

---

It would work like this:
```
# just get the list of jobs
openqa-client jobs/overview build=589.1 distri=sle version=15 groupid=123
[
  {
    id => 28,
    name => "sle-15-Installer-DVD-x86_64-Build589.1-create_hdd_minimal_base+sdk\@64bit",
  },
  {
    id => 27,
    name => "sle-15-Installer-DVD-x86_64-Build589.1-install_ltp+sle+15+Installer-DVD\@64bit",
  },
]

# restart such jobs
openqa-client jobs/overview/restart build=589.1 distri=sle version=15 groupid=123
[
  {
    id => 28,
    name => "sle-15-Installer-DVD-x86_64-Build589.1-create_hdd_minimal_base+sdk\@64bit",
  },
  {
    id => 27,
    name => "sle-15-Installer-DVD-x86_64-Build589.1-install_ltp+sle+15+Installer-DVD\@64bit",
  },
]
http://localhost:9526/api/v1/jobs/restart?jobs=28&jobs=27
{ result => [37], test_url => ["/tests/37"] }
```

That should already cover AC1:

> AC1: openQA::Client is able to trigger a build only for the specified jobgroup

---

Not sure how to deal with jobs which are already running/scheduled. That's what currently happens:
* If a job is already running, it is canceled and a new job rescheduled. The canceled job has the result 'user_restarted'.
* If a job is already scheduled, it is skipped and a new job rescheduled.

> AC2: Builds that were triggered in the normal way, are not obsoleted or canceled

So jobs which are already running or are scheduled should be excluded?

---

> AC3: Builds for a jobgroup that were previously scheduled can be handled in a similar fashion as other builds (Parameters, et al)

Not sure what that means.

---

Since @foursixnine mentioned that multi-machine tests might be problematic, I assume we can't just rely on the scheduler to figure this?