### PR TITLE
Allow inter-machine dependency

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -62,9 +62,8 @@ sub _settings_key {
 
 =item _parse_dep_variable()
 
-Parse dependency variable in format like "suite1,suite2,suite3"
-and return settings key for each entry. Internal method. B<TODO>:
-allow inter-machine dependency.
+Parse dependency variable in format like "suite1,suite2,suite3[:machine]"
+and return settings key for each entry. Internal method.
 
 =back
 
@@ -75,9 +74,14 @@ sub _parse_dep_variable {
 
     return unless defined $value;
 
+    my $machine = $settings->{MACHINE};
+    if ($value =~ /^(.+):([^:]+)$/) {
+        $value   = $1;
+        $machine = $2;
+    }
     my @after = split(/\s*,\s*/, $value);
 
-    return map { $_ . ':' . $settings->{MACHINE} } @after;
+    return map { $_ . ':' . $machine } @after;
 }
 
 =over 4


### PR DESCRIPTION
I would like to discuss the following. If it makes sense this way. I'm going to write the tests.

Allow to specify the machine in the job dependency. If the job dependency has the format "job1,job2:machine", the given machine is used instead of MACHINE variable.
WHY

I would like to have following test job dependencies:
test0@64bit
test1@m1 (START_AFTER_TEST=test0@64bit)
test1@m2 (START_AFTER_TEST=test0@64bit)

I need to run one test on different VM types in public cloud. The idea is to specify each VM type
as a machine in openQA.
The problem is, that all test should run after the test _upload_img_ and _upload_img_ should not run twice at the same time.

Verification run: http://cfconrad-vm.qa.suse.de/tests/1773#settings