### PR TITLE
Move cache service into OpenQA::CacheService namespace

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -13,13 +13,14 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache::Service;
+package OpenQA::CacheService;
 
 use strict;
 use warnings;
 
 use OpenQA::Worker::Settings;
-use OpenQA::Worker::Cache qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE STATUS_ERROR);
+use OpenQA::CacheService::Model::Cache
+  qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE STATUS_ERROR);
 use Mojolicious::Lite;
 use Mojolicious::Plugin::Minion;
 use Mojolicious::Plugin::Minion::Admin;
@@ -43,10 +44,10 @@ app->hook(
         $enqueued = Mojo::Collection->new;
     });
 
-plugin Minion => {SQLite => 'sqlite:' . OpenQA::Worker::Cache->from_worker->db_file};
+plugin Minion => {SQLite => 'sqlite:' . OpenQA::CacheService::Model::Cache->from_worker->db_file};
 plugin 'Minion::Admin';
-plugin 'OpenQA::Worker::Cache::Task::Asset';
-plugin 'OpenQA::Worker::Cache::Task::Sync';
+plugin 'OpenQA::CacheService::Task::Asset';
+plugin 'OpenQA::CacheService::Task::Sync';
 
 sub SESSION_TOKEN { $_token }
 
@@ -154,26 +155,26 @@ post '/dequeue' => sub {
 
 =head1 NAME
 
-OpenQA::Worker::Cache::Service - OpenQA Cache Service
+OpenQA::CacheService - OpenQA Cache Service
 
 =head1 SYNOPSIS
 
-    use OpenQA::Worker::Cache::Service;
+    use OpenQA::CacheService;
 
     # Start the daemon
-    OpenQA::Worker::Cache::Service->run(qw(daemon));
+    OpenQA::CacheService->run(qw(daemon));
 
     # Start one or more Minions with:
-    OpenQA::Worker::Cache::Service->run(qw(minion worker))
+    OpenQA::CacheService->run(qw(minion worker))
 
 =head1 DESCRIPTION
 
-OpenQA::Worker::Cache::Service is the OpenQA Cache Service, which is meant to be run
+OpenQA::CacheService is the OpenQA Cache Service, which is meant to be run
 standalone.
 
 =head1 GET ROUTES
 
-OpenQA::Worker::Cache::Service is a L<Mojolicious::Lite> application, and it is exposing the following GET routes.
+OpenQA::CacheService is a L<Mojolicious::Lite> application, and it is exposing the following GET routes.
 
 =head2 /minion
 
@@ -189,7 +190,7 @@ Returns the current session token.
 
 =head1 POST ROUTES
 
-OpenQA::Worker::Cache::Service is exposing the following POST routes.
+OpenQA::CacheService is exposing the following POST routes.
 
 =head2 /execute_task
 

--- a/lib/OpenQA/CacheService/Client.pm
+++ b/lib/OpenQA/CacheService/Client.pm
@@ -13,13 +13,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache::Client;
+package OpenQA::CacheService::Client;
 use Mojo::Base -base;
 
 use OpenQA::Worker::Settings;
-use OpenQA::Worker::Cache qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE);
-use OpenQA::Worker::Cache::Request::Asset;
-use OpenQA::Worker::Cache::Request::Sync;
+use OpenQA::CacheService::Model::Cache qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE);
+use OpenQA::CacheService::Request::Asset;
+use OpenQA::CacheService::Request::Sync;
 use OpenQA::Utils 'base_host';
 use Mojo::URL;
 use Mojo::File 'path';
@@ -130,12 +130,12 @@ sub asset_exists { -e shift->asset_path(@_) }
 
 sub asset_request {
     my $self = shift;
-    return OpenQA::Worker::Cache::Request::Asset->new(@_);
+    return OpenQA::CacheService::Request::Asset->new(@_);
 }
 
 sub rsync_request {
     my $self = shift;
-    return OpenQA::Worker::Cache::Request::Sync->new(@_);
+    return OpenQA::CacheService::Request::Sync->new(@_);
 }
 
 sub availability_error {
@@ -151,13 +151,13 @@ sub availability_error {
 
 =head1 NAME
 
-OpenQA::Worker::Cache::Client - OpenQA Cache Service Client
+OpenQA::CacheService::Client - OpenQA Cache Service Client
 
 =head1 SYNOPSIS
 
-    use OpenQA::Worker::Cache::Client;
+    use OpenQA::CacheService::Client;
 
-    my $client = OpenQA::Worker::Cache::Client->new(host=> 'http://127.0.0.1:7844', retry => 5, cache_dir => '/tmp/cache/path');
+    my $client = OpenQA::CacheService::Client->new(host=> 'http://127.0.0.1:7844', retry => 5, cache_dir => '/tmp/cache/path');
     my $request = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
     $client->enqueue($request);
     until ($client->processed($request)) {
@@ -168,6 +168,6 @@ OpenQA::Worker::Cache::Client - OpenQA Cache Service Client
 
 =head1 DESCRIPTION
 
-OpenQA::Worker::Cache::Client is the client used for interacting with the OpenQA Cache Service.
+OpenQA::CacheService::Client is the client used for interacting with the OpenQA Cache Service.
 
 =cut

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright (C) 2017-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache;
+package OpenQA::CacheService::Model::Cache;
 use Mojo::Base -base;
 
 use Carp 'croak';

--- a/lib/OpenQA/CacheService/Request.pm
+++ b/lib/OpenQA/CacheService/Request.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache::Request;
+package OpenQA::CacheService::Request;
 use Mojo::Base -base;
 
 use Carp 'croak';

--- a/lib/OpenQA/CacheService/Request/Asset.pm
+++ b/lib/OpenQA/CacheService/Request/Asset.pm
@@ -13,21 +13,23 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache::Request::Sync;
-use Mojo::Base 'OpenQA::Worker::Cache::Request';
+package OpenQA::CacheService::Request::Asset;
+use Mojo::Base 'OpenQA::CacheService::Request';
 
-# See task OpenQA::Cache::Task::Sync
-has [qw(from to)];
-has task => 'cache_tests';
+# See task OpenQA::Cache::Task::Asset
+has [qw(id type asset host)];
+has task => 'cache_asset';
 
 sub lock {
     my $self = shift;
-    return join('.', map { $self->$_ } qw(from to));
+
+    # Generate same lock for asset/host
+    return join('.', map { $self->$_ } qw(asset host));
 }
 
 sub to_array {
     my $self = shift;
-    return [$self->from, $self->to];
+    return [$self->id, $self->type, $self->asset, $self->host];
 }
 
 1;

--- a/lib/OpenQA/CacheService/Request/Sync.pm
+++ b/lib/OpenQA/CacheService/Request/Sync.pm
@@ -13,23 +13,21 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache::Request::Asset;
-use Mojo::Base 'OpenQA::Worker::Cache::Request';
+package OpenQA::CacheService::Request::Sync;
+use Mojo::Base 'OpenQA::CacheService::Request';
 
-# See task OpenQA::Cache::Task::Asset
-has [qw(id type asset host)];
-has task => 'cache_asset';
+# See task OpenQA::Cache::Task::Sync
+has [qw(from to)];
+has task => 'cache_tests';
 
 sub lock {
     my $self = shift;
-
-    # Generate same lock for asset/host
-    return join('.', map { $self->$_ } qw(asset host));
+    return join('.', map { $self->$_ } qw(from to));
 }
 
 sub to_array {
     my $self = shift;
-    return [$self->id, $self->type, $self->asset, $self->host];
+    return [$self->from, $self->to];
 }
 
 1;

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -13,14 +13,14 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache::Task::Asset;
+package OpenQA::CacheService::Task::Asset;
 use Mojo::Base 'Mojolicious::Plugin';
 
 use constant LOCK_RETRY_DELAY   => 30;
 use constant MINION_LOCK_EXPIRE => 99999;    # ~27 hours
 
-use OpenQA::Worker::Cache;
-use OpenQA::Worker::Cache::Client;
+use OpenQA::CacheService::Model::Cache;
+use OpenQA::CacheService::Client;
 
 sub register {
     my ($self, $app) = @_;
@@ -34,8 +34,8 @@ sub _cache_asset {
     my $app = $job->app;
     my $log = $app->log;
 
-    my $cache      = OpenQA::Worker::Cache->from_worker;
-    my $client     = OpenQA::Worker::Cache::Client->new;
+    my $cache      = OpenQA::CacheService::Model::Cache->from_worker;
+    my $client     = OpenQA::CacheService::Client->new;
     my $req        = $client->asset_request(id => $id, type => $type, asset => $asset_name, host => $host);
     my $guard_name = $client->session_token . '.' . $req->lock;
 
@@ -66,15 +66,15 @@ sub _cache_asset {
 
 =head1 NAME
 
-OpenQA::Worker::Cache::Task::Asset - Cache Service task
+OpenQA::CacheService::Task::Asset - Cache Service task
 
 =head1 SYNOPSIS
 
-    plugin 'OpenQA::Worker::Cache::Task::Asset';
+    plugin 'OpenQA::CacheService::Task::Asset';
 
 =head1 DESCRIPTION
 
-OpenQA::Worker::Cache::Task::Asset is the task that minions of the OpenQA Cache Service
+OpenQA::CacheService::Task::Asset is the task that minions of the OpenQA Cache Service
 are executing to handle the asset download.
 
 =cut

--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -13,10 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::Worker::Cache::Task::Sync;
+package OpenQA::CacheService::Task::Sync;
 use Mojo::Base 'Mojolicious::Plugin';
 
-use OpenQA::Worker::Cache::Client;
+use OpenQA::CacheService::Client;
 use Mojo::URL;
 
 use constant LOCK_RETRY_DELAY   => 30;
@@ -34,7 +34,7 @@ sub _cache_tests {
     my $app = $job->app;
     my $log = $app->log;
 
-    my $client     = OpenQA::Worker::Cache::Client->new;
+    my $client     = OpenQA::CacheService::Client->new;
     my $req        = $client->rsync_request(from => $from, to => $to);
     my $guard_name = $client->session_token . '.' . $req->lock;
 
@@ -61,15 +61,15 @@ sub _cache_tests {
 
 =head1 NAME
 
-OpenQA::Worker::Cache::Task::Sync - Cache Service task Sync
+OpenQA::CacheService::Task::Sync - Cache Service task Sync
 
 =head1 SYNOPSIS
 
-    plugin 'OpenQA::Worker::Cache::Task::Sync';
+    plugin 'OpenQA::CacheService::Task::Sync';
 
 =head1 DESCRIPTION
 
-OpenQA::Worker::Cache::Task::Sync is the task that minions of the OpenQA Cache Service
+OpenQA::CacheService::Task::Sync is the task that minions of the OpenQA Cache Service
 are executing to handle the tests and needles syncing.
 
 =cut

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -570,7 +570,7 @@ sub check_availability {
 
     # check whether the cache service is available if caching enabled
     if ($self->settings->global_settings->{CACHEDIRECTORY}) {
-        my $error = OpenQA::Worker::Cache::Client->new->availability_error;
+        my $error = OpenQA::CacheService::Client->new->availability_error;
         if ($error) {
             log_error('Worker cache not available: ' . $error);
             $self->current_error($error);

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -27,9 +27,8 @@ use File::Spec::Functions 'catdir';
 use File::Basename;
 use Errno;
 use Cwd qw(abs_path getcwd);
-use OpenQA::Worker::Cache;
-use OpenQA::Worker::Cache::Client;
-use OpenQA::Worker::Cache::Request;
+use OpenQA::CacheService::Client;
+use OpenQA::CacheService::Request;
 use Time::HiRes 'sleep';
 use IO::Handle;
 use Mojo::IOLoop::ReadWriteProcess 'process';
@@ -109,7 +108,7 @@ sub detect_asset_keys {
 
 sub cache_assets {
     my ($job, $vars, $assetkeys, $webui_host, $pooldir) = @_;
-    my $cache_client = OpenQA::Worker::Cache::Client->new;
+    my $cache_client = OpenQA::CacheService::Client->new;
     # TODO: Enqueue all, and then wait
     for my $this_asset (sort keys %$assetkeys) {
         my $asset;
@@ -228,7 +227,7 @@ sub engine_workit {
         if (my $rsync_source = $client->testpool_server) {
             $shared_cache = catdir($global_settings->{CACHEDIRECTORY}, $host_to_cache);
 
-            my $cache_client  = OpenQA::Worker::Cache::Client->new;
+            my $cache_client  = OpenQA::CacheService::Client->new;
             my $rsync_request = $cache_client->rsync_request(
                 from => $rsync_source,
                 to   => $shared_cache

--- a/script/openqa-workercache
+++ b/script/openqa-workercache
@@ -23,5 +23,5 @@ BEGIN {
     unshift @INC, "$FindBin::Bin/../lib";
 }
 
-require OpenQA::Worker::Cache::Service;
-OpenQA::Worker::Cache::Service->run(@ARGV);
+require OpenQA::CacheService;
+OpenQA::CacheService->run(@ARGV);

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -27,7 +27,7 @@ use Test::Warnings;
 use Test::MockModule;
 use OpenQA::Utils;
 use OpenQA::Utils 'base_host';
-use OpenQA::Worker::Cache;
+use OpenQA::CacheService::Model::Cache;
 use DBI;
 use File::Path qw(remove_tree make_path);
 use File::Spec::Functions qw(catdir catfile);
@@ -120,10 +120,10 @@ sub stop_server {
     $server_instance->stop();
 }
 
-my $cache = OpenQA::Worker::Cache->new(host => $host, location => $cachedir);
+my $cache = OpenQA::CacheService::Model::Cache->new(host => $host, location => $cachedir);
 
 subtest 'base_host' => sub {
-    my $cache_test = OpenQA::Worker::Cache->new(host => $host, location => $cachedir);
+    my $cache_test = OpenQA::CacheService::Model::Cache->new(host => $host, location => $cachedir);
     is base_host($cache_test->host), 'localhost';
 };
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -49,7 +49,7 @@ use Test::Output 'stderr_like';
 use autodie ':all';
 use IO::Socket::INET;
 use POSIX '_exit';
-use OpenQA::Worker::Cache::Client;
+use OpenQA::CacheService::Client;
 use Fcntl ':mode';
 use DBI;
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
@@ -331,7 +331,7 @@ subtest 'Cache tests' => sub {
     $worker_cache_service->restart->restart;
     $cache_service->restart->restart;
 
-    my $cache_client = OpenQA::Worker::Cache::Client->new;
+    my $cache_client = OpenQA::CacheService::Client->new;
 
     sleep 5 and diag "Waiting for cache service to be available"        until $cache_client->available;
     sleep 5 and diag "Waiting for cache service worker to be available" until $cache_client->available_workers;

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -48,9 +48,9 @@ sub cache_minion_worker {
         sub {
 
             # this service can be very noisy
-            require OpenQA::Worker::Cache::Service;
+            require OpenQA::CacheService;
             local $ENV{MOJO_MODE} = 'test';
-            OpenQA::Worker::Cache::Service->run(qw(minion worker));
+            OpenQA::CacheService->run(qw(minion worker));
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);
         })->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0);
@@ -61,9 +61,9 @@ sub cache_worker_service {
         sub {
 
             # this service can be very noisy
-            require OpenQA::Worker::Cache::Service;
+            require OpenQA::CacheService;
             local $ENV{MOJO_MODE} = 'test';
-            OpenQA::Worker::Cache::Service->run(qw(daemon -l http://*:7844));
+            OpenQA::CacheService->run(qw(daemon -l http://*:7844));
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);
         })->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0);


### PR DESCRIPTION
When i first started learning how the worker code actually works, one of the biggest problems was understanding how all the modules in the `OpenQA::Worker` namespace are actually connected. The cache service has been a bit of a special case, since it is not part of the worker service, but started as two separate services. And all communication goes exclusively through a client module and a REST API application that triggers background jobs.

So this PR adds the `OpenQA::CacheService` namespace, turning the cache service into a micro service similar to `OpenQA::Scheduler` and `OpenQA::WebSockets` (sharing the same application structure), just on the worker side instead of webui. And all code in `OpenQA::Worker` communicates with this micro service exclusively through `OpenQA::CacheService::Client`, consistent with our other micro service client modules.

I have not yet converted the main service from `Mojolicious::Lite` to `Mojolicious`, that can be a separate PR. So there should be no functional changes at all here.