### PR TITLE
devel mode: Allow to skip assert/check_screen timeout

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -342,6 +342,7 @@ var developerMode = {
     moduleToPauseAt: undefined,             // name of the module to pause at, eg. "installation-welcome"
     pauseAtTimeout: undefined,              // whether to pause on assert_screen timeout
     isPaused: undefined,                    // if paused the reason why as a string; otherwise something which evaluates to false
+    currentApiFunction: undefined,          // the currently executed API function (eg. assert_screen)
     outstandingImagesToUpload: undefined,   // number of images which still need to be uploaded by the worker
     outstandingFilesToUpload: undefined,    // number of other files which still need to be uploaded by the worker
     uploadingUpToCurrentModule: undefined,  // whether the worker will upload up to the current module (happens when paused in the middle of a module)
@@ -364,6 +365,11 @@ var developerMode = {
             this.uploadingUpToCurrentModule &&
             this.outstandingImagesToUpload === 0 &&
             this.outstandingFilesToUpload === 0;
+    },
+
+    // returns whether it is possible to skip the timeout
+    canSkipTimeout: function() {
+        return this.ownSession && !this.isPaused && (this.currentApiFunction === 'assert_screen' || this.currentApiFunction === 'check_screen');
     },
 
     // returns the specified property evaluating possibly assigned functions
@@ -839,6 +845,10 @@ var messageToStatusVariable = [
         msg: 'upload_up_to_current_module',
         statusVar: 'uploadingUpToCurrentModule',
     },
+    {
+        msg: 'current_api_function',
+        statusVar: 'currentApiFunction',
+    },
 ];
 
 // handles messages received via web socket connection
@@ -937,6 +947,14 @@ function sendWsCommand(obj) {
 // resumes the test execution (if currently paused)
 function resumeTestExecution() {
     sendWsCommand({ cmd: "resume_test_execution" });
+}
+
+// sets the timeout of the currently ongoing assert/check_screen to zero
+function skipTimeout() {
+    sendWsCommand({
+        cmd: "set_assert_screen_timeout",
+        timeout: 0,
+    });
 }
 
 // starts the developer session (if not already done yet)

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -33,6 +33,7 @@ use JSON 'decode_json';
 use constant ALLOWED_OS_AUTOINST_COMMANDS => {
     set_pause_at_test                  => 1,
     set_pause_on_assert_screen_timeout => 1,
+    set_assert_screen_timeout          => 1,
     status                             => 1,
     resume_test_execution              => 1,
 };

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -184,7 +184,9 @@ my $on_prompt_needle         = $needle_dir . '/boot-on_prompt';
 my $on_prompt_needle_renamed = $needle_dir . '/../disabled_needles/boot-on_prompt';
 note('renaming needles for on_prompt to ' . $on_prompt_needle_renamed . '.{json,png}');
 for my $ext (qw(.json .png)) {
-    ok(rename($on_prompt_needle . $ext => $on_prompt_needle_renamed . $ext), 'can rename needle ' . $ext);
+    ok(-f $on_prompt_needle_renamed . $ext
+          or rename($on_prompt_needle . $ext => $on_prompt_needle_renamed . $ext),
+        'can rename needle ' . $ext);
 }
 
 sub start_worker {

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -161,6 +161,7 @@ my $JOB_SETUP
   . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1 '
   . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2 '
   . 'TESTING_ASSERT_SCREEN_TIMEOUT=1';
+# setting TESTING_ASSERT_SCREEN_TIMEOUT is important here (see os-autoinst/t/data/tests/tests/boot.pm)
 
 subtest 'schedule job' => sub {
     OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP");
@@ -238,7 +239,7 @@ my $first_tab = $driver->get_current_window_handle();
 my $second_tab;
 
 subtest 'pause at assert_screen timeout' => sub {
-    # send command to pause on assert_screen timeout (hopefully the test wasn't so fast that it already failed)
+    # send command to pause on assert_screen timeout
     my $command_input = $driver->find_element('#msg');
     $command_input->send_keys('{"cmd":"set_pause_on_assert_screen_timeout","flag":true}');
     $command_input->send_keys(Selenium::Remote::WDKeys->KEYS->{'enter'});
@@ -246,6 +247,15 @@ subtest 'pause at assert_screen timeout' => sub {
         $driver,
         qr/\"set_pause_on_assert_screen_timeout\":true/,
         'response to set_pause_on_assert_screen_timeout'
+    );
+
+    # skip timeout
+    $command_input->send_keys('{"cmd":"set_assert_screen_timeout","timeout":0}');
+    $command_input->send_keys(Selenium::Remote::WDKeys->KEYS->{'enter'});
+    OpenQA::Test::FullstackUtils::wait_for_developer_console_contains_log_message(
+        $driver,
+        qr/\"set_assert_screen_timeout\":0/,
+        'response to set_assert_screen_timeout'
     );
 
     # wait until test paused
@@ -260,6 +270,15 @@ subtest 'pause at assert_screen timeout' => sub {
     $command_input->send_keys(Selenium::Remote::WDKeys->KEYS->{'enter'});
     OpenQA::Test::FullstackUtils::wait_for_developer_console_contains_log_message($driver,
         qr/\"resume_test_execution\":/, 'resume');
+
+    # skip timeout (again)
+    $command_input->send_keys('{"cmd":"set_assert_screen_timeout","timeout":0}');
+    $command_input->send_keys(Selenium::Remote::WDKeys->KEYS->{'enter'});
+    OpenQA::Test::FullstackUtils::wait_for_developer_console_contains_log_message(
+        $driver,
+        qr/\"set_assert_screen_timeout\":0/,
+        'response to set_assert_screen_timeout'
+    );
 
     # wait until test is paused (again)
     OpenQA::Test::FullstackUtils::wait_for_developer_console_contains_log_message(

--- a/templates/test/live.html.ep
+++ b/templates/test/live.html.ep
@@ -109,6 +109,11 @@
                     class="btn btn-secondary developer-mode-element" data-visible-on="isPaused">
                     <i class="far fa-play-circle"></i> Resume test execution
                 </a>
+                <a href="#" onclick="skipTimeout(); return false;"
+                    class="btn btn-warning developer-mode-element" data-visible-on="canSkipTimeout"
+                    data-toggle="tooltip" data-placement="bottom" title="Causes the current assert_screen/check_screen to fail immediately (supposed to be combined with pause on assert_screen)">
+                    <i class="far fa-play-circle"></i> Skip timeout
+                </a>
                 <a href="<%= url_for('edit_test', testid => $testid) %>"
                     class="btn btn-secondary developer-mode-element"
                     data-visible-on="needleEditorReady">


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/44249
* Requires https://github.com/os-autoinst/os-autoinst/pull/1067

---

![screenshot_20181127_141313](https://user-images.githubusercontent.com/10248953/49084009-94a4cf80-f24e-11e8-82d1-0c57a726ca99.png)