### PR TITLE
Prevent over-escaping of bug titles in test result overview

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -24,6 +24,7 @@ use OpenQA::Schema::Result::JobDependencies;
 use OpenQA::WebAPI::Controller::Developer;
 use OpenQA::Utils qw(determine_web_ui_web_socket_url get_ws_status_only_url);
 use Mojo::ByteStream;
+use Mojo::Util 'xml_escape';
 use File::Basename;
 use POSIX 'strftime';
 
@@ -372,7 +373,8 @@ sub job_next_previous_ajax {
                 bug   => $bug,
                 url   => $self->bugurl_for($bug),
                 icon  => $self->bugicon_for($bug, $bugdetails->{$bug}),
-                title => $self->bugtitle_for($bug, $bugdetails->{$bug})};
+                title => xml_escape($self->bugtitle_for($bug, $bugdetails->{$bug})),
+              };
         }
 
         $data->{bugs}  = \@bugs;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -19,7 +19,6 @@ use Mojo::Base 'Mojolicious::Plugin';
 
 use Mojo::ByteStream;
 use OpenQA::Schema;
-use Mojo::Util 'xml_escape';
 use OpenQA::Utils qw(bugurl render_escaped_refs href_to_bugref);
 use OpenQA::Events;
 
@@ -68,7 +67,7 @@ sub register {
             my ($c, $bugid, $bug) = @_;
             my $text = "Bug referenced: $bugid";
             if ($bug && $bug->existing && $bug->title) {
-                $text .= "\n" . xml_escape($bug->title);
+                $text .= "\n" . $bug->title;
             }
             return $text;
         });

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -35,6 +35,13 @@ sub schema_hook {
     # create a parent group
     my $schema = OpenQA::Test::Database->new->create;
     $schema->resultset('JobGroupParents')->create({id => 1, name => 'Test parent', sort_order => 0});
+    $schema->resultset('Bugs')->create(
+        {
+            bugid     => 'bsc#1234',
+            title     => 'some title with "quotes" and <html>elements</html>',
+            existing  => 1,
+            refreshed => 1,
+        });
 }
 
 my $driver = call_driver(\&schema_hook);
@@ -325,8 +332,8 @@ subtest 'commenting in test results including labels' => sub {
         $driver->find_element('#current-build-overview a')->click();
         is(
             $driver->find_element('#res_DVD_x86_64_doc .fa-bug')->get_attribute('title'),
-            'Bug referenced: bsc#1234',
-            'bug icon shown for bsc#1234'
+            "Bug referenced: bsc#1234\nsome title with \"quotes\" and <html>elements</html>",
+            'bug icon shown for bsc#1234, title rendered with new-line, HTML code is rendered as text'
         );
         is(
             $driver->find_element('#res_DVD_x86_64_doc .fa-bolt')->get_attribute('title'),


### PR DESCRIPTION
* Additionally, add tests for the two occurrences of bug-title rendering in our code (test result overview and 'Next & Previous' tab via JavaScript)
* See https://progress.opensuse.org/issues/53420

By the way, this is *not* security relevant because we were previously escaping one time too often.