### PR TITLE
Fix PROVE_ARGS in spec file

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -251,7 +251,7 @@ rm -f t/00-tidy.t
 #make test
 rm -rf %{buildroot}/DB
 export LC_ALL=en_US.UTF-8
-make test-with-database OBS_RUN=1 PROVE_ARGS='-rv' TEST_PG_PATH=%{buildroot}/DB || true
+make test-with-database OBS_RUN=1 PROVE_ARGS='-l -r -v' TEST_PG_PATH=%{buildroot}/DB || true
 rm -rf %{buildroot}/DB
 %endif
 


### PR DESCRIPTION
I forgot this when i submitted #2233, so tests fail currently because `@INC` is wrong.