### PR TITLE
Refactor jobs::duplicate 

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -163,12 +163,12 @@ Variables are accessible via the *get_var* and *check_var* functions.
 === Capturing kernel exceptions and/or any other exceptions from the serial console
 
 Soft and hard failures can be triggered on demand by regular expressions when they match the
-serial output which is done after the test is executed. To use this functionality the test 
-developer needs to define the patterns to look for in the serial output either in the main.pm 
-or in the test itself. Any pattern change done in a test it will be reflected in the next 
+serial output which is done after the test is executed. To use this functionality the test
+developer needs to define the patterns to look for in the serial output either in the main.pm
+or in the test itself. Any pattern change done in a test it will be reflected in the next
 tests.
 
-The patterns defined in the main.pm will be valid for all the tests. 
+The patterns defined in the main.pm will be valid for all the tests.
 
 [caption="Example: "]
 .Defining serial exception capture in the main.pm
@@ -547,7 +547,7 @@ sub run {
     # any job id can be queried for details with get_job_info()
     # it returns a hash ref containing these keys:
     #   name priority state result worker_id
-    #   retry_avbl t_started t_finished test
+    #   t_started t_finished test
     #   group_id group settings
     my $parent_info = get_job_info($parent_id);
 
@@ -1064,4 +1064,3 @@ avoid them by informing the shell that it is running on a 'dumb' terminal (see
 the SUSE distribution's serial terminal utility library). However some
 programs ignore this, but piping there output into +tee+ is usually enough to
 stop them outputting non-printable characters.
-

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -30,6 +30,7 @@ use OpenQA::Utils ();
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
+# TODO: kill jobs::retry_avbl on next bump
 our $VERSION = 63;
 
 __PACKAGE__->load_namespaces;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -105,12 +105,10 @@ sub setup_log {
     }
 
     $self->log($log);
-    unless ($self->isa('OpenQA::Setup')) {
-        if ($ENV{OPENQA_SQL_DEBUG} // $self->config->{logging}->{sql_debug} // 'false' eq 'true') {
-            # avoid enabling the SQL debug unless we really want to see it
-            # it's rather expensive
-            db_profiler::enable_sql_debugging($self);
-        }
+    if ($ENV{OPENQA_SQL_DEBUG} // $self->config->{logging}->{sql_debug} // 'false' eq 'true') {
+        # avoid enabling the SQL debug unless we really want to see it
+        # it's rather expensive
+        db_profiler::enable_sql_debugging($self);
     }
 
     $OpenQA::Utils::app = $self;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -371,7 +371,7 @@ sub update_status {
 =item update()
 
 Updates the settings of a job with information specified in a passed JSON argument.
-Columns group_id, priority and retry_avbl cannot be set.
+Columns group_id and priority cannot be set.
 
 =back
 
@@ -387,7 +387,7 @@ sub update {
     my $settings = delete $json->{settings};
 
     # validate specified columns (print error if at least one specified column does not exist)
-    my @allowed_cols = qw(group_id priority retry_avbl);
+    my @allowed_cols = qw(group_id priority);
     for my $key (keys %$json) {
         if (!grep $_ eq $key, @allowed_cols) {
             return $self->render(json => {error => "Column $key can not be set"}, status => 400);

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -149,12 +149,11 @@ my $job_ref = {
     assets => {
         iso => ['whatever.iso'],
     },
-    t_started  => undef,
-    state      => "scheduled",
-    worker_id  => 0,
-    clone_id   => undef,
-    group_id   => undef,
-    retry_avbl => 3,
+    t_started => undef,
+    state     => "scheduled",
+    worker_id => 0,
+    clone_id  => undef,
+    group_id  => undef,
     # to be removed
     test => 'rainbow'
 };
@@ -192,7 +191,6 @@ my $jobs = [
         test       => 'rainbow',
         clone_id   => undef,
         group_id   => undef,
-        retry_avbl => 3,
         settings   => {
             DESKTOP     => "DESKTOP",
             DISTRI      => 'Unicorn',
@@ -222,7 +220,6 @@ my $jobs = [
         test       => 'rainbow',
         clone_id   => undef,
         group_id   => undef,
-        retry_avbl => 3,
         settings   => {
             DESKTOP     => "DESKTOP",
             DISTRI      => 'Unicorn',

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -26,7 +26,7 @@ use strict;
 use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Data::Dump qw(pp dd);
+use Data::Dump qw(pp dd dump);
 use OpenQA::Scheduler::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
@@ -401,17 +401,17 @@ $jobX->discard_changes;
 # X <---- Y
 # done    sch.
 
-is_deeply($jobY->to_hash(deps => 1)->{parents}, { Chained => [$jobX->id], Parallel => [] }, "JobY parents fit");
+is_deeply($jobY->to_hash(deps => 1)->{parents}, {Chained => [$jobX->id], Parallel => []}, "JobY parents fit");
 # when Y is scheduled and X is duplicated, Y must be cancelled and Y2 needs to depend on X2
 my $jobX2 = $jobX->auto_duplicate;
 $jobY->discard_changes;
 is($jobY->state, "skipped", "jobY was skipped");
 my $jobY2 = $jobY->clone;
 ok(defined $jobY2, "jobY was cloned too");
-is_deeply($jobY2->to_hash(deps => 1)->{parents}, { Chained => [$jobX2->id], Parallel => [] }, "JobY parents fit");
+is_deeply($jobY2->to_hash(deps => 1)->{parents}, {Chained => [$jobX2->id], Parallel => []}, "JobY parents fit");
 is($jobX2->id,    $jobY2->parents->single->parent_job_id, 'jobY2 parent is now jobX clone');
-is($jobX2->clone, undef,                                 "no clone");
-is($jobY2->clone,  undef,                                 "no clone");
+is($jobX2->clone, undef,                                  "no clone");
+is($jobY2->clone, undef,                                  "no clone");
 
 # current state:
 # X
@@ -500,8 +500,11 @@ my $jobJ2 = $jobL2->to_hash(deps => 1)->{parents}->{Parallel}->[0];
 is($jobJ2, $jobJ->clone->id, 'J2 cloned with parallel parent dep');
 my $jobH2 = job_get_deps($jobJ2)->{parents}->{Parallel}->[0];
 is($jobH2, $jobH->clone->id, 'H2 cloned with parallel parent dep');
-my $jobK2 = job_get_deps($jobH2)->{children}->{Parallel}->[0];
-is($jobK2, $jobK->clone->id, 'K2 cloned with parallel children dep');
+is_deeply(
+    job_get_deps($jobH2)->{children}->{Parallel},
+    [$jobK->clone->id, $jobJ2],
+    'K2 cloned with parallel children dep'
+);
 
 # checking all-in mixed scenario
 # original state:
@@ -600,35 +603,41 @@ _jobs_update_state([$jobP, $jobO, $jobI], OpenQA::Schema::Result::Jobs::DONE);
 
 # cloning O gets to expected state
 #
-# P2 <-(parallel) O2 (clone of) O <-(parallel) I
+# P2 <-(parallel) O2 (clone of) O <-(parallel) I2
 #
 my $jobO2 = $jobO->auto_duplicate;
 ok($jobO2, 'jobO duplicated');
 # reload data from DB
 $_->discard_changes for ($jobP, $jobO, $jobI);
 # check other clones
-ok($jobP->clone,  'jobP cloned');
-ok($jobO->clone,  'jobO cloned');
-ok(!$jobI->clone, 'jobI not cloned');
+ok($jobP->clone, 'jobP cloned');
+ok($jobO->clone, 'jobO cloned');
+ok($jobI->clone, 'jobI cloned');
 
 $jobO2 = job_get_deps($jobO2->id);
 $jobI  = job_get_deps($jobI->id);
+my $jobI2 = job_get_deps($jobI->{clone_id});
 my $jobP2 = job_get_deps($jobP->clone->id);
 
 is_deeply($jobI->{parents}->{Parallel},  [$jobO->id],    'jobI retain its original parent');
+is_deeply($jobI2->{parents}->{Parallel}, [$jobO2->{id}], 'jobI2 got new parent');
 is_deeply($jobO2->{parents}->{Parallel}, [$jobP2->{id}], 'clone jobO2 gets new parent jobP2');
 
 # get Jobs RS from ids for cloned jobs
 $jobO2 = $schema->resultset('Jobs')->search({id => $jobO2->{id}})->single;
 $jobP2 = $schema->resultset('Jobs')->search({id => $jobP2->{id}})->single;
+$jobI2 = $schema->resultset('Jobs')->search({id => $jobI2->{id}})->single;
 # set P2 running and O2 done
 _jobs_update_state([$jobP2], OpenQA::Schema::Result::Jobs::RUNNING);
 _jobs_update_state([$jobO2], OpenQA::Schema::Result::Jobs::DONE);
+_jobs_update_state([$jobI2], OpenQA::Schema::Result::Jobs::DONE);
 
 # cloning I gets to expected state:
 # P3 <-(parallel) O3 <-(parallel) I2
-my $jobI2 = job_get($jobI->{id})->auto_duplicate;
-ok($jobI2, 'jobI duplicated');
+
+# let's call this one I2'
+$jobI2 = $jobI2->auto_duplicate;
+ok($jobI2, 'jobI2 duplicated');
 
 # reload data from DB
 $_->discard_changes for ($jobP2, $jobO2);
@@ -716,18 +725,18 @@ $_->discard_changes for ($jobA, $jobB, $jobC, $jobD);
 # A2 <- B2 (clone of Bc)
 #    |- C2
 #    \- D2
-ok($jobB->clone->clone, 'jobB clone jobBc was cloned');
-my $jobB2_h = job_get_deps($jobB->clone->clone->id);
+ok($jobB->clone->clone, 'jobB clone jobBd was cloned');
+my $jobB2_h = job_get_deps($jobB->clone->clone->clone->id);
 is_deeply($jobB2_h->{parents}->{Chained}, [$jobA2->id], 'jobB2 has jobA2 as chained parent');
 is($jobB2_h->{settings}{TEST}, $jobB->TEST, 'jobB2 test and jobB test are equal');
 
 ok($jobC->clone, 'jobC was cloned');
-my $jobC2_h = job_get_deps($jobC->clone->id);
+my $jobC2_h = job_get_deps($jobC->clone->clone->id);
 is_deeply($jobC2_h->{parents}->{Chained}, [$jobA2->id], 'jobC2 has jobA2 as chained parent');
 is($jobC2_h->{settings}{TEST}, $jobC->TEST, 'jobC2 test and jobC test are equal');
 
 ok($jobD->clone, 'jobD was cloned');
-my $jobD2_h = job_get_deps($jobD->clone->id);
+my $jobD2_h = job_get_deps($jobD->clone->clone->id);
 is_deeply($jobD2_h->{parents}->{Chained}, [$jobA2->id], 'jobD2 has jobA2 as chained parent');
 is($jobD2_h->{settings}{TEST}, $jobD->TEST, 'jobD2 test and jobD test are equal');
 
@@ -772,16 +781,17 @@ is($jobA2->id, $jobA2->id, 'jobA2 is indeed jobA clone');
 $jobA2->state(OpenQA::Schema::Result::Jobs::RUNNING);
 $jobA2->update;
 my $jobA3 = $jobA2->auto_duplicate;
+ok($jobA3, "cloned A2");
 $_->discard_changes for ($jobA, $jobB, $jobC, $jobD);
 
 # check all children were cloned anymore and has $jobA3 as parent
 for ($jobB, $jobC, $jobD) {
-    ok(!$_->clone->clone, 'job correctly not cloned');
-    my $h = job_get_deps($_->clone->id);
+    ok($_->clone->clone, 'job correctly not cloned');
+    my $h = job_get_deps($_->clone->clone->id);
     is_deeply($h->{parents}{Chained}, [$jobA3->id], 'job has jobA3 as parent');
 }
 
-# situation: chanied parent is done, children are all failed and has parallel dependency to the first sibling
+# situation: chained parent is done, children are all failed and has parallel dependency to the first sibling
 #    /- C
 #    |  |
 # A <-- B

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -73,9 +73,11 @@ is_deeply(
     job_get_rs(99926)->jobs_to_duplicate,
     {
         '99926' => {
+            'parallel_parents'  => [],
+            'chained_parents'   => [],
             'parallel_children' => [],
             'chained_children'  => [],
-            'parents'           => []}
+        }
     },
     '99926 has no siblings'
 );
@@ -122,12 +124,14 @@ is_deeply(
     {
         '99937' => {
             'chained_children'  => [99938],
-            'parents'           => [],
+            'parallel_parents'  => [],
+            'chained_parents'   => [],
             'parallel_children' => []
         },
         '99938' => {
             'parallel_children' => [],
-            'parents'           => [],
+            'parallel_parents'  => [],
+            'chained_parents'   => [99937],
             'chained_children'  => []}
     },
     '99937 has one chained child'
@@ -157,14 +161,16 @@ is_deeply(
     job_get_rs(99963)->jobs_to_duplicate,
     {
         '99963' => {
-            'parents'           => [99961],
+            'parallel_parents'  => [99961],
+            'chained_parents'   => [],
             'chained_children'  => [],
             'parallel_children' => []
         },
         '99961' => {
             'parallel_children' => [99963],
             'chained_children'  => [],
-            'parents'           => []}
+            'chained_parents'   => [],
+            'parallel_parents'  => []}
     },
     '99963 has one parallel parent'
 );

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -143,11 +143,9 @@ is_deeply($job1, $job2, "running job unchanged after cancel");
 my $job3 = job_get(99938)->{clone_id};
 job_get_rs($job3)->done(result => OpenQA::Schema::Result::Jobs::INCOMPLETE);
 $job3 = job_get($job3);
-is($job3->{retry_avbl}, 3, "the retry counter setup ");
 my $round1 = job_get_rs($job3->{id})->auto_duplicate({dup_type_auto => 1});
 ok(defined $round1, "auto-duplicate works");
 $job3 = job_get($round1->id);
-is($job3->{retry_avbl}, 2, "the retry counter decreased");
 # need to change state from scheduled
 $job3 = job_get($round1->id);
 job_get_rs($job3->{id})->done(result => OpenQA::Schema::Result::Jobs::INCOMPLETE);
@@ -155,28 +153,20 @@ $round1->discard_changes;
 my $round2 = $round1->auto_duplicate({dup_type_auto => 1});
 ok(defined $round2, "auto-duplicate works");
 $job3 = job_get($round2->id);
-is($job3->{retry_avbl}, 1, "the retry counter decreased");
 # need to change state from scheduled
 job_get_rs($job3->{id})->done(result => OpenQA::Schema::Result::Jobs::INCOMPLETE);
 $round2->discard_changes;
 my $round3 = $round2->auto_duplicate({dup_type_auto => 1});
 ok(defined $round3, "auto-duplicate works");
 $job3 = job_get($round3->id);
-is($job3->{retry_avbl}, 0, "the retry counter decreased");
 # need to change state from scheduled
 job_get_rs($job3->{id})->done(result => OpenQA::Schema::Result::Jobs::INCOMPLETE);
-my $round4_id;
-stderr_like {
-    $round4_id = job_get_rs($round3->id)->auto_duplicate({dup_type_auto => 1});
-}
-qr/Could not auto-duplicated! The job are auto-duplicated too many times/;
-ok(!defined $round4_id, "no longer auto-duplicating");
+
 # need to change state from scheduled
 $job3 = job_get($round3->id);
 job_get_rs($job3->{id})->done(result => OpenQA::Schema::Result::Jobs::INCOMPLETE);
 my $round5 = job_get_rs($round3->id)->auto_duplicate;
 ok(defined $round5, "manual-duplicate works");
 $job3 = job_get($round5->id);
-is($job3->{retry_avbl}, 1, "the retry counter increased");
 
 done_testing;

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -34,9 +34,10 @@ use Test::Warnings;
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-my $minimalx = $t->app->db->resultset("Jobs")->find({id => 99926});
-my %clones   = $minimalx->duplicate();
-my $clone    = $clones{$minimalx->id};
+my $rset     = $t->app->db->resultset("Jobs");
+my $minimalx = $rset->find(99926);
+my $clones   = $minimalx->duplicate();
+my $clone    = $rset->find($clones->{$minimalx->id}->{clone});
 
 isnt($clone->id, $minimalx->id, "is not the same job");
 is($clone->TEST,     "minimalx",  "but is the same test");
@@ -60,8 +61,8 @@ is($minimalx->duplicate, undef, "cannot clone after reloading");
 
 # But cloning the clone should be possible after job state change
 $clone->state(OpenQA::Schema::Result::Jobs::CANCELLED);
-%clones = $clone->duplicate({prio => 35});
-my $second = $clones{$clone->id};
+$clones = $clone->duplicate({prio => 35});
+my $second = $rset->find($clones->{$clone->id}->{clone});
 is($second->TEST,     "minimalx", "same test again");
 is($second->priority, 35,         "with adjusted priority");
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -39,11 +39,10 @@ my %clones   = $minimalx->duplicate();
 my $clone    = $clones{$minimalx->id};
 
 isnt($clone->id, $minimalx->id, "is not the same job");
-is($clone->TEST,       "minimalx",  "but is the same test");
-is($clone->priority,   56,          "with the same priority");
-is($clone->retry_avbl, 3,           "with the same retry_avbl");
-is($minimalx->state,   "done",      "original test keeps its state");
-is($clone->state,      "scheduled", "the new job is scheduled");
+is($clone->TEST,     "minimalx",  "but is the same test");
+is($clone->priority, 56,          "with the same priority");
+is($minimalx->state, "done",      "original test keeps its state");
+is($clone->state,    "scheduled", "the new job is scheduled");
 
 # Second attempt
 ok($minimalx->can_be_duplicated, "looks cloneable");
@@ -61,10 +60,9 @@ is($minimalx->duplicate, undef, "cannot clone after reloading");
 
 # But cloning the clone should be possible after job state change
 $clone->state(OpenQA::Schema::Result::Jobs::CANCELLED);
-%clones = $clone->duplicate({prio => 35, retry_avbl => 2});
+%clones = $clone->duplicate({prio => 35});
 my $second = $clones{$clone->id};
-is($second->TEST,       "minimalx", "same test again");
-is($second->priority,   35,         "with adjusted priority");
-is($second->retry_avbl, 2,          "with adjusted retry_avbl");
+is($second->TEST,     "minimalx", "same test again");
+is($second->priority, 35,         "with adjusted priority");
 
 done_testing();

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -68,7 +68,7 @@ subtest 'worker with job and not updated in last 120s is considered dead' => sub
     stderr_like {
         OpenQA::WebSockets::Server::_workers_checker();
     }
-    qr/dead job 99961 aborted and duplicated 99983\n.*dead job 99963 aborted as incomplete/;
+    qr/dead job 99961 aborted and duplicated 99982\n.*dead job 99963 aborted as incomplete/;
     _check_job_incomplete($_) for (99961, 99963);
 };
 

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -38,12 +38,11 @@
     },
     Jobs => {
         # job with empty value settings as default
-        id         => 80000,
-        priority   => 50,
-        result     => "passed",
-        retry_avbl => 3,
-        TEST       => 'minimalx',
-        state      => "done",
+        id       => 80000,
+        priority => 50,
+        result   => "passed",
+        TEST     => 'minimalx',
+        state    => "done",
         # Really old
         t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 36000, 'UTC'),
         # Really long ago
@@ -51,12 +50,11 @@
         t_created => time2str('%Y-%m-%d %H:%M:%S', time - 72000, 'UTC'),
     },
     Jobs => {
-        id         => 99926,
-        group_id   => 1001,
-        priority   => 56,
-        result     => "incomplete",
-        retry_avbl => 3,
-        settings   => [
+        id       => 99926,
+        group_id => 1001,
+        priority => 56,
+        result   => "incomplete",
+        settings => [
             {key => 'DESKTOP',     value => 'minimalx'},
             {key => 'ISO',         value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'},
             {key => 'ISO_MAXSIZE', value => 737280000},
@@ -90,7 +88,6 @@
         t_finished => undef,
         t_started  => undef,
         TEST       => "RAID0",
-        retry_avbl => 3,
         ARCH       => 'i586',
         FLAVOR     => 'DVD',
         DISTRI     => 'opensuse',
@@ -119,7 +116,6 @@
         t_started  => undef,
         backend    => 'qemu',
         TEST       => "RAID1",
-        retry_avbl => 3,
         FLAVOR     => 'DVD',
         BUILD      => '0091',
         DISTRI     => 'opensuse',
@@ -147,7 +143,6 @@
         t_created   => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),      # Two hours ago
         TEST        => "kde",
         jobs_assets => [{asset_id => 1},],
-        retry_avbl  => 3,
         ARCH        => 'i586',
         VERSION     => '13.1',
         FLAVOR      => 'DVD',
@@ -182,7 +177,6 @@
         DISTRI     => 'opensuse',
         MACHINE    => '64bit',
         backend    => 'qemu',
-        retry_avbl => 3,
         result_dir => '00099938-opensuse-Factory-DVD-x86_64-Build0048-doc',
         settings   => [
             {key => 'DVD',         value => '1'},
@@ -209,7 +203,6 @@
         BUILD      => '0048',
         DISTRI     => 'opensuse',
         MACHINE    => '64bit-uefi',
-        retry_avbl => 3,
         settings   => [
             {key => 'DVD',         value => '1'},
             {key => 'DESKTOP',     value => 'kde'},
@@ -230,16 +223,15 @@
         # Two hours ago
         t_started => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),
         # One hour ago
-        t_created  => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),
-        TEST       => "kde",
-        ARCH       => 'x86_64',
-        VERSION    => 'Factory',
-        backend    => 'qemu',
-        FLAVOR     => 'DVD',
-        BUILD      => '0048',
-        DISTRI     => 'opensuse',
-        MACHINE    => '64bit',
-        retry_avbl => 3,
+        t_created => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),
+        TEST      => "kde",
+        ARCH      => 'x86_64',
+        VERSION   => 'Factory',
+        backend   => 'qemu',
+        FLAVOR    => 'DVD',
+        BUILD     => '0048',
+        DISTRI    => 'opensuse',
+        MACHINE   => '64bit',
         # no result dir, let us assume that this is an old test that has
         # already be pruned
         settings => [
@@ -271,7 +263,6 @@
         DISTRI     => 'opensuse',
         MACHINE    => '64bit',
         backend    => 'qemu',
-        retry_avbl => 3,
         result_dir => '00099938-opensuse-Factory-DVD-x86_64-Build0048-doc',
         settings   => [
             {key => 'DVD',         value => '1'},
@@ -301,7 +292,6 @@
         MACHINE     => '32bit',
         backend     => 'qemu',
         jobs_assets => [{asset_id => 1}, {asset_id => 5}],
-        retry_avbl  => 3,
         result_dir  => '00099946-opensuse-13.1-DVD-i586-Build0091-textmode',
         settings    => [
             {key => 'QEMUCPU',     value => 'qemu32'},
@@ -332,7 +322,6 @@
         MACHINE     => '32bit',
         ARCH        => 'i586',
         jobs_assets => [{asset_id => 1},],
-        retry_avbl  => 3,
         settings    => [
             {key => 'QEMUCPU',     value => 'qemu32'},
             {key => 'DVD',         value => '1'},
@@ -360,7 +349,6 @@
         MACHINE     => '32bit',
         ARCH        => 'i586',
         jobs_assets => [{asset_id => 1},],
-        retry_avbl  => 3,
         settings    => [
             {key => 'QEMUCPU',     value => 'qemu32'},
             {key => 'DVD',         value => '1'},
@@ -387,7 +375,6 @@
         MACHINE     => '32bit',
         ARCH        => 'i586',
         jobs_assets => [{asset_id => 1},],
-        retry_avbl  => 3,
         settings    => [
             {key => 'QEMUCPU',     value => 'qemu32'},
             {key => 'DVD',         value => '1'},
@@ -413,7 +400,6 @@
         VERSION     => '13.1',
         backend     => 'qemu',
         jobs_assets => [{asset_id => 2},],
-        retry_avbl  => 3,
         ARCH        => 'x86_64',
         settings    => [
             {key => 'DESKTOP',     value => 'kde'},
@@ -441,7 +427,6 @@
         VERSION     => '13.1',
         backend     => 'qemu',
         jobs_assets => [{asset_id => 2},],
-        retry_avbl  => 3,
         ARCH        => 'x86_64',
         result_dir  => '00099962-opensuse-13.1-DVD-x86_64-Build0091-kde',
         settings    => [
@@ -469,7 +454,6 @@
         BUILD       => '0091',
         DISTRI      => 'opensuse',
         jobs_assets => [{asset_id => 3},],
-        retry_avbl  => 3,
         settings    => [
             {key => 'DESKTOP',     value => 'gnome'},
             {key => 'ISO_MAXSIZE', value => '999999999'},
@@ -501,7 +485,6 @@
         MACHINE     => '64bit',
         VERSION     => '13.1',
         jobs_assets => [{asset_id => 2}, {asset_id => 6},],
-        retry_avbl  => 3,
         result_dir  => '00099961-opensuse-13.1-DVD-x86_64-Build0091-kde',
         settings    => [
             {key => 'DESKTOP',     value => 'kde'},


### PR DESCRIPTION
Related issues:
 https://progress.opensuse.org/issues/34504
 https://progress.opensuse.org/issues/35914
 https://progress.opensuse.org/issues/30361

I removed the recursive nature of duplicate, which now that I looked into it was very dangerous as the DB transactions happened per job within that recursion, but there was no global rollback - but dependencies were already added partly.

I also removed some - let's say - optimizations that reused scheduled jobs for the new cluster jobs, which lead to unclear dependencies of the chain (*especially* if partly jobs failed to duplicate).

I also revisted one decision that makes restarting multimachine jobs very hard in practise: done parents were excluded from restarting. I don't know what use case lead to that decision, but in our daily practise we rely on a multimachine test to have multiple machines running in parallel - so we currently have to be very careful always to restart the parent. I fixed this and now the full cluster is restarted. Test cases have been adapted, but many test cases in 05-scheduler-dependencies.t lost their full sense - as they tested old (IMO broken) behaviour.
