### PR TITLE
travis_test: Fix typo in 'python3-future'

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -36,7 +36,7 @@ RUN zypper in -y -C \
        optipng \
        python3-base \
        python3-requests \
-       python3-futures \
+       python3-future \
        sqlite3 \
        postgresql-server \
        which \


### PR DESCRIPTION
Tested with

```
docker run -it --rm -v $PWD:/opt/openqa:ro registry.opensuse.org/opensuse/leap:42.3 sh -c 'zypper ref && zypper -n in python3-future python3-requests python3-base && /opt/openqa/script/openqa-label-all --help'
```