### PR TITLE
Revert "Fix deprecation warnings regarding Mojo::Transaction::error"

### DIFF
--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -100,7 +100,7 @@ subtest 'dependency json' => sub {
         },
         'single node for job without dependencies'
     );
-    diag explain $t->tx->res->json unless !$t->error;
+    diag explain $t->tx->res->json unless $t->success;
 
     $t->get_ok($baseurl . 'tests/99938/dependencies')->status_is(200)->json_is(
         undef => {
@@ -163,7 +163,7 @@ subtest 'dependency json' => sub {
         },
         'nodes, edges and cluster computed'
     );
-    diag explain $t->tx->res->json unless !$t->error;
+    diag explain $t->tx->res->json unless $t->success;
 };
 
 subtest 'job without dependencies' => sub {


### PR DESCRIPTION
Seems like the remaining `success -> !error` substitutions of https://github.com/os-autoinst/openQA/pull/1867 were not correct.

I'm wondering why the tests were not red when I merged it. Maybe my browser tab was outdated.