### PR TITLE
Exclude external links in 22-dashboard.t

### DIFF
--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -151,7 +151,7 @@ check_test_parent('collapsed');
 # links are correct
 my @urls = $get->tx->res->dom->find('h2 a, .row a')->map('attr', 'href')->each;
 for my $url (@urls) {
-    next if ($url =~ /^#/);
+    next if ($url =~ /^#/ || $url =~ /^.*\:\//);
     $get = $t->get_ok($url)->status_is(200);
 }
 


### PR DESCRIPTION
Here https://www.suse.com redirects to https://www.suse.com/de-de
causing the test to fail.

So just exclude external links when checking for dead links.

Note that the only other external link we have on the page is
currently http://open.qa/.