### PR TITLE
Enforce same width for nodes in dependency graph

### DIFF
--- a/assets/stylesheets/dependency_graph.scss
+++ b/assets/stylesheets/dependency_graph.scss
@@ -61,6 +61,7 @@
             &:last-child {
                 background-color: #efefef;
                 width: 80px;
+                min-width: 80px;
                 max-width: 80px;
                 text-align: center;
             }


### PR DESCRIPTION
In Firefox nodes in different states had different sizes which didn't look very nice.