### PR TITLE
developer mode: Show only modules which are still ahead

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -310,6 +310,7 @@ var developerMode = {
     panelExpanded: false,                   // whether the panel is supposed to be expanded
     panelActuallyExpanded: false,           // whether the panel is currently expanded
     reconnectAttempts: 0,                   // number of (re)connect attempts (reset after successful connect)
+    currentModuleIndex: undefined,          // the index of the current module
 
     // state of the test execution (comes from os-autoinst cmd srv through the openQA ws proxy)
     currentModule: undefined,               // name of the current module, eg. "installation-welcome"
@@ -399,7 +400,7 @@ function updateDeveloperPanel() {
         panelBody.toggle(200);
     }
 
-    // find modules
+    // find modules and determine the index of the current module
     var moduleToPauseAtSelect = $('#developer-pause-at-module');
     var moduleToPauseAtOptions = moduleToPauseAtSelect.find('option');
     var modules = moduleToPauseAtOptions.map(function() {
@@ -408,6 +409,24 @@ function updateDeveloperPanel() {
         return category ? (category + '-' + option.val()) : option.val();
     }).get();
     var currentModuleIndex = modules.indexOf(developerMode.currentModule);
+
+    // hide modules which have already been executed when the current module index has changed
+    if (developerMode.currentModuleIndex !== currentModuleIndex) {
+        developerMode.currentModuleIndex = currentModuleIndex;
+        for (var i = 0; i <= currentModuleIndex; ++i) {
+            var optionElement = moduleToPauseAtOptions[i];
+            var optgroupElement = optionElement.parentNode;
+            if (!optgroupElement || optgroupElement.nodeName !== 'OPTGROUP') {
+                continue;
+            }
+            optionElement.style.display = 'none';
+            if (optgroupElement.lastElementChild.isEqualNode(optionElement)) {
+                optgroupElement.style.display = 'none';
+            }
+        }
+    }
+
+    // determine whether the module to pause at is still ahead
     var toPauseAtIndex = modules.indexOf(developerMode.moduleToPauseAt);
     if (toPauseAtIndex < 0) {
         toPauseAtIndex = 0;

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -161,12 +161,18 @@ subtest 'state shown when connected' => sub {
     fake_state(developerMode => {currentModule => '"installation-welcome"'});
     element_hidden('#developer-instructions');
     element_visible('#developer-panel .card-header', qr/current module: installation-welcome/, qr/paused/,);
+    my @options   = $driver->find_elements('#developer-pause-at-module option');
+    my @optgroups = $driver->find_elements('#developer-pause-at-module optgroup');
+    is(
+        $_->get_css_attribute('display'),
+        (($_->get_value() // '') =~ qr/boot|welcome/) ? 'none' : 'block',
+        'only modules after the current module displayed'
+    ) for (@options, @optgroups);
 
     # will pause at certain module
     fake_state(developerMode => {moduleToPauseAt => '"installation-foo"'});
     element_hidden('#developer-instructions');
     element_visible('#developer-panel .card-header', qr/will pause at module: installation-foo/, qr/paused/,);
-    my @options = $driver->find_elements('#developer-pause-at-module option');
     is(scalar @options, 5, '5 options in module to pause at selection present');
     is($_->is_selected(), $_->get_value() eq 'foo' ? 1 : 0, 'only foo selected') for (@options);
 
@@ -218,6 +224,7 @@ subtest 'expand developer panel' => sub {
         \@expected_text_on_initial_session_creation,
         [@expected_text_after_session_created, qr/Resume/],
     );
+    element_visible('#developer-pause-at-module');
 
     subtest 'behavior when changes have not been confirmed' => sub {
         my @options = $driver->find_elements('#developer-pause-at-module option');


### PR DESCRIPTION
Because pausing at a module which is currently running or has already been completed isn't possible anyways.

(I think this was also mentioned in the review by @foursixnine and I postponed it because the PR was so big already.)