### PR TITLE
Fix missing 'qemu-kvm' in non-x86_64 package tests

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -57,7 +57,12 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 %define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Test::Mojo) perl(Test::More) perl(Test::Strict) perl(Test::Fatal) perl(Test::MockModule) perl(Test::Output) perl(Test::Pod) perl(Test::Warnings) perl(Selenium::Remote::Driver) perl(Selenium::Remote::WDKeys) ShellCheck os-autoinst-devel
-%define devel_requires %build_requires %test_requires rsync curl postgresql-devel qemu qemu-kvm tar postgresql-server xorg-x11-fonts sudo perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
+%ifarch x86_64
+%define qemu qemu qemu-kvm
+%else
+%define qemu qemu
+%endif
+%define devel_requires %build_requires %test_requires rsync curl postgresql-devel %qemu tar postgresql-server xorg-x11-fonts sudo perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 
 Name:           openQA
 Version:        4.6


### PR DESCRIPTION
As qemu-kvm is not provided on e.g. ppc64le and aarch64 we should not
try to pull it in. This should fix unresolvables as reported in
https://build.opensuse.org/package/show/devel:openQA/openQA