### PR TITLE
Clone only the latest revision of the SLE needles

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -58,8 +58,13 @@ fi
 /usr/share/openqa/script/fetchneedles
 
 if ping -c1 gitlab.suse.de. ; then
+        sles_needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git"
+        sles_needles_directory="/var/lib/openqa/tests/opensuse/products/sle/needles"
 	# clone SLE needles if run from within SUSE network
-	[ -d /var/lib/openqa/tests/opensuse/products/sle/needles ] || git clone --depth 1 https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git /var/lib/openqa/tests/opensuse/products/sle/needles
+	if [ -d $sles_needles_directory ]; then
+		echo "cloning $sles_needles_giturl shallow. Call 'git fetch --unshallow' for full history"
+                git clone --depth 1 "$sles_needles_giturl" "$sles_needles_directory"
+        fi
 	chown -R $dbuser: /var/lib/openqa/tests/opensuse/products/sle/needles
 fi
 

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -59,7 +59,7 @@ fi
 
 if ping -c1 gitlab.suse.de. ; then
 	# clone SLE needles if run from within SUSE network
-	[ -d /var/lib/openqa/tests/opensuse/products/sle/needles ] || git clone https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git /var/lib/openqa/tests/opensuse/products/sle/needles
+	[ -d /var/lib/openqa/tests/opensuse/products/sle/needles ] || git clone --depth 1 https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git /var/lib/openqa/tests/opensuse/products/sle/needles
 	chown -R $dbuser: /var/lib/openqa/tests/opensuse/products/sle/needles
 fi
 


### PR DESCRIPTION
Pulling the full repository is slower and requires more disk space than using shallow pull.

`$ time git clone --depth 1 https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git`
Cloning into 'os-autoinst-needles-sles'...
remote: Counting objects: 17155, done.
remote: Compressing objects: 100% (15213/15213), done.
remote: Total 17155 (delta 2040), reused 16509 (delta 1942)
Receiving objects: 100% (17155/17155), 683.02 MiB | 910.00 KiB/s, done.
Resolving deltas: 100% (2040/2040), done.
Checking out files: 100% (17588/17588), done.

**real	12m58.397s**
user	0m43.839s
sys	0m23.478s

`$ time git clone  https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git os-autoinst-needles-sles-full`
Cloning into 'os-autoinst-needles-sles-full'...
remote: Counting objects: 51293, done.
remote: Compressing objects: 100% (34665/34665), done.
remote: Total 51293 (delta 16950), reused 50675 (delta 16628)
Receiving objects: 100% (51293/51293), 1.14 GiB | 863.00 KiB/s, done.
Resolving deltas: 100% (16950/16950), done.
Checking out files: 100% (17588/17588), done.

**real	24m20.721s**
user	2m5.960s
sys	0m29.608s

` $ du -h --max-depth 1 os-autoinst-needles-sles/`
686M	os-autoinst-needles-sles/.git
0	os-autoinst-needles-sles/tests
**1.5G	os-autoinst-needles-sles/**

`$ du -h --max-depth 1 os-autoinst-needles-sles-full/`
1.2G	os-autoinst-needles-sles-full/.git
0	os-autoinst-needles-sles-full/tests
**2.0G	os-autoinst-needles-sles-full/**
