### PR TITLE
Reduce use of project dir to be more flexible regarding custom test runs

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -266,19 +266,12 @@ sub store_needle_infos {
         $needle_cache = \%hash;
     }
 
-    my %needles;
-
     for my $detail (@{$details}) {
         if ($detail->{needle}) {
-            my $nfn    = $detail->{json};
-            my $needle = OpenQA::Schema::Result::Needles::update_needle($nfn, $self, 1, $needle_cache);
-            $needles{$needle->id} ||= 1;
+            OpenQA::Schema::Result::Needles::update_needle($detail->{json}, $self, 1, $needle_cache);
         }
         for my $needle (@{$detail->{needles} || []}) {
-            my $nfn    = $needle->{json};
-            my $needle = OpenQA::Schema::Result::Needles::update_needle($nfn, $self, 0, $needle_cache);
-            # failing needles are more interesting than succeeding, so ignore previous values
-            $needles{$needle->id} = -1;
+            OpenQA::Schema::Result::Needles::update_needle($needle->{json}, $self, 0, $needle_cache);
         }
     }
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -42,7 +42,6 @@ our @EXPORT  = qw(
   $resultdir
   &data_name
   &locate_needle
-  &needle_info
   &needledir
   &productdir
   &testcasedir
@@ -193,41 +192,6 @@ sub locate_needle {
 
     log_error("Needle file $relative_needle_path not found within $needles_dir.");
     return undef;
-}
-
-sub needle_info {
-    my ($name, $distri, $version, $file_name, $needles_dir) = @_;
-
-    $file_name = locate_needle($file_name, $needles_dir) if !-f $file_name;
-    return undef unless defined $file_name;
-
-    my $needle;
-    try {
-        $needle = decode_json(Mojo::File->new($file_name)->slurp);
-    }
-    catch {
-        log_warning("Failed to parse $file_name: $_");
-    };
-    return undef unless defined $needle;
-
-    my $png_fname = basename($file_name, '.json') . '.png';
-    my $pngfile   = File::Spec->catpath('', $needles_dir, $png_fname);
-
-    $needle->{needledir} = $needles_dir;
-    $needle->{image}     = $pngfile;
-    $needle->{json}      = $file_name;
-    $needle->{name}      = $name;
-    $needle->{distri}    = $distri;
-    $needle->{version}   = $version;
-
-    # Skip code to support compatibility if HASH-workaround properties already present
-    return $needle unless $needle->{properties};
-
-    # Transform string-workaround-properties into HASH-workaround-properties
-    $needle->{properties}
-      = [map { ref($_) eq "HASH" ? $_ : {name => $_, value => find_bug_number($name)} } @{$needle->{properties}}];
-
-    return $needle;
 }
 
 # Adds a timestamp to a string (eg. needle name) or replace the already present timestamp

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -34,19 +34,16 @@ sub needle {
     my $distri   = $self->param('distri');
     my $version  = $self->param('version') || '';
     my $jsonfile = $self->param('jsonfile') || '';
-    # make sure the directory of the file parameter is a real subdir of
-    # testcasedir before applying it as needledir to prevent access
-    # outside of the zoo
+
+    # make sure the directory of the file parameter is a real subdir of testcasedir before
+    # applying it as needledir to prevent access outside of the zoo
     if ($jsonfile && !is_in_tests($jsonfile)) {
         warn "$jsonfile is not in a subdir of $prjdir/share/tests or $prjdir/tests";
         return $self->render(text => 'Forbidden', status => 403);
     }
-    my $needle = needle_info($name, $distri, $version, $jsonfile);
-    return $self->reply->not_found unless $needle;
 
-    $self->{static} = Mojolicious::Static->new;
-    # needledir is an absolute path from the needle database
-    push @{$self->{static}->paths}, $needle->{needledir};
+    # locate the needle in the needle directory for the given distri and version
+    push(@{($self->{static} = Mojolicious::Static->new)->paths}, needledir($distri, $version));
 
     # name is an URL parameter and can't contain slashes, so it should be safe
     return $self->serve_static_($name . $format);

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -339,11 +339,9 @@ sub _extended_needle_info {
     my $distri               = $basic_needle_data->{distri};
     my $version              = $basic_needle_data->{version};
     my $needle_info          = $self->_basic_needle_info($needle_name, $distri, $version, $file_name, $needle_dir);
-    if (!$needle_info) {
-        my $error_message = sprintf('Could not parse needle: %s for %s %s', $needle_name, $distri, $version);
-        $self->app->log->error($error_message);
-        push(@$error_messages, $error_message);
-        return;
+    unless (defined $needle_info) {
+        push(@$error_messages, sprintf('Could not parse needle: %s for %s %s', $needle_name, $distri, $version));
+        return undef;
     }
 
     $needle_info->{title}          = $needle_name;

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -299,6 +299,7 @@ sub _new_screenshot {
 sub _basic_needle_info {
     my ($self, $name, $distri, $version, $file_name, $needles_dir) = @_;
 
+    $file_name //= "$name.json";
     $file_name = locate_needle($file_name, $needles_dir) if !-f $file_name;
     return undef unless defined $file_name;
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -204,7 +204,6 @@ sub engine_workit {
         OPENQA_URL      => $openqa_url,
         WORKER_INSTANCE => $instance,
         WORKER_ID       => $workerid,
-        PRJDIR          => $OpenQA::Utils::sharedir,
         %$job_settings
     );
     log_debug('Job settings:');
@@ -230,8 +229,6 @@ sub engine_workit {
                 to   => $shared_cache
             );
             my $rsync_request_description = "Rsync cache request from '$rsync_source' to '$shared_cache'";
-
-            $vars{PRJDIR} = $shared_cache;
 
             # enqueue rsync task; retry in some error cases
             for (my $remaining_tries = 3; $remaining_tries > 0; --$remaining_tries) {

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl -w
 
 # Copyright (C) 2016 Red Hat
+# Copyright (C) 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,10 +21,12 @@ use warnings;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
+use Cwd 'abs_path';
 use OpenQA::Schema;
 use OpenQA::Test::Database;
 use OpenQA::Task::Needle::Scan;
 use File::Find;
+use Test::Output 'combined_like';
 use Test::More;
 use Test::Mojo;
 use Test::Warnings;
@@ -167,5 +170,39 @@ OpenQA::Task::Needle::Scan::_needles($t->app);
 is($needles->find({filename => "test-nonexistent.json"})->file_present, 0);
 # this needle exists, so it should have file_present set to 1
 is($needles->find({filename => "installer/test-nestedneedle-1.json"})->file_present, 1);
+
+subtest 'handling relative paths in update_needle' => sub {
+    is($module->job->needle_dir,
+        $needledir_fedora, 'needle dir of job deduced from settings (prerequisite for handling relative paths)');
+
+    subtest 'handle needle path relative to share dir (legacy os-autoinst)' => sub {
+        my $needle
+          = OpenQA::Schema::Result::Needles::update_needle('tests/fedora/needles/test-rootneedle.json', $module, 0);
+        is(
+            $needle->path,
+            abs_path('t/data/openqa/share/tests/fedora/needles/test-rootneedle.json'),
+            'needle path correct'
+        );
+    };
+    subtest 'handle needle path relative to needle dir' => sub {
+        my $needle = OpenQA::Schema::Result::Needles::update_needle('test-rootneedle.json', $module, 0);
+        is(
+            $needle->path,
+            abs_path('t/data/openqa/share/tests/fedora/needles/test-rootneedle.json'),
+            'needle path correct'
+        );
+    };
+    subtest 'handle needle path to non existent needle' => sub {
+        my $needle;
+        combined_like(
+            sub {
+                $needle = OpenQA::Schema::Result::Needles::update_needle('test-does-not-exist.json', $module, 0);
+            },
+            qr/Needle file test-does-not-exist\.json not found within $needledir_fedora/,
+            'error logged',
+        );
+        is($needle, undef, 'no needle created');
+    };
+};
 
 done_testing;


### PR DESCRIPTION
* Locate needles relative to the job's needles directory
* No longer pass the project dir to isotovideo
* See https://progress.opensuse.org/issues/56789 and https://progress.opensuse.org/issues/58184

---

The os-autoinst part is still missing.