### PR TITLE
Always include the group property editor

### DIFF
--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -581,6 +581,14 @@ subtest 'edit the yaml' => sub() {
     $driver->find_element_by_id('preview-template')->click();
     wait_for_ajax;
     ok($result->get_text() =~ m/There was a problem applying the changes/, 'error shown');
+
+    # Group properties remain accessible
+    $driver->find_element_by_id('toggle-group-properties')->click();
+    ok($driver->find_element_by_id('editor-name')->is_displayed(), 'Group name can be edited');
+    $driver->refresh();
+    wait_for_ajax;
+    $driver->find_element_by_id('toggle-group-properties')->click();
+    ok($driver->find_element_by_id('editor-name')->is_displayed(), 'Group name can still be edited after refresh');
 };
 
 sub get_cell_contents {

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -69,8 +69,8 @@
             <span id="job-group-name"><%= $group->name %></span>
         </h2>
         %= include 'layouts/info'
+        %= include 'admin/group/group_property_editor', group => $group, is_parent => 0
         % if (!$group->template) {
-            %= include 'admin/group/group_property_editor', group => $group, is_parent => 0
             <div id="media">
                 <p id="loading"><i class="fa fa-spinner fa-spin"></i> Loading…</p>
 


### PR DESCRIPTION
The include ended up inside the if block by mistake, which results in a
silent failure when trying to toggle it later. Only the media
selection should be hidden if the group is configured in YAML.

Fixes: [poo#55646](https://progress.opensuse.org/issues/55646)