### PR TITLE
Rename architectures to scenarios

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -138,8 +138,8 @@ sub get_job_groups {
           ->search({group_id => $group->id}, {order_by => 'me.test_suite_id'});
 
         # Always set the hash of test suites to account for empty groups
-        $group{architectures} = {};
-        $group{products}      = {};
+        $group{scenarios} = {};
+        $group{products}  = {};
 
         my %machines;
         # Extract products and tests per architecture
@@ -161,21 +161,21 @@ sub get_job_groups {
             my $settings = $template->settings_hash;
             $test_suite{settings} = $settings if %$settings;
 
-            my $test_suites = $group{architectures}{$template->product->arch}{$template->product->name};
+            my $test_suites = $group{scenarios}{$template->product->arch}{$template->product->name};
             push @$test_suites, {$template->test_suite->name => \%test_suite};
-            $group{architectures}{$template->product->arch}{$template->product->name} = $test_suites;
+            $group{scenarios}{$template->product->arch}{$template->product->name} = $test_suites;
         }
 
         # Split off defaults
-        foreach my $arch (keys %{$group{architectures}}) {
+        foreach my $arch (keys %{$group{scenarios}}) {
             $group{defaults}{$arch}{priority} = $group->default_priority;
             my $default_machine
               = (sort { $machines{$arch}->{$b} <=> $machines{$arch}->{$a} or $b cmp $a } keys %{$machines{$arch}})[0];
             $group{defaults}{$arch}{machine} = $default_machine;
 
-            foreach my $product (keys %{$group{architectures}->{$arch}}) {
+            foreach my $product (keys %{$group{scenarios}->{$arch}}) {
                 my @test_suites;
-                foreach my $test_suite (@{$group{architectures}->{$arch}->{$product}}) {
+                foreach my $test_suite (@{$group{scenarios}->{$arch}->{$product}}) {
                     foreach my $name (keys %$test_suite) {
                         my $attr = $test_suite->{$name};
                         if ($attr->{machine} eq $default_machine) {
@@ -190,7 +190,7 @@ sub get_job_groups {
                         }
                     }
                 }
-                $group{architectures}{$arch}{$product} = \@test_suites;
+                $group{scenarios}{$arch}{$product} = \@test_suites;
             }
         }
 
@@ -285,7 +285,7 @@ sub update {
                 # Add/update job templates from YAML data
                 # (create test suites if not already present, fail if referenced machine and product is missing)
                 my @job_template_ids;
-                my $yaml_archs    = $yaml->{architectures};
+                my $yaml_archs    = $yaml->{scenarios};
                 my $yaml_products = $yaml->{products};
                 my $yaml_defaults = $yaml->{defaults};
                 foreach my $arch (keys %$yaml_archs) {

--- a/public/schema/JobTemplate.yaml
+++ b/public/schema/JobTemplate.yaml
@@ -4,11 +4,11 @@ description: openQA job template
 type: object
 additionalProperties: false
 required:
-- architectures
 - products
+- scenarios
 properties:
-  architectures:
-    description: A set of architectures with a list of test suite(s) eg. ppc64le
+  scenarios:
+    description: The scenarios to run, i.e. lists of test suites per architecture and medium
     type: object
     additionalProperties: false
     patternProperties:

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -464,7 +464,7 @@ subtest 'job property editor' => sub() {
         ok($form->is_displayed(),                             'editor form is shown');
         ok($form->child('.progress-indication')->is_hidden(), 'spinner is hidden');
         my $yaml = $driver->execute_script('return editor.doc.getValue();');
-        ok($yaml =~ m/architectures:/, 'YAML was fetched');
+        ok($yaml =~ m/scenarios:/, 'YAML was fetched');
         $driver->find_element_by_id('update-template')->click();
         my $result = $form->child('.result');
         wait_for_ajax;

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -99,11 +99,11 @@
                         <div>Define test suites per arch/medium:</div>
                         <code>
 <b>'My Group'</b>:
-  architectures:
+  scenarios:
     <b>ARCH</b>:
       <i>medium</i>-<b>ARCH</b>:
-      - test_suite
-      - test_suite:
+      - test-suite
+      - test-suite:
           machine: <b>MACHINE</b>
           priority: <b>PRIORITY</b>
           settings:
@@ -121,7 +121,7 @@
                         </code>
                         <div>Re-use test suites with YAML aliases:</div>
                         <code>
-architectures:
+scenarios:
   <b>i586</b>:
     <i>medium</i>-<b>i586</b>: <b>&amp;tests</b>
     - foo


### PR DESCRIPTION
User feedback included that it would make sense for the defaults to go first and the test suites to go last. There's also a consideration that the `architectures` key really specifies a list of test suites. So my solution is to rename the key to `test-suites` which automatically makes it the last top-level key.

Use of hyphes in YAML is preferred as I understand, and although it requires quoting in Perl I'd go by what users will be exposed to rather than what's less of a tiny inconvenience for developers in this case. User feedback is why I'm doing the renaming as well afterall.

- These are in fact a list of test suites
- They will appear at the bottom by default

![Screenshot from 2019-06-18 10-37-39](https://user-images.githubusercontent.com/1204189/59667851-b8fad600-91b7-11e9-83f1-054bde6ef371.png)

Related: [poo#46673](https://progress.opensuse.org/issues/46673)