### PR TITLE
Reduce sleep times in 25-cache-service.t to slightly save testing time

### DIFF
--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -107,7 +107,7 @@ sub test_default_usage {
     my $asset_request = $cache_client->asset_request(id => $id, asset => $a, type => 'hdd', host => $host);
 
     if ($cache_client->enqueue($asset_request)) {
-        sleep .5 until $cache_client->status($asset_request)->is_processed;
+        sleep .1 until $cache_client->status($asset_request)->is_processed;
     }
     ok($cache_client->asset_exists('localhost', $a), "Asset $a downloaded");
     ok($asset_request->minion_id, "Minion job id recorded in the request object") or die diag explain $asset_request;
@@ -125,7 +125,7 @@ sub test_sync {
 
     ok $cache_client->enqueue($rsync_request);
 
-    sleep .5 until $cache_client->status($rsync_request)->is_processed;
+    sleep .1 until $cache_client->status($rsync_request)->is_processed;
 
     my $status = $cache_client->status($rsync_request);
     is $status->result, 0;
@@ -277,11 +277,11 @@ subtest 'Client can check if there are available workers' => sub {
     $cache_service->stop;
     ok !$cache_client->info->available, 'Cache server is not available';
     $cache_service->restart;
-    sleep .5 until $cache_client->info->available;
+    sleep .1 until $cache_client->info->available;
     ok $cache_client->info->available, 'Cache server is available';
     ok !$cache_client->info->available_workers, 'No available workers at the moment';
     $worker_cache_service->start;
-    sleep 5 and diag "waiting for minion worker to be available" until $cache_client->info->available_workers;
+    sleep .1 and note "waiting for minion worker to be available" until $cache_client->info->available_workers;
     ok $cache_client->info->available_workers, 'Workers are available now';
 };
 
@@ -312,7 +312,7 @@ subtest 'Race for same asset' => sub {
 
     my $concurrent_test = sub {
         if ($cache_client->enqueue($asset_request)) {
-            sleep .5 until $cache_client->status($asset_request)->is_processed;
+            sleep .1 until $cache_client->status($asset_request)->is_processed;
             Devel::Cover::report() if Devel::Cover->can('report');
 
             return 1 if $cache_client->asset_exists('localhost', $a);
@@ -341,7 +341,7 @@ subtest 'Default usage' => sub {
     ok(!$cache_client->asset_exists('localhost', $a), 'Asset absent') or die diag "Asset already exists - abort test";
 
     if ($cache_client->enqueue($asset_request)) {
-        sleep .5 until $cache_client->status($asset_request)->is_processed;
+        sleep .1 until $cache_client->status($asset_request)->is_processed;
         my $out = $cache_client->status($asset_request)->output;
         ok($out, 'Output should be present') or die diag $out;
         like $out, qr/Downloading $a from/, "Asset download attempt logged";
@@ -396,7 +396,7 @@ subtest 'Multiple minion workers (parallel downloads, almost simulating real sce
       = map { $_ => $cache_client->asset_request(id => 922756, asset => $_, type => 'hdd', host => $host) } @assets;
     ok($cache_client->enqueue($requests{$_}), "Download enqueued for $_") for @assets;
 
-    sleep 1 until (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets;
+    sleep .1 until (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets;
 
     ok($cache_client->asset_exists('localhost', $_), "Asset $_ downloaded correctly") for @assets;
 
@@ -406,7 +406,7 @@ subtest 'Multiple minion workers (parallel downloads, almost simulating real sce
       = map { $_ => $cache_client->asset_request(id => 922756, asset => $_, type => 'hdd', host => $host) } @assets;
     ok($cache_client->enqueue($requests{$_}), "Download enqueued for $_") for @assets;
 
-    sleep 1 until (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets;
+    sleep .1 until (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets;
 
     ok($cache_client->asset_exists('localhost', "sle-12-SP3-x86_64-0368-200_88888\@64bit.qcow2"),
         "Asset $_ downloaded correctly")


### PR DESCRIPTION
The runtime is 196s+-2s vs. 201s+-2s in before