### PR TITLE
Don't log jobtemplate_create event if in preview mode

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -375,7 +375,7 @@ sub update {
             return;
         }
 
-        $self->emit_event('openqa_jobtemplate_create', $json);
+        $self->emit_event('openqa_jobtemplate_create', $json) unless $self->param('preview');
         $self->respond_to(json => {json => $json});
 
         # Process only one group


### PR DESCRIPTION
See https://progress.opensuse.org/issues/52490

---

This does not implement the issue but prevents the immediate problem of polluting the database. Besides, it makes no sense to log events which didn't happen for real.