### PR TITLE
Add loading indication when saving needle

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -324,6 +324,9 @@ function setMatch() {
 }
 
 function reactToSaveNeedle(data) {
+  $('#needle_editor_loading_indication').hide();
+  $('#needle_editor_save_buttons').show();
+
   var failed = data.status !== 200 ||
     !data.responseJSON ||
     (!data.responseJSON.success && !data.responseJSON.requires_overwrite);
@@ -381,6 +384,8 @@ function saveNeedle(e) {
       return false;
   }
   $('#save').prop('disabled', true);
+  $('#needle_editor_save_buttons').hide();
+  $('#needle_editor_loading_indication').show();
   $.ajax({
     type: "POST",
     url: form.attr('action'),

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -151,8 +151,13 @@
                                 %>
                             </p>
                         </div>
-                        <button type="button" class="btn btn-default" id="review_json" title="Review JSON">Review JSON</button>
-                        <button type="submit" class="btn btn-primary" id="save">Save</button>
+                        <div id="needle_editor_save_buttons">
+                            <button type="button" class="btn btn-default" id="review_json" title="Review JSON">Review JSON</button>
+                            <button type="submit" class="btn btn-primary" id="save">Save</button>
+                        </div>
+                        <div id="needle_editor_loading_indication" class="properties-progress-indication" style="display: none;">
+                            <i class="fa fa-cog fa-spin fa-1x fa-fw"></i> Saving needle, this might take a few seconds.
+                        </div>
                     % end
                 </div>
                 <div class="col-md-6">


### PR DESCRIPTION
Because it might take a few seconds on a production instance. Of course real-time feedback would be even better but this is a start.