### PR TITLE
Do not log an error when trying to unlink an nonexisting file

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -535,6 +535,7 @@ sub start_job {
         my $fd;
         print $fd, "" if open($fd, '>', "$pooldir/worker-log.txt") or log_error "could not open worker log $!";
         foreach my $file (qw(serial0.txt autoinst-log.txt serial_terminal.txt)) {
+            next unless -e "$pooldir/$file";
             unlink("$pooldir/$file") or log_error "Could not unlink '$file': $!";
         }
     }


### PR DESCRIPTION
The worker typically cleans up after itself on stop already.