### PR TITLE
Fix URLs for needles in subdirectories (POO #58959)

### DIFF
--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -614,9 +614,15 @@ subtest '(created) needles can be accessed over API' => sub {
       ->status_is(200, 'needle accessible')->content_type_is('image/png');
     @warnings = warnings {
         $t->get_ok('/needles/opensuse/test-newneedle.png?jsonfile=/try/to/break_out.json')
-          ->status_is(403, 'access to files outside the test directory not granted');
+          ->status_is(403, 'access to files outside the test directory not granted (absolute)');
     };
     map { like($_, qr/is not in a subdir of/, 'expected warning') } @warnings;
+    @warnings = warnings {
+        $t->get_ok(
+'/needles/opensuse/test-newneedle.png?jsonfile=t/data/openqa/share/tests/opensuse/needles/../../../../try/to/break_out.json'
+        )->status_is(403, 'access to files outside the test directory not granted (relative)');
+    };
+    map { like($_, qr/cannot contain ../, 'expected warning') } @warnings;
 
     my $tmp_dir = 't/tmp_needles';
     File::Path::rmtree($tmp_dir);


### PR DESCRIPTION
As discussed in the POO, this was broken by PR #2410 commit
36aa974 - it assumes you can always find a needle simply by
sticking the needle filename on the end of a `needledir` call,
but you can't, needles are allowed to be in subdirectories of
needledir. This should hopefully fix that without breaking
the custom run case by using the *whole* of the JSON file path -
we just figure out the subdirectory component from it. This works
for me in the 'needle is in a subdirectory of the normal needle
dir' case, but I didn't test it in the custom run case.

Signed-off-by: Adam Williamson <awilliam@redhat.com>