### PR TITLE
Ignore SQL deprecate warning when querying job modules that are running

### DIFF
--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -174,7 +174,7 @@ sub currentstep {
     my ($self) = @_;
 
     return unless ($self->job);
-    my $r = $self->job->modules->find({result => 'running'});
+    my $r = $self->job->modules->find({result => 'running'}, {order_by => {-desc => 't_updated'}, rows => 1});
     $r->name if $r;
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -61,7 +61,7 @@ sub status {
     my $job      = $self->stash('job');
     my $workerid = $job->worker_id;
     my $results  = {workerid => $workerid, state => $job->state};
-    my $r        = $job->modules->find({result => 'running'});
+    my $r        = $job->modules->find({result => 'running'}, {order_by => {-desc => 't_updated'}, rows => 1});
     $results->{running} = $r->name() if $r;
     $self->render(json => $results);
 }


### PR DESCRIPTION
This modification is just used to avoid reporting deprecate warning message
when querying running job modules.
As Sebastian and Tina mentioned, the true reason is that there are two same
name job modules in one job.

See: https://progress.opensuse.org/issues/55541