### PR TITLE
Provide the script `openqa-clone-job` already in source

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -232,19 +232,20 @@ Basics are described in the
 
 === Triggering tests
 
-Tests can be triggered over multiple ways, using `clone_job.pl`, `jobs post`,
-`isos post` as well as retriggering existing jobs or whole media over the web
-UI.
+Tests can be triggered over multiple ways, using `openqa-clone-job`,
+`jobs post`, `isos post` as well as retriggering existing jobs or whole media
+over the web UI.
 
 
-==== Cloning existing jobs - clone_job.pl ====
+==== Cloning existing jobs - openqa-clone-job ====
 
 If one wants to recreate an existing job from any publically available openQA
-instance the script `clone_job.pl` can be used to copy the necessary settings
-and assets to another instance and schedule the test. For the test to be
-executed it has to be ensured that matching ressources can be found, for
+instance the script `openqa-clone-job` can be used to copy the necessary
+settings and assets to another instance and schedule the test. For the test to
+be executed it has to be ensured that matching ressources can be found, for
 example a worker with matching `WORKER_CLASS` must be registered. More details
-on `clone_job.pl` can be found in <<WritingTests.asciidoc#writingtests,Writing Tests>>.
+on `openqa-clone-job` can be found in
+<<WritingTests.asciidoc#writingtests,Writing Tests>>.
 
 
 ==== Spawning single new jobs - jobs post ====

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1157,13 +1157,13 @@ stop them outputting non-printable characters.
 To trigger new tests with custom settings the command line client
 +openqa-client+ can be used. To trigger new tests relying on all settings from
 existing tests runs but modifying specific settings the +openqa-clone-job+
-script can be used. Within the openQA repository the script is called
-+clone_job.pl+ and is located at +/usr/share/openqa/script/+.  This tool can
-be used to create a new job that adds, removes or changes settings.
+script can be used. Within the openQA repository the script is located at
++/usr/share/openqa/script/+.  This tool can be used to create a new job that
+adds, removes or changes settings.
 
 [source,sh]
 --------------------------------------------------------------------------------
-/usr/share/openqa/script/clone_job.pl --from localhost --host localhost 42 FOO=bar BAZ=
+openqa-clone-job --from localhost --host localhost 42 FOO=bar BAZ=
 --------------------------------------------------------------------------------
 
 If you do not want a cloned job to start up in the same job group as the job
@@ -1173,7 +1173,7 @@ name, e.g.:
 
 [source,sh]
 -------------
-clone_job.pl --from localhost 42 _GROUP="openSUSE Tumbleweed"
+openqa-clone-job --from localhost 42 _GROUP="openSUSE Tumbleweed"
 -------------
 
 The special group value +0+ means that the group connection will be separated
@@ -1181,7 +1181,7 @@ and the job will not appear as a job in any job group, e.g.:
 
 [source,sh]
 -------------
-clone_job.pl --from localhost 42 _GROUP=0
+openqa-clone-job --from localhost 42 _GROUP=0
 -------------
 
 === Backend variables for faster test execution
@@ -1236,14 +1236,15 @@ existing job and adding the setting:
 
 [source,sh]
 ----
-clone_job.pl --from https://openqa.opensuse.org  --host localhost 24 MAKETESTSNAPSHOTS=1
+openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 MAKETESTSNAPSHOTS=1
 ----
 
-* Create a job again, this time setting the +SKIPTO+ variable to the snapshot you need. Again, +clone_job.pl+ comes handy here:
+* Create a job again, this time setting the +SKIPTO+ variable to the snapshot
+* you need. Again, +openqa-clone-job+ comes handy here:
 
 [source,sh]
 ----
-clone_job.pl --from https://openqa.opensuse.org  --host localhost 24 SKIPTO=consoletest-yast2_i
+openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 SKIPTO=consoletest-yast2_i
 ----
 
 * Use qemu-img snapshot -l something.img to find out what snapshots are in the image. Snapshots are named
@@ -1257,7 +1258,7 @@ successful test module run. Snapshots are overwritten. The snapshot is named `la
 
 [source,sh]
 ----
-clone_job.pl --from https://openqa.opensuse.org  --host localhost 24 TESTDEBUG=1
+openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 TESTDEBUG=1
 ----
 
 * Create a job again, this time setting the +SKIPTO+ variable to the snapshot
@@ -1267,7 +1268,7 @@ the clone source job or specifying the variable explicitly:
 
 [source,sh]
 ----
-clone_job.pl --from https://openqa.opensuse.org  --host localhost 24 TESTDEBUG=1 SKIPTO=consoletest-yast2_i
+openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 TESTDEBUG=1 SKIPTO=consoletest-yast2_i
 ----
 
 === Defining a custom test schedule or custom test modules

--- a/openQA.spec
+++ b/openQA.spec
@@ -247,7 +247,7 @@ ln -s %{_sysconfdir}/openqa/openqa.ini %{buildroot}%{_datadir}/openqa%{_sysconfd
 ln -s %{_sysconfdir}/openqa/database.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 mkdir -p %{buildroot}%{_bindir}
 ln -s %{_datadir}/openqa/script/client %{buildroot}%{_bindir}/openqa-client
-ln -s %{_datadir}/openqa/script/clone_job.pl %{buildroot}%{_bindir}/openqa-clone-job
+ln -s %{_datadir}/openqa/script/openqa-clone-job %{buildroot}%{_bindir}/openqa-clone-job
 ln -s %{_datadir}/openqa/script/dump_templates %{buildroot}%{_bindir}/openqa-dump-templates
 ln -s %{_datadir}/openqa/script/load_templates %{buildroot}%{_bindir}/openqa-load-templates
 ln -s %{_datadir}/openqa/script/openqa-clone-custom-git-refspec %{buildroot}%{_bindir}/openqa-clone-custom-git-refspec
@@ -474,6 +474,7 @@ fi
 %{_datadir}/openqa/script/clone_job.pl
 %{_datadir}/openqa/script/dump_templates
 %{_datadir}/openqa/script/load_templates
+%{_datadir}/openqa/script/openqa-clone-job
 %{_datadir}/openqa/script/openqa-clone-custom-git-refspec
 %dir %{_datadir}/openqa/lib
 %{_datadir}/openqa/lib/OpenQA/Client.pm

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -1,0 +1,1 @@
+./clone_job.pl


### PR DESCRIPTION
By providing a nicer script name already in source we can also reference
that path in the documentation. In before the script link
`openqa-clone-job` was only provided in the openSUSE package.

I verified the openSUSE package build locally.