### PR TITLE
Provide style check feedback earlier with parallel execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ docker-test-build:
 
 .PHONY: docker.env
 docker.env:
-	env | grep -E 'FULLSTACK|UITEST|GH|TRAVIS|CPAN|DEBUG|ZYPPER' > $(docker_env_file)
+	env | grep -E 'CHECKSTYLE|FULLSTACK|UITEST|GH|TRAVIS|CPAN|DEBUG|ZYPPER' > $(docker_env_file)
 
 .PHONY: launch-docker-to-run-tests-within
 launch-docker-to-run-tests-within: docker.env

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -440,6 +440,7 @@ container. It does some preparations to be able to run the full stack test withi
 environment variables defining our test matrix:
 
 |============================
+|CHECKSTYLE=1|
 |FULLSTACK=0| UITESTS=0
 |FULLSTACK=0| UITESTS=1
 |FULLSTACK=1|

--- a/script/run-tests-within-container
+++ b/script/run-tests-within-container
@@ -47,11 +47,12 @@ elif [ "x$SCHEDULER_FULLSTACK" = x1 ]; then
     run_fullstack_test t/05-scheduler-full.t
 elif [ "x$DEVELOPER_FULLSTACK" = x1 ]; then
     run_fullstack_test t/33-developer_mode.t
+elif [ "x$CHECKSTYLE" = x1 ]; then
+    make checkstyle || touch tests_failed
 else
     if [ "x$UITESTS" = x1 ]; then
         list=$(find ./t/ui -name '*.t' | sort)
     else
-        make checkstyle || touch tests_failed
         list=$(find ./t/ -name '*.t' -not -path './t/ui/*' | sort)
     fi
     # Allow command line options without quotes


### PR DESCRIPTION
The test matrix part "FULLSTACK=0 UITESTS=0" was commonly the longest
running on travis CI already with about 23 minutes in comparison to the
next longest which is "FULLSTACK=0 UITESTS=1" with about 17 minutes.
Other parts take even less then that. This commit will conduct the style
checks in parallel to get earlier feedback on style issues as well as
save overall test runtime.