### PR TITLE
Store test JUnit results for CircleCI

### DIFF
--- a/.circleci/build_dependencies.sh
+++ b/.circleci/build_dependencies.sh
@@ -39,6 +39,7 @@ docker exec -t gendep sudo zypper ar -f http://download.opensuse.org/repositorie
 docker exec -t gendep sudo zypper --gpg-auto-import-keys ref
 docker exec -t gendep sudo zypper -n install openQA-devel
 docker exec -t gendep sudo zypper -n install chromedriver
+docker exec -t gendep sudo zypper -n install perl-TAP-Harness-JUnit
 
 docker exec -t gendep rpm -qa --qf "%{NAME}-%{VERSION}\n" |sort > gendep_after.txt
 comm -13 gendep_before.txt gendep_after.txt | grep -v gpg-pubkey | grep -v openQA | grep -v os-autoinst > "$thisdir/dependencies.txt"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,19 @@ aliases:
           sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
         fi
 
+  - &test_junit
+    name: "Enabling JUnit output for Perl tests"
+    command: |
+      mkdir -p test-results/junit
+      echo 'export JUNIT_OUTPUT_FILE=test-results/junit/${CIRCLE_JOB}.xml' >> $BASH_ENV
+
+  - &store_test_results
+    path: test-results/junit
+
+  - &store_artifacts
+    path: test-results/t
+    destination: artifacts
+
   - &build_autoinst
     command: |
       if [ ! -z "$CIRCLE_WORKFLOW_ID" ]; then # only in workflow
@@ -68,6 +81,9 @@ images:
     environment:
       USER: squamata
       PERL5LIB: lib
+      JUNIT_PACKAGE: openQA
+      JUNIT_NAME_MANGLE: perl
+      PERL_TEST_HARNESS_DUMP_TAP: test-results
       TRAVIS: yes
       COVER_OPTS: -select_re "^/lib" -ignore_re '^t/.*' +ignore_re lib/perlcritic/Perl/Critic/Policy -coverage statement
 
@@ -154,8 +170,11 @@ jobs:
       - restore_cache: *restore_cache
       - run: *check_cache
       - run: *install_cached_packages
+      - run: *test_junit
       - run: sudo zypper -n install python3-six # workaround bug https://bugzilla.suse.com/show_bug.cgi?id=1150895
-      - run: eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove -v t/*.t
+      - run: eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove --harness TAP::Harness::JUnit t/*.t
+      - store_test_results: *store_test_results
+      - store_artifacts: *store_artifacts
 
   testui:
     docker:
@@ -166,9 +185,12 @@ jobs:
       - restore_cache: *restore_cache
       - run: *check_cache
       - run: *install_cached_packages
+      - run: *test_junit
       - run:
           command: |
-            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove -v $(find t/ui/ -type f -name '*.t' | grep -vf .circleci/unstable_tests.txt | sort)
+            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove --harness TAP::Harness::JUnit $(find t/ui/ -type f -name '*.t' | grep -vf .circleci/unstable_tests.txt | sort)
+      - store_test_results: *store_test_results
+      - store_artifacts: *store_artifacts
 
   testui-unstable:
     docker:
@@ -179,12 +201,15 @@ jobs:
       - restore_cache: *restore_cache
       - run: *check_cache
       - run: *install_cached_packages
+      - run: *test_junit
       - run:
           command: |
             export openqa_unstable_tests="$(cat .circleci/unstable_tests.txt)"
             if [ ! -z "$openqa_unstable_tests" ]; then
-              eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove -v $openqa_unstable_tests || echo FAIL
+              eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove --harness TAP::Harness::JUnit $openqa_unstable_tests || echo FAIL
             fi
+      - store_test_results: *store_test_results
+      - store_artifacts: *store_artifacts
 
   testapi:
     docker:
@@ -195,9 +220,12 @@ jobs:
       - restore_cache: *restore_cache
       - run: *check_cache
       - run: *install_cached_packages
+      - run: *test_junit
       - run:
           command: |
-            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove -v t/api/*.t
+            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib prove --harness TAP::Harness::JUnit t/api/*.t
+      - store_test_results: *store_test_results
+      - store_artifacts: *store_artifacts
 
   testfullstack:
     docker:
@@ -210,10 +238,13 @@ jobs:
       - restore_cache: *restore_integration_cache
       - run: *check_cache
       - run: *install_cached_packages
+      - run: *test_junit
       - run: *build_autoinst
       - run:
           command: |
-            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib FULLSTACK=1 prove -v t/full-stack.t
+            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib FULLSTACK=1 prove --harness TAP::Harness::JUnit t/full-stack.t
+      - store_test_results: *store_test_results
+      - store_artifacts: *store_artifacts
 
   testdeveloperfullstack:
     docker:
@@ -226,10 +257,13 @@ jobs:
       - restore_cache: *restore_integration_cache
       - run: *check_cache
       - run: *install_cached_packages
+      - run: *test_junit
       - run: *build_autoinst
       - run:
           command: |
-            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib DEVELOPER_FULLSTACK=1 prove -v t/33-developer_mode.t
+            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib DEVELOPER_FULLSTACK=1 prove --harness TAP::Harness::JUnit t/33-developer_mode.t
+      - store_test_results: *store_test_results
+      - store_artifacts: *store_artifacts
 
   testschedulerfullstack:
     docker:
@@ -242,10 +276,13 @@ jobs:
       - restore_cache: *restore_integration_cache
       - run: *check_cache
       - run: *install_cached_packages
+      - run: *test_junit
       - run: *build_autoinst
       - run:
           command: |
-            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib SCHEDULER_FULLSTACK=1 OPENQA_BASEDIR=. prove -v t/05-scheduler-full.t
+            eval "$(t/test_postgresql | grep TEST_PG=)" && PERL5LIB=lib SCHEDULER_FULLSTACK=1 OPENQA_BASEDIR=. prove --harness TAP::Harness::JUnit t/05-scheduler-full.t
+      - store_test_results: *store_test_results
+      - store_artifacts: *store_artifacts
 
 workflows:
   version: 2

--- a/.circleci/dependencies.txt
+++ b/.circleci/dependencies.txt
@@ -11,6 +11,7 @@ perl-App-cpanminus-1.7043
 perl-Archive-Extract-0.80
 perl-Archive-Zip-1.60
 perl-bareword-filehandles-0.006
+perl-B-Debug-1.26
 perl-B-Hooks-EndOfScope-0.21
 perl-B-Hooks-OP-Check-0.22
 perl-B-Keywords-1.18
@@ -65,7 +66,7 @@ perl-DBIx-Class-DeploymentHandler-0.002233
 perl-DBIx-Class-DynamicDefault-0.04
 perl-DBIx-Class-OptimisticLocking-0.02
 perl-DBIx-Class-Schema-Config-0.001011
-perl-Devel-Cover-1.29
+perl-Devel-Cover-1.33
 perl-Devel-Cover-Report-Codecov-0.25
 perl-Devel-GlobalDestruction-0.14
 perl-Devel-OverloadInfo-0.005
@@ -196,6 +197,7 @@ perl-Sub-Quote-2.004000
 perl-Sub-Retry-0.06
 perl-Sub-Uplevel-0.240.0
 perl-SUPER-1.20141117
+perl-TAP-Harness-JUnit-0.42
 perl-Task-Weaken-1.06
 perl-Test-Compile-1.3.0
 perl-Test-Exception-0.430000

--- a/script/tidy
+++ b/script/tidy
@@ -46,7 +46,7 @@ find . -name '*.tdy' -delete
 # .pc directory is used for "quilt" patch system (in Debian/Ubuntu)
 # it contains pre-patched files and should be ignored
 # shellcheck disable=SC2207
-files=($(find . ! -path '*/.pc/*' -type f \( -name '*.p[lm]' -o -name '*.t' \)) $(file --mime-type script/* | sed -n 's/^\(.*\):.*text\/x-perl.*$/\1/p'))
+files=($(find . ! -path '*/.pc/*' ! -path './test-results/*' -type f \( -name '*.p[lm]' -o -name '*.t' \)) $(file --mime-type script/* | sed -n 's/^\(.*\):.*text\/x-perl.*$/\1/p'))
 find_changed_files
 # shellcheck disable=SC2128
 [[ $changed_files ]] && perltidy --pro=.../.perltidyrc "${changed_files[@]}"


### PR DESCRIPTION
Rather than dumping verbose logs, we should generate proper test results that can be read by CircleCI. [TAP::Harness::JUnit](https://metacpan.org/pod/TAP::Harness::JUnit) is a module that effectively allows `prove` to output `JUnit XML`. See [Configuring CircleCI](https://circleci.com/docs/2.0/configuration-reference/#store_test_results) on the mechanism used here.