### PR TITLE
Make the websocket server tests less noisy

### DIFF
--- a/lib/OpenQA/WebSockets/Client.pm
+++ b/lib/OpenQA/WebSockets/Client.pm
@@ -32,8 +32,10 @@ sub embed_server_for_testing {
     unless ($self->{test_server}) {
         my $server = $self->{test_server} = Mojo::Server::Daemon->new(
             ioloop => $self->client->ioloop,
-            listen => ['http://127.0.0.1']);
-        $server->build_app('OpenQA::WebSockets');
+            listen => ['http://127.0.0.1'],
+            silent => 1
+        );
+        $server->build_app('OpenQA::WebSockets')->mode('production');
         $server->start;
         $self->port($server->ports->[0]);
     }


### PR DESCRIPTION
Simple change to remove these and similar lines from the test output:
```
./t/05-scheduler-full.t ................... skipped: set SCHEDULER_FULLSTACK=1 (be careful)
[2019-07-13 15:12:13.73972] [1345] [info] Listening at "http://127.0.0.1"
[2019-07-13 15:12:15.28877] [1345] [debug] POST "/api/send_msg" (3f9ae2ed)
[2019-07-13 15:12:15.29244] [1345] [debug] Routing to controller "OpenQA::Shared::Controller::Auth" and action "check"
[2019-07-13 15:12:15.29419] [1345] [debug] Routing to controller "OpenQA::WebSockets::Controller::API" and action "send_msg"
[2019-07-13 15:12:15.29514] [1345] [debug] 200 OK (0.006352s, 157.431/s)
[2019-07-13 15:12:15.34022] [1345] [debug] POST "/api/send_msg" (4a082453)
[2019-07-13 15:12:15.34168] [1345] [debug] Routing to controller "OpenQA::Shared::Controller::Auth" and action "check"
[2019-07-13 15:12:15.34221] [1345] [debug] Routing to controller "OpenQA::WebSockets::Controller::API" and action "send_msg"
[2019-07-13 15:12:15.34302] [1345] [debug] 200 OK (0.002776s, 360.231/s)
```