### PR TITLE
Fix usage of $blocked in test results template

### DIFF
--- a/templates/test/list.html.ep
+++ b/templates/test/list.html.ep
@@ -18,7 +18,7 @@
 % if (@$scheduled) {
     <div>
         % my $str = scalar(@$scheduled) . " scheduled jobs";
-        % $str .= " (@{[scalar(keys $blocked)]} blocked by other jobs)" if $blocked && keys %$blocked > 0;
+        % $str .= " (@{[scalar(keys %$blocked)]} blocked by other jobs)" if $blocked && keys %$blocked > 0;
         %= tag 'h2' => $str
         %= include 'test/scheduled_table'
     </div>


### PR DESCRIPTION
Otherwise we get 'Experimental keys on scalar is now forbidden at
template test/list.html.ep line 21.'