### PR TITLE
openqa-clone-custom-git-refspec: make use of GROUP var

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -39,4 +39,4 @@ build="${build:-"$repo_name#$pr"}"
 casedir="${casedir:-"$repo#$branch"}"
 GROUP="${GROUP:-0}"
 dry_run="${dry_run:-""}"
-$dry_run openqa-clone-job --skip-chained-deps --within-instance $host $job _GROUP=0 TEST=$test BUILD=$build CASEDIR=$casedir PRODUCTDIR=$productdir NEEDLES_DIR=$needles_dir
+$dry_run openqa-clone-job --skip-chained-deps --within-instance $host $job _GROUP=$GROUP TEST=$test BUILD=$build CASEDIR=$casedir PRODUCTDIR=$productdir NEEDLES_DIR=$needles_dir


### PR DESCRIPTION
Currently, `GROUP` var is not used and `_GROUP` is always set to `0`.