### PR TITLE
spec: Fix Perl::Tidy mismatch in build tests

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -220,6 +220,7 @@ make %{?_smp_mflags}
 %check
 #for double checking
 %if %{with tests}
+sed -i '/Perl::Tidy/d' cpanfile
 cpanm --installdeps --with-feature=test .
 %endif
 


### PR DESCRIPTION
Patch out Perl::Tidy dependency in spec-file to prevent mismatch in
build tests as we are not calling "tidy" during build-time anyway.

Fixes problems as observed in
https://build.opensuse.org/package/live_build_log/devel:openQA:tested/openQA/openSUSE_Factory/x86_64

```
[  191s] ! Couldn't find module or a distribution Perl::Tidy (== 20181120)
[  191s] ! Installing the dependencies failed: Installed version (20190601) of Perl::Tidy is not in range '== 20181120'
```

Tested locally by overwriting the spec-file of an OBS checkout.