### PR TITLE
Don't fail if there's no package logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,7 @@ aliases:
     name: Log cached packages
     command: |
       mkdir -p logs
-      find /var/cache/zypp/packages/ | wc -l > ./logs/packages.txt
-      [ -z "$CIRCLE_WORKFLOW_ID" ] || ls -lRa /var/cache/zypp/packages/openQA > ./logs/packages.openQA.txt
+      find /var/cache/zypp/packages/ -iname *.rpm > ./logs/packages.txt
 
   - &store_logs
       path: logs


### PR DESCRIPTION
I'm not sure why this started failing... the dep change in #2417 doesn't seem like it would have caused it.

This is a simple fix, though, which basically changes a fatal error to an empty log file.