### PR TITLE
Make openqa-webui.service depend on openqa-gru.service

### DIFF
--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=The openQA gru daemon
+Description=The openQA daemon for various background tasks like cleanup and saving needles
 After=postgresql.service openqa-setup-db.service
 Wants=openqa-setup-db.service
 

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -3,7 +3,7 @@ Description=The openQA web UI
 Wants=apache2.service openqa-setup-db.service
 Before=apache2.service
 After=postgresql.service openqa-setup-db.service openqa-scheduler.service
-Requires=openqa-livehandler.service openqa-websockets.service
+Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service
 
 [Service]
 # TODO: define whether we want to run the web ui with the same user


### PR DESCRIPTION
The GRU service is required for saving needles in the needle editor and might be required for other background tasks in the future.