### PR TITLE
needle editor: Assign new background image instantly

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -156,9 +156,9 @@ NeedleEditor.prototype.DrawAreas = function() {
 NeedleEditor.prototype.LoadBackground = function(url) {
   var editor = this;
   var image = new Image();
+  editor.bgImage = image;
   image.src = url;
   image.onload = function() {
-    editor.bgImage = image;
     editor.init();
   };
 };


### PR DESCRIPTION
This should not affect the behavior.

However, it hopefully makes the test 12-needle-edit.t more stable to prevent wrong failures like `not ok 10 - new needle image shown`.

Note that this issue is hard to reproduce, so I'm not sure whether this change will help (we will have to try out).