### PR TITLE
Skip UEFI_PFLASH_VARS asset when UEFI is disabled

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -119,6 +119,8 @@ sub cache_assets {
     for my $this_asset (sort keys %$assetkeys) {
         my $asset;
         my $asset_uri = trim($vars->{$this_asset});
+        # Skip UEFI_PFLASH_VARS asset if the job won't use UEFI.
+        next if (($this_asset eq 'UEFI_PFLASH_VARS') and !$vars->{UEFI});
         log_debug("Found $this_asset, caching " . $vars->{$this_asset});
 
         # check cache availability


### PR DESCRIPTION
Caching of the UEFI_PFLASH_VARS is often causing mixed messages to test
reviewers, as it will sometimes not be used and thus was declared non
critical on #1737 and #1732