### PR TITLE
full-stack.t: Add sleep before sending first command

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -169,6 +169,7 @@ subtest 'wait until developer console becomes available' => sub {
     OpenQA::Test::FullstackUtils::wait_for_developer_console_available($driver);
 };
 
+sleep 8;
 subtest 'pause at certain test' => sub {
     # load Selenium::Remote::WDKeys module or skip this test if not available
     unless (can_load(modules => {'Selenium::Remote::WDKeys' => undef,})) {


### PR DESCRIPTION
Startup time of the backend can take several seconds.
When sending the set_pause_at_test command too early, the backend doesn't read it.
(Still have to figure out where the command is lost exactly.)