### PR TITLE
Enable regex search in 'Medium types' table

### DIFF
--- a/assets/javascripts/admintable.js
+++ b/assets/javascripts/admintable.js
@@ -353,7 +353,7 @@ function renderEditableAdminTableActions(data, type, row, meta) {
     }
 }
 
-function setupAdminTable(isAdmin, enableRegexForFiltering) {
+function setupAdminTable(isAdmin) {
     // adjust sorting so empty strings come last
     jQuery.extend(jQuery.fn.dataTableExt.oSort, {
         'empty-string-last-asc': function(str1, str2) {
@@ -439,7 +439,7 @@ function setupAdminTable(isAdmin, enableRegexForFiltering) {
         columns: columns,
         columnDefs: columnDefs,
         search: {
-            regex: enableRegexForFiltering,
+            regex: true,
         },
     });
     dataTable.rowData = [];

--- a/templates/admin/machine/index.html.ep
+++ b/templates/admin/machine/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Machines';
 
 % content_for 'ready_function' => begin
-    setupAdminTable(<%= is_admin_js %>, true);
+    setupAdminTable(<%= is_admin_js %>);
 % end
 
 <div class="row">

--- a/templates/admin/product/index.html.ep
+++ b/templates/admin/product/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Medium types';
 
 % content_for 'ready_function' => begin
-   setupAdminTable(<%= is_admin_js %>, false);
+   setupAdminTable(<%= is_admin_js %>);
 % end
 
 <div class="row">

--- a/templates/admin/test_suite/index.html.ep
+++ b/templates/admin/test_suite/index.html.ep
@@ -2,7 +2,7 @@
 % title 'Test suites';
 
 % content_for 'ready_function' => begin
-    setupAdminTable(<%= is_admin_js %>, true);
+    setupAdminTable(<%= is_admin_js %>);
 % end
 
 <div class="row">


### PR DESCRIPTION
* All admin tables have a regex-enabled search now
* Fix https://progress.opensuse.org/issues/58625