### PR TITLE
Fix substitution for job_templates schedule list

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -121,7 +121,7 @@ sub schedules {
     # Re-indent with group names at the toplevel in case of multiple groups
     if (keys %$yaml > 1) {
         foreach my $group (keys %$yaml) {
-            $yaml->{$group} = "'$group': |\n" . ($yaml->{$group} =~ s/(.+)\n/  $1\n/gr);
+            $yaml->{$group} = "'$group': |\n" . ($yaml->{$group} =~ s/^(.+)/  $1/mgr);
         }
     }
     $self->render(yaml => join("\n", map { $yaml->{$_} } sort keys %$yaml));


### PR DESCRIPTION
Some templates don't have a final newline, which resulted in the last line not being indented correctly

I haven't added a specific test for this but can do if needed

Example:
https://openqa.opensuse.org/api/v1/job_templates_scheduling/
```
...
'openSUSE Leap 42.1': |
  products: {}
scenarios: {}
'openSUSE Leap 42.2': |
  products: {}
scenarios: {}
'openSUSE Leap 42.2 Maintenance': |
  products: {}
  scenarios: {}
...
```