### PR TITLE
Prevent blank line in worker caching output

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -137,8 +137,9 @@ sub cache_assets {
         if ($asset_request->enqueue) {
             log_debug("Downloading " . $asset_uri . " - request sent to Cache Service.", channels => 'autoinst');
             update_setup_status and sleep 5 until $asset_request->processed;
-            log_debug("Download of " . $asset_uri . " processed", channels => 'autoinst');
-            log_debug($asset_request->output,                     channels => 'autoinst');
+            my $msg = "Download of $asset_uri processed";
+            if (my $output = $asset_request->output) { $msg .= ": $output" }
+            log_debug($msg, channels => 'autoinst');
         }
 
         $asset = $cache_client->asset_path($current_host, $asset_uri)


### PR DESCRIPTION
Normally `$asset_request->output` would be empty causing output in the
log file like in
https://openqa.opensuse.org/tests/962019/file/autoinst-log.txt

```
[2019-06-18T08:53:00.0081 CEST] [debug] Downloading opensuse-Tumbleweed-aarch64-20190614-textmode@aarch64.qcow2 - request sent to Cache Service.
[2019-06-18T08:53:05.0141 CEST] [debug] Download of opensuse-Tumbleweed-aarch64-20190614-textmode@aarch64.qcow2 processed
[2019-06-18T08:53:05.0145 CEST] [debug]
[2019-06-18T08:53:05.0169 CEST] [debug] Downloading openSUSE-Tumbleweed-DVD-aarch64-Snapshot20190614-Media.iso - request sent to Cache Service.
[2019-06-18T08:53:10.0218 CEST] [debug] Download of openSUSE-Tumbleweed-DVD-aarch64-Snapshot20190614-Media.iso processed
[2019-06-18T08:53:10.0221 CEST] [debug]
```

This can be prevented by only providing the output if it is non-empty.