### PR TITLE
Allow custom CASEDIR/PRODUCTDIR/ASSETDIR

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -253,9 +253,9 @@ sub engine_workit {
         return $error if $error;
     }
 
-    $vars{ASSETDIR}   = $OpenQA::Utils::assetdir;
-    $vars{CASEDIR}    = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
-    $vars{PRODUCTDIR} = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
+    $vars{ASSETDIR}   //= $OpenQA::Utils::assetdir;
+    $vars{CASEDIR}    //= OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
+    $vars{PRODUCTDIR} //= OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
 
     _save_vars(\%vars);
 


### PR DESCRIPTION
Tested locally together with
https://github.com/os-autoinst/os-autoinst/pull/1083

Local verification run:
```
openqa-clone-job --skip-chained-deps --from http://openqa.suse.de 2341662 \
WORKER_CLASS=qemu_x86_64_sle MAKETESTSNAPSHOTS=1 SKIPTO= \
EXIT_AFTER_START_INSTALL=1 \
CASEDIR=https://github.com/okurz/os-autoinst-distri-opensuse.git#test/custom_git_branch \
PRODUCTDIR=os-autoinst-distri-opensuse/products/sle _EXIT_AFTER_SCHEDULE=1
```

-> http://lord.arch/tests/1961/file/autoinst-log.txt

showing that the tests try to load the non-existing test module "not_welcome"
from the custom git repo and branch as specified instead of "welcome" which is
the module in the current master version of
os-autoinst/os-autoinst-distri-opensuse.

Related progress issue: https://progress.opensuse.org/issues/44327