### PR TITLE
Add Perl::Critic::Freenode to the test container

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -95,6 +95,7 @@ RUN zypper in -y -C \
        'perl(Net::SNMP)' \
        'perl(Net::SSH2)' \
        'perl(Perl::Critic)' \
+       'perl(Perl::Critic::Freenode)' \
        'perl(Perl::Tidy)' \
        'perl(Pod::POM)' \
        'perl(Pod::Coverage)' \


### PR DESCRIPTION
Needed for https://github.com/os-autoinst/os-autoinst/pull/1070.