### PR TITLE
Add web socket console for isotovideo commands

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -150,6 +150,12 @@
 ! job_next_previous.js
 < javascripts/job_next_previous.js
 
+! ws_console.scss
+< stylesheets/ws_console.scss
+
+! ws_console.js
+< javascripts/ws_console.js
+
 ! logo-16.png
 < images/logo-16.png
 

--- a/assets/javascripts/ws_console.js
+++ b/assets/javascripts/ws_console.js
@@ -1,0 +1,48 @@
+function setupWebSocketContosle(url) {
+    var form = $('#ws_console_form');
+    var url = form.data('url');
+    if (!url.length) {
+        return;
+    }
+
+    var msg = $('#msg');
+    var log = $('#log');
+    var followLogCheckBox = $('#follow_log');
+
+    // setup logging
+    var followLog = function() {
+        if (!followLogCheckBox.prop('checked')) {
+            return;
+        }
+        log[0].scrollTop = log[0].scrollHeight;
+    };
+    followLogCheckBox.change(followLog);
+    var logLine = function(msg) {
+        log.append(msg + "\n");
+        followLog();
+    };
+
+    // establish and handle web socket connection
+    var ws = new WebSocket(url);
+    logLine('Connecting to ' + url);
+    ws.onopen = function () {
+        logLine('Connection opened');
+    };
+    ws.onerror = function(error) {
+        logLine('Connection error: ' + error.type + " (check JavaScript console for details)");
+    }
+    ws.onclose = function() {
+        logLine('Connection closed');
+    }
+    ws.onmessage = function(msg) {
+        logLine(msg.data);
+    };
+
+    // send command when user presses return
+    form.submit(function(event) {
+        event.preventDefault();
+        ws.send(msg.val());
+        msg.val('');
+    });
+    msg.focus();
+}

--- a/assets/stylesheets/ws_console.scss
+++ b/assets/stylesheets/ws_console.scss
@@ -1,0 +1,7 @@
+#msg, #log {
+    width: 100%;
+    font-family: monospace;
+}
+#log {
+    height: 40em;
+}

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -217,6 +217,10 @@ sub startup {
     $test_r->get('/asset/#assettype/#assetname')->name('test_asset_name')->to('file#test_asset');
     $test_r->get('/asset/#assettype/#assetname/*subpath')->name('test_asset_name_path')->to('file#test_asset');
 
+    my $developer_auth = $test_r->under('/developer')->to('session#ensure_admin');
+    my $developer_r = $developer_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller');
+    $developer_r->get('/ws-console')->name('developer_ws_console')->to('developer#ws_console');
+
     my $step_r = $test_r->route('/modules/:moduleid/steps/:stepid', stepid => qr/[1-9]\d*/)->to(controller => 'step');
     my $step_auth = $test_auth->route('/modules/:moduleid/steps/:stepid', stepid => qr/[1-9]\d*/);
     $step_r->get('/view')->to(action => 'view');

--- a/lib/OpenQA/WebAPI/Controller/Developer.pm
+++ b/lib/OpenQA/WebAPI/Controller/Developer.pm
@@ -1,0 +1,51 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::WebAPI::Controller::Developer;
+use strict;
+use Mojo::Base 'Mojolicious::Controller';
+use OpenQA::Utils;
+use OpenQA::Schema::Result::Jobs;
+
+# returns the isotovideo web socket URL for the given job or undef if not available
+sub determine_web_socket_url {
+    my ($job) = @_;
+
+    return unless $job->state eq OpenQA::Schema::Result::Jobs::RUNNING;
+    my $worker    = $job->assigned_worker             or return;
+    my $job_token = $worker->get_property('JOBTOKEN') or return;
+    my $host      = $worker->host                     or return;
+    my $port      = ($worker->get_property('QEMUPORT') // 20012) + 1;
+    # FIXME: don't hardcode port
+    return "ws://$host:$port/$job_token/ws";
+}
+
+sub ws_console {
+    my ($self) = @_;
+
+    # find job
+    return $self->reply->not_found if (!defined $self->param('testid'));
+    my $jobs = $self->app->schema->resultset('Jobs');
+    my $job = $jobs->search({id => $self->param('testid')})->first;
+    return $self->reply->not_found unless $job;
+    $self->stash(job => $job);
+
+    $self->stash(ws_url => (determine_web_socket_url($job) // ''));
+    return $self->render;
+}
+
+1;
+# vim: set sw=4 et:

--- a/templates/developer/ws_console.html.ep
+++ b/templates/developer/ws_console.html.ep
@@ -1,0 +1,30 @@
+% layout 'bootstrap';
+% content_for 'head' => begin
+  %= asset 'ws_console.js'
+  %= asset 'ws_console.scss'
+% end
+% content_for 'ready_function' => begin
+    setupWebSocketContosle();
+% end
+% title 'WebSocket console';
+%= include 'layouts/info'
+
+<h2>WebSocket console for job <%= $job->name %></h2>
+<form id="ws_console_form" data-url="<%= $ws_url %>" action="#">
+% if ($ws_url) {
+    <p>
+        <input type="text" id="msg" placeholder="enter command">
+    </p>
+    <p>
+        <textarea id="log" readonly></textarea>
+    </p>
+    <p>
+        <input type="checkbox" id="follow_log" checked="checked" />
+        <label for="follow_log">Follow log</label>
+    </p>
+% }
+% else {
+    <p>The command server is not available.</p>
+% }
+</form>
+<p><a href="<%= url_for('test', testid => $job->id) %>">Back to test details</a></p>


### PR DESCRIPTION
* Accessible via `/tests/:testid/developer/ws-console`
  (admin-only)
* See
    * https://progress.opensuse.org/issues/36442#note-2
    * https://progress.opensuse.org/issues/36454

---

![screenshot_20180523_174150](https://user-images.githubusercontent.com/10248953/40435268-942287b4-5eb0-11e8-9d1e-c65974097d19.png)

---

Not sure whether I handle the port correctly. I use `($worker->get_property('QEMUPORT') // 20012) + 1`. In my case `QEMUPORT` isn't actually set in openQA, but the worker log says it is 20012 so I used that as default.

I currently just use the public folder for `developer.js` so this file isn't included in every page. But I can change it to be a regular asset of course.