### PR TITLE
Update AppArmor profile for Leap 15.0

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -1,4 +1,4 @@
-# Last Modified: Thu May  3 18:32:11 2018
+# Last Modified: Thu Sep 27 15:25:16 2018
 #include <tunables/global>
 
 # ------------------------------------------------------------------
@@ -58,9 +58,10 @@
   /sys/bus/ r,
   /sys/bus/usb/devices/ r,
   /sys/class/ r,
-  /sys/devices/system/node/node0/meminfo r,
-  /sys/fs/cgroup/systemd/openqa.slice/** rw,
+  /sys/devices/system/cpu/** r,
+  /sys/devices/system/node/** r,
   /sys/firmware/devicetree/base/ r,
+  /sys/fs/cgroup/systemd/openqa.slice/** rw,
   /tmp/* rwk,
   /usr/bin/Xvnc rCx,
   /usr/bin/cat rix,
@@ -112,7 +113,7 @@
   /usr/share/openqa/lib/DBIx/Class/Timestamps.pm r,
   /usr/share/openqa/lib/OpenQA/** r,
   /usr/share/openqa/script/worker r,
-  /usr/share/qemu/* r,
+  /usr/share/qemu/* rk,
   /usr/share/qemu/keymaps/* r,
   /var/lib/openqa/cache/ r,
   /var/lib/openqa/cache/** rwk,


### PR DESCRIPTION
Hit the following errors on openqaworker1 on o3

the rk for /usr/share/qemu is needed to handle qemu-img properly on Leap 15

the changes for /sys are to based on a broad amount of apparmor blocks detected in those paths.