### PR TITLE
Fix height of embedded logfile

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -380,6 +380,15 @@ function setupExternalResults() {
 }
 
 function setupResult(state, jobid, status_url, details_url) {
+  // load embedded logfiles
+  $('.embedded-logfile').each(function(index, logFileElement) {
+    $.ajax(logFileElement.dataset.src).done(function(response) {
+      logFileElement.innerHTML = response;
+    }).fail(function(jqXHR, textStatus, errorThrown) {
+      logFileElement.innerHTML = 'Unable to load logfile: ' + errorThrown;
+    });
+  });
+
   setupLazyLoadingFailedSteps();
   $(".current_preview").removeClass("current_preview");
 

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -226,6 +226,9 @@ span.resborder_na {
     max-height: none;
     box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.2);
 }
+pre.embedded-logfile {
+    white-space: pre-wrap;
+}
 
 h2.modcategory {
     margin-top: 0.9em !important;

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -176,7 +176,9 @@ subtest 'bug reporting' => sub {
 subtest 'log details on incomplete jobs' => sub {
     $driver->get('/tests/99926');
     is(current_tab, 'Details', 'starting on Details tab also for incomplete jobs');
-    like($driver->find_element('#details embed')->get_attribute('src'), qr/autoinst-log.txt/, 'log file embedded');
+    my $log_element = $driver->find_element_by_xpath('//*[@id="details"]//pre[string-length(text()) > 0]');
+    like($log_element->get_attribute('data-src'), qr/autoinst-log.txt/, 'log file embedded');
+    like($log_element->get_text(),                qr/Crashed\?/,        'log contents loaded');
 };
 
 # test running view with Test::Mojo as phantomjs would get stuck on the

--- a/templates/test/result.html.ep
+++ b/templates/test/result.html.ep
@@ -20,8 +20,7 @@
 <div class="row" id="result-row">
     <div class="col-sm-12">
         %= include 'test/infopanel', worker => $assigned_worker
-        <div role="tabpanel" style="height: 100%">
-
+        <div role="tabpanel">
             <ul class="nav nav-tabs" role="tablist" id="result_tabs">
                 <li role="presentation" class="nav-item">
                     <a href="#details" aria-controls="details" role="tab" data-toggle="tab" class="nav-link active">Details</a>
@@ -60,8 +59,8 @@
                 </li>
             </ul>
 
-            <div class="tab-content" style="height: 100%">
-                <div role="tabpanel" class="tab-pane active" id="details" style="height: 100%">
+            <div class="tab-content">
+                <div role="tabpanel" class="tab-pane active" id="details">
                 % if (@$modlist) {
                     %= include 'test/details'
                 % }
@@ -69,7 +68,7 @@
                     % for my $resultfile (@$resultfiles) {
                         % next unless ($resultfile =~ /autoinst-log.txt$/);
                         Likely error from autoinst-log.txt:<br>
-                        <embed src=<%= url_for('test_file', testid => $testid, filename => $resultfile) %> type="text/plain" style="width: 100%; height: 100%">
+                        <pre class="embedded-logfile" data-src="<%= url_for('test_file', testid => $testid, filename => $resultfile) %>"></pre>
                     % }
                 % }
                 </div>


### PR DESCRIPTION
* Just use an ordinary pre element and load contents via AJAX
* Remove previous attempts to set the height
* Adding further embedded logfiles is possible without further JavaScript (just add an element with attributes class="embedded-logfile" and data-src)