### PR TITLE
AMQP: don't encode message body to JSON before publishing

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -16,8 +16,6 @@
 package OpenQA::WebAPI::Plugin::AMQP;
 use Mojo::Base 'Mojolicious::Plugin';
 
-use Mojo::JSON;    # booleans
-use Cpanel::JSON::XS ();
 use Mojo::IOLoop;
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
@@ -62,9 +60,6 @@ sub log_event {
     $event =~ s/_/\./;
 
     my $topic = $self->{config}->{amqp}{topic_prefix} . '.' . $event;
-
-    # convert data to JSON, with reliable key ordering (helps the tests)
-    $event_data = Cpanel::JSON::XS->new->canonical(1)->allow_blessed(1)->ascii(1)->encode($event_data);
 
     # seperate function for tests
     $self->publish_amqp($topic, $event_data);


### PR DESCRIPTION
Mojo::RabbitMQ::Client::Publisher will do this for us if we just
pass it a reference. This makes three things better in one go:

1) By encoding to a JSON string in publish_amqp and passing a
string to publish_p, but not including a content_type header,
we're actually doing it wrong: the published message will get
'text/plain' as its content_type header. If we pass publish_p a
reference like this it will automatically encode it to JSON and
set the content_type header to 'application/json'

2) Removes an unnecessary use of CPanel::JSON::XS

3) Lets us make the test cleaner, as we can compare the message
body as a hash ref rather than a JSON string, which reads much
more nicely

One note about this: the publisher uses Mojo::JSON to do the
encoding, which escapes forward slashes. CPanel::JSON::XS did
not do this, so this actually changes the message content a
little. However, the change should be fine, as / and \/ are
considered identical by the JSON spec so any parser should
handle it correctly.

Signed-off-by: Adam Williamson <awilliam@redhat.com>