### PR TITLE
Add type/additionalProperties to products spec

### DIFF
--- a/public/schema/JobTemplate.yaml
+++ b/public/schema/JobTemplate.yaml
@@ -60,8 +60,10 @@ properties:
           priority:
             type: number
   products:
+    type: object
+    additionalProperties: false
     patternProperties:
-      "^[a-z0-9_]+$":
+      "^[A-Za-z0-9._-]+$":
         type: object
         description: The name of a product (medium)
         required:
@@ -75,4 +77,6 @@ properties:
           flavor:
             type: string
           version:
-            type: string
+            oneOf:
+              - type: string
+              - type: number

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -543,6 +543,13 @@ is_deeply(@{$t->app->validate_yaml($yaml, 1)}[0], '/products/opensuse/flavor: Mi
 $yaml->{products}{'opensuse'}{flavor} = 'DVD';
 is_deeply($t->app->validate_yaml($yaml, 1), ['/products/opensuse/version: Missing property.'], 'No version specified')
   or diag explain YAML::XS::Dump($yaml);
+$yaml->{products}{'opensuse'}{distribution} = 'sle';
+is_deeply(
+    @{$t->app->validate_yaml($yaml, 1)}[0],
+    '/products/opensuse: Properties not allowed: distribution.',
+    'Invalid product property specified'
+) or diag explain YAML::XS::Dump($yaml);
+delete $yaml->{products}{'opensuse'}{distribution};
 $yaml->{products}{'opensuse'}{version} = '42.1';
 # Add non-trivial test suites to exercise the validation
 $yaml->{scenarios}{'x86_64'}{opensuse} = [


### PR DESCRIPTION
Without these, even the schema validation itself doesn't fail but the regex is effectively ignored and typos in property names aren't caught early.

We're still catching errors with product definitions as-is but the error is much less clear than it could be.