### PR TITLE
Trigger tasks for limiting assets and results/logs hourly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,8 @@ install:
 	install -m 644 systemd/openqa-scheduler.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-enqueue-audit-event-cleanup.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-enqueue-audit-event-cleanup.timer "$(DESTDIR)"/usr/lib/systemd/system
+	install -m 644 systemd/openqa-enqueue-asset-and-result-cleanup.service "$(DESTDIR)"/usr/lib/systemd/system
+	install -m 644 systemd/openqa-enqueue-asset-and-result-cleanup.timer "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-setup-db.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -332,10 +332,6 @@ sub _schedule_iso {
         @successful_job_ids = ();
     };
 
-    # enqueue cleanup task
-    $gru->enqueue_limit_assets();
-    $gru->enqueue(limit_results_and_logs => [], {priority => 5, ttl => 172800, limit => 1});
-
     # emit events
     for my $succjob (@successful_job_ids) {
         OpenQA::Events->singleton->emit_event('openqa_job_create', data => {id => $succjob}, user_id => $user_id);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -263,7 +263,6 @@ sub create {
         my $downloads = create_downloads_list(\%params);
         my $gru       = $self->gru;
         $gru->enqueue_download_jobs($downloads, [$job->id]);
-        $gru->enqueue_limit_assets;
         $job->calculate_blocked_by;
         OpenQA::Scheduler::Client->singleton->wakeup;
     }

--- a/openQA.spec
+++ b/openQA.spec
@@ -17,7 +17,7 @@
 
 
 # can't use linebreaks here!
-%define openqa_services openqa-webui.service openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer
+%define openqa_services openqa-webui.service openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer openqa-enqueue-asset-and-result-cleanup.service openqa-enqueue-asset-and-result-cleanup.timer
 %define openqa_worker_services openqa-worker.target openqa-slirpvde.service openqa-vde_switch.service openqa-worker-cacheservice.service openqa-worker-cacheservice-minion.service
 %if %{undefined tmpfiles_create}
 %define tmpfiles_create() \
@@ -399,6 +399,8 @@ fi
 %{_unitdir}/openqa-websockets.service
 %{_unitdir}/openqa-enqueue-audit-event-cleanup.service
 %{_unitdir}/openqa-enqueue-audit-event-cleanup.timer
+%{_unitdir}/openqa-enqueue-asset-and-result-cleanup.service
+%{_unitdir}/openqa-enqueue-asset-and-result-cleanup.timer
 # web libs
 %dir %{_datadir}/openqa
 %{_datadir}/openqa/templates

--- a/systemd/openqa-enqueue-asset-and-result-cleanup.service
+++ b/systemd/openqa-enqueue-asset-and-result-cleanup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Enqueues an asset cleanup and a result/logs cleanup task for the openQA.
+After=postgresql.service openqa-setup-db.service
+Wants=openqa-setup-db.service
+
+[Service]
+Type=oneshot
+User=geekotest
+ExecStart=/usr/share/openqa/script/openqa eval -m production -V '[app->gru->enqueue_limit_assets(), app->gru->enqueue(limit_results_and_logs => [], {priority => 5, ttl => 172800, limit => 1})]'

--- a/systemd/openqa-enqueue-asset-and-result-cleanup.timer
+++ b/systemd/openqa-enqueue-asset-and-result-cleanup.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Enqueues an asset cleanup and a result/logs cleanup task for the openQA every hour.
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -3,7 +3,7 @@ Description=The openQA web UI
 Wants=apache2.service openqa-setup-db.service
 Before=apache2.service
 After=postgresql.service openqa-setup-db.service openqa-scheduler.service
-Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service
+Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-and-result-cleanup.timer
 
 [Service]
 # TODO: define whether we want to run the web ui with the same user


### PR DESCRIPTION
instead every time after a job or an ISO has been posted which can happen quite frequently.

See https://progress.opensuse.org/issues/55241