### PR TITLE
Fix handling of unknown workers in the websocket server

### DIFF
--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -32,10 +32,8 @@ sub ws {
 
     my $workerid = $self->param('workerid');
     unless ($workers->{$workerid}) {
-        my $db = $self->app->schema->resultset("Workers")->find($workerid);
-        unless ($db) {
-            return $self->render(text => 'Unauthorized', status =>);
-        }
+        return $self->render(text => 'Unknown worker', status => 400)
+          unless my $db = $self->app->schema->resultset('Workers')->find($workerid);
         $workers->{$workerid}
           = {id => $workerid, db => $db, socket => undef, last_seen => time()};
     }

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -59,6 +59,7 @@ subtest 'Authentication' => sub {
 };
 
 subtest 'API' => sub {
+    $t->tx($t->ua->start($t->ua->build_websocket_tx('/ws/23')))->status_is(400)->content_like(qr/Unknown worker/);
     $t->get_ok('/api/is_worker_connected/1')->status_is(200)->json_is({connected => Mojo::JSON::false});
     local $t->app->status->workers->{1} = {socket => 1};
     $t->get_ok('/api/is_worker_connected/1')->status_is(200)->json_is({connected => Mojo::JSON::true});


### PR DESCRIPTION
Currently the websocket server responds with a 500 error when a worker tries to connect that is not in the database. This patch fixes the broken render call responsible and replaces the useless `Unauthorized` message with `Unknown worker`.