### PR TITLE
Remove safe_call from OpenQA::Utils since it is no longer needed

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -92,7 +92,6 @@ our @EXPORT  = qw(
   wakeup_scheduler
   read_test_modules
   exists_worker
-  safe_call
   feature_scaling
   logistic_map_steps
   logistic_map
@@ -1270,24 +1269,6 @@ sub walker {
     }
 }
 
-
-sub safe_call {
-    # no critic is for symbol de/reference
-    no strict 'refs';    ## no critic
-    my $ret;
-    log_debug("Safe call: " . pp(@_));
-    eval {
-        $ret
-          = blessed $_[0] ? [+shift->${\+shift()}(splice @_, 1)]
-          : *{"$_[0]::$_[1]"}{CODE} ? [*{"$_[0]::$_[1]"}{CODE}(splice @_, 2)]
-          :                           die(qq|Can't locate object method "$_[1]" via package "$_[0]"|);
-    };
-    if ($@) {
-        log_error("Safe call error: $@");
-        return [];
-    }
-    return $ret;
-}
 
 # Args:
 # First is i-th element, Second is maximum element number, Third and Fourth are the range limit (lower and upper)

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -234,27 +234,6 @@ subtest 'Plugins handling' => sub {
     is_deeply \%reconstructed_hash, $test_hash, "hashwalker() reconstructed original hash correctly";
 };
 
-subtest safe_call => sub {
-    use OpenQA::Utils 'safe_call';
-    my $output;
-    redirect_output(\$output);
-    my $foo = foo->new;
-
-    is @{safe_call($foo => baz => qw(a b c))}[1], 'a';
-    is @{safe_call($foo => baz => qw(a b c))}[2], 'b';
-    is @{safe_call($foo => baz => qw(a b c))}[3], 'c';
-    ok scalar(@{safe_call($foo => not_existant2 => qw(a b c))}) == 0;
-    like $@, qr/Can't locate object method "not_existant2" via package "foo"/;
-
-    my $test = safe_call($foo => baz => qw(a b c));
-    is @$test[3], 'c';
-
-    ok(scalar(@{safe_call(foo => 'baz')}) == 0);
-    is_deeply safe_call(foo => baz => qw(a b c)), [qw(a b c)];
-    ok scalar(@{safe_call(foo => not_existant => qw(a b c))}) == 0;
-    like $@, qr/Can't locate object method "not_existant" via package "foo"/;
-};
-
 subtest asset_type_from_setting => sub {
     use OpenQA::Utils 'asset_type_from_setting';
     is asset_type_from_setting('ISO'),              'iso', 'simple from ISO';


### PR DESCRIPTION
Just removing some more technical debt.