### PR TITLE
Split off creation/ update of job templates

### DIFF
--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -831,7 +831,7 @@ subtest 'Create and modify groups with YAML' => sub {
             template => YAML::XS::Dump($yaml)}
     )->status_is(400, 'Post rejected because testsuite does not exist')->json_is(
         '' => {
-            error        => ['Testsuite \'foobar\' is invalid'],
+            error        => ['Testsuite \'eggs\' is invalid'],
             error_status => 400,
             id           => $job_group_id3
         },


### PR DESCRIPTION
Going through the code with @perlpunk and answering some questions made me realize I've been putting off splitting of this logic for long enough. And it should be a good idea to do that before adding more features like [poo#56534](https://progress.opensuse.org/issues/56534) which will add more complexity.

I feel like this might not be the most elegant method signature.. although the most important thing is to split off the actual creation of job templates from the whole YAML parsing, so this is where I'm starting. Suggestions to make it more beautiful are welcome, though.

There's no functional changes here.