### PR TITLE
Give the API authentication routes plugins will use names and test them

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -55,6 +55,14 @@ sub startup {
     my $logged_in = $r->under('/')->to("session#ensure_user");
     my $auth      = $r->under('/')->to("session#ensure_operator");
 
+    # Routes used by plugins
+    my $admin_auth = $r->under('/admin')->to('session#ensure_admin')->name('ensure_admin');
+    my $op_auth    = $r->under('/admin')->to('session#ensure_operator')->name('ensure_operator');
+    my $api_auth_operator
+      = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_operator')->name('api_ensure_operator');
+    my $api_auth_admin
+      = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_admin')->name('api_ensure_admin');
+
     OpenQA::Setup::setup_template_search_path($self);
     OpenQA::Setup::load_plugins($self, $auth);
     OpenQA::Setup::set_secure_flag_on_cookies_of_https_connection($self);
@@ -181,9 +189,7 @@ sub startup {
     ## Admin area starts here
     ###
     my %api_description;
-    my $admin_auth  = $r->under('/admin')->to('session#ensure_admin')->name('ensure_admin');
     my $admin_r     = $admin_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
-    my $op_auth     = $r->under('/admin')->to('session#ensure_operator')->name('ensure_operator');
     my $op_r        = $op_auth->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
     my $pub_admin_r = $r->route('/admin')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
 
@@ -238,8 +244,6 @@ sub startup {
     # Array to store new API routes' references, so they can all be checked to get API description from POD
     my @api_routes        = ();
     my $api_auth_any_user = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth');
-    my $api_auth_operator = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_operator');
-    my $api_auth_admin    = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_admin');
     my $api_ru            = $api_auth_any_user->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     my $api_ro            = $api_auth_operator->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     my $api_ra            = $api_auth_admin->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -42,6 +42,15 @@ my $app = $t->app;
 $t->ua(OpenQA::Client->new()->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
+subtest 'authentication routes for plugins' => sub {
+    my $ensure_admin = $t->app->routes->find('api_ensure_admin');
+    ok $ensure_admin, 'api_ensure_admin route found';
+    $ensure_admin->put('/admin_plugin' => sub { shift->render(text => 'API admin plugin works!') });
+    my $ensure_operator = $t->app->routes->find('api_ensure_operator');
+    ok $ensure_operator, 'api_ensure_operator route found';
+    $ensure_operator->put('/operator_plugin' => sub { shift->render(text => 'API operator plugin works!') });
+};
+
 subtest 'access limiting for non authenticated users' => sub() {
     $t->get_ok('/api/v1/jobs')->status_is(200);
     $t->get_ok('/api/v1/products')->status_is(200);
@@ -55,6 +64,8 @@ subtest 'access limiting for non authenticated users' => sub() {
         },
         'error returned as JSON'
     );
+    $t->put_ok('/api/v1/admin_plugin')->status_is(403);
+    $t->put_ok('/api/v1/operator_plugin')->status_is(403);
 };
 
 subtest 'access limiting for authenticated users but not operators nor admins' => sub() {
@@ -63,6 +74,8 @@ subtest 'access limiting for authenticated users but not operators nor admins' =
     $t->get_ok('/api/v1/jobs')->status_is(200, 'accessible (public)');
     $t->post_ok('/api/v1/assets')->status_is(403, 'restricted (operator and admin only)');
     $t->delete_ok('/api/v1/assets/1')->status_is(403, 'restricted (admin only)');
+    $t->put_ok('/api/v1/admin_plugin')->status_is(403);
+    $t->put_ok('/api/v1/operator_plugin')->status_is(403);
 };
 
 subtest 'access limiting for authenticated operators but not admins' => sub() {
@@ -71,6 +84,8 @@ subtest 'access limiting for authenticated operators but not admins' => sub() {
     $t->get_ok('/api/v1/jobs')->status_is(200, 'accessible (public)');
     $t->post_ok('/api/v1/jobs/99927/set_done')->status_is(200, 'accessible (operator and admin only)');
     $t->delete_ok('/api/v1/assets/1')->status_is(403, 'restricted (admin only)');
+    $t->put_ok('/api/v1/admin_plugin')->status_is(403);
+    $t->put_ok('/api/v1/operator_plugin')->status_is(200)->content_is('API operator plugin works!');
 };
 
 subtest 'access granted for admins' => sub() {
@@ -79,6 +94,8 @@ subtest 'access granted for admins' => sub() {
     $t->get_ok('/api/v1/jobs')->status_is(200, 'accessible (public)');
     $t->post_ok('/api/v1/jobs/99927/set_done')->status_is(200, 'accessible (operator and admin only)');
     $t->delete_ok('/api/v1/assets/1')->status_is(200, 'accessible (admin only)');
+    $t->put_ok('/api/v1/admin_plugin')->status_is(200)->content_is('API admin plugin works!');
+    $t->put_ok('/api/v1/operator_plugin')->status_is(200)->content_is('API operator plugin works!');
 };
 
 subtest 'wrong api key - expired' => sub() {


### PR DESCRIPTION
This is also for #2173, and a followup to #2182. Again making sure everything is tested properly.