### PR TITLE
client: Prevent warnings when receiving no HTML status code at all

### DIFF
--- a/script/client
+++ b/script/client
@@ -160,7 +160,7 @@ sub usage($) {
 sub handle_result {
     my $res = shift;
 
-    if ($res->code == 200) {
+    if (($res->code // 0) == 200) {
         my $json = $res->json;
         if ($options{'json-output'}) {
             print Cpanel::JSON::XS->new->pretty->encode($json);
@@ -171,7 +171,7 @@ sub handle_result {
         return $json;
     }
 
-    printf(STDERR "ERROR: %s - %s\n", $res->code, $res->{error}->{message});
+    printf(STDERR "ERROR: %s - %s\n", ($res->code // ''), $res->{error}->{message});
     if ($res->body) {
         if ($options{json}) {
             print Cpanel::JSON::XS->new->pretty->encode($res->json);


### PR DESCRIPTION
In case of no useful HTML status code received at all the openQA client
would previously output two misleading perl warnings about the comparison
with undefined values. This commit provides fallback values in this case
while preserving the code and error message output when available.

Example output when trying to connect to an unavailable local https
server and against a local http server without using valid credentials:

```
$ openqa-client --host https://localhost jobs post
ERROR:  - Connection refused
$ openqa-client --host http://localhost jobs post
ERROR: 403 - Forbidden
{ error => "Not authorized", error_status => 403 }
```