### PR TITLE
Always use spaces in CodeMirror editor

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -380,6 +380,12 @@ function toggleTemplateEditor() {
             lineWrapping: true,
             readOnly: 'nocursor',
         });
+        editor.setOption('extraKeys', {
+            Tab: function(editor) {
+                // Convert tabs to spaces
+                editor.replaceSelection(Array(editor.getOption('indentUnit') + 1).join(' '));
+            }
+        });
     }
     editor.setSize(null, $('#editor-yaml-guide').height());
     $.ajax(form.data('put-url')).done(prepareTemplateEditor);


### PR DESCRIPTION
Although tabs are valid characters in YAML, spaces are used for indentation and mixing tabs with spaces for indentation results in error messages that can be very confusing to deal with.
We always indent with spaces, so it makes sense to enforce spaces.

The code is based [on a snippet](https://codemirror.net/doc/manual.html#keymaps) from the official docs.