### PR TITLE
Fix empty documentation commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,13 +283,14 @@ jobs:
       - run:
           command: |
             export GEM_HOME=$(pwd)/.gem
-            if [[ "${CIRCLE_JOB}" == *nightly ]]; then
-                export PULL_REQUEST_USER=${CIRCLE_PROJECT_USERNAME:-os-autoinst}
-                export TARGET_BRANCH=gh-pages-$(date +%y%m%d%H%M%S)
-                export PUBLISH=1
+            if [[ "${CIRCLE_JOB}" != *nightly ]]; then
+                bash -xe script/generate-documentation
+            else
                 sudo zypper -n install hub
+                export PULL_REQUEST_USER=${CIRCLE_PROJECT_USERNAME:-os-autoinst}
+                export PUBLISH=1
+                bash -xe script/generate-documentation https://token@github.com/openqabot/openQA.git gh-pages-$(date +%y%m%d%H%M%S)
             fi
-            bash -xe script/generate-documentation https://token@github.com/openqabot/openQA.git $TARGET_BRANCH
 
   build-docs-nightly:
     <<: *docs-template

--- a/script/generate-documentation
+++ b/script/generate-documentation
@@ -46,6 +46,24 @@
 # target remote ($1). Target branch will be created based on
 # PULL_REQUEST_USER:gh_pages
 
+set -eo pipefail
+
+# exit status 0 if any changes detected
+anything_changed() {
+    echo '*.pdf -diff' >> .gitattributes
+    git --no-pager diff --shortstat
+    
+    local lines_changed_in_index lines_changed_in_api other_files_changed
+
+    # it looks it is a challenge to ignore lines in git diff
+    lines_changed_in_index="$(git --no-pager diff -U0 -- index.html     | grep -v -e 'Last updated ' -e '^\@\@' -e '+++ b' -e '^index ' -e '--- a' | tail -n +2 | wc -l)"
+    lines_changed_in_api="$(git --no-pager diff -U0 -- api/testapi.html | grep -v -e 'Last updated ' -e '^\@\@' -e '+++ b' -e '^index ' -e '--- a' | tail -n +2 | wc -l)"
+    other_files_changed="$(git --no-pager diff --name-only -- '(:!index.html)' '(:!api/testapi.html)' '(:!current.pdf)' | wc -l)"
+
+    # if any other file changed || any line besides containing 'Last Updated' in .html
+    test "$other_files_changed" -gt 0 || test "$((lines_changed_in_index+lines_changed_in_api))" -gt 0
+}
+
 update_docs() {
         mkdir out || exit 1
         (
@@ -71,11 +89,7 @@ update_docs() {
         update_schemas
         ln -f openqa-documentation-"${verbose_doc_name}".html index.html
         ln -f openqa-documentation-"${verbose_doc_name}".pdf current.pdf
-        # "Change is inevitable, except for vending machines"
-        # gh#1480
-        # 2 files changed, 2 insertions(+), 2 deletions(-)
-        ANYTHING_CHANGED=$(git diff --shortstat | perl -ne 'my $n; print $n = () = m/(?: 2 \w+)/g')
-        if [ -n "${ANYTHING_CHANGED}" ] && [ "${ANYTHING_CHANGED}" -ne 3 ]; then
+        if anything_changed; then
             cd ..
             git add _includes/api.html
             git add docs/index.html docs/current.pdf docs/api/testapi.html


### PR DESCRIPTION
https://progress.opensuse.org/issues/59957

First commit should fix cosmetic problem when too many documentation changes are detected in CI run for every PR

Before: https://circleci.com/gh/os-autoinst/openQA/6397 : `4 files changed, 13617 insertions(+), 9819 deletions(-)`
After: 'Documentation is up to date' if nothing changes, otherwise relevant diff info.

Second commit is challenged by inability of `git diff` to ignore specific lines and introduces more reliable hacks to detect actual changes.