### PR TITLE
Use the correct new port in cache service monitoring tests

### DIFF
--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -471,8 +471,8 @@ subtest 'Minion monitoring with InfluxDB' => sub {
     my $ua  = $cache_client->ua;
     my $res = $ua->get($url)->result;
     is $res->body, <<'EOF', 'three workers still running';
-openqa_minion_jobs,url=http://127.0.0.1:7844 active=0i,delayed=0i,failed=0i,inactive=0i
-openqa_minion_workers,url=http://127.0.0.1:7844 active=0i,inactive=3i
+openqa_minion_jobs,url=http://127.0.0.1:9530 active=0i,delayed=0i,failed=0i,inactive=0i
+openqa_minion_workers,url=http://127.0.0.1:9530 active=0i,inactive=3i
 EOF
 
     my $app    = OpenQA::CacheService->new;
@@ -480,8 +480,8 @@ EOF
     my $worker = $minion->repair->worker->register;
     $res = $ua->get($url)->result;
     is $res->body, <<'EOF', 'four workers running now';
-openqa_minion_jobs,url=http://127.0.0.1:7844 active=0i,delayed=0i,failed=0i,inactive=0i
-openqa_minion_workers,url=http://127.0.0.1:7844 active=0i,inactive=4i
+openqa_minion_jobs,url=http://127.0.0.1:9530 active=0i,delayed=0i,failed=0i,inactive=0i
+openqa_minion_workers,url=http://127.0.0.1:9530 active=0i,inactive=4i
 EOF
 
     $minion->add_task(test => sub { });
@@ -490,22 +490,22 @@ EOF
     my $job     = $worker->dequeue(0);
     $res = $ua->get($url)->result;
     is $res->body, <<'EOF', 'two jobs';
-openqa_minion_jobs,url=http://127.0.0.1:7844 active=1i,delayed=0i,failed=0i,inactive=1i
-openqa_minion_workers,url=http://127.0.0.1:7844 active=1i,inactive=3i
+openqa_minion_jobs,url=http://127.0.0.1:9530 active=1i,delayed=0i,failed=0i,inactive=1i
+openqa_minion_workers,url=http://127.0.0.1:9530 active=1i,inactive=3i
 EOF
 
     $job->fail('test');
     $res = $ua->get($url)->result;
     is $res->body, <<'EOF', 'one job failed';
-openqa_minion_jobs,url=http://127.0.0.1:7844 active=0i,delayed=0i,failed=1i,inactive=1i
-openqa_minion_workers,url=http://127.0.0.1:7844 active=0i,inactive=4i
+openqa_minion_jobs,url=http://127.0.0.1:9530 active=0i,delayed=0i,failed=1i,inactive=1i
+openqa_minion_workers,url=http://127.0.0.1:9530 active=0i,inactive=4i
 EOF
 
     $job->retry({delay => 3600});
     $res = $ua->get($url)->result;
     is $res->body, <<'EOF', 'job is being retried';
-openqa_minion_jobs,url=http://127.0.0.1:7844 active=0i,delayed=1i,failed=0i,inactive=2i
-openqa_minion_workers,url=http://127.0.0.1:7844 active=0i,inactive=4i
+openqa_minion_jobs,url=http://127.0.0.1:9530 active=0i,delayed=1i,failed=0i,inactive=2i
+openqa_minion_workers,url=http://127.0.0.1:9530 active=0i,inactive=4i
 EOF
 };
 


### PR DESCRIPTION
To fix the currently failing tests in the repo.