### PR TITLE
apparmor: Allow virtio_console based on named PIPE

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -52,6 +52,7 @@
   /proc/filesystems r,
   /proc/meminfo r,
   /proc/sys/vm/overcommit_memory r,
+  /proc/sys/fs/pipe-max-size r,
   /run/nscd/group r,
   /run/openqa/vde.ctl/* rw,
   /run/udev/queue.bin r,


### PR DESCRIPTION
Necessary for https://github.com/os-autoinst/os-autoinst/pull/1182

Related progress issue: https://progress.opensuse.org/issues/55412