### PR TITLE
Let tmpfiles.d create the mount point "share"

### DIFF
--- a/systemd/tmpfiles-openqa.conf
+++ b/systemd/tmpfiles-openqa.conf
@@ -1,1 +1,2 @@
 d /run/openqa 0755 _openqa-worker root
+d /var/lib/openqa/share 0755 _openqa-worker root


### PR DESCRIPTION
With caching enabled worker still requires /var/lib/openqa/share
- https://progress.opensuse.org/issues/32632