### PR TITLE
Fix production mode setting for cache service tests

### DIFF
--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -54,7 +54,6 @@ use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service);
 use Mojo::Util qw(md5_sum);
-use constant DEBUG => $ENV{DEBUG} // 0;
 use OpenQA::Worker::Cache::Request;
 
 my $sql;
@@ -67,12 +66,11 @@ my $openqalogs;
 my $cachedir = $ENV{OPENQA_CACHE_DIR};
 
 my $db_file = "$cachedir/cache.sqlite";
-$ENV{LOGDIR} = catdir(getcwd(), 't', 'cache.d', 'logs');
-my $logfile = catdir($ENV{LOGDIR}, 'cache.log');
+my $logdir  = path(getcwd(), 't', 'cache.d', 'logs')->make_path;
+my $logfile = $logdir->child('cache.log');
 my $port    = Mojo::IOLoop::Server->generate_port;
 my $host    = "http://localhost:$port";
 
-path($ENV{LOGDIR})->make_path;
 use OpenQA::Worker::Cache::Client;
 
 my $cache_client = OpenQA::Worker::Cache::Client->new();
@@ -87,7 +85,7 @@ my $worker_cache_service = cache_minion_worker;
 
 my $server_instance = process sub {
     # Connect application with web server and start accepting connections
-    $daemon = Mojo::Server::Daemon->new(app => fake_asset_server, listen => [$host])->silent(!DEBUG);
+    $daemon = Mojo::Server::Daemon->new(app => fake_asset_server, listen => [$host])->silent(1);
     $daemon->run;
     _exit(0);
 };

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -54,14 +54,14 @@ my $serverpid;
 my $openqalogs;
 
 my $cachedir = catdir(getcwd(), 't', 'cache.d', 'cache');
-my $db_file = "$cachedir/cache.sqlite";
-$ENV{LOGDIR} = catdir(getcwd(), 't', 'cache.d', 'logs');
-my $logfile = catdir($ENV{LOGDIR}, 'cache.log');
-my $port    = Mojo::IOLoop::Server->generate_port;
-my $host    = "http://localhost:$port";
+my $db_file  = "$cachedir/cache.sqlite";
+my $logdir   = path(getcwd(), 't', 'cache.d', 'logs');
+my $logfile  = $logdir->child('cache.log');
+my $port     = Mojo::IOLoop::Server->generate_port;
+my $host     = "http://localhost:$port";
 
 remove_tree($cachedir);
-make_path($ENV{LOGDIR});
+$logdir->make_path;
 
 # reassign STDOUT, STDERR
 open my $FD, '>>', $logfile;
@@ -163,7 +163,7 @@ for (1 .. 3) {
 }
 
 
-chdir $ENV{LOGDIR};
+chdir $logdir;
 
 $cache->sleep_time(1);
 $cache->init;


### PR DESCRIPTION
You can now actually see the output of other tests again. 😉

Progress: https://progress.opensuse.org/issues/44387.