### PR TITLE
Make web socket and livehandler daemons listen on IPv4 and IPv6

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2017 SUSE LLC
+# Copyright (C) 2012-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ use Regexp::Common 'URI';
 use Try::Tiny;
 use Mojo::File 'path';
 use IO::Handle;
+use IO::Socket::IP;
 use Time::HiRes 'gettimeofday';
 use POSIX 'strftime';
 use Scalar::Util 'blessed';
@@ -96,6 +97,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   in_range
   walker
   &ensure_timestamp_appended
+  set_listen_address
 );
 
 @EXPORT_OK = qw(determine_web_ui_web_socket_url get_ws_status_only_url);
@@ -1141,6 +1143,20 @@ sub logistic_map_steps {
 sub rand_range { $_[0] + rand($_[1] - $_[0]) }
 sub in_range { $_[0] >= $_[1] && $_[0] <= $_[2] ? 1 : 0 }
 
+sub set_listen_address {
+    my ($port) = @_;
+
+    if ($ENV{MOJO_LISTEN}) {
+        return;
+    }
+
+    my @listen_addresses = ("http://127.0.0.1:$port");
+    if (IO::Socket::IP->new(Listen => 5, LocalAddr => '::1')) {
+        push(@listen_addresses, "http://[::1]:$port");
+    }
+
+    $ENV{MOJO_LISTEN} = join(',', @listen_addresses);
+}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -474,9 +474,6 @@ sub setup {
     app->plugin("Helpers");
     app->asset->process;
 
-    # use port one higher than WebAPI
-    my $listen = $ENV{MOJO_LISTEN} || "http://localhost:9527";
-
     my $ca = under \&check_authorized;
     $ca->websocket('/ws/:workerid' => [workerid => qr/\d+/] => \&ws_create);
 
@@ -493,7 +490,7 @@ sub setup {
         });
 
 
-    return Mojo::Server::Daemon->new(app => app, listen => ["$listen"]);
+    return Mojo::Server::Daemon->new(app => app);
 }
 
 

--- a/script/openqa-livehandler
+++ b/script/openqa-livehandler
@@ -21,7 +21,9 @@ use warnings;
 use FindBin;
 BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
 
-$ENV{MOJO_LISTEN} ||= 'http://localhost:9528/';
+# listen only locally on port 9528 (preferably on both - IPv4 and IPv6)
+use OpenQA::Utils;
+set_listen_address(9528);
 
 # ensure the web socket connection won't timeout
 $ENV{MOJO_INACTIVITY_TIMEOUT} ||= 15 * 60;

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -35,7 +35,9 @@ BEGIN {
     }
 }
 
-$ENV{MOJO_LISTEN} ||= 'http://localhost:9527/';
+# listen only locally on port 9527 (preferably on both - IPv4 and IPv6)
+use OpenQA::Utils;
+set_listen_address(9527);
 
 # allow up to 20GB - hdd images
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 1024 * 1024 * 1024 * 20;


### PR DESCRIPTION
This ensures the daemons listen on IPv4 and if available also on IPv6.