### PR TITLE
Make needle deletion a Minion job

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -40,7 +40,7 @@ requires 'IPC::Run';
 requires 'Cpanel::JSON::XS';
 requires 'JavaScript::Minifier::XS', '>= 0.11';
 requires 'LWP::UserAgent';
-requires 'Minion', '9.0';
+requires 'Minion', '>= 9.09';
 requires 'Minion::Backend::Pg';
 requires 'Minion::Backend::SQLite';
 requires 'MRO::Compat';

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -190,14 +190,16 @@ sub remove {
 
     my $fname      = $self->path;
     my $screenshot = $fname =~ s/.json$/.png/r;
-    $OpenQA::Utils::app->log->debug("Remove needle $fname and $screenshot");
+    my $app        = $OpenQA::Utils::app;
+    $app->log->debug("Remove needle $fname and $screenshot");
 
-    if (($OpenQA::Utils::app->config->{global}->{scm} || '') eq 'git') {
-        my $args = {
+    if (($app->config->{global}->{scm} || '') eq 'git') {
+        my $directory = $self->directory;
+        my $args      = {
             dir     => $self->directory->path,
             rm      => [$fname, $screenshot],
             user    => $user,
-            message => sprintf("admin remove of %s/%s", $self->directory->name, $self->filename)};
+            message => sprintf("Remove %s/%s", $directory->name, $self->filename)};
         my $error = commit_git($args);
         return $error if $error;
     }
@@ -207,7 +209,7 @@ sub remove {
         unlink($screenshot) or push(@error_files, $screenshot);
         if (@error_files) {
             my $error = 'Unable to delete ' . join(' and ', @error_files);
-            $OpenQA::Utils::app->log->debug($error);
+            $app->log->debug($error);
             return $error;
         }
     }

--- a/lib/OpenQA/Task/Needle/Delete.pm
+++ b/lib/OpenQA/Task/Needle/Delete.pm
@@ -1,0 +1,74 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Task::Needle::Delete;
+use Mojo::Base 'Mojolicious::Plugin';
+
+use OpenQA::Utils;
+use Scalar::Util 'looks_like_number';
+
+sub register {
+    my ($self, $app) = @_;
+    $app->minion->add_task(delete_needles => sub { _delete_needles($app, @_) });
+}
+
+sub _delete_needles {
+    my ($app, $minion_job, $args) = @_;
+
+    # prevent multiple save_needle and delete_needles tasks to run in parallel
+    return $minion_job->fail({error => 'Another save or delete needle job is ongoing. Try again later.'})
+      unless my $guard = $app->minion->guard('limit_needle_task', 300);
+
+    my $schema     = $app->schema;
+    my $needles    = $schema->resultset('Needles');
+    my $user       = $schema->resultset('Users')->find($args->{user_id});
+    my $needle_ids = $args->{needle_ids};
+
+    my (@removed_ids, @errors);
+
+    for my $needle_id (@$needle_ids) {
+        my $needle = looks_like_number($needle_id) ? $needles->find($needle_id) : undef;
+        if (!$needle) {
+            push(
+                @errors,
+                {
+                    id      => $needle_id,
+                    message => "Unable to find needle with ID \"$needle_id\"",
+                });
+            next;
+        }
+
+        if (my $error = $needle->remove($user)) {
+            push(
+                @errors,
+                {
+                    id           => $needle_id,
+                    display_name => $needle->filename,
+                    message      => $error,
+                });
+            next;
+        }
+
+        push(@removed_ids, $needle_id);
+    }
+
+    return $minion_job->finish(
+        {
+            removed_ids => \@removed_ids,
+            errors      => \@errors
+        });
+}
+
+1;

--- a/lib/OpenQA/Task/Needle/Delete.pm
+++ b/lib/OpenQA/Task/Needle/Delete.pm
@@ -28,7 +28,7 @@ sub _delete_needles {
     my ($app, $minion_job, $args) = @_;
 
     # prevent multiple save_needle and delete_needles tasks to run in parallel
-    return $minion_job->fail({error => 'Another save or delete needle job is ongoing. Try again later.'})
+    return $minion_job->finish({error => 'Another save or delete needle job is ongoing. Try again later.'})
       unless my $guard = $app->minion->guard('limit_needle_task', 300);
 
     my $schema     = $app->schema;

--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -61,9 +61,9 @@ sub _format_git_error {
 sub _save_needle {
     my ($app, $minion_job, $args) = @_;
 
-    # prevent multiple save_needle tasks to run in parallel
-    return $minion_job->fail({error => 'Another save needle job is ongoing. Try again later.'})
-      unless my $guard = $app->minion->guard('limit_save_needle_task', 300);
+    # prevent multiple save_needle and delete_needles tasks to run in parallel
+    return $minion_job->fail({error => 'Another save or delete needle job is ongoing. Try again later.'})
+      unless my $guard = $app->minion->guard('limit_needle_task', 300);
 
     my $schema       = $app->schema;
     my $openqa_job   = $schema->resultset('Jobs')->find($args->{job_id});

--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -62,7 +62,7 @@ sub _save_needle {
     my ($app, $minion_job, $args) = @_;
 
     # prevent multiple save_needle and delete_needles tasks to run in parallel
-    return $minion_job->fail({error => 'Another save or delete needle job is ongoing. Try again later.'})
+    return $minion_job->finish({error => 'Another save or delete needle job is ongoing. Try again later.'})
       unless my $guard = $app->minion->guard('limit_needle_task', 300);
 
     my $schema       = $app->schema;
@@ -82,7 +82,7 @@ sub _save_needle {
     if ($@) {
         my $error = $@;
         $app->log->error("Error validating needle: $error");
-        return $minion_job->fail({error => "<strong>Failed to validate $needlename.</strong><br>$error"});
+        return $minion_job->finish({error => "<strong>Failed to validate $needlename.</strong><br>$error"});
     }
 
     # determine imagepath
@@ -122,7 +122,7 @@ sub _save_needle {
     if (-e "$baseneedle.png" && !$args->{overwrite}) {
         #my $returned_data = $self->req->params->to_hash;
         #$returned_data->{requires_overwrite} = 1;
-        return $minion_job->fail({requires_overwrite => 1});
+        return $minion_job->finish({requires_overwrite => 1});
     }
 
     # copy image

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -125,69 +125,24 @@ sub module {
 sub delete {
     my ($self) = @_;
 
-    # check whether Minion worker are available to get a nice error message instead of an inactive job
-    my $gru = $self->gru;
-    if (!$gru->has_workers) {
-        return $self->render(
-            json => {error => 'No Minion worker available. The <code>openqa-gru</code> service is likely not running.'}
-        );
-    }
+    $self->gru->enqueue_and_keep_track(
+        task_name        => 'delete_needles',
+        task_description => 'deleting needles',
+        task_args        => {
+            needle_ids => $self->every_param('id'),
+            user_id    => $self->current_user->id,
+        },
+        on_success => sub {
+            my ($result) = @_;
 
-    # enqueue Minion job delete needles with specified IDs
-    my %minion_args = (
-        needle_ids => $self->every_param('id'),
-        user_id    => $self->current_user->id,
-    );
-    my %minion_options = (
-        priority => 10,
-        ttl      => 60,
-    );
-    my $ids = $gru->enqueue(delete_needles => \%minion_args, \%minion_options);
-    my $minion_id;
-    if (ref $ids eq 'HASH') {
-        $minion_id = $ids->{minion_id};
-    }
-    my $minion     = $self->app->minion;
-    my $minion_job = $minion->job($minion_id);
-    if (!$minion_job) {
-        return $self->render(json => {error => 'Unable to enqueue Minion job for deleting needles.'});
-    }
-
-    # keep track of the Minion job and continue rendering if it has completed
-    my $timer_id;
-    my $check_results = sub {
-        my ($loop) = @_;
-
-        eval {
-            # find the minion job
-            my $minion_job = $minion->job($minion_id);
-            if (!$minion_job) {
-                $loop->remove($timer_id);
-                return $self->render(json => {error => 'Minion job for deleting needles has been removed.'});
-            }
-            my $info  = $minion_job->info;
-            my $state = $info->{state};
-
-            # retry on next tick if the job is still running
-            return unless $state && ($state eq 'finished' || $state eq 'failed');
-            $loop->remove($timer_id);
-
-            # ensure resulting data structure contains all required fields, even in the error case
-            my $result      = $info->{result};
             my $removed_ids = ($result->{removed_ids} //= []);
-
-            # return result
             $self->emit_event(openqa_needle_delete => {id => $removed_ids}) if (@$removed_ids);
             return $self->render(json => $result);
-        };
-
-        # ensure the timer is removed and something rendered in any case
-        if ($@) {
-            $loop->remove($timer_id);
-            return $self->render(json => {error => 'An internal error occured.'}, status => 500);
-        }
-    };
-    $timer_id = Mojo::IOLoop->recurring(0.5 => $check_results);
+        },
+        on_error => sub {
+            $self->reply->gru_result(@_);
+        },
+    );
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -131,18 +131,19 @@ sub delete {
         task_args        => {
             needle_ids => $self->every_param('id'),
             user_id    => $self->current_user->id,
-        },
-        on_success => sub {
+        }
+    )->then(
+        sub {
             my ($result) = @_;
 
             my $removed_ids = ($result->{removed_ids} //= []);
             $self->emit_event(openqa_needle_delete => {id => $removed_ids}) if (@$removed_ids);
-            return $self->render(json => $result);
-        },
-        on_error => sub {
+            $self->render(json => $result);
+        }
+    )->catch(
+        sub {
             $self->reply->gru_result(@_);
-        },
-    );
+        });
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -402,8 +402,9 @@ sub save_needle_ajax {
             imageversion => $validation->param('imageversion'),
             needledir    => $needledir,
             needlename   => $needlename,
-        },
-        on_success => sub {
+        }
+    )->then(
+        sub {
             my ($result) = @_;
 
             # handle request for overwrite
@@ -427,12 +428,12 @@ sub save_needle_ajax {
             # add the URL to restart if that should be proposed to the user
             $result->{restart} = $self->url_for('apiv1_restart', jobid => $job_id) if ($result->{propose_restart});
 
-            return $self->render(json => $result);
-        },
-        on_error => sub {
+            $self->render(json => $result);
+        }
+    )->catch(
+        sub {
             $self->reply->gru_result(@_);
-        },
-    );
+        });
 }
 
 sub map_error_to_avg {

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -388,63 +388,25 @@ sub save_needle_ajax {
     my $needledir  = needledir($job->DISTRI, $job->VERSION);
     my $needlename = $validation->param('needlename');
 
-    # check whether Minion worker are available to get a nice error message instead of an inactive job
-    my $gru = $self->gru;
-    if (!$gru->has_workers) {
-        return $self->render(
-            json => {error => 'No Minion worker available. The <code>openqa-gru</code> service is likely not running.'}
-        );
-    }
-
-    # enqueue Minion job to copy the image and (if configured) run Git commands
-    my %minion_args = (
-        job_id       => $job_id,
-        user_id      => $self->current_user->id,
-        needle_json  => $validation->param('json'),
-        overwrite    => $self->param('overwrite'),
-        imagedir     => $self->param('imagedir') // '',
-        imagedistri  => $validation->param('imagedistri'),
-        imagename    => $validation->param('imagename'),
-        imageversion => $validation->param('imageversion'),
-        needledir    => $needledir,
-        needlename   => $needlename,
-    );
-    my %minion_options = (
-        priority => 10,
-        ttl      => 60,
-    );
-    my $ids = $gru->enqueue(save_needle => \%minion_args, \%minion_options);
-    my $minion_id;
-    if (ref $ids eq 'HASH') {
-        $minion_id = $ids->{minion_id};
-    }
-    my $minion     = $app->minion;
-    my $minion_job = $minion->job($minion_id);
-    if (!$minion_job) {
-        return $self->render(json => {error => 'Unable to enqueue Minion job for saving needle.'});
-    }
-
-    # keep track of the Minion job and continue rendering if it has completed
-    my $timer_id;
-    my $check_results = sub {
-        my ($loop) = @_;
-
-        eval {
-            # find the minion job
-            my $minion_job = $minion->job($minion_id);
-            if (!$minion_job) {
-                $loop->remove($timer_id);
-                return $self->render(json => {error => 'Minion job for saving needle has been removed.'});
-            }
-            my $info  = $minion_job->info;
-            my $state = $info->{state};
-
-            # retry on next tick if the job is still running
-            return unless $state && ($state eq 'finished' || $state eq 'failed');
-            $loop->remove($timer_id);
+    $self->gru->enqueue_and_keep_track(
+        task_name        => 'save_needle',
+        task_description => 'saving needles',
+        task_args        => {
+            job_id       => $job_id,
+            user_id      => $self->current_user->id,
+            needle_json  => $validation->param('json'),
+            overwrite    => $self->param('overwrite'),
+            imagedir     => $self->param('imagedir') // '',
+            imagedistri  => $validation->param('imagedistri'),
+            imagename    => $validation->param('imagename'),
+            imageversion => $validation->param('imageversion'),
+            needledir    => $needledir,
+            needlename   => $needlename,
+        },
+        on_success => sub {
+            my ($result) = @_;
 
             # handle request for overwrite
-            my $result = $info->{result};
             if ($result->{requires_overwrite}) {
                 my $initial_request = $self->req->params->to_hash;
                 $initial_request->{requires_overwrite} = 1;
@@ -455,8 +417,7 @@ sub save_needle_ajax {
             if (my $json_data = $result->{json_data}) {
                 $app->gru->enqueue('scan_needles');
                 $app->emit_event(
-                    'openqa_needle_modify',
-                    {
+                    openqa_needle_modify => {
                         needle => "$needledir/$needlename.png",
                         tags   => $json_data->{tags},
                         update => 0,
@@ -467,15 +428,11 @@ sub save_needle_ajax {
             $result->{restart} = $self->url_for('apiv1_restart', jobid => $job_id) if ($result->{propose_restart});
 
             return $self->render(json => $result);
-        };
-
-        # ensure the timer is removed and something rendered in any case
-        if ($@) {
-            $loop->remove($timer_id);
-            return $self->render(json => {error => 'An internal error occured.'}, status => 500);
-        }
-    };
-    $timer_id = Mojo::IOLoop->recurring(0.5 => $check_results);
+        },
+        on_error => sub {
+            $self->reply->gru_result(@_);
+        },
+    );
 }
 
 sub map_error_to_avg {

--- a/lib/OpenQA/WebAPI/GruJob.pm
+++ b/lib/OpenQA/WebAPI/GruJob.pm
@@ -17,6 +17,7 @@ package OpenQA::WebAPI::GruJob;
 use Mojo::Base 'Minion::Job';
 
 use OpenQA::Utils 'log_error';
+use Data::Dumper 'Dumper';
 
 sub execute {
     my $self = shift;
@@ -49,6 +50,7 @@ sub execute {
     my $state = $info->{state};
     if ($state eq 'failed' || defined $err) {
         $err //= $info->{result};
+        $err = Dumper($err) if (ref $err);
         log_error("Gru command issue: $err");
         $self->fail({defined $buffer ? (output => $buffer) : (), error => $err});
         $self->_fail_gru($gru_id => $err);

--- a/lib/OpenQA/WebAPI/Plugin/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Gru.pm
@@ -40,7 +40,8 @@ sub register_tasks {
     $app->plugin($_)
       for (
         qw(OpenQA::Task::Asset::Download OpenQA::Task::Asset::Limit OpenQA::Task::Job::Limit),
-        qw(OpenQA::Task::Needle::Scan OpenQA::Task::Needle::Save OpenQA::Task::Screenshot::Scan)
+        qw(OpenQA::Task::Needle::Scan OpenQA::Task::Needle::Save OpenQA::Task::Needle::Delete),
+        qw(OpenQA::Task::Screenshot::Scan),
       );
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -363,6 +363,12 @@ sub register {
             );
         });
 
+    $app->helper(
+        'reply.gru_result' => sub {
+            my ($c, $result, $error_code) = @_;
+            return $c->render(json => $result, status => ($error_code // 200));
+        });
+
     $app->helper('reply.validation_error' => \&_validation_error);
 }
 

--- a/openQA.spec
+++ b/openQA.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package openQA
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2018-2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -55,13 +55,13 @@ BuildRequires:  os-autoinst
 BuildRequires:  systemd
 # critical bug fix
 BuildRequires:  perl(DBIx::Class) >= 0.082801
-BuildRequires:  perl(Minion) >= 9.02
+BuildRequires:  perl(Minion) >= 9.09
 BuildRequires:  perl(Mojolicious) >= 7.92
 BuildRequires:  perl(Mojolicious::Plugin::AssetPack) >= 1.36
 BuildRequires:  perl(Mojo::RabbitMQ::Client) >= 0.2
 BuildRequires:  rubygem(sass)
 Requires:       dbus-1
-Requires:       perl(Minion) >= 9.02
+Requires:       perl(Minion) >= 9.09
 Requires:       perl(Mojo::RabbitMQ::Client) >= 0.2
 # needed for test suite
 Requires:       git-core


### PR DESCRIPTION
* Avoid interference with saving needles via the needle editor by
  preventing saving and deletion to run in parallel.
* Remove one more (potentially long) blocking operation from the event
  loop
* Reduce number of API requests by deleting 5 needles at a time
* Change the commit message to "Remove $dir/$name"
  (e.g. "Remove sle-15-SP1/password-prompt-20190313")

See https://progress.opensuse.org/issues/49175

---

I'm aware that common parts of `OpenQA::WebAPI::Controller::Admin::Needle::delete` and `OpenQA::WebAPI::Controller::Step::save_needle_ajax` should be extracted to avoid duplicating code.