### PR TITLE
Hide YAML guide by default, expose via a button

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -387,8 +387,18 @@ function toggleTemplateEditor() {
                 editor.replaceSelection(Array(editor.getOption('indentUnit') + 1).join(' '));
             }
         });
+
+        $('.CodeMirror').css('width', window.innerWidth * 0.9 + 'px');
+        $('.CodeMirror').css('height', window.innerHeight * 0.7 + 'px');
+        $(window).on('resize', function() {
+            $('.CodeMirror').css('height', window.innerHeight * 0.7 + 'px');
+        });
+        $('#toggle-yaml-guide').click(function() {
+            $('.editor-yaml-guide').toggle();
+            var guide_width = $('.editor-yaml-guide').is(':visible') ? $('.editor-yaml-guide').width() : 0;
+            $('.CodeMirror').css('width', window.innerWidth * 0.9 - guide_width + 'px');
+        });
     }
-    editor.setSize(null, $('#editor-yaml-guide').height());
     $.ajax(form.data('put-url')).done(prepareTemplateEditor);
 }
 

--- a/assets/stylesheets/codemirror_customization.css
+++ b/assets/stylesheets/codemirror_customization.css
@@ -1,3 +1,3 @@
 .CodeMirror {
-    height: 100%;
+    height: auto;
 }

--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -2,7 +2,10 @@
 .btn, .form-control {
     font-size: 0.94rem;
     padding: 0.6rem;
-    line-height: 0.7rem;
+    line-height: 0.8rem;
+}
+.btn .fas {
+    padding-right: 3pt;
 }
 .form-control {
     padding: 0.4rem;
@@ -20,10 +23,6 @@
     .form-group .control-label {
         text-align: right;
     }
-}
-.btn {
-    padding: 0.6rem;
-    line-height: 0.7rem;
 }
 select.form-control {
     padding: 0rem;

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -106,8 +106,8 @@
         <form action="#" id="editor-form" class="form-horizontal" style="display: none;"
               data-put-url="<%= url_for('apiv1_job_templates_schedules' => (id => $group->id)) %>" data-reference="<%= $yaml_template %>">
             <div class="form-group row">
-                <label for="editor-template" class="col-sm-5 control-label">
-                    <div id="editor-yaml-guide">
+                <label for="editor-template" class="col-sm-5 control-label editor-yaml-guide" style="display: none;">
+                    <div>
                         <div>Define job templates per arch/medium:</div>
                         <code>
 defaults:
@@ -164,10 +164,11 @@ scenarios:
                 </div>
             </div>
             <div class="form-group row">
-                <div class="col-sm-5 control-label"><%= link_to 'See the docs for more details' => 'http://open.qa/docs/#_job_group_editor_gh2111', target => '_blank' %></div>
+                <div class="col-sm-5 control-label editor-yaml-guide" style="display: none;"><%= link_to 'See the docs for more details' => 'http://open.qa/docs/#_job_group_editor_gh2111', target => '_blank' %></div>
                 <div class="col-sm-7">
                     <p class="buttons">
                     % if (is_admin) {
+                        <button id="toggle-yaml-guide" type="button" class="btn btn-help"><i class="fas fa-question-circle"></i>Show YAML guide</button>
                         <button id="expand-template" type="button" class="btn btn-tertiary"><i class="fas"></i>Show expanded version</button>
                         <button id="preview-template" type="button" class="btn btn-secondary"><i class="fas fa-preview"></i>Preview changes</button>
                         <button id="save-template" type="button" class="btn btn-primary"><i class="fas fa-save"></i>Save changes</button>

--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -169,8 +169,8 @@ scenarios:
                     <p class="buttons">
                     % if (is_admin) {
                         <button id="toggle-yaml-guide" type="button" class="btn btn-help"><i class="fas fa-question-circle"></i>Show YAML guide</button>
-                        <button id="expand-template" type="button" class="btn btn-tertiary"><i class="fas"></i>Show expanded version</button>
-                        <button id="preview-template" type="button" class="btn btn-secondary"><i class="fas fa-preview"></i>Preview changes</button>
+                        <button id="expand-template" type="button" class="btn btn-tertiary">Show expanded version</button>
+                        <button id="preview-template" type="button" class="btn btn-secondary">Preview changes</button>
                         <button id="save-template" type="button" class="btn btn-primary"><i class="fas fa-save"></i>Save changes</button>
                     % }
                     </p>


### PR DESCRIPTION
Since the sizing relied on the visibility of the guide, we also need to
switch from javascript to CSS for the height adjustment.

![Screenshot from 2019-11-14 12-51-39](https://user-images.githubusercontent.com/1204189/68854990-9674d680-06dd-11ea-9dbc-b6be31f5c52d.png)


Fixes: [poo#59094](https://progress.opensuse.org/issues/59094)