### PR TITLE
Prevent download tasks for the same asset running in parallel

### DIFF
--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -32,6 +32,11 @@ sub register {
 sub _download {
     my ($app, $job, $url, $assetpath, $do_extract) = @_;
 
+    # prevent multiple asset download tasks for the same asset to run
+    # in parallel
+    return $job->retry({delay => 30})
+      unless my $guard = $app->minion->guard("limit_asset_download_${assetpath}_task", 3600);
+
     my $ipc = OpenQA::IPC->ipc;
 
     # Bail if the dest file exists (in case multiple downloads of same ISO


### PR DESCRIPTION
The way scheduling works at least in Fedora, we may wind up with
multiple tasks to download the same asset. Since feef1726, this
may wind up causing them to run in parallel with each other, and
when this happens, the check which causes the task to bail if
the destination file already exists won't help, because the file
won't exist until one of the tasks *completes*. So we may well
go ahead and have multiple tasks all running in parallel and
downloading the same file, then all renaming it to the target
filename at the end. This probably won't break anything but it
sure will waste bandwidth. To avoid this happening, add the same
'guard' that was added to other non-self-parallel-safe tasks,
but using `$assetpath` as part of the guard name so download
tasks for *different* assets *can* run in parallel.

Signed-off-by: Adam Williamson <awilliam@redhat.com>