### PR TITLE
Include external reporting template for parsed results too

### DIFF
--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -185,6 +185,10 @@ span.resborder {
     .fa-question {
         padding: 5px;
     }
+    .step_actions {
+        white-space: normal;
+        float: right;
+    }
 }
 span.resborder_na {
     overflow: hidden;

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -182,7 +182,7 @@ span.resborder {
     font-size: small;
     padding: 1px;
 
-    .fa-question {
+    .fa-question, .step_actions {
         padding: 5px;
     }
     .step_actions {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -203,7 +203,7 @@ sub list_scheduled_ajax {
     $self->render(json => {data => \@scheduled});
 }
 
-sub stash_module_list {
+sub stash_job_and_module_list {
     my ($self) = @_;
 
     my $job_id = $self->param('testid') or return;
@@ -218,6 +218,7 @@ sub stash_module_list {
       or return;
 
     my $test_modules = read_test_modules($job);
+    $self->stash(job     => $job);
     $self->stash(modlist => ($test_modules ? $test_modules->{modules} : []));
     return 1;
 }
@@ -225,14 +226,14 @@ sub stash_module_list {
 sub details {
     my ($self) = @_;
 
-    $self->stash_module_list or return $self->reply->not_found;
+    $self->stash_job_and_module_list or return $self->reply->not_found;
     $self->render('test/details');
 }
 
 sub module_components {
     my ($self) = @_;
 
-    $self->stash_module_list or return $self->reply->not_found;
+    $self->stash_job_and_module_list or return $self->reply->not_found;
     $self->render('test/module_components');
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -72,7 +72,11 @@ sub register {
             return $text;
         });
 
-    $app->helper(bug_report_actions => sub { shift->include_branding('external_reporting') });
+    $app->helper(
+        bug_report_actions => sub {
+            my ($c, %args) = @_;
+            return $c->include_branding('external_reporting', %args);
+        });
 
     $app->helper(
         stepaction_for => sub {
@@ -232,15 +236,15 @@ sub register {
         # falls back to 'plain' if brand doesn't include the template, so
         # allowing partial brands
         include_branding => sub {
-            my ($c, $name) = @_;
+            my ($c, $name, %args) = @_;
             my $path = "branding/" . $c->app->config->{global}->{branding} . "/$name";
-            my $ret  = $c->render_to_string($path);
+            my $ret  = $c->render_to_string($path, %args);
             if (defined($ret)) {
                 return $ret;
             }
             else {
                 $path = "branding/plain/$name";
-                return $c->render_to_string($path);
+                return $c->render_to_string($path, %args);
             }
         });
 

--- a/templates/branding/openSUSE/external_reporting.html.ep
+++ b/templates/branding/openSUSE/external_reporting.html.ep
@@ -1,6 +1,10 @@
 % my $build = $job->BUILD;
 % my $step_url = url_for('step')->to_abs;
 % my $module = stash('moduleid');
+% my $step = stash('stepid');
+% if ($step) {
+%     $step_url = url_for('step', moduleid => $module, stepid => $step)->to_abs;
+% }
 % my %product_details = ();
 % my $scenario_description = $job->scenario_description // '';
 

--- a/templates/test/module_table.html.ep
+++ b/templates/test/module_table.html.ep
@@ -49,9 +49,9 @@
                             % my $href  = "#step/$module->{name}/$step->{num}";
                             % if ($is_parser_text_result) {
                                 <span title="<%= $title %>" data-href="<%= $href %>" onclick="toggleTextPreview(this)" class="text-result">
-                                    <span class="resborder <%= $resborder %>"><%= $step->{text_data} %><span class="step_actions">
+                                    <span class="resborder <%= $resborder %>"><span class="step_actions">
                                         %= bug_report_actions(moduleid => $module->{name}, stepid => $step->{num});
-                                    </span></span>
+                                    </span><%= $step->{text_data} %></span>
                                 </span>
                             % }
                             % else {

--- a/templates/test/module_table.html.ep
+++ b/templates/test/module_table.html.ep
@@ -49,7 +49,9 @@
                             % my $href  = "#step/$module->{name}/$step->{num}";
                             % if ($is_parser_text_result) {
                                 <span title="<%= $title %>" data-href="<%= $href %>" onclick="toggleTextPreview(this)" class="text-result">
-                                    <span class="resborder <%= $resborder %>"><%= $step->{text_data} %></span>
+                                    <span class="resborder <%= $resborder %>"><%= $step->{text_data} %><span class="step_actions">
+                                        %= bug_report_actions(moduleid => $module->{name}, stepid => $step->{num});
+                                    </span></span>
                                 </span>
                             % }
                             % else {


### PR DESCRIPTION
Allow branding to set external reporting link to parsed results too.
Since parsed results are all rendered as part of a single template,
module and step id needs to be set directly in a template during
the iteration. And branding template modified to actually use those
values.

I'm not an expert in CSS, and this is the best I can do - the action link is at the bottom right of expanded parsed result text. If anyone know how to put it at the top right (but not increasing height of the collapsed row), that would be more consistent with other places.
You can see how it looks now here: https://openqa.qubes-os.org/tests/4710#step/QubeManagerTest/69

I've included changes to openSUSE branding, but in fact I've tested it on a Qubes OS one (not published yet). BTW is there a way to load branding from an alternative directory?
