### PR TITLE
Remove likely unneeded dependency xorg-x11-fonts

### DIFF
--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -6,7 +6,7 @@ FROM opensuse/leap:15.1
 RUN zypper install -y autoconf automake gcc-c++ libtool pkgconfig\(opencv\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) make
 
 # openQA dependencies
-RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo
+RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar sudo
 
 # openQA test dependency - experimental
 RUN zypper install -y chromedriver

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -41,7 +41,6 @@ RUN zypper in -y -C \
        postgresql-server \
        which \
        chromedriver \
-       xorg-x11-fonts \
        'rubygem(sass)' \
        perl \
        ShellCheck \

--- a/openQA.spec
+++ b/openQA.spec
@@ -62,7 +62,7 @@
 %else
 %define qemu qemu
 %endif
-%define devel_requires %build_requires %test_requires rsync curl postgresql-devel %qemu tar xorg-x11-fonts sudo perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
+%define devel_requires %build_requires %test_requires rsync curl postgresql-devel %qemu tar sudo perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 
 Name:           openQA
 Version:        4.6


### PR DESCRIPTION
This should help Fedora where the package does not exist.
Most likely we do not actually need this package. If it all we might
need it for xterm-console in os-autoinst for some remote backends.

OBS test project: https://build.opensuse.org/project/show/home:okurz:branches:devel:openQA:enhance:fonts