### PR TITLE
openQA.spec: multiline macros for services and dependencies

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -16,9 +16,19 @@
 #
 
 
-# can't use linebreaks here!
-%define openqa_services openqa-webui.service openqa-gru.service openqa-websockets.service openqa-scheduler.service
-%define openqa_worker_services openqa-worker.target openqa-slirpvde.service openqa-vde_switch.service openqa-worker-cacheservice.service openqa-worker-cacheservice-minion.service
+%define openqa_services \\\
+    openqa-webui.service \\\
+    openqa-gru.service \\\
+    openqa-websockets.service \\\
+    openqa-scheduler.service \\\
+    #EOL
+%define openqa_worker_services \\\
+    openqa-worker.target \\\
+    openqa-slirpvde.service \\\
+    openqa-vde_switch.service \\\
+    openqa-worker-cacheservice.service \\\
+    openqa-worker-cacheservice-minion.service \\\
+    #EOL
 %if %{undefined tmpfiles_create}
 %define tmpfiles_create() \
 %{_bindir}/systemd-tmpfiles --create %{?*} || : \
@@ -34,7 +44,45 @@
 %bcond_with tests
 %endif
 # runtime requirements that also the testsuite needs
-%define t_requires perl(DBD::Pg) perl(DBIx::Class) perl(Config::IniFiles) perl(SQL::Translator) perl(Date::Format) perl(File::Copy::Recursive) perl(DateTime::Format::Pg) perl(Net::OpenID::Consumer) perl(Mojolicious::Plugin::RenderFile) perl(Mojolicious::Plugin::AssetPack) perl(aliased) perl(Config::Tiny) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(IO::Socket::SSL) perl(Data::Dump) perl(DBIx::Class::OptimisticLocking) perl(Text::Markdown) perl(Net::DBus) perl(JSON::Validator) perl(YAML::XS) perl(IPC::Run) perl(Archive::Extract) perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS) perl(Time::ParseDate) perl(Sort::Versions) perl(Mojo::RabbitMQ::Client) perl(BSD::Resource) perl(Cpanel::JSON::XS) perl(Pod::POM) perl(Mojo::IOLoop::ReadWriteProcess) perl(Minion) perl(Mojo::Pg) perl(Mojo::SQLite) perl(Minion::Backend::SQLite)
+%define _t_requires \\\
+    perl(DBD::Pg) \\\
+    perl(DBIx::Class) \\\
+    perl(Config::IniFiles) \\\
+    perl(SQL::Translator) \\\
+    perl(Date::Format) \\\
+    perl(File::Copy::Recursive) \\\
+    perl(DateTime::Format::Pg) \\\
+    perl(Net::OpenID::Consumer) \\\
+    perl(Mojolicious::Plugin::RenderFile) \\\
+    perl(Mojolicious::Plugin::AssetPack) \\\
+    perl(aliased) \\\
+    perl(Config::Tiny) \\\
+    perl(DBIx::Class::DynamicDefault) \\\
+    perl(DBIx::Class::Schema::Config) \\\
+    perl(DBIx::Class::Storage::Statistics) \\\
+    perl(IO::Socket::SSL) \\\
+    perl(Data::Dump) \\\
+    perl(DBIx::Class::OptimisticLocking) \\\
+    perl(Text::Markdown) \\\
+    perl(Net::DBus) \\\
+    perl(JSON::Validator) \\\
+    perl(YAML::XS) \\\
+    perl(IPC::Run) \\\
+    perl(Archive::Extract) \\\
+    perl(CSS::Minifier::XS) \\\
+    perl(JavaScript::Minifier::XS) \\\
+    perl(Time::ParseDate) \\\
+    perl(Sort::Versions) \\\
+    perl(Mojo::RabbitMQ::Client) \\\
+    perl(BSD::Resource) \\\
+    perl(Cpanel::JSON::XS) \\\
+    perl(Pod::POM) \\\
+    perl(Mojo::IOLoop::ReadWriteProcess) \\\
+    perl(Minion) \\\
+    perl(Mojo::Pg) \\\
+    perl(Mojo::SQLite) \\\
+    perl(Minion::Backend::SQLite) \\\
+    #EOL
 Name:           openQA
 Version:        4.6
 Release:        0
@@ -49,7 +97,7 @@ Source1:        cache.txz
 Source100:      openQA-rpmlintrc
 Source101:      update-cache.sh
 Source102:      Dockerfile
-BuildRequires:  %{t_requires}
+BuildRequires:  %{expand:t_requires}
 BuildRequires:  fdupes
 BuildRequires:  os-autoinst
 BuildRequires:  systemd
@@ -133,7 +181,7 @@ operating system.
 %package common
 Summary:        The openQA common tools for web-frontend and workers
 Group:          Development/Tools/Other
-Requires:       %{t_requires}
+Requires:       %{expand:t_requires}
 Requires:       perl(Mojolicious) >= 7.92
 
 %description common


### PR DESCRIPTION
The extremely long lines tend to cause confusion when it comes to
checking existing dependencies and if something needs to be added.

can use linebreaks here afterall?