### PR TITLE
Lock test suites in YAML-based groups for manual updates and deletion

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -41,7 +41,7 @@ function templateRemoved(chosen, deselected) {
     var jid = chosen.find('option[value="' + deselected + '"]').data('jid');
     $.ajax({url: job_templates_url + "/" + jid,
         type: 'DELETE',
-        dataType: 'json'}).done(function() { highlightChosen(chosen); });
+        dataType: 'json'}).done(function() { highlightChosen(chosen); }).fail(addFailed);
 }
 
 function addFailed(data) {

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -933,6 +933,21 @@ subtest 'References' => sub {
       || diag explain $t->tx->res->body;
 };
 
+# Test suites which are part of a group managed in YAML can't be modified manually
+ok($opensuse->template, 'Group ' . $opensuse->name . ' is managed in YAML');
+# set priority for particular test suite
+$t->post_ok(
+    '/api/v1/job_templates',
+    form => {
+        group_id      => $opensuse->id,
+        test_suite_id => 1002,
+        prio          => 15,
+        prio_only     => 1,
+    })->status_is(400, 'Attempt to modify priority was blocked');
+
+$t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(400, 'Attempt to delete was blocked');
+$opensuse->update({template => undef});
+
 $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(200);
 $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(404);
 


### PR DESCRIPTION
Updating or deleting test suites which are associated with a group managed in a YAML template should be an error.

- `create` and `destroy` render an error if a YAML template is set
- Deletion of templates needs to handle errors

Follow-up for: #2103