### PR TITLE
Add a new parameter to support not schedule parent test suite

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -644,6 +644,8 @@ mean existing jobs for earlier builds with the same DISTRI and VERSION are
 no longer interesting, but you still want to be able to re-submit jobs for a
 build and have existing jobs for the exact same build obsoleted.
 
+_SKIP_CHAINED_DEPS:: Do not schedule parent test suites which are specified in START_AFTER_TEST.
+
 _GROUP:: Job templates *not* matching the given group name are ignored. Does *not*
          affect obsoletion behavior, so you might want to combine with `_NO_OBSOLETE`.
 


### PR DESCRIPTION
When users use 'client isos post' to schedule test suite, if they specify
'_NO_TRIGGER_DEPENDENCY=1', do not schedule parent test suites that defined by
'START_AFTER_TEST'.

See: https://progress.opensuse.org/issues/30730