### PR TITLE
[wip] Emit catch_exit when worker gets interrupted, clean up lock in such case

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -108,6 +108,7 @@ sub prepare_cache_directory {
 sub catch_exit {
     my ($sig) = @_;
     log_info("quit due to signal $sig");
+    Mojo::IOLoop->singleton->emit('catch_exit');
     if ($job) {
         Mojo::IOLoop->next_tick(
             sub {


### PR DESCRIPTION
This should reduce the occurences of https://progress.opensuse.org/issues/39833 while we move the cache as a service

Note: this is still racy