### PR TITLE
Limit concurrency for webui workers

### DIFF
--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -9,7 +9,7 @@ Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service
 # TODO: define whether we want to run the web ui with the same user
 User=geekotest
 # Our API commands are very expensive, so the default timeouts are too tight
-ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 20 -G 800
+ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 30 -c 1 -G 800
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We currently allow up to 1000 (the default) requests to be handled concurrently by every webui worker. Unfortunately that doesn't always work, because many requests take multiple seconds to be processed and they block during this time with database queries and the like.

This becomes a problem when a purely non-blocking request (such as an upload) is in progress, while another request arrives that will block the worker process for a few seconds (such as a worker status update). In this case both requests would be blocked for a few seconds, the upload might even be stalled and new incoming data could not be received from the socket until the status update is finished.

So, this PR changes the `-c` option of the prefork command to `1`, enforcing that only one request can be processed at a time by each worker. To offset this a little bit, i've also increased the number of workers from `20` to `30` with the `-w` option. That means the webui will be able to handle `30` requests concurrently (and safely) by default from now.