### PR TITLE
Expand devel controls by default if paused and owning the session

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -333,6 +333,7 @@ var developerMode = {
     ownSession: false,                      // whether the development session belongs to us
     panelExpanded: false,                   // whether the panel is supposed to be expanded
     panelActuallyExpanded: false,           // whether the panel is currently expanded
+    panelExplicitelyCollapsed: false,          // whether the panel has been explicitely collapsed since the page has been opened
     reconnectAttempts: 0,                   // number of (re)connect attempts (reset to 0 when we finally receive a message from os-autoinst)
     currentModuleIndex: undefined,          // the index of the current module
 
@@ -415,6 +416,9 @@ function setupDeveloperPanel() {
             var panelBody = panel.find('.card-body');
             developerMode.panelExpanded = !developerMode.panelExpanded;
             developerMode.panelActuallyExpanded = developerMode.panelExpanded;
+            if (!developerMode.panelExpanded) {
+                developerMode.panelExplicitelyCollapsed = true;
+            }
             panelBody.toggle(200);
         });
     } else {
@@ -475,6 +479,11 @@ function updateDeveloperPanel() {
         return;
     }
     panel.show();
+
+    // expand the controls if the test is paused (unless previously manually collapsed)
+    if (developerMode.ownSession && developerMode.isPaused && !developerMode.panelExplicitelyCollapsed) {
+        developerMode.panelExpanded = true;
+    }
 
     // toggle panel body if its current state doesn't match developerMode.panelExpanded
     var panelBody = panel.find('.card-body');
@@ -897,7 +906,7 @@ function processWsCommand(obj) {
     }
 
     if (somethingChanged) {
-        // check whether the development session is ours and to change the proxy
+        // check whether the development session is ours to change to the proxy with write-access
         if (!developerMode.useDeveloperWsRoute && developerMode.ownSession) {
             developerMode.useDeveloperWsRoute = true;
             setupWebsocketConnection();
@@ -938,6 +947,7 @@ function quitDeveloperSession() {
         return;
     }
     developerMode.useDeveloperWsRoute = undefined;
+    developerMode.panelExplicitelyCollapsed = true;
     developerMode.panelExpanded = false;
     updateDeveloperPanel();
     sendWsCommand({ cmd: "quit_development_session" });

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -334,29 +334,25 @@ subtest 'developer session visible in live view' => sub {
     $driver->get($job_page_url);
     $driver->find_element_by_link_text('Live View')->click();
 
-    subtest 'initial state of UI controls' => sub {
-        wait_for_session_info(qr/owned by Demo/, 'user displayed');
-        element_visible('#developer-instructions',       qr/connect to .* at port 91/);
-        element_visible('#developer-panel .card-header', qr/paused/);
-        element_hidden('#developer-panel .card-body');
-    };
+    wait_for_session_info(qr/owned by Demo/, 'user displayed');
+    element_visible('#developer-instructions',       qr/connect to .* at port 91/);
+    element_visible('#developer-panel .card-header', qr/paused/);
 
-    subtest 'expand developer panel' => sub {
-        $driver->find_element('#developer-panel .card-header')->click();
-        element_visible(
-            '#developer-panel .card-body',
-            [
-                qr/Change the test behaviour with the controls below\./,
-                qr/Resume test execution/,
-                qr/Cancel job/, qr/Resume/,
-            ],
-            [qr/Confirm to control this test/,],
-        );
+    # panel should be expaned by default because we're already owning the session through the developer console
+    # and the test is paused
+    element_visible(
+        '#developer-panel .card-body',
+        [
+            qr/Change the test behaviour with the controls below\./,
+            qr/Resume test execution/,
+            qr/Cancel job/, qr/Resume/,
+        ],
+        [qr/Confirm to control this test/,],
+    );
 
-        my @module_options = $driver->find_elements('#developer-pause-at-module option');
-        my @module_names = map { $_->get_text() } @module_options;
-        is_deeply(\@module_names, ['Do not pause', 'boot', 'shutdown',], 'module');
-    };
+    my @module_options = $driver->find_elements('#developer-pause-at-module option');
+    my @module_names = map { $_->get_text() } @module_options;
+    is_deeply(\@module_names, ['Do not pause', 'boot', 'shutdown',], 'module');
 };
 
 subtest 'status-only route accessible for other users' => sub {


### PR DESCRIPTION
See https://progress.opensuse.org/issues/43952