### PR TITLE
Add link to test distribution docs

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -50,6 +50,13 @@ layout: default
 
     {% include api.html %}
 
+    <dl>
+      <dt>
+        <a href="https://os-autoinst.github.io/os-autoinst-distri-opensuse/">Library documentation of os-autoinst-distri-opensuse test distribution</a>
+      </dt>
+      <dd>Documentation of libraries used by the openSUSE and SLE tests.</dd>
+    </dl>
+
   </div>
 </div>
 

--- a/documentation.html
+++ b/documentation.html
@@ -52,7 +52,7 @@ layout: default
 
     <dl>
       <dt>
-        <a href="https://os-autoinst.github.io/os-autoinst-distri-opensuse/">Library documentation of os-autoinst-distri-opensuse test distribution</a>
+        <a href="https://os-autoinst.github.io/os-autoinst-distri-opensuse/">Main test library documentation (os-autoinst-distri-opensuse)</a>
       </dt>
       <dd>Documentation of libraries used by the openSUSE and SLE tests.</dd>
     </dl>


### PR DESCRIPTION
Add link to [os-autoinst-distri-opensuse docs](https://os-autoinst.github.io/os-autoinst-distri-opensuse/)