### PR TITLE
Allow needle commits in git repo subdirectory

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -478,7 +478,7 @@ sub commit_git_return_error {
         use Cwd 'abs_path';
         $dir = abs_path($dir);
     }
-    my @git = ('git', '--git-dir', "$dir/.git", '--work-tree', $dir);
+    my @git = ('git', '-C', $dir);
     my @files;
 
     for my $cmd (qw(add rm)) {

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -507,8 +507,8 @@ sub save_needle_ajax {
     # commit needle in Git repository
     $self->app->gru->enqueue('scan_needles');
     if (($self->app->config->{global}->{scm} || '') eq 'git') {
-        if (!$needledir || !(-d "$needledir/.git")) {
-            return $self->render(json => {error => "$needledir is not a git repo"});
+        if (!$needledir || !(-d "$needledir")) {
+            return $self->render(json => {error => "$needledir is not a directory"});
         }
         try {
             $self->_commit_git($job, $needledir, $needlename);


### PR DESCRIPTION
Git commits were failing if the needle directory wasn't the root of the git repository. However, there's no reason to require that and `git` can reliably walk up the tree to figure out the repository structure.