### PR TITLE
Treat IPv4 and IPv6 the same for localhost authentication

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -67,6 +67,8 @@ sub startup {
     $self->secrets(['nosecretshere']);
     $self->config->{no_localhost_auth} ||= 1;
 
+    $self->plugin('OpenQA::Shared::Plugin::Helpers');
+
     # The reactor interval might be set to 1 ms in case the scheduler has been woken up by the
     # web UI (In this case it is important to set it back to OpenQA::Scheduler::SCHEDULE_TICK_MS)
     OpenQA::Scheduler::Model::Jobs->singleton->on(

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -25,10 +25,7 @@ sub check {
 
     my $req = $self->req;
     if ($self->app->config->{no_localhost_auth}) {
-
-        # IPv4 and IPv6 should be treated the same
-        my $address = $self->tx->remote_address;
-        return 1 if $address eq '127.0.0.1' || $address eq '::1';
+        return 1 if $self->is_local_request;
     }
 
     my $headers   = $req->headers;

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -25,7 +25,10 @@ sub check {
 
     my $req = $self->req;
     if ($self->app->config->{no_localhost_auth}) {
-        return 1 if $self->tx->remote_address eq '127.0.0.1';
+
+        # IPv4 and IPv6 should be treated the same
+        my $address = $self->tx->remote_address;
+        return 1 if $address eq '127.0.0.1' || $address eq '::1';
     }
 
     my $headers   = $req->headers;

--- a/lib/OpenQA/Shared/Plugin/Helpers.pm
+++ b/lib/OpenQA/Shared/Plugin/Helpers.pm
@@ -1,0 +1,34 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::Shared::Plugin::Helpers;
+use Mojo::Base 'Mojolicious::Plugin';
+
+sub register {
+    my ($self, $app) = @_;
+
+    $app->helper(is_local_request => \&_is_local_request);
+}
+
+sub _is_local_request {
+    my $c = shift;
+
+    # IPv4 and IPv6 should be treated the same
+    my $address = $c->tx->remote_address;
+    return $address eq '127.0.0.1' || $address eq '::1';
+}
+
+1;

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -36,6 +36,7 @@ sub startup {
 
     push @{$self->plugins->namespaces}, 'OpenQA::WebSockets::Plugin';
     $self->plugin('Helpers');
+    $self->plugin('OpenQA::Shared::Plugin::Helpers');
 
     my $r = $self->routes;
     $r->namespaces(['OpenQA::WebSockets::Controller', 'OpenQA::Shared::Controller']);

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -48,6 +48,14 @@ subtest 'Authentication' => sub {
         OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton)
     )->app($app);
     $t->get_ok('/')->status_is(200)->json_is({name => $app->defaults('appname')});
+
+    my $c = $t->app->build_controller;
+    $c->tx->remote_address('127.0.0.1');
+    ok $c->is_local_request, 'is localhost';
+    $c->tx->remote_address('::1');
+    ok $c->is_local_request, 'is localhost';
+    $c->tx->remote_address('192.168.2.1');
+    ok !$c->is_local_request, 'not localhost';
 };
 
 subtest 'API' => sub {


### PR DESCRIPTION
This is a quick fix for the problem where the scheduler and websocket servers required an API key for localhost IPC if IPv6 was used instead of IPv4.