### PR TITLE
Test/Coverage: Monkeypatch B::Deparse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ endif
 .PHONY: test-with-database
 test-with-database:
 	test -d $(TEST_PG_PATH) && (pg_ctl -D $(TEST_PG_PATH) -s status >&/dev/null || pg_ctl -D $(TEST_PG_PATH) -s start) || ./t/test_postgresql $(TEST_PG_PATH)
-	$(MAKE) test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)"
+	PERL5OPT="$(PERL5OPT) -I$(PWD)/t/lib -MOpenQA::Test::PatchDeparse" $(MAKE) test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)"
 	-pg_ctl -D $(TEST_PG_PATH) stop
 
 # prepares running the tests within Docker (eg. pulls os-autoinst) and then runs the tests considering

--- a/t/lib/OpenQA/Test/PatchDeparse.pm
+++ b/t/lib/OpenQA/Test/PatchDeparse.pm
@@ -1,0 +1,64 @@
+package OpenQA::Test::PatchDeparse;
+use strict;
+use warnings;
+use Test::More;
+
+# Monkeypatch B::Deparse
+# https://progress.opensuse.org/issues/40895
+# related: https://github.com/pjcj/Devel--Cover/issues/142
+# http://perlpunks.de/corelist/mversion?module=B::Deparse
+
+
+# This might be fixed in newer versions of perl/B::Deparse
+# We only see a warning when running with Devel::Cover
+if ($B::Deparse::VERSION and $B::Deparse::VERSION eq '1.40') {
+
+#<<<  do not let perltidy touch this
+# This is not our code, and formatting should stay the same for
+# better comparison with new versions of B::Deparse
+# <---- PATCH
+package B::Deparse;
+no warnings 'redefine';
+no strict 'refs';
+
+*{"B::Deparse::walk_lineseq"} = sub {
+
+    my ($self, $op, $kids, $callback) = @_;
+    my @kids = @$kids;
+    for (my $i = 0; $i < @kids; $i++) {
+	my $expr = "";
+	if (is_state $kids[$i]) {
+        # Patch for:
+        # Use of uninitialized value $expr in concatenation (.) or string at /usr/lib/perl5/5.26.1/B/Deparse.pm line 1794.
+	    $expr = $self->deparse($kids[$i++], 0) // ''; # prevent undef $expr
+	    if ($i > $#kids) {
+		$callback->($expr, $i);
+		last;
+	    }
+	}
+	if (is_for_loop($kids[$i])) {
+	    $callback->($expr . $self->for_loop($kids[$i], 0),
+		$i += $kids[$i]->sibling->name eq "unstack" ? 2 : 1);
+	    next;
+	}
+	my $expr2 = $self->deparse($kids[$i], (@kids != 1)/2);
+	$expr2 =~ s/^sub :(?!:)/+sub :/; # statement label otherwise
+	$expr .= $expr2;
+	$callback->($expr, $i);
+    }
+
+};
+# ----> PATCH
+#>>>
+
+}
+elsif ($B::Deparse::VERSION) {
+    # when we update to a new perl version, this will remind us about checking
+    # if the bug is still there
+    diag
+"Using B::Deparse v$B::Deparse::VERSION. If you see 'uninitialized' warnings, update patch in t/lib/OpenQA/Test/PatchDeparse.pm";
+}
+
+1;
+
+


### PR DESCRIPTION
We are getting a lot of warnings like this in our tests when run with Devel::Cover:
```
Use of uninitialized value $expr in concatenation (.) or string at /usr/lib/perl5/5.26.1/B/Deparse.pm line 1794.
```

Problem seems to be a bug in B::Deparse

https://progress.opensuse.org/issues/40895