### PR TITLE
Fix race conditions in worker cache

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -295,7 +295,9 @@ sub _log_msg {
         $log_to_standard = 0;
     }
     else {
-
+        # TODO: We need to get rid of $app here :(
+        $msg = "[pid:$$] " . $msg
+          if defined $app && $app->can('log') && $app->log->can('level') && $app->log->level eq 'debug';
         if ($options{channels}) {
             if (ref($options{channels}) eq 'ARRAY') {
                 for my $channel (@{$options{channels}}) {

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -31,7 +31,6 @@ use Cpanel::JSON::XS;
 use DBI;
 use Mojo::File 'path';
 use Mojo::Base -base;
-use Cwd 'getcwd';
 use POSIX;
 
 has [qw(host cache location db_file dsn dbh cache_real_size)];

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -37,6 +37,10 @@ has [qw(host cache location db_file dsn dbh cache_real_size)];
 has limit => 50 * (1024**3);
 has sleep_time => 5;
 
+sub new {
+    shift->SUPER::new(@_)->init;
+}
+
 sub DESTROY {
     my $self = shift;
 
@@ -76,11 +80,7 @@ sub deploy_cache {
 
 sub init {
     my $self = shift;
-    my ($host, $location) = @_;
-    $self->host($host);
-    $self->location($location);
-
-
+    my ($host, $location) = ($self->host, $self->location);
     my $db_file = catdir($location, 'cache.sqlite');
 
     $self->db_file($db_file);
@@ -96,7 +96,7 @@ sub init {
     #Ideally we only need $limit, and $need no extra space
     $self->check_limits(0);
     log_info(__PACKAGE__ . ": Initialized with $host at $location, current size is " . $self->cache_real_size);
-    return 1;
+    return $self;
 }
 
 sub cache_assets {

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -33,9 +33,6 @@ use Mojo::File 'path';
 use Mojo::Base -base;
 use Cwd 'getcwd';
 
-our @EXPORT = qw(get_asset);
-use Exporter 'import';
-
 has [qw(host cache location db_file dsn dbh cache_real_size)];
 has limit => 50 * (1024**3);
 has sleep_time => 5;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -174,8 +174,8 @@ sub engine_workit {
     # do asset caching if CACHEDIRECTORY is set
     if ($worker_settings->{CACHEDIRECTORY}) {
         my $host_to_cache = Mojo::URL->new($current_host)->host;
-        my $cache         = OpenQA::Worker::Cache->new;
-        $cache->init($current_host, $worker_settings->{CACHEDIRECTORY});
+        my $cache = OpenQA::Worker::Cache->new(host => $current_host, location => $worker_settings->{CACHEDIRECTORY});
+        #  $cache->init($current_host, $worker_settings->{CACHEDIRECTORY});
         my $error = $cache->cache_assets($job => \%vars => $assetkeys);
         return $error if $error;
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -175,7 +175,6 @@ sub engine_workit {
     if ($worker_settings->{CACHEDIRECTORY}) {
         my $host_to_cache = Mojo::URL->new($current_host)->host;
         my $cache = OpenQA::Worker::Cache->new(host => $current_host, location => $worker_settings->{CACHEDIRECTORY});
-        #  $cache->init($current_host, $worker_settings->{CACHEDIRECTORY});
         my $error = $cache->cache_assets($job => \%vars => $assetkeys);
         return $error if $error;
 

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -304,6 +304,13 @@ like $openqalogs, qr/ andi \$a3, \$t1, 41399 and 256/, "Etag and size are logged
 like $openqalogs, qr/removed.*sle-12-SP3-x86_64-0368-200\@64bit.qcow2*/, "Reclaimed space for new smaller asset";
 truncate_log $logfile;
 
+$cache->add_asset("Foobar", 0);
+
+is $cache->toggle_asset_lock("Foobar", 1), 1, 'Could acquire lock';
+is $cache->toggle_asset_lock("Foobar", 0), 1, 'Could acquire lock';
+
+$cache->dbh->prepare("delete from assets")->execute();
+
 my $tot_proc   = $ENV{STRESS_TEST} ? 60 : 10;
 my $concurrent = $ENV{STRESS_TEST} ? 30 : 2;
 my $q          = queue;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -304,11 +304,12 @@ like $openqalogs, qr/removed.*sle-12-SP3-x86_64-0368-200\@64bit.qcow2*/, "Reclai
 truncate_log $logfile;
 
 subtest 'concurrent access' => sub {
+    plan skip_all => "set STRESS_TEST=1 (be careful)" unless $ENV{STRESS_TEST};
 
     use List::Util qw(shuffle uniq sum);
 
-    my $tot_proc   = $ENV{STRESS_TEST} ? 160 : 40;
-    my $concurrent = $ENV{STRESS_TEST} ? 40  : 20;
+    my $tot_proc   = 60;
+    my $concurrent = 30;
     my $q          = queue;
     $q->pool->maximum_processes($concurrent);
     $q->queue->maximum_processes($tot_proc);
@@ -320,7 +321,6 @@ subtest 'concurrent access' => sub {
         process(
             sub {
                 srand int time;
-                sleep rand int 2 for 1 .. 4;
                 $cache->limit($sum);
                 $cache->init;
                 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-200_' . $_ . '@64bit.qcow2')

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -304,7 +304,7 @@ like $openqalogs, qr/removed.*sle-12-SP3-x86_64-0368-200\@64bit.qcow2*/, "Reclai
 truncate_log $logfile;
 
 subtest 'concurrent access' => sub {
-    plan skip_all => "set STRESS_TEST=1 (be careful)" unless $ENV{STRESS_TEST};
+    plan skip_all => "set STRESS_TEST=1 (be careful)" unless exists $ENV{STRESS_TEST} && $ENV{STRESS_TEST} == 1;
 
     use List::Util qw(shuffle uniq sum);
 
@@ -343,10 +343,4 @@ subtest 'concurrent access' => sub {
 };
 
 stop_server;
-
-sub END {
-    stop_server;
-    session->all->each(sub { shift->stop });
-}
-
 done_testing();

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -325,6 +325,7 @@ my $concurrent_test = sub {
     $cache->limit($sum);
     $cache->init;
     $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-200_' . $_ . '@64bit.qcow2') for shuffle @test;
+    Devel::Cover::report() if Devel::Cover->can('report');
 };
 
 $q->add(process($concurrent_test)->set_pipes(0)->internal_pipes(0)) for 1 .. $tot_proc;

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -26,9 +26,9 @@ use File::Path qw(make_path remove_tree);
 use Sys::Hostname;
 use File::Spec::Functions 'catfile';
 
-my $reFile    = qr/\[.*?\] \[(.*?)\] (.*?) message/;
-my $reStdOut  = qr/(?:.*?)\[(.*?)\] (.*?) message/;
-my $reChannel = qr/\[.*?\] \[(.*?)\] (.*?) message/;
+my $reFile    = qr/\[.*?\] \[(.*?)\] (?:\[pid:\d+\]\s)?(.*?) message/;
+my $reStdOut  = qr/(?:.*?)\[(.*?)\] (?:\[pid:\d+\]\s)?(.*?) message/;
+my $reChannel = qr/\[.*?\] \[(.*?)\] (?:\[pid:\d+\]\s)?(.*?) message/;
 
 subtest 'load correct configs' => sub {
     local $ENV{OPENQA_CONFIG} = 't/data/logging/';
@@ -93,6 +93,8 @@ subtest 'Logging to stdout' => sub {
     close STDOUT;
     open(STDOUT, '>&', $oldSTDOUT) or die "Can't dup \$oldSTDOUT: $!";
     my @matches = ($output =~ m/$reStdOut/gm);
+
+    like $output, qr/$$/, 'Pid is printed in debug mode';
     ok(@matches / 2 == 3, 'Worker log matches');
     for (my $i = 0; $i < @matches; $i += 2) {
         ok($matches[$i] eq $matches[$i + 1], "OK $matches[$i]");

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -515,7 +515,7 @@ subtest 'Check job status and output' => sub {
         }
         else {
             $post->status_is(400);
-            ok($output =~ /\[.*info\] Got status update for job .*? but does not contain a worker id!/,
+            ok($output =~ /Got status update for job .*? but does not contain a worker id!/,
                 "Check status update for job $job->{id}");
         }
     }
@@ -534,8 +534,8 @@ subtest 'Check job status and output' => sub {
 
     $bogus_job_post->status_is(400);
     $bogus_worker_post->status_is(400);
-    ok($output =~ /\[.*info\] Got status update for non-existing job/, 'Check status update for non-existing job');
-    ok($output =~ /\[.*info\] Got status update for job .* that does not belong to Worker/,
+    ok($output =~ /Got status update for non-existing job/, 'Check status update for non-existing job');
+    ok($output =~ /Got status update for job .* that does not belong to Worker/,
         'Got status update for job that doesnt belong to worker');
 };
 # Test /jobs/cancel

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -396,10 +396,6 @@ subtest 'Cache tests' => sub {
         sleep 1;    # so that last_use is not the same for every item
     }
 
-    # Mark the Core-7.2 iso as being downloaded to force the worker to wait for the lock later on.
-    $sql = "update assets set downloading = 1 where filename = ? ";
-    $dbh->prepare($sql)->execute($result->{filename});
-
     $sql    = "SELECT * from assets order by last_use desc";
     $sth    = $dbh->prepare($sql);
     $result = $dbh->selectrow_hashref($sql);

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -295,13 +295,9 @@ if (!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i) {
 
     like($autoinst_log, qr/result: setup failure/, 'Test 4 state correct: setup failure');
 
-    like((split(/\n/, $autoinst_log))[0], qr/\[info\] \+\+\+ setup notes \+\+\+/,
-        'Test 4 correct autoinst setup notes');
-    like(
-        (split(/\n/, $autoinst_log))[-1],
-        qr/\[info\] uploading autoinst-log.txt/,
-        'Test 4 correct autoinst uploading autoinst'
-    );
+    like((split(/\n/, $autoinst_log))[0], qr/\+\+\+ setup notes \+\+\+/, 'Test 4 correct autoinst setup notes');
+    like((split(/\n/, $autoinst_log))[-1], qr/uploading autoinst-log.txt/,
+        'Test 4 correct autoinst uploading autoinst');
 }
 
 kill_worker;    # Ensure that the worker can be killed with TERM signal
@@ -363,15 +359,11 @@ subtest 'Cache tests' => sub {
 
         like($autoinst_log, qr/Downloading Core-7.2.iso/, 'Test 5, downloaded the right iso.');
         like($autoinst_log, qr/11116544/,                 'Test 5 Core-7.2.iso size is correct.');
-        like($autoinst_log, qr/\[info\] result: done/,    'Test 5 result done');
-        like(
-            (split(/\n/, $autoinst_log))[0],
-            qr/\[info\] \+\+\+ setup notes \+\+\+/,
-            'Test 5 correct autoinst setup notes'
-        );
+        like($autoinst_log, qr/result: done/,             'Test 5 result done');
+        like((split(/\n/, $autoinst_log))[0], qr/\+\+\+ setup notes \+\+\+/, 'Test 5 correct autoinst setup notes');
         like(
             (split(/\n/, $autoinst_log))[-1],
-            qr/\[info\] uploading autoinst-log.txt/,
+            qr/uploading autoinst-log.txt/,
             'Test 5 correct autoinst uploading autoinst'
         );
     }
@@ -437,16 +429,12 @@ subtest 'Cache tests' => sub {
         my $autoinst_log = do { local ($/); <$f> };
         close($f);
 
-        like($autoinst_log, qr/Content has not changed/, 'Test 7 Core-7.2.iso has not changed.');
-        like($autoinst_log, qr/\[info\] \+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
-        like(
-            (split(/\n/, $autoinst_log))[0],
-            qr/\[info\] \+\+\+ setup notes \+\+\+/,
-            'Test 7 correct autoinst setup notes'
-        );
+        like($autoinst_log, qr/Content has not changed/,     'Test 7 Core-7.2.iso has not changed.');
+        like($autoinst_log, qr/\+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
+        like((split(/\n/, $autoinst_log))[0], qr/\+\+\+ setup notes \+\+\+/, 'Test 7 correct autoinst setup notes');
         like(
             (split(/\n/, $autoinst_log))[-1],
-            qr/\[info\] uploading autoinst-log.txt/,
+            qr/uploading autoinst-log.txt/,
             'Test 7 correct autoinst uploading autoinst'
         );
     }
@@ -463,15 +451,11 @@ subtest 'Cache tests' => sub {
         my $autoinst_log = do { local ($/); <$f> };
         close($f);
 
-        like($autoinst_log, qr/\[info\] \+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
-        like(
-            (split(/\n/, $autoinst_log))[0],
-            qr/\[info\] \+\+\+ setup notes \+\+\+/,
-            'Test 8 correct autoinst setup notes'
-        );
+        like($autoinst_log, qr/\+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
+        like((split(/\n/, $autoinst_log))[0], qr/\+\+\+ setup notes \+\+\+/, 'Test 8 correct autoinst setup notes');
         like(
             (split(/\n/, $autoinst_log))[-1],
-            qr/\[info\] uploading autoinst-log.txt/,
+            qr/uploading autoinst-log.txt/,
             'Test 8 correct autoinst uploading autoinst'
         );
 

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -28,7 +28,6 @@ seq:
      - ./t/22-dashboard.t
      - ./t/23-amqp.t
      - ./t/24-worker.t
-     - ./t/25-cache.t
      - ./t/27-errorpages.t
      - ./t/30-test_parser.t
      - ./t/31-api_descriptions.t


### PR DESCRIPTION
This is still a WIP, i'm collecting test runs of the concurrent access test (that can be run only if STRESS_TEST is set, otherwise travis likely crashes) but so far is passing always in my local machine (25-cache.t). 

Gathering acceptance tests now.
- http://e122.suse.de/tests/overview?distri=sle&version=12-SP3&build=0473&groupid=28


Changes includes: 
- The Worker::Cache has been refactored in a OOP-style
- Added concurrent access test (disabled on travis) and extended unit tests
- Change of logic in locking mechanism, still kept within SQLite cache

One problem which was present and is still, is that it could potentially suffer of deadlock wrt single assets in case of hard crashes when being in the critical section, but i honestly would move it away to something different - this is a fairly simple caching system and SQLite already feels as an overkill solution to me.

See related progress issue: https://progress.opensuse.org/issues/34597