### PR TITLE
Fix tests that used Test::Mojo return values incorrectly

### DIFF
--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -39,50 +39,48 @@ sub get_summary {
 #
 # Overview of build 0091
 #
-my $get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', build => '0091'});
-$get->status_is(200);
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', build => '0091'})->status_is(200);
 
 my $summary = get_summary;
 like($summary, qr/Overall Summary of opensuse 13\.1 build 0091/i);
 like($summary, qr/Passed: 3 Failed: 0 Scheduled: 2 Running: 2 None: 1/i);
 
 # Check the headers
-$get->element_exists('#flavor_DVD_arch_i586');
-$get->element_exists('#flavor_DVD_arch_x86_64');
-$get->element_exists('#flavor_GNOME-Live_arch_i686');
-$get->element_exists_not('#flavor_GNOME-Live_arch_x86_64');
-$get->element_exists_not('#flavor_DVD_arch_i686');
+$t->element_exists('#flavor_DVD_arch_i586');
+$t->element_exists('#flavor_DVD_arch_x86_64');
+$t->element_exists('#flavor_GNOME-Live_arch_i686');
+$t->element_exists_not('#flavor_GNOME-Live_arch_x86_64');
+$t->element_exists_not('#flavor_DVD_arch_i686');
 
 # Check some results (and it's overview_xxx classes)
-$get->element_exists('#res_DVD_i586_kde .result_passed');
-$get->element_exists('#res_GNOME-Live_i686_RAID0 i.state_cancelled');
-$get->element_exists('#res_DVD_i586_RAID1 i.state_scheduled');
-$get->element_exists_not('#res_DVD_x86_64_doc');
+$t->element_exists('#res_DVD_i586_kde .result_passed');
+$t->element_exists('#res_GNOME-Live_i686_RAID0 i.state_cancelled');
+$t->element_exists('#res_DVD_i586_RAID1 i.state_scheduled');
+$t->element_exists_not('#res_DVD_x86_64_doc');
 
 my $form = {distri => 'opensuse', version => '13.1', build => '0091', group => 'opensuse 13.1'};
-$get = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+$t->get_ok('/tests/overview' => form => $form)->status_is(200);
 like(get_summary, qr/Overall Summary of opensuse 13\.1 build 0091/i, 'specifying group parameter');
 $form = {distri => 'opensuse', version => '13.1', build => '0091', groupid => 1001};
-$get  = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+$t->get_ok('/tests/overview' => form => $form)->status_is(200);
 like(get_summary, qr/Overall Summary of opensuse build 0091/i, 'specifying groupid parameter');
 
 #
 # Overview of build 0048
 #
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048'});
-$get->status_is(200);
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048'})->status_is(200);
 like(get_summary, qr/\QPassed: 0 Soft-Failed: 2 Failed: 1\E/i);
 
 # Check the headers
-$get->element_exists('#flavor_DVD_arch_x86_64');
-$get->element_exists_not('#flavor_DVD_arch_i586');
-$get->element_exists_not('#flavor_GNOME-Live_arch_i686');
+$t->element_exists('#flavor_DVD_arch_x86_64');
+$t->element_exists_not('#flavor_DVD_arch_i586');
+$t->element_exists_not('#flavor_GNOME-Live_arch_i686');
 
 # Check some results (and it's overview_xxx classes)
-$get->element_exists('#res_DVD_x86_64_doc .result_failed');
-$get->element_exists('#res_DVD_x86_64_kde .result_softfailed');
-$get->element_exists_not('#res_DVD_i586_doc');
-$get->element_exists_not('#res_DVD_i686_doc');
+$t->element_exists('#res_DVD_x86_64_doc .result_failed');
+$t->element_exists('#res_DVD_x86_64_kde .result_softfailed');
+$t->element_exists_not('#res_DVD_i586_doc');
+$t->element_exists_not('#res_DVD_i686_doc');
 
 my $failedmodules
   = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#res_DVD_x86_64_doc .failedmodule')->all_text);
@@ -91,14 +89,13 @@ like($failedmodules, qr/logpackages/i, "failed modules are listed");
 #
 # Default overview for 13.1
 #
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1'});
-$get->status_is(200);
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1'})->status_is(200);
 $summary = get_summary;
 like($summary, qr/Summary of opensuse 13\.1 build 0091/i);
 like($summary, qr/Passed: 3 Failed: 0 Scheduled: 2 Running: 2 None: 1/i);
 
 $form = {distri => 'opensuse', version => '13.1', groupid => 1001};
-$get  = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+$t->get_ok('/tests/overview' => form => $form)->status_is(200);
 like(
     get_summary,
     qr/Summary of opensuse build 0091/i,
@@ -108,8 +105,7 @@ like(
 #
 # Default overview for Factory
 #
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory'});
-$get->status_is(200);
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory'})->status_is(200);
 $summary = get_summary;
 like($summary, qr/Summary of opensuse Factory build 0048\@0815/i);
 like($summary, qr/\QPassed: 0 Failed: 1\E/i);
@@ -118,35 +114,35 @@ like($summary, qr/\QPassed: 0 Failed: 1\E/i);
 #
 # Still possible to check an old build
 #
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '87.5011'});
-$get->status_is(200);
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '87.5011'})
+  ->status_is(200);
 $summary = get_summary;
 like($summary, qr/Summary of opensuse Factory build 87.5011/);
 like($summary, qr/Passed: 0 Incomplete: 1 Failed: 0/);
 
 # Advanced query parameters can be forwarded
-$form    = {distri => 'opensuse', version => '13.1', result => 'passed'};
-$get     = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+$form = {distri => 'opensuse', version => '13.1', result => 'passed'};
+$t->get_ok('/tests/overview' => form => $form)->status_is(200);
 $summary = get_summary;
 like($summary, qr/Summary of opensuse 13\.1 build 0091/i, "Still references the last build");
 like($summary, qr/Passed: 3 Failed: 0/i, "Only passed are shown");
-$get->element_exists('#res_DVD_i586_kde .result_passed');
-$get->element_exists('#res_DVD_i586_textmode .result_passed');
-$get->element_exists_not('#res_DVD_i586_RAID0 .state_scheduled');
-$get->element_exists_not('#res_DVD_x86_64_kde .state_running');
-$get->element_exists_not('#res_GNOME-Live_i686_RAID0 .state_cancelled');
-$get->element_exists_not('.result_failed');
-$get->element_exists_not('.state_cancelled');
+$t->element_exists('#res_DVD_i586_kde .result_passed');
+$t->element_exists('#res_DVD_i586_textmode .result_passed');
+$t->element_exists_not('#res_DVD_i586_RAID0 .state_scheduled');
+$t->element_exists_not('#res_DVD_x86_64_kde .state_running');
+$t->element_exists_not('#res_GNOME-Live_i686_RAID0 .state_cancelled');
+$t->element_exists_not('.result_failed');
+$t->element_exists_not('.state_cancelled');
 
 # This time show only failed
 $form = {distri => 'opensuse', version => 'Factory', build => '0048', result => 'failed'};
-$get  = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+$t->get_ok('/tests/overview' => form => $form)->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 1/i);
-$get->element_exists('#res_DVD_x86_64_doc .result_failed');
-$get->element_exists_not('#res_DVD_x86_64_kde .result_passed');
+$t->element_exists('#res_DVD_x86_64_doc .result_failed');
+$t->element_exists_not('#res_DVD_x86_64_kde .result_passed');
 
 $form = {distri => 'opensuse', version => 'Factory', build => '0048', todo => 1};
-$get  = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+$t->get_ok('/tests/overview' => form => $form)->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 1/i, 'todo=1 shows only unlabeled left failed');
 
 # add a failing module to one of the softfails to test 'TODO' option
@@ -159,7 +155,7 @@ my $failing_module = $t->app->schema->resultset('JobModules')->create(
         result   => 'failed'
     });
 
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', todo => 1})
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', todo => 1})
   ->status_is(200);
 like(
     get_summary,
@@ -175,7 +171,7 @@ my $review_comment = $t->app->schema->resultset('Comments')->create(
         text    => 'bsc#1234',
         user_id => 99903,
     });
-$get = $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', todo => 1})
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Factory', build => '0048', todo => 1})
   ->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 1/i, 'todo=1 shows only unlabeled left failed after new failed was labeled');
 $t->element_exists_not('#res-99936', 'reviewed failed filtered out');
@@ -184,16 +180,16 @@ $review_comment->delete();
 $failing_module->delete();
 
 # multiple groups can be shown at the same time
-$get = $t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002&build=0091')->status_is(200);
+$t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002&build=0091')->status_is(200);
 $summary = get_summary;
 like($summary, qr/Summary of opensuse, opensuse test/i, 'references both groups selected by query');
 like($summary, qr/Passed: 2 Failed: 0 Scheduled: 1 Running: 2 None: 1/i,
     'shows latest jobs from both groups 1001/1002');
-$get->element_exists('#res_DVD_i586_kde',                           'job from group 1001 is shown');
-$get->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled', 'another job from group 1001');
-$get->element_exists('#res_NET_x86_64_kde .state_running',          'job from group 1002 is shown');
+$t->element_exists('#res_DVD_i586_kde',                           'job from group 1001 is shown');
+$t->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled', 'another job from group 1001');
+$t->element_exists('#res_NET_x86_64_kde .state_running',          'job from group 1002 is shown');
 
-$get     = $t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002')->status_is(200);
+$t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1002')->status_is(200);
 $summary = get_summary;
 like(
     $summary,
@@ -206,7 +202,7 @@ like($summary, qr/Passed: 2 Failed: 0 Scheduled: 1 Running: 2 None: 1/i);
 $t->get_ok('/tests/overview' => form => {build => '0091', version => '13.1'})->status_is(200);
 $t->get_ok('/tests/overview' => form => {build => '0091', distri  => 'opensuse'})->status_is(200);
 $t->get_ok('/tests/overview' => form => {build => '0091'})->status_is(200);
-$get     = $t->get_ok('/tests/overview')->status_is(200);
+$t->get_ok('/tests/overview')->status_is(200);
 $summary = get_summary;
 like($summary, qr/Summary of opensuse/i, 'shows all available latest jobs for the only present distri');
 like(
@@ -214,9 +210,9 @@ like(
     qr/Passed: 3 Failed: 0 Scheduled: 2 Running: 2 None: 1/i,
     'shows latest jobs from all distri, version, build, flavor, arch'
 );
-$get->element_exists('#res_DVD_i586_kde');
-$get->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled');
-$get->element_exists('#res_NET_x86_64_kde .state_running');
+$t->element_exists('#res_DVD_i586_kde');
+$t->element_exists('#res_GNOME-Live_i686_RAID0 .state_cancelled');
+$t->element_exists('#res_NET_x86_64_kde .state_running');
 
 #
 # Test filter form
@@ -224,7 +220,7 @@ $get->element_exists('#res_NET_x86_64_kde .state_running');
 
 # Test initial state of architecture text box
 $form = {distri => 'opensuse', version => 'Factory', result => 'passed', arch => 'i686'};
-$get  = $t->get_ok('/tests/overview' => form => $form)->status_is(200);
+$t->get_ok('/tests/overview' => form => $form)->status_is(200);
 # FIXME: works when testing manually, but accessing the value via Mojo doesn't work
 #is($t->tx->res->dom->at('#filter-arch')->val, 'i686', 'default state of architecture');
 
@@ -236,18 +232,18 @@ $t->get_ok('/tests/99937/modules/zypper_up/fails')
 
 # Check if logpackages has failed, filtering with failed_modules
 $form = {distri => 'opensuse', version => 'Factory', failed_modules => 'logpackages'};
-$get  = $t->get_ok('/tests/overview', form => $form)->status_is(200);
+$t->get_ok('/tests/overview', form => $form)->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 0/i, 'all jobs filtered out');
-$get->element_exists_not('#res_DVD_x86_64_doc .result_failed', 'old job not revealed');
-$get->element_exists_not('#res_DVD_x86_64_kde .result_passed', 'passed job hidden');
+$t->element_exists_not('#res_DVD_x86_64_doc .result_failed', 'old job not revealed');
+$t->element_exists_not('#res_DVD_x86_64_kde .result_passed', 'passed job hidden');
 
 # make job with logpackages the latest by 'disabling' the currently latest
 my $latest_job = $schema->resultset('Jobs')->find(99940);
 $latest_job->update({DISTRI => 'not opensuse'});
-$get = $t->get_ok('/tests/overview', form => $form)->status_is(200);
+$t->get_ok('/tests/overview', form => $form)->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 1/i);
-$get->element_exists('#res_DVD_x86_64_doc .result_failed', 'job with failed module logpackages still shown');
-$get->element_exists_not('#res_DVD_x86_64_kde .result_passed', 'passed job hidden');
+$t->element_exists('#res_DVD_x86_64_doc .result_failed', 'job with failed module logpackages still shown');
+$t->element_exists_not('#res_DVD_x86_64_kde .result_passed', 'passed job hidden');
 
 # Check if another random module has failed
 $latest_job->update({DISTRI => 'opensuse'});
@@ -259,7 +255,7 @@ $failing_module = $schema->resultset('JobModules')->create(
         name     => 'failing_module',
         result   => 'failed'
     });
-$get = $t->get_ok(
+$t->get_ok(
     '/tests/overview' => form => {
         distri         => 'opensuse',
         version        => 'Factory',
@@ -267,8 +263,8 @@ $get = $t->get_ok(
     })->status_is(200);
 
 like(get_summary, qr/Passed: 0 Failed: 1/i, 'failed_modules shows failed jobs');
-$get->element_exists('#res-99940',                         'foo_bar_failed_module failed');
-$get->element_exists('#res_DVD_x86_64_doc .result_failed', 'foo_bar_failed_module module failed');
+$t->element_exists('#res-99940',                         'foo_bar_failed_module failed');
+$t->element_exists('#res_DVD_x86_64_doc .result_failed', 'foo_bar_failed_module module failed');
 
 # Check if another random module has failed
 $schema->resultset('JobModules')->create(
@@ -279,7 +275,7 @@ $schema->resultset('JobModules')->create(
         name     => 'failing_module',
         result   => 'failed'
     });
-$get = $t->get_ok(
+$t->get_ok(
     '/tests/overview' => form => {
         distri         => 'opensuse',
         version        => 'Factory',
@@ -298,13 +294,13 @@ $failing_module = $schema->resultset('JobModules')->create(
         name     => 'failing_module',
         result   => 'failed'
     });
-$get = $t->get_ok(
+$t->get_ok(
     '/tests/overview' => form => {
         distri         => 'opensuse',
         version        => '13.1',
         failed_modules => 'failing_module',
     })->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 0/i, 'Job was successful, so failed_modules does not show it');
-$get->element_exists_not('#res-99946', 'no module has failed');
+$t->element_exists_not('#res-99946', 'no module has failed');
 
 done_testing();

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -97,7 +97,7 @@ subtest 'tag icon on group overview on important build' => sub {
     for my $comment ($tag, $unrelated_comment) {
         post_comment_1001 $comment;
     }
-    my $get  = $t->get_ok('/group_overview/1001')->status_is(200);
+    $t->get_ok('/group_overview/1001')->status_is(200);
     my @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 1,    'one build tagged');
     is($tags[0],     'GM', 'tag description shown');
@@ -105,7 +105,7 @@ subtest 'tag icon on group overview on important build' => sub {
 
 subtest 'test whether tags with @ work, too' => sub {
     post_comment_1001 'tag:0048@0815:important:RC2';
-    my $get  = $t->get_ok('/group_overview/1001')->status_is(200);
+    $t->get_ok('/group_overview/1001')->status_is(200);
     my @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 2, 'two builds tagged');
     # this build will sort *above* the first build, so item 0
@@ -119,14 +119,14 @@ Then on page 'group_overview' build C<<build_ref>> is not shown as important
 =cut
 subtest 'mark build as non-important build' => sub {
     post_comment_1001 'tag:0048@0815:-important';
-    my $get  = $t->get_ok('/group_overview/1001')->status_is(200);
+    $t->get_ok('/group_overview/1001')->status_is(200);
     my @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 1, 'only first build tagged');
 };
 
 subtest 'tag on non-existent build does not show up' => sub {
     post_comment_1001 'tag:0066:important';
-    my $get  = $t->get_ok('/group_overview/1001')->status_is(200);
+    $t->get_ok('/group_overview/1001')->status_is(200);
     my @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 1, 'only first build tagged');
 };
@@ -134,29 +134,29 @@ subtest 'tag on non-existent build does not show up' => sub {
 subtest 'builds first tagged important, then unimportant dissappear (poo#12028)' => sub {
     post_comment_1001 'tag:0091:important';
     post_comment_1001 'tag:0091:-important';
-    my $get  = $t->get_ok('/group_overview/1001?limit_builds=1')->status_is(200);
+    $t->get_ok('/group_overview/1001?limit_builds=1')->status_is(200);
     my @tags = $t->tx->res->dom->find('a[href^=/tests/]')->map('text')->each;
     is(scalar @tags, 1, 'only one build');
     is($tags[0], 'Build87.5011', 'only newest build present');
 };
 
 subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {
-    my $get = $t->get_ok('/group_overview/1001?only_tagged=1')->status_is(200);
+    $t->get_ok('/group_overview/1001?only_tagged=1')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 1, 'only one tagged build is shown (on group overview)');
-    $get = $t->get_ok('/group_overview/1001?only_tagged=0')->status_is(200);
+    $t->get_ok('/group_overview/1001?only_tagged=0')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 5, 'all builds shown again (on group overview)');
 
-    $get = $t->get_ok('/?only_tagged=1')->status_is(200);
+    $t->get_ok('/?only_tagged=1')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 1, 'only one tagged build is shown (on index page)');
     is(scalar @{$t->tx->res->dom->find('h2')},               1, 'only one group shown anymore');
-    $get = $t->get_ok('/?only_tagged=0')->status_is(200);
+    $t->get_ok('/?only_tagged=0')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 4, 'all builds shown again (on index page)');
     is(scalar @{$t->tx->res->dom->find('h2')},               2, 'two groups shown again');
 };
 
 subtest 'show_tags query parameter enables/disables tags on index page' => sub {
     for my $enabled (0, 1) {
-        my $get = $t->get_ok('/?show_tags=' . $enabled)->status_is(200);
+        $t->get_ok('/?show_tags=' . $enabled)->status_is(200);
         is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')},
             4, "all builds shown on index page (show_tags=$enabled)");
         is(scalar @{$t->tx->res->dom->find("i[title='important']")},
@@ -167,7 +167,7 @@ subtest 'show_tags query parameter enables/disables tags on index page' => sub {
 subtest 'test tags for Fedora compose-style BUILD values' => sub {
     create_job_version_build('26', 'Fedora-26-20170329.n.0');
     post_comment_1001 'tag:Fedora-26-20170329.n.0:important:candidate';
-    my $get  = $t->get_ok('/group_overview/1001')->status_is(200);
+    $t->get_ok('/group_overview/1001')->status_is(200);
     my @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 2, 'two builds tagged');
     # this build will sort *after* the remaining SUSE build, so item 1
@@ -177,7 +177,7 @@ subtest 'test tags for Fedora compose-style BUILD values' => sub {
 subtest 'test tags for Fedora update-style BUILD values' => sub {
     create_job_version_build('26', 'FEDORA-2017-3456ba4c93');
     post_comment_1001 'tag:FEDORA-2017-3456ba4c93:important:critpath';
-    my $get  = $t->get_ok('/group_overview/1001')->status_is(200);
+    $t->get_ok('/group_overview/1001')->status_is(200);
     my @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 3, 'three builds tagged');
     # this build will sort *before* the other Fedora build, so item 1

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -47,14 +47,14 @@ sub set_up {
 
 sub comments {
     my ($url) = @_;
-    my $get = $t->get_ok($url)->status_is(200);
-    return $get->tx->res->dom->find('div.comments .media-comment > p')->map('content');
+    $t->get_ok($url)->status_is(200);
+    return $t->tx->res->dom->find('div.comments .media-comment > p')->map('content');
 }
 
 sub restart_with_result {
     my ($old_job, $result) = @_;
-    my $get     = $t->post_ok("/api/v1/jobs/$old_job/restart", $auth)->status_is(200);
-    my $res     = decode_json($get->tx->res->body);
+    $t->post_ok("/api/v1/jobs/$old_job/restart", $auth)->status_is(200);
+    my $res     = decode_json($t->tx->res->body);
     my $new_job = $res->{result}[0]->{$old_job};
     $t->post_ok("/api/v1/jobs/$new_job/set_done", $auth => form => {result => $result})->status_is(200);
     return $res;

--- a/t/18-fedmsg.t
+++ b/t/18-fedmsg.t
@@ -81,8 +81,8 @@ my $settings = {
 my $commonexpr = '/usr/sbin/daemonize /usr/bin/fedmsg-logger-3 --cert-prefix=openqa --modname=openqa';
 my $commonci   = '/usr/sbin/daemonize /usr/bin/fedmsg-logger-3 --cert-prefix=ci --modname=ci';
 # create a job via API
-my $post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
-my $job  = $post->tx->res->json->{id};
+$t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+my $job = $t->tx->res->json->{id};
 is(
     $args[0],
     $commonexpr
@@ -116,7 +116,7 @@ is(
 # FIXME: restarting job via API emits an event in real use, but not if we do it here
 
 # set the job as done (implicit failed, it seems) via API
-$post = $t->post_ok("/api/v1/jobs/" . $job . "/set_done")->status_is(200);
+$t->post_ok("/api/v1/jobs/" . $job . "/set_done")->status_is(200);
 # check plugin called fedmsg-logger-3 correctly
 is(
     $args[0],
@@ -151,8 +151,8 @@ is(
 # we don't test update_results as comment indicates it's obsolete
 
 # duplicate the job via API
-$post = $t->post_ok("/api/v1/jobs/" . $job . "/duplicate")->status_is(200);
-my $newjob = $post->tx->res->json->{id};
+$t->post_ok("/api/v1/jobs/" . $job . "/duplicate")->status_is(200);
+my $newjob = $t->tx->res->json->{id};
 # check plugin called fedmsg-logger-3 correctly
 is(
     $args[0],
@@ -188,7 +188,7 @@ is(
 @args = ();
 
 # cancel the new job via API
-$post = $t->post_ok("/api/v1/jobs/" . $newjob . "/cancel")->status_is(200);
+$t->post_ok("/api/v1/jobs/" . $newjob . "/cancel")->status_is(200);
 # check plugin called fedmsg-logger-3 correctly
 is(
     $args[0],
@@ -219,14 +219,14 @@ is(
 );
 
 # duplicate the job once more via API (so we can test 'passed')
-$post = $t->post_ok("/api/v1/jobs/" . $newjob . "/duplicate")->status_is(200);
-my $newerjob = $post->tx->res->json->{id};
+$t->post_ok("/api/v1/jobs/" . $newjob . "/duplicate")->status_is(200);
+my $newerjob = $t->tx->res->json->{id};
 
 # reset $args
 @args = ();
 
 # set the job as done (explicit passed) via API
-$post = $t->post_ok("/api/v1/jobs/" . $newerjob . "/set_done?result=passed")->status_is(200);
+$t->post_ok("/api/v1/jobs/" . $newerjob . "/set_done?result=passed")->status_is(200);
 # check plugin called fedmsg-logger-3 correctly
 is(
     $args[0],
@@ -261,9 +261,9 @@ is(
 # FIXME: deleting job via DELETE call to api/v1/jobs/$newjob fails with 500?
 
 # add a job comment via API
-$post = $t->post_ok("/api/v1/jobs/$job/comments" => form => {text => "test comment"})->status_is(200);
+$t->post_ok("/api/v1/jobs/$job/comments" => form => {text => "test comment"})->status_is(200);
 # stash the comment ID
-my $comment = $post->tx->res->json->{id};
+my $comment = $t->tx->res->json->{id};
 # check plugin called fedmsg-logger-3 correctly
 my $dateexpr = '\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}Z';
 like(
@@ -275,7 +275,7 @@ qr/$commonexpr --topic=comment.create --json-input --message=\{"created":"$datee
 @args = ();
 
 # update job comment via API
-my $put = $t->put_ok("/api/v1/jobs/$job/comments/$comment" => form => {text => "updated comment"})->status_is(200);
+$t->put_ok("/api/v1/jobs/$job/comments/$comment" => form => {text => "updated comment"})->status_is(200);
 # check plugin called fedmsg-logger-3 correctly
 like(
     $args[0],
@@ -289,7 +289,7 @@ qr/$commonexpr --topic=comment.update --json-input --message=\{"created":"$datee
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 # delete comment via API
-my $delete = $t->delete_ok("/api/v1/jobs/$job/comments/$comment")->status_is(200);
+$t->delete_ok("/api/v1/jobs/$job/comments/$comment")->status_is(200);
 like(
     $args[0],
 qr/$commonexpr --topic=comment.delete --json-input --message=\{"created":"$dateexpr","group_id":null,"id":$comment,"job_id":$job,"text":"updated comment","updated":"$dateexpr","user":"perci"\}/,
@@ -301,8 +301,8 @@ qr/$commonexpr --topic=comment.delete --json-input --message=\{"created":"$datee
 # create another job via API, this time for an update
 $settings->{BUILD} = 'Update-FEDORA-2018-3c876babb9';
 delete $settings->{ISO};
-$post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
-my $updatejob = $post->tx->res->json->{id};
+$t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+my $updatejob = $t->tx->res->json->{id};
 is(
     $args[0],
     $commonexpr

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -33,21 +33,18 @@ my $schema = OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # export all jobs
-my $r = $t->get_ok("/tests/export")->status_is(200);
-$t->content_type_is('text/plain');
-$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
-$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is skipped/);
+$t->get_ok("/tests/export")->status_is(200)->content_type_is('text/plain')
+  ->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/)
+  ->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is skipped/);
 
 # filter
-$r = $t->get_ok("/tests/export?from=99981")->status_is(200);
-$t->content_type_is('text/plain');
-$t->content_unlike(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
-$t->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is skipped/);
+$t->get_ok("/tests/export?from=99981")->status_is(200)->content_type_is('text/plain')
+  ->content_unlike(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/)
+  ->content_like(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is skipped/);
 
-$r = $t->get_ok("/tests/export?to=99981")->status_is(200);
-$t->content_type_is('text/plain');
-$t->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/);
 # to is exclusiv
-$t->content_unlike(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is skipped/);
+$t->get_ok("/tests/export?to=99981")->status_is(200)->content_type_is('text/plain')
+  ->content_like(qr/Job 99937: opensuse-13.1-DVD-i586-Build0091-kde\@32bit is passed/)
+  ->content_unlike(qr/Job 99981: opensuse-13.1-GNOME-Live-i686-Build0091-RAID0\@32bit is skipped/);
 
 done_testing();

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -88,8 +88,8 @@ my $settings = {
 # create a job via API
 my $job;
 subtest 'create job' => sub {
-    my $post = $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
-    ok($job = $post->tx->res->json->{id}, 'got ID of new job');
+    $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+    ok($job = $t->tx->res->json->{id}, 'got ID of new job');
     is(
         $published{'suse.openqa.job.create'},
         '{"ARCH":"x86_64","BUILD":"666","DESKTOP":"DESKTOP","DISTRI":"Unicorn","FLAVOR":"pink","ISO":"whatever.iso",'
@@ -101,7 +101,7 @@ subtest 'create job' => sub {
 };
 
 subtest 'mark job as done' => sub {
-    my $post = $t->post_ok("/api/v1/jobs/$job/set_done")->status_is(200);
+    $t->post_ok("/api/v1/jobs/$job/set_done")->status_is(200);
     is(
         $published{'suse.openqa.job.done'},
         '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
@@ -124,7 +124,7 @@ subtest 'mark job with taken over bugref as done' => sub {
     is($previous_job->bugref, 'bsc#123', 'added bugref recognized');
 
     # mark so far running job 99963 as failed which should trigger bug carry over
-    my $post = $t->post_ok(
+    $t->post_ok(
         "/api/v1/jobs/99963/set_done",
         form => {
             result => OpenQA::Jobs::Constants::FAILED
@@ -139,8 +139,8 @@ subtest 'mark job with taken over bugref as done' => sub {
 };
 
 subtest 'duplicate and cancel job' => sub {
-    my $post   = $t->post_ok("/api/v1/jobs/$job/duplicate")->status_is(200);
-    my $newjob = $post->tx->res->json->{id};
+    $t->post_ok("/api/v1/jobs/$job/duplicate")->status_is(200);
+    my $newjob = $t->tx->res->json->{id};
     is(
         $published{'suse.openqa.job.duplicate'},
         '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
@@ -151,7 +151,7 @@ subtest 'duplicate and cancel job' => sub {
         'job duplicate triggers amqp'
     );
 
-    $post = $t->post_ok("/api/v1/jobs/$newjob/cancel")->status_is(200);
+    $t->post_ok("/api/v1/jobs/$newjob/cancel")->status_is(200);
     is(
         $published{'suse.openqa.job.cancel'},
         '{"ARCH":"x86_64","BUILD":"666","FLAVOR":"pink","ISO":"whatever.iso","MACHINE":"RainbowPC",'
@@ -173,7 +173,7 @@ sub assert_common_comment_json {
 }
 
 subtest 'create job group comment' => sub {
-    my $post = $t->post_ok('/api/v1/groups/1001/comments' => form => {text => 'test'})->status_is(200);
+    $t->post_ok('/api/v1/groups/1001/comments' => form => {text => 'test'})->status_is(200);
     my $json = decode_json($published{'suse.openqa.comment.create'});
     assert_common_comment_json($json);
     is($json->{group_id},        1001,  'job group id');
@@ -181,7 +181,7 @@ subtest 'create job group comment' => sub {
 };
 
 subtest 'create parent group comment' => sub {
-    my $post = $t->post_ok('/api/v1/parent_groups/2000/comments' => form => {text => 'test'})->status_is(200);
+    $t->post_ok('/api/v1/parent_groups/2000/comments' => form => {text => 'test'})->status_is(200);
     my $json = decode_json($published{'suse.openqa.comment.create'});
     assert_common_comment_json($json);
     is($json->{group_id},        undef, 'job group id');

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -32,11 +32,11 @@ $test_case->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 subtest '404 error page' => sub {
-    my $get = $t->get_ok('/unavailable_page')->status_is(404);
-    my $dom = $get->tx->res->dom;
+    $t->get_ok('/unavailable_page')->status_is(404);
+    my $dom = $t->tx->res->dom;
     is_deeply([$dom->find('h1')->map('text')->each], ['Page not found'],   'correct page');
     is_deeply([$dom->find('h2')->map('text')->each], ['Available routes'], 'available routes shown');
-    ok(index($get->tx->res->text, 'Each entry contains the') >= 0, 'description shown');
+    ok(index($t->tx->res->text, 'Each entry contains the') >= 0, 'description shown');
 };
 
 subtest 'error pages shown for OpenQA::WebAPI::Controller::Step' => sub {

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -88,8 +88,8 @@ subtest 'upload public assets' => sub {
     ok(-e $rp, 'Asset exists after upload');
 
     is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
-    my $ret = $t->get_ok('/api/v1/assets/hdd/hdd_image2.qcow2')->status_is(200);
-    is($ret->tx->res->json->{name}, 'hdd_image2.qcow2');
+    $t->get_ok('/api/v1/assets/hdd/hdd_image2.qcow2')->status_is(200);
+    is($t->tx->res->json->{name}, 'hdd_image2.qcow2');
 
 };
 
@@ -129,8 +129,8 @@ subtest 'upload private assets' => sub {
     ok(-e $rp, 'Asset exists after upload');
 
     is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
-    my $ret = $t->get_ok('/api/v1/assets/hdd/00099963-hdd_image3.qcow2')->status_is(200);
-    is($ret->tx->res->json->{name}, '00099963-hdd_image3.qcow2');
+    $t->get_ok('/api/v1/assets/hdd/00099963-hdd_image3.qcow2')->status_is(200);
+    is($t->tx->res->json->{name}, '00099963-hdd_image3.qcow2');
 
 };
 
@@ -175,8 +175,8 @@ subtest 'upload other assets' => sub {
     ok(-e $rp, 'Asset exists after upload');
 
     is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
-    my $ret = $t->get_ok('/api/v1/assets/other/00099963-hdd_image3.xml')->status_is(200);
-    is($ret->tx->res->json->{name}, '00099963-hdd_image3.xml');
+    $t->get_ok('/api/v1/assets/other/00099963-hdd_image3.xml')->status_is(200);
+    is($t->tx->res->json->{name}, '00099963-hdd_image3.xml');
 
 };
 
@@ -229,8 +229,8 @@ subtest 'upload retrials' => sub {
     ok(-e $rp, 'Asset exists after upload');
 
     is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
-    my $ret = $t->get_ok('/api/v1/assets/other/00099963-hdd_image4.xml')->status_is(200);
-    is($ret->tx->res->json->{name}, '00099963-hdd_image4.xml');
+    $t->get_ok('/api/v1/assets/other/00099963-hdd_image4.xml')->status_is(200);
+    is($t->tx->res->json->{name}, '00099963-hdd_image4.xml');
 
 };
 
@@ -286,7 +286,7 @@ subtest 'upload failures' => sub {
 
     ok(!-e $rp, 'Asset does not exists after upload');
 
-    my $ret = $t->get_ok('/api/v1/assets/other/00099963-hdd_image5.xml')->status_is(404);
+    $t->get_ok('/api/v1/assets/other/00099963-hdd_image5.xml')->status_is(404);
 };
 
 subtest 'upload internal errors' => sub {
@@ -332,7 +332,7 @@ subtest 'upload internal errors' => sub {
 
     ok(!-e $rp, 'Asset does not exists after upload');
 
-    my $ret = $t->get_ok('/api/v1/assets/other/00099963-hdd_image6.xml')->status_is(404);
+    $t->get_ok('/api/v1/assets/other/00099963-hdd_image6.xml')->status_is(404);
 };
 
 

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -59,14 +59,12 @@ $t->app($app);
 
 sub la {
     return unless $ENV{HARNESS_IS_VERBOSE};
-    my $ret    = $t->get_ok('/api/v1/assets')->status_is(200);
-    my @assets = @{$ret->tx->res->json->{assets}};
+    $t->get_ok('/api/v1/assets')->status_is(200);
+    my @assets = @{$t->tx->res->json->{assets}};
     for my $a (@assets) {
         printf "%d %-5s %s\n", $a->{id}, $a->{type}, $a->{name};
     }
 }
-
-my $ret;
 
 sub iso_path {
     my ($iso) = @_;
@@ -108,75 +106,75 @@ my $listing = [
 la;
 
 # register an iso
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200);
-is($ret->tx->res->json->{id}, $listing->[0]->{id}, "asset has correct id");
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200);
+is($t->tx->res->json->{id}, $listing->[0]->{id}, "asset has correct id");
 
 # register same iso again yields same id
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200);
-is($ret->tx->res->json->{id}, $listing->[0]->{id}, "asset still has correct id, no duplicate");
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200);
+is($t->tx->res->json->{id}, $listing->[0]->{id}, "asset still has correct id, no duplicate");
 
 la;
 
 # check data
-$ret = $t->get_ok('/api/v1/assets/iso/' . $iso1)->status_is(200);
-is_deeply(nots($ret->tx->res->json), $listing->[0], "asset correctly entered by name");
-$ret = $t->get_ok('/api/v1/assets/' . $listing->[0]->{id})->status_is(200);
-is_deeply(nots($ret->tx->res->json), $listing->[0], "asset correctly entered by id");
+$t->get_ok('/api/v1/assets/iso/' . $iso1)->status_is(200);
+is_deeply(nots($t->tx->res->json), $listing->[0], "asset correctly entered by name");
+$t->get_ok('/api/v1/assets/' . $listing->[0]->{id})->status_is(200);
+is_deeply(nots($t->tx->res->json), $listing->[0], "asset correctly entered by id");
 
 # check 404 for non existing isos
-$ret = $t->get_ok('/api/v1/assets/iso/' . $iso2)->status_is(404);
+$t->get_ok('/api/v1/assets/iso/' . $iso2)->status_is(404);
 
 # register a second one
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso2})->status_is(200);
-is($ret->tx->res->json->{id}, $listing->[1]->{id}, "asset has corect id");
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso2})->status_is(200);
+is($t->tx->res->json->{id}, $listing->[1]->{id}, "asset has corect id");
 
 # check data
-$ret = $t->get_ok('/api/v1/assets/' . $listing->[1]->{id})->status_is(200);
-is_deeply(nots($ret->tx->res->json), $listing->[1], "asset correctly entered by id");
+$t->get_ok('/api/v1/assets/' . $listing->[1]->{id})->status_is(200);
+is_deeply(nots($t->tx->res->json), $listing->[1], "asset correctly entered by id");
 
 # check listing
-$ret = $t->get_ok('/api/v1/assets')->status_is(200);
-is_deeply(nots($ret->tx->res->json->{assets}->[6]), $listing->[0], "listing ok");
+$t->get_ok('/api/v1/assets')->status_is(200);
+is_deeply(nots($t->tx->res->json->{assets}->[6]), $listing->[0], "listing ok");
 
 la;
 
 # test delete operation
-$ret = $t->delete_ok('/api/v1/assets/' . $listing->[0]->{id})->status_is(200);
-is($ret->tx->res->json->{count}, 1, "one asset deleted");
+$t->delete_ok('/api/v1/assets/' . $listing->[0]->{id})->status_is(200);
+is($t->tx->res->json->{count}, 1, "one asset deleted");
 
 # verify it's really gone
-$ret = $t->get_ok('/api/v1/assets/' . $listing->[0]->{id})->status_is(404);
+$t->get_ok('/api/v1/assets/' . $listing->[0]->{id})->status_is(404);
 ok(!-e iso_path($iso1), 'iso file 1 has been removed');
 # but two must be still there
-$ret = $t->get_ok('/api/v1/assets/' . $listing->[1]->{id})->status_is(200);
+$t->get_ok('/api/v1/assets/' . $listing->[1]->{id})->status_is(200);
 ok(-e iso_path($iso2), 'iso file 2 is still there');
 
 # register it again
 touch_isos [$iso1];
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200);
-is($ret->tx->res->json->{id}, $listing->[1]->{id} + 1, "asset has next id");
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200);
+is($t->tx->res->json->{id}, $listing->[1]->{id} + 1, "asset has next id");
 
 # delete by name
-$ret = $t->delete_ok('/api/v1/assets/iso/' . $iso2)->status_is(200);
-is($ret->tx->res->json->{count}, 1, "one asset deleted");
+$t->delete_ok('/api/v1/assets/iso/' . $iso2)->status_is(200);
+is($t->tx->res->json->{count}, 1, "one asset deleted");
 ok(!-e iso_path($iso2), 'iso file 2 has been removed');
 # but three must be still there
-$ret = $t->get_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(200);
+$t->get_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(200);
 
 la;
 
 # try to register with invalid type
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'foo', name => $iso1})->status_is(400);
+$t->post_ok('/api/v1/assets', form => {type => 'foo', name => $iso1})->status_is(400);
 
 # try to register with invalid name
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => ''})->status_is(400);
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => ''})->status_is(400);
 
 # try to register non existing asset
-$ret = $t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})->status_is(400);
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => 'foo.iso'})->status_is(400);
 
 # check/delete asset by invalid id that should give 404 rather than 500
-$ret = $t->get_ok('/api/v1/assets/iso')->status_is(404);
-$ret = $t->delete_ok('/api/v1/assets/iso')->status_is(404);
+$t->get_ok('/api/v1/assets/iso')->status_is(404);
+$t->delete_ok('/api/v1/assets/iso')->status_is(404);
 
 # trigger cleanup task
 my $gru       = $t->app->gru;
@@ -199,12 +197,11 @@ $t->ua(
 $t->app($app);
 
 # test delete operation
-$ret = $t->delete_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))
-  ->status_is(403, 'asset deletion forbidden for operator');
+$t->delete_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(403, 'asset deletion forbidden for operator');
 # delete by name
-$ret = $t->delete_ok('/api/v1/assets/iso/' . $iso1)->status_is(403, 'asset deletion forbidden for operator');
+$t->delete_ok('/api/v1/assets/iso/' . $iso1)->status_is(403, 'asset deletion forbidden for operator');
 # asset must be still there
-$ret = $t->get_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(200);
+$t->get_ok('/api/v1/assets/' . ($listing->[1]->{id} + 1))->status_is(200);
 ok(-e iso_path($iso1),      'iso file 1 is still there');
 ok(unlink(iso_path($iso1)), 'remove iso file 1 manually');
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -53,8 +53,8 @@ my $scheduled_products = $schema->resultset('ScheduledProducts');
 
 sub lj {
     return unless $ENV{HARNESS_IS_VERBOSE};
-    my $ret  = $t->get_ok('/api/v1/jobs')->status_is(200);
-    my @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs')->status_is(200);
+    my @jobs = @{$t->tx->res->json->{jobs}};
     for my $j (@jobs) {
         printf "%d %-10s %s (%s)\n", $j->{id}, $j->{state}, $j->{name}, $j->{priority};
     }
@@ -62,14 +62,14 @@ sub lj {
 
 sub job_state {
     my $job_id = shift;
-    my $ret    = $t->get_ok("/api/v1/jobs/$job_id")->status_is(200);
-    return $ret->tx->res->json->{job}->{state};
+    $t->get_ok("/api/v1/jobs/$job_id")->status_is(200);
+    return $t->tx->res->json->{job}->{state};
 }
 
 sub job_result {
     my $job_id = shift;
-    my $ret    = $t->get_ok("/api/v1/jobs/$job_id")->status_is(200);
-    return $ret->tx->res->json->{job}->{result};
+    $t->get_ok("/api/v1/jobs/$job_id")->status_is(200);
+    return $t->tx->res->json->{job}->{result};
 }
 
 sub job_gru {
@@ -102,31 +102,29 @@ sub schedule_iso {
     my $url = Mojo::URL->new('/api/v1/isos');
     $url->query($query_params);
 
-    my $ret = $t->post_ok($url, form => $args)->status_is($status);
-    return $ret->tx->res;
+    $t->post_ok($url, form => $args)->status_is($status);
+    return $t->tx->res;
 }
-
-my $ret;
 
 my $iso = 'openSUSE-13.1-DVD-i586-Build0091-Media.iso';
 
-$ret = $t->get_ok('/api/v1/jobs/99927')->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job 99927 is scheduled');
-$ret = $t->get_ok('/api/v1/jobs/99928')->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job 99928 is scheduled');
-$ret = $t->get_ok('/api/v1/jobs/99963')->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'running', 'job 99963 is running');
+$t->get_ok('/api/v1/jobs/99927')->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'scheduled', 'job 99927 is scheduled');
+$t->get_ok('/api/v1/jobs/99928')->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'scheduled', 'job 99928 is scheduled');
+$t->get_ok('/api/v1/jobs/99963')->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'running', 'job 99963 is running');
 
-$ret = $t->get_ok('/api/v1/jobs/99981')->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'cancelled', 'job 99981 is cancelled');
+$t->get_ok('/api/v1/jobs/99981')->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'cancelled', 'job 99981 is cancelled');
 
-$ret = $t->post_ok('/api/v1/jobs/99981/restart')->status_is(200);
+$t->post_ok('/api/v1/jobs/99981/restart')->status_is(200);
 
-$ret = $t->get_ok('/api/v1/jobs/99981')->status_is(200);
-my $clone99981 = $ret->tx->res->json->{job}->{clone_id};
+$t->get_ok('/api/v1/jobs/99981')->status_is(200);
+my $clone99981 = $t->tx->res->json->{job}->{clone_id};
 
-$ret = $t->get_ok("/api/v1/jobs/$clone99981")->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job $clone99981 is scheduled');
+$t->get_ok("/api/v1/jobs/$clone99981")->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'scheduled', 'job $clone99981 is scheduled');
 
 lj;
 
@@ -299,8 +297,8 @@ is($res->json->{count}, 10, '10 new jobs created');
 my @newids = @{$res->json->{ids}};
 my $newid  = $newids[0];
 
-$ret = $t->get_ok('/api/v1/jobs');
-my @jobs = @{$ret->tx->res->json->{jobs}};
+$t->get_ok('/api/v1/jobs');
+my @jobs = @{$t->tx->res->json->{jobs}};
 
 my $server_32       = find_job(\@jobs, \@newids, 'server',       '32bit');
 my $client1_32      = find_job(\@jobs, \@newids, 'client1',      '32bit');
@@ -391,27 +389,27 @@ is($server_64->{settings}->{PRECEDENCE}, 'overridden', "precedence override (sui
 lj;
 
 subtest 'old tests are cancelled unless they are marked as important' => sub {
-    $ret = $t->get_ok('/api/v1/jobs/99927')->status_is(200);
-    is($ret->tx->res->json->{job}->{state}, 'cancelled', 'job 99927 is cancelled');
-    $ret = $t->get_ok('/api/v1/jobs/99928')->status_is(200);
-    is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job 99928 is marked as important and therefore preserved');
-    $ret = $t->get_ok('/api/v1/jobs/99963')->status_is(200);
-    is($ret->tx->res->json->{job}->{state}, 'running', 'job 99963 is running');
+    $t->get_ok('/api/v1/jobs/99927')->status_is(200);
+    is($t->tx->res->json->{job}->{state}, 'cancelled', 'job 99927 is cancelled');
+    $t->get_ok('/api/v1/jobs/99928')->status_is(200);
+    is($t->tx->res->json->{job}->{state}, 'scheduled', 'job 99928 is marked as important and therefore preserved');
+    $t->get_ok('/api/v1/jobs/99963')->status_is(200);
+    is($t->tx->res->json->{job}->{state}, 'running', 'job 99963 is running');
 };
 
 # make sure unrelated jobs are not cancelled
-$ret = $t->get_ok("/api/v1/jobs/$clone99981")->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'scheduled', "job $clone99981 is still scheduled");
+$t->get_ok("/api/v1/jobs/$clone99981")->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'scheduled', "job $clone99981 is still scheduled");
 
 # ... and we have a new test
-$ret = $t->get_ok("/api/v1/jobs/$newid")->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'scheduled', "new job $newid is scheduled");
+$t->get_ok("/api/v1/jobs/$newid")->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'scheduled', "new job $newid is scheduled");
 
 # cancel the iso
-$ret = $t->post_ok("/api/v1/isos/$iso/cancel")->status_is(200);
+$t->post_ok("/api/v1/isos/$iso/cancel")->status_is(200);
 
-$ret = $t->get_ok("/api/v1/jobs/$newid")->status_is(200);
-is($ret->tx->res->json->{job}->{state}, 'cancelled', "job $newid is cancelled");
+$t->get_ok("/api/v1/jobs/$newid")->status_is(200);
+is($t->tx->res->json->{job}->{state}, 'cancelled', "job $newid is cancelled");
 
 # make sure we can't post invalid parameters
 $res = schedule_iso({iso => $iso, tests => "kde/usb"}, 400);
@@ -434,34 +432,34 @@ is($res->json->{count}, 5, '5 new jobs created (two twice for both machine types
 
 # delete the iso
 # can not do as operator
-$ret = $t->delete_ok("/api/v1/isos/$iso")->status_is(403);
+$t->delete_ok("/api/v1/isos/$iso")->status_is(403);
 # switch to admin and continue
 $app = $t->app;
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
-$ret = $t->delete_ok("/api/v1/isos/$iso")->status_is(200);
+$t->delete_ok("/api/v1/isos/$iso")->status_is(200);
 # now the jobs should be gone
-$ret = $t->get_ok('/api/v1/jobs/$newid')->status_is(404);
+$t->get_ok('/api/v1/jobs/$newid')->status_is(404);
 
 subtest 'jobs belonging to important builds are not cancelled by new iso post' => sub {
-    $ret = $t->get_ok('/api/v1/jobs/99963')->status_is(200);
-    is($ret->tx->res->json->{job}->{state}, 'running', 'job in build 0091 running');
+    $t->get_ok('/api/v1/jobs/99963')->status_is(200);
+    is($t->tx->res->json->{job}->{state}, 'running', 'job in build 0091 running');
     my $tag = 'tag:0091:important';
     $t->app->schema->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
     $res = schedule_iso(
         {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091'});
     is($res->json->{count}, 10, '10 jobs created');
     my $example = $res->json->{ids}->[9];
-    $ret = $t->get_ok("/api/v1/jobs/$example")->status_is(200);
-    is($ret->tx->res->json->{job}->{state}, 'scheduled');
+    $t->get_ok("/api/v1/jobs/$example")->status_is(200);
+    is($t->tx->res->json->{job}->{state}, 'scheduled');
     $res = schedule_iso(
         {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0092'});
-    $ret = $t->get_ok("/api/v1/jobs/$example")->status_is(200);
-    is($ret->tx->res->json->{job}->{state}, 'scheduled', 'job in old important build still scheduled');
+    $t->get_ok("/api/v1/jobs/$example")->status_is(200);
+    is($t->tx->res->json->{job}->{state}, 'scheduled', 'job in old important build still scheduled');
     $res = schedule_iso(
         {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0093'});
-    $ret = $t->get_ok('/api/v1/jobs?state=scheduled');
-    my @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs?state=scheduled');
+    my @jobs = @{$t->tx->res->json->{jobs}};
     lj;
     ok(!grep({ $_->{settings}->{BUILD} =~ '009[2]' } @jobs), 'no jobs from intermediate, not-important build');
     is(scalar @jobs, 21, 'only the important jobs, jobs from the current build and the important build are scheduled');
@@ -470,8 +468,8 @@ subtest 'jobs belonging to important builds are not cancelled by new iso post' =
     $t->app->schema->resultset("JobGroups")->find(1001)->comments->create({text => $tag, user_id => 99901});
     $res = schedule_iso(
         {ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0094'});
-    $ret  = $t->get_ok('/api/v1/jobs?state=scheduled');
-    @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs?state=scheduled');
+    @jobs = @{$t->tx->res->json->{jobs}};
     lj;
     ok(grep({ $_->{settings}->{BUILD} eq '0091' } @jobs), 'we have jobs from important build 0091');
     ok(grep({ $_->{settings}->{BUILD} eq '0093' } @jobs), 'we have jobs from important build 0093');
@@ -481,25 +479,25 @@ subtest 'jobs belonging to important builds are not cancelled by new iso post' =
 subtest 'build obsoletion/depriorization' => sub {
     my %iso = (ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0095');
     $res = schedule_iso({%iso, BUILD => '0095'});
-    $ret = $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
-    my @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
+    my @jobs = @{$t->tx->res->json->{jobs}};
     lj;
     ok(!grep({ $_->{settings}->{BUILD} =~ '009[24]' } @jobs), 'recent non-important builds were obsoleted');
     is(scalar @jobs, 31, 'current build and the important build are scheduled');
-    $res  = schedule_iso({%iso, BUILD => '0096', '_NO_OBSOLETE' => 1});
-    $ret  = $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
-    @jobs = @{$ret->tx->res->json->{jobs}};
+    $res = schedule_iso({%iso, BUILD => '0096', '_NO_OBSOLETE' => 1});
+    $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
+    @jobs = @{$t->tx->res->json->{jobs}};
     lj;
     my @jobs_previous_build = grep { $_->{settings}->{BUILD} eq '0095' } @jobs;
     ok(@jobs_previous_build, 'previous build was not obsoleted');
     is($jobs_previous_build[0]->{priority}, 40, 'job is at same priority as before');
     is($jobs_previous_build[1]->{priority}, 40, 'second job, same priority');
     # set one job to already highest allowed
-    $ret = $t->put_ok('/api/v1/jobs/' . $jobs_previous_build[1]->{id}, json => {priority => 100})->status_is(200);
-    my $job_at_prio_limit = $ret->tx->res->json->{job_id};
-    $res  = schedule_iso({%iso, BUILD => '0097', '_DEPRIORITIZEBUILD' => 1});
-    $ret  = $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
-    @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->put_ok('/api/v1/jobs/' . $jobs_previous_build[1]->{id}, json => {priority => 100})->status_is(200);
+    my $job_at_prio_limit = $t->tx->res->json->{job_id};
+    $res = schedule_iso({%iso, BUILD => '0097', '_DEPRIORITIZEBUILD' => 1});
+    $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
+    @jobs = @{$t->tx->res->json->{jobs}};
     lj;
     @jobs_previous_build = grep { $_->{settings}->{BUILD} eq '0095' } @jobs;
     ok(@jobs_previous_build, 'old build still in progress');
@@ -508,9 +506,9 @@ subtest 'build obsoletion/depriorization' => sub {
     $t->json_is('/job/state' => 'cancelled', 'older job already at priorization limit was cancelled');
     # test 'only same build' obsoletion
     my @jobs_0097 = grep { $_->{settings}->{BUILD} eq '0097' } @jobs;
-    $res  = schedule_iso({%iso, BUILD => '0097', '_ONLY_OBSOLETE_SAME_BUILD' => 1});
-    $ret  = $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
-    @jobs = @{$ret->tx->res->json->{jobs}};
+    $res = schedule_iso({%iso, BUILD => '0097', '_ONLY_OBSOLETE_SAME_BUILD' => 1});
+    $t->get_ok('/api/v1/jobs?state=scheduled')->status_is(200);
+    @jobs = @{$t->tx->res->json->{jobs}};
     lj;
     # jobs from previous build shouldn't be cancelled
     @jobs_previous_build = grep { $_->{settings}->{BUILD} eq '0095' } @jobs;
@@ -866,8 +864,8 @@ subtest 'Create dependency for jobs on different machines - dependency setting a
     my @newids = @{$res->json->{ids}};
     my $newid  = $newids[0];
 
-    $ret = $t->get_ok('/api/v1/jobs');
-    my @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs');
+    my @jobs = @{$t->tx->res->json->{jobs}};
 
     my $server1_64    = find_job(\@jobs, \@newids, 'supportserver1', '64bit');
     my $server2_ipmi  = find_job(\@jobs, \@newids, 'supportserver2', '64bit-ipmi');
@@ -916,8 +914,8 @@ subtest 'Create dependency for jobs on different machines - best match and log e
     my @newids = @{$res->json->{ids}};
     my $newid  = $newids[0];
 
-    $ret = $t->get_ok('/api/v1/jobs');
-    my @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs');
+    my @jobs = @{$t->tx->res->json->{jobs}};
 
     my $install_ltp   = find_job(\@jobs, \@newids, 'install_ltp', 'powerpc');
     my $use_ltp_64    = find_job(\@jobs, \@newids, 'use_ltp',     '64bit');
@@ -979,8 +977,8 @@ subtest 'Create dependency for jobs on different machines - log error parents' =
     my @newids = @{$res->json->{ids}};
     my $newid  = $newids[0];
 
-    $ret = $t->get_ok('/api/v1/jobs');
-    my @jobs = @{$ret->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs');
+    my @jobs = @{$t->tx->res->json->{jobs}};
 
     my $supportserver_ppc   = find_job(\@jobs, \@newids, 'supportserver', 'ppc');
     my $supportserver_64    = find_job(\@jobs, \@newids, 'supportserver', '64bit');

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -84,8 +84,8 @@ $jobs->find(99963)->update({assigned_worker_id => 1});
 # 99926 done       no clone
 
 # First, let's try /jobs and ensure the initial state
-my $get        = $t->get_ok('/api/v1/jobs');
-my @jobs       = @{$get->tx->res->json->{jobs}};
+$t->get_ok('/api/v1/jobs');
+my @jobs       = @{$t->tx->res->json->{jobs}};
 my $jobs_count = scalar @jobs;
 is($jobs_count, 18);
 my %jobs = map { $_->{id} => $_ } @jobs;
@@ -100,67 +100,67 @@ is($jobs{99946}->{origin_id},          99945, 'original job');
 is($jobs{99963}->{clone_id},           undef, 'no clone');
 
 # That means that only 9 are current and only 10 are relevant
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 15);
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 16);
+$t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
+is(scalar(@{$t->tx->res->json->{jobs}}), 15);
+$t->get_ok('/api/v1/jobs' => form => {scope => 'relevant'});
+is(scalar(@{$t->tx->res->json->{jobs}}), 16);
 
 # check limit quantity
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current', limit => 5});
-is(scalar(@{$get->tx->res->json->{jobs}}), 5);    # 9 jobs for current
+$t->get_ok('/api/v1/jobs' => form => {scope => 'current', limit => 5});
+is(scalar(@{$t->tx->res->json->{jobs}}), 5);    # 9 jobs for current
 
 # check job group
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current', group => 'opensuse test'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 1);
-is($get->tx->res->json->{jobs}->[0]->{id}, 99961);
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current', group => 'foo bar'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 0);
+$t->get_ok('/api/v1/jobs' => form => {scope => 'current', group => 'opensuse test'});
+is(scalar(@{$t->tx->res->json->{jobs}}), 1);
+is($t->tx->res->json->{jobs}->[0]->{id}, 99961);
+$t->get_ok('/api/v1/jobs' => form => {scope => 'current', group => 'foo bar'});
+is(scalar(@{$t->tx->res->json->{jobs}}), 0);
 
 # Test restricting list
 
 # query for existing jobs by iso
-$get = $t->get_ok('/api/v1/jobs?iso=openSUSE-13.1-DVD-i586-Build0091-Media.iso');
-is(scalar(@{$get->tx->res->json->{jobs}}), 6);
+$t->get_ok('/api/v1/jobs?iso=openSUSE-13.1-DVD-i586-Build0091-Media.iso');
+is(scalar(@{$t->tx->res->json->{jobs}}), 6);
 
 # query for existing jobs by build
-$get = $t->get_ok('/api/v1/jobs?build=0091');
-is(scalar(@{$get->tx->res->json->{jobs}}), 11);
+$t->get_ok('/api/v1/jobs?build=0091');
+is(scalar(@{$t->tx->res->json->{jobs}}), 11);
 
 # query for existing jobs by hdd_1
-$get = $t->get_ok('/api/v1/jobs?hdd_1=openSUSE-13.1-x86_64.hda');
-is(scalar(@{$get->tx->res->json->{jobs}}), 3);
+$t->get_ok('/api/v1/jobs?hdd_1=openSUSE-13.1-x86_64.hda');
+is(scalar(@{$t->tx->res->json->{jobs}}), 3);
 
 # query for some combinations with test
-$get = $t->get_ok('/api/v1/jobs?test=kde');
-is(scalar(@{$get->tx->res->json->{jobs}}), 6);
-$get = $t->get_ok('/api/v1/jobs?test=kde&result=passed');
-is(scalar(@{$get->tx->res->json->{jobs}}), 1);
-$get = $t->get_ok('/api/v1/jobs?test=kde&result=softfailed');
-is(scalar(@{$get->tx->res->json->{jobs}}), 2);
-$get = $t->get_ok('/api/v1/jobs?test=kde&result=softfailed&machine=64bit');
-is(scalar(@{$get->tx->res->json->{jobs}}), 1);
-$get = $t->get_ok('/api/v1/jobs?test=kde&result=passed&machine=64bit');
-is(scalar(@{$get->tx->res->json->{jobs}}), 0);
+$t->get_ok('/api/v1/jobs?test=kde');
+is(scalar(@{$t->tx->res->json->{jobs}}), 6);
+$t->get_ok('/api/v1/jobs?test=kde&result=passed');
+is(scalar(@{$t->tx->res->json->{jobs}}), 1);
+$t->get_ok('/api/v1/jobs?test=kde&result=softfailed');
+is(scalar(@{$t->tx->res->json->{jobs}}), 2);
+$t->get_ok('/api/v1/jobs?test=kde&result=softfailed&machine=64bit');
+is(scalar(@{$t->tx->res->json->{jobs}}), 1);
+$t->get_ok('/api/v1/jobs?test=kde&result=passed&machine=64bit');
+is(scalar(@{$t->tx->res->json->{jobs}}), 0);
 
 # test limiting options
-$get = $t->get_ok('/api/v1/jobs?limit=5');
-is(scalar(@{$get->tx->res->json->{jobs}}), 5);
-$get = $t->get_ok('/api/v1/jobs?limit=1');
-is(scalar(@{$get->tx->res->json->{jobs}}), 1);
-is($get->tx->res->json->{jobs}->[0]->{id}, 99981);
-$get = $t->get_ok('/api/v1/jobs?limit=1&page=2');
-is(scalar(@{$get->tx->res->json->{jobs}}), 1);
-is($get->tx->res->json->{jobs}->[0]->{id}, 99963);
-$get = $t->get_ok('/api/v1/jobs?before=99928');
-is(scalar(@{$get->tx->res->json->{jobs}}), 4);
-$get = $t->get_ok('/api/v1/jobs?after=99945');
-is(scalar(@{$get->tx->res->json->{jobs}}), 6);
+$t->get_ok('/api/v1/jobs?limit=5');
+is(scalar(@{$t->tx->res->json->{jobs}}), 5);
+$t->get_ok('/api/v1/jobs?limit=1');
+is(scalar(@{$t->tx->res->json->{jobs}}), 1);
+is($t->tx->res->json->{jobs}->[0]->{id}, 99981);
+$t->get_ok('/api/v1/jobs?limit=1&page=2');
+is(scalar(@{$t->tx->res->json->{jobs}}), 1);
+is($t->tx->res->json->{jobs}->[0]->{id}, 99963);
+$t->get_ok('/api/v1/jobs?before=99928');
+is(scalar(@{$t->tx->res->json->{jobs}}), 4);
+$t->get_ok('/api/v1/jobs?after=99945');
+is(scalar(@{$t->tx->res->json->{jobs}}), 6);
 
 # test multiple arg forms
-$get = $t->get_ok('/api/v1/jobs?ids=99981,99963,99926');
-is(scalar(@{$get->tx->res->json->{jobs}}), 3);
-$get = $t->get_ok('/api/v1/jobs?ids=99981&ids=99963&ids=99926');
-is(scalar(@{$get->tx->res->json->{jobs}}), 3);
+$t->get_ok('/api/v1/jobs?ids=99981,99963,99926');
+is(scalar(@{$t->tx->res->json->{jobs}}), 3);
+$t->get_ok('/api/v1/jobs?ids=99981&ids=99963&ids=99926');
+is(scalar(@{$t->tx->res->json->{jobs}}), 3);
 
 subtest 'job overview' => sub {
     my $query = Mojo::URL->new('/api/v1/jobs/overview');
@@ -171,9 +171,9 @@ subtest 'job overview' => sub {
         version => 'Factory',
         groupid => '1001',
     );
-    $get = $t->get_ok($query->path_query)->status_is(200);
+    $t->get_ok($query->path_query)->status_is(200);
     is_deeply(
-        $get->tx->res->json,
+        $t->tx->res->json,
         [
             {
                 id   => 99940,
@@ -185,9 +185,9 @@ subtest 'job overview' => sub {
 
     # overview for build 0048
     $query->query(build => '0048',);
-    $get = $t->get_ok($query->path_query)->status_is(200);
+    $t->get_ok($query->path_query)->status_is(200);
     is_deeply(
-        $get->tx->res->json,
+        $t->tx->res->json,
         [
             {
                 id   => 99939,
@@ -207,11 +207,11 @@ subtest 'job overview' => sub {
 };
 
 # Test /jobs/restart
-my $post = $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})
+$t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})
   ->status_is(200);
 
-$get = $t->get_ok('/api/v1/jobs');
-my @new_jobs = @{$get->tx->res->json->{jobs}};
+$t->get_ok('/api/v1/jobs');
+my @new_jobs = @{$t->tx->res->json->{jobs}};
 is(scalar(@new_jobs), $jobs_count + 5, '5 new jobs - for 81, 63, 46, 39 and 61 from dependency');
 my %new_jobs = map { $_->{id} => $_ } @new_jobs;
 is($new_jobs{99981}->{state}, 'cancelled');
@@ -223,15 +223,15 @@ like($new_jobs{99981}->{clone_id}, qr/\d/, 'job cloned');
 my $cloned = $new_jobs{$new_jobs{99939}->{clone_id}};
 
 # The number of current jobs doesn't change
-$get = $t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
-is(scalar(@{$get->tx->res->json->{jobs}}), 15, 'job count stay the same');
+$t->get_ok('/api/v1/jobs' => form => {scope => 'current'});
+is(scalar(@{$t->tx->res->json->{jobs}}), 15, 'job count stay the same');
 
 # Test /jobs/X/restart and /jobs/X
-$get = $t->get_ok('/api/v1/jobs/99926')->status_is(200);
-ok(!$get->tx->res->json->{job}->{clone_id}, 'job is not a clone');
-$post = $t->post_ok('/api/v1/jobs/99926/restart')->status_is(200);
-$get  = $t->get_ok('/api/v1/jobs/99926')->status_is(200);
-like($get->tx->res->json->{job}->{clone_id}, qr/\d/, 'job cloned');
+$t->get_ok('/api/v1/jobs/99926')->status_is(200);
+ok(!$t->tx->res->json->{job}->{clone_id}, 'job is not a clone');
+$t->post_ok('/api/v1/jobs/99926/restart')->status_is(200);
+$t->get_ok('/api/v1/jobs/99926')->status_is(200);
+like($t->tx->res->json->{job}->{clone_id}, qr/\d/, 'job cloned');
 
 use File::Temp;
 my ($fh, $filename) = File::Temp::tempfile(UNLINK => 1);
@@ -241,27 +241,26 @@ close($fh);
 
 my $rp = "t/data/openqa/testresults/00099/00099963-opensuse-13.1-DVD-x86_64-Build0091-kde/video.ogv";
 unlink($rp);                       # make sure previous tests don't fool us
-$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'video.ogv'}})
+$t->post_ok('/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'video.ogv'}})
   ->status_is(200);
 
 ok(-e $rp, 'video exist after');
 is(calculate_file_md5($rp), "feeebd34e507d3a1641c774da135be77", "md5sum matches");
 
 $rp = "t/data/openqa/testresults/00099/00099963-opensuse-13.1-DVD-x86_64-Build0091-kde/ulogs/y2logs.tar.bz2";
-$post
-  = $t->post_ok(
+$t->post_ok(
     '/api/v1/jobs/99963/artefact' => form => {file => {file => $filename, filename => 'y2logs.tar.bz2'}, ulog => 1})
   ->status_is(200);
-$post->content_is('OK');
+$t->content_is('OK');
 ok(-e $rp, 'logs exist after');
 is(calculate_file_md5($rp), "feeebd34e507d3a1641c774da135be77", "md5sum matches");
 
 
 $rp = "t/data/openqa/share/factory/hdd/hdd_image.qcow2";
 unlink($rp);
-$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+$t->post_ok('/api/v1/jobs/99963/artefact' => form =>
       {file => {file => $filename, filename => 'hdd_image.qcow2'}, asset => 'public'})->status_is(500);
-my $error = $post->tx->res->json->{error};
+my $error = $t->tx->res->json->{error};
 like($error, qr/Failed receiving chunk/);
 
 #Get chunks!
@@ -276,12 +275,12 @@ $pieces->each(
     sub {
         $_->prepare;
         my $chunk_asset = Mojo::Asset::Memory->new->add_chunk($_->serialize);
-        $post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+        $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
               {file => {file => $chunk_asset, filename => 'hdd_image.qcow2'}, asset => 'public'})->status_is(200);
-        my $error  = $post->tx->res->json->{error};
-        my $status = $post->tx->res->json->{status};
+        my $error  = $t->tx->res->json->{error};
+        my $status = $t->tx->res->json->{status};
 
-        ok !$error or die diag explain $post->tx->res->json;
+        ok !$error or die diag explain $t->tx->res->json;
         is $status, 'ok';
         ok(-d $chunkdir, 'Chunk directory exists') unless $_->is_last;
         #  ok((-e path($chunkdir, $_->index)), 'Chunk is there') unless $_->is_last;
@@ -293,8 +292,8 @@ ok(!-d $chunkdir, 'Chunk directory should not exist anymore');
 
 ok(-e $rp, 'Asset exists after upload');
 
-my $ret = $t->get_ok('/api/v1/assets/hdd/hdd_image.qcow2')->status_is(200);
-is($ret->tx->res->json->{name}, 'hdd_image.qcow2');
+$t->get_ok('/api/v1/assets/hdd/hdd_image.qcow2')->status_is(200);
+is($t->tx->res->json->{name}, 'hdd_image.qcow2');
 
 $pieces = OpenQA::File->new(file => Mojo::File->new($filename))->split($chunk_size);
 
@@ -304,10 +303,10 @@ $pieces->each(
         $_->prepare;
         $_->content(int(rand(99999)));
         my $chunk_asset = Mojo::Asset::Memory->new->add_chunk($_->serialize);
-        $post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+        $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
               {file => {file => $chunk_asset, filename => 'hdd_image.qcow2'}, asset => 'public'});
-        my $error  = $post->tx->res->json->{error};
-        my $status = $post->tx->res->json->{status};
+        my $error  = $t->tx->res->json->{error};
+        my $status = $t->tx->res->json->{status};
 
         #  like $error, qr/Checksum mismatch expected/ if $_->is_last;
         like $error, qr/Can't verify written data from chunk/ unless $_->is_last();
@@ -328,10 +327,10 @@ $pieces->each(
         $_->content(int(rand(99999))) if $_->is_last;
         $_->prepare;
         my $chunk_asset = Mojo::Asset::Memory->new->add_chunk($_->serialize);
-        $post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+        $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
               {file => {file => $chunk_asset, filename => 'hdd_image.qcow2'}, asset => 'public'});
-        my $error  = $post->tx->res->json->{error};
-        my $status = $post->tx->res->json->{status};
+        my $error  = $t->tx->res->json->{error};
+        my $status = $t->tx->res->json->{status};
         ok !$error unless $_->is_last();
         like $error, qr/Checksum mismatch expected/ if $_->is_last;
         ok(!-d $chunkdir, 'Chunk directory does not exists') if $_->is_last;
@@ -348,10 +347,10 @@ my $first_chunk = $pieces->first;
 $first_chunk->prepare;
 
 my $chunk_asset = Mojo::Asset::Memory->new->add_chunk($first_chunk->serialize);
-$post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+$t->post_ok('/api/v1/jobs/99963/artefact' => form =>
       {file => {file => $chunk_asset, filename => 'hdd_image.qcow2'}, asset => 'public'});
 
-is $post->tx->res->json->{status}, 'ok';
+is $t->tx->res->json->{status}, 'ok';
 ok(-d $chunkdir, 'Chunk directory exists');
 #ok((-e path($chunkdir, $first_chunk->index)), 'Chunk is there') or die;
 
@@ -371,10 +370,10 @@ $first_chunk = $pieces->first;
 $first_chunk->prepare;
 
 $chunk_asset = Mojo::Asset::Memory->new->add_chunk($first_chunk->serialize);
-$post        = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+$t->post_ok('/api/v1/jobs/99963/artefact' => form =>
       {file => {file => $chunk_asset, filename => 'hdd_image.qcow2'}, asset => 'private'});
 
-is $post->tx->res->json->{status}, 'ok';
+is $t->tx->res->json->{status}, 'ok';
 ok(-d $chunkdir, 'Chunk directory exists');
 #ok((-e path($chunkdir, $first_chunk->index)), 'Chunk is there') or die;
 
@@ -399,12 +398,12 @@ $pieces->each(
     sub {
         $_->prepare;
         my $chunk_asset = Mojo::Asset::Memory->new->add_chunk($_->serialize);
-        $post = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+        $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
               {file => {file => $chunk_asset, filename => 'hdd_image.qcow2'}, asset => 'private'})->status_is(200);
-        my $error  = $post->tx->res->json->{error};
-        my $status = $post->tx->res->json->{status};
+        my $error  = $t->tx->res->json->{error};
+        my $status = $t->tx->res->json->{status};
 
-        ok !$error or die diag explain $post->tx->res->json;
+        ok !$error or die diag explain $t->tx->res->json;
         is $status, 'ok';
         ok(-d $chunkdir, 'Chunk directory exists') unless $_->is_last;
         #    ok((-e path($chunkdir, $_->index)), 'Chunk is there') unless $_->is_last;
@@ -413,8 +412,8 @@ $pieces->each(
 ok(!-d $chunkdir, 'Chunk directory should not exist anymore');
 ok(-e $rp,        'Asset exists after upload');
 
-$ret = $t->get_ok('/api/v1/assets/hdd/00099963-hdd_image.qcow2')->status_is(200);
-is($ret->tx->res->json->{name}, '00099963-hdd_image.qcow2');
+$t->get_ok('/api/v1/assets/hdd/00099963-hdd_image.qcow2')->status_is(200);
+is($t->tx->res->json->{name}, '00099963-hdd_image.qcow2');
 
 
 # Test for private assets
@@ -429,10 +428,10 @@ $first_chunk = $pieces->first;
 $first_chunk->prepare;
 
 $chunk_asset = Mojo::Asset::Memory->new->add_chunk($first_chunk->serialize);
-$post        = $t->post_ok('/api/v1/jobs/99963/artefact' => form =>
+$t->post_ok('/api/v1/jobs/99963/artefact' => form =>
       {file => {file => $chunk_asset, filename => 'new_ltp_result_array.json'}, asset => 'other'});
 
-is $post->tx->res->json->{status}, 'ok';
+is $t->tx->res->json->{status}, 'ok';
 ok(!-d $chunkdir, 'Chunk directory doesnt exists');
 $t->get_ok('/api/v1/assets/other/00099963-new_ltp_result_array.json')->status_is(200);
 
@@ -441,8 +440,8 @@ $t->get_ok('/api/v1/assets/other/00099963-new_ltp_result_array.json')->status_is
 my $query = Mojo::URL->new('/api/v1/jobs');
 for my $state (OpenQA::Schema::Result::Jobs->STATES) {
     $query->query(state => $state);
-    $get = $t->get_ok($query->path_query)->status_is(200);
-    my $res = $get->tx->res->json;
+    $t->get_ok($query->path_query)->status_is(200);
+    my $res = $t->tx->res->json;
     for my $job (@{$res->{jobs}}) {
         is($job->{state}, $state);
     }
@@ -450,8 +449,8 @@ for my $state (OpenQA::Schema::Result::Jobs->STATES) {
 
 for my $result (OpenQA::Schema::Result::Jobs->RESULTS) {
     $query->query(result => $result);
-    $get = $t->get_ok($query->path_query)->status_is(200);
-    my $res = $get->tx->res->json;
+    $t->get_ok($query->path_query)->status_is(200);
+    my $res = $t->tx->res->json;
     for my $job (@{$res->{jobs}}) {
         is($job->{result}, $result);
     }
@@ -459,8 +458,8 @@ for my $result (OpenQA::Schema::Result::Jobs->RESULTS) {
 
 for my $result ('failed,none', 'passed,none', 'failed,passed') {
     $query->query(result => $result);
-    $get = $t->get_ok($query->path_query)->status_is(200);
-    my $res  = $get->tx->res->json;
+    $t->get_ok($query->path_query)->status_is(200);
+    my $res  = $t->tx->res->json;
     my $cond = $result =~ s/,/|/r;
     for my $job (@{$res->{jobs}}) {
         like($job->{result}, qr/$cond/);
@@ -468,18 +467,18 @@ for my $result ('failed,none', 'passed,none', 'failed,passed') {
 }
 
 $query->query(result => 'nonexistent_result');
-$get = $t->get_ok($query->path_query)->status_is(200);
-my $res = $get->tx->res->json;
+$t->get_ok($query->path_query)->status_is(200);
+my $res = $t->tx->res->json;
 ok(!@{$res->{jobs}}, 'no result for nonexising result');
 
 $query->query(state => 'nonexistent_state');
-$get = $t->get_ok($query->path_query)->status_is(200);
-$res = $get->tx->res->json;
+$t->get_ok($query->path_query)->status_is(200);
+$res = $t->tx->res->json;
 ok(!@{$res->{jobs}}, 'no result for nonexising state');
 
 subtest 'Check job status and output' => sub {
-    $get      = $t->get_ok('/api/v1/jobs');
-    @new_jobs = @{$get->tx->res->json->{jobs}};
+    $t->get_ok('/api/v1/jobs');
+    @new_jobs = @{$t->tx->res->json->{jobs}};
     my $running_job_id;
 
     local $ENV{MOJO_LOG_LEVEL} = 'debug';
@@ -501,15 +500,15 @@ subtest 'Check job status and output' => sub {
         open STDOUT, '>', \$output;
 
 
-        $post      = $t->post_ok("/api/v1/jobs/$job->{id}/status", json => $json);
+        $t->post_ok("/api/v1/jobs/$job->{id}/status", json => $json);
         $worker_id = 0;
         close STDOUT;
         open(STDOUT, '>&', $oldSTDOUT) or die "Can't dup \$oldSTDOUT: $!";
         if ($job->{id} == 99963) {
-            $post->status_is(200);
+            $t->status_is(200);
         }
         else {
-            $post->status_is(400);
+            $t->status_is(400);
             ok($output =~ /Got status update for job .*? but does not contain a worker id!/,
                 "Check status update for job $job->{id}");
         }
@@ -520,15 +519,12 @@ subtest 'Check job status and output' => sub {
     my $output;
     open STDOUT, '>', \$output;
     # bogus job ID
-    my $bogus_job_post = $t->post_ok("/api/v1/jobs/9999999/status", json => {});
+    $t->post_ok("/api/v1/jobs/9999999/status", json => {})->status_is(400);
     # bogus worker ID
-    my $bogus_worker_post
-      = $t->post_ok("/api/v1/jobs/$running_job_id/status", json => {status => {worker_id => 999999}});
+    $t->post_ok("/api/v1/jobs/$running_job_id/status", json => {status => {worker_id => 999999}})->status_is(400);
     close STDOUT;
     open(STDOUT, '>&', $oldSTDOUT) or die "Can't dup \$oldSTDOUT: $!";
 
-    $bogus_job_post->status_is(400);
-    $bogus_worker_post->status_is(400);
     like($output, qr/Got status update for non-existing job/, 'Check status update for non-existing job');
     like(
         $output,
@@ -539,10 +535,10 @@ subtest 'Check job status and output' => sub {
 # Test /jobs/cancel
 # TODO: cancelling jobs via API in tests doesn't work for some reason
 #
-# $post = $t->post_ok('/api/v1/jobs/cancel?BUILD=0091')->status_is(200);
+# $t->post_ok('/api/v1/jobs/cancel?BUILD=0091')->status_is(200);
 #
-# $get = $t->get_ok('/api/v1/jobs');
-# @new_jobs = @{$get->tx->res->json->{jobs}};
+# $t->get_ok('/api/v1/jobs');
+# @new_jobs = @{$t->tx->res->json->{jobs}};
 #
 # foreach my $job (@new_jobs) {
 #     if ($job->{settings}->{BUILD} eq '0091') {
@@ -565,12 +561,12 @@ sub find_build {
 }
 
 # delete the job with a registered job module
-my $delete = $t->delete_ok('/api/v1/jobs/99937')->status_is(200);
+$t->delete_ok('/api/v1/jobs/99937')->status_is(200);
 $t->get_ok('/api/v1/jobs/99937')->status_is(404);
 
 subtest 'json representation of group overview (actually not part of the API)' => sub {
-    $get = $t->get_ok('/group_overview/1001.json')->status_is(200);
-    my $json       = $get->tx->res->json;
+    $t->get_ok('/group_overview/1001.json')->status_is(200);
+    my $json       = $t->tx->res->json;
     my $group_info = $json->{group};
     ok($group_info, 'group info present');
     is($group_info->{id},   1001,       'group ID');
@@ -602,10 +598,10 @@ subtest 'json representation of group overview (actually not part of the API)' =
     );
 };
 
-$get = $t->get_ok('/index.json?limit_builds=10')->status_is(200);
-$get = $get->tx->res->json;
-is(@{$get->{results}}, 2);
-my $g1 = (shift @{$get->{results}});
+$t->get_ok('/index.json?limit_builds=10')->status_is(200);
+my $ret = $t->tx->res->json;
+is(@{$ret->{results}}, 2);
+my $g1 = (shift @{$ret->{results}});
 is($g1->{group}->{name}, 'opensuse', 'First group is opensuse');
 my $b1 = find_build($g1, '13.1-0092');
 delete $b1->{oldest};
@@ -645,33 +641,32 @@ my %jobs_post_params = (
 );
 
 subtest 'WORKER_CLASS correctly assigned when posting job' => sub {
-    $post = $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
-    is($jobs->find($post->tx->res->json->{id})->settings_hash->{WORKER_CLASS},
+    $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
+    is($jobs->find($t->tx->res->json->{id})->settings_hash->{WORKER_CLASS},
         'qemu_x86_64', 'default WORKER_CLASS assigned (with arch fallback)');
 
     $jobs_post_params{ARCH} = 'aarch64';
-    $post = $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
-    is($jobs->find($post->tx->res->json->{id})->settings_hash->{WORKER_CLASS},
+    $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
+    is($jobs->find($t->tx->res->json->{id})->settings_hash->{WORKER_CLASS},
         'qemu_aarch64', 'default WORKER_CLASS assigned');
 
     $jobs_post_params{WORKER_CLASS} = 'svirt';
-    $post = $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
-    is($jobs->find($post->tx->res->json->{id})->settings_hash->{WORKER_CLASS},
-        'svirt', 'specified WORKER_CLASS assigned');
+    $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
+    is($jobs->find($t->tx->res->json->{id})->settings_hash->{WORKER_CLASS}, 'svirt', 'specified WORKER_CLASS assigned');
 };
 
 subtest 'default priority correctly assigned when posting job' => sub {
     # post new job and check default priority
-    $post = $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
-    $t->get_ok('/api/v1/jobs/' . $post->tx->res->json->{id})->status_is(200);
+    $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
+    $t->get_ok('/api/v1/jobs/' . $t->tx->res->json->{id})->status_is(200);
     $t->json_is('/job/group',    'opensuse');
     $t->json_is('/job/priority', 50);
 
     # post new job in job group with customized default priority
     $t->app->schema->resultset('JobGroups')->find({name => 'opensuse test'})->update({default_priority => 42});
     $jobs_post_params{_GROUP} = 'opensuse test';
-    $post = $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
-    $t->get_ok('/api/v1/jobs/' . $post->tx->res->json->{id})->status_is(200);
+    $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
+    $t->get_ok('/api/v1/jobs/' . $t->tx->res->json->{id})->status_is(200);
     $t->json_is('/job/group',    'opensuse test');
     $t->json_is('/job/priority', 42);
 };
@@ -679,15 +674,15 @@ subtest 'default priority correctly assigned when posting job' => sub {
 subtest 'specifying group by ID' => sub {
     delete $jobs_post_params{_GROUP};
     $jobs_post_params{_GROUP_ID} = 1002;
-    $post = $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
-    $t->get_ok('/api/v1/jobs/' . $post->tx->res->json->{id})->status_is(200);
+    $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
+    $t->get_ok('/api/v1/jobs/' . $t->tx->res->json->{id})->status_is(200);
     $t->json_is('/job/group',    'opensuse test');
     $t->json_is('/job/priority', 42);
 };
 
 subtest 'TEST is only mandatory parameter' => sub {
-    $post = $t->post_ok('/api/v1/jobs', form => {TEST => 'pretty_empty'})->status_is(200);
-    $t->get_ok('/api/v1/jobs/' . $post->tx->res->json->{id})->status_is(200);
+    $t->post_ok('/api/v1/jobs', form => {TEST => 'pretty_empty'})->status_is(200);
+    $t->get_ok('/api/v1/jobs/' . $t->tx->res->json->{id})->status_is(200);
     $t->json_is('/job/settings/TEST'    => 'pretty_empty');
     $t->json_is('/job/settings/MACHINE' => undef, 'machine was not set and is therefore undef');
     $t->json_is('/job/settings/DISTRI'  => undef);
@@ -707,7 +702,7 @@ subtest 'job details' => sub {
     $t->json_is('/job/assets/hdd/0',           => 'hdd_image.qcow2', 'Job has hdd_image.qcow2 as asset');
     $t->json_is('/job/testresults/0/category', => 'installation',    'Job category is "installation"');
 
-    $post = $t->get_ok('/api/v1/jobs/99946/details')->status_is(200);
+    $t->get_ok('/api/v1/jobs/99946/details')->status_is(200);
     $t->json_has('/job/testresults/0', 'Test details are there');
     $t->json_is('/job/assets/hdd/0', => 'openSUSE-13.1-x86_64.hda', 'Job has openSUSE-13.1-x86_64.hda as asset');
     $t->json_is('/job/testresults/0/category', => 'installation', 'Job category is "installation"');
@@ -794,18 +789,18 @@ subtest 'update job and job settings' => sub {
 subtest 'filter by worker_class' => sub {
 
     $query->query(worker_class => ':MiB:');
-    $get = $t->get_ok($query->path_query)->status_is(200);
-    $res = $get->tx->res->json;
+    $t->get_ok($query->path_query)->status_is(200);
+    my $res = $t->tx->res->json;
     ok(!@{$res->{jobs}}, 'Worker class does not exist');
 
     $query->query(worker_class => '::');
-    $get = $t->get_ok($query->path_query)->status_is(200);
-    $res = $get->tx->res->json;
+    $t->get_ok($query->path_query)->status_is(200);
+    $res = $t->tx->res->json;
     ok(!@{$res->{jobs}}, 'Wrong worker class provides zero results');
 
     $query->query(worker_class => ':UFP:');
-    $get = $t->get_ok($query->path_query)->status_is(200);
-    $res = $get->tx->res->json;
+    $t->get_ok($query->path_query)->status_is(200);
+    $res = $t->tx->res->json;
     ok(@{$res->{jobs}} eq 1, 'Known worker class group exists, and returns one job');
 
     $t->json_is('/jobs/0/settings/WORKER_CLASS' => ':UFP:NCC1701F', 'Correct worker class');
@@ -822,7 +817,7 @@ subtest 'Parse extra tests results - LTP' => sub {
     $parser->load($junit);
     my $basedir = "t/data/openqa/testresults/00099/00099963-opensuse-13.1-DVD-x86_64-Build0091-kde/";
 
-    my $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "JUnit",
@@ -830,9 +825,9 @@ subtest 'Parse extra tests results - LTP' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('FAILED'), 'request FAILED' or die diag explain $post->tx->res->content;
+    ok $t->tx->res->content->body_contains('FAILED'), 'request FAILED' or die diag explain $t->tx->res->content;
 
-    $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "foo",
@@ -840,11 +835,11 @@ subtest 'Parse extra tests results - LTP' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('FAILED'), 'request FAILED';
+    ok $t->tx->res->content->body_contains('FAILED'), 'request FAILED';
 
     ok !-e path($basedir, 'details-LTP_syscalls_accept01.json'), 'detail from LTP was NOT written';
 
-    $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "LTP",
@@ -852,8 +847,8 @@ subtest 'Parse extra tests results - LTP' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('OK'), 'request went fine';
-    ok !$post->tx->res->content->body_contains('FAILED'), 'request went fine, really';
+    ok $t->tx->res->content->body_contains('OK'), 'request went fine';
+    ok !$t->tx->res->content->body_contains('FAILED'), 'request went fine, really';
 
     ok !-e path($basedir, $fname), 'file was not uploaded';
 
@@ -898,7 +893,7 @@ subtest 'Parse extra tests results - xunit' => sub {
     $parser->load($junit);
     my $basedir = "t/data/openqa/testresults/00099/00099963-opensuse-13.1-DVD-x86_64-Build0091-kde/";
 
-    my $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "LTP",
@@ -906,9 +901,9 @@ subtest 'Parse extra tests results - xunit' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('FAILED'), 'request FAILED';
+    ok $t->tx->res->content->body_contains('FAILED'), 'request FAILED';
 
-    $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "foo",
@@ -916,11 +911,11 @@ subtest 'Parse extra tests results - xunit' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('FAILED'), 'request FAILED';
+    ok $t->tx->res->content->body_contains('FAILED'), 'request FAILED';
 
     ok !-e path($basedir, 'details-unkn.json'), 'detail from junit was NOT written';
 
-    $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "XUnit",
@@ -928,8 +923,8 @@ subtest 'Parse extra tests results - xunit' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('OK'), 'request went fine';
-    ok !$post->tx->res->content->body_contains('FAILED'), 'request went fine, really';
+    ok $t->tx->res->content->body_contains('OK'), 'request went fine';
+    ok !$t->tx->res->content->body_contains('FAILED'), 'request went fine, really';
 
     ok !-e path($basedir, $fname), 'file was not uploaded';
 
@@ -977,7 +972,7 @@ subtest 'Parse extra tests results - junit' => sub {
     $parser->load($junit);
     my $basedir = "t/data/openqa/testresults/00099/00099963-opensuse-13.1-DVD-x86_64-Build0091-kde/";
 
-    my $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "foo",
@@ -985,11 +980,11 @@ subtest 'Parse extra tests results - junit' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('FAILED'), 'request FAILED';
+    ok $t->tx->res->content->body_contains('FAILED'), 'request FAILED';
 
     ok !-e path($basedir, 'details-1_running_upstream_tests.json'), 'detail from junit was NOT written';
 
-    $post = $t->post_ok(
+    $t->post_ok(
         '/api/v1/jobs/99963/artefact' => form => {
             file       => {file => $junit, filename => $fname},
             type       => "JUnit",
@@ -997,8 +992,8 @@ subtest 'Parse extra tests results - junit' => sub {
             script     => 'test'
         })->status_is(200);
 
-    ok $post->tx->res->content->body_contains('OK'), 'request went fine';
-    ok !$post->tx->res->content->body_contains('FAILED'), 'request went fine, really';
+    ok $t->tx->res->content->body_contains('OK'), 'request went fine';
+    ok !$t->tx->res->content->body_contains('FAILED'), 'request went fine, really';
 
     ok !-e path($basedir, $fname), 'file was not uploaded';
 

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -40,9 +40,9 @@ my $app = $t->app;
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $get = $t->get_ok('/api/v1/machines')->status_is(200);
+$t->get_ok('/api/v1/machines')->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'Machines' => [
             {
@@ -80,44 +80,41 @@ is_deeply(
                     }]}]
     },
     "Initial machines"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 
-my $res = $t->post_ok('/api/v1/machines', form => {name => "testmachine"})->status_is(400)
+$t->post_ok('/api/v1/machines', form => {name => "testmachine"})->status_is(400)
   ->json_is('/error', 'Missing parameter: backend');
 $t->post_ok('/api/v1/machines', form => {backend => "kde/usb"})->status_is(400)
   ->json_is('/error', 'Missing parameter: name');
 $t->post_ok('/api/v1/machines', form => {})->status_is(400)->json_is('/error', 'Missing parameter: backend, name');
 
-$res
-  = $t->post_ok('/api/v1/machines',
+$t->post_ok('/api/v1/machines',
     form => {name => "testmachine", backend => "qemu", "settings[TEST]" => "val1", "settings[TEST2]" => "val1"})
   ->status_is(200);
-my $machine_id = $res->tx->res->json->{id};
+my $machine_id = $t->tx->res->json->{id};
 
-$res = $t->get_ok('/api/v1/machines', form => {name => "testmachine"})->status_is(200);
-is($res->tx->res->json->{Machines}->[0]->{id}, $machine_id);
+$t->get_ok('/api/v1/machines', form => {name => "testmachine"})->status_is(200);
+is($t->tx->res->json->{Machines}->[0]->{id}, $machine_id);
 
-$res
-  = $t->post_ok('/api/v1/machines',
+$t->post_ok('/api/v1/machines',
     form => {name => "testmachineQ", backend => "qemu", "settings[TEST]" => "'v'al1", "settings[TEST2]" => "va'l\'1"})
   ->status_is(200);
-$res = $t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
-is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
-is($res->tx->res->json->{Machines}->[0]->{settings}->[1]->{value}, "va'l\'1");
+$t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
+is($t->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
+is($t->tx->res->json->{Machines}->[0]->{settings}->[1]->{value}, "va'l\'1");
 
 $t->post_ok('/api/v1/machines', form => {name => "testmachineZ", backend => "qemu", "settings[TE'S\'T]" => "'v'al1"})
   ->status_is(200);
-$res = $t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
-is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{key},   "TEST");
-is($res->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
+$t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200);
+is($t->tx->res->json->{Machines}->[0]->{settings}->[0]->{key},   "TEST");
+is($t->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
 
-$res
-  = $t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu"})->status_is(400); #already exists
+$t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu"})->status_is(400);    #already exists
 
-$get = $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
+$t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'Machines' => [
             {
@@ -135,14 +132,14 @@ is_deeply(
                     }]}]
     },
     "Add machine"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
-$res = $t->put_ok("/api/v1/machines/$machine_id",
+$t->put_ok("/api/v1/machines/$machine_id",
     form => {name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1"})->status_is(200);
 
-$get = $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
+$t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'Machines' => [
             {
@@ -156,10 +153,10 @@ is_deeply(
                     }]}]
     },
     "Delete machine variable"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
-$res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(200);
-$res = $t->delete_ok("/api/v1/machines/$machine_id")->status_is(404);    #not found
+$t->delete_ok("/api/v1/machines/$machine_id")->status_is(200);
+$t->delete_ok("/api/v1/machines/$machine_id")->status_is(404);    #not found
 
 subtest 'trim whitespace characters' => sub {
     $t->post_ok(

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -41,9 +41,9 @@ $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->i
 $t->app($app);
 
 
-my $get = $t->get_ok('/api/v1/products')->status_is(200);
+$t->get_ok('/api/v1/products')->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'Products' => [
             {
@@ -81,7 +81,7 @@ is_deeply(
             }]
     },
     "Initial products"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 
 # no arch
@@ -96,7 +96,7 @@ $t->post_ok('/api/v1/products', form => {arch => "x86_64", distri => "opensuse",
 # no version
 $t->post_ok('/api/v1/products', form => {arch => "x86_64", distri => "opensuse", flavor => "DVD"})->status_is(400);
 
-my $res = $t->post_ok(
+$t->post_ok(
     '/api/v1/products',
     form => {
         arch              => "x86_64",
@@ -106,15 +106,14 @@ my $res = $t->post_ok(
         "settings[TEST]"  => "val1",
         "settings[TEST2]" => "val1"
     })->status_is(200);
-my $product_id = $res->tx->res->json->{id};
+my $product_id = $t->tx->res->json->{id};
 
-$res
-  = $t->post_ok('/api/v1/products', form => {arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2})
+$t->post_ok('/api/v1/products', form => {arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2})
   ->status_is(400);    #already exists
 
-$get = $t->get_ok("/api/v1/products/$product_id")->status_is(200);
+$t->get_ok("/api/v1/products/$product_id")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'Products' => [
             {
@@ -136,15 +135,15 @@ is_deeply(
             }]
     },
     "Add product"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 $t->put_ok("/api/v1/products/$product_id",
     form => {arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2, "settings[TEST2]" => "val1"})
   ->status_is(200);
 
-$get = $t->get_ok("/api/v1/products/$product_id")->status_is(200);
+$t->get_ok("/api/v1/products/$product_id")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'Products' => [
             {
@@ -162,10 +161,10 @@ is_deeply(
             }]
     },
     "Delete product variable"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
-$res = $t->delete_ok("/api/v1/products/$product_id")->status_is(200);
-$res = $t->delete_ok("/api/v1/products/$product_id")->status_is(404);    #not found
+$t->delete_ok("/api/v1/products/$product_id")->status_is(200);
+$t->delete_ok("/api/v1/products/$product_id")->status_is(404);    #not found
 
 # switch to operator (percival) and try some modifications
 $app = $t->app;
@@ -185,6 +184,6 @@ $t->post_ok(
 $t->put_ok("/api/v1/products/$product_id",
     form => {arch => "x86_64", distri => "opensuse", flavor => "DVD", version => 13.2, "settings[TEST2]" => "val1"})
   ->status_is(403);
-$res = $t->delete_ok("/api/v1/products/$product_id")->status_is(403);
+$t->delete_ok("/api/v1/products/$product_id")->status_is(403);
 
 done_testing();

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -38,9 +38,9 @@ my $app = $t->app;
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $get = $t->get_ok('/api/v1/test_suites')->status_is(200);
+$t->get_ok('/api/v1/test_suites')->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'TestSuites' => [
             {
@@ -145,12 +145,12 @@ is_deeply(
                     }]}]
     },
     "Initial test suites"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 $t->post_ok('/api/v1/test_suites', form => {})->status_is(400);    #no name
 
 
-my $res = $t->post_ok(
+$t->post_ok(
     '/api/v1/test_suites',
     form => {
         name              => "testsuite",
@@ -158,13 +158,13 @@ my $res = $t->post_ok(
         "settings[TEST2]" => "val1",
         description       => "this is a new testsuite"
     })->status_is(200);
-my $test_suite_id = $res->tx->res->json->{id};
+my $test_suite_id = $t->tx->res->json->{id};
 
-$res = $t->post_ok('/api/v1/test_suites', form => {name => "testsuite"})->status_is(400);    #already exists
+$t->post_ok('/api/v1/test_suites', form => {name => "testsuite"})->status_is(400);    #already exists
 
-$get = $t->get_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
+$t->get_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'TestSuites' => [
             {
@@ -182,14 +182,14 @@ is_deeply(
                     }]}]
     },
     "Add test_suite"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
 $t->put_ok("/api/v1/test_suites/$test_suite_id", form => {name => "testsuite", "settings[TEST2]" => "val1"})
   ->status_is(200);
 
-$get = $t->get_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
+$t->get_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
 is_deeply(
-    $get->tx->res->json,
+    $t->tx->res->json,
     {
         'TestSuites' => [
             {
@@ -202,10 +202,10 @@ is_deeply(
                     }]}]
     },
     "Delete test_suite variable"
-) || diag explain $get->tx->res->json;
+) || diag explain $t->tx->res->json;
 
-$res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
-$res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(404);    #not found
+$t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(200);
+$t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(404);    #not found
 
 # switch to operator (percival) and try some modifications
 $app = $t->app;
@@ -215,6 +215,6 @@ $t->app($app);
 $t->post_ok('/api/v1/test_suites', form => {name => "testsuite"})->status_is(403);
 $t->put_ok("/api/v1/test_suites/$test_suite_id", form => {name => "testsuite", "settings[TEST2]" => "val1"})
   ->status_is(403);
-$res = $t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(403);
+$t->delete_ok("/api/v1/test_suites/$test_suite_id")->status_is(403);
 
 done_testing();

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -43,36 +43,36 @@ $t->app($app);
 
 my $bugs = $app->schema->resultset('Bugs');
 
-my $bug  = $bugs->get_bug('poo#200');
-my $get  = $t->get_ok('/api/v1/bugs');
-my %bugs = %{$get->tx->res->json->{bugs}};
+my $bug = $bugs->get_bug('poo#200');
+$t->get_ok('/api/v1/bugs');
+my %bugs = %{$t->tx->res->json->{bugs}};
 is($bugs{1}, 'poo#200', 'Bug entry exists');
 
-$get  = $t->get_ok('/api/v1/bugs?refreshable=1');
-%bugs = %{$get->tx->res->json->{bugs}};
+$t->get_ok('/api/v1/bugs?refreshable=1');
+%bugs = %{$t->tx->res->json->{bugs}};
 is($bugs{1}, 'poo#200', 'Bug entry is refreshable');
 
-my $put = $t->put_ok('/api/v1/bugs/1', form => {title => "foobar", existing => 1});
-is($put->tx->res->json->{id}, 1, 'Bug #1 updated');
+$t->put_ok('/api/v1/bugs/1', form => {title => "foobar", existing => 1});
+is($t->tx->res->json->{id}, 1, 'Bug #1 updated');
 
 $t->put_ok('/api/v1/bugs/2', form => {title => "foobar", existing => 1})->status_is(404, 'Bug #2 not yet existing');
 
-$get = $t->get_ok('/api/v1/bugs/1');
-is($get->tx->res->json->{title}, 'foobar', 'Bug has correct title');
+$t->get_ok('/api/v1/bugs/1');
+is($t->tx->res->json->{title}, 'foobar', 'Bug has correct title');
 is_deeply(
     [sort keys %{$t->tx->res->json}],
     [qw(assigned assignee bugid existing id open priority refreshed resolution status t_created t_updated title)],
     'All expected columns exposed'
 );
 
-$get = $t->get_ok('/api/v1/bugs?refreshable=1');
-is_deeply($get->tx->res->json->{bugs}, {}, 'All bugs are refreshed');
+$t->get_ok('/api/v1/bugs?refreshable=1');
+is_deeply($t->tx->res->json->{bugs}, {}, 'All bugs are refreshed');
 
-my $post = $t->post_ok('/api/v1/bugs', form => {title => "foobar2", bugid => 'poo#201', existing => 1, refreshed => 1});
-is($post->tx->res->json->{id}, 2, 'Bug #2 created');
+$t->post_ok('/api/v1/bugs', form => {title => "foobar2", bugid => 'poo#201', existing => 1, refreshed => 1});
+is($t->tx->res->json->{id}, 2, 'Bug #2 created');
 
-$get = $t->get_ok('/api/v1/bugs/2');
-is($get->tx->res->json->{title}, 'foobar2', 'Bug #2 has correct title');
+$t->get_ok('/api/v1/bugs/2');
+is($t->tx->res->json->{title}, 'foobar2', 'Bug #2 has correct title');
 
 $t->delete_ok('/api/v1/bugs/2');
 $t->get_ok('/api/v1/bugs/2')->status_is(404, 'Bug #2 deleted');
@@ -80,8 +80,8 @@ $t->get_ok('/api/v1/bugs/2')->status_is(404, 'Bug #2 deleted');
 $t->delete_ok('/api/v1/bugs/2')->status_is(404, 'Bug #2 already deleted');
 
 $t->post_ok('/api/v1/jobs/99926/comments', form => {text => 'wicked bug: jsc#SLE-42999'});
-$get = $t->get_ok('/api/v1/bugs/3');
-is($get->tx->res->json->{bugid}, 'jsc#SLE-42999', 'Bug was created by comment post');
+$t->get_ok('/api/v1/bugs/3');
+is($t->tx->res->json->{bugid}, 'jsc#SLE-42999', 'Bug was created by comment post');
 
 $t->post_ok('/api/v1/bugs', form => {title => "new", bugid => 'bsc#123'});
 my $bugid = $t->tx->res->json->{id};

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -36,8 +36,8 @@ my $app = $t->app;
 $t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $get     = $t->get_ok('/admin/workers.json');
-my %workers = %{$get->tx->res->json->{workers}};
+$t->get_ok('/admin/workers.json');
+my %workers = %{$t->tx->res->json->{workers}};
 is(2, scalar(keys(%workers)), '2 workers seen');
 
 done_testing();

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -168,7 +168,7 @@ wait_for_ajax;
 @expected     = ('3 jobs are running', '2 scheduled jobs', 'Last 1 finished jobs');
 is_deeply(\@header_texts, \@expected, 'limit for finished tests can be adjusted with query parameter');
 
-my $get = $t->get_ok('/tests/99963')->status_is(200);
+$t->get_ok('/tests/99963')->status_is(200);
 $t->content_like(qr/State.*running/, "Running jobs are marked");
 
 subtest 'available comments shown' => sub {

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -30,8 +30,8 @@ $test_case->init_data;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-my $get   = $t->ua->get('/');
-my $token = $get->res->dom->at('meta[name=csrf-token]')->attr('content');
+$t->get_ok('/');
+my $token = $t->tx->res->dom->at('meta[name=csrf-token]')->attr('content');
 
 # test cancel and restart without logging in
 $t->post_ok('/api/v1/jobs/99928/cancel'       => {'X-CSRF-Token' => $token} => form => {})->status_is(403);
@@ -42,13 +42,12 @@ $t->post_ok('/api/v1/jobs/99928/prio?prio=34' => {'X-CSRF-Token' => $token} => f
 # Log in with an authorized user for the rest of the test
 $test_case->login($t, 'percival');
 
-$get = $t->ua->get('/api_keys');
+$t->get_ok('/api_keys');
 
-ok($token =~ /[0-9a-z]{40}/,                                                     "csrf token in meta tag");
-ok($get->res->dom->at('meta[name=csrf-param]')->attr('content') eq 'csrf_token', "csrf param in meta tag");
-#say "csrf token is $token";
+ok($token =~ /[0-9a-z]{40}/,                                                       "csrf token in meta tag");
+ok($t->tx->res->dom->at('meta[name=csrf-param]')->attr('content') eq 'csrf_token', "csrf param in meta tag");
 
-is($token, $get->res->dom->at('form input[name=csrf_token]')->{value}, "token is the same in form");
+is($token, $t->tx->res->dom->at('form input[name=csrf_token]')->{value}, "token is the same in form");
 
 # test cancel with and without CSRF token
 $t->post_ok('/api/v1/jobs/99928/cancel' => form => {csrf_token => 'foobar'})->status_is(403);

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -35,9 +35,9 @@ SKIP: {
 
     my $test_name = 'isosize';
 
-    my $get = $t->get_ok("/tests/99938/modules/$test_name/steps/1/src")->status_is(200);
-    $get->content_like(qr|inst\.d/.*$test_name.pm|i, "$test_name test source found");
-    $get->content_like(qr/ISO_MAXSIZE/i,             "$test_name test source shown");
+    $t->get_ok("/tests/99938/modules/$test_name/steps/1/src")->status_is(200)
+      ->content_like(qr|inst\.d/.*$test_name.pm|i, "$test_name test source found")
+      ->content_like(qr/ISO_MAXSIZE/i,             "$test_name test source shown");
 }
 
 done_testing();

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -37,61 +37,49 @@ $t->get_ok('/api_keys')->status_is(302);
 
 #
 # So let's grab the CSRF token and login as Percival
-my $req   = $t->ua->get('/tests');
-my $token = $req->res->dom->at('meta[name=csrf-token]')->attr('content');
+$t->get_ok('/tests');
+my $token = $t->tx->res->dom->at('meta[name=csrf-token]')->attr('content');
 $test_case->login($t, 'percival');
 
 #
 # And perform some 'legitimate' actions
 
 # Percival can see all his keys, but not the Lancelot's one
-$req = $t->get_ok('/api_keys')->status_is(200);
-$req->element_exists('#api_key_3', 'keys are there');
-$req->element_exists('#api_key_4', 'keys are there');
-$req->element_exists('#api_key_5', 'keys are there');
-$req->element_exists_not('#api_key_99901', "no other users's keys");
-$req->text_isnt('#api_key_3 .expiration' => 'never');
-$req->text_is('#api_key_5 .expiration' => 'never');
+$t->get_ok('/api_keys')->status_is(200)->element_exists('#api_key_3', 'keys are there')
+  ->element_exists('#api_key_4', 'keys are there')->element_exists('#api_key_5', 'keys are there')
+  ->element_exists_not('#api_key_99901', "no other users's keys")->text_isnt('#api_key_3 .expiration' => 'never')
+  ->text_is('#api_key_5 .expiration' => 'never');
 
 # When clicking in 'create' a new API key is displayed in the listing
-$req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {})->status_is(302);
-$req = $t->get_ok('/api_keys')->status_is(200);
-$req->element_exists('#api_key_3', 'keys are there');
-$req->element_exists('#api_key_6', 'keys are there');
+$t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {})->status_is(302);
+$t->get_ok('/api_keys')->status_is(200)->element_exists('#api_key_3', 'keys are there')
+  ->element_exists('#api_key_6', 'keys are there');
 
 # It's also possible to specify an expiration date
-$req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {t_expiration => '2016-01-05'})->status_is(302);
-$req = $t->get_ok('/api_keys')->status_is(200);
-$req->text_is('#api_key_6 .expiration' => 'never');
-$req->text_like('#api_key_7 .expiration' => qr/2016-01-05/);
-
-#die $req->content_like(qr/NOWHERE/);
+$t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {t_expiration => '2016-01-05'})->status_is(302);
+$t->get_ok('/api_keys')->status_is(200)->text_is('#api_key_6 .expiration' => 'never')
+  ->text_like('#api_key_7 .expiration' => qr/2016-01-05/);
 
 # check invalid expiration date
-$req = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {t_expiration => 'asdlfj'})->status_is(302);
-$req = $t->get_ok('/api_keys')->status_is(200);
-$req->element_exists_not('#api_key_8', "No invalid key created");
-$req->element_exists('#flash-messages .alert-danger', "Error message displayed");
+$t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {t_expiration => 'asdlfj'})->status_is(302);
+$t->get_ok('/api_keys')->status_is(200)->element_exists_not('#api_key_8', "No invalid key created")
+  ->element_exists('#flash-messages .alert-danger', "Error message displayed");
 
 # And to delete keys
-$req = $t->delete_ok('/api_keys/6', {'X-CSRF-Token' => $token})->status_is(302);
-$req = $t->get_ok('/api_keys')->status_is(200);
-$req->element_exists_not('#api_key_6', 'API key 6 is gone');
-$req->content_like(qr/API key deleted/, 'deletion is reported');
+$t->delete_ok('/api_keys/6', {'X-CSRF-Token' => $token})->status_is(302);
+$t->get_ok('/api_keys')->status_is(200)->element_exists_not('#api_key_6', 'API key 6 is gone')
+  ->content_like(qr/API key deleted/, 'deletion is reported');
 
 #
 # Now let's try to cheat the system
 
 # Try to delete Lancelot's key
-$req = $t->delete_ok('/api_keys/99901', {'X-CSRF-Token' => $token})->status_is(302);
-$req = $t->get_ok('/api_keys')->status_is(200);
-$req->content_like(qr/API key not found/, 'error is displayed');
+$t->delete_ok('/api_keys/99901', {'X-CSRF-Token' => $token})->status_is(302);
+$t->get_ok('/api_keys')->status_is(200)->content_like(qr/API key not found/, 'error is displayed');
 
 # Try to create an API key for Lancelot
-$req
-  = $t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {user_id => 99902, user => 99902})->status_is(302);
-$req = $t->get_ok('/api_keys')->status_is(200);
-$req->element_exists('#api_key_3', 'Percival keys are there');
-$req->element_exists('#api_key_8', 'and the new one belongs to Percival, not Lancelot');
+$t->post_ok('/api_keys', {'X-CSRF-Token' => $token} => form => {user_id => 99902, user => 99902})->status_is(302);
+$t->get_ok('/api_keys')->status_is(200)->element_exists('#api_key_3', 'Percival keys are there')
+  ->element_exists('#api_key_8', 'and the new one belongs to Percival, not Lancelot');
 
 done_testing();

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -39,32 +39,29 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # we don't want to test javascript here, so we just test the javascript code
 # List with no login
-my $get = $t->get_ok('/tests')->status_is(200);
-$get->content_like(qr/is_operator = false;/, "test list rendered without is_operator");
+$t->get_ok('/tests')->status_is(200)->content_like(qr/is_operator = false;/, "test list rendered without is_operator");
 
 # List with an authorized user
 $test_case->login($t, 'percival');
-$get = $t->get_ok('/tests')->status_is(200);
-$get->content_like(qr/is_operator = true;/, "test list rendered with is_operator");
+$t->get_ok('/tests')->status_is(200)->content_like(qr/is_operator = true;/, "test list rendered with is_operator");
 
 # List with a not authorized user
 $test_case->login($t, 'lancelot', email => 'lancelot@example.com');
-$get = $t->get_ok('/tests')->status_is(200);
-$get->content_like(qr/is_operator = false;/, "test list rendered without is_operator");
+$t->get_ok('/tests')->status_is(200)->content_like(qr/is_operator = false;/, "test list rendered without is_operator");
 
 # now the same for scheduled jobs
 $t->delete_ok('/logout')->status_is(302);
 
 # List with no login (absence of cancel button already checked in 01-list.t)
-$get = $t->get_ok('/tests')->status_is(200);
+$t->get_ok('/tests')->status_is(200);
 
 # List with an authorized user (presence of cancel button already checked in 01-list.t)
 $test_case->login($t, 'percival');
-$get = $t->get_ok('/tests')->status_is(200);
+$t->get_ok('/tests')->status_is(200);
 
 # List with a not authorized user
 $test_case->login($t, 'lancelot', email => 'lancelot@example.com');
-$get = $t->get_ok('/tests')->status_is(200);
+$t->get_ok('/tests')->status_is(200);
 
 # operator has access to part of admin menu - using phantomjs
 $driver->title_is("openQA", "on main page");

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -89,24 +89,23 @@ subtest 'needle download' => sub {
 
 
 # check the download links
-my $req = $t->get_ok('/tests/99946')->status_is(200);
-$req->element_exists('#downloads #asset_1');
-$req->element_exists('#downloads #asset_5');
-my $res = OpenQA::Test::Case::trim_whitespace($req->tx->res->dom->at('#downloads #asset_1')->text);
+$t->get_ok('/tests/99946')->status_is(200)->element_exists('#downloads #asset_1')
+  ->element_exists('#downloads #asset_5');
+my $res = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#downloads #asset_1')->text);
 is($res, "openSUSE-13.1-DVD-i586-Build0091-Media.iso");
-is($req->tx->res->dom->at('#downloads #asset_1')->{href},
+is($t->tx->res->dom->at('#downloads #asset_1')->{href},
     '/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso');
-$res = OpenQA::Test::Case::trim_whitespace($req->tx->res->dom->at('#downloads #asset_5')->text);
-is($res,                                                  "openSUSE-13.1-x86_64.hda");
-is($req->tx->res->dom->at('#downloads #asset_5')->{href}, '/tests/99946/asset/hdd/openSUSE-13.1-x86_64.hda');
+$res = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#downloads #asset_5')->text);
+is($res,                                                "openSUSE-13.1-x86_64.hda");
+is($t->tx->res->dom->at('#downloads #asset_5')->{href}, '/tests/99946/asset/hdd/openSUSE-13.1-x86_64.hda');
 
 # downloads are currently redirects
-$req = $t->get_ok('/tests/99946/asset/1')->status_is(302)
+$t->get_ok('/tests/99946/asset/1')->status_is(302)
   ->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
-$req = $t->get_ok('/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(302)
+$t->get_ok('/tests/99946/asset/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(302)
   ->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/iso\/openSUSE-13.1-DVD-i586-Build0091-Media.iso/);
 
-$req = $t->get_ok('/tests/99946/asset/5')->status_is(302)
+$t->get_ok('/tests/99946/asset/5')->status_is(302)
   ->header_like(Location => qr/(?:http:\/\/localhost:\d+)?\/assets\/hdd\/fixed\/openSUSE-13.1-x86_64.hda/);
 
 # verify error on invalid downloads
@@ -128,7 +127,7 @@ $t->get_ok('/assets/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(
 SKIP: {
     skip "FIXME: allow to download only assets related to a test", 1;
 
-    $req = $t->get_ok('/tests/99946/asset/2')->status_is(400);
+    $t->get_ok('/tests/99946/asset/2')->status_is(400);
 }
 
 done_testing();

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -32,14 +32,14 @@ $test_case->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # First of all, init the session (this should probably be in OpenQA::Test)
-my $req   = $t->ua->get('/tests');
-my $token = $req->res->dom->at('meta[name=csrf-token]')->attr('content');
+$t->get_ok('/tests');
+my $token = $t->tx->res->dom->at('meta[name=csrf-token]')->attr('content');
 
 #
 # So let's login as a admin
 $t->delete_ok('/logout')->status_is(302);
 $test_case->login($t, 'arthur');
-my $get = $t->get_ok('/admin/users')->status_is(200);
+$t->get_ok('/admin/users')->status_is(200);
 is($t->tx->res->dom->at('#user_99901 .role')->attr('data-order'), '11');
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '00');
 is($t->tx->res->dom->at('#user_99903 .role')->attr('data-order'), '01');
@@ -47,12 +47,12 @@ is($t->tx->res->dom->at('#user_99903 .role')->attr('data-order'), '01');
 
 # Make only admin leave
 $t->post_ok('/admin/users/99901', {'X-CSRF-Token' => $token} => form => {role => 'operator'})->status_is(302);
-$get = $t->get_ok('/admin/users')->status_is(403);
+$t->get_ok('/admin/users')->status_is(403);
 $t->delete_ok('/logout')->status_is(302);
 
 # Login and claim the kingdom
 $test_case->login($t, 'morgana');
-$get = $t->get_ok('/admin/users')->status_is(200);
+$t->get_ok('/admin/users')->status_is(200);
 is($t->tx->res->dom->at('#user_99901 .role')->attr('data-order'), '01');
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '00');
 is($t->tx->res->dom->at('#user_99903 .role')->attr('data-order'), '01');
@@ -63,6 +63,6 @@ $t->delete_ok('/logout')->status_is(302);
 
 # No-one else can claim the kingdom
 $test_case->login($t, 'merlin');
-$get = $t->get_ok('/admin/users')->status_is(403);
+$t->get_ok('/admin/users')->status_is(403);
 
 done_testing();

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -32,8 +32,8 @@ $test_case->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # First of all, init the session (this should probably be in OpenQA::Test)
-my $req   = $t->ua->get('/tests');
-my $token = $req->res->dom->at('meta[name=csrf-token]')->attr('content');
+$t->get_ok('/tests');
+my $token = $t->tx->res->dom->at('meta[name=csrf-token]')->attr('content');
 
 #
 # No login, no list, redirect to login
@@ -49,31 +49,28 @@ $t->get_ok('/admin/users')->status_is(403);
 # So let's login as a admin
 $t->delete_ok('/logout')->status_is(302);
 $test_case->login($t, 'arthur');
-my $get = $t->get_ok('/admin/users')->status_is(200);
+$t->get_ok('/admin/users')->status_is(200);
 is($t->tx->res->dom->at('#user_99901 .role')->attr('data-order'), '11');
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '00');
 is($t->tx->res->dom->at('#user_99903 .role')->attr('data-order'), '01');
 
 # Click on "+ admin" for Lancelot
 $t->post_ok('/admin/users/99902', {'X-CSRF-Token' => $token} => form => {role => 'admin'})->status_is(302);
-$get = $t->get_ok('/admin/users')->status_is(200);
-$get->content_like(qr/User lance updated/);
-$get->text_is('#user_99902 .username' => 'https://openid.camelot.uk/lancelot');
+$t->get_ok('/admin/users')->status_is(200)->content_like(qr/User lance updated/)
+  ->text_is('#user_99902 .username' => 'https://openid.camelot.uk/lancelot');
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '11');
 
 
 # We can even update both fields in one request
 $t->post_ok('/admin/users/99902', {'X-CSRF-Token' => $token} => form => {role => 'operator'})->status_is(302);
-$get = $t->get_ok('/admin/users')->status_is(200);
-$get->content_like(qr/User lance updated/);
-$get->text_is('#user_99902 .username' => 'https://openid.camelot.uk/lancelot');
+$t->get_ok('/admin/users')->status_is(200)->content_like(qr/User lance updated/)
+  ->text_is('#user_99902 .username' => 'https://openid.camelot.uk/lancelot');
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '01');
 
 # not giving a role, makes it a user
 $t->post_ok('/admin/users/99902', {'X-CSRF-Token' => $token} => form => {})->status_is(302);
-$get = $t->get_ok('/admin/users')->status_is(200);
-$get->content_like(qr/User lance updated/);
-$get->text_is('#user_99902 .username' => 'https://openid.camelot.uk/lancelot');
+$t->get_ok('/admin/users')->status_is(200)->content_like(qr/User lance updated/)
+  ->text_is('#user_99902 .username' => 'https://openid.camelot.uk/lancelot');
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '00');
 
 done_testing();

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -58,9 +58,9 @@ $driver->title_is("openQA", "back on main page");
 
 # check 'reviewed' labels
 
-my $get = $t->get_ok('/?limit_builds=10')->status_is(200);
-$get->element_count_is('.review', 2, 'exactly two builds marked as \'reviewed\'');
-$get->element_exists('.badge-all-passed', 'one build is marked as \'reviewed-all-passed\' because all tests passed');
+$t->get_ok('/?limit_builds=10')->status_is(200)
+  ->element_count_is('.review', 2, 'exactly two builds marked as \'reviewed\'')
+  ->element_exists('.badge-all-passed', 'one build is marked as \'reviewed-all-passed\' because all tests passed');
 
 $driver->find_element_by_link_text('opensuse')->click();
 
@@ -339,8 +339,8 @@ subtest 'commenting in test results including labels' => sub {
         );
         my @labels = $driver->find_elements('#res_DVD_x86_64_doc .test-label', 'css');
         is(scalar @labels, 3, '3 bugrefs shown');
-        $get = $t->get_ok($driver->get_current_url())->status_is(200);
-        is($get->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href},
+        $t->get_ok($driver->get_current_url())->status_is(200);
+        is($t->tx->res->dom->at('#res_DVD_x86_64_doc .fa-bug')->parent->{href},
             'https://bugzilla.suse.com/show_bug.cgi?id=1234');
         $driver->find_element_by_link_text('opensuse')->click();
         is($driver->find_element('.badge-all-passed')->get_attribute('title'),
@@ -382,8 +382,8 @@ subtest 'commenting in test results including labels' => sub {
             is($bugrefs[1]->get_attribute('title'), 'Bug referenced: poo#9875', 'second bugref shown');
             is($bugrefs[2]->get_attribute('title'), 'Bug referenced: poo#9874', 'third bugref shown');
             is($bugrefs[3],                         undef,                      'correct number of bugrefs shown');
-            $get = $t->get_ok($driver->get_current_url())->status_is(200);
-            is($get->tx->res->dom->at('#res_staging_e_x86_64_minimalx .fa-bolt')->parent->{href},
+            $t->get_ok($driver->get_current_url())->status_is(200);
+            is($t->tx->res->dom->at('#res_staging_e_x86_64_minimalx .fa-bolt')->parent->{href},
                 'https://progress.opensuse.org/issues/9876');
         };
 

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -76,8 +76,7 @@ unless ($driver) {
 }
 
 # check job next and previous not loaded when open tests/x
-my $get = $t->get_ok('/tests/99946')->status_is(200);
-$get->element_exists_not(
+$t->get_ok('/tests/99946')->status_is(200)->element_exists_not(
     '#job_next_previous_table_wrapper .dataTables_wrapper',
     'datatable of job next and previous not loaded when open tests/x'
 );

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -59,7 +59,7 @@ $t->app($app);
 my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
 
 # schedule an ISO
-my $ret = $t->post_ok(
+$t->post_ok(
     $url . '/api/v1/isos',
     form => {
         ISO     => 'whatever.iso',
@@ -70,7 +70,7 @@ my $ret = $t->post_ok(
         BUILD   => '0091',
         FOO     => 'bar',
     })->status_is(200);
-is($ret->tx->res->json->{count}, 9, '9 new jobs created, 1 fails due to wrong START_AFTER_TEST');
+is($t->tx->res->json->{count}, 9, '9 new jobs created, 1 fails due to wrong START_AFTER_TEST');
 
 # access product log without being logged-in
 $driver->get($url . '/admin/productlog');

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -174,14 +174,14 @@ subtest 'bug reporting' => sub {
 
 # test running view with Test::Mojo as phantomjs would get stuck on the
 # liveview/livelog forever
-my $t   = Test::Mojo->new('OpenQA::WebAPI');
-my $get = $t->get_ok($baseurl . 'tests/99963')->status_is(200);
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+$t->get_ok($baseurl . 'tests/99963')->status_is(200);
 
-my @worker_text = $get->tx->res->dom->find('#assigned-worker')->map('all_text')->each;
+my @worker_text = $t->tx->res->dom->find('#assigned-worker')->map('all_text')->each;
 like($worker_text[0], qr/[ \n]*Assigned worker:[ \n]*localhost:1[ \n]*/, 'worker displayed when job running');
-my @worker_href = $get->tx->res->dom->find('#assigned-worker a')->map(attr => 'href')->each;
+my @worker_href = $t->tx->res->dom->find('#assigned-worker a')->map(attr => 'href')->each;
 is($worker_href[0], '/admin/workers/1', 'link to worker correct');
-my @scenario_description = $get->tx->res->dom->find('#scenario-description')->map('all_text')->each;
+my @scenario_description = $t->tx->res->dom->find('#scenario-description')->map('all_text')->each;
 like(
     $scenario_description[0],
     qr/[ \n]*Simple kde test, before advanced_kde[ \n]*/,
@@ -276,22 +276,21 @@ subtest 'render video link if frametime is available' => sub {
 };
 
 subtest 'route to latest' => sub {
-    $get
-      = $t->get_ok('/tests/latest?distri=opensuse&version=13.1&flavor=DVD&arch=x86_64&test=kde&machine=64bit')
+    $t->get_ok('/tests/latest?distri=opensuse&version=13.1&flavor=DVD&arch=x86_64&test=kde&machine=64bit')
       ->status_is(200);
     my $header = $t->tx->res->dom->at('#info_box .card-header a');
     is($header->text,   '99963',        'link shows correct test');
     is($header->{href}, '/tests/99963', 'latest link shows tests/99963');
-    my $first_detail = $get->tx->res->dom->at('#details tbody > tr ~ tr');
+    my $first_detail = $t->tx->res->dom->at('#details tbody > tr ~ tr');
     is($first_detail->at('.component a')->{href}, '/tests/99963/modules/isosize/steps/1/src', 'correct src link');
     is($first_detail->at('.links_a a')->{'data-url'}, '/tests/99963/modules/isosize/steps/1', 'correct needle link');
-    $get    = $t->get_ok('/tests/latest?flavor=DVD&arch=x86_64&test=kde')->status_is(200);
+    $t->get_ok('/tests/latest?flavor=DVD&arch=x86_64&test=kde')->status_is(200);
     $header = $t->tx->res->dom->at('#info_box .card-header a');
     is($header->{href}, '/tests/99963', '... as long as it is unique');
-    $get    = $t->get_ok('/tests/latest?version=13.1')->status_is(200);
+    $t->get_ok('/tests/latest?version=13.1')->status_is(200);
     $header = $t->tx->res->dom->at('#info_box .card-header a');
     is($header->{href}, '/tests/99981', 'returns highest job nr of ambiguous group');
-    $get    = $t->get_ok('/tests/latest?test=kde&machine=32bit')->status_is(200);
+    $t->get_ok('/tests/latest?test=kde&machine=32bit')->status_is(200);
     $header = $t->tx->res->dom->at('#info_box .card-header a');
     is($header->{href}, '/tests/99937', 'also filter on machine');
     my $job_groups_links = $t->tx->res->dom->find('.navbar .dropdown a + ul.dropdown-menu a');
@@ -304,7 +303,7 @@ subtest 'route to latest' => sub {
     like($build_href, qr/groupid=1001/,    'href to test overview');
     like($build_href, qr/version=13.1/,    'href to test overview');
     like($build_href, qr/build=0091/,      'href to test overview');
-    $get = $t->get_ok('/tests/latest?test=foobar')->status_is(404);
+    $t->get_ok('/tests/latest?test=foobar')->status_is(404);
 };
 
 # test /details route
@@ -472,10 +471,10 @@ my $post
   = $t_api->post_ok($baseurl . 'api/v1/jobs/99963/set_done', form => {result => 'FAILED'})
   ->status_is(200, 'set job as done');
 
-$get         = $t->get_ok($baseurl . 'tests/99963')->status_is(200);
-@worker_text = $get->tx->res->dom->find('#assigned-worker')->map('all_text')->each;
+$t->get_ok($baseurl . 'tests/99963')->status_is(200);
+@worker_text = $t->tx->res->dom->find('#assigned-worker')->map('all_text')->each;
 like($worker_text[0], qr/[ \n]*Assigned worker:[ \n]*localhost:1[ \n]*/, 'worker still displayed when job set to done');
-@scenario_description = $get->tx->res->dom->find('#scenario-description')->map('all_text')->each;
+@scenario_description = $t->tx->res->dom->find('#scenario-description')->map('all_text')->each;
 like(
     $scenario_description[0],
     qr/[ \n]*Simple kde test, before advanced_kde[ \n]*/,
@@ -484,7 +483,7 @@ like(
 
 # now test the details of a job with nearly no settings which should yield no
 # warnings
-$get = $t->get_ok('/tests/80000')->status_is(200);
+$t->get_ok('/tests/80000')->status_is(200);
 
 subtest 'test module flags are displayed correctly' => sub {
     # for this job we have exactly each flag set once, so check that not to rely on the order of the test modules

--- a/t/ui/22-job_group_order.t
+++ b/t/ui/22-job_group_order.t
@@ -32,8 +32,8 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 sub verify_navbar {
     my ($expected) = @_;
-    my $get        = $t->get_ok('/')->status_is(200);
-    my $groups     = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('.navbar-nav li.dropdown')->all_text);
+    $t->get_ok('/')->status_is(200);
+    my $groups = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('.navbar-nav li.dropdown')->all_text);
     # in fixtures both are sort_order 0, so they are sorted by name
     is($groups, "Job Groups $expected", "got $expected");
 }


### PR DESCRIPTION
Every week there's at least one PR cargo culting this bug. Almost all methods in `Test::Mojo` simply return their invocant, but many openQA tests assumed that there's a special response object that could be held on to for later tests. Most of the time this is actually harmless, but there were a few cases where tests only accidentally passed.
```perl
my $first = $t->get_ok('/first');
my $second = $t->get_ok('/second');
$first->status_is(400);
$second->status_is(400);
```
You might think this is equal to:
```perl
$t->get_ok('/first')->status_is(400);
$t->get_ok('/second')->status_is(400);
```
But what it actually did was:
```perl
$t->get_ok('/first');
$t->get_ok('/second')->status_is(400)->status_is(400);
```
Because `$first` and `$second` were referencing the same object (`$t`).

`Test::Mojo` has a [tx property](https://mojolicious.org/perldoc/Test/Mojo#tx) containing the request/response state, that's what all the tests like [status_is](https://mojolicious.org/perldoc/Test/Mojo#status_is) are performed on, and that gets updated when you start a new request with [get_ok](https://mojolicious.org/perldoc/Test/Mojo#get_ok). The Mojolicious [testing guide](https://mojolicious.org/perldoc/Mojolicious/Guides/Testing#Test::Mojo-at-a-glance) goes into more detail.