### PR TITLE
Enable nightly circleci dependency job on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,6 @@ workflows:
          filters:
            branches:
              only:
-               - circleci
+               - master
    jobs:
       - dependencies-pr


### PR DESCRIPTION
File `dependencies.txt` will become outdated unless somebody updates it regularly.
The nightly job is intended to create PR with updates.