### PR TITLE
apparmor: Update profile based on current o3 state

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -26,21 +26,21 @@
   /usr/bin/ssh rcx,
   /usr/bin/unzip-plain rix,
   /usr/lib/git/git rix,
-  /usr/lib/git/git-remote rix,
   /usr/lib/git/git-add rix,
-  /usr/lib/git/git-rm rix,
-  /usr/lib/git/git-rebase rix,
   /usr/lib/git/git-commit rix,
   /usr/lib/git/git-push rix,
+  /usr/lib/git/git-rebase rix,
+  /usr/lib/git/git-remote rix,
+  /usr/lib/git/git-rm rix,
+  /usr/share/openqa/assets/** r,
   /usr/share/openqa/dbicdh/** r,
   /usr/share/openqa/lib/** r,
   /usr/share/openqa/public/** r,
-  /usr/share/openqa/assets/** r,
   /usr/share/openqa/script/openqa r,
   /usr/share/openqa/templates/ r,
   /usr/share/openqa/templates/** r,
-  /var/lib/openqa/.gitconfig r,
   /var/lib/openqa/.config/openqa/client.conf r,
+  /var/lib/openqa/.gitconfig r,
   /var/lib/openqa/backlog/ r,
   /var/lib/openqa/cache/** rw,
   /var/lib/openqa/db/ r,
@@ -69,6 +69,7 @@
   /var/lib/openqa/webui/** rw,
   /var/log/openqa rwk,
   /var/tmp/* rw,
+  owner /var/lib/openqa/share/tests/** rwl,
 
 
   profile /usr/bin/ssh {
@@ -77,6 +78,7 @@
     #include <abstractions/nameservice>
 
     /etc/ssh/ssh_config r,
+    /etc/ssh/ssh_known_hosts r,
     /etc/ssl/openssl.cnf r,
     /proc/*/fd/ r,
     /proc/filesystems r,


### PR DESCRIPTION
* Sort alphabetically
* Updated profile with `aa-logprof /var/log/audit/audit.log.1`
    
Related progress issue: https://progress.opensuse.org/issues/57680