### PR TITLE
Add link to test results for multiple job grops

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -44,7 +44,7 @@ td div.progress {
     }
 }
 
-// expandible items on dashboard (mainly the BuildXXXX headings)
+// expandable items on dashboard (mainly the BuildXXXX headings)
 .build-row .h4 {
     text-overflow: ellipsis;
     overflow: hidden;

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -448,6 +448,14 @@ subtest 'job parent groups with multiple version and builds' => sub {
     check_builds(\@build_names, $test_parent, 'parent group builds shown sorted by dotted versions',
         'parent_group_overview');
 
+    my @entire_build_url_list  = $get->tx->res->dom->find('.h4 a:first-child')->each();
+    my $first_entire_build_url = $entire_build_url_list[0]->attr('href');
+    is(
+        $first_entire_build_url,
+        '/tests/overview?distri=suse&version=14.2&build=87.5011&groupid=1001&groupid=1002',
+        'entire build url contains all the child group ids'
+    );
+
     $test_parent->update({build_version_sort => 0});
 
     $get = $t->get_ok('/parent_group_overview/' . $test_parent->id)->status_is(200);

--- a/templates/main/group_builds.html.ep
+++ b/templates/main/group_builds.html.ep
@@ -1,14 +1,15 @@
 % for my $build_res (@$build_results) {
     % my $build = $build_res->{build};
     % my $group_id;
+    % my @tests_overview_url_data = (distri  => [sort keys %{$build_res->{distris}}], version => $build_res->{version}, build => $build);
     <div class="d-md-flex flex-row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
         <div class="px-2 build-label text-nowrap">
             <span class="h4">
                 % if ($children) {
                     % $group_id = "group$group->{id}_build$build_res->{escaped_id}";
-                    <a href="#<%= $group_id %>" onclick="return toggleChildGroups(this);" data-toggle="collapse">Build<%= $build %></a>
+                    <a data-target="#<%= $group_id %>" href="<%= url_for('tests_overview')->query(@tests_overview_url_data, map { (groupid => $_->{id}) } @{$children});%>" onclick="return toggleChildGroups(this);" data-toggle="collapse" title="Open in new tab to view the entire build">Build<%= $build %></a>
                 % } else {
-                    %= link_to "Build$build" => url_for('tests_overview')->query(distri => [sort keys %{$build_res->{distris}}], version => $build_res->{version}, build => $build, groupid => $group->{id} )
+                    %= link_to "Build$build" => url_for('tests_overview')->query(@tests_overview_url_data, groupid => $group->{id})
                 % }
 
                 <span class="smaller-font">(<abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">


### PR DESCRIPTION
Add link to test results for multiple job grops

There were no link to Test Results Page for parent job groups on
Dashboard Page.

The PR adds the link to the parent job group item. It allows to open
Test Results Page in new browser tab by performing middle mouse click or
by calling context menu and selecting 'Open link in new tab'.

Old behavior remains the same while doing left button mouse click.

Related ticket: [42851](https://progress.opensuse.org/issues/42851)