### PR TITLE
Fix vertical scroll area in source code view

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -109,13 +109,13 @@
 
 ! codemirror.css
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/lib/codemirror.css
-< https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/diff/diff.js
 < stylesheets/codemirror_customization.css
 
 ! codemirror.js
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/lib/codemirror.js
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/perl/perl.js
 < https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/yaml/yaml.js
+< https://raw.githubusercontent.com/codemirror/CodeMirror/8097c7e75ce7ef0512debe9967d7568626106e53/mode/diff/diff.js
 
 ! step_edit.js
 < javascripts/needleeditor.js


### PR DESCRIPTION
This fixes a regression introduced in 5c0b45fc0 by moving the .js file
inclusion into the corresponding section for javascript files to not
include it into css code.