### PR TITLE
Allow any suffix for TAP source files

### DIFF
--- a/lib/OpenQA/Parser/Format/TAP.pm
+++ b/lib/OpenQA/Parser/Format/TAP.pm
@@ -45,7 +45,7 @@ sub parse {
     my $m = 0;
     while (my $res = $tap->next) {
         my $result = $res;
-        if ($result->raw =~ m/^(.*\.(:?tap|t)) \.{2}/g) {
+        if ($result->raw =~ m/^(.*\.(?:[a-zA-Z0-9]+)) \.{2}/g) {
             # most cases, teh output of a prove run will contain
             # "/t/$filename.tap .." as name of the file
             # use this to get the filename

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -564,7 +564,7 @@ sub test_tap_file {
         });
 }
 
-subtest tap_parse => sub {
+subtest tap_parse_ok => sub {
     my $parser = OpenQA::Parser::Format::TAP->new;
 
     my $tap_test_file = path($FindBin::Bin, "data")->child("tap_format_example.tap");
@@ -581,7 +581,34 @@ subtest tap_parse => sub {
     is scalar @{$parser->results->last->details}, 6, '1 test cases details';
 
     is $_->{result}, 'ok', 'All testcases are passing' for @{$parser->results->first->details};
+};
 
+subtest tap_parse_fail => sub {
+    # test other suffix and failing test
+    my $tap_test_file = path($FindBin::Bin, "data")->child("tap_format_example2.tap");
+
+    my $parser = OpenQA::Parser::Format::TAP->new;
+    $parser->load($tap_test_file);
+
+    is $parser->results->size, 1, "One test file";
+    is $parser->results->first->result, 'fail', 'tests failed';
+
+    is scalar @{$parser->results->first->details}, 2, '2 test cases details';
+
+    is $parser->results->first->details->[0]->{result}, 'ok',   'Test 1 passed';
+    is $parser->results->first->details->[1]->{result}, 'fail', 'Test 2 failed';
+};
+
+subtest tap_parse_invalid => sub {
+    # test invalid TAP
+    my $tap_test_file = path($FindBin::Bin, "data")->child("tap_format_example3.tap");
+
+    my $parser = OpenQA::Parser::Format::TAP->new;
+
+    eval { $parser->load($tap_test_file) };
+    my $error = $@;
+
+    like $error, qr{A valid TAP starts with filename.tap}, "Invalid TAP example";
 };
 
 sub test_ltp_file {

--- a/t/data/tap_format_example2.tap
+++ b/t/data/tap_format_example2.tap
@@ -1,0 +1,5 @@
+t/some-script.bash ..
+# Some comment
+ok 1 - Some bash test
+not ok 2 - failing test
+2..2

--- a/t/data/tap_format_example3.tap
+++ b/t/data/tap_format_example3.tap
@@ -1,0 +1,4 @@
+t/invalid. ..
+1..1
+ok 1 - Some test
+


### PR DESCRIPTION
This will allow also to write bash scripts named `something.bash` to output TAP and get it parsed.

Also this fixes the regex by swapping ':?' to '?:'