### PR TITLE
Fix '--no-cleanup' on worker start regression

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -348,7 +348,7 @@ sub accept_job {
 
     # ensure the pool directory is cleaned up before starting a new job
     # note: The cleanup after finishing the last job might have been prevented via --no-cleanup.
-    $self->_clean_pool_directory;
+    $self->_clean_pool_directory unless $self->no_cleanup;
 
     $self->current_job($job);
     $self->current_webui_host($webui_host);


### PR DESCRIPTION
Previously, with the latest worker rework the pool directory was not
cleanup up with '--no-cleanup' on stopping a job but still when a job is
started. The option for '--no-cleanup' should simply not clean up
anything at all, the user needs to take care about this then.