### PR TITLE
Don't hardcode remote and branch names for saving needles

### DIFF
--- a/docker/openqa_data/data.template/conf/openqa.ini
+++ b/docker/openqa_data/data.template/conf/openqa.ini
@@ -19,6 +19,11 @@ branding = plain
 # hsts = 365
 
 #[scm git]
+# name of remote to get updates from before commiting changes (e.g. origin, leave out-commented to disable remote update)
+#update_remote = origin
+# name of branch to rebase against before commiting changes (e.g. origin/master, leave out-commented to disable rebase)
+#update_branch = origin/master
+# whether commited changes should be pushed
 #do_push = no
 
 ## Authentication method to use for user management

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -380,6 +380,16 @@ do_push = yes
 Depending on your setup, you might need to generate and propagate
 ssh keys for user 'geekotest' to be able to push.
 
+It might also be useful to rebase first. To enable that, add the remote to get the
+latest updates from and the branch to rebase against to your openqa.ini:
+
+[source,ini]
+--------------------------------------------------------------------------------
+[scm git]
+update_remote = origin
+update_branch = origin/master
+--------------------------------------------------------------------------------
+
 === Referer settings to auto-mark important jobs
 
 Automatic cleanup of old results (see GRU jobs) can sometimes render important

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -58,6 +58,11 @@
 #max_rss_limit = 180000
 
 #[scm git]
+# name of remote to get updates from before commiting changes (e.g. origin, leave out-commented to disable remote update)
+#update_remote = origin
+# name of branch to rebase against before commiting changes (e.g. origin/master, leave out-commented to disable rebase)
+#update_branch = origin/master
+# whether commited changes should be pushed
 #do_push = no
 
 ## Authentication method to use for user management

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -144,7 +144,9 @@ sub read_config {
             method => 'OpenID',
         },
         'scm git' => {
-            do_push => 'no',
+            update_remote => '',
+            update_branch => '',
+            do_push       => 'no',
         },
         logging => {
             level     => undef,

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -518,13 +518,21 @@ sub _format_git_error {
 sub set_to_latest_git_master {
     my ($args) = @_;
 
+    my $git_config = $app->config->{'scm git'};
+    return undef unless $git_config;
+
     my @git = _prepare_git_command($args);
 
-    my $res = run_cmd_with_log_return_error([@git, 'remote', 'update', 'origin']);
-    return _format_git_error($res, 'Unable to fetch from origin master') unless $res->{status};
+    if (my $update_remote = $git_config->{update_remote}) {
+        my $res = run_cmd_with_log_return_error([@git, 'remote', 'update', $update_remote]);
+        return _format_git_error($res, 'Unable to fetch from origin master') unless $res->{status};
+    }
 
-    $res = run_cmd_with_log_return_error([@git, 'rebase', 'origin/master']);
-    return _format_git_error($res, 'Unable to reset repository to origin/master') unless $res->{status};
+    if (my $update_branch = $git_config->{update_branch}) {
+        my $res = run_cmd_with_log_return_error([@git, 'rebase', $update_branch]);
+        return _format_git_error($res, 'Unable to reset repository to origin/master') unless $res->{status};
+    }
+
     return undef;
 }
 

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -101,8 +101,22 @@ subtest 'git commands with mocked run_cmd_with_log_return_error' => sub {
             return \%mock_return_value;
         });
 
+    # check default config
+    my $git_config = $t->app->config->{'scm git'};
+    is($git_config->{update_remote}, '', 'by default no remote configured');
+    is($git_config->{update_branch}, '', 'by default no branch configured');
+
+    # test set_to_latest_git_master effectively being a no-op because not update remove and branch have been configured
+    is(set_to_latest_git_master({dir => 'foo/bar'}), undef, 'no error if no update remote and branch configured');
+    is_deeply(\@executed_commands, [], 'no commands executed if no update remote and branch configured')
+      or diag explain \@executed_commands;
+
+    # configure update branch and remote
+    $git_config->{update_remote} = 'origin';
+    $git_config->{update_branch} = 'origin/master';
+
     # test set_to_latest_git_master (non-error case)
-    is(set_to_latest_git_master({dir => 'foo/bar'}), undef, 'no error occured');
+    is(set_to_latest_git_master({dir => 'foo/bar'}), undef, 'no error');
     is_deeply(
         \@executed_commands,
         [[qw(git -C foo/bar remote update origin)], [qw(git -C foo/bar rebase origin/master)],],

--- a/t/config.t
+++ b/t/config.t
@@ -52,7 +52,9 @@ subtest 'Test configuration default modes' => sub {
             method => 'Fake',
         },
         'scm git' => {
-            do_push => 'no',
+            update_remote => '',
+            update_branch => '',
+            do_push       => 'no',
         },
         openid => {
             provider  => 'https://www.opensuse.org/openid/user/',


### PR DESCRIPTION
It was already mentioned in the last PR that hard coding remote and branch names isn't nice.

So this reverts the behavior of openQA to not execute `git remote update <remote>` and `git rebase <branch>` by default. That would only happen anymore if openQA is configured to update from a given remote and branch.

---

Before deploying this we should adjust the config file on OSD and o3.