### PR TITLE
Use localized signal handling instead of global sigtrap for modules

### DIFF
--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -14,9 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::IPC;
-
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use Net::DBus;
 use Net::DBus::Callback;
@@ -61,7 +59,7 @@ sub new {
 }
 
 sub ipc {
-    CORE::state $ipc = shift->new(@_);
+    state $ipc = shift->new(@_);
 }
 
 sub register_service {

--- a/lib/OpenQA/ResourceAllocator.pm
+++ b/lib/OpenQA/ResourceAllocator.pm
@@ -29,11 +29,10 @@ use OpenQA::Utils qw(log_debug wakeup_scheduler exists_worker safe_call);
 use OpenQA::Resource::Jobs  ();
 use OpenQA::Resource::Locks ();
 use OpenQA::Setup;
-use sigtrap handler => \&normal_signals_handler, 'normal-signals';
 
 my $singleton;
 
-sub normal_signals_handler {
+sub quit {
     log_debug("Received abort signal");
     exit 0;
 }
@@ -59,6 +58,12 @@ sub new {
 
 sub run {
     my $self = shift;
+
+    # Catch normal signals
+    local $SIG{HUP} = local $SIG{INT} = local $SIG{PIPE} = local $SIG{TERM} = sub {
+        quit();
+    };
+
     my $setup = OpenQA::Setup->new(log_name => 'resource-allocator');
     OpenQA::Setup::read_config($setup);
     OpenQA::Setup::setup_log($setup);

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -51,6 +51,12 @@ sub _is_method_allowed {
 
 our $setup;
 sub run {
+
+    # Catch normal signals
+    local $SIG{HUP} = local $SIG{INT} = local $SIG{PIPE} = local $SIG{TERM} = sub {
+        OpenQA::Scheduler::Scheduler::quit();
+    };
+
     $setup = OpenQA::Setup->new(log_name => 'scheduler');
     OpenQA::Setup::read_config($setup);
     OpenQA::Setup::setup_log($setup);

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -14,9 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Scheduler::Scheduler;
-
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 # we need the critical fix for update
 # see https://github.com/dbsrgits/dbix-class/commit/31160673f390e178ee347e7ebee1f56b3f54ba7a
@@ -42,7 +40,6 @@ use db_helpers 'rndstr';
 use Time::HiRes 'time';
 use List::Util qw(all shuffle);
 use OpenQA::IPC;
-use sigtrap handler => \&normal_signals_handler, 'normal-signals';
 use OpenQA::Scheduler;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use Carp;
@@ -50,8 +47,8 @@ use Exporter 'import';
 
 our @EXPORT = qw(job_grab);
 
-CORE::state $summoned = 0;
-CORE::state $quit     = 0;
+state $summoned = 0;
+state $quit     = 0;
 
 my $shuffle_workers = 1;
 
@@ -61,7 +58,7 @@ sub shuffle_workers {
     return $shuffle_workers;
 }
 
-sub normal_signals_handler {
+sub quit {
     log_debug("Received signal to stop");
     $quit++;
     _reschedule(1);
@@ -82,7 +79,7 @@ Getter/Setter for the main Net::DBus::Reactor in the current loop:
 =cut
 
 sub reactor {
-    CORE::state $reactor;
+    state $reactor;
     return $reactor if $reactor;
     $reactor = shift;
     weaken $reactor;
@@ -90,13 +87,13 @@ sub reactor {
 }
 
 sub schema {
-    CORE::state $schema;
+    state $schema;
     $schema = OpenQA::Schema::connect_db() unless $schema;
     return $schema;
 }
 
 sub scheduled_jobs {
-    CORE::state $scheduled_jobs;
+    state $scheduled_jobs;
     $scheduled_jobs = {} unless $scheduled_jobs;
     return $scheduled_jobs;
 }

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -17,6 +17,7 @@ package OpenQA::Schema;
 
 use strict;
 use warnings;
+use feature ':5.10';
 
 use parent 'DBIx::Class::Schema';
 
@@ -36,7 +37,7 @@ our $VERSION = 72;
 __PACKAGE__->load_namespaces;
 
 sub _get_schema {
-    CORE::state $schema;
+    state $schema;
     return \$schema;
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -209,7 +209,6 @@ sub cmd_run {
     while (1) {
         next unless my $job = $worker->register->dequeue(5);
         $self->execute_job($job);
-        sleep 5;
     }
     $worker->unregister;
 }


### PR DESCRIPTION
The use of sigtrap just got in the way when i was trying to simplify Gru a bit. Merely loading a module like OpenQA::Scheduler shouldn't change global state like signal handlers (action at a distance etc.). A better way to handle signals in modules is to localize them to the method/function that runs the mainloop. Unless some part of openQA depends on sigtrap magic, this change should not result in any noticeable differences in behaviour.