### PR TITLE
Load build results on dashboard via AJAX

### DIFF
--- a/assets/javascripts/filter_form.js
+++ b/assets/javascripts/filter_form.js
@@ -1,4 +1,4 @@
-function setupFilterForm() {
+function setupFilterForm(options) {
     // make filter form expandable
     $('#filter-panel .card-header').on('click', function() {
         $('#filter-panel .card-body').toggle(200);
@@ -12,6 +12,10 @@ function setupFilterForm() {
     $('#filter-panel .help_popover').on('click', function(event) {
         event.stopPropagation();
     });
+
+    if (options && options.preventLoadingIndication) {
+        return;
+    }
 
     $('#filter-form').on('submit', function(event) {
         if($('#filter-form').serialize() !== window.location.search.substring(1)) {

--- a/assets/javascripts/fullscreen.js
+++ b/assets/javascripts/fullscreen.js
@@ -1,34 +1,35 @@
-function hideNavbar(fullscreen) {
-    // do nothing if not in full screen mode
-    if (!$('#filter-fullscreen').is(':checked') && fullscreen !== 1) {
-        return;
-    }
-
+function toggleFullscreenMode(fullscreen) {
     // change ID of main container (to change applied CSS rules)
-    $("#content").attr('id', 'content_fullscreen');
+    $('#content').attr('id', fullscreen ? 'content_fullscreen' : 'content');
 
-    // hide some elements
-    $(".navbar, .footer, .jumbotron").hide();
-    if (fullscreen === 1) {
-        $("#group_description").hide();
-    }
+    // change visiblity of some elements
+    $('.navbar, .footer, .jumbotron, #group_description')[fullscreen ? 'hide' : 'show']();
 
     // toggle navbar visibility
-    var navbar = $(".navbar");
+    var navbar = $('.navbar');
     var navbarHeight = navbar.outerHeight();
-    document.addEventListener('mousemove', function(e) {
+    var handler = document.showNavbarIfItWouldContainMouse;
+    if (!fullscreen) {
+        if (handler === undefined) {
+            return;
+        }
+        document.removeEventListener('mousemove', handler, false);
+        return;
+    }
+    handler = document.showNavbarIfItWouldContainMouse = function(e) {
         var mouseY = e.clientY || e.pageY;
-        if (mouseY <= navbarHeight || navbar.find("[aria-expanded='true']").length != 0) {
+        if (mouseY <= navbarHeight || navbar.find("[aria-expanded='true']").length !== 0) {
             navbar.show();
         }
-        else if (mouseY > navbarHeight && !$("li").hasClass('dropdown open')) {
+        else if (mouseY > navbarHeight && !$('li').hasClass('dropdown open')) {
             navbar.hide();
         }
-    }, false);
+    };
+    document.addEventListener('mousemove', handler, false);
 }
 
 function autoRefresh(fullscreen, interval) {
-    if (fullscreen != 1) {
+    if (!fullscreen) {
         return;
     }
     $($(document).ready(function() {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -172,11 +172,12 @@ sub startup {
 
     # Favicon
     $r->get('/favicon.ico' => sub { my $c = shift; $c->render_static('favicon.ico') });
-    $r->get('/index'       => [format => ['html', 'json']])->to('main#index');
-    $r->get('/api_help'    => sub { shift->render('admin/api_help') })->name('api_help');
+    $r->get('/index'       => sub { shift->render('main/index') });
+    $r->get('/dashboard_build_results')->name('dashboard_build_results')->to('main#dashboard_build_results');
+    $r->get('/api_help' => sub { shift->render('admin/api_help') })->name('api_help');
 
     # Default route
-    $r->get('/')->name('index')->to('main#index');
+    $r->get('/' => sub { shift->render('main/index') })->name('index');
     $r->get('/changelog')->name('changelog')->to('main#changelog');
 
     # shorter version of route to individual job results

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,21 +41,20 @@ sub _map_tags_into_build {
     return;
 }
 
-sub index {
+sub dashboard_build_results {
     my ($self) = @_;
 
     my $limit_builds = $self->param('limit_builds');
     $limit_builds = 3 unless looks_like_number($limit_builds);
     my $time_limit_days = $self->param('time_limit_days');
     $time_limit_days = 14 unless looks_like_number($time_limit_days);
-    $self->app->log->debug("Retrieving results for up to $limit_builds builds up to $time_limit_days days old");
     my $only_tagged      = $self->param('only_tagged')      // 0;
     my $default_expanded = $self->param('default_expanded') // 0;
     my $show_tags        = $self->param('show_tags')        // $only_tagged;
     my $group_params     = $self->every_param('group');
-    my @results;
-    my $groups = $self->stash('job_groups_and_parents');
+    my $groups           = $self->stash('job_groups_and_parents');
 
+    my @results;
     for my $group (@$groups) {
         if (@$group_params) {
             next unless grep { $_ eq '' || $group->matches_nested($_) } @$group_params;
@@ -72,13 +71,16 @@ sub index {
         }
         push(@results, $build_results) if @{$build_results_for_group};
     }
-    $self->stash('limit_builds',     $limit_builds);
-    $self->stash('time_limit_days',  $time_limit_days);
-    $self->stash('default_expanded', $default_expanded);
-    $self->stash('results',          \@results);
+
+    $self->stash(
+        default_expanded => $default_expanded,
+        results          => \@results,
+    );
+
     $self->respond_to(
         json => {json     => {results => \@results}},
-        html => {template => 'main/index'});
+        html => {template => 'main/dashboard_build_results'},
+    );
 }
 
 sub group_overview {

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -155,17 +155,17 @@ subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {
     $t->get_ok('/group_overview/1001?only_tagged=0')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 5, 'all builds shown again (on group overview)');
 
-    $t->get_ok('/?only_tagged=1')->status_is(200);
+    $t->get_ok('/dashboard_build_results?only_tagged=1')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 1, 'only one tagged build is shown (on index page)');
     is(scalar @{$t->tx->res->dom->find('h2')},               1, 'only one group shown anymore');
-    $t->get_ok('/?only_tagged=0')->status_is(200);
+    $t->get_ok('/dashboard_build_results?only_tagged=0')->status_is(200);
     is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 4, 'all builds shown again (on index page)');
     is(scalar @{$t->tx->res->dom->find('h2')},               2, 'two groups shown again');
 };
 
 subtest 'show_tags query parameter enables/disables tags on index page' => sub {
     for my $enabled (0, 1) {
-        $t->get_ok('/?show_tags=' . $enabled)->status_is(200);
+        $t->get_ok('/dashboard_build_results?show_tags=' . $enabled)->status_is(200);
         is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')},
             4, "all builds shown on index page (show_tags=$enabled)");
         is(scalar @{$t->tx->res->dom->find("i[title='important']")},

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright (C) 2015-2017 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -608,7 +608,7 @@ subtest 'json representation of group overview (actually not part of the API)' =
     );
 };
 
-$t->get_ok('/index.json?limit_builds=10')->status_is(200);
+$t->get_ok('/dashboard_build_results.json?limit_builds=10')->status_is(200);
 my $ret = $t->tx->res->json;
 is(@{$ret->{results}}, 2);
 my $g1 = (shift @{$ret->{results}});

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -165,7 +165,7 @@ subtest 'create job group' => sub() {
         'list created job group'
     );
 
-    $t->get_ok('/index.json')->status_is(200);
+    $t->get_ok('/dashboard_build_results.json')->status_is(200);
     my $res = $t->tx->res->json;
     is(@{$res->{results}}, 2, 'empty job groups are not shown on index page');
 

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright (C) 2016-2018 SUSE LLC
+# Copyright (C) 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,6 +98,7 @@ my $baseurl = $driver->get_current_url();
 
 $driver->get($baseurl . '?limit_builds=20');
 disable_bootstrap_animations();
+wait_for_ajax();
 
 # test expanding/collapsing
 is(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, 'link to child group collapsed (in the first place)');
@@ -115,6 +116,7 @@ ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_hidden(), 'link to 
 # go to parent group overview
 $driver->find_element_by_link_text('Test parent')->click();
 disable_bootstrap_animations();
+wait_for_ajax();
 
 ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_displayed(), 'link to child group displayed');
 my @links = $driver->find_elements('.h4 a', 'css');
@@ -129,11 +131,14 @@ isnt(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, "child group 
 $driver->find_element_by_class('navbar-brand')->click();
 $driver->find_element_by_link_text('Test parent 2')->click();
 disable_bootstrap_animations();
+wait_for_ajax();
 isnt(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, "child group 'opensuse' in 'Test parent 2'");
 
 # test filtering for nested groups
 subtest 'filtering subgroups' => sub {
     $driver->get('/');
+    disable_bootstrap_animations();
+    wait_for_ajax();
     my $url = $driver->get_current_url;
     $driver->find_element('#filter-panel .card-header')->click();
     $driver->find_element_by_id('filter-group')->send_keys('Test parent / .* test$');
@@ -144,8 +149,9 @@ subtest 'filtering subgroups' => sub {
     $ele = $driver->find_element_by_id('filter-time-limit-days');
     $ele->click();
     $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{end}, '0');    # appended
-    $driver->find_element('#filter-form button')->click();
-    $url .= '?group=Test+parent+%2F+.*+test%24&default_expanded=1&limit_builds=30&time_limit_days=140#';
+    $driver->find_element('#filter-apply-button')->click();
+    wait_for_ajax();
+    $url .= '?group=Test%20parent%20%2F%20.*%20test%24&default_expanded=1&limit_builds=30&time_limit_days=140';
     is($driver->get_current_url,                                  $url, 'URL parameters for filter are correct');
     is(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0,    "child group 'opensuse' filtered out");
     isnt(scalar @{$driver->find_elements('opensuse test', 'link_text')}, 0, "child group 'opensuse test' present'");

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright (C) 2015-2017 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -62,7 +62,7 @@ $driver->title_is("openQA", "back on main page");
 
 # check 'reviewed' labels
 
-$t->get_ok('/?limit_builds=10')->status_is(200)
+$t->get_ok('/dashboard_build_results?limit_builds=10')->status_is(200)
   ->element_count_is('.review', 2, 'exactly two builds marked as \'reviewed\'')
   ->element_exists('.badge-all-passed', 'one build is marked as \'reviewed-all-passed\' because all tests passed');
 

--- a/templates/main/dashboard_build_results.html.ep
+++ b/templates/main/dashboard_build_results.html.ep
@@ -1,0 +1,17 @@
+% for my $groupresults (@$results) {
+    % my $group         = $groupresults->{group};
+    % my $build_results = $groupresults->{build_results};
+    % my $max_jobs      = $groupresults->{max_jobs};
+
+    % if (@{$groupresults->{children}}) {
+        <h2>
+            %= link_to $group->{name} => url_for('parent_group_overview', groupid => $group->{id})
+        </h2>
+        %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => $default_expanded
+    % } else {
+        <h2>
+            %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})
+        </h2>
+        %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => undef, default_expanded => 0
+    % }
+% }

--- a/templates/main/group_overview.html.ep
+++ b/templates/main/group_overview.html.ep
@@ -5,7 +5,7 @@
 
 % content_for 'ready_function' => begin
     $('.timeago').timeago();
-    hideNavbar(<%= $fullscreen %>);
+    toggleFullscreenMode(<%= $fullscreen %>);
     autoRefresh(<%= $fullscreen %>, <%= $interval %>);
     alignBuildLabels();
 % end

--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -5,8 +5,6 @@
 
 % content_for 'ready_function' => begin
     setupIndexPage();
-    hideNavbar();
-    alignBuildLabels();
 % end
 
 <div class="jumbotron">
@@ -22,24 +20,13 @@
   </div>
 </div>
 
-<div id="build-results"></div>
-% for my $groupresults (@$results) {
-    % my $group              = $groupresults->{group};
-    % my $build_results      = $groupresults->{build_results};
-    % my $max_jobs           = $groupresults->{max_jobs};
-
-    % if (@{$groupresults->{children}}) {
-        <h2>
-            %= link_to $group->{name} => url_for('parent_group_overview', groupid => $group->{id})
-        </h2>
-        %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => $default_expanded
-    % } else {
-        <h2>
-            %= link_to $group->{name} => url_for('group_overview', groupid => $group->{id})
-        </h2>
-        %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => undef, default_expanded => 0
-    % }
-% }
+<div id="build-results-loading">
+    <div class="d-flex justify-content-center">
+        <i class="fas fa-circle-notch fa-spin fa-4x" role="status"><span class="sr-only">Loading…</span></i>
+    </div>
+</div>
+<div id="build-results" data-build-results-url="<%= url_for('dashboard_build_results') %>">
+</div>
 
 <div class="card card-outline-secondary filter-panel-bottom" id="filter-panel">
     <div class="card-header"><strong>Filter</strong> <span>no filter present, click to toggle filter form</span></div>
@@ -93,7 +80,7 @@
                 <%= help_popover('Help for <i>Full screen</i>' => '<p>Show builds in full screen mode</p>')
                 %>
             </div>
-            <button type="submit" class="btn btn-default">Apply</button>
+            <button type="submit" class="btn btn-default" id="filter-apply-button">Apply</button>
         </form>
     </div>
 </div>


### PR DESCRIPTION
So it works like the dashboard on GitHub. Additionally, when submitting the filter form the whole page doesn't need to reload anymore.

See https://progress.opensuse.org/issues/55112

---

This was quite easy. I guess adapting the tests will be the annoying part.

---

Note that the `.json` representation of the index page (which is not considered part of openQA's stable API) is removed by this change but the same info is now available via `/dashboard_build_results.json`.