### PR TITLE
Move helper from OpenQA::Utils to plugin

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -77,7 +77,6 @@ our @EXPORT  = qw(
   &human_readable_size
   &locate_asset
   &job_groups_and_parents
-  &find_job
   &detect_current_version
   wait_with_progress
   mark_job_linked
@@ -835,18 +834,6 @@ sub job_groups_and_parents {
         }
     }
     return \@res;
-}
-
-sub find_job {
-    my ($controller, $job_id) = @_;
-
-    my $job = $controller->app->schema->resultset('Jobs')->find(int($job_id));
-    if (!$job) {
-        $controller->render(json => {error => 'Job does not exist'}, status => 404);
-        return;
-    }
-
-    return $job;
 }
 
 # returns the search args for the job overview according to the parameter of the specified controller

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -381,8 +381,7 @@ sub save_needle_ajax {
     }
 
     # read parameter
-    my $job = find_job($self, $self->param('testid'))
-      or return $self->render(json => {error => 'The specified job ID is invalid.'});
+    my $job        = $self->find_job_or_render_not_found($self->param('testid')) or return;
     my $job_id     = $job->id;
     my $needledir  = needledir($job->DISTRI, $job->VERSION);
     my $needlename = $validation->param('needlename');

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -351,6 +351,8 @@ sub register {
             );
         });
 
+    $app->helper(find_job_or_render_not_found => \&_find_job_or_render_not_found);
+
     $app->helper(
         'reply.gru_result' => sub {
             my ($c, $result, $error_code) = @_;
@@ -358,6 +360,15 @@ sub register {
         });
 
     $app->helper('reply.validation_error' => \&_validation_error);
+}
+
+sub _find_job_or_render_not_found {
+    my ($c, $job_id) = @_;
+
+    my $job = $c->schema->resultset('Jobs')->find(int($job_id));
+    return $job if $job;
+    $c->render(json => {error => 'Job does not exist'}, status => 404);
+    return undef;
 }
 
 sub _step_thumbnail {


### PR DESCRIPTION
While working on another bug i noticed that there was a helper in `OpenQA::Utils` that should have been in the helper plugin. And i've given it a more descriptive name because in two instances it had actually been used wrong (a response was rendered more than once).