### PR TITLE
Typo in travis and improvement of the Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install: yes
 before_script:
   - docker pull dasantiago/openqa-tests  
 script:
-  - docker run --cap-add SYS_ADMIN -v $TRAVIS_BUILD_DIR:/opt/openqa -v /var/run/dbus:/var/run/dbus --env-file <(env | grep TRAVIS) -e TRAVIS=true -e FULLSTACK -e UITESTS -e SCHEDULER_FULL_STACK -e GH_PUBLISH dasantiago/openqa-tests make travis-codecov
+  - docker run --cap-add SYS_ADMIN -v $TRAVIS_BUILD_DIR:/opt/openqa -v /var/run/dbus:/var/run/dbus --env-file <(env | grep TRAVIS) -e TRAVIS=true -e FULLSTACK -e UITESTS -e SCHEDULER_FULLSTACK -e GH_PUBLISH dasantiago/openqa-tests make travis-codecov
 after_failure:
   - cat /tmp/openqa-debug.log
 after_script: yes

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,9 @@ docker-tests:
 	  fi ;\
           prove ${PROVE_ARGS} -r $$list | tee $$tmp_file ;\
 	fi ;\
-	tail -n 1 $$tmp_file | grep -o -E "PASS|[[:digit:]]+..[[:digit:]]+" ;\
+	grep -o -E -v "Looks like you failed [[:digit:]]+ test|not ok [[:digit:]]|Result: FAIL" $$tmp_file ;\
 	test_failed=$$? ;\
+	echo $$test_failed ;\
 	if [[ $$test_failed -ne 0 && $$TRAVIS ]]; then\
 		cat /tmp/openqa-debug.log ;\
 	fi ;\


### PR DESCRIPTION
This PR solves the SCHEDULER_FULLSTACK typo, and fixes the test false positives.

Unfortunately propagating the exit code doesn't work all the times as shown in test, https://travis-ci.org/dasantiago/openQA/jobs/385108697#L881

So we are checking all the ways perl or prove can exit with error:

1. [not ok](https://travis-ci.org/dasantiago/openQA/jobs/385108697)

2. [Result: FAIL](https://travis-ci.org/foursixnine/openQA/jobs/389227774#L2067) 

3. [Looks like you failed](https://travis-ci.org/foursixnine/openQA/jobs/389227774#L1714)
