### PR TITLE
Make sure all four levels of API access have named routes

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -55,13 +55,16 @@ sub startup {
     my $logged_in = $r->under('/')->to("session#ensure_user");
     my $auth      = $r->under('/')->to("session#ensure_operator");
 
-    # Routes used by plugins
+    # Routes used by plugins (UI and API)
     my $admin_auth = $r->under('/admin')->to('session#ensure_admin')->name('ensure_admin');
     my $op_auth    = $r->under('/admin')->to('session#ensure_operator')->name('ensure_operator');
     my $api_auth_operator
       = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_operator')->name('api_ensure_operator');
     my $api_auth_admin
       = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth_admin')->name('api_ensure_admin');
+    my $api_auth_any_user
+      = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth')->name('api_ensure_user');
+    my $api_public = $r->route('/api/v1')->name('api_public');
 
     OpenQA::Setup::setup_template_search_path($self);
     OpenQA::Setup::load_plugins($self, $auth);
@@ -242,12 +245,11 @@ sub startup {
     ## JSON API starts here
     ###
     # Array to store new API routes' references, so they can all be checked to get API description from POD
-    my @api_routes        = ();
-    my $api_auth_any_user = $r->under('/api/v1')->to(controller => 'API::V1', action => 'auth');
-    my $api_ru            = $api_auth_any_user->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
-    my $api_ro            = $api_auth_operator->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
-    my $api_ra            = $api_auth_admin->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
-    my $api_public_r      = $r->route('/api/v1')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my @api_routes   = ();
+    my $api_ru       = $api_auth_any_user->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_ro       = $api_auth_operator->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_ra       = $api_auth_admin->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_public_r = $api_public->route('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     push @api_routes, $api_ru, $api_ro, $api_ra, $api_public_r;
     # this is fallback redirect if one does not use apache
     $api_public_r->websocket(

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -43,6 +43,12 @@ $t->ua(OpenQA::Client->new()->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
 subtest 'authentication routes for plugins' => sub {
+    my $public = $t->app->routes->find('api_public');
+    ok $public, 'api_pubic route found';
+    $public->put('/public_plugin' => sub { shift->render(text => 'API public plugin works!') });
+    my $ensure_user = $t->app->routes->find('api_ensure_user');
+    ok $ensure_user, 'api_ensure_user route found';
+    $ensure_user->put('/user_plugin' => sub { shift->render(text => 'API user plugin works!') });
     my $ensure_admin = $t->app->routes->find('api_ensure_admin');
     ok $ensure_admin, 'api_ensure_admin route found';
     $ensure_admin->put('/admin_plugin' => sub { shift->render(text => 'API admin plugin works!') });
@@ -64,6 +70,8 @@ subtest 'access limiting for non authenticated users' => sub() {
         },
         'error returned as JSON'
     );
+    $t->put_ok('/api/v1/public_plugin')->status_is(200)->content_is('API public plugin works!');
+    $t->put_ok('/api/v1/user_plugin')->status_is(403);
     $t->put_ok('/api/v1/admin_plugin')->status_is(403);
     $t->put_ok('/api/v1/operator_plugin')->status_is(403);
 };
@@ -74,6 +82,8 @@ subtest 'access limiting for authenticated users but not operators nor admins' =
     $t->get_ok('/api/v1/jobs')->status_is(200, 'accessible (public)');
     $t->post_ok('/api/v1/assets')->status_is(403, 'restricted (operator and admin only)');
     $t->delete_ok('/api/v1/assets/1')->status_is(403, 'restricted (admin only)');
+    $t->put_ok('/api/v1/public_plugin')->status_is(200)->content_is('API public plugin works!');
+    $t->put_ok('/api/v1/user_plugin')->status_is(200)->content_is('API user plugin works!');
     $t->put_ok('/api/v1/admin_plugin')->status_is(403);
     $t->put_ok('/api/v1/operator_plugin')->status_is(403);
 };
@@ -84,6 +94,8 @@ subtest 'access limiting for authenticated operators but not admins' => sub() {
     $t->get_ok('/api/v1/jobs')->status_is(200, 'accessible (public)');
     $t->post_ok('/api/v1/jobs/99927/set_done')->status_is(200, 'accessible (operator and admin only)');
     $t->delete_ok('/api/v1/assets/1')->status_is(403, 'restricted (admin only)');
+    $t->put_ok('/api/v1/public_plugin')->status_is(200)->content_is('API public plugin works!');
+    $t->put_ok('/api/v1/user_plugin')->status_is(200)->content_is('API user plugin works!');
     $t->put_ok('/api/v1/admin_plugin')->status_is(403);
     $t->put_ok('/api/v1/operator_plugin')->status_is(200)->content_is('API operator plugin works!');
 };
@@ -94,6 +106,8 @@ subtest 'access granted for admins' => sub() {
     $t->get_ok('/api/v1/jobs')->status_is(200, 'accessible (public)');
     $t->post_ok('/api/v1/jobs/99927/set_done')->status_is(200, 'accessible (operator and admin only)');
     $t->delete_ok('/api/v1/assets/1')->status_is(200, 'accessible (admin only)');
+    $t->put_ok('/api/v1/public_plugin')->status_is(200)->content_is('API public plugin works!');
+    $t->put_ok('/api/v1/user_plugin')->status_is(200)->content_is('API user plugin works!');
     $t->put_ok('/api/v1/admin_plugin')->status_is(200)->content_is('API admin plugin works!');
     $t->put_ok('/api/v1/operator_plugin')->status_is(200)->content_is('API operator plugin works!');
 };


### PR DESCRIPTION
This PR is a followup to #2198. We have four levels of API access (public, user, operator and admin), but so far only operator and admin were available for use in plugins.