### PR TITLE
doc: remove mention of openQA-devel package

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -19,7 +19,7 @@ assumed that the reader is already familiar with openQA and has already read the
 Starter Guide, available at the
 https://github.com/os-autoinst/openQA[official repository].
 
-== Installation
+== Repositories and installation
 
 Keep in mind that there can be disruptive changes between openQA versions.
 You need to be sure that the webui and the worker that you are using have the
@@ -30,7 +30,7 @@ version on Tumbleweed.
 And the package distributed with Tumbleweed may not be compatible with the
 version in the development package.
 
-=== Installation from distribution packages
+=== Official repositories
 
 The easiest way to install openQA is from distribution packages.
 
@@ -38,20 +38,7 @@ The easiest way to install openQA is from distribution packages.
 - For Fedora, packages are available in the official repositories for Fedora 23
 and later.
 
-You can install the packages using these commands.
-
-[source,sh]
--------------------------------------------------------------------------------
-# openSUSE Leap 42.3+
-zypper in openQA
-
-
-# Fedora 23+
-dnf install openqa openqa-httpd
--------------------------------------------------------------------------------
-
-
-=== Installation from development versions of packages
+=== Development version repository
 
 You can find the development version of openQA in OBS in the
 https://build.opensuse.org/project/show/devel:openQA[openQA:devel] repository.
@@ -71,12 +58,17 @@ zypper ar -f obs://devel:openQA:Leap:<version>/openSUSE_Leap_$LEAP_VERSION devel
 
 As required change +LEAP_VERSION+ to the version of openSUSE Leap you have installed.
 
-Then you can install them using this command.
+=== Installation
+You can install the packages using these commands.
 
 [source,sh]
 -------------------------------------------------------------------------------
-# all openSUSE
-zypper install devel-openQA:openQA
+# openSUSE Leap 42.3+
+zypper in openQA
+
+
+# Fedora 23+
+dnf install openqa openqa-httpd
 -------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Current version of installation documentation mention that for development repo  you need to install  devel-openQA:openQA which is not true  