### PR TITLE
Use `croak` in OpenQA::Utils::log_fatal

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -236,7 +236,7 @@ sub log_error {
 # log_fatal("message"[, param1=>val1, param2=>val2]);
 sub log_fatal {
     _log_msg('fatal', @_);
-    die $_[0];
+    croak $_[0];
 }
 
 sub _current_log_level {

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -154,14 +154,16 @@ subtest 'log fatal to stderr' => sub {
     $app->setup_log();
     $OpenQA::Utils::app = undef;    # To make sure we don't are setting it in other tests
     eval { log_fatal('fatal message'); };
+    my $eval_error       = $@;
     my $exception_raised = 0;
-    $exception_raised++ if $@;
+    $exception_raised++ if $eval_error;
     ### End of the Testing code ###
     # Close the capture (current stdout) and restore STDOUT (by dupping the old STDOUT);
     close STDERR;
     open(STDERR, '>&', $oldSTDERR) or die "Can't dup \$oldSTDERR: $!";
     ok($exception_raised == 1, 'Fatal raised exception');
     like($output, qr/\[FATAL\] fatal message/, 'OK fatal');
+    like($eval_error, qr{fatal message.*t/28-logging.t});
 
 };
 


### PR DESCRIPTION
...instead of die.
This way we will get the correct location of the calling method

Issue: https://progress.opensuse.org/issues/57776

I accidentally deleted my branch in #2436, so this is the same change