### PR TITLE
Avoid problems with localized PostgreSQL error messages

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1074,8 +1074,7 @@ sub insert_module {
     }
     catch {
         my $err = $_;
-        die $err
-          unless $err =~ /duplicate key value violates unique constraint "job_modules_job_id_name_category_script"/;
+        die $err unless $err =~ /"job_modules_job_id_name_category_script"/;
     };
 }
 

--- a/lib/OpenQA/Schema/ResultSet/Screenshots.pm
+++ b/lib/OpenQA/Schema/ResultSet/Screenshots.pm
@@ -38,8 +38,7 @@ sub populate_images_to_job {
         }
         catch {
             my $err = $_;
-            die $err
-              unless $err =~ /duplicate key value violates unique constraint "screenshots_filename"/;
+            die $err unless $err =~ /"screenshots_filename"/;
             $ids{$img} = $self->find({filename => $img})->id;
         };
     }


### PR DESCRIPTION
This problem can happen when you initialize your PostgreSQL database with a non-english [locale](https://www.postgresql.org/docs/current/locale.html). Suddenly PostgreSQL error messages cannot be string matched anymore. There are other ways to detect unique constraint violations, like:
```perl
        log_debug "creating $img";
        local our $is_unique_violation;
        try {

            # Unique violation
            my $dbh = $self->result_source->storage->dbh;
            local $dbh->{HandleError} = sub { $is_unique_violation = $dbh->state eq '23505' };

            $ids{$img} = $self->create({filename => $img, t_created => $now})->id;
        }
        catch {
            my $err = $_;
            die $err unless $is_unique_violation;
            $ids{$img} = $self->find({filename => $img})->id;
        };
```
But it requires some trickery that's not easily explained, like the use of `local our`. So i think for now just using string comparisons on the name of the unique constraint might be the most sensible option. But only slightly.