### PR TITLE
Fix needle lookup for current os-autoinst version

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -204,8 +204,13 @@ sub engine_workit {
         OPENQA_URL      => $openqa_url,
         WORKER_INSTANCE => $instance,
         WORKER_ID       => $workerid,
+        PRJDIR          => $OpenQA::Utils::sharedir,
         %$job_settings
     );
+    # note: PRJDIR is used as base for relative needle paths by os-autoinst. This is supposed to change
+    #       but for compatibility with current old os-autoinst we need to set PRJDIR for a consistent
+    #       behavior.
+
     log_debug('Job settings:');
     log_debug(join("\n", '', map { "    $_=$vars{$_}" } sort keys %vars));
 
@@ -229,6 +234,8 @@ sub engine_workit {
                 to   => $shared_cache
             );
             my $rsync_request_description = "Rsync cache request from '$rsync_source' to '$shared_cache'";
+
+            $vars{PRJDIR} = $shared_cache;
 
             # enqueue rsync task; retry in some error cases
             for (my $remaining_tries = 3; $remaining_tries > 0; --$remaining_tries) {


### PR DESCRIPTION
Apparently the needle directory used by os-autoinst so far is relative to the test case directory and not the share directory.