### PR TITLE
Add _GROUP filter to isos post

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -224,7 +224,10 @@ mean existing jobs for earlier builds with the same DISTRI and VERSION are
 no longer interesting, but you still want to be able to re-submit jobs for a
 build and have existing jobs for the exact same build obsoleted.
 
-_GROUP:: Job templates *not* matching the given group ID are ignored.
+_GROUP:: Job templates *not* matching the given group name are ignored. Does *not*
+         affect obsoletion behavior, so you might want to combine with `_NO_OBSOLETE`.
+
+_GROUP_ID:: Same as `_GROUP` but allows to specify the group directly by ID.
 
 Example for `_DEPRIORITIZEBUILD` and `_DEPRIORITIZE_LIMIT`.
 

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -224,6 +224,8 @@ mean existing jobs for earlier builds with the same DISTRI and VERSION are
 no longer interesting, but you still want to be able to re-submit jobs for a
 build and have existing jobs for the exact same build obsoleted.
 
+_GROUP:: Job templates *not* matching the given group ID are ignored.
+
 Example for `_DEPRIORITIZEBUILD` and `_DEPRIORITIZE_LIMIT`.
 
 [source,sh]

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -183,7 +183,12 @@ sub _generate_jobs {
     my @tests = $args->{TEST} ? split(/\s*,\s*/, $args->{TEST}) : ();
 
     for my $product (@products) {
-        my @templates = $product->job_templates;
+        my $templates = $product->job_templates;
+        my $group_id  = $args->{_GROUP};
+        if (defined $group_id) {
+            $templates = $templates->search({group_id => $group_id});
+        }
+        my @templates = $templates->all;
         unless (@templates) {
             carp "no templates found for " . join('-', map { $args->{$_} } qw(DISTRI VERSION FLAVOR ARCH));
         }
@@ -216,7 +221,7 @@ sub _generate_jobs {
                 next if $_ eq 'TEST' || $_ eq 'MACHINE';
                 $settings{uc $_} = $args->{$_};
             }
-            # Makes sure tha the DISTRI is lowercase
+            # make sure that the DISTRI is lowercase
             $settings{DISTRI} = lc($settings{DISTRI});
 
             $settings{PRIO}     = $job_template->prio;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -138,6 +138,34 @@ is(scalar @tasks, 0, 'we have no gru download tasks to start with');
 # later on is found as important and handled accordingly
 $t->app->db->resultset("Jobs")->find(99928)->comments->create({text => 'any text', user_id => 99901});
 
+subtest 'group filter' => sub {
+    # add a job template for group 1002
+    my $job_template = $t->app->db->resultset('JobTemplates')->create(
+        {
+            machine    => {name => '64bit'},
+            test_suite => {name => 'textmode-2'},
+            prio       => 42,
+            group_id   => 1002,
+            product_id => 1,
+        });
+
+    my $res = schedule_iso(
+        {
+            ISO        => $iso,
+            DISTRI     => 'opensuse',
+            VERSION    => '13.1',
+            FLAVOR     => 'DVD',
+            ARCH       => 'i586',
+            BUILD      => '0091',
+            PRECEDENCE => 'original',
+            _GROUP     => '1002',
+        });
+    is($res->json->{count}, 1, 'only one job created due to group filter');
+
+    # delete job template again so the remaining tests are unaffected
+    $job_template->delete;
+};
+
 # schedule the iso, this should not actually be possible. Only isos
 # with different name should result in new tests...
 my $res = schedule_iso(

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -158,9 +158,35 @@ subtest 'group filter' => sub {
             ARCH       => 'i586',
             BUILD      => '0091',
             PRECEDENCE => 'original',
-            _GROUP     => '1002',
+            _GROUP     => 'invalid group name',
+        });
+    is($res->json->{count}, 0, 'no jobs created if group invalid');
+
+    $res = schedule_iso(
+        {
+            ISO        => $iso,
+            DISTRI     => 'opensuse',
+            VERSION    => '13.1',
+            FLAVOR     => 'DVD',
+            ARCH       => 'i586',
+            BUILD      => '0091',
+            PRECEDENCE => 'original',
+            _GROUP     => 'opensuse test',
         });
     is($res->json->{count}, 1, 'only one job created due to group filter');
+
+    $res = schedule_iso(
+        {
+            ISO        => $iso,
+            DISTRI     => 'opensuse',
+            VERSION    => '13.1',
+            FLAVOR     => 'DVD',
+            ARCH       => 'i586',
+            BUILD      => '0091',
+            PRECEDENCE => 'original',
+            _GROUP_ID  => '1002',
+        });
+    is($res->json->{count}, 1, 'only one job created due to group filter (by ID)');
 
     # delete job template again so the remaining tests are unaffected
     $job_template->delete;

--- a/t/fixtures/04-products.pl
+++ b/t/fixtures/04-products.pl
@@ -71,6 +71,7 @@
         ],
     },
     Products => {
+        id       => 1,
         name     => '',
         distri   => 'opensuse',
         version  => '13.1',


### PR DESCRIPTION
See https://progress.opensuse.org/issues/33892

AC1 is tested and works. Job templates *not* matching the given group ID are ignored when creating new jobs via `POST isos`.

Not sure about AC2. Does "Builds that were triggered in the normal way" mean "jobs that were spawned before, but without explicit group filtering"? If yes, that wouldn't be completely trivial to implement because we would need to save whether the group filtering was used when spawning a job.

Also not sure about AC3. For me it sounds like I don't have to do anything further here. This PR just introduces a filter. The usual behavior for obsoletion isn't changed - just limited to the specified group.