### PR TITLE
Wipe out waiting state

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -19,7 +19,7 @@ var logElements;
 
 // Update global variable testStatus
 function updateTestStatus(newStatus) {
-    if (newStatus.state != 'running' && newStatus.state != 'waiting') {
+    if (newStatus.state != 'running') {
         setTimeout(function() {location.reload();}, 2000);
         return;
     }

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -307,7 +307,6 @@ function setupResult(state, jobid, status_url, details_url) {
   }
   // This could be easily rewritten as $.inArray
   if ( state == "running"   ||
-       state == "waiting"   ||
        state == "uploading" ||
        state == "assigned"  ||
        state == "setup" ) {
@@ -388,6 +387,7 @@ function setupResult(state, jobid, status_url, details_url) {
           trElement[stepMaches ? 'show' : 'hide']();
       });
   };
+
   detailsNameFilter.keyup(applyFilterChanges);
   detailsFailedOnlyFilter.change(applyFilterChanges);
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -46,15 +46,14 @@ use constant {
     SETUP     => 'setup',
     RUNNING   => 'running',
     CANCELLED => 'cancelled',
-    WAITING   => 'waiting',
     DONE      => 'done',
     UPLOADING => 'uploading',
     ASSIGNED  => 'assigned'
 };
 
-use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, WAITING, DONE, CANCELLED);
-use constant PENDING_STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, WAITING, UPLOADING);
-use constant EXECUTION_STATES => (ASSIGNED, SETUP, WAITING, RUNNING, UPLOADING);
+use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, DONE, CANCELLED);
+use constant PENDING_STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING);
+use constant EXECUTION_STATES => (ASSIGNED, SETUP, RUNNING, UPLOADING);
 use constant PRE_EXECUTION_STATES => (SCHEDULED);    # Assigned belongs to pre execution, but makes no sense for now
 use constant FINAL_STATES => (DONE, CANCELLED);
 
@@ -1396,7 +1395,7 @@ sub update_status {
         $assigned_worker->set_property(CMD_SRV_URL => ($status->{cmd_srv_url} // ''));
     }
 
-    $self->state(RUNNING) and $self->t_started(now()) if grep { $_ eq $self->state } (WAITING, ASSIGNED, SETUP);
+    $self->state(RUNNING) and $self->t_started(now()) if grep { $_ eq $self->state } (ASSIGNED, SETUP);
     $self->update();
 
     # result=1 for the call, job_result for the current state

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1654,11 +1654,6 @@ sub carry_over_bugrefs {
     return;
 }
 
-sub running_or_waiting {
-    my ($self) = @_;
-    return ($self->state eq 'running' || $self->state eq 'waiting');
-}
-
 # extend to finish
 sub store_column {
     my ($self, %args) = @_;

--- a/templates/test/infopanel.html.ep
+++ b/templates/test/infopanel.html.ep
@@ -48,7 +48,7 @@
                             <i class="fa fa-2 fa-redo" title="Restart Job"></i>
                         %= end
                     % }
-                    % if (is_operator && ($job->running_or_waiting || $job->state eq 'scheduled')) {
+                    % if (is_operator && ($job->state eq 'running' || $job->state eq 'scheduled')) {
                         %= link_post url_for('apiv1_cancel', jobid => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin
                             <i class="far fa-2 fa-times-circle" title="Cancel Job"></i>
                         % end

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -26,7 +26,7 @@
                 <li role="presentation" class="nav-item">
                     <a href="#details" aria-controls="details" role="tab" data-toggle="tab" class="nav-link active">Details</a>
                 </li>
-                % if ($job->running_or_waiting) {
+                % if ($job->state eq 'running') {
                     <li role="presentation" class="nav-item">
                         <a href="#live" aria-controls="live" role="tab" data-toggle="tab" class="nav-link">Live View</a>
                     </li>
@@ -50,7 +50,7 @@
                     %= include 'test/details'
                 </div>
 
-                % if ($job->running_or_waiting) {
+                % if ($job->state eq 'running') {
                     <div role="tabpanel" class="tab-pane" id="live">
                         %= include 'test/live'
                     </div>


### PR DESCRIPTION
Since waiting state is deprecated, and isotovideo now is able to
report the state of the test via /status, running_or_waiting is now
useless, so remove it