### PR TITLE
21-needles.t: Use `discard_changes` instead of re-calling `find`

### DIFF
--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -86,7 +86,7 @@ subtest 'handling of last update' => sub {
             t_updated    => time2str('%Y-%m-%dT%H:%M:%S', time - ($seconds_per_day * 2.5)),
         });
 
-    $needle = $needles->find(1);
+    $needle->discard_changes;
     my $t_created          = $needle->t_created;
     my $t_updated          = $needle->t_updated;
     my $last_actual_update = $needle->last_updated;
@@ -94,14 +94,14 @@ subtest 'handling of last update' => sub {
 
     $needle->update({last_matched_time => $new_last_match});
 
-    $needle = $needles->find(1);
+    $needle->discard_changes;
     is($needle->last_updated, $t_created, 'last_updated not altered');
     ok($t_updated lt $needle->t_updated, 't_updated still updated');
     is($needle->last_matched_time, $new_last_match, 'last match updated');
 
     $needles->update_needle_from_editor($needle->directory->path, 'test-rootneedle', {tags => [qw(foo bar)]},);
 
-    $needle = $needles->find(1);
+    $needle->discard_changes;
     my $last_actual_update2 = $needle->last_updated;
     ok(
         $last_actual_update lt $last_actual_update2,


### PR DESCRIPTION
This test seems to fail quite often in Fedora package builds, on
the "last_updated changed after updating needle from editor"
check. I'm not 100% sure, but I *think* this may be because
the test's `$needle` is not reliably refreshed by this approach
of calling `find` on the resultset again. Changing it to use
discard_changes instead seems to help.

Signed-off-by: Adam Williamson <awilliam@redhat.com>