### PR TITLE
worker: Fix two perl warnings

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -242,8 +242,8 @@ sub engine_workit {
             sleep 5 and update_setup_status until $rsync_request->processed;
             my $exit = $rsync_request->result;
 
-            log_info("rsync: " . $rsync_request->output, channels => 'autoinst');
-            return {error => "Failed to rsync tests: exit " . $exit} unless $exit == 0;
+            if (my $output = $rsync_request->output) { log_info("rsync: " . $output, channels => 'autoinst') }
+            return {error => "Failed to rsync tests: exit " . $exit} unless ($exit && $exit == 0);
 
             $shared_cache = catdir($shared_cache, 'tests');
         }


### PR DESCRIPTION
Observed on power8:

```
Jan 17 20:23:54 power8 worker[15039]: Use of uninitialized value in concatenation (.) or string at /usr/share/openqa/script/../lib/OpenQA/Worker/Engines/isotovideo.pm line 245.
Jan 17 20:23:54 power8 worker[15039]: Use of uninitialized value $exit in numeric eq (==) at /usr/share/openqa/script/../lib/OpenQA/Worker/Engines/isotovideo.pm line 246.
```