### PR TITLE
Fix warning caused by filename getting removed from form hashref

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -796,36 +796,43 @@ sub _upload_results_step_2_upload_images {
                 my $file = $images_to_send->{$md5};
                 $self->_optimize_image("$fileprefix/$file");
 
-                my $form = {
-                    file => {
-                        file     => "$fileprefix/$file",
-                        filename => $file
-                    },
-                    image => 1,
-                    thumb => 0,
-                    md5   => $md5
-                };
-                $client->send_artefact($job_id, $form);
+                $client->send_artefact(
+                    $job_id => {
+                        file => {
+                            file     => "$fileprefix/$file",
+                            filename => $file
+                        },
+                        image => 1,
+                        thumb => 0,
+                        md5   => $md5
+                    });
 
-                $file = "$fileprefix/.thumbs/$file";
-                if (-f $file) {
-                    $self->_optimize_image($file);
-                    $form->{file}{file} = $file;
-                    $form->{thumb} = 1;
-                    $client->send_artefact($job_id, $form);
+                my $thumb = "$fileprefix/.thumbs/$file";
+                if (-f $thumb) {
+                    $self->_optimize_image($thumb);
+                    $client->send_artefact(
+                        $job_id => {
+                            file => {
+                                file     => $thumb,
+                                filename => $file
+                            },
+                            image => 1,
+                            thumb => 1,
+                            md5   => $md5
+                        });
                 }
             }
 
             for my $file (@{$self->files_to_send}) {
-                my $form = {
-                    file => {
-                        file     => "$pooldir/testresults/$file",
-                        filename => $file,
-                    },
-                    image => 0,
-                    thumb => 0,
-                };
-                $client->send_artefact($job_id, $form);
+                $client->send_artefact(
+                    $job_id => {
+                        file => {
+                            file     => "$pooldir/testresults/$file",
+                            filename => $file,
+                        },
+                        image => 0,
+                        thumb => 0,
+                    });
             }
         },
         sub {


### PR DESCRIPTION
This resolves #2321. The filename was getting removed in `Mojo::UserAgent` during HTTP message body generation, since form hashrefs are not actually meant to be reusable.
```
[debug] [pid:1382] Optimizing /home/sri/work/openQA/openqa/pool/1/testresults/boot5-2.png
[debug] [pid:1382] Uploading artefact boot5-2.png as 29e32850478011f9ddd98948593de9d7
[debug] [pid:1382] Optimizing /home/sri/work/openQA/openqa/pool/1/testresults/.thumbs/boot5-2.png
Use of uninitialized value $name in concatenation (.) or string at /home/sri/work/openQA/repos/openQA/script/../lib/OpenQA/Worker/WebUIConnection.pm line 421.
[debug] [pid:1382] Uploading artefact  as 29e32850478011f9ddd98948593de9d7
```