### PR TITLE
Add extra table for external results

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -331,10 +331,31 @@ function setupExternalResults() {
     if (!externalTable.length || externalTable.data('initialized')) {
         return;
     }
+
+    // make the table use DataTable
     externalTable.data('initialized', true);
-    externalTable.DataTable({
+    externalTable = externalTable.DataTable({
         lengthMenu: [[10, 25, 50, 100], [10, 25, 50, 100]],
         order: [],
+    });
+
+    // setup filtering
+    var onlyFailedCheckbox = $('#external-only-failed-filter');
+    onlyFailedCheckbox.change(function(event) {
+        externalTable.draw();
+    });
+    $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
+        // don't apply filter if checkbox not checked
+        if (!onlyFailedCheckbox.prop('checked')) {
+            return true;
+        }
+        // filter out everything but failures and softfailures
+        var data = externalTable.row(dataIndex).data();
+        if (!data) {
+            return false;
+        }
+        var result = data[2];
+        return result && (result.indexOf('result_fail') > 0 || result.indexOf('result_softfail') > 0);
     });
 }
 
@@ -395,7 +416,7 @@ function setupResult(state, jobid, status_url, details_url) {
   });
 
   // setup result filter, define function to apply filter changes
-  var detailsFilter = $('.details-filter');
+  var detailsFilter = $('#details-filter');
   var detailsNameFilter = $('#details-name-filter');
   var detailsFailedOnlyFilter = $('#details-only-failed-filter');
   var resultsTable = $('#results');

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -313,6 +313,8 @@ function handleKeyDownOnTestDetails(e) {
 function setupTab(tabHash) {
     if (tabHash === '#dependencies') {
         setupDependencyGraph();
+    } else if (tabHash === '#external') {
+        setupExternalResults();
     }
     if (tabHash === '#live') {
         setupDeveloperPanel();
@@ -320,6 +322,20 @@ function setupTab(tabHash) {
     } else {
         pauseLiveView();
     }
+}
+
+function setupExternalResults() {
+    var externalTable = $('#external-table');
+    // skip if table is not present (meaning no external results available) or if the table has
+    // already been initialized
+    if (!externalTable.length || externalTable.data('initialized')) {
+        return;
+    }
+    externalTable.data('initialized', true);
+    externalTable.DataTable({
+        lengthMenu: [[10, 25, 50, 100], [10, 25, 50, 100]],
+        order: [],
+    });
 }
 
 function setupResult(state, jobid, status_url, details_url) {

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -84,15 +84,15 @@ div.flags {
 .fa.module_none { color: $color-module-none; }
 .fa.module_passed { color: $color-module-passed !important; }
 .fa.module_softfailed { color: $color-softfailed; }
-.fa.result_failed {color: $color-failed; }
+.fa.result_failed, .fa.result_fail {color: $color-failed; }
 .fa.result_incomplete { color: $color-incomplete; }
 .fa.result_none { color: $color-module-none; }
 .fa.result_obsoleted { color: $color-module-none; }
 .fa.result_parallel_failed { color: $color-module-none; }
 .fa.result_parallel_restarted { color: $color-module-none; }
-.fa.result_passed { color: $color-module-passed !important; }
+.fa.result_passed, .fa.result_ok { color: $color-module-passed !important; }
 .fa.result_skipped { color: $color-module-none; }
-.fa.result_softfailed { color: $color-softfailed; }
+.fa.result_softfailed, .fa.result_softfail { color: $color-softfailed; }
 .fa.result_unknown { color:$color-warning; }
 .fa.result_user_cancelled { color: $color-module-none; }
 .fa.result_user_restarted { color: $color-module-none; }
@@ -292,7 +292,7 @@ ul.modcategory {
     td[colspan="4"] {
         border-right: 1px solid $table-border-color;
     }
-    td:nth-child(0n+3) {
+    td:nth-child(0n+4) {
         height: auto;
         font-family: monospace;
         text-align: left;

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -286,3 +286,30 @@ ul.modcategory {
     // ensure filter icon and last .nav-item for tabs don't overlap
     padding-right: 40px;
 }
+
+// table for external results
+#external-table {
+    td[colspan="4"] {
+        border-right: 1px solid $table-border-color;
+    }
+    td:nth-child(0n+3) {
+        height: auto;
+        font-family: monospace;
+        text-align: left;
+        background-color: #e8f1f1;
+        max-height: 3.5rem;
+        white-space: pre-wrap;
+    }
+    td.result {
+        text-align: center;
+    }
+    td.result-ok {
+        background-color: $color-ok;
+    }
+    td.result-fail {
+        background-color: $color-failed;
+    }
+    td.result-softfail {
+        background-color: $color-softfailed;
+    }
+}

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -562,7 +562,8 @@ sub to_hash {
         $j = {%$j, %{$job->deps_hash}};
     }
     if ($args{details}) {
-        $j->{testresults} = read_test_modules($job);
+        my $test_modules = read_test_modules($job);
+        $j->{testresults} = ($test_modules ? $test_modules->{modules} : []);
         $j->{logs}        = $job->test_resultfile_list;
         $j->{ulogs}       = $job->test_uploadlog_list;
     }

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -992,9 +992,13 @@ sub read_test_modules {
         my $num = 1;
 
         for my $step (@{$module->details}) {
+            my $text   = $step->{text};
+            my $source = $step->{_source};
+
             $step->{num} = $num++;
-            if ($step->{text}) {
-                my $file = path($job->result_dir(), $step->{text});
+            $step->{display_title} = ($text ? $step->{title} : $step->{name}) // '';
+            if ($text) {
+                my $file = path($job->result_dir(), $text);
                 if (-e $file) {
                     log_debug("Reading information from " . encode_json($step));
                     $step->{text_data} = $file->slurp;
@@ -1003,6 +1007,9 @@ sub read_test_modules {
                     log_debug("Cannot read file: $file");
                 }
             }
+            $step->{is_parser_text_result} = $source && $source eq 'parser' && $text && $step->{text_data};
+            $step->{resborder} = 'resborder_' . (($step->{result} && !(ref $step->{result})) ? $step->{result} : 'unk');
+
             push(@details, $step);
         }
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -979,9 +979,10 @@ sub read_test_modules {
     my ($job) = @_;
 
     my $testresultdir = $job->result_dir();
-    return [] unless $testresultdir;
+    return unless $testresultdir;
 
     my $category;
+    my $has_parser_text_results = 0;
     my @modlist;
 
     for my $module (OpenQA::Schema::Result::JobModules::job_modules($job)) {
@@ -989,7 +990,8 @@ sub read_test_modules {
         # add link to $testresultdir/$name*.png via png CGI
         my @details;
 
-        my $num = 1;
+        my $num                           = 1;
+        my $has_module_parser_text_result = 0;
 
         for my $step (@{$module->details}) {
             my $text   = $step->{text};
@@ -1007,22 +1009,31 @@ sub read_test_modules {
                     log_debug("Cannot read file: $file");
                 }
             }
-            $step->{is_parser_text_result} = $source && $source eq 'parser' && $text && $step->{text_data};
+
+            $step->{is_parser_text_result} = 0;
+            if ($source && $source eq 'parser' && $text && $step->{text_data}) {
+                $step->{is_parser_text_result} = 1;
+                $has_module_parser_text_result = 1;
+            }
+
             $step->{resborder} = 'resborder_' . (($step->{result} && !(ref $step->{result})) ? $step->{result} : 'unk');
 
             push(@details, $step);
         }
 
+        $has_parser_text_results = 1 if ($has_module_parser_text_result);
+
         push(
             @modlist,
             {
-                name            => $module->name,
-                result          => $module->result,
-                details         => \@details,
-                milestone       => $module->milestone,
-                important       => $module->important,
-                fatal           => $module->fatal,
-                always_rollback => $module->always_rollback,
+                name                   => $module->name,
+                result                 => $module->result,
+                details                => \@details,
+                milestone              => $module->milestone,
+                important              => $module->important,
+                fatal                  => $module->fatal,
+                always_rollback        => $module->always_rollback,
+                has_parser_text_result => $has_module_parser_text_result,
             });
 
         if (!$category || $category ne $module->category) {
@@ -1032,7 +1043,10 @@ sub read_test_modules {
 
     }
 
-    return \@modlist;
+    return {
+        modules                 => \@modlist,
+        has_parser_text_results => $has_parser_text_results,
+    };
 }
 
 sub wait_with_progress {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -214,7 +214,8 @@ sub stash_module_list {
       )->first
       or return;
 
-    $self->stash(modlist => read_test_modules($job));
+    my $test_modules = read_test_modules($job);
+    $self->stash(modlist => ($test_modules ? $test_modules->{modules} : []));
     return 1;
 }
 
@@ -255,25 +256,26 @@ sub _show {
     my ($self, $job) = @_;
     return $self->reply->not_found unless $job;
 
-    my $modlist         = read_test_modules($job);
+    my $test_modules    = read_test_modules($job);
     my $worker          = $job->worker;
     my $clone_of        = $self->db->resultset('Jobs')->find({clone_id => $job->id});
     my $websocket_proxy = determine_web_ui_web_socket_url($job->id);
 
     $self->stash(
         {
-            job               => $job,
-            testname          => $job->name,
-            distri            => $job->DISTRI,
-            version           => $job->VERSION,
-            build             => $job->BUILD,
-            scenario          => $job->scenario,
-            worker            => $worker,
-            assigned_worker   => $job->assigned_worker,
-            show_dependencies => !defined($job->clone_id) && $job->has_dependencies,
-            clone_of          => $clone_of,
-            modlist           => $modlist,
-            ws_url            => $websocket_proxy,
+            job                     => $job,
+            testname                => $job->name,
+            distri                  => $job->DISTRI,
+            version                 => $job->VERSION,
+            build                   => $job->BUILD,
+            scenario                => $job->scenario,
+            worker                  => $worker,
+            assigned_worker         => $job->assigned_worker,
+            show_dependencies       => !defined($job->clone_id) && $job->has_dependencies,
+            clone_of                => $clone_of,
+            modlist                 => ($test_modules ? $test_modules->{modules} : []),
+            ws_url                  => $websocket_proxy,
+            has_parser_text_results => $test_modules->{has_parser_text_results},
         });
 
     my $rd = $job->result_dir();

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -209,9 +209,30 @@ subtest 'render text results' => sub {
         'text results not from parser shown in ordinary preview container'
     );
 # note: check whether the softfailure is unaffected is already done in subtest 'render bugref links in thumbnail text windows'
+
+    subtest 'external table' => sub {
+        my $external_table = $driver->find_element_by_id('external-table');
+        is($external_table->is_displayed(), 0, 'external table not visible by default');
+        $driver->find_element_by_link_text('External results')->click();
+        is($external_table->is_displayed(), 1, 'external table visible after clicking its tab header');
+        my @rows = $driver->find_child_elements($external_table, 'tr');
+        is(scalar @rows, 3, 'external table has 3 rows (heading and 2 results)');
+        my $res1
+          = 'logpackages Some text result from external parser This is a dummy result to test rendering text results from external parsers.';
+        my $res2
+          = qr/logpackages Another text result from external parser Another dummy result to test rendering text results from external parsers\..*/;
+        is($rows[1]->get_text(), $res1, 'first result displayed');
+        like($rows[2]->get_text(), $res2, 'second result displayed');
+
+        $driver->find_element_by_id('external-only-failed-filter')->click();
+        @rows = $driver->find_child_elements($external_table, 'tr');
+        is(scalar @rows,         2,     'passed results filtered out');
+        is($rows[1]->get_text(), $res1, 'softfailure still displayed');
+    };
 };
 
 subtest 'render video link if frametime is available' => sub {
+    $driver->find_element_by_link_text('Details')->click();
     $driver->find_element('[href="#step/bootloader/1"]')->click();
     wait_for_ajax;
     my @links = $driver->find_elements('.step_actions .fa-file-video');

--- a/templates/test/details.html.ep
+++ b/templates/test/details.html.ep
@@ -4,7 +4,7 @@
         <i class="fas fa-filter"></i>
     </a>
 </div>
-<form class="row details-filter hidden">
+<form class="row details-filter hidden" id="details-filter">
     <div class="col-sm-12 col-md-6">
         Name:
         <input type="search" class="form-control form-control-sm" placeholder="Filter by name" aria-controls="results" id="details-name-filter">

--- a/templates/test/external.html.ep
+++ b/templates/test/external.html.ep
@@ -1,0 +1,37 @@
+% return unless (@$modlist);
+<table id="external-table" class="display table table-striped" style="width: 100%">
+    <thead>
+        <tr>
+            <th class="name">Test suite</th>
+            <th>Test case</th>
+            <th>Log/output</th>
+            <th>Result</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for my $module (@$modlist) {
+            % next unless ($module->{has_parser_text_result});
+            % if ($module->{category}) {
+                <tr>
+                    <td colspan="4">
+                        <i class="fas fa-folder-open"></i>&nbsp;
+                        %= $module->{category}
+                    </td>
+                    %# make DataTable happy
+                    <td style="display: none;"></td>
+                    <td style="display: none;"></td>
+                    <td style="display: none;"></td>
+                </tr>
+            % }
+            % for my $step (@{$module->{details}}) {
+                % next unless ($step->{is_parser_text_result});
+                <tr>
+                    <td><%= $module->{name} %></td>
+                    <td><%= $step->{display_title} %></td>
+                    <td><%= $step->{text_data} %></td>
+                    <td class="result-<%= $step->{result} %>"><%= $step->{result} %></td>
+                </tr>
+            % }
+        % }
+    </tbody>
+</table>

--- a/templates/test/external.html.ep
+++ b/templates/test/external.html.ep
@@ -4,8 +4,8 @@
         <tr>
             <th class="name">Test suite</th>
             <th>Test case</th>
-            <th>Log/output</th>
             <th>Result</th>
+            <th>Log/output</th>
         </tr>
     </thead>
     <tbody>
@@ -28,8 +28,8 @@
                 <tr>
                     <td><%= $module->{name} %></td>
                     <td><%= $step->{display_title} %></td>
+                    <td><i class="status result_<%= $step->{result} %> fa fa-circle" title="<%= $step->{result} %>"></i></td>
                     <td><%= $step->{text_data} %></td>
-                    <td class="result-<%= $step->{result} %>"><%= $step->{result} %></td>
                 </tr>
             % }
         % }

--- a/templates/test/external.html.ep
+++ b/templates/test/external.html.ep
@@ -1,4 +1,12 @@
 % return unless (@$modlist);
+<form class="row details-filter">
+    <div class="col-sm-12 col-md-6">
+    </div>
+    <div class="col-sm-12 col-md-6 result-filter-container">
+        <input id="external-only-failed-filter" name="relevant" type="checkbox" value="1">
+        <label for="external-only-failed-filter">Show only failures</label>
+    </div>
+</form>
 <table id="external-table" class="display table table-striped" style="width: 100%">
     <thead>
         <tr>

--- a/templates/test/external.html.ep
+++ b/templates/test/external.html.ep
@@ -19,18 +19,6 @@
     <tbody>
         % for my $module (@$modlist) {
             % next unless ($module->{has_parser_text_result});
-            % if ($module->{category}) {
-                <tr>
-                    <td colspan="4">
-                        <i class="fas fa-folder-open"></i>&nbsp;
-                        %= $module->{category}
-                    </td>
-                    %# make DataTable happy
-                    <td style="display: none;"></td>
-                    <td style="display: none;"></td>
-                    <td style="display: none;"></td>
-                </tr>
-            % }
             % for my $step (@{$module->{details}}) {
                 % next unless ($step->{is_parser_text_result});
                 <tr>

--- a/templates/test/module_table.html.ep
+++ b/templates/test/module_table.html.ep
@@ -41,14 +41,13 @@
                 </td>
                 <td class="links">
                     % for my $step (@{$module->{details}}) {
-                        % my $title = $step->{text} ? $step->{title} : $step->{name} // '';
-                        % my $source = $step->{_source};
-                        % my $resborder = 'resborder_' . (($step->{result} && !(ref $step->{result})) ? $step->{result} : 'unk');
-                        % my $is_parser_result =  $source && $source eq 'parser' && $step->{text} && $step->{text_data};
-                        <div class="links_a <%= $is_parser_result ? 'text-result-container' : '' %>">
+                        % my $title = $step->{display_title};
+                        % my $resborder = $step->{resborder};
+                        % my $is_parser_text_result =  $step->{is_parser_text_result};
+                        <div class="links_a <%= $is_parser_text_result ? 'text-result-container' : '' %>">
                             % my $url   = url_for('step', moduleid => $module->{name}, stepid => $step->{num}, testid => $testid);
                             % my $href  = "#step/$module->{name}/$step->{num}";
-                            % if ($is_parser_result) {
+                            % if ($is_parser_text_result) {
                                 <span title="<%= $title %>" data-href="<%= $href %>" onclick="toggleTextPreview(this)" class="text-result">
                                     <span class="resborder <%= $resborder %>"><%= $step->{text_data} %></span>
                                 </span>

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -26,6 +26,11 @@
                 <li role="presentation" class="nav-item">
                     <a href="#details" aria-controls="details" role="tab" data-toggle="tab" class="nav-link active">Details</a>
                 </li>
+                % if ($has_parser_text_results) {
+                    <li role="presentation" class="nav-item">
+                        <a href="#external" aria-controls="external" role="tab" data-toggle="tab" class="nav-link">External results</a>
+                    </li>
+                % }
                 % if ($job->state eq 'running') {
                     <li role="presentation" class="nav-item">
                         <a href="#live" aria-controls="live" role="tab" data-toggle="tab" class="nav-link">Live View</a>
@@ -54,6 +59,12 @@
                 <div role="tabpanel" class="tab-pane active" id="details">
                     %= include 'test/details'
                 </div>
+
+                % if ($has_parser_text_results) {
+                    <div role="tabpanel" class="tab-pane" id="external">
+                        %= include 'test/external'
+                    </div>
+                % }
 
                 % if ($job->state eq 'running') {
                     <div role="tabpanel" class="tab-pane" id="live">


### PR DESCRIPTION
A revival of my old branch for an extra table to display external test results, see https://progress.opensuse.org/issues/36232

Unlike https://github.com/os-autoinst/openQA/pull/1492, it renders the generic data from the openQA parser and not a specific format.

---

The current details page would stay as it is, eg.:  
![screenshot_20181113_124416](https://user-images.githubusercontent.com/10248953/48411439-d52a2680-e741-11e8-8b27-9c12bc5f7503.png)

The additional tab "External results" would show test results from external testsuites which have been parsed by openQA to a generic JSON representation:
![screenshot_20181113_124847](https://user-images.githubusercontent.com/10248953/48411660-76b17800-e742-11e8-90c9-4fc59f6a03bc.png)
![screenshot_20181113_130801](https://user-images.githubusercontent.com/10248953/48412498-2687e500-e745-11e8-8e88-015d1088543d.png)

* It *only* contains the external results.
* It can be sorted and filtered on the level of the particular test details (and not only on  test module level).
* The tab is only shown if external results are available.
* The table is not updated while the test is running. That would be too much effort for such a feature in my opinion.

---

Tests are missing because I want to wait for feedback before taking the effort.

@metan-ucw @richiejp What do you think?