### PR TITLE
Prevent accessing comment label without check for undef

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -1030,7 +1030,8 @@ sub mark_job_linked {
         my $found    = 0;
         my $comments = $job->comments;
         while (my $comment = $comments->next) {
-            if ($comment->label eq 'linked') {
+            my $label = $comment->label;
+            if ($label && $label eq 'linked') {
                 $found = 1;
                 last;
             }

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -517,8 +517,9 @@ sub job_is_linked {
     my ($job) = @_;
     $job->discard_changes;
     my $comments = $job->comments;
-    while (my $c = $comments->next) {
-        if ($c->label eq 'linked') {
+    while (my $comment = $comments->next) {
+        my $label = $comment->label;
+        if ($label && $label eq 'linked') {
             return 1;
         }
     }


### PR DESCRIPTION
See https://progress.opensuse.org/issues/51749