### PR TITLE
Implement an expand feature for job group YAML

### DIFF
--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -882,9 +882,49 @@ subtest 'Create and modify groups with YAML' => sub {
         form => {
             schema   => $schema_filename,
             preview  => 1,
+            expand   => 1,
             template => YAML::XS::Dump($yaml),
         });
     $t->status_is(200, 'Posting preview successful');
+    is_deeply(
+        YAML::XS::Load(YAML::XS::Load($t->tx->res->body)->{result}),
+        {
+            products => {
+                'opensuse-13.1-DVD-i586' => {
+                    distri  => 'opensuse',
+                    flavor  => 'DVD',
+                    version => '13.1',
+                }
+            },
+            scenarios => {
+                i586 => {
+                    'opensuse-13.1-DVD-i586' => [
+                        {
+                            eggs => {
+                                machine  => '32bit',
+                                priority => 20,
+                                settings => {BAR => 'updated later', FOO => 'removed later'},
+                            }
+                        },
+                        {
+                            foobar => {
+                                machine  => '64bit',
+                                priority => 40,
+                                settings => {},
+                            }
+                        },
+                        {
+                            spam => {
+                                machine  => '64bit',
+                                priority => 40,
+                                settings => {},
+                            }
+                        },
+                    ]}
+            },
+        },
+        'Expected result returned in response'
+    ) || diag explain $t->tx->res->body;
     $t->get_ok("/api/v1/job_templates_scheduling/$job_group_id3");
     is_deeply(
         YAML::XS::Load($t->tx->res->body),

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -585,6 +585,15 @@ subtest 'edit job templates using YAML' => sub() {
     like($result->get_text(), qr/No changes were made!/, 'preview, nothing changed')
       or diag explain $result->get_text();
 
+    # Expansion
+    $driver->find_element_by_id('expand-template')->click();
+    wait_for_ajax;
+    like($result->get_text(), qr/Result of expanding the YAML/, 'expansion shown') or diag explain $result->get_text();
+    like($result->get_text(), qr/settings: \{\}/, 'expanded YAML has empty settings')
+      or diag explain $result->get_text();
+    unlike($result->get_text(), qr/defaults:/, 'expanded YAML has no defaults')
+      or diag explain $result->get_text();
+
     # Save
     $driver->find_element_by_id('save-template')->click();
     $result = $form->child('.result');

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -21,8 +21,9 @@
     % else {
         setupJobTemplates("<%= url_for('apiv1_job_templates') %>", <%= $group->id %>);
     % }
-    $('#preview-template').click(function() { submitTemplateEditor(1); });
-    $('#save-template').click(function() { submitTemplateEditor(0); });
+    $('#expand-template').click(function() { submitTemplateEditor('expand'); });
+    $('#preview-template').click(function() { submitTemplateEditor('preview'); });
+    $('#save-template').click(function() { submitTemplateEditor('save'); });
 % end
 
 <div class="row">
@@ -167,6 +168,7 @@ scenarios:
                 <div class="col-sm-7">
                     <p class="buttons">
                     % if (is_admin) {
+                        <button id="expand-template" type="button" class="btn btn-tertiary"><i class="fas"></i>Show expanded version</button>
                         <button id="preview-template" type="button" class="btn btn-secondary"><i class="fas fa-preview"></i>Preview changes</button>
                         <button id="save-template" type="button" class="btn btn-primary"><i class="fas fa-save"></i>Save changes</button>
                     % }


### PR DESCRIPTION
We have the parsed scenarios in a hash. Generating a result is as easy as feeding the data back into the job template format.

The API takes an additional `expand` option to compute the result YAML after expanding aliases, settings and defaults.

The web UI exposes the feature as a new `Show expanded version` button which doesn't save the changes.

This also adds additional documentation on the API response to be clearer about the available fields with different options.

Fixes: [poo#56279](https://progress.opensuse.org/issues/56279)