### PR TITLE
worker: Upload serial_terminal.txt for svirt backend

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -74,6 +74,7 @@ RUN zypper in -y -C \
        'perl(Exception::Class)' \
        'perl(File::Copy::Recursive)' \
        'perl(File::Touch)' \
+       'perl(IO::Scalar)' \
        'perl(IO::Socket::SSL)' \
        'perl(IPC::Run)' \
        'perl(IPC::System::Simple)' \

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1097,11 +1097,12 @@ the effect of pressing the magic SysRq key if you are lucky.
 
 The os-autoinst package supports several types of 'consoles' of which the
 virtio serial terminal is one. The majority of code for this console is
-located in consoles/virtio_terminal.pm and consoles/virtio_screen.pm. However
-there is also related code in backends/qemu.pm and distribution.pm.
+located in consoles/virtio_terminal.pm and consoles/serial_screen.pm (used also
+svirt serial console). However there is also related code in backends/qemu.pm
+and distribution.pm.
 
 You may find it useful to read the documentation in virtio_terminal.pm and
-virtio_screen.pm if you need to perform some special action on a terminal such
+serial_screen.pm if you need to perform some special action on a terminal such
 as triggering a signal or simulating the SysRq key. There are also some
 console specific arguments to +wait_serial+ and +type_string+ such as
 +record_output+.

--- a/lib/OpenQA/Worker/Jobs.pm
+++ b/lib/OpenQA/Worker/Jobs.pm
@@ -481,7 +481,9 @@ sub _stop_job_kill_and_upload {
         }
 
         # upload other logs and files
-        for my $file (qw(video.ogv video_time.vtt vars.json serial0 autoinst-log.txt virtio_console.log worker-log.txt))
+        for my $file (
+            qw(video.ogv video_time.vtt vars.json serial0 autoinst-log.txt serial_terminal.txt virtio_console.log worker-log.txt)
+          )
         {
             next unless -e $file;
 


### PR DESCRIPTION
Unlike virtio console on qemu, which creates virtio_console.log
file which needs to be renamed to serial_terminal.txt svirt
creates this file directly.

This is a worker support for PR
https://github.com/os-autoinst/os-autoinst/pull/1109

PoC: 
http://quasar.suse.cz/tests/1892#downloads
http://quasar.suse.cz/tests/1892/file/serial_terminal.txt