### PR TITLE
YAML: don't merge scenarios with multiple machines with defaults

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -143,6 +143,7 @@ sub get_job_groups {
         $group{products}  = {};
 
         my %machines;
+        my %test_suites;
         # Extract products and tests per architecture
         while (my $template = $templates->next) {
             $group{products}{$template->product->name} = {
@@ -162,9 +163,10 @@ sub get_job_groups {
             my $settings = $template->settings_hash;
             $test_suite{settings} = $settings if %$settings;
 
-            my $test_suites = $group{scenarios}{$template->product->arch}{$template->product->name};
-            push @$test_suites, {$template->test_suite->name => \%test_suite};
-            $group{scenarios}{$template->product->arch}{$template->product->name} = $test_suites;
+            my $scenarios = $group{scenarios}{$template->product->arch}{$template->product->name};
+            push @$scenarios, {$template->test_suite->name => \%test_suite};
+            $group{scenarios}{$template->product->arch}{$template->product->name} = $scenarios;
+            $test_suites{$template->product->arch}{$template->test_suite->name}++;
         }
 
         # Split off defaults
@@ -175,23 +177,23 @@ sub get_job_groups {
             $group{defaults}{$arch}{machine} = $default_machine;
 
             foreach my $product (keys %{$group{scenarios}->{$arch}}) {
-                my @test_suites;
+                my @scenarios;
                 foreach my $test_suite (@{$group{scenarios}->{$arch}->{$product}}) {
                     foreach my $name (keys %$test_suite) {
                         my $attr = $test_suite->{$name};
                         if ($attr->{machine} eq $default_machine) {
-                            delete $attr->{machine};
+                            delete $attr->{machine} if $test_suites{$arch}{$name} == 1;
                         }
                         if (%$attr) {
                             $test_suite->{$name} = $attr;
-                            push @test_suites, $test_suite;
+                            push @scenarios, $test_suite;
                         }
                         else {
-                            push @test_suites, $name;
+                            push @scenarios, $name;
                         }
                     }
                 }
-                $group{scenarios}{$arch}{$product} = \@test_suites;
+                $group{scenarios}{$arch}{$product} = \@scenarios;
             }
         }
 

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -584,7 +584,11 @@ is_deeply(
         scenarios => {
             i586 => {
                 'opensuse-13.1-DVD-i586' => [
-                    'textmode',
+                    {
+                        textmode => {
+                            machine => '64bit',
+                        }
+                    },
                     {
                         textmode => {
                             machine => '32bit',
@@ -595,7 +599,11 @@ is_deeply(
                             machine => '32bit',
                         }
                     },
-                    'kde',
+                    {
+                        kde => {
+                            machine => '64bit',
+                        }
+                    },
                     {
                         RAID0 => {
                             priority => 20,
@@ -606,8 +614,16 @@ is_deeply(
                             machine => '32bit',
                         }
                     },
-                    'client1',
-                    'server',
+                    {
+                        client1 => {
+                            machine => '64bit',
+                        }
+                    },
+                    {
+                        server => {
+                            machine => '64bit',
+                        }
+                    },
                     {
                         server => {
                             machine => '32bit',
@@ -618,7 +634,11 @@ is_deeply(
                             machine => '32bit',
                         }
                     },
-                    'client2',
+                    {
+                        client2 => {
+                            machine => '64bit',
+                        }
+                    },
                     {
                         advanced_kde => {
                             settings => {


### PR DESCRIPTION
Default should only be used when a scenario is defined once per architecture, at least in the initial generated YAML.

Fixes: [poo#53588](https://progress.opensuse.org/issues/53588)

Note: `t/api/02-iso.t` doesn't require changes, but trying to debug failures before I reconsidered changes to the fixtures, these changes made it a little bit easier.