### PR TITLE
Distinguish scheduled and blocked jobs on test result overview & Use purple for blocked jobs 

### DIFF
--- a/assets/stylesheets/openqa_theme.scss
+++ b/assets/stylesheets/openqa_theme.scss
@@ -53,7 +53,7 @@ $color-labels:                gray;
 $color-bolt:                  #f2b500;
 $color-bug-closed:            $color-failed;
 $color-state-scheduled:       #67A2B7;
-$color-state-blocked:         #FF7417;
+$color-state-blocked:         #9167b7;
 $color-state-cancelled:       $color-module-none;
 $color-state-running:         #8BDFFF;
 $color-step-actions:          #666666;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -538,6 +538,7 @@ sub prepare_job_results {
             };
             if ($job->state eq OpenQA::Jobs::Constants::SCHEDULED) {
                 $aggregated->{scheduled}++;
+                $result->{blocked} = 1 if defined $job->blocked_by_id;
             }
             else {
                 $aggregated->{none}++;

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2016 SUSE LLC
+# Copyright (C) 2014-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -36,6 +36,7 @@ sub get_summary {
 #
 # Overview of build 0091
 #
+$schema->resultset('Jobs')->find(99928)->update({blocked_by_id => 99927});
 $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', build => '0091'})->status_is(200);
 
 my $summary = get_summary;
@@ -52,8 +53,15 @@ $t->element_exists_not('#flavor_DVD_arch_i686');
 # Check some results (and it's overview_xxx classes)
 $t->element_exists('#res_DVD_i586_kde .result_passed');
 $t->element_exists('#res_GNOME-Live_i686_RAID0 i.state_cancelled');
-$t->element_exists('#res_DVD_i586_RAID1 i.state_scheduled');
+$t->element_exists('#res_DVD_i586_RAID1 i.state_blocked');
 $t->element_exists_not('#res_DVD_x86_64_doc');
+
+# Check distinction between scheduled and blocked
+my $dom = $t->tx->res->dom;
+is_deeply($dom->find('.status.state_scheduled')->map('parent')->map(attr => 'href')->to_array,
+    ['/tests/99927'], '99927 is scheduled');
+is_deeply($dom->find('.status.state_blocked')->map('parent')->map(attr => 'href')->to_array,
+    ['/tests/99928'], '99928 is blocked');
 
 my $form = {distri => 'opensuse', version => '13.1', build => '0091', group => 'opensuse 13.1'};
 $t->get_ok('/tests/overview' => form => $form)->status_is(200);

--- a/templates/test/tr_job_result.html.ep
+++ b/templates/test/tr_job_result.html.ep
@@ -5,8 +5,8 @@
                  %= link_post url_for('apiv1_restart', jobid => $jobid) => ('data-remote' => 'true', class => 'restart', 'data-jobid' => $jobid) => begin
                  <i class="action fa fa-redo" title="Restart the job"></i>
                  % end
-             % } elsif ($state eq "running" || $state eq "scheduled")
-             % {
+             % }
+             % elsif ($state eq "running" || $state eq "scheduled") {
                  %= link_post url_for('apiv1_cancel', jobid => $jobid) => ('data-remote' => 'true', class => 'cancel', 'data-jobid' => $jobid) => begin
                      <i class="action far fa-times-circle" title="Cancel the job"></i>
                  % end
@@ -21,13 +21,14 @@
                      <i class="status fa fa-circle<%=  $css %>" title="Done: <%= $res->{overall} %>"></i>
                  </a>
              </span>
-         % } elsif ($state eq "scheduled")
-         % {
+         % }
+         % elsif ($state eq "scheduled") {
+             % my $substate = $res->{blocked} ? 'blocked' : 'scheduled';
              <a href="<%= url_for('test', 'testid' => $jobid) %>">
-                 <i class="status state_scheduled fa fa-circle" title="scheduled@<%= $res->{priority} %>"></i>
+                 <i class="status state_<%= $substate %> fa fa-circle" title="<%= $substate %>@<%= $res->{priority} %>"></i>
              </a>
-         % } else
-         % {
+         % }
+         % else {
              <a href="<%= url_for('test', 'testid' => $jobid) %>">
                  <i class="status state_<%= $state %> fa fa-circle" title="<%= $state %>"></i>
              </a>


### PR DESCRIPTION
See https://progress.opensuse.org/issues/43112