### PR TITLE
Fix Mojolicious version requirement

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -56,7 +56,7 @@ requires 'Mojo::Pg';
 requires 'Mojo::RabbitMQ::Client';
 requires 'Mojo::URL';
 requires 'Mojo::Util';
-requires 'Mojolicious', '>= 7.24';
+requires 'Mojolicious', '>= 7.92';
 requires 'Mojolicious::Commands';
 requires 'Mojolicious::Plugin';
 requires 'Mojolicious::Plugin::AssetPack';

--- a/openQA.spec
+++ b/openQA.spec
@@ -56,7 +56,7 @@ BuildRequires:  os-autoinst
 BuildRequires:  systemd
 # critical bug fix
 BuildRequires:  perl(DBIx::Class) >= 0.082801
-BuildRequires:  perl(Mojolicious) >= 7.24
+BuildRequires:  perl(Mojolicious) >= 7.92
 BuildRequires:  perl(Mojolicious::Plugin::AssetPack) >= 1.36
 BuildRequires:  perl(Minion) >= 9.02
 BuildRequires:  rubygem(sass)
@@ -129,7 +129,7 @@ operating system.
 Summary:        The openQA common tools for web-frontend and workers
 Group:          Development/Tools/Other
 Requires:       %{t_requires}
-Requires:       perl(Mojolicious) >= 7.24
+Requires:       perl(Mojolicious) >= 7.92
 
 %description common
 This package contain shared resources for openQA web-frontend and


### PR DESCRIPTION
The Mojolicious releases between 7.82 and 7.92 were unfortunately very unstable and would cause openQA to fail randomly. https://github.com/kraih/mojo/commit/61f6cbf22c7bf8eb4787bd1014d91ee2416c73e7