### PR TITLE
Do not set the MOJO_LOG_LEVEL environment variable by default

### DIFF
--- a/docker/openqa/entrypoint.sh
+++ b/docker/openqa/entrypoint.sh
@@ -48,7 +48,6 @@ function run_as_normal_user {
 
     if [ $? -eq 0 ]; then
         create_db
-        export MOJO_LOG_LEVEL=debug
         export MOJO_TMPDIR=$(mktemp -d)
         export OPENQA_LOGFILE=/tmp/openqa-debug.log
     else

--- a/docker/testing/test.sh
+++ b/docker/testing/test.sh
@@ -14,7 +14,6 @@ git fetch test
 git reset --hard test/$2
 eval $(dbus-launch --sh-syntax)
 export FULLSTACK=1
-export MOJO_LOG_LEVEL=debug
 if test -n "$3"; then
   /root/bin/perlw "perl $3"
 else

--- a/openQA.spec
+++ b/openQA.spec
@@ -222,7 +222,7 @@ rm -rf %{buildroot}/DB
 export LC_ALL=en_US.UTF-8
 ./t/test_postgresql %{buildroot}/DB
 export TEST_PG="DBI:Pg:dbname=openqa_test;host=%{buildroot}/DB"
-MOJO_LOG_LEVEL=debug OBS_RUN=1 prove -rv || true
+OBS_RUN=1 prove -rv || true
 pg_ctl -D %{buildroot}/DB stop
 rm -rf %{buildroot}/DB
 %endif


### PR DESCRIPTION
In Travis the test logs are still way too verbose to find anything (in fact Travis will refuse to display them completely https://travis-ci.org/os-autoinst/openQA/jobs/467944626). You might have noticed that when testing locally the test output is much more manageable. The reason for that is the global `MOJO_LOG_LEVEL=debug` environment variable we are setting for docker tests.

`MOJO_LOG_LEVEL` is a sledge hammer that overrides all other settings, including the Mojolicious application mode, which many tests use to decide what makes sense to log. I think by default we should leave it up to the tests to make this decision. `MOJO_LOG_LEVEL=debug` can still be used for debugging purposes by developers, but only on-demand.