### PR TITLE
Add YAML::XS and JSON::Validator dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -39,8 +39,6 @@ requires 'IPC::Cmd';
 requires 'IPC::Run';
 requires 'Cpanel::JSON::XS';
 requires 'JavaScript::Minifier::XS', '>= 0.11';
-requires 'JSON::Validator';
-requires 'YAML::XS';
 requires 'LWP::UserAgent';
 requires 'Minion', '9.0';
 requires 'Minion::Backend::Pg';

--- a/cpanfile
+++ b/cpanfile
@@ -39,6 +39,8 @@ requires 'IPC::Cmd';
 requires 'IPC::Run';
 requires 'Cpanel::JSON::XS';
 requires 'JavaScript::Minifier::XS', '>= 0.11';
+requires 'JSON::Validator';
+requires 'YAML::XS';
 requires 'LWP::UserAgent';
 requires 'Minion', '9.0';
 requires 'Minion::Backend::Pg';

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -90,6 +90,8 @@ RUN zypper in -y -C \
        'perl(Mojolicious)' \
        'perl(Mojolicious::Plugin::AssetPack)' \
        'perl(Mojolicious::Plugin::RenderFile)' \
+       'perl(JSON::Validator)' \
+       'perl(YAML::XS)' \
        'perl(Net::DBus)' \
        'perl(Net::OpenID::Consumer)' \
        'perl(Net::SNMP)' \

--- a/openQA.spec
+++ b/openQA.spec
@@ -63,6 +63,8 @@ BuildRequires:  rubygem(sass)
 Requires:       dbus-1
 Requires:       perl(Minion) >= 9.02
 Requires:       perl(Mojo::RabbitMQ::Client) >= 0.2
+Requires:       perl(JSON::Validator)
+Requires:       perl(YAML::XS)
 # needed for test suite
 Requires:       git-core
 Requires:       openQA-client = %{version}

--- a/openQA.spec
+++ b/openQA.spec
@@ -34,7 +34,7 @@
 %bcond_with tests
 %endif
 # runtime requirements that also the testsuite needs
-%define t_requires perl(DBD::Pg) perl(DBIx::Class) perl(Config::IniFiles) perl(SQL::Translator) perl(Date::Format) perl(File::Copy::Recursive) perl(DateTime::Format::Pg) perl(Net::OpenID::Consumer) perl(Mojolicious::Plugin::RenderFile) perl(Mojolicious::Plugin::AssetPack) perl(aliased) perl(Config::Tiny) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(IO::Socket::SSL) perl(Data::Dump) perl(DBIx::Class::OptimisticLocking) perl(Text::Markdown) perl(Net::DBus) perl(IPC::Run) perl(Archive::Extract) perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS) perl(Time::ParseDate) perl(Sort::Versions) perl(Mojo::RabbitMQ::Client) perl(BSD::Resource) perl(Cpanel::JSON::XS) perl(Pod::POM) perl(Mojo::IOLoop::ReadWriteProcess) perl(Minion) perl(Mojo::Pg) perl(Mojo::SQLite) perl(Minion::Backend::SQLite)
+%define t_requires perl(DBD::Pg) perl(DBIx::Class) perl(Config::IniFiles) perl(SQL::Translator) perl(Date::Format) perl(File::Copy::Recursive) perl(DateTime::Format::Pg) perl(Net::OpenID::Consumer) perl(Mojolicious::Plugin::RenderFile) perl(Mojolicious::Plugin::AssetPack) perl(aliased) perl(Config::Tiny) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(IO::Socket::SSL) perl(Data::Dump) perl(DBIx::Class::OptimisticLocking) perl(Text::Markdown) perl(Net::DBus) perl(JSON::Validator) perl(YAML::XS) perl(IPC::Run) perl(Archive::Extract) perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS) perl(Time::ParseDate) perl(Sort::Versions) perl(Mojo::RabbitMQ::Client) perl(BSD::Resource) perl(Cpanel::JSON::XS) perl(Pod::POM) perl(Mojo::IOLoop::ReadWriteProcess) perl(Minion) perl(Mojo::Pg) perl(Mojo::SQLite) perl(Minion::Backend::SQLite)
 Name:           openQA
 Version:        4.6
 Release:        0
@@ -63,8 +63,6 @@ BuildRequires:  rubygem(sass)
 Requires:       dbus-1
 Requires:       perl(Minion) >= 9.02
 Requires:       perl(Mojo::RabbitMQ::Client) >= 0.2
-Requires:       perl(JSON::Validator)
-Requires:       perl(YAML::XS)
 # needed for test suite
 Requires:       git-core
 Requires:       openQA-client = %{version}


### PR DESCRIPTION
Adding these dependencies is a prerequisite for #1999 which as I understand it has to be prepared before test cases can pass on the actual branch.