### PR TITLE
Print autoinst-log.txt after Travis testrun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ cache:
 script:
 - mkdir -p assets/cache
 - chmod a+w assets/cache
-- touch openqa-debug.log
-- chmod a+w openqa-debug.log
+- touch openqa-debug.log autoinst-log.txt
+- chmod a+w openqa-debug.log autoinst-log.txt
 - docker run --cap-add SYS_ADMIN -v $TRAVIS_BUILD_DIR:/opt/openqa -v /var/run/dbus:/var/run/dbus
   --env-file <(env | grep TRAVIS) -e TRAVIS=true -e FULLSTACK -e UITESTS -e SCHEDULER_FULLSTACK -e DEVELOPER_FULLSTACK
   -e GH_PUBLISH registry.opensuse.org/devel/openqa/containers/openqa_dev make travis-codecov
 after_failure:
 - cat openqa-debug.log
+- cat autoinst-log.txt

--- a/script/docker-tests
+++ b/script/docker-tests
@@ -28,7 +28,11 @@ function run_fullstack_test {
 
     eval $(dbus-launch --sh-syntax)
     export PERL5OPT="$PERL5OPT $HARNESS_PERL_SWITCHES"
-    perl "$@" || touch tests_failed
+    if ! perl "$@"; then
+        touch tests_failed
+        find '/tmp' -path '*/t/full-stack.d/openqa/testresults/*/autoinst-log.txt' \
+            -exec echo 'contents of' {} \; -exec cat {} \; 2> /dev/null > '/opt/openqa/autoinst-log.txt'
+    fi
 }
 
 if [ "x$FULLSTACK" = x1 ]; then


### PR DESCRIPTION
Maybe useful to debug failing fullstack tests. Let's see whether it works.