### PR TITLE
Add colors for more job results in dependency graph

### DIFF
--- a/assets/stylesheets/dependency_graph.scss
+++ b/assets/stylesheets/dependency_graph.scss
@@ -68,13 +68,13 @@
             &.passed {
                 background-color: $color-ok;
             }
-            &.failed {
+            &.failed, &.parallel_failed {
                 background-color: $color-result-failed;
             }
             &.softfailed {
                 background-color: $color-softfailed;
             }
-            &.incomplete {
+            &.incomplete, &.timeout_exceeded {
                 color: white;
                 background-color: $color-incomplete;
             }
@@ -85,7 +85,7 @@
                 color: white;
                 background-color: $color-state-scheduled;
             }
-            &.cancelled {
+            &.cancelled, &.user_cancelled {
                 background-color: $color-state-cancelled;
             }
             &.assigned, &.running, &.uploading {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -761,7 +761,7 @@ sub has_pending_jobs {
 sub pending_job_ids {
     my ($self) = @_;
 
-    return [keys %{$self->{_pending_job_ids}}];
+    return [sort keys %{$self->{_pending_job_ids}}];
 }
 
 sub _find_job_in_queue {


### PR DESCRIPTION
So especially parallel failed jobs are not confused with skipped ones.