### PR TITLE
Remove dead validation code and replace it with route placeholder types

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -155,8 +155,8 @@ sub startup {
     # due to the split md5_dirname having a /
     $r->get('/image/:md5_1/:md5_2/.thumbs/#md5_basename')->to('file#thumb_image');
 
-    $r->get('/group_overview/:groupid')->name('group_overview')->to('main#job_group_overview');
-    $r->get('/parent_group_overview/:groupid')->name('parent_group_overview')->to('main#parent_group_overview');
+    $r->get('/group_overview/<groupid:num>')->name('group_overview')->to('main#job_group_overview');
+    $r->get('/parent_group_overview/<groupid:num>')->name('parent_group_overview')->to('main#parent_group_overview');
 
     # Favicon
     $r->get('/favicon.ico' => sub { my $c = shift; $c->render_static('favicon.ico') });
@@ -192,14 +192,14 @@ sub startup {
     $pub_admin_r->get('/machines')->name('admin_machines')->to('machine#index');
     $pub_admin_r->get('/test_suites')->name('admin_test_suites')->to('test_suite#index');
 
-    $pub_admin_r->get('/job_templates/:groupid')->name('admin_job_templates')->to('job_template#index');
+    $pub_admin_r->get('/job_templates/<groupid:num>')->name('admin_job_templates')->to('job_template#index');
 
     $pub_admin_r->get('/groups')->name('admin_groups')->to('job_group#index');
-    $pub_admin_r->get('/job_group/:groupid')->name('admin_job_group_row')->to('job_group#job_group_row');
-    $pub_admin_r->get('/parent_group/:groupid')->name('admin_parent_group_row')->to('job_group#parent_group_row');
-    $pub_admin_r->get('/edit_parent_group/:groupid')->name('admin_edit_parent_group')
+    $pub_admin_r->get('/job_group/<groupid:num>')->name('admin_job_group_row')->to('job_group#job_group_row');
+    $pub_admin_r->get('/parent_group/<groupid:num>')->name('admin_parent_group_row')->to('job_group#parent_group_row');
+    $pub_admin_r->get('/edit_parent_group/<groupid:num>')->name('admin_edit_parent_group')
       ->to('job_group#edit_parent_group');
-    $pub_admin_r->get('/groups/connect/:groupid')->name('job_group_new_media')->to('job_group#connect');
+    $pub_admin_r->get('/groups/connect/<groupid:num>')->name('job_group_new_media')->to('job_group#connect');
 
     $pub_admin_r->get('/assets')->name('admin_assets')->to('asset#index');
     $pub_admin_r->get('/assets/status')->name('admin_asset_status_json')->to('asset#status_json');
@@ -220,7 +220,7 @@ sub startup {
     $admin_r->delete('/needles/delete')->name('admin_needle_delete')->to('needle#delete');
     $admin_r->get('/auditlog')->name('audit_log')->to('audit_log#index');
     $admin_r->get('/auditlog/ajax')->name('audit_ajax')->to('audit_log#ajax');
-    $admin_r->post('/groups/connect/:groupid')->name('job_group_save_media')->to('job_group#save_connect');
+    $admin_r->post('/groups/connect/<groupid:num>')->name('job_group_save_media')->to('job_group#save_connect');
 
     # Workers list as default option
     $op_r->get('/')->name('admin')->to('workers#index');
@@ -264,18 +264,18 @@ sub startup {
 
     # api/v1/job_groups
     $api_public_r->get('/job_groups')->name('apiv1_list_job_groups')->to('job_group#list');
-    $api_public_r->get('/job_groups/:group_id')->name('apiv1_get_job_group')->to('job_group#list');
-    $api_public_r->get('/job_groups/:group_id/jobs')->name('apiv1_get_job_group_jobs')->to('job_group#list_jobs');
+    $api_public_r->get('/job_groups/<group_id:num>')->name('apiv1_get_job_group')->to('job_group#list');
+    $api_public_r->get('/job_groups/<group_id:num>/jobs')->name('apiv1_get_job_group_jobs')->to('job_group#list_jobs');
     $api_ra->post('/job_groups')->name('apiv1_post_job_group')->to('job_group#create');
-    $api_ra->put('/job_groups/:group_id')->name('apiv1_put_job_group')->to('job_group#update');
-    $api_ra->delete('/job_groups/:group_id')->name('apiv1_delete_job_group')->to('job_group#delete');
+    $api_ra->put('/job_groups/<group_id:num>')->name('apiv1_put_job_group')->to('job_group#update');
+    $api_ra->delete('/job_groups/<group_id:num>')->name('apiv1_delete_job_group')->to('job_group#delete');
 
     # api/v1/parent_groups
     $api_public_r->get('/parent_groups')->name('apiv1_list_parent_groups')->to('job_group#list');
-    $api_public_r->get('/parent_groups/:group_id')->name('apiv1_get_parent_group')->to('job_group#list');
+    $api_public_r->get('/parent_groups/<group_id:num>')->name('apiv1_get_parent_group')->to('job_group#list');
     $api_ra->post('/parent_groups')->name('apiv1_post_parent_group')->to('job_group#create');
-    $api_ra->put('/parent_groups/:group_id')->name('apiv1_put_parent_group')->to('job_group#update');
-    $api_ra->delete('/parent_groups/:group_id')->name('apiv1_delete_parent_group')->to('job_group#delete');
+    $api_ra->put('/parent_groups/<group_id:num>')->name('apiv1_put_parent_group')->to('job_group#update');
+    $api_ra->delete('/parent_groups/<group_id:num>')->name('apiv1_delete_parent_group')->to('job_group#delete');
 
     # api/v1/jobs
     $api_public_r->get('/jobs')->name('apiv1_jobs')->to('job#list');
@@ -395,26 +395,28 @@ sub startup {
     $api_ra->delete('job_templates/:job_template_id')->to('job_template#destroy');
 
     # api/v1/comments
-    $api_public_r->get('/jobs/:job_id/comments')->name('apiv1_list_comments')->to('comment#list');
-    $api_public_r->get('/jobs/:job_id/comments/:comment_id')->name('apiv1_get_comment')->to('comment#text');
-    $api_ru->post('/jobs/:job_id/comments')->name('apiv1_post_comment')->to('comment#create');
-    $api_ru->put('/jobs/:job_id/comments/:comment_id')->name('apiv1_put_comment')->to('comment#update');
-    $api_ra->delete('/jobs/:job_id/comments/:comment_id')->name('apiv1_delete_comment')->to('comment#delete');
-    $api_public_r->get('/groups/:group_id/comments')->name('apiv1_list_group_comment')->to('comment#list');
-    $api_public_r->get('/groups/:group_id/comments/:comment_id')->name('apiv1_get_group_comment')->to('comment#text');
-    $api_ru->post('/groups/:group_id/comments')->name('apiv1_post_group_comment')->to('comment#create');
-    $api_ru->put('/groups/:group_id/comments/:comment_id')->name('apiv1_put_group_comment')->to('comment#update');
-    $api_ra->delete('/groups/:group_id/comments/:comment_id')->name('apiv1_delete_group_comment')->to('comment#delete');
-    $api_public_r->get('/parent_groups/:parent_group_id/comments')->name('apiv1_list_parent_group_comment')
-      ->to('comment#list');
-    $api_public_r->get('/parent_groups/:parent_group_id/comments/:comment_id')->name('apiv1_get_parent_group_comment')
+    $api_public_r->get('/jobs/<job_id:num>/comments')->name('apiv1_list_comments')->to('comment#list');
+    $api_public_r->get('/jobs/<job_id:num>/comments/:comment_id')->name('apiv1_get_comment')->to('comment#text');
+    $api_ru->post('/jobs/<job_id:num>/comments')->name('apiv1_post_comment')->to('comment#create');
+    $api_ru->put('/jobs/<job_id:num>/comments/:comment_id')->name('apiv1_put_comment')->to('comment#update');
+    $api_ra->delete('/jobs/<job_id:num>/comments/:comment_id')->name('apiv1_delete_comment')->to('comment#delete');
+    $api_public_r->get('/groups/<group_id:num>/comments')->name('apiv1_list_group_comment')->to('comment#list');
+    $api_public_r->get('/groups/<group_id:num>/comments/:comment_id')->name('apiv1_get_group_comment')
       ->to('comment#text');
-    $api_ru->post('/parent_groups/:parent_group_id/comments')->name('apiv1_post_parent_group_comment')
-      ->to('comment#create');
-    $api_ru->put('/parent_groups/:parent_group_id/comments/:comment_id')->name('apiv1_put_parent_group_comment')
-      ->to('comment#update');
-    $api_ra->delete('/parent_groups/:parent_group_id/comments/:comment_id')->name('apiv1_delete_parent_group_comment')
+    $api_ru->post('/groups/<group_id:num>/comments')->name('apiv1_post_group_comment')->to('comment#create');
+    $api_ru->put('/groups/<group_id:num>/comments/:comment_id')->name('apiv1_put_group_comment')->to('comment#update');
+    $api_ra->delete('/groups/<group_id:num>/comments/:comment_id')->name('apiv1_delete_group_comment')
       ->to('comment#delete');
+    $api_public_r->get('/parent_groups/<parent_group_id:num>/comments')->name('apiv1_list_parent_group_comment')
+      ->to('comment#list');
+    $api_public_r->get('/parent_groups/<parent_group_id:num>/comments/:comment_id')
+      ->name('apiv1_get_parent_group_comment')->to('comment#text');
+    $api_ru->post('/parent_groups/<parent_group_id:num>/comments')->name('apiv1_post_parent_group_comment')
+      ->to('comment#create');
+    $api_ru->put('/parent_groups/<parent_group_id:num>/comments/:comment_id')->name('apiv1_put_parent_group_comment')
+      ->to('comment#update');
+    $api_ra->delete('/parent_groups/<parent_group_id:num>/comments/:comment_id')
+      ->name('apiv1_delete_parent_group_comment')->to('comment#delete');
 
     # json-rpc methods not migrated to this api: echo, list_commands
     ###

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -66,14 +66,12 @@ sub edit_parent_group {
 sub connect {
     my ($self) = @_;
 
-    $self->validation->required('groupid')->like(qr/^[0-9]+$/);
-    $self->stash('group', $self->db->resultset("JobGroups")->find($self->param('groupid')));
-
-    my $products = $self->db->resultset("Products")->search(undef, {order_by => 'name'});
+    $self->stash('group', $self->db->resultset('JobGroups')->find($self->param('groupid')));
+    my $products = $self->db->resultset('Products')->search(undef, {order_by => 'name'});
     $self->stash('products', $products);
-    my $tests = $self->db->resultset("TestSuites")->search(undef, {order_by => 'name'});
+    my $tests = $self->db->resultset('TestSuites')->search(undef, {order_by => 'name'});
     $self->stash('tests', $tests);
-    my $machines = $self->db->resultset("Machines")->search(undef, {order_by => 'name'});
+    my $machines = $self->db->resultset('Machines')->search(undef, {order_by => 'name'});
     $self->stash('machines', $machines);
 
     $self->render('admin/group/connect');
@@ -82,11 +80,10 @@ sub connect {
 sub save_connect {
     my ($self) = @_;
 
-    $self->validation->required('groupid')->like(qr/^[0-9]+$/);
     my $group = $self->db->resultset("JobGroups")->find($self->param('groupid'));
     if (!$group) {
         $self->flash(error => 'Specified group ID ' . $self->param('groupid') . 'doesn\'t exist.');
-        $self->redirect_to('admin_groups');
+        return $self->redirect_to('admin_groups');
     }
 
     my $values = {
@@ -98,11 +95,11 @@ sub save_connect {
     eval { $self->db->resultset("JobTemplates")->create($values)->id };
     if ($@) {
         $self->flash(error => $@);
-        $self->redirect_to('job_group_new_media', groupid => $group->id);
+        return $self->redirect_to('job_group_new_media', groupid => $group->id);
     }
     else {
         $self->emit_event('openqa_jobgroup_connect', $values);
-        $self->redirect_to('admin_job_templates', groupid => $group->id);
+        return $self->redirect_to('admin_job_templates', groupid => $group->id);
     }
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'Mojolicious::Controller';
 
 sub index {
     my ($self) = @_;
-    $self->validation->required('groupid')->like(qr/^[0-9]+$/);
+
     $self->stash('group', $self->db->resultset("JobGroups")->find($self->param('groupid')));
 
     my @machines = $self->db->resultset("Machines")->search(undef, {order_by => 'name'});

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -362,6 +362,8 @@ sub register {
                 status   => 404,
             );
         });
+
+    $app->helper('reply.validation_error' => \&_validation_error);
 }
 
 sub _step_thumbnail {
@@ -388,6 +390,13 @@ sub _step_thumbnail {
         class   => "resborder resborder_$result"
     );
     return $content;
+}
+
+sub _validation_error {
+    my $c      = shift;
+    my $failed = join ', ', @{$c->validation->failed};
+    my $error  = "Invalid request parameters ($failed)";
+    $c->render(text => $error, status => 400);
 }
 
 1;

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -361,5 +361,14 @@ $t->post_ok($b_prefix . '/barrier2', form => {action => 'wait', check_dead_job =
 set_token_header($t->ua, 'token' . $jC);
 $t->post_ok($b_prefix . '/barrier2', form => {action => 'wait', check_dead_job => 1})->status_is(200);
 
+# input validation
+$t->post_ok($m_prefix)->status_is(400)->content_is('Invalid request parameters (name)');
+$t->post_ok("$m_prefix/foo")->status_is(400)->content_is('Invalid request parameters (action)');
+$t->post_ok($b_prefix => form => {tasks => 'abc'})->status_is(400)
+  ->content_is('Invalid request parameters (name, tasks)');
+$t->post_ok("$b_prefix/foo" => form => {where => 'abc'})->status_is(400)
+  ->content_is('Invalid request parameters (where)');
+$t->delete_ok("$b_prefix/foo" => form => {where => 'abc'})->status_is(400)
+  ->content_is('Invalid request parameters (where)');
 
 done_testing();

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -33,11 +33,7 @@ use OpenQA::WebSockets;
 OpenQA::Test::Case->new->init_data;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
-
-my $app = $t->app;
-# we don't need API keys for this route
-$t->app($app);
-$app->config->{global}->{base_url} = 'http://example.com';
+$t->app->config->{global}->{base_url} = 'http://example.com';
 
 $t->get_ok('/admin/influxdb/jobs')->status_is(200)->content_is(
     "openqa_jobs,url=http://example.com blocked=0i,running=2i,scheduled=2i


### PR DESCRIPTION
While showing how to use validation properly earlier today i noticed that quite a few of the current uses in openQA did not actually work. Most could actually be replaced with a route placeholder type (`<job_id:num>`). But i was still a little unhappy that we did not have a clean example for how to do input validation right. So i also cleaned up `OpenQA::WebAPI::Controller::API::V1::Locks`, and i hope it can serve that purpose from now on.