### PR TITLE
Allow . for job template name/ test suite in schema

### DIFF
--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -28,7 +28,7 @@ properties:
                 description: A test suite with machine and/ or priority specified, or a custom job template name if testsuite was specified
                 additionalProperties: false
                 patternProperties:
-                  "^[A-Za-z\\s0-9_*+-]+$":
+                  "^[A-Za-z\\s0-9_*.+-]+$":
                     type: object
                     additionalProperties: false
                     properties:
@@ -49,7 +49,7 @@ properties:
                             type: string
                       testsuite:
                         type: string
-                        pattern: "^[A-Za-z\\s0-9_*+-]+$"
+                        pattern: "^[A-Za-z\\s0-9_*.+-]+$"
                         description: The test suite this scenario is based on if a custom job template name was used
   defaults:
     description: A set of architectures with default configurations

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -571,12 +571,12 @@ $yaml->{products}{$product}{version} = '42.1';
 # Add non-trivial test suites to exercise the validation
 $yaml->{scenarios}{'x86_64'}{$product} = [
     'spam',
-    "eg-G_S +133t*\t",
+    "eg-G_S +133t*.\t",
     {
         'foo' => {},
     },
     {
-        "b-A_RRRR +133t*\t" => {
+        "b-A_RRRR +133t*.\t" => {
             machine  => 'x86_64',
             priority => 33,
         },


### PR DESCRIPTION
- Update the schema
- Use . in validation unit test

Fixes: [poo#58130](https://progress.opensuse.org/issues/58130)