### PR TITLE
[WIP] Check if SHARE_DIRECTORY is set in workers.ini

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -67,12 +67,14 @@ sub main {
             $shared_cache = prepare_cache_directory($h, $worker_settings->{CACHEDIRECTORY});
         }
         # this is being also duplicated by OpenQA::Test::Utils since 49c06362d
-        my @dirs = ($host_settings->{$h}{SHARE_DIRECTORY}, catdir($OpenQA::Utils::prjdir, 'share'));
-        ($dir) = grep { $_ && -d } @dirs;
-        unless ($dir) {
-            map { log_debug("Found possible working directory for $h: $_") if $_ } @dirs;
-            log_error("Ignoring host '$h': Working directory does not exist.");
-            next;
+        if ($worker_settings->{SHARE_DIRECTORY}) {
+            my @dirs = ($host_settings->{$h}{SHARE_DIRECTORY}, catdir($OpenQA::Utils::prjdir, 'share'));
+            ($dir) = grep { $_ && -d } @dirs;
+            unless ($dir) {
+                map { log_debug("Found possible working directory for $h: $_") if $_ } @dirs;
+                log_error("Ignoring host '$h': Working directory does not exist.");
+                next;
+            }
         }
 
         log_info("Project dir for host $h is $dir");


### PR DESCRIPTION
With caching enabled worker still requires /var/lib/openqa/share
- https://progress.opensuse.org/issues/32632