### PR TITLE
Unit test posting an ISO with templates in YAML

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -543,7 +543,7 @@ sub _generate_jobs {
             $settings{TEST}              = $job_template->test_suite->name;
             $settings{MACHINE}           = $job_template->machine->name;
             $settings{BACKEND}           = $job_template->machine->backend;
-            $settings{JOB_TEMPLATE_NAME} = $job_template->name if $settings{JOB_TEMPLATE_NAME};
+            $settings{JOB_TEMPLATE_NAME} = $job_template->name if $job_template->name;
 
             # merge worker classes
             $settings{WORKER_CLASS} = @worker_classes ? join(',', sort(@worker_classes)) : "qemu_$args->{ARCH}";

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -332,8 +332,8 @@ sub update {
                                         $machine_name = $attr->{machine};
                                     }
                                     if ($attr->{testsuite}) {
-                                        $testsuite_name    = $attr->{testsuite};
                                         $job_template_name = $testsuite_name;
+                                        $testsuite_name    = $attr->{testsuite};
                                     }
                                     if ($attr->{settings}) {
                                         %$settings = (%{$settings // {}}, %{$attr->{settings}});


### PR DESCRIPTION
Investigating variable expension issues in the context of [poo#56540](https://progress.opensuse.org/issues/56540) motivated me to try and reproduce them in a unit test.

- [x] This adds a test posting an ISO after configuring  job templates in YAML
to exercise settings expansion.
- [x] This has uncovered a bug with not updating the job template name
correctly when 'testsuite' is being used.
- [ ] This doesn't seem to reproduce `%MACHINE%` being expanded wrongly so far