### PR TITLE
openqa-bootstrap-container: do more error checking, fix a hang

### DIFF
--- a/script/openqa-bootstrap-container
+++ b/script/openqa-bootstrap-container
@@ -5,10 +5,11 @@ set -e
 # which is not available there
 
 if [ $(id -ru) -ne 0 ]; then
-	echo "$0 must be run as root"
-	exit 1
+    echo "$0 must be run as root"
+    exit 1
 fi
 
+# Enable -x only here to show above error message cleanly
 set -x
 
 CONTAINER_NAME="openqa1"
@@ -55,24 +56,21 @@ WantedBy=machines.target
 EOF
 
 if [ ! -d $CONTAINER_PATH ] ; then
-	mkdir -p $CONTAINER_PATH
-	zypper -n --root $CONTAINER_PATH addrepo $DEFAULT_REPO defaultrepo
-	zypper -n --root $CONTAINER_PATH --gpg-auto-import-keys refresh
-	# There are non-fatal errors when zyppering inside chroot, so ignoring
-	set +e
-	zypper -n --root $CONTAINER_PATH install --no-recommends -ly $PKGS_TO_INSTALL
-	set -e
+    mkdir -p $CONTAINER_PATH
+    zypper -n --root $CONTAINER_PATH addrepo $DEFAULT_REPO defaultrepo
+    zypper -n --root $CONTAINER_PATH --gpg-auto-import-keys refresh
+    # There are non-fatal errors when zyppering inside chroot, so ignoring errors on the next line
+    zypper -n --root $CONTAINER_PATH install --no-recommends -ly $PKGS_TO_INSTALL || test $? == 107
 else
-	echo Container path $CONTAINER_PATH already exists, stopping here. Please clean manually and rerun.
-	exit 1
+    echo Container path $CONTAINER_PATH already exists, stopping here. Please clean manually and rerun.
+    exit 1
 fi
 
 systemctl daemon-reload
 systemctl start systemd-nspawn-openqa@$CONTAINER_NAME
-# Wait a bit to avoid 'Failed to create bus connection: Protocol error'
-sleep 1
 # ensure that the container is really running
-while ! timeout -s9 2 systemd-run -qPM $CONTAINER_NAME /bin/bash -c whoami ; do systemctl restart systemd-nspawn-openqa@$CONTAINER_NAME.service ; sleep 3 ; done
+# ignore expected errors about 'Failed to create bus connection: Protocol error' and restarting error
+while ! timeout -s9 2 systemd-run -qPM $CONTAINER_NAME /bin/bash -c whoami >& /dev/null ; do systemctl restart systemd-nspawn-openqa@$CONTAINER_NAME.service || true ; sleep 3 ; done
 systemd-run -qPM $CONTAINER_NAME /bin/bash -c '/usr/share/openqa/script/openqa-bootstrap'
 
 echo -e "$(tput setaf 2;tput bold)Your openQA container has been created. Run 'systemd-run -tM $CONTAINER_NAME /bin/bash' to get a shell in the container$(tput sgr0)"

--- a/script/openqa-bootstrap-container
+++ b/script/openqa-bootstrap-container
@@ -1,11 +1,18 @@
-#!/bin/bash -x
+#!/bin/bash
+set -e
 
 # This script doesn't work on Leap 15.0 as it makes use of the -P option of systemd-run
 # which is not available there
 
+if [ $(id -ru) -ne 0 ]; then
+	echo "$0 must be run as root"
+	exit 1
+fi
+
+set -x
 
 CONTAINER_NAME="openqa1"
-CONTANER_PATH="/var/lib/machines/${CONTAINER_NAME}"
+CONTAINER_PATH="/var/lib/machines/${CONTAINER_NAME}"
 
 DEFAULT_REPO="http://download.opensuse.org/tumbleweed/repo/oss/"
 PKGS_TO_INSTALL="aaa_base systemd shadow zypper openSUSE-release vim iproute2 iputils openQA-local-db openQA-worker sudo apache2 net-tools curl wget ca-certificates-mozilla qemu-kvm openQA-bootstrap"
@@ -47,13 +54,23 @@ DeviceAllow=block-blkext rw
 WantedBy=machines.target
 EOF
 
-mkdir $CONTANER_PATH
-zypper -n --root $CONTANER_PATH addrepo $DEFAULT_REPO defaultrepo
-zypper -n --root $CONTANER_PATH --gpg-auto-import-keys refresh
-zypper -n --root $CONTANER_PATH install --no-recommends -ly $PKGS_TO_INSTALL
+if [ ! -d $CONTAINER_PATH ] ; then
+	mkdir -p $CONTAINER_PATH
+	zypper -n --root $CONTAINER_PATH addrepo $DEFAULT_REPO defaultrepo
+	zypper -n --root $CONTAINER_PATH --gpg-auto-import-keys refresh
+	# There are non-fatal errors when zyppering inside chroot, so ignoring
+	set +e
+	zypper -n --root $CONTAINER_PATH install --no-recommends -ly $PKGS_TO_INSTALL
+	set -e
+else
+	echo Container path $CONTAINER_PATH already exists, stopping here. Please clean manually and rerun.
+	exit 1
+fi
 
 systemctl daemon-reload
 systemctl start systemd-nspawn-openqa@$CONTAINER_NAME
+# Wait a bit to avoid 'Failed to create bus connection: Protocol error'
+sleep 1
 # ensure that the container is really running
 while ! timeout -s9 2 systemd-run -qPM $CONTAINER_NAME /bin/bash -c whoami ; do systemctl restart systemd-nspawn-openqa@$CONTAINER_NAME.service ; sleep 3 ; done
 systemd-run -qPM $CONTAINER_NAME /bin/bash -c '/usr/share/openqa/script/openqa-bootstrap'


### PR DESCRIPTION
I was trying to run `openqa-bootstrap-container` on my TW but bumped into a few problems:
- Trying without root or sudo resulted in various commands being tried to be executed without checking that all of them errored out.
- Later on I kept getting error "Failed to create bus connection: Protocol error" and an apparent hang when trying to run the script as is, even though the container seemed to work fine when I manually looked at it.

These changes thus:
- Check if there are root rights and if not, asking to execute as root (sudo fine too)
- Exiting on error everywhere but in one place (zypper package installation causes error code even on success in this case)
- Checks existence of the container directory before continuing to allow trying a rerun of the command without causing problems.
- Works around the Protocol error notice with waiting a bit after starting the container - I have verified that without this line it always gives the error message and then hangs on the following systemctl restart command.
- Fixes a typo
