### PR TITLE
Correct limit_assets task arguments

### DIFF
--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -40,7 +40,7 @@ sub _remove_if {
 }
 
 sub _limit {
-    my ($app, $j, $job, $url) = @_;
+    my ($app, $job) = @_;
 
     # prevent multiple limit_assets tasks to run in parallel
     return $job->finish('Previous limit_assets job is still active')


### PR DESCRIPTION
These arguments were completely wrong, so far as I can tell.
Per https://mojolicious.org/perldoc/Minion#add_task , when you
add a task, the @_ array's contents are the job as the first
item, plus any items that were included in the array when
`enqueue()` is called. So in the example on the doc page,
the contents of @_ are the job, then 1, then 1 again.

When we enqueue `limit_assets` we just pass an empty array. So
the contents of @_ should be just the job. Then the subroutine
we use in the `add_task` call just calls `_limit` with the args
as $app and then the contents of @_. Put all that together, and
the args `_limit` actually receives should be just the app and
the job. There is no 'j' or 'url'.

This causes a real problem: if you go to the minion job monitor
UI and look at failed tasks, there are hundreds of failures for
`limit_assets` with this error:

"Can't call method \"finish\" on an undefined value at /usr/share/openqa/script/../lib/OpenQA/Task/Asset/Limit.pm line 46.\n"

This bug is the cause of that. We try to call `$job->finish`,
but because we're unpacking the args incorrectly, $job is
undefined (it's the non-existent third member of the array). If
we correct the args, `$job` should actually exist and this call
should work.

Signed-off-by: Adam Williamson <awilliam@redhat.com>