### PR TITLE
Implement optional defaults.settings key in YAML

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -311,7 +311,7 @@ sub update {
                             my $testsuite_name;
                             my $prio;
                             my $machine_name;
-                            my $settings;
+                            my $settings = $yaml_defaults_for_arch->{settings};
                             if (ref $spec eq 'HASH') {
                                 foreach my $name (keys %$spec) {
                                     my $attr = $spec->{$name};
@@ -323,7 +323,7 @@ sub update {
                                         $machine_name = $attr->{machine};
                                     }
                                     if ($attr->{settings}) {
-                                        $settings = $attr->{settings};
+                                        %$settings = (%{$settings // {}}, %{$attr->{settings}});
                                     }
                                 }
                             }

--- a/public/schema/JobTemplate.yaml
+++ b/public/schema/JobTemplate.yaml
@@ -59,6 +59,13 @@ properties:
             type: string
           priority:
             type: number
+          settings:
+            type: object
+            description: Additional test variables to be set
+            additionalProperties: false
+            patternProperties:
+              "^[A-Z_]+[A-Z0-9_]*$":
+                type: string
   products:
     type: object
     additionalProperties: false


### PR DESCRIPTION
Settings defined as defaults are merged into scenarios along with
machine and priority values, and will be overridden by explicitly
defined settings.

Fixes: [poo#55829](https://progress.opensuse.org/issues/55829)