### PR TITLE
Add empty local apparmor profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ install:
 	install -d -m 755 "$(DESTDIR)"/etc/apparmor.d
 	install -m 644 profiles/apparmor.d/usr.share.openqa.script.openqa "$(DESTDIR)"/etc/apparmor.d
 	install -m 644 profiles/apparmor.d/usr.share.openqa.script.worker "$(DESTDIR)"/etc/apparmor.d
+	install -d -m 755 "$(DESTDIR)"/etc/apparmor.d/local
+	install -m 644 profiles/apparmor.d/local/usr.share.openqa.script.openqa "$(DESTDIR)"/etc/apparmor.d/local
 
 	cp -Ra dbicdh "$(DESTDIR)"/usr/share/openqa/dbicdh
 

--- a/profiles/apparmor.d/local/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/local/usr.share.openqa.script.openqa
@@ -1,0 +1,1 @@
+# Site-specific additions and overrides for 'usr.share.openqa.script.openqa'


### PR DESCRIPTION
Without empty profile apparmor shows error:
```
sudo aa-complain /usr/share/openqa/script/openqa
ERROR: Include file /etc/apparmor.d/local/usr.share.openqa.script.openqa not found
```
Related to https://github.com/os-autoinst/openQA/pull/2386
