### PR TITLE
Prevent multiple limit_* tasks from running in parallel

### DIFF
--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -31,6 +31,10 @@ sub _limit {
     return $job->finish('Previous limit_results_and_logs job is still active')
       unless my $guard = $app->minion->guard('limit_results_and_logs_task', 7200);
 
+    # prevent multiple limit_* tasks to run in parallel
+    return $job->retry({delay => 60})
+      unless my $limit_guard = $app->minion->guard('limit_tasks', 7200);
+
     # create temporary job group outside of DB to collect
     # jobs without job_group_id
     my $schema = $app->schema;


### PR DESCRIPTION
This should take care of the foreign key violation issues with multiple limit_* jobs running in parallel.

Progress: https://progress.opensuse.org/issues/49886