### PR TITLE
Allow scheduling additional test modules at job runtime

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -691,11 +691,16 @@ sub _upload_results_step_0_prepare {
     if ($is_final_upload || $status_from_os_autoinst->{running}) {
         my @file_info = stat $self->_result_file_path('test_order.json');
         my $test_order;
-        if (!$current_test_module or $file_info[9] != $self->{_test_order_mtime}) {
+        if (  !$current_test_module
+            or $file_info[9] != $self->{_test_order_mtime}
+            or $file_info[7] != $self->{_test_order_fsize})
+        {
+            log_info('Test schedule has changed, reloading test_order.json');
             $test_order                = $self->_read_json_file('test_order.json');
             $status{test_order}        = $test_order;
             $self->{_test_order}       = $test_order;
             $self->{_test_order_mtime} = $file_info[9];
+            $self->{_test_order_fsize} = $file_info[7];
         }
         if (!$current_test_module) {    # first test
             if (!$test_order) {


### PR DESCRIPTION
Test schedules are sometimes generated from configuration files installed by a testcase (e.g. `install_ltp`). Running both installation and the tests themselves in a single job would solve some outstanding issues with baremetal kernel testing. While it's possible to call `autotest::loadtest()` at the end of installation task to append additional modules to test schedule of the current job, the test results will be ignored by OpenQA.

This pull request simply checks whether `test_order.json` has changed on every test result upload and updates the test schedule in OpenQA if it did. The ony minor outstanding issue is that the user will need to refresh the job webpage manually to see the updated schedule before the job finishes. The testcase that schedules additional modules is responsible for calling `autotest::write_test_order()` to notify OpenQA that the test schedule has changed.

os-autoinst/os-autoinst-distri-opensuse#8329 depends on this PR.
