### PR TITLE
Fix regression of test caching failing introduced by c9735699

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -243,7 +243,7 @@ sub engine_workit {
             my $exit = $rsync_request->result;
 
             if (my $output = $rsync_request->output) { log_info("rsync: " . $output, channels => 'autoinst') }
-            return {error => "Failed to rsync tests: exit " . $exit} unless ($exit && $exit == 0);
+            return {error => "Failed to rsync tests: exit " . $exit} unless (defined $exit && $exit == 0);
 
             $shared_cache = catdir($shared_cache, 'tests');
         }


### PR DESCRIPTION
The exit code of "0" must not be evaluated in boolean context in perl.

Related progress issue: https://progress.opensuse.org/issues/46658