### PR TITLE
Mojolicious 8.13 compatibility

### DIFF
--- a/lib/OpenQA/Schema/Result/Users.pm
+++ b/lib/OpenQA/Schema/Result/Users.pm
@@ -20,6 +20,9 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+use URI::Escape 'uri_escape';
+use Digest::MD5 'md5_hex';
+
 __PACKAGE__->table('users');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
@@ -79,9 +82,6 @@ sub name {
     return $self->{_name};
 }
 
-use URI::Escape 'uri_escape';
-use Digest::MD5 'md5_hex';
-
 sub gravatar {
     my ($self, $size) = @_;
     $size //= 40;
@@ -94,22 +94,6 @@ sub gravatar {
     }
 }
 
-
-sub create_user {
-    my ($self, $id, $db, %attrs) = @_;
-
-    return unless $id;
-    my $user = $db->resultset("Users")->update_or_new({username => $id, %attrs});
-
-    if (!$user->in_storage) {
-        if (not $db->resultset("Users")->find({is_admin => 1}, {rows => 1})) {
-            $user->is_admin(1);
-            $user->is_operator(1);
-        }
-        $user->insert;
-    }
-    return $user;
-}
 
 1;
 # vim: set sw=4 et:

--- a/lib/OpenQA/Schema/ResultSet/Users.pm
+++ b/lib/OpenQA/Schema/ResultSet/Users.pm
@@ -1,0 +1,40 @@
+# Copyright (C) 2019 LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::Schema::ResultSet::Users;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::ResultSet';
+
+sub create_user {
+    my ($self, $id, %attrs) = @_;
+
+    return unless $id;
+    my $user = $self->update_or_new({username => $id, %attrs});
+
+    if (!$user->in_storage) {
+        if (not $self->find({is_admin => 1}, {rows => 1})) {
+            $user->is_admin(1);
+            $user->is_operator(1);
+        }
+        $user->insert;
+    }
+    return $user;
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -18,7 +18,6 @@ package OpenQA::WebAPI::Auth::Fake;
 use strict;
 use warnings;
 
-use OpenQA::Schema::Result::Users;
 use Exporter 'import';
 
 our @EXPORT_OK = qw(auth_login auth_logout);
@@ -48,8 +47,8 @@ sub auth_login {
     my $userinfo = $users{$user}             || die "No such user";
     $userinfo->{username} = $user;
 
-    $user = OpenQA::Schema::Result::Users->create_user(
-        $userinfo->{username}, $self->schema,
+    $user = $self->schema->resultset('Users')->create_user(
+        $userinfo->{username},
         email    => $userinfo->{email},
         nickname => $userinfo->{username},
         fullname => $userinfo->{fullname});

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -18,7 +18,6 @@ package OpenQA::WebAPI::Auth::OpenID;
 use strict;
 use warnings;
 
-use OpenQA::Schema::Result::Users;
 use LWP::UserAgent;
 use Net::OpenID::Consumer;
 use Exporter 'import';
@@ -148,8 +147,8 @@ sub auth_response {
                 }
             }
 
-            my $user = OpenQA::Schema::Result::Users->create_user(
-                $vident->{identity}, $self->schema,
+            my $user = $self->schema->resultset('Users')->create_user(
+                $vident->{identity},
                 email    => $email,
                 nickname => $nickname,
                 fullname => $fullname

--- a/lib/OpenQA/WebAPI/Auth/iChain.pm
+++ b/lib/OpenQA/WebAPI/Auth/iChain.pm
@@ -18,7 +18,6 @@ package OpenQA::WebAPI::Auth::iChain;
 use strict;
 use warnings;
 
-use OpenQA::Schema::Result::Users;
 use Exporter 'import';
 
 our @EXPORT_OK = qw(auth_login auth_logout);
@@ -36,8 +35,8 @@ sub auth_login {
 
     if ($username) {
         # iChain login
-        OpenQA::Schema::Result::Users->create_user(
-            $username, $self->schema,
+        $self->schema->resultset('Users')->create_user(
+            $username,
             email    => $email,
             nickname => $username,
             fullname => $fullname

--- a/script/create_admin
+++ b/script/create_admin
@@ -23,7 +23,6 @@ BEGIN {
 use strict;
 use warnings;
 use OpenQA::Schema::Result::ApiKeys;
-use OpenQA::Schema::Result::Users;
 use OpenQA::Schema;
 use Getopt::Long;
 
@@ -80,8 +79,8 @@ if ($users != 0) {
     warn "An admin user already exists! Use client or web UI to create further users.\n";
     exit 1;
 }
-my $account = OpenQA::Schema::Result::Users->create_user(
-    $user, $schema,
+my $account = $schema->resultset('Users')->create_user(
+    $user,
     email    => $email,
     nickname => $nickname,
     fullname => $fullname,

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -50,13 +50,13 @@ subtest 'system user presence' => sub {
 };
 
 subtest 'new user is admin if no admin is present' => sub {
-    my $admins = $t->app->schema->resultset('Users')->search({is_admin => 1});
+    my $users  = $t->app->schema->resultset('Users');
+    my $admins = $users->search({is_admin => 1});
     while (my $u = $admins->next) {
         $u->update({is_admin => 0});
     }
-    ok(!$t->app->schema->resultset('Users')->search({is_admin => 1})->all, 'no admin is present');
-    require OpenQA::Schema::Result::Users;
-    my $user = OpenQA::Schema::Result::Users->create_user('test_user', $t->app->schema);
+    ok(!$users->search({is_admin => 1})->all, 'no admin is present');
+    my $user = $users->create_user('test_user');
     ok($user->is_admin,    'new user is admin by default if there was no admin');
     ok($user->is_operator, 'new user is operator by default if there was no admin');
 };


### PR DESCRIPTION
There was a pretty ugly hack in `OpenQA::Test::Case` for mock logins. That hack broke when Mojolicious got a little more secure recently. This PR reimplements the functionality, but only uses public Mojolicious APIs which are unlikely to break. And i've also used the opportunity to fix `create_user`, which shouldn't have been a function (but a resultset method).

Progress: https://progress.opensuse.org/issues/49946