### PR TITLE
Fix removal of untracked assets

### DIFF
--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -62,7 +62,7 @@ sub _limit {
         $update_sth->execute($asset->{max_job} && $asset->{max_job} >= 0 ? $asset->{max_job} : undef, $asset->{id});
         next if $asset->{fixed} || scalar(keys %{$asset->{groups}}) > 0;
 
-        my $age = int(DateTime::Format::Pg->parse_datetime($asset->{t_created})->delta_ms($now)->in_units('days'));
+        my $age = $now->delta_days(DateTime::Format::Pg->parse_datetime($asset->{t_created}))->in_units('days');
         if ($age >= $untracked_assets_storage_duration || !$asset->{size}) {
             _remove_if($app->db, $asset);
         }


### PR DESCRIPTION
This is probably the most stupid bug ever - we basically only deleted untracked
assets by chance. delta_ms returns a Duration object - and that Duration object's
in_units only supports certain conversions. If the conversion is not supported,
0 is returned. So all these assets had basically all the time an age of 0

Using delta_days returns just that: the age in days and we happily remove them