### PR TITLE
Move errors regarding developer mode into the devel panel

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -31,18 +31,21 @@ function setupForAll() {
     });
 }
 
-function addFlash(status, text) {
-    // keep design in line with the static in layouts/info
-    var flash = $('#flash-messages');
+function addFlash(status, text, container) {
+    // add flash messages by default on top of the page
+    if (!container) {
+        container = $('#flash-messages');
+    }
+
     var div = $('<div class="alert alert-primary alert-dismissible fade show" role="alert"></div>');
     div.append($('<span>' + text + '</span>'));
     div.append($('<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>'));
     div.addClass('alert-' + status);
-    flash.append(div);
+    container.append(div);
     return div;
 }
 
-function addUniqueFlash(status, id, text) {
+function addUniqueFlash(status, id, text, container) {
     // add hash to store present flash messages
     if (!window.uniqueFlashMessages) {
         window.uniqueFlashMessages = {};
@@ -52,7 +55,7 @@ function addUniqueFlash(status, id, text) {
         return;
     }
 
-    var msgElement = addFlash(status, text);
+    var msgElement = addFlash(status, text, container);
     window.uniqueFlashMessages[id] = msgElement;
     msgElement.on('closed.bs.alert', function () {
         delete window.uniqueFlashMessages[id];

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -114,6 +114,16 @@ div.flags {
         margin: 12px 0px;
     }
 }
+#developer-flash-messages {
+    &:first-child {
+        margin-top: 20px;
+    }
+    .alert span {
+        text-align: left !important;
+        font-weight: normal !important;
+        cursor: default !important;
+    }
+}
 
 // misc
 .component {

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -102,7 +102,7 @@ sub assert_flash_messages {
     my ($kind, $expected_messages, $test_name) = @_;
     my $kind_selector = $kind eq 'any' ? 'alert' : '.alert-' . $kind;
 
-    my @flash_messages = $driver->find_elements("#flash-messages $kind_selector > span");
+    my @flash_messages = $driver->find_elements("#developer-flash-messages $kind_selector > span");
     is(
         scalar @flash_messages,
         scalar @$expected_messages,
@@ -488,6 +488,9 @@ subtest 'process state changes from os-autoinst' => sub {
                 'unique flash message appears again after dismissed'
             );
         };
+
+        $driver->execute_script('handleWebsocketConnectionOpened();');
+        assert_flash_messages(any => [], 'obsolete messages cleared after successful connect');
     };
 };
 

--- a/templates/test/live.html.ep
+++ b/templates/test/live.html.ep
@@ -42,6 +42,10 @@
                 </span>
             </div>
         </div>
+        <div class="row">
+            <div class="col-sm-12" id="developer-flash-messages">
+            </div>
+        </div>
     </div>
     <div class="card-body">
         <form action="#" method="get" id="developer-form" class="developer-mode-element"


### PR DESCRIPTION
* So the context of those messages is clear and the messages are less disturbing
* Remove obsolete error messages when the error is gone
* See https://progress.opensuse.org/issues/39227