### PR TITLE
Fix 'devel' package

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -143,7 +143,7 @@ operating system.
 %package devel
 Summary:        Development package pulling in all build+test dependencies
 Group:          Development/Tools/Other
-Requires:       %devel_requires
+Requires:       %devel_requires %test_requires
 
 %description devel
 Development package pulling in all build+test dependencies.


### PR DESCRIPTION
This is a quick fix to prevent the package build being blocked however
there are actually more packages required for a complete development
environment. This will be covered in another change.