### PR TITLE
Use a fixed version of perltidy

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -96,7 +96,7 @@ requires 'POSIX';
 on 'test' => sub {
   requires 'Perl::Critic';
   requires 'Perl::Critic::Freenode';
-  requires 'Perl::Tidy', '>= 20180101, != 20180219';
+  requires 'Perl::Tidy', '== 20181120';
   requires 'Selenium::Remote::Driver', '>= 1.23';
   requires 'Selenium::Remote::WDKeys';
   requires 'Test::Compile';


### PR DESCRIPTION
We should avoid suprises on travis - but update explicitly whenever
we feel the need to do so

(in accordance with https://github.com/os-autoinst/os-autoinst/pull/927)