### PR TITLE
Make asset and log file uploads non-blocking

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -401,64 +401,76 @@ sub _stop_step_5_upload {
 
     # upload logs and assets
     if ($reason ne 'quit' && $reason ne 'abort' && $reason ne 'api-failure') {
-        # upload ulogs
-        my @uploaded_logfiles = glob "$pooldir/ulogs/*";
-        for my $file (@uploaded_logfiles) {
-            next unless -f $file;
 
-            my %upload_parameter = (
-                file => {file => $file, filename => basename($file)},
-                ulog => 1,
-            );
-            if (!$self->_upload_log_file_or_asset(\%upload_parameter)) {
-                $reason = 'api-failure';
-                last;
-            }
-        }
-
-        # upload assets created by successfull jobs
-        if ($reason eq 'done' || $reason eq 'cancel') {
-            for my $dir (qw(private public)) {
-                my @assets        = glob "$pooldir/assets_$dir/*";
-                my $upload_result = 1;
-
-                for my $file (@assets) {
+        Mojo::IOLoop->subprocess(
+            sub {
+                # upload ulogs
+                my @uploaded_logfiles = glob "$pooldir/ulogs/*";
+                for my $file (@uploaded_logfiles) {
                     next unless -f $file;
 
                     my %upload_parameter = (
-                        file  => {file => $file, filename => basename($file)},
-                        asset => $dir,
+                        file => {file => $file, filename => basename($file)},
+                        ulog => 1,
                     );
-                    last unless ($upload_result = $self->_upload_log_file_or_asset(\%upload_parameter));
+                    if (!$self->_upload_log_file_or_asset(\%upload_parameter)) {
+                        $reason = 'api-failure';
+                        last;
+                    }
                 }
-                if (!$upload_result) {
-                    $reason = 'api-failure';
-                    last;
+
+                # upload assets created by successfull jobs
+                if ($reason eq 'done' || $reason eq 'cancel') {
+                    for my $dir (qw(private public)) {
+                        my @assets        = glob "$pooldir/assets_$dir/*";
+                        my $upload_result = 1;
+
+                        for my $file (@assets) {
+                            next unless -f $file;
+
+                            my %upload_parameter = (
+                                file  => {file => $file, filename => basename($file)},
+                                asset => $dir,
+                            );
+                            last unless ($upload_result = $self->_upload_log_file_or_asset(\%upload_parameter));
+                        }
+                        if (!$upload_result) {
+                            $reason = 'api-failure';
+                            last;
+                        }
+                    }
                 }
-            }
-        }
 
-        # upload other logs and files
-        for my $file (
-            qw(video.ogv video_time.vtt vars.json serial0 autoinst-log.txt serial_terminal.txt virtio_console.log worker-log.txt)
-          )
-        {
-            next unless -e $file;
+                # upload other logs and files
+                for my $file (
+                    qw(video.ogv video_time.vtt vars.json serial0 autoinst-log.txt serial_terminal.txt virtio_console.log worker-log.txt)
+                  )
+                {
+                    next unless -e $file;
 
-            # replace some file names
-            my $ofile = $file;
-            $ofile =~ s/serial0/serial0.txt/;
-            $ofile =~ s/virtio_console.log/serial_terminal.txt/;
+                    # replace some file names
+                    my $ofile = $file;
+                    $ofile =~ s/serial0/serial0.txt/;
+                    $ofile =~ s/virtio_console.log/serial_terminal.txt/;
 
-            my %upload_parameter = (file => {file => "$pooldir/$file", filename => $ofile},);
-            if (!$self->_upload_log_file_or_asset(\%upload_parameter)) {
-                $reason = 'api-failure';
-                last;
-            }
-        }
+                    my %upload_parameter = (file => {file => "$pooldir/$file", filename => $ofile},);
+                    if (!$self->_upload_log_file_or_asset(\%upload_parameter)) {
+                        $reason = 'api-failure';
+                        last;
+                    }
+                }
+                return $reason;
+            },
+            sub {
+                my ($subprocess, $err, $reason) = @_;
+                log_error("Upload subprocess error: $err") if $err;
+                $self->_stop_step_5_1_upload($reason, $callback);
+            });
     }
 
-    Mojo::IOLoop->next_tick(sub { $self->_stop_step_5_1_upload($reason, $callback) });
+    else {
+        Mojo::IOLoop->next_tick(sub { $self->_stop_step_5_1_upload($reason, $callback) });
+    }
 }
 
 sub _stop_step_5_1_upload {

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -56,7 +56,7 @@ my $client = OpenQA::Worker::WebUIConnection->new(
         apisecret => 'bar'
     });
 
-my @happended_events;
+my @happened_events;
 $client->on(
     status_changed => sub {
         my ($event_client, $event_data) = @_;
@@ -64,7 +64,7 @@ $client->on(
         is($event_client,   $client, 'client passed correctly');
         is(ref $event_data, 'HASH',  'event data is a HASH');
         push(
-            @happended_events,
+            @happened_events,
             {
                 status        => $event_data->{status},
                 error_message => $event_data->{error_message},
@@ -198,7 +198,7 @@ subtest 'attempt to register and send a command' => sub {
         'api-failure', 'attempted to stop current job with reason "api-failure"');
 
     is_deeply(
-        \@happended_events,
+        \@happened_events,
         [
             {
                 status        => 'registering',
@@ -210,7 +210,7 @@ subtest 'attempt to register and send a command' => sub {
             }
         ],
         'events emitted'
-    ) or diag explain \@happended_events;
+    ) or diag explain \@happened_events;
 };
 
 

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -896,7 +896,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
         $t_livehandler->finished_ok(1011);
         is($fake_cmd_srv_tx->finish_called, 1, 'connection to os-autoinst closed');
 
-        # check whether usual cleanup happended here, too
+        # check whether usual cleanup happened here, too
         wait_for_finished_handled();
         is($developer_sessions->find(99961)->ws_connection_count, 0, 'ws connection finished');
         is(scalar @{$t_livehandler->app->devel_java_script_transactions_by_job->{99961} // []},


### PR DESCRIPTION
Over the past few days i've been looking into making all the uploader parts of `OpenQA::Worker::Job` non-blocking. While a rewrite of the entire uploader will probably be necessary in the future for performance improvements, it is also possible to perform uploads in a subprocess for now. That has the advantage that uploads no longer block the worker event loop, allowing it to keep sending status updates to the webui.

I also tried to make image uploads non-blocking in the same way, but unfortunately the test `24-worker-job.t` depends very heavily on timing bugs that make it impossible to change without removing the whole test (i've attempted to fix it, but there are just too many bugs).

This can also be seen as a proof of concept for moving asset/log file uploading into a Minion job, since the subprocess already behaves very similarly.