### PR TITLE
Timeout for wait_for_ajax

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -197,9 +197,18 @@ sub _default_check_interval {
 
 sub wait_for_ajax {
     my $check_interval = _default_check_interval(shift);
-    while (!$_driver->execute_script("return jQuery.active == 0")) {
+    my $timeout        = 60 * 5;
+
+    while (!$_driver->execute_script('return window.jQuery && jQuery.active === 0')) {
+        if ($timeout <= 0) {
+            fail("Wait for jQuery timed out");
+            return undef;
+        }
+
+        $timeout -= $check_interval;
         sleep $check_interval;
     }
+    pass("Wait for jQuery successful");
 }
 
 sub disable_bootstrap_animations {


### PR DESCRIPTION
This function currently has two flaws:

- if jQuery is not defined, it'll produce errors forever
- if jQuery.active is never set to  1, the test will run forever

There should be a maximum timeout for the wait, as well as a check that
avoids repeated Javascript errors which turn into redundant test failures.

As a bonus, showing successful waits is probably nice to have.