### PR TITLE
Use wss protocol for websocket connection when page loaded via https

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -112,7 +112,8 @@ function makeWsUrlAbsolute(url, servicePortDelta) {
     }
 
     // read port from the page's current URL
-    var port = Number.parseInt(window.location.port);
+    var location = window.location;
+    var port = Number.parseInt(location.port);
     if (Number.isNaN(port)) {
         // don't put a port in the URL if there's no explicit port
         port = '';
@@ -127,8 +128,8 @@ function makeWsUrlAbsolute(url, servicePortDelta) {
         port = ':' + port;
     }
 
-    return 'ws://'
-        + window.location.hostname + port
+    return (location.protocol == 'https:' ? 'wss://' : 'ws:/')
+        + location.hostname + port
         + (url.indexOf('/') !== 0 ? '/' : '')
         + url;
 }

--- a/etc/apache2/vhosts.d/openqa-ssl.conf.template
+++ b/etc/apache2/vhosts.d/openqa-ssl.conf.template
@@ -1,6 +1,10 @@
 # sample apache config file for the ssl enabled openqa vhost.
 # At the very minimum you need to set the ServerName.
 
+# Note that this file will be ignored unless "SSL" is added to
+# APACHE_SERVER_FLAGS in /etc/sysconfig/apache2 (at least under
+# openSUSE).
+
 <IfDefine SSL>
 <IfDefine !NOSSL>
 


### PR DESCRIPTION
<s>Not working yet because Apache doesn't proxy wss so far.</s> Apparently it is actually working for me locally. Tested Apache reverse proxy without SSL, Apache reverse proxy with SSL and accessing the Mojo servers directly.

I'll enable SSL on e212 and deploy. Let's see whether it works there, too.