### PR TITLE
Fix various uses of the is_admin helper in templates

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -15,14 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Plugin::Helpers;
+use Mojo::Base 'Mojolicious::Plugin';
 
-use strict;
-use warnings;
 use Mojo::ByteStream;
 use OpenQA::Utils qw(bugurl render_escaped_refs href_to_bugref);
 use db_helpers;
-
-use base 'Mojolicious::Plugin';
 
 sub register {
 
@@ -179,6 +176,8 @@ sub register {
 
             return ($user && $user->is_admin);
         });
+
+    $app->helper(is_admin_js => sub { Mojo::ByteStream->new(shift->helpers->is_admin ? 'true' : 'false') });
 
     $app->helper(
         # CSS class for a job or module based on its result

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -1,0 +1,54 @@
+#! /usr/bin/perl
+
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Mojo::Base -strict;
+
+BEGIN {
+    unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
+}
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More;
+use Test::Mojo;
+use Test::Warnings;
+use OpenQA::Test::Case;
+use OpenQA::SeleniumTest;
+
+my $test_case = OpenQA::Test::Case->new;
+$test_case->init_data;
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver();
+
+# First page without login
+$driver->title_is("openQA");
+
+# Test suites without login
+is $driver->get('/admin/test_suites'), 1, 'opened test suites';
+$driver->title_is('openQA: Test suites');
+like $driver->find_element('#test-suites tbody tr.odd td')->get_text(),  qr/textmode/, 'first entry';
+like $driver->find_element('#test-suites tbody tr.even td')->get_text(), qr/kde/,      'second entry';
+like $driver->find_element('#test-suites tbody tr.even td:nth-child(3)')->get_text(),
+  qr/Simple kde test, before advanced_kde/,
+  'second entry has a description';
+like $driver->find_element('#test-suites tbody tr:last-child td')->get_text(), qr/advanced_kde/, 'last entry';
+
+kill_driver();
+done_testing();

--- a/templates/admin/group/parent_group_property_editor.html.ep
+++ b/templates/admin/group/parent_group_property_editor.html.ep
@@ -3,7 +3,7 @@
 % title 'Parent group ' . $group->name;
 
 % content_for 'ready_function' => begin
-    setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>, <%= is_admin %>);
+    setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>);
     checkJobGroupForm('#group_properties_form');
 % end
 

--- a/templates/admin/machine/index.html.ep
+++ b/templates/admin/machine/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Machines';
 
 % content_for 'ready_function' => begin
-    populate_admin_table(<%= is_admin ? 'true' : 'false' %>, true);
+    populate_admin_table(<%= is_admin_js %>, true);
 % end
 
 <div class="row">

--- a/templates/admin/machine/index.html.ep
+++ b/templates/admin/machine/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Machines';
 
 % content_for 'ready_function' => begin
-    populate_admin_table(<%= is_admin %>, true);
+    populate_admin_table(<%= is_admin ? 'true' : 'false' %>, true);
 % end
 
 <div class="row">

--- a/templates/admin/product/index.html.ep
+++ b/templates/admin/product/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Medium types';
 
 % content_for 'ready_function' => begin
-   populate_admin_table(<%= is_admin ? 'true' : 'false' %>, false);
+   populate_admin_table(<%= is_admin_js %>, false);
 % end
 
 <div class="row">

--- a/templates/admin/product/index.html.ep
+++ b/templates/admin/product/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Medium types';
 
 % content_for 'ready_function' => begin
-   populate_admin_table(<%= is_admin %>, false);
+   populate_admin_table(<%= is_admin ? 'true' : 'false' %>, false);
 % end
 
 <div class="row">

--- a/templates/admin/test_suite/index.html.ep
+++ b/templates/admin/test_suite/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Test suites';
 
 % content_for 'ready_function' => begin
-    populate_admin_table(<%= is_admin %>, true);
+    populate_admin_table(<%= is_admin ? 'true' : 'false' %>, true);
 % end
 
 <div class="row">

--- a/templates/admin/test_suite/index.html.ep
+++ b/templates/admin/test_suite/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Test suites';
 
 % content_for 'ready_function' => begin
-    populate_admin_table(<%= is_admin ? 'true' : 'false' %>, true);
+    populate_admin_table(<%= is_admin_js %>, true);
 % end
 
 <div class="row">


### PR DESCRIPTION
The `is_admin` helper returns a Perl boolean, but was used to generate JavaScript booleans directly here. There was one more use of `<%= is_admin %>` for `setupJobTemplates`, but that function does not actually use that argument at all, so i opted to remove it.

While the fix was very simple, i'm still trying to find a good place to test this and am learning Selenium in the process. So please consider this pull request a work in progress for now.

Progress issue: https://progress.opensuse.org/issues/44039
