### PR TITLE
Fix openqa-load-templates example in documentation

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -691,7 +691,7 @@ openqa-dump-templates --json --group test > test.json
 
 [source,sh]
 --------------------------------------------------------------------------------
-openqa-load-templates --group test test.json
+openqa-load-templates test.json
 --------------------------------------------------------------------------------
 
 == Asset handling ==


### PR DESCRIPTION
@Amrysliu mentioned in the chat that the documentation is wrong.

---

The `--group` parameter is only used with `openqa-dump-templates` to filter the output and must not be used with `openqa-load-templates` to load the (already filtered) JSON file.