### PR TITLE
Unify schema access with a singleton method

### DIFF
--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -43,7 +43,7 @@ sub job_restart {
     my ($jobids) = @_ or die "missing name parameter\n";
 
     # first, duplicate all jobs that are either running or done
-    my $schema = OpenQA::Schema::connect_db;
+    my $schema = OpenQA::Schema->singleton;
     my $jobs   = $schema->resultset("Jobs")->search(
         {
             id    => $jobids,

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -81,11 +81,7 @@ sub reactor {
     return $reactor;
 }
 
-sub schema {
-    state $schema;
-    $schema = OpenQA::Schema::connect_db() unless $schema;
-    return $schema;
-}
+sub schema { OpenQA::Schema->singleton }
 
 sub scheduled_jobs {
     state $scheduled_jobs;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -46,8 +46,6 @@ has 'instance';
 
 has 'log_dir';
 
-has schema => sub { OpenQA::Schema::connect_db() };
-
 sub setup_log {
     my ($self) = @_;
     my ($logfile, $logdir, $level, $log);
@@ -262,6 +260,8 @@ sub update_config {
         };
     }
 }
+
+sub schema { OpenQA::Schema->singleton }
 
 sub setup_app_defaults {
     my ($server) = @_;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -29,10 +29,6 @@ use DateTime;
 use Cwd 'abs_path';
 use File::Path 'make_path';
 
-has schema => sub {
-    return OpenQA::Schema::connect_db();
-};
-
 has secrets => sub {
     my ($self) = @_;
     return $self->schema->read_application_secrets();
@@ -45,6 +41,7 @@ sub log_name {
 # This method will run once at server start
 sub startup {
     my $self = shift;
+
     OpenQA::Setup::read_config($self);
     OpenQA::Setup::setup_log($self);
     OpenQA::Setup::setup_app_defaults($self);
@@ -52,7 +49,7 @@ sub startup {
     OpenQA::Setup::add_build_tx_time_header($self);
 
     # take care of DB deployment or migration before starting the main app
-    my $schema = OpenQA::Schema::connect_db;
+    my $schema = $self->schema;
 
     # register basic routes
     my $r         = $self->routes;
@@ -464,6 +461,8 @@ sub run {
     # Start command line interface for application
     Mojolicious::Commands->start_app('OpenQA::WebAPI');
 }
+
+sub schema { OpenQA::Schema->singleton }
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -116,7 +116,7 @@ sub check_authorized {
     my $user;
     log_debug($key ? "API key from client: *$key*" : "No API key from client.");
 
-    my $schema  = OpenQA::Schema::connect_db;
+    my $schema  = OpenQA::Schema->singleton;
     my $api_key = $schema->resultset("ApiKeys")->find({key => $key});
     if ($api_key) {
         if (time - $timestamp <= 300) {
@@ -340,7 +340,7 @@ sub _message {
 sub _get_stale_worker_jobs {
     my ($threshold) = @_;
 
-    my $schema = OpenQA::Schema::connect_db;
+    my $schema = OpenQA::Schema->singleton;
 
     # grab the workers we've seen lately
     my @ok_workers;
@@ -384,7 +384,7 @@ sub _is_job_considered_dead {
 # Check if worker with job has been updated recently; if not, assume it
 # got stuck somehow and duplicate or incomplete the job
 sub _workers_checker {
-    my $schema = OpenQA::Schema::connect_db;
+    my $schema = OpenQA::Schema->singleton;
     try {
         $schema->txn_do(
             sub {
@@ -457,7 +457,7 @@ sub setup {
 
 
     app->helper(log_name => sub { return 'websockets' });
-    app->helper(schema   => sub { return OpenQA::Schema::connect_db; });
+    app->helper(schema   => sub { return OpenQA::Schema->singleton });
     app->defaults(appname => "openQA Websocket Server");
     app->mode('production');
 

--- a/script/clean_needles
+++ b/script/clean_needles
@@ -90,7 +90,7 @@ $options{days} = 60 unless $options{days} // 0 > 0;
 
 usage(0) if $options{help};
 
-my $schema = OpenQA::Schema::connect_db;
+my $schema = OpenQA::Schema->singleton;
 
 sub list_jobs {
     my %args = (state => 'done', maxage => $options{days} * 24 * 60 * 60,);

--- a/script/create_admin
+++ b/script/create_admin
@@ -27,20 +27,20 @@ use OpenQA::Schema::Result::Users;
 use OpenQA::Schema;
 use Getopt::Long;
 
-my $email       = 'admin@example.com';
-my $nickname    = 'admin';
-my $fullname    = 'Administrator';
-my $key         = "";
-my $secret      = "";
-my $help        = 0;
+my $email    = 'admin@example.com';
+my $nickname = 'admin';
+my $fullname = 'Administrator';
+my $key      = "";
+my $secret   = "";
+my $help     = 0;
 
 my $result = GetOptions(
-    "email=s"       => \$email,
-    "nickname=s"    => \$nickname,
-    "fullname=s"    => \$fullname,
-    "key=s"         => \$key,
-    "secret=s"      => \$secret,
-    "help"          => \$help,
+    "email=s"    => \$email,
+    "nickname=s" => \$nickname,
+    "fullname=s" => \$fullname,
+    "key=s"      => \$key,
+    "secret=s"   => \$secret,
+    "help"       => \$help,
 );
 
 my $user = $ARGV[0];
@@ -60,8 +60,9 @@ if ($help) {
     exit;
 }
 
-if (($key || $secret) &&
-    !($key =~ /^[[:xdigit:]]{16}$/ && $secret =~ /^[[:xdigit:]]{16}$/)) {
+if (($key || $secret)
+    && !($key =~ /^[[:xdigit:]]{16}$/ && $secret =~ /^[[:xdigit:]]{16}$/))
+{
     warn "--key and --secret must both be 16 digit hexadecimals.\n";
     exit 1;
 }
@@ -73,13 +74,19 @@ unless ($key) {
     print "Secret: $secret\n";
 }
 
-my $schema = OpenQA::Schema::connect_db();
-my $users = $schema->resultset('Users')->find({ is_admin => 1 });
+my $schema = OpenQA::Schema->singleton;
+my $users  = $schema->resultset('Users')->find({is_admin => 1});
 if ($users != 0) {
     warn "An admin user already exists! Use client or web UI to create further users.\n";
     exit 1;
 }
-my $account = OpenQA::Schema::Result::Users->create_user($user, $schema, email => $email, nickname => $nickname, fullname => $fullname, is_admin => 1);
+my $account = OpenQA::Schema::Result::Users->create_user(
+    $user, $schema,
+    email    => $email,
+    nickname => $nickname,
+    fullname => $fullname,
+    is_admin => 1
+);
 
 $schema->resultset("ApiKeys")->create({user_id => $account->id, key => $key, secret => $secret});
 


### PR DESCRIPTION
This should be a rather harmless change. Our `DBIx::Class` schema is used as a singleton object that we access from all over OpenQA. But so far we accessed it in various inconsistent ways, sometimes storing the object in attributes or state variables for no reason at all. That can result in unintended copies and hard to debug problems when you end up with multiple instances of the schema in different states. So i've replaced those with a single `OpenQA::Schema->singleton` class method that you can always use to get the right instance. `OpenQA::Schema::connect_db()` and `OpenQA::Schema::disconnect_db()` still exist, but are only used for controlling the actual database connection now. There are still a few `schema` shortcut methods, but they all just delegate to the singleton instance now.