### PR TITLE
Limit logs and results for groupless jobs

### DIFF
--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -27,15 +27,13 @@ sub register {
 sub _limit {
     my ($app, $job) = @_;
 
+    # create temporary job group outside of DB to collect
+    # jobs without job_group_id
+    $app->db->resultset('JobGroups')->new({})->limit_results_and_logs;
+
     my $groups = $app->db->resultset('JobGroups');
     while (my $group = $groups->next) {
-        my $important_builds = $group->important_builds;
-        for my $job (@{$group->find_jobs_with_expired_results($important_builds)}) {
-            $job->delete;
-        }
-        for my $job (@{$group->find_jobs_with_expired_logs($important_builds)}) {
-            $job->delete_logs;
-        }
+        $group->limit_results_and_logs;
     }
 }
 


### PR DESCRIPTION
So far we only removed old jobs of job groups - jobs that were posted
through the jobs controller or moved to group 0 afterwards weren't
taken care of.

As we have a default setting for result removal, use it to remove
jobs without group.

See https://progress.opensuse.org/issues/41174