### PR TITLE
Add support for OPENQA_BASE_PORT environment variable

### DIFF
--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -93,9 +93,7 @@ sub startup {
     OpenQA::Setup::setup_validator_check_for_datetime($self);
 }
 
-sub run {
-    Mojolicious::Commands->start_app('OpenQA::LiveHandler');
-}
+sub run { __PACKAGE__->new->start }
 
 sub schema { OpenQA::Schema->singleton }
 

--- a/lib/OpenQA/Scheduler/Client.pm
+++ b/lib/OpenQA/Scheduler/Client.pm
@@ -17,10 +17,10 @@ package OpenQA::Scheduler::Client;
 use Mojo::Base -base;
 
 use OpenQA::Client;
-use OpenQA::Scheduler;
+use OpenQA::Utils 'service_port';
 
 has client => sub { OpenQA::Client->new(api => 'localhost') };
-has port   => 9529;
+has port   => sub { service_port('scheduler') };
 
 sub wakeup {
     my ($self, $worker_id) = @_;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -458,12 +458,8 @@ sub startup {
         });
 }
 
-sub run {
-    # Start command line interface for application
-    Mojolicious::Commands->start_app('OpenQA::WebAPI');
-}
-
 sub schema { OpenQA::Schema->singleton }
 
+sub run { __PACKAGE__->new->start }
+
 1;
-# vim: set sw=4 et:

--- a/lib/OpenQA/WebSockets/Client.pm
+++ b/lib/OpenQA/WebSockets/Client.pm
@@ -19,10 +19,10 @@ use Mojo::Base -base;
 use Mojo::Server::Daemon;
 use Carp 'croak';
 use OpenQA::Client;
-use OpenQA::WebSockets;
+use OpenQA::Utils 'service_port';
 
 has client => sub { OpenQA::Client->new(api => 'localhost') };
-has port   => 9527;
+has port   => sub { service_port('websocket') };
 
 sub embed_server_for_testing {
     my $self = shift;

--- a/script/openqa
+++ b/script/openqa
@@ -15,22 +15,21 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use FindBin;
 BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
 
-$ENV{'MOJO_LISTEN'} ||= 'http://localhost:9526/';
+use OpenQA::WebAPI;
+use OpenQA::Utils qw(service_port set_listen_address);
 
 # allow up to 20GB - hdd images
 $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
 $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
+
 # the default is EV, and this heavily screws with our children handling
 $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
 
-use OpenQA::WebAPI;
-
+set_listen_address(service_port('webui'));
 OpenQA::WebAPI::run;
 
-# vim: set sw=4 sts=4 et:

--- a/script/openqa-livehandler
+++ b/script/openqa-livehandler
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018 SUSE Linux GmbH
+# Copyright (C) 2018-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,28 +15,16 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use FindBin;
 BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
 
-# listen only locally on port 9528 (preferably on both - IPv4 and IPv6)
-use OpenQA::Utils;
-set_listen_address(9528);
+use OpenQA::LiveHandler;
+use OpenQA::Utils qw(service_port set_listen_address);
 
 # ensure the web socket connection won't timeout
 $ENV{MOJO_INACTIVITY_TIMEOUT} ||= 15 * 60;
 
-use OpenQA::LiveHandler;
-
-# prevent use of prefork command
-my $first_arg = $ARGV[0];
-if ($first_arg && $first_arg eq 'prefork') {
-    print STDERR "Can't use prefork for openqa-livehandler.\n";
-    exit -1;
-}
-
+set_listen_address(service_port('livehandler'));
 OpenQA::LiveHandler::run;
-
-# vim: set sw=4 sts=4 et:

--- a/script/openqa-scheduler
+++ b/script/openqa-scheduler
@@ -15,30 +15,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use FindBin;
-use Mojo::Home;
-BEGIN {
-    unshift @INC, "$FindBin::Bin/../lib";
-    if (!$ENV{MOJO_HOME}) {
-        # override default home as Mojo gets it wrong for our sub apps
-        # This 'require' is here because the 'home detect' method
-        # relies on %INC, which is only populated when the module is
-        # loaded: see #870 and #876
-        require OpenQA::Utils;
-        $ENV{MOJO_HOME} = Mojo::Home->new->detect('OpenQA::Utils');
-    }
-}
+BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
 
-# listen only locally on port 9529 (preferably on both - IPv4 and IPv6)
-use OpenQA::Utils;
-set_listen_address(9529);
-
-use OpenQA::Schema;
 use OpenQA::Scheduler;
+use OpenQA::Utils qw(service_port set_listen_address);
 
+set_listen_address(service_port('scheduler'));
 OpenQA::Scheduler::run;
-
-# vim: set sw=4 sts=4 et:

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,32 +15,16 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use FindBin;
-use Mojo::Home;
-BEGIN {
-    unshift @INC, "$FindBin::Bin/../lib";
-    if (!$ENV{MOJO_HOME}) {
-        # override default home as Mojo gets it wrong for our sub apps
-        # This 'require' is here because the 'home detect' method
-        # relies on %INC, which is only populated when the module is
-        # loaded: see #870 and #876
-        require OpenQA::Utils;
-        $ENV{MOJO_HOME} = Mojo::Home->new->detect('OpenQA::Utils');
-    }
-}
+BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
 
-# listen only locally on port 9527 (preferably on both - IPv4 and IPv6)
-use OpenQA::Utils;
-set_listen_address(9527);
+use OpenQA::WebSockets;
+use OpenQA::Utils qw(service_port set_listen_address);
 
 # allow up to 20GB - hdd images
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 1024 * 1024 * 1024 * 20;
 
-use OpenQA::WebSockets;
-
+set_listen_address(service_port('websocket'));
 OpenQA::WebSockets::run;
-
-# vim: set sw=4 sts=4 et:

--- a/systemd/openqa-scheduler.service
+++ b/systemd/openqa-scheduler.service
@@ -5,7 +5,7 @@ Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-scheduler
+ExecStart=/usr/share/openqa/script/openqa-scheduler daemon -m production
 TimeoutStopSec=120
 
 [Install]

--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -7,7 +7,7 @@ After=openqa-scheduler.service postgresql.service network.target openqa-setup-db
 [Service]
 # TODO: define whether we want to run the websockets with the same user
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-websockets
+ExecStart=/usr/share/openqa/script/openqa-websockets daemon -m production
 
 [Install]
 WantedBy=multi-user.target

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -31,6 +31,29 @@ use Test::More;
 use Scalar::Util 'reftype';
 use Mojo::File qw(path tempdir tempfile);
 
+subtest 'service ports' => sub {
+    local $ENV{OPENQA_BASE_PORT} = undef;
+    is service_port('webui'),       9526, 'webui port';
+    is service_port('websocket'),   9527, 'websocket port';
+    is service_port('livehandler'), 9528, 'livehandler port';
+    is service_port('scheduler'),   9529, 'scheduler port';
+    local $ENV{OPENQA_BASE_PORT} = 9530;
+    is service_port('webui'),       9530, 'webui port';
+    is service_port('websocket'),   9531, 'websocket port';
+    is service_port('livehandler'), 9532, 'livehandler port';
+    is service_port('scheduler'),   9533, 'scheduler port';
+    eval { service_port('unknown') };
+    like $@, qr/Unknown service: unknown/, 'unknown port';
+};
+
+subtest 'set listen address' => sub {
+    local $ENV{MOJO_LISTEN} = undef;
+    set_listen_address(9526);
+    like $ENV{MOJO_LISTEN}, qr/127\.0\.0\.1:9526/, 'address set';
+    set_listen_address(9527);
+    unlike $ENV{MOJO_LISTEN}, qr/127\.0\.0\.1:9527/, 'not changed';
+};
+
 is bugurl('bsc#1234'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bug url is properly expanded';
 ok find_bugref('gh#os-autoinst/openQA#1234'), 'github bugref is recognized';
 is(find_bugref('bsc#1234 poo#4321'), 'bsc#1234', 'first bugres found');

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -13,7 +13,9 @@ use OpenQA::Worker::Common;
 use Config::IniFiles;
 use Data::Dumper 'Dumper';
 use OpenQA::Utils qw(log_error log_info log_debug);
+use OpenQA::WebSockets;
 use OpenQA::WebSockets::Client;
+use OpenQA::Scheduler;
 use OpenQA::Scheduler::Client;
 use Mojo::Home;
 use Mojo::File 'path';
@@ -209,6 +211,7 @@ sub create_websocket_server {
         }
         monkey_patch 'OpenQA::WebSockets::Plugin::Helpers', _workers_checker => sub { 1 }
           if ($noworkercheck);
+        local @ARGV = ('daemon');
         OpenQA::WebSockets::run;
         Devel::Cover::report() if Devel::Cover->can('report');
         _exit(0);
@@ -240,7 +243,7 @@ sub create_scheduler {
     if ($pid == 0) {
         local $ENV{MOJO_LISTEN}             = "http://127.0.0.1:$port";
         local $ENV{MOJO_INACTIVITY_TIMEOUT} = 9999;
-
+        local @ARGV                         = ('daemon');
         OpenQA::Scheduler::run;
         Devel::Cover::report() if Devel::Cover->can('report');
         _exit(0);


### PR DESCRIPTION
This PR makes all our micro services on the webui side use the `OPENQA_BASE_PORT` environment variable. Allowing for multiple webui instances to run on the same host.

Additionally the websocket and scheduler services also use the Mojolicious command system consistently with the other services now. So the tooling available (routes command and the like) as well as configuration options for systemd task files are all the same.

Progress: https://progress.opensuse.org/issues/52685