### PR TITLE
Add cacheservice as part of openqa-worker.target

### DIFF
--- a/systemd/openqa-worker-cacheservice-minion.service
+++ b/systemd/openqa-worker-cacheservice-minion.service
@@ -2,6 +2,7 @@
 Description=OpenQA Worker Cache Service Minion
 After=openqa-worker-cacheservice.service
 Requires=openqa-worker-cacheservice.service
+PartOf=openqa-worker.target
 
 [Service]
 Restart=on-failure

--- a/systemd/openqa-worker-cacheservice.service
+++ b/systemd/openqa-worker-cacheservice.service
@@ -2,6 +2,7 @@
 Description=OpenQA Worker Cache Service
 After=network-online.target
 Wants=network-online.target
+PartOf=openqa-worker.target
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
This enables better control over the openQA units on servers.