### PR TITLE
Remove the DBIx::Class dependency from the worker completely

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -34,7 +34,7 @@
 %bcond_with tests
 %endif
 # runtime requirements that also the testsuite needs
-%define t_requires perl(DBD::Pg) perl(DBIx::Class) perl(Config::IniFiles) perl(SQL::Translator) perl(Date::Format) perl(File::Copy::Recursive) perl(DateTime::Format::Pg) perl(Net::OpenID::Consumer) perl(Mojolicious::Plugin::RenderFile) perl(Mojolicious::Plugin::AssetPack) perl(aliased) perl(Config::Tiny) perl(DBIx::Class::DeploymentHandler) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(IO::Socket::SSL) perl(Data::Dump) perl(DBIx::Class::OptimisticLocking) perl(Text::Markdown) perl(JSON::Validator) perl(YAML::XS) perl(IPC::Run) perl(Archive::Extract) perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS) perl(Time::ParseDate) perl(Sort::Versions) perl(Mojo::RabbitMQ::Client) perl(BSD::Resource) perl(Cpanel::JSON::XS) perl(Pod::POM) perl(Mojo::IOLoop::ReadWriteProcess) perl(Minion) perl(Mojo::Pg) perl(Mojo::SQLite) perl(Minion::Backend::SQLite)
+%define t_requires perl(DBD::Pg) perl(Config::IniFiles) perl(SQL::Translator) perl(Date::Format) perl(File::Copy::Recursive) perl(DateTime::Format::Pg) perl(Net::OpenID::Consumer) perl(Mojolicious::Plugin::RenderFile) perl(Mojolicious::Plugin::AssetPack) perl(aliased) perl(Config::Tiny) perl(IO::Socket::SSL) perl(Data::Dump) perl(Text::Markdown) perl(JSON::Validator) perl(YAML::XS) perl(IPC::Run) perl(Archive::Extract) perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS) perl(Time::ParseDate) perl(Sort::Versions) perl(Mojo::RabbitMQ::Client) perl(BSD::Resource) perl(Cpanel::JSON::XS) perl(Pod::POM) perl(Mojo::IOLoop::ReadWriteProcess) perl(Minion) perl(Mojo::Pg) perl(Mojo::SQLite) perl(Minion::Backend::SQLite)
 Name:           openQA
 Version:        4.6
 Release:        0
@@ -60,6 +60,7 @@ BuildRequires:  perl(Mojolicious) >= 7.92
 BuildRequires:  perl(Mojolicious::Plugin::AssetPack) >= 1.36
 BuildRequires:  perl(Mojo::RabbitMQ::Client) >= 0.2
 BuildRequires:  rubygem(sass)
+BuildRequires:  perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::OptimisticLocking)
 Requires:       perl(Minion) >= 9.09
 Requires:       perl(Mojo::RabbitMQ::Client) >= 0.2
 Requires:       perl(YAML::XS) >= 0.67
@@ -70,6 +71,7 @@ Requires:       openQA-common = %{version}
 # needed for saving needles optimized
 Requires:       optipng
 Requires:       perl(DBIx::Class) >= 0.082801
+Requires:       perl(DBIx::Class::DeploymentHandler) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(DBIx::Class::OptimisticLocking)
 # needed for openid support
 Requires:       perl(LWP::Protocol::https)
 Requires:       perl(URI)
@@ -103,6 +105,7 @@ BuildRequires:  perl(Selenium::Remote::Driver) >= 1.20
 BuildRequires:  perl(Test::Compile)
 BuildRequires:  perl(Test::MockObject)
 BuildRequires:  perl(Test::Warnings)
+BuildRequires:  perl(DBIx::Class::DeploymentHandler)
 BuildRequires:  rsync
 %endif
 %if 0%{?suse_version} >= 1330


### PR DESCRIPTION
With https://github.com/os-autoinst/openQA/pull/2120 we are back to the
old state where the worker does not actually need DBIx::Class. As we
have that solved now we can partially revert
https://github.com/os-autoinst/openQA/pull/2121 and go further.

Tested locally with a checkout of OBS and Tumbleweed container trying to
start a worker:

```
osc build --ccache --no-checks --keep-pkgs=$HOME/local/tmp --prefer-pkgs=$HOME/local/tmp --no-service && docker run -it --rm -v /home/okurz/local/tmp:/tmp/local/tmp:ro opensuse/tumbleweed sh -c 'zypper --no-refresh -n in --allow-unsigned-rpm /tmp/local/tmp/openQA-{client,common,worker}-4.6.156093*.noarch.rpm && /usr/share/openqa/script/worker --verbose --instance 1 || bash'
```

However, the only package I could find that was not pulled anymore is
perl-DBIx-Class-DeploymentHandler, probably due to dependencies in other
packages.