### PR TITLE
Add hints to fix dependencies when using devel

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -98,6 +98,20 @@ zypper ar -f obs://devel:openQA:Leap:$LEAP_VERSION/openSUSE_Leap_$LEAP_VERSION d
 
 As required change +LEAP_VERSION+ to the version of openSUSE Leap you have installed.
 
+[NOTE]
+If you installed openQA from the official repository first, you may need to change the vendor of the dependencies.
+
+[source,sh]
+-------------------------------------------------------------------------------
+# openSUSE Tumbleweed and Leap
+zypper dup --from devel-openQA --allow-vendor-change
+
+
+# openSUSE Leap
+zypper dup --from devel-openQA-perl-modules --allow-vendor-change
+-------------------------------------------------------------------------------
+
+
 === Installation
 You can install the packages using these commands.
 


### PR DESCRIPTION
When a user install openQA from official repositories, and then try to install the version from devel project, it often comes to the situation where dependency conflicts appear.

These hints should help the user to fix them and to be aware of the issue.