### PR TITLE
Prevent use of global variables in LiveViewHandler.pm

### DIFF
--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -38,6 +38,19 @@ has secrets => sub {
     return $self->schema->read_application_secrets();
 };
 
+# add attributes to store ws connections/transactions by job
+# (see LiveViewHandler.pm for further descriptions of the paricular attributes)
+has(
+    [
+        qw(cmd_srv_transactions_by_job
+          devel_java_script_transactions_by_job
+          status_java_script_transactions_by_job)
+    ],
+    sub {
+        return {};
+    },
+);
+
 sub log_name {
     return $$;
 }

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -460,8 +460,6 @@ sub not_found_ws {
 sub not_found_http {
     my ($self) = @_;
 
-    print("not_found_http\n");
-
     return $self->respond_to(
         any => {
             text   => "route does not exist\n",

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -362,14 +362,6 @@ sub ws_proxy {
     my $job_id             = $job->id;
     my $developer_sessions = $app->schema->resultset('DeveloperSessions');
 
-
-    # add JavaScript transaction to the list of JavaScript transactions for this job
-    # (needed for broadcasting to all clients)
-    my $java_script_transaction_container
-      = $status_only ? $self->status_java_script_transactions_by_job : $self->devel_java_script_transactions_by_job;
-    my $java_script_transactions_for_current_job = ($java_script_transaction_container->{$job_id} //= []);
-    push(@$java_script_transactions_for_current_job, $java_script_tx);
-
     # register development session, ensure only one development session is opened per job
     if (!$status_only) {
         $user = $self->current_user()
@@ -385,6 +377,13 @@ sub ws_proxy {
         # mark session as active
         $developer_session->update({ws_connection_count => \'ws_connection_count + 1'});   #'restore syntax highlighting
     }
+
+    # add JavaScript transaction to the list of JavaScript transactions for this job
+    # (needed for broadcasting to all clients)
+    my $java_script_transaction_container
+      = $status_only ? $self->status_java_script_transactions_by_job : $self->devel_java_script_transactions_by_job;
+    my $java_script_transactions_for_current_job = ($java_script_transaction_container->{$job_id} //= []);
+    push(@$java_script_transactions_for_current_job, $java_script_tx);
 
     # determine url to os-autoinst command server
     my $cmd_srv_raw_url = OpenQA::WebAPI::Controller::Developer::determine_os_autoinst_web_socket_url($job);

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -265,12 +265,12 @@ subtest 'cancel a scheduled job' => sub {
         undef, 0.2,
     );
 
-    my $cancel_button = $driver->find_element('cancel_running', 'id');
-    if (!$cancel_button) {
+    my @cancel_button = $driver->find_elements('cancel_running', 'id');
+    if (!@cancel_button) {
         note('test is already assigned, can not test cancelling');
         return;
     }
-    $cancel_button->click();
+    $cancel_button[0]->click();
 };
 
 $driver->click_element_ok('All Tests',     'link_text');


### PR DESCRIPTION
* Use constant for allowed os-autoinst commands
  (the hash won't be const, only the reference to it)
* Use attributes on application-scope to store web socket
  transactions