### PR TITLE
runcmd tests: handle differently-cased git error message

### DIFF
--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -60,6 +60,10 @@ stderr_like {
     };
 }
 qr/fatal: Not a git repository.*\n.*cmd returned non-zero value/i;
-is($res, 'Unable to commit via Git: fatal: Not a git repository: \'/some/dir/.git\'', 'Git error message returned');
+like(
+    $res,
+    qr'^Unable to commit via Git: fatal: (N|n)ot a git repository: \'/some/dir/.git\'$',
+    'Git error message returned'
+);
 
 done_testing();


### PR DESCRIPTION
A git error message that 16-utils-runcmd.t expects to run into
has had its case changed in upstream git - formerly it was "Not
a git repository...", now it's "not a git repository...". This
was changed in fc045fe , "Mark messages for translations"; the
discussion on the upstream git mailing list indicates this is
to stay in line with a general policy on error messages for the
git project. As we're fairly likely to want this test to pass
with versions of git both before and after the change, let's
accept either form.

Signed-off-by: Adam Williamson <awilliam@redhat.com>