### PR TITLE
Fix artefact upload errors to show the message

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -424,7 +424,7 @@ sub send_artefact {
     $url->path("jobs/$job_id/artefact");
 
     my $tx = $ua->post($url => form => $form);
-    if (my $err = $tx->error) { log_error("Artefact upload failed: $err") }
+    if (my $err = $tx->error) { log_error("Artefact upload failed: $err->{message}") }
 }
 
 sub _calculate_status_update_interval {


### PR DESCRIPTION
Small followup to #2270, there was a typo in the error message so it showed the hash address in the logs instead of the error message.