### PR TITLE
Revert support for ASSET_\d+_URL

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -93,10 +93,6 @@ sub detect_asset_keys {
         $res{$isokey} = 'iso' if $vars->{$isokey};
     }
 
-    for my $otherkey (grep { /ASSET_\d+$/ } keys %{$vars}) {
-        $res{$otherkey} = 'other';
-    }
-
     for my $otherkey (qw(KERNEL INITRD)) {
         $res{$otherkey} = 'other' if $vars->{$otherkey};
     }


### PR DESCRIPTION
For the time being seems that the dynamic schedule of tests with
caching seems a bit complicated. Mainly due to some tests using ASSET_\d
as part of an URL and others using it as a file to be expected to be
downloaded. The cache service should only treat assets as something to
download.

The feature introduced in #1855 is nice, but won't work with caching for
the time being. See https://progress.opensuse.org/issues/43511.

Note: This ~~feature~~ broke autoyast tests :)

One idea that I have is to introduce a separate [ASSET_LOCAL_](https://github.com/foursixnine/openQA/commit/304573d0d67dc029884831dad91404e0aca23082) for the cases when we _expect_ the cache service to actually download the thing and link it to the worker pool.

PS: With #1943 and subsequent related pr's, we wouldn't need to specify the ASSET_X_URL, which makes all of this even easier. 