### PR TITLE
Increase SQLite busy timeout and reduce the number of SQLite connections

### DIFF
--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -16,8 +16,6 @@
 package OpenQA::CacheService::Task::Asset;
 use Mojo::Base 'Mojolicious::Plugin';
 
-use OpenQA::CacheService::Model::Cache;
-
 sub register {
     my ($self, $app) = @_;
 
@@ -51,8 +49,8 @@ sub _cache_asset {
             $output .= "[$level] " . join "\n", @lines, '';
         });
 
-    my $cache = OpenQA::CacheService::Model::Cache->from_worker(log => $ctx);
-    $cache->host($host)->get_asset({id => $id}, $type, $asset_name);
+    my $cache = $app->cache->log($ctx)->init;
+    $cache->get_asset($host, {id => $id}, $type, $asset_name);
     $job->note(output => $output);
     $ctx->info('Finished download');
 }

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -261,6 +261,12 @@ subtest 'Asset exists' => sub {
 
 };
 
+subtest 'Increased SQLite busy timeout' => sub {
+    my $cache = OpenQA::CacheService->new;
+    is $cache->cache->sqlite->db->dbh->sqlite_busy_timeout, 360000, '5 minute busy timeout';
+    is $cache->minion->backend->sqlite->db->dbh->sqlite_busy_timeout, 360000, '5 minute busy timeout';
+};
+
 subtest 'Job progress (guard against parallel downloads of the same file)' => sub {
     my $app = OpenQA::CacheService->new;
     ok !$app->progress->is_downloading('foo'), 'Queue works';


### PR DESCRIPTION
This PR increases the SQLite busy timeout from 30 seconds to 5 minutes. That should give slower operations like Minion queue repairs enough time to finish even on very slow workers. I've also removed the explicit `exclusive` locks, since we only perform a single query in every case, and those will automatically acquire the lock they need. And finally each process will now only use one SQLite connection.

All of this should be enough to resolve the problems we had with jobs getting stuck and the cache service dying.

Progress: https://progress.opensuse.org/issues/58484