### PR TITLE
Turn cache service into a full Mojolicious application

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -54,6 +54,7 @@ sub startup {
     $r->post('/status')->to('API#status');
     $r->post('/execute_task')->to('API#execute_task');
     $r->post('/dequeue')->to('API#dequeue');
+    $r->any('/*whatever' => {whatever => ''})->to(status => 404, text => 'Not found');
 }
 
 sub setup_workers {
@@ -73,7 +74,7 @@ sub run {
 
     my $app = __PACKAGE__->new;
     $app->log->short(1);
-    local $ENV{MOJO_INACTIVITY_TIMEOUT} //= 300;
+    $ENV{MOJO_INACTIVITY_TIMEOUT} //= 300;
     $app->log->debug("Starting cache service: $0 @args");
 
     return $app->start(@args);

--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -56,7 +56,7 @@ sub startup {
     $r->post('/dequeue')->to('API#dequeue');
 }
 
-sub _setup_workers {
+sub setup_workers {
     return @_ unless grep { /worker/i } @_;
     my @args = @_;
 
@@ -69,7 +69,7 @@ sub _setup_workers {
 }
 
 sub run {
-    my @args = _setup_workers(@_);
+    my @args = setup_workers(@_);
 
     my $app = __PACKAGE__->new;
     $app->log->short(1);

--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -14,16 +14,11 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::CacheService;
-
-use strict;
-use warnings;
+use Mojo::Base 'Mojolicious';
 
 use OpenQA::Worker::Settings;
 use OpenQA::CacheService::Model::Cache
   qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE STATUS_ERROR);
-use Mojolicious::Lite;
-use Mojolicious::Plugin::Minion;
-use Mojolicious::Plugin::Minion::Admin;
 use Mojo::Collection;
 use Mojo::Util 'md5_sum';
 
@@ -36,18 +31,88 @@ my $_token;
 sub _gen_session_token { $_token = md5_sum($$ . time . rand) }
 
 my $enqueued = Mojo::Collection->new;
-app->hook(
-    before_server_start => sub {
-        my ($server, $app) = @_;
-        $server->silent(1) if $app->mode eq 'test';
-        _gen_session_token();
-        $enqueued = Mojo::Collection->new;
-    });
 
-plugin Minion => {SQLite => 'sqlite:' . OpenQA::CacheService::Model::Cache->from_worker->db_file};
-plugin 'Minion::Admin';
-plugin 'OpenQA::CacheService::Task::Asset';
-plugin 'OpenQA::CacheService::Task::Sync';
+sub startup {
+    my $self = shift;
+
+    $self->hook(
+        before_server_start => sub {
+            my ($server, $app) = @_;
+            $server->silent(1) if $app->mode eq 'test';
+            _gen_session_token();
+            $enqueued = Mojo::Collection->new;
+        });
+
+    $self->plugin(Minion => {SQLite => 'sqlite:' . OpenQA::CacheService::Model::Cache->from_worker->db_file});
+    $self->plugin('Minion::Admin');
+    $self->plugin('OpenQA::CacheService::Task::Asset');
+    $self->plugin('OpenQA::CacheService::Task::Sync');
+
+    my $r = $self->routes;
+
+    $r->get('/session_token' => sub { shift->render(json => {session_token => SESSION_TOKEN()}) });
+
+    $r->get('/info' => sub { $_[0]->render(json => shift->minion->stats) });
+
+    $r->post(
+        '/status' => sub {
+            my $c         = shift;
+            my $data      = $c->req->json;
+            my $lock_name = $data->{lock};
+            return $c->render(json => {error => 'No lock specified.'}, status => 400) unless $lock_name;
+
+            my $lock = _gen_guard_name($lock_name);
+            my %res
+              = (status =>
+                  ($c->app->_active($lock) ? STATUS_DOWNLOADING : enqueued($lock) ? STATUS_IGNORE : STATUS_PROCESSED));
+
+            if ($data->{id}) {
+                my $job = $c->minion->job($data->{id});
+                return $c->render(json => {error => 'Specified job ID is invalid.'}, status => 404) unless $job;
+
+                my $job_info = $job->info;
+                return $c->render(json => {error => 'Job info not available.'}, status => 404) unless $job_info;
+                $res{result} = $job_info->{result};
+                $res{output} = $job_info->{notes}->{output};
+            }
+
+            $c->render(json => \%res);
+        });
+
+    $r->post(
+        '/execute_task' => sub {
+            my $c    = shift;
+            my $data = $c->req->json;
+            my $task = $data->{task};
+            my $args = $data->{args};
+
+            return $c->render(json => {status => STATUS_ERROR, error => 'No Task defined'})
+              unless defined $task;
+            return $c->render(json => {status => STATUS_ERROR, error => 'No Arguments defined'})
+              unless defined $args;
+
+            my $lock = _gen_guard_name($data->{lock} ? $data->{lock} : @$args);
+            $c->app->log->debug("Requested [$task] Args: @{$args} Lock: $lock");
+
+            return $c->render(json => {status => STATUS_DOWNLOADING()}) if $c->app->_active($lock);
+            return $c->render(json => {status => STATUS_IGNORE()})      if enqueued($lock);
+
+            enqueue($lock);
+            my $id = $c->minion->enqueue($task => $args);
+
+            $c->render(json => {status => STATUS_ENQUEUED, id => $id});
+        });
+
+    $r->get('/' => sub { shift->redirect_to('/minion') });
+
+    $r->post(
+        '/dequeue' => sub {
+            my $c    = shift;
+            my $data = $c->req->json;
+            dequeue(_gen_guard_name($data->{lock}));
+            $c->render(json => {status => STATUS_PROCESSED});
+        });
+}
 
 sub SESSION_TOKEN { $_token }
 
@@ -55,7 +120,7 @@ sub _gen_guard_name { join('.', SESSION_TOKEN, pop) }
 
 sub _exists { !!(defined $_[0] && exists $_[0]->{total} && $_[0]->{total} > 0) }
 
-sub active { !app->minion->lock(shift, 0) }
+sub _active { !shift->minion->lock(shift, 0) }
 
 sub enqueued {
     my $lock = shift;
@@ -83,73 +148,17 @@ sub _setup_workers {
 }
 
 sub run {
-    my $self = shift;
-    app->log->short(1);
-    require OpenQA::Utils;
-    OpenQA::Utils::set_listen_address(7844);
-    $ENV{MOJO_INACTIVITY_TIMEOUT} //= 300;
     my @args = _setup_workers(@_);
-    app->log->debug("Starting cache service: $0 @args");
-    app->start(@args);
+
+    my $app = __PACKAGE__->new;
+    $app->log->short(1);
+    local $ENV{MOJO_INACTIVITY_TIMEOUT} //= 300;
+    $app->log->debug("Starting cache service: $0 @args");
+
+    return $app->start(@args);
 }
 
-get '/session_token' => sub { shift->render(json => {session_token => SESSION_TOKEN()}) };
-
-get '/info' => sub { $_[0]->render(json => shift->minion->stats) };
-
-post '/status' => sub {
-    my $c         = shift;
-    my $data      = $c->req->json;
-    my $lock_name = $data->{lock};
-    return $c->render(json => {error => 'No lock specified.'}, status => 400) unless $lock_name;
-
-    my $lock = _gen_guard_name($lock_name);
-    my %res  = (status => (active($lock) ? STATUS_DOWNLOADING : enqueued($lock) ? STATUS_IGNORE : STATUS_PROCESSED));
-
-    if ($data->{id}) {
-        my $job = app->minion->job($data->{id});
-        return $c->render(json => {error => 'Specified job ID is invalid.'}, status => 404) unless $job;
-
-        my $job_info = $job->info;
-        return $c->render(json => {error => 'Job info not available.'}, status => 404) unless $job_info;
-        $res{result} = $job_info->{result};
-        $res{output} = $job_info->{notes}->{output};
-    }
-
-    $c->render(json => \%res);
-};
-
-post '/execute_task' => sub {
-    my $c    = shift;
-    my $data = $c->req->json;
-    my $task = $data->{task};
-    my $args = $data->{args};
-
-    return $c->render(json => {status => STATUS_ERROR, error => 'No Task defined'})
-      unless defined $task;
-    return $c->render(json => {status => STATUS_ERROR, error => 'No Arguments defined'})
-      unless defined $args;
-
-    my $lock = _gen_guard_name($data->{lock} ? $data->{lock} : @$args);
-    app->log->debug("Requested [$task] Args: @{$args} Lock: $lock");
-
-    return $c->render(json => {status => STATUS_DOWNLOADING()}) if active($lock);
-    return $c->render(json => {status => STATUS_IGNORE()})      if enqueued($lock);
-
-    enqueue($lock);
-    my $id = $c->minion->enqueue($task => $args);
-
-    $c->render(json => {status => STATUS_ENQUEUED, id => $id});
-};
-
-get '/' => sub { shift->redirect_to('/minion') };
-
-post '/dequeue' => sub {
-    my $c    = shift;
-    my $data = $c->req->json;
-    dequeue(_gen_guard_name($data->{lock}));
-    $c->render(json => {status => STATUS_PROCESSED});
-};
+1;
 
 =encoding utf-8
 
@@ -211,5 +220,3 @@ Dequeues a job from the queue of jobs which are still inactive. It acceps a POST
       { asset=> 'default.qcow2' }
 
 =cut
-
-1;

--- a/lib/OpenQA/CacheService/Controller/API.pm
+++ b/lib/OpenQA/CacheService/Controller/API.pm
@@ -1,0 +1,93 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::CacheService::Controller::API;
+use Mojo::Base 'Mojolicious::Controller';
+
+use OpenQA::CacheService::Model::Cache
+  qw(STATUS_PROCESSED STATUS_ENQUEUED STATUS_DOWNLOADING STATUS_IGNORE STATUS_ERROR);
+
+sub session_token {
+    my $self = shift;
+    $self->render(json => {session_token => $self->app->session_token});
+}
+
+sub info {
+    my $self = shift;
+    $self->render(json => $self->minion->stats);
+}
+
+sub status {
+    my $self = shift;
+
+    my $data      = $self->req->json;
+    my $lock_name = $data->{lock};
+    return $self->render(json => {error => 'No lock specified.'}, status => 400) unless $lock_name;
+
+    my $lock = $self->gen_guard_name($lock_name);
+    my %res  = (
+        status => (
+              $self->_active($lock)         ? STATUS_DOWNLOADING
+            : $self->locks->enqueued($lock) ? STATUS_IGNORE
+            :                                 STATUS_PROCESSED
+        ));
+
+    if ($data->{id}) {
+        my $job = $self->minion->job($data->{id});
+        return $self->render(json => {error => 'Specified job ID is invalid.'}, status => 404) unless $job;
+
+        my $job_info = $job->info;
+        return $self->render(json => {error => 'Job info not available.'}, status => 404) unless $job_info;
+        $res{result} = $job_info->{result};
+        $res{output} = $job_info->{notes}->{output};
+    }
+
+    $self->render(json => \%res);
+}
+
+sub execute_task {
+    my $self = shift;
+
+    my $data = $self->req->json;
+    my $task = $data->{task};
+    my $args = $data->{args};
+
+    return $self->render(json => {status => STATUS_ERROR, error => 'No Task defined'})
+      unless defined $task;
+    return $self->render(json => {status => STATUS_ERROR, error => 'No Arguments defined'})
+      unless defined $args;
+
+    my $lock = $self->gen_guard_name($data->{lock} ? $data->{lock} : @$args);
+    $self->app->log->debug("Requested [$task] Args: @{$args} Lock: $lock");
+
+    return $self->render(json => {status => STATUS_DOWNLOADING()}) if $self->_active($lock);
+    return $self->render(json => {status => STATUS_IGNORE()})      if $self->locks->enqueued($lock);
+
+    $self->locks->enqueue($lock);
+    my $id = $self->minion->enqueue($task => $args);
+
+    $self->render(json => {status => STATUS_ENQUEUED, id => $id});
+}
+
+sub dequeue {
+    my $self = shift;
+    my $data = $self->req->json;
+    $self->locks->dequeue($self->gen_guard_name($data->{lock}));
+    $self->render(json => {status => STATUS_PROCESSED});
+}
+
+sub _active { !shift->minion->lock(shift, 0) }
+
+1;

--- a/lib/OpenQA/CacheService/Model/Locks.pm
+++ b/lib/OpenQA/CacheService/Model/Locks.pm
@@ -1,0 +1,38 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::CacheService::Model::Locks;
+use Mojo::Base -base;
+
+use Mojo::Collection;
+
+has queue => sub { Mojo::Collection->new };
+
+sub enqueued {
+    my ($self, $lock) = @_;
+    return !!($self->queue->grep(sub { $_ eq $lock })->size == 1);
+}
+
+sub dequeue {
+    my ($self, $lock) = @_;
+    $self->queue($self->queue->grep(sub { $_ ne $lock }));
+}
+
+sub enqueue {
+    my ($self, $lock) = @_;
+    push @{$self->queue}, $lock;
+}
+
+1;

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use warnings;
 use Mojo::Base -strict;
 
 use FindBin;

--- a/script/openqa-workercache
+++ b/script/openqa-workercache
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
+
 use FindBin;
+BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
 
-BEGIN {
-    unshift @INC, "$FindBin::Bin/../lib";
-}
+use OpenQA::CacheService;
+use OpenQA::Utils 'set_listen_address';
 
-require OpenQA::CacheService;
-OpenQA::CacheService->run(@ARGV);
+set_listen_address(7844);
+OpenQA::CacheService::run(@ARGV);

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -259,34 +259,19 @@ subtest 'different token between restarts' => sub {
 };
 
 subtest 'enqueued' => sub {
-    require OpenQA::CacheService;
-
-    OpenQA::CacheService::enqueue('bar');
-    ok !OpenQA::CacheService::enqueued('foo'), "Queue works" or die;
-    OpenQA::CacheService::enqueue('foo');
-    ok OpenQA::CacheService::enqueued('foo'), "Queue works";
-    OpenQA::CacheService::dequeue('foo');
-    ok !OpenQA::CacheService::enqueued('foo'), "Dequeue works";
+    my $app = OpenQA::CacheService->new;
+    $app->locks->enqueue('bar');
+    ok !$app->locks->enqueued('foo'), 'Queue works';
+    $app->locks->enqueue('foo');
+    ok $app->locks->enqueued('foo'), 'Queue works';
+    $app->locks->dequeue('foo');
+    ok !$app->locks->enqueued('foo'), 'Dequeue works';
 };
 
-subtest '_gen_guard_name' => sub {
-    require OpenQA::CacheService;
-
-    ok !OpenQA::CacheService::SESSION_TOKEN(), "Session token is not there" or die;
-    OpenQA::CacheService::_gen_session_token();
-    ok OpenQA::CacheService::SESSION_TOKEN(), "Session token is there" or die;
-    is OpenQA::CacheService::_gen_guard_name('foo'),
-      OpenQA::CacheService::SESSION_TOKEN() . '.foo', "Session token is there"
-      or die;
-};
-
-subtest '_exists' => sub {
-    require OpenQA::CacheService;
-
-    ok !OpenQA::CacheService::_exists();
-    ok !OpenQA::CacheService::_exists({total => 0});
-    ok OpenQA::CacheService::_exists({total => 1});
-    ok OpenQA::CacheService::_exists({total => 100});
+subtest 'gen_guard_name' => sub {
+    my $app = OpenQA::CacheService->new;
+    is $app->gen_guard_name('foo'), $app->session_token . '.foo', 'Session token is there';
+    is $app->gen_guard_name('bar'), $app->session_token . '.bar', 'Session token is there';
 };
 
 subtest 'Client can check if there are available workers' => sub {

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -58,6 +58,8 @@ use OpenQA::Test::FakeWebSocketTransaction;
 use Mojo::Util qw(md5_sum);
 use OpenQA::CacheService::Request;
 use OpenQA::CacheService::Client;
+use OpenQA::CacheService::Task::Asset;
+use OpenQA::CacheService::Task::Sync;
 use Test::MockModule;
 
 my $sql;

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -56,6 +56,7 @@ use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service);
 use OpenQA::Test::FakeWebSocketTransaction;
 use Mojo::Util qw(md5_sum);
+use OpenQA::CacheService;
 use OpenQA::CacheService::Request;
 use OpenQA::CacheService::Client;
 use OpenQA::CacheService::Task::Asset;
@@ -180,18 +181,16 @@ subtest 'Availability check and worker status' => sub {
 };
 
 subtest 'Configurable minion workers' => sub {
-    require OpenQA::CacheService;
-
-    is_deeply([OpenQA::CacheService::_setup_workers(qw(minion test))],   [qw(minion test)]);
-    is_deeply([OpenQA::CacheService::_setup_workers(qw(minion worker))], [qw(minion worker -j 10)]);
-    is_deeply([OpenQA::CacheService::_setup_workers(qw(minion daemon))], [qw(minion daemon)]);
+    is_deeply([OpenQA::CacheService::setup_workers(qw(minion test))],   [qw(minion test)]);
+    is_deeply([OpenQA::CacheService::setup_workers(qw(minion worker))], [qw(minion worker -j 10)]);
+    is_deeply([OpenQA::CacheService::setup_workers(qw(minion daemon))], [qw(minion daemon)]);
 
     path($ENV{OPENQA_CONFIG})->child("workers.ini")->spurt("
 [global]
 CACHEDIRECTORY = $cachedir
 CACHELIMIT = 100");
 
-    is_deeply([OpenQA::CacheService::_setup_workers(qw(minion worker))], [qw(minion worker -j 5)]);
+    is_deeply([OpenQA::CacheService::setup_workers(qw(minion worker))], [qw(minion worker -j 5)]);
 };
 
 subtest 'Cache Requests' => sub {

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -50,7 +50,7 @@ sub cache_minion_worker {
             # this service can be very noisy
             require OpenQA::CacheService;
             local $ENV{MOJO_MODE} = 'test';
-            OpenQA::CacheService->run(qw(minion worker));
+            OpenQA::CacheService::run(qw(minion worker));
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);
         })->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0);
@@ -63,7 +63,7 @@ sub cache_worker_service {
             # this service can be very noisy
             require OpenQA::CacheService;
             local $ENV{MOJO_MODE} = 'test';
-            OpenQA::CacheService->run(qw(daemon -l http://*:7844));
+            OpenQA::CacheService::run(qw(daemon -l http://*:7844));
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);
         })->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0);


### PR DESCRIPTION
This patch turns the cache service into a full Mojolicious application, just like the scheduler and websocket services. There should be no functional changes, just a cleaner structure and less dead code.