### PR TITLE
Unify schema access in OpenQA::WebAPI

### DIFF
--- a/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
+++ b/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
@@ -79,7 +79,7 @@ sub scan_images {
         }
     }
     closedir($dh);
-    $app->db->resultset('Screenshots')->populate(\@files);
+    $app->schema->resultset('Screenshots')->populate(\@files);
     return;
 }
 

--- a/lib/OpenQA/ServerSideDataTable.pm
+++ b/lib/OpenQA/ServerSideDataTable.pm
@@ -30,7 +30,7 @@ sub render_response {
     my $filter_conds  = $args{filter_conds};
     my $params        = $args{additional_params} // {};
 
-    my $resultset = $controller->db->resultset($resultset_name);
+    my $resultset = $controller->schema->resultset($resultset_name);
 
     # determine total count
     my $total_count

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -33,9 +33,10 @@ sub _limit {
 
     # create temporary job group outside of DB to collect
     # jobs without job_group_id
-    $app->db->resultset('JobGroups')->new({})->limit_results_and_logs;
+    my $schema = $app->schema;
+    $schema->resultset('JobGroups')->new({})->limit_results_and_logs;
 
-    my $groups = $app->db->resultset('JobGroups');
+    my $groups = $schema->resultset('JobGroups');
     while (my $group = $groups->next) {
         $group->limit_results_and_logs;
     }

--- a/lib/OpenQA/Task/Needle/Scan.pm
+++ b/lib/OpenQA/Task/Needle/Scan.pm
@@ -33,7 +33,7 @@ sub _needles {
     return $job->finish('Previous scan_needles job is still active')
       unless my $guard = $app->minion->guard('limit_scan_needles_task', 7200);
 
-    my $dirs = $app->db->resultset('NeedleDirs');
+    my $dirs = $app->schema->resultset('NeedleDirs');
 
     while (my $dir = $dirs->next) {
         my $needles = $dir->needles;

--- a/lib/OpenQA/Task/Screenshot/Scan.pm
+++ b/lib/OpenQA/Task/Screenshot/Scan.pm
@@ -70,11 +70,12 @@ sub _scan_images {
         }
     }
     closedir($dh);
+    my $schema = $app->schema;
     while (@files) {
         my @part = splice @files, 0, 100;
         try {
             unshift(@part, [qw(filename t_created)]);
-            $app->db->resultset('Screenshots')->populate(\@part);
+            $schema->resultset('Screenshots')->populate(\@part);
             @part = ();
         }
         catch { };
@@ -83,7 +84,7 @@ sub _scan_images {
         shift @part;    # columns
         for my $row (@part) {
             try {
-                $app->db->resultset('Screenshots')->create({filename => $row->[0], t_created => $row->[1]});
+                $schema->resultset('Screenshots')->create({filename => $row->[0], t_created => $row->[1]});
             }
             catch {
                 my $error = shift;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -49,7 +49,7 @@ sub startup {
     OpenQA::Setup::add_build_tx_time_header($self);
 
     # take care of DB deployment or migration before starting the main app
-    my $schema = $self->schema;
+    OpenQA::Schema->singleton;
 
     # register basic routes
     my $r         = $self->routes;

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -49,7 +49,7 @@ sub auth_login {
     $userinfo->{username} = $user;
 
     $user = OpenQA::Schema::Result::Users->create_user(
-        $userinfo->{username}, $self->db,
+        $userinfo->{username}, $self->schema,
         email    => $userinfo->{email},
         nickname => $userinfo->{username},
         fullname => $userinfo->{fullname});

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -149,7 +149,7 @@ sub auth_response {
             }
 
             my $user = OpenQA::Schema::Result::Users->create_user(
-                $vident->{identity}, $self->db,
+                $vident->{identity}, $self->schema,
                 email    => $email,
                 nickname => $nickname,
                 fullname => $fullname

--- a/lib/OpenQA/WebAPI/Auth/iChain.pm
+++ b/lib/OpenQA/WebAPI/Auth/iChain.pm
@@ -37,7 +37,7 @@ sub auth_login {
     if ($username) {
         # iChain login
         OpenQA::Schema::Result::Users->create_user(
-            $username, $self->db,
+            $username, $self->schema,
             email    => $email,
             nickname => $username,
             fullname => $fullname

--- a/lib/OpenQA/WebAPI/Controller/API/V1.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1.pm
@@ -39,7 +39,7 @@ sub auth {
         my $api_key;
         if ($key) {
             $log->debug("API key from client: *$key*");
-            $api_key = $self->db->resultset("ApiKeys")->find({key => $key});
+            $api_key = $self->schema->resultset("ApiKeys")->find({key => $key});
         }
         else {
             $log->debug("No API key from client.");
@@ -113,7 +113,7 @@ sub auth_jobtoken {
 
     if ($token) {
         $self->app->log->debug("Received JobToken: $token");
-        my $job = $self->db->resultset('Jobs')->search(
+        my $job = $self->schema->resultset('Jobs')->search(
             {'properties.key' => 'JOBTOKEN', 'properties.value' => $token},
             {columns => ['id'], join => {worker => 'properties'}})->single;
         if ($job) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
@@ -51,7 +51,7 @@ sub create {
     my $self     = shift;
     my $workerid = $self->stash('workerid');
     my $command  = $self->param('command');
-    my $worker   = $self->db->resultset('Workers')->find($workerid);
+    my $worker   = $self->schema->resultset('Workers')->find($workerid);
 
     if (!$worker) {
         log_warning("Trying to send command \'$command\' to unknown worker id $workerid");

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -136,7 +136,7 @@ sub text {
 sub _insert_bugs_for_comment {
     my ($self, $comment) = @_;
 
-    my $bugs = $self->app->db->resultset('Bugs');
+    my $bugs = $self->app->schema->resultset('Bugs');
     if (my $bugrefs = $comment->bugrefs) {
         for my $bug (@$bugrefs) {
             $bugs->get_bug($bug);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -65,7 +65,7 @@ Returns results for a set of groups.
 
 sub resultset {
     my ($self) = @_;
-    return $self->db->resultset($self->is_parent ? 'JobGroupParents' : 'JobGroups');
+    return $self->schema->resultset($self->is_parent ? 'JobGroupParents' : 'JobGroups');
 }
 
 =over 4

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -54,10 +54,11 @@ and test suite (id and name).
 sub list {
     my $self = shift;
 
+    my $schema = $self->schema;
     my @templates;
     eval {
         if (my $id = $self->param('job_template_id')) {
-            @templates = $self->db->resultset("JobTemplates")->search({id => $id});
+            @templates = $schema->resultset("JobTemplates")->search({id => $id});
         }
 
         else {
@@ -80,11 +81,11 @@ sub list {
             if ($has_query) {
                 my $attrs
                   = {join => ['machine', 'test_suite', 'product'], prefetch => [qw(machine test_suite product)]};
-                @templates = $self->db->resultset("JobTemplates")->search(\%cond, $attrs);
+                @templates = $schema->resultset("JobTemplates")->search(\%cond, $attrs);
             }
             else {
                 @templates
-                  = $self->db->resultset("JobTemplates")->search({}, {prefetch => [qw(machine test_suite product)]});
+                  = $schema->resultset("JobTemplates")->search({}, {prefetch => [qw(machine test_suite product)]});
             }
         }
     };
@@ -154,6 +155,7 @@ sub create {
     my $prio = $self->param('prio');
     $prio = ((!$prio || $prio eq 'inherit') ? undef : $prio);
 
+    my $schema = $self->schema;
 
     if ($has_product_id) {
         for my $param (qw(machine_id group_id test_suite_id)) {
@@ -173,7 +175,7 @@ sub create {
                 machine_id    => $self->param('machine_id'),
                 group_id      => $self->param('group_id'),
                 test_suite_id => $self->param('test_suite_id')};
-            eval { $id = $self->db->resultset("JobTemplates")->create($values)->id };
+            eval { $id = $schema->resultset("JobTemplates")->create($values)->id };
             $error = $@;
         }
     }
@@ -190,7 +192,7 @@ sub create {
         }
         else {
             eval {
-                $affected_rows = $self->db->resultset("JobTemplates")->search(
+                $affected_rows = $schema->resultset("JobTemplates")->search(
                     {
                         group_id      => $self->param('group_id'),
                         test_suite_id => $self->param('test_suite_id'),
@@ -226,7 +228,7 @@ sub create {
                 machine    => {name => $self->param('machine_name')},
                 prio       => $prio,
                 test_suite => {name => $self->param('test_suite_name')}};
-            eval { $id = $self->db->resultset("JobTemplates")->create($values)->id };
+            eval { $id = $schema->resultset("JobTemplates")->create($values)->id };
             $error = $@;
         }
     }
@@ -277,7 +279,7 @@ a 400 code on other errors or a 303 code on success.
 
 sub destroy {
     my $self          = shift;
-    my $job_templates = $self->db->resultset('JobTemplates');
+    my $job_templates = $self->schema->resultset('JobTemplates');
 
     my $status;
     my $json = {};

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
@@ -64,7 +64,7 @@ sub get_children_status {
     }
     my $jobid = $self->stash('job_id');
 
-    my @res = $self->db->resultset('Jobs')
+    my @res = $self->schema->resultset('Jobs')
       ->search({'parents.parent_job_id' => $jobid, state => $status}, {columns => ['id'], join => 'parents'});
     my @res_ids = map { $_->id } @res;
     return $self->render(json => {jobs => \@res_ids}, status => 200);
@@ -85,7 +85,7 @@ sub get_children {
     my ($self) = @_;
     my $jobid = $self->stash('job_id');
 
-    my @res = $self->db->resultset('Jobs')->search(
+    my @res = $self->schema->resultset('Jobs')->search(
         {'parents.parent_job_id' => $jobid, 'parents.dependency' => OpenQA::Schema::Result::JobDependencies::PARALLEL},
         {columns                 => ['id', 'state'], join => 'parents'});
     my %res_ids = map { ($_->id, $_->state) } @res;
@@ -107,7 +107,7 @@ sub get_parents {
     my ($self) = @_;
     my $jobid = $self->stash('job_id');
 
-    my @res = $self->db->resultset('Jobs')->search(
+    my @res = $self->schema->resultset('Jobs')->search(
         {'children.child_job_id' => $jobid, 'children.dependency' => OpenQA::Schema::Result::JobDependencies::PARALLEL},
         {columns                 => ['id'], join                  => 'children'});
     my @res_ids = map { $_->id } @res;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -57,7 +57,7 @@ websocket status.
 sub list {
     my ($self) = @_;
     my $live    = !looks_like_number($self->param('live')) ? 0 : !!$self->param('live');
-    my $workers = $self->db->resultset("Workers");
+    my $workers = $self->schema->resultset("Workers");
     my $ret     = [];
 
     while (my $w = $workers->next) {
@@ -164,7 +164,7 @@ sub create {
 
     my $id;
     try {
-        $id = $self->_register($self->db, $host, $instance, $caps);
+        $id = $self->_register($self->schema, $host, $instance, $caps);
     }
     catch {
         if (/Incompatible/) {
@@ -197,7 +197,7 @@ A worker can be considered "up" when "connected=1" and "status!=dead"'
 
 sub show {
     my ($self) = @_;
-    my $worker = $self->db->resultset("Workers")->find($self->param('workerid'));
+    my $worker = $self->schema->resultset("Workers")->find($self->param('workerid'));
     if ($worker) {
         $self->render(json => {worker => $worker->info(1)});
     }

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -30,7 +30,8 @@ sub index {
     $self->stash(audit_enabled => $self->app->config->{global}{audit_enabled});
     if ($self->param('eventid')) {
         my $event
-          = $self->db->resultset('AuditEvents')->search({'me.id' => $self->param('eventid')}, {prefetch => 'owner'});
+          = $self->schema->resultset('AuditEvents')
+          ->search({'me.id' => $self->param('eventid')}, {prefetch => 'owner'});
         if ($event) {
             $event = $event->single;
             $self->stash('id',         $event->id);
@@ -50,7 +51,7 @@ sub productlog {
     my ($self) = @_;
     my $entries = $self->param('entries') // 100;
     $self->stash(audit_enabled => $self->app->config->{global}{audit_enabled});
-    my $events_rs = $self->db->resultset("AuditEvents")
+    my $events_rs = $self->schema->resultset("AuditEvents")
       ->search({event => 'iso_create'}, {order_by => {-desc => 'me.id'}, prefetch => 'owner', rows => $entries});
     my @events;
     while (my $event = $events_rs->next) {

--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -37,15 +37,16 @@ sub jobs {
 
     my $result = {};
 
+    my $schema = $self->schema;
     my $rs
-      = $self->db->resultset('Jobs')->search({state => OpenQA::Jobs::Constants::SCHEDULED, blocked_by_id => undef});
+      = $schema->resultset('Jobs')->search({state => OpenQA::Jobs::Constants::SCHEDULED, blocked_by_id => undef});
     _queue_sub_stats($rs, 'scheduled', $result);
-    $rs = $self->db->resultset('Jobs')
+    $rs = $schema->resultset('Jobs')
       ->search({state => OpenQA::Jobs::Constants::SCHEDULED, -not => {blocked_by_id => undef}});
     _queue_sub_stats($rs, 'blocked', $result);
-    $rs = $self->db->resultset('Jobs')->search({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]});
+    $rs = $schema->resultset('Jobs')->search({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]});
     _queue_sub_stats($rs, 'running', $result);
-    $rs = $self->db->resultset('Jobs')->search(
+    $rs = $schema->resultset('Jobs')->search(
         {state => [OpenQA::Jobs::Constants::EXECUTION_STATES]},
         {
             join     => [qw(assigned_worker)],
@@ -60,7 +61,7 @@ sub jobs {
     }
 
     # map group ids to names (and group by parent)
-    my $groups = $self->db->resultset('JobGroups')->search({}, {prefetch => 'parent', select => [qw(id name)]});
+    my $groups = $self->schema->resultset('JobGroups')->search({}, {prefetch => 'parent', select => [qw(id name)]});
     while (my $g = $groups->next) {
         my $name = $g->name;
         $name = $g->parent->name if $g->parent;

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -22,10 +22,11 @@ use OpenQA::Utils 'job_groups_and_parents';
 sub index {
     my ($self) = @_;
 
-    my $parent_groups = $self->db->resultset('JobGroupParents')
-      ->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
+    my $schema = $self->schema;
+    my $parent_groups
+      = $schema->resultset('JobGroupParents')->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
     my $groups
-      = $self->db->resultset('JobGroups')->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
+      = $schema->resultset('JobGroups')->search(undef, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]});
 
     $self->stash('job_groups_and_parents_for_editor', job_groups_and_parents);
     $self->stash('parent_groups',                     $parent_groups);
@@ -39,7 +40,7 @@ sub group_page {
     my $group_id = $self->param('groupid');
     return $self->reply->not_found unless $group_id;
 
-    my $group = $self->db->resultset($resultset)->find($group_id);
+    my $group = $self->schema->resultset($resultset)->find($group_id);
     return $self->reply->not_found unless $group;
 
     $self->stash('group',     $group);
@@ -66,12 +67,13 @@ sub edit_parent_group {
 sub connect {
     my ($self) = @_;
 
-    $self->stash('group', $self->db->resultset('JobGroups')->find($self->param('groupid')));
-    my $products = $self->db->resultset('Products')->search(undef, {order_by => 'name'});
+    my $schema = $self->schema;
+    $self->stash('group', $schema->resultset('JobGroups')->find($self->param('groupid')));
+    my $products = $schema->resultset('Products')->search(undef, {order_by => 'name'});
     $self->stash('products', $products);
-    my $tests = $self->db->resultset('TestSuites')->search(undef, {order_by => 'name'});
+    my $tests = $schema->resultset('TestSuites')->search(undef, {order_by => 'name'});
     $self->stash('tests', $tests);
-    my $machines = $self->db->resultset('Machines')->search(undef, {order_by => 'name'});
+    my $machines = $schema->resultset('Machines')->search(undef, {order_by => 'name'});
     $self->stash('machines', $machines);
 
     $self->render('admin/group/connect');
@@ -80,7 +82,8 @@ sub connect {
 sub save_connect {
     my ($self) = @_;
 
-    my $group = $self->db->resultset("JobGroups")->find($self->param('groupid'));
+    my $schema = $self->schema;
+    my $group  = $schema->resultset("JobGroups")->find($self->param('groupid'));
     if (!$group) {
         $self->flash(error => 'Specified group ID ' . $self->param('groupid') . 'doesn\'t exist.');
         return $self->redirect_to('admin_groups');
@@ -92,7 +95,7 @@ sub save_connect {
         machine_id    => $self->param('machine'),
         group_id      => $group->id,
         test_suite_id => $self->param('test')};
-    eval { $self->db->resultset("JobTemplates")->create($values)->id };
+    eval { $schema->resultset("JobTemplates")->create($values)->id };
     if ($@) {
         $self->flash(error => $@);
         return $self->redirect_to('job_group_new_media', groupid => $group->id);

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
@@ -20,11 +20,12 @@ use Mojo::Base 'Mojolicious::Controller';
 sub index {
     my ($self) = @_;
 
-    $self->stash('group', $self->db->resultset("JobGroups")->find($self->param('groupid')));
+    my $schema = $self->schema;
+    $self->stash('group', $schema->resultset("JobGroups")->find($self->param('groupid')));
 
-    my @machines = $self->db->resultset("Machines")->search(undef, {order_by => 'name'});
+    my @machines = $schema->resultset("Machines")->search(undef, {order_by => 'name'});
     $self->stash('machines', \@machines);
-    my @tests = $self->db->resultset("TestSuites")->search(undef, {order_by => 'name'});
+    my @tests = $schema->resultset("TestSuites")->search(undef, {order_by => 'name'});
     $self->stash('tests', \@tests);
 
     $self->render('admin/job_template/index');

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -110,8 +110,9 @@ sub ajax {
 sub module {
     my ($self) = @_;
 
-    my $module = $self->db->resultset('JobModules')->find($self->param('module_id'));
-    my $needle = $self->db->resultset('Needles')->find($self->param('needle_id'))->name;
+    my $schema = $self->schema;
+    my $module = $schema->resultset('JobModules')->find($self->param('module_id'));
+    my $needle = $schema->resultset('Needles')->find($self->param('needle_id'))->name;
 
     my $index = 1;
     for my $detail (@{$module->details}) {
@@ -127,7 +128,7 @@ sub delete {
     my @removed_ids;
     my @errors;
     for my $needle_id (@{$self->every_param('id')}) {
-        my $needle = $self->db->resultset('Needles')->find($needle_id);
+        my $needle = $self->schema->resultset('Needles')->find($needle_id);
         if (!$needle) {
             push(
                 @errors,

--- a/lib/OpenQA/WebAPI/Controller/Admin/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/User.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'Mojolicious::Controller';
 
 sub index {
     my ($self) = @_;
-    my @users = $self->db->resultset("Users")->search(undef)->all;
+    my @users = $self->schema->resultset("Users")->search(undef)->all;
 
     $self->stash('users', \@users);
     $self->render('admin/user/index');
@@ -27,7 +27,7 @@ sub index {
 
 sub update {
     my ($self)      = @_;
-    my $set         = $self->db->resultset('Users');
+    my $set         = $self->schema->resultset('Users');
     my $is_admin    = 0;
     my $is_operator = 0;
     my $role = $self->param('role') // 'user';

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -33,7 +33,7 @@ sub _extend_info {
 sub index {
     my ($self) = @_;
 
-    my $workers_db          = $self->db->resultset('Workers');
+    my $workers_db          = $self->schema->resultset('Workers');
     my $total_online        = grep { !$_->dead } $workers_db->all();
     my $total               = $workers_db->count;
     my $free_active_workers = grep { !$_->dead } $workers_db->search({job_id => undef, error => undef})->all();
@@ -64,7 +64,7 @@ sub index {
 sub show {
     my ($self) = @_;
 
-    my $w = $self->db->resultset('Workers')->find($self->param('worker_id'))
+    my $w = $self->schema->resultset('Workers')->find($self->param('worker_id'))
       or return $self->reply->not_found;
     $self->stash(worker => _extend_info($w, 1));
 

--- a/lib/OpenQA/WebAPI/Controller/ApiKey.pm
+++ b/lib/OpenQA/WebAPI/Controller/ApiKey.pm
@@ -43,7 +43,7 @@ sub create {
         $error = $@;
     }
     unless ($error) {
-        eval { $self->db->resultset("ApiKeys")->create({user_id => $user->id, t_expiration => $expiration}) };
+        eval { $self->schema->resultset("ApiKeys")->create({user_id => $user->id, t_expiration => $expiration}) };
         $error = $@;
     }
     if ($error) {

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -56,7 +56,7 @@ sub _needle_by_id_and_extension {
     my ($self, $extension) = @_;
 
     my $needle_id = $self->param('needle_id') or return $self->reply->not_found;
-    my $needle = $self->db->resultset('Needles')->find($needle_id) or return $self->reply->not_found;
+    my $needle = $self->schema->resultset('Needles')->find($needle_id) or return $self->reply->not_found;
     my $needle_dir      = $needle->directory->path;
     my $needle_filename = $needle->name . $extension;
 
@@ -78,7 +78,7 @@ sub needle_json_by_id {
 sub _set_test($) {
     my $self = shift;
 
-    $self->{job} = $self->db->resultset("Jobs")->find({'me.id' => $self->param('testid')});
+    $self->{job} = $self->schema->resultset("Jobs")->find({'me.id' => $self->param('testid')});
     return unless $self->{job};
 
     $self->{testdirname} = $self->{job}->result_dir;
@@ -124,7 +124,7 @@ sub test_asset {
 
     my %asset;
     my $attrs = {join => {jobs_assets => 'asset'}, +select => [qw(asset.name asset.type)], +as => [qw(name type)]};
-    my $res   = $self->db->resultset('Jobs')->search(\%cond, $attrs);
+    my $res   = $self->schema->resultset('Jobs')->search(\%cond, $attrs);
     if ($res and $res->first) { %asset = $res->first->get_columns }
     else                      { return $self->reply->not_found }
 

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -93,7 +93,7 @@ sub group_overview {
     my $only_tagged = $self->param('only_tagged') // 0;
     my $group_id    = $self->param('groupid');
     return $self->reply->not_found unless looks_like_number($group_id);
-    my $group = $self->db->resultset($resultset)->find($group_id);
+    my $group = $self->schema->resultset($resultset)->find($group_id);
     return $self->reply->not_found unless $group;
     $self->stash('fullscreen', $self->param('fullscreen') // 0);
     my $interval = $self->param('interval') // 60;

--- a/lib/OpenQA/WebAPI/GruJob.pm
+++ b/lib/OpenQA/WebAPI/GruJob.pm
@@ -68,13 +68,13 @@ sub execute {
 
 sub _delete_gru {
     my ($self, $id) = @_;
-    my $gru = $self->minion->app->db->resultset('GruTasks')->find($id);
+    my $gru = $self->minion->app->schema->resultset('GruTasks')->find($id);
     $gru->delete() if $gru;
 }
 
 sub _fail_gru {
     my ($self, $id, $reason) = @_;
-    my $gru = $self->minion->app->db->resultset('GruTasks')->find($id);
+    my $gru = $self->minion->app->schema->resultset('GruTasks')->find($id);
     $gru->fail($reason) if $gru;
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -91,7 +91,7 @@ sub on_job_event {
     my ($self, $args) = @_;
 
     my ($user_id, $connection_id, $event, $event_data) = @$args;
-    my $jobs = $self->{app}->db->resultset('Jobs');
+    my $jobs = $self->{app}->schema->resultset('Jobs');
     my $job  = $jobs->find({id => $event_data->{id}});
 
     # find count of pending jobs for the same build to know whether all tests for a build are done
@@ -124,7 +124,7 @@ sub on_comment_event {
     my ($comment_id, $connection_id, $event, $event_data) = @$args;
 
     # find comment in database
-    my $comment = $self->{app}->db->resultset('Comments')->find($event_data->{id});
+    my $comment = $self->{app}->schema->resultset('Comments')->find($event_data->{id});
     return unless $comment;
 
     # just send the hash already used for JSON representation

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -51,9 +51,10 @@ sub register {
         OpenQA::Events->singleton->on("openqa_$e" => sub { shift; $self->on_event($app, @_) });
     }
 
-    my $user = $app->db->resultset('Users')->find({username => 'system'});
+    my $schema = $app->schema;
+    my $user   = $schema->resultset('Users')->find({username => 'system'});
 
-    $app->db->resultset('AuditEvents')
+    $schema->resultset('AuditEvents')
       ->create({user_id => $user->id, connection_id => 0, event => 'startup', event_data => 'openQA restarted'});
 }
 
@@ -63,7 +64,7 @@ sub on_event {
     my ($user_id, $connection_id, $event, $event_data) = @$args;
     # no need to log openqa_ prefix in openqa log
     $event =~ s/^openqa_//;
-    $app->db->resultset('AuditEvents')->create(
+    $app->schema->resultset('AuditEvents')->create(
         {
             user_id       => $user_id,
             connection_id => $connection_id,

--- a/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Fedmsg.pm
@@ -226,11 +226,12 @@ sub on_job_event {
     my ($user_id, $connection_id, $event, $event_data) = @$args;
     # find count of pending jobs for the same build
     # this is so we can tell when all tests for a build are done
-    my $job = $app->db->resultset('Jobs')->find({id => $event_data->{id}});
+    my $schema = $app->schema;
+    my $job    = $schema->resultset('Jobs')->find({id => $event_data->{id}});
     # Get app baseurl, as the ci_standard logger needs it
     my $baseurl = $app->config->{global}->{base_url} || "http://UNKNOWN";
     my $build   = $job->BUILD;
-    $event_data->{remaining} = $app->db->resultset('Jobs')->search(
+    $event_data->{remaining} = $schema->resultset('Jobs')->search(
         {
             'me.BUILD' => $build,
             state      => [OpenQA::Jobs::Constants::PENDING_STATES],
@@ -256,7 +257,7 @@ sub on_comment_event {
     # find comment in database. on comment deletion, the mojo event
     # is emitted *before* the comment is actually deleted, so this
     # should still work
-    my $comment = $app->db->resultset('Comments')->find($event_data->{id});
+    my $comment = $app->schema->resultset('Comments')->find($event_data->{id});
     return unless $comment;
 
     # just send the hash already used for JSON representation

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -18,6 +18,7 @@ package OpenQA::WebAPI::Plugin::Helpers;
 use Mojo::Base 'Mojolicious::Plugin';
 
 use Mojo::ByteStream;
+use OpenQA::Schema;
 use OpenQA::Utils qw(bugurl render_escaped_refs href_to_bugref);
 use OpenQA::Events;
 use db_helpers;
@@ -143,7 +144,7 @@ sub register {
             return Mojo::ByteStream->new($crumbs);
         });
 
-    $app->helper(db => sub { shift->app->schema });
+    $app->helper(schema => sub { OpenQA::Schema->singleton });
 
     $app->helper(
         current_user => sub {
@@ -153,7 +154,7 @@ sub register {
             my $current_user = $c->stash('current_user');
             unless ($current_user && ($current_user->{no_user} || defined $current_user->{user})) {
                 my $id   = $c->session->{user};
-                my $user = $id ? $c->db->resultset("Users")->find({username => $id}) : undef;
+                my $user = $id ? $c->schema->resultset("Users")->find({username => $id}) : undef;
                 $c->stash(current_user => $current_user = $user ? {user => $user} : {no_user => 1});
             }
 

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -39,7 +39,7 @@ use constant STATUS_ERROR       => 5;
 
 our @EXPORT_OK = qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE STATUS_ERROR);
 
-has [qw(host cache location db_file dsn dbh cache_real_size)];
+has [qw(host cache location db_file dsn cache_real_size)];
 has limit      => 50 * (1024**3);
 has sleep_time => 5;
 has sqlite     => sub { Mojo::SQLite->new(shift->dsn) };

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -36,13 +36,13 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 subtest 'new users are not ops and admins' => sub {
     my $mordred_id = 'https://openid.badguys.uk/mordred';
-    my $user       = $t->app->db->resultset('Users')->create({username => $mordred_id});
+    my $user       = $t->app->schema->resultset('Users')->create({username => $mordred_id});
     ok(!$user->is_admin,    'new users are not admin by default');
     ok(!$user->is_operator, 'new users are not operator by default');
 };
 
 subtest 'system user presence' => sub {
-    my $system_user = $t->app->db->resultset("Users")->search({username => 'system'})->first;
+    my $system_user = $t->app->schema->resultset("Users")->search({username => 'system'})->first;
     ok($system_user,               'system user exists');
     ok(!$system_user->is_admin,    'system user is not an admin');
     ok(!$system_user->is_operator, 'system user is not an operator');
@@ -50,13 +50,13 @@ subtest 'system user presence' => sub {
 };
 
 subtest 'new user is admin if no admin is present' => sub {
-    my $admins = $t->app->db->resultset('Users')->search({is_admin => 1});
+    my $admins = $t->app->schema->resultset('Users')->search({is_admin => 1});
     while (my $u = $admins->next) {
         $u->update({is_admin => 0});
     }
-    ok(!$t->app->db->resultset('Users')->search({is_admin => 1})->all, 'no admin is present');
+    ok(!$t->app->schema->resultset('Users')->search({is_admin => 1})->all, 'no admin is present');
     require OpenQA::Schema::Result::Users;
-    my $user = OpenQA::Schema::Result::Users->create_user('test_user', $t->app->db);
+    my $user = OpenQA::Schema::Result::Users->create_user('test_user', $t->app->schema);
     ok($user->is_admin,    'new user is admin by default if there was no admin');
     ok($user->is_operator, 'new user is operator by default if there was no admin');
 };

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -36,8 +36,8 @@ OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 
-my $arthur = $t->app->db->resultset("Users")->find({username => 'arthur'});
-my $key = $t->app->db->resultset("ApiKeys")->create({user_id => $arthur->id});
+my $arthur = $t->app->schema->resultset("Users")->find({username => 'arthur'});
+my $key = $t->app->schema->resultset("ApiKeys")->create({user_id => $arthur->id});
 like($key->key,    qr/[0-9a-fA-F]{16}/, 'new keys have a valid random key attribute');
 like($key->secret, qr/[0-9a-fA-F]{16}/, 'new keys have a valid random secret attribute');
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -34,7 +34,7 @@ use Test::Warnings;
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-my $rset     = $t->app->db->resultset("Jobs");
+my $rset     = $t->app->schema->resultset("Jobs");
 my $minimalx = $rset->find(99926);
 my $clones   = $minimalx->duplicate();
 my $clone    = $rset->find($clones->{$minimalx->id}->{clone});

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -38,7 +38,7 @@ use OpenQA::Parser::Result::Output;
 
 my $schema = OpenQA::Test::Case->new->init_data;
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
-my $rs     = $t->app->db->resultset("Jobs");
+my $rs     = $t->app->schema->resultset("Jobs");
 
 is($rs->latest_build, '0091');
 is($rs->latest_build(version => 'Factory', distri => 'opensuse'), '0048@0815');
@@ -647,7 +647,7 @@ subtest 'Old logs are deleted when nocleanup is set' => sub {
 $t->get_ok('/t99946')->status_is(302)->header_like(Location => qr{tests/99946});
 
 subtest 'delete job assigned as last use for asset' => sub {
-    my $assets     = $t->app->db->resultset('Assets');
+    my $assets     = $t->app->schema->resultset('Assets');
     my $some_job   = $rs->first;
     my $some_asset = $assets->first;
     my $asset_id   = $some_asset->id;

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -150,7 +150,7 @@ $get = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 1/i, 'todo=1 shows only unlabeled left failed');
 
 # add a failing module to one of the softfails to test 'TODO' option
-my $failing_module = $t->app->db->resultset('JobModules')->create(
+my $failing_module = $t->app->schema->resultset('JobModules')->create(
     {
         script   => 'tests/x11/failing_module.pm',
         job_id   => 99936,
@@ -169,7 +169,7 @@ like(
 $t->element_exists_not('#res-99939', 'softfailed filtered out');
 $t->element_exists('#res-99936', 'unreviewed failed because of new failing module present');
 
-my $review_comment = $t->app->db->resultset('Comments')->create(
+my $review_comment = $t->app->schema->resultset('Comments')->create(
     {
         job_id  => 99936,
         text    => 'bsc#1234',

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -325,7 +325,7 @@ sub create_temp_job_log_file {
 }
 
 subtest 'limit_results_and_logs gru task cleans up logs' => sub {
-    my $job = $t->app->db->resultset('Jobs')->find(99937);
+    my $job = $t->app->schema->resultset('Jobs')->find(99937);
     $job->update({t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600 * 24 * 12, 'UTC')});
     $job->group->update({"keep_logs_in_days" => 5});
     my $filename = create_temp_job_log_file($job->result_dir);
@@ -342,23 +342,23 @@ subtest 'human readable size' => sub {
 };
 
 subtest 'scan_images' => sub {
-    is($t->app->db->resultset('Screenshots')->count, 0, "no screenshots in fixtures");
+    is($t->app->schema->resultset('Screenshots')->count, 0, "no screenshots in fixtures");
     run_gru('scan_images' => {prefix => '347'});
-    is($t->app->db->resultset('Screenshots')->count, 1, "one screenshot found");
+    is($t->app->schema->resultset('Screenshots')->count, 1, "one screenshot found");
 
     run_gru('scan_images_links' => {min_job => 0, max_job => 100000});
-    my @links = sort map { $_->job_id } $t->app->db->resultset('ScreenshotLinks')->all;
+    my @links = sort map { $_->job_id } $t->app->schema->resultset('ScreenshotLinks')->all;
     is_deeply(\@links, [99937, 99938, 99940, 99946, 99962, 99963], "all links found");
 };
 
 subtest 'labeled jobs considered important' => sub {
-    my $job = $t->app->db->resultset('Jobs')->find(99938);
+    my $job = $t->app->schema->resultset('Jobs')->find(99938);
     # but gets cleaned after important limit - change finished to 12 days ago
     $job->update({t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600 * 24 * 12, 'UTC')});
     $job->group->update({"keep_logs_in_days"           => 5});
     $job->group->update({"keep_important_logs_in_days" => 20});
     my $filename = create_temp_job_log_file($job->result_dir);
-    my $user     = $t->app->db->resultset('Users')->find({username => 'system'});
+    my $user     = $t->app->schema->resultset('Users')->find({username => 'system'});
     $job->comments->create({text => 'label:linked from test.domain', user_id => $user->id});
     run_gru('limit_results_and_logs');
     ok(-e $filename, 'file did not get cleaned');

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -42,7 +42,7 @@ my $t    = Test::Mojo->new('OpenQA::WebAPI');
 my $auth = {'X-CSRF-Token' => $t->ua->get('/tests')->res->dom->at('meta[name=csrf-token]')->attr('content')};
 $test_case->login($t, 'percival');
 
-my $schema        = $t->app->db;
+my $schema        = $t->app->schema;
 my $jobs          = $schema->resultset('Jobs');
 my $job_groups    = $schema->resultset('JobGroups');
 my $parent_groups = $schema->resultset('JobGroupParents');
@@ -264,7 +264,7 @@ sub _map_expired {
 }
 
 subtest 'expired jobs' => sub {
-    my $jg = $t->app->db->resultset('JobGroups')->find(1001);
+    my $jg = $t->app->schema->resultset('JobGroups')->find(1001);
     my $m;
 
     for my $file_type (qw(results logs)) {
@@ -281,7 +281,7 @@ subtest 'expired jobs' => sub {
 
         is_deeply($jg->$m, [], 'no jobs with expired ' . $file_type);
 
-        $t->app->db->resultset('Jobs')->find(99938)
+        $t->app->schema->resultset('Jobs')->find(99938)
           ->update({t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600 * 24 * 12, 'UTC')});
         is_deeply($jg->$m, [], 'still no jobs with expired ' . $file_type);
         $jg->update({"keep_${file_type}_in_days" => 5});
@@ -296,7 +296,7 @@ subtest 'expired jobs' => sub {
             [qw(99937 99938 99981)], 'now also important job 99938 with expired ' . $file_type);
     }
 
-    $t->app->db->resultset('Jobs')->find(99938)->update({logs_present => 0});
+    $t->app->schema->resultset('Jobs')->find(99938)->update({logs_present => 0});
     is_deeply(_map_expired($jg, $m),
         [qw(99937 99981)], 'job with deleted logs not return among jobs with expired logs');
 };

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -45,7 +45,7 @@ sub set_up {
     $t = Test::Mojo->new('OpenQA::WebAPI');
     my $sh = OpenQA::Scheduler->new;
     my $ws = OpenQA::WebSockets->new;
-    $rs   = $t->app->db->resultset("Jobs");
+    $rs   = $t->app->schema->resultset("Jobs");
     $auth = {'X-CSRF-Token' => $t->ua->get('/tests')->res->dom->at('meta[name=csrf-token]')->attr('content')};
     $test_case->login($t, 'percival');
 }
@@ -78,7 +78,7 @@ subtest '"happy path": failed->failed carries over last issue reference' => sub 
     is($comments_previous[0],     $label,          'comment present on previous test result');
     is($comments_previous[2],     $simple_comment, 'another comment present');
 
-    my $group = $t->app->db->resultset('JobGroups')->find(1001);
+    my $group = $t->app->schema->resultset('JobGroups')->find(1001);
 
     subtest 'carry over prevented via job group settings' => sub {
         $group->update({carry_over_bugrefs => 0});

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -35,9 +35,9 @@ $test_case->init_data;
 my $t    = Test::Mojo->new('OpenQA::WebAPI');
 my $auth = {'X-CSRF-Token' => $t->ua->get('/tests')->res->dom->at('meta[name=csrf-token]')->attr('content')};
 $test_case->login($t, 'percival');
-my $job_groups    = $t->app->db->resultset('JobGroups');
-my $parent_groups = $t->app->db->resultset('JobGroupParents');
-my $jobs          = $t->app->db->resultset('Jobs');
+my $job_groups    = $t->app->schema->resultset('JobGroups');
+my $parent_groups = $t->app->schema->resultset('JobGroupParents');
+my $jobs          = $t->app->schema->resultset('Jobs');
 
 # regular job groups shown
 my $get = $t->get_ok('/')->status_is(200);
@@ -218,7 +218,7 @@ my $job_hash = {
     group_id => $opensuse_test_group->id
 };
 my $not_reviewed_job = $jobs->create($job_hash);
-$t->app->db->resultset('JobModules')->create(
+$t->app->schema->resultset('JobModules')->create(
     {
         script   => 'tests/x11/failing_module.pm',
         job_id   => $not_reviewed_job->id,
@@ -263,7 +263,7 @@ sub check_badge {
 }
 
 # make one of the softfailed jobs a failed because of failed not-important modules
-$t->app->db->resultset('JobModules')->create(
+$t->app->schema->resultset('JobModules')->create(
     {
         script   => 'tests/x11/failing_module.pm',
         job_id   => 99936,

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -33,7 +33,7 @@ use Test::Warnings;
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 my $t    = Test::Mojo->new('OpenQA::WebAPI');
 my $app  = $t->app;
-my $bugs = $app->db->resultset('Bugs');
+my $bugs = $app->schema->resultset('Bugs');
 
 my $bug = $bugs->get_bug('poo#200');
 ok(!defined $bug, 'bug not refreshed');

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -90,12 +90,12 @@ sub read_log {
 
 sub db_handle_connection {
     my ($cache, $disconnect) = @_;
-    if ($cache->dbh) {
-        $cache->dbh->db->disconnect;
+    if ($cache->sqlite) {
+        $cache->sqlite->db->disconnect;
         return if $disconnect;
     }
 
-    $cache->dbh(Mojo::SQLite->new("sqlite:$db_file"));
+    $cache->sqlite(Mojo::SQLite->new("sqlite:$db_file"));
 }
 
 sub _port { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => shift) }
@@ -159,7 +159,7 @@ for (1 .. 3) {
         log_info "Inserting $_";
         $sql = "INSERT INTO assets (filename,size, etag,last_use)
                 VALUES ( ?, ?, 'Not valid', strftime('\%s','now'));";
-        $cache->dbh->db->query($sql, $filename, 84);
+        $cache->sqlite->db->query($sql, $filename, 84);
     }
 }
 
@@ -274,7 +274,7 @@ truncate_log $logfile;
 
 $cache->track_asset("Foobar", 0);
 
-$cache->dbh->db->query("delete from assets");
+$cache->sqlite->db->query("delete from assets");
 
 my $fake_asset = "$cachedir/test.qcow";
 

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -121,7 +121,7 @@ sub login {
 login('arthur');
 
 # get resultset
-my $db                 = $t->app->db;
+my $db                 = $t->app->schema;
 my $jobs               = $db->resultset('Jobs');
 my $users              = $db->resultset('Users');
 my $developer_sessions = $db->resultset('DeveloperSessions');

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -35,9 +35,9 @@ $test_case->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # get resultsets
-my $db            = $t->app->db;
-my $job_groups    = $db->resultset('JobGroups');
-my $parent_groups = $db->resultset('JobGroupParents');
+my $schema        = $t->app->schema;
+my $job_groups    = $schema->resultset('JobGroups');
+my $parent_groups = $schema->resultset('JobGroupParents');
 
 # create new parent group
 my $new_parent_group_id = $parent_groups->create({name => 'new parent group'})->id;

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -34,7 +34,7 @@ $test_case->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # get resultsets
-my $db      = $t->app->db;
+my $db      = $t->app->schema;
 my $workers = $db->resultset('Workers');
 my $jobs    = $db->resultset('Jobs');
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -77,7 +77,7 @@ sub job_result {
 
 sub job_gru {
     my $job_id = shift;
-    return $t->app->db->resultset("GruDependencies")->search({job_id => $job_id})->single->gru_task->id;
+    return $t->app->schema->resultset("GruDependencies")->search({job_id => $job_id})->single->gru_task->id;
 }
 
 sub find_job {
@@ -342,7 +342,7 @@ subtest 'jobs belonging to important builds are not cancelled by new iso post' =
     $ret = $t->get_ok('/api/v1/jobs/99963')->status_is(200);
     is($ret->tx->res->json->{job}->{state}, 'running', 'job in build 0091 running');
     my $tag = 'tag:0091:important';
-    $t->app->db->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
+    $t->app->schema->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
     $res = schedule_iso(
         {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'});
     is($res->json->{count}, 10, '10 jobs created');
@@ -362,7 +362,7 @@ subtest 'jobs belonging to important builds are not cancelled by new iso post' =
     is(scalar @jobs, 21, 'only the important jobs, jobs from the current build and the important build are scheduled');
     # now test with a VERSION-BUILD format tag
     $tag = 'tag:13.1-0093:important';
-    $t->app->db->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
+    $t->app->schema->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
     $res = schedule_iso(
         {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0094'});
     $ret  = $t->get_ok('/api/v1/jobs?state=scheduled');
@@ -431,7 +431,7 @@ my $rsp;
 # the test description so you know which one failed, if it fails.
 sub check_download_asset {
     my ($desc, $expectargs) = @_;
-    my $rs = $t->app->db->resultset("GruTasks")->search({taskname => 'download_asset'});
+    my $rs = $t->app->schema->resultset("GruTasks")->search({taskname => 'download_asset'});
     if ($expectargs) {
         is($rs->count, 1, "gru task should be created: $desc");
         my $args = $rs->first->args;
@@ -620,7 +620,7 @@ foreach my $j (@{$rsp->json->{ids}}) {
     is job_result($j), 'none', 'Job has no result';
 }
 
-$t->app->db->resultset("GruTasks")->search({id => $gru})->single->fail;
+$t->app->schema->resultset("GruTasks")->search({id => $gru})->single->fail;
 
 foreach my $j (@{$rsp->json->{ids}}) {
     is job_state($j), 'done';
@@ -634,13 +634,13 @@ sub add_opensuse_test {
     for my $key (keys %settings) {
         push(@mapped_settings, {key => $key, value => $settings{$key}});
     }
-    $t->app->db->resultset('TestSuites')->create(
+    $t->app->schema->resultset('TestSuites')->create(
         {
             name     => $name,
             settings => \@mapped_settings
         });
     for my $machine (@{$settings{MACHINE}}) {
-        $t->app->db->resultset('JobTemplates')->create(
+        $t->app->schema->resultset('JobTemplates')->create(
             {
                 machine    => {name => $machine},
                 test_suite => {name => $name},

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -675,7 +675,7 @@ subtest 'default priority correctly assigned when posting job' => sub {
     $t->json_is('/job/priority', 50);
 
     # post new job in job group with customized default priority
-    $t->app->db->resultset('JobGroups')->find({name => 'opensuse test'})->update({default_priority => 42});
+    $t->app->schema->resultset('JobGroups')->find({name => 'opensuse test'})->update({default_priority => 42});
     $jobs_post_params{_GROUP} = 'opensuse test';
     $post = $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
     $t->get_ok('/api/v1/jobs/' . $post->tx->res->json->{id})->status_is(200);

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -38,8 +38,8 @@ my $app = $t->app;
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $db           = $app->db;
-my $audit_events = $db->resultset('AuditEvents');
+my $schema       = $app->schema;
+my $audit_events = $schema->resultset('AuditEvents');
 
 sub check_for_event {
     my ($event_name, $expectations) = @_;

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -40,7 +40,7 @@ $t->ua(
     OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $bugs = $app->db->resultset('Bugs');
+my $bugs = $app->schema->resultset('Bugs');
 
 my $bug  = $bugs->get_bug('poo#200');
 my $get  = $t->get_ok('/api/v1/bugs');

--- a/t/ui/22-job_group_order.t
+++ b/t/ui/22-job_group_order.t
@@ -42,15 +42,15 @@ sub verify_navbar {
 verify_navbar("opensuse opensuse test");
 
 # move 'opensuse' to a higher sort order (further down)
-$t->app->db->resultset('JobGroups')->find(1001)->update({sort_order => 1});
+$t->app->schema->resultset('JobGroups')->find(1001)->update({sort_order => 1});
 verify_navbar("opensuse test opensuse");
 
 # move 'opensuse test' to an even higher sort order (further down)
-$t->app->db->resultset('JobGroups')->find(1002)->update({sort_order => 3});
+$t->app->schema->resultset('JobGroups')->find(1002)->update({sort_order => 3});
 verify_navbar("opensuse opensuse test");
 
 # create a new parent group - default sort order, no children
-my $parent = $t->app->db->resultset('JobGroupParents')->create({name => 'Hallo'});
+my $parent = $t->app->schema->resultset('JobGroupParents')->create({name => 'Hallo'});
 # it's not shown (no children)
 verify_navbar("opensuse opensuse test");
 


### PR DESCRIPTION
Mixing `db` and `schema` to describe the same thing caused a little big of confusion in the past. And `schema` is the correct term for `DBIx::Class`. This also resulted in some very inefficient uses of `$app->db` that create temporary controller instances, which especially for queries in loops can be very costly. Overall this should be a fairly harmless change and result in slight performance gains.