### PR TITLE
Increase lock timeouts a bit

### DIFF
--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -35,7 +35,7 @@ sub _download {
     # prevent multiple asset download tasks for the same asset to run
     # in parallel
     return $job->retry({delay => 30})
-      unless my $guard = $app->minion->guard("limit_asset_download_${assetpath}_task", 3600);
+      unless my $guard = $app->minion->guard("limit_asset_download_${assetpath}_task", 7200);
 
     # Bail if the dest file exists (in case multiple downloads of same ISO
     # are scheduled)

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -44,11 +44,11 @@ sub _limit {
 
     # prevent multiple limit_assets tasks to run in parallel
     return $job->finish('Previous limit_assets job is still active')
-      unless my $guard = $app->minion->guard('limit_assets_task', 3600);
+      unless my $guard = $app->minion->guard('limit_assets_task', 86400);
 
     # prevent multiple limit_* tasks to run in parallel
     return $job->retry({delay => 60})
-      unless my $limit_guard = $app->minion->guard('limit_tasks', 7200);
+      unless my $limit_guard = $app->minion->guard('limit_tasks', 86400);
 
     # scan for untracked assets, refresh the size of all assets
     my $schema = $app->schema;

--- a/lib/OpenQA/Task/AuditEvents/Limit.pm
+++ b/lib/OpenQA/Task/AuditEvents/Limit.pm
@@ -26,11 +26,11 @@ sub _limit {
 
     # prevent multiple limit_audit_events tasks to run in parallel
     return $job->finish('Previous limit_audit_events job is still active')
-      unless my $guard = $app->minion->guard('limit_audit_events_task', 3600);
+      unless my $guard = $app->minion->guard('limit_audit_events_task', 86400);
 
     # prevent multiple limit_* tasks to run in parallel
     return $job->retry({delay => 60})
-      unless my $limit_guard = $app->minion->guard('limit_tasks', 7200);
+      unless my $limit_guard = $app->minion->guard('limit_tasks', 86400);
 
     $app->schema->resultset('AuditEvents')->delete_entries_exceeding_storage_duration;
 }

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -29,11 +29,11 @@ sub _limit {
 
     # prevent multiple limit_results_and_logs tasks to run in parallel
     return $job->finish('Previous limit_results_and_logs job is still active')
-      unless my $guard = $app->minion->guard('limit_results_and_logs_task', 7200);
+      unless my $guard = $app->minion->guard('limit_results_and_logs_task', 86400);
 
     # prevent multiple limit_* tasks to run in parallel
     return $job->retry({delay => 60})
-      unless my $limit_guard = $app->minion->guard('limit_tasks', 7200);
+      unless my $limit_guard = $app->minion->guard('limit_tasks', 86400);
 
     # create temporary job group outside of DB to collect
     # jobs without job_group_id

--- a/lib/OpenQA/Task/Needle/Delete.pm
+++ b/lib/OpenQA/Task/Needle/Delete.pm
@@ -29,7 +29,7 @@ sub _delete_needles {
 
     # prevent multiple save_needle and delete_needles tasks to run in parallel
     return $minion_job->finish({error => 'Another save or delete needle job is ongoing. Try again later.'})
-      unless my $guard = $app->minion->guard('limit_needle_task', 300);
+      unless my $guard = $app->minion->guard('limit_needle_task', 7200);
 
     my $schema     = $app->schema;
     my $needles    = $schema->resultset('Needles');

--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -65,7 +65,7 @@ sub _save_needle {
 
     # prevent multiple save_needle and delete_needles tasks to run in parallel
     return $minion_job->finish({error => 'Another save or delete needle job is ongoing. Try again later.'})
-      unless my $guard = $app->minion->guard('limit_needle_task', 300);
+      unless my $guard = $app->minion->guard('limit_needle_task', 7200);
 
     my $schema       = $app->schema;
     my $openqa_job   = $schema->resultset('Jobs')->find($args->{job_id});

--- a/lib/OpenQA/Task/Screenshot/Scan.pm
+++ b/lib/OpenQA/Task/Screenshot/Scan.pm
@@ -55,7 +55,7 @@ sub _scan_images {
 
     # prevent multiple scan_images* tasks to run in parallel
     return $job->retry({delay => 30})
-      unless my $guard = $app->minion->guard('limit_scan_images_task', 3600);
+      unless my $guard = $app->minion->guard('limit_scan_images_task', 7200);
 
     return unless $args->{prefix};
     my $dh;
@@ -102,7 +102,7 @@ sub _scan_images_links {
 
     # prevent multiple scan_images* tasks to run in parallel
     return $job->retry({delay => 30})
-      unless my $guard = $app->minion->guard('limit_scan_images_task', 3600);
+      unless my $guard = $app->minion->guard('limit_scan_images_task', 7200);
 
     my $schema = OpenQA::Schema->singleton;
     my $jobs   = $schema->resultset("Jobs")->search(


### PR DESCRIPTION
The short lock timeout just became a problem on OSD with a `limit_results_and_logs` job. There is actually very little reason to not be generous with timeouts, since the chance that one of them doesn't get cleared automatically at the end of a job is very small. So i've increased most of them to 1 day.