### PR TITLE
Apparmor: Add /dev/hugepages

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -30,6 +30,7 @@
   /bin/pkill rix,
   /dev/ r,
   /dev/bus/usb/ r,
+  /dev/hugepages/** rwk,
   /dev/kvm rw,
   /dev/net/tun rw,
   /dev/ptmx rw,


### PR DESCRIPTION
On some hosts we may want to make use of hugepages. For those, we want access
to the standardized /dev/hugepages directory.

Beware that to make this useful, you will also need to adapt permissions for
the /dev/hugepages mount. For that, do

  $ systemctl edit dev-hugepages.mount

and add

  [Mount]
  DirectoryMode=1777
  Options=mode=1777

so that on boot the mount point comes up as world writable.

Signed-off-by: Alexander Graf <agraf@suse.de>