### PR TITLE
apparmor: Fix custom git repo clone "env" denied

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -72,6 +72,7 @@
   /usr/bin/date rix,
   /usr/bin/dirname rix,
   /usr/bin/eatmydata rix,
+  /usr/bin/env rix,
   /usr/bin/find rix,
   /usr/bin/flock rix,
   /usr/bin/git rix,


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/829418/file/autoinst-log.txt

Verification run: https://openqa.opensuse.org/tests/829421

Related issue: https://progress.opensuse.org/issues/44327