### PR TITLE
Prevent the ws server to query itself

### DIFF
--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -79,6 +79,7 @@ sub ws_send {
             log_debug("Unable to send command \"$msg\" to worker $workerid");
         }
     }
+    return $res;
 }
 
 sub ws_send_job {

--- a/lib/OpenQA/WebSockets/Model/Status.pm
+++ b/lib/OpenQA/WebSockets/Model/Status.pm
@@ -21,6 +21,7 @@ use OpenQA::Schema;
 use OpenQA::Schema::Result::Workers ();
 use OpenQA::Utils qw(log_debug log_warning log_info);
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
+use OpenQA::Jobs::Constants;
 use DateTime;
 use Try::Tiny;
 


### PR DESCRIPTION
This should prevent https://progress.opensuse.org/issues/57017 from happening.

Note that the ws server is supposed to be reactive and the possibly extensive task of cancelling job clusters should be moved to the scheduler in the future.