### PR TITLE
Allow deleting offline workers via API and web UI

### DIFF
--- a/assets/javascripts/admin_worker.js
+++ b/assets/javascripts/admin_worker.js
@@ -62,3 +62,20 @@ function loadWorkerTable() {
       event.stopPropagation();
   });
 }
+
+function deleteWorker(deleteLink){
+	var post_url = $(deleteLink).attr("post_delete_url");
+	$.ajax({
+		url: post_url,
+		method: 'DELETE',
+		dataType: 'json',
+		success: function(data) {
+			$(deleteLink).parent().parent().remove();
+            addFlash('info', data.message);
+		},
+		error: function(xhr, ajaxOptions, thrownError){
+            var message = xhr.responseJSON.error;
+            addFlash('danger', 'The worker couldn\'t be deleted: ' + message);
+		}
+	});
+}

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -319,6 +319,7 @@ sub startup {
     push @api_routes, $worker_r;
     $api_public_r->route('/workers/<workerid:num>')->get('/')->name('apiv1_worker')->to('worker#show');
     $worker_r->post('/commands/')->name('apiv1_create_command')->to('command#create');
+    $api_ro->delete('/workers/<worker_id:num>')->name('apiv1_worker_delete')->to('worker#delete');
 
     # redirect for older workers
     $worker_r->websocket(

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -47,12 +47,17 @@ sub index {
         next unless $w->id;
         $workers{$w->name} = _extend_info($w);
     }
+
+    my $is_admin = 0;
+    $is_admin = 1 if ($self->is_admin);
+
     $self->stash(
         workers_online      => $total_online,
         total               => $total,
         workers_active_free => $free_active_workers,
         workers_broken_free => $free_broken_workers,
         workers_busy        => $busy_workers,
+        is_admin            => $is_admin,
         workers             => \%workers
     );
 

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -28,7 +28,7 @@ my @jobtemplate_events = qw(jobtemplate_create jobtemplate_delete);
 my @user_events        = qw(user_update user_login user_new_comment user_update_comment user_delete_comment);
 my @asset_events       = qw(asset_register asset_delete);
 my @iso_events         = qw(iso_create iso_delete iso_cancel);
-my @worker_events      = qw(command_enqueue worker_register);
+my @worker_events      = qw(command_enqueue worker_register worker_delete);
 my @needle_events      = qw(needle_modify needle_delete);
 
 # disabled events:

--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -47,6 +47,7 @@
                     <th>Status</th>
                     <th>Websocket Api version</th>
                     <th>os-autoinst version</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -74,6 +75,13 @@
                         </td>
                         <td class="version">
                             <%= exists $worker->{properties} && $worker->{properties}->{ISOTOVIDEO_INTERFACE_VERSION} ? $worker->{properties}->{ISOTOVIDEO_INTERFACE_VERSION} : 'unknown' %>
+                        </td>
+                        <td class='action'>
+                            % if($is_admin == 1 && ($worker->{status} eq 'dead' && !$worker->{job})){
+                                <a href='#' post_delete_url="<%= url_for('apiv1_worker_delete', worker_id => $worker->{id}) %>" onclick="deleteWorker(this);">
+                                    Delete
+                                </a>
+                            % }
                         </td>
                     </tr>
                 % }


### PR DESCRIPTION
Add a delete function in Workers module. When worker status
is offline, and the login user is administrator, show the delete
action. Users can click delete action to remove the offline worker.

Related ticket: 
   https://progress.opensuse.org/issues/48791

Signed-off-by: Liu Xiaojing <xiaojing.liu@suse.com>