### PR TITLE
Categorize UEFI PFLASH drives as HDD assets

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -507,7 +507,7 @@ sub asset_type_from_setting {
     if ($setting eq 'ISO' || $setting =~ /^ISO_\d+$/) {
         return 'iso';
     }
-    if ($setting =~ /^HDD_\d+$/) {
+    if ($setting =~ /^HDD_\d+$/ || $setting =~ /^UEFI_PFLASH_\w+$/) {
         return 'hdd';
     }
     if ($setting =~ /^REPO_\d+$/) {


### PR DESCRIPTION
Allow UEFI firmware code and variable images to be stored in the HDD
folder. They are block devices the same as the other contents of the HDD
folder.

This is related to: https://github.com/os-autoinst/os-autoinst/pull/942

Without this change absolute paths need to be given for the UEFI_PFLASH_CODE and UEFI_PFLASH_VARS variables. The variables could be put in a different folder if necessary.