### PR TITLE
Calculate coverage in Circleci in all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,7 @@ aliases:
   - &make_test
     name: "Running unit tests"
     command: |
-      # calculate coverage only on PR and master to save time
-      # include 'cover' into branch name if you need coverage
-      case "$CIRCLE_BRANCH" in
-      master |  pull* | *cover*) export PERL5OPT="$COVEROPT,-db,cover_db_${CIRCLE_JOB}";;
-      *) mkdir -p "cover_db_${CIRCLE_JOB}_stub";; # otherwise persist_to_workspace will show error
-      esac
+      export PERL5OPT="$COVEROPT,-db,cover_db_${CIRCLE_JOB}"
       echo PERL5OPT="$PERL5OPT"
       case "$CIRCLE_JOB" in
       t)         make test CHECKSTYLE=1 PROVE_ARGS="$HARNESS t/*.t"     GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
@@ -309,12 +304,6 @@ workflows:
            - fullstack
            - developer
            - scheduler
-         filters:
-           branches:
-             only:
-               - /pull.*/
-               - master
-               - /.*cover.*/
       - build.docs:
          requires:
            - cache


### PR DESCRIPTION
Previously coverage was not calculated on local branches (unless PR is created) to reduce testing time (sometimes down to 50%).
But developers' workflow was affected in negative way, because creating PR will not re-trigger CI until next commit. So we disable the feature and CI will always calculate coverage.
After the change having own fork enabled in CircleCI permanently should be enough for PR to be properly tested in CI.