### PR TITLE
Extend retry delay of worker to 60 seconds if web UI busy

### DIFF
--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -81,6 +81,10 @@ sub new {
         $ENV{VNC}      = $instance_number + 90;
     }
 
+    # assign default retry-delay for web UI connection
+    $global_settings{RETRY_DELAY}               //= 5;
+    $global_settings{RETRY_DELAY_IF_WEBUI_BUSY} //= 60;
+
     my $self = $class->SUPER::new(
         global_settings              => \%global_settings,
         webui_hosts                  => \@hosts,

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -282,7 +282,10 @@ my %BUSY_ERROR_CODES = map { $_ => 1 } 502, 503, 504, 598;
 
 sub _retry_delay {
     my ($self, $is_webui_busy) = @_;
-    return $is_webui_busy ? 60 : 5;
+    my $key                    = $is_webui_busy ? 'RETRY_DELAY_IF_WEBUI_BUSY' : 'RETRY_DELAY';
+    my $settings               = $self->worker->settings;
+    my $host_specific_settings = $settings->webui_host_specific_settings->{$self->webui_host} // {};
+    return $host_specific_settings->{$key} // $settings->global_settings->{$key};
 }
 
 # sends a command to the web UI via its REST API

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -278,7 +278,7 @@ sub disable {
 
 # define list of HTTP error codes which indicate that the web UI is overloaded or down for maintenance
 # (in these cases the re-try delay should be increased)
-my %busy_error_codes = (502 => 1, 503 => 1, 504 => 1, 598 => 1);
+my %BUSY_ERROR_CODES = map { $_ => 1 } 502, 503, 504, 598;
 
 sub _retry_delay {
     my ($self, $is_webui_busy) = @_;
@@ -296,7 +296,6 @@ sub send {
     my $json_data = $args{json};
     my $callback  = $args{callback} // sub { };
     my $tries     = $args{tries} // 3;
-
 
     # if set ignore errors completely and don't retry
     my $ignore_errors = $args{ignore_errors} // 0;
@@ -365,7 +364,7 @@ sub send {
                 $tries = 0;
             }
             else {
-                $is_webui_busy = $busy_error_codes{$error_code};
+                $is_webui_busy = $BUSY_ERROR_CODES{$error_code};
             }
         }
         else {

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -276,6 +276,15 @@ sub disable {
     $self->finish_websocket_connection;
 }
 
+# define list of HTTP error codes which indicate that the web UI is overloaded or down for maintenance
+# (in these cases the re-try delay should be increased)
+my %busy_error_codes = (502 => 1, 503 => 1, 504 => 1, 598 => 1);
+
+sub _retry_delay {
+    my ($self, $is_webui_busy) = @_;
+    return $is_webui_busy ? 60 : 5;
+}
+
 # sends a command to the web UI via its REST API
 # note: This function may be called when the websocket connection has been interrupted as long as we still have a
 #       worker ID. If the websocket connection is down that should not affect any of the REST API calls.
@@ -287,6 +296,7 @@ sub send {
     my $json_data = $args{json};
     my $callback  = $args{callback} // sub { };
     my $tries     = $args{tries} // 3;
+
 
     # if set ignore errors completely and don't retry
     my $ignore_errors = $args{ignore_errors} // 0;
@@ -322,7 +332,7 @@ sub send {
     my $tx = $ua->build_tx(@args);
     if ($callback eq "no") {
         $ua->start($tx);
-        return;
+        return undef;
     }
     my $cb;
     $cb = sub {
@@ -339,6 +349,7 @@ sub send {
         --$tries;
         my $err = $tx->error;
         my $msg;
+        my $is_webui_busy;
 
         # format error message for log
         if ($tx->res && $tx->res->json) {
@@ -346,16 +357,20 @@ sub send {
             $msg = $tx->res->json->{error};
         }
         $msg //= $err->{message};
-        if ($err->{code}) {
-            $msg = "$err->{code} response: $msg";
-            if ($err->{code} == 404) {
+        if (my $error_code = $err->{code}) {
+            $msg = "$error_code response: $msg";
+            if ($error_code == 404) {
                 # don't retry on 404 errors (in this case we can't expect different
                 # results on further attempts)
                 $tries = 0;
             }
+            else {
+                $is_webui_busy = $busy_error_codes{$error_code};
+            }
         }
         else {
-            $msg = "Connection error: $msg";
+            $msg           = "Connection error: $msg";
+            $is_webui_busy = 1 if $err->{message} =~ qr/timeout/i;
         }
         log_error("$msg (remaining tries: $tries)");
 
@@ -368,19 +383,19 @@ sub send {
                 $worker->stop_current_job('api-failure');
             }
             $callback->();
-            return;
+            return undef;
         }
 
         # handle non-critical error when no more attempts remain
         if ($tries <= 0) {
             $callback->();
-            return;
+            return undef;
         }
 
-        # retry in 5 seconds if there are remaining attempts
+        # retry in 5 seconds or a minute if there are remaining attempts
         $tx = $ua->build_tx(@args);
         Mojo::IOLoop->timer(
-            5,
+            $self->_retry_delay($is_webui_busy),
             sub {
                 $ua->start($tx => sub { $cb->(@_, $tries) });
             });

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -32,10 +32,12 @@ my $settings = OpenQA::Worker::Settings->new;
 is_deeply(
     $settings->global_settings,
     {
-        GLOBAL          => 'setting',
-        WORKER_HOSTNAME => '127.0.0.1',
-        LOG_LEVEL       => 'test',
-        LOG_DIR         => 'log/dir',
+        GLOBAL                    => 'setting',
+        WORKER_HOSTNAME           => '127.0.0.1',
+        LOG_LEVEL                 => 'test',
+        LOG_DIR                   => 'log/dir',
+        RETRY_DELAY               => 5,
+        RETRY_DELAY_IF_WEBUI_BUSY => 60,
     },
     'global settings, spaces trimmed'
 ) or diag explain $settings->global_settings;
@@ -83,11 +85,13 @@ subtest 'instance-specific settings' => sub {
     is_deeply(
         $settings1->global_settings,
         {
-            GLOBAL          => 'setting',
-            WORKER_HOSTNAME => '127.0.0.1',
-            WORKER_CLASS    => 'qemu_i386,qemu_x86_64',
-            LOG_LEVEL       => 'test',
-            LOG_DIR         => 'log/dir',
+            GLOBAL                    => 'setting',
+            WORKER_HOSTNAME           => '127.0.0.1',
+            WORKER_CLASS              => 'qemu_i386,qemu_x86_64',
+            LOG_LEVEL                 => 'test',
+            LOG_DIR                   => 'log/dir',
+            RETRY_DELAY               => 5,
+            RETRY_DELAY_IF_WEBUI_BUSY => 60,
         },
         'global settings (instance 1)'
     ) or diag explain $settings1->global_settings;
@@ -95,12 +99,14 @@ subtest 'instance-specific settings' => sub {
     is_deeply(
         $settings2->global_settings,
         {
-            GLOBAL          => 'setting',
-            WORKER_HOSTNAME => '127.0.0.1',
-            WORKER_CLASS    => 'qemu_aarch64',
-            LOG_LEVEL       => 'test',
-            LOG_DIR         => 'log/dir',
-            FOO             => 'bar',
+            GLOBAL                    => 'setting',
+            WORKER_HOSTNAME           => '127.0.0.1',
+            WORKER_CLASS              => 'qemu_aarch64',
+            LOG_LEVEL                 => 'test',
+            LOG_DIR                   => 'log/dir',
+            FOO                       => 'bar',
+            RETRY_DELAY               => 10,
+            RETRY_DELAY_IF_WEBUI_BUSY => 120,
         },
         'global settings (instance 2)'
     ) or diag explain $settings2->global_settings;

--- a/t/data/24-worker-settings/workers.ini
+++ b/t/data/24-worker-settings/workers.ini
@@ -13,6 +13,8 @@ WORKER_CLASS = qemu_i386,qemu_x86_64
 [2]
 WORKER_CLASS = qemu_aarch64  
 FOO = bar
+RETRY_DELAY = 10
+RETRY_DELAY_IF_WEBUI_BUSY = 120
 
 [http://localhost:9527]
 HOST_SPECIFIC = setting (localhost)


### PR DESCRIPTION
This should reduce load on the web UI and helps to reduce the number of incomplete jobs. Regular API errors (no timeout) are treated as before.