### PR TITLE
Treat all non-asset "_URL" settings as debug message only, not warning

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -709,7 +709,7 @@ sub create_downloads_list {
             }
             $args->{$short} = $filename;
             if (!$args->{$short}) {
-                OpenQA::Utils::log_warning("Unable to get filename from $url. Ignoring $arg");
+                OpenQA::Utils::log_debug("Unable to get filename from $url. Ignoring $arg");
                 delete $args->{$short} unless $args->{$short};
                 next;
             }


### PR DESCRIPTION
Any variable with the suffix "_URL" was understood as an asset by openQA so a
setting like "OPENQA_HOST_URL=https://openqa.opensuse.org" would cause a
warning "Unable to get filename from http://openqa.opensuse.org" which we can
accept with a simple debug message and ignore.

Related progress issue: https://progress.opensuse.org/issues/53399