### PR TITLE
Give the authentication routes plugins will use names and test them

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -181,9 +181,9 @@ sub startup {
     ## Admin area starts here
     ###
     my %api_description;
-    my $admin_auth  = $r->under('/admin')->to('session#ensure_admin');
+    my $admin_auth  = $r->under('/admin')->to('session#ensure_admin')->name('ensure_admin');
     my $admin_r     = $admin_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
-    my $op_auth     = $r->under('/admin')->to('session#ensure_operator');
+    my $op_auth     = $r->under('/admin')->to('session#ensure_operator')->name('ensure_operator');
     my $op_r        = $op_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
     my $pub_admin_r = $r->route('/admin')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
 


### PR DESCRIPTION
This is also for #2173. I just wanted to make sure the routing hooks plugins are supposed to use are treated as a security feature and have tests.