### PR TITLE
devel mode: Suppress connection errors if no module running

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -831,10 +831,21 @@ function processWsCommand(obj) {
     var somethingChanged = false;
     var what = obj.what;
     var data = obj.data;
+    var category;
+    if (data) {
+        category = data.category;
+    }
 
     switch(obj.type) {
     case "error":
         // handle errors
+
+        // ignore connection errors if there's no running module according to OpenQA::WebAPI::Controller::Running::status
+        if (!testStatus.running && category === 'cmdsrv-connection') {
+            console.log('ignoring error from ws proxy: ' + what);
+            break;
+        }
+
         console.log("Error from ws proxy: " + what);
         addLivehandlerFlash('danger', 'ws_proxy_error-' + what,
                             '<strong>Error from livehandler daemon:</strong><p>' + what + '</p>');

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -684,7 +684,10 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
             {
                 type => 'error',
                 what => 'os-autoinst command server not available, job is likely not running',
-                data => undef,
+                data => {
+                    reason   => 'URL to command server unknown',
+                    category => 'cmdsrv-connection',
+                },
             });
         $t_livehandler->finished_ok(1011);
 


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/39227
* If there's no running module according to
  OpenQA::WebAPI::Controller::Running::status we can assume that
  the os-autoinst command server is inavailable because it just
  hasn't been started yet and suppress the error message.