### PR TITLE
Adapt codecov target to current coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
     changes: no
     project:
       default:
-        target: 88.8
+        target: 84.9
         threshold: 0.1
     patch:
       default:


### PR DESCRIPTION
It seems with our recent work, e.g. a bigger worker restructuring, we
have effectively "lost coverage" in the numbers as codecov gathers them.
It does not make sense to keep ignoring the failed coverage test and
force the merge so we should rather adjust the target numbers to what we
currently have and improve from there.

Related progress issue: https://progress.opensuse.org/issues/54278