### PR TITLE
Fix comparision of cluster ID for dependency graph

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -736,7 +736,7 @@ sub _add_dependency_to_graph {
     if ($job1_cluster_id && $job2_cluster_id) {
         # both jobs are already part of a cluster: merge clusters unless they're already the same
         push(@{$cluster->{$job1_cluster_id}}, @{delete $cluster_by_job->{$job2_cluster_id}})
-          unless $job1_cluster_id == $job2_cluster_id;
+          unless $job1_cluster_id eq $job2_cluster_id;
     }
     elsif ($job1_cluster_id) {
         # only job1 is already in a cluster: move job2 into that cluster, too


### PR DESCRIPTION
Those IDs are not numerical so 'eq' must be used.

This is a 'spin off' of https://github.com/os-autoinst/openQA/pull/2067 because it makes sense to merge this tiny change soon so the dependency graph always works as expected and does not produce any Perl warnings on the log.