### PR TITLE
Log isotovideo startup more detailed

### DIFF
--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -632,6 +632,8 @@ sub start_job {
         log_warning('job errored. Releasing job', channels => ['worker', 'autoinst'], default => 1);
         return stop_job("job run failure");
     }
+    my $isotovideo_pid = $worker->{child}->pid() // 'unknown';
+    log_info("isotovideo has been started (PID: $isotovideo_pid)");
 
     my $jobid = $job->{id};
 


### PR DESCRIPTION
I think the most important case where the worker sometimes hangs is during, right before or right after the isotovideo startup. So I'd like to add a few more log lines in that stage. Compared to the length of the overall worker log this is actually nothing. But it would be useful to debug

* https://progress.opensuse.org/issues/47060
* https://progress.opensuse.org/issues/47087

---

@nicksinger Can you actually deploy this when it is merged? It would be sufficient to deploy on selected worker instances. We could reproduce the issue recently on `openqaworker2` and `grenache-1` so that would be good candidates.