### PR TITLE
Include the cache service when generating ports dynamically

### DIFF
--- a/docs/images/architecture.graphml
+++ b/docs/images/architecture.graphml
@@ -1124,7 +1124,7 @@ communicate with each other<y:LabelModel>
               <y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="-0.5" nodeRatioX="1.1102230246251565E-16" nodeRatioY="-0.5" offsetX="0.0" offsetY="4.0" upX="0.0" upY="-1.0"/>
             </y:ModelParameter>
           </y:NodeLabel>
-          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Liberation Sans" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.40625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="214.123046875" x="59.4384765625" y="20.73349761962936">listening on TCP port 7844 (dashboard)<y:LabelModel>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Liberation Sans" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.40625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="214.123046875" x="59.4384765625" y="20.73349761962936">listening on TCP port 9530 (dashboard)<y:LabelModel>
               <y:SmartNodeLabelModel distance="4.0"/>
             </y:LabelModel>
             <y:ModelParameter>

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -838,7 +838,7 @@
       <text x="183.954" xml:space="preserve" y="537.6614" clip-path="url(#clipPath2)" font-family="'Liberation Sans'" stroke="none">communicate with each other</text>
       <rect fill="none" x="935" width="333" height="42.1397" y="518.085" clip-path="url(#clipPath2)"/>
       <text x="1011.6245" font-size="14px" y="536.7589" clip-path="url(#clipPath2)" font-family="'Liberation Sans'" stroke="none" xml:space="preserve">openqa-worker-cacheservice</text>
-      <text x="996.4385" xml:space="preserve" y="551.6818" clip-path="url(#clipPath2)" font-family="'Liberation Sans'" stroke="none">listening on TCP port 7844 (dashboard)</text>
+      <text x="996.4385" xml:space="preserve" y="551.6818" clip-path="url(#clipPath2)" font-family="'Liberation Sans'" stroke="none">listening on TCP port 9530 (dashboard)</text>
     </g>
     <g fill="white" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,12,88)" stroke="white">
       <circle r="10" clip-path="url(#clipPath2)" cx="734.4208" cy="867.563" stroke="none"/>

--- a/lib/OpenQA/CacheService/Client.pm
+++ b/lib/OpenQA/CacheService/Client.pm
@@ -21,11 +21,11 @@ use OpenQA::CacheService::Request::Asset;
 use OpenQA::CacheService::Request::Sync;
 use OpenQA::CacheService::Response::Info;
 use OpenQA::CacheService::Response::Status;
-use OpenQA::Utils 'base_host';
+use OpenQA::Utils qw(base_host service_port);
 use Mojo::URL;
 use Mojo::File 'path';
 
-has host      => 'http://127.0.0.1:7844';
+has host      => 'http://127.0.0.1:' . service_port('cache_service');
 has cache_dir => sub { $ENV{OPENQA_CACHE_DIR} || OpenQA::Worker::Settings->new->global_settings->{CACHEDIRECTORY} };
 has ua        => sub { Mojo::UserAgent->new };
 
@@ -93,7 +93,7 @@ OpenQA::CacheService::Client - OpenQA Cache Service Client
 
     use OpenQA::CacheService::Client;
 
-    my $client = OpenQA::CacheService::Client->new(host=> 'http://127.0.0.1:7844', retry => 5, cache_dir => '/tmp/cache/path');
+    my $client = OpenQA::CacheService::Client->new(host=> 'http://127.0.0.1:9530', retry => 5, cache_dir => '/tmp/cache/path');
     my $request = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
     $client->enqueue($request);
     until ($client->status($request)->is_processed) {

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -1158,10 +1158,11 @@ sub service_port {
     my $base = $ENV{OPENQA_BASE_PORT} ||= 9526;
 
     my $offsets = {
-        webui       => 0,
-        websocket   => 1,
-        livehandler => 2,
-        scheduler   => 3
+        webui         => 0,
+        websocket     => 1,
+        livehandler   => 2,
+        scheduler     => 3,
+        cache_service => 4
     };
     croak "Unknown service: $service" unless exists $offsets->{$service};
     return $base + $offsets->{$service};

--- a/script/openqa-workercache
+++ b/script/openqa-workercache
@@ -21,7 +21,7 @@ use FindBin;
 BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
 
 use OpenQA::CacheService;
-use OpenQA::Utils 'set_listen_address';
+use OpenQA::Utils qw(service_port set_listen_address);
 
-set_listen_address(7844);
+set_listen_address(service_port('cache_service'));
 OpenQA::CacheService::run(@ARGV);

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -30,15 +30,17 @@ use Mojo::File qw(path tempdir tempfile);
 
 subtest 'service ports' => sub {
     local $ENV{OPENQA_BASE_PORT} = undef;
-    is service_port('webui'),       9526, 'webui port';
-    is service_port('websocket'),   9527, 'websocket port';
-    is service_port('livehandler'), 9528, 'livehandler port';
-    is service_port('scheduler'),   9529, 'scheduler port';
+    is service_port('webui'),         9526, 'webui port';
+    is service_port('websocket'),     9527, 'websocket port';
+    is service_port('livehandler'),   9528, 'livehandler port';
+    is service_port('scheduler'),     9529, 'scheduler port';
+    is service_port('cache_service'), 9530, 'cache service port';
     local $ENV{OPENQA_BASE_PORT} = 9530;
-    is service_port('webui'),       9530, 'webui port';
-    is service_port('websocket'),   9531, 'websocket port';
-    is service_port('livehandler'), 9532, 'livehandler port';
-    is service_port('scheduler'),   9533, 'scheduler port';
+    is service_port('webui'),         9530, 'webui port';
+    is service_port('websocket'),     9531, 'websocket port';
+    is service_port('livehandler'),   9532, 'livehandler port';
+    is service_port('scheduler'),     9533, 'scheduler port';
+    is service_port('cache_service'), 9534, 'cache service port';
     eval { service_port('unknown') };
     like $@, qr/Unknown service: unknown/, 'unknown port';
 };

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -9,7 +9,7 @@ use POSIX '_exit';
 use OpenQA::Worker;
 use Config::IniFiles;
 use Data::Dumper 'Dumper';
-use OpenQA::Utils qw(log_error log_info log_debug);
+use OpenQA::Utils qw(log_error log_info log_debug service_port);
 use OpenQA::WebSockets;
 use OpenQA::WebSockets::Client;
 use OpenQA::Scheduler;
@@ -63,7 +63,8 @@ sub cache_worker_service {
             # this service can be very noisy
             require OpenQA::CacheService;
             local $ENV{MOJO_MODE} = 'test';
-            OpenQA::CacheService::run(qw(daemon -l http://*:7844));
+            my $port = service_port 'cache_service';
+            OpenQA::CacheService::run('daemon', '-l', "http://*:$port");
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);
         })->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0);


### PR DESCRIPTION
Small change to include the cache service in `OPENQA_BASE_PORT` for consistency. Just in case someone wants to run the cache service for local development.