### PR TITLE
Improve and simplify compile check

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -100,7 +100,7 @@ on 'test' => sub {
   requires 'Perl::Tidy', '== 20190601';
   requires 'Selenium::Remote::Driver', '>= 1.23';
   requires 'Selenium::Remote::WDKeys';
-  requires 'Test::Compile';
+  requires 'Test::Strict';
   requires 'Test::Fatal';
   requires 'Test::MockModule';
   requires 'Test::MockObject';

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -110,7 +110,6 @@ RUN zypper in -y -C \
        'perl(Selenium::Remote::Driver)' \
        'perl(Socket::MsgHdr)' \
        'perl(Sort::Versions)' \
-       'perl(Test::Compile)' \
        'perl(Test::Strict)' \
        'perl(Test::Fatal)' \
        'perl(Test::Pod)' \

--- a/lib/OpenQA/Worker/Cache/Service.pm
+++ b/lib/OpenQA/Worker/Cache/Service.pm
@@ -15,6 +15,9 @@
 
 package OpenQA::Worker::Cache::Service;
 
+use strict;
+use warnings;
+
 use OpenQA::Worker::Settings;
 use OpenQA::Worker::Cache::Task::Asset;
 use OpenQA::Worker::Cache qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE STATUS_ERROR);

--- a/openQA.spec
+++ b/openQA.spec
@@ -100,7 +100,7 @@ BuildRequires:  perl(DBD::SQLite)
 BuildRequires:  perl(Perl::Critic)
 BuildRequires:  perl(Perl::Critic::Freenode)
 BuildRequires:  perl(Selenium::Remote::Driver) >= 1.20
-BuildRequires:  perl(Test::Compile)
+BuildRequires:  perl(Test::Strict)
 BuildRequires:  perl(Test::MockObject)
 BuildRequires:  perl(Test::Warnings)
 BuildRequires:  rsync

--- a/script/create_admin
+++ b/script/create_admin
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use strict;
+use warnings;
+
 BEGIN {
     use FindBin qw($Bin);
     use lib "$Bin/../lib";
 }
 
-use strict;
-use warnings;
 use OpenQA::Schema::Result::ApiKeys;
 use OpenQA::Schema;
 use OpenQA::Utils 'random_hex';

--- a/script/load_templates
+++ b/script/load_templates
@@ -61,9 +61,11 @@ lorem ipsum ...
 
 =cut
 
+use strict;
+use warnings;
+
 use FindBin;
 use lib "$FindBin::RealBin/../lib";
-use strict;
 use File::Basename qw(dirname);
 use Try::Tiny;
 use Data::Dump 'dd';

--- a/script/openqa
+++ b/script/openqa
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use warnings;
 use Mojo::Base -strict;
 
 use FindBin;

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use warnings;
 use Mojo::Base -strict;
 
 use FindBin;

--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,36 +13,19 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# require all modules to check if they even load
-
 use strict;
 use warnings;
 
-use Test::Compile;
-use Mojo::File 'tempdir';
+use FindBin;
+unshift @INC, "$FindBin::Bin/lib", "$FindBin::Bin/../lib";
 
-my $tempdir;
-BEGIN {
-    unshift @INC, 'lib';
+use Test::Strict;
 
-    # FIXME: Requiring OpenQA::Worker::Cache::Service
-    # Sets up Minion with Mojo::SQLite, that on DESTROY automatically disconnects from the database.
-    # If the database is not existant or can't be accessed we get a warning, that translates to test failure.
-
-    $tempdir = tempdir;
-    $ENV{OPENQA_CACHE_DIR} = $tempdir;
-}
-
-my $test = Test::Compile->new();
-$test->verbose(1);
-
-my @files = $test->all_pm_files();
-for my $file (@files) {
-    $test->ok($test->pm_file_compiles($file), "Compile test for $file");
-}
-
-@files = $test->all_pl_files();
-for my $file (@files) {
-    $test->ok($test->pl_file_compiles($file), "Compile test for $file");
-}
-$test->done_testing();
+$Test::Strict::TEST_SYNTAX   = 1;
+$Test::Strict::TEST_STRICT   = 1;
+$Test::Strict::TEST_WARNINGS = 1;
+$Test::Strict::TEST_SKIP     = [
+    # skip test module which would require test API from os-autoinst to be present
+    't/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm'
+];
+all_perl_files_ok(qw(lib script t));

--- a/t/fake-isotovideo.pl
+++ b/t/fake-isotovideo.pl
@@ -1,5 +1,8 @@
 #!/usr/bin/perl
 
+use strict;
+use warnings;
+
 if ($ARGV[0] ne '--version') {
     print("This script is only meant to test the isotovideo version check.\n");
     exit(-1);

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 [
     Assets => {
         type => 'iso',

--- a/t/fixtures/02-workers.pl
+++ b/t/fixtures/02-workers.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 [
     Workers => {
         host       => 'localhost',

--- a/t/fixtures/03-users.pl
+++ b/t/fixtures/03-users.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 [
     Users => {
         id              => 99901,

--- a/t/fixtures/04-products.pl
+++ b/t/fixtures/04-products.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 [
     Machines => {
         id       => 1001,

--- a/t/fixtures/05-job_modules.pl
+++ b/t/fixtures/05-job_modules.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 [
     JobModules => {
         script   => 'tests/installation/isosize.pm',

--- a/t/fixtures/06-job_dependencies.pl
+++ b/t/fixtures/06-job_dependencies.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 [
     # parallel dependency for running test
     JobDependencies => {

--- a/t/fixtures/07-needles.pl
+++ b/t/fixtures/07-needles.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 [
     NeedleDirs => {
         id   => 1,

--- a/t/lib/OpenQA/FakePlugin/FooBar.pm
+++ b/t/lib/OpenQA/FakePlugin/FooBar.pm
@@ -1,4 +1,8 @@
 package OpenQA::FakePlugin::FooBar;
+
+use strict;
+use warnings;
+
 sub configuration_fields {
     {
         bar => {


### PR DESCRIPTION
* Use Test::Strict instead of Test::Compile
    * Check for presence of 'use strict;'
    * Check for presence of 'use warnings;'
    * Cover all Perl files (was not possible with
      Test::Compile because it tried to load scripts
      as modules)
* Simplify code of 01-compile-check-all.t
* Adjust all files to comply with the new checks