### PR TITLE
Revert to usual wording "distri" in YAML schedules

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -145,9 +145,9 @@ sub get_job_groups {
         # Extract products and tests per architecture
         while (my $template = $templates->next) {
             $group{products}{$template->product->name} = {
-                distribution => $template->product->distri,
-                flavor       => $template->product->flavor,
-                version      => $template->product->version
+                distri  => $template->product->distri,
+                flavor  => $template->product->flavor,
+                version => $template->product->version
             };
 
             my %test_suite;
@@ -330,7 +330,7 @@ sub update {
                             my $product      = $products->find(
                                 {
                                     arch    => $arch,
-                                    distri  => $product_spec->{distribution},
+                                    distri  => $product_spec->{distri},
                                     flavor  => $product_spec->{flavor},
                                     version => $product_spec->{version},
                                 });

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -124,7 +124,7 @@ sub edit {
     my $module_detail = $self->stash('module_detail');
     my $job           = $self->stash('job');
     my $imgname       = $module_detail->{screenshot};
-    my $distribution  = $job->DISTRI;
+    my $distri        = $job->DISTRI;
     my $dversion      = $job->VERSION || '';
 
     # Each object in @needles will contain the name, both the url and the local path
@@ -141,7 +141,7 @@ sub edit {
     my $screenshot;
     my %basic_needle_data = (
         tags       => $tags,
-        distri     => $distribution,
+        distri     => $distri,
         version    => $dversion,
         image_name => $imgname,
     );
@@ -474,8 +474,8 @@ sub viewimg {
     my $module_detail = $self->stash('module_detail');
     my $job           = $self->stash('job');
     return $self->reply->not_found unless $job;
-    my $distribution = $job->DISTRI;
-    my $dversion     = $job->VERSION || '';
+    my $distri   = $job->DISTRI;
+    my $dversion = $job->VERSION || '';
 
     # initialize hash to store needle lists by tags
     my %needles_by_tag;
@@ -507,10 +507,10 @@ sub viewimg {
     # load primary needle match
     my $primary_match;
     if (my $needle = $module_detail->{needle}) {
-        if (my $needleinfo = needle_info($needle, $distribution, $dversion, $module_detail->{json})) {
+        if (my $needleinfo = needle_info($needle, $distri, $dversion, $module_detail->{json})) {
             my $info = {
                 name          => $needle,
-                image         => $self->needle_url($distribution, $needle . '.png', $dversion, $needleinfo->{json}),
+                image         => $self->needle_url($distri, $needle . '.png', $dversion, $needleinfo->{json}),
                 areas         => $needleinfo->{area},
                 error         => $module_detail->{error},
                 matches       => [],
@@ -527,11 +527,11 @@ sub viewimg {
     if ($module_detail->{needles}) {
         for my $needle (@{$module_detail->{needles}}) {
             my $needlename = $needle->{name};
-            my $needleinfo = needle_info($needlename, $distribution, $dversion, $needle->{json});
+            my $needleinfo = needle_info($needlename, $distri, $dversion, $needle->{json});
             next unless $needleinfo;
             my $info = {
                 name    => $needlename,
-                image   => $self->needle_url($distribution, "$needlename.png", $dversion, $needleinfo->{json}),
+                image   => $self->needle_url($distri, "$needlename.png", $dversion, $needleinfo->{json}),
                 error   => $needle->{error},
                 areas   => $needleinfo->{area},
                 matches => [],

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -584,7 +584,7 @@ sub overview {
     my @latest_jobs = $self->schema->resultset('Jobs')->complex_query(%$search_args)->latest_jobs;
     ($stash{archs}, $stash{results}, $stash{aggregated}) = $self->prepare_job_results(\@latest_jobs);
 
-    # determine distribution/version from job results if not explicitely specified via search args
+    # determine distri/version from job results if not explicitely specified via search args
     my @distris     = keys %{$stash{results}};
     my $only_distri = scalar @distris == 1;
     if (!defined $stash{distri} && $only_distri) {

--- a/public/schema/JobTemplate.yaml
+++ b/public/schema/JobTemplate.yaml
@@ -65,12 +65,12 @@ properties:
         type: object
         description: The name of a product (medium)
         required:
-          - distribution
+          - distri
           - flavor
           - version
         additionalProperties: false
         properties:
-          distribution:
+          distri:
             type: string
           flavor:
             type: string

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -534,12 +534,9 @@ $yaml->{scenarios}{'x86_64'}{opensuse} = ['spam', 'eggs'];
 is_deeply($t->app->validate_yaml($yaml, 1), ["/products: Missing property."], 'No products defined')
   or diag explain YAML::XS::Dump($yaml);
 $yaml->{products}{'opensuse'} = {};
-is_deeply(
-    @{$t->app->validate_yaml($yaml, 1)}[0],
-    '/products/opensuse/distribution: Missing property.',
-    'No distri specified'
-) or diag explain YAML::XS::Dump($yaml);
-$yaml->{products}{'opensuse'}{distribution} = 'sle';
+is_deeply(@{$t->app->validate_yaml($yaml, 1)}[0], '/products/opensuse/distri: Missing property.', 'No distri specified')
+  or diag explain YAML::XS::Dump($yaml);
+$yaml->{products}{'opensuse'}{distri} = 'sle';
 is_deeply(@{$t->app->validate_yaml($yaml, 1)}[0], '/products/opensuse/flavor: Missing property.', 'No flavor specified')
   or diag explain YAML::XS::Dump($yaml);
 $yaml->{products}{'opensuse'}{flavor} = 'DVD';
@@ -632,9 +629,9 @@ is_deeply(
         },
         products => {
             'opensuse-13.1-DVD-i586' => {
-                distribution => 'opensuse',
-                flavor       => 'DVD',
-                version      => '13.1',
+                distri  => 'opensuse',
+                flavor  => 'DVD',
+                version => '13.1',
             },
         },
     },
@@ -737,9 +734,9 @@ subtest 'Create and modify groups with YAML' => sub {
         },
         products => {
             'opensuse-13.1-DVD-i586' => {
-                distribution => 'opensuse',
-                flavor       => 'DVD',
-                version      => '13.1',
+                distri  => 'opensuse',
+                flavor  => 'DVD',
+                version => '13.1',
             },
         },
     };
@@ -862,8 +859,8 @@ subtest 'Create and modify groups with YAML' => sub {
             'Invalid machine in defaults'
         );
 
-        $yaml->{defaults}{i586}{'machine'}                          = '64bit';
-        $yaml->{products}{'opensuse-13.1-DVD-i586'}{'distribution'} = 'geeko';
+        $yaml->{defaults}{i586}{'machine'}                    = '64bit';
+        $yaml->{products}{'opensuse-13.1-DVD-i586'}{'distri'} = 'geeko';
         $t->post_ok(
             "/api/v1/experimental/job_templates_scheduling/$job_group_id3",
             form => {
@@ -907,13 +904,13 @@ subtest 'References' => sub {
           priority: 50
       products:
         opensuse-13.1-DVD-i586: &opensuse13
-          distribution: opensuse
+          distri: opensuse
           flavor: DVD
           version: 13.1
         opensuse-13.1-DVD-ppc64:
           *opensuse13
         sle-12-SP1-Server-DVD-Updates-x86_64:
-          distribution: sle
+          distri: sle
           flavor: Server-DVD-Updates
           version: 12-SP1
     ');

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -115,7 +115,7 @@
       priority: <b>PRIORITY</b>
   products:
     <i>medium</i>-<b>ARCH</b>:
-      distribution: <b>DISTRIBUTION</b>
+      distri: <b>DISTRI</b>
       flavor: <b>FLAVOR</b>
       version: <b>VERSION</b>
                         </code>


### PR DESCRIPTION
Despite we might think that spelling out words is better for
understanding we have to stick to our defined wording and also the API.
http://open.qa/docs/#concepts defines the word "distri" and we also use
that in os-autoinst as well as the actual test distributions, e.g.
os-autoinst-distri-opensuse. In case we really want to change that we
would need to handle all downstream uses as well.

Related progress issue: https://progress.opensuse.org/issues/46667