### PR TITLE
Turn the WebSocket server into a real Mojolicious application

### DIFF
--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -22,7 +22,6 @@ use Mojo::File 'path';
 use Mojo::URL;
 use Carp 'croak';
 use Mojo::JSON 'encode_json';
-use Data::Dump;
 
 my $job;
 my $path;

--- a/lib/OpenQA/IPC.pm
+++ b/lib/OpenQA/IPC.pm
@@ -16,22 +16,19 @@
 package OpenQA::IPC;
 use Mojo::Base -strict;
 
+use Carp 'confess';
 use Net::DBus;
 use Net::DBus::Callback;
 use Net::DBus::Binding::Watch;
 use Mojo::IOLoop;
-use Data::Dump 'pp';
 use Try::Tiny;
-use Carp;
-use Scalar::Util 'weaken';
-use OpenQA::Utils qw(log_debug log_warning log_error);
+use OpenQA::Utils qw(log_debug log_error);
 use OpenQA::Events;
 
 my $openqa_prefix = 'org.opensuse.openqa';
 my %services      = (
     scheduler  => 'Scheduler',
-    websockets => 'WebSockets',
-    webapi     => 'WebAPI'
+    websockets => 'WebSockets'
 );
 
 my %handles;
@@ -246,12 +243,6 @@ sub scheduler {
 sub websockets {
     my ($self, @param) = @_;
     return $self->_dispatch('websockets', @param);
-}
-
-# webapi - send message to WebUI/API
-sub webapi {
-    my ($self, @param) = @_;
-    return $self->_dispatch('webapi', @param);
 }
 
 1;

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -22,7 +22,6 @@ use base 'Net::DBus::Object';
 
 use Net::DBus::Exporter 'org.opensuse.openqa.Scheduler';
 use Net::DBus::Reactor;
-use Data::Dump 'pp';
 use OpenQA::IPC;
 use OpenQA::Setup;
 use OpenQA::Utils 'log_debug';

--- a/lib/OpenQA/Scheduler/Scheduler.pm
+++ b/lib/OpenQA/Scheduler/Scheduler.pm
@@ -17,8 +17,7 @@ package OpenQA::Scheduler::Scheduler;
 use Mojo::Base -strict;
 
 use Digest::MD5;
-use Data::Dumper;
-use Data::Dump qw(dd pp);
+use Data::Dump 'pp';
 use Date::Format 'time2str';
 use DBIx::Class::Timestamps 'now';
 use DateTime;

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -24,7 +24,6 @@ use base 'DBIx::Class::Core';
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Utils;
-use OpenQA::IPC;
 use Date::Format;
 use Archive::Extract;
 use File::Basename;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -38,7 +38,7 @@ use File::Path ();
 use DBIx::Class::Timestamps 'now';
 use File::Temp 'tempdir';
 use Mojo::File qw(tempfile path);
-use Data::Dump qw(dump pp);
+use Data::Dump 'dump';
 use OpenQA::File;
 use OpenQA::Parser 'parser';
 # The state and results constants are duplicated in the Python client:

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -30,7 +30,6 @@ use IO::Socket::IP;
 use Time::HiRes 'gettimeofday';
 use POSIX 'strftime';
 use Scalar::Util 'blessed';
-use Data::Dump 'pp';
 use Mojo::Log;
 use Scalar::Util qw(blessed reftype);
 use Exporter 'import';

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,17 +38,21 @@ sub _is_method_allowed {
 }
 
 sub run {
+
     # config Mojo to get reactor
-    my $server = OpenQA::WebSockets::Server->setup;
+    my $server = OpenQA::WebSockets::Server->new->setup;
+
     # start DBus
     my $self = OpenQA::WebSockets->new;
     $self->{server} = $server;
+
     # start IOLoop
     $server->run;
 }
 
 sub new {
     my ($class) = @_;
+
     $class = ref $class || $class;
     my $ipc = OpenQA::IPC->ipc(1);
     return unless $ipc;
@@ -56,6 +60,7 @@ sub new {
     my $self    = $class->SUPER::new($service, '/WebSockets');
     $self->{ipc} = $ipc;
     bless $self, $class;
+
     # hook DBus to Mojo reactor
     $ipc->manage_events(Mojo::IOLoop->singleton->reactor, $self);
 

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -23,7 +23,7 @@ use base 'Net::DBus::Object';
 use Net::DBus::Exporter 'org.opensuse.openqa.WebSockets';
 use Mojo::IOLoop;
 use OpenQA::IPC;
-use OpenQA::WebSockets::Server ();
+use OpenQA::WebSockets::Server;
 use OpenQA::Utils 'log_debug';
 
 # monkey patching for debugging IPC

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -71,7 +71,7 @@ sub new {
 dbus_method('ws_is_worker_connected', ['uint32'], ['bool']);
 sub ws_is_worker_connected {
     my ($self, @args) = @_;
-    return $self->{server}->app->ws_is_worker_connected(@args);
+    return OpenQA::WebSockets::Server::ws_is_worker_connected(@args);
 }
 
 dbus_method('ws_send_job', [['dict', 'string', ['variant']]], [['dict', 'string', ['variant']]]);

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -71,7 +71,7 @@ sub new {
 dbus_method('ws_is_worker_connected', ['uint32'], ['bool']);
 sub ws_is_worker_connected {
     my ($self, @args) = @_;
-    return OpenQA::WebSockets::Server::ws_is_worker_connected(@args);
+    return $self->{server}->app->ws_is_worker_connected(@args);
 }
 
 dbus_method('ws_send_job', [['dict', 'string', ['variant']]], [['dict', 'string', ['variant']]]);

--- a/lib/OpenQA/WebSockets/Controller/Auth.pm
+++ b/lib/OpenQA/WebSockets/Controller/Auth.pm
@@ -1,0 +1,54 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebSockets::Controller::Auth;
+use Mojo::Base 'Mojolicious::Controller';
+
+use OpenQA::Schema;
+use OpenQA::Utils 'log_debug';
+use Mojo::Util 'hmac_sha1_sum';
+
+sub check {
+    my $self = shift;
+
+    my $headers   = $self->req->headers;
+    my $key       = $headers->header('X-API-Key');
+    my $hash      = $headers->header('X-API-Hash');
+    my $timestamp = $headers->header('X-API-Microtime');
+    my $user;
+    log_debug($key ? "API key from client: *$key*" : "No API key from client.");
+
+    my $schema  = OpenQA::Schema->singleton;
+    my $api_key = $schema->resultset('ApiKeys')->find({key => $key});
+    if ($api_key) {
+        if (time - $timestamp <= 300) {
+            my $exp = $api_key->t_expiration;
+            # It has no expiration date or it's in the future
+            if (!$exp || $exp->epoch > time) {
+                if (my $secret = $api_key->secret) {
+                    my $sum = hmac_sha1_sum($self->req->url->to_string . $timestamp, $secret);
+                    $user = $api_key->user;
+                    log_debug(sprintf "API auth by user: %s, operator: %d", $user->username, $user->is_operator);
+                }
+            }
+        }
+    }
+    return 1 if ($user && $user->is_operator);
+
+    $self->render(json => {error => 'Not authorized'}, status => 403);
+    return undef;
+}
+
+1;

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -1,0 +1,232 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebSockets::Controller::Worker;
+use Mojo::Base 'Mojolicious::Controller';
+
+use OpenQA::Schema;
+use OpenQA::Utils qw(log_debug log_error log_info log_warning);
+use OpenQA::Constants qw(WEBSOCKET_API_VERSION WORKERS_CHECKER_THRESHOLD);
+use DateTime;
+use Data::Dumper 'Dumper';
+use Data::Dump 'pp';
+use Try::Tiny;
+
+sub ws {
+    my $self = shift;
+
+    my $workerid = $self->param('workerid');
+    unless ($OpenQA::WebSockets::Server::WORKERS->{$workerid}) {
+        my $db = $self->app->schema->resultset("Workers")->find($workerid);
+        unless ($db) {
+            return $self->render(text => 'Unauthorized', status =>);
+        }
+        $OpenQA::WebSockets::Server::WORKERS->{$workerid}
+          = {id => $workerid, db => $db, socket => undef, last_seen => time()};
+    }
+    my $worker = $OpenQA::WebSockets::Server::WORKERS->{$workerid};
+
+    # upgrade connection to websocket by subscribing to events
+    $self->on(json   => \&_message);
+    $self->on(finish => \&_finish);
+    $self->inactivity_timeout(0);    # Do not force connection close due to inactivity
+    $worker->{socket} = $self->tx->max_websocket_size(10485760);
+}
+
+sub _finish {
+    my ($self, $code, $reason) = @_;
+    return unless ($self);
+
+    my $worker = _get_worker($self->tx);
+    unless ($worker) {
+        log_error('Worker not found for given connection during connection close');
+        return;
+    }
+    log_info(sprintf("Worker %u websocket connection closed - $code", $worker->{id}));
+    # if the server disconnected from web socket, mark it dead so it doesn't get new
+    # jobs assigned from scheduler (which will check DB and not WS state)
+    my $dt = DateTime->now(time_zone => 'UTC');
+    # 2 minutes is long enough for the scheduler not to take it
+    $dt->subtract(seconds => (WORKERS_CHECKER_THRESHOLD + 20));
+    $worker->{db}->update({t_updated => $dt});
+    $worker->{socket} = undef;
+}
+
+sub _get_worker {
+    my ($tx) = @_;
+
+    for my $worker (values %$OpenQA::WebSockets::Server::WORKERS) {
+        if ($worker->{socket} && ($worker->{socket}->connection eq $tx->connection)) {
+            return $worker;
+        }
+    }
+
+    return undef;
+}
+
+sub _message {
+    my ($self, $json) = @_;
+
+    my $app    = $self->app;
+    my $schema = $app->schema;
+    my $worker = _get_worker($self->tx);
+    unless ($worker) {
+        $app->log->warn("A message received from unknown worker connection");
+        log_debug(sprintf('A message received from unknown worker connection (terminating ws): %s', Dumper($json)));
+        $self->finish("1008", "Connection terminated from WebSocket server - thought dead");
+        return;
+    }
+    unless (ref($json) eq 'HASH') {
+        log_error(sprintf('Received unexpected WS message "%s from worker %u', Dumper($json), $worker->{id}));
+        $self->finish("1003", "Received unexpected data from worker, forcing close");
+        return;
+    }
+
+    # This is to make sure that no worker can skip the _registration.
+    if (($worker->{db}->websocket_api_version() || 0) != WEBSOCKET_API_VERSION) {
+        log_warning("Received a message from an incompatible worker " . $worker->{id});
+        $self->tx->send({json => {type => 'incompatible'}});
+        $self->finish("1008",
+            "Connection terminated from WebSocket server - incompatible communication protocol version");
+        return;
+    }
+
+    $worker->{last_seen} = time();
+    if ($json->{type} eq 'accepted') {
+        my $jobid = $json->{jobid};
+        log_debug("Worker: $worker->{id} accepted job $jobid");
+    }
+    elsif ($json->{type} eq 'status') {
+        # handle job status update through web socket
+        my $jobid  = $json->{jobid};
+        my $status = $json->{data};
+        my $job    = $schema->resultset("Jobs")->find($jobid);
+        return $self->tx->send(json => {result => 'nack'}) unless $job;
+        my $ret = $job->update_status($status);
+        $self->tx->send({json => $ret});
+    }
+    elsif ($json->{type} eq 'worker_status') {
+        my $current_worker_status = $json->{status};
+        my $current_worker_error  = $current_worker_status eq 'broken' ? $json->{reason} : undef;
+        my $job_status            = $json->{job}->{state};
+        my $jobid                 = $json->{job}->{id};
+        my $wid                   = $worker->{id};
+
+        $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid} = $json;
+        log_debug(sprintf('Received from worker "%u" worker_status message "%s"', $wid, Dumper($json)));
+
+        try {
+            $schema->txn_do(
+                sub {
+                    return unless my $w = $schema->resultset("Workers")->find($wid);
+                    log_debug("Updating worker seen from worker_status");
+                    $w->seen;
+                    $w->update({error => $current_worker_error});
+                });
+        }
+        catch {
+            log_error("Failed updating worker seen and error status: $_");
+        };
+
+        my $registered_job_id;
+        my $registered_job_token;
+        try {
+            $registered_job_id = $schema->resultset("Workers")->find($wid)->job->id();
+            log_debug("Found Job($registered_job_id) in DB from worker_status update sent by Worker($wid)")
+              if $registered_job_id && $wid;
+            log_debug("Received request has id: " . $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{id})
+              if $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{id};
+        };
+
+        try {
+            my $workers_population = $schema->resultset("Workers")->count();
+            my $msg                = {type => 'info', population => $workers_population};
+            $self->tx->send({json => $msg} => sub { log_debug("Sent population to worker: " . pp($msg)) });
+        }
+        catch {
+            log_debug("Could not send the population number to worker: $_");
+        };
+
+        try {
+            # We cover the case where id can be the same, but the token will differ.
+            die "Do not check" unless ($registered_job_id);
+            $registered_job_token = $schema->resultset("Workers")->find($wid)->get_property('JOBTOKEN');
+            log_debug("Worker($wid) for Job($registered_job_id) has token $registered_job_token")
+              if $registered_job_token && $registered_job_id && $wid;
+            log_debug("Received request has token: "
+                  . $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{settings}{JOBTOKEN})
+              if $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{settings}{JOBTOKEN};
+        };
+
+        try {
+            # XXX: we should have a field in the DB as well so scheduler can allocate directly on free workers.
+            $schema->txn_do(
+                sub {
+                    my $w = $schema->resultset("Workers")->find($wid);
+                    log_debug('Possibly worker ' . $w->id() . ' should be freed.');
+                    return unless ($w && $w->job);
+                    return $w->job->incomplete_and_duplicate
+                      if ( $w->job->result eq OpenQA::Jobs::Constants::NONE
+                        && $w->job->state eq OpenQA::Jobs::Constants::RUNNING
+                        && $current_worker_status eq "free");
+                    return $w->job->reschedule_state
+                      if ($w->job->state eq OpenQA::Jobs::Constants::ASSIGNED);    # Was a stale job
+                })
+              if (
+                # Check if worker is doing a job for another WebUI
+                (
+                       $registered_job_id
+                    && exists $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}
+                    && exists $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}
+                    && exists $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{id}
+                    && $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{id} != $registered_job_id
+                )
+                || (   $registered_job_token
+                    && exists $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}
+                    && exists $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}
+                    && exists $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{settings}{JOBTOKEN}
+                    && $OpenQA::WebSockets::Server::WORKER_STATUS->{$wid}{job}{settings}{JOBTOKEN} ne
+                    $registered_job_token))
+              ||
+              # Or if it declares itself free.
+              ($current_worker_status && $current_worker_status eq "free");
+
+            return unless $jobid && $job_status && $job_status eq OpenQA::Jobs::Constants::RUNNING;
+            $schema->txn_do(
+                sub {
+                    my $job = $schema->resultset("Jobs")->find($jobid);
+                    return
+                      if (
+                        (
+                            $job && (($job->state eq OpenQA::Jobs::Constants::RUNNING)
+                                || ($job->result ne OpenQA::Jobs::Constants::NONE)))
+                        || !$job
+                      );
+                    $job->set_running();
+                    log_debug(sprintf('Job "%s" set to running states from ws status updates', $jobid));
+                });
+
+        }
+        catch {
+            log_debug("Failed parsing status message : $_");
+        };
+
+    }
+    else {
+        log_error(sprintf('Received unknown message type "%s" from worker %u', $json->{type}, $worker->{id}));
+    }
+}
+
+1;

--- a/lib/OpenQA/WebSockets/Model/Status.pm
+++ b/lib/OpenQA/WebSockets/Model/Status.pm
@@ -1,0 +1,24 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::WebSockets::Model::Status;
+use Mojo::Base -base;
+
+has ['workers', 'worker_status'] => sub { {} };
+
+sub singleton { state $status ||= __PACKAGE__->new }
+
+1;

--- a/lib/OpenQA/WebSockets/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebSockets/Plugin/Helpers.pm
@@ -1,0 +1,37 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::WebSockets::Plugin::Helpers;
+use Mojo::Base 'Mojolicious::Plugin';
+
+use OpenQA::Schema;
+
+sub register {
+    my ($self, $app) = @_;
+
+    $app->helper(log_name => sub { 'websockets' });
+    $app->helper(schema   => sub { OpenQA::Schema->singleton });
+
+    $app->helper(ws_is_worker_connected => \&_ws_is_worker_connected);
+}
+
+sub _ws_is_worker_connected {
+    my ($c, $workerid) = @_;
+    my $workers = $OpenQA::WebSockets::Server::WORKERS;
+    return ($workers->{$workerid} && $workers->{$workerid}->{socket} ? 1 : 0);
+}
+
+1;

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -17,14 +17,10 @@ package OpenQA::WebSockets::Server;
 use Mojo::Base 'Mojolicious';
 
 use Mojo::Server::Daemon;
-use Try::Tiny;
 use OpenQA::IPC;
-use OpenQA::Utils qw(log_debug log_warning log_info);
-use OpenQA::Schema;
 use OpenQA::Setup;
+use OpenQA::Utils qw(log_debug log_warning log_info);
 use db_profiler;
-use OpenQA::Schema::Result::Workers ();
-use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
 
 # id->worker mapping
 our $WORKERS = {};
@@ -32,12 +28,8 @@ our $WORKERS = {};
 # Will be filled out from worker status messages
 our $WORKER_STATUS = {};
 
-# Mojolicious startup
-sub setup {
+sub startup {
     my $self = shift;
-
-    OpenQA::Setup::read_config($self);
-    OpenQA::Setup::setup_log($self);
 
     $self->defaults(appname => 'openQA Websocket Server');
     $self->mode('production');
@@ -56,9 +48,16 @@ sub setup {
     $self->routes->namespaces(['OpenQA::WebSockets::Controller']);
     my $ca = $r->under('/')->to('Auth#check');
     $ca->websocket('/ws/<workerid:num>')->to('Worker#ws');
+}
+
+sub setup {
+    my $self = shift;
+
+    OpenQA::Setup::read_config($self);
+    OpenQA::Setup::setup_log($self);
 
     # start worker checker - check workers each 2 minutes
-    Mojo::IOLoop->recurring(120 => \&_workers_checker);
+    Mojo::IOLoop->recurring(120 => sub { $self->workers_checker });
 
     Mojo::IOLoop->recurring(
         380 => sub {
@@ -69,8 +68,15 @@ sub setup {
     return Mojo::Server::Daemon->new(app => $self);
 }
 
+sub ws_is_worker_connected {
+    my ($workerid) = @_;
+    my $workers = $WORKERS;
+    return ($workers->{$workerid} && $workers->{$workerid}->{socket} ? 1 : 0);
+}
+
 sub ws_send {
     my ($workerid, $msg, $jobid, $retry) = @_;
+
     return unless ($workerid && $msg && $WORKERS->{$workerid});
     $jobid ||= '';
     my $res;
@@ -132,78 +138,6 @@ sub ws_send_all {
             $tx->{socket}->send({json => {type => $msg}});
         }
     }
-}
-
-sub _get_stale_worker_jobs {
-    my ($threshold) = @_;
-
-    my $schema = OpenQA::Schema->singleton;
-
-    # grab the workers we've seen lately
-    my @ok_workers;
-    for my $worker (values %$WORKERS) {
-        if (time - $worker->{last_seen} <= $threshold) {
-            push(@ok_workers, $worker->{id});
-        }
-        else {
-            log_debug(sprintf("Worker %s not seen since %d seconds", $worker->{db}->name, time - $worker->{last_seen}));
-        }
-    }
-    my $dtf = $schema->storage->datetime_parser;
-    my $dt  = DateTime->from_epoch(epoch => time() - $threshold, time_zone => 'UTC');
-
-    my %cond = (
-        state              => [OpenQA::Jobs::Constants::EXECUTION_STATES],
-        'worker.t_updated' => {'<' => $dtf->format_datetime($dt)},
-        'worker.id'        => {-not_in => [sort @ok_workers]});
-    my %attrs = (join => 'worker', order_by => 'worker.id desc');
-
-    return $schema->resultset("Jobs")->search(\%cond, \%attrs);
-}
-
-sub _is_job_considered_dead {
-    my ($job) = @_;
-
-    # much bigger timeout for uploading jobs; while uploading files,
-    # worker process is blocked and cannot send status updates
-    if ($job->state eq OpenQA::Jobs::Constants::UPLOADING) {
-        my $delta = DateTime->now()->epoch() - $job->worker->t_updated->epoch();
-        log_debug("uploading worker not updated for $delta seconds " . $job->id);
-        return ($delta > 1000);
-    }
-
-    log_debug(
-        "job considered dead: " . $job->id . " worker " . $job->worker->id . " not seen. In state " . $job->state);
-    # default timeout for the rest
-    return 1;
-}
-
-# Check if worker with job has been updated recently; if not, assume it
-# got stuck somehow and duplicate or incomplete the job
-sub _workers_checker {
-    my $schema = OpenQA::Schema->singleton;
-    try {
-        $schema->txn_do(
-            sub {
-                my $stale_jobs = _get_stale_worker_jobs(WORKERS_CHECKER_THRESHOLD);
-                for my $job ($stale_jobs->all) {
-                    next unless _is_job_considered_dead($job);
-
-                    $job->done(result => OpenQA::Jobs::Constants::INCOMPLETE);
-                    # XXX: auto_duplicate was killing ws server in production
-                    my $res = $job->auto_duplicate;
-                    if ($res) {
-                        log_warning(sprintf('dead job %d aborted and duplicated %d', $job->id, $res->id));
-                    }
-                    else {
-                        log_warning(sprintf('dead job %d aborted as incomplete', $job->id));
-                    }
-                }
-            });
-    }
-    catch {
-        log_info("Failed dead job detection : $_");
-    };
 }
 
 1;

--- a/lib/OpenQA/WebSockets/Server.pm
+++ b/lib/OpenQA/WebSockets/Server.pm
@@ -40,9 +40,11 @@ sub startup {
     $self->asset->process;
 
     my $r = $self->routes;
-    $self->routes->namespaces(['OpenQA::WebSockets::Controller']);
+    $r->namespaces(['OpenQA::WebSockets::Controller']);
     my $ca = $r->under('/')->to('Auth#check');
+    $ca->get('/' => {json => {name => $self->defaults('appname')}});
     $ca->websocket('/ws/<workerid:num>')->to('Worker#ws');
+    $r->any('/*whatever' => {whatever => ''})->to(status => 404, text => 'Not found');
 }
 
 sub setup {

--- a/script/clean_needles
+++ b/script/clean_needles
@@ -63,7 +63,7 @@ BEGIN {
 
 use strict;
 use OpenQA::Schema;
-use Data::Dump;
+use Data::Dump 'dd';
 use v5.10;
 use DBIx::Class::DeploymentHandler;
 use Getopt::Long;

--- a/script/client
+++ b/script/client
@@ -139,7 +139,7 @@ BEGIN { unshift @INC, "$FindBin::RealBin/../lib" }
 
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
-use Data::Dump;
+use Data::Dump 'dd';
 use Mojo::URL;
 use OpenQA::Client;
 use Getopt::Long;

--- a/script/clone_job.pl
+++ b/script/clone_job.pl
@@ -113,7 +113,7 @@ added to the also cloned parent jobs.
 
 use strict;
 use warnings;
-use Data::Dump qw(dd pp);
+use Data::Dump 'pp';
 use Getopt::Long;
 use LWP::UserAgent;
 Getopt::Long::Configure("no_ignore_case");

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -106,8 +106,9 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
 use strict;
-use Data::Dump;
 use v5.10;
+
+use Data::Dump 'dd';
 use Getopt::Long;
 use Mojo::Util qw(decamelize);
 use Mojo::URL;

--- a/script/load_templates
+++ b/script/load_templates
@@ -66,7 +66,7 @@ use lib "$FindBin::RealBin/../lib";
 use strict;
 use File::Basename qw(dirname);
 use Try::Tiny;
-use Data::Dump qw(dd pp);
+use Data::Dump 'dd';
 use Mojo::Util qw(decamelize);
 use Mojo::URL;
 use OpenQA::Client;

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -24,7 +24,6 @@ BEGIN {
 use strict;
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Data::Dump qw(pp dd);
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -28,6 +28,7 @@ use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Database;
+use Mojo::Util 'monkey_patch';
 use DBIx::Class::Timestamps 'now';
 use Net::DBus;
 use Test::More;
@@ -200,15 +201,12 @@ subtest 'chained parent fails -> chilren are canceled (skipped)' => sub {
 
 subtest 'parallel parent fails -> children are cancelled (parallel_failed)' => sub {
     # monkey patch ws_send of OpenQA::WebSockets::Server to store received command
-    package OpenQA::WebSockets::Server;
-    no warnings "redefine";
     my @commands = ();
-    sub ws_send {
+    monkey_patch 'OpenQA::WebSockets::Server', 'ws_send', sub {
         my ($workerid, $command, $jobid) = @_;
         push @OpenQA::WebSockets::Server::commands, $command;
-    }
+    };
 
-    package main;
     my %settingsA = %settings;
     my %settingsB = %settings;
     my %settingsC = %settings;

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -26,7 +26,6 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Data::Dump qw(pp dd);
 use OpenQA::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -26,7 +26,6 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Data::Dump qw(pp dd dump);
 use OpenQA::Scheduler::Scheduler;
 use OpenQA::WebSockets;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -40,7 +40,6 @@ BEGIN {
 }
 
 use lib "$FindBin::Bin/lib";
-use Data::Dump qw(pp dd);
 use OpenQA::Scheduler;
 use OpenQA::Scheduler::Scheduler;
 use OpenQA::Utils;

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -239,7 +239,7 @@ subtest 'Websocket server - close connection test' => sub {
     my $w2_pid          = create_worker($k->key, $k->secret, "http://localhost:$mojoport", 2, $log_file);
     my $re              = qr/\[.*?\]\sConnection turned off from .*?\- (.*?)\s\:(.*?) dead/;
 
-    my $attempts = 800;
+    my $attempts = 300;
     do {
         sleep 1;
         $attempts--;

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -26,7 +26,6 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Data::Dump qw(pp dd);
 use OpenQA::Resource::Jobs;
 use OpenQA::Resource::Locks;
 use OpenQA::WebSockets;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -36,7 +36,7 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use File::Which 'which';
 use File::Path ();
-use Data::Dumper;
+use Data::Dumper 'Dumper';
 use Date::Format 'time2str';
 use Fcntl ':mode';
 use Mojo::File 'tempdir';

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -24,7 +24,6 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Data::Dump qw(pp dd);
 use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';
 use Test::More;

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -64,7 +64,7 @@ subtest 'worker with job and not updated in last 120s is considered dead' => sub
 
     $schema->resultset('Workers')->update_all({t_updated => $dtf->format_datetime($dt)});
     stderr_like {
-        OpenQA::WebSockets::Server::_workers_checker();
+        OpenQA::WebSockets::Server->new->workers_checker();
     }
     qr/dead job 99961 aborted and duplicated 99982\n.*dead job 99963 aborted as incomplete/;
     _check_job_incomplete($_) for (99961, 99963);

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -30,19 +30,19 @@ use OpenQA::Test::Utils 'redirect_output';
 
 OpenQA::WebSockets::Server->new();
 
-subtest "WebSocket Server _workers_checker" => sub {
+subtest "WebSocket Server workers_checker" => sub {
     use Mojo::Util 'monkey_patch';
     monkey_patch "OpenQA::Schema", connect_db => sub { FooBarTransaction->new };
     my $buffer;
     {
         open my $handle, '>', \$buffer;
         local *STDOUT = $handle;
-        OpenQA::WebSockets::Server::_workers_checker;
+        OpenQA::WebSockets::Server->new->workers_checker;
     };
     like $buffer, qr/Failed dead job detection/;
 };
 
-subtest "WebSocket Server _get_stale_worker_jobs" => sub {
+subtest "WebSocket Server get_stale_worker_jobs" => sub {
     use Mojo::Util 'monkey_patch';
     monkey_patch 'OpenQA::WebSockets::Controller::Worker', app => sub { FooBarTransaction->new };
     FooBarTransaction->new->OpenQA::WebSockets::Controller::Worker::ws();
@@ -50,9 +50,9 @@ subtest "WebSocket Server _get_stale_worker_jobs" => sub {
     {
         open my $handle, '>', \$buffer;
         local *STDOUT = $handle;
-        OpenQA::WebSockets::Server::_get_stale_worker_jobs(-9999999999);
+        OpenQA::WebSockets::Server->new->get_stale_worker_jobs(-9999999999);
     };
-    like $buffer, qr/Worker Boooo not seen since 0 seconds/;
+    like $buffer, qr/Worker Boooo not seen since \d+ seconds/;
 };
 
 subtest "WebSocket Server _message()" => sub {

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -119,6 +119,7 @@ sub tx  { shift }
 sub app { shift }
 sub log { shift }
 sub schema             { shift }
+sub status             { OpenQA::WebSockets::Model::Status->singleton }
 sub resultset          { shift }
 sub find               { shift->{w} }
 sub on                 { shift }

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -43,7 +43,7 @@ subtest "WebSocket Server _workers_checker" => sub {
 subtest "WebSocket Server _get_stale_worker_jobs" => sub {
     use Mojo::Util 'monkey_patch';
     monkey_patch "OpenQA::WebSockets::Server", app => sub { FooBarTransaction->new };
-    FooBarWorker->new->OpenQA::WebSockets::Server::ws_create();
+    FooBarTransaction->new->OpenQA::WebSockets::Server::_ws_create();
     my $buffer;
     {
         open my $handle, '>', \$buffer;
@@ -117,17 +117,21 @@ sub new { bless({w => FooBarWorker->new()->set}, shift) }
 sub tx  { shift }
 sub app { shift }
 sub log { shift }
-sub schema          { shift }
-sub resultset       { shift }
-sub find            { shift->{w} }
-sub warn            { return $_[1] }
-sub finish          { main::_store(shift, "out", @_) }
-sub send            { main::_store(shift, "send", @_) }
-sub storage         { shift }
-sub datetime_parser { shift }
-sub format_datetime { shift }
-sub search          { shift }
-sub txn_do          { die "BHUAHUAHUAHUA"; }
+sub schema             { shift }
+sub resultset          { shift }
+sub find               { shift->{w} }
+sub on                 { shift }
+sub param              { 1 }
+sub warn               { return $_[1] }
+sub finish             { main::_store(shift, "out", @_) }
+sub send               { main::_store(shift, "send", @_) }
+sub storage            { shift }
+sub datetime_parser    { shift }
+sub inactivity_timeout { shift }
+sub max_websocket_size { shift }
+sub format_datetime    { shift }
+sub search             { shift }
+sub txn_do             { die "BHUAHUAHUAHUA"; }
 
 package FooBarWorker;
 my $singleton;
@@ -140,11 +144,7 @@ sub set {
 sub id                    { 1 }
 sub update_status         { main::_store(shift, "status", @_) }
 sub set_property          { main::_store(shift, "property", @_) }
-sub param                 { 1 }
-sub on                    { shift }
-sub inactivity_timeout    { shift }
 sub tx                    { shift }
-sub max_websocket_size    { shift }
 sub name                  { "Boooo" }
 sub websocket_api_version { OpenQA::Constants::WEBSOCKET_API_VERSION() }
 

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -22,29 +22,50 @@ use Test::More;
 use POSIX;
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
-use Mojo::Util 'monkey_patch';
+use OpenQA::Client;
 use OpenQA::WebSockets::Server;
 use OpenQA::WebSockets::Controller::Worker;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
+use OpenQA::Test::Database;
 use OpenQA::Test::Utils 'redirect_output';
+use Test::MockModule;
+use Test::Mojo;
 
-OpenQA::WebSockets::Server->new();
+# Pretend the class was loaded with "require"
+$INC{'FooBarWorker.pm'} = 1;
 
-subtest "WebSocket Server workers_checker" => sub {
-    use Mojo::Util 'monkey_patch';
-    monkey_patch "OpenQA::Schema", connect_db => sub { FooBarTransaction->new };
+OpenQA::Test::Database->new->create;
+my $t = Test::Mojo->new('OpenQA::WebSockets::Server');
+
+subtest 'Authentication' => sub {
+    $t->get_ok('/test')->status_is(404);
+
+    $t->get_ok('/')->status_is(403)->json_is({error => 'Not authorized'});
+    my $app = $t->app;
+    $t->ua(
+        OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton)
+    )->app($app);
+    $t->get_ok('/')->status_is(200)->json_is({name => $app->defaults('appname')});
+};
+
+subtest 'WebSocket Server workers_checker' => sub {
+    my $mock_schema = Test::MockModule->new('OpenQA::Schema');
+    my $mock_singleton_called;
+    $mock_schema->mock(singleton => sub { $mock_singleton_called++; FooBarTransaction->new });
     my $buffer;
     {
         open my $handle, '>', \$buffer;
         local *STDOUT = $handle;
         OpenQA::WebSockets::Server->new->workers_checker;
     };
-    like $buffer, qr/Failed dead job detection/;
+    like $buffer,              qr/Failed dead job detection/;
+    ok $mock_singleton_called, 'mocked singleton method has been called';
 };
 
-subtest "WebSocket Server get_stale_worker_jobs" => sub {
-    use Mojo::Util 'monkey_patch';
-    monkey_patch 'OpenQA::WebSockets::Controller::Worker', app => sub { FooBarTransaction->new };
+subtest 'WebSocket Server get_stale_worker_jobs' => sub {
+    my $mock_schema = Test::MockModule->new('OpenQA::Schema');
+    my $mock_singleton_called;
+    $mock_schema->mock(singleton => sub { $mock_singleton_called++; FooBarTransaction->new });
     FooBarTransaction->new->OpenQA::WebSockets::Controller::Worker::ws();
     my $buffer;
     {
@@ -52,59 +73,65 @@ subtest "WebSocket Server get_stale_worker_jobs" => sub {
         local *STDOUT = $handle;
         OpenQA::WebSockets::Server->new->get_stale_worker_jobs(-9999999999);
     };
-    like $buffer, qr/Worker Boooo not seen since \d+ seconds/;
+    like $buffer,              qr/Worker Boooo not seen since \d+ seconds/;
+    ok $mock_singleton_called, 'mocked singleton method has been called';
 };
 
-subtest "WebSocket Server _message()" => sub {
-    monkey_patch 'OpenQA::WebSockets::Controller::Worker', _get_worker => sub { FooBarWorker->new };
+subtest 'WebSocket Server _message()' => sub {
+    my $mock_controller = Test::MockModule->new('OpenQA::WebSockets::Controller::Worker');
+    my $mock_get_worker_called;
+    $mock_controller->mock(_get_worker => sub { $mock_get_worker_called++; FooBarWorker->new });
     my $fake_tx = FooBarTransaction->new;
     my $buf;
     redirect_output(\$buf);
 
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message("");
-
     is @{$fake_tx->{out}}[0], "1003,Received unexpected data from worker, forcing close",
       "WS Server returns 1003 when message is not a hash";
+    ok $mock_get_worker_called, 'mocked _get_worker method has been called';
 
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message({type => "status", jobid => 1, data => "mydata"});
     is @{$fake_tx->{w}->{status}}[0], "mydata", "status got updated";
 
     $buf = undef;
-
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message({type => "FOOBAR"});
     like $buf, qr/Received unknown message type "FOOBAR" from worker/, "log_error on unknown message";
 
-    monkey_patch "Mojo::Transaction::Websocket", send => sub { undef };
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message({type => 'worker_status'});
     like($buf, qr/Could not send the population number to worker/, 'worker population unavailable')
       or diag explain $buf;
 
-    monkey_patch "OpenQA::WebAPI", schema => sub { undef };
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message({type => 'worker_status'});
     like($buf, qr/Failed updating worker seen and error status/, 'seen/error not available')
       or diag explain $buf;
 
-    no warnings 'redefine';
-    *FooBarWorker::websocket_api_version = sub { };
+    my $mock_foo = Test::MockModule->new('FooBarWorker');
+    my $mock_version_called;
+    $mock_foo->mock(websocket_api_version => sub { $mock_version_called++; undef });
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message({type => 'worker_status'});
     like($buf, qr/Received a message from an incompatible worker/, 'worker incompatible')
       or diag explain $buf;
     is @{$fake_tx->{out}}[1],
       "1008,Connection terminated from WebSocket server - incompatible communication protocol version";
+    ok $mock_version_called, 'mocked websocket_api_version method has been called';
 
-    $buf                                 = undef;
-    *FooBarWorker::websocket_api_version = sub { 0 };
+    $buf                 = undef;
+    $mock_version_called = undef;
+    $mock_foo->mock(websocket_api_version => sub { $mock_version_called++; 0 });
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message({type => 'property_change'});
     like $buf, qr/Received a message from an incompatible worker/ or diag explain $buf;
     is @{$fake_tx->{out}}[2],
       "1008,Connection terminated from WebSocket server - incompatible communication protocol version";
+    ok $mock_version_called, 'mocked websocket_api_version method has been called';
 
-    $buf                                 = undef;
-    *FooBarWorker::websocket_api_version = sub { WEBSOCKET_API_VERSION + 1 };
+    $buf                 = undef;
+    $mock_version_called = undef;
+    $mock_foo->mock(websocket_api_version => sub { $mock_version_called++; WEBSOCKET_API_VERSION + 1 });
     $fake_tx->OpenQA::WebSockets::Controller::Worker::_message({type => 'accepted'});
     like $buf, qr/Received a message from an incompatible worker/ or diag explain $buf;
     is @{$fake_tx->{out}}[3],
       "1008,Connection terminated from WebSocket server - incompatible communication protocol version";
+    ok $mock_version_called, 'mocked websocket_api_version method has been called';
 
 };
 

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -28,7 +28,6 @@ use OpenQA::Parser::Format::XUnit;
 use OpenQA::Parser::Format::TAP;
 use OpenQA::Parser::Format::IPA;
 use Mojo::File qw(path tempdir);
-use Data::Dumper;
 use Mojo::JSON qw(decode_json encode_json);
 
 subtest 'Result base class object' => sub {

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -47,7 +47,6 @@ use lib "$FindBin::Bin/lib";
 use Test::More;
 use Test::Mojo;
 use Test::Output 'stderr_like';
-use Data::Dumper;
 use IO::Socket::INET;
 use POSIX '_exit';
 use Fcntl ':mode';

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -24,6 +24,7 @@ BEGIN {
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Date::Format;
+use Data::Dumper 'Dumper';
 use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
@@ -651,7 +652,6 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
     # dumps the state of the websocket connections established in the following subtests
     # note: not actually used after all, but useful during development
     sub dump_websocket_state {
-        use Data::Dumper;
         print('finished: ' . Dumper($t_livehandler->{finished}) . "\n");
         print('messages: ' . Dumper($t_livehandler->{messages}) . "\n");
     }

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -30,8 +30,6 @@ use Test::Warnings ':all';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
-use Data::Dump;
-
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -31,7 +31,6 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
-use Data::Dump;
 
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -30,7 +30,6 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
-use Data::Dump;
 
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -30,7 +30,6 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
-use Data::Dump;
 
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -28,7 +28,6 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
-use Data::Dump;
 
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -27,7 +27,6 @@ use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
-use Data::Dump;
 
 OpenQA::Test::Case->new->init_data;
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -47,7 +47,6 @@ use lib "$FindBin::Bin/lib";
 use Test::More;
 use Test::Mojo;
 use Test::Output 'stderr_like';
-use Data::Dumper;
 use IO::Socket::INET;
 use POSIX '_exit';
 use OpenQA::Worker::Cache::Client;

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -193,6 +193,7 @@ sub create_websocket_server {
         use Mojo::Util 'monkey_patch';
         use OpenQA::WebSockets::Server;
         use OpenQA::WebSockets::Controller::Worker;
+        use OpenQA::WebSockets::Plugin::Helpers;
 
         # TODO: Kill it with fire!
         if ($bogus) {
@@ -203,7 +204,7 @@ sub create_websocket_server {
                 $c->on(finish => \&OpenQA::WebSockets::Controller::Worker::_finish);
             };
         }
-        monkey_patch 'OpenQA::WebSockets::Server', _workers_checker => sub { 1 }
+        monkey_patch 'OpenQA::WebSockets::Plugin::Helpers', _workers_checker => sub { 1 }
           if ($noworkercheck);
         OpenQA::WebSockets::run;
         Devel::Cover::report() if Devel::Cover->can('report');

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -188,14 +188,19 @@ sub create_websocket_server {
     if ($wspid == 0) {
         $ENV{MOJO_LISTEN}             = "http://127.0.0.1:$port";
         $ENV{MOJO_INACTIVITY_TIMEOUT} = 9999;
+
         use OpenQA::WebSockets;
         use Mojo::Util 'monkey_patch';
         use OpenQA::WebSockets::Server;
+        use OpenQA::WebSockets::Controller::Worker;
+
+        # TODO: Kill it with fire!
         if ($bogus) {
-            monkey_patch 'OpenQA::WebSockets::Server', _get_worker => sub { return };
-            monkey_patch 'OpenQA::WebSockets::Server', ws_create => sub {
-                $_[0]->on(json   => \&OpenQA::WebSockets::Server::_message);
-                $_[0]->on(finish => \&OpenQA::WebSockets::Server::_finish);
+            monkey_patch 'OpenQA::WebSockets::Controller::Worker', _get_worker => sub { return };
+            monkey_patch 'OpenQA::WebSockets::Controller::Worker', ws => sub {
+                my $c = shift;
+                $c->on(json   => \&OpenQA::WebSockets::Controller::Worker::_message);
+                $c->on(finish => \&OpenQA::WebSockets::Controller::Worker::_finish);
             };
         }
         monkey_patch 'OpenQA::WebSockets::Server', _workers_checker => sub { 1 }

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -11,6 +11,7 @@ use POSIX '_exit';
 use OpenQA::Worker;
 use OpenQA::Worker::Common;
 use Config::IniFiles;
+use Data::Dumper 'Dumper';
 use OpenQA::Utils qw(log_error log_info log_debug);
 use Mojo::Home;
 use Mojo::File 'path';
@@ -345,7 +346,6 @@ sub c_worker {
         if ($bogus) {
             monkey_patch 'OpenQA::Worker::Commands', websocket_commands => sub {
                 my ($tx, $json) = @_;
-                use Data::Dumper;
                 log_debug("Received " . Dumper($json));
             };
         }

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -25,8 +25,6 @@ use lib "$FindBin::Bin/../lib";
 use Test::More;
 use Test::Mojo;
 use OpenQA::Test::Case;
-use Data::Dumper;
-
 use OpenQA::WebSockets;
 use OpenQA::Scheduler;
 

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -26,7 +26,6 @@ use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Test::Database;
-use Data::Dumper;
 use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;


### PR DESCRIPTION
These are preparations for replacing dbus RPC in the WebSocket server with HTTP endpoints (Redis is not actually needed). `OpenQA::WebSockets::Server` used to be a mess of spaghetti code around a `Mojolicious::Lite` core, making it really hard to test and change things. Now it is a normal `Mojolicious` application, with controllers, models, and plugins, very similar to `OpenQA::WebAPI`. 

This is only the first step though. The class `OpenQA::WebSockets::Server` will soon vanish, and be renamed to `OpenQA::WebSockets` (which currently contains the dbus glue code). And the `ws_*` functions available via dbus RPC will be replaced with HTTP endpoints. Authentication is already prepared and tested for this.

Progress: https://progress.opensuse.org/issues/46778