### PR TITLE
Cache service migrations

### DIFF
--- a/lib/OpenQA/Worker/Cache/Service.pm
+++ b/lib/OpenQA/Worker/Cache/Service.pm
@@ -148,8 +148,6 @@ post '/dequeue' => sub {
     $c->render(json => {status => STATUS_PROCESSED});
 };
 
-app->minion->reset;
-
 =encoding utf-8
 
 =head1 NAME

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -139,8 +139,9 @@ subtest '_base_host' => sub {
 
 is $cache->init, $cache;
 $openqalogs = read_log($logfile);
+is $cache->sqlite->migrations->latest, 1, 'version 1 is the latest version';
+is $cache->sqlite->migrations->active, 1, 'version 1 is the active version';
 like $openqalogs, qr/Creating cache directory tree for/, "Cache directory tree created.";
-like $openqalogs, qr/Deploying DB/,                      "Cache deploys the database.";
 like $openqalogs, qr/Configured limit: 53687091200/,     "Cache limit is default (50GB).";
 ok(-e $db_file, "cache.sqlite is present");
 truncate_log $logfile;
@@ -167,9 +168,8 @@ chdir $logdir;
 
 $cache->sleep_time(1);
 $cache->init;
-
+is $cache->sqlite->migrations->active, 1, 'version 1 is still the active version';
 $openqalogs = read_log($logfile);
-unlike $openqalogs, qr/Deploying DB/, "Cache deploys the database.";
 like $openqalogs, qr/CACHE: Health: Real size: 168, Configured limit: 53687091200/,
   "Cache limit/size match the expected 100GB/168)";
 unlike $openqalogs, qr/CACHE: Purging non registered.*[13].qcow2/, "Registered assets 1 and 3 were kept";


### PR DESCRIPTION
While fixing our openQA staging machines for testing #1990 we stumbled over a problem with the cache service SQLite database. As it turns out there were no migrations used to manage the schema, so the commit https://github.com/os-autoinst/openQA/commit/bd72dca44f1a0e4d439be35ff109f0be3bfb28fb broke all workers that upgraded without clearing the `/var/lib/openqa/cache` directory. To make sure this doesn't happen again in the future i'm introducing `Mojo::SQLite` migrations in this pull request, so we have a versioned schema from now on.

This pull request also removes a call to `app->minion->reset;` from `OpenQA::Worker::Cache::Service`, which deleted all jobs from the job queue every time the cache service was restarted (even if the cache service minion was still running). That seemed rather dangerous and would have prevented any future use of the worker job queue for other worker related tasks (which we plan to do in the future). There is more work to be done regarding this, but we have to start somewhere. 😉