### PR TITLE
Allow monitoring of Minion jobs on every worker

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -59,6 +59,7 @@ sub startup {
     $r->get('/info')->to('API#info');
     $r->get('/status/<id:num>')->to('API#status');
     $r->post('/enqueue')->to('API#enqueue');
+    $r->get('/influxdb/minion')->to('Influxdb#minion');
     $r->any('/*whatever' => {whatever => ''})->to(status => 404, text => 'Not found');
 }
 
@@ -123,6 +124,10 @@ Returns Minon statistics, see L<https://metacpan.org/pod/Minion#stats>.
 =head2 /status/<id>
 
 Retrieve current job status in JSON format.
+
+=head2 /influxdb/minion
+
+Minion job queue statistics in InfluxDB format for easy monitoring.
 
 =head1 POST ROUTES
 

--- a/lib/OpenQA/CacheService/Controller/Influxdb.pm
+++ b/lib/OpenQA/CacheService/Controller/Influxdb.pm
@@ -1,0 +1,45 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::CacheService::Controller::Influxdb;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub minion {
+    my $self = shift;
+
+    my $stats = $self->app->minion->stats;
+    my $jobs  = {
+        active   => $stats->{active_jobs},
+        delayed  => $stats->{delayed_jobs},
+        failed   => $stats->{failed_jobs},
+        inactive => $stats->{inactive_jobs}};
+    my $workers = {active => $stats->{active_workers}, inactive => $stats->{inactive_workers}};
+
+    my $url  = $self->req->url->base->to_string;
+    my $text = '';
+    $text .= _output_measure($url, 'openqa_minion_jobs',    $jobs);
+    $text .= _output_measure($url, 'openqa_minion_workers', $workers);
+
+    $self->render(text => $text);
+}
+
+sub _output_measure {
+    my ($url, $key, $states) = @_;
+    my $line = "$key,url=$url ";
+    $line .= join(',', map { "$_=$states->{$_}i" } sort keys %$states);
+    return $line . "\n";
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 package OpenQA::WebAPI::Controller::Admin::Influxdb;
 use Mojo::Base 'Mojolicious::Controller';
 

--- a/systemd/openqa-worker-cacheservice.service
+++ b/systemd/openqa-worker-cacheservice.service
@@ -7,7 +7,7 @@ PartOf=openqa-worker.target
 [Service]
 Restart=on-failure
 User=_openqa-worker
-ExecStart=/usr/share/openqa/script/openqa-workercache daemon -m production
+ExecStart=/usr/share/openqa/script/openqa-workercache prefork -m production -i 100 -H 400 -w 4 -c 1 -G 80
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a fairly small change to allow the job queue on the worker side to be monitored just like we already monitor the job queue on the webui side. Format is exactly the same, just the route is `/influxdb/minion` instead of `/admin/influxdb/minion`.

To make sure normal cache service operations are not affected negatively in any way by the extra load, this patch also switched from `daemon` to `prefork`, with similar settings as the webui. That should also be a pretty harmless change after the recent refactorings, but i will test it on the staging machines anyway before merging this PR.

Progress: https://progress.opensuse.org/issues/60440