### PR TITLE
When detecting asset keys, don't use the _URL form for ASSET

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -93,7 +93,7 @@ sub detect_asset_keys {
         $res{$isokey} = 'iso' if $vars->{$isokey};
     }
 
-    for my $otherkey (grep { /ASSET_\d+_URL$/ } keys %{$vars}) {
+    for my $otherkey (grep { /ASSET_\d+$/ } keys %{$vars}) {
         $res{$otherkey} = 'other';
     }
 


### PR DESCRIPTION
In aee5e58, @foursixnine attempted to fix the use of `ASSET_`-
type assets with asset caching. However, I think the fix was
wrong and will not work.

If you look at all the other asset types in this code, they do
*not* look for the `_URL` form of the asset parameter. This is
the only one that tries to do it that way. Doing it that way is
just not going to work, because the value of the `_URL` form
is an entire URL, not just a filename. I'm pretty sure this is
going to wind up looking for `factory/other/http://blah/moo.pm`,
or something along those lines, and is never going to find it.

The `_URL` download stuff has already been handled by the time
we hit this point, and the file it pointed to should already
have been downloaded to the asset directory, and the 'bare'
form of the parameter put into the job variables. So we should
be looking for *that* form of the parameter, not the `_URL`
form. I'm pretty sure if we do it this way, it will work.

Signed-off-by: Adam Williamson <awilliam@redhat.com>