### PR TITLE
Improve asset download

### DIFF
--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -34,77 +34,66 @@ sub _download {
 
     # prevent multiple asset download tasks for the same asset to run
     # in parallel
-    return $job->retry({delay => 30})
+    return undef $job->retry({delay => 30})
       unless my $guard = $app->minion->guard("limit_asset_download_${assetpath}_task", 7200);
 
-    # Bail if the dest file exists (in case multiple downloads of same ISO
-    # are scheduled)
-    return if (-e $assetpath);
+    # bail if the dest file exists (in case multiple downloads of same ISO are scheduled)
+    return undef if -e $assetpath;
     my $assetdir = (splitpath($assetpath))[1];
+    OpenQA::Utils::log_fatal("asset download: cannot write to $assetdir") unless -w $assetdir;
 
-    OpenQA::Utils::log_fatal("download_asset: cannot write to $assetdir") unless (-w $assetdir);
-
-    # check URL is whitelisted for download. this should never fail;
+    # check whether URL is whitelisted for download. this should never fail;
     # if it does, it means this task has been created without going
     # through the ISO API controller, and that means either a code
     # change we didn't think through or someone being evil
-    my @check = OpenQA::Utils::check_download_url($url, $app->config->{global}->{download_domains});
-    if (@check) {
+    if (my @check = OpenQA::Utils::check_download_url($url, $app->config->{global}->{download_domains})) {
         my ($status, $host) = @check;
-        if ($status == 2) {
-            OpenQA::Utils::log_fatal("download_asset: no hosts are whitelisted for asset download!");
-        }
-        else {
-            OpenQA::Utils::log_fatal("download_asset: URL $url host $host is blacklisted!");
-        }
-        OpenQA::Utils::log_fatal("**API MAY HAVE BEEN BYPASSED TO CREATE THIS TASK!**");
+        my $empty_whitelist_note = ($status == 2 ? ' (which is empty)' : '');
+        OpenQA::Utils::log_fatal("asset download: host $host of URL $url is not on the whitelist$empty_whitelist_note");
     }
+
     if ($do_extract) {
-        OpenQA::Utils::log_debug("Downloading $url, uncompressing to $assetpath...");
+        OpenQA::Utils::log_debug("asset download: downloading $url, uncompressing to $assetpath...");
     }
     else {
-        OpenQA::Utils::log_debug("Downloading $url to $assetpath...");
+        OpenQA::Utils::log_debug("asset download: downloading $url to $assetpath...");
     }
+
+    # start tx allowing >16MiB downloads (http://mojolicio.us/perldoc/Mojolicious/Guides/Cookbook#Large-file-downloads)
     my $ua = Mojo::UserAgent->new(max_redirects => 5);
     my $tx = $ua->build_tx(GET => $url);
-
-    # Allow >16MiB downloads
-    # http://mojolicio.us/perldoc/Mojolicious/Guides/Cookbook#Large-file-downloads
     $tx->res->max_message_size(0);
     $tx = $ua->start($tx);
-    if (!$tx->error) {
-        try {
-            if ($do_extract) {
 
-                # Rename the downloaded data to the original file name, in
-                # MOJO_TMPDIR
-                my $tempfile = catfile($ENV{MOJO_TMPDIR}, Mojo::URL->new($url)->path->parts->[-1]);
-                $tx->res->content->asset->move_to($tempfile);
-
-                # Extract the temp archive file to the requested asset location
-                my $ae = Archive::Extract->new(archive => $tempfile);
-                my $ok = $ae->extract(to => $assetpath);
-
-                # Remove the temporary file
-                unlink($tempfile);
-
-                OpenQA::Utils::log_fatal("Extracting $tempfile to $assetpath failed!") unless $ok;
-            }
-            else {
-                # Just directly move the downloaded data to the requested
-                # asset location
-                $tx->res->content->asset->move_to($assetpath);
-            }
-        }
-        catch {
-            OpenQA::Utils::log_fatal("Error renaming or extracting temporary file to $assetpath: $_");
-        };
-    }
-    else {
-        # Clean up after ourselves. Probably won't exist, but just in case
+    # check for 4xx/5xx response and connection errors
+    if (my $err = $tx->error) {
+        # clean possibly created incomplete file
         unlink($assetpath);
-        OpenQA::Utils::log_fatal("Download of $url to $assetpath failed! Deleting files.");
+
+        my $msg = $err->{code} ? "$err->{code} response: $err->{message}" : "connection error: $err->{message}";
+        OpenQA::Utils::log_fatal("asset download: download of $url to $assetpath failed: $msg");
     }
+
+    try {
+        # move the downloaded data directly to the requested asset location unless extraction is enabled
+        return $tx->res->content->asset->move_to($assetpath) unless $do_extract;
+
+        # rename the downloaded data to the original file name, in MOJO_TMPDIR
+        my $tempfile = catfile($ENV{MOJO_TMPDIR}, Mojo::URL->new($url)->path->parts->[-1]);
+        $tx->res->content->asset->move_to($tempfile);
+
+        # extract the temp archive file to the requested asset location
+        my $ae = Archive::Extract->new(archive => $tempfile);
+        my $ok = $ae->extract(to => $assetpath);
+
+        # remove the temporary file
+        unlink($tempfile);
+
+        OpenQA::Utils::log_fatal("asset download: extracting $tempfile to $assetpath failed") unless $ok;
+    }
+    catch {
+        OpenQA::Utils::log_fatal("asset download: error renaming or extracting temporary file to $assetpath: $_");
+    };
 
     # set proper permissions for downloaded asset
     chmod 0644, $assetpath;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -24,6 +24,7 @@ use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use File::Copy;
+use OpenQA::SeleniumTest;
 use OpenQA::Test::Database;
 use Test::Output 'combined_like';
 use Test::MockModule;
@@ -85,6 +86,9 @@ $assets_mock->mock(scan_for_untracked_assets => sub { });
 $assets_mock->mock(refresh_assets            => sub { });
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+# launch an additional app to serve some file for testing blocking downloads
+my $mojo_port = OpenQA::SeleniumTest::start_app(sub { });
 
 # Allow Devel::Cover to collect stats for background jobs
 $t->app->minion->on(
@@ -347,11 +351,11 @@ subtest 'limit audit events' => sub {
     my $app            = $t->app;
     my $audit_events   = $app->schema->resultset('AuditEvents');
     my $startup_events = $audit_events->search({event => 'startup'});
-    is($startup_events->count, 1, 'one startup event present');
+    is($startup_events->count, 2, 'two startup events present');
 
     $startup_events->first->update({t_created => '2019-01-01'});
     run_gru('limit_audit_events');
-    is($audit_events->search({event => 'startup'})->count, 0, 'startup events deleted');
+    is($audit_events->search({event => 'startup'})->count, 1, 'old startup event deleted');
 };
 
 subtest 'human readable size' => sub {
@@ -506,8 +510,9 @@ subtest 'Gru manual task' => sub {
 $t->app->log(Mojo::Log->new(level => 'debug'));
 
 subtest 'download assets with correct permissions' => sub {
-    my $assetsource = 'https://github.com/os-autoinst/os-autoinst/blob/master/t/data/Core-7.2.iso';
-    my $assetpath   = 't/data/openqa/share/factory/iso/Core-7.2.iso';
+    my $local_domain = "127.0.0.1";
+    my $assetsource  = "http://$local_domain:$mojo_port/tests/99926/file/autoinst-log.txt";
+    my $assetpath    = 't/data/openqa/share/factory/iso/Core-7.2.iso';
 
     # be sure the asset does not exist from a previous test run
     unlink($assetpath);
@@ -516,22 +521,20 @@ subtest 'download assets with correct permissions' => sub {
         sub {
             run_gru('download_asset' => [$assetsource, $assetpath, 0]);
         },
-        qr/host github\.com .* is not on the whitelist \(which is empty\)/,
+        qr/host $local_domain .* is not on the whitelist \(which is empty\)/,
         'download refused if whitelist empty',
     );
 
-    $t->app->config->{global}->{download_domains} = 'gitlab.com';
+    $t->app->config->{global}->{download_domains} = 'foo';
     combined_like(
         sub {
             run_gru('download_asset' => [$assetsource, $assetpath, 0]);
         },
-        qr/host github\.com .* is not on the whitelist/,
+        qr/host $local_domain .* is not on the whitelist/,
         'download refused if host not on whitelist',
     );
 
-    plan skip_all => 'no network available' if $ENV{OBS_RUN};
-
-    $t->app->config->{global}->{download_domains} .= ' github.com';
+    $t->app->config->{global}->{download_domains} .= " $local_domain";
     combined_like(
         sub {
             run_gru('download_asset' => [$assetsource . '.foo', $assetpath, 0]);
@@ -543,6 +546,20 @@ subtest 'download assets with correct permissions' => sub {
     run_gru('download_asset' => [$assetsource, $assetpath, 0]);
     ok(-f $assetpath, 'asset downloaded');
     is(S_IMODE((stat($assetpath))[2]), 0644, 'asset downloaded with correct permissions');
+
+    my $ua = Mojo::UserAgent->new(max_redirects => 5);
+    my $tx = $ua->build_tx(GET => $assetsource);
+    $tx->res->max_message_size(0);
+    $tx = $ua->start($tx);
+
+    # check for 4xx/5xx response and connection errors
+    if (my $err = $tx->error) {
+        # clean possibly created incomplete file
+        unlink($assetpath);
+
+        my $msg = $err->{code} ? "$err->{code} response: $err->{message}" : "connection error: $err->{message}";
+        note("asset download: download of $assetsource to $assetpath failed: $msg");
+    }
 };
 
 done_testing();


### PR DESCRIPTION
* Remove unreachable code
* Add test for download errors
* Make code more readable, e.g. avoid nesting
* Improve error messages, e.g. include HTTP return code

See https://progress.opensuse.org/issues/57782