### PR TITLE
Push documentation nightly to openqabot fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,13 @@ aliases:
       fullstack) make test CHECKSTYLE=0 FULLSTACK=1           PROVE_ARGS="$HARNESS t/full-stack.t" RETRY=3;;
       scheduler) make test CHECKSTYLE=0 SCHEDULER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/05-scheduler-full.t";;
       developer) make test CHECKSTYLE=0 DEVELOPER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/33-developer_mode.t";;
-      build.docs) COMMIT_AUTHOR_EMAIL=skynet@open.qa GEM_HOME=$(pwd)/.gem script/generate-documentation $encrypted_e2c381aa6b8c_key $encrypted_e2c381aa6b8c_iv;;
       esac
+
+  - &git_token_notification
+    command: |
+      echo 'echo $GITHUB_TOKEN' > $(pwd)/.git-askpass
+      export GIT_ASKPASS=$(pwd)/.git-askpass
+      chmod +x $(pwd)/.git-askpass
 
 images:
   - &docker_config
@@ -108,6 +113,7 @@ images:
       PERL_TEST_HARNESS_DUMP_TAP: test-results
       HARNESS: --harness TAP::Harness::JUnit
       COVEROPT: -MDevel::Cover=-select_re,'^/lib',-ignore_re,'^t/.*',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement
+      COMMIT_AUTHOR_EMAIL: skynet@open.qa
 
   - &base
     image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
@@ -125,10 +131,11 @@ jobs:
       - setup_remote_docker
       - run:
           command: |
-            git config user.email "skynet@open.qa"
+            git config user.email "${COMMIT_AUTHOR_EMAIL}"
             git config user.name "Dependency bot circleci"
             git config core.autocrlf true
             hub --version
+      - run: *git_token_notification
       - run:
           command: |
             depid=$(date +%y%m%d%H%M%S)
@@ -142,11 +149,8 @@ jobs:
                 curl -s https://api.github.com/repos/os-autoinst/os-autoinst/commits | grep sha | head -n 1 | grep -o -E '[0-9a-f]{40}' > .circleci/autoinst.sha
                 git add .circleci/dependencies.txt .circleci/autoinst.sha
                 git commit -m "Dependency cron $depid"
-                echo 'echo $GITHUB_TOKEN' > $(pwd)/.git-askpass
-                export GIT_ASKPASS=$(pwd)/.git-askpass
-                chmod +x $(pwd)/.git-askpass
                 git push -q -f https://token@github.com/openqabot/openQA.git dependency_$depid
-                hub pull-request -m "Dependency cron $depid" --base $CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH --head openqabot:dependency_$depid
+                hub pull-request -m "Dependency cron $depid" --base "$CIRCLE_PROJECT_USERNAME":"$CIRCLE_BRANCH" --head "openqabot:dependency_$depid"
             )
 
   cache:
@@ -261,9 +265,28 @@ jobs:
       - store_artifacts: *store_cover_db
       - run: cover -select_re '^lib/' -report codecov
 
-  build.docs:
-    <<: *test-template
+  build.docs: &docs-template
     name: "Generating docs"
+    docker:
+      - <<: *base
+    steps:
+      - checkout
+      - run: *chown_hack_for_cache
+      - restore_cache: *restore_cache
+      - run: *check_cache
+      - run: *install_cached_packages
+      - run: sudo zypper -n install hub
+      - run: *git_token_notification
+      - run:
+          command: |
+            export GEM_HOME=$(pwd)/.gem
+            [ -z "${CIRCLE_PROJECT_USERNAME}" ] || export PULL_REQUEST_TARGET="${CIRCLE_PROJECT_USERNAME}:gh-pages"
+            bash -xe script/generate-documentation https://token@github.com/openqabot/openQA.git gh-pages-daily
+
+  build.docs.nightly:
+    <<: *docs-template
+    environment:
+      PUBLISH: 1
 
 workflows:
   version: 2
@@ -317,3 +340,4 @@ workflows:
                - master
    jobs:
       - dependencies-pr
+      - build.docs.nightly

--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -15,8 +15,19 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# the script accepts input arguments:
+# $1 - target repo (which repository is used for documentation commit), 
+# defaults to current repo
+# $2 - target branch, defaults to gh-pages
+
+# the script uses environment variables:
+# PUBLISH - non-empty string indicates that commit should be pushed back to target repo
+# (authentification must be set up in advance)
+# PULL_REQUEST_TARGET - if set, then will be passed to `hub pull-request` command
+# (authentification must be set up in advance)
+
 update_docs() {
-        git clone -b "$TARGET_BRANCH" --single-branch "$REPO" out
+        git clone -b "$TARGET_BRANCH" --single-branch "$TARGET_REMOTE" out
         cd out
         if [ -n "${COMMIT_AUTHOR_EMAIL}" ]; then
             git config user.name "CI"
@@ -35,20 +46,23 @@ update_docs() {
         # gh#1480
         # 2 files changed, 2 insertions(+), 2 deletions(-)
         ANYTHING_CHANGED=$(git diff --shortstat | perl -ne 'my $n; print $n = () = m/(?: 2 \w+)/g')
-        if [ "${ANYTHING_CHANGED}" -ne 3 ]; then
+        if [ "${ANYTHING_CHANGED}" -ne 3 ] && [ -n "${ANYTHING_CHANGED}" ]; then
             cd ..
             git add _includes/api.html
             git add docs/index.html docs/current.pdf docs/api/testapi.html
             git add docs/api/schema
-            echo "Update documentation to commit ${shortref}" > last.commit
+            topic="Update documentation to commit ${shortref}"
+            echo "$topic" > last.commit
             echo "" >> last.commit # somehow travis does not like \n
             [[ -z "${CIRCLE_SHA1}" ]] || (cd .. && git log --pretty=fuller "${CIRCLE_SHA1}" -1 >> out/last.commit)
             git commit -F last.commit
-            [[ -n ${publish} ]] && git push "$SSH_REPO" "$TARGET_BRANCH"
+            if [[ -n "${PUBLISH}" ]] && [[ "${PUBLISH}" != 0 ]]; then
+                git push "$TARGET_REMOTE" "$TARGET_BRANCH"
+                [[ -z "${PULL_REQUEST_TARGET}" ]] || hub pull-request -m "$topic" --base "${PULL_REQUEST_TARGET}"
+            fi
             cd ..
         fi
         rm -rf out
-
 }
 
 update_api() {
@@ -91,14 +105,10 @@ asciidoctor_bin="/bin/not/set"
 shortref=$(git rev-parse --short HEAD)
 verbose_doc_name=$(date +%Y%m%d)"_"${shortref} #we are not intending to run this off a git repository
 scriptroot="$( cd "$(dirname "$0")" ; pwd -P )"
-publish=
 tmpwd=$(mktemp -d -t openqa-doc-XXXX)
-REPO=$(git config remote.origin.url)
-SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
-TARGET_BRANCH="gh-pages"
-SSH_KEY=$1
-SSH_IV=$2
-
+TARGET_REMOTE="${1:-$(git config --get remote.origin.url)}"
+TARGET_BRANCH="${2:-gh-pages}"
+PUBLISH="${PUBLISH}"
 
 check_asciidoctor() {
     asciidoctor_bin=$(command -v asciidoctor) || true
@@ -113,13 +123,6 @@ check_asciidoctor() {
         echo "    sudo zypper install 'perl(Pod::AsciiDoctor)'"
         exit 1
     fi
-}
-
-set_sshkey() {
-    openssl aes-256-cbc -K "$SSH_KEY" -iv "$SSH_IV" -in .openqa-travis.enc -out .openqa-travis -d
-    chmod 600 .openqa-travis
-    eval "$(ssh-agent -s)"
-    ssh-add .openqa-travis
 }
 
 install_asciidoctor() {
@@ -145,10 +148,6 @@ call_asciidoctor() {
     cd ..
 }
 
-if [[ ${TRAVIS_PULL_REQUEST} == false ]] && [[ -n ${SSH_KEY} ]] && [[ -n ${SSH_IV} ]]; then
-    publish=1
-    set_sshkey
-fi
 if [[ -n ${CI} ]]; then
     cpanm --local-lib=~/perl5 local::lib && eval "$(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)"
     install_asciidoctor


### PR DESCRIPTION
Since we don't want to give CI push permissions to upstream, this PR will generate and push documentation nightly to openqabot fork, then create PR on upstream with daily changes.
(Very similar to nightly dependencies job).

Fixes: [poo#57548](https://progress.opensuse.org/issues/57548)