### PR TITLE
Import of job template specification from YAML

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -398,6 +398,10 @@ function submitTemplateEditor() {
             template: $('#editor-template').val()
         }
     }).done(function(data) {
+        if (data.hasOwnProperty('id') && data.id != job_group_id) {
+            result.text('Error: Changing the group name here is not supported');
+            return true;
+        }
         result.text('Preview of the YAML:');
         if (data.hasOwnProperty('template')) {
             $('<code/>').text(data.template).appendTo($('<p/>').appendTo(result));

--- a/assets/stylesheets/admin-pages.scss
+++ b/assets/stylesheets/admin-pages.scss
@@ -311,6 +311,15 @@ h2 + * {
         text-align: center;
     }
 }
+#editor-form code {
+    display: inline-block;
+    font-weight: normal;
+    text-align: left !important;
+    white-space: pre;
+}
+#editor-template {
+    font-family: monospace, monospace; 
+}
 
 // users
 table#users {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -398,6 +398,7 @@ sub startup {
     # api/v1/job_templates_scheduling
     $api_public_r->get('experimental/job_templates_scheduling/<id:num>')->name('apiv1_job_templates_schedules')
       ->to('job_template#schedules', id => undef);
+    $api_ra->post('experimental/job_templates_scheduling/<id:num>')->to('job_template#update', id => undef);
 
     # api/v1/comments
     $api_public_r->get('/jobs/<job_id:num>/comments')->name('apiv1_list_comments')->to('comment#list');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2019 SUSE Linux Products GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -298,8 +298,9 @@ sub update {
                                 die "Machine is empty and there is no default for architecture $arch\n"
                                   unless $machine_name;
 
-                                # Find machine and product
-                                my $machine      = $machines->find({name => $machine_name});
+                                # Find machine, product and testsuite
+                                my $machine = $machines->find({name => $machine_name});
+                                die "Machine '$machine_name' is invalid\n" unless $machine;
                                 my $product_spec = $yaml_products->{$product_name};
                                 my $product      = $products->find(
                                     {
@@ -308,16 +309,9 @@ sub update {
                                         flavor  => $product_spec->{flavor},
                                         version => $product_spec->{version},
                                     });
-                                die "Machine '$machine_name' is invalid\n" unless $machine;
                                 die "Product '$product_name' is invalid\n" unless $product;
-                                # TODO: Consider adding new machines/products via this import as well but it would raise
-                                #       a similar concern as for test suites above.
-
-                                # Find or create test suite
-                                my $test_suite = $test_suites->find_or_create({name => $testsuite_name});
-                                # TODO: This may silently add a new testsuite with no settings and description. So
-                                #       at least inform the user so he is aware. (The new test suite likely should
-                                #       be populated with settings and a description or it was just a typo.)
+                                my $test_suite = $test_suites->find({name => $testsuite_name});
+                                die "Testsuite '$testsuite_name' is invalid\n" unless $test_suite;
 
                                 # Create/update job template
                                 my $job_template = $job_templates->find_or_create(

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -16,6 +16,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::JobTemplate;
 use Mojo::Base 'Mojolicious::Controller';
+use Try::Tiny;
 use JSON::Validator;
 
 =pod
@@ -201,6 +202,160 @@ sub schedules {
     }
 
     $self->render(yaml => \%yaml);
+}
+
+=over 4
+
+=item update()
+
+Updates a job group according to the given YAML template. Test suites are added or modified
+as needed to reflect the difference to what's specified in the template.
+The given YAML will be validated and results in an error if it doesn't confom to the schema.
+
+Returns a 400 code on error, or a 303 code and the job template id within a JSON block on success.
+
+=back
+
+=cut
+
+sub update {
+    my $self = shift;
+
+    my $yaml   = {};
+    my $errors = [];
+    try {
+        # No objects (aka SafeYAML)
+        $YAML::XS::LoadBlessed = 0;
+        $yaml                  = YAML::XS::Load($self->param('template'));
+        $errors                = $self->app->validate_yaml($yaml, $self->app->log->level eq 'debug');
+    }
+    catch {
+        # Push the exception to the list of errors without the trailing new line
+        push @$errors, substr($_, 0, -1);
+    };
+
+    if (@$errors) {
+        $self->app->log->error(@$errors);
+        $self->respond_to(json => {json => {error => \@$errors}, status => 400},);
+        return;
+    }
+
+    my $job_groups    = $self->schema->resultset("JobGroups");
+    my $job_templates = $self->schema->resultset("JobTemplates");
+    my $machines      = $self->schema->resultset("Machines");
+    my $test_suites   = $self->schema->resultset("TestSuites");
+    my $products      = $self->schema->resultset("Products");
+    foreach my $group (keys %{$yaml}) {
+        my $json = {};
+
+        try {
+            $self->schema->txn_do(
+                sub {
+                    my $group_id = $job_groups->find_or_create({name => $group}, {select => [qw(id name)]})->id;
+                    $json->{id} = $group_id;
+
+                    # Add/update job templates from YAML data
+                    # (create test suites if not already present, fail if referenced machine and product is missing)
+                    my @job_template_ids;
+                    my $yaml_group    = $yaml->{$group};
+                    my $yaml_archs    = $yaml_group->{architectures};
+                    my $yaml_products = $yaml_group->{products};
+                    my $yaml_defaults = $yaml_group->{defaults};
+                    foreach my $arch (keys %$yaml_archs) {
+                        my $yaml_products_for_arch = $yaml_archs->{$arch};
+                        my $yaml_defaults_for_arch = $yaml_defaults->{$arch};
+                        foreach my $product_name (keys %$yaml_products_for_arch) {
+                            foreach my $spec (@{$yaml_products_for_arch->{$product_name}}) {
+                                # Get testsuite, machine and prio from YAML data
+                                my $testsuite_name;
+                                my $prio;
+                                my $machine_name;
+                                if (ref $spec eq 'HASH') {
+                                    foreach my $name (keys %$spec) {
+                                        my $attr = $spec->{$name};
+                                        $testsuite_name = $name;
+                                        if ($attr->{priority}) {
+                                            $prio = $attr->{priority};
+                                        }
+                                        if ($attr->{machine}) {
+                                            $machine_name = $attr->{machine};
+                                        }
+                                    }
+                                }
+                                else {
+                                    $testsuite_name = $spec;
+                                }
+
+                                # Assign defaults
+                                $prio         //= $yaml_defaults_for_arch->{priority};
+                                $machine_name //= $yaml_defaults_for_arch->{machine};
+                                die "Machine is empty and there is no default for architecture $arch\n"
+                                  unless $machine_name;
+
+                                # Find machine and product
+                                my $machine      = $machines->find({name => $machine_name});
+                                my $product_spec = $yaml_products->{$product_name};
+                                my $product      = $products->find(
+                                    {
+                                        arch    => $arch,
+                                        distri  => $product_spec->{distribution},
+                                        flavor  => $product_spec->{flavor},
+                                        version => $product_spec->{version},
+                                    });
+                                die "Machine '$machine_name' is invalid\n" unless $machine;
+                                die "Product '$product_name' is invalid\n" unless $product;
+                                # TODO: Consider adding new machines/products via this import as well but it would raise
+                                #       a similar concern as for test suites above.
+
+                                # Find or create test suite
+                                my $test_suite = $test_suites->find_or_create({name => $testsuite_name});
+                                # TODO: This may silently add a new testsuite with no settings and description. So
+                                #       at least inform the user so he is aware. (The new test suite likely should
+                                #       be populated with settings and a description or it was just a typo.)
+
+                                # Create/update job template
+                                my $job_template = $job_templates->find_or_create(
+                                    {
+                                        group_id      => $group_id,
+                                        product_id    => $product->id,
+                                        machine_id    => $machine->id,
+                                        test_suite_id => $test_suite->id,
+                                    });
+                                $job_template->update({prio => $prio}) if (defined $prio);
+                                push(@job_template_ids, $job_template->id);
+
+                                # Stop iterating if there were errors with this test suite
+                                last if (@$errors);
+                            }
+                        }
+                    }
+
+                    # Drop entries we haven't touched in add/update loop
+                    $job_templates->search(
+                        {
+                            id       => {'not in' => \@job_template_ids},
+                            group_id => $group_id,
+                        })->delete();
+                });
+        }
+        catch {
+            # Push the exception to the list of errors without the trailing new line
+            push @$errors, substr($_, 0, -1);
+        };
+
+        if (@$errors) {
+            $json->{error} = \@$errors;
+            $self->app->log->error(@$errors);
+            $self->respond_to(json => {json => $json, status => 400},);
+            return;
+        }
+
+        $self->emit_event('openqa_jobtemplate_create', $json);
+        $self->respond_to(json => {json => $json});
+
+        # Process only one group
+        last;
+    }
 }
 
 =over 4

--- a/public/schema/JobTemplate.yaml
+++ b/public/schema/JobTemplate.yaml
@@ -32,7 +32,7 @@ patternProperties:
                     description: A test suite with machine and/ or priority specified
                     additionalProperties: false
                     patternProperties:
-                      "^[A-Za-z0-9_+]+$":
+                      "^[A-Za-z\\s0-9_*+-]+$":
                         type: object
                         additionalProperties: false
                         properties:

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -70,6 +70,22 @@ is_deeply(
                     }
                 ],
                 'version' => '13.1'
+            },
+            {
+                id       => 2,
+                distri   => 'sle',
+                version  => '12-SP1',
+                flavor   => 'Server-DVD-Updates',
+                arch     => 'x86_64',
+                settings => [],
+            },
+            {
+                id       => 3,
+                distri   => 'opensuse',
+                version  => '13.1',
+                flavor   => 'DVD',
+                arch     => 'ppc64',
+                settings => [],
             }]
     },
     "Initial products"

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2019 SUSE Linux Products GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,8 +26,8 @@ use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
 use OpenQA::Client;
-use Mojo::IOLoop;
 use OpenQA::WebAPI::Controller::API::V1::JobTemplate;
+use Mojo::IOLoop;
 
 OpenQA::Test::Case->new->init_data;
 
@@ -39,12 +39,14 @@ my $app = $t->app;
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $job_templates = $app->schema->resultset('JobTemplates');
-my $test_suites   = $app->schema->resultset('TestSuites');
+my $schema        = $app->schema;
+my $job_groups    = $schema->resultset('JobGroups');
+my $job_templates = $schema->resultset('JobTemplates');
+my $test_suites   = $schema->resultset('TestSuites');
 
-my $get = $t->get_ok('/api/v1/job_templates')->status_is(200);
+$t->get_ok('/api/v1/job_templates')->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'JobTemplates' => [
             {
@@ -259,10 +261,10 @@ is_deeply(
             }]
     },
     "Initial job templates"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 
-my $res = $t->post_ok(
+$t->post_ok(
     '/api/v1/job_templates',
     form => {
         group_id      => 1001,
@@ -271,10 +273,10 @@ my $res = $t->post_ok(
         product_id    => 1,
         prio          => 30
     })->status_is(200);
-my $job_template_id1 = $res->tx->res->json->{id};
+my $job_template_id1 = $t->tx->res->json->{id};
 ok($job_template_id1, 'got ID (1)');
 
-$res = $t->post_ok(
+$t->post_ok(
     '/api/v1/job_templates',
     form => {
         group_name      => 'opensuse',
@@ -286,17 +288,17 @@ $res = $t->post_ok(
         version         => '13.1',
         prio            => 20
     })->status_is(200);
-my $job_template_id2 = $res->tx->res->json->{id};
+my $job_template_id2 = $t->tx->res->json->{id};
 ok($job_template_id2, 'got ID (2)');
 is_deeply(
-    OpenQA::Test::Case::find_most_recent_event($app->schema, 'jobtemplate_create'),
+    OpenQA::Test::Case::find_most_recent_event($schema, 'jobtemplate_create'),
     {id => $job_template_id2},
     'Create was logged correctly'
 );
 
-$get = $t->get_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
+$t->get_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'JobTemplates' => [
             {
@@ -322,11 +324,11 @@ is_deeply(
 
     },
     "Initial job templates"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
-$get = $t->get_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
+$t->get_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'JobTemplates' => [
             {
@@ -352,10 +354,10 @@ is_deeply(
             }]
     },
     "Initial job templates"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 # search by name
-$get = $t->get_ok(
+$t->get_ok(
     "/api/v1/job_templates",
     form => {
         machine_name    => '64bit',
@@ -366,7 +368,7 @@ $get = $t->get_ok(
         'version'       => '13.1'
     })->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'JobTemplates' => [
             {
@@ -391,12 +393,12 @@ is_deeply(
                 }}]
     },
     "Initial job templates"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 #search all job templates with testsuite 'kde'
-$get = $t->get_ok("/api/v1/job_templates", form => {test_suite_name => 'kde'})->status_is(200);
+$t->get_ok("/api/v1/job_templates", form => {test_suite_name => 'kde'})->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'JobTemplates' => [
             {
@@ -442,7 +444,7 @@ is_deeply(
                 }}]
     },
     "Initial job templates"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 # need to specify 'prio_only' for setting prio of job tempaltes by group and testsuite
 $t->post_ok(
@@ -559,16 +561,16 @@ $yaml->{groupname}{architectures}{'x86_64'}{opensuse} = [
 is_deeply($t->app->validate_yaml($yaml, 1), [], 'YAML valid as expected')
   or diag explain YAML::XS::Dump($yaml);
 # Make 40 our default priority, which matters when we look at the "defaults" key later
-$app->schema->resultset('JobGroups')->find({name => 'opensuse'})->update({default_priority => 40});
+$job_groups->find({name => 'opensuse'})->update({default_priority => 40});
 # Get all groups
-$get  = $t->get_ok("/api/v1/experimental/job_templates_scheduling")->status_is(200);
-$yaml = YAML::XS::Load($get->tx->res->body);
+$t->get_ok("/api/v1/experimental/job_templates_scheduling")->status_is(200);
+$yaml = YAML::XS::Load($t->tx->res->body);
 is_deeply($t->app->validate_yaml($yaml, 1), [], 'YAML of all groups is valid');
 is($yaml->{opensuse}{products}{'opensuse-13.1-DVD-i586'}{version}, '13.1', 'Version of opensuse group')
-  || diag explain $get->tx->res->body;
+  || diag explain $t->tx->res->body;
 # Get one group with defined architectures, products and defaults
-$get  = $t->get_ok("/api/v1/experimental/job_templates_scheduling/1001")->status_is(200);
-$yaml = YAML::XS::Load($get->tx->res->body);
+$t->get_ok("/api/v1/experimental/job_templates_scheduling/1001")->status_is(200);
+$yaml = YAML::XS::Load($t->tx->res->body);
 is_deeply($t->app->validate_yaml($yaml, 1), [], 'YAML of single group is valid');
 is_deeply(
     $yaml,
@@ -632,19 +634,20 @@ is_deeply(
         },
     },
     'YAML for opensuse group'
-) || diag explain $get->tx->res->body;
+) || diag explain $t->tx->res->body;
+
 # Add unicode characters to group name to see if the encoding is correct
-$app->schema->resultset('JobGroups')->find({name => 'opensuse'})->update({name => 'öpensüse'});
+$job_groups->find({name => 'opensuse'})->update({name => 'öpensüse'});
 # Swap the group name in the expected YAML
 $yaml->{'öpensüse'} = $yaml->{'opensuse'};
 delete $yaml->{'opensuse'};
-$get = $t->get_ok("/api/v1/experimental/job_templates_scheduling/1001")->status_is(200)
+$t->get_ok("/api/v1/experimental/job_templates_scheduling/1001")->status_is(200)
   ->content_type_is('text/yaml;charset=UTF-8');
-is_deeply(YAML::XS::Load($get->tx->res->body), $yaml, 'Test suite with unicode characters encoded correctly')
-  || diag explain $get->tx->res->body;
+is_deeply(YAML::XS::Load($t->tx->res->body), $yaml, 'Test suite with unicode characters encoded correctly')
+  || diag explain $t->tx->res->body;
 
 # Remove unicode characters from the group name to simplify further testing
-$app->schema->resultset('JobGroups')->find({name => 'öpensüse'})->update({name => 'opensuse'});
+$job_groups->find({name => 'öpensüse'})->update({name => 'opensuse'});
 # Swap the group name in the expected YAML
 $yaml->{'opensuse'} = $yaml->{'öpensüse'};
 delete $yaml->{'öpensüse'};
@@ -667,7 +670,7 @@ $t->post_ok(
 );
 
 subtest 'Create and modify groups with YAML' => sub {
-    # Create group based on YAML template
+    # Create group and job templates based on YAML template
     $yaml = {
         foo => {
             architectures => {
@@ -699,11 +702,11 @@ subtest 'Create and modify groups with YAML' => sub {
             },
         },
     };
-    $res = $t->post_ok(
+    $t->post_ok(
         '/api/v1/experimental/job_templates_scheduling',
         form => {
             template => YAML::XS::Dump($yaml)}
-    )->status_is(400, 'Job template rejected because testsuite does not exist')->json_is(
+    )->status_is(400, 'Post rejected because testsuite does not exist')->json_is(
         '' => {
             error        => ['Testsuite \'foobar\' is invalid'],
             error_status => 400,
@@ -727,26 +730,28 @@ subtest 'Create and modify groups with YAML' => sub {
     $t->status_is(200, 'Posting preview successful');
     my $job_group_id3 = $t->tx->res->json->{id};
     $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id3");
-    is_deeply(YAML::XS::Load($t->tx->res->body), {}, 'No job template added to the database')
+    is_deeply(YAML::XS::Load($t->tx->res->body), {}, 'No job group and templates added to the database')
       || diag explain $t->tx->res->body;
 
     $t->post_ok('/api/v1/experimental/job_templates_scheduling', form => {template => YAML::XS::Dump($yaml)});
-    $t->status_is(200, 'New job template was added to the database');
-    if ($t->success) {
-        $job_group_id3 = $t->tx->res->json->{id};
-        $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id3");
-        # Prepare expected result
-        splice @{$yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}}, 0, 2;
-        unshift @{$yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}}, {'spam'   => {priority => 40}};
-        unshift @{$yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}}, {'foobar' => {priority => 40}};
-        # Use per-arch default priority which deviates from the group default_priority
-        $yaml->{foo}{defaults}{i586}{'priority'} = 50;
-        is_deeply(YAML::XS::Load($t->tx->res->body), $yaml, 'Added job template reflected in the database')
-          || diag explain $t->tx->res->body;
+    $t->status_is(200, 'Changes applied to the database');
+    if (!$t->success) {
+        return undef;
+    }
+    $job_group_id3 = $t->tx->res->json->{id};
+    $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id3");
+    # Prepare expected result
+    splice @{$yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}}, 0, 2;
+    unshift @{$yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}}, {'spam'   => {priority => 40}};
+    unshift @{$yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}}, {'foobar' => {priority => 40}};
+    # Use per-arch default priority which deviates from the group default_priority
+    $yaml->{foo}{defaults}{i586}{'priority'} = 50;
+    is_deeply(YAML::XS::Load($t->tx->res->body), $yaml, 'Added job template reflected in the database')
+      || diag explain $t->tx->res->body;
 
-        # Modify test attributes in group according to YAML template
+    subtest 'Modify test attributes in group according to YAML template' => sub {
         $yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}
-          = [{'foobar' => {priority => 11, machine => '32bit'}}, 'spam', 'eggs',];
+          = [{'foobar' => {priority => 11, machine => '32bit'}}, 'spam', 'eggs'];
         # Use per-arch default priority which deviates from the group default_priority
         $yaml->{foo}{defaults}{i586}{'priority'} = 70;
         $t->post_ok(
@@ -760,18 +765,16 @@ subtest 'Create and modify groups with YAML' => sub {
             'Test suite was updated'
         );
         # Prepare expected result
-        $yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'} = [
-            {'foobar' => {priority => 11, machine => '32bit'}},
-            {'spam'   => {priority => 70}},
-            {'eggs'   => {priority => 70}},
-        ];
+        $yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}
+          = [{foobar => {priority => 11, machine => '32bit'}}, {spam => {priority => 70}}, {eggs => {priority => 70}}];
         # Result *should* in fact be 70, but we get the default_priority
         $yaml->{foo}{defaults}{i586}{'priority'} = 50;
-        $get = $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id3");
-        is_deeply(YAML::XS::Load($get->tx->res->body), $yaml, 'Modified test suite should be reflected in the database')
-          || diag explain $get->tx->res->body;
+        $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id3");
+        is_deeply(YAML::XS::Load($t->tx->res->body), $yaml, 'Modified test suite should be reflected in the database')
+          || diag explain $t->tx->res->body;
+    };
 
-        # Post unmodified group
+    subtest 'Post unmodified job template' => sub {
         $t->post_ok(
             '/api/v1/experimental/job_templates_scheduling',
             form => {
@@ -780,15 +783,16 @@ subtest 'Create and modify groups with YAML' => sub {
             '' => {
                 id => $job_group_id3
             },
-            'No-op import of existing group'
+            'No-op import of existing job template'
         );
-        $get = $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id3");
-        is_deeply(YAML::XS::Load($get->tx->res->body), $yaml, 'Unmodified group should not result in any changes')
-          || diag explain $get->tx->res->body;
+        $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id3");
+        is_deeply(YAML::XS::Load($t->tx->res->body), $yaml, 'Unmodified group should not result in any changes')
+          || diag explain $t->tx->res->body;
+    };
 
-        # Errors due to invalid properties
+    subtest 'Errors due to invalid properties' => sub {
         $yaml->{foo}{architectures}{i586}{'opensuse-13.1-DVD-i586'}
-          = [{'foobar' => {priority => 11, machine => '31bit'}}];
+          = [{foobar => {priority => 11, machine => '31bit'}}];
         $t->post_ok(
             '/api/v1/experimental/job_templates_scheduling',
             form => {
@@ -831,7 +835,7 @@ subtest 'Create and modify groups with YAML' => sub {
             },
             'Invalid product'
         );
-    }
+    };
 };
 
 subtest 'References' => sub {
@@ -875,8 +879,9 @@ subtest 'References' => sub {
     $t->status_is(200, 'New group with references was added to the database');
     if (!$t->success) {
         diag explain $t->tx->res->json;
-        return;
+        return undef;
     }
+
     my $job_group_id4 = $t->tx->res->json->{id};
     $t->get_ok("/api/v1/experimental/job_templates_scheduling/$job_group_id4");
     # Prepare expected result
@@ -886,11 +891,11 @@ subtest 'References' => sub {
       || diag explain $t->tx->res->body;
 };
 
-$res = $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
-$res = $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(404);    #not found
+$t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
+$t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(404);
 
-$res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
-$res = $t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(404);    #not found
+$t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(200);
+$t->delete_ok("/api/v1/job_templates/$job_template_id2")->status_is(404);
 is_deeply(
     OpenQA::Test::Case::find_most_recent_event($app->schema, 'jobtemplate_delete'),
     {id => "$job_template_id2"},

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -544,6 +544,17 @@ is_deeply(
     'No version specified'
 ) or diag explain YAML::XS::Dump($yaml);
 $yaml->{groupname}{products}{'opensuse'}{version} = '42.1';
+# Add non-trivial test suites to exercise the validation
+$yaml->{groupname}{architectures}{'x86_64'}{opensuse} = [
+    'spam',
+    "eg-G_S +133t*\t",
+    {
+        'foo'               => {},
+        "b-A_RRRR +133t*\t" => {
+            machine  => 'x86_64',
+            priority => 33,
+        },
+    }];
 is_deeply($t->app->validate_yaml($yaml, 1), [], 'YAML valid as expected')
   or diag explain YAML::XS::Dump($yaml);
 # Make 40 our default priority, which matters when we look at the "defaults" key later

--- a/t/fixtures/04-products.pl
+++ b/t/fixtures/04-products.pl
@@ -100,5 +100,21 @@
             {machine => {name => '64bit'}, test_suite => {name => 'advanced_kde'}, prio => 40, group_id => 1001},
         ],
     },
+    Products => {
+        id      => 2,
+        name    => '',
+        distri  => 'sle',
+        version => '12-SP1',
+        flavor  => 'Server-DVD-Updates',
+        arch    => 'x86_64',
+    },
+    Products => {
+        id      => 3,
+        name    => '',
+        distri  => 'opensuse',
+        version => '13.1',
+        flavor  => 'DVD',
+        arch    => 'ppc64',
+    },
 ]
 # vim: set sw=4 et:

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -372,7 +372,7 @@ subtest 'job property editor' => sub() {
 
     # navigate to editor first
     $driver->find_element_by_link('Cool Group')->click();
-    $driver->find_element('.corner-buttons button')->click();
+    $driver->find_element_by_id('toggle-group-properties')->click();
 
     subtest 'current/default values present' => sub() {
         is($driver->find_element_by_id('editor-name')->get_value(),              'Cool Group', 'name');
@@ -394,7 +394,7 @@ subtest 'job property editor' => sub() {
         # update group name with empty
         $groupname->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $groupname->send_keys(Selenium::Remote::WDKeys->KEYS->{backspace});
-        is($driver->find_element('p.buttons button.btn-primary')->get_attribute('disabled'),
+        is($driver->find_element('#properties p.buttons button.btn-primary')->get_attribute('disabled'),
             'true', 'group properties save button is disabled if leave name is empty');
         is(
             $driver->find_element('#editor-name')->get_attribute('class'),
@@ -402,13 +402,13 @@ subtest 'job property editor' => sub() {
             'editor name input marked as invalid'
         );
         $driver->refresh();
-        $driver->find_element('.corner-buttons button')->click();
+        $driver->find_element_by_id('toggle-group-properties')->click();
 
         # update group name with blank
         $groupname = $driver->find_element_by_id('editor-name');
         $groupname->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $groupname->send_keys('   ');
-        is($driver->find_element('p.buttons button.btn-primary')->get_attribute('disabled'),
+        is($driver->find_element('#properties p.buttons button.btn-primary')->get_attribute('disabled'),
             'true', 'group properties save button is disabled if leave name is empty');
         is(
             $driver->find_element('#editor-name')->get_attribute('class'),
@@ -416,7 +416,7 @@ subtest 'job property editor' => sub() {
             'editor name input marked as invalid'
         );
         $driver->refresh();
-        $driver->find_element('.corner-buttons button')->click();
+        $driver->find_element_by_id('toggle-group-properties')->click();
     };
 
     subtest 'edit some properties' => sub() {
@@ -429,16 +429,16 @@ subtest 'job property editor' => sub() {
         $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $ele->send_keys('500');
         $driver->find_element_by_id('editor-description')->send_keys('Test group');
-        is($driver->find_element('p.buttons button.btn-primary')->get_attribute('disabled'),
+        is($driver->find_element('#properties p.buttons button.btn-primary')->get_attribute('disabled'),
             undef, 'group properties save button is enabled');
         $driver->find_element_by_id('editor-carry-over-bugrefs')->click();
-        $driver->find_element('p.buttons button.btn-primary')->click();
+        $driver->find_element('#properties p.buttons button.btn-primary')->click();
         # ensure there is no race condition, even though the page is reloaded
         wait_for_ajax;
 
         $driver->refresh();
         $driver->title_is('openQA: Jobs for Cool Group has been edited!', 'new name on title');
-        $driver->find_element('.corner-buttons button')->click();
+        $driver->find_element_by_id('toggle-group-properties')->click();
         is($driver->find_element_by_id('editor-name')->get_value(), 'Cool Group has been edited!', 'name edited');
         is($driver->find_element_by_id('editor-size-limit')->get_value(), '1000', 'size edited');
         is($driver->find_element_by_id('editor-keep-important-results-in-days')->get_value(),

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -124,7 +124,7 @@ subtest 'add product' => sub() {
     is((shift @headers)->get_text(), "DVD",      "flavor");
     is((shift @headers)->get_text(), "i586",     "arch");
 
-    is(@{$driver->find_elements('//button[@title="Edit"]', 'xpath')}, 1, "1 edit button before");
+    is(@{$driver->find_elements('//button[@title="Edit"]', 'xpath')}, 3, "3 edit buttons/media before");
 
     is($driver->find_element_by_xpath('//input[@value="New medium"]')->click(), 1, 'new medium');
 
@@ -140,7 +140,7 @@ subtest 'add product' => sub() {
 
     is($driver->find_element_by_xpath('//button[@title="Add"]')->click(), 1, 'added');
     wait_for_ajax;
-    is(@{$driver->find_elements('//button[@title="Edit"]', 'xpath')}, 2, "2 edit buttons afterwards");
+    is(@{$driver->find_elements('//button[@title="Edit"]', 'xpath')}, 4, "4 edit buttons/media afterwards");
 
     # check the distri name will be lowercase after added a new one
     is($driver->find_element_by_xpath('//input[@value="New medium"]')->click(), 1, 'new medium');
@@ -159,7 +159,7 @@ subtest 'add product' => sub() {
 
     is($driver->find_element_by_xpath('//button[@title="Add"]')->click(), 1, 'added');
     wait_for_ajax;
-    is(@{$driver->find_elements('//button[@title="Edit"]', 'xpath')}, 3, "3 edit buttons afterwards");
+    is(@{$driver->find_elements('//button[@title="Edit"]', 'xpath')}, 5, "5 edit buttons/media afterwards");
 };
 
 subtest 'add machine' => sub() {
@@ -460,7 +460,7 @@ sub is_element_text {
     is_deeply(\@texts, $expected, $message) or diag explain \@texts;
 }
 
-subtest 'edit mediums' => sub() {
+subtest 'edit media' => sub() {
     $driver->title_is('openQA: Jobs for Cool Group has been edited!', 'on jobs for Cool Test has been edited!');
 
     wait_for_ajax;

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -17,7 +17,18 @@
 <div class="row">
     <div class="col-sm-12">
         <form action="<%= url_for('admin_groups') %>" class="corner-buttons">
-            <button type="button" class="btn btn-default" onclick="toggleEdit();">
+            <button type="button" id="toggle-yaml-editor" class="btn btn-default" onclick="toggleTemplateEditor();">
+                <span>
+                    <i class="fas fa-edit"></i>
+                    % if (is_admin) {
+                        Edit YAML
+                    % }
+                    % else {
+                        Show YAML
+                    % }
+                </span>
+            </button>
+            <button type="button" id="toggle-group-properties" class="btn btn-default" onclick="toggleEdit();">
                 <span>
                     <i class="fas fa-edit"></i>
                     % if (is_admin) {
@@ -76,6 +87,66 @@
             </select>
 
         </div>
+        <form action="#" id="editor-form" class="form-horizontal" style="display: none;" onsubmit="return submitTemplateEditor();"
+          data-put-url="<%= url_for('apiv1_job_templates_schedules' => (id => $group->id)) %>">
+            <div class="form-group row">
+                <label for="editor-template" class="col-sm-4 control-label" data-toggle="tooltip" title="Changes in the YAML will be reflected in the database">
+                    <div id="editor-yaml-guide">
+                        <div>Define test suites per arch/medium:</div>
+                        <code>
+<b>'My Group'</b>:
+  architectures:
+    <b>ARCH</b>:
+      <i>medium</i>-<b>ARCH</b>:
+      - test_suite
+      - test_suite:
+          machine: <b>MACHINE</b>
+          priority: <b>PRIORITY</b>
+  defaults:
+    <b>ARCH</b>:
+      machine: <b>MACHINE</b>
+      priority: <b>PRIORITY</b>
+  products:
+    <i>medium</i>-<b>ARCH</b>:
+      distribution: <b>DISTRIBUTION</b>
+      flavor: <b>FLAVOR</b>
+      version: <b>VERSION</b>
+                        </code>
+                        <div>Re-use test suites with YAML aliases:</div>
+                        <code>
+architectures:
+  <b>i586</b>:
+    <i>medium</i>-<b>i586</b>: <b>&amp;tests</b>
+    - foo
+    - bar:
+        machine: <b>64bit</b>
+        priority: <b>70</b>
+  <b>x86_64</b>:
+    <i>medium</i>-<b>x86_64</b>:
+      <b>*tests</b>
+                        </code>
+                    </div>
+                </label>
+                <div class="col-sm-8">
+                    <textarea class="form-control" id="editor-template" name="template" spellcheck="false"></textarea>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-sm-4 control-label"></div>
+                <div class="col-sm-8">
+                    <p class="buttons">
+                    % if (is_admin) {
+                    <button id="update-template" type="submit" class="btn btn-primary"><i class="fas fa-update"></i>Preview changes</button>
+                    % }
+                    </p>
+                    <p class="progress-indication">
+                        <i class="fa fa-cog fa-spin fa-3x fa-fw"></i>
+                        <span class="sr-only">Loading…</span>
+                    </p>
+                    <div class="result"></div>
+                </div>
+            </div>
+        </form>
 
         % if (is_admin) {
             <p>


### PR DESCRIPTION
This is the route updating job templates according to YAML, which may include adding, modifying or deleting of test suites.

On the UI side, a text editor is provided as well as a little guide to the format. The "preview" mode allows trying out the changes without modifying the database.

Fixes: [poo#46670](https://progress.opensuse.org/issues/46670)