### PR TITLE
Bring back 'xorg-x11-fonts' needed for chromium startup

### DIFF
--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -6,7 +6,7 @@ FROM opensuse/leap:15.1
 RUN zypper install -y autoconf automake gcc-c++ libtool pkgconfig\(opencv\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) make
 
 # openQA dependencies
-RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar sudo
+RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo
 
 # openQA test dependency - experimental
 RUN zypper install -y chromedriver

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -41,6 +41,7 @@ RUN zypper in -y -C \
        postgresql-server \
        which \
        chromedriver \
+       xorg-x11-fonts \
        'rubygem(sass)' \
        perl \
        ShellCheck \

--- a/openQA.spec
+++ b/openQA.spec
@@ -62,7 +62,7 @@
 %else
 %define qemu qemu
 %endif
-%define devel_requires %build_requires %test_requires rsync curl postgresql-devel %qemu tar sudo perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
+%define devel_requires %build_requires %test_requires rsync curl postgresql-devel %qemu tar xorg-x11-fonts sudo perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 
 Name:           openQA
 Version:        4.6


### PR DESCRIPTION
This reverts commit 123bd1e80dd8722b98edf63838c713a101d2f78c as our
circle CI tests in follow-up PRs showed that chromium could not start up
anymore.