### PR TITLE
Move websocket server helpers to the model

### DIFF
--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -126,7 +126,7 @@ sub _setup {
     OpenQA::Setup::setup_log($self);
 
     # start worker checker - check workers each 2 minutes
-    Mojo::IOLoop->recurring(120 => sub { $self->workers_checker });
+    Mojo::IOLoop->recurring(120 => sub { $self->status->workers_checker });
 
     Mojo::IOLoop->recurring(
         380 => sub {

--- a/lib/OpenQA/WebSockets/Model/Status.pm
+++ b/lib/OpenQA/WebSockets/Model/Status.pm
@@ -17,8 +17,90 @@
 package OpenQA::WebSockets::Model::Status;
 use Mojo::Base -base;
 
+use OpenQA::Schema;
+use OpenQA::Schema::Result::Workers ();
+use OpenQA::Utils qw(log_debug log_warning log_info);
+use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
+use DateTime;
+use Try::Tiny;
+
 has ['workers', 'worker_status'] => sub { {} };
 
 sub singleton { state $status ||= __PACKAGE__->new }
+
+sub get_stale_worker_jobs {
+    my ($self, $threshold) = @_;
+
+    my $schema  = OpenQA::Schema->singleton;
+    my $workers = $self->workers;
+
+    # grab the workers we've seen lately
+    my @ok_workers;
+    for my $worker (values %$workers) {
+        if (time - $worker->{last_seen} <= $threshold) {
+            push(@ok_workers, $worker->{id});
+        }
+        else {
+            log_debug(sprintf("Worker %s not seen since %d seconds", $worker->{db}->name, time - $worker->{last_seen}));
+        }
+    }
+    my $dtf = $schema->storage->datetime_parser;
+    my $dt  = DateTime->from_epoch(epoch => time() - $threshold, time_zone => 'UTC');
+
+    my %cond = (
+        state              => [OpenQA::Jobs::Constants::EXECUTION_STATES],
+        'worker.t_updated' => {'<' => $dtf->format_datetime($dt)},
+        'worker.id'        => {-not_in => [sort @ok_workers]});
+    my %attrs = (join => 'worker', order_by => 'worker.id desc');
+
+    return $schema->resultset("Jobs")->search(\%cond, \%attrs);
+}
+
+# Check if worker with job has been updated recently; if not, assume it
+# got stuck somehow and duplicate or incomplete the job
+sub workers_checker {
+    my $self = shift;
+
+    my $schema = OpenQA::Schema->singleton;
+    try {
+        $schema->txn_do(
+            sub {
+                my $stale_jobs = $self->get_stale_worker_jobs(WORKERS_CHECKER_THRESHOLD);
+                for my $job ($stale_jobs->all) {
+                    next unless _is_job_considered_dead($job);
+
+                    $job->done(result => OpenQA::Jobs::Constants::INCOMPLETE);
+                    # XXX: auto_duplicate was killing ws server in production
+                    my $res = $job->auto_duplicate;
+                    if ($res) {
+                        log_warning(sprintf('dead job %d aborted and duplicated %d', $job->id, $res->id));
+                    }
+                    else {
+                        log_warning(sprintf('dead job %d aborted as incomplete', $job->id));
+                    }
+                }
+            });
+    }
+    catch {
+        log_info("Failed dead job detection : $_");
+    };
+}
+
+sub _is_job_considered_dead {
+    my $job = shift;
+
+    # much bigger timeout for uploading jobs; while uploading files,
+    # worker process is blocked and cannot send status updates
+    if ($job->state eq OpenQA::Jobs::Constants::UPLOADING) {
+        my $delta = DateTime->now()->epoch() - $job->worker->t_updated->epoch();
+        log_debug("uploading worker not updated for $delta seconds " . $job->id);
+        return ($delta > 1000);
+    }
+
+    log_debug(
+        "job considered dead: " . $job->id . " worker " . $job->worker->id . " not seen. In state " . $job->state);
+    # default timeout for the rest
+    return 1;
+}
 
 1;

--- a/lib/OpenQA/WebSockets/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebSockets/Plugin/Helpers.pm
@@ -18,12 +18,7 @@ package OpenQA::WebSockets::Plugin::Helpers;
 use Mojo::Base 'Mojolicious::Plugin';
 
 use OpenQA::Schema;
-use OpenQA::Schema::Result::Workers ();
 use OpenQA::WebSockets::Model::Status;
-use OpenQA::Utils qw(log_debug log_warning log_info);
-use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
-use DateTime;
-use Try::Tiny;
 
 sub register {
     my ($self, $app) = @_;
@@ -32,84 +27,6 @@ sub register {
 
     $app->helper(schema => sub { OpenQA::Schema->singleton });
     $app->helper(status => sub { OpenQA::WebSockets::Model::Status->singleton });
-
-    $app->helper(get_stale_worker_jobs => \&_get_stale_worker_jobs);
-    $app->helper(workers_checker       => \&_workers_checker);
-}
-
-sub _get_stale_worker_jobs {
-    my ($c, $threshold) = @_;
-
-    my $schema  = $c->schema;
-    my $workers = $c->status->workers;
-
-    # grab the workers we've seen lately
-    my @ok_workers;
-    for my $worker (values %$workers) {
-        if (time - $worker->{last_seen} <= $threshold) {
-            push(@ok_workers, $worker->{id});
-        }
-        else {
-            log_debug(sprintf("Worker %s not seen since %d seconds", $worker->{db}->name, time - $worker->{last_seen}));
-        }
-    }
-    my $dtf = $schema->storage->datetime_parser;
-    my $dt  = DateTime->from_epoch(epoch => time() - $threshold, time_zone => 'UTC');
-
-    my %cond = (
-        state              => [OpenQA::Jobs::Constants::EXECUTION_STATES],
-        'worker.t_updated' => {'<' => $dtf->format_datetime($dt)},
-        'worker.id'        => {-not_in => [sort @ok_workers]});
-    my %attrs = (join => 'worker', order_by => 'worker.id desc');
-
-    return $schema->resultset("Jobs")->search(\%cond, \%attrs);
-}
-
-sub _is_job_considered_dead {
-    my $job = shift;
-
-    # much bigger timeout for uploading jobs; while uploading files,
-    # worker process is blocked and cannot send status updates
-    if ($job->state eq OpenQA::Jobs::Constants::UPLOADING) {
-        my $delta = DateTime->now()->epoch() - $job->worker->t_updated->epoch();
-        log_debug("uploading worker not updated for $delta seconds " . $job->id);
-        return ($delta > 1000);
-    }
-
-    log_debug(
-        "job considered dead: " . $job->id . " worker " . $job->worker->id . " not seen. In state " . $job->state);
-    # default timeout for the rest
-    return 1;
-}
-
-# Check if worker with job has been updated recently; if not, assume it
-# got stuck somehow and duplicate or incomplete the job
-sub _workers_checker {
-    my $c = shift;
-
-    my $schema = OpenQA::Schema->singleton;
-    try {
-        $schema->txn_do(
-            sub {
-                my $stale_jobs = $c->get_stale_worker_jobs(WORKERS_CHECKER_THRESHOLD);
-                for my $job ($stale_jobs->all) {
-                    next unless _is_job_considered_dead($job);
-
-                    $job->done(result => OpenQA::Jobs::Constants::INCOMPLETE);
-                    # XXX: auto_duplicate was killing ws server in production
-                    my $res = $job->auto_duplicate;
-                    if ($res) {
-                        log_warning(sprintf('dead job %d aborted and duplicated %d', $job->id, $res->id));
-                    }
-                    else {
-                        log_warning(sprintf('dead job %d aborted as incomplete', $job->id));
-                    }
-                }
-            });
-    }
-    catch {
-        log_info("Failed dead job detection : $_");
-    };
 }
 
 1;

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -59,7 +59,7 @@ subtest 'worker with job and not updated in last 120s is considered dead' => sub
 
     $schema->resultset('Workers')->update_all({t_updated => $dtf->format_datetime($dt)});
     stderr_like {
-        OpenQA::WebSockets->new->workers_checker();
+        OpenQA::WebSockets::Model::Status->singleton->workers_checker();
     }
     qr/dead job 99961 aborted and duplicated 99982\n.*dead job 99963 aborted as incomplete/;
     _check_job_incomplete($_) for (99961, 99963);

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -72,7 +72,7 @@ subtest 'WebSocket Server workers_checker' => sub {
     {
         open my $handle, '>', \$buffer;
         local *STDOUT = $handle;
-        OpenQA::WebSockets->new->workers_checker;
+        OpenQA::WebSockets::Model::Status->singleton->workers_checker;
     };
     like $buffer,              qr/Failed dead job detection/;
     ok $mock_singleton_called, 'mocked singleton method has been called';
@@ -87,7 +87,7 @@ subtest 'WebSocket Server get_stale_worker_jobs' => sub {
     {
         open my $handle, '>', \$buffer;
         local *STDOUT = $handle;
-        OpenQA::WebSockets->new->get_stale_worker_jobs(-9999999999);
+        OpenQA::WebSockets::Model::Status->singleton->get_stale_worker_jobs(-9999999999);
     };
     like $buffer,              qr/Worker Boooo not seen since \d+ seconds/;
     ok $mock_singleton_called, 'mocked singleton method has been called';

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -209,7 +209,7 @@ sub create_websocket_server {
                 $c->on(finish => \&OpenQA::WebSockets::Controller::Worker::_finish);
             };
         }
-        monkey_patch 'OpenQA::WebSockets::Plugin::Helpers', _workers_checker => sub { 1 }
+        monkey_patch 'OpenQA::WebSockets::Model::Status', workers_checker => sub { 1 }
           if ($noworkercheck);
         local @ARGV = ('daemon');
         OpenQA::WebSockets::run;


### PR DESCRIPTION
I made a small mistake when refactoring the websocket server. Those helpers should have been part of the model. There might be more opportunities to move code from `OpenQA::WebSockets::Controller::Worker` to the model, but that's more complicated, so we can see about that later.