### PR TITLE
Remove tidy from spec file

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -101,7 +101,6 @@ BuildRequires:  perl-App-cpanminus
 BuildRequires:  perl(DBD::SQLite)
 BuildRequires:  perl(Perl::Critic)
 BuildRequires:  perl(Perl::Critic::Freenode)
-BuildRequires:  perl(Perl::Tidy)
 BuildRequires:  perl(Selenium::Remote::Driver) >= 1.20
 BuildRequires:  perl(Test::Compile)
 BuildRequires:  perl(Test::MockObject)


### PR DESCRIPTION
It is no longer required since the it has been patched out from the CPAN file.