### PR TITLE
Handle `app` and `tx` attributes of Controller being weakened

### DIFF
--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -58,8 +58,10 @@ subtest streamtext => sub {
 
     my $stream = Mojo::IOLoop::Stream->new($handle);
     $id = Mojo::IOLoop->stream($stream);
-    my $controller = OpenQA::WebAPI::Controller::Running->new(app => Mojolicious->new);
-    $controller->tx(Mojo::Transaction::Fake->new(fakestream => $id));
+    my $contapp = Mojolicious->new;
+    my $controller = OpenQA::WebAPI::Controller::Running->new(app => $contapp);
+    my $faketx = Mojo::Transaction::Fake->new(fakestream => $id);
+    $controller->tx($faketx);
     $controller->stash("job", Job->new);
 
     my @fake_data = ("Foo bar\n", "Foo baz\n", "bar\n");


### PR DESCRIPTION
In Mojolicious 8.03, the `tx` and `app` attributes of the
Controller class were weakened. This appears to mean that you
must set them using an object that's referenced elsewhere, or
else they just sort of...disappear, and the test blows up, with
rather cryptic errors about calling methods on undefined values.

Signed-off-by: Adam Williamson <awilliam@redhat.com>