### PR TITLE
Add a retry on webui service for making sure it will boot up always

### DIFF
--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -10,6 +10,7 @@ Requires=openqa-livehandler.service openqa-resource-allocator.service openqa-web
 User=geekotest
 Environment="DBUS_STARTER_BUS_TYPE=system"
 # Our API commands are very expensive, so the default timeouts are too tight
+Restart=on-failure
 ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 20 -G 800
 
 [Install]


### PR DESCRIPTION
On my testing box, this openqa-webui service can't boot up with
system boot. even 'systemctl enable openqa-webui' is done.
I saw the comments said our API a little bit expensive, so I guess
might be something isn't ready on first time trying.
If adding this retry opportunity, service could start up successful.