### PR TITLE
Allow CodeMirror to render off screen

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -379,6 +379,7 @@ function toggleTemplateEditor() {
             lineNumbers: true,
             lineWrapping: true,
             readOnly: 'nocursor',
+            viewportMargin: Infinity,
         });
         editor.setOption('extraKeys', {
             Tab: function(editor) {


### PR DESCRIPTION
Normally only the visible lines are rendered (and a little more). We can just override that, though, to work around issues with searching the text.

Fixes: [poo#56480](https://progress.opensuse.org/issues/56480)