### PR TITLE
Fix the remaining issues of deleting workers

### DIFF
--- a/assets/javascripts/admin_worker.js
+++ b/assets/javascripts/admin_worker.js
@@ -63,14 +63,15 @@ function loadWorkerTable() {
   });
 }
 
-function deleteWorker(deleteLink){
-    var post_url = $(deleteLink).attr("post_delete_url");
+function deleteWorker(deleteBtn){
+    var post_url = $(deleteBtn).attr("post_delete_url");
     $.ajax({
         url: post_url,
         method: 'DELETE',
         dataType: 'json',
         success: function(data) {
-            $(deleteLink).parent().parent().remove();
+            var table = $("#workers").DataTable();
+            table.row($(deleteBtn).parents('tr')).remove().draw();
             addFlash('info', data.message);
         },
         error: function(xhr, ajaxOptions, thrownError) {

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -120,8 +120,8 @@ subtest 'worker overview' => sub {
     is($driver->find_element("tr#worker_$broken_worker_id .action")->get_text(), '', 'foo do not show delete button');
     is($driver->find_element("tr#worker_$online_worker_id .action")->get_text(),
         '', 'online_test do not show delete button');
-    is($driver->find_element("tr#worker_$offline_worker_id .action")->get_text(),
-        'Delete', 'offline worker show delete button');
+    is($driver->find_element("tr#worker_$offline_worker_id .action .btn")->is_displayed(),
+        1, 'offline worker show delete button');
 
     # check worker 1
     is($driver->find_element('tr#worker_1 .worker')->get_text(), 'localhost:1', 'localhost:1 shown');
@@ -151,7 +151,7 @@ subtest 'worker overview' => sub {
 
 # test delete offline worker function
 subtest 'delete offline worker' => sub {
-    $driver->find_element("tr#worker_$offline_worker_id .action a")->click();
+    $driver->find_element("tr#worker_$offline_worker_id .btn")->click();
     is(
         $driver->find_element("div#flash-messages .alert span")->get_text(),
         'Delete worker offline_test:1 successfully.',

--- a/templates/admin/workers/index.html.ep
+++ b/templates/admin/workers/index.html.ep
@@ -78,9 +78,7 @@
                         </td>
                         <td class='action'>
                             % if($is_admin == 1 && ($worker->{status} eq 'dead' && !$worker->{job})){
-                                <a href='#' post_delete_url="<%= url_for('apiv1_worker_delete', worker_id => $worker->{id}) %>" onclick="deleteWorker(this);">
-                                    Delete
-                                </a>
+                                <button class='btn' type='submit' alt='Delete' title='Delete' post_delete_url="<%= url_for('apiv1_worker_delete', worker_id => $worker->{id}) %>" onclick='deleteWorker(this)'><i class="fa fa-trash-alt"></i></button>
                             % }
                         </td>
                     </tr>


### PR DESCRIPTION
1. Use row(tr).remove.draw() instead of $(tr).remove(),
    as it might remove the specified row from the DataTable completely.

2. Use a icon to replace the delete text link.

fixes: progress#48791

Signed-off-by: Liu Xiaojing <xiaojing.liu@suse.com>