### PR TITLE
Fix JSON boolean warnings

### DIFF
--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -19,7 +19,7 @@ package OpenQA::Parser::Format::IPA;
 # The parser results will be a collection of OpenQA::Parser::Result::IPA::Test
 use Mojo::Base 'OpenQA::Parser::Format::Base';
 use Carp qw(croak confess);
-use Mojo::JSON;   # booleans
+use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 use OpenQA::Parser::Result::Test;
 

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -19,7 +19,7 @@ package OpenQA::Parser::Format::IPA;
 # The parser results will be a collection of OpenQA::Parser::Result::IPA::Test
 use Mojo::Base 'OpenQA::Parser::Format::Base';
 use Carp qw(croak confess);
-use Cpanel::JSON::XS ();
+use Mojo::JSON 'from_json';
 use OpenQA::Parser::Result::Test;
 
 sub _add_single_result { shift->results->add(OpenQA::Parser::Result::OpenQA->new(@_)) }
@@ -28,7 +28,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::OpenQA->new
 sub parse {
     my ($self, $json) = @_;
     confess "No JSON given/loaded" unless $json;
-    my $decoded_json = Cpanel::JSON::XS->new->utf8(0)->decode($json);
+    my $decoded_json = from_json($json);
 
     # may be optional since format result_array:v2
     $self->generated_tests_extra->add(OpenQA::Parser::Result::IPA::Info->new($decoded_json->{info}))

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -19,7 +19,8 @@ package OpenQA::Parser::Format::IPA;
 # The parser results will be a collection of OpenQA::Parser::Result::IPA::Test
 use Mojo::Base 'OpenQA::Parser::Format::Base';
 use Carp qw(croak confess);
-use Mojo::JSON 'from_json';
+use Mojo::JSON;   # booleans
+use Cpanel::JSON::XS ();
 use OpenQA::Parser::Result::Test;
 
 sub _add_single_result { shift->results->add(OpenQA::Parser::Result::OpenQA->new(@_)) }
@@ -28,7 +29,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::OpenQA->new
 sub parse {
     my ($self, $json) = @_;
     confess "No JSON given/loaded" unless $json;
-    my $decoded_json = from_json($json);
+    my $decoded_json = Cpanel::JSON::XS->new->utf8(0)->decode($json);
 
     # may be optional since format result_array:v2
     $self->generated_tests_extra->add(OpenQA::Parser::Result::IPA::Info->new($decoded_json->{info}))

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -19,8 +19,7 @@ package OpenQA::Parser::Format::IPA;
 # The parser results will be a collection of OpenQA::Parser::Result::IPA::Test
 use Mojo::Base 'OpenQA::Parser::Format::Base';
 use Carp qw(croak confess);
-use Mojo::JSON;    # booleans
-use Cpanel::JSON::XS ();
+use Mojo::JSON;
 use OpenQA::Parser::Result::Test;
 
 sub _add_single_result { shift->results->add(OpenQA::Parser::Result::OpenQA->new(@_)) }
@@ -29,7 +28,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::OpenQA->new
 sub parse {
     my ($self, $json) = @_;
     confess "No JSON given/loaded" unless $json;
-    my $decoded_json = Cpanel::JSON::XS->new->utf8(0)->decode($json);
+    my $decoded_json = Mojo::JSON::from_json($json);
 
     # may be optional since format result_array:v2
     $self->generated_tests_extra->add(OpenQA::Parser::Result::IPA::Info->new($decoded_json->{info}))

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -19,7 +19,7 @@ package OpenQA::Parser::Format::LTP;
 # The parser results will be a collection of OpenQA::Parser::Result::LTP::Test
 use Mojo::Base 'OpenQA::Parser::Format::JUnit';
 use Carp qw(croak confess);
-use Cpanel::JSON::XS ();
+use Mojo::JSON 'from_json';
 use Storable 'dclone';
 has include_results => 1;
 
@@ -29,7 +29,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::LTP::Test->
 sub parse {
     my ($self, $json) = @_;
     confess "No JSON given/loaded" unless $json;
-    my $decoded_json = Cpanel::JSON::XS->new->utf8(0)->decode($json);
+    my $decoded_json = from_json($json);
 
     # may be optional since format result_array:v2
     $self->generated_tests_extra->add(OpenQA::Parser::Result::LTP::Environment->new($decoded_json->{environment}))

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -20,6 +20,7 @@ package OpenQA::Parser::Format::LTP;
 use Mojo::Base 'OpenQA::Parser::Format::JUnit';
 use Carp qw(croak confess);
 use Mojo::JSON 'from_json';
+use Cpanel::JSON::XS ();
 use Storable 'dclone';
 has include_results => 1;
 
@@ -29,7 +30,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::LTP::Test->
 sub parse {
     my ($self, $json) = @_;
     confess "No JSON given/loaded" unless $json;
-    my $decoded_json = from_json($json);
+    my $decoded_json = Cpanel::JSON::XS->new->utf8(0)->decode($json);
 
     # may be optional since format result_array:v2
     $self->generated_tests_extra->add(OpenQA::Parser::Result::LTP::Environment->new($decoded_json->{environment}))

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -19,7 +19,7 @@ package OpenQA::Parser::Format::LTP;
 # The parser results will be a collection of OpenQA::Parser::Result::LTP::Test
 use Mojo::Base 'OpenQA::Parser::Format::JUnit';
 use Carp qw(croak confess);
-use Mojo::JSON 'from_json';
+use Mojo::JSON 'from_json';    # booleans
 use Cpanel::JSON::XS ();
 use Storable 'dclone';
 has include_results => 1;

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -19,8 +19,7 @@ package OpenQA::Parser::Format::LTP;
 # The parser results will be a collection of OpenQA::Parser::Result::LTP::Test
 use Mojo::Base 'OpenQA::Parser::Format::JUnit';
 use Carp qw(croak confess);
-use Mojo::JSON 'from_json';    # booleans
-use Cpanel::JSON::XS ();
+use Mojo::JSON;
 use Storable 'dclone';
 has include_results => 1;
 
@@ -30,7 +29,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::LTP::Test->
 sub parse {
     my ($self, $json) = @_;
     confess "No JSON given/loaded" unless $json;
-    my $decoded_json = Cpanel::JSON::XS->new->utf8(0)->decode($json);
+    my $decoded_json = Mojo::JSON::from_json($json);
 
     # may be optional since format result_array:v2
     $self->generated_tests_extra->add(OpenQA::Parser::Result::LTP::Environment->new($decoded_json->{environment}))

--- a/lib/OpenQA/Schema/Result/GruTasks.pm
+++ b/lib/OpenQA/Schema/Result/GruTasks.pm
@@ -18,7 +18,7 @@ package OpenQA::Schema::Result::GruTasks;
 use base 'DBIx::Class::Core';
 use strict;
 use OpenQA::Schema::Result::Jobs ();
-use Cpanel::JSON::XS;
+use Mojo::JSON qw(decode_json encode_json);
 use db_helpers;
 use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;

--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -22,7 +22,7 @@ use db_helpers;
 use OpenQA::Scheduler::Scheduler;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
-use Cpanel::JSON::XS qw(decode_json encode_json);
+use Mojo::JSON qw(decode_json encode_json);
 use File::Basename qw(dirname basename);
 use File::Path 'remove_tree';
 use Cwd 'abs_path';

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use base 'DBIx::Class::Core';
 use Try::Tiny;
-use Cpanel::JSON::XS;
+use Mojo::JSON 'encode_json';
 use Fcntl;
 use DateTime;
 use db_helpers;

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -21,7 +21,7 @@ use DBIx::Class::Timestamps 'now';
 use OpenQA::Utils qw(log_warning locate_asset human_readable_size log_debug);
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
-use Cpanel::JSON::XS 'encode_json';
+use Mojo::JSON 'encode_json';
 use File::Basename;
 use Try::Tiny;
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -20,7 +20,7 @@ use base 'DBIx::Class::ResultSet';
 use DBIx::Class::Timestamps 'now';
 use Date::Format 'time2str';
 use OpenQA::Schema::Result::JobDependencies;
-use Cpanel::JSON::XS;
+use Mojo::JSON 'encode_json';
 
 =head2 latest_build
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -116,7 +116,7 @@ use File::Basename;
 use File::Spec;
 use File::Spec::Functions qw(catfile catdir);
 use Fcntl;
-use Cpanel::JSON::XS qw(encode_json decode_json);
+use Mojo::JSON qw(encode_json decode_json);
 use Mojo::Util 'xml_escape';
 our $basedir   = $ENV{OPENQA_BASEDIR} || "/var/lib";
 our $prj       = "openqa";

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -16,9 +16,6 @@
 package OpenQA::WebAPI;
 use strict;
 
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
-
 use Mojolicious 7.18;
 use Mojo::Base 'Mojolicious';
 use OpenQA::Schema;

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -21,7 +21,6 @@ use parent 'Mojolicious::Controller';
 use Time::Piece;
 use Time::Seconds;
 use Time::ParseDate;
-use Cpanel::JSON::XS ();
 use OpenQA::Utils 'log_warning';
 use OpenQA::ServerSideDataTable;
 
@@ -53,8 +52,6 @@ sub productlog {
     my $events_rs = $self->db->resultset("AuditEvents")
       ->search({event => 'iso_create'}, {order_by => {-desc => 'me.id'}, prefetch => 'owner', rows => $entries});
     my @events;
-    my $json = Cpanel::JSON::XS->new();
-    $json->allow_nonref(1);
     while (my $event = $events_rs->next) {
         my $data = {
             id         => $event->id,

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -20,7 +20,7 @@ use warnings;
 use Mojo::Base 'Mojolicious::Controller';
 use Mojo::Util 'b64_encode';
 use Mojo::File 'path';
-use Cpanel::JSON::XS qw(encode_json decode_json);
+use Mojo::JSON qw(encode_json decode_json);
 use OpenQA::Utils;
 use OpenQA::IPC;
 use OpenQA::Jobs::Constants;

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -25,7 +25,7 @@ use File::Copy;
 use File::Which 'which';
 use POSIX 'strftime';
 use Try::Tiny;
-use Cpanel::JSON::XS;
+use Mojo::JSON 'decode_json';
 
 sub init {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -19,7 +19,8 @@ use strict;
 use warnings;
 
 use parent 'Mojolicious::Plugin';
-use Cpanel::JSON::XS;
+use Mojo::JSON;    # booleans
+use Cpanel::JSON::XS ();
 use Mojo::IOLoop;
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -20,7 +20,7 @@ use warnings;
 
 use parent 'Mojolicious::Plugin';
 use Mojo::IOLoop;
-use Cpanel::JSON::XS ();
+use Mojo::JSON 'to_json';
 
 my @table_events = qw(table_create table_update table_delete);
 my @job_events   = qw(job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result
@@ -65,14 +65,12 @@ sub on_event {
     my ($user_id, $connection_id, $event, $event_data) = @$args;
     # no need to log openqa_ prefix in openqa log
     $event =~ s/^openqa_//;
-    my $json = Cpanel::JSON::XS->new();
-    $json->allow_nonref(1);
     $app->db->resultset('AuditEvents')->create(
         {
             user_id       => $user_id,
             connection_id => $connection_id,
             event         => $event,
-            event_data    => $json->encode($event_data)});
+            event_data    => to_json($event_data)});
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -25,7 +25,7 @@ use warnings;
 
 use parent 'Mojolicious::Plugin';
 use IPC::Run;
-use Cpanel::JSON::XS;
+use Mojo::JSON 'to_json';
 use Mojo::IOLoop;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
@@ -64,7 +64,7 @@ sub log_event {
     $event =~ s/_/\./g;
 
     # convert data to JSON, with reliable key ordering (helps the tests)
-    $event_data = Cpanel::JSON::XS->new->canonical(1)->allow_blessed(1)->encode($event_data);
+    $event_data = to_json($event_data);
 
     OpenQA::Utils::log_debug("Sending fedmsg for $event");
 
@@ -207,7 +207,7 @@ sub log_event_ci_standard {
     $msg_data{body}{artifact}{hdd_1} = $job->settings_hash->{HDD_1} if ($job->settings_hash->{HDD_1});
 
     # convert data to JSON, with reliable key ordering (helps the tests)
-    my $msg_json = Cpanel::JSON::XS->new->canonical(1)->allow_blessed(1)->encode(\%msg_data);
+    my $msg_json = to_json(\%msg_data);
 
     # create the topic
     my $topic = "$artifact.test.$stdevent";

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -25,7 +25,7 @@ use warnings;
 
 use parent 'Mojolicious::Plugin';
 use IPC::Run;
-use Mojo::JSON;   # booleans
+use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 use Mojo::IOLoop;
 use OpenQA::Jobs::Constants;

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -25,7 +25,8 @@ use warnings;
 
 use parent 'Mojolicious::Plugin';
 use IPC::Run;
-use Mojo::JSON 'to_json';
+use Mojo::JSON;   # booleans
+use Cpanel::JSON::XS ();
 use Mojo::IOLoop;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
@@ -64,7 +65,7 @@ sub log_event {
     $event =~ s/_/\./g;
 
     # convert data to JSON, with reliable key ordering (helps the tests)
-    $event_data = to_json($event_data);
+    $event_data = Cpanel::JSON::XS->new->canonical(1)->allow_blessed(1)->encode($event_data);
 
     OpenQA::Utils::log_debug("Sending fedmsg for $event");
 
@@ -207,7 +208,7 @@ sub log_event_ci_standard {
     $msg_data{body}{artifact}{hdd_1} = $job->settings_hash->{HDD_1} if ($job->settings_hash->{HDD_1});
 
     # convert data to JSON, with reliable key ordering (helps the tests)
-    my $msg_json = to_json(\%msg_data);
+    my $msg_json = Cpanel::JSON::XS->new->canonical(1)->allow_blessed(1)->encode(\%msg_data);
 
     # create the topic
     my $topic = "$artifact.test.$stdevent";

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -19,7 +19,6 @@ package OpenQA::WebAPI::Plugin::Gru;
 
 use strict;
 use warnings;
-use Cpanel::JSON::XS;
 use Minion;
 use Scalar::Util ();
 

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -14,11 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebSockets::Server;
-use Cpanel::JSON::XS;
 use Mojolicious::Lite;
+
 use Mojo::Util 'hmac_sha1_sum';
 use Try::Tiny;
-
 use OpenQA::IPC;
 use OpenQA::Utils qw(log_debug log_warning log_info log_error);
 use OpenQA::Schema;

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -24,7 +24,6 @@ use OpenQA::Utils
   qw(log_error log_info log_debug get_channel_handle add_log_channel append_channel_to_defaults remove_channel_from_defaults);
 use OpenQA::Worker::Common;
 use List::MoreUtils;
-use Cpanel::JSON::XS;
 use Mojo::SQLite;
 use Mojo::File 'path';
 use Mojo::Base -base;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -21,7 +21,7 @@ use OpenQA::Worker::Common;
 use OpenQA::Utils qw(locate_asset log_error log_info log_debug log_warning get_channel_handle);
 
 use POSIX qw(:sys_wait_h strftime uname _exit);
-use Mojo::JSON 'encode_json';
+use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();
 use Fcntl;
 use File::Spec::Functions 'catdir';

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -21,7 +21,8 @@ use OpenQA::Worker::Common;
 use OpenQA::Utils qw(locate_asset log_error log_info log_debug log_warning get_channel_handle);
 
 use POSIX qw(:sys_wait_h strftime uname _exit);
-use Cpanel::JSON::XS 'encode_json';
+use Mojo::JSON 'encode_json';
+use Cpanel::JSON::XS ();
 use Fcntl;
 use File::Spec::Functions 'catdir';
 use File::Basename;

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -27,7 +27,7 @@ use OpenQA::Utils
 use POSIX qw(strftime SIGTERM);
 use File::Copy qw(copy move);
 use File::Path 'remove_tree';
-use Cpanel::JSON::XS 'decode_json';
+use Mojo::JSON 'decode_json';
 use Fcntl;
 use MIME::Base64;
 use File::Basename 'basename';

--- a/script/clean_needles
+++ b/script/clean_needles
@@ -69,7 +69,7 @@ use DBIx::Class::DeploymentHandler;
 use Getopt::Long;
 use OpenQA::Utils;
 use OpenQA::Scheduler::Scheduler;
-use Cpanel::JSON::XS 'decode_json';
+use Mojo::JSON 'decode_json';
 
 Getopt::Long::Configure("no_ignore_case");
 

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -256,6 +256,7 @@ for my $table (keys %result) {
 }
 
 if ($options{json}) {
+    use Mojo::JSON;    # booleans
     use Cpanel::JSON::XS;
     print Cpanel::JSON::XS->new->ascii->pretty->encode(\%result);
 }

--- a/script/initdb
+++ b/script/initdb
@@ -23,8 +23,6 @@ BEGIN {
 
 use strict;
 use warnings;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use DBIx::Class::DeploymentHandler;
 use File::Basename qw(dirname);
 use POSIX qw(getuid getgid setuid setgid);

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -18,9 +18,6 @@
 use strict;
 use warnings;
 
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
-
 use FindBin;
 use Mojo::Home;
 BEGIN {

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -22,8 +22,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Scheduler;

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -22,8 +22,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Data::Dump qw(pp dd);

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -22,8 +22,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Data::Dump qw(pp dd);

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -22,8 +22,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Data::Dump qw(pp dd dump);

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -38,8 +38,6 @@ BEGIN {
 
 use strict;
 use lib "$FindBin::Bin/lib";
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use Data::Dump qw(pp dd);
 use OpenQA::Scheduler;
 use OpenQA::Scheduler::Scheduler;

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -22,8 +22,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Data::Dump qw(pp dd);

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -21,8 +21,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -20,8 +20,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -17,8 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -21,8 +21,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -22,8 +22,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -20,8 +20,6 @@ BEGIN {
     $ENV{OPENQA_TEST_IPC} = 1;
 }
 
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -21,8 +21,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -20,8 +20,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -24,8 +24,6 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use Data::Dump qw(pp dd);
 use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -21,8 +21,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -19,8 +19,6 @@ use warnings;
 
 BEGIN { unshift @INC, 'lib'; }
 
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Test::Database;

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -25,8 +25,6 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use DateTime;
 use Test::More;
 use Test::Warnings;

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -21,8 +21,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Schema;

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -18,8 +18,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -18,8 +18,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -20,8 +20,6 @@ BEGIN {
 }
 
 use strict;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -20,8 +20,6 @@ BEGIN {
 
 use strict;
 use warnings;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;

--- a/t/29-openqa_commands.t
+++ b/t/29-openqa_commands.t
@@ -16,8 +16,6 @@
 
 use strict;
 use warnings;
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
 use Test::More tests => 3;

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -21,6 +21,8 @@
 #  * a qemu instance is still running (maybe leftover from last failed test
 #    execution)
 
+use Mojo::Base -strict;
+
 my $tempdir;
 BEGIN {
     unshift @INC, 'lib';
@@ -41,10 +43,6 @@ BEGIN {
     # DO NOT SET OPENQA_IPC_TEST HERE
 }
 
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
-
-use Mojo::Base -strict;
 use lib "$FindBin::Bin/lib";
 use Test::More;
 use Test::Mojo;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -19,8 +19,6 @@
 use strict;
 BEGIN { unshift @INC, 'lib'; }
 
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
 use Test::More;
 use Test::Warnings;
 use DBIx::Class::DeploymentHandler;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -21,6 +21,8 @@
 #  * a qemu instance is still running (maybe leftover from last failed test
 #    execution)
 
+use Mojo::Base -strict;
+
 my $tempdir;
 BEGIN {
     unshift @INC, 'lib';
@@ -41,10 +43,6 @@ BEGIN {
     # DO NOT SET OPENQA_IPC_TEST HERE
 }
 
-# https://github.com/rurban/Cpanel-JSON-XS/issues/65
-use JSON::PP;
-
-use Mojo::Base -strict;
 use lib "$FindBin::Bin/lib";
 use Test::More;
 use Test::Mojo;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -29,7 +29,7 @@ use Test::Mojo;
 use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use Cwd 'abs_path';
-use Cpanel::JSON::XS 'decode_json';
+use Mojo::JSON 'decode_json';
 use File::Path qw(make_path remove_tree);
 use Date::Format 'time2str';
 use POSIX 'strftime';

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -32,7 +32,7 @@ use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use Time::HiRes qw(sleep);
 use OpenQA::SeleniumTest;
-use Cpanel::JSON::XS 'decode_json';
+use Mojo::JSON 'decode_json';
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data;

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -1,6 +1,6 @@
 % layout 'bootstrap';
 % title "Needle Editor";
-% use Mojo::JSON 'encode_json';
+% use Mojo::JSON 'encode_json';    # booleans
 % use Cpanel::JSON::XS ();
 
 % content_for 'head' => begin

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -1,5 +1,7 @@
 % layout 'bootstrap';
 % title "Needle Editor";
+% use Mojo::JSON 'encode_json';
+% use Cpanel::JSON::XS ();
 
 % content_for 'head' => begin
     %= asset 'step_edit.js'
@@ -10,7 +12,7 @@
     % for my $needle (@$needles) {
         window.needles['<%= $needle->{name} %>'] = <%= b(Cpanel::JSON::XS->new->pretty->encode($needle)) %>;
     % }
-    setup_needle_editor( <%= b(Cpanel::JSON::XS::encode_json($default_needle)) %> );
+    setup_needle_editor( <%= b(encode_json($default_needle)) %> );
     setupResultButtons();
 % end
 

--- a/templates/step/viewimg.html.ep
+++ b/templates/step/viewimg.html.ep
@@ -1,3 +1,4 @@
+% use Mojo::JSON 'encode_json';
 <div class="aligncenter" data-image="<%= url_for('test_img', filename => $screenshot) %>" id="step_view">
     <span class="candidate_needles">
         Candidate needles and tags:
@@ -36,8 +37,8 @@
                                 <tbody>
                                     % for my $needle (@{$needles_by_tag->{$tag}}) {
                                         <tr data-image="<%= $needle->{image} %>"
-                                            data-areas="<%= Cpanel::JSON::XS::encode_json($needle->{areas})%>"
-                                            data-matches="<%= Cpanel::JSON::XS::encode_json($needle->{matches}) %>"
+                                            data-areas="<%= encode_json($needle->{areas})%>"
+                                            data-matches="<%= encode_json($needle->{matches}) %>"
                                             data-label="<%= $needle->{label} %>"
                                         % if (!$has_selection && $needle->{selected}) {
                                             % $has_selection = 1;


### PR DESCRIPTION
I've replaced most uses of `Cpanel::JSON::XS` with `Mojo::JSON`, which takes care of setting up booleans properly and uses `Cpanel::JSON::XS` internally for performance. That should fix all the random JSON boolean warnings.

There are still a few uses left, where `Cpanel::JSON::XS` gets configured to generate strict ASCII, or to pretty print JSON, those can not be replaced with `Mojo::JSON`, but it can be used to fix booleans there. It might be worth turning those cases into functions in `OpenQA::Util`, which should end up with 3 cases (pretty print, pretty print strict ascii, and just strict ascii).

Progress: https://progress.opensuse.org/issues/29048.