### PR TITLE
Unset PERL5OPT when executing isotovideo

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -334,6 +334,9 @@ sub engine_workit {
             STDOUT->fdopen($handle, 'w');
             STDERR->fdopen($handle, 'w');
 
+            # PERL5OPT may have Devel::Cover options, we don't need and want
+            # them in the spawned process as it does not belong to openQA code
+            local $ENV{PERL5OPT} = "";
             exec "perl", "$isotovideo", '-d';
             die "exec failed: $!\n";
         });


### PR DESCRIPTION
PERL5OPT may contain Devel::Cover options. When spawning isotovideo, we don't need and want that, as that's not code in openQA itself.

Related issue: https://progress.opensuse.org/issues/40895