### PR TITLE
Treat UEFI_PFLASH_VARS as non critical asset

### DIFF
--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -104,7 +104,9 @@ sub cache_assets {
         my $asset = $self->get_asset($job, $assetkeys->{$this_asset}, $vars->{$this_asset});
         if ($this_asset eq 'UEFI_PFLASH_VARS' && !defined $asset) {
             log_error("Can't download $vars->{$this_asset}");
-            $vars->{$this_asset} = catdir(getcwd, basename($vars->{$this_asset}));
+            # assume that if we have a full path, that's what we should use
+            $vars->{$this_asset} = $vars->{$this_asset} if (-e $vars->{$this_asset});
+            # don't kill the job if the asset is not found
             next;
         }
         return {error => "Can't download $vars->{$this_asset}"} unless $asset;

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -102,6 +102,11 @@ sub cache_assets {
     for my $this_asset (sort keys %$assetkeys) {
         log_debug("Found $this_asset, caching " . $vars->{$this_asset});
         my $asset = $self->get_asset($job, $assetkeys->{$this_asset}, $vars->{$this_asset});
+        if ($this_asset eq 'UEFI_PFLASH_VARS' && !defined $asset) {
+            log_error("Can't download $vars->{$this_asset}");
+            $vars->{$this_asset} = catdir(getcwd, basename($vars->{$this_asset}));
+            next;
+        }
         return {error => "Can't download $vars->{$this_asset}"} unless $asset;
         unlink basename($asset) if -l basename($asset);
         symlink($asset, basename($asset)) or die "cannot create link: $asset, $pooldir";

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -144,7 +144,8 @@ $livehandlerpid = create_live_view_handler($mojoport);
 my $JOB_SETUP
   = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 QEMU_NO_KVM=1 '
   . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1'
-  . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2';
+  . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2'
+  . 'UEFI_PFLASH_VARS=nonexistent.qcow2';
 
 # schedule job
 OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP");

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -145,7 +145,7 @@ my $JOB_SETUP
   = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 QEMU_NO_KVM=1 '
   . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1'
   . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2'
-  . 'UEFI_PFLASH_VARS=nonexistent.qcow2';
+  . 'UEFI_PFLASH_VARS=/usr/share/qemu/ovmf-x86_64.bin';
 
 # schedule job
 OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP");


### PR DESCRIPTION
We need the UEFI_PFLASH_VARS to be treated as non critical, to avoid tests failing only because they are not able to be downloaded, regardless of wether the tests will use them or not. 

So let it hard fail instead if the asset is not downloaded, and the test uses it. 

As a bonus, allow full paths to be used as a valid asset, this will search for said file in the worker after failing to download it from the webui. 