### PR TITLE
Forward asset and sync job logs to the cache service journal

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -26,13 +26,17 @@ sub startup {
 
     $self->defaults(appname => 'openQA Cache Service');
 
+    # Allow for very quiet tests
     $self->hook(
         before_server_start => sub {
             my ($server, $app) = @_;
             $server->silent(1) if $app->mode eq 'test';
         });
+    my $log = $self->log;
+    $log->unsubscribe('message') if $ENV{OPENQA_CACHE_SERVICE_QUIET};
 
-    $self->plugin(Minion => {SQLite => 'sqlite:' . OpenQA::CacheService::Model::Cache->from_worker->db_file});
+    my $db_file = OpenQA::CacheService::Model::Cache->from_worker(log => $log)->db_file;
+    $self->plugin(Minion => {SQLite => "sqlite:$db_file"});
     $self->plugin('Minion::Admin');
     $self->plugin('OpenQA::CacheService::Task::Asset');
     $self->plugin('OpenQA::CacheService::Task::Sync');

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -63,7 +63,6 @@ sub init {
 
     my $db_file = path($location, 'cache.sqlite');
     $self->db_file($db_file);
-    $log->info("Loading cache database from $db_file");
     $self->dsn("sqlite:$db_file");
     $self->_deploy_cache unless -e $db_file;
     eval { $self->sqlite->migrations->name('cache_service')->from_data->migrate };
@@ -72,7 +71,7 @@ sub init {
 
     $self->_cache_sync;
     $self->_check_limits(0);
-    $log->info("Cache size is $self->{cache_real_size}, with limit " . $self->limit);
+    $log->info("Cache size is $self->{cache_real_size}, with limit " . $self->limit . " ($location)");
 
     return $self;
 }

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -42,7 +42,8 @@ sub from_worker {
     return $class->new(
         host     => 'localhost',
         location => ($ENV{OPENQA_CACHE_DIR} || $global_settings->{CACHEDIRECTORY}),
-        exists $global_settings->{CACHELIMIT} ? (limit => int($global_settings->{CACHELIMIT}) * (1024**3)) : ());
+        exists $global_settings->{CACHELIMIT} ? (limit => int($global_settings->{CACHELIMIT}) * (1024**3)) : (), @_
+    );
 }
 
 sub _deploy_cache {

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -20,15 +20,16 @@ use Carp 'croak';
 use File::Basename;
 use Fcntl ':flock';
 use Mojo::UserAgent;
-use OpenQA::Utils
-  qw(base_host log_error log_info log_debug get_channel_handle add_log_channel append_channel_to_defaults remove_channel_from_defaults);
+use OpenQA::Utils qw(base_host);
 use OpenQA::Worker::Settings;
 use Mojo::SQLite;
 use Mojo::File 'path';
+use Mojo::Log;
 use POSIX;
 
 has [qw(host cache location db_file dsn)];
 has limit      => 50 * (1024**3);
+has log        => sub { Mojo::Log->new };
 has sleep_time => 5;
 has sqlite     => sub { Mojo::SQLite->new(shift->dsn) };
 
@@ -47,7 +48,7 @@ sub from_worker {
 sub _deploy_cache {
     my $self = shift;
 
-    log_info "Creating cache directory tree for " . $self->location;
+    $self->log->info("Creating cache directory tree for " . $self->location);
     path($self->location)->remove_tree({keep_root => 1});
     path($self->location)->make_path;
     path($self->location, 'tmp')->make_path;
@@ -60,7 +61,8 @@ sub init {
 
     my $db_file = path($location, 'cache.sqlite');
     $self->db_file($db_file);
-    log_info __PACKAGE__ . ": loading database from $db_file";
+    my $log = $self->log;
+    $log->info(__PACKAGE__ . ": loading database from $db_file");
     $self->dsn("sqlite:$db_file");
     $self->_deploy_cache unless -e $db_file;
     eval { $self->sqlite->migrations->name('cache_service')->from_data->migrate };
@@ -70,7 +72,7 @@ sub init {
 
     # Ideally we only need $limit, and $need no extra space
     $self->_check_limits(0);
-    log_info __PACKAGE__ . ": Initialized with $host at $location, current size is $self->{cache_real_size}";
+    $log->info(__PACKAGE__ . ": Initialized with $host at $location, current size is $self->{cache_real_size}");
 
     return $self;
 }
@@ -78,17 +80,11 @@ sub init {
 sub _download_asset {
     my ($self, $id, $type, $asset, $etag) = @_;
 
-    if (get_channel_handle('autoinst')) {
-        append_channel_to_defaults('autoinst');
-    }
-    else {
-        add_log_channel('autoinst', path => 'autoinst-log.txt', level => 'debug', default => 'append');
-    }
-
     my $ua = Mojo::UserAgent->new(max_redirects => 2);
     $ua->max_response_size(0);
     my $url = sprintf '%s/tests/%d/asset/%s/%s', $self->host, $id, $type, basename($asset);
-    log_info "Downloading " . basename($asset) . " from $url";
+    my $log = $self->log;
+    $log->info("Downloading " . basename($asset) . " from $url");
     my $tx = $ua->build_tx(GET => $url);
     my $headers;
 
@@ -116,7 +112,7 @@ sub _download_asset {
                         $last_updated = time;
                         if ($progress < $current) {
                             $progress = $current;
-                            log_debug "CACHE: Downloading $asset: " . ($size == $len ? 100 : $progress) . "%";
+                            $log->debug("CACHE: Downloading $asset: " . ($size == $len ? 100 : $progress) . "%");
                         }
                     }
                 });
@@ -127,16 +123,16 @@ sub _download_asset {
     my $size;
     if ($code eq 304) {
         if ($self->_update_asset_last_use($asset)) {
-            log_debug "CACHE: Content has not changed, not downloading the $asset but updating last use";
+            $log->debug("CACHE: Content has not changed, not downloading the $asset but updating last use");
         }
         else {
-            log_debug 'CACHE: Abnormal situation, code 304. Retrying download';
+            $log->debug('CACHE: Abnormal situation, code 304. Retrying download');
             $asset = 520;
         }
     }
     elsif ($tx->res->is_server_error) {
-        log_debug "CACHE: Could not download the asset, triggering a retry for $code.";
-        log_debug "CACHE: Abnormal situation, server error. Retrying download";
+        $log->debug("CACHE: Could not download the asset, triggering a retry for $code.");
+        $log->debug("CACHE: Abnormal situation, server error. Retrying download");
         $asset = $code;
     }
     elsif ($tx->res->is_success) {
@@ -151,29 +147,27 @@ sub _download_asset {
             # We can't just throw it away if database locks.
             my $att = 0;
             my $ok;
-            ++$att and sleep 1 and log_debug("CACHE: Error updating Cache: attempting again: $att")
+            ++$att and sleep 1 and $log->debug("CACHE: Error updating Cache: attempting again: $att")
               until ($ok = $self->_update_asset($asset, $etag, $size)) || $att > 5;
             unless ($ok) {
-                log_error 'CACHE: FAIL Could not update DB - purging asset';
+                $log->error('CACHE: FAIL Could not update DB - purging asset');
                 $self->purge_asset($asset);
                 $asset = undef;
             }
-            log_debug "CACHE: Asset download successful to $asset, Cache size is: $self->{cache_real_size}" if $ok;
+            $log->debug("CACHE: Asset download successful to $asset, Cache size is: $self->{cache_real_size}") if $ok;
         }
         else {
-            log_debug "CACHE: Size of $asset differs, Expected: "
-              . $headers->content_length
-              . " / Downloaded: " . "$size";
+            $log->debug(
+                "CACHE: Size of $asset differs, Expected: " . $headers->content_length . " / Downloaded: " . "$size");
             $asset = 598;    # 598 (Informal convention) Network read timeout error
         }
     }
     else {
         my $message = $tx->res->error->{message};
-        log_debug "CACHE: Download of $asset failed with: $code - $message";
+        $log->debug("CACHE: Download of $asset failed with: $code - $message");
         $self->purge_asset($asset);
         $asset = undef;
     }
-    remove_channel_from_defaults('autoinst');
     return $asset;
 }
 
@@ -183,6 +177,7 @@ sub get_asset {
     my $location = path($self->location, base_host($self->host));
     $location->make_path unless -d $location;
     $asset = $location->child(path($asset)->basename);
+    my $log = $self->log;
 
     my $n = 5;
     while (1) {
@@ -199,14 +194,14 @@ sub get_asset {
             last;
         }
         elsif ($ret =~ /^5[0-9]{2}$/ && --$n) {
-            log_debug "CACHE: Error $ret, retrying download for $n more tries";
-            log_debug "CACHE: Waiting " . $self->sleep_time . " seconds for the next retry";
+            $log->debug("CACHE: Error $ret, retrying download for $n more tries");
+            $log->debug("CACHE: Waiting " . $self->sleep_time . " seconds for the next retry");
 
             sleep $self->sleep_time;
             next;
         }
         elsif (!$n) {
-            log_debug "CACHE: Too many download errors, aborting";
+            $log->debug("CACHE: Too many download errors, aborting");
             $asset = undef;
             last;
         }
@@ -232,14 +227,15 @@ sub track_asset {
         $tx->commit;
     };
     if ($@) {
-        log_error "track_asset: Failed: $@";
+        $self->log->error("track_asset: Failed: $@");
     }
 }
 
 sub _update_asset_last_use {
     my ($self, $asset) = @_;
 
-    log_info "CACHE: updating the $asset last usage";
+    my $log = $self->log;
+    $log->info("CACHE: updating the $asset last usage");
 
     eval {
         my $db  = $self->sqlite->db;
@@ -249,7 +245,7 @@ sub _update_asset_last_use {
         $tx->commit;
     };
     if ($@) {
-        log_error "Update asset failed: $@";
+        $log->error("Update asset failed: $@");
         return undef;
     }
 
@@ -259,6 +255,7 @@ sub _update_asset_last_use {
 sub _update_asset {
     my ($self, $asset, $etag, $size) = @_;
 
+    my $log = $self->log;
     eval {
         my $db  = $self->sqlite->db;
         my $tx  = $db->begin('exclusive');
@@ -267,11 +264,11 @@ sub _update_asset {
         $tx->commit;
     };
     if ($@) {
-        log_error "Update asset $asset failed. Rolling back $@";
+        $log->error("Update asset $asset failed. Rolling back $@");
         return undef;
     }
 
-    log_info "CACHE: updating the $asset with $etag and $size";
+    $log->info("CACHE: updating the $asset with $etag and $size");
     $self->_increase($size);
 
     return 1;
@@ -280,19 +277,20 @@ sub _update_asset {
 sub purge_asset {
     my ($self, $asset) = @_;
 
+    my $log = $self->log;
     eval {
         my $db = $self->sqlite->db;
         my $tx = $db->begin();
         $db->delete('assets', {filename => $asset});
         $tx->commit;
         if (-e $asset) {
-            if   (unlink $asset) { log_debug "CACHE: removed $asset" }
-            else                 { log_error "CACHE: Could not remove $asset ($!)" }
+            if   (unlink $asset) { $log->debug("CACHE: removed $asset") }
+            else                 { $log->error("CACHE: Could not remove $asset ($!)") }
         }
-        else { log_debug "CACHE: requested to remove nonexisting asset $asset" }
+        else { $log->debug("CACHE: requested to remove nonexisting asset $asset") }
     };
     if ($@) {
-        log_error "purge_asset: $@";
+        $log->error("purge_asset: $@");
         return undef;
     }
 
@@ -326,7 +324,7 @@ sub asset_lookup {
     }
 
     if ($results->arrays->size == 0) {
-        log_info "CACHE: Purging non registered $asset";
+        $self->log->info("CACHE: Purging non registered $asset");
         $self->purge_asset($asset);
         return undef;
     }
@@ -337,10 +335,11 @@ sub asset_lookup {
 sub _decrease {
     my ($self, $size) = (shift, shift // 0);
 
-    log_debug "Current cache size: $self->{cache_real_size}";
+    my $log = $self->log;
+    $log->debug("Current cache size: $self->{cache_real_size}");
     if ($size > $self->{cache_real_size}) { $self->{cache_real_size} = 0 }
     else                                  { $self->{cache_real_size} -= $size }
-    log_debug "Reclaiming $size from $self->{cache_real_size} to make space for " . $self->limit;
+    $log->debug("Reclaiming $size from $self->{cache_real_size} to make space for " . $self->limit);
 }
 
 sub _increase { $_[0]{cache_real_size} += $_[1] }
@@ -351,6 +350,7 @@ sub _check_limits {
     my ($self, $needed) = @_;
 
     my $limit = $self->limit;
+    my $log   = $self->log;
 
     eval {
         my $db      = $self->sqlite->db;
@@ -361,9 +361,9 @@ sub _check_limits {
             last if !$self->_exceeds_limit($needed);
         }
     } if $self->_exceeds_limit($needed);
-    if ($@) { log_error "CACHE: check_limit failed: $@" }
+    if ($@) { $log->error("CACHE: check_limit failed: $@") }
 
-    log_debug "CACHE: Health: Real size: $self->{cache_real_size}, Configured limit: $limit";
+    $log->debug("CACHE: Health: Real size: $self->{cache_real_size}, Configured limit: $limit");
 }
 
 1;

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -96,14 +96,11 @@ sub _download_asset {
     my $code = $res->code // 521;    # Used by cloudflare to indicate web server is down.
     if ($code eq 304) {
         $log->info("Content of $asset has not changed, updating last use");
-        unless ($self->_update_asset_last_use($asset)) {
-            $log->warn('Abnormal situation, status 304');
-            $ret = 520;
-        }
+        $ret = 520 unless $self->_update_asset_last_use($asset);
     }
 
     elsif ($res->is_server_error) {
-        $log->warn("Abnormal situation, server error $code");
+        $log->warn("Downloading $asset failed with server error $code");
         $ret = $code;
     }
 

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -34,13 +34,13 @@ sub _cache_asset {
     my $guard = $app->progress->guard($lock);
     unless ($guard) {
         $job->note(
-            output => "Asset $asset_name was downloaded by another job, details are therefore unavailable to us");
+            output => qq{Asset "$asset_name" was downloaded by another job, details are therefore unavailable here});
         return $job->finish;
     }
 
     my $log = $app->log;
     my $ctx = $log->context('[#' . $job->id . ']');
-    $ctx->info("Downloading $asset_name");
+    $ctx->info(qq{Downloading: "$asset_name"});
 
     # Log messages need to be logged by this service as well as captured and
     # forwarded to the worker (for logging on both sides)

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -42,7 +42,6 @@ sub _cache_asset {
 
     my $job_prefix = "[Job #" . $job->id . "]";
     $log->debug("$job_prefix Download: $asset_name");
-    $OpenQA::Utils::app = undef;
     my $output;
     {
         open my $handle, '>', \$output;

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -44,7 +44,6 @@ sub _cache_asset {
 
     # Log messages need to be logged by this service as well as captured and
     # forwarded to the worker (for logging on both sides)
-    my $cache  = OpenQA::CacheService::Model::Cache->from_worker->log($ctx);
     my $output = '';
     $log->on(
         message => sub {
@@ -52,8 +51,8 @@ sub _cache_asset {
             $output .= "[$level] " . join "\n", @lines, '';
         });
 
-    $cache->host($host);
-    $cache->get_asset({id => $id}, $type, $asset_name);
+    my $cache = OpenQA::CacheService::Model::Cache->from_worker(log => $ctx);
+    $cache->host($host)->get_asset({id => $id}, $type, $asset_name);
     $job->note(output => $output);
     $ctx->info('Finished download');
 }

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -33,13 +33,14 @@ sub _cache_asset {
     return $job->finish unless defined $asset_name && defined $type && defined $host && defined $lock;
     my $guard = $app->progress->guard($lock);
     unless ($guard) {
-        $job->note(output => 'Asset was already requested by another job');
+        $job->note(
+            output => "Asset $asset_name was downloaded by another job, details are therefore unavailable to us");
         return $job->finish;
     }
 
     my $log = $app->log;
     my $ctx = $log->context('[#' . $job->id . ']');
-    $ctx->info("Download: $asset_name");
+    $ctx->info("Downloading $asset_name");
 
     # Log messages need to be logged by this service as well as captured and
     # forwarded to the worker (for logging on both sides)
@@ -54,7 +55,7 @@ sub _cache_asset {
     $cache->host($host);
     $cache->get_asset({id => $id}, $type, $asset_name);
     $job->note(output => $output);
-    $ctx->info('Finished');
+    $ctx->info('Finished download');
 }
 
 1;

--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -33,12 +33,12 @@ sub _cache_tests {
     return $job->finish unless defined $from && defined $to && defined $lock;
     my $guard = $app->progress->guard($lock);
     unless ($guard) {
-        $job->note(output => 'Sync was already requested by another job');
+        $job->note(output => "Sync $from to $to was performed by another job, details are therefore unavailable to us");
         return $job->finish(0);
     }
 
     my $ctx = $app->log->context('[#' . $job->id . ']');
-    $ctx->info("Sync: $from to $to");
+    $ctx->info("Sync $from to $to");
 
     my @cmd = (qw(rsync -avHP), "$from/", qw(--delete), "$to/tests/");
     $ctx->info('Calling: ' . join(' ', @cmd));
@@ -46,7 +46,7 @@ sub _cache_tests {
     my $status = $? >> 8;
     $job->finish($status);
     $job->note(output => $output);
-    $ctx->info("Finished: $status");
+    $ctx->info("Finished sync ($status)");
 }
 
 1;

--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -28,7 +28,6 @@ sub _cache_tests {
     my ($job, $from, $to) = @_;
 
     my $app = $job->app;
-    my $log = $app->log;
 
     my $lock = $job->info->{notes}{lock};
     return $job->finish unless defined $from && defined $to && defined $lock;
@@ -38,16 +37,16 @@ sub _cache_tests {
         return $job->finish(0);
     }
 
-    my $job_prefix = "[Job #" . $job->id . "]";
-    $log->debug("$job_prefix Sync: $from to $to");
+    my $ctx = $app->log->context('[#' . $job->id . ']');
+    $ctx->info("Sync: $from to $to");
 
     my @cmd = (qw(rsync -avHP), "$from/", qw(--delete), "$to/tests/");
-    $log->debug("$job_prefix Calling " . join(' ', @cmd));
+    $ctx->info('Calling: ' . join(' ', @cmd));
     my $output = `@cmd`;
     my $status = $? >> 8;
     $job->finish($status);
     $job->note(output => $output);
-    $log->debug("$job_prefix Finished: $status");
+    $ctx->info("Finished: $status");
 }
 
 1;

--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -33,12 +33,13 @@ sub _cache_tests {
     return $job->finish unless defined $from && defined $to && defined $lock;
     my $guard = $app->progress->guard($lock);
     unless ($guard) {
-        $job->note(output => "Sync $from to $to was performed by another job, details are therefore unavailable to us");
+        $job->note(
+            output => qq{Sync "$from" to "$to" was performed by another job, details are therefore unavailable here});
         return $job->finish(0);
     }
 
     my $ctx = $app->log->context('[#' . $job->id . ']');
-    $ctx->info("Sync $from to $to");
+    $ctx->info(qq{Sync: "$from" to "$to"});
 
     my @cmd = (qw(rsync -avHP), "$from/", qw(--delete), "$to/tests/");
     $ctx->info('Calling: ' . join(' ', @cmd));
@@ -46,7 +47,7 @@ sub _cache_tests {
     my $status = $? >> 8;
     $job->finish($status);
     $job->note(output => $output);
-    $ctx->info("Finished sync ($status)");
+    $ctx->info("Finished sync: $status");
 }
 
 1;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -130,7 +130,7 @@ sub cache_assets {
 
         if ($cache_client->enqueue($asset_request)) {
             my $minion_id = $asset_request->minion_id;
-            log_debug("Downloading $asset_uri, request sent to Cache Service ($minion_id)", channels => 'autoinst');
+            log_debug("Downloading $asset_uri, request #$minion_id sent to Cache Service", channels => 'autoinst');
             my $status = $cache_client->status($asset_request);
             until ($status->is_processed) {
                 sleep 5;
@@ -138,7 +138,7 @@ sub cache_assets {
                 $status = $cache_client->status($asset_request);
             }
             my $msg = "Download of $asset_uri processed";
-            if (my $output = $status->output) { $msg .= ": $output" }
+            if (my $output = $status->output) { $msg .= ":\n$output" }
             log_debug($msg, channels => 'autoinst');
         }
 
@@ -253,7 +253,7 @@ sub engine_workit {
                 }
 
                 if (my $output = $status->output) {
-                    log_info('Output of rsync: ' . $output, channels => 'autoinst');
+                    log_info("Output of rsync:\n$output", channels => 'autoinst');
                 }
 
                 # treat "no sync necessary" as success as well

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -24,6 +24,8 @@ BEGIN {
     use Mojo::File qw(path tempdir);
     use FindBin;
 
+    $ENV{OPENQA_CACHE_SERVICE_QUIET} = $ENV{HARNESS_IS_VERBOSE} ? 0 : 1;
+
     $tempdir = tempdir;
     my $basedir = $tempdir->child('t', 'cache.d');
     $ENV{OPENQA_CACHE_DIR} = path($basedir, 'cache');
@@ -35,10 +37,6 @@ CACHEDIRECTORY = ' . $ENV{OPENQA_CACHE_DIR} . '
 CACHEWORKERS = 10
 CACHELIMIT = 100');
 }
-
-# Avoid warning error: Name "Config::IniFiles::t/cache.d/cache/config/workers.ini" used only once
-use OpenQA::CacheService::Model::Cache;
-OpenQA::CacheService::Model::Cache->from_worker;
 
 use Test::More;
 use Test::Warnings;

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -20,9 +20,7 @@ use warnings;
 
 my $tempdir;
 BEGIN {
-    unshift @INC, 't/lib';
     use Mojo::File qw(path tempdir);
-    use FindBin;
 
     $ENV{OPENQA_CACHE_SERVICE_QUIET} = $ENV{HARNESS_IS_VERBOSE} ? 0 : 1;
 
@@ -37,6 +35,9 @@ CACHEDIRECTORY = ' . $ENV{OPENQA_CACHE_DIR} . '
 CACHEWORKERS = 10
 CACHELIMIT = 100');
 }
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
 
 use Test::More;
 use Test::Warnings;
@@ -342,7 +343,7 @@ subtest 'Default usage' => sub {
         sleep .1 until $cache_client->status($asset_request)->is_processed;
         my $out = $cache_client->status($asset_request)->output;
         ok($out, 'Output should be present') or die diag $out;
-        like $out, qr/Downloading $a from/, "Asset download attempt logged";
+        like $out, qr/Downloading "$a" from/, "Asset download attempt logged";
         ok(-e path($cachedir, 'localhost')->child($a), 'Asset downloaded') or die diag "Failed - no asset is there";
     }
     else {
@@ -363,7 +364,7 @@ subtest 'Small assets causes racing when releasing locks' => sub {
         1 until $cache_client->status($asset_request)->is_processed;
         my $out = $cache_client->status($asset_request)->output;
         ok($out, 'Output should be present') or die diag $out;
-        like $out, qr/Downloading $a from/, "Asset download attempt logged";
+        like $out, qr/Downloading "$a" from/, "Asset download attempt logged";
         ok($cache_client->asset_exists('localhost', $a), 'Asset downloaded') or die diag "Failed - no asset is there";
     }
     else {

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -15,104 +15,56 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-BEGIN {
-    unshift @INC, 't/lib';
-}
+use Mojo::Base -strict;
 
-use strict;
-use warnings;
+BEGIN { unshift @INC, 't/lib' }
 
 use Test::More;
 use Test::Warnings;
-use Test::MockModule;
 use OpenQA::Utils;
 use OpenQA::Utils 'base_host';
 use OpenQA::CacheService::Model::Cache;
-use DBI;
-use File::Path qw(remove_tree make_path);
-use File::Spec::Functions qw(catdir catfile);
-use Digest::MD5 qw(md5);
-use Cwd qw(abs_path getcwd);
-
-use Mojolicious;
 use IO::Socket::INET;
 use Mojo::Server::Daemon;
 use Mojo::IOLoop::Server;
 use Mojo::SQLite;
 use Mojo::File qw(path);
+use Mojo::Log;
 use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
-use List::Util qw(shuffle uniq sum);
 use OpenQA::Test::Utils qw(fake_asset_server);
 
-my $sql;
-my $sth;
-my $result;
-my $dbh;
-my $filename;
-my $serverpid;
-my $openqalogs;
+my $cached   = path()->child('t', 'cache.d');
+my $cachedir = $cached->child('cache');
+my $db_file  = $cachedir->child('cache.sqlite');
+my $port     = Mojo::IOLoop::Server->generate_port;
+my $host     = "http://localhost:$port";
+$cachedir->remove_tree;
+ok($cachedir->make_path, "creating cachedir under $cachedir");
 
-my $cached   = catdir(getcwd(), 't', 'cache.d');
-my $cachedir = catdir($cached,  'cache');
-my $db_file  = "$cachedir/cache.sqlite";
-my $logdir  = path(getcwd(), 't', 'cache.d', 'logs');
-my $logfile = $logdir->child('cache.log');
-my $port    = Mojo::IOLoop::Server->generate_port;
-my $host    = "http://localhost:$port";
+# Capture logs
+my $log = Mojo::Log->new;
+$log->unsubscribe('message');
+my $cache_log = '';
+$log->on(
+    message => sub {
+        my ($log, $level, @lines) = @_;
+        $cache_log .= "[$level] " . join "\n", @lines, '';
+    });
 
-remove_tree($cachedir);
-ok($logdir->make_path, "creating cachedir under $cachedir");
-
-# reassign STDOUT, STDERR
-open my $FD, '>>', $logfile;
-*STDOUT = $FD;
-*STDERR = $FD;
-
-$SIG{INT} = sub {
-    session->clean;
-};
+$SIG{INT} = sub { session->clean };
 
 END { session->clean }
 
-sub truncate_log {
-    my ($new_log) = @_;
-    my $logfile_ = ($new_log) ? $new_log : $logfile;
-    open(my $f, '>', $logfile_) or die "OPENING $logfile_: $!\n";
-    truncate $f, 0 or warn("Could not truncate");
-    close $f;
-}
-
-sub read_log {
-    my ($logfile) = @_;
-    my $log_lines = path($logfile)->slurp;
-    return $log_lines;
-}
-
-sub db_handle_connection {
-    my ($cache, $disconnect) = @_;
-    if ($cache->sqlite) {
-        $cache->sqlite->db->disconnect;
-        return if $disconnect;
-    }
-
-    $cache->sqlite(Mojo::SQLite->new("sqlite:$db_file"));
-}
-
-sub _port { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => shift) }
-
-my $daemon;
-my $mock            = Mojolicious->new;
 my $server_instance = process sub {
-    $daemon = Mojo::Server::Daemon->new(app => fake_asset_server, listen => [$host]);
-    $daemon->run;
+    Mojo::Server::Daemon->new(app => fake_asset_server, listen => [$host], silent => 1)->run;
     _exit(0);
 };
 
 sub start_server {
     $server_instance->set_pipes(0)->start;
-    sleep 1 while !_port($port);
+    sleep 1 while !IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port);
     return;
 }
 
@@ -121,68 +73,53 @@ sub stop_server {
     $server_instance->stop();
 }
 
-my $cache = OpenQA::CacheService::Model::Cache->new(host => $host, location => $cachedir);
+my $cache = OpenQA::CacheService::Model::Cache->new(host => $host, location => $cachedir->to_string, log => $log);
 
 subtest 'base_host' => sub {
-    my $cache_test = OpenQA::CacheService::Model::Cache->new(host => $host, location => $cachedir);
+    my $cache_test
+      = OpenQA::CacheService::Model::Cache->new(host => $host, location => $cachedir->to_string, log => $log);
     is base_host($cache_test->host), 'localhost';
 };
 
 is $cache->init, $cache;
-$openqalogs = read_log($logfile);
 is $cache->sqlite->migrations->latest, 1, 'version 1 is the latest version';
 is $cache->sqlite->migrations->active, 1, 'version 1 is the active version';
-like $openqalogs, qr/Creating cache directory tree for/, "Cache directory tree created.";
-like $openqalogs, qr/Configured limit: 53687091200/,     "Cache limit is default (50GB).";
+like $cache_log, qr/Creating cache directory tree for/, "Cache directory tree created.";
+like $cache_log, qr/Configured limit: 53687091200/,     "Cache limit is default (50GB).";
 ok(-e $db_file, "cache.sqlite is present");
-truncate_log $logfile;
+$cache_log = '';
 
-db_handle_connection($cache);
-make_path("$cachedir/127.0.0.1/");
-
-for (1 .. 3) {
-    $filename = "$cachedir/127.0.0.1/$_.qcow2";
-    open(my $tmpfd, '>:raw', $filename);
-    print $tmpfd "\0" x 84 or die($filename);
-    close $tmpfd;
-
-    if ($_ % 2) {
-        log_info "Inserting $_";
-        $sql = "INSERT INTO assets (filename,size, etag,last_use)
+$cachedir->child('127.0.0.1')->make_path;
+for my $i (1 .. 3) {
+    my $file = $cachedir->child('127.0.0.1', "$i.qcow2")->spurt("\0" x 84);
+    if ($i % 2) {
+        my $sql = "INSERT INTO assets (filename,size, etag,last_use)
                 VALUES ( ?, ?, 'Not valid', strftime('\%s','now'));";
-        $cache->sqlite->db->query($sql, $filename, 84);
+        $cache->sqlite->db->query($sql, $file->to_string, 84);
     }
 }
-
-
-chdir $logdir;
 
 $cache->sleep_time(1);
 $cache->init;
 is $cache->sqlite->migrations->active, 1, 'version 1 is still the active version';
-$openqalogs = read_log($logfile);
-like $openqalogs, qr/CACHE: Health: Real size: 168, Configured limit: 53687091200/,
+like $cache_log, qr/CACHE: Health: Real size: 168, Configured limit: 53687091200/,
   "Cache limit/size match the expected 100GB/168)";
-unlike $openqalogs, qr/CACHE: Purging non registered.*[13].qcow2/, "Registered assets 1 and 3 were kept";
-like $openqalogs,   qr/CACHE: Purging non registered.*2.qcow2/,    "Asset 2 was removed";
-truncate_log $logfile;
+unlike $cache_log, qr/CACHE: Purging non registered.*[13].qcow2/, "Registered assets 1 and 3 were kept";
+like $cache_log,   qr/CACHE: Purging non registered.*2.qcow2/,    "Asset 2 was removed";
+$cache_log = '';
 
 $cache->limit(100);
 $cache->init;
-
-$openqalogs = read_log($logfile);
-like $openqalogs, qr/CACHE: Health: Real size: 84, Configured limit: 100/,
-  "Cache limit/size match the expected 100/84)";
-like $openqalogs, qr/CACHE: removed.*1.qcow2/, "Oldest asset (1.qcow2) removal was logged";
-like $openqalogs, qr/$host/, "Host was initialized correctly ($host).";
+like $cache_log, qr/CACHE: Health: Real size: 84, Configured limit: 100/, "Cache limit/size match the expected 100/84)";
+like $cache_log, qr/CACHE: removed.*1.qcow2/, "Oldest asset (1.qcow2) removal was logged";
+like $cache_log , qr/$host/, "Host was initialized correctly ($host).";
 ok(!-e "1.qcow2", "Oldest asset (1.qcow2) was sucessfully removed");
-truncate_log $logfile;
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-textmode@64bit.qcow2');
-my $autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/failed with: 521/, "Asset download fails with: 521 - Connection refused";
-truncate_log 'autoinst-log.txt';
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/failed with: 521/, "Asset download fails with: 521 - Connection refused";
+$cache_log = '';
 
 $port = Mojo::IOLoop::Server->generate_port;
 $host = "http://127.0.0.1:$port";
@@ -193,104 +130,82 @@ $cache->limit(1024);
 $cache->init;
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-404@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-404\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/failed with: 404/, "Asset download fails with: 404 - Not Found";
-truncate_log 'autoinst-log.txt';
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-404\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/failed with: 404/, "Asset download fails with: 404 - Not Found";
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-400@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-400\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/failed with: 400/, "Asset download fails with 400 - Bad Request";
-truncate_log 'autoinst-log.txt';
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-400\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/failed with: 400/, "Asset download fails with 400 - Bad Request";
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-589@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-589\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/Expected: 10 \/ Downloaded: 6/, "Incomplete download logged";
-truncate_log 'autoinst-log.txt';
-
-$openqalogs = read_log($logfile);
-like $openqalogs, qr/CACHE: Error 598, retrying download for 4 more tries/, "4 tries remaining";
-like $openqalogs, qr/CACHE: Waiting 1 seconds for the next retry/,          "1 second sleep_time set";
-like $openqalogs, qr/CACHE: Too many download errors, aborting/,            "Bailing out after too many retries";
-truncate_log $logfile;
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-589\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/Expected: 10 \/ Downloaded: 6/,                            "Incomplete download logged";
+like $cache_log, qr/CACHE: Error 598, retrying download for 4 more tries/,     "4 tries remaining";
+like $cache_log, qr/CACHE: Waiting 1 seconds for the next retry/,              "1 second sleep_time set";
+like $cache_log, qr/CACHE: Too many download errors, aborting/,                "Bailing out after too many retries";
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-503@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-503\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/triggering a retry for 503/, "Asset download fails with 503 - Server not available";
-truncate_log 'autoinst-log.txt';
-
-$openqalogs = read_log($logfile);
-like $openqalogs, qr/CACHE: Error 503, retrying download for 4 more tries/, "4 tries remaining";
-like $openqalogs, qr/CACHE: Waiting 1 seconds for the next retry/,          "1 second sleep_time set";
-like $openqalogs, qr/CACHE: Too many download errors, aborting/,            "Bailing out after too many retries";
-truncate_log $logfile;
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-503\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/triggering a retry for 503/, "Asset download fails with 503 - Server not available";
+like $cache_log, qr/CACHE: Error 503, retrying download for 4 more tries/, "4 tries remaining";
+like $cache_log, qr/CACHE: Waiting 1 seconds for the next retry/,          "1 second sleep_time set";
+like $cache_log, qr/CACHE: Too many download errors, aborting/,            "Bailing out after too many retries";
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/CACHE: Asset download successful to .*sle-12-SP3-x86_64-0368-200.*, Cache size is: 1024/,
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/CACHE: Asset download successful to .*sle-12-SP3-x86_64-0368-200.*, Cache size is: 1024/,
   "Full download logged";
-truncate_log 'autoinst-log.txt';
+like $cache_log, qr/ andi \$a3, \$t1, 41399 and 1024/, "Etag and size are logged";
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/CACHE: Content has not changed, not downloading .* but updating last use/, "Upading last use";
-truncate_log 'autoinst-log.txt';
-
-$openqalogs = read_log($logfile);
-like $openqalogs, qr/ andi \$a3, \$t1, 41399 and 1024/, "Etag and size are logged";
-truncate_log $logfile;
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/CACHE: Content has not changed, not downloading .* but updating last use/, "Upading last use";
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/,      "Asset download attempt";
-like $autoinst_log, qr/sle-12-SP3-x86_64-0368-200\@64bit.qcow2 but updating last use/, "last use gets updated";
-truncate_log 'autoinst-log.txt';
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/,      "Asset download attempt";
+like $cache_log, qr/sle-12-SP3-x86_64-0368-200\@64bit.qcow2 but updating last use/, "last use gets updated";
+$cache_log = '';
 
 $cache->get_asset({id => 922756}, "hdd", 'sle-12-SP3-x86_64-0368-200_256@64bit.qcow2');
-$autoinst_log = read_log('autoinst-log.txt');
-like $autoinst_log, qr/Downloading sle-12-SP3-x86_64-0368-200_256\@64bit.qcow2 from/, "Asset download attempt";
-like $autoinst_log, qr/CACHE: Asset download successful to .*sle-12-SP3-x86_64-0368-200_256.*, Cache size is: 256/,
+like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200_256\@64bit.qcow2 from/, "Asset download attempt";
+like $cache_log, qr/CACHE: Asset download successful to .*sle-12-SP3-x86_64-0368-200_256.*, Cache size is: 256/,
   "Full download logged";
-truncate_log 'autoinst-log.txt';
-
-$openqalogs = read_log($logfile);
-like $openqalogs, qr/ andi \$a3, \$t1, 41399 and 256/, "Etag and size are logged";
-like $openqalogs, qr/removed.*sle-12-SP3-x86_64-0368-200\@64bit.qcow2*/, "Reclaimed space for new smaller asset";
-truncate_log $logfile;
+like $cache_log, qr/ andi \$a3, \$t1, 41399 and 256/, "Etag and size are logged";
+like $cache_log, qr/removed.*sle-12-SP3-x86_64-0368-200\@64bit.qcow2*/, "Reclaimed space for new smaller asset";
+$cache_log = '';
 
 $cache->track_asset("Foobar", 0);
-
 $cache->sqlite->db->query("delete from assets");
 
-my $fake_asset = "$cachedir/test.qcow2";
-
-path($fake_asset)->spurt('');
+my $fake_asset = $cachedir->child('test.qcow2');
+$fake_asset->spurt('');
 ok -e $fake_asset, 'Asset is there';
-$cache->asset_lookup($fake_asset);
+$cache->asset_lookup($fake_asset->to_string);
 ok !-e $fake_asset, 'Asset was purged since was not tracked';
 
-path($fake_asset)->spurt('');
+$fake_asset->spurt('');
 ok -e $fake_asset, 'Asset is there';
-$cache->purge_asset($fake_asset);
+$cache->purge_asset($fake_asset->to_string);
 ok !-e $fake_asset, 'Asset was purged';
 
-$cache->track_asset($fake_asset);
-is(ref($cache->_asset($fake_asset)), 'HASH', 'Asset was just inserted, so it must be there')
-  or die diag explain $cache->_asset($fake_asset);
+$cache->track_asset($fake_asset->to_string);
+is(ref($cache->_asset($fake_asset->to_string)), 'HASH', 'Asset was just inserted, so it must be there')
+  or die diag explain $cache->_asset($fake_asset->to_string);
 
-is $cache->_asset($fake_asset)->{etag}, undef, 'Can get downloading state with _asset()';
+is $cache->_asset($fake_asset->to_string)->{etag}, undef, 'Can get downloading state with _asset()';
 is_deeply $cache->_asset('foobar'), {}, '_asset() returns {} if asset is not present';
 
 subtest 'cache directory is symlink' => sub {
-    my $symlink = catdir($cached, 'symlink');
+    my $symlink = $cached->child('symlink')->to_string;
     unlink($symlink);
     ok(symlink($cachedir, $symlink), "symlinking cache dir to $symlink");
-    path($fake_asset)->spurt('not a real image');
+    $fake_asset->spurt('not a real image');
     ok(-e $fake_asset, 'fake asset created');
 
     $cache->location($symlink);
@@ -298,6 +213,6 @@ subtest 'cache directory is symlink' => sub {
     is($cache->{cache_real_size}, 16, 'cache size could be determined');
 };
 
-
 stop_server;
+
 done_testing();

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -17,7 +17,8 @@
 
 use Mojo::Base -strict;
 
-BEGIN { unshift @INC, 't/lib' }
+use FindBin;
+use lib "$FindBin::Bin/lib";
 
 use Test::More;
 use Test::Warnings;
@@ -84,8 +85,8 @@ subtest 'base_host' => sub {
 is $cache->init, $cache;
 is $cache->sqlite->migrations->latest, 1, 'version 1 is the latest version';
 is $cache->sqlite->migrations->active, 1, 'version 1 is the active version';
-like $cache_log, qr/Creating cache directory tree for $cachedir/,           'Cache directory tree created';
-like $cache_log, qr/Cache size is 0, with limit 53687091200 \($cachedir\)/, 'Cache limit is default (50GB)';
+like $cache_log, qr/Creating cache directory tree for "$cachedir"/,          'Cache directory tree created';
+like $cache_log, qr/Cache size of "$cachedir" is 0, with limit 53687091200/, 'Cache limit is default (50GB)';
 ok(-e $db_file, 'cache.sqlite is present');
 $cache_log = '';
 
@@ -102,23 +103,25 @@ for my $i (1 .. 3) {
 $cache->sleep_time(1);
 $cache->init;
 is $cache->sqlite->migrations->active, 1, 'version 1 is still the active version';
-like $cache_log, qr/Cache size is 168, with limit 53687091200/, 'Cache limit/size match the expected 100GB/168)';
-unlike $cache_log, qr/Purging .*[13].qcow2/, 'Registered assets 1 and 3 were kept';
-like $cache_log, qr/Purging .*2.qcow2 because the asset is not registered/, 'Asset 2 was removed';
+like $cache_log, qr/Cache size of "$cachedir" is 168, with limit 53687091200/,
+  'Cache limit/size match the expected 100GB/168)';
+unlike $cache_log, qr/Purging ".*[13].qcow2"/, 'Registered assets 1 and 3 were kept';
+like $cache_log, qr/Purging ".*2.qcow2" because the asset is not registered/, 'Asset 2 was removed';
 $cache_log = '';
 
 $cache->limit(100);
 $cache->init;
-like $cache_log, qr/Cache size is 84, with limit 100/, 'Cache limit/size match the expected 100/84)';
-like $cache_log, qr/Cache size 168 \+ 0 exceeds limit of 100, purging least used assets/, 'Requested size is logged';
-like $cache_log, qr/Purging.*1.qcow2 because we need space for new assets, reclaiming 84/,
+like $cache_log, qr/Cache size of "$cachedir" is 84, with limit 100/, 'Cache limit/size match the expected 100/84)';
+like $cache_log, qr/Cache size 168 \+ needed 0 exceeds limit of 100, purging least used assets/,
+  'Requested size is logged';
+like $cache_log, qr/Purging ".*1.qcow2" because we need space for new assets, reclaiming 84/,
   'Oldest asset (1.qcow2) removal was logged';
 ok(!-e '1.qcow2', 'Oldest asset (1.qcow2) was sucessfully removed');
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-textmode@64bit.qcow2');
 my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2 from $from/, 'Asset download attempt';
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2" from "$from"/, 'Asset download attempt';
 like $cache_log, qr/failed: 521/, 'Asset download fails with: 521 - Connection refused';
 $cache_log = '';
 
@@ -131,17 +134,17 @@ $cache->limit(1024);
 $cache->init;
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-404@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-404\@64bit.qcow2 from/, 'Asset download attempt';
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-404\@64bit.qcow2" from/, 'Asset download attempt';
 like $cache_log, qr/failed: 404/, 'Asset download fails with: 404 - Not Found';
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-400@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-400\@64bit.qcow2 from/, 'Asset download attempt';
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-400\@64bit.qcow2" from/, 'Asset download attempt';
 like $cache_log, qr/failed: 400/, 'Asset download fails with 400 - Bad Request';
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-589@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-589\@64bit.qcow2 from/,           'Asset download attempt';
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-589\@64bit.qcow2" from/,         'Asset download attempt';
 like $cache_log, qr/Size of .+ differs, expected 10 but downloaded 6/,                   'Incomplete download logged';
 like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
 like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
@@ -151,43 +154,43 @@ like $cache_log, qr/Too many download errors, aborting/, 'Bailing out after too 
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-503@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-503\@64bit.qcow2 from/, 'Asset download attempt';
-like $cache_log, qr/Downloading .*0368-503\@64bit.qcow2 failed with server error 503/,
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-503\@64bit.qcow2" from/, 'Asset download attempt';
+like $cache_log, qr/Downloading ".*0368-503\@64bit.qcow2" failed with server error 503/,
   'Asset download fails with 503 - Server not available';
 like $cache_log, qr/Download error 503, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
 like $cache_log, qr/Too many download errors, aborting/, 'Bailing out after too many retries';
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/, 'Asset download attempt';
-like $cache_log, qr/Download of .*sle-12-SP3-x86_64-0368-200.* successful, new cache size is 1024/,
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200\@64bit.qcow2" from/, 'Asset download attempt';
+like $cache_log, qr/Download of ".*sle-12-SP3-x86_64-0368-200.*" successful, new cache size is 1024/,
   'Full download logged';
 like $cache_log, qr/Size of .* is 1024, with ETag "andi \$a3, \$t1, 41399"/, 'Etag and size are logged';
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/,             'Asset download attempt';
-like $cache_log, qr/Content of .*0368-200@64bit.qcow2 has not changed, updating last use/, 'Content has not changed';
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200\@64bit.qcow2" from/,             'Asset download attempt';
+like $cache_log, qr/Content of ".*0368-200@64bit.qcow2" has not changed, updating last use/, 'Content has not changed';
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200\@64bit.qcow2 from/, 'Asset download attempt';
-like $cache_log, qr/Content of .*-0368-200@64bit.qcow2 has not changed, updating last use/, 'Content has not changed';
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200\@64bit.qcow2" from/, 'Asset download attempt';
+like $cache_log, qr/Content of ".*-0368-200@64bit.qcow2" has not changed, updating last use/, 'Content has not changed';
 $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_256@64bit.qcow2');
-like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-200_256\@64bit.qcow2 from/, 'Asset download attempt';
-like $cache_log, qr/Download of .*sle-12-SP3-x86_64-0368-200_256.* successful, new cache size is 256/,
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200_256\@64bit.qcow2" from/, 'Asset download attempt';
+like $cache_log, qr/Download of ".*sle-12-SP3-x86_64-0368-200_256.*" successful, new cache size is 256/,
   'Full download logged';
 like $cache_log, qr/is 256, with ETag "andi \$a3, \$t1, 41399"/, 'Etag and size are logged';
-like $cache_log, qr/Cache size 1024 \+ 256 exceeds limit of 1024, purging least used assets/,
+like $cache_log, qr/Cache size 1024 \+ needed 256 exceeds limit of 1024, purging least used assets/,
   'Requested size is logged';
 like $cache_log,
-  qr/Purging .*0368-503@64bit.qcow2 because we need space for new assets, reclaiming 0/,
+  qr/Purging ".*0368-503@64bit.qcow2" because we need space for new assets, reclaiming 0/,
   'Reclaimed no space from missing asset';
-like $cache_log, qr/Purging .*0368-503@64bit.qcow2 failed because the asset did not exist/, 'Asset was missing';
+like $cache_log, qr/Purging ".*0368-503@64bit.qcow2" failed because the asset did not exist/, 'Asset was missing';
 like $cache_log,
-  qr/Purging .*sle-12-SP3-x86_64-0368-200\@64bit.qcow2 because we need space for new assets, reclaiming 1024/,
+  qr/Purging ".*sle-12-SP3-x86_64-0368-200\@64bit.qcow2" because we need space for new assets, reclaiming 1024/,
   'Reclaimed space for new smaller asset';
 $cache_log = '';
 

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -153,7 +153,8 @@ $cache_log = '';
 
 $cache->get_asset({id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-503@64bit.qcow2');
 like $cache_log, qr/Downloading sle-12-SP3-x86_64-0368-503\@64bit.qcow2 from/, 'Asset download attempt';
-like $cache_log, qr/Abnormal situation, server error 503/, 'Asset download fails with 503 - Server not available';
+like $cache_log, qr/Downloading .*0368-503\@64bit.qcow2 failed with server error 503/,
+  'Asset download fails with 503 - Server not available';
 like $cache_log, qr/Download error 503, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
 like $cache_log, qr/Too many download errors, aborting/, 'Bailing out after too many retries';
 $cache_log = '';

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -84,9 +84,8 @@ subtest 'base_host' => sub {
 is $cache->init, $cache;
 is $cache->sqlite->migrations->latest, 1, 'version 1 is the latest version';
 is $cache->sqlite->migrations->active, 1, 'version 1 is the active version';
-like $cache_log, qr/Creating cache directory tree for $cachedir/, 'Cache directory tree created';
-like $cache_log, qr/Loading cache database from $db_file/,        'Cache database loaded';
-like $cache_log, qr/Cache size is 0, with limit 53687091200/,     'Cache limit is default (50GB)';
+like $cache_log, qr/Creating cache directory tree for $cachedir/,           'Cache directory tree created';
+like $cache_log, qr/Cache size is 0, with limit 53687091200 \($cachedir\)/, 'Cache limit is default (50GB)';
 ok(-e $db_file, 'cache.sqlite is present');
 $cache_log = '';
 


### PR DESCRIPTION
This PR is a followup to #2463. It will allow us to finally follow the entire life cycle of every asset processed by the cache service.

Asset download and test sync tasks used to only send their logs to the `autoinst-log.txt` file of the job that requested the task first. This PR ensures that all those log messages are also written to the cache service journal. So we can from now on always look at the `openqa-worker-cacheservice-minion` journal to see exactly what happened with a specific asset.

Additionally the content of the cache service log messages has been rephrased a bit to make it easier to understand what actually happened and to follow the flow of events. Some log messages got moved to a higher level to be able to add more context information.

Progress: https://progress.opensuse.org/issues/46742