### PR TITLE
Fix warnings in 30-test_parser.t

### DIFF
--- a/lib/OpenQA/Files.pm
+++ b/lib/OpenQA/Files.pm
@@ -91,7 +91,7 @@ sub verify_chunks {
           unless $chunk->verify_content($verify_file);
     }
 
-    my $final_sum = OpenQA::File::_file_digest(Mojo::File->new($verify_file)->to_string);
+    my $final_sum = OpenQA::File->file_digest(Mojo::File->new($verify_file)->to_string);
     return Mojo::Exception->new("Total checksum failed: expected $sum, computed " . $final_sum)
       if $sum ne $final_sum;
     return undef;

--- a/lib/OpenQA/Files.pm
+++ b/lib/OpenQA/Files.pm
@@ -1,0 +1,100 @@
+# Copyright (C) 2018 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::Files;
+use Mojo::Base 'OpenQA::Parser::Results';
+
+use Digest::SHA 'sha1_base64';
+use Mojo::File 'path';
+use OpenQA::File;
+use Mojo::Exception;
+
+sub join {
+    my $self = shift;
+    return join '', map { $_->read } $self->each;
+}
+
+sub serialize {
+    my $self = shift;
+    $self->join();    # Be sure content was read
+    return map { $_->serialize } $self->each;
+}
+
+sub deserialize {
+    my $self = shift;
+    return $self->new(map { OpenQA::File->deserialize($_) } @_);
+}
+
+sub write { Mojo::File->new(pop())->spurt(shift()->join()) }
+
+sub generate_sum { sha1_base64(shift()->join()) }
+
+sub is_sum { shift->generate_sum eq shift }
+
+sub prepare {
+    my $self = shift;
+    return $self->each(sub { $_->prepare });
+}
+
+sub write_chunks {
+    my ($class, $chunk_path, $file) = @_;
+
+    return Mojo::File->new($chunk_path)->list_tree()->sort->each(
+        sub {
+            my $chunk = OpenQA::File->deserialize($_->slurp);
+            $chunk->decode_content;    # Decode content before writing it
+            $chunk->write_content($file);
+        });
+}
+
+sub write_verify_chunks {
+    my ($class, $chunk_path, $file) = @_;
+    $class->write_chunks($chunk_path => $file);
+    return $class->verify_chunks($chunk_path => $file);
+}
+
+sub spurt {
+    my ($self, $dir) = @_;
+    return $self->each(
+        sub {
+            $_->prepare;    # Prepare your data first before serializing
+            Mojo::File->new($dir, $_->index)->spurt($_->serialize);
+        });
+}
+
+sub verify_chunks {
+    my ($class, $chunk_path, $verify_file) = @_;
+
+    my $sum;
+    for (Mojo::File->new($chunk_path)->list_tree()->each) {
+        my $chunk = OpenQA::File->deserialize($_->slurp);
+
+        $chunk->decode_content;
+        $sum = $chunk->total_cksum if !$sum;
+        return Mojo::Exception->new(
+            "Chunk: " . $chunk->id() . " differs in total checksum, expected $sum given " . $chunk->total_cksum)
+          if $sum ne $chunk->total_cksum;
+        return Mojo::Exception->new("Can't verify written data from chunk")
+          unless $chunk->verify_content($verify_file);
+    }
+
+    my $final_sum = OpenQA::File::_file_digest(Mojo::File->new($verify_file)->to_string);
+    return Mojo::Exception->new("Total checksum failed: expected $sum, computed " . $final_sum)
+      if $sum ne $final_sum;
+    return undef;
+}
+
+1;

--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -22,7 +22,6 @@ use OpenQA::Parser::Result::OpenQA;
 use Mojo::DOM;
 
 has include_results => 0;
-has [qw(_dom)];
 
 # Override to use specific OpenQA Result class.
 sub _add_single_result { shift->generated_tests_results->add(OpenQA::Parser::Result::OpenQA->new(@_)) }
@@ -47,10 +46,9 @@ sub _add_result {
 sub parse {
     my ($self, $xml) = @_;
     confess "No XML given/loaded" unless $xml;
-    $self->_dom(Mojo::DOM->new($xml));
-    confess "Failed parsing XML" unless @{$self->_dom->tree} > 2;
+    my $dom = Mojo::DOM->new($xml);
+    confess "Failed parsing XML" unless @{$dom->tree} > 2;
 
-    my $dom = $self->_dom();
     my @tests;
     for my $ts ($dom->find('testsuite')->each) {
         my $ts_category = $ts->{package};
@@ -61,7 +59,7 @@ sub parse {
         $ts_category =~ s/\..*$//;
         $ts_name     =~ s/^[^.]*\.//;
         $ts_name     =~ s/\./_/;
-        if ($ts->{id} =~ /^[0-9]+$/) {
+        if (($ts->{id} // '') =~ /^[0-9]+$/) {
             # make sure that the name is unique
             # prepend numeric $ts->{id}, start counting from 1
             $ts_name = ($ts->{id} + 1) . '_' . $ts_name;

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -26,9 +26,8 @@ sub addproperty { shift->{properties}->add(OpenQA::Parser::Result::XUnit::Proper
 sub parse {
     my ($self, $xml) = @_;
     confess "No XML given/loaded" unless $xml;
-    $self->_dom(Mojo::DOM->new->xml(1)->parse($xml));
+    my $dom = Mojo::DOM->new->xml(1)->parse($xml);
 
-    my $dom = $self->_dom();
     my @tests;
     my %t_names;
     my $i = 1;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1326,7 +1326,7 @@ sub create_asset {
             }
             else {
                 $sum      = $chunk->total_cksum;
-                $real_sum = $chunk->_file_digest($temp_final_file->to_string);
+                $real_sum = $chunk->file_digest($temp_final_file->to_string);
             }
 
             $temp_chunk_folder->remove_tree

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -61,7 +61,7 @@ subtest 'upload public assets' => sub {
     seek($fh, 20 * 1024 * 1024, 0);    # create 200MB quick
     syswrite($fh, "X");
     close($fh);
-    my $sum = OpenQA::File::_file_digest($filename);
+    my $sum = OpenQA::File->file_digest($filename);
 
     my $client = OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')
       ->ioloop(Mojo::IOLoop->singleton);
@@ -88,7 +88,7 @@ subtest 'upload public assets' => sub {
 
     ok(-e $rp, 'Asset exists after upload');
 
-    is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
+    is $sum, OpenQA::File->file_digest($rp), 'cksum match!';
     $t->get_ok('/api/v1/assets/hdd/hdd_image2.qcow2')->status_is(200);
     is($t->tx->res->json->{name}, 'hdd_image2.qcow2');
 
@@ -103,7 +103,7 @@ subtest 'upload private assets' => sub {
     seek($fh, 20 * 1024 * 1024, 0);    # create 200MB quick
     syswrite($fh, "A");
     close($fh);
-    my $sum = OpenQA::File::_file_digest($filename);
+    my $sum = OpenQA::File->file_digest($filename);
 
     my $client = OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')
       ->ioloop(Mojo::IOLoop->singleton);
@@ -129,7 +129,7 @@ subtest 'upload private assets' => sub {
 
     ok(-e $rp, 'Asset exists after upload');
 
-    is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
+    is $sum, OpenQA::File->file_digest($rp), 'cksum match!';
     $t->get_ok('/api/v1/assets/hdd/00099963-hdd_image3.qcow2')->status_is(200);
     is($t->tx->res->json->{name}, '00099963-hdd_image3.qcow2');
 
@@ -144,7 +144,7 @@ subtest 'upload other assets' => sub {
     seek($fh, 20 * 1024 * 1024, 0);    # create 200MB quick
     syswrite($fh, "V");
     close($fh);
-    my $sum = OpenQA::File::_file_digest($filename);
+    my $sum = OpenQA::File->file_digest($filename);
 
     my $client = OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')
       ->ioloop(Mojo::IOLoop->singleton);
@@ -175,7 +175,7 @@ subtest 'upload other assets' => sub {
 
     ok(-e $rp, 'Asset exists after upload');
 
-    is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
+    is $sum, OpenQA::File->file_digest($rp), 'cksum match!';
     $t->get_ok('/api/v1/assets/other/00099963-hdd_image3.xml')->status_is(200);
     is($t->tx->res->json->{name}, '00099963-hdd_image3.xml');
 
@@ -189,7 +189,7 @@ subtest 'upload retrials' => sub {
     seek($fh, 20 * 1024 * 1024, 0);    # create 200MB quick
     syswrite($fh, "V");
     close($fh);
-    my $sum = OpenQA::File::_file_digest($filename);
+    my $sum = OpenQA::File->file_digest($filename);
 
     my $client = OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')
       ->ioloop(Mojo::IOLoop->singleton);
@@ -229,7 +229,7 @@ subtest 'upload retrials' => sub {
 
     ok(-e $rp, 'Asset exists after upload');
 
-    is $sum, OpenQA::File::_file_digest($rp), 'cksum match!';
+    is $sum, OpenQA::File->file_digest($rp), 'cksum match!';
     $t->get_ok('/api/v1/assets/other/00099963-hdd_image4.xml')->status_is(200);
     is($t->tx->res->json->{name}, '00099963-hdd_image4.xml');
 
@@ -244,7 +244,7 @@ subtest 'upload failures' => sub {
     seek($fh, 20 * 1024 * 1024, 0);    # create 200MB quick
     syswrite($fh, "V");
     close($fh);
-    my $sum = OpenQA::File::_file_digest($filename);
+    my $sum = OpenQA::File->file_digest($filename);
 
     my $client = OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')
       ->ioloop(Mojo::IOLoop->singleton);
@@ -298,7 +298,7 @@ subtest 'upload internal errors' => sub {
     seek($fh, 20 * 1024 * 1024, 0);    # create 200MB quick
     syswrite($fh, "V");
     close($fh);
-    my $sum = OpenQA::File::_file_digest($filename);
+    my $sum = OpenQA::File->file_digest($filename);
 
     my $client = OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')
       ->ioloop(Mojo::IOLoop->singleton);

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -394,7 +394,7 @@ $t->get_ok('/api/v1/assets/hdd/00099963-hdd_image.qcow2')->status_is(404);
 
 $pieces = OpenQA::File->new(file => Mojo::File->new($filename))->split($chunk_size);
 ok(!-d $chunkdir, 'Chunk directory empty');
-my $sum = OpenQA::File::_file_digest($filename);
+my $sum = OpenQA::File->file_digest($filename);
 is $sum, $pieces->first->total_cksum or die 'Computed cksum is not same';
 $pieces->each(
     sub {


### PR DESCRIPTION
While learning more about how the worker uploads results i stumbled over a few issues. The most noticeable change in this PR will be lack of this block of warnings from test results.
```
Serialization is offically supported only if object can be turned into an array with ->to_array() at lib/OpenQA/Parser.pm line 105.
Serialization is offically supported only if object can be turned into an array with ->to_array() at lib/OpenQA/Parser.pm line 105.
Serialization is offically supported only if object can be turned into an array with ->to_array() at lib/OpenQA/Parser.pm line 105.
Serialization is offically supported only if object can be turned into an array with ->to_array() at lib/OpenQA/Parser.pm line 105.
Serialization is offically supported only if object can be turned into an array with ->to_array() at lib/OpenQA/Parser.pm line 105.
Use of uninitialized value in pattern match (m//) at lib/OpenQA/Parser/Format/JUnit.pm line 64.
    # Serialization test for OpenQA::Parser::Format::IPA and ipa.json with test test_ipa_file
    # JSON serialization tests
    # Serialization test for OpenQA::Parser::Format::LTP and ltp_test_result_format.json with test test_ltp_file
    # JSON serialization tests
    # Serialization test for OpenQA::Parser::Format::LTP and new_ltp_result_array.json with test test_ltp_file_v2
    # JSON serialization tests
    # Serialization test for OpenQA::Parser::Format::JUnit and slenkins_control-junit-results.xml with test test_junit_file
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
    # JSON serialization tests
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
    # Serialization test for OpenQA::Parser::Format::XUnit and xunit_format_example.xml with test test_xunit_file
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
    # JSON serialization tests
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
Data type with format not supported for serialization at lib/OpenQA/Parser.pm line 113.
    # Serialization test for OpenQA::Parser::Format::TAP and tap_format_example.tap with test test_tap_file
    # JSON serialization tests
```
Then i've removed the inlined class `OpenQA::Files` from `OpenQA::File` and renamed private methods that were used as part of the public API. The argument handling of many methods also had to be cleaned up.
```perl
sub write_verify_chunks {
    my $file       = pop();
    my $chunk_path = pop();
    ...
```
The `path` function exported by `OpenQA::File` also didn't appear to serve a purpose.

There is still more left to clean up, but this branch is already getting a bit large and we all hate reviewing those.