### PR TITLE
Fix rendering of the openqa.cmd

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller.pm
@@ -51,7 +51,7 @@ sub folder {
         read_files_sh   => $files->grep(qr/read_files\.sh/)->join(),
         rsync_commands  => $files->grep(qr/rsync_.*\.cmd/)->to_array,
         rsync_sh        => $files->grep(qr/print_rsync.*\.sh/)->to_array,
-        openqa_commands => $files->grep(qr/openqa\.cmd/)->join(),
+        openqa_commands => $files->grep(qr/openqa\.cmd/)->to_array,
         openqa_sh       => $files->grep(qr/print_openqa\.sh/)->join());
 }
 


### PR DESCRIPTION
Fixes url to openqa.cmd used to trigger build and logs of the command execution.