### PR TITLE
Make virtio_console1.log etc. show up as result files

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1824,6 +1824,12 @@ sub test_resultfile_list {
         }
     }
 
+    for (my $i = 1; $i < ($self->settings_hash->{VIRTIO_CONSOLE_NUM} // 1); $i++) {
+        if (-s "$testresdir/virtio_console$i.log") {
+            push(@filelist_existing, "virtio_console$i.log");
+        }
+    }
+
     return \@filelist_existing;
 }
 

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -299,6 +299,7 @@ $engine_mock->mock(
                 $job->stop('done');
             });
         $pool_directory->child('serial_terminal.txt')->spurt('Works!');
+        $pool_directory->child('virtio_console1.log')->spurt('Works too!');
         return {child => $isotovideo->is_running(1)};
     });
 
@@ -402,6 +403,13 @@ subtest 'Successful job' => sub {
                     file => {
                         file     => "$pool_directory/worker-log.txt",
                         filename => 'worker-log.txt'
+                    }}
+            ],
+            [
+                {
+                    file => {
+                        file     => "$pool_directory/virtio_console1.log",
+                        filename => 'virtio_console1.log'
                     }}]
         ],
         'would have uploaded logs'
@@ -587,6 +595,13 @@ subtest 'Livelog' => sub {
                     file => {
                         file     => "$pool_directory/worker-log.txt",
                         filename => 'worker-log.txt'
+                    }}
+            ],
+            [
+                {
+                    file => {
+                        file     => "$pool_directory/virtio_console1.log",
+                        filename => 'virtio_console1.log'
                     }}]
         ],
         'would have uploaded logs'


### PR DESCRIPTION
See POO #60059 - this fixes one part, by making the logs of
virtio consoles after the first show up as result files in the
Logs & Assets tab.

Signed-off-by: Adam Williamson <awilliam@redhat.com>