### PR TITLE
Make job template code for testsuites clearer

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -397,22 +397,21 @@ sub update {
                     my $machine_name = $yaml_defaults_for_arch->{machine};
                     my $settings     = dclone($yaml_defaults_for_arch->{settings} // {});
                     if (ref $spec eq 'HASH') {
-                        foreach my $name (sort keys %$spec) {
-                            my $attr = $spec->{$name};
-                            $testsuite_name = $name;
-                            if ($attr->{priority}) {
-                                $prio = $attr->{priority};
-                            }
-                            if ($attr->{machine}) {
-                                $machine_name = $attr->{machine};
-                            }
-                            if ($attr->{testsuite}) {
-                                $job_template_name = $testsuite_name;
-                                $testsuite_name    = $attr->{testsuite};
-                            }
-                            if ($attr->{settings}) {
-                                %$settings = (%{$settings // {}}, %{$attr->{settings}});
-                            }
+                        # We only have one key. Asserted by schema
+                        $testsuite_name = (keys %$spec)[0];
+                        my $attr = $spec->{$testsuite_name};
+                        if ($attr->{priority}) {
+                            $prio = $attr->{priority};
+                        }
+                        if ($attr->{machine}) {
+                            $machine_name = $attr->{machine};
+                        }
+                        if ($attr->{testsuite}) {
+                            $job_template_name = $testsuite_name;
+                            $testsuite_name    = $attr->{testsuite};
+                        }
+                        if ($attr->{settings}) {
+                            %$settings = (%{$settings // {}}, %{$attr->{settings}});
                         }
                     }
                     else {

--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -24,6 +24,7 @@ properties:
               - type: string
                 description: Name of a test suite name
               - type: object
+                maxProperties: 1
                 description: A test suite with machine and/ or priority specified, or a custom job template name if testsuite was specified
                 additionalProperties: false
                 patternProperties:

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -573,7 +573,9 @@ $yaml->{scenarios}{'x86_64'}{$product} = [
     'spam',
     "eg-G_S +133t*\t",
     {
-        'foo'               => {},
+        'foo' => {},
+    },
+    {
         "b-A_RRRR +133t*\t" => {
             machine  => 'x86_64',
             priority => 33,
@@ -782,6 +784,36 @@ $t->post_ok(
             {path => '/products',  message => 'Missing property.'},
             {path => '/scenarios', message => 'Missing property.'},
         ],
+    },
+    'posting invalid YAML template results in error'
+);
+
+my $template_yaml = <<'EOM';
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+      - x:
+          machine: 32bit
+        y:
+          machine: 32bit
+products:
+  opensuse-13.1-DVD-i586:
+    distri:  opensuse
+    flavor:  DVD
+    version: '13.1'
+EOM
+# Assure that testsuite hashes with more than one key are detected as invalid
+$t->post_ok(
+    '/api/v1/job_templates_scheduling/' . $opensuse->id,
+    form => {
+        schema   => $schema_filename,
+        template => $template_yaml,
+    },
+)->status_is(400)->json_is(
+    '' => {
+        error_status => 400,
+        error =>
+          [{path => '/scenarios/i586/opensuse-13.1-DVD-i586/0', message => '/anyOf/1 Too many properties: 2/1.'},],
     },
     'posting invalid YAML template results in error'
 );


### PR DESCRIPTION
In case of a hash we only expect one key. This way it is clearer and
will also die if we get more than one key.