### PR TITLE
Adapt order of job template example

### DIFF
--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -98,6 +98,15 @@
                     <div id="editor-yaml-guide">
                         <div>Define test suites per arch/medium:</div>
                         <code>
+defaults:
+  <b>ARCH</b>:
+    machine: <b>MACHINE</b>
+    priority: <b>PRIORITY</b>
+products:
+  <i>medium</i>-<b>ARCH</b>:
+    distri: <b>DISTRI</b>
+    flavor: <b>FLAVOR</b>
+    version: <b>VERSION</b>
 <b>'My Group'</b>:
   scenarios:
     <b>ARCH</b>:
@@ -109,15 +118,6 @@
           settings:
             <b>SOME_TEST_VARIABLE</b>: <b>VALUE</b>
             <b>ANOTHER_TEST_VARIABLE</b>: <b>YET_ANOTHER_VALUE</b>
-  defaults:
-    <b>ARCH</b>:
-      machine: <b>MACHINE</b>
-      priority: <b>PRIORITY</b>
-  products:
-    <i>medium</i>-<b>ARCH</b>:
-      distri: <b>DISTRI</b>
-      flavor: <b>FLAVOR</b>
-      version: <b>VERSION</b>
                         </code>
                         <div>Re-use test suites with YAML aliases:</div>
                         <code>

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -107,17 +107,16 @@ products:
     distri: <b>DISTRI</b>
     flavor: <b>FLAVOR</b>
     version: <b>VERSION</b>
-<b>'My Group'</b>:
-  scenarios:
-    <b>ARCH</b>:
-      <i>medium</i>-<b>ARCH</b>:
-      - test-suite
-      - test-suite:
-          machine: <b>MACHINE</b>
-          priority: <b>PRIORITY</b>
-          settings:
-            <b>SOME_TEST_VARIABLE</b>: <b>VALUE</b>
-            <b>ANOTHER_TEST_VARIABLE</b>: <b>YET_ANOTHER_VALUE</b>
+scenarios:
+  <b>ARCH</b>:
+    <i>medium</i>-<b>ARCH</b>:
+    - test-suite
+    - test-suite:
+        machine: <b>MACHINE</b>
+        priority: <b>PRIORITY</b>
+        settings:
+          <b>SOME_TEST_VARIABLE</b>: <b>VALUE</b>
+          <b>ANOTHER_TEST_VARIABLE</b>: <b>YET_ANOTHER_VALUE</b>
                         </code>
                         <div>Re-use test suites with YAML aliases:</div>
                         <code>


### PR DESCRIPTION
Defaults and products have been moved to the top. This adapts the example to the new order.