### PR TITLE
fetchneedles: Go back to old, quiet mode

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -47,7 +47,6 @@ needlesdir() {
 
 do_fetch() {
     local target=$1
-    echo "fetching $target"
     git fetch -q
     git rebase -q
     if [ "$needles_separate" = 1 ]; then


### PR DESCRIPTION
For a shell script which does not support a "quiet" mode we should try
to stick to the *nix best practices of not outputtin anything unless it
is an error. The main reason for that is to not spam the cron account
running "fetchneedles" recurringly with unneeded cron output emails.