### PR TITLE
tidy: Apply to all regular perl modules and scripts

### DIFF
--- a/script/modify_needle
+++ b/script/modify_needle
@@ -71,14 +71,14 @@ for my $needle (@ARGV) {
     close $fh;
 
     my $changed = 0;
-    my %tags = map { $_ => 1 } @{$info->{tags}};
+    my %tags    = map { $_ => 1 } @{$info->{tags}};
     for my $at (@add_tags) {
-	$changed = 1 unless $tags{$at};
-	$tags{$at} = 1;
+        $changed = 1 unless $tags{$at};
+        $tags{$at} = 1;
     }
-    $info->{tags} = [ sort keys %tags ];
+    $info->{tags} = [sort keys %tags];
     next unless $changed;
-    
+
     open($fh, '>', $needle) || die "can't open $needle";
     print $fh Cpanel::JSON::XS->new->pretty->encode($info);
     close $fh;

--- a/script/tidy
+++ b/script/tidy
@@ -46,7 +46,7 @@ find . -name '*.tdy' -delete
 # .pc directory is used for "quilt" patch system (in Debian/Ubuntu)
 # it contains pre-patched files and should be ignored
 # shellcheck disable=SC2207
-files=($(find . ! -path '*/.pc/*' \( -name '*.p[lm]' -o -name '*.t' \)))
+files=($(find . ! -path '*/.pc/*' -type f \( -name '*.p[lm]' -o -name '*.t' \)) $(file --mime-type script/* | sed -n 's/^\(.*\):.*text\/x-perl.*$/\1/p'))
 find_changed_files
 # shellcheck disable=SC2128
 [[ $changed_files ]] && perltidy --pro=.../.perltidyrc "${changed_files[@]}"


### PR DESCRIPTION
This fixes tidy exchanging symlinks with file-copies in case the symlink
target appears later in the alphabet. Also we previously did not cover
the files in the "script/" subdirectory unless we used the '.pl'
extensions.

Therefore also apply current tidy rules to all script files in script/.