### PR TITLE
Fix error in nightly doc CI job

### DIFF
--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -53,7 +53,8 @@ update_docs() {
         if [[ -z "${PULL_REQUEST_USER}" ]]; then
             git clone --depth 1 --branch "$PUSH_BRANCH" "$PUSH_REMOTE_URL" .
         else
-            git clone --depth 1 --branch gh-pages "https://github.com/$PULL_REQUEST_USER/openQA" .
+            # we cannot have --depth here because will push to new branch
+            git clone --branch gh-pages "https://github.com/$PULL_REQUEST_USER/openQA" .
             git checkout -b "$PUSH_BRANCH"
         fi
 


### PR DESCRIPTION
Removed parameter --depth while cloning in script/generate-documentation
because it will result in error (shallow update not allowed) while pushing
new branch