### PR TITLE
Fix typo in installation documentation

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -443,7 +443,7 @@ configure where the shared storage is mounted. Example:
 [source,ini]
 --------------------------------------------------------------------------------
 [global]
-HOSTS = openqa.opensuse.org openqa.fedora.fedoraproject.org
+HOST = openqa.opensuse.org openqa.fedora.fedoraproject.org
 
 [openqa.opensuse.org]
 SHARE_DIRECTORY = /var/lib/openqa/opensuse


### PR DESCRIPTION
HOSTS variable doesn't exist in workers.ini, only HOST.

Tested on my lab (that's how I saw the mistake :)).