### PR TITLE
[DISCUSSION] .travis.yml: Keep a docker image in cache to save downloading time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 env:
   global:
   - COMMIT_AUTHOR_EMAIL=skynet@open.qa
+  - IMAGE=registry.opensuse.org/devel/openqa/containers/openqa_dev:latest
+  - CACHE_FILE=container_cache/openqa_dev.tgz
 matrix:
   include:
     - name: "unit- and integration tests"
@@ -21,10 +23,20 @@ matrix:
       if: branch = master AND fork = false
       env: GH_PUBLISH=true
 before_script:
-- docker pull registry.opensuse.org/devel/openqa/containers/openqa_dev:latest
+  # Keep a docker image in cache to save downloading time, inspired by
+  # https://github.com/travis-ci/travis-ci/issues/5358#issuecomment-485726973
+  - |
+    if [ -f $CACHE_FILE ]; then
+      docker load -i $CACHE_FILE
+    else
+      mkdir -p container_cache
+      docker pull $IMAGE
+      docker save $IMAGE | gzip -c > $CACHE_FILE
+    fi
 cache:
   directories:
   - assets/cache
+  - container_cache
 script:
   - |
     if [ -n "$GH_PUBLISH" ]; then


### PR DESCRIPTION
Pulling a new container image from registry.opensuse.org takes roughly 2
minutes for every travis CI job we run, e.g. see
https://travis-ci.org/okurz/openQA/jobs/556770422#L470 . Using the cache
on travis CI we can save on longer downloading times and only pull the
actual differences in the image – if any.

If the image is not present in cache the complete image is pulled from
the registry and stored in cache for any subsequent run.

Caveat: Currently there is no approach for updating the image in cache

Time measurements on my local machine:

```
$ time docker pull $IMAGE
latest: Pulling from devel/openqa/containers/openqa_dev
fc0f39850622: Already exists
3e8c476b96ad: Pull complete
Digest: sha256:7eba242d61c6c80258689da672bb784da57e3c22ec04ea6853c52976d15c4d5b
Status: Downloaded newer image for registry.opensuse.org/devel/openqa/containers/openqa_dev:latest

real	1m21.486s
user	0m0.100s
sys	0m0.037s

$ time docker save $IMAGE | gzip -c > $CACHE_FILE

real	2m4.013s
user	1m23.958s
sys	0m2.744s

$ test -f $CACHE_FILE && echo "### load" && time docker load -i $CACHE_FILE && echo "### pull" && time docker pull $IMAGE
The image registry.opensuse.org/devel/openqa/containers/openqa_dev:latest already exists, renaming the old one with ID sha256:5f9ba5b67a5bb639138543f336e6bb5a55e24c96ed6f49bcead1a93003c5590f to empty string
Loaded image: registry.opensuse.org/devel/openqa/containers/openqa_dev:latest

real	0m31.062s
user	0m0.156s
sys	0m0.396s
latest: Pulling from devel/openqa/containers/openqa_dev
Digest: sha256:7eba242d61c6c80258689da672bb784da57e3c22ec04ea6853c52976d15c4d5b
Status: Downloaded newer image for registry.opensuse.org/devel/openqa/containers/openqa_dev:latest

real	0m0.226s
user	0m0.048s
sys	0m0.014s
```

so loading the image and only pulling any differences – if any – could
be significantly faster than any initial pull however saving takes long.
When we need to do that often the approach would not be beneficial.

For results on travis CI
https://travis-ci.org/okurz/openQA/jobs/556810740#L469
shows 66 seconds for loading the container image from cache instead of
the bare pull.