### PR TITLE
Mojolicious 8.02 support

### DIFF
--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -69,7 +69,7 @@ sub _download {
     # http://mojolicio.us/perldoc/Mojolicious/Guides/Cookbook#Large-file-downloads
     $tx->res->max_message_size(0);
     $tx = $ua->start($tx);
-    if ($tx->success) {
+    if (!$tx->error) {
         try {
             if ($do_extract) {
 

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -55,7 +55,7 @@ sub ws_send {
     if ($tx) {
         $res = $tx->send({json => {type => $msg, jobid => $jobid}});
     }
-    unless ($res && $res->success) {
+    unless ($res && !$res->error) {
         $retry ||= 0;
         if ($retry < 3) {
             Mojo::IOLoop->timer(2 => sub { ws_send($workerid, $msg, $jobid, ++$retry); });
@@ -86,7 +86,7 @@ sub ws_send_job {
     if ($tx) {
         $res = $tx->send({json => {type => 'grab_job', job => $job}});
     }
-    unless ($res && $res->success) {
+    unless ($res && !$res->error) {
         # Since it is used by scheduler, it's fine to let it fail,
         # will be rescheduled on next round
         log_debug("Unable to allocate job to worker $job->{assigned_worker_id}");

--- a/lib/OpenQA/Worker/Cache/Client.pm
+++ b/lib/OpenQA/Worker/Cache/Client.pm
@@ -67,7 +67,7 @@ sub _retry {
     my $att = 0;
     $times ||= 0;
 
-    do { ++$att and $res = $cb->() } until $res->success || $att >= $times;
+    do { ++$att and $res = $cb->() } until !$res->error || $att >= $times;
 
     return $res;
 }
@@ -95,7 +95,7 @@ sub processed { !!(shift->status(shift) == STATUS_PROCESSED) }
 sub output    { shift->_result(output => pop) }
 sub result    { shift->_result(result => pop) }
 sub info      { $_[0]->ua->get($_[0]->_url("info")) }
-sub available { shift->info->success }
+sub available { !shift->info->error }
 sub available_workers {
     return unless $_[0]->available;
     return unless my $res = $_[0]->info->result->json;

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -222,8 +222,8 @@ sub api_call {
     my $cb;
     $cb = sub {
         my ($ua, $tx, $tries) = @_;
-        if ($tx->success && $tx->success->json) {
-            my $res = $tx->success->json;
+        if (!$tx->error && $tx->res->json) {
+            my $res = $tx->res->json;
             return $callback->($res);
         }
         elsif ($ignore_errors) {

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -889,7 +889,7 @@ sub upload_images {
         $tx = $hosts->{$current_host}{ua}->post($ua_url => form => $form);
     }
     $tosend_files = [];
-    return !$tx || $tx->success;
+    return !$tx || !$tx->error;
 }
 
 sub read_json_file {

--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -187,12 +187,12 @@ sub get_job {
     my $url = $remote_url->clone;
     $url->path("jobs/$jobid");
     my $tx = $remote->max_redirects(3)->get($url);
-    if ($tx->success) {
-        if ($tx->success->code == 200) {
-            $job = $tx->success->json->{job};
+    if (!$tx->error) {
+        if ($tx->res->code == 200) {
+            $job = $tx->res->json->{job};
         }
         else {
-            warn sprintf("unexpected return code: %s %s", $tx->success->code, $tx->success->message);
+            warn sprintf("unexpected return code: %s %s", $tx->res->code, $tx->res->message);
             exit 1;
         }
     }
@@ -293,8 +293,8 @@ sub clone_job {
     print JSON->new->pretty->encode(\%settings) if ($options{verbose});
     $url->query(%settings);
     my $tx = $local->max_redirects(3)->post($url);
-    if ($tx->success) {
-        my $r = $tx->success->json->{id};
+    if (!$tx->error) {
+        my $r = $tx->res->json->{id};
         if ($r) {
             my $url = openqa_baseurl($local_url) . '/t' . $r;
             print "Created job #$r: $job->{name} -> $url\n";

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -89,7 +89,7 @@ my $workers = [
     }];
 
 $ret = $t->get_ok('/api/v1/workers?live=1');
-ok($ret->tx->success, 'listing workers works');
+ok(!$ret->tx->error, 'listing workers works');
 is(ref $ret->tx->res->json, 'HASH', 'workers returned hash');
 is_deeply(
     $ret->tx->res->json,
@@ -103,7 +103,7 @@ $workers->[0]->{connected} = 1;
 $workers->[1]->{connected} = 1;
 
 $ret = $t->get_ok('/api/v1/workers');
-ok($ret->tx->success, 'listing workers works');
+ok(!$ret->tx->error, 'listing workers works');
 is(ref $ret->tx->res->json, 'HASH', 'workers returned hash');
 is_deeply(
     $ret->tx->res->json,


### PR DESCRIPTION
`Mojo::Transaction::success` has been deprecated in Mojolicious 8.02. Using `!$tx->error` is a short term fix for that. Long term it is recommended to use `$tx->result` instead, which has very different semantics and will therefore require quite a bit more work. But there are no plans to get rid of `Mojo::Transaction::error`, so this is fine for now.