### PR TITLE
Hide cloned jobs from job dependency graph

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -523,9 +523,11 @@ function setupDependencyGraph() {
                 return;
             }
             statusElement.style.textAlign = 'left';
-            statusElement.innerHTML = 'Arrows visualize chained dependencies specified via <code>START_AFTER_TEST</code>. \
+            statusElement.innerHTML = '<p>Arrows visualize chained dependencies specified via <code>START_AFTER_TEST</code>. \
                                        Blue boxes visualize parallel dependencies specified via <code>PARALLEL_WITH</code>. \
-                                       The current job is highlighted with a bolder border and yellow background.';
+                                       The current job is highlighted with a bolder border and yellow background.</p> \
+                                       <p>The graph shows only the latest jobs. That means jobs which have been cloned will \
+                                       never show up.</p>';
             renderDependencyGraph(containerElement, nodes, edges, cluster, containerElement.dataset.currentJobId);
         },
         error: function(xhr, ajaxOptions, thrownError) {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -259,14 +259,14 @@ sub _show {
 
     $self->stash(
         {
-            testname         => $job->name,
-            distri           => $job->DISTRI,
-            version          => $job->VERSION,
-            build            => $job->BUILD,
-            scenario         => $job->scenario,
-            worker           => $job->worker,
-            assigned_worker  => $job->assigned_worker,
-            has_dependencies => $job->has_dependencies,
+            testname          => $job->name,
+            distri            => $job->DISTRI,
+            version           => $job->VERSION,
+            build             => $job->BUILD,
+            scenario          => $job->scenario,
+            worker            => $job->worker,
+            assigned_worker   => $job->assigned_worker,
+            show_dependencies => !defined($job->clone_id) && $job->has_dependencies,
         });
 
     my $clone_of = $self->db->resultset("Jobs")->find({clone_id => $job->id});
@@ -711,6 +711,11 @@ sub _add_job {
     my $job_id = $job->id;
     return $job_id if $visited->{$job_id};
     $visited->{$job_id} = 1;
+
+    # skip if the job has been cloned and the clone is also part of the dependency tree
+    if (my $clone = $job->clone) {
+        return _add_job($visited, $nodes, $edges, $cluster, $cluster_by_job, $clone);
+    }
 
     push(
         @$nodes,

--- a/templates/test/dependencies.html.ep
+++ b/templates/test/dependencies.html.ep
@@ -2,10 +2,12 @@
   %= asset 'dagre-d3.js'
   %= asset 'dependency_graph.css'
 % end
-<p id="dependencygraph_status">
-    <i class="fas fa-spinner fa-spin fa-lg"></i>
-    Loading dependency graph ...
-</p>
+<div id="dependencygraph_status">
+    <p>
+        <i class="fas fa-spinner fa-spin fa-lg"></i>
+        Loading dependency graph ...
+    </p>
+</div>
 <svg
     id="dependencygraph"
     data-url="<%= url_for('test_dependencies', testid => $job->id) %>"

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -37,7 +37,7 @@
                 <li role="presentation" class="nav-item">
                     <a href="#settings" aria-controls="settings" role="tab" data-toggle="tab" class="nav-link">Settings</a>
                 </li>
-                % if ($has_dependencies) {
+                % if ($show_dependencies) {
                     <li role="presentation" class="nav-item">
                         <a href="#dependencies" aria-controls="dependencies" role="tab" data-toggle="tab" class="nav-link">Dependencies</a>
                     </li>
@@ -68,7 +68,7 @@
                 <div role="tabpanel" class="tab-pane" id="settings">
                     %= include 'test/settings'
                 </div>
-                % if ($has_dependencies) {
+                % if ($show_dependencies) {
                     <div role="tabpanel" class="tab-pane" id="dependencies">
                         %= include 'test/dependencies'
                     </div>


### PR DESCRIPTION
See https://progress.opensuse.org/issues/42563

* Don't show cloned jobs in the dependency tree
* Don't show dependency tab for cloned jobs
  (otherwise we would show a dependency tree where the
   job itself isn't part of)