### PR TITLE
Default to HTTPS instead of HTTP with openqa-client

### DIFF
--- a/script/client
+++ b/script/client
@@ -239,7 +239,7 @@ my $url;
 if ($options{host} !~ '/') {
     $url = Mojo::URL->new();
     $url->host($options{host});
-    $url->scheme('http');
+    $url->scheme('https');
 }
 else {
     $url = Mojo::URL->new($options{host});


### PR DESCRIPTION
There's a problem with `openqa.opensuse.org` where all HTTP requests are redirected to HTTPS and changed to GET requests. Technically, this is not really a bug, but i think defaulting to HTTP for hosts without a scheme should be considered a minor security flaw. Credentials can be accidentally leaked very easily if one is not careful.

I think it's better to be more secure by default and require HTTP to be selected explicitly. So `--host openqa.opensuse.org` would be equivalent to `--host https://openqa.opensuse.org` from now on.

Progress: https://progress.opensuse.org/issues/53891