### PR TITLE
travis_test: Ensure shellcheck is installed as part of dependencies

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -41,6 +41,7 @@ RUN zypper in -y -C \
        xorg-x11-fonts \
        'rubygem(sass)' \
        perl \
+       ShellCheck \
        sudo \
        'perl(App::cpanminus)' \
        'perl(Archive::Extract)' \


### PR DESCRIPTION
For https://github.com/os-autoinst/openQA/pull/2134