### PR TITLE
UserAgent: get URL even if first route fails

### DIFF
--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -65,6 +65,27 @@ sub new {
     return $self;
 }
 
+sub get {
+    my ($self, $url) = @_;
+
+    my $tx;
+
+    # Resolve the URL manually in case one of the routes doesn't work
+    use Socket;
+    my ($err, @addrs) = Socket::getaddrinfo($url->host);
+    for my $addr (@addrs) {
+        my ($err, $host) = Socket::getnameinfo($addr->{addr}, Socket::NI_NUMERICHOST);
+        $url->host($host);
+        $tx = $self->SUPER::get($url);
+        if (!$tx->error) {
+          last;
+        }
+        warn "failed to resolve $host: ".$tx->error->{message};
+    }
+
+    return $tx;
+};
+
 sub _add_auth_headers {
     my ($self, $ua, $tx) = @_;
 

--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -195,7 +195,7 @@ sub get_job {
     my $job;
     my $url = $remote_url->clone;
     $url->path("jobs/$jobid");
-    my $tx = $remote->max_redirects(3)->get($url);
+    my $tx = $remote->max_redirects(3)->connect_timeout(3)->get($url);
     if (!$tx->error) {
         if ($tx->res->code == 200) {
             $job = $tx->res->json->{job};


### PR DESCRIPTION
I was having the very confusing problem that I could see a test I was interested in just fine by looking at the browser, but `clone_job.pl` would fail with:

    failed to get job:  Connect timeout at ~/dev/openQA/script/clone_job.pl line 212

which only started to make sense when I realized that curl was getting stuck when asked to specifically use IPv6:

    $ curl -6 https://openqa.suse.de/api/v1/jobs/2370612
    curl: (6) Could not resolve host: openqa.suse.de


I'm not sure if my proposed solution is the best approach here - but usually I expect tools, such as `curl` or the browser, to fallback if the first attempt won't work. `Mojo::UserAgent` doesn't seem to have any configuration options for this, so I ended up overriding `OpenQA::UserAgent::get` in such a way that it would try harder to resolve the host in the way I expect.