### PR TITLE
Fix openQA-client package for openSUSE

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -406,6 +406,7 @@ fi
 %dir %{_datadir}/openqa
 %{_datadir}/openqa/lib
 %exclude %{_datadir}/openqa/lib/OpenQA/Client.pm
+%exclude %{_datadir}/openqa/lib/OpenQA/UserAgent.pm
 %dir %{_localstatedir}/lib/openqa
 %ghost %dir %{_localstatedir}/lib/openqa/share/
 %{_localstatedir}/lib/openqa/factory
@@ -450,6 +451,7 @@ fi
 %{_datadir}/openqa/script/load_templates
 %dir %{_datadir}/openqa/lib
 %{_datadir}/openqa/lib/OpenQA/Client.pm
+%{_datadir}/openqa/lib/OpenQA/UserAgent.pm
 %{_bindir}/openqa-client
 %{_bindir}/openqa-clone-job
 %{_bindir}/openqa-dump-templates

--- a/openQA.spec
+++ b/openQA.spec
@@ -164,7 +164,10 @@ Requires:       perl(Cpanel::JSON::XS)
 Requires:       perl(Data::Dump)
 Requires:       perl(Getopt::Long)
 Requires:       perl(IO::Socket::SSL) >= 2.009
+Requires:       perl(JSON)
+Requires:       perl(LWP::UserAgent)
 Requires:       perl(Mojolicious)
+Requires:       perl(Try::Tiny)
 
 %description client
 Tools and support files for openQA client script. Client script is


### PR DESCRIPTION
See
* https://progress.opensuse.org/issues/40898
* https://progress.opensuse.org/issues/38351

I executed `grep 'use ' $(rpm -ql openQA-client)` and added all modules we're using. I excluded those which are provided by an already existing `Requires`, `perl-base` or `perl`.