### PR TITLE
Only read test_order.json at start and when changed

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -695,7 +695,7 @@ sub _upload_results_step_0_prepare {
     if ($is_final_upload || $running_or_finished) {
         my @file_info = stat $self->_result_file_path('test_order.json');
         my $test_order;
-        if (  !$current_test_module
+        if (   not $self->{_test_order_mtime}
             or $file_info[9] != $self->{_test_order_mtime}
             or $file_info[7] != $self->{_test_order_fsize})
         {


### PR DESCRIPTION
Before it was also loaded if `$current_test_module` was undef.
Now it does only load it if it was never loaded before or the file changed.

Issue: https://progress.opensuse.org/issues/58700