### PR TITLE
Cut the test result directory shorter when its length is more than 255

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1122,6 +1122,7 @@ sub create_result_dir {
 
     if (!$dir) {
         $dir = sprintf "%08d-%s", $self->id, $self->name;
+        $dir = substr($dir, 0, 255);
         $self->update({result_dir => $dir});
         $dir = $self->result_dir();
     }


### PR DESCRIPTION
The job will fail when the length of the test result directory is more than 255. Because there is a limit in creating directory that the directory name length cannot exceed 255. 

See: https://progress.opensuse.org/issues/56405