### PR TITLE
Show needle tags for assert_screen/check_screen

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -949,7 +949,7 @@ var messageToStatusVariable = [
         action: function (value, data) {
             developerMode.currentApiFunctionArgs = '';
             if ((value === 'assert_screen' || value === 'check_screen') && data.check_screen) {
-                developerMode.currentApiFunctionArgs = data.check_screen['mustmatch'];
+                developerMode.currentApiFunctionArgs = data.check_screen.mustmatch;
             }
         }
     },

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -366,6 +366,7 @@ var developerMode = {
     pauseOnNextCommand: undefined,          // whether to pause on the next command (current command *not* affected, eg. *no* timeouts skipped or failures suppressed)
     isPaused: undefined,                    // if paused the reason why as a string; otherwise something which evaluates to false
     currentApiFunction: undefined,          // the currently executed API function (eg. assert_screen)
+    currentApiFunctionArgs: '',             // arguments of the currently executed API function (eg. assert_screen)
     outstandingImagesToUpload: undefined,   // number of images which still need to be uploaded by the worker
     outstandingFilesToUpload: undefined,    // number of other files which still need to be uploaded by the worker
     uploadingUpToCurrentModule: undefined,  // whether the worker will upload up to the current module (happens when paused in the middle of a module)
@@ -574,12 +575,18 @@ function updateDeveloperPanel() {
             statusAppendix = 'currently at: ' + developerMode.currentModule;
             if (developerMode.currentApiFunction) {
                 statusAppendix += ', ' + developerMode.currentApiFunction;
+                if (developerMode.currentApiFunctionArgs) {
+                    statusAppendix += ' ' + developerMode.currentApiFunctionArgs;
+                }
             }
         }
     } else if (developerMode.currentModule) {
         statusInfo = 'current module: ' + developerMode.currentModule;
         if (developerMode.currentApiFunction) {
             statusAppendix += 'at ' + developerMode.currentApiFunction;
+            if (developerMode.currentApiFunctionArgs) {
+                statusAppendix += ' ' + developerMode.currentApiFunctionArgs;
+            }
         }
     }
     if (!developerMode.badConfiguration && developerMode.currentApiFunction) {
@@ -939,6 +946,12 @@ var messageToStatusVariable = [
     {
         msg: 'current_api_function',
         statusVar: 'currentApiFunction',
+        action: function (value, data) {
+            developerMode.currentApiFunctionArgs = '';
+            if ((value == 'assert_screen' || value == 'check_screen') && data['check_screen']) {
+                developerMode.currentApiFunctionArgs = data['check_screen']['mustmatch'];
+            }
+        }
     },
     {
         msg: 'stopping_test_execution',

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -948,8 +948,8 @@ var messageToStatusVariable = [
         statusVar: 'currentApiFunction',
         action: function (value, data) {
             developerMode.currentApiFunctionArgs = '';
-            if ((value == 'assert_screen' || value == 'check_screen') && data['check_screen']) {
-                developerMode.currentApiFunctionArgs = data['check_screen']['mustmatch'];
+            if ((value === 'assert_screen' || value === 'check_screen') && data.check_screen) {
+                developerMode.currentApiFunctionArgs = data.check_screen['mustmatch'];
             }
         }
     },

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -659,14 +659,14 @@ subtest 'process state changes from os-autoinst/worker' => sub {
         $driver->execute_script(
 'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_api_function\":\"assert_screen\",\"check_screen\":{\"check\":0,\"mustmatch\":\"generic-desktop\",\"timeout\":30}}}" });'
         );
-        is(js_variable('developerMode.currentApiFunction'), 'assert_screen', 'current API function set');
+        is(js_variable('developerMode.currentApiFunction'),     'assert_screen',   'current API function set');
         is(js_variable('developerMode.currentApiFunctionArgs'), 'generic-desktop', 'current API function set');
 
         $driver->execute_script(
 'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_api_function\":\"wait_serial\"}}" });'
         );
-        is(js_variable('developerMode.currentApiFunction'), 'wait_serial', 'current API function set');
-        is(js_variable('developerMode.currentApiFunctionArgs'), '', 'current API function set');
+        is(js_variable('developerMode.currentApiFunction'),     'wait_serial', 'current API function set');
+        is(js_variable('developerMode.currentApiFunctionArgs'), '',            'current API function set');
 
         $driver->execute_script(
 'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_api_function\":\"assert_screen\",\"check_screen\":{\"check\":0,\"mustmatch\":[\"foo\",\"bar\"],\"timeout\":30}}}" });'

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -654,6 +654,19 @@ subtest 'process state changes from os-autoinst/worker' => sub {
 'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_api_function\":\"assert_screen\"}}" });'
         );
         is(js_variable('developerMode.currentApiFunction'), 'assert_screen', 'current API function set');
+        is(js_variable('developerMode.currentApiFunctionArgs'), '', 'current API function set');
+
+        $driver->execute_script(
+'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_api_function\":\"assert_screen\",\"check_screen\":{\"check\":0,\"mustmatch\":\"generic-desktop\",\"timeout\":30}}}" });'
+        );
+        is(js_variable('developerMode.currentApiFunction'), 'assert_screen', 'current API function set');
+        is(js_variable('developerMode.currentApiFunctionArgs'), 'generic-desktop', 'current API function set');
+
+        $driver->execute_script(
+'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_api_function\":\"wait_serial\"}}" });'
+        );
+        is(js_variable('developerMode.currentApiFunction'), 'wait_serial', 'current API function set');
+        is(js_variable('developerMode.currentApiFunctionArgs'), '', 'current API function set');
     };
 
     subtest 'error handling, flash messages' => sub {

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -667,6 +667,12 @@ subtest 'process state changes from os-autoinst/worker' => sub {
         );
         is(js_variable('developerMode.currentApiFunction'), 'wait_serial', 'current API function set');
         is(js_variable('developerMode.currentApiFunctionArgs'), '', 'current API function set');
+
+        $driver->execute_script(
+'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_api_function\":\"assert_screen\",\"check_screen\":{\"check\":0,\"mustmatch\":[\"foo\",\"bar\"],\"timeout\":30}}}" });'
+        );
+        is(js_variable('developerMode.currentApiFunction'), 'assert_screen', 'current API function set');
+        is_deeply(js_variable('developerMode.currentApiFunctionArgs'), ['foo', 'bar'], 'current API function set');
     };
 
     subtest 'error handling, flash messages' => sub {


### PR DESCRIPTION
Hello, it'd be nice if the developer panel showed expected needle tags when openQA worker is waiting for check_screen/assert_screen.

Here's a patch.