### PR TITLE
Exit worker with non-zero return code in error cases

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -59,6 +59,7 @@ sub main {
     my $lockfd = lockit();
     my $dir;
     my $shared_cache;
+    my $return_code = 0;
     clean_pool();
 
     # register error handler
@@ -66,10 +67,11 @@ sub main {
         error => sub {
             my ($reactor, $err) = @_;
 
+            $return_code = 1;
             try {
                 # log error using print because logging utils might have caused the exception
                 # (no need to repeat $err, it is printed anyways)
-                print("stopping because a critical error occurred.\n");
+                log_error('stopping because a critical error occurred');
 
                 # try to stop the job nicely
                 stop('exception');
@@ -108,7 +110,7 @@ sub main {
     # start event loop - this will block until stop is called
     Mojo::IOLoop->start;
 
-    return 0;
+    return $return_code;
 }
 
 sub prepare_cache_directory {

--- a/script/worker
+++ b/script/worker
@@ -134,6 +134,6 @@ $ENV{QEMUPORT} = ($options{instance}) * 10 + 20002;
 $ENV{VNC}      = ($options{instance}) + 90;
 
 OpenQA::Worker::init($host_settings, \%options);
-OpenQA::Worker::main($host_settings);
+exit OpenQA::Worker::main($host_settings);
 
 # vim: set sw=4 sts=4 et:


### PR DESCRIPTION
So systemd tries to restart the worker (instead of keeping it "inactive").

E.g. I had to restart workers manually after issues with the new cache service: https://progress.opensuse.org/issues/44351

Tested locally by manually inserting some wrong code.