### PR TITLE
Cache: Fix missing download progress output and warning

### DIFF
--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -132,7 +132,7 @@ sub download_asset {
                         $last_updated = time;
                         if ($progress < $current) {
                             $progress = $current;
-                            log_debug("CACHE: Downloading $asset: ", $size == $len ? 100 : $progress . "%");
+                            log_debug("CACHE: Downloading $asset: " . ($size == $len ? 100 : $progress) . "%");
                         }
                     }
                 });


### PR DESCRIPTION
Fixes a regression introduced by 4f546904. See
https://openqa.suse.de/tests/2956457/file/autoinst-log.txt for an
example of the problem.
