### PR TITLE
Update DBI requirement

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -8,6 +8,7 @@ requires 'Crypt::DH::GMP';
 requires 'Cwd';
 requires 'DBD::SQLite';
 requires 'DBD::Pg';
+requires 'DBI',         '>= 1.632';
 requires 'DBIx::Class', '>= 0.082801';
 requires 'DBIx::Class::Core';
 requires 'DBIx::Class::DeploymentHandler';
@@ -95,23 +96,23 @@ requires 'warnings';
 requires 'POSIX';
 
 on 'test' => sub {
-  requires 'Perl::Critic';
-  requires 'Perl::Critic::Freenode';
-  requires 'Perl::Tidy', '== 20190601';
-  requires 'Selenium::Remote::Driver', '>= 1.23';
-  requires 'Selenium::Remote::WDKeys';
-  requires 'Test::Strict';
-  requires 'Test::Fatal';
-  requires 'Test::MockModule';
-  requires 'Test::MockObject';
-  requires 'Test::Mojo';
-  requires 'Test::More';
-  requires 'Test::Output';
-  requires 'Test::Pod';
-  requires 'Test::Warnings';
+    requires 'Perl::Critic';
+    requires 'Perl::Critic::Freenode';
+    requires 'Perl::Tidy',               '== 20190601';
+    requires 'Selenium::Remote::Driver', '>= 1.23';
+    requires 'Selenium::Remote::WDKeys';
+    requires 'Test::Strict';
+    requires 'Test::Fatal';
+    requires 'Test::MockModule';
+    requires 'Test::MockObject';
+    requires 'Test::Mojo';
+    requires 'Test::More';
+    requires 'Test::Output';
+    requires 'Test::Pod';
+    requires 'Test::Warnings';
 };
 
 feature 'coverage', 'coverage for travis' => sub {
-  requires 'Devel::Cover';
-  requires 'Devel::Cover::Report::Codecov';
+    requires 'Devel::Cover';
+    requires 'Devel::Cover::Report::Codecov';
 };

--- a/openQA.spec
+++ b/openQA.spec
@@ -67,11 +67,13 @@ BuildRequires:  systemd
 # critical bug fix
 BuildRequires:  perl(DBIx::Class) >= 0.082801
 BuildRequires:  perl(Minion) >= 9.09
+BuildRequires:  perl(DBI) >= 1.632
 BuildRequires:  perl(Mojolicious) >= 7.92
 BuildRequires:  perl(Mojolicious::Plugin::AssetPack) >= 1.36
 BuildRequires:  perl(Mojo::RabbitMQ::Client) >= 0.2
 BuildRequires:  rubygem(sass)
 Requires:       perl(Minion) >= 9.09
+Requires:       perl(DBI) >= 1.632
 Requires:       perl(Mojo::RabbitMQ::Client) >= 0.2
 Requires:       perl(YAML::XS) >= 0.67
 # needed for test suite


### PR DESCRIPTION
This change fixes warnings that started to appear in Travis tests today.
```
./t/13-joblocks.t ......................... ok
	(in cleanup) Can't locate object method "DELETE" via package "DBI::db" at /usr/lib/perl5/vendor_perl/5.18.2/Mojo/Pg.pm line 105.
	(in cleanup) Can't locate object method "DELETE" via package "DBI::db" at /usr/lib/perl5/vendor_perl/5.18.2/Mojo/Pg.pm line 105.
	(in cleanup) Can't locate object method "DELETE" via package "DBI::db" at /usr/lib/perl5/vendor_perl/5.18.2/Mojo/Pg.pm line 105.
```
Unfortunately we use `Test::Warnings`, so these warnings resulted in test failures.