### PR TITLE
fullstack test: Prevent auto page reload when waiting for result panel

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -122,6 +122,11 @@ function alignBuildLabels() {
   $('.build-label').css('min-width', max + 'px');
 }
 
+// reloads the page - this wrapper exists to be able to disable the reload during tests
+function reloadPage() {
+    location.reload();
+}
+
 // returns an absolute "ws://" URL for the specified URL which might be relative
 function makeWsUrlAbsolute(url, servicePortDelta) {
     // don't adjust URLs which are already absolute

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -19,7 +19,7 @@ var logElements;
 // Update global variable testStatus
 function updateTestStatus(newStatus) {
     if (newStatus.state != 'running') {
-        setTimeout(function() {location.reload();}, 2000);
+        setTimeout(reloadPage, 2000);
         return;
     }
     testStatus.workerid = newStatus.workerid;
@@ -135,7 +135,7 @@ function updateStatus() {
             updateTestStatus(status);
             setTimeout(function() { updateStatus(); }, 5000);
         }).fail(function() {
-            setTimeout(function() {location.reload();}, 5000);
+            setTimeout(reloadPage, 5000);
         });
 }
 

--- a/assets/javascripts/scheduler.js
+++ b/assets/javascripts/scheduler.js
@@ -58,7 +58,7 @@ document.observe('dom:loaded', function() {
       // Let's bother the user to have time to really cancel
       alert('Job canceled. Postprocessing. You will be redirected to the results page in a few seconds.');
       // Even though, it will most likely not be enough
-      setTimeout(function() {location.reload();}, 5000);
+      setTimeout(reloadPage, 5000);
     });
   }
 
@@ -71,7 +71,7 @@ document.observe('dom:loaded', function() {
         window.location = url;
       } else {
         // We need to wait a little bit before accessing the results
-        setTimeout(function() {location.reload();}, 5000);
+        setTimeout(reloadPage, 5000);
       }
     });
   }


### PR DESCRIPTION
Because on page reload elements found via `find_element()` are invalidated
which is hard to handle and otherwise causes random failures.