### PR TITLE
Make containers non-x86 archs friendly and update to leap 15.1

### DIFF
--- a/docker/openqa_data/Dockerfile
+++ b/docker/openqa_data/Dockerfile
@@ -1,6 +1,6 @@
-FROM opensuse:42.2
+FROM opensuse/leap:15.1
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
-LABEL version="0.2"
+LABEL version="0.3"
 
 RUN zypper --non-interactive in ca-certificates-mozilla git wget
 

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -1,9 +1,9 @@
-FROM opensuse:42.2
+FROM opensuse/leap:15.1
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
-LABEL version="0.2"
+LABEL version="0.3"
 
-RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_42.2 openQA && \
-    zypper ar -f obs://devel:openQA:Leap:42.2/openSUSE_Leap_42.2 openQA-perl-modules && \
+RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.1 openQA && \
+    zypper ar -f obs://devel:openQA:Leap:15.1/openSUSE_Leap_15.1 openQA-perl-modules && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in ca-certificates-mozilla curl && \
     zypper --non-interactive in --force-resolution openQA apache2 hostname which w3m

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,15 +1,15 @@
-FROM opensuse:42.2
+FROM opensuse/leap:15.1
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
-LABEL version="0.2"
+LABEL version="0.3"
 
-RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_42.2 openQA && \
-    zypper ar -f obs://devel:openQA:Leap:42.2/openSUSE_Leap_42.2 openQA-perl-modules && \
-    zypper ar -f obs://Virtualization/openSUSE_Leap_42.2 Virtualization && \
+RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.1 openQA && \
+    zypper ar -f obs://devel:openQA:Leap:15.1/openSUSE_Leap_15.1 openQA-perl-modules && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in ca-certificates-mozilla curl && \
-    zypper --non-interactive in openQA-worker qemu-kvm && \
+    zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 && \
     zypper --non-interactive in kmod && \
-    zypper --non-interactive in --from Virtualization qemu-ovmf-x86_64
+    (zypper --non-interactive in qemu-ovmf-x86_64 || true) && \
+    (zypper --non-interactive in qemu-uefi-aarch64 || true)
 
 # set-up qemu
 RUN mkdir -p /root/qemu

--- a/docker/worker/kvm-mknod.sh
+++ b/docker/worker/kvm-mknod.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-lsmod | grep '\<kvm\>' > /dev/null || {
+test $(gunzip -c /proc/config.gz | grep CONFIG_KVM=y) || lsmod | grep '\<kvm\>' > /dev/null || {
   echo >&2 "KVM module not loaded; software emulation will be used"
   exit 1
 }

--- a/script/openqa-bootstrap-container
+++ b/script/openqa-bootstrap-container
@@ -14,7 +14,13 @@ set -x
 CONTAINER_NAME="openqa1"
 CONTAINER_PATH="/var/lib/machines/${CONTAINER_NAME}"
 
-DEFAULT_REPO="${DEFAULT_REPO:="http://download.opensuse.org/tumbleweed/repo/oss/"}"
+ARCH="${ARCH:=$(arch)}"
+if [ "$ARCH" = "x86_64" ]; then
+    DEFAULT_REPO="${DEFAULT_REPO:="http://download.opensuse.org/tumbleweed/repo/oss/"}"
+else
+    DEFAULT_REPO="${DEFAULT_REPO:="http://download.opensuse.org/ports/$ARCH/tumbleweed/repo/oss/"}"
+fi
+
 PKGS_TO_INSTALL="aaa_base systemd shadow zypper openSUSE-release vim iproute2 iputils openQA-local-db openQA-worker sudo apache2 net-tools curl wget ca-certificates-mozilla qemu-arm qemu-ppc qemu-x86 openQA-bootstrap"
 
 zypper -n install systemd-container
@@ -56,7 +62,7 @@ EOF
 
 if [ ! -d $CONTAINER_PATH ] ; then
     mkdir -p $CONTAINER_PATH
-    zypper -n --root $CONTAINER_PATH addrepo $DEFAULT_REPO defaultrepo
+    zypper -n --root $CONTAINER_PATH addrepo "$DEFAULT_REPO" defaultrepo
     zypper -n --root $CONTAINER_PATH --gpg-auto-import-keys refresh
     # There are non-fatal errors when zyppering inside chroot, so ignoring errors on the next line
     # Allow command line options without quotes


### PR DESCRIPTION
`script/openqa-bootstrap-container` has been tested successfully on aarch64.
