### PR TITLE
Expose saving of YAML templates and hide the legacy UI

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -408,7 +408,9 @@ sub update {
 
                 # Preview mode: Get the expected YAML and rollback the result
                 if ($self->param('preview')) {
+                    $job_group->update({template => ''});
                     $json->{template} = $self->get_job_groups($group_id)->{$job_group->name};
+                    $json->{preview}  = int($self->param('preview'));
                     $self->schema->txn_rollback;
                 }
                 else {

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -464,28 +464,6 @@ subtest 'job property editor' => sub() {
         is($driver->find_element_by_id('editor-carry-over-bugrefs')->is_selected(), 0, 'bug carry over disabled');
         is($driver->find_element_by_id('editor-description')->get_value(), 'Test group', 'description added');
     };
-
-    subtest 'edit the yaml' => sub() {
-        $driver->refresh();
-        my $form = $driver->find_element_by_id('editor-form');
-        ok($form->is_hidden(), 'editor form is hidden');
-        $driver->find_element_by_id('toggle-yaml-editor')->click();
-        wait_for_ajax;
-        ok($form->is_displayed(),                             'editor form is shown');
-        ok($form->child('.progress-indication')->is_hidden(), 'spinner is hidden');
-        my $yaml = $driver->execute_script('return editor.doc.getValue();');
-        ok($yaml =~ m/scenarios:/, 'YAML was fetched') or diag explain $yaml;
-        $driver->find_element_by_id('update-template')->click();
-        my $result = $form->child('.result');
-        wait_for_ajax;
-        ok($result->get_text() =~ m/Preview of the YAML/, 'preview shown') or diag explain $result->get_text();
-
-        # Make the YAML invalid
-        $driver->execute_script('editor.doc.setValue("invalid: true");');
-        $driver->find_element_by_id('update-template')->click();
-        wait_for_ajax;
-        ok($result->get_text() =~ m/There was a problem applying the changes/, 'error shown');
-    };
 };
 
 sub is_element_text {
@@ -573,6 +551,40 @@ subtest 'edit media' => sub() {
     javascript_console_has_no_warnings_or_errors;
     my @picks = $driver->find_elements('.search-choice');
     is_element_text(\@picks, [qw(64bit 64bit HURRA)], 'chosen tests present');
+};
+
+subtest 'edit the yaml' => sub() {
+    $driver->refresh();
+    my $form = $driver->find_element_by_id('editor-form');
+    ok($form->is_hidden(), 'editor form is hidden');
+    $driver->find_element_by_id('toggle-yaml-editor')->click();
+    wait_for_ajax;
+    ok($form->is_displayed(),                             'editor form is shown');
+    ok($form->child('.progress-indication')->is_hidden(), 'spinner is hidden');
+    my $yaml = $driver->execute_script('return editor.doc.getValue();');
+    ok($yaml =~ m/scenarios:/, 'YAML was fetched') or diag explain $yaml;
+    # Preview
+    $driver->find_element_by_id('preview-template')->click();
+    my $result = $form->child('.result');
+    wait_for_ajax;
+    ok($result->get_text() =~ m/Preview of the YAML/, 'preview shown') or diag explain $result->get_text();
+
+    # Save
+    $driver->find_element_by_id('save-template')->click();
+    $result = $form->child('.result');
+    wait_for_ajax;
+    ok($result->get_text() =~ m/YAML saved!/, 'saving confirmed') or diag explain $result->get_text();
+
+    # Legacy UI is hidden and no longer available
+    ok($driver->find_element_by_id('toggle-yaml-editor')->is_hidden(), 'editor toggle hidden');
+    ok($driver->find_element_by_id('media')->is_hidden(),              'media editor hidden');
+    ok($driver->find_element_by_id('media-add')->is_hidden(),          'media add button hidden');
+
+    # Make the YAML invalid
+    $driver->execute_script('editor.doc.setValue("invalid: true");');
+    $driver->find_element_by_id('preview-template')->click();
+    wait_for_ajax;
+    ok($result->get_text() =~ m/There was a problem applying the changes/, 'error shown');
 };
 
 sub get_cell_contents {

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -15,12 +15,20 @@
         false
     % }
     ;
-    setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>);
+    % if ($group->template) {
+        toggleTemplateEditor();
+    % }
+    % else {
+        setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>);
+    % }
+    $('#preview-template').click(function() { submitTemplateEditor(1); });
+    $('#save-template').click(function() { submitTemplateEditor(0); });
 % end
 
 <div class="row">
     <div class="col-sm-12">
         <form action="<%= url_for('admin_groups') %>" class="corner-buttons">
+            % if (!$group->template) {
             <button type="button" id="toggle-yaml-editor" class="btn btn-default" onclick="toggleTemplateEditor();">
                 <span>
                     <i class="fas fa-edit"></i>
@@ -32,6 +40,7 @@
                     % }
                 </span>
             </button>
+            % }
             <button type="button" id="toggle-group-properties" class="btn btn-default" onclick="toggleEdit();">
                 <span>
                     <i class="fas fa-edit"></i>
@@ -60,39 +69,41 @@
             <span id="job-group-name"><%= $group->name %></span>
         </h2>
         %= include 'layouts/info'
-        %= include 'admin/group/group_property_editor', group => $group, is_parent => 0
-        <div id="media">
-            <p id="loading"><i class="fa fa-spinner fa-spin"></i> Loading…</p>
+        % if (!$group->template) {
+            %= include 'admin/group/group_property_editor', group => $group, is_parent => 0
+            <div id="media">
+                <p id="loading"><i class="fa fa-spinner fa-spin"></i> Loading…</p>
 
-            <select id="machines-template" multiple="true"
-                % if (! is_admin ) {
-                    disabled
-                % }
-                data-placeholder="None" style="display: none">
-                % for my $machine (@$machines) {
-                    <option value="<%= $machine->name %>"
-                            data-machine-id="<%= $machine->id %>" >
-                        %= $machine->name
-                    </option>
-                % }
-            </select>
+                <select id="machines-template" multiple="true"
+                    % if (! is_admin ) {
+                        disabled
+                    % }
+                    data-placeholder="None" style="display: none">
+                    % for my $machine (@$machines) {
+                        <option value="<%= $machine->name %>"
+                                data-machine-id="<%= $machine->id %>" >
+                            %= $machine->name
+                        </option>
+                    % }
+                </select>
 
-            <select id="tests-template"
-                % if (! is_admin ) {
-                    disabled
-                % }
-                style="display: none">
-                <option value="">Select…</option>
-                % for my $test (@$tests) {
-                    <option value="<%= $test->name %>" data-test-id="<%= $test->id %>">
-                        %= $test->name
-                    </option>
-                % }
-            </select>
+                <select id="tests-template"
+                    % if (! is_admin ) {
+                        disabled
+                    % }
+                    style="display: none">
+                    <option value="">Select…</option>
+                    % for my $test (@$tests) {
+                        <option value="<%= $test->name %>" data-test-id="<%= $test->id %>">
+                            %= $test->name
+                        </option>
+                    % }
+                </select>
 
-        </div>
-        <form action="#" id="editor-form" class="form-horizontal" style="display: none;" onsubmit="return submitTemplateEditor();"
-          data-put-url="<%= url_for('apiv1_job_templates_schedules' => (id => $group->id)) %>">
+            </div>
+        % }
+        <form action="#" id="editor-form" class="form-horizontal" style="display: none;"
+              data-put-url="<%= url_for('apiv1_job_templates_schedules' => (id => $group->id)) %>" data-reference="<%= $group->template %>">
             <div class="form-group row">
                 <label for="editor-template" class="col-sm-4 control-label">
                     <div id="editor-yaml-guide">
@@ -143,7 +154,8 @@ scenarios:
                 <div class="col-sm-8">
                     <p class="buttons">
                     % if (is_admin) {
-                    <button id="update-template" type="submit" class="btn btn-primary"><i class="fas fa-update"></i>Preview changes</button>
+                        <button id="preview-template" type="button" class="btn btn-secondary"><i class="fas fa-preview"></i>Preview changes</button>
+                        <button id="save-template" type="button" class="btn btn-primary"><i class="fas fa-save"></i>Save changes</button>
                     % }
                     </p>
                     <p class="progress-indication">
@@ -155,9 +167,9 @@ scenarios:
             </div>
         </form>
 
-        % if (is_admin) {
+        % if (!$group->template && is_admin) {
             <p>
-                %= link_to url_for('job_group_new_media', groupid => $group->id) => begin
+                %= link_to url_for('job_group_new_media', groupid => $group->id), id =>  'media-add', begin
                     <i class="fa fa-plus-square"></i> Test new medium as part of this group
                 % end
             </p>


### PR DESCRIPTION
- Expose Save button in the UI
- Hide legacy UI when YAML is/was stored
- Handle conflicts via the `reference` feature (no diff here, just a simple error)

![Screenshot from 2019-06-18 11-21-54](https://user-images.githubusercontent.com/1204189/59669906-51468a00-91bb-11e9-8ee0-a7d847306577.png)

Prerequisite: #2103 

Fixes: [poo#54146](https://progress.opensuse.org/issues/54146)