### PR TITLE
Non-experimental YAML routes with explicit schema

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -414,6 +414,7 @@ function submitTemplateEditor(preview) {
         type: 'POST',
         dataType: 'json',
         data: {
+            schema: 'JobTemplates-01.yaml',
             preview: preview,
             template: editor.doc.getValue(),
             reference: form.data('reference'),

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -403,6 +403,11 @@ sub startup {
     $api_ra->delete('job_templates/:job_template_id')->to('job_template#destroy');
 
     # api/v1/job_templates_scheduling
+    $api_public_r->get('job_templates_scheduling/<id:num>')->name('apiv1_job_templates_schedules')
+      ->to('job_template#schedules', id => undef);
+    $api_public_r->get('job_templates_scheduling/<name:str>')->to('job_template#schedules', name => undef);
+    $api_ra->post('job_templates_scheduling/<id:num>')->to('job_template#update', id => undef);
+    # Deprecated experimental aliases for the above routes
     $api_public_r->get('experimental/job_templates_scheduling/<id:num>')->name('apiv1_job_templates_schedules')
       ->to('job_template#schedules', id => undef);
     $api_public_r->get('experimental/job_templates_scheduling/<name:str>')->to('job_template#schedules', name => undef);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -240,6 +240,12 @@ If specified, this must be a YAML document matching the last known state. If the
 database changes before the update transaction it's considered an error.
 A client can use this to handle editing conflicts between multiple users.
 
+=item schema
+
+  schema => JobTemplates-01.yaml
+
+The schema must be specified to indicate the format of the posted document.
+
 =back
 
 Returns a 400 code on error, or a 303 code and the job template id within a JSON block on success.
@@ -257,7 +263,7 @@ sub update {
         # No objects (aka SafeYAML)
         $YAML::XS::LoadBlessed = 0;
         $yaml                  = YAML::XS::Load($self->param('template'));
-        $errors                = $self->app->validate_yaml($yaml, $self->app->log->level eq 'debug');
+        $errors = $self->app->validate_yaml($yaml, $self->param('schema'), $self->app->log->level eq 'debug');
     }
     catch {
         # Push the exception to the list of errors without the trailing new line

--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -1,4 +1,4 @@
-$id: http://open.qa/api/jobs/schema
+$id: http://open.qa/api/schema/JobTemplates-01.yaml
 $schema: http://json-schema.org/draft-04/schema#
 description: openQA job template
 type: object

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -192,7 +192,7 @@ my %result;
 
 if ($tables{'JobGroups'}) {
     my $group = (keys %{$options{'group'}})[0];
-    $url->path($options{'apibase'} . '/experimental/job_templates_scheduling/' . ($group // ''));
+    $url->path($options{'apibase'} . '/job_templates_scheduling/' . ($group // ''));
     my $res = $client->get($url)->res;
     if ($res->code && $res->code == 200) {
         if ($group) {

--- a/script/load_templates
+++ b/script/load_templates
@@ -143,8 +143,8 @@ sub post_entry {
     my %param;
 
     if ($table eq 'JobGroups') {
-        $url->path($options{'apibase'} . '/experimental/job_templates_scheduling');
-        $url->query({name => $entry->{group_name}, template => $entry->{template}});
+        $url->path($options{'apibase'} . '/job_templates_scheduling');
+        $url->query({name => $entry->{group_name}, template => $entry->{template}, schema => 'JobTemplates-01.yaml'});
         my $res = $client->post($url)->res;
         if (!($res->code && $res->code == 200)) {
             print_error($res);


### PR DESCRIPTION
- [x] Use a schema filename `JobTemplates-01.yaml` which also includes format and version
- [x] Move `job_templates_scheduling` routes out of `experimental` prefix
- [x] The `schema` needs to be specified when posting YAML
- [x] Unit tests to handle errors on missing or invalid schemas
- [ ] Publish schema under http://open.qa/api/schema/JobTemplates-01.yaml

Fixes: [poo#56426](https://progress.opensuse.org/issues/56426)