### PR TITLE
Adjust overflow behavior of dashboard progress bars

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -20,6 +20,7 @@ td div.progress {
     .progress-bar {
         // don' use flex box because it leads to undesired overflow behavior
         display: inline;
+        overflow: hidden;
     }
     .progress-bar-passed {
         background-color: $color-module-passed;


### PR DESCRIPTION
This prevents the text to overlap:

* Before:  
  ![screenshot_20180703_132430](https://user-images.githubusercontent.com/10248953/42217160-6bd42c70-7ec4-11e8-8b2e-2f22c4e69804.png)
* After:  
  ![screenshot_20180703_132513](https://user-images.githubusercontent.com/10248953/42217187-85483d04-7ec4-11e8-9066-61789368e207.png)

