### PR TITLE
Show log content in test details tab on no module results

### DIFF
--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -63,14 +63,15 @@ use warnings;
             {key => 'ISO_MAXSIZE', value => 737280000},
             {key => 'ISO_1',       value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'}
         ],
-        ARCH    => 'x86_64',
-        BUILD   => '87.5011',
-        DISTRI  => 'opensuse',
-        FLAVOR  => 'staging_e',
-        TEST    => 'minimalx',
-        VERSION => 'Factory',
-        MACHINE => '32bit',
-        state   => "done",
+        ARCH       => 'x86_64',
+        BUILD      => '87.5011',
+        DISTRI     => 'opensuse',
+        FLAVOR     => 'staging_e',
+        TEST       => 'minimalx',
+        VERSION    => 'Factory',
+        MACHINE    => '32bit',
+        result_dir => '00099926-opensuse-Factory-staging_e-x86_64-Build87.5011-minimalx',
+        state      => "done",
         # One hour ago
         t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),
         # Two hours ago

--- a/t/testresults/00099/00099926-opensuse-Factory-staging_e-x86_64-Build87.5011-minimalx
+++ b/t/testresults/00099/00099926-opensuse-Factory-staging_e-x86_64-Build87.5011-minimalx
@@ -1,0 +1,1 @@
+00099961-opensuse-13.1-DVD-x86_64-Build0091-kde

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -170,6 +170,12 @@ subtest 'bug reporting' => sub {
     };
 };
 
+subtest 'log details on incomplete jobs' => sub {
+    $driver->get('/tests/99926');
+    is(current_tab, 'Details', 'starting on Details tab also for incomplete jobs');
+    like($driver->find_element('#details embed')->get_attribute('src'), qr/autoinst-log.txt/, 'log file embedded');
+};
+
 # test running view with Test::Mojo as phantomjs would get stuck on the
 # liveview/livelog forever
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -20,7 +20,7 @@
 <div class="row" id="result-row">
     <div class="col-sm-12">
         %= include 'test/infopanel', worker => $assigned_worker
-        <div role="tabpanel">
+        <div role="tabpanel" style="height: 100%">
 
             <ul class="nav nav-tabs" role="tablist" id="result_tabs">
                 <li role="presentation" class="nav-item">
@@ -55,9 +55,18 @@
                 </li>
             </ul>
 
-            <div class="tab-content">
-                <div role="tabpanel" class="tab-pane active" id="details">
+            <div class="tab-content" style="height: 100%">
+                <div role="tabpanel" class="tab-pane active" id="details" style="height: 100%">
+                % if (@$modlist) {
                     %= include 'test/details'
+                % }
+                % else {
+                    % for my $resultfile (@$resultfiles) {
+                        % next unless ($resultfile =~ /autoinst-log.txt$/);
+                        Likely error from autoinst-log.txt:<br>
+                        <embed src=<%= url_for('test_file', testid => $testid, filename => $resultfile) %> type="text/plain" style="width: 100%; height: 100%">
+                    % }
+                % }
                 </div>
 
                 % if ($has_parser_text_results) {


### PR DESCRIPTION
If job results do not have any test modules a job very likely aborted
very early and an empty details tab would not provide useful information
so instead we show the content of the log directly in the details tab
where a test reviewer can most likely see the failure reason.

Example screenshot:

![Screenshot_20191127_164931](https://user-images.githubusercontent.com/1693432/69738561-9e4d6580-1136-11ea-9af4-c9782f76acec.png)

Related progress issue: https://progress.opensuse.org/issues/35017