### PR TITLE
Add an own result jobs which exceeded the timeout

### DIFF
--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -88,6 +88,7 @@ div.flags {
 .fa.module_skipped { color: $color-module-skipped; }
 .fa.result_failed, .fa.result_fail {color: $color-failed; }
 .fa.result_incomplete { color: $color-incomplete; }
+.fa.result_timeout_exceeded { color: $color-incomplete; }
 .fa.result_none { color: $color-module-none; }
 .fa.result_obsoleted { color: $color-module-none; }
 .fa.result_parallel_failed { color: $color-module-none; }

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -153,8 +153,15 @@ following list.
   that workaround needles are in place, a softfailure has been recorded explicitly
   via +record_soft_failure+ (from os-autoinst) or a job failure has been ignored
   explicitly via a <<UsersGuide.asciidoc#https://github.com/os-autoinst/openQA/blob/master/docs/UsersGuide.asciidoc#show-bug-or-label-icon-on-overview-if-labeled-gh550,job label>>.
-* *incomplete* The job is no longer running but no result was provided. Either
-  it was cancelled while running or it crashed.
+* *timeout_exceeded* The job was aborted because +MAX_JOB_TIME+ was exceeded, which is
+  by default two hours.
+* *skipped* Dependencies failed so the job was not started.
+* *obsoleted* The job was superseded by scheduling a new product.
+* *parallel_failed*/*parallel_restarted* The job could not continue because a job
+  which is supposed to run in parallel failed or was restarted.
+* *user_cancelled*/*user_restarted* The job was cancelled/restarted by the user.
+* *incomplete* The test execution failed due to an unexpected error, e.g. the network
+  connection to the worker was lost.
 
 Sometimes, the reason of a failure is not an error in the tested operating system
 itself, but an outdated test or a problem in the execution of the job for some

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -55,6 +55,7 @@ sub count_job {
             return;
         }
         if (   $job->result eq OpenQA::Jobs::Constants::FAILED
+            || $job->result eq OpenQA::Jobs::Constants::TIMEOUT_EXCEEDED
             || $job->result eq OpenQA::Jobs::Constants::INCOMPLETE)
         {
             $jr->{failed}++;
@@ -65,6 +66,7 @@ sub count_job {
             $jr->{skipped}++;
             return;
         }
+        # note: Incompletes and timeouts are accounted to both categories - failed and skipped.
     }
     if (   $job->state eq OpenQA::Jobs::Constants::CANCELLED
         || $job->state eq OpenQA::Jobs::Constants::OBSOLETED)

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -33,14 +33,16 @@ use constant {
     PARALLEL_RESTARTED => 'parallel_restarted',          # parallel job was restarted, this job has to be restarted too
     USER_CANCELLED     => 'user_cancelled',              # cancelled by user via job_cancel
     USER_RESTARTED     => 'user_restarted',              # restarted by user via job_restart
+    TIMEOUT_EXCEEDED   => 'timeout_exceeded',            # killed by the worker after MAX_JOB_TIME has been exceeded
 };
 use constant RESULTS => (NONE, PASSED, SOFTFAILED, FAILED, INCOMPLETE, SKIPPED,
-    OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED
+    OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED, TIMEOUT_EXCEEDED
 );
 use constant COMPLETE_RESULTS => (PASSED, SOFTFAILED, FAILED);
 use constant OK_RESULTS       => (PASSED, SOFTFAILED);
-use constant INCOMPLETE_RESULTS =>
-  (INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED, PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED);
+use constant INCOMPLETE_RESULTS => (INCOMPLETE, SKIPPED, OBSOLETED, PARALLEL_FAILED,
+    PARALLEL_RESTARTED, USER_CANCELLED, USER_RESTARTED, TIMEOUT_EXCEEDED
+);
 use constant NOT_OK_RESULTS => (INCOMPLETE_RESULTS, FAILED);
 use constant MODULE_RESULTS => (CANCELLED, FAILED, NONE, PASSED, RUNNING, SKIPPED, SOFTFAILED);
 

--- a/lib/OpenQA/Schema/Result/JobNextPrevious.pm
+++ b/lib/OpenQA/Schema/Result/JobNextPrevious.pm
@@ -36,7 +36,7 @@ __PACKAGE__->result_source_instance->view_definition(
     WITH allofjobs AS(
     SELECT me.*
     FROM jobs me WHERE me.state=?
-    AND me.result NOT IN (?, ?, ?, ?, ?, ?, ?)
+    AND me.result NOT IN (?, ?, ?, ?, ?, ?, ?, ?)
     AND me.DISTRI=? AND me.VERSION=? AND me.FLAVOR=? AND me.ARCH=?
     AND me.TEST=? AND me.MACHINE=?
     )

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -183,7 +183,7 @@ sub register {
     $app->helper(is_admin_js => sub { Mojo::ByteStream->new(shift->helpers->is_admin ? 'true' : 'false') });
 
     $app->helper(
-        # CSS class for a job or module based on its result
+        # CSS class for a test module based on its result
         css_for => sub {
             my ($c, $hash) = @_;
             return unless $hash;

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -107,7 +107,7 @@ sub wait_for_result_panel {
     for (my $count = 0; $count < ((3 * 60) / $refresh_interval); $count++) {
         my $status_text = $driver->find_element('#result-row .card-body')->get_text();
         last if ($status_text =~ $result_panel);
-        if ($fail_on_incomplete && $status_text =~ qr/Result: incomplete/) {
+        if ($fail_on_incomplete && $status_text =~ qr/Result: (incomplete|timeout_exceeded)/) {
             fail('test result is incomplete but shouldn\'t');
             return;
         }

--- a/templates/test/list.html.ep
+++ b/templates/test/list.html.ep
@@ -60,6 +60,7 @@
                     <option value="parallel_restarted">Parallel restarted</option>
                     <option value="user_cancelled">User cancelled</option>
                     <option value="user_restarted">User restarted</option>
+                    <option value="timeout_exceeded">Timeout exceeded</option>
                 </select>
             </div>
     </div>


### PR DESCRIPTION
This change aims to treat those jobs still like incomplete jobs. It makes it only more obvious in the web UI that the timeout exceeded.

See https://progress.opensuse.org/issues/50225