### PR TITLE
Handle undefined `$text` in `find_bugref` and `find_bugrefs`

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -626,12 +626,14 @@ sub bugref_regex {
 
 sub find_bugref {
     my ($text) = @_;
+    $text //= '';
     $text =~ bugref_regex;
     return $+{match};
 }
 
 sub find_bugrefs {
     my ($text) = @_;
+    $text //= '';
     my @bugrefs;
     my $bugref_regex = bugref_regex;
 


### PR DESCRIPTION
We have quite a few warnings like this in Fedora's openQA logs:

Jan 09 17:55:55 openqa-stg01.qa.fedoraproject.org openqa[27943]: Use of uninitialized value $text in pattern match (m//) at /usr/share/openqa/script/../lib/OpenQA/Utils.pm line 629

It seems like something is calling `find_bugref` with `$text`
undefined. Rather than figuring out exactly what's doing that,
it seems easier to just tweak `find_bugref` to handle being
called with the text undefined. And we may as well do the same
for `find_bugrefs` since it's, like, right there!

See https://progress.opensuse.org/issues/39923

Signed-off-by: Adam Williamson <awilliam@redhat.com>