### PR TITLE
Make OpenQA::Worker::Cache easier to read

### DIFF
--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -56,12 +56,6 @@ sub from_worker {
         exists $global_settings->{CACHELIMIT} ? (limit => int($global_settings->{CACHELIMIT}) * (1024**3)) : ());
 }
 
-sub DESTROY {
-    my $self = shift;
-
-    $self->sqlite->db->disconnect() if $self->sqlite;
-}
-
 sub deploy_cache {
     my $self = shift;
 

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -14,9 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::Cache;
-
-use strict;
-use warnings;
+use Mojo::Base -base;
 
 use Carp 'croak';
 use File::Basename;
@@ -27,7 +25,6 @@ use OpenQA::Utils
 use OpenQA::Worker::Settings;
 use Mojo::SQLite;
 use Mojo::File 'path';
-use Mojo::Base -base;
 use Exporter 'import';
 use POSIX;
 
@@ -39,24 +36,24 @@ use constant STATUS_ERROR       => 5;
 
 our @EXPORT_OK = qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE STATUS_ERROR);
 
-has [qw(host cache location db_file dsn cache_real_size)];
+has [qw(host cache location db_file dsn)];
 has limit      => 50 * (1024**3);
 has sleep_time => 5;
 has sqlite     => sub { Mojo::SQLite->new(shift->dsn) };
 
-sub new {
-    shift->SUPER::new(@_)->init;
-}
+sub new { shift->SUPER::new(@_)->init }
 
 sub from_worker {
+    my $class = shift;
+
     my $global_settings = OpenQA::Worker::Settings->new->global_settings;
-    __PACKAGE__->new(
+    return $class->new(
         host     => 'localhost',
         location => ($ENV{OPENQA_CACHE_DIR} || $global_settings->{CACHEDIRECTORY}),
         exists $global_settings->{CACHELIMIT} ? (limit => int($global_settings->{CACHELIMIT}) * (1024**3)) : ());
 }
 
-sub deploy_cache {
+sub _deploy_cache {
     my $self = shift;
 
     log_info "Creating cache directory tree for " . $self->location;
@@ -67,28 +64,28 @@ sub deploy_cache {
 
 sub init {
     my $self = shift;
+
     my ($host, $location) = ($self->host, $self->location);
 
     my $db_file = path($location, 'cache.sqlite');
     $self->db_file($db_file);
-    log_info(__PACKAGE__ . ': loading database from ' . $db_file);
+    log_info __PACKAGE__ . ": loading database from $db_file";
     $self->dsn("sqlite:$db_file");
-    $self->deploy_cache unless -e $db_file;
+    $self->_deploy_cache unless -e $db_file;
     eval { $self->sqlite->migrations->name('cache_service')->from_data->migrate };
     croak qq{Deploying SQLite "$db_file" failed (Maybe the file is corrupted and needs to be deleted?): $@} if $@;
 
-    $self->cache_real_size(0);
-    $self->cache_sync();
+    $self->_cache_sync;
 
     # Ideally we only need $limit, and $need no extra space
-    $self->check_limits(0);
-    log_info(__PACKAGE__ . ": Initialized with $host at $location, current size is " . $self->cache_real_size);
+    $self->_check_limits(0);
+    log_info __PACKAGE__ . ": Initialized with $host at $location, current size is $self->{cache_real_size}";
+
     return $self;
 }
 
-sub download_asset {
-    my $self = shift;
-    my ($id, $type, $asset, $etag) = @_;
+sub _download_asset {
+    my ($self, $id, $type, $asset, $etag) = @_;
 
     if (get_channel_handle('autoinst')) {
         append_channel_to_defaults('autoinst');
@@ -100,13 +97,14 @@ sub download_asset {
     my $ua = Mojo::UserAgent->new(max_redirects => 2);
     $ua->max_response_size(0);
     my $url = sprintf '%s/tests/%d/asset/%s/%s', $self->host, $id, $type, basename($asset);
-    log_info("Downloading " . basename($asset) . " from $url");
+    log_info "Downloading " . basename($asset) . " from $url";
     my $tx = $ua->build_tx(GET => $url);
     my $headers;
 
     $ua->on(
         start => sub {
             my ($ua, $tx) = @_;
+
             my $progress     = 0;
             my $last_updated = time;
             if (-e $asset) {    # Assets might be deleted by a sysadmin
@@ -121,12 +119,13 @@ sub download_asset {
                     my $size = $msg->content->progress;
                     $headers = $msg->headers if !$headers;
                     my $current = int($size / ($len / 100));
+
                     # Don't spam the webui, update only every 5 seconds
                     if (time - $last_updated > 5) {
                         $last_updated = time;
                         if ($progress < $current) {
                             $progress = $current;
-                            log_debug("CACHE: Downloading $asset: " . ($size == $len ? 100 : $progress) . "%");
+                            log_debug "CACHE: Downloading $asset: " . ($size == $len ? 100 : $progress) . "%";
                         }
                     }
                 });
@@ -137,46 +136,49 @@ sub download_asset {
     my $size;
     if ($code eq 304) {
         if ($self->_update_asset_last_use($asset)) {
-            log_debug("CACHE: Content has not changed, not downloading the $asset but updating last use");
+            log_debug "CACHE: Content has not changed, not downloading the $asset but updating last use";
         }
         else {
-            log_debug("CACHE: Abnormal situation, code 304. Retrying download");
+            log_debug 'CACHE: Abnormal situation, code 304. Retrying download';
             $asset = 520;
         }
     }
     elsif ($tx->res->is_server_error) {
-        log_debug("CACHE: Could not download the asset, triggering a retry for $code.");
-        log_debug("CACHE: Abnormal situation, server error. Retrying download");
+        log_debug "CACHE: Could not download the asset, triggering a retry for $code.";
+        log_debug "CACHE: Abnormal situation, server error. Retrying download";
         $asset = $code;
     }
     elsif ($tx->res->is_success) {
         $etag = $headers->etag;
         unlink($asset);
-        $self->cache_sync;
+        $self->_cache_sync;
         my $size = $tx->res->content->asset->move_to($asset)->size;
         if ($size == $headers->content_length) {
-            $self->check_limits($size);
-            my $att = 0;
-            my $ok;
+            $self->_check_limits($size);
+
             # This needs to go in to the database at any cost - we have the lock and we succeeded in download
             # We can't just throw it away if database locks.
+            my $att = 0;
+            my $ok;
             ++$att and sleep 1 and log_debug("CACHE: Error updating Cache: attempting again: $att")
-              until ($ok = $self->update_asset($asset, $etag, $size)) || $att > 5;
-            log_error("CACHE: FAIL Could not update DB - purging asset")
-              and $self->purge_asset($asset)
-              and $asset = undef
-              unless $ok;
-            log_debug("CACHE: Asset download successful to $asset, Cache size is: " . $self->cache_real_size) if $ok;
+              until ($ok = $self->_update_asset($asset, $etag, $size)) || $att > 5;
+            unless ($ok) {
+                log_error 'CACHE: FAIL Could not update DB - purging asset';
+                $self->purge_asset($asset);
+                $asset = undef;
+            }
+            log_debug "CACHE: Asset download successful to $asset, Cache size is: $self->{cache_real_size}" if $ok;
         }
         else {
-            log_debug(
-                "CACHE: Size of $asset differs, Expected: " . $headers->content_length . " / Downloaded: " . "$size");
+            log_debug "CACHE: Size of $asset differs, Expected: "
+              . $headers->content_length
+              . " / Downloaded: " . "$size";
             $asset = 598;    # 598 (Informal convention) Network read timeout error
         }
     }
     else {
         my $message = $tx->res->error->{message};
-        log_debug("CACHE: Download of $asset failed with: $code - $message");
+        log_debug "CACHE: Download of $asset failed with: $code - $message";
         $self->purge_asset($asset);
         $asset = undef;
     }
@@ -184,28 +186,25 @@ sub download_asset {
     return $asset;
 }
 
-sub _base_host { Mojo::URL->new($_[0])->host || shift }
+sub _base_host { Mojo::URL->new($_[0])->host || $_[0] }
 sub _host { _base_host(shift->host) }
 
 sub get_asset {
-    my $self = shift;
-    my ($job, $asset_type, $asset) = @_;
-    my $type;
-    my $result;
-    my $ret;
+    my ($self, $job, $asset_type, $asset) = @_;
 
     my $location = path($self->location, $self->_host);
     $location->make_path unless -d $location;
     $asset = $location->child(path($asset)->basename);
 
     my $n = 5;
-    while () {
+    while (1) {
         $self->track_asset($asset);    # Track asset - make sure it's in DB
-        $result = $self->_asset($asset);
-        local $@;
+        my $result = $self->_asset($asset);
+        my $ret;
         eval {
             $ret
-              = $self->download_asset($job->{id}, lc($asset_type), $asset, ($result->{etag}) ? $result->{etag} : undef);
+              = $self->_download_asset($job->{id}, lc($asset_type), $asset,
+                ($result->{etag}) ? $result->{etag} : undef);
         };
         if (!$ret) {
             $asset = undef;
@@ -230,161 +229,157 @@ sub get_asset {
 
 sub _asset {
     my ($self, $asset) = @_;
-    my $result = $self->sqlite->db->select('assets', [qw(etag size last_use)], {filename => $asset})->hashes;
-
-    return {} if $result->size == 0 || $@;
-    return $result->first;
+    my $results = $self->sqlite->db->select('assets', [qw(etag size last_use)], {filename => $asset})->hashes;
+    return $results->first || {};
 }
 
 sub track_asset {
     my ($self, $asset) = @_;
 
-    my $res;
-    my $sql = "INSERT OR IGNORE INTO assets (filename, size, last_use) VALUES (?, 0,  strftime('%s','now'));";
-
     eval {
-        my $db = $self->sqlite->db;
-        my $tx = $db->begin('exclusive');
-        $res = $db->query($sql, $asset)->arrays;
+        my $db  = $self->sqlite->db;
+        my $tx  = $db->begin('exclusive');
+        my $sql = "INSERT OR IGNORE INTO assets (filename, size, last_use) VALUES (?, 0, strftime('%s','now'))";
+        $db->query($sql, $asset)->arrays;
         $tx->commit;
     };
     if ($@) {
         log_error "track_asset: Failed: $@";
     }
-
-    return !!0 if $res->size == 0 || $@;
-    return !!1 if $res->size > 0;
 }
 
 sub _update_asset_last_use {
     my ($self, $asset) = @_;
 
+    log_info "CACHE: updating the $asset last usage";
+
     eval {
         my $db  = $self->sqlite->db;
         my $tx  = $db->begin('exclusive');
-        my $sql = q(UPDATE assets set last_use = strftime('%s','now') where filename = ?;);
+        my $sql = "UPDATE assets set last_use = strftime('%s','now') where filename = ?";
         $db->query($sql, $asset);
         $tx->commit;
     };
-
     if ($@) {
         log_error "Update asset failed: $@";
-        return !!0;
+        return undef;
     }
 
-    log_info "CACHE: updating the $asset last usage";
-    return !!1;
+    return 1;
 }
 
-sub update_asset {
+sub _update_asset {
     my ($self, $asset, $etag, $size) = @_;
+
     eval {
         my $db  = $self->sqlite->db;
         my $tx  = $db->begin('exclusive');
-        my $sql = q(UPDATE assets set etag =? , size = ?, last_use = strftime('%s','now') where filename = ?;);
+        my $sql = "UPDATE assets set etag = ?, size = ?, last_use = strftime('%s','now') where filename = ?";
         $db->query($sql, $etag, $size, $asset);
         $tx->commit;
     };
     if ($@) {
         log_error "Update asset $asset failed. Rolling back $@";
-        return !!0;
-    }
-    else {
-        log_info "CACHE: updating the $asset with $etag and $size";
+        return undef;
     }
 
-    $self->increase($size);
-    return !!1;
+    log_info "CACHE: updating the $asset with $etag and $size";
+    $self->_increase($size);
+
+    return 1;
 }
 
 sub purge_asset {
     my ($self, $asset) = @_;
+
     eval {
         my $db = $self->sqlite->db;
         my $tx = $db->begin();
         $db->delete('assets', {filename => $asset});
         $tx->commit;
         if (-e $asset) {
-            unlink($asset) or eval { log_error "CACHE: Could not remove $asset" if -e $asset };
-            log_debug "CACHE: removed $asset";
+            if   (unlink $asset) { log_debug "CACHE: removed $asset" }
+            else                 { log_error "CACHE: Could not remove $asset ($!)" }
         }
-        else {
-            log_debug "CACHE: requested to remove nonexisting asset $asset";
-        }
+        else { log_debug "CACHE: requested to remove nonexisting asset $asset" }
     };
-
     if ($@) {
         log_error "purge_asset: $@";
-        return !!0;
+        return undef;
     }
-    return !!1;
+
+    return 1;
 }
 
-sub file_size { (stat(pop))[7] }
+sub _cache_sync {
+    my $self = shift;
 
-sub cache_sync {
-    my $self     = shift;
     my $location = $self->location;
     my $ext;
     $ext .= "-o -name '*.$_' " for qw(qcow2 iso vhd vhdx);
     my @assets = `find $location -maxdepth 2 -type f -name '*.img' $ext`;
     chomp @assets;
-    $self->cache_real_size(0);
+    $self->{cache_real_size} = 0;
     foreach my $file (@assets) {
-        my $asset_size = $self->file_size($file);
+        my $asset_size = -s $file;
         next if !defined $asset_size;
-        $self->increase($asset_size) if $self->asset_lookup($file);
+        $self->_increase($asset_size) if $self->asset_lookup($file);
     }
 }
 
 sub asset_lookup {
     my ($self, $asset) = @_;
-    my $sth;
-    my $result;
+
+    my $results;
     eval {
         my $db = $self->sqlite->db;
         my $tx = $db->begin('exclusive');
-        $result = $db->select('assets', [qw(filename etag last_use size)], {filename => $asset});
+        $results = $db->select('assets', [qw(filename etag last_use size)], {filename => $asset});
         $tx->commit;
     };
     if ($@) {
-        return !!0;
+        return undef;
     }
 
-    if ($result->arrays->size == 0) {
+    if ($results->arrays->size == 0) {
         log_info "CACHE: Purging non registered $asset";
         $self->purge_asset($asset);
-        return !!0;
+        return undef;
     }
 
-    return !!1;
+    return 1;
 }
 
-sub exceeds_limit { !!($_[0]->cache_real_size + $_[1] > $_[0]->limit) }
-sub limit_reached { !!($_[0]->cache_real_size > shift->limit) }
-sub decrease {
-    my ($self, $size) = @_;
-    log_debug "Current cache size: " . $self->cache_real_size;
-    $self->cache_real_size(
-        !defined $size ? $self->cache_real_size : $size > $self->cache_real_size ? 0 : $self->cache_real_size - $size);
-    log_debug "Reclaiming " . $size . " from " . $self->cache_real_size . " to make space for " . $self->limit;
+sub _decrease {
+    my ($self, $size) = (shift, shift // 0);
+
+    log_debug "Current cache size: $self->{cache_real_size}";
+    if ($size > $self->{cache_real_size}) { $self->{cache_real_size} = 0 }
+    else                                  { $self->{cache_real_size} -= $size }
+    log_debug "Reclaiming $size from $self->{cache_real_size} to make space for " . $self->limit;
 }
 
-sub increase { $_[0]->cache_real_size($_[0]->cache_real_size + pop) }
+sub _increase { $_[0]{cache_real_size} += $_[1] }
 
-sub check_limits {
+sub _exceeds_limit { $_[0]->{cache_real_size} + $_[1] > $_[0]->limit }
+
+sub _check_limits {
     my ($self, $needed) = @_;
-    my $db = $self->sqlite->db;
+
+    my $limit = $self->limit;
+
     eval {
-        my $sth = $db->select('assets', [qw(filename size last_use)], undef, {-asc => 'last_use'});
-        while (my $asset = $sth->hash) {
-            my $asset_size = $asset->{size} || $self->file_size($asset->{filename});
-            $self->decrease($asset_size)
-              if $self->exceeds_limit($needed) && $self->purge_asset($asset->{filename}) && defined $asset_size;
+        my $db      = $self->sqlite->db;
+        my $results = $db->select('assets', [qw(filename size last_use)], undef, {-asc => 'last_use'});
+        for my $asset ($results->hashes->each) {
+            my $asset_size = $asset->{size} || -s $asset->{filename};
+            $self->_decrease($asset_size) if $self->purge_asset($asset->{filename});
+            last if !$self->_exceeds_limit($needed);
         }
-    } if $self->exceeds_limit($needed) || $self->limit_reached;
-    log_error "CACHE: check_limit failed: $@" if $@;
-    log_debug "CACHE: Health: Real size: " . $self->cache_real_size . ", Configured limit: " . $self->limit;
+    } if $self->_exceeds_limit($needed);
+    if ($@) { log_error "CACHE: check_limit failed: $@" }
+
+    log_debug "CACHE: Health: Real size: $self->{cache_real_size}, Configured limit: $limit";
 }
 
 1;


### PR DESCRIPTION
Some cleanups in preparation for more cache service changes. I'll try to split them up into smaller PRs for easier review.

There were a lot of public methods in `OpenQA::Worker::Cache` that should have been private. Some dead code, unnecessary use of the shell, and the usual (`$_[0]` followed by `pop`/`shift`...) Perl style quirks that make the code a bit hard to read. Overall this patch should cause no functional differences.