### PR TITLE
Improve tour test

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -11,7 +11,7 @@ our @EXPORT = qw($drivermissing check_driver_modules start_driver
   call_driver kill_driver wait_for_ajax disable_bootstrap_animations
   open_new_tab mock_js_functions element_visible element_hidden
   element_not_present javascript_console_has_no_warnings_or_errors
-  wait_until wait_until_element_gone);
+  wait_until wait_until_element_gone wait_for_element);
 
 use Data::Dump 'pp';
 use Mojo::IOLoop::Server;
@@ -350,6 +350,30 @@ sub wait_until_element_gone {
         $selector . ' gone',
         @_,
     );
+}
+
+sub wait_for_element {
+    my (%args)                = @_;
+    my $selector              = $args{selector};
+    my $expected_is_displayed = $args{is_displayed};
+
+    my $element;
+    wait_until(
+        sub {
+            my @elements = $_driver->find_elements($selector);
+            if (scalar @elements >= 1
+                && (!defined $expected_is_displayed || $elements[0]->is_displayed == $expected_is_displayed))
+            {
+                $element = $elements[0];
+                return 1;
+            }
+            return 0;
+        },
+        $args{description} // ($selector . ' present'),
+        $args{timeout},
+        $args{check_interval},
+    );
+    return $element;
 }
 
 sub kill_driver() {

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -324,7 +324,7 @@ sub element_not_present {
 sub wait_until {
     my ($check_function, $check_description, $timeout, $check_interval) = @_;
     $timeout        //= 10;
-    $check_interval //= 0.2;
+    $check_interval //= 1;
 
     while (1) {
         if ($check_function->()) {

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -58,7 +58,7 @@ $driver->find_element_by_link_text('Logout')->click();
 
 # quit tour temporarly
 $driver->get('/login?user=nobody');
-ok($driver->find_element('#step-0')->is_displayed(), 'tour popover is displayed');
+wait_for_element(selector => '#step-0', is_displayed => 1, description => 'tour popover is displayed');
 my $text = $driver->find_element('h3.popover-header')->get_text();
 is($text, 'All tests area');
 $driver->find_element_by_link_text('Logged in as nobody')->click();
@@ -71,11 +71,11 @@ my $clear = q{
 $driver->execute_script($clear);
 $driver->refresh();
 $driver->get('/login?user=nobody');
-ok($driver->find_element('#step-0')->is_displayed(), 'tour popover is displayed again');
+wait_for_element(selector => '#step-0', is_displayed => 1, description => 'tour popover is displayed again');
 
 # do the tour
 $driver->find_element_by_id('next')->click();
-ok($driver->find_element('#step-1')->is_displayed(), 'tour popover is displayed');
+wait_for_element(selector => '#step-1', is_displayed => 1, description => 'tour popover is displayed');
 $driver->pause();
 $driver->find_element_by_id('prev')->click();
 $driver->execute_script($clear);


### PR DESCRIPTION
See particular commit messages. This will hopefully prevent

```
not ok 6 - tour popover is displayed again

#   Failed test 'tour popover is displayed again'
#   at t/ui/24-feature-tour.t line 74.
```

which has been observed quite often lately in the CI.