### PR TITLE
Use OPENQA_TEST_IPC in developer mode unit test

### DIFF
--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use FindBin;


### PR DESCRIPTION
It hits dbus during "register developer session", so it needs
this or else it will fail in Fedora's Koji build env (and other
similar envs, most likely).

Signed-off-by: Adam Williamson <awilliam@redhat.com>