### PR TITLE
Make the overview page responsive again

### DIFF
--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,7 +1,7 @@
 % for my $build_res (@$build_results) {
     % my $build = $build_res->{build};
     % my $group_id;
-    <div class="d-flex flex-row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
+    <div class="d-md-flex flex-row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
         <div class="px-2 build-label text-nowrap">
             <span class="h4">
                 % if ($children) {
@@ -36,7 +36,7 @@
                 % my $child_res = $build_res->{children}->{$child->{id}};
                 % my $jobs = $child_res->{passed} + $child_res->{unfinished} + $child_res->{softfailed} + $child_res->{failed} + $child_res->{skipped};
                 % if ($jobs) {
-                    <div class="d-flex flex-row build-row">
+                    <div class="d-md-flex flex-row build-row">
                         <div class="px-2 build-label text-nowrap">
                             <span class="h4">
                                 %= link_to $child->{name} => url_for('tests_overview')->query(distri => [sort keys %{$child_res->{distris}}], version => $child_res->{version}, build => $build, groupid => $child->{id})


### PR DESCRIPTION
Break the progress bars below the title on medium size screens (<992px)

See https://progress.opensuse.org/issues/39896