### PR TITLE
AMQP: allow passing headers to publish_amqp

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -71,7 +71,9 @@ sub log_event {
 }
 
 sub publish_amqp {
-    my ($self, $topic, $event_data) = @_;
+    my ($self, $topic, $event_data, $headers) = @_;
+    $headers //= {};
+    die "publish_amqp headers must be a hashref!" unless (ref($headers) eq 'HASH');
 
     log_debug("Sending AMQP event: $topic");
     my $publisher = Mojo::RabbitMQ::Client::Publisher->new(
@@ -79,7 +81,7 @@ sub publish_amqp {
 
     # A hard reference to the publisher object needs to be kept until the event
     # has been published asynchronously, or it gets destroyed too early
-    $publisher->publish_p($event_data, routing_key => $topic)->then(
+    $publisher->publish_p($event_data, $headers, routing_key => $topic)->then(
         sub {
             log_debug "$topic published";
         }


### PR DESCRIPTION
Fedora's new AMQP-based messaging system requires messages to
have certain headers:

https://fedora-messaging.readthedocs.io/en/stable/wire-format.html

I'm planning to write a plugin for emitting Fedora-compliant
AMQP messages as a subclass of the existing AMQP plugin, but in
order to be able to use `publish_amqp` in that plugin, I need to
be able to pass it headers like this. Otherwise I'd have to
reimplement it.

This implementation aims to ensure it works just as before if
you *don't* want to pass it headers, and without needing to
duplicate the `publish_p` calls for "headers" and "no headers"
cases - that's the reason for making `$headers` a reference to
an empty hash if it's not defined, and then checking that it's
a hashref: to be sure about what we're asking `publish_p` to do.
Passing it a ref to an empty hash should effectively be a no-op
so far as headers are concerned, and not interfere with passing
`routing_key` as a param.

Signed-off-by: Adam Williamson <awilliam@redhat.com>