### PR TITLE
 Allow authenticated calls to the github api 

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -7,6 +7,10 @@
 #  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6529 https://openqa.opensuse.org/tests/835060 DESKTOP=textmode
 #
 set -o pipefail
+if [ -n $GITHUB_TOKEN ]; then
+    AUTHENTICATED_REQUEST=" -u $GITHUB_TOKEN:x-oauth-basic "
+    echo "Token provided ${AUTHENTICATED_REQUEST}"
+fi
 if [ -z ${repo_name+x} ] || [ -z ${pr+x} ]; then
     pr_url="${1:?"Need 'pr_url' as parameter pointing to a github pull request or 'repo_name' (sending repo) and 'pr' variables, e.g. either 'https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1234' 'me/os-autoinst-distri-opensuse' and '1234'"}"
     target_repo_part=${pr_url%%/pull*}
@@ -19,8 +23,15 @@ if [ -z ${host+x} ] || [ -z ${job+x} ]; then
 fi
 
 if [ -z ${branch+x} ] || [ -z ${repo_name+x} ]; then
-    pr_content=$(curl -s ${target_repo_part/github.com/api.github.com/repos}/pulls/$pr)
+    pr_content=$(curl ${AUTHENTICATED_REQUEST} -s ${target_repo_part/github.com/api.github.com/repos}/pulls/$pr)
     label=$(echo $pr_content | jq -r '.head.label')
+    if [ "${label}" == "null" ]; then
+        echo "Github API rate limit might have been exceeded. If this is the case, generate one at
+        https://github.com/settings/tokens and then export it as an environment variable"
+        echo 'export GITHUB_TOKEN=foobar'
+        echo "Github reply: " $( echo ${pr_content} | jq -r '.message')
+        exit 1
+    fi
     repo_name="${repo_name:-"${label%:*}/${target_repo_part##*/}"}"
     branch="${branch:-"${label##*:}"}"
     repo="${repo:-"https://github.com/${repo_name}.git"}"


### PR DESCRIPTION
Avoid cases where the Custom git ref spec script fails to get details on the pull request due to rate limiting on the github api and creating tests that will inevitably fail

[sle-15-SP1-Installer-DVD-aarch64-Buildnull_os-autoinst-distri-opensuse_7330-extra_tests_in_textmode@null_os-autoinst-distri-opensuse_null@aarch64](https://openqa.suse.de/tests/2828324).