### PR TITLE
Fix config assets/storage_duration

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -202,7 +202,7 @@ sub read_config {
             untracked_assets_storage_duration => 14,
         },
         'assets/storage_duration' => {
-            # intentionally left blank for overview
+            CURRENT => 30,
         },
     );
 


### PR DESCRIPTION
Add CURRENT to list of known keywords in Setup.pm, otherwise it is ignored here:

https://github.com/os-autoinst/openQA/blob/d93df0ea5bcab9b4b8e6967a9b5e21a0c04c7e59/lib/OpenQA/Setup.pm#L245
