### PR TITLE
Improve error handling in worker cache /status route

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -151,6 +151,7 @@ sub cache_assets {
             # assume that if we have a full path, that's what we should use
             $vars->{$this_asset} = $asset_uri if -e $asset_uri;
             # don't kill the job if the asset is not found
+            # TODO: This seems to leave the job stuck in some cases (observed in production on openqaworker3).
             next;
         }
         return {error => "Can't download $asset_uri to " . $cache_client->asset_path($current_host, $asset_uri)}

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -246,6 +246,23 @@ subtest 'Cache Requests' => sub {
 
 start_server;
 
+subtest 'Invalid requests' => sub {
+    my $url             = $cache_client->_url('/status');
+    my $invalid_request = $cache_client->ua->post($url => json => {lock => "some lock"});
+    my $json            = $invalid_request->result->json;
+    is_deeply($json, {status => 1}, 'no job ID accepted') or diag explain $json;
+
+    $url             = $cache_client->_url('/status');
+    $invalid_request = $cache_client->ua->post($url => json => {id => "foo", lock => "some lock"});
+    $json            = $invalid_request->result->json;
+    is_deeply($json, {error => 'Specified job ID is invalid.'}, 'invalid job ID') or diag explain $json;
+
+    $url             = $cache_client->_url('/status');
+    $invalid_request = $cache_client->ua->post($url => json => {});
+    $json            = $invalid_request->result->json;
+    is_deeply($json, {error => 'No lock specified.'}, 'no lock') or diag explain $json;
+};
+
 subtest 'Asset exists' => sub {
 
     ok(!$cache_client->asset_exists('localhost', 'foobar'), 'Asset absent');


### PR DESCRIPTION
Prevents error like

    openqaworker3 openqa-workercache[9158]: [e] Can't call method "info" on an undefined value at /usr/share/openqa/script/../lib/OpenQA/Worker/Cache/Service.pm line 101

on the cache service daemon.