### PR TITLE
Split configured hosts by whitespace

### DIFF
--- a/lib/OpenQA/Worker/Common.pm
+++ b/lib/OpenQA/Worker/Common.pm
@@ -603,7 +603,7 @@ sub read_worker_config {
     my $host_settings;
     $host ||= $sets->{HOST} ||= 'localhost';
     delete $sets->{HOST};
-    my @hosts = split / /, $host;
+    my @hosts = split ' ', $host;
     for my $section (@hosts) {
         if ($cfg && $cfg->SectionExists($section)) {
             for my $set ($cfg->Parameters($section)) {


### PR DESCRIPTION
This allows the HOST variable in `/etc/openqa/workers.ini` to be split by several white-spaces (including multiple spaces or tabs) instead of just only one single space (as before).