### PR TITLE
fetchneedles: Save on execution time by skipping over needle dir symlinks

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -57,7 +57,7 @@ do_fetch() {
     [ "$needles_separate" = 1 ] || return 0
     if test -d products; then
         for nd in products/*/needles; do
-            ! [ -L "$target/$nd" ] || continue
+            [ -h "$target/$nd" ] && continue
             (cd "$target/$nd" && git_update)
         done
     else
@@ -70,7 +70,7 @@ if [ "$updateall" = 1 ]; then
     fail=0
     for repo in *; do
         target="$dir/$repo"
-        ! [ -L "$target" ] || continue
+        [ -h "$target" ] && continue
         [ -d "$target/.git" ] || continue
         (cd "$target" && do_fetch "$target") || fail=1
     done

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -1,10 +1,10 @@
-#!/bin/bash -e
+#!/bin/sh -e
 : "${dbuser:="geekotest"}"
 
 : "${dist:="opensuse"}"
 : "${giturl:="git://github.com/os-autoinst/os-autoinst-distri-opensuse.git"}"
 : "${branch:="master"}"
-: "${email:="openqa@$HOSTNAME"}"
+: "${email:="openqa@$HOST"}"
 : "${username:="openQA web UI"}"
 : "${product:="$dist"}"
 
@@ -52,7 +52,7 @@ git_update() {
 }
 
 do_fetch() {
-    local target=$1
+    target=$1
     git_update
     [ "$needles_separate" = 1 ] || return 0
     if test -d products; then

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -57,6 +57,7 @@ do_fetch() {
     [ "$needles_separate" = 1 ] || return 0
     if test -d products; then
         for nd in products/*/needles; do
+            ! [ -L "$target/$nd" ] || continue
             (cd "$target/$nd" && git_update)
         done
     else


### PR DESCRIPTION
This decreases execution time on o3 from 17s to 9s.