### PR TITLE
apparmor: rk permission on hdd contents

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -123,7 +123,7 @@
   /var/lib/openqa/pool/*/** rwk,
   /var/lib/openqa/share/* r,
   /var/lib/openqa/share/factory/hdd/ r,
-  /var/lib/openqa/share/factory/hdd/* r,
+  /var/lib/openqa/share/factory/hdd/* rk,
   /var/lib/openqa/share/factory/hdd/fixed/* r,
   /var/lib/openqa/share/factory/iso/* rk,
   /var/lib/openqa/share/factory/iso/fixed/* r,


### PR DESCRIPTION
Opening qcow2 image has denied by apparmor.

type=AVC msg=audit(1547117832.842:491): apparmor="DENIED" operation="file_lock" profile="/usr/share/openqa/script/worker" name="/var/lib/openqa/share/factory/hdd/opensuse-Tumbleweed-x86_64-20190108-gnome@64bit.qcow2" pid=21062 comm="qemu-img" requested_mask="k" denied_mask="k" fsuid=456 ouid=458