### PR TITLE
Fixed blocked_by calculation not to create loops

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -695,6 +695,12 @@ sub create_clones {
         # when dependency network is recreated, associate assets
         $res->register_assets_from_settings;
     }
+
+    # calculate blocked_by
+    for my $job (keys %$jobs) {
+        $clones{$job}->calculate_blocked_by;
+    }
+
     # reduce the clone object to ID (easier to use later on)
     for my $job (keys %$jobs) {
         $jobs->{$job}->{clone} = $clones{$job}->id;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -100,7 +100,7 @@ sub list {
         groupid => $groupid,
         assetid => $assetid
     );
-    $self->stash(blocked => $scheduled->search({-not => {blocked_by_id => undef}})->count);
+    $self->stash(blocked => {map { $_->id => \undef } $scheduled->search({-not => {blocked_by_id => undef}})->all});
 
     # @scheduled = sort {
     #     if ($b->{job} && $a->{job}) {


### PR DESCRIPTION
blocked_by means: either one job in the parallel cluster or
a parent of a chained parent is not final. So looking at
chained_children of the cluster gives us possibly a cycle

As such don't look at the full cluster's chained deps, but
only of those pointing up