### PR TITLE
Add basic documentation for OpenQA::Events

### DIFF
--- a/lib/OpenQA/Events.pm
+++ b/lib/OpenQA/Events.pm
@@ -19,3 +19,36 @@ use Mojo::Base 'Mojo::EventEmitter';
 sub singleton { state $events = shift->SUPER::new }
 
 1;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::Events - A global event emitter for openQA
+
+=head1 SYNOPSIS
+
+  use OpenQA::Events;
+
+  # Emit events
+  OpenQA::Events->singleton->emit(some_event => ['some', 'argument']);
+
+  # Do something whenever an event occurs
+  OpenQA::Events->singleton->on(some_event => sub {
+    my ($events, @args) = @_;
+    ...
+  });
+
+  # Do something only once if an event occurs
+  OpenQA::Events->singleton->once(some_event => sub {
+    my ($events, @args) = @_;
+    ...
+  });
+
+=head1 DESCRIPTION
+
+L<OpenQA::Events> is a global event emitter for L<OpenQA> that is usually used
+as a singleton object. It is based on L<Mojo::EventEmitter> and can be used from
+anywhere inside the same process.
+
+=cut


### PR DESCRIPTION
This pull request is less about the actual change, and more about getting a discussion started about module documentation.

While we might not be in a state yet where we can document every individual method/attribute/function, i think it would make sense to at least have a basic description for every Perl module in the openQA repo. As an example i've used the module OpenQA::Events (which i just added). And the POD skeleton is the same Mojolicious uses upstream (and which is considered rather good style in the community).

Thoughts/Ideas?