### PR TITLE
Expand Machine and Medium Type settings when creating job with 'jobs post'

### DIFF
--- a/lib/OpenQA/ExpandPlaceholder.pm
+++ b/lib/OpenQA/ExpandPlaceholder.pm
@@ -1,0 +1,53 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+package OpenQA::ExpandPlaceholder;
+
+use strict;
+use warnings;
+
+# replace %NAME% with $settings{NAME}
+sub expand_placeholders {
+    my ($settings) = @_;
+
+    for my $value (values %$settings) {
+        next unless defined $value;
+
+        my %visited_top_level_placeholders;
+
+        eval { $value =~ s/%(\w+)%/_expand_placeholder($settings, $1, \%visited_top_level_placeholders)/eg; };
+        if ($@) {
+            return "Error: $@";
+        }
+    }
+    return undef;
+}
+
+sub _expand_placeholder {
+    my ($settings, $key, $visited_placeholders_in_parent_scope) = @_;
+
+    return '' unless defined $settings->{$key};
+
+    my %visited_placeholders = %$visited_placeholders_in_parent_scope;
+    if ($visited_placeholders{$key}++) {
+        die "The key $key contains a circular reference, its value is $settings->{$key}.\n";
+    }
+
+    my $value = $settings->{$key};
+    $value =~ s/%(\w+)%/_expand_placeholder($settings, $1, \%visited_placeholders)/eg;
+
+    return $value;
+}
+
+1;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -1111,4 +1111,23 @@ subtest 're-schedule product' => sub {
     is_deeply($json->{settings}, \%scheduling_params, 'parameter idential to the original scheduled product');
 };
 
+subtest 'circular reference' => sub {
+    $res = schedule_iso(
+        {
+            ISO      => $iso,
+            DISTRI   => 'opensuse',
+            VERSION  => '13.1',
+            FLAVOR   => 'DVD',
+            ARCH     => 'i586',
+            ISO      => 'openSUSE-13.1-DVD-i586-Build%BUILD%-Media.iso',
+            TEST     => 'textmode',
+            BUILD    => '%BUILD_HA%',
+            BUILD_HA => '%BUILD%'
+        },
+        400
+    );
+    like($res->json->{error}, qr/The key (\w+) contains a circular reference, its value is %\w+%/,
+        'circular reference');
+};
+
 done_testing();


### PR DESCRIPTION
When users created jobs using 'client jobs post', the jobs settings did
not expand Machine and Medium Type settings. This PR is used to support
to expand settings from Machine and Medium Type when creating jobs with
'jobs post'.

See: https://progress.opensuse.org/issues/20464
Related: https://progress.opensuse.org/issues/51479