### PR TITLE
Fedmsg plugin: emit 'standardized' fedmsg

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -30,6 +30,15 @@ use Mojo::IOLoop;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 
+# note: there is also job_cancel_by_settings, but that is quite an odd one;
+# it basically does a search by the specified settings and cancels all
+# jobs it finds. this is very difficult to translate into a fedmsg - classic
+# or standardized - that'd be of any particular use to anyone; just saying
+# 'some jobs were cancelled and here's the search that found them' isn't
+# much good. You could try to duplicate the search and list all pending job
+# IDs that are found, but there's a race there, and I don't think anything
+# guarantees that we'd get to find the jobs before they got cancelled; trying
+# to find ones that were *just* cancelled seems like a thankless task.
 my @job_events     = qw(job_create job_delete job_cancel job_duplicate job_restart job_update_result job_done);
 my @comment_events = qw(comment_create comment_update comment_delete);
 
@@ -73,6 +82,146 @@ sub log_event {
     IPC::Run::run(\@command, \$stdin, \$output, \$stderr);
 }
 
+sub log_event_ci_standard {
+    # this is for emitting messages in the standardized format for
+    # Factory 2.0 CI systems
+    my ($event, $job, $baseurl) = @_;
+    my $stdevent;
+    my $clone_of;
+    my $job_id;
+    # first, get the standard 'state' (from 'queued', 'running',
+    # 'complete', 'error'; we cannot do 'running' at present
+    if ($event eq 'openqa_job_create') {
+        $stdevent = 'queued';
+        $job_id   = $job->id;
+    }
+    elsif ($event eq 'openqa_job_restart' || $event eq 'openqa_job_duplicate') {
+        $stdevent = 'queued';
+        $clone_of = $job->id;
+        $job_id   = $job->clone_id;
+    }
+    elsif ($event eq 'openqa_job_cancel') {
+        $stdevent = 'error';
+        $job_id   = $job->id;
+    }
+    elsif ($event eq 'openqa_job_done') {
+        $job_id = $job->id;
+        # lifecycle note: any job cancelled directly via the web API will
+        # see both job_cancel and job_done with result USER_CANCELLED, so
+        # we emit duplicate standardized fedmsgs in this case. This is
+        # kinda unavoidable, though, as it's possible for a job to wind up
+        # USER_CANCELLED *without* an openqa_job_cancel event happening,
+        # so we can't just throw away all openqa_job_done USER_CANCELLED
+        # events...
+        if (grep { $job->result eq $_ } OpenQA::Schema::Result::Jobs::INCOMPLETE_RESULTS) {
+            $stdevent = 'error';
+        }
+        else {
+            $stdevent = 'complete';
+        }
+    }
+    else {
+        return;
+    }
+
+    # next, get the 'artifact' (type of thing we tested)
+    my $artifact;
+    my $artifact_id;
+    my $artifact_issuer;
+    my $artifact_release;
+    my $build = $job->BUILD;
+    if ($build =~ /^Fedora/) {
+        $artifact        = 'productmd-compose';
+        $artifact_id     = $build;
+        $artifact_issuer = 'releng';
+        $artifact_issuer = 'respins-sig' if ($build =~ /^FedoraRespin/);
+    }
+    elsif ($build =~ /^Update-/) {
+        $artifact    = 'fedora-update';
+        $artifact_id = $build;
+        $artifact_id =~ s/^Update-//;
+        $artifact_release = $job->VERSION;
+        # FIXME: this info is in Bodhi but not known to openQA ATM
+        $artifact_issuer = 'unknown';
+    }
+    else {
+        # unhandled artifact type
+        return;
+    }
+
+    # finally, construct the message content
+    my %msg_data = (
+        headers => {
+            type => $artifact,
+            id   => $artifact_id,
+        },
+        body => {
+            ci => {
+                name  => 'Fedora openQA',
+                team  => 'Fedora QA',
+                url   => $baseurl,
+                irc   => '#fedora-qa',
+                email => 'qa-devel@lists.fedoraproject.org',
+            },
+            run => {
+                url => "$baseurl/tests/$job_id",
+                log => "$baseurl/tests/$job_id/file/autoinst-log.txt",
+                id  => $job_id,
+            },
+            artifact => {
+                type   => $artifact,
+                id     => $artifact_id,
+                issuer => $artifact_issuer,
+                # FIXME: we're gonna need to define more useful fields
+                # in the spec for artifacts besides brew/koji builds,
+                # but for now let's just do the obvious ones
+            },
+            # test identifier: test name plus scenario keys
+            type => join(' ', $job->TEST, $job->MACHINE, $job->FLAVOR, $job->ARCH),
+            # openQA tests are pretty much always validation
+            category => 'validation',
+        },
+    );
+
+    # add keys that don't exist in all cases to the message
+    if ($stdevent eq 'complete') {
+        $msg_data{body}{status} = $job->result;
+        $msg_data{body}{status} = 'info' if $job->result eq 'softfailed';
+    }
+    elsif ($stdevent eq 'error') {
+        $msg_data{body}{reason} = $job->result;
+    }
+    elsif ($stdevent eq 'queued') {
+        # this is a hint to consumers that the job probably went away
+        # if they don't get a 'complete' or 'error' in 4 hours
+        # FIXME: we should set this as 2 hours on 'running', but we
+        # can't emit running ATM...
+        $msg_data{body}{lifetime} = 240;
+    }
+    $msg_data{body}{run}{clone_of} = $clone_of if ($clone_of);
+
+    $msg_data{body}{artifact}{release} = $artifact_release if ($artifact_release);
+
+    $msg_data{body}{artifact}{iso} = $job->settings_hash->{ISO} if ($job->settings_hash->{ISO});
+    # FIXME: hdd_2?
+    $msg_data{body}{artifact}{hdd_1} = $job->settings_hash->{HDD_1} if ($job->settings_hash->{HDD_1});
+
+    # convert data to JSON, with reliable key ordering (helps the tests)
+    my $msg_json = Cpanel::JSON::XS->new->canonical(1)->allow_blessed(1)->encode(\%msg_data);
+
+    # create the topic
+    my $topic = "$artifact.test.$stdevent";
+
+    # finally, send the message
+    OpenQA::Utils::log_debug("Sending standardized fedmsg for $event");
+    my @command = (
+        "/usr/sbin/daemonize", "/usr/bin/fedmsg-logger", "--cert-prefix=ci", "--modname=ci",
+        "--topic=$topic",      "--json-input",           "--message=$msg_json"
+    );
+    my ($stdin, $stderr, $output) = (undef, undef, undef);
+    IPC::Run::run(\@command, \$stdin, \$output, \$stderr);
+}
+
 # when we get an event, convert it to fedmsg format and send it
 
 sub on_job_event {
@@ -81,6 +230,8 @@ sub on_job_event {
     # find count of pending jobs for the same build
     # this is so we can tell when all tests for a build are done
     my $job = $app->db->resultset('Jobs')->find({id => $event_data->{id}});
+    # Get app baseurl, as the ci_standard logger needs it
+    my $baseurl = $app->config->{global}->{base_url} || "http://UNKNOWN";
     my $build = $job->BUILD;
     $event_data->{remaining} = $app->db->resultset('Jobs')->search(
         {
@@ -97,6 +248,7 @@ sub on_job_event {
     $event_data->{HDD_1}   //= $job->settings_hash->{HDD_1} if ($job->settings_hash->{HDD_1});
 
     log_event($event, $event_data);
+    log_event_ci_standard($event, $job, $baseurl);
 }
 
 sub on_comment_event {

--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -38,13 +38,13 @@ use Test::Mojo;
 use Test::Warnings;
 use Mojo::File qw(tempdir path);
 
-my $args;
+my @args;
 
 # this is a mock IPC::Run which just stores the args it's called with
 # so we can check the plugin did the right thing
 sub mock_ipc_run {
     my ($cmd, $stdin, $stdout, $stderr) = @_;
-    $args = join(" ", @$cmd);
+    push @args, join(" ", @$cmd);
 }
 
 my $module = new Test::MockModule('IPC::Run');
@@ -53,7 +53,7 @@ $module->mock('run', \&mock_ipc_run);
 my $schema = OpenQA::Test::Database->new->create();
 
 # this test also serves to test plugin loading via config file
-my @conf = ("[global]\n", "plugins=Fedmsg\n");
+my @conf = ("[global]\n", "plugins=Fedmsg\n", "base_url=https://openqa.stg.fedoraproject.org\n");
 $ENV{OPENQA_CONFIG} = tempdir;
 path($ENV{OPENQA_CONFIG})->make_path->child("openqa.ini")->spurt(@conf);
 
@@ -74,7 +74,7 @@ my $settings = {
     DISTRI      => 'Unicorn',
     FLAVOR      => 'pink',
     VERSION     => '42',
-    BUILD       => '666',
+    BUILD       => 'Fedora-Rawhide-20180129.n.0',
     TEST        => 'rainbow',
     ISO         => 'whatever.iso',
     DESKTOP     => 'DESKTOP',
@@ -85,39 +85,74 @@ my $settings = {
 };
 
 my $commonexpr = '/usr/sbin/daemonize /usr/bin/fedmsg-logger --cert-prefix=openqa --modname=openqa';
+my $commonci   = '/usr/sbin/daemonize /usr/bin/fedmsg-logger --cert-prefix=ci --modname=ci';
 # create a job via API
 my $post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
 my $job = $post->tx->res->json->{id};
 is(
-    $args,
+    $args[0],
     $commonexpr
       . ' --topic=job.create --json-input --message='
-      . '{"ARCH":"x86_64","BUILD":"666","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink","ISO":"whatever.iso",'
+      . '{"ARCH":"x86_64","BUILD":"Fedora-Rawhide-20180129.n.0","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink","ISO":"whatever.iso",'
       . '"ISO_MAXSIZE":"1","KVM":"KVM","MACHINE":"RainbowPC","TEST":"rainbow","VERSION":"42","id":'
       . $job
       . ',"remaining":1}',
     "job create triggers fedmsg"
 );
+is(
+    $args[1],
+    $commonci
+      . ' --topic=productmd-compose.test.queued --json-input --message='
+      . '{"body":{"artifact":{"id":"Fedora-Rawhide-20180129.n.0","iso":"whatever.iso","issuer":"releng","type":"productmd-compose"},"category":"validation",'
+      . '"ci":{"email":"qa-devel@lists.fedoraproject.org","irc":"#fedora-qa","name":"Fedora openQA","team":"Fedora QA",'
+      . '"url":"https://openqa.stg.fedoraproject.org"},"lifetime":240,"run":{"id":'
+      . $job . ','
+      . '"log":"https://openqa.stg.fedoraproject.org/tests/'
+      . $job
+      . '/file/autoinst-log.txt",'
+      . '"url":"https://openqa.stg.fedoraproject.org/tests/'
+      . $job . '"},'
+      . '"type":"rainbow RainbowPC pink x86_64"},'
+      . '"headers":{"id":"Fedora-Rawhide-20180129.n.0","type":"productmd-compose"}}',
+    "job create triggers standardized fedmsg"
+);
 # reset $args
-$args = '';
+@args = ();
 
 # FIXME: restarting job via API emits an event in real use, but not if we do it here
 
-# set the job as done via API
+# set the job as done (implicit failed, it seems) via API
 $post = $t->post_ok("/api/v1/jobs/" . $job . "/set_done")->status_is(200);
 # check plugin called fedmsg-logger correctly
 is(
-    $args,
+    $args[0],
     $commonexpr
       . ' --topic=job.done --json-input --message='
-      . '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
+      . '{"ARCH":"x86_64","BUILD":"Fedora-Rawhide-20180129.n.0","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
       . '"TEST":"rainbow","id":'
       . $job
       . ',"newbuild":null,"remaining":0,"result":"failed"}',
     "job done triggers fedmsg"
 );
+is(
+    $args[1],
+    $commonci
+      . ' --topic=productmd-compose.test.complete --json-input --message='
+      . '{"body":{"artifact":{"id":"Fedora-Rawhide-20180129.n.0","iso":"whatever.iso","issuer":"releng","type":"productmd-compose"},"category":"validation",'
+      . '"ci":{"email":"qa-devel@lists.fedoraproject.org","irc":"#fedora-qa","name":"Fedora openQA","team":"Fedora QA",'
+      . '"url":"https://openqa.stg.fedoraproject.org"},"run":{"id":'
+      . $job . ','
+      . '"log":"https://openqa.stg.fedoraproject.org/tests/'
+      . $job
+      . '/file/autoinst-log.txt",'
+      . '"url":"https://openqa.stg.fedoraproject.org/tests/'
+      . $job . '"},'
+      . '"status":"failed","type":"rainbow RainbowPC pink x86_64"},'
+      . '"headers":{"id":"Fedora-Rawhide-20180129.n.0","type":"productmd-compose"}}',
+    "job done triggers standardized fedmsg"
+);
 # reset $args
-$args = '';
+@args = ();
 
 # we don't test update_results as comment indicates it's obsolete
 
@@ -126,34 +161,108 @@ $post = $t->post_ok("/api/v1/jobs/" . $job . "/duplicate")->status_is(200);
 my $newjob = $post->tx->res->json->{id};
 # check plugin called fedmsg-logger correctly
 is(
-    $args,
+    $args[0],
     $commonexpr
       . ' --topic=job.duplicate --json-input --message='
-      . '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
+      . '{"ARCH":"x86_64","BUILD":"Fedora-Rawhide-20180129.n.0","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
       . '"TEST":"rainbow","auto":0,"id":'
       . $job
       . ',"remaining":1,"result":'
       . $newjob . '}',
     "job duplicate triggers fedmsg"
 );
+is(
+    $args[1],
+    $commonci
+      . ' --topic=productmd-compose.test.queued --json-input --message='
+      . '{"body":{"artifact":{"id":"Fedora-Rawhide-20180129.n.0","iso":"whatever.iso","issuer":"releng","type":"productmd-compose"},"category":"validation",'
+      . '"ci":{"email":"qa-devel@lists.fedoraproject.org","irc":"#fedora-qa","name":"Fedora openQA","team":"Fedora QA",'
+      . '"url":"https://openqa.stg.fedoraproject.org"},"lifetime":240,"run":{"clone_of":'
+      . $job
+      . ',"id":'
+      . $newjob . ','
+      . '"log":"https://openqa.stg.fedoraproject.org/tests/'
+      . $newjob
+      . '/file/autoinst-log.txt",'
+      . '"url":"https://openqa.stg.fedoraproject.org/tests/'
+      . $newjob . '"},'
+      . '"type":"rainbow RainbowPC pink x86_64"},'
+      . '"headers":{"id":"Fedora-Rawhide-20180129.n.0","type":"productmd-compose"}}',
+    "job duplicate triggers standardized fedmsg"
+);
 # reset $args
-$args = '';
+@args = ();
 
 # cancel the new job via API
 $post = $t->post_ok("/api/v1/jobs/" . $newjob . "/cancel")->status_is(200);
 # check plugin called fedmsg-logger correctly
 is(
-    $args,
+    $args[0],
     $commonexpr
       . ' --topic=job.cancel --json-input --message='
-      . '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
+      . '{"ARCH":"x86_64","BUILD":"Fedora-Rawhide-20180129.n.0","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
       . '"TEST":"rainbow","id":'
       . $newjob
       . ',"remaining":0}',
     "job cancel triggers fedmsg"
 );
+is(
+    $args[1],
+    $commonci
+      . ' --topic=productmd-compose.test.error --json-input --message='
+      . '{"body":{"artifact":{"id":"Fedora-Rawhide-20180129.n.0","iso":"whatever.iso","issuer":"releng","type":"productmd-compose"},"category":"validation",'
+      . '"ci":{"email":"qa-devel@lists.fedoraproject.org","irc":"#fedora-qa","name":"Fedora openQA","team":"Fedora QA",'
+      . '"url":"https://openqa.stg.fedoraproject.org"},"reason":"user_cancelled","run":{"id":'
+      . $newjob . ','
+      . '"log":"https://openqa.stg.fedoraproject.org/tests/'
+      . $newjob
+      . '/file/autoinst-log.txt",'
+      . '"url":"https://openqa.stg.fedoraproject.org/tests/'
+      . $newjob . '"},'
+      . '"type":"rainbow RainbowPC pink x86_64"},'
+      . '"headers":{"id":"Fedora-Rawhide-20180129.n.0","type":"productmd-compose"}}',
+    "job cancel triggers standardized fedmsg"
+);
+
+# duplicate the job once more via API (so we can test 'passed')
+$post = $t->post_ok("/api/v1/jobs/" . $newjob . "/duplicate")->status_is(200);
+my $newerjob = $post->tx->res->json->{id};
+
 # reset $args
-$args = '';
+@args = ();
+
+# set the job as done (explicit passed) via API
+$post = $t->post_ok("/api/v1/jobs/" . $newerjob . "/set_done?result=passed")->status_is(200);
+# check plugin called fedmsg-logger correctly
+is(
+    $args[0],
+    $commonexpr
+      . ' --topic=job.done --json-input --message='
+      . '{"ARCH":"x86_64","BUILD":"Fedora-Rawhide-20180129.n.0","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
+      . '"TEST":"rainbow","id":'
+      . $newerjob
+      . ',"newbuild":null,"remaining":0,"result":"passed"}',
+    "job done (passed) triggers fedmsg"
+);
+is(
+    $args[1],
+    $commonci
+      . ' --topic=productmd-compose.test.complete --json-input --message='
+      . '{"body":{"artifact":{"id":"Fedora-Rawhide-20180129.n.0","iso":"whatever.iso","issuer":"releng","type":"productmd-compose"},"category":"validation",'
+      . '"ci":{"email":"qa-devel@lists.fedoraproject.org","irc":"#fedora-qa","name":"Fedora openQA","team":"Fedora QA",'
+      . '"url":"https://openqa.stg.fedoraproject.org"},"run":{"id":'
+      . $newerjob . ','
+      . '"log":"https://openqa.stg.fedoraproject.org/tests/'
+      . $newerjob
+      . '/file/autoinst-log.txt",'
+      . '"url":"https://openqa.stg.fedoraproject.org/tests/'
+      . $newerjob . '"},'
+      . '"status":"passed","type":"rainbow RainbowPC pink x86_64"},'
+      . '"headers":{"id":"Fedora-Rawhide-20180129.n.0","type":"productmd-compose"}}',
+    "job done (passed) triggers standardized fedmsg"
+);
+# reset $args
+@args = ();
 
 # FIXME: deleting job via DELETE call to api/v1/jobs/$newjob fails with 500?
 
@@ -164,23 +273,23 @@ my $comment = $post->tx->res->json->{id};
 # check plugin called fedmsg-logger correctly
 my $dateexpr = '\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}Z';
 like(
-    $args,
+    $args[0],
 qr/$commonexpr --topic=comment.create --json-input --message=\{"created":"$dateexpr","group_id":null,"id":$comment,"job_id":$job,"text":"test comment","updated":"$dateexpr","user":"perci"\}/,
     'comment post triggers fedmsg'
 );
 # reset $args
-$args = '';
+@args = ();
 
 # update job comment via API
 my $put = $t->put_ok("/api/v1/jobs/$job/comments/$comment" => form => {text => "updated comment"})->status_is(200);
 # check plugin called fedmsg-logger correctly
 like(
-    $args,
+    $args[0],
 qr/$commonexpr --topic=comment.update --json-input --message=\{"created":"$dateexpr","group_id":null,"id":$comment,"job_id":$job,"text":"updated comment","updated":"$dateexpr","user":"perci"\}/,
     'comment update triggers fedmsg'
 );
 # reset $args
-$args = '';
+@args = ();
 
 # become admin (so we can delete the comment)
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
@@ -188,11 +297,46 @@ $t->app($app);
 # delete comment via API
 my $delete = $t->delete_ok("/api/v1/jobs/$job/comments/$comment")->status_is(200);
 like(
-    $args,
+    $args[0],
 qr/$commonexpr --topic=comment.delete --json-input --message=\{"created":"$dateexpr","group_id":null,"id":$comment,"job_id":$job,"text":"updated comment","updated":"$dateexpr","user":"perci"\}/,
     'comment delete triggers fedmsg'
 );
 # reset $args
-$args = '';
+@args = ();
+
+# create another job via API, this time for an update
+$settings->{BUILD} = 'Update-FEDORA-2018-3c876babb9';
+delete $settings->{ISO};
+$post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+my $updatejob = $post->tx->res->json->{id};
+is(
+    $args[0],
+    $commonexpr
+      . ' --topic=job.create --json-input --message='
+      . '{"ARCH":"x86_64","BUILD":"Update-FEDORA-2018-3c876babb9","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink",'
+      . '"ISO_MAXSIZE":"1","KVM":"KVM","MACHINE":"RainbowPC","TEST":"rainbow","VERSION":"42","id":'
+      . $updatejob
+      . ',"remaining":1}',
+    "update job create triggers fedmsg"
+);
+is(
+    $args[1],
+    $commonci
+      . ' --topic=fedora-update.test.queued --json-input --message='
+      . '{"body":{"artifact":{"id":"FEDORA-2018-3c876babb9","issuer":"unknown","release":"42","type":"fedora-update"},"category":"validation",'
+      . '"ci":{"email":"qa-devel@lists.fedoraproject.org","irc":"#fedora-qa","name":"Fedora openQA","team":"Fedora QA",'
+      . '"url":"https://openqa.stg.fedoraproject.org"},"lifetime":240,"run":{"id":'
+      . $updatejob . ','
+      . '"log":"https://openqa.stg.fedoraproject.org/tests/'
+      . $updatejob
+      . '/file/autoinst-log.txt",'
+      . '"url":"https://openqa.stg.fedoraproject.org/tests/'
+      . $updatejob . '"},'
+      . '"type":"rainbow RainbowPC pink x86_64"},'
+      . '"headers":{"id":"FEDORA-2018-3c876babb9","type":"fedora-update"}}',
+    "update job create triggers standardized fedmsg"
+);
+# reset $args
+@args = ();
 
 done_testing();


### PR DESCRIPTION
There is a Red Hat-ish universe standard being established for
'CI'-ish message bus messages, the idea being that if many
different test systems emit messages in a common format, it
makes things much easier for other systems trying to follow
what all the test systems are doing. This makes the openQA
fedmsg plugin emit messages in this standardized format (at
least, in an initial approximation of it, with as-yet unapproved
extensions...) as well as the existing messages.

https://pagure.io/fedora-ci/messages