### PR TITLE
Prevent cleaning pool directory in worker availability check

### DIFF
--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -124,6 +124,8 @@ subtest 'status' => sub {
         },
         'worker is broken if CACHEDIRECTORY set but worker cache not available'
     );
+
+    delete $worker->settings->global_settings->{CACHEDIRECTORY};
 };
 
 subtest 'check negative cases for is_qemu_running' => sub {
@@ -184,6 +186,9 @@ subtest 'handle status changes' => sub {
         is($cleanup_called,             0,     'pool directory not cleaned up');
         is($worker->current_job,        undef, 'current job unassigned');
         is($worker->current_webui_host, undef, 'current web UI host unassigned');
+
+        $worker->check_availability;
+        is($cleanup_called, 0, 'pool directory not cleaned up within periodic availability check');
 
         # stop job with cleanup enabled
         $worker->no_cleanup(0);


### PR DESCRIPTION
* Seems the last PR missed one place where the cleanup was done, see https://progress.opensuse.org/issues/54203#note-5
* Extended unit tests and this time I also tested all cases manually, too.