### PR TITLE
Activate strictures in tests as soon as possible

### DIFF
--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -17,6 +17,7 @@
 
 use strict;
 use warnings;
+
 use Test::Compile;
 use Mojo::File 'tempdir';
 

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -16,11 +16,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use strict;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::WebSockets::Client;

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -16,11 +16,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use strict;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -15,12 +15,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use strict;
-use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use File::Path qw(remove_tree);

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;

--- a/t/20-workers-ws.t
+++ b/t/20-workers-ws.t
@@ -15,12 +15,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use strict;
-use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -16,13 +16,14 @@
 
 # see also t/ui/14-dashboard.t and t/ui/14-dashboard-parents.t for PhantomJS test
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base;
 use Mojo::IOLoop;
 
 use FindBin;
@@ -45,7 +46,7 @@ $plugin_mock->mock(
         $published{$topic} = $data;
     });
 
-my $schema = OpenQA::Test::Database->new->create();
+OpenQA::Test::Database->new->create();
 
 # this test also serves to test plugin loading via config file
 my @conf    = ("[global]\n", "plugins=AMQP\n");

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -13,12 +13,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use strict;
-use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;

--- a/t/24-worker.t
+++ b/t/24-worker.t
@@ -13,12 +13,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use strict;
-use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 
@@ -27,8 +30,6 @@ BEGIN {
     };
 }
 
-use strict;
-use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Setup;

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -14,12 +14,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use strict;
+use warnings;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use strict;
-use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -14,13 +14,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -15,9 +15,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use 5.018;
-use warnings;
 use strict;
+use warnings;
+
+use 5.018;
 use Test::More;
 use POSIX;
 use FindBin;

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -16,6 +16,7 @@
 
 use strict;
 use warnings;
+
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
 use Test::More;
@@ -920,8 +921,6 @@ subtest nested_parsers => sub {
 };
 
 done_testing;
-
-1;
 
 {
     package OpenQA::Parser::Format::Dummy;

--- a/t/31-api_descriptions.t
+++ b/t/31-api_descriptions.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/31-client.t
+++ b/t/31-client.t
@@ -14,6 +14,7 @@
 
 use strict;
 use warnings;
+
 use FindBin;
 use lib "$FindBin::Bin/lib", "lib";
 

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -16,6 +16,7 @@
 
 use strict;
 use warnings;
+
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
 use Test::More;
@@ -208,4 +209,3 @@ subtest 'get_piece' => sub {
 };
 
 done_testing();
-1;

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -16,6 +16,7 @@
 
 use strict;
 use warnings;
+
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
 use Test::More;
@@ -337,5 +338,3 @@ subtest 'upload internal errors' => sub {
 
 
 done_testing();
-
-1;

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -16,6 +16,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
@@ -24,7 +26,6 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Date::Format;
 use Data::Dumper 'Dumper';
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -16,13 +16,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -16,13 +16,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -16,13 +16,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -16,13 +16,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -17,11 +17,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -15,12 +15,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use Date::Format;
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/basic.t
+++ b/t/basic.t
@@ -13,9 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN { unshift @INC, 'lib'; }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;

--- a/t/config.t
+++ b/t/config.t
@@ -17,6 +17,7 @@ BEGIN { unshift @INC, 'lib'; }
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 use Mojo::Base -strict;
+
 use FindBin;
 use lib "$FindBin::Bin/lib";
 

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -1,8 +1,9 @@
 package OpenQA::SeleniumTest;
-use base 'Exporter';
 
 use strict;
 use warnings;
+
+use base 'Exporter';
 
 require OpenQA::Test::Database;
 

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -16,11 +16,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
-
-use Mojo::Base -strict;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format 'time2str';

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use File::Path qw(remove_tree);

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -16,12 +16,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use Module::Load::Conditional qw(can_load);
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -16,12 +16,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use Module::Load::Conditional qw(can_load);
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base;
 use Mojo::JSON 'decode_json';
 use FindBin;
 use lib "$FindBin::Bin/../lib";

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/20-bugzilla-links.t
+++ b/t/ui/20-bugzilla-links.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/22-job_group_order.t
+++ b/t/ui/22-job_group_order.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -16,11 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -20,12 +20,13 @@
 #       web socket connection to the live view handler is established here.
 #       Instead, the state is injected via JavaScript commands.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
 use Module::Load::Conditional qw(can_load);
-use Mojo::Base -strict;
 use Mojo::File qw(path tempdir);
 use FindBin;
 use lib "$FindBin::Bin/../lib";

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use Mojo::Base -strict;
+
 BEGIN {
     unshift @INC, 'lib';
 }
 
-use Mojo::Base -strict;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;


### PR DESCRIPTION
Noticed that some tests don't correctly activate strictures at the beginning. Some were also missing `warnings` completely.