### PR TITLE
Add more MIME types so test assets do not get served as text/plain

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -332,7 +332,7 @@ sub load_plugins {
 
     push @{$server->plugins->namespaces}, 'OpenQA::WebAPI::Plugin';
 
-    foreach my $plugin (qw(Helpers CSRF REST HashedParams Gru YAMLRenderer)) {
+    foreach my $plugin (qw(Helpers MIMETypes CSRF REST HashedParams Gru YAMLRenderer)) {
         $server->plugin($plugin);
     }
 

--- a/lib/OpenQA/WebAPI/Plugin/MIMETypes.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MIMETypes.pm
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 SUSE LINUX GmbH, Nuernberg, Germany
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Plugin::MIMETypes;
+use Mojo::Base 'Mojolicious::Plugin';
+
+sub register {
+    my ($self, $app) = @_;
+
+    my $types = $app->types;
+    $types->type(yaml => 'text/yaml;charset=UTF-8');
+    $types->type(bz2  => 'application/x-bzip2');
+    $types->type(xz   => 'application/x-xz');
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Plugin/YAMLRenderer.pm
+++ b/lib/OpenQA/WebAPI/Plugin/YAMLRenderer.pm
@@ -22,8 +22,6 @@ use Try::Tiny;
 sub register {
     my ($self, $app) = @_;
 
-    # register YAML output type
-    $app->types->type(yaml => 'text/yaml;charset=UTF-8');
     $app->renderer->add_handler(
         yaml => sub {
             my ($renderer, $c, $output, $options) = @_;

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -36,6 +36,12 @@ my $job_groups    = $t->app->schema->resultset('JobGroups');
 my $parent_groups = $t->app->schema->resultset('JobGroupParents');
 my $jobs          = $t->app->schema->resultset('Jobs');
 
+subtest 'MIME types' => sub {
+    is $t->app->types->type('yaml'), 'text/yaml;charset=UTF-8', 'right type';
+    is $t->app->types->type('bz2'),  'application/x-bzip2',     'right type';
+    is $t->app->types->type('xz'),   'application/x-xz',        'right type';
+};
+
 # regular job groups shown
 $t->get_ok('/dashboard_build_results')->status_is(200);
 my @h2 = $t->tx->res->dom->find('h2 a')->map('text')->each;


### PR DESCRIPTION
Small change so `.bz2` and `.xz` files do not get served with `text/plain` MIME type.

Progress: https://progress.opensuse.org/issues/44564