### PR TITLE
Set log for failing to stop cmd srv to info level

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -364,14 +364,14 @@ sub _stop_step_3_announce {
                 my $res            = $tx->res;
 
                 if (!$res->is_success) {
-                    log_error('Unable to stop the command server gracefully: ');
-                    log_error($res->code ? $res->to_string : 'Command server likely not reachable at all');
+                    log_info('Unable to stop the command server gracefully: ');
+                    log_info($res->code ? $res->to_string : 'Command server likely not reachable at all');
                 }
                 $callback->();
             });
     }
     catch {
-        log_error('Unable to stop the command server gracefully: ' . $_);
+        log_info('Unable to stop the command server gracefully: ' . $_);
 
         # ensure stopping is proceeded (failing announcement is not critical)
         $callback->();


### PR DESCRIPTION
It can have many reasons why the command server is not reachable anymore at this point. Those messages can be useful but are completely uncritical and very unlikely the cause of potential subsequent errors.