### PR TITLE
Add Test::More based error handler to SeleniumTest

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -114,6 +114,11 @@ sub start_driver {
                 loggingPrefs  => {browser => 'ALL'},
                 chromeOptions => {args    => []}
             },
+            error_handler => sub {
+                # generate Test::More failure instead of croaking to preserve context
+                my ($driver, $exception, $args) = @_;
+                fail((split /\n/, $exception)[0] =~ s/Error while executing command: //r);
+            },
         );
 
         # chromedriver is unfortunately hidden on openSUSE

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -93,8 +93,7 @@ for my $item ('Medium types', 'Machines', 'Workers', 'Assets', 'Scheduled produc
 
 # we shouldn't see users, audit
 for my $item ('Users', 'Needles', 'Audit log') {
-    eval { $driver->find_element($item, 'link_text') };
-    ok($@, "can not see $item");
+    ok(!scalar @{$driver->find_elements($item, 'link_text')}, "can not see $item");
 }
 
 kill_driver();


### PR DESCRIPTION
By default [Selenium::Remote::Driver](https://metacpan.org/pod/Selenium::Remote::Driver#error_handler) will croak and generate a stack
trace at the end of the test run. There's a couple issues with this:

- It looks like an internal error.
- The stack trace isn't useful outside of developing the driver.
- Context is lost. The referenced code is not linked to the test case.

Overriding the handler, we can [fail](https://metacpan.org/pod/Test::More#fail) and get a message within the
context of the test that actually failed.