### PR TITLE
Remove dead code from OpenQA::Utils

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -453,12 +453,12 @@ sub get_ws_status_only_url {
     return "liveviewhandler/tests/$job_id/developer/ws-proxy/status";
 }
 
-sub run_cmd_with_log($) {
+sub run_cmd_with_log {
     my ($cmd) = @_;
     return run_cmd_with_log_return_error($cmd)->{status};
 }
 
-sub run_cmd_with_log_return_error($) {
+sub run_cmd_with_log_return_error {
     my ($cmd) = @_;
 
     log_info('Running cmd: ' . join(' ', @$cmd));

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -85,7 +85,6 @@ our @EXPORT  = qw(
   loaded_plugins
   hashwalker
   read_test_modules
-  exists_worker
   feature_scaling
   logistic_map_steps
   logistic_map
@@ -411,7 +410,7 @@ sub get_channel_handle {
     }
 }
 
-sub save_base64_png($$$) {
+sub save_base64_png {
     my ($dir, $newfile, $png) = @_;
     return unless $newfile;
     # sanitize
@@ -760,15 +759,6 @@ sub create_downloads_list {
         }
     }
     return \%downloads;
-}
-
-sub exists_worker($$) {
-    my $schema   = shift;
-    my $workerid = shift;
-    die "invalid worker id\n" unless $workerid;
-    my $rs = $schema->resultset("Workers")->find($workerid);
-    die "invalid worker id $workerid\n" unless $rs;
-    return $rs;
 }
 
 sub _round_a_bit {


### PR DESCRIPTION
This came up in #2102 as an unrelated warning.
```
Prototype mismatch: sub OpenQA::Git::run_cmd_with_log_return_error ($) vs none at /usr/lib/perl5/vendor_perl/5.18.2/Test/MockModule.pm line 135.
Prototype mismatch: sub OpenQA::Git::run_cmd_with_log_return_error: none vs ($) at /usr/lib/perl5/vendor_perl/5.18.2/Test/MockModule.pm line 135.
```
Unsurprisingly all uses of prototypes in `OpenQA::Utils` were pointless, so i just removed them, fixing the warnings in the process.

The `exists_worker` function appears to be dead code that was [never used](https://github.com/os-autoinst/openQA/commit/2f4280b3229cf3e6c172664485a31d1ef7ff760c).