### PR TITLE
AMQP plugin: optionally emit Fedora CI message spec messages too

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -484,6 +484,9 @@ reconnect_timeout = 5
 url = amqp://guest:guest@localhost:5672/
 exchange = pubsub
 topic_prefix = suse
+# whether to also emit messages in Fedora CI messages format:
+# https://pagure.io/fedora-ci/messages
+fedora_ci_messages = 0
 --------------------------------------------------------------------------------
 
 For a TLS connection use +amqps://+ and port +5671+.

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -96,6 +96,9 @@ blacklist = job_grab job_done
 #url = amqp://guest:guest@localhost:5672/
 #exchange = pubsub
 #topic_prefix = suse
+# whether to also emit messages in Fedora CI messages format:
+# https://pagure.io/fedora-ci/messages
+#fedora_ci_messages = 0
 
 # Default limits for cleanup (sizes are in GiB, durations in days, zero denotes infinity)
 [default_group_limits]

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -163,10 +163,11 @@ sub read_config {
             blacklist => '',
         },
         amqp => {
-            reconnect_timeout => 5,
-            url               => 'amqp://guest:guest@localhost:5672/',
-            exchange          => 'pubsub',
-            topic_prefix      => 'suse',
+            reconnect_timeout  => 5,
+            url                => 'amqp://guest:guest@localhost:5672/',
+            exchange           => 'pubsub',
+            topic_prefix       => 'suse',
+            fedora_ci_messages => 0,
         },
         default_group_limits => {
             asset_size_limit                  => OpenQA::Schema::JobGroupDefaults::SIZE_LIMIT_GB,

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -24,6 +24,7 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Events;
 use Mojo::RabbitMQ::Client::Publisher;
+use POSIX qw(strftime);
 
 my @job_events     = qw(job_create job_delete job_cancel job_duplicate job_restart job_update_result job_done);
 my @comment_events = qw(comment_create comment_update comment_delete);
@@ -68,6 +69,184 @@ sub log_event {
 
     # seperate function for tests
     $self->publish_amqp($topic, $event_data);
+}
+
+sub log_event_fedora_ci_messages {
+    # this is for emitting messages in the "CI Messages" format:
+    # https://pagure.io/fedora-ci/messages
+    # This is a Fedora/Red Hat-ish thing in a way, but in theory
+    # anyone could adopt it
+    my ($self, $event, $job, $baseurl) = @_;
+    my $stdevent;
+    my $clone_of;
+    my $job_id;
+    # first, get the standard 'state' (from 'queued', 'running',
+    # 'complete', 'error'; we cannot do 'running' at present
+    if ($event eq 'openqa_job_create') {
+        $stdevent = 'queued';
+        $job_id   = $job->id;
+    }
+    elsif ($event eq 'openqa_job_restart' || $event eq 'openqa_job_duplicate') {
+        $stdevent = 'queued';
+        $clone_of = $job->id;
+        $job_id   = $job->clone_id;
+    }
+    elsif ($event eq 'openqa_job_cancel') {
+        $stdevent = 'error';
+        $job_id   = $job->id;
+    }
+    elsif ($event eq 'openqa_job_done') {
+        $job_id = $job->id;
+        # lifecycle note: any job cancelled directly via the web API will
+        # see both job_cancel and job_done with result USER_CANCELLED, so
+        # we emit duplicate standardized fedmsgs in this case. This is
+        # kinda unavoidable, though, as it's possible for a job to wind up
+        # USER_CANCELLED *without* an openqa_job_cancel event happening,
+        # so we can't just throw away all openqa_job_done USER_CANCELLED
+        # events...
+        $stdevent = (grep { $job->result eq $_ } INCOMPLETE_RESULTS) ? 'error' : 'complete';
+    }
+    else {
+        return undef;
+    }
+
+    # we need this for the system dict; it should be the release of
+    # the system-under-test (the VM in which the test runs) at the
+    # *start* of the test, I think. We're trying to capture info about
+    # the environment in which the test runs
+    my $sysrelease = $job->VERSION;
+    my $hdd1;
+    my $bootfrom;
+    $hdd1     = $job->settings_hash->{HDD_1}    if ($job->settings_hash->{HDD_1});
+    $bootfrom = $job->settings_hash->{BOOTFROM} if ($job->settings_hash->{BOOTFROM});
+    if ($hdd1 && $bootfrom) {
+        $sysrelease = $1 if ($hdd1 =~ /disk_f(\d+)/ && $bootfrom eq 'c');
+    }
+
+    # next, get the 'artifact' (type of thing we tested)
+    my $artifact;
+    my $artifact_id;
+    my $artifact_release;
+    my $compose_type;
+    my $test_namespace;
+    # current date/time in ISO 8601 format
+    my $generated_at = strftime("%Y-%m-%dT%H:%M:%S", gmtime()) . 'Z';
+
+    # this is used as a 'pipeline ID', see
+    # https://pagure.io/fedora-ci/messages/blob/master/f/schemas/pipeline.yaml
+    my $pipeid = join('.', "openqa", $job->BUILD, $job->TEST, $job->MACHINE, $job->FLAVOR, $job->ARCH);
+
+    my $build = $job->BUILD;
+    if ($build =~ /^Fedora/) {
+        $artifact       = 'productmd-compose';
+        $artifact_id    = $build;
+        $compose_type   = 'production';
+        $compose_type   = 'nightly' if ($build =~ /\.n\./);
+        $compose_type   = 'test' if ($build =~ /\.t\./);
+        $test_namespace = 'compose';
+    }
+    elsif ($build =~ /^Update-FEDORA/) {
+        $artifact    = 'fedora-update';
+        $artifact_id = $build;
+        $artifact_id =~ s/^Update-//;
+        $artifact_release = $job->VERSION;
+        $test_namespace   = 'update';
+    }
+    else {
+        # unhandled artifact type
+        return undef;
+    }
+
+    # finally, construct the message content
+    my %msg_data = (
+        contact => {
+            name  => 'Fedora openQA',
+            team  => 'Fedora QA',
+            url   => $baseurl,
+            docs  => 'https://fedoraproject.org/wiki/OpenQA',
+            irc   => '#fedora-qa',
+            email => 'qa-devel@lists.fedoraproject.org',
+        },
+        run => {
+            url => "$baseurl/tests/$job_id",
+            log => "$baseurl/tests/$job_id/file/autoinst-log.txt",
+            id  => $job_id,
+        },
+        artifact => {
+            type => $artifact,
+            id   => $artifact_id,
+        },
+        pipeline => {
+            # per https://pagure.io/fedora-ci/messages/issue/61 this
+            # is meant to be unique per test scenario *and* artifact,
+            # so we construct it out of BUILD and the scenario keys.
+            # 'name' is supposed to be a 'human readable name', well,
+            # this is human readable, so we'll just use it twice
+            id   => $pipeid,
+            name => $pipeid,
+        },
+        test => {
+            # openQA tests are pretty much always validation
+            category => 'validation',
+            # test identifier: test name plus scenario keys
+            type      => join(' ', $job->TEST, $job->MACHINE, $job->FLAVOR, $job->ARCH),
+            namespace => $test_namespace,
+        },
+        system => {
+            # it's interesting whether we should record info on the
+            # *worker host itself* or the *SUT* (the VM run on top of
+            # the worker host environment) here...on the whole I think
+            # SUT is more in line with expectations, so let's do that
+            os => "fedora-${sysrelease}",
+            # openqa provisions itself...we *could* I guess set this
+            # to 'createhdds' if we booted a disk image, but ehhhh
+            provider     => 'openqa',
+            architecture => $job->ARCH,
+            variant      => $job->settings_hash->{SUBVARIANT},
+        },
+        generated_at => $generated_at,
+        version      => "0.2.1",
+    );
+
+    # add keys that don't exist in all cases to the message
+    if ($stdevent eq 'complete') {
+        $msg_data{test}{result} = $job->result;
+        $msg_data{test}{result} = 'info' if $job->result eq 'softfailed';
+    }
+    elsif ($stdevent eq 'error') {
+        $msg_data{error} = {};
+        $msg_data{error}{reason} = $job->result;
+    }
+    elsif ($stdevent eq 'queued') {
+        # this is a hint to consumers that the job probably went away
+        # if they don't get a 'complete' or 'error' in 4 hours
+        # FIXME: we should set this as 2 hours on 'running', but we
+        # can't emit running because there is no internal event for
+        # it, there is no job_running event or anything like it -
+        # this is part of https://progress.opensuse.org/issues/31069
+        $msg_data{test}{lifetime} = 240;
+    }
+    $msg_data{run}{clone_of} = $clone_of if ($clone_of);
+
+    $msg_data{artifact}{release} = $artifact_release if ($artifact_release);
+
+    $msg_data{artifact}{compose_type} = $compose_type if ($compose_type);
+
+    $msg_data{artifact}{iso} = $job->settings_hash->{ISO} if ($job->settings_hash->{ISO});
+    # 9 hard disks ought to be enough for anyone
+    for my $i (1 .. 9) {
+        $msg_data{artifact}{"hdd_$i"} = $job->settings_hash->{"HDD_$i"} if ($job->settings_hash->{"HDD_$i"});
+    }
+
+    # convert data to JSON, with reliable key ordering (helps the tests)
+    my $msg_json = Cpanel::JSON::XS->new->canonical(1)->allow_blessed(1)->encode(\%msg_data);
+
+    # create the topic
+    my $topic = "ci.$artifact.test.$stdevent";
+
+    # finally, send the message
+    log_debug("Sending CI Messages AMQP message for $event");
+    $self->publish_amqp($topic, $msg_json);
 }
 
 sub publish_amqp {
@@ -119,6 +298,10 @@ sub on_job_event {
     }
 
     $self->log_event($event, $event_data);
+    if ($self->{config}->{amqp}{fedora_ci_messages}) {
+        my $baseurl = $self->{config}->{global}->{base_url} || "http://UNKNOWN";
+        $self->log_event_fedora_ci_messages($event, $job, $baseurl);
+    }
 }
 
 sub on_comment_event {

--- a/t/23-amqp-fedoraci.t
+++ b/t/23-amqp-fedoraci.t
@@ -1,0 +1,273 @@
+#! /usr/bin/perl
+
+# Copyright (C) 2016-2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+BEGIN {
+    unshift @INC, 'lib';
+}
+
+use Mojo::Base;
+use Mojo::IOLoop;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use OpenQA::Client;
+use OpenQA::Jobs::Constants;
+use OpenQA::Test::Database;
+use Test::MockModule;
+use Test::More;
+use Test::Mojo;
+use Test::Warnings;
+use Mojo::File qw(tempdir path);
+use Mojo::JSON qw(decode_json);
+use OpenQA::WebAPI::Plugin::AMQP;
+
+my %published;
+my $mock_callcount;
+
+my $plugin_mock = Test::MockModule->new('OpenQA::WebAPI::Plugin::AMQP');
+$plugin_mock->mock(
+    publish_amqp => sub {
+        my ($self, $topic, $data) = @_;
+        # ignore the non-fedoraci messages, makes it easier to
+        # understand the expected call counts
+        if ($topic =~ /^ci\./) {
+            $mock_callcount++;
+            $published{$topic} = $data;
+        }
+    });
+
+my $schema = OpenQA::Test::Database->new->create();
+
+# this test also serves to test plugin loading via config file
+my $conf = << 'EOF';
+[global]
+plugins=AMQP
+base_url=https://openqa.stg.fedoraproject.org
+[amqp]
+fedora_ci_messages=1
+EOF
+
+my $tempdir = tempdir;
+$ENV{OPENQA_CONFIG} = $tempdir;
+path($ENV{OPENQA_CONFIG})->make_path->child("openqa.ini")->spurt($conf);
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+# XXX: Test::Mojo loses its app when setting a new ua
+# https://github.com/kraih/mojo/issues/598
+my $app = $t->app;
+$t->ua(
+    OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+my $settings = {
+    DISTRI      => 'Unicorn',
+    FLAVOR      => 'pink',
+    VERSION     => '42',
+    BUILD       => 'Fedora-Rawhide-20180129.n.0',
+    TEST        => 'rainbow',
+    ISO         => 'whatever.iso',
+    DESKTOP     => 'DESKTOP',
+    KVM         => 'KVM',
+    ISO_MAXSIZE => 1,
+    MACHINE     => "RainbowPC",
+    ARCH        => 'x86_64',
+    SUBVARIANT  => 'workstation'
+};
+
+my $expected_artifact = {
+    id           => 'Fedora-Rawhide-20180129.n.0',
+    iso          => 'whatever.iso',
+    type         => 'productmd-compose',
+    compose_type => 'nightly',
+};
+
+my $expected_contact = {
+    name  => 'Fedora openQA',
+    team  => 'Fedora QA',
+    url   => 'https://openqa.stg.fedoraproject.org',
+    docs  => 'https://fedoraproject.org/wiki/OpenQA',
+    irc   => '#fedora-qa',
+    email => 'qa-devel@lists.fedoraproject.org',
+};
+
+my $expected_pipeline = {
+    id   => 'openqa.Fedora-Rawhide-20180129.n.0.rainbow.RainbowPC.pink.x86_64',
+    name => 'openqa.Fedora-Rawhide-20180129.n.0.rainbow.RainbowPC.pink.x86_64',
+};
+
+my $expected_run = {
+    url => '',
+    log => '',
+    id  => '',
+};
+
+my $expected_system = {
+    os           => 'fedora-42',
+    provider     => 'openqa',
+    architecture => 'x86_64',
+    variant      => 'workstation',
+};
+
+my $expected_test = {
+    category  => 'validation',
+    type      => 'rainbow RainbowPC pink x86_64',
+    namespace => 'compose',
+    lifetime  => 240,
+};
+
+my $expected_error;
+
+my $expected_version = '0.2.1';
+
+sub get_expected {
+    my $expected = {
+        artifact => $expected_artifact,
+        contact  => $expected_contact,
+        pipeline => $expected_pipeline,
+        run      => $expected_run,
+        system   => $expected_system,
+        test     => $expected_test,
+        version  => $expected_version,
+    };
+    $expected->{'error'} = $expected_error if ($expected_error);
+    return $expected;
+}
+
+# create a job via API
+my $job;
+my $newjob;
+subtest 'create job' => sub {
+    # reset the call count
+    $mock_callcount = 0;
+    $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+    ok($job = $t->tx->res->json->{id}, 'got ID of new job');
+    ok($mock_callcount == 1,           'mock was called');
+    my $publishedref = decode_json($published{'ci.productmd-compose.test.queued'});
+    delete $publishedref->{'generated_at'};
+    $expected_run = {
+        url => "https://openqa.stg.fedoraproject.org/tests/$job",
+        log => "https://openqa.stg.fedoraproject.org/tests/$job/file/autoinst-log.txt",
+        id  => $job,
+    };
+    my $expected = get_expected;
+    is_deeply($publishedref, $expected, 'job create triggers standardized amqp');
+};
+
+subtest 'mark job as done' => sub {
+    $mock_callcount = 0;
+    $t->post_ok("/api/v1/jobs/$job/set_done")->status_is(200);
+    ok($mock_callcount == 1, 'mock was called');
+    my $publishedref = decode_json($published{'ci.productmd-compose.test.complete'});
+    delete $publishedref->{'generated_at'};
+    $expected_test->{'result'} = 'failed';
+    delete $expected_test->{'lifetime'};
+    my $expected = get_expected;
+    is_deeply($publishedref, $expected, 'job done (failed) triggers standardized amqp');
+};
+
+subtest 'duplicate and cancel job' => sub {
+    $mock_callcount = 0;
+    $t->post_ok("/api/v1/jobs/$job/duplicate")->status_is(200);
+    $newjob = $t->tx->res->json->{id};
+    ok($mock_callcount == 1, 'mock was called');
+    my $publishedref = decode_json($published{'ci.productmd-compose.test.queued'});
+    delete $publishedref->{'generated_at'};
+    $expected_run = {
+        clone_of => $job,
+        url      => "https://openqa.stg.fedoraproject.org/tests/$newjob",
+        log      => "https://openqa.stg.fedoraproject.org/tests/$newjob/file/autoinst-log.txt",
+        id       => $newjob,
+    };
+    $expected_test->{'lifetime'} = 240;
+    delete $expected_test->{'result'};
+    my $expected = get_expected;
+    is_deeply($publishedref, $expected, 'job duplicate triggers standardized amqp');
+
+    $mock_callcount = 0;
+    $t->post_ok("/api/v1/jobs/$newjob/cancel")->status_is(200);
+    ok($mock_callcount == 1, 'mock was called');
+    my $publishedref = decode_json($published{'ci.productmd-compose.test.error'});
+    delete $publishedref->{'generated_at'};
+    $expected_error = {reason => 'user_cancelled',};
+    delete $expected_test->{'lifetime'};
+    delete $expected_run->{'clone_of'};
+    my $expected = get_expected;
+    is_deeply($publishedref, $expected, 'job cancel triggers standardized amqp');
+};
+
+subtest 'duplicate and pass job' => sub {
+    $mock_callcount = 0;
+    $t->post_ok("/api/v1/jobs/$newjob/duplicate")->status_is(200);
+    my $newerjob = $t->tx->res->json->{id};
+    # explicitly set job as passed
+    $t->post_ok("/api/v1/jobs/$newerjob/set_done?result=passed")->status_is(200);
+    ok($mock_callcount == 2, 'mock was called');
+    my $publishedref = decode_json($published{'ci.productmd-compose.test.complete'});
+    delete $publishedref->{'generated_at'};
+    $expected_run = {
+        url => "https://openqa.stg.fedoraproject.org/tests/$newerjob",
+        log => "https://openqa.stg.fedoraproject.org/tests/$newerjob/file/autoinst-log.txt",
+        id  => $newerjob,
+    };
+    $expected_test->{'result'} = 'passed';
+    $expected_error = '';
+    my $expected = get_expected;
+    is_deeply($publishedref, $expected, 'job done (passed) triggers standardized amqp');
+};
+
+subtest 'create update job' => sub {
+    $mock_callcount = 0;
+    diag("Count: $mock_callcount");
+    $settings->{BUILD} = 'Update-FEDORA-2018-3c876babb9';
+    # let's test HDD_* here too
+    $settings->{HDD_1}    = 'disk_f40_minimal.qcow2';
+    $settings->{HDD_2}    = 'someotherdisk.img';
+    $settings->{BOOTFROM} = 'c';
+    delete $settings->{ISO};
+    $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+    ok(my $updatejob = $t->tx->res->json->{id}, 'got ID of update job');
+    diag("Count: $mock_callcount");
+    ok($mock_callcount == 1, 'mock was called');
+    my $publishedref = decode_json($published{'ci.fedora-update.test.queued'});
+    delete $publishedref->{'generated_at'};
+    $expected_artifact = {
+        id      => 'FEDORA-2018-3c876babb9',
+        type    => 'fedora-update',
+        release => '42',
+        hdd_1   => 'disk_f40_minimal.qcow2',
+        hdd_2   => 'someotherdisk.img',
+    };
+    $expected_pipeline = {
+        id   => 'openqa.Update-FEDORA-2018-3c876babb9.rainbow.RainbowPC.pink.x86_64',
+        name => 'openqa.Update-FEDORA-2018-3c876babb9.rainbow.RainbowPC.pink.x86_64',
+    };
+    $expected_run = {
+        url => "https://openqa.stg.fedoraproject.org/tests/$updatejob",
+        log => "https://openqa.stg.fedoraproject.org/tests/$updatejob/file/autoinst-log.txt",
+        id  => $updatejob,
+    };
+    $expected_system->{'os'}      = 'fedora-40';
+    $expected_test->{'namespace'} = 'update';
+    $expected_test->{'lifetime'}  = 240;
+    delete $expected_test->{'result'};
+    my $expected = get_expected;
+    is_deeply($publishedref, $expected, 'update job create triggers standardized amqp');
+};
+
+done_testing();

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -20,7 +20,7 @@ BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base;
+use Mojo::Base -strict;
 use Mojo::IOLoop;
 
 use FindBin;
@@ -55,7 +55,7 @@ path($ENV{OPENQA_CONFIG})->make_path->child("openqa.ini")->spurt(@conf);
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-# XXX: Test::Mojo loses its app when setting a new ua
+# Test::Mojo loses its app when setting a new ua
 # https://github.com/kraih/mojo/issues/598
 my $app = $t->app;
 $t->ua(
@@ -63,7 +63,7 @@ $t->ua(
 $t->app($app);
 
 # create a parent group
-my $schema        = $app->schema;
+$schema = $app->schema;
 my $parent_groups = $schema->resultset('JobGroupParents');
 $parent_groups->create(
     {

--- a/t/config.t
+++ b/t/config.t
@@ -68,10 +68,11 @@ subtest 'Test configuration default modes' => sub {
             blacklist => '',
         },
         amqp => {
-            reconnect_timeout => 5,
-            url               => 'amqp://guest:guest@localhost:5672/',
-            exchange          => 'pubsub',
-            topic_prefix      => 'suse',
+            reconnect_timeout  => 5,
+            url                => 'amqp://guest:guest@localhost:5672/',
+            exchange           => 'pubsub',
+            topic_prefix       => 'suse',
+            fedora_ci_messages => 0,
         },
         default_group_limits => {
             asset_size_limit                  => OpenQA::Schema::JobGroupDefaults::SIZE_LIMIT_GB,


### PR DESCRIPTION
This makes the AMQP publisher plugin emit messages in Fedora CI
message spec format, if a config key is set. See
https://pagure.io/fedora-ci/messages for more on this format.
The Fedmsg plugin already does this (with a slightly earlier
version of the format), but Fedora is migrating off ZMQ-based
fedmsg onto AMQP-based fedora-messaging, so I want to switch
Fedora from the Fedmsg plugin to this one.

Signed-off-by: Adam Williamson <awilliam@redhat.com>