### PR TITLE
Improve worker status update performance

### DIFF
--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -537,7 +537,8 @@ subtest 'job is marked as linked if accessed from recognized referal' => sub {
     $_settings{TEST} = 'refJobTest-step';
     $job = _job_create(\%_settings);
 
-    my $module = $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
+    my $module = $job->modules->find({name => 'a'});
     $job->update;
     $linked = job_is_linked($job);
     is($linked, 0, 'new job is not linked');

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -46,7 +46,8 @@ my $needledir_fedora    = "t/data/openqa/share/tests/fedora/needles";
 # create dummy job
 my $job = $schema->resultset('Jobs')->create_from_settings(\%settings);
 # create dummy module
-my $module = $job->insert_module({name => "a", category => "a", script => "a", flags => {}});
+$job->insert_module({name => "a", category => "a", script => "a", flags => {}});
+my $module = $job->modules->find({name => 'a'});
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
 
 sub process {


### PR DESCRIPTION
According to my profiling data, worker status updates containing `test_order` data are by far the slowest. They can take over 60 seconds for large jobs (LTP). This change slightly optimizes one of the responsible hot spots and increases performance by roughly 30%. Much of the overhead is caused by `DBIx::Class`, so i'm not sure i can improve it much more without adding custom SQL queries.

Progress: https://progress.opensuse.org/issues/55904