### PR TITLE
Add dependency for test in os-autoinst

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -113,6 +113,7 @@ RUN zypper in -y -C \
        'perl(Text::Markdown)' \
        'perl(Time::ParseDate)' \
        'perl(XSLoader) >= 0.24' \
+       'perl(XML::SemanticDiff)' \
        'TimeDate' \
        perl-Archive-Extract \
        perl-Test-Simple \


### PR DESCRIPTION
Basically, I want to update the docker image used to conduct the tests in the os-autoinst repository for https://github.com/os-autoinst/os-autoinst/pull/1048.

I'm not sure how our Docker/OBS setup works, but I suppose if I add the dependency to the CPAN file here, it will update the Docker image which is used in os-autoinst, too.

If this is true:

* There shouldn't be cyclic dependencies between os-autoinst and openQA - also not for the testing environment. So it would make sense to move the files for the Travis/Docker test environment to a separate repository.
* Document the current weirdness for the time being.