### PR TITLE
Require YAML::XS >= 0.67

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -92,7 +92,7 @@ RUN zypper in -y -C \
        'perl(Mojolicious::Plugin::AssetPack)' \
        'perl(Mojolicious::Plugin::RenderFile)' \
        'perl(JSON::Validator)' \
-       'perl(YAML::XS)' \
+       'perl(YAML::XS) >= 0.67' \
        'perl(Net::DBus)' \
        'perl(Net::OpenID::Consumer)' \
        'perl(Net::SNMP)' \

--- a/openQA.spec
+++ b/openQA.spec
@@ -63,6 +63,7 @@ BuildRequires:  rubygem(sass)
 Requires:       dbus-1
 Requires:       perl(Minion) >= 9.09
 Requires:       perl(Mojo::RabbitMQ::Client) >= 0.2
+Requires:       perl(YAML::XS) >= 0.67
 # needed for test suite
 Requires:       git-core
 Requires:       openQA-client = %{version}


### PR DESCRIPTION
When trying to preview/validate YAML in the editor on osd, the following error message can be seen:

    [JSON::Validator] The optional YAML::XS module is missing or could not be loaded:
    YAML::XS version 0.67 required--this is only version 0.38 at (eval 33558) line 1.
    BEGIN failed--compilation aborted at (eval 33558) line 1.

![Screenshot from 2019-05-17 10-08-26](https://user-images.githubusercontent.com/1204189/57912942-cefd3a00-788b-11e9-944a-8474baf9da89.png)
