### PR TITLE
Adapt fullstack tests to changes in os-autoinst

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -232,7 +232,7 @@ subtest 'pause at certain test' => sub {
 
     # wait until the shutdown test is started and hence the test execution paused
     OpenQA::Test::FullstackUtils::wait_for_developer_console_contains_log_message($driver,
-        qr/(\"paused\":|\"test_execution_paused\":1)/, 'paused');
+        qr/(\"paused\":|\"test_execution_paused\":\".*\")/, 'paused');
 };
 
 subtest 'developer session visible in live view' => sub {

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -198,7 +198,7 @@ subtest 'pause at certain test' => sub {
 
     # wait until the shutdown test is started and hence the test execution paused
     OpenQA::Test::FullstackUtils::wait_for_developer_console_contains_log_message($driver,
-        qr/(\"paused\":|\"test_execution_paused\":1)/, 'paused');
+        qr/(\"paused\":|\"test_execution_paused\":\".*\")/, 'paused');
 
     # resume the test execution again
     $command_input->send_keys('{"cmd":"resume_test_execution"}');


### PR DESCRIPTION
change in os-autoinst: https://github.com/os-autoinst/os-autoinst/pull/993/commits/67e21e3e732104a1652dc71e767632e5858985de

---

Note that I haven't tested this because the condition where 2nd pattern is required is hard to hit. (The 2nd pattern is supposed to match if a disconnect occurs and the client is therefore disconnected in the moment where the pause is propagated.)