### PR TITLE
Fix updating needle Git repository

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -521,7 +521,7 @@ sub set_to_latest_git_master {
 
     my @git = _prepare_git_command($args);
 
-    my $res = run_cmd_with_log_return_error([@git, 'fetch', 'origin', 'master:master']);
+    my $res = run_cmd_with_log_return_error([@git, 'remote', 'update', 'origin']);
     return _format_git_error($res, 'Unable to fetch from origin master') unless $res->{status};
 
     $res = run_cmd_with_log_return_error([@git, 'rebase', 'origin/master']);

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -105,8 +105,8 @@ subtest 'git commands with mocked run_cmd_with_log_return_error' => sub {
     is(set_to_latest_git_master({dir => 'foo/bar'}), undef, 'no error occured');
     is_deeply(
         \@executed_commands,
-        [[qw(git -C foo/bar fetch origin master:master)], [qw(git -C foo/bar rebase origin/master)],],
-        'git fetch and reset executed',
+        [[qw(git -C foo/bar remote update origin)], [qw(git -C foo/bar rebase origin/master)],],
+        'git remote update and rebase executed',
     ) or diag explain \@executed_commands;
 
     # test set_to_latest_git_master (error case)
@@ -116,9 +116,9 @@ subtest 'git commands with mocked run_cmd_with_log_return_error' => sub {
     is(
         set_to_latest_git_master({dir => 'foo/bar'}),
         'Unable to fetch from origin master: mocked error',
-        'an error occured on fetch'
+        'an error occured on remote update'
     );
-    is_deeply(\@executed_commands, [[qw(git -C foo/bar fetch origin master:master)],], 'git reset not attempted',)
+    is_deeply(\@executed_commands, [[qw(git -C foo/bar remote update origin)],], 'git reset not attempted',)
       or diag explain \@executed_commands;
 
     # test commit_git


### PR DESCRIPTION
I made openQA updating the needle Git repository before committing new needles. It seems that `git fetch origin master:master` does not work in production because the `master` branch is checked out there by default. The PR changes the command to `git remote update origin` which also works in that case. This change is hot-patched on OSD and seems to work.