### PR TITLE
Fix bug that cannot update job group using load_templates

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -214,7 +214,7 @@ sub get_job_groups {
 }
 
 sub create_or_update_job_template {
-    my ($self, $args) = @_;
+    my ($self, $group_id, $args) = @_;
 
     my $schema                = $self->schema;
     my $machines              = $schema->resultset('Machines');
@@ -222,8 +222,6 @@ sub create_or_update_job_template {
     my $products              = $schema->resultset('Products');
     my $job_templates         = $schema->resultset('JobTemplates');
     my $job_template_settings = $schema->resultset('JobTemplateSettings');
-
-    my $group_id = $self->param('id');
 
     die "Machine is empty and there is no default for architecture $args->{arch}\n"
       unless $args->{machine_name};
@@ -385,7 +383,7 @@ sub update {
                 my @job_template_ids;
                 foreach my $job_template_key (sort keys %$job_template_names) {
                     push @job_template_ids,
-                      $self->create_or_update_job_template($job_template_names->{$job_template_key});
+                      $self->create_or_update_job_template($group_id, $job_template_names->{$job_template_key});
                 }
 
                 # Drop entries we haven't touched in add/update loop

--- a/script/load_templates
+++ b/script/load_templates
@@ -197,7 +197,7 @@ sub post_entry {
 
     if (!$options{'clean'}) {    # with --clean the entry should not exist at this point, no need to check
         my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table))->query(%param))->res;
-        if ($res->code && $res->code == 200 && @{$res->json->{$table}} == 1 && $res->json->{$table}[0]{id}) {
+        if ($res->code && $res->code == 200 && @{$res->json->{$table}} > 0 && $res->json->{$table}[0]{id}) {
             if ($options{'update'} && $table ne 'JobTemplates')
             {                    # there is nothing to update in JobTemplates, the entry just exists or not
                 my $id = $res->json->{$table}[0]{id};


### PR DESCRIPTION
The reason for this failure message is when update the job group using load_templates, there is no group_id in `$self->param`, so we need to pass the group_id to the function.

Fixes: [poo#58490](https://progress.opensuse.org/issues/58490)