### PR TITLE
Allow specifying test vars for openqa-clone-custom-git-refspec

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -1,10 +1,10 @@
 #!/bin/sh -e
 
 # Usage:
-#  openqa-clone-custom-git-refspec GITHUB_PR_URL OPENQA_JOB_URL
+#  openqa-clone-custom-git-refspec GITHUB_PR_URL OPENQA_JOB_URL [CUSTOM_TEST_VAR_1=foo] [CUSTOM_TEST_VAR_2=bar]
 #
 # Example:
-#  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6529 https://openqa.opensuse.org/tests/835060
+#  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6529 https://openqa.opensuse.org/tests/835060 DESKTOP=textmode
 #
 set -o pipefail
 if [ -z ${repo_name+x} ] || [ -z ${pr+x} ]; then
@@ -39,4 +39,4 @@ build="${build:-"$repo_name#$pr"}"
 casedir="${casedir:-"$repo#$branch"}"
 GROUP="${GROUP:-0}"
 dry_run="${dry_run:-""}"
-$dry_run openqa-clone-job --skip-chained-deps --within-instance $host $job _GROUP=$GROUP TEST=$test BUILD=$build CASEDIR=$casedir PRODUCTDIR=$productdir NEEDLES_DIR=$needles_dir
+$dry_run openqa-clone-job --skip-chained-deps --within-instance $host $job _GROUP=$GROUP TEST=$test BUILD=$build CASEDIR=$casedir PRODUCTDIR=$productdir NEEDLES_DIR=$needles_dir "${@:3}"


### PR DESCRIPTION
Eg:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6925 https://openqa.opensuse.org/tests/865136 INSTALLONLY=42 BETA=2
```