### PR TITLE
spec: Split out all dependencies properly per sub-package

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -23,7 +23,6 @@ use File::Spec::Functions 'catfile';
 use Mojo::File 'path';
 use Mojo::Util 'trim';
 use Config::IniFiles;
-use OpenQA::Schema::Profiler;
 use OpenQA::Utils;
 use OpenQA::Utils 'random_string';
 use File::Path 'make_path';
@@ -105,6 +104,7 @@ sub setup_log {
 
     $self->log($log);
     if ($ENV{OPENQA_SQL_DEBUG} // $self->config->{logging}->{sql_debug} // 'false' eq 'true') {
+        require OpenQA::Schema::Profiler;
         # avoid enabling the SQL debug unless we really want to see it
         # it's rather expensive
         OpenQA::Schema::Profiler->enable_sql_debugging;


### PR DESCRIPTION
The meaning of "t_requires" was probably not really clear to many so this commit
provides better names to explain the meaning. In the same go we split the
requirements per sub-package and pull in all runtime requirements as needed
into the build environment to execute the tests without pulling in more
runtime dependencies into the individual tickets than needed.

https://build.opensuse.org/package/show/home:okurz:branches:devel:openQA:feature:spec_split_deps/openQA shows the build results based on this branch