### PR TITLE
developer mode: versioning, pause on check_screen timeout

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -341,7 +341,7 @@ var developerMode = {
     // state of the test execution (comes from os-autoinst cmd srv through the openQA ws proxy)
     currentModule: undefined,               // name of the current module, eg. "installation-welcome"
     moduleToPauseAt: undefined,             // name of the module to pause at, eg. "installation-welcome"
-    pauseOnScreenMismatch: undefined,       // 'assert_screen' (to pause on assert_screen) or 'check_screen' (to pause on assert/check_screen)
+    pauseOnScreenMismatch: undefined,       // 'assert_screen' (to pause on assert_screen timeout) or 'check_screen' (to pause on assert/check_screen timeout)
     isPaused: undefined,                    // if paused the reason why as a string; otherwise something which evaluates to false
     currentApiFunction: undefined,          // the currently executed API function (eg. assert_screen)
     outstandingImagesToUpload: undefined,   // number of images which still need to be uploaded by the worker

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -902,8 +902,7 @@ function processWsCommand(obj) {
         }
 
         console.log("Error from ws proxy: " + what);
-        addLivehandlerFlash('danger', 'ws_proxy_error-' + what,
-                            '<strong>Error from livehandler daemon:</strong><p>' + what + '</p>');
+        addLivehandlerFlash('danger', 'ws_proxy_error-' + what, '<p>' + what + '</p>');
         break;
     case "info":
         // map info message to internal status variables

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -38,7 +38,14 @@ use constant ALLOWED_OS_AUTOINST_COMMANDS => {
 };
 
 # define error categories
-use constant {ERROR_CATEGORY_CMDSRV_CONNECTION => 'cmdsrv-connection',};
+use constant {
+    ERROR_CATEGORY_CMDSRV_CONNECTION => 'cmdsrv-connection',
+    ERROR_CATEGORY_BAD_CONFIGURATION => 'bad-configuration',
+};
+
+# define required major version and minimum minor version for os-autoinst command server's developer mode API
+use constant OS_AUTOINST_DEVEL_MODE_MAJOR_VERSION => 1;
+use constant OS_AUTOINST_DEVEL_MODE_MINOR_VERSION => 0;
 
 has(
     developer_sessions => sub {
@@ -176,6 +183,17 @@ sub quit_development_session {
     }
 }
 
+# checks whether the os-autoinst developer mode version reported by the specified status info it compatible
+sub check_os_autoinst_devel_mode_version {
+    my ($self, $status_info) = @_;
+
+    my $major_version = $status_info->{devel_mode_major_version} //= 0;
+    my $minor_version = $status_info->{devel_mode_minor_version} //= 0;
+    return 0 if ($major_version ne OS_AUTOINST_DEVEL_MODE_MAJOR_VERSION);
+    return 0 if ($minor_version lt OS_AUTOINST_DEVEL_MODE_MINOR_VERSION);
+    return 1;
+}
+
 # handles a message from the java script web socket connection (not status-only)
 #  * expecting valid JSON here in 'os-autoinst' compatible form, eg.
 #      {"cmd":"set_pause_at_test","name":"installation-welcome"}
@@ -231,7 +249,7 @@ sub handle_message_from_java_script {
     $self->send_message_to_os_autoinst($job_id, $json);
 }
 
-# attachs new needles to the resume command before passing it to the command server (called in handle_message_from_java_script)
+# attaches new needles to the resume command before passing it to the command server (called in handle_message_from_java_script)
 sub _handle_command_resume_test_execution {
     my ($self, $job_id, $json) = @_;
 
@@ -301,10 +319,23 @@ sub add_further_info_to_hash {
     }
 }
 
-# broadcasts a message from os-autoinst to js clients; adds the session info if the message is the status hash
+# broadcasts a message from os-autoinst to js clients; checks the version and adds the session info if the message is the status hash
 sub handle_message_from_os_autoinst {
     my ($self, $job_id, $json) = @_;
-    $self->add_further_info_to_hash($job_id, $json) if ($json->{running});
+
+    my $is_status_message = defined($json->{running});
+    if ($is_status_message) {
+        if (!$self->check_os_autoinst_devel_mode_version($json)) {
+            my $actual_version_str = "$json->{devel_mode_major_version}.$json->{devel_mode_minor_version}";
+            my $required_version_str
+              = OS_AUTOINST_DEVEL_MODE_MAJOR_VERSION . '.' . OS_AUTOINST_DEVEL_MODE_MINOR_VERSION;
+            my $disconnect_reason
+              = "os-autoinst version \"$actual_version_str\" is incompatible, version \"$required_version_str\" is required";
+            $self->disconnect_from_os_autoinst($job_id, $disconnect_reason);
+            return;
+        }
+        $self->add_further_info_to_hash($job_id, $json);
+    }
     $self->send_message_to_java_script_clients($job_id, info => 'cmdsrvmsg', $json);
 }
 
@@ -400,6 +431,35 @@ sub send_message_to_os_autoinst {
         return;
     }
     $cmd_srv_tx->send({json => $msg});
+}
+
+# disconnects explicitely from os-autoinst command server, supressing the usual handling when disconnecting from
+# os-autoinst
+# note: This connection is actually not supposed to be cancelled from the liveviewhandler's side. The only exception
+#       is when a bad configuration (such as an incompatible version) is detected.
+sub disconnect_from_os_autoinst {
+    my ($self, $job_id, $reason, $status_code) = @_;
+
+    # find relevant transaction and skip if there nothing to do if already disconnected
+    my $cmd_srv_tx = $self->cmd_srv_transactions_by_job->{$job_id};
+    return unless ($cmd_srv_tx);
+
+    # assume disconnecting due to an error by default
+    $status_code //= 1011;
+
+    # prevent the usual handling when disconnecting from os-autoinst
+    $self->cmd_srv_transactions_by_job->{$job_id} = undef;
+
+    $cmd_srv_tx->finish($status_code);
+
+    # inform the JavaScript clients and disconnect from them as well
+    $self->send_message_to_java_script_clients_and_finish(
+        $job_id,
+        error => $reason,
+        {
+            code     => $status_code,
+            category => ERROR_CATEGORY_BAD_CONFIGURATION,
+        });
 }
 
 # sends information about the developer session to all JavaScript clients

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -30,11 +30,11 @@ use Mojo::JSON 'decode_json';
 
 # define a whitelist of commands to be passed to os-autoinst via ws_proxy
 use constant ALLOWED_OS_AUTOINST_COMMANDS => {
-    set_pause_at_test                  => 1,
-    set_pause_on_assert_screen_timeout => 1,
-    set_assert_screen_timeout          => 1,
-    status                             => 1,
-    resume_test_execution              => 1,
+    set_pause_at_test            => 1,
+    set_pause_on_screen_mismatch => 1,
+    set_assert_screen_timeout    => 1,
+    status                       => 1,
+    resume_test_execution        => 1,
 };
 
 # define error categories

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -508,8 +508,8 @@ subtest 'test cancelled by quitting the session' => sub {
     $driver->get($job_page_url);
     OpenQA::Test::FullstackUtils::wait_for_result_panel(
         $driver,
-        qr/Result: user_cancelled/,
-        'test 1 has been cancelled'
+        qr/Result: (user_cancelled|passed)/,
+        'test 1 has been cancelled (if it was fast enough to actually pass that is ok, too)'
     );
     ok(-s path($resultdir, '00000', "00000001-$job_name")->make_path->child('autoinst-log.txt'), 'log file generated');
 };

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -248,12 +248,12 @@ subtest 'pause at assert_screen timeout' => sub {
 
     # send command to pause on assert_screen timeout
     my $command_input = $driver->find_element('#msg');
-    $command_input->send_keys('{"cmd":"set_pause_on_assert_screen_timeout","flag":true}');
+    $command_input->send_keys('{"cmd":"set_pause_on_screen_mismatch","pause_on":"assert_screen"}');
     $command_input->send_keys(Selenium::Remote::WDKeys->KEYS->{'enter'});
     OpenQA::Test::FullstackUtils::wait_for_developer_console_contains_log_message(
         $driver,
-        qr/\"set_pause_on_assert_screen_timeout\":true/,
-        'response to set_pause_on_assert_screen_timeout'
+        qr/\"set_pause_on_screen_mismatch\":\"assert_screen\"/,
+        'response to set_pause_on_screen_mismatch'
     );
 
     # skip timeout
@@ -384,7 +384,7 @@ subtest 'developer session visible in live view' => sub {
 
     my @module_options = $driver->find_elements('#developer-pause-at-module option');
     my @module_names   = map { $_->get_text() } @module_options;
-    is_deeply(\@module_names, ['Do not pause', 'boot', 'shutdown',], 'module');
+    is_deeply(\@module_names, ['Do not pause at a certain module', 'boot', 'shutdown'], 'module');
 };
 
 subtest 'status-only route accessible for other users' => sub {

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -141,7 +141,7 @@ my %no_developer = (
 
 subtest 'version check' => sub {
     my $live_view_handler = OpenQA::WebAPI::Controller::LiveViewHandler->new();
-    my %status_info = (running => 'installation-welcome');
+    my %status_info       = (running => 'installation-welcome');
 
     is($live_view_handler->check_os_autoinst_devel_mode_version(\%status_info), 0, 'no version at all not accepted');
 

--- a/t/lib/OpenQA/Test/FakeWebSocketTransaction.pm
+++ b/t/lib/OpenQA/Test/FakeWebSocketTransaction.pm
@@ -16,6 +16,8 @@
 package OpenQA::Test::FakeWebSocketTransaction;
 use Mojo::Base 'Mojo::EventEmitter';
 
+use Test::More;
+
 has finish_called => 0;
 has sent_messages => sub { return []; };
 

--- a/templates/test/live.html.ep
+++ b/templates/test/live.html.ep
@@ -85,19 +85,23 @@
                 </div>
                 <div class="col-sm-5">
                     <label for="developer-pause-on-timeout" class="col-form-label">
-                        Pause on <code>assert_screen</code> timeout
+                        Pause on screen mismatch
                     </label>
                     <%= help_popover('Help for <i>pause test execution</i>' => '
                         <p>
-                            Pauses the test execution on the next <code>assert_screen</code> timeout.
-                            The SUT/VM itself is not paused.
+                            Pauses the test execution on the next <code>assert_screen</code> or <code>check_screen</code>
+                            timeout. The SUT/VM itself is not paused.
                         </p>
                         <p>On resume, the needles will be reloaded and the assertion is tried again.</p>
                         <p>A paused job still has the <code>MAX_JOB_TIME</code> constraint to be applied.</p>')
                     %>
                 </div>
                 <div class="col-sm-7">
-                    <input type="checkbox" id="developer-pause-on-timeout">
+                    <select class="custom-select" id="developer-pause-on-mismatch">
+                        <option value="fail" selected style="font-style: italic;">Fail on mismatch as usual</option>
+                        <option value="assert_screen"><code>assert_screen</code> timeout</option>
+                        <option value="check_screen"><code>assert_screen</code> and <code>check_screen</code> timeout</option>
+                    </select>
                 </div>
             </div>
             <hr>

--- a/templates/test/live.html.ep
+++ b/templates/test/live.html.ep
@@ -11,10 +11,10 @@
                 <strong>Developer mode</strong>
             </div>
             <div class="col-sm-5">
-                <span class="developer-mode-element" data-hidden-on="isConnected">
+                <span class="developer-mode-element" data-visible-on="isConnecting">
                 retrieving status <i class="fas fa-spinner fa-spin fa-lg"></i>
                 </span>
-                <span class="developer-mode-element" id="developer-status-info" data-visible-on="isConnected">
+                <span class="developer-mode-element" id="developer-status-info" data-hidden-on="isConnecting">
                     unknown status
                 </span>
             </div>
@@ -143,8 +143,16 @@
         <div class="developer-mode-element" data-visible-on="lockedByOtherDeveloper">
             Another user has already locked this job.
         </div>
-        <div class="developer-mode-element" data-hidden-on="isConnected">
+        <div class="developer-mode-element" data-visible-on="isConnecting">
             <i class="fas fa-spinner fa-spin fa-lg"></i> <span id="developer-loading-info">establishing connection to backend ...</span>
+            <p>
+                See <a href="http://open.qa/docs/#_steps_to_debug_developer_mode_setup" target="blank">steps to debug developer mode setup</a> if the the connection can
+                not be established in reasonable time.
+            </p>
+        </div>
+        <div id="developer-config-issue-note" class="developer-mode-element" data-visible-on="badConfiguration">
+            The developer mode is not available because of a configuration isse.
+            See <a href="http://open.qa/docs/#_steps_to_debug_developer_mode_setup" target="blank">steps to debug developer mode setup</a>.
         </div>
     </div>
 </div>

--- a/templates/test/module_select.html.ep
+++ b/templates/test/module_select.html.ep
@@ -1,5 +1,5 @@
 <select class="custom-select" name="pause-at-module" id="developer-pause-at-module">
-    <option selected style="font-style: italic;">Do not pause</option>
+    <option selected style="font-style: italic;">Do not pause at a certain module</option>
     % my $in_optgroup = 0;
     % for my $module (@$modlist) {
         % my $category = $module->{category};


### PR DESCRIPTION
os-autoinst already has (almost) the code to pause on `check_screen` timeouts so I thought making this accessible via the web UI would make sense.

This is still WIP and would look like this:

![screenshot_20181129_152114](https://user-images.githubusercontent.com/10248953/49227871-69ef7e00-f3ea-11e8-927c-370922631789.png)

There's no ticket requesting this feature (and defining how it is supposed to look like) so some feedback would be nice.

Another improvement I could do (when I'm already over it) is a "Pause after current command" checkbox. I suppose this feature (combined with "Skip current assert/check_screen timeout") was present in the previous interactive mode as well.