### PR TITLE
openqa-clone-custom-git-refspec: Fix use of "-n" on GITHUB_TOKEN

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -7,7 +7,7 @@
 #  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6529 https://openqa.opensuse.org/tests/835060 DESKTOP=textmode
 #
 set -o pipefail
-if [ -n $GITHUB_TOKEN ]; then
+if [ -n "$GITHUB_TOKEN" ]; then
     AUTHENTICATED_REQUEST=" -u $GITHUB_TOKEN:x-oauth-basic "
     echo "Github oauth token provided, peforming authenticated requests"
 fi


### PR DESCRIPTION
Message from "shellcheck":
"SC2070: -n doesn't work with unquoted arguments. Quote or use [[ ]]."