### PR TITLE
Carry comment over if test suite failed with same serial failure

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -170,11 +170,19 @@ tests.
 
 The patterns defined in the main.pm will be valid for all the tests.
 
+To simplify tests results review, if job fails with the same message, which is defined
+for the pattern, as previous job, automatic comment carryover will work even if
+test suites have failed due to different test modules.
+
 [caption="Example: "]
 .Defining serial exception capture in the main.pm
 [source,perl]
 --------------------------------------------------------------
-$testapi::distri->set_serial_failures(soft=>[quotemeta 'Error'], hard=>[qr/exception/]);
+$testapi::distri->set_expected_serial_failures([
+        {type => 'soft', message => 'known issue',  pattern => quotemeta 'Error'},
+        {type => 'hard', message => 'broken build', pattern => qr/exception/},
+    ]
+);
 --------------------------------------------------------------
 
 [caption="Example: "]
@@ -183,7 +191,20 @@ $testapi::distri->set_serial_failures(soft=>[quotemeta 'Error'], hard=>[qr/excep
 --------------------------------------------------------------
 sub run {
     my ($self) = @_;
-    $self->set_serial_failures(soft=>[quotemeta 'Error'], hard=>[qr/exception/]);
+    $self->{serial_failures} = [
+        {type => 'soft', message => 'known issue',  pattern => quotemeta 'Error'},
+        {type => 'hard', message => 'broken build', pattern => qr/exception/},
+    ];
+    ...
+}
+--------------------------------------------------------------
+[caption="Example: "]
+.Adding serial exception capture in the test
+[source,perl]
+--------------------------------------------------------------
+sub run {
+    my ($self) = @_;
+    push @$self->{serial_failures}, {type => 'soft', message => 'known issue',  pattern => quotemeta 'Error'};
     ...
 }
 --------------------------------------------------------------
@@ -357,7 +378,7 @@ sub run {
 sub run {
     # wait until ftp service is ready
     # performs mutex lock & unlock internally
-    mutex_wait 'ftp_service_ready'; 
+    mutex_wait 'ftp_service_ready';
 
     # connect to ftp and start downloading
     script_run 'ftp parent.job.ip';
@@ -368,7 +389,7 @@ sub run {
 # Example on child when only one job should access ftp at time
 sub run {
     # wait until ftp service is ready
-    mutex_lock 'ftp_service_ready'; 
+    mutex_lock 'ftp_service_ready';
 
     # Perform operation with exclusive access
     script_run 'ftp parent.job.ip';
@@ -376,7 +397,7 @@ sub run {
     script_run 'bye';
 
     # Allow other jobs to connect afterwards
-    mutex_unlock 'ftp_service_ready'; 
+    mutex_unlock 'ftp_service_ready';
 }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Follows [PR#998](https://github.com/os-autoinst/os-autoinst/pull/998) in os-autoinst (not yet merged).
Our use case is that we have kernel bug, which fails different modules,
depending on our luck. Therefore, automatic comment carryover won't help
to the reviewers and they have to do monkey job to label them.

With this change, if failure reason will be marked with bug reference,
it will be treated as a reason of test suite failure. Therefore, if same
failure is thrown in multiple runs, irregardless the module where it was
detected, last comment will be taken over.

See [poo#36448](https://progress.opensuse.org/issues/36448).

[Verification run](http://g226.suse.de/tests/2176#next_previous). Here you can see that test failed in 2 different modules, but comment from the first one was added to the last.

This PR doesn't yet include documentation update and a test.