### PR TITLE
Add a new module for global events

### DIFF
--- a/lib/OpenQA/Events.pm
+++ b/lib/OpenQA/Events.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 package OpenQA::Events;
 use Mojo::Base 'Mojo::EventEmitter';
 

--- a/lib/OpenQA/Events.pm
+++ b/lib/OpenQA/Events.pm
@@ -1,0 +1,6 @@
+package OpenQA::Events;
+use Mojo::Base 'Mojo::EventEmitter';
+
+sub singleton { state $events = shift->SUPER::new }
+
+1;

--- a/lib/OpenQA/Events.pm
+++ b/lib/OpenQA/Events.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright (C) 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -296,7 +296,7 @@ sub load_plugins {
     }
 
     if ($server->config->{global}{audit_enabled}) {
-        $server->plugin('AuditLog', Mojo::IOLoop->singleton);
+        $server->plugin('AuditLog');
     }
     # Load arbitrary plugins defined in config: 'plugins' in section
     # '[global]' can be a space-separated list of plugins to load, by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -20,6 +20,7 @@ use OpenQA::Utils;
 use OpenQA::IPC;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
+use OpenQA::Events;
 use Try::Tiny;
 use DBIx::Class::Timestamps 'now';
 use Mojo::Asset::Memory;
@@ -475,9 +476,9 @@ sub create_artefact {
             sub {
                 die "Transaction empty" if $tx->is_empty;
                 @{Mojo::IOLoop->singleton}{@ioloop_evs} = @evs;
-                Mojo::IOLoop->singleton->emit('chunk_upload.start' => $self);
+                OpenQA::Events->singleton->emit('chunk_upload.start' => $self);
                 my ($e, $fname, $type, $last) = $job->create_asset($self->param('file'), $self->param('asset'));
-                Mojo::IOLoop->singleton->emit('chunk_upload.end' => ($self, $e, $fname, $type, $last));
+                OpenQA::Events->singleton->emit('chunk_upload.end' => ($self, $e, $fname, $type, $last));
                 die "$e" if $e;
                 return $fname, $type, $last;
             },

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -22,6 +22,7 @@ use Mojo::IOLoop;
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
+use OpenQA::Events;
 use Mojo::RabbitMQ::Client::Publisher;
 
 my @job_events     = qw(job_create job_delete job_cancel job_duplicate job_restart job_update_result job_done);
@@ -41,16 +42,14 @@ sub register {
     my $self = shift;
     $self->{app}    = shift;
     $self->{config} = $self->{app}->config;
-    my $ioloop = Mojo::IOLoop->singleton;
-
-    $ioloop->next_tick(
+    Mojo::IOLoop->singleton->next_tick(
         sub {
             # register for events
             for my $e (@job_events) {
-                $ioloop->on("openqa_$e" => sub { shift; $self->on_job_event(@_) });
+                OpenQA::Events->singleton->on("openqa_$e" => sub { shift; $self->on_job_event(@_) });
             }
             for my $e (@comment_events) {
-                $ioloop->on("openqa_$e" => sub { shift; $self->on_comment_event(@_) });
+                OpenQA::Events->singleton->on("openqa_$e" => sub { shift; $self->on_comment_event(@_) });
             }
         });
 }

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -18,6 +18,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 
 use Mojo::IOLoop;
 use Mojo::JSON 'to_json';
+use OpenQA::Events;
 
 my @table_events = qw(table_create table_update table_delete);
 my @job_events   = qw(job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result
@@ -34,7 +35,7 @@ my @needle_events      = qw(needle_modify needle_delete);
 # job_grab
 
 sub register {
-    my ($self, $app, $reactor) = @_;
+    my ($self, $app) = @_;
 
     # register for events
     my @events = (
@@ -47,7 +48,7 @@ sub register {
         @events = grep { $_ ne $e } @events;
     }
     for my $e (@events) {
-        $reactor->on("openqa_$e" => sub { shift; $self->on_event($app, @_) });
+        OpenQA::Events->singleton->on("openqa_$e" => sub { shift; $self->on_event($app, @_) });
     }
 
     my $user = $app->db->resultset('Users')->find({username => 'system'});

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -26,6 +26,7 @@ use Cpanel::JSON::XS ();
 use Mojo::IOLoop;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
+use OpenQA::Events;
 
 # note: there is also job_cancel_by_settings, but that is quite an odd one;
 # it basically does a search by the specified settings and cancels all
@@ -41,14 +42,13 @@ my @comment_events = qw(comment_create comment_update comment_delete);
 
 sub register {
     my ($self, $app) = @_;
-    my $reactor = Mojo::IOLoop->singleton;
 
     # register for events
     for my $e (@job_events) {
-        $reactor->on("openqa_$e" => sub { shift; $self->on_job_event($app, @_) });
+        OpenQA::Events->singleton->on("openqa_$e" => sub { shift; $self->on_job_event($app, @_) });
     }
     for my $e (@comment_events) {
-        $reactor->on("openqa_$e" => sub { shift; $self->on_comment_event($app, @_) });
+        OpenQA::Events->singleton->on("openqa_$e" => sub { shift; $self->on_comment_event($app, @_) });
     }
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -19,6 +19,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 
 use Mojo::ByteStream;
 use OpenQA::Utils qw(bugurl render_escaped_refs href_to_bugref);
+use OpenQA::Events;
 use db_helpers;
 
 sub register {
@@ -289,7 +290,7 @@ sub register {
             my ($self, $event, $data) = @_;
             die 'Missing event name' unless $event;
             my $user = $self->current_user ? $self->current_user->id : undef;
-            return Mojo::IOLoop->singleton->emit($event, [$user, $self->tx->connection, $event, $data]);
+            return OpenQA::Events->singleton->emit($event, [$user, $self->tx->connection, $event, $data]);
         });
 
     $app->helper(

--- a/lib/OpenQA/WebAPI/Plugin/MemoryLimit.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MemoryLimit.pm
@@ -1,0 +1,43 @@
+# Copyright (C) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Plugin::MemoryLimit;
+use Mojo::Base 'Mojolicious::Plugin';
+
+use BSD::Resource 'getrusage';
+use Mojo::IOLoop;
+
+# Stop prefork workers gracefully once they reach a certain size
+sub register {
+    my ($self, $app) = @_;
+
+    my $max = $app->config->{global}{max_rss_limit};
+    return unless $max && $max > 0;
+
+    my $parent = $$;
+    Mojo::IOLoop->next_tick(
+        sub {
+            Mojo::IOLoop->recurring(
+                5 => sub {
+                    my $rss = (getrusage())[2];
+                    # RSS is in KB under Linux
+                    return unless $rss > $max;
+                    $app->log->debug(qq{Worker exceeded RSS limit "$rss > $max", restarting});
+                    Mojo::IOLoop->stop_gracefully;
+                }) if $parent ne $$;
+        });
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Plugin/MemoryLimit.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MemoryLimit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright (C) 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/Commands.pm
+++ b/lib/OpenQA/Worker/Commands.pm
@@ -22,6 +22,7 @@ use warnings;
 use OpenQA::Utils qw(log_error log_warning log_debug add_log_channel remove_log_channel);
 use OpenQA::Worker::Common;
 use OpenQA::Worker::Jobs;
+use OpenQA::Events;
 use POSIX ':sys_wait_h';
 use OpenQA::Worker::Engines::isotovideo;
 use Data::Dump 'pp';
@@ -128,7 +129,7 @@ sub websocket_commands {
 
             $job_in_progress = 1;
             $check_job_running->{$host} = 1;
-            Mojo::IOLoop->singleton->once(
+            OpenQA::Events->singleton->once(
                 "stop_job" => sub {
                     log_debug("Build finished, setting us free to pick up new jobs",);
                     $job_in_progress = 0;
@@ -148,7 +149,7 @@ sub websocket_commands {
                 );
 
                 log_debug("Job " . $job->{id} . " scheduled for next cycle");
-                Mojo::IOLoop->singleton->once(
+                OpenQA::Events->singleton->once(
                     "start_job" => sub {
                         $OpenQA::Worker::Common::job->{state} = "running";
                         OpenQA::Worker::Common::send_status($tx);

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -36,6 +36,7 @@ use File::Which 'which';
 use Mojo::File 'path';
 use Mojo::IOLoop;
 use OpenQA::File;
+use OpenQA::Events;
 use Mojo::IOLoop::ReadWriteProcess;
 use POSIX ':sys_wait_h';
 use Exporter 'import';
@@ -163,7 +164,7 @@ sub _reset_state {
     $worker           = undef;
     $stop_job_running = 0;
     $current_host     = undef;
-    Mojo::IOLoop->singleton->emit("stop_job");
+    OpenQA::Events->singleton->emit("stop_job");
 }
 
 sub _upload_state {
@@ -585,7 +586,7 @@ sub start_job {
         },
         1
     );
-    Mojo::IOLoop->singleton->emit("start_job");
+    OpenQA::Events->singleton->emit("start_job");
 }
 
 sub log_snippet {

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -24,7 +24,7 @@ use Test::Mojo;
 use OpenQA::WebAPI;
 use Mojo::File qw(tempfile path);
 use OpenQA::Client;
-
+use OpenQA::Events;
 use OpenQA::Test::Case;
 
 require OpenQA::Schema::Result::Jobs;
@@ -37,7 +37,7 @@ $ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-Mojo::IOLoop->singleton->on(
+OpenQA::Events->singleton->on(
     'chunk_upload.end' => sub {
         Devel::Cover::report() if Devel::Cover->can('report');
     });

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -34,6 +34,7 @@ use Digest::MD5;
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 use OpenQA::ResourceAllocator;
+use OpenQA::Events;
 
 require OpenQA::Schema::Result::Jobs;
 
@@ -46,7 +47,7 @@ my $ra = OpenQA::ResourceAllocator->new;
 
 my $chunk_size = 10000000;
 
-Mojo::IOLoop->singleton->on('chunk_upload.end' => sub { Devel::Cover::report() if Devel::Cover->can('report'); });
+OpenQA::Events->singleton->on('chunk_upload.end' => sub { Devel::Cover::report() if Devel::Cover->can('report'); });
 
 sub calculate_file_md5($) {
     my ($file) = @_;


### PR DESCRIPTION
So far Mojo::IOLoop and Mojo::Reactor have been used to emit global events. That's very risky since it's not officially supported upstream and can therefore break at any time. This pull request adds a new module OpenQA::Events that will serve as the global openQA event emitter from now on.

I've also moved the memory limit code that looked a bit put of place in OpenQA::WebAPI into the plugin OpenQA::WebAPI::Plugin::MemoryLimit since i was cleaning up plugins anyway.

Both shouldn't be too controversial. 😄

Progress: https://progress.opensuse.org/issues/45014.