### PR TITLE
Add UEFI_PFLASH_VARS to detect_asset_keys

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -95,6 +95,7 @@ sub cache_tests {
     exit($res);
 }
 
+# When changing something here, also take a look at OpenQA::Utils::asset_type_from_setting
 sub detect_asset_keys {
     my ($vars) = @_;
 
@@ -112,6 +113,9 @@ sub detect_asset_keys {
         my $hddkey = "HDD_$i";
         $res{$hddkey} = 'hdd' if $vars->{$hddkey};
     }
+
+    $res{UEFI_PFLASH_VARS} = 'hdd' if $vars->{UEFI_PFLASH_VARS};
+
     return \%res;
 }
 

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -1,0 +1,71 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use strict;
+# https://github.com/rurban/Cpanel-JSON-XS/issues/65
+use JSON::PP;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Test::More;
+use Test::Warnings;
+use OpenQA::Worker::Engines::isotovideo;
+
+my $settings = {
+    DISTRI           => 'Unicorn',
+    FLAVOR           => 'pink',
+    VERSION          => '42',
+    BUILD            => '666',
+    ISO              => 'whatever.iso',
+    ISO_1            => 'another.iso',
+    KERNEL           => 'linux',
+    INITRD           => 'initrd',
+    DESKTOP          => 'DESKTOP',
+    KVM              => 'KVM',
+    ISO_MAXSIZE      => 1,
+    MACHINE          => 'RainbowPC',
+    ARCH             => 'x86_64',
+    TEST             => 'testA',
+    NUMDISKS         => 3,
+    WORKER_CLASS     => 'testAworker',
+    UEFI_PFLASH_VARS => 'however.qcow2'
+};
+
+my $expected = {
+    'ISO'              => 'iso',
+    'ISO_1'            => 'iso',
+    'UEFI_PFLASH_VARS' => 'hdd',
+    'KERNEL'           => 'other',
+    'INITRD'           => 'other',
+};
+
+my $got = OpenQA::Worker::Engines::isotovideo::detect_asset_keys($settings);
+
+is_deeply($got, $expected, 'Asset settings are correct') or diag explain $got;
+
+delete($expected->{UEFI_PFLASH_VARS});
+delete($expected->{NUMDISKS});
+
+delete($settings->{UEFI_PFLASH_VARS});
+delete($settings->{NUMDISKS});
+
+$got = OpenQA::Worker::Engines::isotovideo::detect_asset_keys($settings);
+is_deeply($got, $expected, 'Asset settings are correct') or diag explain $got;
+
+done_testing();

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -28,6 +28,7 @@ seq:
      - ./t/22-dashboard.t
      - ./t/23-amqp.t
      - ./t/24-worker.t
+     - ./t/24-worker-engine.t
      - ./t/27-errorpages.t
      - ./t/30-test_parser.t
      - ./t/31-api_descriptions.t


### PR DESCRIPTION
Allow the worker cache code to download the PFLASH by treating them as
an hdd