### PR TITLE
load_templates: fix --clean and reading perl templates

### DIFF
--- a/script/load_templates
+++ b/script/load_templates
@@ -105,7 +105,7 @@ try {
     dd $info;
 }
 catch {
-    $info = do $datafile;
+    $info = eval $datafile;
     if (my $error = $@) {
         die "Error in data file: $error\n";
     }
@@ -227,6 +227,8 @@ sub post_entry {
 
 if ($options{'clean'}) {
     for my $table (@tables) {
+        # we can't clean job groups as they're not deletable unless empty
+        next if ($table eq "JobGroups");
         my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table)))->res;
         if ($res->code && $res->code == 200) {
             my $result = $res->json;


### PR DESCRIPTION
This fixes two bugs in load_templates since #2204 landed. First,
`--clean` couldn't work once JobGroups was added to `@tables`
because that API endpoint returns an array (not a hash) and the
script would choke on that (it only knows how to handle hashes).
The correct fix is just to skip JobGroups when doing `--clean`
because we usually cannot delete them anyway, as non-empty job
groups cannot be deleted. There's no point trying to handle the
array.

Second, loading perl format template files was broken by the
change to make `$datafile` the slurped contents of the file
rather than simply the filename. We have to change `do` to `eval`
to handle that change.

Signed-off-by: Adam Williamson <awilliam@redhat.com>