### PR TITLE
Update license of test spec-file to current SPDX format

### DIFF
--- a/openQA-test.spec
+++ b/openQA-test.spec
@@ -3,7 +3,7 @@ Name:           %{short_name}-test
 Version:        4.6
 Release:        0
 Summary:        Test package for openQA
-License:        GPL-2.0+
+License:        GPL-2.0-or-later
 BuildRequires:  %{short_name} == %{version}
 BuildRequires:  openQA-local-db
 ExcludeArch:    i586


### PR DESCRIPTION
See https://build.opensuse.org/request/show/656943 for reasoning. I am
not sure how and why coolo created
https://build.opensuse.org/request/show/655987 for manual update but now
we would revert to old license identifier format.