### PR TITLE
Add regex filter for admin tables

### DIFF
--- a/assets/javascripts/admintable.js
+++ b/assets/javascripts/admintable.js
@@ -299,7 +299,7 @@ function add_table_row_button ()
     table.find('tr:last').after(html);
 }
 
-function populate_admin_table (is_admin)
+function populate_admin_table (is_admin, filter_regex_first_column)
 {
     var url = $("#admintable_api_url").val();
     if (url) {
@@ -317,11 +317,18 @@ function populate_admin_table (is_admin)
                 }
                 table.find('tbody').html(html);
                 // a really stupid datatable
-                table.DataTable( {
+                var tbl = table.DataTable( {
                     "paging" : false,
                     "lengthChange": false,
                     "ordering": false
                 } );
+                if (filter_regex_first_column) {
+                    var search_box = $('.dataTables_filter input[type=search]');
+                    var search_events = 'cut input keypress keyup paste search';
+                    search_box.off(search_events).on(search_events, function() {
+                        tbl.columns(0).search(search_box.val(), true, false).draw();
+                    });
+                }
             },
             error: admintable_api_error
         });

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -278,6 +278,11 @@ subtest 'add test suite' => sub() {
     wait_for_ajax;
     $elem = $driver->find_element('.admintable tbody tr:last-child');
     is($elem->get_text(), "$suiteName testKey=$suiteValue", 'stored text is the same except key');
+
+    $elem = $driver->find_element('input[type=search]');
+    $elem->send_keys("^kde");
+    @fields = $driver->find_elements('.admintable tbody tr');
+    is(@fields, 1, "search using regex");
 };
 
 subtest 'add job group' => sub() {

--- a/templates/admin/machine/index.html.ep
+++ b/templates/admin/machine/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Machines';
 
 % content_for 'ready_function' => begin
-    populate_admin_table(<%= is_admin %>);
+    populate_admin_table(<%= is_admin %>, true);
 % end
 
 <div class="row">
@@ -10,6 +10,21 @@
         <h2><%= title %></h2>
 
         %= include 'layouts/info'
+
+        <span id="audit_log_search_popover">
+            <%= help_popover('Search' => '
+                <p>Allows to filter the machines.</p>
+                <p>
+                    The filter will only consider the <em>Name</em> column.
+                    You can use regular expressions for searching.
+                </p>
+                <p>
+                    <strong>Example</strong><br>
+                    <code>^64bit$</code>
+                </p>
+                ', undef, undef, 'left');
+            %>
+        </span>
 
         <table class="admintable table table-striped" id='machines'>
             <thead>

--- a/templates/admin/product/index.html.ep
+++ b/templates/admin/product/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Medium types';
 
 % content_for 'ready_function' => begin
-   populate_admin_table(<%= is_admin %>);
+   populate_admin_table(<%= is_admin %>, false);
 % end
 
 <div class="row">

--- a/templates/admin/test_suite/index.html.ep
+++ b/templates/admin/test_suite/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Test suites';
 
 % content_for 'ready_function' => begin
-    populate_admin_table(<%= is_admin %>);
+    populate_admin_table(<%= is_admin %>, true);
 % end
 
 <div class="row">
@@ -10,6 +10,21 @@
         <h2><%= title %></h2>
 
         %= include 'layouts/info'
+
+        <span id="audit_log_search_popover">
+            <%= help_popover('Search' => '
+                <p>Allows to filter the testsuites.</p>
+                <p>
+                    The filter will only consider the <em>Name</em> column.
+                    You can use regular expressions for searching.
+                </p>
+                <p>
+                    <strong>Example</strong><br>
+                    <code>^textmode$</code>
+                </p>
+                ', undef, undef, 'left');
+            %>
+        </span>
 
         <table class="admintable table table-striped" id='test-suites'>
             <thead>


### PR DESCRIPTION
This introduces a way to find a testsuite as the current search is completely unusable.
Even using `CTRL+F` for searching a testsuite doesn't really help as eg `textmode` is a too common string that also appears as substring within other testsuite names.

With this patch it is possible to query for an exact testsuite name using a regex:

```
/admin/test_suites?filter_name=^textmode$
```