### PR TITLE
Let Minion background jobs finish gracefully

### DIFF
--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -4,6 +4,7 @@ After=postgresql.service openqa-setup-db.service
 Wants=openqa-setup-db.service
 
 [Service]
+SendSIGKILL=no
 User=geekotest
 ExecStart=/usr/share/openqa/script/openqa gru -m production run
 Nice=19

--- a/systemd/openqa-worker-cacheservice-minion.service
+++ b/systemd/openqa-worker-cacheservice-minion.service
@@ -5,6 +5,7 @@ Requires=openqa-worker-cacheservice.service
 PartOf=openqa-worker.target
 
 [Service]
+SendSIGKILL=no
 Restart=on-failure
 User=_openqa-worker
 ExecStart=/usr/share/openqa/script/openqa-workercache minion worker -m production


### PR DESCRIPTION
By default systemd will attempts to stop our background jobs with a SIGTERM on restarts, and if they don't stop fast enough follow up with a SIGKILL. This has the negative side effect of leaving Minion locks active that delay future background jobs. Disabling SIGKILL for our Minion services is one possible solution for fixing this.

Progress: https://progress.opensuse.org/issues/57689