### PR TITLE
Use the boring standard return value for all Perl modules

### DIFF
--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -386,4 +386,4 @@ It returns the Parser object with the original data.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Parser/Format/Base.pm
+++ b/lib/OpenQA/Parser/Format/Base.pm
@@ -205,4 +205,4 @@ It merely calls write() on each element of the C<output()> collection.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -144,4 +144,4 @@ C<parse()> to generate a tree of results.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -181,4 +181,4 @@ C<parse()> to generate a tree of results.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -170,4 +170,4 @@ C<parse()> to generate a tree of results.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Parser/Format/TAP.pm
+++ b/lib/OpenQA/Parser/Format/TAP.pm
@@ -166,4 +166,4 @@ are discarded by the parser.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -188,4 +188,4 @@ C<parse()> to generate a tree of results.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Worker/Cache/Client.pm
+++ b/lib/OpenQA/Worker/Cache/Client.pm
@@ -289,4 +289,4 @@ Sets the default cache directory.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Worker/Cache/Request.pm
+++ b/lib/OpenQA/Worker/Cache/Request.pm
@@ -68,4 +68,4 @@ the Minion Tasks information to dispatch a remote request to the Cache Service.
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Worker/Cache/Request/Asset.pm
+++ b/lib/OpenQA/Worker/Cache/Request/Asset.pm
@@ -29,4 +29,4 @@ sub lock {
 sub to_hash { {id => $_[0]->id, type => $_[0]->type, asset => $_[0]->asset, host => $_[0]->host} }
 sub to_array { [$_[0]->id, $_[0]->type, $_[0]->asset, $_[0]->host] }
 
-!!42;
+1;

--- a/lib/OpenQA/Worker/Cache/Request/Sync.pm
+++ b/lib/OpenQA/Worker/Cache/Request/Sync.pm
@@ -28,4 +28,4 @@ sub lock {
 sub to_hash { {from => $_[0]->from, to => $_[0]->to} }
 sub to_array { [$_[0]->from, $_[0]->to] }
 
-!!42;
+1;

--- a/lib/OpenQA/Worker/Cache/Service.pm
+++ b/lib/OpenQA/Worker/Cache/Service.pm
@@ -205,4 +205,4 @@ Dequeues a job from the queue of jobs which are still inactive. It acceps a POST
 
 =cut
 
-!!42;
+1;

--- a/lib/OpenQA/Worker/Cache/Task.pm
+++ b/lib/OpenQA/Worker/Cache/Task.pm
@@ -21,4 +21,4 @@ has client => sub { OpenQA::Worker::Cache::Client->new };
 sub _dequeue { shift->client->_dequeue_lock(pop) }
 sub _gen_guard_name { join('.', shift->client->session_token, pop) }
 
-!!42;
+1;


### PR DESCRIPTION
The `return !!42;` does nothing else than confuse Perl beginners.