### PR TITLE
Fix test doing an equality check on exceptions

### DIFF
--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -168,9 +168,9 @@ subtest 'verify_chunks' => sub {
     is $original->slurp, Mojo::File->new($copied_file)->slurp, 'Same content';
 
     $pieces->first->content('42')->write_content($copied_file);    #Let's simulate a writing error
-    is(
+    like(
         OpenQA::Files->verify_chunks($t_dir => $copied_file),
-        'Can\'t verify written data from chunk',
+        qr/^Can't verify written data from chunk/,
         'Verify chunks fail'
     );
     isnt $original->slurp, Mojo::File->new($copied_file)->slurp, 'Not same content';


### PR DESCRIPTION
This is an alternative solution for #2193. The return value of `OpenQA::Files->verify_chunks` is a `Mojo::Exception` object. So it should be treated as an exception and only the beginning of the stringified value checked with a regular expression.