### PR TITLE
Add YAML support to {dump,load}_templates

### DIFF
--- a/lib/OpenQA/Schema/Result/JobTemplates.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplates.pm
@@ -120,7 +120,10 @@ sub to_hash {
             name => $test_suite->name,
         },
     );
-    $result{settings} = $settings if (%$settings);
+    if ($settings) {
+        my @settings = sort { $a->key cmp $b->key } $self->settings;
+        $result{settings} = [map { {key => $_->key, value => $_->value} } @settings] if @settings;
+    }
 
     return \%result;
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -93,6 +93,7 @@ sub startup {
     # placeholder types
     $r->add_type(step    => qr/[1-9]\d*/);
     $r->add_type(barrier => qr/[0-9a-zA-Z_]+/);
+    $r->add_type(str     => qr/[A-Za-z]+/);
 
     # register routes
     $r->post('/session')->to('session#create');
@@ -404,7 +405,8 @@ sub startup {
     # api/v1/job_templates_scheduling
     $api_public_r->get('experimental/job_templates_scheduling/<id:num>')->name('apiv1_job_templates_schedules')
       ->to('job_template#schedules', id => undef);
-    $api_ra->post('experimental/job_templates_scheduling/<id:num>')->to('job_template#update');
+    $api_public_r->get('experimental/job_templates_scheduling/<name:str>')->to('job_template#schedules', name => undef);
+    $api_ra->post('experimental/job_templates_scheduling/<id:num>')->to('job_template#update', id => undef);
 
     # api/v1/comments
     $api_public_r->get('/jobs/<job_id:num>/comments')->name('apiv1_list_comments')->to('comment#list');

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -83,6 +83,8 @@ print help
 
 =item B<JobTemplates>
 
+=item B<JobGroups>
+
 =back
 
 =head1 SYNOPSIS
@@ -106,6 +108,7 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
 use strict;
+use warnings;
 use v5.10;
 
 use Data::Dump 'dd';
@@ -113,10 +116,11 @@ use Getopt::Long;
 use Mojo::Util qw(decamelize);
 use Mojo::URL;
 use OpenQA::Client;
+use YAML::XS;
 
 Getopt::Long::Configure("no_ignore_case");
 
-my %tables = map { $_ => 1 } qw(Machines TestSuites Products JobTemplates);
+my %tables = map { $_ => 1 } qw(Machines TestSuites Products JobTemplates JobGroups);
 
 my %options;
 
@@ -139,6 +143,13 @@ usage(0) if $options{help};
 
 if (@ARGV) {
     my %want = map { $_ => 1 } @ARGV;
+    # Show an error and refer to usage if a non-existing table name is passed
+    for my $t (keys %want) {
+        if (!exists $tables{$t}) {
+            printf STDERR "Invalid table name $t\n\n";
+            usage(1);
+        }
+    }
     for my $t (keys %tables) {
         $tables{$t} = $want{$t} ? 1 : 0;
     }
@@ -147,6 +158,7 @@ if (@ARGV) {
 if ($options{group}) {
     $options{group}       = {map { $_ => 1 } @{$options{group}}};
     $tables{JobTemplates} = 1;
+    $tables{JobGroups}    = 1;
 }
 if ($options{test}) {
     $options{test}      = {map { $_ => 1 } @{$options{test}}};
@@ -178,6 +190,31 @@ my $client = OpenQA::Client->new(apikey => $options{'apikey'}, apisecret => $opt
 
 my %result;
 
+if ($tables{'JobGroups'}) {
+    my $group = (keys %{$options{'group'}})[0];
+    $url->path($options{'apibase'} . '/experimental/job_templates_scheduling/' . ($group // ''));
+    my $res = $client->get($url)->res;
+    if ($res->code && $res->code == 200) {
+        if ($group) {
+            # This is already the YAML document of a single group
+            push @{$result{'JobGroups'}}, {group_name => $group, template => $res->body};
+        }
+        else {
+            my $yaml = YAML::XS::Load($res->body);
+            foreach my $group (keys %$yaml) {
+                push @{$result{'JobGroups'}}, {group_name => $group, template => $yaml->{$group}};
+            }
+        }
+    }
+    else {
+        printf STDERR "ERROR requesting %s: %s - %s\n", $group // 'all groups',
+          $res->code // 'unknown error code - host ' . $url->host . ' unreachable?',
+          $res->message // 'no error message';
+        dd($res->json || $res->body);
+        exit(1);
+    }
+}
+
 for my $table (qw(Machines TestSuites Products JobTemplates)) {
     next unless $tables{$table};
 
@@ -193,7 +230,8 @@ for my $table (qw(Machines TestSuites Products JobTemplates)) {
         %result = %tmp;
     }
     else {
-        printf STDERR "ERROR requesting %s: %s - %s\n", $table, $res->code // 'unknown error code',
+        printf STDERR "ERROR requesting %s via %s: %s - %s\n", $table, $url,
+          $res->code // 'unknown error code - host ' . $url->host . ' unreachable?',
           $res->message // 'no error message';
         if ($res->body) {
             dd($res->json || $res->body);

--- a/script/load_templates
+++ b/script/load_templates
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -74,6 +74,7 @@ use Mojo::URL;
 use OpenQA::Client;
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
+use YAML::XS;
 
 use Getopt::Long;
 
@@ -93,24 +94,22 @@ GetOptions(\%options, "apibase=s", "apikey=s", "apisecret=s", "clean", "host=s",
 
 usage(1) if $options{help} || $#ARGV;
 
-my $datafile = shift @ARGV;
-die "Data file not found\n" unless $datafile && -r $datafile;
+# Slurp file specified as an argument or STDIN in case of "-"
+my $datafile = join("", <>);
+die "Data file not found\n" unless length $datafile;
 
 my $info;
 
-if ($datafile =~ /\.json$/) {
-    local $/;
-    open(my $fh, '<', $datafile);
-    $info = Cpanel::JSON::XS->new->relaxed->decode(<$fh>);
-    close $fh;
+try {
+    $info = Cpanel::JSON::XS->new->relaxed->decode($datafile);
     dd $info;
 }
-else {
+catch {
     $info = do $datafile;
     if (my $error = $@) {
         die "Error in data file: $error\n";
     }
-}
+};
 
 $options{'host'}    ||= 'localhost';
 $options{'apibase'} ||= '/api/v1';
@@ -127,11 +126,12 @@ else {
 
 my $client = OpenQA::Client->new(apikey => $options{'apikey'}, apisecret => $options{'apisecret'}, api => $url->host);
 
-my @tables = (qw(Machines TestSuites Products JobTemplates));
+my @tables = (qw(Machines TestSuites Products JobTemplates JobGroups));
 
 sub print_error {
     my ($res) = @_;
-    printf STDERR "ERROR: %s - %s\n", $res->code // 'unknown error code', $res->message // 'no error message';
+    printf STDERR "ERROR: %s - %s\n", $res->code // 'unknown error code - host ' . $url->host . ' unreachable?',
+      $res->message // 'no error message';
     if ($res->body) {
         dd($res->json || $res->body);
     }
@@ -141,6 +141,17 @@ sub post_entry {
     my ($table, $entry) = @_;
 
     my %param;
+
+    if ($table eq 'JobGroups') {
+        $url->path($options{'apibase'} . '/experimental/job_templates_scheduling');
+        $url->query({name => $entry->{group_name}, template => $entry->{template}});
+        my $res = $client->post($url)->res;
+        if (!($res->code && $res->code == 200)) {
+            print_error($res);
+            return 0;
+        }
+        return 1;
+    }
 
     if ($table eq 'JobTemplates') {
         unless (defined($entry->{prio})) {
@@ -186,14 +197,14 @@ sub post_entry {
 
     if (!$options{'clean'}) {    # with --clean the entry should not exist at this point, no need to check
         my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table))->query(%param))->res;
-        if ($res->code == 200 && @{$res->json->{$table}} == 1 && $res->json->{$table}[0]{id}) {
+        if ($res->code && $res->code == 200 && @{$res->json->{$table}} == 1 && $res->json->{$table}[0]{id}) {
             if ($options{'update'} && $table ne 'JobTemplates')
             {                    # there is nothing to update in JobTemplates, the entry just exists or not
                 my $id = $res->json->{$table}[0]{id};
                 my $res
                   = $client->put($url->path($options{'apibase'} . '/' . decamelize($table) . "/$id")->query(%param))
                   ->res;
-                if ($res->code != 200) {
+                if (!($res->code && $res->code == 200)) {
                     print_error($res);
                     return 0;
                 }
@@ -207,7 +218,7 @@ sub post_entry {
 
     my $res = $client->post($url->path($options{'apibase'} . '/' . decamelize($table))->query(%param))->res;
 
-    if ($res->code != 200) {
+    if (!($res->code && $res->code == 200)) {
         print_error($res);
         return 0;
     }
@@ -217,16 +228,16 @@ sub post_entry {
 if ($options{'clean'}) {
     for my $table (@tables) {
         my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table)))->res;
-        if ($res->code == 200) {
+        if ($res->code && $res->code == 200) {
             my $result = $res->json;
             for my $i (0 .. $#{$result->{$table}}) {
                 my $id = $result->{$table}->[$i]->{id};
                 $res = $client->delete($url->path($options{'apibase'} . '/' . decamelize($table) . "/$id"))->res;
-                last if $res->code != 200;
+                last if !($res->code && $res->code == 200);
             }
         }
 
-        if ($res->code != 200) {
+        if (!($res->code && $res->code == 200)) {
             print_error($res);
             exit(1);
         }


### PR DESCRIPTION
- Add a new "table" option `JobGroups` to `{dump,load}_templates`
- Add and use `str` type to accept `<name:str>` in routes
- Expose YAML of multiple groups as strings with their group names
- Error handling fixes handling unset `code` and invalid "table"
- Accept `STDIN` as input for `load_templates`

Fixes: [poo#54143](https://progress.opensuse.org/issues/54143)