### PR TITLE
Fix PR leftovers

### DIFF
--- a/assets/javascripts/admin_worker.js
+++ b/assets/javascripts/admin_worker.js
@@ -64,18 +64,18 @@ function loadWorkerTable() {
 }
 
 function deleteWorker(deleteLink){
-	var post_url = $(deleteLink).attr("post_delete_url");
-	$.ajax({
-		url: post_url,
-		method: 'DELETE',
-		dataType: 'json',
-		success: function(data) {
-			$(deleteLink).parent().parent().remove();
+    var post_url = $(deleteLink).attr("post_delete_url");
+    $.ajax({
+        url: post_url,
+        method: 'DELETE',
+        dataType: 'json',
+        success: function(data) {
+            $(deleteLink).parent().parent().remove();
             addFlash('info', data.message);
-		},
-		error: function(xhr, ajaxOptions, thrownError){
+        },
+        error: function(xhr, ajaxOptions, thrownError) {
             var message = xhr.responseJSON.error;
             addFlash('danger', 'The worker couldn\'t be deleted: ' + message);
-		}
-	});
+        }
+    });
 }

--- a/lib/OpenQA/Events.pm
+++ b/lib/OpenQA/Events.pm
@@ -18,18 +18,18 @@ use Mojo::Base 'Mojo::EventEmitter';
 
 sub singleton { state $events = shift->SUPER::new }
 
-# emits an event via singleton
+# emits an event allowing to pass the usual arguments via named parameter
 # note: Supposed to be used from non-controller context. Use the equally named helper
 #       to emit events from a controller.
 sub emit_event {
-    my ($type, %args) = @_;
+    my ($self, $type, %args) = @_;
     die 'missing event type' unless $type;
 
     my $data       = $args{data};
     my $user_id    = $args{user_id};
     my $connection = $args{connection};
 
-    return singleton->emit($type, [$user_id, $connection, $type, $data]);
+    return $self->emit($type, [$user_id, $connection, $type, $data]);
 }
 
 1;

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -236,7 +236,7 @@ sub _schedule_iso {
             # Prefer new build jobs over old ones either by cancelling old
             # ones or deprioritizing them (up to a limit)
             try {
-                OpenQA::Events::emit_event(
+                OpenQA::Events->singleton->emit_event(
                     'openqa_iso_cancel',
                     data    => {scheduled_product_id => $self->id},
                     user_id => $user_id
@@ -333,7 +333,7 @@ sub _schedule_iso {
 
     # emit events
     for my $succjob (@successful_job_ids) {
-        OpenQA::Events::emit_event('openqa_job_create', data => {id => $succjob}, user_id => $user_id);
+        OpenQA::Events->singleton->emit_event('openqa_job_create', data => {id => $succjob}, user_id => $user_id);
     }
 
     wakeup_scheduler;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -233,7 +233,7 @@ sub delete {
 
     eval { $worker->delete };
     if ($@) {
-        return $self->render(json => {error => $@}, status => 402);
+        return $self->render(json => {error => $@}, status => 409);
     }
     $message = "Delete worker " . $worker->name . " successfully.";
     $self->emit_event('openqa_worker_delete', {id => $worker->id, name => $worker->name});


### PR DESCRIPTION
* Make OpenQA::Events::emit_event a non-static member function: https://github.com/os-autoinst/openQA/pull/2036/files/e5bcd1a5fdc391ce44bd909d582b93753e9ac1c8#r271654290
* Fix 2 details of https://github.com/os-autoinst/openQA/pull/2027 (indentation and HTTP status code).

---

@Amrysliu So keep in mind that `script/tidy` does not work for JavaScript (the function you've added had tabs and spaces mixed).

Unfortunately that are not the only bugs in the PR for deleting workers. But I've left the remaining issues for you:

* The line `$(deleteLink).parent().parent().remove();` does not really work. If you use the pagination or basically any data tables feature the row will be inserted again. You have to use the data tables API: https://datatables.net/reference/api/row().remove()
* I'd also use a font-awesome icon instead of a text link (of course 'Delete' should be a tool-tip then).