### PR TITLE
Reset all leftover Gru locks after restart

### DIFF
--- a/.circleci/dependencies.txt
+++ b/.circleci/dependencies.txt
@@ -124,7 +124,7 @@ perl-local-lib-2.000023
 perl-Log-Contextual-0.008001
 perl-LWP-MediaTypes-6.02
 perl-Meta-Builder-0.003
-perl-Minion-9.13
+perl-Minion-10.0
 perl-Minion-Backend-SQLite-4.005
 perl-Module-Build-0.422400
 perl-Module-Find-0.13

--- a/cpanfile
+++ b/cpanfile
@@ -38,7 +38,7 @@ requires 'Cpanel::JSON::XS';
 requires 'JavaScript::Minifier::XS', '>= 0.11';
 requires 'JSON::Validator';
 requires 'LWP::UserAgent';
-requires 'Minion', '>= 9.13';
+requires 'Minion', '>= 10.0';
 requires 'Minion::Backend::SQLite';
 requires 'MRO::Compat';
 requires 'Module::Implementation';

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -86,7 +86,7 @@ RUN zypper in -y -C \
        'perl(JSON::XS)' \
        'perl(JavaScript::Minifier::XS)' \
        'perl(LWP::Protocol::https)' \
-       'perl(Minion) >= 9.13' \
+       'perl(Minion) >= 10.0' \
        'perl(Module::CPANfile)' \
        'perl(Module::Pluggable)' \
        'perl(Mojo::IOLoop::ReadWriteProcess)' \

--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -25,7 +25,7 @@ has usage       => sub { shift->extract_usage };
 sub run {
     my ($self, @args) = @_;
 
-    getopt \@args, 'o|oneshot' => \(my $oneshot);
+    getopt \@args, 'o|oneshot' => \my $oneshot, 'reset-locks' => \my $reset_locks;
 
     my $minion = $self->app->minion;
     $minion->on(
@@ -43,8 +43,10 @@ sub run {
 
     return $minion->perform_jobs if $oneshot;
 
-    $self->app->log->info('Resetting all leftover Gru locks after restart');
-    $minion->reset({locks => 1});
+    if ($reset_locks) {
+        $self->app->log->info('Resetting all leftover Gru locks after restart');
+        $minion->reset({locks => 1});
+    }
     $self->SUPER::run(@args);
 }
 
@@ -64,7 +66,8 @@ OpenQA::WebAPI::Command::gru::run - Gru run command
     script/openqa gru run -o
 
   Options:
-    -o, --oneshot   Perform all currently enqueued jobs and then exit
+    -o, --oneshot       Perform all currently enqueued jobs and then exit
+        --reset-locks   Reset all remaining locks before startup
 
     See 'script/openqa minion worker -h' for all available options.
 

--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -41,8 +41,11 @@ sub run {
                 });
         });
 
-    if   ($oneshot) { $minion->perform_jobs }
-    else            { $self->SUPER::run(@args) }
+    return $minion->perform_jobs if $oneshot;
+
+    $self->app->log->info('Resetting all leftover Gru locks after restart');
+    $minion->reset({locks => 1});
+    $self->SUPER::run(@args);
 }
 
 1;

--- a/openQA.spec
+++ b/openQA.spec
@@ -79,7 +79,7 @@ Source100:      openQA-rpmlintrc
 Source101:      update-cache.sh
 BuildRequires:  fdupes
 BuildRequires:  %{build_requires}
-Requires:       perl(Minion) >= 9.13
+Requires:       perl(Minion) >= 10.0
 Requires:       %{main_requires}
 Requires:       openQA-client = %{version}
 Requires:       openQA-common = %{version}

--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -5,7 +5,7 @@ Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa gru -m production run
+ExecStart=/usr/share/openqa/script/openqa gru -m production run --reset-locks
 Nice=19
 Restart=on-failure
 


### PR DESCRIPTION
Small change to trigger a reset of all remaining Gru locks after a restart of the service. It does require Minion 10.0 though.

Progress: https://progress.opensuse.org/issues/57689