### PR TITLE
.travis.yml: Save travis CI some testing time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - name: "developer fullstack test"
       env: DEVELOPER_FULLSTACK=1
     - name: "documentation generation job"
-      if: branch = master
+      if: branch = master AND fork = false
       env: GH_PUBLISH=true
 before_script:
 - docker pull registry.opensuse.org/devel/openqa/containers/openqa_dev:latest


### PR DESCRIPTION
Run the whole documentation generation job only in case it is really
needed, i.e. if a push happens to the master branch in the original repo
itself. Previously the job would be triggered also on pushes to feature
branches in forks but abort early in the doc generation script anyway.

See https://travis-ci.org/os-autoinst/openQA/builds/558244401?utm_source=github_status&utm_medium=notification