### PR TITLE
Docs for the job group editor and YAML REST

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -554,6 +554,28 @@ Steps 4. to 6. can be repeated for further +assert_screen+s/needles without rest
 test.
 
 
+=== Job group editor https://github.com/os-autoinst/openQA/pull/2111[gh#2111] ===
+
+Scenarios are defined as part of a job group. The `Edit job group` button exposes the editor.
+
+By default the scenarios are listed in a table per medium. Changes to the priority are
+applied immediately. Machines can be added by selecting the architecture column and picking
+a machine from the list. Remove scenarios by removing all of their machines. Add new scenarios
+via the blue Plus icon at the top of the table.
+
+The `Edit YAML` button can be used to reveal the YAML editor and migrate a group. After
+saving for the first time, the group can only be configured in YAML. The table view will not
+be shown anymore.
+
+Note that making a backup before migrating groups may be a good idea, for example using
+`openqa-dump-templates`.
+
+Settings can be specified as a key/value pair for each scenario. There is no
+equivalent in the table view so you need to migrate groups to use this feature.
+
+YAML-only groups need to be updated through the YAML editor or the YAML-related
+REST API routes.
+
 == Use of the REST API
 
 openQA includes a _client_ script which - depending on the distribution - is
@@ -638,6 +660,28 @@ openqa-client isos post ISO=my_iso.iso DISTRI=my_distri FLAVOR=sweet \
          _DEPRIORITIZEBUILD=1 _DEPRIORITIZE_LIMIT=120 \
 --------------------------------------------------------------------------------
 
+
+=== Job template YAML ===
+
+Job groups can be queried via the experimental REST API:
+
+    api/v1/experimental/job_templates_scheduling
+
+The GET request will get the YAML for one or multiple groups while a POST request
+conversely updates the YAML for a particular group.
+
+
+Two scripts using these routes can be used to import and export YAML templates:
+
+[source,sh]
+--------------------------------------------------------------------------------
+openqa-dump-templates --json --group test > test.json
+--------------------------------------------------------------------------------
+
+[source,sh]
+--------------------------------------------------------------------------------
+openqa-load-templates --group test test.json
+--------------------------------------------------------------------------------
 
 == Asset handling ==
 

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -94,7 +94,7 @@
         <form action="#" id="editor-form" class="form-horizontal" style="display: none;" onsubmit="return submitTemplateEditor();"
           data-put-url="<%= url_for('apiv1_job_templates_schedules' => (id => $group->id)) %>">
             <div class="form-group row">
-                <label for="editor-template" class="col-sm-4 control-label" data-toggle="tooltip" title="Changes in the YAML will be reflected in the database">
+                <label for="editor-template" class="col-sm-4 control-label">
                     <div id="editor-yaml-guide">
                         <div>Define test suites per arch/medium:</div>
                         <code>
@@ -131,6 +131,7 @@ scenarios:
     <i>medium</i>-<b>x86_64</b>:
       <b>*tests</b>
                         </code>
+                        <p><%= link_to 'See the docs for more details' => 'http://open.qa/docs/#_job_group_editor_gh2111', target => '_blank' %></p>
                     </div>
                 </label>
                 <div class="col-sm-8">


### PR DESCRIPTION
Two new sections

- Job group editor
- Job template YAML (REST API)

And the guide in the YAML editor links to the docs as well, instead of the not so useful tooltip.