### PR TITLE
worker: Fix handling errors caused by connection issues with web UI

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -260,10 +260,7 @@ sub api_call {
         # handle critical error when no more attempts remain
         if ($tries <= 0 && !$non_critical) {
             # abort the current job, we're in trouble - but keep running to grab the next
-            OpenQA::Worker::Jobs::stop_job('api-failure');
-            # stop accepting jobs and schedule reregistration - keep the rest running
-            $hosts->{$host}{accepting_jobs} = 0;
-            add_timer("register_worker-$host", 10, sub { register_worker($host) }, 1);
+            OpenQA::Worker::Jobs::stop_job('api-failure', undef, $host);
             $callback->();
             return;
         }
@@ -467,9 +464,7 @@ sub call_websocket {
                             # worker id suddenly not known anymore. Abort. If workerid
                             # is unset we already detected that in api_call
                             $hosts->{$host}{workerid} = undef;
-                            OpenQA::Worker::Jobs::stop_job('api-failure');
-                            $hosts->{$host}{timers}{register_worker}
-                              = add_timer("register_worker-$host", 10, sub { register_worker($host) }, 1);
+                            OpenQA::Worker::Jobs::stop_job('api-failure', undef, $host);
                             return;
                         }
                     }

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -109,7 +109,7 @@ test_via_io_loop sub {
                 callback => sub { my $res = shift; is($res, undef, 'error handled'); Mojo::IOLoop->stop() });
             while (Mojo::IOLoop->is_running) { Mojo::IOLoop->singleton->reactor->one_tick }
         },
-        qr/.*\[ERROR\] Connection error:.*(remaining tries: 0).*\[DEBUG\] .* no job running.*/s,
+        qr/.*\[ERROR\] Connection error:.*(remaining tries: 0).*\[DEBUG\].*no job was running.*/s,
         'warning about 503 error'
     );
 };

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -268,16 +268,17 @@ subtest 'mock test stop_job' => sub {
     OpenQA::Worker::Jobs::update_status;
 
     OpenQA::Worker::Jobs::stop_job(0, 9999);
-    is $stop_job, 1, "stop_job() reached";
+    is($stop_job, 1, "stop_job() reached");
     print STDERR $stdout;
     my @matches = ($stdout =~ m/\[DEBUG\] updating status/g);
-    ok(@matches == 1, 'Updating status log');
+    my $ok      = is(scalar @matches, 1, 'Updating status log');
     @matches = ($stdout =~ m/\[DEBUG\] stop_job/g);
-    ok(@matches == 1, 'Stop job log');
+    $ok      = is(scalar @matches, 1, 'Stop job log') && $ok;
     @matches = ($stdout =~ m/\[DEBUG\] ## removing timer/g);
-    ok(@matches == 2, 'Changing timer log');
-    @matches = ($stdout =~ m/\[DEBUG\] waiting for update_status/g);
-    ok(@matches == 1, 'Waiting for update status log');
+    $ok      = is(scalar @matches, 2, 'Changing timer log') && $ok;
+    @matches = ($stdout =~ m/\[DEBUG\] postpone stopping until ongoing status update is concluded/g);
+    $ok      = is(scalar @matches, 1, 'Waiting for update status log') && $ok;
+    diag explain $stdout unless $ok;
 
     close STDOUT;
     open(STDOUT, '>&', $oldSTDOUT) or die "Can't dup \$oldSTDOUT: $!";
@@ -500,15 +501,15 @@ subtest 'handling upload finished' => sub {
 
     subtest 'behavor when result for status upload is undef' => sub {
         OpenQA::Worker::Jobs::handle_status_upload_finished($job_id, $upload_up_to, $callback, undef);
-        is($stop_job_aborted,     'abort', 'job aborted if status upload result is undef');
-        is($upload_images_called, 0,       'no image upload if status upload result is undef');
+        is($stop_job_aborted,     'api-failure', 'undefined status upload result is considered an API failure');
+        is($upload_images_called, 0,             'no image upload if status upload result is undef');
     };
 
     subtest 'behavior when image upload fails' => sub {
         $stop_job_aborted = 0;
         OpenQA::Worker::Jobs::handle_status_upload_finished($job_id, $upload_up_to, $callback, {});
-        is($upload_images_called, 1,       'image upload attempted');
-        is($stop_job_aborted,     'abort', 'job aborted if image upload fails');
+        is($upload_images_called, 1,             'image upload attempted');
+        is($stop_job_aborted,     'api-failure', 'failing image upload is considered an API failure');
     };
 
     subtest 'successful upload' => sub {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -535,9 +535,12 @@ subtest 'Check job status and output' => sub {
 
     $bogus_job_post->status_is(400);
     $bogus_worker_post->status_is(400);
-    ok($output =~ /Got status update for non-existing job/, 'Check status update for non-existing job');
-    ok($output =~ /Got status update for job .* that does not belong to Worker/,
-        'Got status update for job that doesnt belong to worker');
+    like($output, qr/Got status update for non-existing job/, 'Check status update for non-existing job');
+    like(
+        $output,
+        qr/Got status update for job .* with unexpected worker ID 999999/,
+        'Got status update for job that doesnt belong to worker'
+    );
 };
 # Test /jobs/cancel
 # TODO: cancelling jobs via API in tests doesn't work for some reason


### PR DESCRIPTION
Treat those errors as API failures so the worker does not try to
report connection issues with the web UI to the web UI.

See https://progress.opensuse.org/issues/45275

---

WIP because I still need to test.