### PR TITLE
Disable INSTALL_FROM_CPAN by default

### DIFF
--- a/docker/openqa/entrypoint.sh
+++ b/docker/openqa/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEBUG="${DEBUG:-0}"
-INSTALL_FROM_CPAN="${INSTALL_FROM_CPAN:-1}"
+INSTALL_FROM_CPAN="${INSTALL_FROM_CPAN:-0}"
 UPGRADE_FROM_ZYPPER="${UPGRADE_FROM_ZYPPER:-0}"
 
 export LANG="en_US.UTF-8"
@@ -39,10 +39,12 @@ HEREDOC
 
 
 function run_as_normal_user {
-    [ "$INSTALL_FROM_CPAN" -eq 1 ] && \
-             echo ">> Trying to get dependencies from CPAN"
-	      (cpanm --local-lib=~/perl5 local::lib && cpanm -n --installdeps . ) || \
-	      cpanm -n --mirror http://no.where/ --installdeps .
+    if [ "$INSTALL_FROM_CPAN" -eq 1 ]; then
+       echo ">> Trying to get dependencies from CPAN"
+           cpanm --local-lib=~/perl5 local::lib && cpanm -n --installdeps .
+    else
+           cpanm -n --mirror http://no.where/ --installdeps .
+    fi
 
     if [ $? -eq 0 ]; then
         create_db

--- a/script/docker-tests
+++ b/script/docker-tests
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
-INSTALL_FROM_CPAN="${INSTALL_FROM_CPAN:-1}"
+INSTALL_FROM_CPAN="${INSTALL_FROM_CPAN:-0}"
 
 export OPENQA_LOGFILE=/opt/openqa/openqa-debug.log
 
@@ -18,9 +18,11 @@ function prepare_fullstack_test {
     fi
 
     cd ../os-autoinst
-    [ "$INSTALL_FROM_CPAN" -eq 1 ] && \
-	      (cpanm --local-lib=~/perl5 local::lib && cpanm -n --installdeps . ) || \
-	      cpanm -n --mirror http://no.where/ --installdeps .
+    if [ "$INSTALL_FROM_CPAN" -eq 1 ]; then
+        cpanm --local-lib=~/perl5 local::lib && cpanm -n --installdeps .
+    else
+        cpanm -n --mirror http://no.where/ --installdeps .
+    fi
     if ! [ $? -eq 0 ]; then
         echo "OS autoinst dependencies not match. Please check output above"
         exit 1


### PR DESCRIPTION
We really need to see if cpanfile changes need to be moved into the
container. While this is not the case, developers can set INSTALL_FROM_CPAN
in their dev branches - to be removed before merge