### PR TITLE
Fix modules filter wrong results while using comma

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -962,8 +962,8 @@ sub compose_job_overview_search_args {
             $search_args{$arg} = {-in => $params};
         }
     }
-    if ($controller->param('modules')) {
-        $search_args{modules} = $controller->every_param('modules');
+    if (my $modules = param_hash($controller, 'modules')) {
+        $search_args{modules} = [keys %$modules];
     }
     if ($controller->param('modules_result')) {
         $search_args{modules_result} = $controller->every_param('modules_result');

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -267,14 +267,24 @@ subtest 'filtering by module' => sub {
         my $number_of_found_jobs = 4;
         $driver->get("/tests/overview?arch=&distri=opensuse&modules_result=$result");
         my @jobs = $driver->find_elements($JOB_ICON_SELECTOR);
-        # Assert that all the jobs with the specified module and result are shown in the results
+        # Assert that all the jobs with the specified result are shown in the results
         is(scalar @jobs, $number_of_found_jobs,
             "$number_of_found_jobs jobs where modules with \"$result\" result found");
         element_visible('#res_DVD_i586_kde');
         element_visible('#res_DVD_x86_64_kde');
         element_visible('#res_DVD_i586_textmode');
         element_visible('#res_DVD_x86_64_doc');
-    }
+    };
+    subtest "jobs containing all the modules separated by comma are present" => sub {
+        my $modules              = 'kate,zypper_up';
+        my $number_of_found_jobs = 2;
+        $driver->get("/tests/overview?arch=&distri=opensuse&modules=$modules&modules_result=$result");
+        my @jobs = $driver->find_elements($JOB_ICON_SELECTOR);
+        # Assert that all the jobs with the specified modules and result are shown in the results
+        is(scalar @jobs, $number_of_found_jobs, "$number_of_found_jobs jobs with \"$modules\" modules found");
+        element_visible('#res_DVD_i586_kde');
+        element_visible('#res_DVD_i586_textmode');
+    };
 };
 
 kill_driver();


### PR DESCRIPTION
Filter returned results only when one module was specified in the Module
filter field on Test Result Overview page. It returned no results while
using comma-separated module names.

The commit fixes the issue and allows to filter job groups by several
module names separated by comma (e.g. module1,module2).