### PR TITLE
Modify workaround property to support adding reason

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -253,14 +253,8 @@ sub edit {
     $screenshot->{tags} = $screenshot->{area} = $screenshot->{matches} = [];
     unshift(@needles, $screenshot);
 
-    # stash properties
-    my $properties = {};
-    for my $property (@{$default_needle->{properties}}) {
-        $properties->{$property} = $property;
-    }
     $self->stash('needles',        \@needles);
     $self->stash('tags',           $tags);
-    $self->stash('properties',     $properties);
     $self->stash('default_needle', $default_needle);
     $self->stash('error_messages', \@error_messages);
     $self->render('step/edit');

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -96,6 +96,8 @@ like bugref_to_href('boo#2345,poo#3456'),
   'interpunctation is not consumed by href';
 is bugref_to_href('jsc#SLE-3275'), '<a href="https://jira.suse.de/browse/SLE-3275">jsc#SLE-3275</a>';
 is href_to_bugref('https://jira.suse.de/browse/FOOBAR-1234'), 'jsc#FOOBAR-1234', 'jira tickets url to bugref';
+is find_bug_number('yast_roleconf-ntp-servers-empty-bsc1114818-20181115.png'), 'bsc1114818',
+  'find the bug number from the needle name';
 
 my $t3 = {
     bar => {

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -134,8 +134,10 @@ sub add_needle_tag(;$) {
 
 sub add_workaround_property() {
     $driver->find_element_by_id('property_workaround')->click();
+    $driver->find_element_by_id('input_workaround_desc')->send_keys('bsc#123456 - this is a test');
     wait_for_ajax;
-    is($driver->find_element_by_id('property_workaround')->is_selected(), 1, "workaround property selected");
+    is($driver->find_element_by_id('property_workaround')->is_selected(),    1, 'workaround property selected');
+    is($driver->find_element_by_id('input_workaround_desc')->is_displayed(), 1, 'workaround description displayed');
 }
 
 sub create_needle {
@@ -304,7 +306,8 @@ subtest 'Needle editor layout' => sub {
     is($driver->find_element_by_xpath('//input[@value="inst-timezone"]')->is_selected(), 1, "tag selected");
 
     # workaround property isn't selected
-    is($driver->find_element_by_id('property_workaround')->is_selected(), 0, "workaround property unselected");
+    is($driver->find_element_by_id('property_workaround')->is_selected(),    0, 'workaround property unselected');
+    is($driver->find_element_by_id('input_workaround_desc')->is_displayed(), 0, 'workaround description not displayed');
 
     $elem            = $driver->find_element_by_id('needleeditor_textarea');
     $decode_textarea = decode_json($elem->get_value());
@@ -465,7 +468,13 @@ subtest 'New needle instantly visible after reloading needle editor' => sub {
     $based_on_option->[0]->click();
     is($driver->find_element_by_id('tag_inst-timezone')->is_selected(),
         1, 'tag_inst-timezone checked again via new needle');
-
+    is($driver->find_element_by_id('property_workaround')->is_selected(),    1, 'workaround property selected');
+    is($driver->find_element_by_id('input_workaround_desc')->is_displayed(), 1, 'workaround description displayed');
+    is(
+        $driver->find_element_by_id('input_workaround_desc')->get_value(),
+        'bsc#123456 - this is a test',
+        'workaround description is shown'
+    );
     # check selecting/displaying image
     my $current_image_script = 'return nEditor.bgImage.src;';
     my $current_image        = $driver->execute_script($current_image_script);

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -140,15 +140,17 @@
                             </p>
                             <p>
                                 <!-- lists the specific properties -->
-                                <input type="checkbox" name="workaround" id="property_workaround"
-                                        %= 'checked' if $properties->{workaround}
-                                        >
+                                <input type="checkbox" name="workaround" id="property_workaround" >
                                 <label for="property_workaround">workaround</label>
                                 <%= help_popover('Help for the workaround property' =>
                                     'If a needle with the workaround property matches the match result is recorded as
-                                    a \'soft-fail\'. It is suggested to mark the reason for this choice in either the
-                                    name of the needle (e.g. my-name-bsc1234-20161224) or with special tags')
+                                    a \'soft-fail\'. It is suggested to input the reason in the \'Description\' textbox(e.g. bsc#12345 - summary of ticket).')
                                 %>
+                                <span id="workaround_reason" style="display:none;">
+                                    <br/>
+                                    <label for="input_workaround_desc">Description:</label>
+                                    <input tupe="input" name="workaround_desc" id="input_workaround_desc" class="form-control" value="">
+                                </span>
                             </p>
                         </div>
                         <div id="needle_editor_save_buttons">


### PR DESCRIPTION
See https://progress.opensuse.org/issues/33706

By now we recommend adding related ticket number in needle name
when tester create a new needle with workaround property.
Modify the code to support adding workaround reason when create
needles with workaround property.