### PR TITLE
Defer loading the schema in OpenQA::Schema::Profiler

### DIFF
--- a/lib/OpenQA/Schema/Profiler.pm
+++ b/lib/OpenQA/Schema/Profiler.pm
@@ -20,7 +20,6 @@ use warnings;
 
 use base 'DBIx::Class::Storage::Statistics';
 
-use OpenQA::Schema;
 use OpenQA::Utils 'log_debug';
 use Time::HiRes qw(gettimeofday tv_interval);
 
@@ -34,7 +33,10 @@ sub query_end {
 }
 
 sub enable_sql_debugging {
-    my $class   = shift;
+    my $class = shift;
+
+    # Defer loading to prevent the worker from triggering a migration
+    require OpenQA::Schema;
     my $storage = OpenQA::Schema->singleton->storage;
     $storage->debugobj($class->new);
     $storage->debug(1);


### PR DESCRIPTION
This should revert the profiler to the previous behaviour that prevented #2119 from happening.

Progress: https://progress.opensuse.org/issues/53285