### PR TITLE
Actually use a Minion worker for Gru

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -72,6 +72,9 @@ sub startup {
     # set cookie timeout to 48 hours (will be updated on each request)
     $self->app->sessions->default_expiration(48 * 60 * 60);
 
+    # commands
+    push @{$self->commands->namespaces}, 'OpenQA::WebAPI::Command';
+
     # add actions before dispatching page
     $self->hook(
         before_dispatch => sub {

--- a/lib/OpenQA/WebAPI/Command/gru.pm
+++ b/lib/OpenQA/WebAPI/Command/gru.pm
@@ -1,100 +1,45 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 package OpenQA::WebAPI::Command::gru;
-use Mojo::Base 'Mojolicious::Command';
+use Mojo::Base 'Mojolicious::Commands';
 
-use Mojo::Pg;
-use Minion::Command::minion::job;
-use OpenQA::Utils 'log_error';
+has description => 'Gru job queue';
+has hint        => <<EOF;
+See 'APPLICATION gru help COMMAND' for more information on a specific
+command.
+EOF
+has message    => sub { shift->extract_usage . "\nCommands:\n" };
+has namespaces => sub { ['OpenQA::WebAPI::Command::gru'] };
 
-has usage       => "usage: $0 gru [-o]\n";
-has description => 'Run a gru to process jobs - give -o to exit _o_nce everything is done';
-has job         => sub { Minion::Command::minion::job->new(app => shift->app) };
-
-sub delete_gru {
-    my ($self, $id) = @_;
-    my $gru = $self->app->db->resultset('GruTasks')->find($id);
-    $gru->delete() if $gru;
-}
-
-sub fail_gru {
-    my ($self, $id, $reason) = @_;
-    my $gru = $self->app->db->resultset('GruTasks')->find($id);
-    $gru->fail($reason) if $gru;
-}
-
-sub cmd_list { shift->job->run(@_) }
-
-sub execute_job {
-    my ($self, $job) = @_;
-
-    my $ttl       = $job->info->{notes}{ttl};
-    my $elapsed   = time - $job->info->{created};
-    my $ttl_error = 'TTL Expired';
-
-    return
-      exists $job->info->{notes}{gru_id}
-      ? $job->fail({error => $ttl_error}) && $self->fail_gru($job->info->{notes}{gru_id} => $ttl_error)
-      : $job->fail({error => $ttl_error})
-      if (defined $ttl && $elapsed > $ttl);
-
-    my $buffer;
-    my $err;
-    {
-        open my $handle, '>', \$buffer;
-        local *STDERR = $handle;
-        local *STDOUT = $handle;
-        $err = $job->execute;
-    };
-
-    if (defined $err) {
-        log_error("Gru command issue: $err");
-        $self->fail_gru($job->info->{notes}{gru_id} => $err)
-          if $job->fail({(output => $buffer) x !!(defined $buffer), error => $err})
-          && exists $job->info->{notes}{gru_id};
-    }
-    else {
-        $job->finish(defined $buffer ? $buffer : 'Job successfully executed');
-        $self->delete_gru($job->info->{notes}{gru_id}) if exists $job->info->{notes}{gru_id};
-    }
-
-}
-
-sub cmd_run {
-    my $self = shift;
-    my $opt  = $_[0] || '';
-
-    my $worker = $self->app->minion->repair->worker->register;
-
-    if ($opt eq '-o') {
-        while (my $job = $worker->register->dequeue(0)) {
-            $self->execute_job($job);
-        }
-        return $worker->unregister;
-    }
-
-    while (1) {
-        next unless my $job = $worker->register->dequeue(5);
-        $self->execute_job($job);
-    }
-    $worker->unregister;
-}
-
-sub run {
-    # only fetch first 2 args
-    my $self = shift;
-    my $cmd  = shift;
-
-    if (!$cmd) {
-        print "gru: [list|run]\n";
-        return;
-    }
-    if ($cmd eq 'list') {
-        $self->cmd_list(@_);
-        return;
-    }
-    if ($cmd eq 'run') {
-        $self->cmd_run(@_);
-        return;
-    }
-}
+sub help { shift->run(@_) }
 
 1;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::WebAPI::Command::gru - gru command
+
+=head1 SYNOPSIS
+
+  Usage: APPLICATION gru COMMAND [OPTIONS]
+
+=head1 DESCRIPTION
+
+L<OpenQA::WebAPI::Command::gru> lists available Gru commands.
+
+=cut

--- a/lib/OpenQA/WebAPI/Command/gru.pm
+++ b/lib/OpenQA/WebAPI/Command/gru.pm
@@ -1,0 +1,100 @@
+package OpenQA::WebAPI::Command::gru;
+use Mojo::Base 'Mojolicious::Command';
+
+use Mojo::Pg;
+use Minion::Command::minion::job;
+use OpenQA::Utils 'log_error';
+
+has usage       => "usage: $0 gru [-o]\n";
+has description => 'Run a gru to process jobs - give -o to exit _o_nce everything is done';
+has job         => sub { Minion::Command::minion::job->new(app => shift->app) };
+
+sub delete_gru {
+    my ($self, $id) = @_;
+    my $gru = $self->app->db->resultset('GruTasks')->find($id);
+    $gru->delete() if $gru;
+}
+
+sub fail_gru {
+    my ($self, $id, $reason) = @_;
+    my $gru = $self->app->db->resultset('GruTasks')->find($id);
+    $gru->fail($reason) if $gru;
+}
+
+sub cmd_list { shift->job->run(@_) }
+
+sub execute_job {
+    my ($self, $job) = @_;
+
+    my $ttl       = $job->info->{notes}{ttl};
+    my $elapsed   = time - $job->info->{created};
+    my $ttl_error = 'TTL Expired';
+
+    return
+      exists $job->info->{notes}{gru_id}
+      ? $job->fail({error => $ttl_error}) && $self->fail_gru($job->info->{notes}{gru_id} => $ttl_error)
+      : $job->fail({error => $ttl_error})
+      if (defined $ttl && $elapsed > $ttl);
+
+    my $buffer;
+    my $err;
+    {
+        open my $handle, '>', \$buffer;
+        local *STDERR = $handle;
+        local *STDOUT = $handle;
+        $err = $job->execute;
+    };
+
+    if (defined $err) {
+        log_error("Gru command issue: $err");
+        $self->fail_gru($job->info->{notes}{gru_id} => $err)
+          if $job->fail({(output => $buffer) x !!(defined $buffer), error => $err})
+          && exists $job->info->{notes}{gru_id};
+    }
+    else {
+        $job->finish(defined $buffer ? $buffer : 'Job successfully executed');
+        $self->delete_gru($job->info->{notes}{gru_id}) if exists $job->info->{notes}{gru_id};
+    }
+
+}
+
+sub cmd_run {
+    my $self = shift;
+    my $opt  = $_[0] || '';
+
+    my $worker = $self->app->minion->repair->worker->register;
+
+    if ($opt eq '-o') {
+        while (my $job = $worker->register->dequeue(0)) {
+            $self->execute_job($job);
+        }
+        return $worker->unregister;
+    }
+
+    while (1) {
+        next unless my $job = $worker->register->dequeue(5);
+        $self->execute_job($job);
+    }
+    $worker->unregister;
+}
+
+sub run {
+    # only fetch first 2 args
+    my $self = shift;
+    my $cmd  = shift;
+
+    if (!$cmd) {
+        print "gru: [list|run]\n";
+        return;
+    }
+    if ($cmd eq 'list') {
+        $self->cmd_list(@_);
+        return;
+    }
+    if ($cmd eq 'run') {
+        $self->cmd_run(@_);
+        return;
+    }
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Command/gru/list.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/list.pm
@@ -32,6 +32,20 @@ OpenQA::WebAPI::Command::gru::list - Gru list command
   Usage: APPLICATION gru list [OPTIONS] [IDS]
 
     script/openqa gru list
+    script/openqa gru list 10023
+    script/openqa gru list -w
+    script/openqa gru list -w 23
+    script/openqa gru list -s
+    script/openqa gru list -f 10023
+    script/openqa gru list -q important -t foo -t bar -S inactive
+    script/openqa gru list -e foo -a '[23, "bar"]'
+    script/openqa gru list -e foo -P 10023 -P 10024 -p 5 -q important
+    script/openqa gru list -R -d 10 10023
+    script/openqa gru list --remove 10023
+    script/openqa gru list -L
+    script/openqa gru list -L some_lock some_other_lock
+    script/openqa gru list -b jobs -a '[12]'
+    script/openqa gru list -b jobs -a '[12]' 23 24 25
 
   Options:
     -A, --attempts <number>     Number of times performing this new job will be

--- a/lib/OpenQA/WebAPI/Command/gru/list.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/list.pm
@@ -1,0 +1,80 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Command::gru::list;
+use Mojo::Base 'Minion::Command::minion::job';
+
+has description => 'List Gru jobs and more';
+has usage       => sub { shift->extract_usage };
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::WebAPI::Command::gru::list - Gru list command
+
+=head1 SYNOPSIS
+
+  Usage: APPLICATION gru list [OPTIONS] [IDS]
+
+    script/openqa gru list
+
+  Options:
+    -A, --attempts <number>     Number of times performing this new job will be
+                                attempted, defaults to 1
+    -a, --args <JSON array>     Arguments for new job or worker remote control
+                                command in JSON format
+    -b, --broadcast <command>   Broadcast remote control command to one or more
+                                workers
+    -d, --delay <seconds>       Delay new job for this many seconds
+    -e, --enqueue <task>        New job to be enqueued
+    -f, --foreground            Retry job in "minion_foreground" queue and
+                                perform it right away in the foreground (very
+                                useful for debugging)
+    -H, --history               Show queue history
+    -h, --help                  Show this summary of available options
+        --home <path>           Path to home directory of your application,
+                                defaults to the value of MOJO_HOME or
+                                auto-detection
+    -L, --locks                 List active named locks
+    -l, --limit <number>        Number of jobs/workers to show when listing
+                                them, defaults to 100
+    -m, --mode <name>           Operating mode for your application, defaults to
+                                the value of MOJO_MODE/PLACK_ENV or
+                                "development"
+    -o, --offset <number>       Number of jobs/workers to skip when listing
+                                them, defaults to 0
+    -P, --parent <id>           One or more jobs the new job depends on
+    -p, --priority <number>     Priority of new job, defaults to 0
+    -q, --queue <name>          Queue to put new job in, defaults to "default",
+                                or list only jobs in these queues
+    -R, --retry                 Retry job
+        --remove                Remove job
+    -S, --state <name>          List only jobs in these states
+    -s, --stats                 Show queue statistics
+    -t, --task <name>           List only jobs for these tasks
+    -U, --unlock <name>         Release named lock
+    -w, --workers               List workers instead of jobs, or show
+                                information for a specific worker
+
+=head1 DESCRIPTION
+
+L<OpenQA::WebAPI::Command::gru::list> is a subclass of
+L<Minion::Command::minion::job> that merely renames the command for backwards
+compatibility.
+
+=cut

--- a/lib/OpenQA/WebAPI/Command/gru/list.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/list.pm
@@ -32,58 +32,9 @@ OpenQA::WebAPI::Command::gru::list - Gru list command
   Usage: APPLICATION gru list [OPTIONS] [IDS]
 
     script/openqa gru list
-    script/openqa gru list 10023
-    script/openqa gru list -w
-    script/openqa gru list -w 23
-    script/openqa gru list -s
-    script/openqa gru list -f 10023
-    script/openqa gru list -q important -t foo -t bar -S inactive
-    script/openqa gru list -e foo -a '[23, "bar"]'
-    script/openqa gru list -e foo -P 10023 -P 10024 -p 5 -q important
-    script/openqa gru list -R -d 10 10023
-    script/openqa gru list --remove 10023
-    script/openqa gru list -L
-    script/openqa gru list -L some_lock some_other_lock
-    script/openqa gru list -b jobs -a '[12]'
-    script/openqa gru list -b jobs -a '[12]' 23 24 25
 
   Options:
-    -A, --attempts <number>     Number of times performing this new job will be
-                                attempted, defaults to 1
-    -a, --args <JSON array>     Arguments for new job or worker remote control
-                                command in JSON format
-    -b, --broadcast <command>   Broadcast remote control command to one or more
-                                workers
-    -d, --delay <seconds>       Delay new job for this many seconds
-    -e, --enqueue <task>        New job to be enqueued
-    -f, --foreground            Retry job in "minion_foreground" queue and
-                                perform it right away in the foreground (very
-                                useful for debugging)
-    -H, --history               Show queue history
-    -h, --help                  Show this summary of available options
-        --home <path>           Path to home directory of your application,
-                                defaults to the value of MOJO_HOME or
-                                auto-detection
-    -L, --locks                 List active named locks
-    -l, --limit <number>        Number of jobs/workers to show when listing
-                                them, defaults to 100
-    -m, --mode <name>           Operating mode for your application, defaults to
-                                the value of MOJO_MODE/PLACK_ENV or
-                                "development"
-    -o, --offset <number>       Number of jobs/workers to skip when listing
-                                them, defaults to 0
-    -P, --parent <id>           One or more jobs the new job depends on
-    -p, --priority <number>     Priority of new job, defaults to 0
-    -q, --queue <name>          Queue to put new job in, defaults to "default",
-                                or list only jobs in these queues
-    -R, --retry                 Retry job
-        --remove                Remove job
-    -S, --state <name>          List only jobs in these states
-    -s, --stats                 Show queue statistics
-    -t, --task <name>           List only jobs for these tasks
-    -U, --unlock <name>         Release named lock
-    -w, --workers               List workers instead of jobs, or show
-                                information for a specific worker
+    See 'script/openqa minion job -h' for all available options.
 
 =head1 DESCRIPTION
 

--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Command::gru::run;
-use Mojo::Base 'Mojolicious::Command';
+use Mojo::Base 'Minion::Command::minion::worker';
 
 use Mojo::Util 'getopt';
 use OpenQA::WebAPI::GruJob;
@@ -46,7 +46,7 @@ sub run {
         });
 
     if   ($oneshot) { $minion->perform_jobs }
-    else            { $minion->worker->run }
+    else            { $self->SUPER::run(@args) }
 }
 
 1;
@@ -64,11 +64,35 @@ OpenQA::WebAPI::Command::gru::run - Gru run command
     script/openqa gru run
 
   Options:
-    -o, --oneshot   Perform all currently enqueued jobs and then exit
+    -C, --command-interval <seconds>     Worker remote control command interval,
+                                         defaults to 10
+    -D, dequeue-timeout <seconds>        Maximum amount of time to wait for
+                                         jobs, defaults to 5
+    -h, --help                           Show this summary of available options
+        --home <path>                    Path to home directory of your
+                                         application, defaults to the value of
+                                         MOJO_HOME or auto-detection
+    -I, --heartbeat-interval <seconds>   Heartbeat interval, defaults to 300
+    -j, --jobs <number>                  Maximum number of jobs to perform
+                                         parallel in forked worker processes,
+                                         defaults to 4
+    -m, --mode <name>                    Operating mode for your application,
+                                         defaults to the value of
+                                         MOJO_MODE/PLACK_ENV or "development"
+    -o, --oneshot                        Perform all currently enqueued jobs and
+                                         then exit
+    -q, --queue <name>                   One or more queues to get jobs from,
+                                         defaults to "default"
+    -R, --repair-interval <seconds>      Repair interval, up to half of this
+                                         value can be subtracted randomly to
+                                         make sure not all workers repair at the
+                                         same time, defaults to 21600 (6 hours)
+
 
 =head1 DESCRIPTION
 
-L<OpenQA::WebAPI::Command::gru::run> is a wrapper around L<Minion::Worker> that
-runs a L<Minion> worker with some Gru extensions.
+L<OpenQA::WebAPI::Command::gru::run> is a subclass of
+L<Minion::Command::minion::worker> that adds Gru features with
+L<OpenQA::WebAPI::GruJob>.
 
 =cut

--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -62,6 +62,9 @@ OpenQA::WebAPI::Command::gru::run - Gru run command
   Usage: APPLICATION gru run [OPTIONS]
 
     script/openqa gru run
+    script/openqa gru run -o
+    script/openqa gru run -m production -I 15 -C 5 -R 3600 -j 10
+    script/openqa gru run -q important -q default
 
   Options:
     -C, --command-interval <seconds>     Worker remote control command interval,

--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -1,0 +1,74 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Command::gru::run;
+use Mojo::Base 'Mojolicious::Command';
+
+use Mojo::Util 'getopt';
+use OpenQA::WebAPI::GruJob;
+
+has description => 'Start Gru worker';
+has usage       => sub { shift->extract_usage };
+
+sub run {
+    my ($self, @args) = @_;
+
+    getopt \@args, 'o|oneshot' => \(my $oneshot);
+
+    my $minion = $self->app->minion;
+    $minion->on(
+        worker => sub {
+            my ($minion, $worker) = @_;
+
+            # Only one job can run at a time for now (until all Gru tasks are parallelism safe)
+            $worker->status->{jobs} = 1;
+
+            $worker->on(
+                dequeue => sub {
+                    my ($worker, $job) = @_;
+
+                    # Reblessing the job is fine for now, but in the future it would be nice
+                    # to use a role instead
+                    bless $job, 'OpenQA::WebAPI::GruJob';
+                });
+        });
+
+    if   ($oneshot) { $minion->perform_jobs }
+    else            { $minion->worker->run }
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::WebAPI::Command::gru::run - Gru run command
+
+=head1 SYNOPSIS
+
+  Usage: APPLICATION gru run [OPTIONS]
+
+    script/openqa gru run
+
+  Options:
+    -o, --oneshot   Perform all currently enqueued jobs and then exit
+
+=head1 DESCRIPTION
+
+L<OpenQA::WebAPI::Command::gru::run> is a wrapper around L<Minion::Worker> that
+runs a L<Minion> worker with some Gru extensions.
+
+=cut

--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -63,33 +63,11 @@ OpenQA::WebAPI::Command::gru::run - Gru run command
 
     script/openqa gru run
     script/openqa gru run -o
-    script/openqa gru run -m production -I 15 -C 5 -R 3600 -j 10
-    script/openqa gru run -q important -q default
 
   Options:
-    -C, --command-interval <seconds>     Worker remote control command interval,
-                                         defaults to 10
-    -D, dequeue-timeout <seconds>        Maximum amount of time to wait for
-                                         jobs, defaults to 5
-    -h, --help                           Show this summary of available options
-        --home <path>                    Path to home directory of your
-                                         application, defaults to the value of
-                                         MOJO_HOME or auto-detection
-    -I, --heartbeat-interval <seconds>   Heartbeat interval, defaults to 300
-    -j, --jobs <number>                  Maximum number of jobs to perform
-                                         parallel in forked worker processes,
-                                         defaults to 4
-    -m, --mode <name>                    Operating mode for your application,
-                                         defaults to the value of
-                                         MOJO_MODE/PLACK_ENV or "development"
-    -o, --oneshot                        Perform all currently enqueued jobs and
-                                         then exit
-    -q, --queue <name>                   One or more queues to get jobs from,
-                                         defaults to "default"
-    -R, --repair-interval <seconds>      Repair interval, up to half of this
-                                         value can be subtracted randomly to
-                                         make sure not all workers repair at the
-                                         same time, defaults to 21600 (6 hours)
+    -o, --oneshot   Perform all currently enqueued jobs and then exit
+
+    See 'script/openqa minion worker -h' for all available options.
 
 
 =head1 DESCRIPTION

--- a/lib/OpenQA/WebAPI/GruJob.pm
+++ b/lib/OpenQA/WebAPI/GruJob.pm
@@ -21,7 +21,6 @@ use OpenQA::Utils 'log_error';
 sub execute {
     my $self = shift;
 
-    # TTL
     my $ttl     = $self->info->{notes}{ttl};
     my $elapsed = time - $self->info->{created};
     if (defined $ttl && $elapsed > $ttl) {

--- a/lib/OpenQA/WebAPI/GruJob.pm
+++ b/lib/OpenQA/WebAPI/GruJob.pm
@@ -1,0 +1,89 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::GruJob;
+use Mojo::Base 'Minion::Job';
+
+use OpenQA::Utils 'log_error';
+
+sub execute {
+    my $self = shift;
+
+    # TTL
+    my $ttl     = $self->info->{notes}{ttl};
+    my $elapsed = time - $self->info->{created};
+    if (defined $ttl && $elapsed > $ttl) {
+        my $ttl_error = 'TTL Expired';
+        if (exists $self->info->{notes}{gru_id}) {
+            $self->_fail_gru($self->info->{notes}{gru_id} => $ttl_error) if $self->fail({error => $ttl_error});
+        }
+        else {
+            $self->fail({error => $ttl_error});
+        }
+        return undef;
+    }
+
+    my ($buffer, $err);
+    {
+        open my $handle, '>', \$buffer;
+        local *STDERR = $handle;
+        local *STDOUT = $handle;
+        $err = $self->SUPER::execute;
+    };
+
+    if (defined $err) {
+        log_error("Gru command issue: $err");
+        $self->_fail_gru($self->info->{notes}{gru_id} => $err)
+          if $self->fail({(output => $buffer) x !!(defined $buffer), error => $err})
+          && exists $self->info->{notes}{gru_id};
+    }
+    else {
+        $self->finish(defined $buffer ? $buffer : 'Job successfully executed');
+        $self->_delete_gru($self->info->{notes}{gru_id}) if exists $self->info->{notes}{gru_id};
+    }
+
+    return undef;
+}
+
+sub _delete_gru {
+    my ($self, $id) = @_;
+    my $gru = $self->minion->app->db->resultset('GruTasks')->find($id);
+    $gru->delete() if $gru;
+}
+
+sub _fail_gru {
+    my ($self, $id, $reason) = @_;
+    my $gru = $self->minion->app->db->resultset('GruTasks')->find($id);
+    $gru->fail($reason) if $gru;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::WebAPI::GruJob - A Gru Job
+
+=head1 SYNOPSIS
+
+    use OpenQA::WebAPI::GruJob;
+
+=head1 DESCRIPTION
+
+L<OpenQA::WebAPI::GruJob> is a subclass of L<Minion::Job> used by
+L<OpenQA::WebAPI::Plugin::Gru> that adds Gru metadata handling and TTL support.
+
+=cut

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -19,25 +19,21 @@ package OpenQA::WebAPI::Plugin::Gru;
 use Mojo::Base 'Mojolicious::Plugin';
 
 use Minion;
-use Scalar::Util ();
 use DBIx::Class::Timestamps 'now';
 use Mojo::Pg;
 
-has [qw(app dsn)];
+has app => undef, weak => 1;
+has 'dsn';
 
 sub new {
-    my $class = shift;
-    my $self  = $class->SUPER::new(@_);
-    my $app   = shift;
-    $self->app($app);
-    Scalar::Util::weaken $self->{app};
-    return $self;
+    my $self = shift->SUPER::new;
+    return $self->app(shift);
 }
 
 sub register_tasks {
     my $self = shift;
-    my $app  = $self->app;
 
+    my $app = $self->app;
     $app->plugin($_)
       for (
         qw(OpenQA::Task::Asset::Download OpenQA::Task::Asset::Limit),
@@ -49,6 +45,7 @@ sub register_tasks {
 
 sub register {
     my ($self, $app, $config) = @_;
+
     $self->app($app) unless $self->app;
     $self->{schema} = $self->app->db if $self->app->db;
 
@@ -74,15 +71,11 @@ sub register {
     $app->helper(gru => sub { $gru });
 }
 
-sub schema {
-    my ($self) = @_;
-    $self->{schema} ||= OpenQA::Schema::connect_db();
-}
+sub schema { shift->{schema} ||= OpenQA::Schema::connect_db() }
 
 # counts the number of jobs for a certain task in the specified states
 sub count_jobs {
     my ($self, $task, $states) = @_;
-
     my $res = $self->app->minion->backend->list_jobs(0, undef, {tasks => [$task], states => $states});
     return ($res && exists $res->{total}) ? $res->{total} : 0;
 }
@@ -90,19 +83,15 @@ sub count_jobs {
 # checks whether at least on job for the specified task is active
 sub is_task_active {
     my ($self, $task) = @_;
-
     return $self->count_jobs($task, ['active']) > 0;
 }
 
 sub enqueue {
-    my ($self, $task) = (shift, shift);
-    my $args    = shift // [];
-    my $options = shift // {};
-    my $jobs    = shift // [];
+    my ($self, $task, $args, $options, $jobs) = (shift, shift, shift // [], shift // {}, shift // []);
+
     my $ttl   = $options->{ttl}   ? $options->{ttl}   : undef;
     my $limit = $options->{limit} ? $options->{limit} : undef;
-
-    return if defined $limit && $self->count_jobs($task, ['inactive']) >= $limit;
+    return undef if defined $limit && $self->count_jobs($task, ['inactive']) >= $limit;
 
     $args = [$args] if ref $args eq 'HASH';
 
@@ -133,3 +122,21 @@ sub enqueue_limit_assets {
 }
 
 1;
+
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::WebAPI::Plugin::Gru - The Gru job queue
+
+=head1 SYNOPSIS
+
+    $app->plugin('OpenQA::WebAPI::Plugin::Gru');
+
+=head1 DESCRIPTION
+
+L<OpenQA::WebAPI::Plugin::Gru> is the WebAPI job queue (and a tiny wrapper
+around L<Minion>).
+
+=cut

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -70,8 +70,6 @@ sub register {
     my $auth = $app->routes->under('/minion')->to('session#ensure_admin');
     $app->plugin('Minion::Admin' => {route => $auth});
 
-    push @{$app->commands->namespaces}, 'OpenQA::WebAPI::Plugin::Gru::Command';
-
     my $gru = OpenQA::WebAPI::Plugin::Gru->new($app);
     $app->helper(gru => sub { $gru });
 }
@@ -132,104 +130,6 @@ sub enqueue {
 sub enqueue_limit_assets {
     my ($self) = @_;
     return $self->enqueue(limit_assets => [] => {priority => 10, ttl => 172800, limit => 1});
-}
-
-package OpenQA::WebAPI::Plugin::Gru::Command::gru;
-use Mojo::Base 'Mojolicious::Command';
-use Mojo::Pg;
-use Minion::Command::minion::job;
-use OpenQA::Utils 'log_error';
-
-has usage       => "usage: $0 gru [-o]\n";
-has description => 'Run a gru to process jobs - give -o to exit _o_nce everything is done';
-has job         => sub { Minion::Command::minion::job->new(app => shift->app) };
-
-sub delete_gru {
-    my ($self, $id) = @_;
-    my $gru = $self->app->db->resultset('GruTasks')->find($id);
-    $gru->delete() if $gru;
-}
-
-sub fail_gru {
-    my ($self, $id, $reason) = @_;
-    my $gru = $self->app->db->resultset('GruTasks')->find($id);
-    $gru->fail($reason) if $gru;
-}
-
-sub cmd_list { shift->job->run(@_) }
-
-sub execute_job {
-    my ($self, $job) = @_;
-
-    my $ttl       = $job->info->{notes}{ttl};
-    my $elapsed   = time - $job->info->{created};
-    my $ttl_error = 'TTL Expired';
-
-    return
-      exists $job->info->{notes}{gru_id}
-      ? $job->fail({error => $ttl_error}) && $self->fail_gru($job->info->{notes}{gru_id} => $ttl_error)
-      : $job->fail({error => $ttl_error})
-      if (defined $ttl && $elapsed > $ttl);
-
-    my $buffer;
-    my $err;
-    {
-        open my $handle, '>', \$buffer;
-        local *STDERR = $handle;
-        local *STDOUT = $handle;
-        $err = $job->execute;
-    };
-
-    if (defined $err) {
-        log_error("Gru command issue: $err");
-        $self->fail_gru($job->info->{notes}{gru_id} => $err)
-          if $job->fail({(output => $buffer) x !!(defined $buffer), error => $err})
-          && exists $job->info->{notes}{gru_id};
-    }
-    else {
-        $job->finish(defined $buffer ? $buffer : 'Job successfully executed');
-        $self->delete_gru($job->info->{notes}{gru_id}) if exists $job->info->{notes}{gru_id};
-    }
-
-}
-
-sub cmd_run {
-    my $self = shift;
-    my $opt  = $_[0] || '';
-
-    my $worker = $self->app->minion->repair->worker->register;
-
-    if ($opt eq '-o') {
-        while (my $job = $worker->register->dequeue(0)) {
-            $self->execute_job($job);
-        }
-        return $worker->unregister;
-    }
-
-    while (1) {
-        next unless my $job = $worker->register->dequeue(5);
-        $self->execute_job($job);
-    }
-    $worker->unregister;
-}
-
-sub run {
-    # only fetch first 2 args
-    my $self = shift;
-    my $cmd  = shift;
-
-    if (!$cmd) {
-        print "gru: [list|run]\n";
-        return;
-    }
-    if ($cmd eq 'list') {
-        $self->cmd_list(@_);
-        return;
-    }
-    if ($cmd eq 'run') {
-        $self->cmd_run(@_);
-        return;
-    }
 }
 
 1;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -112,7 +112,7 @@ is($job_groups->find(1001)->exclusively_kept_asset_size,
 sub run_gru {
     my ($task, $args) = @_;
     $t->app->gru->enqueue($task => $args);
-    $t->app->start('gru', 'run', '-o');
+    $t->app->start('gru', 'run', '--oneshot');
 }
 
 # understanding / revising these tests requires understanding the
@@ -407,26 +407,26 @@ subtest 'Gru tasks limit' => sub {
 
     is $t->app->minion->backend->list_jobs(0, undef, {tasks => ['limit_assets'], states => ['inactive']})->{total}, 2;
 
-    $t->app->start('gru', 'run', '-o');
+    $t->app->start('gru', 'run', '--oneshot');
     $id = $t->app->gru->enqueue(limit_assets => [] => {priority => 10, limit => 2});
     ok defined $id, 'task is scheduled';
     $id = $t->app->gru->enqueue(limit_assets => [] => {priority => 10, limit => 2});
     ok defined $id, 'task is scheduled';
     $res = $t->app->gru->enqueue(limit_assets => [] => {priority => 10, limit => 2});
     is $res, undef, 'Other tasks is not scheduled anymore';
-    $t->app->start('gru', 'run', '-o');
+    $t->app->start('gru', 'run', '--oneshot');
 };
 
 subtest 'Gru tasks TTL' => sub {
     $t->app->minion->reset;
     my $job_id = $t->app->gru->enqueue(limit_assets => [] => {priority => 10, ttl => -20})->{minion_id};
-    $t->app->start('gru', 'run', '-o');
+    $t->app->start('gru', 'run', '--oneshot');
     my $result = $t->app->minion->job($job_id)->info->{result};
     is ref $result, 'HASH', 'We have a result' or diag explain $result;
     is $result->{error}, 'TTL Expired', 'TTL Expired - job discarded' or diag explain $result;
 
     $job_id = $t->app->gru->enqueue(limit_assets => [] => {priority => 10, ttl => 20})->{minion_id};
-    $t->app->start('gru', 'run', '-o');
+    $t->app->start('gru', 'run', '--oneshot');
     $result = $t->app->minion->job($job_id)->info->{result};
 
     is ref $result, '', 'Result is the output';
@@ -438,7 +438,7 @@ subtest 'Gru tasks TTL' => sub {
     for (1 .. 100) {
         push @ids, $t->app->gru->enqueue(limit_assets => [] => {priority => 10, ttl => -50})->{minion_id};
     }
-    $t->app->start('gru', 'run', '-o');
+    $t->app->start('gru', 'run', '--oneshot');
 
     is $t->app->minion->job($_)->info->{result}->{error}, 'TTL Expired', 'TTL Expired - job discarded' for @ids;
 

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -228,7 +228,7 @@ is(
     'kept assets for group 1002 accumulated (26 GiB per asset)'
 );
 
-# empty the tracking arrays before next test
+# remove mock tracking data
 unlink $tempdir->child('removed');
 unlink $tempdir->child('deleted');
 
@@ -264,7 +264,7 @@ is(
     'kept assets for group 1002 accumulated (34 GiB per asset)'
 );
 
-# empty the tracking arrays before next test
+# remove mock tracking data
 unlink $tempdir->child('removed');
 unlink $tempdir->child('deleted');
 

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -292,7 +292,7 @@ subtest 'no cleanup of important builds' => sub {
     close $fh;
 
     $t->app->gru->enqueue('limit_results_and_logs');
-    $t->app->start('gru', 'run', '-o');
+    $t->app->start('gru', 'run', '--oneshot');
     ok(-e $filename, 'file still exists');
 };
 

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -275,7 +275,6 @@ And job OR job_group OR asset linked to build which is marked as important by co
 Then "important builds" are skipped from cleanup
 =cut
 subtest 'no cleanup of important builds' => sub {
-    my $c = OpenQA::WebAPI::Plugin::Gru::Command::gru->new(app => $t->app);
 
     # build 0048 has already been tagged as important before
     my $job      = $jobs->search({id => 99938, state => 'done', group_id => 1001, BUILD => '0048'})->first;
@@ -293,7 +292,7 @@ subtest 'no cleanup of important builds' => sub {
     close $fh;
 
     $t->app->gru->enqueue('limit_results_and_logs');
-    $c->run(qw(run -o));
+    $t->app->start('gru', 'run', '-o');
     ok(-e $filename, 'file still exists');
 };
 

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -28,6 +28,9 @@ sub create {
         $schema->{tmp_schema} = 'tmp_' . rndstr();
         $schema->storage->dbh->do("create schema $schema->{tmp_schema}");
         $schema->storage->dbh->do("SET search_path TO $schema->{tmp_schema}");
+
+        # Handle reconnects
+        $schema->storage->on_connect_do("SET search_path TO $schema->{tmp_schema}");
     }
 
     OpenQA::Schema::deployment_check($schema);


### PR DESCRIPTION
While learning the Gru code i noticed that it's actually not too hard to remove all the workarounds and make `gru run` start a normal Minion worker. With all the available features activated, such as processing each job in a separate process (which will free up the memory each job used after it is done). Currently there is still a hardcoded limit since some tasks can't handle parallel execution yet, but theoretically once that is fixed Gru could also run jobs in parallel (which should make it easier to move more work into background processes).

I've introduced a new `OpenQA::WebAPI::Command` namespace so there is no need anymore to hide secondary classes in the plugins.

There were also some fork related issues in `t/14-grutasks.t` (mock IPC) and `t/lib/OpenQA/Test/Database.t` (didn't handle reconnects) that i've resolved too.

Progress: https://progress.opensuse.org/issues/45290.