### PR TITLE
Accept a list of machines in defaults and job templates

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -450,9 +450,9 @@ sub _create_job_templates_from_yaml {
                 my $testsuite_name;
                 my $job_template_name;
                 # Assign defaults
-                my $prio         = $yaml_defaults_for_arch->{priority};
-                my $machine_name = $yaml_defaults_for_arch->{machine};
-                my $settings     = dclone($yaml_defaults_for_arch->{settings} // {});
+                my $prio          = $yaml_defaults_for_arch->{priority};
+                my $machine_names = $yaml_defaults_for_arch->{machine};
+                my $settings      = dclone($yaml_defaults_for_arch->{settings} // {});
                 if (ref $spec eq 'HASH') {
                     # We only have one key. Asserted by schema
                     $testsuite_name = (keys %$spec)[0];
@@ -461,7 +461,7 @@ sub _create_job_templates_from_yaml {
                         $prio = $attr->{priority};
                     }
                     if ($attr->{machine}) {
-                        $machine_name = $attr->{machine};
+                        $machine_names = $attr->{machine};
                     }
                     if ($attr->{testsuite}) {
                         $job_template_name = $testsuite_name;
@@ -475,26 +475,30 @@ sub _create_job_templates_from_yaml {
                     $testsuite_name = $spec;
                 }
 
-                my $job_template_key
-                  = $arch . $product_name . $machine_name . $testsuite_name . ($job_template_name // '');
-                die "Job template name '"
-                  . ($job_template_name // $testsuite_name)
-                  . "' is defined more than once. "
-                  . "Use a unique name and specify 'testsuite' to re-use test suites in multiple scenarios.\n"
-                  if $job_template_names{$job_template_key};
-                $job_template_names{$job_template_key} = {
-                    prio              => $prio,
-                    machine_name      => $machine_name,
-                    arch              => $arch,
-                    product_name      => $product_name,
-                    product_spec      => $yaml_products->{$product_name},
-                    job_template_name => $job_template_name,
-                    testsuite_name    => $testsuite_name,
-                    settings          => $settings
-                };
+                $machine_names = [$machine_names] if ref($machine_names) ne 'ARRAY';
+                foreach my $machine_name (@{$machine_names}) {
+                    my $job_template_key
+                      = $arch . $product_name . $machine_name . $testsuite_name . ($job_template_name // '');
+                    die "Job template name '"
+                      . ($job_template_name // $testsuite_name)
+                      . "' is defined more than once. "
+                      . "Use a unique name and specify 'testsuite' to re-use test suites in multiple scenarios.\n"
+                      if $job_template_names{$job_template_key};
+                    $job_template_names{$job_template_key} = {
+                        prio              => $prio,
+                        machine_name      => $machine_name,
+                        arch              => $arch,
+                        product_name      => $product_name,
+                        product_spec      => $yaml_products->{$product_name},
+                        job_template_name => $job_template_name,
+                        testsuite_name    => $testsuite_name,
+                        settings          => $settings
+                    };
+                }
             }
         }
     }
+
     return \%job_template_names;
 }
 

--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -33,7 +33,11 @@ properties:
                     additionalProperties: false
                     properties:
                       machine:
-                        type: string
+                        oneOf:
+                          - type: string
+                          - type: array
+                            items:
+                            - type: string
                       priority:
                         type: number
                       settings:
@@ -61,7 +65,11 @@ properties:
         additionalProperties: false
         properties:
           machine:
-            type: string
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                - type: string
           priority:
             type: number
           settings:

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -131,6 +131,11 @@ scenarios:
         settings:
           <b>SOME_TEST_VARIABLE</b>: <b>VALUE</b>
                         </code>
+                        <div>Specify multiple machines:</div>
+                        <code>
+    - <b>TESTSUITE</b>:
+        machine: [<b>MACHINE1</b>, <b>MACHINE2</b>]
+                        </code>
                         <div>Re-use a test suite with a custom job template name:</div>
                         <code>
     - <b>JOBNAME</b>:


### PR DESCRIPTION
- Extend the schema to accept an array of strings or a string
- Transparently convert a single machine to an array
- Loop through the machines to create/ update the job template

Fixes: [poo#56534](https://progress.opensuse.org/issues/56534)