### PR TITLE
Fix accidentally removed dependency

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -80,6 +80,7 @@ RUN zypper in -y -C \
        'perl(IO::Scalar)' \
        'perl(IO::Socket::SSL)' \
        'perl(IPC::Run)' \
+       'perl(IPC::System::Simple)' \
        'perl(JSON::XS)' \
        'perl(JavaScript::Minifier::XS)' \
        'perl(LWP::Protocol::https)' \


### PR DESCRIPTION
All Travis tests currently fail because #2225 accidentally removed a dependency required by os-autoinst. This PR is required to fix the container again, tests are expected to fail until it has been merged.