### PR TITLE
Also set assigned jobs to parallel_failed

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1694,16 +1694,17 @@ sub _job_stop_child {
     $job = $rset->search({id => $job, result => NONE})->first;
     return 0 unless $job;
 
-    if ($job->state eq SCHEDULED) {
+    if ($job->state eq SCHEDULED || $job->state eq ASSIGNED) {
         $job->release_networks;
         $job->update({result => SKIPPED, state => CANCELLED});
     }
     else {
         $job->update({result => PARALLEL_FAILED});
-        if ($job->worker) {
-            $job->worker->send_command(command => 'cancel', job_id => $job->id);
-        }
     }
+    if ($job->worker) {
+        $job->worker->send_command(command => 'cancel', job_id => $job->id);
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
Otherwise their state will stay on assigned as only the result is updated
and then we reset it to scheduled if the worker finally wakes up

Related issue: https://progress.opensuse.org/issues/42986