### PR TITLE
openqa-clone-job: Improve handling --from parameter

### DIFF
--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -147,8 +147,13 @@ sub usage($) {
 
 sub split_jobid {
     my ($url_string) = @_;
-    my $url          = Mojo::URL->new($url_string);
-    my $host_url     = $url->scheme . '://' . $url->host;
+    my $url = Mojo::URL->new($url_string);
+
+    # handle scheme being omitted and support specifying only a domain (e.g. 'openqa.opensuse.org')
+    $url->scheme('http') unless $url->scheme;
+    $url->host($url->path->parts->[0]) unless $url->host;
+
+    my $host_url = Mojo::URL->new->scheme($url->scheme)->host($url->host)->to_string;
     (my $jobid) = $url->path =~ /([0-9]+)/;
     return ($host_url, $jobid);
 }


### PR DESCRIPTION
* Use 'http' scheme if omitted instead of printing Perl warnings
* Allow specifying only a domain

The openqa-clone-job script worked this way before support for full test URLs was added (https://github.com/os-autoinst/openQA/pull/2137).