### PR TITLE
Use fixed header for overview table

### DIFF
--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -139,3 +139,11 @@ table.overview {
         }
     }
 }
+
+table.fixedheader {
+    th {
+        position: sticky;
+        top: 0px;
+        background: white; // prevent transparent during scrolling
+    }
+}

--- a/templates/test/overview_result_table.html.ep
+++ b/templates/test/overview_result_table.html.ep
@@ -1,5 +1,5 @@
 % use OpenQA::Utils;
-<table id="results_<%= $type %>" class="overview table table-striped table-hover">
+<table id="results_<%= $type %>" class="overview fixedheader table table-striped table-hover">
     <thead>
         <tr>
             <th>Test</th>


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/42779
![chrome](https://user-images.githubusercontent.com/9360645/48885044-d48c4100-ee61-11e8-85a6-b03c7edbd488.png)
