### PR TITLE
Don't silently exit doc generation if asciidoctor not available

### DIFF
--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -143,7 +143,7 @@ call_asciidoctor() {
     cd ..
 }
 
-if [[ -z ${TRAVIS_PULL_REQUEST} ]] && [[ -n ${SSH_KEY} ]] && [[ -n ${SSH_IV} ]]; then
+if [[ ${TRAVIS_PULL_REQUEST} == false ]] && [[ -n ${SSH_KEY} ]] && [[ -n ${SSH_IV} ]]; then
     publish=1
     set_sshkey
 fi

--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -102,9 +102,8 @@ SSH_IV=$2
 
 
 check_asciidoctor() {
-    asciidoctor_bin=$(command -v asciidoctor)
-
-    if [ -z "${asciidoctor_bin}" ] || [ ! -f "${asciidoctor_bin}" ]; then
+    asciidoctor_bin=$(command -v asciidoctor) || true
+    if [[ -z $asciidoctor_bin ]] || [[ ! -f $asciidoctor_bin ]]; then
         echo "Could not find asciidoctor binary in your path, please install it and run this command again:"
         echo "    sudo gem install asciidoctor pygments.rb"
         echo "    sudo gem install asciidoctor-pdf --pre"
@@ -112,7 +111,6 @@ check_asciidoctor() {
         echo "    sudo zypper install 'perl(Pod::AsciiDoctor)'"
         exit 1
     fi
-
 }
 
 set_sshkey() {


### PR DESCRIPTION
Instead, show the error message which is already present (but never shown).