### PR TITLE
apparmor: Fix worker startup on openSUSE Leap 15.1

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -156,6 +156,7 @@
   profile /usr/bin/lscpu {
     #include <abstractions/base>
 
+    /proc/ r,
     /proc/** r,
     /sys/devices/** r,
     /usr/bin/lscpu mr,


### PR DESCRIPTION
After upgrading the o3 aarch64 worker the workers failed to startup due
to `lspci` failing to read /proc/cpuinfo as access to /proc/ was denied.

Profile tested locally on aarch64.o.o.

Related progress issue: https://progress.opensuse.org/issues/50453