### PR TITLE
Allow to enable monitoring using mojo-status

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -30,8 +30,15 @@
 ## Set to 0 to disable auditing backend
 # audit_enabled = 1
 
-## Set to 1 to enable profiling. Needs Mojolicious::Plugin::NYTProf
+## Set to 1 to enable profiling
+## * Needs Mojolicious::Plugin::NYTProf
+## * Profiling data will be PUBLICLY accessible under /nytprof route.
 # profiling_enabled = 0
+
+## Set to 1 to enable monitoring
+## * Needs Mojolicious::Plugin::Status
+## * Monitoring will be accessible to operators and admins under /monitoring route.
+# monitoring_enabled = 0
 
 ## space-separated list of extra plugins to load; plugin must be under
 ## OpenQA::WebAPI::Plugin and correctly-cased module name given here,

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -135,6 +135,7 @@ sub read_config {
             audit_enabled       => 1,
             max_rss_limit       => 0,
             profiling_enabled   => 0,
+            monitoring_enabled  => 0,
             plugins             => undef,
             hide_asset_types    => 'repo',
             recognized_referers => '',
@@ -287,7 +288,7 @@ sub setup_mojo_tmpdir {
 }
 
 sub load_plugins {
-    my ($server) = @_;
+    my ($server, $monitoring_root_route) = @_;
 
     push @{$server->plugins->namespaces}, 'OpenQA::WebAPI::Plugin';
 
@@ -310,6 +311,9 @@ sub load_plugins {
     }
     if ($server->config->{global}{profiling_enabled}) {
         $server->plugin(NYTProf => {nytprof => {}});
+    }
+    if ($monitoring_root_route && $server->config->{global}{monitoring_enabled}) {
+        $server->plugin(Status => {route => $monitoring_root_route->get('/monitoring')});
     }
     # load auth module
     my $auth_method = $server->config->{auth}->{method};

--- a/t/config.t
+++ b/t/config.t
@@ -42,6 +42,7 @@ subtest 'Test configuration default modes' => sub {
             audit_enabled       => 1,
             max_rss_limit       => 0,
             profiling_enabled   => 0,
+            monitoring_enabled  => 0,
             hide_asset_types    => 'repo',
             recognized_referers => [],
             changelog_file      => '/usr/share/openqa/public/Changelog',


### PR DESCRIPTION
Btw, it looks like this:

![screenshot_20180824_104848](https://user-images.githubusercontent.com/10248953/44575005-484b7e80-a78b-11e8-9481-2f52c909cdbb.png)

I made it only available to operators/admins, so you can enable it on the production instance.
