### PR TITLE
Support job template parameter in dump_templates and load_templates

### DIFF
--- a/lib/OpenQA/Schema/Result/JobTemplates.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplates.pm
@@ -59,27 +59,6 @@ __PACKAGE__->has_many(
 
 =over 4
 
-=item settings_hash()
-
-Returns a hash with the assigned settings.
-
-=back
-
-=cut
-
-sub settings_hash {
-    my ($self) = @_;
-
-    my $settings = $self->settings;
-    my %settings_hash;
-    while (my $setting = $settings->next) {
-        $settings_hash{$setting->key} = $setting->value;
-    }
-    return \%settings_hash;
-}
-
-=over 4
-
 =item to_hash()
 
 Creates a hash for the job template including testsuite, machine and product details
@@ -97,7 +76,7 @@ sub to_hash {
     my $machine    = $self->machine;
     my $test_suite = $self->test_suite;
     my $group      = $self->group;
-    my $settings   = $self->settings_hash;
+    my @settings   = sort { $a->key cmp $b->key } $self->settings;
 
     my %result = (
         id         => $self->id,
@@ -120,7 +99,9 @@ sub to_hash {
             name => $test_suite->name,
         },
     );
-    $result{settings} = $settings if (%$settings);
+    if (@settings) {
+        $result{settings} = [map { {key => $_->key, value => $_->value} } @settings];
+    }
 
     return \%result;
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -393,7 +393,8 @@ sub startup {
     $api_public_r->get('job_templates')->name('apiv1_job_templates')->to('job_template#list');
     $api_ra->post('job_templates')->to('job_template#create');
     $api_public_r->get('job_templates/:job_template_id')->name('apiv1_job_template')->to('job_template#list');
-    $api_ra->delete('job_templates/:job_template_id')->to('job_template#destroy');
+    $api_ra->put('job_templates/<job_template_id:num>')->to('job_template#update_properties');
+    $api_ra->delete('job_templates/<job_template_id:num>')->to('job_template#destroy');
 
     # api/v1/job_templates_scheduling
     $api_public_r->get('experimental/job_templates_scheduling/<id:num>')->name('apiv1_job_templates_schedules')

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -158,8 +158,8 @@ sub get_job_groups {
                 $test_suite{priority} = $template->prio;
             }
 
-            my $settings = $template->settings_hash;
-            $test_suite{settings} = $settings if %$settings;
+            my %settings = map { $_->key => $_->value } $template->settings;
+            $test_suite{settings} = \%settings if %settings;
 
             my $test_suites = $group{architectures}{$template->product->arch}{$template->product->name};
             push @$test_suites, {$template->test_suite->name => \%test_suite};

--- a/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
+++ b/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
@@ -61,6 +61,9 @@ sub register {
 
                     $self->stash(hparams => $ret);
                 }
+                else {
+                    $self->stash(hparams => {});
+                }
             }
             else {
                 $self->stash(hparams => {});

--- a/lib/OpenQA/WebAPI/TableHelper.pm
+++ b/lib/OpenQA/WebAPI/TableHelper.pm
@@ -1,0 +1,57 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::WebAPI::TableHelper;
+
+use strict;
+use warnings;
+
+sub prepare_settings {
+    my ($settings_hparams) = @_;
+
+    my @settings;
+    my @keys;
+    if ($settings_hparams) {
+        for my $k (keys %$settings_hparams) {
+            push(@settings, {key => $k, value => $settings_hparams->{$k}});
+            push(@keys, $k);
+        }
+    }
+    return {
+        settings => \@settings,
+        keys     => \@keys,
+    };
+}
+
+sub update_settings {
+    my ($settings, $dbix_result) = @_;
+
+    for my $var (@{$settings->{settings}}) {
+        $dbix_result->update_or_create_related(settings => $var);
+    }
+    $dbix_result->delete_related(settings => {key => {'not in' => $settings->{keys}}});
+}
+
+1;
+
+=encoding utf-8
+
+=head1 NAME
+
+OpenQA::WebAPI::TableHelper - Defines helper used by OpenQA::WebAPI::Controller::API::V1::Table
+and OpenQA::WebAPI::Controller::API::V1::JobTemplate
+
+=cut

--- a/script/load_templates
+++ b/script/load_templates
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -133,6 +133,9 @@ sub print_error {
     if ($res->body) {
         dd($res->json || $res->body);
     }
+    if ($url) {
+        print("requested URL was: $url\n");
+    }
 }
 
 sub post_entry {
@@ -185,8 +188,7 @@ sub post_entry {
     if (!$options{'clean'}) {    # with --clean the entry should not exist at this point, no need to check
         my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table))->query(%param))->res;
         if ($res->code == 200 && @{$res->json->{$table}} == 1 && $res->json->{$table}[0]{id}) {
-            if ($options{'update'} && $table ne 'JobTemplates')
-            {                    # there is nothing to update in JobTemplates, the entry just exists or not
+            if ($options{'update'}) {
                 my $id = $res->json->{$table}[0]{id};
                 my $res
                   = $client->put($url->path($options{'apibase'} . '/' . decamelize($table) . "/$id")->query(%param))
@@ -198,7 +200,7 @@ sub post_entry {
                 return 1;
             }
             else {
-                return 0;        # already exists
+                return 0;    # already exists
             }
         }
     }


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/46673
* See particular commit messages

---

Although this requires relatively many changes I think we should continue to support these scripts. The new API route has its unit tests. The export, first-time import and re-import have been tested manually with OSD data.

This also lets me think about supporting parent groups within those scripts.