### PR TITLE
Remove possibly localized quotes when checking PostgreSQL errors

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1074,7 +1074,7 @@ sub insert_module {
     }
     catch {
         my $err = $_;
-        die $err unless $err =~ /"job_modules_job_id_name_category_script"/;
+        die $err unless $err =~ /job_modules_job_id_name_category_script/;
     };
 }
 

--- a/lib/OpenQA/Schema/ResultSet/Screenshots.pm
+++ b/lib/OpenQA/Schema/ResultSet/Screenshots.pm
@@ -38,7 +38,7 @@ sub populate_images_to_job {
         }
         catch {
             my $err = $_;
-            die $err unless $err =~ /"screenshots_filename"/;
+            die $err unless $err =~ /screenshots_filename/;
             $ids{$img} = $self->find({filename => $img})->id;
         };
     }


### PR DESCRIPTION
E.g. here the error message is actually
```
doppelter Schlüsselwert verletzt Unique-Constraint »screenshots_filename«
```