### PR TITLE
Update serial terminal function

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -913,7 +913,7 @@ suite.
 
 [source,perl]
 --------------------------------------------------------------------------------
-if (select_virtio_console()) {
+if (select_serial_terminal()) {
         # Do something which only works, or is necessary, on a serial terminal
 }
 --------------------------------------------------------------------------------


### PR DESCRIPTION
select_virtio_console() was replaced by select_serial_terminal()
in commit in os-autoinst-distri-opensuse 13018da1b ("Remove
select_virtio_console() and replace it with select_serial_terminal()")