### PR TITLE
job cancel: Explicitly return a number to avoid warning

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -463,7 +463,7 @@ sub _cancel_or_deprioritize {
             return 0;
         }
     }
-    return $job->cancel($newbuild);
+    return $job->cancel($newbuild) // 0;
 }
 
 sub next_previous_jobs_query {


### PR DESCRIPTION
See issue https://progress.opensuse.org/issues/55631

    Use of uninitialized value in addition (+) at
    .../lib/OpenQA/Schema/ResultSet/Jobs.pm line 451