### PR TITLE
[WIP] Add tar to apparmor profile to fix poo#52022

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -77,6 +77,7 @@
   /usr/bin/flock rix,
   /usr/bin/git rix,
   /usr/bin/gzip rix,
+  /usr/bin/tar rix,
   /usr/bin/head rix,
   /usr/bin/icewm-default rix,
   /usr/bin/ionice rix,


### PR DESCRIPTION
With https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7527 we introduced to use `tar` on the worker. 
This fails on https://openqa.opensuse.org/tests/942637#step/before_test/76 in case of apparmor.
