### PR TITLE
Activate strict and warnings consistently for all modules

### DIFF
--- a/lib/DBIx/Class/Timestamps.pm
+++ b/lib/DBIx/Class/Timestamps.pm
@@ -1,12 +1,14 @@
 package DBIx::Class::Timestamps;
-use base 'DBIx::Class';
-use DateTime;
-use strict;
 
-require Exporter;
-our (@ISA, @EXPORT_OK);
-@ISA       = qw(Exporter);
-@EXPORT_OK = qw(now);
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+use DateTime;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(now);
 
 sub add_timestamps {
     my $self = shift;

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -15,7 +15,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::BuildResults;
+
 use strict;
+use warnings;
+
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Utils;

--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -22,7 +22,6 @@ use Mojo::File 'path';
 use Mojo::URL;
 use Carp 'croak';
 use JSON;
-
 use Data::Dump;
 
 my $job;

--- a/lib/OpenQA/Client/Handler.pm
+++ b/lib/OpenQA/Client/Handler.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::Client::Handler;
 use Mojo::Base 'Mojo::EventEmitter';
+
 use OpenQA::Client;
 
 has client => sub { OpenQA::Client->new };

--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -1,5 +1,9 @@
 package OpenQA::Constants;
+
 use strict;
+use warnings;
+
+use Exporter 'import';
 
 # Minimal worker version that allows them to connect;
 # To be modified manuallly when we want to break compability and force workers to update
@@ -16,12 +20,7 @@ use constant MAX_TIMER => 100;
 # Time verification to be use with WORKERS_CHECKER_THRESHOLD.
 use constant MIN_TIMER => 20;
 
-require Exporter;
-our (@ISA, @EXPORT, @EXPORT_OK);
-
-@ISA       = qw(Exporter);
-@EXPORT    = ();
-@EXPORT_OK = qw(
+our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION
   WORKERS_CHECKER_THRESHOLD
   MAX_TIMER

--- a/lib/OpenQA/File.pm
+++ b/lib/OpenQA/File.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::File;
 use Mojo::Base 'OpenQA::Parser::Result';
+
 use OpenQA::Parser::Results;
 use Exporter 'import';
 use Carp 'croak';

--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -21,12 +21,10 @@ use warnings;
 use Net::DBus;
 use Net::DBus::Callback;
 use Net::DBus::Binding::Watch;
-
 use Mojo::IOLoop;
 use Data::Dump 'pp';
 use Try::Tiny;
 use Carp;
-
 use Scalar::Util 'weaken';
 use OpenQA::Utils qw(log_debug log_warning log_error);
 

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -1,7 +1,7 @@
 package OpenQA::Jobs::Constants;
-
 use Mojo::Base -base;
-our @ISA = qw(Exporter);
+
+use Exporter 'import';
 
 # States
 use constant {

--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -14,10 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::LiveHandler;
-use strict;
+use Mojo::Base 'Mojolicious';
 
 use Mojolicious 7.18;
-use Mojo::Base 'Mojolicious';
 use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
 use OpenQA::Utils qw(log_warning detect_current_version);

--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -14,8 +14,8 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser;
-
 use Mojo::Base -base;
+
 use Carp qw(croak confess);
 use Mojo::File 'path';
 use Mojo::Collection;
@@ -30,9 +30,9 @@ use Scalar::Util qw(blessed reftype);
 use constant DATA_FIELD => '__data__';
 use constant TYPE_FIELD => '__type__';
 use OpenQA::Utils 'walker';
+use Exporter 'import';
 
 our @EXPORT_OK = qw(parser p);
-use Exporter 'import';
 
 has include_content => 0;
 has 'content';

--- a/lib/OpenQA/Parser/Format/Base.pm
+++ b/lib/OpenQA/Parser/Format/Base.pm
@@ -14,8 +14,8 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Format::Base;
-
 use Mojo::Base 'OpenQA::Parser';
+
 use Carp 'croak';
 use OpenQA::Parser::Result::Test;
 use OpenQA::Parser::Result;

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -14,10 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Format::IPA;
+use Mojo::Base 'OpenQA::Parser::Format::Base';
 
 # Translates to JSON IPA format -> OpenQA internal representation
 # The parser results will be a collection of OpenQA::Parser::Result::IPA::Test
-use Mojo::Base 'OpenQA::Parser::Format::Base';
 use Carp qw(croak confess);
 use Mojo::JSON;
 use OpenQA::Parser::Result::Test;

--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -14,8 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Format::JUnit;
-# Translates to JUnit -> openQA internal
 use Mojo::Base 'OpenQA::Parser::Format::Base';
+
+# Translates to JUnit -> openQA internal
 use Carp qw(croak confess);
 use OpenQA::Parser::Result::OpenQA;
 use Mojo::DOM;

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -14,13 +14,14 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Format::LTP;
+use Mojo::Base 'OpenQA::Parser::Format::JUnit';
 
 # Translates to JSON LTP format -> LTP internal representation
 # The parser results will be a collection of OpenQA::Parser::Result::LTP::Test
-use Mojo::Base 'OpenQA::Parser::Format::JUnit';
 use Carp qw(croak confess);
 use Mojo::JSON;
 use Storable 'dclone';
+
 has include_results => 1;
 
 sub _add_single_result { shift->results->add(OpenQA::Parser::Result::LTP::Test->new(@_)) }

--- a/lib/OpenQA/Parser/Format/TAP.pm
+++ b/lib/OpenQA/Parser/Format/TAP.pm
@@ -14,8 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Format::TAP;
-# Translates to TAP -> openQA internal
 use Mojo::Base 'OpenQA::Parser::Format::Base';
+
+# Translates to TAP -> openQA internal
 use Carp qw(croak confess);
 use OpenQA::Parser::Result::OpenQA;
 use TAP::Parser;

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -14,8 +14,8 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Format::XUnit;
-
 use Mojo::Base 'OpenQA::Parser::Format::JUnit';
+
 use Carp qw(croak confess);
 use Mojo::DOM;
 

--- a/lib/OpenQA/Parser/Result.pm
+++ b/lib/OpenQA/Parser/Result.pm
@@ -14,13 +14,13 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Result;
+use Mojo::Base -base;
+
 # Base class that holds the test result
 # Used while parsing from format X to Whatever
 
-use Mojo::Base -base;
 use OpenQA::Parser::Results;
 use OpenQA::Parser;
-
 use Mojo::JSON qw(decode_json encode_json);
 use Carp 'croak';
 use Mojo::File 'path';

--- a/lib/OpenQA/Parser/Result/OpenQA.pm
+++ b/lib/OpenQA/Parser/Result/OpenQA.pm
@@ -14,10 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Result::OpenQA;
+use Mojo::Base 'OpenQA::Parser::Result';
+
 # Basic class that holds the tests details and results as seen by openQA
 # Used while parsing from format X to OpenQA test modules.
-
-use Mojo::Base 'OpenQA::Parser::Result';
 use OpenQA::Parser::Results;
 use Mojo::File 'path';
 

--- a/lib/OpenQA/Parser/Result/Output.pm
+++ b/lib/OpenQA/Parser/Result/Output.pm
@@ -14,10 +14,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Result::Output;
+use Mojo::Base 'OpenQA::Parser::Result';
+
 # OpenQA test result class - this is how openQA internally draws the output results
 # Used while parsing from format X to OpenQA test modules.
-use Mojo::Base 'OpenQA::Parser::Result';
 use Mojo::File 'path';
+
 has 'file';
 has 'content';
 

--- a/lib/OpenQA/Parser/Result/Test.pm
+++ b/lib/OpenQA/Parser/Result/Test.pm
@@ -14,9 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Result::Test;
+use Mojo::Base 'OpenQA::Parser::Result';
+
 # OpenQA test result class - this is how test modules are represented in openQA
 # Used while parsing from format X to OpenQA test modules.
-use Mojo::Base 'OpenQA::Parser::Result';
 
 has flags => sub { {} };
 has [qw(category name script)];

--- a/lib/OpenQA/Parser/Results.pm
+++ b/lib/OpenQA/Parser/Results.pm
@@ -14,9 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Parser::Results;
+use Mojo::Base 'Mojo::Collection';
+
 # Generic result class.
 
-use Mojo::Base 'Mojo::Collection';
 use Scalar::Util 'blessed';
 use OpenQA::Parser;
 use Mojo::JSON qw(encode_json decode_json);

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -17,7 +17,6 @@ package OpenQA::Resource::Jobs;
 
 use strict;
 use warnings;
-use diagnostics;
 
 # we need the critical fix for update
 # see https://github.com/dbsrgits/dbix-class/commit/31160673f390e178ee347e7ebee1f56b3f54ba7a
@@ -29,11 +28,9 @@ use OpenQA::Schema::Result::Jobs;
 use OpenQA::Schema::Result::JobDependencies;
 use OpenQA::Utils 'log_debug';
 use OpenQA::ResourceAllocator;
+use Exporter 'import';
 
-require Exporter;
-our (@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
-@ISA    = qw(Exporter);
-@EXPORT = qw(job_restart job_create);
+our @EXPORT = qw(job_restart job_create);
 
 sub schema { OpenQA::ResourceAllocator->instance->schema }
 

--- a/lib/OpenQA/ResourceAllocator.pm
+++ b/lib/OpenQA/ResourceAllocator.pm
@@ -17,12 +17,13 @@ package OpenQA::ResourceAllocator;
 
 use strict;
 use warnings;
+
 use base 'Net::DBus::Object';
+
 use Net::DBus::Exporter 'org.opensuse.openqa.ResourceAllocator';
 use Net::DBus::Reactor;
 use Data::Dump 'pp';
 use Scalar::Util 'blessed';
-
 use OpenQA::IPC;
 use OpenQA::Utils qw(log_debug wakeup_scheduler exists_worker safe_call);
 use OpenQA::Resource::Jobs  ();

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -17,14 +17,14 @@ package OpenQA::Scheduler;
 
 use strict;
 use warnings;
+
 use base 'Net::DBus::Object';
+
 use Net::DBus::Exporter 'org.opensuse.openqa.Scheduler';
 use Net::DBus::Reactor;
 use Data::Dump 'pp';
-
 use OpenQA::IPC;
 use OpenQA::Setup;
-
 use OpenQA::Utils 'log_debug';
 
 # How many jobs to allocate in one tick. Defaults to 80 ( set it to 0 for as much as possible)

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -17,7 +17,6 @@ package OpenQA::Scheduler::Scheduler;
 
 use strict;
 use warnings;
-use diagnostics;
 
 # we need the critical fix for update
 # see https://github.com/dbsrgits/dbix-class/commit/31160673f390e178ee347e7ebee1f56b3f54ba7a
@@ -47,11 +46,9 @@ use sigtrap handler => \&normal_signals_handler, 'normal-signals';
 use OpenQA::Scheduler;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use Carp;
+use Exporter 'import';
 
-require Exporter;
-our (@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
-@ISA    = qw(Exporter);
-@EXPORT = qw(job_grab);
+our @EXPORT = qw(job_grab);
 
 CORE::state $summoned = 0;
 CORE::state $quit     = 0;

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -14,9 +14,11 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema;
-use parent 'DBIx::Class::Schema';
+
 use strict;
 use warnings;
+
+use parent 'DBIx::Class::Schema';
 
 use DBIx::Class::DeploymentHandler;
 use Config::IniFiles;
@@ -25,7 +27,6 @@ use Try::Tiny;
 use FindBin '$Bin';
 use Fcntl ':flock';
 use File::Spec::Functions 'catfile';
-
 use OpenQA::Utils ();
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file

--- a/lib/OpenQA/Schema/JobGroupDefaults.pm
+++ b/lib/OpenQA/Schema/JobGroupDefaults.pm
@@ -14,6 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::JobGroupDefaults;
+
 use strict;
 use warnings;
 

--- a/lib/OpenQA/Schema/Result/ApiKeys.pm
+++ b/lib/OpenQA/Schema/Result/ApiKeys.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::ApiKeys;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Assets;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;

--- a/lib/OpenQA/Schema/Result/AuditEvents.pm
+++ b/lib/OpenQA/Schema/Result/AuditEvents.pm
@@ -14,7 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::AuditEvents;
+
 use strict;
+use warnings;
+
 use base 'DBIx::Class::Core';
 
 # use db_helpers;

--- a/lib/OpenQA/Schema/Result/Bugs.pm
+++ b/lib/OpenQA/Schema/Result/Bugs.pm
@@ -14,8 +14,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::Bugs;
+
 use strict;
+use warnings;
+
 use base 'DBIx::Class::Core';
+
 use Mojo::UserAgent;
 use OpenQA::Utils;
 use DBIx::Class::Timestamps 'now';

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -14,9 +14,13 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::Comments;
-use base 'DBIx::Class::Core';
-use OpenQA::Utils qw(find_bugref find_bugrefs);
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+use OpenQA::Utils qw(find_bugref find_bugrefs);
 
 __PACKAGE__->load_components(qw(Core));
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));

--- a/lib/OpenQA/Schema/Result/DeveloperSessions.pm
+++ b/lib/OpenQA/Schema/Result/DeveloperSessions.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::DeveloperSessions;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;

--- a/lib/OpenQA/Schema/Result/GruDependencies.pm
+++ b/lib/OpenQA/Schema/Result/GruDependencies.pm
@@ -20,8 +20,11 @@
 # completes, the entry will be deleted.
 
 package OpenQA::Schema::Result::GruDependencies;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/GruTasks.pm
+++ b/lib/OpenQA/Schema/Result/GruTasks.pm
@@ -15,8 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::GruTasks;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
 use OpenQA::Schema::Result::Jobs ();
 use Mojo::JSON qw(decode_json encode_json);
 use db_helpers;

--- a/lib/OpenQA/Schema/Result/JobDependencies.pm
+++ b/lib/OpenQA/Schema/Result/JobDependencies.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::JobDependencies;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/Result/JobGroupParents.pm
@@ -15,11 +15,15 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::JobGroupParents;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
 use OpenQA::Schema::JobGroupDefaults;
 use OpenQA::Utils 'parse_tags_from_comments';
 use Class::Method::Modifiers;
-use base 'DBIx::Class::Core';
-use strict;
 
 __PACKAGE__->table('job_group_parents');
 __PACKAGE__->load_components(qw(Timestamps));

--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -14,12 +14,16 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::JobGroups;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
 use OpenQA::Schema::JobGroupDefaults;
 use Class::Method::Modifiers;
-use base 'DBIx::Class::Core';
 use OpenQA::Utils qw(log_debug parse_tags_from_comments);
 use Date::Format 'time2str';
-use strict;
 
 __PACKAGE__->table('job_groups');
 __PACKAGE__->load_components(qw(Timestamps));

--- a/lib/OpenQA/Schema/Result/JobLocks.pm
+++ b/lib/OpenQA/Schema/Result/JobLocks.pm
@@ -14,8 +14,11 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::JobLocks;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components(qw(OptimisticLocking Core));
 __PACKAGE__->load_components(qw(Core));

--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -15,9 +15,13 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::JobModules;
-use base 'DBIx::Class::Core';
 
 use strict;
+use warnings;
+
+use 5.012;    # so readdir assigns to $_ in a lone while test
+use base 'DBIx::Class::Core';
+
 use db_helpers;
 use OpenQA::Scheduler::Scheduler;
 use OpenQA::Jobs::Constants;
@@ -27,7 +31,6 @@ use File::Basename qw(dirname basename);
 use File::Path 'remove_tree';
 use Cwd 'abs_path';
 use Try::Tiny;
-use 5.012;    # so readdir assigns to $_ in a lone while test
 
 __PACKAGE__->table('job_modules');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));

--- a/lib/OpenQA/Schema/Result/JobNetworks.pm
+++ b/lib/OpenQA/Schema/Result/JobNetworks.pm
@@ -14,8 +14,11 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::JobNetworks;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 __PACKAGE__->table('job_networks');
 __PACKAGE__->add_columns(

--- a/lib/OpenQA/Schema/Result/JobNextPrevious.pm
+++ b/lib/OpenQA/Schema/Result/JobNextPrevious.pm
@@ -14,8 +14,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::JobNextPrevious;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
 use Moose;
 extends 'OpenQA::Schema::Result::Jobs';
 

--- a/lib/OpenQA/Schema/Result/JobSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobSettings.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::JobSettings;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/JobTemplates.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplates.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::JobTemplates;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -15,9 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Jobs;
+
 use strict;
 use warnings;
+
 use base 'DBIx::Class::Core';
+
 use Try::Tiny;
 use Mojo::JSON 'encode_json';
 use Fcntl;

--- a/lib/OpenQA/Schema/Result/JobsAssets.pm
+++ b/lib/OpenQA/Schema/Result/JobsAssets.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::JobsAssets;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/MachineSettings.pm
+++ b/lib/OpenQA/Schema/Result/MachineSettings.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::MachineSettings;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/Machines.pm
+++ b/lib/OpenQA/Schema/Result/Machines.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Machines;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/NeedleDirs.pm
+++ b/lib/OpenQA/Schema/Result/NeedleDirs.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::NeedleDirs;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -15,14 +15,17 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Needles;
+
 use 5.018;
+use strict;
 use warnings;
+
 use base 'DBIx::Class::Core';
+
 use DBIx::Class::Timestamps 'now';
 use File::Basename;
 use Cwd 'realpath';
 use File::Spec::Functions 'catdir';
-
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Utils qw(log_error commit_git_return_error);

--- a/lib/OpenQA/Schema/Result/ProductSettings.pm
+++ b/lib/OpenQA/Schema/Result/ProductSettings.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::ProductSettings;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/Products.pm
+++ b/lib/OpenQA/Schema/Result/Products.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Products;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
+++ b/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
@@ -14,8 +14,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::ScreenshotLinks;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
 use File::Spec::Functions 'catfile';
 use OpenQA::Utils qw(log_debug log_warning);
 use Try::Tiny;

--- a/lib/OpenQA/Schema/Result/Screenshots.pm
+++ b/lib/OpenQA/Schema/Result/Screenshots.pm
@@ -14,8 +14,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::Screenshots;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
 use File::Spec::Functions 'catfile';
 use File::Basename qw(basename dirname);
 use OpenQA::Utils qw(log_debug log_warning);

--- a/lib/OpenQA/Schema/Result/Secrets.pm
+++ b/lib/OpenQA/Schema/Result/Secrets.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Secrets;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
+++ b/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::TestSuiteSettings;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/TestSuites.pm
+++ b/lib/OpenQA/Schema/Result/TestSuites.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::TestSuites;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/Users.pm
+++ b/lib/OpenQA/Schema/Result/Users.pm
@@ -14,8 +14,11 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Schema::Result::Users;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 __PACKAGE__->table('users');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));

--- a/lib/OpenQA/Schema/Result/WorkerProperties.pm
+++ b/lib/OpenQA/Schema/Result/WorkerProperties.pm
@@ -15,8 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::WorkerProperties;
-use base 'DBIx::Class::Core';
+
 use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
 
 use db_helpers;
 

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -16,9 +16,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::Result::Workers;
+
 use strict;
 use warnings;
+
 use base 'DBIx::Class::Core';
+
 use DBIx::Class::Timestamps 'now';
 use Try::Tiny;
 use OpenQA::Utils 'log_error';

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -15,8 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::ResultSet::Assets;
+
 use strict;
+use warnings;
+
 use base 'DBIx::Class::ResultSet';
+
 use DBIx::Class::Timestamps 'now';
 use OpenQA::Utils qw(log_warning locate_asset human_readable_size log_debug);
 use OpenQA::Jobs::Constants;

--- a/lib/OpenQA/Schema/ResultSet/DeveloperSessions.pm
+++ b/lib/OpenQA/Schema/ResultSet/DeveloperSessions.pm
@@ -15,8 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::ResultSet::DeveloperSessions;
+
 use strict;
+use warnings;
+
 use base 'DBIx::Class::ResultSet';
+
 use OpenQA::Schema::Result::DeveloperSessions;
 use OpenQA::IPC;
 

--- a/lib/OpenQA/Schema/ResultSet/JobSettings.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobSettings.pm
@@ -15,7 +15,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::ResultSet::JobSettings;
+
 use strict;
+use warnings;
+
 use base 'DBIx::Class::ResultSet';
 
 =head2 query_for_settings

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -15,8 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::ResultSet::Jobs;
+
 use strict;
+use warnings;
+
 use base 'DBIx::Class::ResultSet';
+
 use DBIx::Class::Timestamps 'now';
 use Date::Format 'time2str';
 use OpenQA::Schema::Result::JobDependencies;

--- a/lib/OpenQA/Schema/ResultSet/Needles.pm
+++ b/lib/OpenQA/Schema/ResultSet/Needles.pm
@@ -15,8 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::Schema::ResultSet::Needles;
+
 use strict;
+use warnings;
+
 use base 'DBIx::Class::ResultSet';
+
 use OpenQA::Schema::Result::Needles;
 use OpenQA::Schema::Result::NeedleDirs;
 use DateTime::Format::Pg;

--- a/lib/OpenQA/Script.pm
+++ b/lib/OpenQA/Script.pm
@@ -13,13 +13,13 @@
 # You should have received a copy of the GNU General Public License
 
 package OpenQA::Script;
+
 use strict;
 use warnings;
 
-require Exporter;
-our (@ISA, @EXPORT);
-@ISA    = qw(Exporter);
-@EXPORT = qw(
+use Exporter 'import';
+
+our @EXPORT = qw(
   clone_job_apply_settings
 );
 

--- a/lib/OpenQA/ServerSideDataTable.pm
+++ b/lib/OpenQA/ServerSideDataTable.pm
@@ -14,7 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::ServerSideDataTable;
+
 use strict;
+use warnings;
 
 sub render_response {
     my (%args) = @_;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -14,11 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Setup;
-use Mojo::Log;
-use Mojo::Home;
-use strict;
-use warnings;
 use Mojo::Base -base;
+
+use Mojo::Home;
+use Mojo::Log;
 use Sys::Hostname;
 use File::Spec::Functions 'catfile';
 use Mojo::File 'path';

--- a/lib/OpenQA/Task/Needle/Scan.pm
+++ b/lib/OpenQA/Task/Needle/Scan.pm
@@ -15,6 +15,7 @@
 
 package OpenQA::Task::Needle::Scan;
 use Mojo::Base 'Mojolicious::Plugin';
+
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Utils;

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -15,8 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::UserAgent;
-
 use Mojo::Base 'Mojo::UserAgent';
+
 use Mojo::Util 'hmac_sha1_sum';
 use Config::IniFiles;
 use Scalar::Util ();

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 
 package OpenQA::Utils;
+
 use strict;
-require 5.002;
+use warnings;
 
 use Carp;
 use IPC::Run();
@@ -31,12 +32,10 @@ use Scalar::Util 'blessed';
 use Data::Dump 'pp';
 use Mojo::Log;
 use Scalar::Util qw(blessed reftype);
+use Exporter 'import';
 
-require Exporter;
-our ($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
-$VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
-@ISA     = qw(Exporter);
-@EXPORT  = qw(
+our $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
+our @EXPORT = qw(
   $prj
   $basedir
   $prjdir
@@ -103,7 +102,7 @@ $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
   set_listen_address
 );
 
-@EXPORT_OK = qw(determine_web_ui_web_socket_url get_ws_status_only_url);
+our @EXPORT_OK = qw(determine_web_ui_web_socket_url get_ws_status_only_url);
 
 if ($0 =~ /\.t$/) {
     # This should result in the 't' directory, even if $0 is in a subdirectory

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -14,10 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI;
-use strict;
+use Mojo::Base 'Mojolicious';
 
 use Mojolicious 7.18;
-use Mojo::Base 'Mojolicious';
 use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
 use OpenQA::IPC;

--- a/lib/OpenQA/WebAPI/AssetPipe.pm
+++ b/lib/OpenQA/WebAPI/AssetPipe.pm
@@ -1,5 +1,6 @@
 package OpenQA::WebAPI::AssetPipe;
 use Mojo::Base "Mojolicious::Plugin::AssetPack::Pipe";
+
 use Mojolicious::Plugin::AssetPack::Util qw(diag DEBUG);
 
 # rewrite links to chosen images - actually something that the

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -14,13 +14,14 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Auth::Fake;
-use OpenQA::Schema::Result::Users;
-use strict;
 
-require Exporter;
-our (@ISA, @EXPORT_OK);
-@ISA       = qw(Exporter);
-@EXPORT_OK = qw(auth_login auth_logout);
+use strict;
+use warnings;
+
+use OpenQA::Schema::Result::Users;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(auth_login auth_logout);
 
 sub auth_logout {
     return;

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -14,16 +14,16 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Auth::OpenID;
-use OpenQA::Schema::Result::Users;
-use strict;
 
+use strict;
+use warnings;
+
+use OpenQA::Schema::Result::Users;
 use LWP::UserAgent;
 use Net::OpenID::Consumer;
+use Exporter 'import';
 
-require Exporter;
-our (@ISA, @EXPORT_OK);
-@ISA       = qw(Exporter);
-@EXPORT_OK = qw(auth_login auth_response);
+our @EXPORT_OK = qw(auth_login auth_response);
 
 sub auth_login {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Auth/iChain.pm
+++ b/lib/OpenQA/WebAPI/Auth/iChain.pm
@@ -14,13 +14,14 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Auth::iChain;
-use OpenQA::Schema::Result::Users;
-use strict;
 
-require Exporter;
-our (@ISA, @EXPORT_OK);
-@ISA       = qw(Exporter);
-@EXPORT_OK = qw(auth_login auth_logout);
+use strict;
+use warnings;
+
+use OpenQA::Schema::Result::Users;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(auth_login auth_logout);
 
 sub auth_logout {
     return;

--- a/lib/OpenQA/WebAPI/Controller/API/V1.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1;
 use Mojo::Base 'Mojolicious::Controller';
+
 use Mojo::Util 'hmac_sha1_sum';
 
 sub auth {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -15,6 +15,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::Asset;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::Utils;
 use OpenQA::IPC;
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
@@ -15,6 +15,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::Bug;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::IPC;
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
@@ -15,6 +15,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::Command;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::Utils;
 use OpenQA::IPC;
 use Try::Tiny;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -14,8 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Controller::API::V1::Comment;
-use Date::Format;
 use Mojo::Base 'Mojolicious::Controller';
+
+use Date::Format;
 use OpenQA::Utils;
 use OpenQA::IPC;
 use OpenQA::Utils 'href_to_bugref';

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Feature.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Feature.pm
@@ -1,6 +1,4 @@
 package OpenQA::WebAPI::Controller::API::V1::Feature;
-use strict;
-use warnings;
 use Mojo::Base 'Mojolicious::Controller';
 
 =pod

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -15,8 +15,8 @@
 
 package OpenQA::WebAPI::Controller::API::V1::Iso;
 use Mojo::Base 'Mojolicious::Controller';
-use File::Basename;
 
+use File::Basename;
 use OpenQA::Utils;
 use OpenQA::IPC;
 use Try::Tiny;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -15,6 +15,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::Job;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::Utils;
 use OpenQA::IPC;
 use OpenQA::Jobs::Constants;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -15,6 +15,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::JobGroup;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::Schema::Result::JobGroups;
 
 =pod

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::Worker;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::IPC;
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
@@ -24,6 +25,7 @@ use DBIx::Class::Timestamps 'now';
 use Try::Tiny;
 use Scalar::Util 'looks_like_number';
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
+
 =pod
 
 =head1 NAME

--- a/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::Admin::Asset;
 use Mojo::Base 'Mojolicious::Controller';
+
 use Mojolicious::Static;
 use Mojo::File;
 

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -15,9 +15,10 @@
 
 
 package OpenQA::WebAPI::Controller::Admin::AuditLog;
+use Mojo::Base 'Mojolicious::Controller';
+
 use 5.018;
-use warnings;
-use parent 'Mojolicious::Controller';
+
 use Time::Piece;
 use Time::Seconds;
 use Time::ParseDate;

--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -1,8 +1,8 @@
 package OpenQA::WebAPI::Controller::Admin::Influxdb;
+use Mojo::Base 'Mojolicious::Controller';
 
 use 5.018;
-use warnings;
-use parent 'Mojolicious::Controller';
+
 use OpenQA::Jobs::Constants;
 
 =over 4

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -15,9 +15,9 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Admin::JobGroup;
-use OpenQA::Utils 'job_groups_and_parents';
-use strict;
 use Mojo::Base 'Mojolicious::Controller';
+
+use OpenQA::Utils 'job_groups_and_parents';
 
 sub index {
     my ($self) = @_;

--- a/lib/OpenQA/WebAPI/Controller/Admin/Machine.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Machine.pm
@@ -15,8 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Admin::Machine;
-use strict;
-use parent 'OpenQA::WebAPI::Controller::Admin::Table';
+use Mojo::Base 'OpenQA::WebAPI::Controller::Admin::Table';
 
 sub index {
     shift->SUPER::admintable('machine');

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::Admin::Needle;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::Utils;
 use OpenQA::ServerSideDataTable;
 use Date::Format 'time2str';

--- a/lib/OpenQA/WebAPI/Controller/Admin/Product.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Product.pm
@@ -15,8 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Admin::Product;
-use parent 'OpenQA::WebAPI::Controller::Admin::Table';
-use strict;
+use Mojo::Base 'OpenQA::WebAPI::Controller::Admin::Table';
 
 sub index {
     shift->SUPER::admintable('product');

--- a/lib/OpenQA/WebAPI/Controller/Admin/TestSuite.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/TestSuite.pm
@@ -15,8 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Admin::TestSuite;
-use parent 'OpenQA::WebAPI::Controller::Admin::Table';
-use strict;
+use Mojo::Base 'OpenQA::WebAPI::Controller::Admin::Table';
 
 sub index {
     shift->SUPER::admintable('test_suite');

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::Admin::Workers;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::Utils;
 use OpenQA::ServerSideDataTable;
 use Scalar::Util 'looks_like_number';

--- a/lib/OpenQA/WebAPI/Controller/ApiKey.pm
+++ b/lib/OpenQA/WebAPI/Controller/ApiKey.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::ApiKey;
 use Mojo::Base 'Mojolicious::Controller';
+
 use DateTime::Format::Pg;
 
 sub index {

--- a/lib/OpenQA/WebAPI/Controller/Developer.pm
+++ b/lib/OpenQA/WebAPI/Controller/Developer.pm
@@ -15,10 +15,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Developer;
-use strict;
+use Mojo::Base 'Mojolicious::Controller';
+
 use Try::Tiny;
 use Mojo::URL;
-use Mojo::Base 'Mojolicious::Controller';
 use OpenQA::Utils 'determine_web_ui_web_socket_url';
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -14,18 +14,15 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Controller::File;
-
-use strict;
-use warnings;
 use Mojo::Base 'Mojolicious::Controller';
+
 BEGIN { $ENV{MAGICK_THREAD_LIMIT} = 1; }
+
 use OpenQA::Utils;
 use File::Basename;
 use File::Spec;
 use File::Spec::Functions 'catfile';
-
 use Data::Dump 'pp';
-
 use Mojolicious::Static;
 
 sub needle {

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -15,10 +15,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::LiveViewHandler;
-use strict;
+use Mojo::Base 'OpenQA::WebAPI::Controller::Developer';
+
 use Try::Tiny;
 use Mojo::URL;
-use Mojo::Base 'OpenQA::WebAPI::Controller::Developer';
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -15,9 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Main;
-use strict;
-use warnings;
 use Mojo::Base 'Mojolicious::Controller';
+
 use Date::Format;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -15,9 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Running;
-use strict;
-use warnings;
 use Mojo::Base 'Mojolicious::Controller';
+
 use Mojo::Util 'b64_encode';
 use Mojo::File 'path';
 use Mojo::JSON qw(encode_json decode_json);

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::Step;
 use Mojo::Base 'Mojolicious::Controller';
+
 use Mojo::File 'path';
 use Mojo::Util 'decode';
 use OpenQA::Utils;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -15,8 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Controller::Test;
-use strict;
 use Mojo::Base 'Mojolicious::Controller';
+
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;

--- a/lib/OpenQA/WebAPI/Description.pm
+++ b/lib/OpenQA/WebAPI/Description.pm
@@ -13,17 +13,17 @@
 # You should have received a copy of the GNU General Public License
 
 package OpenQA::WebAPI::Description;
+
 use strict;
+use warnings;
 
 use OpenQA::Utils 'log_warning';
 use Mojo::File 'path';
 use Pod::POM;
+use Exporter 'import';
 
-require Exporter;
-our ($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
-$VERSION = sprintf "%d.%03d", q$Revision: 0.01 $ =~ /(\d+)/g;
-@ISA     = qw(Exporter);
-@EXPORT  = qw(
+our $VERSION = sprintf "%d.%03d", q$Revision: 0.01 $ =~ /(\d+)/g;
+our @EXPORT = qw(
   get_pod_from_controllers
   set_api_desc
 );

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -14,11 +14,8 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Plugin::AMQP;
+use Mojo::Base 'Mojolicious::Plugin';
 
-use strict;
-use warnings;
-
-use parent 'Mojolicious::Plugin';
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 use Mojo::IOLoop;

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -14,11 +14,8 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Plugin::AuditLog;
+use Mojo::Base 'Mojolicious::Plugin';
 
-use strict;
-use warnings;
-
-use parent 'Mojolicious::Plugin';
 use Mojo::IOLoop;
 use Mojo::JSON 'to_json';
 

--- a/lib/OpenQA/WebAPI/Plugin/CSRF.pm
+++ b/lib/OpenQA/WebAPI/Plugin/CSRF.pm
@@ -15,11 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Plugin::CSRF;
-
-use strict;
-use warnings;
-
-use base 'Mojolicious::Plugin';
+use Mojo::Base 'Mojolicious::Plugin';
 
 use Scalar::Util ();
 use Carp         ();

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -19,11 +19,8 @@
 # fedmsg-logger.
 
 package OpenQA::WebAPI::Plugin::Fedmsg;
+use Mojo::Base 'Mojolicious::Plugin';
 
-use strict;
-use warnings;
-
-use parent 'Mojolicious::Plugin';
 use IPC::Run;
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -16,14 +16,11 @@
 
 # a lot of this is inspired (and even in parts copied) from Minion (Artistic-2.0)
 package OpenQA::WebAPI::Plugin::Gru;
+use Mojo::Base 'Mojolicious::Plugin';
 
-use strict;
-use warnings;
 use Minion;
 use Scalar::Util ();
-
 use DBIx::Class::Timestamps 'now';
-use Mojo::Base 'Mojolicious::Plugin';
 use Mojo::Pg;
 
 has [qw(app dsn)];

--- a/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
+++ b/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
@@ -1,5 +1,4 @@
 package OpenQA::WebAPI::Plugin::HashedParams;
-
 use Mojo::Base 'Mojolicious::Plugin';
 
 our $VERSION = '0.04';

--- a/lib/OpenQA/WebAPI/Plugin/REST.pm
+++ b/lib/OpenQA/WebAPI/Plugin/REST.pm
@@ -15,11 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package OpenQA::WebAPI::Plugin::REST;
-
-use strict;
-use warnings;
-
-use base 'Mojolicious::Plugin';
+use Mojo::Base 'Mojolicious::Plugin';
 
 use Scalar::Util ();
 use Carp         ();

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -14,11 +14,14 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebSockets;
+
+use strict;
+use warnings;
+
 use base 'Net::DBus::Object';
+
 use Net::DBus::Exporter 'org.opensuse.openqa.WebSockets';
 use Mojo::IOLoop;
-use strict;
-
 use OpenQA::IPC;
 use OpenQA::WebSockets::Server ();
 use OpenQA::Utils 'log_debug';

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -27,13 +27,10 @@ use Data::Dump 'pp';
 use db_profiler;
 use OpenQA::Schema::Result::Workers ();
 use OpenQA::Constants qw(WEBSOCKET_API_VERSION WORKERS_CHECKER_THRESHOLD);
+use Exporter 'import';
 
-require Exporter;
-our (@ISA, @EXPORT, @EXPORT_OK);
-
-@ISA       = qw(Exporter);
-@EXPORT    = qw(ws_send ws_send_all ws_send_job);
-@EXPORT_OK = qw(ws_create ws_is_worker_connected);
+our @EXPORT    = qw(ws_send ws_send_all ws_send_job);
+our @EXPORT_OK = qw(ws_create ws_is_worker_connected);
 
 # id->worker mapping
 my $workers;

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -14,18 +14,17 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker;
+
 use 5.018;
+use strict;
 use warnings;
 
 use Mojolicious::Lite;
 use Mojo::Server::Daemon;
 use Mojo::IOLoop;
-
 use File::Spec::Functions 'catdir';
 use Mojo::File 'path';
-
 use Try::Tiny;
-
 use OpenQA::Client;
 use OpenQA::Utils qw(log_error log_info log_debug);
 use OpenQA::Worker::Common;

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -14,6 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache;
+
 use strict;
 use warnings;
 

--- a/lib/OpenQA/Worker/Cache/Client.pm
+++ b/lib/OpenQA/Worker/Cache/Client.pm
@@ -14,15 +14,13 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache::Client;
+use Mojo::Base -base;
 
 use OpenQA::Worker::Cache qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE);
 use OpenQA::Worker::Common;
-
 use OpenQA::Worker::Cache::Request;
 use OpenQA::Worker::Cache::Request::Asset;
 use OpenQA::Worker::Cache::Request::Sync;
-
-use Mojo::Base -base;
 use Mojo::URL;
 use Mojo::File 'path';
 

--- a/lib/OpenQA/Worker/Cache/Request.pm
+++ b/lib/OpenQA/Worker/Cache/Request.pm
@@ -14,9 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache::Request;
+use Mojo::Base -base;
+
 use OpenQA::Worker::Cache::Request::Sync;
 use OpenQA::Worker::Cache::Request::Asset;
-use Mojo::Base -base;
 use Carp 'croak';
 use OpenQA::Worker::Cache::Client;
 

--- a/lib/OpenQA/Worker/Cache/Request/Asset.pm
+++ b/lib/OpenQA/Worker/Cache/Request/Asset.pm
@@ -14,7 +14,6 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache::Request::Asset;
-
 use Mojo::Base 'OpenQA::Worker::Cache::Request';
 
 # See task OpenQA::Cache::Task::Asset

--- a/lib/OpenQA/Worker/Cache/Request/Sync.pm
+++ b/lib/OpenQA/Worker/Cache/Request/Sync.pm
@@ -14,7 +14,6 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache::Request::Sync;
-
 use Mojo::Base 'OpenQA::Worker::Cache::Request';
 
 # See task OpenQA::Cache::Task::Sync

--- a/lib/OpenQA/Worker/Cache/Task.pm
+++ b/lib/OpenQA/Worker/Cache/Task.pm
@@ -14,7 +14,6 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache::Task;
-
 use Mojo::Base 'Mojolicious::Plugin';
 
 has client => sub { OpenQA::Worker::Cache::Client->new };

--- a/lib/OpenQA/Worker/Cache/Task/Asset.pm
+++ b/lib/OpenQA/Worker/Cache/Task/Asset.pm
@@ -14,9 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache::Task::Asset;
-
 use Mojo::Base 'OpenQA::Worker::Cache::Task';
+
 use Mojo::URL;
+
 use constant LOCK_RETRY_DELAY   => 30;
 use constant MINION_LOCK_EXPIRE => 99999;    # ~27 hours
 

--- a/lib/OpenQA/Worker/Cache/Task/Sync.pm
+++ b/lib/OpenQA/Worker/Cache/Task/Sync.pm
@@ -14,9 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache::Task::Sync;
-
 use Mojo::Base 'OpenQA::Worker::Cache::Task';
+
 use Mojo::URL;
+
 use constant LOCK_RETRY_DELAY   => 30;
 use constant MINION_LOCK_EXPIRE => 99999;    # ~27 hours
 

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -14,7 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Commands;
+
 use 5.018;
+use strict;
 use warnings;
 
 use OpenQA::Utils qw(log_error log_warning log_debug add_log_channel remove_log_channel);

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -14,7 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Common;
+
 use 5.018;
+use strict;
 use warnings;
 use feature 'state';
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -14,12 +14,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Engines::isotovideo;
+
 use strict;
 use warnings;
 
 use OpenQA::Worker::Common;
 use OpenQA::Utils qw(locate_asset log_error log_info log_debug log_warning get_channel_handle);
-
 use POSIX qw(:sys_wait_h strftime uname _exit);
 use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -14,7 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Jobs;
+
 use 5.018;
+use strict;
 use warnings;
 use feature 'state';
 
@@ -23,7 +25,6 @@ use OpenQA::Worker::Pool 'clean_pool';
 use OpenQA::Worker::Engines::isotovideo;
 use OpenQA::Utils
   qw(wait_with_progress log_error log_warning log_debug log_info add_log_channel remove_log_channel get_channel_handle);
-
 use POSIX qw(strftime SIGTERM);
 use File::Copy qw(copy move);
 use File::Path 'remove_tree';
@@ -36,10 +37,9 @@ use Mojo::File 'path';
 use Mojo::IOLoop;
 use OpenQA::File;
 use Mojo::IOLoop::ReadWriteProcess;
-
 use POSIX ':sys_wait_h';
+use Exporter 'import';
 
-use base 'Exporter';
 our @EXPORT = qw(start_job stop_job check_job backend_running);
 
 my $worker;

--- a/lib/OpenQA/Worker/Pool.pm
+++ b/lib/OpenQA/Worker/Pool.pm
@@ -14,18 +14,17 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Pool;
+
 use strict;
 use warnings;
 
 use Fcntl;
 use File::Path qw(make_path remove_tree);
-
 use OpenQA::Worker::Common qw($nocleanup $pooldir);
 use OpenQA::Utils 'log_error';
+use Exporter 'import';
 
-use base 'Exporter';
-our (@EXPORT_OK);
-@EXPORT_OK = qw(lockit clean_pool);
+our @EXPORT_OK = qw(lockit clean_pool);
 
 sub lockit() {
     if (!-e $pooldir) {

--- a/lib/db_helpers.pm
+++ b/lib/db_helpers.pm
@@ -15,8 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package db_helpers;
-
 use Mojo::Base 'Exporter';
+
 our @EXPORT_OK = qw(create_auto_timestamps rndstr rndhex rndstrU rndhexU);
 
 use Carp;

--- a/lib/db_profiler.pm
+++ b/lib/db_profiler.pm
@@ -16,6 +16,8 @@
 package db_profiler;
 
 use strict;
+use warnings;
+
 use base 'DBIx::Class::Storage::Statistics';
 
 use Time::HiRes 'time';

--- a/lib/perlcritic/Perl/Critic/Policy/ConsistentQuoteLikeWords.pm
+++ b/lib/perlcritic/Perl/Critic/Policy/ConsistentQuoteLikeWords.pm
@@ -3,8 +3,9 @@ package Perl::Critic::Policy::ConsistentQuoteLikeWords;
 use strict;
 use warnings;
 
-use Perl::Critic::Utils qw( :severities :classification :ppi );
 use base 'Perl::Critic::Policy';
+
+use Perl::Critic::Utils qw( :severities :classification :ppi );
 
 our $VERSION = '0.0.1';
 

--- a/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
+++ b/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
@@ -3,8 +3,9 @@ package Perl::Critic::Policy::HashKeyQuotes;
 use strict;
 use warnings;
 
-use Perl::Critic::Utils qw( :severities :classification :ppi );
 use base 'Perl::Critic::Policy';
+
+use Perl::Critic::Utils qw( :severities :classification :ppi );
 
 our $VERSION = '0.0.1';
 


### PR DESCRIPTION
There were many modules that did not have `warnings` activated. `strict` and `warnings` (or a module that activates both like `Mojo::Base`) should really be the first thing in every module.

Progress: https://progress.opensuse.org/issues/44435.