### PR TITLE
Fix duplicate path name in ObsRsync Plugin

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -49,7 +49,7 @@ sub register {
 
         $plugin_r->get('/obs_rsync/queue')->name('plugin_obs_rsync_queue')
           ->to('Plugin::ObsRsync::Controller::Gru#index');
-        $plugin_r->post('/obs_rsync/#folder/runs')->name('plugin_obs_rsync_run')
+        $plugin_r->post('/obs_rsync/#folder/runs')->name('plugin_obs_rsync_queue_run')
           ->to('Plugin::ObsRsync::Controller::Gru#run');
 
         $plugin_r->get('/obs_rsync/#folder/runs/#subfolder/download/#filename')->name('plugin_obs_rsync_download_file')

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_folder.html.ep
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_folder.html.ep
@@ -71,4 +71,4 @@
 <%= link_to "all logs" => url_for('plugin_obs_rsync_runs', folder => $obs_project) %>
 </div>
 <hr>
-<%= link_post 'Sync Now!' => url_for('plugin_obs_rsync_run', folder => $obs_project) %>
+<%= link_post 'Sync Now!' => url_for('plugin_obs_rsync_queue_run', folder => $obs_project) %>


### PR DESCRIPTION
While adding Gru Controller to the plugin duplicate path was introduced. So this PR fixes the problem.
No test case is provided, because automated check of every path name expansion or every link is costly and other tasks have higher priority. (E.g. it will be more beneficial to add link crawler which ensures that all links in forms are resolvable or duplicate path names finder).