### PR TITLE
Prevent 'Summary of HASH(...)' if multiple distris/versions specified

### DIFF
--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -191,6 +191,11 @@ subtest 'filtering by test' => sub {
     my @rows = $driver->find_elements('#content tbody tr');
     is(scalar @rows, 1, 'exactly one row present');
     like($rows[0]->get_text(), qr/textmode/, 'test is textmode');
+    is(
+        OpenQA::Test::Case::trim_whitespace($driver->find_element('#summary .card-header')->get_text()),
+        'Overall Summary of opensuse 13.1 build 0092',
+        'summary states "opensuse 13.1" although no explicit search params',
+    );
 };
 
 subtest 'filtering by distri' => sub {
@@ -202,6 +207,11 @@ subtest 'filtering by distri' => sub {
     subtest 'distri filters are ORed' => sub {
         $driver->get('/tests/overview?distri=foo&distri=opensuse&distri=bar&version=13.1&build=0091');
         check_build_0091_defaults;
+        is(
+            OpenQA::Test::Case::trim_whitespace($driver->find_element('#summary .card-header b')->get_text()),
+            'foo/opensuse/bar 13.1',
+            'filter also visible in summary'
+        );
     };
 
     subtest 'everything filtered out' => sub {

--- a/templates/test/overview.html.ep
+++ b/templates/test/overview.html.ep
@@ -6,26 +6,13 @@
   setupOverview();
 % end
 
-% my @distris = keys %$results;
-% my $only_distri = scalar @distris == 1;
-% if (!defined $distri and $only_distri) {
-    % $distri = $distris[0];
-    % if (!defined $version) {
-        % my @versions = keys %{$results->{$distri}};
-        % $version = $versions[0] if (scalar @versions == 1);
-    % }
-% }
-
 <div>
     <h2>Test result overview</h2>
     <div id="summary" class="card <%= ($aggregated->{failed} + $aggregated->{incomplete}) ? 'border-danger' : 'border-success' %>">
         <div class="card-header">
             Overall Summary of
-            % if (@$groups) {
-                <b><%= b join(', ', map { link_to $_->name => url_for('group_overview', groupid => $_->id) } @$groups) %></b>
-            % }
-            % elsif ($distri or $version) {
-                <b><%= $distri %> <%= $version %></b>
+            % if ($summary_name) {
+                <b><%= b $summary_name %></b>
             % }
             % else {
                 multiple distri/version


### PR DESCRIPTION
* Move logic for summary name into controller
* Show multiple distris or versions separated by '/'