### PR TITLE
Move private function used across multiple classes into OpenQA::Utils

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -97,7 +97,7 @@ our @EXPORT  = qw(
   service_port
 );
 
-our @EXPORT_OK = qw(determine_web_ui_web_socket_url get_ws_status_only_url random_string random_hex);
+our @EXPORT_OK = qw(base_host determine_web_ui_web_socket_url get_ws_status_only_url random_string random_hex);
 
 if ($0 =~ /\.t$/) {
     # This should result in the 't' directory, even if $0 is in a subdirectory
@@ -1247,5 +1247,7 @@ sub any_array_item_contained_by_hash {
     }
     return 0;
 }
+
+sub base_host { Mojo::URL->new($_[0])->host || $_[0] }
 
 1;

--- a/lib/OpenQA/Worker/Cache.pm
+++ b/lib/OpenQA/Worker/Cache.pm
@@ -21,7 +21,7 @@ use File::Basename;
 use Fcntl ':flock';
 use Mojo::UserAgent;
 use OpenQA::Utils
-  qw(log_error log_info log_debug get_channel_handle add_log_channel append_channel_to_defaults remove_channel_from_defaults);
+  qw(base_host log_error log_info log_debug get_channel_handle add_log_channel append_channel_to_defaults remove_channel_from_defaults);
 use OpenQA::Worker::Settings;
 use Mojo::SQLite;
 use Mojo::File 'path';
@@ -186,14 +186,10 @@ sub _download_asset {
     return $asset;
 }
 
-sub _base_host { Mojo::URL->new($_[0])->host || $_[0] }
-
-sub _host { _base_host(shift->host) }
-
 sub get_asset {
     my ($self, $job, $asset_type, $asset) = @_;
 
-    my $location = path($self->location, $self->_host);
+    my $location = path($self->location, base_host($self->host));
     $location->make_path unless -d $location;
     $asset = $location->child(path($asset)->basename);
 

--- a/lib/OpenQA/Worker/Cache/Client.pm
+++ b/lib/OpenQA/Worker/Cache/Client.pm
@@ -21,6 +21,7 @@ use OpenQA::Worker::Cache qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING
 use OpenQA::Worker::Cache::Request;
 use OpenQA::Worker::Cache::Request::Asset;
 use OpenQA::Worker::Cache::Request::Sync;
+use OpenQA::Utils 'base_host';
 use Mojo::URL;
 use Mojo::File 'path';
 
@@ -102,7 +103,7 @@ sub session_token { shift->_query('session_token') }
 sub enqueue       { _reply(shift->execute_task(@_)) }
 
 # TODO: This could go in a separate object (?)
-sub asset_path { path(shift->cache_dir, @_ > 1 ? (OpenQA::Worker::Cache::_base_host($_[0]) || shift) : ())->child(pop) }
+sub asset_path { path(shift->cache_dir, @_ > 1 ? (base_host($_[0]) || shift) : ())->child(pop) }
 sub asset_exists { !!(-e shift->asset_path(@_)) }
 
 sub request { OpenQA::Worker::Cache::Request->new(client => shift) }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -18,7 +18,7 @@ package OpenQA::Worker::Engines::isotovideo;
 use strict;
 use warnings;
 
-use OpenQA::Utils qw(locate_asset log_error log_info log_debug log_warning get_channel_handle);
+use OpenQA::Utils qw(base_host locate_asset log_error log_info log_debug log_warning get_channel_handle);
 use POSIX qw(:sys_wait_h strftime uname _exit);
 use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();
@@ -216,7 +216,7 @@ sub engine_workit {
 
     # do asset caching if CACHEDIRECTORY is set
     if ($global_settings->{CACHEDIRECTORY}) {
-        my $host_to_cache = OpenQA::Worker::Cache::_base_host($webui_host);
+        my $host_to_cache = base_host($webui_host);
         my $error         = cache_assets($job, \%vars, $assetkeys, $webui_host, $pooldir);
         return $error if $error;
 

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -22,7 +22,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
-use OpenQA::Utils qw(random_string random_hex);
+use OpenQA::Utils qw(base_host random_string random_hex);
 use OpenQA::Test::Utils 'redirect_output';
 use Test::More;
 use Scalar::Util 'reftype';
@@ -331,6 +331,13 @@ subtest parse_assets_from_settings => sub {
     $assets                        = parse_assets_from_settings($settings);
     $refassets->{UEFI_PFLASH_VARS} = {type => "hdd", name => "uefi_pflash_vars.qcow2"};
     is_deeply $assets, $refassets, "correct with relative UEFI_PFLASH_VARS";
+};
+
+subtest 'base_host' => sub {
+    is base_host('http://opensuse.org'),             'opensuse.org';
+    is base_host('www.opensuse.org'),                'www.opensuse.org';
+    is base_host('test'),                            'test';
+    is base_host('https://opensuse.org/test/1/2/3'), 'opensuse.org';
 };
 
 done_testing;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -26,6 +26,7 @@ use Test::More;
 use Test::Warnings;
 use Test::MockModule;
 use OpenQA::Utils;
+use OpenQA::Utils 'base_host';
 use OpenQA::Worker::Cache;
 use DBI;
 use File::Path qw(remove_tree make_path);
@@ -121,20 +122,9 @@ sub stop_server {
 
 my $cache = OpenQA::Worker::Cache->new(host => $host, location => $cachedir);
 
-subtest '_base_host' => sub {
-    is OpenQA::Worker::Cache::_base_host('http://opensuse.org'),             'opensuse.org';
-    is OpenQA::Worker::Cache::_base_host('www.opensuse.org'),                'www.opensuse.org';
-    is OpenQA::Worker::Cache::_base_host('test'),                            'test';
-    is OpenQA::Worker::Cache::_base_host('https://opensuse.org/test/1/2/3'), 'opensuse.org';
-
+subtest 'base_host' => sub {
     my $cache_test = OpenQA::Worker::Cache->new(host => $host, location => $cachedir);
-    is $cache_test->_host, 'localhost';
-
-    $cache_test->host('http://opensuse.org');
-    is $cache_test->_host, 'opensuse.org';
-
-    $cache_test->host('foo');
-    is $cache_test->_host, 'foo';
+    is base_host($cache_test->host), 'localhost';
 };
 
 is $cache->init, $cache;


### PR DESCRIPTION
Functions used across multiple classes belong in `OpenQA::Utils`. Just cleanup, no functional changes.