### PR TITLE
client: Fix the default host 'http://localhost' instead of https

### DIFF
--- a/script/client
+++ b/script/client
@@ -239,7 +239,7 @@ my $url;
 if ($options{host} !~ '/') {
     $url = Mojo::URL->new();
     $url->host($options{host});
-    $url->scheme('https');
+    $url->scheme($options{host} eq 'localhost' ? 'http' : 'https');
 }
 else {
     $url = Mojo::URL->new($options{host});


### PR DESCRIPTION
e3557fcd2 tried to make openqa-client more secure by defaulting to https
however this is not that suitable for localhost which is also the
default.