### PR TITLE
Allow plugins to add links to the menu

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -163,6 +163,10 @@ sub read_config {
         audit => {
             blacklist => '',
         },
+        plugin_links => {
+            operator => {},
+            admin    => {}
+        },
         amqp => {
             reconnect_timeout => 5,
             url               => 'amqp://guest:guest@localhost:5672/',

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -482,4 +482,17 @@ subtest 'job parent groups with multiple version and builds' => sub {
 
 };
 
+subtest 'extra plugin links' => sub {
+    $t->app->config->{plugin_links}{operator}{Test1} = 'tests_overview';
+    $t->app->config->{plugin_links}{operator}{Test2} = 'latest';
+    $t->app->config->{plugin_links}{admin}{Test3}    = 'tests_export';
+    $t->get_ok('/')->status_is(200)->element_exists('a[href*="/tests/overview"]')
+      ->text_like('a[href*="/tests/overview"]', qr/Test1/)->element_exists('a[href*="/tests/latest"]')
+      ->text_like('a[href*="/tests/latest"]',   qr/Test2/)->element_exists_not('a[href*="/tests/export"]');
+    $t->app->schema->resultset('Users')->search({username => 'percival'})->next->update({is_admin => 1});
+    $t->get_ok('/')->status_is(200)->element_exists('a[href*="/tests/overview"]')
+      ->element_exists('a[href*="/tests/latest"]')->element_exists('a[href*="/tests/export"]')
+      ->text_like('a[href*="/tests/export"]', qr/Test3/);
+};
+
 done_testing;

--- a/t/config.t
+++ b/t/config.t
@@ -68,6 +68,10 @@ subtest 'Test configuration default modes' => sub {
         audit => {
             blacklist => '',
         },
+        plugin_links => {
+            operator => {},
+            admin    => {}
+        },
         amqp => {
             reconnect_timeout => 5,
             url               => 'amqp://guest:guest@localhost:5672/',

--- a/templates/layouts/navbar.html.ep
+++ b/templates/layouts/navbar.html.ep
@@ -53,6 +53,10 @@
                   <!-- Sure this is not the proper place for the workers view,
                   but the previous one was even more annoying -->
                   %= link_to 'Workers' => url_for('admin_workers') => class => 'dropdown-item'
+                  % my $operator_links = config->{plugin_links}{operator};
+                  % for my $name (sort keys %$operator_links) {
+                    %= link_to $name => url_for($operator_links->{$name}) => class => 'dropdown-item'
+                  % }
                   % if (is_admin) {
                       %= tag 'div' => class => 'dropdown-divider'
                       %= tag 'h3' => class => 'dropdown-header' => 'Administrators Menu'
@@ -60,6 +64,10 @@
                       %= link_to('Needles' => url_for('admin_needles') => class => 'dropdown-item')
                       %= link_to('Audit log' => url_for('audit_log') => class => 'dropdown-item')
                       %= link_to('Minion Dashboard' => url_for('minion_dashboard') => class => 'dropdown-item')
+                      % my $admin_links = config->{plugin_links}{admin};
+                      % for my $name (sort keys %$admin_links) {
+                        %= link_to $name => url_for($admin_links->{$name}) => class => 'dropdown-item'
+                      % }
                   % }
                   %= tag 'div' => class => 'dropdown-divider'
                   % if (is_operator) {


### PR DESCRIPTION
This feature is for #2173. It allows plugins to add new links to the operator and admin menus with a config option, like:
```perl
$app->config->{plugin_links}{operator}{'Link Name'} = 'route_name';
```
I'm not too fond of the name `plugin_links`, but couldn't really think of something more fitting.
<img width="350" alt="menu" src="https://user-images.githubusercontent.com/30094/61042790-28d63800-a3d5-11e9-8897-8fe97f39ef34.png">
