### PR TITLE
Prevent potential deadlocks in scheduler and ws server

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -36,6 +36,8 @@ our $RUNNING;
 sub startup {
     my $self = shift;
 
+    OpenQA::Scheduler::Client::mark_current_process_as_scheduler;
+
     $self->_setup if $RUNNING;
 
     $self->defaults(appname => 'openQA Scheduler');

--- a/lib/OpenQA/Scheduler/Client.pm
+++ b/lib/OpenQA/Scheduler/Client.pm
@@ -22,6 +22,17 @@ use OpenQA::Utils 'service_port';
 has client => sub { OpenQA::Client->new(api => 'localhost') };
 has port   => sub { service_port('scheduler') };
 
+my $IS_SCHEDULER_ITSELF;
+sub mark_current_process_as_scheduler { $IS_SCHEDULER_ITSELF = 1; }
+sub is_current_process_the_scheduler { return $IS_SCHEDULER_ITSELF; }
+
+sub new {
+    my $class = shift;
+    die 'creating an OpenQA::Scheduler::Client from the scheduler itself is forbidden'
+      if is_current_process_the_scheduler;
+    $class->SUPER::new(@_);
+}
+
 sub wakeup {
     my ($self, $worker_id) = @_;
     return if $self->{wakeup};

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -243,9 +243,7 @@ sub send_command {
     };
 
     # prevent ws server querying itself (which would cause it to hang until the connection times out)
-    # FIXME: Marking jobs as incomplete (and therefore possibly having send commands to abort other jobs in the cluster)
-    #        should not be the web socket server's responsibility.
-    if (defined $OpenQA::Utils::app && ($OpenQA::Utils::app->defaults('appname') eq 'openQA Websocket Server')) {
+    if (OpenQA::WebSockets::Client::is_current_process_the_websocket_server) {
         my $result = OpenQA::WebSockets::ws_send($self->id, $args{command}, $args{job_id}, undef);
         return $result && !$result->error;
     }

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -244,8 +244,7 @@ sub send_command {
 
     # prevent ws server querying itself (which would cause it to hang until the connection times out)
     if (OpenQA::WebSockets::Client::is_current_process_the_websocket_server) {
-        my $result = OpenQA::WebSockets::ws_send($self->id, $args{command}, $args{job_id}, undef);
-        return $result && !$result->error;
+        return OpenQA::WebSockets::ws_send($self->id, $args{command}, $args{job_id}, undef);
     }
 
     my $client = OpenQA::WebSockets::Client->singleton;

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -26,6 +26,8 @@ our $RUNNING;
 sub startup {
     my $self = shift;
 
+    OpenQA::WebSockets::Client::mark_current_process_as_websocket_server;
+
     $self->_setup if $RUNNING;
 
     $self->defaults(appname => 'openQA Websocket Server');

--- a/lib/OpenQA/WebSockets/Client.pm
+++ b/lib/OpenQA/WebSockets/Client.pm
@@ -24,6 +24,17 @@ use OpenQA::Utils 'service_port';
 has client => sub { OpenQA::Client->new(api => 'localhost') };
 has port   => sub { service_port('websocket') };
 
+my $IS_WS_SERVER_ITSELF;
+sub mark_current_process_as_websocket_server { $IS_WS_SERVER_ITSELF = 1; }
+sub is_current_process_the_websocket_server { return $IS_WS_SERVER_ITSELF; }
+
+sub new {
+    my $class = shift;
+    die 'creating an OpenQA::WebSockets::Client from the Websocket server itself is forbidden'
+      if is_current_process_the_websocket_server;
+    $class->SUPER::new(@_);
+}
+
 sub send_job {
     my ($self, $job) = @_;
     my $res = $self->client->post($self->_api('send_job'), json => $job)->result;


### PR DESCRIPTION
This prevents the scheduler and ws server from querying itself which would lead to a deadlock (see https://progress.opensuse.org/issues/57017).

This change makes problems like this easier to debug by letting the scheduler and ws server die in that situation with a clear error message.

OpenQA::Schema::Result::Workers::send_command is still handling the case that it is being called from the ws server itself because that function is called all over the place and I like to keep it robust. However, the hack to use the application's name for that check has been removed.