### PR TITLE
travis_test: Fix Dockerfile based on tests in OBS

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -1,11 +1,11 @@
 #!BuildTag: openqa_dev
-FROM opensuse:15.1
+FROM opensuse/leap:15.1
 
 # Define environment variable
 ENV NAME openQA test environment
 ENV LANG en_US.UTF-8
 
-RUN zypper ar -f -G 'http://download.opensuse.org/repositories/devel:/openQA:/Leap:/$releasever/openSUSE_Leap_$releasever' devel_openqa
+RUN zypper ar -f -G 'http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.1/openSUSE_Leap_15.1' devel_openqa
 
 RUN zypper in -y -C \
        glibc-i18ndata \
@@ -127,7 +127,6 @@ RUN zypper in -y -C \
        'perl(Time::ParseDate)' \
        'perl(XSLoader) >= 0.24' \
        'perl(XML::SemanticDiff)' \
-       'TimeDate' \
        perl-Archive-Extract \
        perl-Test-Simple \
        'perl(aliased)' \


### PR DESCRIPTION
See https://build.opensuse.org/package/show/devel:openQA/openqa_dev
for current test results where I deleted the _service file and maintained the
Dockerfile manually.

https://github.com/os-autoinst/os-autoinst/pull/1271#issuecomment-556009996
shows that the generated container can be used within os-autoinst tests.

Related progress issue: https://progress.opensuse.org/issues/53915