### PR TITLE
openqa-bootstrap: Fix logic of git clone

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -62,7 +62,7 @@ if ping -c1 gitlab.suse.de. ; then
         sles_needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git"
         sles_needles_directory="/var/lib/openqa/tests/opensuse/products/sle/needles"
     # clone SLE needles if run from within SUSE network
-    if [ -d $sles_needles_directory ]; then
+    if [ ! -d $sles_needles_directory ]; then
         echo "cloning $sles_needles_giturl shallow. Call 'git fetch --unshallow' for full history"
                 git clone --depth 1 "$sles_needles_giturl" "$sles_needles_directory"
         fi


### PR DESCRIPTION
We want to clone if the directory does *not* yet exist

