### PR TITLE
Update reference after saving YAML in editor

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -426,6 +426,8 @@ function submitTemplateEditor(preview) {
             // Once a valid YAML template was saved we no longer offer the legacy editor
             $('#toggle-yaml-editor').hide();
             $('#media-add').hide();
+            // Update the reference to the saved document
+            form.data('reference', editor.doc.getValue());
         }
         if (data.hasOwnProperty('changes')) {
             var preview = CodeMirror(result[0], {


### PR DESCRIPTION
The API verifies that the YAML document given as a reference matches the current state in the database, so that mid-air collisions can be caught when two people edit the same group.

The editor needs to update its reference after saving, otherwise it'll provoke false conflict errors.

Fixes: [poo#57065](https://progress.opensuse.org/issues/57065)