### PR TITLE
Handle newline characters in form parameters correctly with openqa-client

### DIFF
--- a/script/client
+++ b/script/client
@@ -229,7 +229,7 @@ for my $arg (@ARGV) {
     if ($arg =~ /^(?:get|post|delete|put)$/i) {
         $method = lc $arg;
     }
-    elsif ($arg =~ /^([[:alnum:]_\[\]\.]+)=(.+)/) {
+    elsif ($arg =~ /^([[:alnum:]_\[\]\.]+)=(.+)$/s) {
         $params{$1} = $2;
     }
 }


### PR DESCRIPTION
This makes `openqa-client ... jobs/1/comment post $'text=test\n\n123'` work. This is now required because proper Markdown requires newlines where previously raw HTML tags like `<br>` could be used in comments.

Progress: https://progress.opensuse.org/issues/55751