### PR TITLE
travis_test: Add missing dictionary for os-autoinst

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -132,6 +132,7 @@ RUN zypper in -y -C \
        perl-Test-Simple \
        'perl(aliased)' \
        aspell-spell \
+       aspell-en \
        systemd-sysvinit \
        systemd libudev1 tack
 


### PR DESCRIPTION
travis tests for os-autoinst find aspell but no dic.