### PR TITLE
Move codemirror javascript file to javescript label

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -109,13 +109,13 @@
 
 ! codemirror.css
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/lib/codemirror.css
-< https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/diff/diff.js
 < stylesheets/codemirror_customization.css
 
 ! codemirror.js
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/lib/codemirror.js
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/perl/perl.js
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/yaml/yaml.js
+< https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/diff/diff.js
 
 ! step_edit.js
 < javascripts/needleeditor.js


### PR DESCRIPTION
After adding codemirro diff.js in css label, the code container in
the webpage is short. Try to fix this issue by moving it.