### PR TITLE
.circleci: Fix ignored test results of unstable tests within loop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ aliases:
       t)         make test CHECKSTYLE=1 PROVE_ARGS="$HARNESS t/*.t"     GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
       ui)        make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/ui/*.t"  GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
       api)       make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/api/*.t" GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
-      unstable)  for f in $(cat .circleci/unstable_tests.txt); do make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS $f" RETRY=3; done;;
+      unstable)  for f in $(cat .circleci/unstable_tests.txt); do make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS $f" RETRY=3 || break; done;;
       fullstack) make test CHECKSTYLE=0 FULLSTACK=1           PROVE_ARGS="$HARNESS t/full-stack.t" RETRY=3;;
       scheduler) make test CHECKSTYLE=0 SCHEDULER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/05-scheduler-full.t";;
       developer) make test CHECKSTYLE=0 DEVELOPER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/33-developer_mode.t";;


### PR DESCRIPTION
Calling "make test" within a for loop will ignore all results for final
exit code evaluation except the last run which was for
"t/ui/26-jobs_restart.t". This means that all other tests within
"unstable_tests.txt" were effectively ignored. This can for example be
seen in
https://app.circleci.com/jobs/github/os-autoinst/openQA/6274/parallel-runs/0/steps/0-108

This commit fixes this by aborting the for-loop with a failure properly
propagated if any of the "make test" runs fails to succeed within the
specified retries.