### PR TITLE
Move stale job detection from ws server to scheduler relying on t_updated for the worker's online status

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -96,6 +96,12 @@ sub _setup {
     OpenQA::Setup::read_config($self);
     OpenQA::Setup::setup_log($self);
 
+    # check for stale jobs every 2 minutes
+    Mojo::IOLoop->recurring(
+        120 => sub {
+            OpenQA::Scheduler::Model::Jobs->singleton->incomplete_and_duplicate_stale_jobs;
+        });
+
     # initial schedule
     Mojo::IOLoop->next_tick(
         sub {

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -42,8 +42,6 @@ sub schedule {
     my @f_w = grep { !$_->dead && ($_->websocket_api_version() || 0) == WEBSOCKET_API_VERSION }
       $schema->resultset("Workers")->search({job_id => undef, error => undef})->all();
 
-    # NOTE: $worker->connected is too much expensive since is over HTTP, prefer dead
-    #       (shuffle avoids starvation if a free worker keeps failing)
     my @free_workers = $self->shuffle_workers ? shuffle(@f_w) : @f_w;
     if (@free_workers == 0) {
         $self->emit('conclude');

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -21,8 +21,9 @@ use DateTime;
 use File::Temp 'tempdir';
 use Try::Tiny;
 use OpenQA::Jobs::Constants;
-use OpenQA::Utils qw(log_debug random_string);
-use OpenQA::Constants 'WEBSOCKET_API_VERSION';
+use OpenQA::Utils qw(log_debug log_info log_warning random_string);
+use OpenQA::Constants qw(WEBSOCKET_API_VERSION WORKERS_CHECKER_THRESHOLD);
+use OpenQA::Schema;
 use Time::HiRes 'time';
 use List::Util qw(all shuffle);
 
@@ -469,6 +470,31 @@ sub _assign_multiple_jobs_to_worker {
     }
 
     return OpenQA::WebSockets::Client->singleton->send_jobs(\%job_info);
+}
+
+sub incomplete_and_duplicate_stale_jobs {
+    my ($self) = @_;
+
+    try {
+        my $schema = OpenQA::Schema->singleton;
+        $schema->txn_do(
+            sub {
+                my $stale_jobs = $schema->resultset('Jobs')->stale_ones(WORKERS_CHECKER_THRESHOLD);
+                for my $job ($stale_jobs->all) {
+                    $job->done(result => OpenQA::Jobs::Constants::INCOMPLETE);
+                    my $res = $job->auto_duplicate;
+                    if ($res) {
+                        log_warning(sprintf('Dead job %d aborted and duplicated %d', $job->id, $res->id));
+                    }
+                    else {
+                        log_warning(sprintf('Dead job %d aborted as incomplete', $job->id));
+                    }
+                }
+            });
+    }
+    catch {
+        log_info("Failed stale job detection : $_");
+    };
 }
 
 1;

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -187,12 +187,6 @@ sub status {
     return 'idle';
 }
 
-sub connected {
-    my ($self) = @_;
-    my $client = OpenQA::WebSockets::Client->singleton;
-    return $client->is_worker_connected($self->id) ? 1 : 0;
-}
-
 sub unprepare_for_work {
     my $self = shift;
 
@@ -224,12 +218,13 @@ sub info {
         my $cs = $self->currentstep;
         $settings->{currentstep} = $cs if $cs;
     }
-    $settings->{alive}     = $self->dead ? 0                      : 1;
-    $settings->{connected} = $live       ? $self->connected       : $settings->{alive};
-    $settings->{websocket} = $live       ? $settings->{connected} : 0;
+    my $alive = $settings->{alive} = $settings->{connected} = $self->dead ? 0 : 1;
+    $settings->{websocket} = $live ? $alive : 0;
 
-    # $self->connected is expensive
-    # should be done only on single view
+    # note: The keys "connected" and "websocket" are only provided for compatibility. The "live"
+    #       parameter makes no actual difference anymore. (`t_updated` is decrease when a worker
+    #       disconnects from the ws server so relying on it is as live as it gets.)
+
     return $settings;
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -195,10 +195,11 @@ sub create {
 
 =item show()
 
-Prints information from a worker given its ID. Each entry contains the "hostname",
-the boolean flag "connected" which can be 0 or 1 depending on the connection to
-the websockets server and the field "status" which can be "dead", "idle", "running".
-A worker can be considered "up" when "connected=1" and "status!=dead"'
+Prints information from a worker given its ID. Each entry contains the "hostname"
+and the field "status" which can be "dead", "idle", "running" and "broken".
+A worker can be considered online when the status is not "dead". Broken means that
+the worker is able to connect but there is some setup problem on the worker host
+preventing it from taking jobs.
 
 =back
 

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -124,9 +124,6 @@ sub _setup {
     OpenQA::Setup::read_config($self);
     OpenQA::Setup::setup_log($self);
 
-    # start worker checker - check workers each 2 minutes
-    Mojo::IOLoop->recurring(120 => sub { $self->status->workers_checker });
-
     Mojo::IOLoop->recurring(
         380 => sub {
             log_debug('Resetting worker status table');

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -43,7 +43,6 @@ sub startup {
     my $ca = $r->under('/')->to('Auth#check');
     $ca->get('/' => {json => {name => $self->defaults('appname')}});
     my $api = $ca->any('/api');
-    $api->get('/is_worker_connected/<worker_id:num>')->to('API#is_worker_connected');
     $api->post('/send_job')->to('API#send_job');
     $api->post('/send_jobs')->to('API#send_jobs');
     $api->post('/send_msg')->to('API#send_msg');

--- a/lib/OpenQA/WebSockets/Client.pm
+++ b/lib/OpenQA/WebSockets/Client.pm
@@ -24,13 +24,6 @@ use OpenQA::Utils 'service_port';
 has client => sub { OpenQA::Client->new(api => 'localhost') };
 has port   => sub { service_port('websocket') };
 
-sub is_worker_connected {
-    my ($self, $worker_id) = @_;
-    my $res = $self->client->get($self->_api("is_worker_connected/$worker_id"))->result;
-    croak "Expected 2xx status from WebSocket server but received @{[$res->code]}" unless $res->is_success;
-    return $res->json->{connected};
-}
-
 sub send_job {
     my ($self, $job) = @_;
     my $res = $self->client->post($self->_api('send_job'), json => $job)->result;

--- a/lib/OpenQA/WebSockets/Controller/API.pm
+++ b/lib/OpenQA/WebSockets/Controller/API.pm
@@ -19,17 +19,6 @@ use Mojo::Base 'Mojolicious::Controller';
 use OpenQA::WebSockets;
 use OpenQA::WebSockets::Model::Status;
 
-sub is_worker_connected {
-    my ($self) = @_;
-
-    $self->render(
-        json => {
-            connected => OpenQA::WebSockets::Model::Status->singleton->is_worker_connected($self->param('worker_id'))
-            ? \1
-            : \0
-        });
-}
-
 sub send_msg {
     my ($self) = @_;
 

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -56,10 +56,9 @@ sub _finish {
     }
     log_info(sprintf("Worker %u websocket connection closed - $code", $worker->{id}));
 
-    # if the worker disconnected from web socket, mark it dead so it doesn't get new
-    # jobs assigned from scheduler (which will check DB and not WS state)
+    # mark worker as dead in the database so it doesn't get new jobs assigned from scheduler and
+    # appears as offline in the web UI
     my $dt = DateTime->now(time_zone => 'UTC');
-    # 2 minutes is long enough for the scheduler not to take it
     $dt->subtract(seconds => (WORKERS_CHECKER_THRESHOLD + 20));
     $worker->{db}->update({t_updated => $dt});
 }

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -92,7 +92,6 @@ sub _message {
         return undef;
     }
 
-    $worker->{last_seen} = time();
     if ($json->{type} eq 'accepted') {
         my $job_id = $json->{jobid};
         return undef unless $job_id;

--- a/lib/OpenQA/WebSockets/Model/Status.pm
+++ b/lib/OpenQA/WebSockets/Model/Status.pm
@@ -60,14 +60,6 @@ sub remove_worker_connection {
     return delete $self->worker_by_transaction->{$transaction};
 }
 
-sub is_worker_connected {
-    my ($self, $worker_id) = @_;
-
-    return 0 unless my $worker = $self->workers->{$worker_id};
-    return 0 unless my $tx     = $worker->{tx};
-    return !$tx->is_finished;
-}
-
 sub get_stale_worker_jobs {
     my ($self, $threshold) = @_;
 

--- a/lib/OpenQA/WebSockets/Model/Status.pm
+++ b/lib/OpenQA/WebSockets/Model/Status.pm
@@ -20,10 +20,7 @@ use Mojo::Base -base;
 use OpenQA::Schema;
 use OpenQA::Schema::Result::Workers ();
 use OpenQA::Utils qw(log_debug log_warning log_info);
-use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
 use OpenQA::Jobs::Constants;
-use DateTime;
-use Try::Tiny;
 
 has [qw(workers worker_by_transaction worker_status)] => sub { {} };
 
@@ -39,10 +36,9 @@ sub add_worker_connection {
         my $schema = OpenQA::Schema->singleton;
         return undef unless my $db = $schema->resultset('Workers')->find($worker_id);
         $worker = $workers->{$worker_id} = {
-            id        => $worker_id,
-            db        => $db,
-            tx        => undef,
-            last_seen => time(),
+            id => $worker_id,
+            db => $db,
+            tx => undef,
         };
     }
 
@@ -58,81 +54,6 @@ sub add_worker_connection {
 sub remove_worker_connection {
     my ($self, $transaction) = @_;
     return delete $self->worker_by_transaction->{$transaction};
-}
-
-sub get_stale_worker_jobs {
-    my ($self, $threshold) = @_;
-
-    my $schema  = OpenQA::Schema->singleton;
-    my $workers = $self->workers;
-
-    # grab the workers we've seen lately
-    my @ok_workers;
-    for my $worker (values %$workers) {
-        if (time - $worker->{last_seen} <= $threshold) {
-            push(@ok_workers, $worker->{id});
-        }
-        else {
-            log_debug(sprintf("Worker %s not seen since %d seconds", $worker->{db}->name, time - $worker->{last_seen}));
-        }
-    }
-    my $dtf = $schema->storage->datetime_parser;
-    my $dt  = DateTime->from_epoch(epoch => time() - $threshold, time_zone => 'UTC');
-
-    my %cond = (
-        state              => [OpenQA::Jobs::Constants::EXECUTION_STATES],
-        'worker.t_updated' => {'<' => $dtf->format_datetime($dt)},
-        'worker.id'        => {-not_in => [sort @ok_workers]});
-    my %attrs = (join => 'worker', order_by => 'worker.id desc');
-
-    return $schema->resultset("Jobs")->search(\%cond, \%attrs);
-}
-
-# Check if worker with job has been updated recently; if not, assume it
-# got stuck somehow and duplicate or incomplete the job
-sub workers_checker {
-    my $self = shift;
-
-    my $schema = OpenQA::Schema->singleton;
-    try {
-        $schema->txn_do(
-            sub {
-                my $stale_jobs = $self->get_stale_worker_jobs(WORKERS_CHECKER_THRESHOLD);
-                for my $job ($stale_jobs->all) {
-                    next unless _is_job_considered_dead($job);
-
-                    $job->done(result => OpenQA::Jobs::Constants::INCOMPLETE);
-                    # XXX: auto_duplicate was killing ws server in production
-                    my $res = $job->auto_duplicate;
-                    if ($res) {
-                        log_warning(sprintf('dead job %d aborted and duplicated %d', $job->id, $res->id));
-                    }
-                    else {
-                        log_warning(sprintf('dead job %d aborted as incomplete', $job->id));
-                    }
-                }
-            });
-    }
-    catch {
-        log_info("Failed dead job detection : $_");
-    };
-}
-
-sub _is_job_considered_dead {
-    my $job = shift;
-
-    # much bigger timeout for uploading jobs; while uploading files,
-    # worker process is blocked and cannot send status updates
-    if ($job->state eq OpenQA::Jobs::Constants::UPLOADING) {
-        my $delta = DateTime->now()->epoch() - $job->worker->t_updated->epoch();
-        log_debug("uploading worker not updated for $delta seconds " . $job->id);
-        return ($delta > 1000);
-    }
-
-    log_debug(
-        "job considered dead: " . $job->id . " worker " . $job->worker->id . " not seen. In state " . $job->state);
-    # default timeout for the rest
-    return 1;
 }
 
 1;

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -62,7 +62,7 @@ my $schema = OpenQA::Test::Database->new->create(skip_schema => 1);
 
 # Create webapi and websocket server services
 my $mojoport = Mojo::IOLoop::Server->generate_port();
-my $wspid    = create_websocket_server($mojoport + 1, 0, 1, 1, 1);
+my $wspid    = create_websocket_server($mojoport + 1, 0, 1, 1);
 my $webapi   = create_webapi($mojoport);
 
 # Setup needed files for workers.
@@ -236,7 +236,7 @@ subtest 'Websocket server - close connection test' => sub {
     local $ENV{MOJO_LOG_LEVEL};
 
     my $log_file        = tempfile;
-    my $unstable_ws_pid = create_websocket_server($mojoport + 1, 1, 0, 1);
+    my $unstable_ws_pid = create_websocket_server($mojoport + 1, 1, 0);
     my $w2_pid          = create_worker($k->key, $k->secret, "http://localhost:$mojoport", 2, $log_file);
 
     my $found_connection_closed_in_log = 0;

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -67,33 +67,12 @@ subtest 'API' => sub {
     $t->tx($t->ua->start($t->ua->build_websocket_tx('/ws/23')))->status_is(400)->content_like(qr/Unknown worker/);
 };
 
-subtest 'workers_checker' => sub {
-    my $mock_schema = Test::MockModule->new('OpenQA::Schema');
-    my $mock_singleton_called;
-    $mock_schema->mock(singleton => sub { $mock_singleton_called++; bless({}); });
-    combined_like(
-        sub { OpenQA::WebSockets::Model::Status->singleton->workers_checker; },
-        qr/Failed dead job detection/,
-        'failure logged'
-    );
-    ok $mock_singleton_called, 'mocked singleton method has been called';
-};
-
 my $workers   = $schema->resultset('Workers');
 my $worker    = $workers->search({host => 'localhost', instance => 1})->first;
 my $worker_id = $worker->id;
 OpenQA::WebSockets::Model::Status->singleton->workers->{$worker_id} = {
-    id        => $worker_id,
-    db        => $worker,
-    last_seen => '0001-01-01',
-};
-
-subtest 'get_stale_worker_jobs' => sub {
-    combined_like(
-        sub { OpenQA::WebSockets::Model::Status->singleton->get_stale_worker_jobs(-9999999999); },
-        qr/Worker localhost:1 not seen since \d+ seconds/,
-        'not seen message logged'
-    );
+    id => $worker_id,
+    db => $worker,
 };
 
 subtest 'web socket message handling' => sub {

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -65,9 +65,6 @@ subtest 'Authentication' => sub {
 
 subtest 'API' => sub {
     $t->tx($t->ua->start($t->ua->build_websocket_tx('/ws/23')))->status_is(400)->content_like(qr/Unknown worker/);
-    $t->get_ok('/api/is_worker_connected/1')->status_is(200)->json_is({connected => Mojo::JSON::false});
-    local $t->app->status->workers->{1} = {tx => OpenQA::Test::FakeWebSocketTransaction->new};
-    $t->get_ok('/api/is_worker_connected/1')->status_is(200)->json_is({connected => Mojo::JSON::true});
 };
 
 subtest 'workers_checker' => sub {

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -104,7 +104,7 @@ ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'));
 
 my $mojoport = Mojo::IOLoop::Server->generate_port;
 my $wsport   = $mojoport + 1;
-$wspid = create_websocket_server($wsport, 0, 0, 0);
+$wspid = create_websocket_server($wsport, 0, 0);
 
 my $schedulerport = $mojoport + 3;
 $schedulerpid = create_scheduler($schedulerport);

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -65,9 +65,9 @@ my @workers = (
     {
         id         => 1,
         instance   => 1,
-        connected  => 0,
+        connected  => 1,                              # deprecated
+        websocket  => 1,                              # deprecated
         error      => undef,
-        websocket  => 0,
         alive      => 1,
         jobid      => 99963,
         host       => 'localhost',
@@ -80,9 +80,9 @@ my @workers = (
             JOBTOKEN => 'token99961'
         },
         id        => 2,
-        connected => 0,
+        connected => 1,              # deprecated
+        websocket => 1,              # deprecated
         error     => undef,
-        websocket => 0,
         alive     => 1,
         status    => 'running',
         host      => 'remotehost',
@@ -100,8 +100,11 @@ is_deeply(
     'worker present'
 ) or diag explain $t->tx->res->json;
 
-$workers[0]->{connected} = 1;
-$workers[1]->{connected} = 1;
+# note: The live flag is deprecated and makes no difference anymore (not padding the flag
+#       is as good as passing it). For compatibility "connected" and "websocket" are still
+#       provided.
+
+$_->{websocket} = 0 for @workers;
 
 $t->get_ok('/api/v1/workers');
 ok(!$t->tx->error, 'listing workers works');

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -104,7 +104,7 @@ ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'));
 # we don't want no fixtures
 my $mojoport = Mojo::IOLoop::Server->generate_port;
 my $wsport   = $mojoport + 1;
-$wspid = create_websocket_server($wsport, 0, 0, 0);
+$wspid = create_websocket_server($wsport, 0, 0);
 my $driver       = call_driver(sub { }, {mojoport => $mojoport});
 my $connect_args = OpenQA::Test::FullstackUtils::get_connect_args();
 

--- a/templates/admin/workers/worker_status.html.ep
+++ b/templates/admin/workers/worker_status.html.ep
@@ -16,7 +16,7 @@
     %>
 % } elsif ($worker->{status} eq 'broken') {
     Broken <%= help_popover(Error => $worker->{error}) %>
-% } elsif ($worker->{connected}) {
+% } elsif ($worker->{alive}) {
     Online
 % } else {
     Offline


### PR DESCRIPTION
* See the individual commit messages
* Supersedes https://github.com/os-autoinst/openQA/pull/2344
* Solves one part of https://progress.opensuse.org/issues/57017
* Solves https://progress.opensuse.org/issues/27454