### PR TITLE
Allow monitoring of Gru/Minion

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -108,11 +108,11 @@ sub deployment_check {
 }
 
 # Class attribute used for testing with OpenQA::Test::Database
-sub tmp_schema {
+sub search_path_for_tests {
     my $class = shift;
-    state $tmp_schema;
-    $tmp_schema = shift if @_;
-    return $tmp_schema;
+    state $search_path;
+    $search_path = shift if @_;
+    return $search_path;
 }
 
 sub _try_deploy_db {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -226,6 +226,7 @@ sub startup {
     $op_r->get('/')->name('admin')->to('workers#index');
 
     $pub_admin_r->get('/influxdb/jobs')->to('influxdb#jobs');
+    $pub_admin_r->get('/influxdb/minion')->to('influxdb#minion');
 
     ###
     ## Admin area ends here

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -61,7 +61,7 @@ sub register {
     $conn->dsn($self->dsn());
 
     # set the search path in accordance with the test setup done in OpenQA::Test::Database
-    if (my $search_path = $ENV{TEST_PG_SEARCH_PATH}) {
+    if (my $search_path = $self->schema->tmp_schema) {
         log_info("setting database search path to $search_path when registering Minion plugin\n");
         $conn->search_path([$search_path]);
     }

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -61,7 +61,7 @@ sub register {
     $conn->dsn($self->dsn());
 
     # set the search path in accordance with the test setup done in OpenQA::Test::Database
-    if (my $search_path = $self->schema->tmp_schema) {
+    if (my $search_path = $self->schema->search_path_for_tests) {
         log_info("setting database search path to $search_path when registering Minion plugin\n");
         $conn->search_path([$search_path]);
     }

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -39,16 +39,43 @@ my $app = $t->app;
 $t->app($app);
 $app->config->{global}->{base_url} = 'http://example.com';
 
-my $get = $t->get_ok('/admin/influxdb/jobs');
-is(
-    $get->tx->res->body,
+$t->get_ok('/admin/influxdb/jobs')->status_is(200)->content_is(
     "openqa_jobs,url=http://example.com blocked=0i,running=2i,scheduled=2i
 openqa_jobs_by_group,url=http://example.com,group=No\\ Group scheduled=1i
 openqa_jobs_by_group,url=http://example.com,group=opensuse running=1i,scheduled=1i
 openqa_jobs_by_group,url=http://example.com,group=opensuse\\ test running=1i
 openqa_jobs_by_arch,url=http://example.com,arch=i586 scheduled=2i
 openqa_jobs_by_arch,url=http://example.com,arch=x86_64 running=2i
-", "matches"
+"
 );
+
+$t->get_ok('/admin/influxdb/minion')->status_is(200)->content_is(
+    "openqa_minion_jobs,url=http://example.com active=0i,delayed=0i,failed=0i,inactive=0i
+openqa_minion_workers,url=http://example.com active=0i,inactive=0i
+"
+);
+$t->app->minion->add_task(test => sub { });
+my $job_id  = $t->app->minion->enqueue('test');
+my $job_id2 = $t->app->minion->enqueue('test');
+my $worker  = $t->app->minion->worker->register;
+my $job     = $worker->dequeue(0);
+$t->get_ok('/admin/influxdb/minion')->status_is(200)->content_is(
+    "openqa_minion_jobs,url=http://example.com active=1i,delayed=0i,failed=0i,inactive=1i
+openqa_minion_workers,url=http://example.com active=1i,inactive=0i
+"
+);
+$job->fail('test');
+$t->get_ok('/admin/influxdb/minion')->status_is(200)->content_is(
+    "openqa_minion_jobs,url=http://example.com active=0i,delayed=0i,failed=1i,inactive=1i
+openqa_minion_workers,url=http://example.com active=0i,inactive=1i
+"
+);
+$job->retry({delay => 3600});
+$t->get_ok('/admin/influxdb/minion')->status_is(200)->content_is(
+    "openqa_minion_jobs,url=http://example.com active=0i,delayed=1i,failed=0i,inactive=2i
+openqa_minion_workers,url=http://example.com active=0i,inactive=1i
+"
+);
+$worker->unregister;
 
 done_testing();

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -33,7 +33,7 @@ sub create {
     unless (defined $options{skip_schema}) {
         my $schema_name = $options{schema_name} // generate_schema_name();
         log_info("using database schema \"$schema_name\"\n");
-        $schema->{tmp_schema} = $schema_name;
+        $schema->tmp_schema($schema_name);
         $schema->storage->dbh->do("create schema \"$schema_name\"");
         $schema->storage->dbh->do("SET search_path TO \"$schema_name\"");
         # handle reconnects
@@ -93,7 +93,7 @@ sub insert_fixtures {
 sub disconnect {
     my $schema = shift;
     my $dbh    = $schema->storage->dbh;
-    $dbh->do("drop schema $schema->{tmp_schema}");
+    if (my $tmp = $schema->tmp_schema) { $dbh->do("drop schema $tmp") }
     return $dbh->disconnect;
 }
 

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -33,7 +33,7 @@ sub create {
     unless (defined $options{skip_schema}) {
         my $schema_name = $options{schema_name} // generate_schema_name();
         log_info("using database schema \"$schema_name\"\n");
-        $schema->tmp_schema($schema_name);
+        $schema->search_path_for_tests($schema_name);
         $schema->storage->dbh->do("create schema \"$schema_name\"");
         $schema->storage->dbh->do("SET search_path TO \"$schema_name\"");
         # handle reconnects
@@ -93,7 +93,7 @@ sub insert_fixtures {
 sub disconnect {
     my $schema = shift;
     my $dbh    = $schema->storage->dbh;
-    if (my $tmp = $schema->tmp_schema) { $dbh->do("drop schema $tmp") }
+    if (my $search_path = $schema->search_path_for_tests) { $dbh->do("drop schema $search_path") }
     return $dbh->disconnect;
 }
 

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -44,7 +44,6 @@ my $sh = OpenQA::Scheduler->new;
 my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema      = $test_case->init_data(schema_name => $schema_name);
-$ENV{TEST_PG_SEARCH_PATH} = $schema_name;
 
 use OpenQA::SeleniumTest;
 


### PR DESCRIPTION
This patch adds a new public API endpoint `/admin/influxdb/minion`, similar to `/admin/influxdb/jobs`. It should contain all the stats needed to improve monitoring. I've also fixed a small bug with tmp schema handling in tests, where Gru would still use the default schema. The `$SINGLETON` variable in `OpenQA::Schema` is only a first step for a more complete cleanup in a future pull request.