### PR TITLE
Make clickable links if a setting looks like a URL

### DIFF
--- a/templates/test/settings.html.ep
+++ b/templates/test/settings.html.ep
@@ -8,7 +8,14 @@
         % for my $k (sort keys %{$job->settings_hash}) {
         <tr>
             <td style="text-align: left;"><%= $k %></td>
-            <td style="text-align: left;"><%= $job->settings_hash->{$k} %></td>
+            <td style="text-align: left;">
+            % if ($job->settings_hash->{$k} =~ m{^https?://}) {
+                <a href="<%= $job->settings_hash->{$k} %>"><%= $job->settings_hash->{$k} %></a>
+            % } else
+            % {
+                <%= $job->settings_hash->{$k} %>
+            % }
+            </td>
         </tr>
         % }
     </tbody>


### PR DESCRIPTION
See https://progress.opensuse.org/issues/15384

It simply checks if the setting starts with `https?://` and creates a clickable link.