### PR TITLE
bootstrap: make errors fatal and deal with re-runs

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+: ${dbuser:="geekotest"}
+
 : ${dist:="opensuse"}
 : ${giturl:="git://github.com/os-autoinst/os-autoinst-distri-opensuse.git"}
 : ${branch:="master"}
@@ -17,10 +19,10 @@ dir="/var/lib/openqa/share/tests"
 if [ -w / ]; then
 	if [ ! -e "$dir/$dist" ]; then
 		mkdir -p "$dir/$dist"
-		chown geekotest:www "$dir/$dist"
+		chown $dbuser:www "$dir/$dist"
 	fi
-	echo "running as root, re-exec as geekotest ..."
-	exec sudo -u geekotest env \
+	echo "running as root, re-exec as $dbuser ..."
+	exec sudo -u $dbuser env \
 		dist="$dist" \
 		giturl="$giturl" \
 		branch="$branch" \
@@ -48,6 +50,7 @@ needlesdir()
 do_fetch()
 {
 	local target=$1
+	echo fetching $target
 	git fetch -q
 	git rebase -q
 	if [ "$needles_separate" = 1 ]; then

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -1,4 +1,7 @@
 #!/bin/bash -x
+set -e
+: ${dbname:="openqa"}
+: ${dbuser:="geekotest"}
 
 
 # add extra repos for leap
@@ -16,15 +19,15 @@ zypper -n install --no-recommends openQA-local-db apache2 openQA-worker qemu-kvm
 
 # setup database
 systemctl enable --now postgresql
-su postgres -c "createuser -D geekotest"
-su postgres -c "createdb -O geekotest openqa"
+getent passwd $dbuser || su postgres -c "createuser -D $dbuser"
+su postgres -c "psql -lqt" | cut -d \| -f 1 | grep -qw $dbname || su postgres -c "createdb -O $dbuser $dbname"
 
 
 # setup webserver and fake-auth
 # from script/setup-single-instance (https://github.com/os-autoinst/openQA/pull/1933)
 for i in headers proxy proxy_http proxy_wstunnel rewrite ; do a2enmod $i ; done
 sed -i -e 's/^.*httpsonly.*$/httpsonly = 0/g' /etc/openqa/openqa.ini
-sed -i -e 's/#.*method.*OpenID.*$/&\nmethod = Fake/' /etc/openqa/openqa.ini
+sed -i -e 's/#*.*method.*=.*$/method = Fake/' /etc/openqa/openqa.ini
 sed "s/#ServerName.*$/ServerName $(hostname)/" /etc/apache2/vhosts.d/openqa.conf.template > /etc/apache2/vhosts.d/openqa.conf
 
 
@@ -50,8 +53,8 @@ fi
 
 if ping -c1 gitlab.suse.de. ; then
 	# clone SLE needles if run from within SUSE network
-	git clone https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git /var/lib/openqa/tests/opensuse/products/sle/needles
-	chown -R geekotest: /var/lib/openqa/tests/opensuse/products/sle/needles
+	[ -d /var/lib/openqa/tests/opensuse/products/sle/needles ] || git clone https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git /var/lib/openqa/tests/opensuse/products/sle/needles
+	chown -R $dbuser: /var/lib/openqa/tests/opensuse/products/sle/needles
 fi
 
 
@@ -77,7 +80,7 @@ done
 curl http://localhost/login # create demo user (id=2)
 API_KEY=$(hexdump -n 8 -e '2/4 "%08X" 1 "\n"' /dev/random)
 API_SECRET=$(hexdump -n 8 -e '2/4 "%08X" 1 "\n"' /dev/random)
-echo "INSERT INTO api_keys (key, secret, user_id, t_created, t_updated) VALUES ('${API_KEY}', '${API_SECRET}', 2, NOW(), NOW());" | su postgres -c 'psql openqa'
+echo "INSERT INTO api_keys (key, secret, user_id, t_created, t_updated) VALUES ('${API_KEY}', '${API_SECRET}', 2, NOW(), NOW());" | su postgres -c "psql $dbname"
 
 cat >> /etc/openqa/client.conf <<EOF
 [localhost]


### PR DESCRIPTION
I was running into some problems with `openqa-bootstrap`:

* the config file had been modified from a previous installation
* zypper failed due to a vendor change
* after the vendor change was fixed the script wouldn't re-run

With these changes, running the script
- will stop if eg. zypper is demanding attention
- existing user/database/needles are fine
- fetchneedles gained a log message which was invaluable for me to track down permission problems (due to the original very bad run)
- variables for database name/user