### PR TITLE
Inherit specified settings when create job with 'Jobs post'

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -563,38 +563,23 @@ sub _generate_jobs {
 
             # variable expansion
             # replace %NAME% with $settings{NAME}
-            my $expanded;
-            do {
-                $expanded = 0;
-                for my $var (keys %settings) {
-                    my $val = $settings{$var};
-                    next unless ($val && $val =~ /(%\w+%)/);
-                    my $replace_var = $1;
-                    $replace_var =~ s/^%(\w+)%$/$1/;
-                    my $replace_val = $settings{$replace_var};
-                    next unless (defined $replace_val);
-                    $replace_val = '' if $replace_var eq $var;    #stop infinite recursion
-                    $val =~ s/%${replace_var}%/$replace_val/g;
-                    $settings{$var} = $val;
-                    $expanded = 1;
-                }
-            } while ($expanded);
+            my $new_settings = OpenQA::Utils::reset_settings(\%settings);
 
-            if (!$args->{MACHINE} || $args->{MACHINE} eq $settings{MACHINE}) {
+            if (!$args->{MACHINE} || $args->{MACHINE} eq $new_settings->{MACHINE}) {
                 if (!@tests) {
-                    $wanted{_settings_key(\%settings)} = 1;
+                    $wanted{_settings_key($new_settings)} = 1;
                 }
                 else {
                     foreach my $test (@tests) {
-                        if ($test eq $settings{TEST}) {
-                            $wanted{_settings_key(\%settings)} = 1;
+                        if ($test eq $new_settings->{TEST}) {
+                            $wanted{_settings_key($new_settings)} = 1;
                             last;
                         }
                     }
                 }
             }
 
-            push @$ret, \%settings;
+            push @$ret, $new_settings;
         }
     }
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -1313,5 +1313,30 @@ sub any_array_item_contained_by_hash {
     return 0;
 }
 
+#replace %NAME% with $settings{NAME}
+sub reset_settings {
+    my ($settings) = @_;
+
+    for my $value (values %$settings) {
+        if (defined $value) {
+            $value =~ s/(%\w+%)/_replace($settings, $1)/eig;
+        }
+    }
+    return $settings;
+}
+
+#only used in reset_settings method
+sub _replace {
+    my ($settings, $param) = @_;
+
+    my $key = $param;
+    $key =~ s/%//g;
+
+    if (defined $settings->{$key}) {
+        return $settings->{$key};
+    }
+    return $param;
+}
+
 1;
 # vim: set sw=4 et:

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -639,7 +639,7 @@ is_deeply(
 );
 
 my %jobs_post_params = (
-    iso     => 'openSUSE-Tumbleweed-DVD-x86_64-Current.iso',
+    iso     => 'openSUSE-%VERSION%-%FLAVOR%-x86_64-Current.iso',
     DISTRI  => 'opensuse',
     VERSION => 'Tumbleweed',
     FLAVOR  => 'DVD',


### PR DESCRIPTION
When creating job with 'Job post', job is capable to inherit settings
from Machine and Product if Machine and Product are specified.

The parameter 'TEST' is mandatory, so job can inherit settings from
the specified testsuit.

fixes: https://progress.opensuse.org/issues/20464

Signed-off-by: Liu Xiaojing <xiaojing.liu@suse.com>