### PR TITLE
Fix wrapping of parser results

### DIFF
--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -165,7 +165,11 @@ span.resborder_na {
     width: 100%;
 
     .resborder {
-        width: 100%;
+        min-width: -moz-available;
+        min-width: -webkit-fill-available;
+        min-width: fill-available;
+        min-width: stretch;
+        max-width: 100%;
         height: auto;
         font-family: monospace;
         text-align: left;
@@ -177,6 +181,7 @@ span.resborder_na {
         background-color: #e8f1f1;
         max-height: 3.5rem;
         white-space: pre-wrap;
+        overflow-wrap: break-word;
     }
 }
 .current_preview .text-result .resborder {


### PR DESCRIPTION
See https://progress.opensuse.org/issues/37519

The problem is that the parser output contains too long, unbreakable lines.

Looks good when using `min-width: fit-content` which currently requires vendor prefixes for Firefox and WebKit-based browsers:  
![screenshot_20180620_110752](https://user-images.githubusercontent.com/10248953/41648780-2d918d62-747a-11e8-82f2-9d361788fa20.png)

Not sure how to fix this otherwise without JavaScript or even some server-side adjustments. Note that this won't work with IE, but I don't think we care.
