### PR TITLE
Sort scheduled jobs via database

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -101,23 +101,8 @@ sub list {
         assetid => $assetid
     );
     $self->stash(blocked => {map { $_->id => \undef } $scheduled->search({-not => {blocked_by_id => undef}})->all});
-
-    # @scheduled = sort {
-    #     if ($b->{job} && $a->{job}) {
-    #         $b->{job}->t_created <=> $a->{job}->t_created || $b->{job}->id <=> $a->{job}->id;
-    #     }
-    #     elsif ($b->{job}) {
-    #         1;
-    #     }
-    #     elsif ($a->{job}) {
-    #         -1;
-    #     }
-    #     else {
-    #         0;
-    #     }
-    # }
-    my @scheduled = sort { $b->t_created <=> $a->t_created || $b->id <=> $a->id } $scheduled->all;
-    $self->stash(scheduled => \@scheduled);
+    $self->stash(
+        scheduled => [$scheduled->search(undef, {order_by => [{-desc => 'me.t_created'}, {-desc => 'me.id'}]})->all]);
 }
 
 sub prefetch_comment_counts {


### PR DESCRIPTION
Because sorting in Perl is usually slower