### PR TITLE
Update serial failures detection documentation

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -163,10 +163,13 @@ Variables are accessible via the *get_var* and *check_var* functions.
 === Capturing kernel exceptions and/or any other exceptions from the serial console
 
 Soft and hard failures can be triggered on demand by regular expressions when they match the
-serial output which is done after the test is executed. To use this functionality the test
-developer needs to define the patterns to look for in the serial output either in the main.pm
-or in the test itself. Any pattern change done in a test it will be reflected in the next
-tests.
+serial output which is done after the test is executed. In case it doesn't make sense
+to continue test run even if current test module doesn't have fatal flag, use `fatal` as
+serial failure type, so all subsequent test modules won't be executed if such failure
+was detected.
+To use this functionality the test developer needs to define the patterns to
+look for in the serial output either in the main.pm or in the test itself.
+Any pattern change done in a test it will be reflected in the next tests.
 
 The patterns defined in the main.pm will be valid for all the tests.
 
@@ -179,8 +182,9 @@ test suites have failed due to different test modules.
 [source,perl]
 --------------------------------------------------------------
 $testapi::distri->set_expected_serial_failures([
-        {type => 'soft', message => 'known issue',  pattern => quotemeta 'Error'},
-        {type => 'hard', message => 'broken build', pattern => qr/exception/},
+        {type => 'soft', message  => 'known issue',  pattern => quotemeta 'Error'},
+        {type => 'hard', message  => 'broken build', pattern => qr/exception/},
+        {type => 'fatal', message => 'critical issue build', pattern => qr/kernel oops/},
     ]
 );
 --------------------------------------------------------------
@@ -192,8 +196,9 @@ $testapi::distri->set_expected_serial_failures([
 sub run {
     my ($self) = @_;
     $self->{serial_failures} = [
-        {type => 'soft', message => 'known issue',  pattern => quotemeta 'Error'},
-        {type => 'hard', message => 'broken build', pattern => qr/exception/},
+        {type => 'soft', message  => 'known issue',  pattern => quotemeta 'Error'},
+        {type => 'hard', message  => 'broken build', pattern => qr/exception/},
+        {type => 'fatal', message => 'critical issue build', pattern => qr/kernel oops/},
     ];
     ...
 }


### PR DESCRIPTION
Changes to reflect changes introduced in [PR#1014](https://github.com/os-autoinst/os-autoinst/pull/1014) to os-autoinst, describing `fatal` type.