### PR TITLE
Use OPENQA_TEST_IPC mock in 37-limit_assets.t

### DIFF
--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -18,6 +18,7 @@
 
 BEGIN {
     unshift @INC, 'lib';
+    $ENV{OPENQA_TEST_IPC} = 1;
 }
 
 use FindBin;


### PR DESCRIPTION
Since 71172fc, this test hits IPC, I think when it calls
`schedule_iso` with an invalid repo name. We need to mock the
IPC or the test will fail in package build environments.

Signed-off-by: Adam Williamson <awilliam@redhat.com>