### PR TITLE
Validate tag input field in needleeditor

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -617,8 +617,10 @@ function setup_needle_editor(imageurl, default_needle)
 
   $('#newtag').bind(
       "propertychange change click keyup input paste",
-      function() { $('#tag_add_button').prop('disabled', !this.value.length); }
-  );
+      function() {
+        var invalid = !this.value.length || !this.validity.valid;
+        $('#tag_add_button').prop('disabled', invalid);
+      });
 
   $('#save_needle_form').submit(saveNeedle);
   $(document).on('click', '.restart-link', function(event) {

--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -8,6 +8,9 @@
     padding: 0.4rem;
     line-height: normal;
 }
+.form-control:invalid {
+    background: #ffaaaa80;
+}
 .form-group .control-label {
     font-weight: bold;
     margin-top: auto;

--- a/templates/step/edit.html.ep
+++ b/templates/step/edit.html.ep
@@ -189,7 +189,8 @@
                         % if (is_operator) {
                             <div class="form-group row">
                                 <div class="col-sm-10">
-                                    <input type="text" class="form-control" id="newtag" placeholder="Add new tags here">
+                                    <input type="text" class="form-control" id="newtag" placeholder="Add new tags here"
+                                            pattern="^[A-Za-z0-9-_]+$" minLength=4 title="[A-Za-z0-9-_], at least 4 characters">
                                 </div>
                                 <div class="col-sm-2">
                                     <button type="button" class="btn btn-secondary form-control" id="tag_add_button" disabled>Add</button>


### PR DESCRIPTION
Currently, it is possible to add a tag with spaces or other arbitrary
characters. Spaces are only inconvenient, as they are only visible when
inspecting the generated JSON, other characters may have worse effects.

Use the HTML5 "pattern" attribute to check the value, and reflect the
state in the form field background (light red) and submit button.