### PR TITLE
Pass affected_rows correctly in openqa_jobtemplate_create

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -242,7 +242,7 @@ sub create {
     else {
         if (defined($affected_rows)) {
             $json->{affected_rows} = $affected_rows;
-            $self->emit_event('openqa_jobtemplate_create', {affected_rows => $id});
+            $self->emit_event('openqa_jobtemplate_create', {affected_rows => $affected_rows});
         }
         else {
             $json->{id} = $id;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -287,6 +287,11 @@ $res = $t->post_ok(
     })->status_is(200);
 my $job_template_id2 = $res->tx->res->json->{id};
 ok($job_template_id2, 'got ID (2)');
+is_deeply(
+    OpenQA::Test::Case::find_most_recent_event($app->schema, 'jobtemplate_create'),
+    {id => $job_template_id2},
+    'Create was logged correctly'
+);
 
 $get = $t->get_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
 is_deeply(
@@ -471,6 +476,11 @@ $t->post_ok(
     'two rows affected'
 );
 is($job_templates->search({prio => 15})->count, 2, 'two rows have now prio 15');
+is_deeply(
+    OpenQA::Test::Case::find_most_recent_event($app->schema, 'jobtemplate_create'),
+    {affected_rows => 2},
+    'Create was logged correctly'
+);
 
 # set priority to undef for inheriting from job group
 $t->post_ok(
@@ -512,6 +522,11 @@ $res = $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(404);
 
 $res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
 $res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(404);    #not found
+is_deeply(
+    OpenQA::Test::Case::find_most_recent_event($app->schema, 'jobtemplate_delete'),
+    {id => "$job_template_id2"},
+    'Delete was logged correctly'
+);
 
 # switch to operator (percival) and try some modifications
 $app = $t->app;

--- a/t/lib/OpenQA/Test/Case.pm
+++ b/t/lib/OpenQA/Test/Case.pm
@@ -21,7 +21,7 @@ use OpenQA::Test::Database;
 use OpenQA::Test::Testresults;
 use OpenQA::Schema::Result::Users;
 use Date::Format 'time2str';
-use Mojo::JSON 'j';
+use Mojo::JSON qw(decode_json j);
 use Mojo::Util qw(b64_decode b64_encode hmac_sha1_sum);
 
 sub new {
@@ -95,6 +95,14 @@ sub new {
 sub trim_whitespace {
     my ($str) = @_;
     return $str =~ s/\s+/ /gr =~ s/(^\s)|(\s$)//gr;
+}
+
+sub find_most_recent_event {
+    my ($schema, $event) = @_;
+
+    my $results
+      = $schema->resultset('AuditEvents')->search({event => $event}, {limit => 1, order_by => {-desc => 'id'}});
+    return $results ? decode_json($results->next->event_data) : undef;
 }
 
 1;


### PR DESCRIPTION
Currently the audit log has messages like this:

    { "affected_rows": null }