### PR TITLE
Make all modules pass Perl::Critic::Freenode with severity level 4

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -194,21 +194,21 @@ sub compute_build_results {
 
     my $max_jobs = 0;
     my $buildnr  = 0;
-    for my $b (@builds) {
+    for my $build (@builds) {
         last if defined($limit) && (--$limit < 0);
 
         my $jobs = $jobs_resultset->search(
             {
-                VERSION  => $b->VERSION,
-                BUILD    => $b->BUILD,
+                VERSION  => $build->VERSION,
+                BUILD    => $build->BUILD,
                 group_id => {in => $group_ids},
                 clone_id => undef,
             },
             {order_by => 'me.id DESC'});
         my %jr = (
-            key     => $b->{key},
-            build   => $b->BUILD,
-            version => $b->VERSION,
+            key     => $build->{key},
+            build   => $build->BUILD,
+            version => $build->VERSION,
             oldest  => DateTime->now
         );
         init_job_figures(\%jr);

--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -117,22 +117,22 @@ sub _manage_watch_on {
     my ($self, $reactor, $watch) = @_;
     my $flags = $watch->get_flags;
 
-    if ($flags & &Net::DBus::Binding::Watch::READABLE) {
+    if ($flags & Net::DBus::Binding::Watch::READABLE()) {
         my $fh = $self->_get_fh_from_fd($watch->get_fileno);
         my $cb = Net::DBus::Callback->new(
             object => $watch,
             method => "handle",
-            args   => [&Net::DBus::Binding::Watch::READABLE]);
+            args   => [Net::DBus::Binding::Watch::READABLE()]);
         # Net::DBus calls dispatch each time some event wakes it up, Mojo::Reactor does not support this kind of hooks
         $reactor->io($fh => sub { my ($self, $writable) = @_; $cb->invoke; $self->emit('dbus-dispatch') });
         $reactor->watch($fh, $watch->is_enabled, 0);
     }
-    if ($flags & &Net::DBus::Binding::Watch::WRITABLE) {
+    if ($flags & Net::DBus::Binding::Watch::WRITABLE()) {
         my $fh = $self->_get_fh_from_fd($watch->get_fileno, 1);
         my $cb = Net::DBus::Callback->new(
             object => $watch,
             method => "handle",
-            args   => [&Net::DBus::Binding::Watch::WRITABLE]);
+            args   => [Net::DBus::Binding::Watch::WRITABLE()]);
        # Net::DBus calls flush event each time some event wakes it up, Mojo::Reactor does not support this kind of hooks
         $reactor->io($fh => sub { my ($self, $writable) = @_; $cb->invoke; $self->emit('dbus-flush') });
         $reactor->watch($fh, 0, $watch->is_enabled);
@@ -144,12 +144,12 @@ sub _manage_watch_off {
     my $flags = $watch->get_flags;
     my ($fh, $rw);
 
-    if ($flags & &Net::DBus::Binding::Watch::READABLE) {
+    if ($flags & Net::DBus::Binding::Watch::READABLE()) {
         $fh = $self->_get_fh_from_fd($watch->get_fileno);
         $rw = '<';
         $reactor->remove($fh);
     }
-    if ($flags & &Net::DBus::Binding::Watch::WRITABLE) {
+    if ($flags & Net::DBus::Binding::Watch::WRITABLE()) {
         $fh = $self->_get_fh_from_fd($watch->get_fileno, 1);
         $rw = '>';
         $reactor->remove($fh);
@@ -162,13 +162,13 @@ sub _manage_watch_toggle {
     my ($self, $reactor, $watch) = @_;
     my $flags = $watch->get_flags;
 
-    if ($flags & &Net::DBus::Binding::Watch::READABLE) {
+    if ($flags & Net::DBus::Binding::Watch::READABLE()) {
         my $fh = $self->{handles}{'<'}{$watch->get_fileno};
         if (defined $fh) {
             $reactor->watch($fh, $watch->is_enabled, 0);
         }
     }
-    if ($flags & &Net::DBus::Binding::Watch::WRITABLE) {
+    if ($flags & Net::DBus::Binding::Watch::WRITABLE()) {
         my $fh = $self->{handles}{'>'}{$watch->get_fileno};
         if (defined $fh) {
             $reactor->watch($fh, 0, $watch->is_enabled);

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -174,7 +174,7 @@ sub update_scheduled_jobs {
         if (!$info->{cluster_jobs}) {
             $info->{cluster_jobs} = $job->cluster_jobs;
             # it's the same cluster for all, so share
-            for my $j (%{$info->{cluster_jobs}}) {
+            for my $j (keys %{$info->{cluster_jobs}}) {
                 $cluster_infos{$j} = $info->{cluster_jobs};
             }
         }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -548,13 +548,13 @@ sub to_hash {
     $j->{test} = $job->TEST;
     if ($args{assets}) {
         if (defined $job->{_assets}) {
-            for my $a (@{$job->{_assets}}) {
-                push @{$j->{assets}->{$a->type}}, $a->name;
+            for my $asset (@{$job->{_assets}}) {
+                push @{$j->{assets}->{$asset->type}}, $asset->name;
             }
         }
         else {
-            for my $a ($job->jobs_assets->all()) {
-                push @{$j->{assets}->{$a->asset->type}}, $a->asset->name;
+            for my $asset ($job->jobs_assets->all()) {
+                push @{$j->{assets}->{$asset->asset->type}}, $asset->asset->name;
             }
         }
     }

--- a/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
+++ b/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
@@ -49,10 +49,10 @@ sub _list_images_subdir {
         return;
     }
     my @ret;
-    while (readdir $dh) {
-        my $fn = catfile($subdir, $_);
+    for my $file (readdir $dh) {
+        my $fn = catfile($subdir, $file);
         if (-f $fn) {
-            push(@ret, catfile($prefix, $dir, $_));
+            push(@ret, catfile($prefix, $dir, $file));
         }
     }
     closedir($dh);
@@ -73,9 +73,9 @@ sub scan_images {
     my @files;
     my $now = DateTime->now;
     push(@files, [qw(filename t_created)]);
-    while (readdir $dh) {
-        if ($_ !~ /^\./ && -d "$prefixdir/$_") {
-            push(@files, map { [$_, $now] } @{_list_images_subdir($app, $args->{prefix}, $_)});
+    for my $file (readdir $dh) {
+        if ($file !~ /^\./ && -d "$prefixdir/$file") {
+            push(@files, map { [$_, $now] } @{_list_images_subdir($app, $args->{prefix}, $file)});
         }
     }
     closedir($dh);

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -74,16 +74,16 @@ sub scan_for_untracked_assets {
         next unless opendir($dh, $OpenQA::Utils::assetdir . "/$type");
         my %assets;
         my @paths;
-        while (readdir($dh)) {
-            unless ($_ eq 'fixed' or $_ eq '.' or $_ eq '..') {
-                push(@paths, "$OpenQA::Utils::assetdir/$type/$_");
+        for my $file (readdir($dh)) {
+            unless ($file eq 'fixed' or $file eq '.' or $file eq '..') {
+                push(@paths, "$OpenQA::Utils::assetdir/$type/$file");
             }
         }
         closedir($dh);
         if (opendir($dh, $OpenQA::Utils::assetdir . "/$type" . "/fixed")) {
-            while (readdir($dh)) {
-                unless ($_ eq 'fixed' or $_ eq '.' or $_ eq '..') {
-                    push(@paths, "$OpenQA::Utils::assetdir/$type/fixed/$_");
+            for my $file (readdir($dh)) {
+                unless ($file eq 'fixed' or $file eq '.' or $file eq '..') {
+                    push(@paths, "$OpenQA::Utils::assetdir/$type/fixed/$file");
                 }
             }
             closedir($dh);

--- a/lib/OpenQA/Task/Job/Modules.pm
+++ b/lib/OpenQA/Task/Job/Modules.pm
@@ -41,10 +41,10 @@ sub _migrate_images {
       unless opendir($dh, $prefixdir);
 
     OpenQA::Utils::log_debug "moving files in $prefixdir";
-    while (readdir $dh) {
+    for my $file (readdir $dh) {
         # only rename .pngs not symlinked
-        if (-f "$prefixdir/$_" && !-l "$prefixdir/$_" && m/^(.*)\.png/) {
-            my $old = $_;
+        if (-f "$prefixdir/$file" && !-l "$prefixdir/$file" && $file =~ m/^(.*)\.png/) {
+            my $old = $file;
             my $md5 = $args->{prefix} . $1;
             my ($img, $thumb) = OpenQA::Utils::image_md5_filename($md5);
 
@@ -71,10 +71,10 @@ sub _relink_dir {
         return;
     }
     OpenQA::Utils::log_debug "relinking images in $dir";
-    while (readdir $dh) {
+    for my $file (readdir $dh) {
         # only relink symlinked .pngs
-        if (-l "$dir/$_" && m/^(.*)\.png/) {
-            my $old     = "$dir/$_";
+        if (-l "$dir/$file" && $file =~ m/^(.*)\.png/) {
+            my $old     = "$dir/$file";
             my $md5path = abs_path($old);
             # skip stale symlinks
             next unless $md5path;
@@ -115,9 +115,9 @@ sub _rm_compat_symlinks {
     my ($app, $args) = @_;
 
     opendir(my $dh, $OpenQA::Utils::imagesdir) || die "Can't open /images: $!";
-    while (readdir $dh) {
-        if (m/^([^.].)$/) {
-            remove_tree("$OpenQA::Utils::imagesdir/$_");
+    for my $file (readdir $dh) {
+        if ($file =~ m/^([^.].)$/) {
+            remove_tree("$OpenQA::Utils::imagesdir/$file");
         }
     }
     closedir $dh;

--- a/lib/OpenQA/Task/Screenshot/Scan.pm
+++ b/lib/OpenQA/Task/Screenshot/Scan.pm
@@ -38,10 +38,10 @@ sub _list_images_subdir {
     log_fatal "Can't open $subdir: $!" unless opendir($dh, $subdir);
 
     my @ret;
-    while (readdir $dh) {
-        my $fn = catfile($subdir, $_);
+    for my $file (readdir $dh) {
+        my $fn = catfile($subdir, $file);
         if ($fn =~ /.png$/ && -f $fn) {
-            push(@ret, catfile($prefix, $dir, $_));
+            push(@ret, catfile($prefix, $dir, $file));
         }
     }
     closedir($dh);
@@ -60,9 +60,9 @@ sub _scan_images {
 
     my @files;
     my $now = DateTime->now;
-    while (readdir $dh) {
-        if ($_ !~ /^\./ && -d "$prefixdir/$_") {
-            push(@files, map { [$_, $now] } @{_list_images_subdir($app, $args->{prefix}, $_)});
+    for my $file (readdir $dh) {
+        if ($file !~ /^\./ && -d "$prefixdir/$file") {
+            push(@files, map { [$_, $now] } @{_list_images_subdir($app, $args->{prefix}, $file)});
         }
     }
     closedir($dh);
@@ -112,8 +112,8 @@ sub _scan_images_links {
             next;
         }
         my @imgs;
-        while (readdir $dh) {
-            my $fn = catfile($rd, $_);
+        for my $file (readdir $dh) {
+            my $fn = catfile($rd, $file);
             if ($fn =~ /\.png$/ && -l $fn) {
                 my $lt = readlink($fn);
                 $lt =~ s,.*/images/,,;

--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -295,24 +295,24 @@ sub _get_capabilities {
     }
     else {
         open(my $LSCPU, "-|", "LC_ALL=C lscpu");
-        while (<$LSCPU>) {
-            chomp;
-            if (m/Model name:\s+(.+)$/) {
+        for my $line (<$LSCPU>) {
+            chomp $line;
+            if ($line =~ m/Model name:\s+(.+)$/) {
                 $caps->{cpu_modelname} = $1;
             }
-            if (m/Architecture:\s+(.+)$/) {
+            if ($line =~ m/Architecture:\s+(.+)$/) {
                 $caps->{cpu_arch} = $1;
             }
-            if (m/CPU op-mode\(s\):\s+(.+)$/) {
+            if ($line =~ m/CPU op-mode\(s\):\s+(.+)$/) {
                 $caps->{cpu_opmode} = $1;
             }
         }
         close($LSCPU);
     }
     open(my $MEMINFO, "<", "/proc/meminfo");
-    while (<$MEMINFO>) {
-        chomp;
-        if (m/MemTotal:\s+(\d+).+kB/) {
+    for my $line (<$MEMINFO>) {
+        chomp $line;
+        if ($line =~ m/MemTotal:\s+(\d+).+kB/) {
             my $mem_max = $1 ? $1 : '';
             $caps->{mem_max} = int($mem_max / 1024) if $mem_max;
         }

--- a/lib/db_helpers.pm
+++ b/lib/db_helpers.pm
@@ -35,10 +35,10 @@ sub rndhex {
 
 sub _rb {
     my ($fd, $max) = @_;
-    my $b;
+    my $byte;
     # uncoverable branch true
-    read($fd, $b, 1) || croak "can't read random byte: $!";
-    return int($max * ord($b) / 256.0);
+    read($fd, $byte, 1) || croak "can't read random byte: $!";
+    return int($max * ord($byte) / 256.0);
 }
 
 sub rndstrU {

--- a/lib/db_profiler.pm
+++ b/lib/db_profiler.pm
@@ -49,7 +49,7 @@ sub query_end {
 sub enable_sql_debugging {
     my ($app) = @_;
     my $storage = $app->schema->storage;
-    $storage->debugobj(new db_profiler());
+    $storage->debugobj(db_profiler->new);
     $storage->debugfh(MojoDebugHandle->new($app->log));
     $storage->debug(1);
 }


### PR DESCRIPTION
Running `perlcritic --theme freenode --stern lib` against openQA showed some interesting potential bugs. Using the varibles `$a`/`$b` outside of their intended purpose, or doing `for my $item (%hash) {` would have most defnitely resulted in unintended side effects (maybe already have). Similarly the use of implicit `$_` is fine for one-liners, but has no place in real applications.

If there are no objections i would like to propose that we try to follow the rules from [Perl::Critic::Freenode](https://metacpan.org/pod/Perl::Critic::Freenode) in the future for openQA. (I have made no changes in that regard yet, and will be waiting for feedback first) There are still quite [a few rules that openQA breaks](https://gist.github.com/kraih/09ebe5083b52eb62a5e17c4f520ae748), but they are all low severity.  I do think all of them make sense and would result in more maintainable code.