### PR TITLE
Fix 31-client_file.t for Mojolicious 8.19+

### DIFF
--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -169,7 +169,7 @@ subtest 'verify_chunks' => sub {
 
     $pieces->first->content('42')->write_content($copied_file);    #Let's simulate a writing error
     is(
-        OpenQA::Files->verify_chunks($t_dir => $copied_file),
+        OpenQA::Files->verify_chunks($t_dir => $copied_file)->message(),
         'Can\'t verify written data from chunk',
         'Verify chunks fail'
     );


### PR DESCRIPTION
A change in Mojolicious 8.19 makes this check no longer pass,
because the exception when evaluated in string context now has
a newline after the message text. I've reported this as a bug
in Mojo:

https://github.com/mojolicious/mojo/issues/1385

but we can avoid the issue easily enough by just checking the
message explicitly like we do a few lines earlier. So let's just
do that.

Signed-off-by: Adam Williamson <awilliam@redhat.com>