### PR TITLE
Support configurable patterns for asset cleanup

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -972,6 +972,21 @@ after a certain number of days. That duration can be adjusted by setting
 +untracked_assets_storage_duration+ in the +misc_limits+ section of the
 openQA config to the desired number of days.
 
+In less trivial cases where a common limit is not enough or certain assets
+need more fine-grained control, patterns based on the filename can be used.
+The patterns are interpreted as Perl regular expressions and if a pattern
+matches the basename of an asset the specified duration in days will be used.
+In simple cases the pattern is just a match on a word.
+
+Consider the following examples to specify custom limits that would match
+assets with the names `testrepo-latest` and `openSUSE-12.3-x86_64.iso`.
+[source,ini]
+--------------------------------------------------------------------------------
+[assets/storage_duration]
+latest = 30
+openSUSE.+x86_64 = 10
+--------------------------------------------------------------------------------
+
 == CLI interface
 Beside the +daemon+ argument to run the actual web service the openQA
 startup script +/usr/share/openqa/script/openqa+ supports further arguments.

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -201,6 +201,9 @@ sub read_config {
         misc_limits => {
             untracked_assets_storage_duration => 14,
         },
+        'assets/storage_duration' => {
+            # intentionally left blank for overview
+        },
     );
 
     # in development mode we use fake auth and log to stderr


### PR DESCRIPTION
Support configurable patterns for asset cleanup

Patterns match the basename and map to a time in days which overrides the default for untracked assets.

While #2460 removes the hard-coded behavior to never delete repos with `CURRENT` in the name, we want to specify when these files will be cleaned up and it should be longer than the default (30 vs 2 days).

Fixes: [poo#59103](https://progress.opensuse.org/issues/59103)