### PR TITLE
developer mode: Show flash messages on errors

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -39,6 +39,24 @@ function addFlash(status, text) {
     div.append($('<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>'));
     div.addClass('alert-' + status);
     flash.append(div);
+    return div;
+}
+
+function addUniqueFlash(status, id, text) {
+    // add hash to store present flash messages
+    if (!window.uniqueFlashMessages) {
+        window.uniqueFlashMessages = {};
+    }
+    // skip if flash message already present
+    if (window.uniqueFlashMessages[id]) {
+        return;
+    }
+
+    var msgElement = addFlash(status, text);
+    window.uniqueFlashMessages[id] = msgElement;
+    msgElement.on('closed.bs.alert', function () {
+        delete window.uniqueFlashMessages[id];
+    });
 }
 
 function toggleChildGroups(link) {

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -570,6 +570,28 @@ function handleWebsocketConnectionClosed(wsConnection) {
     }
 }
 
+function handleMessageVisWebsocketConnection(wsConnection, msg) {
+    if (wsConnection !== developerMode.wsConnection) {
+        return;
+    }
+
+    // parse the message JSON
+    if (!msg.data) {
+        return;
+    }
+    console.log("Received message via ws proxy: " + msg.data);
+    var dataObj;
+    try {
+        dataObj = JSON.parse(msg.data);
+    } catch (ex) {
+        console.log("Unable to parse JSON from ws proxy: " + msg.data);
+        addFlash('danger', '<strong>Unable to parse reply from livehandler daemon (responsible for developer mode).</strong>');
+        return;
+    }
+
+    processWsCommand(dataObj);
+}
+
 function setupWebsocketConnection() {
     // ensure previously opened connections are closed
     closeWebsocketConnection();
@@ -606,23 +628,7 @@ function setupWebsocketConnection() {
         handleWebsocketConnectionClosed(wsConnection);
     };
     wsConnection.onmessage = function(msg) {
-        if (wsConnection !== developerMode.wsConnection) {
-            return;
-        }
-
-        // parse the message JSON
-        if (!msg.data) {
-            return;
-        }
-        console.log("Received message via ws proxy: " + msg.data);
-        try {
-            var dataObj = JSON.parse(msg.data);
-            processWsCommand(dataObj);
-        } catch (ex) {
-            console.log("Unable to parse JSON from ws proxy: " + msg.data);
-            // TODO: log errors visible on the page
-            return;
-        }
+        handleMessageVisWebsocketConnection(wsConnection, msg);
     };
 
     developerMode.wsConnection = wsConnection;

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -621,7 +621,7 @@ function setupWebsocketConnection() {
             return;
         }
 
-        // set the error flag (FIXME: display error state somewhere)
+        // set the error flag
         developerMode.hasWsError = true;
     };
     wsConnection.onclose = function() {
@@ -696,7 +696,7 @@ function processWsCommand(obj) {
     case "error":
         // handle errors
         console.log("Error from ws proxy: " + what);
-        // TODO: log errors visible on the page
+        addFlash('danger', '<strong>Error from livehandler daemon (responsible for developer mode):</strong><p>' + what + '</p>');
         break;
     case "info":
         switch(what) {
@@ -740,7 +740,7 @@ function processWsCommand(obj) {
 function sendWsCommand(obj) {
     if (!developerMode.wsConnection) {
         console.log("Attempt to send something via ws proxy but not connected.");
-        // TODO: log errors visible on the page
+        addFlash('danger', '<strong>Internal error of developer mode:</strong><p>Attempt to send something via web socket proxy but not connected.</p>');
         return;
     }
     var objAsString = JSON.stringify(obj);

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -585,7 +585,8 @@ function handleMessageVisWebsocketConnection(wsConnection, msg) {
         dataObj = JSON.parse(msg.data);
     } catch (ex) {
         console.log("Unable to parse JSON from ws proxy: " + msg.data);
-        addFlash('danger', '<strong>Unable to parse reply from livehandler daemon (responsible for developer mode).</strong>');
+        addUniqueFlash('danger', 'unable_to_pare_livehandler_reply',
+                       '<strong>Unable to parse reply from livehandler daemon (responsible for developer mode).</strong>');
         return;
     }
 
@@ -696,7 +697,8 @@ function processWsCommand(obj) {
     case "error":
         // handle errors
         console.log("Error from ws proxy: " + what);
-        addFlash('danger', '<strong>Error from livehandler daemon (responsible for developer mode):</strong><p>' + what + '</p>');
+        addUniqueFlash('danger', 'ws_proxy_error-' + what,
+                       '<strong>Error from livehandler daemon (responsible for developer mode):</strong><p>' + what + '</p>');
         break;
     case "info":
         switch(what) {
@@ -740,7 +742,8 @@ function processWsCommand(obj) {
 function sendWsCommand(obj) {
     if (!developerMode.wsConnection) {
         console.log("Attempt to send something via ws proxy but not connected.");
-        addFlash('danger', '<strong>Internal error of developer mode:</strong><p>Attempt to send something via web socket proxy but not connected.</p>');
+        addUniqueFlash('danger', 'try_to_send_but_not_connected',
+                       '<strong>Internal error of developer mode:</strong><p>Attempt to send something via web socket proxy but not connected.</p>');
         return;
     }
     var objAsString = JSON.stringify(obj);

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -9,8 +9,9 @@ require Mojolicious::Commands;
 require OpenQA::Test::Database;
 
 our @EXPORT = qw($drivermissing check_driver_modules start_driver
-  call_driver kill_driver wait_for_ajax open_new_tab mock_js_functions
-  element_visible element_hidden javascript_console_has_no_warnings_or_errors);
+  call_driver kill_driver wait_for_ajax disable_bootstrap_animations
+  open_new_tab mock_js_functions element_visible element_hidden
+  javascript_console_has_no_warnings_or_errors);
 
 use Data::Dump 'pp';
 use Test::More;
@@ -174,6 +175,16 @@ sub wait_for_ajax {
     my $check_interval = _default_check_interval(shift);
     while (!$_driver->execute_script("return jQuery.active == 0")) {
         sleep $check_interval;
+    }
+}
+
+sub disable_bootstrap_animations {
+    my @rules = (
+        "'.fade', '-webkit-transition: none !important; transition: none !important;'",
+        "'.collapsing', '-webkit-transition: none !important; transition: none !important;'",
+    );
+    for my $rule (@rules) {
+        $_driver->execute_script("document.styleSheets[0].addRule($rule, 1);");
     }
 }
 

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright (C) 2016-2017 SUSE LLC
+# Copyright (C) 2016-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -96,12 +96,6 @@ unless (can_load(modules => {'Selenium::Remote::WDKeys' => undef,})) {
 }
 
 # don't tests basics here again, this is already done in t/22-dashboard.t and t/ui/14-dashboard.t
-
-sub disable_bootstrap_animations {
-    $driver->execute_script(
-"document.styleSheets[0].addRule('.collapsing', '-webkit-transition: none !important; transition: none !important;', 1);"
-    );
-}
 
 $driver->title_is('openQA', 'on main page');
 my $baseurl = $driver->get_current_url();

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -54,12 +54,6 @@ unless ($driver) {
     exit(0);
 }
 my $baseurl = $driver->get_current_url;
-
-sub disable_bootstrap_fade_animation {
-    $driver->execute_script(
-"document.styleSheets[0].addRule('.fade', '-webkit-transition: none !important; transition: none !important;', 1);"
-    );
-}
 
 # returns the contents of the candidates combo box as hash (key: tag, value: array of needle names)
 sub find_candidate_needles {
@@ -120,7 +114,7 @@ like(
 is($driver->find_element('.cm-comment')->get_text(), '#!/usr/bin/perl -w', "we have a perl comment");
 
 $driver->get("/tests/99937");
-disable_bootstrap_fade_animation;
+disable_bootstrap_animations;
 sub current_tab {
     return $driver->find_element('.nav.nav-tabs .active')->get_text;
 }
@@ -324,7 +318,7 @@ sub test_with_error {
     # check whether candidates are displayed as expected
     my $random_number = int(rand(100000));
     $driver->get("/tests/99946?prevent_caching=$random_number#step/yast2_lan/1");
-    disable_bootstrap_fade_animation;
+    disable_bootstrap_animations;
     wait_for_ajax;
     is_deeply(find_candidate_needles, $expect, $test_name // 'candidates displayed as expected');
 }

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -12,7 +12,7 @@
 % end
 
 <div class="row">
-    <div>
+    <div class="col-sm-12">
         %= include 'layouts/info'
     </div>
 </div>


### PR DESCRIPTION
Because errors regarding the developer mode are currently completely hidden from the user and the page looks like it is just stuck in "retrieving status" (see https://progress.opensuse.org/issues/38447).

It basically works, but still requires a little bit tuning to avoid spamming the user with too many error messages. It would likely be the best if an error occurs again, only a counter is increased rather than adding another message.