### PR TITLE
Don't leave a limit_assets task hanging after 14-grutasks.t

### DIFF
--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -440,6 +440,9 @@ subtest 'Gru tasks TTL' => sub {
     ok exists $result->{minion_id};
     ok exists $result->{gru_id};
     isnt $result->{gru_id}, $result->{minion_id};
+    # clear the task queue: otherwise, if the next test is skipped due
+    # to OBS_RUN, limit_assets may run in a later test and wipe stuff
+    $t->app->minion->reset;
 };
 
 SKIP: {
@@ -457,3 +460,10 @@ SKIP: {
 }
 
 done_testing();
+
+# clear gru task queue at end of execution so no 'dangling' tasks
+# break subsequent tests; can happen if a subtest creates a task but
+# does not execute it, or we crash partway through a subtest...
+END {
+    $t->app->minion->reset;
+}


### PR DESCRIPTION
Since ea55d577, this subtest in grutasks creates a limit_assets
task, but doesn't run it. If the following subtest *does* run,
then it flushes the limit_assets task as well, and there's no
problem. But if the following subtest is skipped, because OBS_RUN
is set, then the limit_assets task just sorta hangs around in
gru's task queue...and the *next* time we actually run gru, which
happens to be in 17-build_tagging.t, the limit_assets task gets
picked up and run. Because the Assets schema `remove_from_disk`
sub is not mocked out in build_tagging as it is in grutasks, this
means gru actually goes ahead and wipes out several asset files.
That then causes 37-limit_assets.t to fail because it relies on
all the expected assets being present.

Signed-off-by: Adam Williamson <awilliam@redhat.com>