### PR TITLE
Fix apparmor profile for access of client.conf and override templates directory

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -40,6 +40,7 @@
   /usr/share/openqa/templates/ r,
   /usr/share/openqa/templates/** r,
   /var/lib/openqa/.gitconfig r,
+  /var/lib/openqa/.config/openqa/client.conf r,
   /var/lib/openqa/backlog/ r,
   /var/lib/openqa/cache/** rw,
   /var/lib/openqa/db/ r,

--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -18,6 +18,8 @@
 
   /etc/openqa/database.ini r,
   /etc/openqa/openqa.ini r,
+  /etc/openqa/templates/ r,
+  /etc/openqa/templates/** r,
   /proc/meminfo r,
   /tmp/** rw,
   /usr/bin/perl ix,


### PR DESCRIPTION
* apparmor: Allow loading of client.conf in usual home of geekotest
* apparmor: Allow loading override templates in /etc/openqa/templates/