### PR TITLE
Render result YAML when previewing

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -429,13 +429,13 @@ function submitTemplateEditor(preview) {
             // Update the reference to the saved document
             form.data('reference', editor.doc.getValue());
         }
-        if (data.hasOwnProperty('changes')) {
-            var preview = CodeMirror(result[0], {
-                mode: data.changes ? 'diff' : 'yaml',
+        if (data.changes || data.preview) {
+            var preview = CodeMirror($('<pre/>').appendTo(result)[0], {
+                mode: data.preview ? 'yaml' : 'diff',
                 lineNumbers: true,
                 lineWrapping: true,
                 readOnly: true,
-                value: data.changes,
+                value: data.preview || data.changes,
             });
         }
         else {

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -885,6 +885,45 @@ subtest 'Create and modify groups with YAML' => sub {
             template => YAML::XS::Dump($yaml),
         });
     $t->status_is(200, 'Posting preview successful');
+    is_deeply(
+        YAML::XS::Load(YAML::XS::Load($t->tx->res->body)->{preview}),
+        {
+            products => {
+                'opensuse-13.1-DVD-i586' => {
+                    distri  => 'opensuse',
+                    flavor  => 'DVD',
+                    version => '13.1',
+                }
+            },
+            scenarios => {
+                i586 => {
+                    'opensuse-13.1-DVD-i586' => [
+                        {
+                            eggs => {
+                                machine  => '32bit',
+                                priority => 20,
+                                settings => {BAR => 'updated later', FOO => 'removed later'},
+                            }
+                        },
+                        {
+                            foobar => {
+                                machine  => '64bit',
+                                priority => 40,
+                                settings => {},
+                            }
+                        },
+                        {
+                            spam => {
+                                machine  => '64bit',
+                                priority => 40,
+                                settings => {},
+                            }
+                        },
+                    ]}
+            },
+        },
+        'Expected result returned in response'
+    ) || diag explain $t->tx->res->body;
     $t->get_ok("/api/v1/job_templates_scheduling/$job_group_id3");
     is_deeply(
         YAML::XS::Load($t->tx->res->body),


### PR DESCRIPTION
We have the parsed scenarios in a hash now. Generating a result is as easy as feeding the data back into the job template format.

Fixes: [poo#56279](https://progress.opensuse.org/issues/56279)