### PR TITLE
Support branch url on openqa-clone-custom-git-refspec

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -2,19 +2,34 @@
 
 # Usage:
 #  openqa-clone-custom-git-refspec GITHUB_PR_URL OPENQA_JOB_URL [CUSTOM_TEST_VAR_1=foo] [CUSTOM_TEST_VAR_2=bar]
+#  openqa-clone-custom-git-refspec GITHUB_BRANCH_URL OPENQA_JOB_URL [CUSTOM_TEST_VAR_1=foo] [CUSTOM_TEST_VAR_2=bar]
 #
 # Example:
 #  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6529 https://openqa.opensuse.org/tests/835060 DESKTOP=textmode
+#  openqa-clone-custom-git-refspec https://github.com/coolgw/os-autoinst-distri-opensuse/tree/nfs https://openqa.opensuse.org/tests/835060 DESKTOP=textmode
 #
 set -o pipefail
 if [[ -n "$GITHUB_TOKEN" ]]; then
     AUTHENTICATED_REQUEST=" -u $GITHUB_TOKEN:x-oauth-basic "
     echo "Github oauth token provided, peforming authenticated requests"
 fi
+
 if [[ -z "$repo_name" ]] || [[ -z "$pr" ]]; then
-    pr_url="${1:?"Need 'pr_url' as parameter pointing to a github pull request or 'repo_name' (sending repo) and 'pr' variables, e.g. either 'https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1234' 'me/os-autoinst-distri-opensuse' and '1234'"}"
-    target_repo_part=${pr_url%%/pull*}
-    pr="${pr_url##*/}"
+    first_arg="${1:?"Need 'pr_url' as parameter pointing to a github pull request or 'repo_name' (sending repo) and 'pr' variables, e.g. either 'https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1234' 'me/os-autoinst-distri-opensuse' and '1234' or 'branch'"}"
+    if [[ $first_arg == *"pull"* ]]; then
+        pr_url=$first_arg
+        target_repo_part=${pr_url%%/pull*}
+        pr="${pr_url##*/}"
+    elif [[ $first_arg  == *"tree"* ]]; then
+        #maybe a branch_url is given
+        branch_url=$first_arg
+        forked_repo_part=${branch_url%%/tree*}
+        branch=${branch_url##*/}
+        repo_name=${forked_repo_part##*github.com/}
+        casedir="${casedir:-"${forked_repo_part}.git#${branch}"}"
+        build="${build:-"$repo_name#$branch"}"
+    fi
+
 fi
 if [[ -z "$host" ]] || [[ -z "$job" ]]; then
     job_url="${2:?"Need 'job_url' as parameter pointing to the openQA job to clone or 'host' and 'job' variables, e.g. either 'https://openqa.opensuse.org/tests/123456' or 'https://openqa.opensuse.org' and '123456'"}"


### PR DESCRIPTION
This change can let script support first parameter like: https://github.com/coolgw/os-autoinst-distri-opensuse/tree/nfs , the reason why i add this is sometimes we need do some verification before create PR.

linux-4360:~/openqa/openQA/script # dry_run=echo sh  ./openqa-clone-custom-git-refspec https://github.com/coolgw/os-autoinst-distri-opensuse/tree/nfs  http://openqa.suse.de/tests/3235878
openqa-clone-job --skip-chained-deps --within-instance http://openqa.suse.de 3235878 _GROUP=0 TEST=offline_sles12sp2_ltss_pscc_sdk+we+lp+asmm+contm+lgm+pcm+tcm+wsm+ltss_all_full_x86_64@coolgw/os-autoinst-distri-opensuse#nfs BUILD=coolgw/os-autoinst-distri-opensuse# CASEDIR=https://github.com/coolgw/os-autoinst-distri-opensuse.git#nfs PRODUCTDIR=os-autoinst-distri-opensuse/products/sle NEEDLES_DIR=/var/lib/openqa/cache/openqa.suse.de/tests/sle/products/sle/needles

linux-4360:~/openqa/openQA/script # dry_run=echo sh ./openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8171  http://openqa.suse.de/tests/3235878
openqa-clone-job --skip-chained-deps --within-instance http://openqa.suse.de 3235878 _GROUP=0 TEST=offline_sles12sp2_ltss_pscc_sdk+we+lp+asmm+contm+lgm+pcm+tcm+wsm+ltss_all_full_x86_64@coolgw/os-autoinst-distri-opensuse#nfs BUILD=coolgw/os-autoinst-distri-opensuse#8171 CASEDIR=https://github.com/coolgw/os-autoinst-distri-opensuse.git#nfs PRODUCTDIR=os-autoinst-distri-opensuse/products/sle NEEDLES_DIR=/var/lib/openqa/cache/openqa.suse.de/tests/sle/products/sle/needles