### PR TITLE
Pass worker setting WORKER_HOSTNAME to web UI

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1379,9 +1379,10 @@ sub update_status {
     # mark the worker as alive
     $self->worker->seen;
 
-    # update URL to os-autoinst command server
+    # update info used to compose the URL to os-autoinst command server
     if (my $assigned_worker = $self->assigned_worker) {
-        $assigned_worker->set_property(CMD_SRV_URL => ($status->{cmd_srv_url} // ''));
+        $assigned_worker->set_property(CMD_SRV_URL     => ($status->{cmd_srv_url} // ''));
+        $assigned_worker->set_property(WORKER_HOSTNAME => ($status->{worker_hostname} // ''));
     }
 
     $self->state(RUNNING) and $self->t_started(now()) if grep { $_ eq $self->state } (ASSIGNED, SETUP);

--- a/lib/OpenQA/WebAPI/Controller/Developer.pm
+++ b/lib/OpenQA/WebAPI/Controller/Developer.pm
@@ -31,7 +31,7 @@ sub determine_os_autoinst_web_socket_url {
     # determine job token and host from worker
     my $worker    = $job->assigned_worker             or return;
     my $job_token = $worker->get_property('JOBTOKEN') or return;
-    my $host      = $worker->host                     or return;
+    my $host = $worker->get_property('WORKER_HOSTNAME') || $worker->host or return;
 
     # determine port
     my $cmd_srv_raw_url = $worker->get_property('CMD_SRV_URL') or return;

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -667,8 +667,9 @@ sub upload_status {
     }
 
     my $status = {
-        worker_id   => $workerid,
-        cmd_srv_url => $job->{URL},
+        worker_id       => $workerid,
+        worker_hostname => $worker_settings->{WORKER_HOSTNAME},
+        cmd_srv_url     => $job->{URL},
     };
 
     my $ua        = Mojo::UserAgent->new;

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -419,6 +419,13 @@ subtest 'URLs for command server and livehandler' => sub {
         'URL for job with assigned worker'
     );
 
+    $worker->set_property(WORKER_HOSTNAME => 'remotehost.qa');
+    is(
+        OpenQA::WebAPI::Controller::Developer::determine_os_autoinst_web_socket_url($job),
+        'ws://remotehost.qa:20013/token99961/ws',
+        'URL for job with assigned worker and WORKER_HOSTNAME property'
+    );
+
     is(determine_web_ui_web_socket_url(99961), 'liveviewhandler/tests/99961/developer/ws-proxy', 'URL for livehandler');
 
     is(
@@ -485,7 +492,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
         $t_livehandler->json_message_is(
             {
                 type => 'info',
-                what => 'connecting to os-autoinst command server at ws://remotehost:20013/token99961/ws',
+                what => 'connecting to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
                 data => undef,
             });
         $t_livehandler->message_ok('another message received');
@@ -517,7 +524,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
         $t_livehandler->json_message_is(
             {
                 type => 'info',
-                what => 'connecting to os-autoinst command server at ws://remotehost:20013/token99961/ws',
+                what => 'connecting to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
                 data => undef,
             });
         $t_livehandler->message_ok('another message received');
@@ -525,7 +532,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
             {
                 type => 'info',
                 what =>
-                  'reusing previous connection to os-autoinst command server at ws://remotehost:20013/token99961/ws',
+                  'reusing previous connection to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
                 data => undef,
             });
 
@@ -575,7 +582,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
         $t_livehandler->json_message_is(
             {
                 type => 'info',
-                what => 'connecting to os-autoinst command server at ws://remotehost:20013/token99961/ws',
+                what => 'connecting to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
                 data => undef,
             });
         $t_livehandler->message_ok('another message received');
@@ -583,7 +590,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
             {
                 type => 'info',
                 what =>
-                  'reusing previous connection to os-autoinst command server at ws://remotehost:20013/token99961/ws',
+                  'reusing previous connection to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
                 data => undef,
             });
 


### PR DESCRIPTION
* Allows the proxy for developer mode to connect
  also when the worker's hostname in the database
  is not fully qualified.
* See https://progress.opensuse.org/issues/39119