### PR TITLE
Provide investigation hints for failed jobs on request

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -313,6 +313,8 @@ function handleKeyDownOnTestDetails(e) {
 function setupTab(tabHash) {
     if (tabHash === '#dependencies') {
         setupDependencyGraph();
+    } else if (tabHash === '#investigation') {
+        setupInvestigation();
     } else if (tabHash === '#external') {
         setupExternalResults();
     }
@@ -322,6 +324,24 @@ function setupTab(tabHash) {
     } else {
         pauseLiveView();
     }
+}
+
+function setupInvestigation() {
+    var element = document.getElementById('investigation_status');
+    $.ajax({
+        url: element.dataset.url,
+        method: 'GET',
+        success: function(response) {
+            element.innerHTML = '';
+            var preElement = document.createElement('pre');
+            preElement.id = 'investigation_status_entry';
+            preElement.appendChild(document.createTextNode(response));
+            element.appendChild(preElement);
+        },
+        error: function(xhr, ajaxOptions, thrownError) {
+            $(element).text('Unable to get investigation info: ' + thrownError);
+        }
+    });
 }
 
 function setupExternalResults() {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -129,6 +129,7 @@ sub startup {
     $test_r->get('/ajax')->name('job_next_previous_ajax')->to('test#job_next_previous_ajax');
     $test_r->get('/modules/:moduleid/fails')->name('test_module_fails')->to('test#module_fails');
     $test_r->get('/dependencies')->name('test_dependencies')->to('test#dependencies');
+    $test_r->get('/investigation')->name('test_investigation')->to('test#investigate');
 
     $test_r->get('/details')->name('details')->to('test#details');
     $test_r->get('/module_components')->name('module_components')->to('test#module_components');

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -803,4 +803,13 @@ sub dependencies {
         });
 }
 
+sub investigate {
+    my ($self) = @_;
+    return $self->reply->not_found unless my $job = $self->get_current_job;
+    my $investigation = $job->investigate;
+    $self->respond_to(
+        json => {json => $investigation},
+        html => {text => join("\n", map { "$_: $investigation->{$_}" } keys %$investigation)});
+}
+
 1;

--- a/t/data/first_bad.json
+++ b/t/data/first_bad.json
@@ -1,0 +1,10 @@
+{
+   "BUILD" : "668",
+   "DESKTOP" : "textmode",
+   "JOBTOKEN" : "fNBevAKhhOQux_GO",
+   "NEEDLES_GIT_HASH" : "3aee70f5f526175469aa189b0c4f820de8f06ae1",
+   "QEMUPORT" : 20002,
+   "TEST_GIT_HASH" : "c65c426a2678223fad4ae7d4ebbe95817e5c725d",
+   "TEXTMODE" : 1,
+   "WORKER_INSTANCE" : 2
+}

--- a/t/data/last_good.json
+++ b/t/data/last_good.json
@@ -1,0 +1,10 @@
+{
+   "BUILD" : "667",
+   "DESKTOP" : "textmode",
+   "JOBTOKEN" : "fNBevAKhhOQux_GN",
+   "NEEDLES_GIT_HASH" : "3aee70f5f526175469aa189b0c4f820de8f06ae1",
+   "QEMUPORT" : 20001,
+   "TEST_GIT_HASH" : "c65c426a2678223fad4ae7d4ebbe95817e5c725d",
+   "TEXTMODE" : 1,
+   "WORKER_INSTANCE" : 1
+}

--- a/templates/test/dependencies.html.ep
+++ b/templates/test/dependencies.html.ep
@@ -5,7 +5,7 @@
 <div id="dependencygraph_status">
     <p>
         <i class="fas fa-spinner fa-spin fa-lg"></i>
-        Loading dependency graph ...
+        Loading dependency graph …
     </p>
 </div>
 <svg

--- a/templates/test/infopanel.html.ep
+++ b/templates/test/infopanel.html.ep
@@ -67,7 +67,7 @@
                 % } else {
                      <div id="developer-global-session-info" style="display: none;"></div>
                 % }
-                <div>
+                <div id="clones">
                     % if ($clone_of) {
                         Clone of
                         %= link_to $clone_of->id => url_for ('test', testid => $clone_of->id)

--- a/templates/test/investigation.html.ep
+++ b/templates/test/investigation.html.ep
@@ -1,0 +1,6 @@
+<div id="investigation_status" data-url="<%= url_for('test_investigation', testid => $job->id) %>" >
+    <p>
+        <i class="fas fa-spinner fa-spin fa-lg"></i>
+        Loading investigation details …
+    </p>
+</div>

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -47,6 +47,11 @@
                         <a href="#dependencies" aria-controls="dependencies" role="tab" data-toggle="tab" class="nav-link">Dependencies</a>
                     </li>
                 % }
+                % if ($job->result eq OpenQA::Jobs::Constants::FAILED) {
+                    <li role="presentation" class="nav-item">
+                        <a href="#investigation" aria-controls="investigation" role="tab" data-toggle="tab" class="nav-link">Investigation</a>
+                    </li>
+                % }
                 <li role="presentation" class="nav-item">
                     <a href="#comments" aria-controls="comments" role="tab" data-toggle="tab" class="nav-link">Comments (<%= scalar($job->comments) %>)</a>
                 </li>
@@ -91,6 +96,13 @@
                 % if ($show_dependencies) {
                     <div role="tabpanel" class="tab-pane" id="dependencies">
                         %= include 'test/dependencies'
+                    </div>
+                % }
+                % if ($job->result eq OpenQA::Jobs::Constants::FAILED) {
+                    <div role="tabpanel" class="tab-pane" id="investigation">
+                        <div class="investigation">
+                            %= include 'test/investigation'
+                        </div>
                     </div>
                 % }
                 <div role="tabpanel" class="tab-pane" id="comments">


### PR DESCRIPTION
In the case of a failed job where not carry over is available, for
example in the common case of a failed job following a passed one, the
important question to answer in general is "what changed" which can have 
multiple different angles. This commit adds a simple "diff" of the "last
good" job vs. the current "first bad" relying on the file vars.json from
the os-autoinst backend which provides all relevant information for the
most cases.

This commit adds a plain HTML route as well as JSON routes. The route is
called from test details when a user clicks on a tab to gather the
investigation details.

Example output corresponding to the investigation details:

Last good: 99983
Difference of job data:

```
--- t/data/openqa/testresults/00099/00099983-Unicorn-42-pink-x86_64-Build667-K@RainbowPC/vars.json>.....Tue Dec  3 16:39:15 2019
+++ t/data/openqa/testresults/00099/00099984-Unicorn-42-pink-x86_64-Build668-K@RainbowPC/vars.json>.....Tue Dec  3 16:39:15 2019
@@ -1,10 +1,10 @@
 {
-   "BUILD" : "667",
+   "BUILD" : "668",
    "DESKTOP" : "textmode",
-   "JOBTOKEN" : "fNBevAKhhOQux_GN",
+   "JOBTOKEN" : "fNBevAKhhOQux_GO",
    "NEEDLES_GIT_HASH" : "3aee70f5f526175469aa189b0c4f820de8f06ae1",
-   "QEMUPORT" : 20001,
+   "QEMUPORT" : 20002,
    "TEST_GIT_HASH" : "c65c426a2678223fad4ae7d4ebbe95817e5c725d",
    "TEXTMODE" : 1,
-   "WORKER_INSTANCE" : 1
+   "WORKER_INSTANCE" : 2
 }
```

https://progress.opensuse.org/issues/39719