### PR TITLE
Add deprecation notice for old job template editor pointing to YAML

### DIFF
--- a/templates/admin/job_template/index.html.ep
+++ b/templates/admin/job_template/index.html.ep
@@ -6,6 +6,14 @@
 
 % title 'Jobs for ' . $group->name;
 
+% unless ($force_yaml_editor) {
+    <div class="alert alert-danger">
+        The old job group view is deprecated and will be removed from
+        future versions of openQA. Please save the job templates in YAML
+        format as soon as possible.
+    </div>
+% }
+
 % content_for 'ready_function' => begin
     user_is_admin =
     % if(is_admin) {


### PR DESCRIPTION
In the near future we plan to remove the old job group UI editor fully
replacing it by job group definitions in YAML. As the old editor is
already not easily accessible anymore, e.g. only shown for old
non-migrated job groups the switch would not concern new users or
already migrated job groups.

![Screenshot_20191119_111533](https://user-images.githubusercontent.com/1693432/69138440-f8a75000-0abe-11ea-8260-a62aa7aac969.png)

Related progress issue: https://progress.opensuse.org/issues/44360