### PR TITLE
AMQP: allow no message prefix

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -59,7 +59,8 @@ sub log_event {
     $event =~ s/_/\./;
     $event =~ s/_/\./;
 
-    my $topic = $self->{config}->{amqp}{topic_prefix} . '.' . $event;
+    my $prefix = $self->{config}->{amqp}{topic_prefix};
+    my $topic  = $prefix ? $prefix . '.' . $event : $event;
 
     # seperate function for tests
     $self->publish_amqp($topic, $event_data);

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -236,6 +236,13 @@ subtest 'create parent group comment' => sub {
     is($json->{parent_group_id}, 2000,  'parent group id');
 };
 
+$t->app->config->{amqp}{topic_prefix} = '';
+
+subtest 'publish without topic prefix' => sub {
+    $t->post_ok("/api/v1/jobs" => form => $settings)->status_is(200);
+    is($published{'openqa.job.create'}->{ARCH}, "x86_64", 'got message with correct topic');
+};
+
 # Now let's unmock publish_amqp so we can test it...
 $plugin_mock->unmock('publish_amqp');
 %published = ();


### PR DESCRIPTION
For Fedora messages we do not actually want a prefix, the topic
is *just* openqa.job.done or whatever. This allows setting
'topic_prefix = ' in the config file to make that work.

Signed-off-by: Adam Williamson <awilliam@redhat.com>