### PR TITLE
Refuse updating job group name with empty or blank

### DIFF
--- a/assets/javascripts/admin_groups.js
+++ b/assets/javascripts/admin_groups.js
@@ -20,6 +20,7 @@ function showAddJobGroup(plusElement) {
 
     addGroupElement.find('.modal-title').text(title);
     addGroupElement.modal();
+    checkJobGroupForm('#new_group_form');
     return false;
 }
 
@@ -31,6 +32,7 @@ function showAddParentGroup() {
     var addGroupElement = $('#add_group_modal');
     addGroupElement.find('.modal-title').text('Add new folder');
     addGroupElement.modal();
+    checkJobGroupForm('#new_group_form');
     return false;
 }
 
@@ -58,20 +60,38 @@ function fetchHtmlEntry(url, targetElement) {
     });
 }
 
+function _checkJobGroupInputs(formID) {
+    var empty = false;
+    $('.form-group input', formID).each(function() {
+        var trimmed = jQuery.trim($(this).val());
+        if (!trimmed.length) {
+            empty = true;
+        }
+    });
+    return empty;
+}
+
+function checkJobGroupForm(formID) {
+    var empty = _checkJobGroupInputs(formID);
+    if (empty) {
+        $('button[type=submit]', formID).attr('disabled', 'disabled');
+    }
+    $('.form-group input', formID).on('keyup change', function() {
+        var trimmed = jQuery.trim($(this).val());
+        if (!trimmed.length) {
+            $(this).addClass('is-invalid');
+            $('button[type=submit]', formID).attr('disabled', 'disabled');
+        } else {
+            $(this).removeClass('is-invalid');
+            $('button[type=submit]', formID).removeAttr('disabled');
+        }
+    });
+}
+
 function createGroup(form) {
     var editorForm = $(form);
-
     $('#new_group_error').hide();
-
-    if(!$('#new_group_name').val().length) {
-        $('#new_group_name_group').addClass('has-error');
-        $('#new_group_name_group .help-block').show();
-        return false;
-    }
-
     $('#new_group_creating').show();
-    $('#new_group_name_group').removeClass('has-error');
-    $('#new_group_name_group .help-block').hide();
 
     var data = editorForm.serialize();
     if(editorForm.data('create-parent')) {
@@ -107,7 +127,12 @@ function createGroup(form) {
             fetchHtmlEntry(rowUrl + response.id, targetElement);
         },
         error: function(xhr, ajaxOptions, thrownError) {
-            showError(thrownError);
+            if(xhr.responseJSON.error) {
+                showError(xhr.responseJSON.error);
+            }
+            else {
+                showError(thrownError);
+            }
         }
     });
 

--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -362,6 +362,7 @@ function alignCols() {
 
 function toggleEdit() {
     $('#properties').toggle(250);
+    checkJobGroupForm('#group_properties_form');
 }
 
 function showSubmitResults(form, result) {
@@ -392,7 +393,11 @@ function submitProperties(form) {
                $('td.prio input').attr('placeholder', defaultPrio);
            },
            error: function(xhr, ajaxOptions, thrownError) {
-               showSubmitResults(editorForm, '<i class="fas fa-trash"></i> Unable to apply changes');
+               var errmsg = '';
+               if (xhr.responseJSON.error) {
+                    errmsg = xhr.responseJSON.error;
+               }
+               showSubmitResults(editorForm, '<i class="fas fa-trash"></i> Unable to apply changes ' + '<strong>' + errmsg + '</strong>');
            }
     });
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -185,6 +185,24 @@ sub check_top_level_group {
 
 =over 4
 
+=item check_group_name()
+
+Check group name to prevent create/update with empty or blank
+
+=back
+
+=cut
+
+sub check_group_name {
+    my ($self) = @_;
+
+    my $group_name = $self->param('name');
+    return 0 if (!defined $group_name || $group_name =~ /^\s*$/);
+    return 1;
+}
+
+=over 4
+
 =item create()
 
 Creates a new job group given a name. Prevents the creation of job groups with the same name.
@@ -196,10 +214,11 @@ Creates a new job group given a name. Prevents the creation of job groups with t
 sub create {
     my ($self) = @_;
 
-    my $group_name = $self->param('name');
-    return $self->render(json => {error => 'No group name specified'}, status => 400) unless $group_name;
+    my $check = $self->check_group_name;
+    return $self->render(json => {error => 'The group name must not be empty or blank'}, status => 400)
+      if ($check == 0);
 
-    my $check = $self->check_top_level_group;
+    $check = $self->check_top_level_group;
     if ($check != 0) {
         return $self->render(
             json   => {error => 'Unable to create group due to not allow duplicated job group on top level'},
@@ -230,7 +249,11 @@ sub update {
     my $group = $self->find_group;
     return unless $group;
 
-    my $check = $self->check_top_level_group($group->id);
+    my $check = $self->check_group_name;
+    return $self->render(json => {error => 'The group name must not be empty or blank'}, status => 400)
+      if ($check == 0);
+
+    $check = $self->check_top_level_group($group->id);
     if ($check != 0) {
         return $self->render(
             json   => {error => 'Unable to update group due to not allow duplicated job group on top level'},

--- a/templates/admin/group/group_property_editor.html.ep
+++ b/templates/admin/group/group_property_editor.html.ep
@@ -12,7 +12,7 @@
         % }
     </div>
     <div class="card-body">
-        <form action="#" class="form-horizontal" onsubmit="return submitProperties(this);"
+        <form action="#" id="group_properties_form" class="form-horizontal" onsubmit="return submitProperties(this);"
           data-put-url="<%= url_for(($is_parent ? 'apiv1_put_parent_group' : 'apiv1_put_job_group') => (group_id => $group->id)) %>">
             % if (!is_admin) {
                 <fieldset disabled>

--- a/templates/admin/group/index.html.ep
+++ b/templates/admin/group/index.html.ep
@@ -25,10 +25,6 @@
                         <label for="new_group_name" class="col-sm-2 control-label">Name</label>
                         <div class="col-sm-10">
                             <input type="text" name="name" id="new_group_name" value="" class="form-control">
-                            <span class="help-block" style="display: none;">
-                                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                The group name must not be empty.
-                            </span>
                         </div>
                     </div>
                     <p id="new_group_creating" style="display: none;">

--- a/templates/admin/group/parent_group_property_editor.html.ep
+++ b/templates/admin/group/parent_group_property_editor.html.ep
@@ -4,6 +4,7 @@
 
 % content_for 'ready_function' => begin
     setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>, <%= is_admin %>);
+    checkJobGroupForm('#group_properties_form');
 % end
 
 <div class="row">


### PR DESCRIPTION
Job group name can be updated with empty or blank that lead to no link clickable, add constraint to refuse it.

See: https://progress.opensuse.org/issues/42947