### PR TITLE
Remove dead code from isotovideo client

### DIFF
--- a/lib/OpenQA/Worker/Isotovideo/Client.pm
+++ b/lib/OpenQA/Worker/Isotovideo/Client.pm
@@ -22,21 +22,6 @@ use OpenQA::Utils qw(log_info log_debug);
 has job => undef, weak => 1;
 has ua  => sub { Mojo::UserAgent->new };
 
-sub status {
-    my ($self, $callback) = @_;
-
-    my $url = $self->url . '/isotovideo/status';
-    $self->ua->get(
-        $url => sub {
-            my ($ua, $tx) = @_;
-            if (my $err = $tx->error) {
-                log_debug(qq{Unable to query isotovideo status via "$url" (probably harmless): $err->{message}});
-            }
-            my $status_from_os_autoinst = $tx->res->json;
-            $self->$callback($status_from_os_autoinst);
-        });
-}
-
 sub stop_gracefully {
     my ($self, $reason, $callback) = @_;
 

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -648,8 +648,7 @@ sub _upload_results {
     }
 
     # return if job setup is insufficient
-    my $job_url = $self->isotovideo_client->url;
-    if (!$job_url || !$self->client->worker_id) {
+    if (!$self->isotovideo_client->url || !$self->client->worker_id) {
         log_warning('Unable to upload results of the job because no command server URL or worker ID have been set.');
         $self->emit(uploading_results_concluded => {});
         return Mojo::IOLoop->next_tick($callback);


### PR DESCRIPTION
This code is not used anymore since we use the status file instead of the API.