### PR TITLE
Stop job directly with reason 'api-failure' on API failures

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -305,18 +305,6 @@ sub exec {
     return $return_code;
 }
 
-sub send_to_webui_host {
-    my ($self, $method, $path, %args) = @_;
-
-    my $webui_host = $args{host} // $self->current_webui_host;
-    die 'send_to_webui_host called but there is no web UI host' unless $webui_host;
-
-    my $client = $self->clients_by_webui_host->{$webui_host};
-    die "send_to_webui_host called for invalid host $webui_host\n" unless $client;
-    $client->send($method, $path, %args);
-}
-
-
 sub _prepare_cache_directory {
     my ($webui_host, $cachedirectory) = @_;
     die 'No cachedir' unless $cachedirectory;

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -390,7 +390,7 @@ sub stop {
 sub stop_current_job {
     my ($self, $reason) = @_;
 
-    if (my $current_job = $self->current_job) { $current_job->stop; }
+    if (my $current_job = $self->current_job) { $current_job->stop($reason); }
 }
 
 sub kill {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -366,7 +366,7 @@ sub stop {
 
     if ($current_job->status eq 'setup') {
         # stop job directly during setup because the IO loop is blocked by isotovideo.pm during setup
-        $current_job->stop($reason);
+        return $current_job->stop($reason);
     }
     Mojo::IOLoop->next_tick(
         sub {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -248,7 +248,7 @@ sub init {
             }
 
             # kill if stopping gracefully does not work
-            log_error('Another error occurred when trying to stop gracefully due to an error.'
+            log_error('Another error occurred when trying to stop gracefully due to an error. '
                   . 'Trying to kill ourself forcefully now.');
             $self->kill();
             Mojo::IOLoop->stop();

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -359,7 +359,7 @@ sub send {
             my $worker             = $self->worker;
             my $current_webui_host = $worker->current_webui_host;
             if ($current_webui_host && $current_webui_host eq $self->webui_host) {
-                $worker->stop_current_job;
+                $worker->stop_current_job('api-failure');
             }
             $callback->();
             return;

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -67,18 +67,19 @@ combined_like(
 );
 
 subtest 'capabilities' => sub {
-    my $capabilities      = $worker->capabilities;
-    my @capabilities_keys = sort keys %$capabilities;
+    my $capabilities = $worker->capabilities;
+    delete $capabilities->{cpu_opmode};    # not always present and also not strictly required anyways
+
     is_deeply(
-        \@capabilities_keys,
+        [sort keys %$capabilities],
         [
             qw(
-              cpu_arch cpu_modelname cpu_opmode host instance isotovideo_interface_version
+              cpu_arch cpu_modelname host instance isotovideo_interface_version
               mem_max websocket_api_version worker_class
               )
         ],
         'capabilities contain expected information'
-    ) or diag explain \@capabilities_keys;
+    ) or diag explain $capabilities;
 };
 
 subtest 'status' => sub {

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -91,8 +91,11 @@ like(
     has stop_current_job_called => 0;
     has current_error           => undef;
     has current_job             => undef;
-    sub stop_current_job { shift->stop_current_job_called(1); }
-    sub status           { {fake_status => 1} }
+    sub stop_current_job {
+        my ($self, $reason) = @_;
+        $self->stop_current_job_called($reason);
+    }
+    sub status { {fake_status => 1} }
     sub accept_job {
         my ($self, $client, $job_info) = @_;
         $self->current_job(OpenQA::Worker::Job->new($self, $client, $job_info));
@@ -183,8 +186,9 @@ subtest 'attempt to register and send a command' => sub {
         'error logged',
     );
 
-    is($callback_invoked,                        1, 'callback has been invoked');
-    is($client->worker->stop_current_job_called, 1, 'attempted to stop current job');
+    is($callback_invoked, 1, 'callback has been invoked');
+    is($client->worker->stop_current_job_called,
+        'api-failure', 'attempted to stop current job with reason "api-failure"');
 
     is_deeply(
         \@happended_events,

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -151,19 +151,8 @@ sub wait_for_developer_console_contains_log_message {
     my $log                    = $log_textarea->get_text();
     my $previous_log           = '';
 
-    my $regex_closed = qr/Connection closed/;
     my $match_index;
     while (($match_index = match_regex_returning_index($message_regex, $log, $position_of_last_match)) < 0) {
-        # check whether connection has been unexpectedly closed/opened
-        if (   $message_regex ne $regex_closed
-            && $diag_info ne 'paused'
-            && $log =~ $regex_closed)
-        {
-            fail('web socket connection closed prematurely, was waiting for ' . $diag_info);
-            note("developer console contained at this point:\n$log");
-            return;
-        }
-
         # poll less frequently when waiting for paused (might take a minute for the first test module to pass)
         sleep($diag_info eq 'paused' ? 5 : 1);
 


### PR DESCRIPTION
* Add test for this as well
* Add test for worker behaviour when stopped due to an API failure
    * It is not supposed to upload results anymore to the web UI
      because that would likely fail, too. Note that the API client
      has already tried to query the web UI multiple times at this
      point. Maybe the web UI even already considers the job dead.
    * It is supposed to re-register which might help in situations
      like https://progress.opensuse.org/issues/47060#note-19.