### PR TITLE
fetchneedles enhancements

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -56,16 +56,14 @@ do_fetch() {
     git_update
     if [ "$needles_separate" = 1 ]; then
         if test -d products; then
-        for nd in products/*/needles; do
-            cd "$target/$nd" && (
+            for nd in products/*/needles; do
+                cd "$target/$nd" && (git_update)
+            done
+        else
+            cd "$target/needles"
             git_update
-            )
-        done
-            else
-        cd "$target/needles"
-        git_update
-        cd ../..
-            fi
+            cd ../..
+        fi
     fi
 }
 

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -54,16 +54,13 @@ git_update() {
 do_fetch() {
     local target=$1
     git_update
-    if [ "$needles_separate" = 1 ]; then
-        if test -d products; then
-            for nd in products/*/needles; do
-                cd "$target/$nd" && (git_update)
-            done
-        else
-            cd "$target/needles"
-            git_update
-            cd ../..
-        fi
+    [ "$needles_separate" = 1 ] || return 0
+    if test -d products; then
+        for nd in products/*/needles; do
+            (cd "$target/$nd" && git_update)
+        done
+    else
+        (cd "$target/needles" && git_update)
     fi
 }
 
@@ -74,8 +71,7 @@ if [ "$updateall" = 1 ]; then
         target="$dir/$repo"
         ! [ -L "$target" ] || continue
         [ -d "$target/.git" ] || continue
-        cd "$target"
-        do_fetch "$target" || fail=1
+        (cd "$target" && do_fetch "$target") || fail=1
     done
     exit "$fail"
 else

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -45,22 +45,25 @@ needlesdir() {
     fi
 }
 
-do_fetch() {
-    local target=$1
+git_update() {
+    git gc --auto --quiet
     git fetch -q
     git rebase -q
+}
+
+do_fetch() {
+    local target=$1
+    git_update
     if [ "$needles_separate" = 1 ]; then
         if test -d products; then
         for nd in products/*/needles; do
             cd "$target/$nd" && (
-            git fetch -q
-            git rebase -q
+            git_update
             )
         done
             else
         cd "$target/needles"
-                git fetch -q
-        git rebase -q
+        git_update
         cd ../..
             fi
     fi


### PR DESCRIPTION
* fetchneedles: Use subshells efficiently for dir changes
* fetchneedles: Fix indention
* fetchneedles: Prevent noisy output about auto-packing git repos

Tested manually with:

```shell
scp script/fetchneedles o3:/tmp && ssh o3 "sudo -u geekotest bash -ex /tmp/fetchneedles"
```