### PR TITLE
Use Perl::Critic::Freenode to determine good coding style

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,10 +1,12 @@
+theme = freenode
+severity = 4
+
+# TODO: Remove once Perl::Critic::Freenode 0.028 is widely available
+[Freenode::DiscouragedModules]
+severity = 3
+
 [Perl::Critic::Policy::HashKeyQuotes]
 severity = 5
 
 [Perl::Critic::Policy::ConsistentQuoteLikeWords]
 severity = 5
-
-# this policy is considered harmful by the wider perl community
-[-Perl::Critic::Policy::Subroutines::ProhibitExplicitReturnUndef]
-
-[-Subroutines::ProhibitSubroutinePrototypes]

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ install:
 .PHONY: checkstyle
 checkstyle:
 ifneq ($(CHECKSTYLE),0)
-	PERL5LIB=lib/perlcritic:$$PERL5LIB perlcritic --gentle lib
+	PERL5LIB=lib/perlcritic:$$PERL5LIB perlcritic lib
 endif
 
 .PHONY: test

--- a/cpanfile
+++ b/cpanfile
@@ -40,7 +40,6 @@ requires 'IPC::Run';
 requires 'Cpanel::JSON::XS';
 requires 'JavaScript::Minifier::XS', '>= 0.11';
 requires 'LWP::UserAgent';
-requires 'List::MoreUtils';
 requires 'Minion', '9.0';
 requires 'Minion::Backend::Pg';
 requires 'Minion::Backend::SQLite';
@@ -96,6 +95,7 @@ requires 'POSIX';
 
 on 'test' => sub {
   requires 'Perl::Critic';
+  requires 'Perl::Critic::Freenode';
   requires 'Perl::Tidy', '>= 20180101, != 20180219';
   requires 'Selenium::Remote::Driver', '>= 1.23';
   requires 'Selenium::Remote::WDKeys';

--- a/dbicdh/_common/upgrade/36-37/02-convert_audit_toJSON.pl
+++ b/dbicdh/_common/upgrade/36-37/02-convert_audit_toJSON.pl
@@ -17,7 +17,8 @@ use strict;
 use warnings;
 use OpenQA::Schema;
 use Safe;
-use JSON ();
+use Mojo::JSON;    # booleans
+use Cpanel::JSON::XS ();
 
 sub {
     my $schema = shift;
@@ -30,7 +31,7 @@ sub {
     $cpt->permit_only(':base_core', ':base_mem', ':base_orig');
 
     # allow nonref to allow encoding of scalars
-    my $json = JSON->new();
+    my $json = Cpanel::JSON::XS->new();
     $json->allow_nonref(1);
 
     while (my $event = $event_data->next) {

--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -21,7 +21,7 @@ use Mojo::Exception;
 use Mojo::File 'path';
 use Mojo::URL;
 use Carp 'croak';
-use JSON;
+use Mojo::JSON 'encode_json';
 use Data::Dump;
 
 my $job;

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -28,7 +28,7 @@ use OpenQA::Utils 'log_error';
 use OpenQA::IPC;
 use db_helpers;
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
-use JSON qw(encode_json decode_json);
+use Mojo::JSON qw(encode_json decode_json);
 
 use constant COMMANDS =>
   qw(quit abort scheduler_abort cancel obsolete livelog_stop livelog_start developer_session_start);

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -22,8 +22,7 @@ use Mojo::URL;
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
-use List::MoreUtils;
-use JSON 'decode_json';
+use Mojo::JSON 'decode_json';
 
 # notes: * routes in this package are served by LiveViewHandler rather than the regular WebAPI server
 #        * using prefork is currently not possible (see notes in send_message_to_java_script_clients and
@@ -427,8 +426,7 @@ sub remove_java_script_transaction {
     my ($self, $job_id, $container, $transaction) = @_;
 
     my $transactions = $container->{$job_id} or return;
-    my $transaction_index = List::MoreUtils::first_index { $_ == $transaction } @$transactions;
-    splice(@$transactions, $transaction_index, 1) if ($transaction_index >= 0);
+    @$transactions = map { $_ == $transaction ? () : $_ } @$transactions;
 }
 
 # note: functions above are just helper, the methods which are actually registered routes start here

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -24,7 +24,6 @@ use Mojo::UserAgent;
 use OpenQA::Utils
   qw(log_error log_info log_debug get_channel_handle add_log_channel append_channel_to_defaults remove_channel_from_defaults);
 use OpenQA::Worker::Common;
-use List::MoreUtils;
 use Mojo::SQLite;
 use Mojo::File 'path';
 use Mojo::Base -base;

--- a/openQA.spec
+++ b/openQA.spec
@@ -34,7 +34,7 @@
 %bcond_with tests
 %endif
 # runtime requirements that also the testsuite needs
-%define t_requires perl(DBD::Pg) perl(DBIx::Class) perl(Config::IniFiles) perl(SQL::Translator) perl(Date::Format) perl(File::Copy::Recursive) perl(DateTime::Format::Pg) perl(Net::OpenID::Consumer) perl(Mojolicious::Plugin::RenderFile) perl(Mojolicious::Plugin::AssetPack) perl(aliased) perl(Config::Tiny) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(IO::Socket::SSL) perl(Data::Dump) perl(DBIx::Class::OptimisticLocking) perl(Text::Markdown) perl(Net::DBus) perl(IPC::Run) perl(Archive::Extract) perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS) perl(Time::ParseDate) perl(Sort::Versions) perl(Mojo::RabbitMQ::Client) perl(BSD::Resource) perl(Cpanel::JSON::XS) perl(Pod::POM) perl(Mojo::IOLoop::ReadWriteProcess) perl(Minion) perl(Mojo::Pg) perl(Mojo::SQLite) perl(Minion::Backend::SQLite)
+%define t_requires perl(DBD::Pg) perl(DBIx::Class) perl(Config::IniFiles) perl(SQL::Translator) perl(Date::Format) perl(File::Copy::Recursive) perl(DateTime::Format::Pg) perl(Net::OpenID::Consumer) perl(Mojolicious::Plugin::RenderFile) perl(Mojolicious::Plugin::AssetPack) perl(aliased) perl(Config::Tiny) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(IO::Socket::SSL) perl(Data::Dump) perl(DBIx::Class::OptimisticLocking) perl(Text::Markdown) perl(Net::DBus) perl(IPC::Run) perl(Archive::Extract) perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS) perl(Time::ParseDate) perl(Sort::Versions) perl(Mojo::RabbitMQ::Client) perl(BSD::Resource) perl(Cpanel::JSON::XS) perl(Pod::POM) perl(Mojo::IOLoop::ReadWriteProcess) perl(Minion) perl(Mojo::Pg) perl(Mojo::SQLite) perl(Minion::Backend::SQLite) perl(Perl::Critic::Freenode)
 Name:           openQA
 Version:        4.6
 Release:        0
@@ -172,7 +172,6 @@ Requires:       perl(Cpanel::JSON::XS)
 Requires:       perl(Data::Dump)
 Requires:       perl(Getopt::Long)
 Requires:       perl(IO::Socket::SSL) >= 2.009
-Requires:       perl(JSON)
 Requires:       perl(LWP::UserAgent)
 Requires:       perl(Mojolicious)
 Requires:       perl(Try::Tiny)

--- a/script/client
+++ b/script/client
@@ -137,7 +137,8 @@ use warnings;
 use FindBin;
 BEGIN { unshift @INC, "$FindBin::RealBin/../lib" }
 
-use JSON;
+use Mojo::JSON;    # booleans
+use Cpanel::JSON::XS ();
 use Data::Dump;
 use Mojo::URL;
 use OpenQA::Client;
@@ -162,7 +163,7 @@ sub handle_result {
     if ($res->code == 200) {
         my $json = $res->json;
         if ($options{'json-output'}) {
-            print JSON->new->pretty->encode($json);
+            print Cpanel::JSON::XS->new->pretty->encode($json);
         }
         else {
             dd($json || $res->body);
@@ -173,7 +174,7 @@ sub handle_result {
     printf(STDERR "ERROR: %s - %s\n", $res->code, $res->{error}->{message});
     if ($res->body) {
         if ($options{json}) {
-            print JSON->new->pretty->encode($res->json);
+            print Cpanel::JSON::XS->new->pretty->encode($res->json);
         }
         else {
             dd($res->json || $res->body);

--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -114,7 +114,8 @@ use Getopt::Long;
 use LWP::UserAgent;
 Getopt::Long::Configure("no_ignore_case");
 use Mojo::URL;
-use JSON;
+use Mojo::JSON;    # booleans
+use Cpanel::JSON::XS;
 use FindBin;
 use lib "$FindBin::RealBin/../lib";
 use OpenQA::Client;
@@ -204,7 +205,7 @@ sub get_job {
         exit 1;
     }
 
-    print JSON->new->pretty->encode($job) if ($options{verbose});
+    print Cpanel::JSON::XS->new->pretty->encode($job) if ($options{verbose});
     return $job;
 }
 
@@ -290,7 +291,7 @@ sub clone_job {
     }
     clone_job_apply_settings(\@ARGV, $depth, \%settings, \%options);
 
-    print JSON->new->pretty->encode(\%settings) if ($options{verbose});
+    print Cpanel::JSON::XS->new->pretty->encode(\%settings) if ($options{verbose});
     $url->query(%settings);
     my $tx = $local->max_redirects(3)->post($url);
     if (!$tx->error) {

--- a/script/load_templates
+++ b/script/load_templates
@@ -70,6 +70,8 @@ use Data::Dump qw(dd pp);
 use Mojo::Util qw(decamelize);
 use Mojo::URL;
 use OpenQA::Client;
+use Mojo::JSON;    # booleans
+use Cpanel::JSON::XS ();
 
 use Getopt::Long;
 
@@ -95,10 +97,9 @@ die "Data file not found\n" unless $datafile && -r $datafile;
 my $info;
 
 if ($datafile =~ /\.json$/) {
-    use JSON;
     local $/;
     open(my $fh, '<', $datafile);
-    $info = JSON->new->relaxed->decode(<$fh>);
+    $info = Cpanel::JSON::XS->new->relaxed->decode(<$fh>);
     close $fh;
     dd $info;
 }

--- a/script/modify_needle
+++ b/script/modify_needle
@@ -43,7 +43,9 @@ print help
 
 use strict;
 use warnings;
-use JSON;
+
+use Mojo::JSON;    # booleans
+use Cpanel::JSON::XS ();
 use Getopt::Long;
 
 sub usage($) {
@@ -65,7 +67,7 @@ for my $needle (@ARGV) {
 
     local $/;
     open(my $fh, '<', $needle) || die "can't open $needle";
-    my $info = JSON->new->relaxed->decode(<$fh>);
+    my $info = Cpanel::JSON::XS->new->relaxed->decode(<$fh>);
     close $fh;
 
     my $changed = 0;
@@ -78,6 +80,6 @@ for my $needle (@ARGV) {
     next unless $changed;
     
     open($fh, '>', $needle) || die "can't open $needle";
-    print $fh JSON->new->pretty->encode($info);
+    print $fh Cpanel::JSON::XS->new->pretty->encode($info);
     close $fh;
 }

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -31,7 +31,7 @@ use OpenQA::Test::Case;
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::ResourceAllocator;
-use JSON qw(decode_json);
+use Mojo::JSON qw(decode_json);
 
 my $test_case;
 my $t;

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -35,7 +35,7 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Mojo::File qw(tempdir path);
-use JSON qw(decode_json);
+use Mojo::JSON qw(decode_json);
 use OpenQA::WebAPI::Plugin::AMQP;
 
 my %published;

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -27,7 +27,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
-use JSON;
+use Mojo::JSON qw(decode_json encode_json);
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;


### PR DESCRIPTION
This should be a well balanced set of rules to encourage a slightly better coding style. I've also fixed the dependency on `JSON`, which was missing from `cpanfile`, and removed the dependency on `List::MoreUtils`, which was unnecessary.

Progress: https://progress.opensuse.org/issues/44597.