### PR TITLE
Fix 'last_match' param of AJAX route for needle table

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -54,11 +54,11 @@ sub ajax {
     push(@filter_conds, {filename => {-like => '%' . $search_value . '%'}}) if $search_value;
     my $seen_query = $self->param('last_seen');
     if ($seen_query && $seen_query ne 'none') {
-        push(@filter_conds, {'last_seen_time' => _translate_cond($self->param('last_seen'))});
+        push(@filter_conds, {last_seen_time => _translate_cond($seen_query)});
     }
     my $match_query = $self->param('last_match');
     if ($match_query && $match_query ne 'none') {
-        push(@filter_conds, {'last_matched_time' => _translate_cond($self->param('last_matched'))});
+        push(@filter_conds, {last_matched_time => _translate_cond($match_query)});
     }
 
     OpenQA::ServerSideDataTable::render_response(


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/41399
* Bug was introduced in 2a50aa7c9f42e72bd95f89378fcb5c745f76a22f