### PR TITLE
Don't run isotovideo with -d

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -318,7 +318,7 @@ sub engine_workit {
             STDOUT->fdopen($handle, 'w');
             STDERR->fdopen($handle, 'w');
 
-            exec "perl", "$isotovideo", '-d';
+            exec "perl", "$isotovideo";
             die "exec failed: $!\n";
         });
 


### PR DESCRIPTION
Isotovideo writes its logfile on its own
and -d will result in double loglines

https://progress.opensuse.org/issues/52235