### PR TITLE
Remove all uses of the Enterprise operator

### DIFF
--- a/lib/OpenQA/Parser/Result/Node.pm
+++ b/lib/OpenQA/Parser/Result/Node.pm
@@ -1,0 +1,33 @@
+# Copyright (C) 2017-2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Parser::Result::Node;
+use Mojo::Base 'OpenQA::Parser::Result';
+
+has 'val';
+
+sub AUTOLOAD {
+    our $AUTOLOAD;
+    my $fn = $AUTOLOAD;
+    $fn =~ s/.*:://;
+    return shift->get($fn);
+}
+
+sub get {
+    my ($self, $name) = @_;
+    return $self->new(val => $self->val->{$name});
+}
+
+1;

--- a/lib/OpenQA/Parser/Result/OpenQA/Results.pm
+++ b/lib/OpenQA/Parser/Result/OpenQA/Results.pm
@@ -1,0 +1,56 @@
+# Copyright (C) 2015-2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::Parser::Result::OpenQA::Results;
+use Mojo::Base 'OpenQA::Parser::Results';
+
+use Scalar::Util 'blessed';
+
+# Returns a new flattened OpenQA::Parser::Results which is a cumulative result of
+# the other collections inside it
+sub search_in_details {
+    my ($self, $field, $re) = @_;
+    return $self->new(
+        map { $_->search_in_details($field, $re) }
+        grep { blessed($_) && $_->isa("OpenQA::Parser::Result") } @{$self})->flatten;
+}
+
+sub search {
+    my ($self, $field, $re) = @_;
+    my $results = $self->new;
+    $self->each(sub { $results->add($_) if $_->{$field} =~ $re });
+    return $results;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::Parser::Result::OpenQA::Results - Results class
+
+=head1 SYNOPSIS
+
+    use OpenQA::Parser::Result::OpenQA::Results;
+
+=head1 DESCRIPTION
+
+L<OpenQA::Parser::Result::OpenQA::Results> is a class that holds the test
+details and results as seen by openQA. It is used while parsing from format X to
+OpenQA test modules.
+
+=cut

--- a/lib/OpenQA/Parser/Result/OpenQA/Results.pm
+++ b/lib/OpenQA/Parser/Result/OpenQA/Results.pm
@@ -25,7 +25,8 @@ sub search_in_details {
     my ($self, $field, $re) = @_;
     return $self->new(
         map { $_->search_in_details($field, $re) }
-        grep { blessed($_) && $_->isa("OpenQA::Parser::Result") } @{$self})->flatten;
+        grep { blessed($_) && $_->isa('OpenQA::Parser::Result') } @$self
+    )->flatten;
 }
 
 sub search {

--- a/lib/OpenQA/Parser/Result/Output.pm
+++ b/lib/OpenQA/Parser/Result/Output.pm
@@ -26,8 +26,10 @@ has 'content';
 sub write {
     my ($self, $dir) = @_;
     path($dir, $self->file)->spurt($self->content);
-    $self;
+    return $self;
 }
+
+1;
 
 =encoding utf-8
 
@@ -98,5 +100,3 @@ and implements the following new ones:
 It will write the file content in the supplied directory.
 
 =cut
-
-1;

--- a/lib/OpenQA/Parser/Result/Test.pm
+++ b/lib/OpenQA/Parser/Result/Test.pm
@@ -23,23 +23,27 @@ has flags => sub { {} };
 has [qw(category name script)];
 
 sub to_openqa {
+    my $self = shift;
     return {
-        category => $_[0]->category(),
-        name     => $_[0]->name(),
-        flags    => $_[0]->flags(),
-        script   => $_[0]->script() // 'unk',
+        category => $self->category(),
+        name     => $self->name(),
+        flags    => $self->flags(),
+        script   => $self->script() // 'unk',
     };
 }
 
 # Fix JSON encoding only to those fields
 sub TO_JSON {
+    my $self = shift;
     return {
-        category => $_[0]->category(),
-        name     => $_[0]->name(),
-        flags    => $_[0]->flags(),
-        script   => $_[0]->script() // 'unk',
+        category => $self->category(),
+        name     => $self->name(),
+        flags    => $self->flags(),
+        script   => $self->script() // 'unk',
     };
 }
+
+1;
 
 =encoding utf-8
 
@@ -98,5 +102,3 @@ It will return a hashref which contains as elements the only one strictly requir
 to parse the test.
 
 =cut
-
-1;

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -260,7 +260,7 @@ subtest 'Nested results' => sub {
 
     is_deeply(NestedResult->deserialize($r->serialize()), $r);
 
-    is_deeply $r->_gen_tree_el,
+    is_deeply $r->gen_tree_el,
       {
         '__data__' => {
             'result1' => {
@@ -278,8 +278,8 @@ subtest 'Nested results' => sub {
         },
         '__type__' => 'NestedResult'
       },
-      '_gen_tree_el is working correctly'
-      or die diag explain $r->_gen_tree_el;
+      'gen_tree_el is working correctly'
+      or die diag explain $r->gen_tree_el;
 
     $deep_p->results->add(
         NestedResult->new(


### PR DESCRIPTION
When i started removing all uses of the [Enterprise operator](https://metacpan.org/pod/distribution/perlsecret/lib/perlsecret.pod#Enterprise) (since it is not considered good style and hard to understand for those that are not Perl experts), i noticed that all related classes contain a lot more bad code. So i refactored them to a cleaner style and removed more technical debt in the process. There were various problems, convoluted map one-liners, multiple classes in a module, private functions being used across modules... and so on.