### PR TITLE
Fix regex and error message for prio

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -569,11 +569,11 @@ sub create {
     my $affected_rows;
 
     my $validation      = $self->validation;
-    my $is_number_regex = qr/^[0-9]+$/;
+    my $is_number_regex = qr/^[0-9]+\z/;
     my $has_product_id  = $validation->optional('product_id')->like($is_number_regex)->is_valid;
 
     # validate/read priority
-    my $prio_regex = qr/^(inherit|[0-9]+)$/;
+    my $prio_regex = qr/^(inherit|[0-9]+)\z/;
     if ($has_product_id) {
         $validation->optional('prio')->like($prio_regex);
     }
@@ -597,7 +597,7 @@ sub create {
 
         if ($validation->has_error) {
             $error = "wrong parameter:";
-            for my $k (qw(product_id machine_id test_suite_id group_id)) {
+            for my $k (qw(product_id machine_id test_suite_id group_id prio)) {
                 $error .= ' ' . $k if $validation->has_error($k);
             }
         }

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -278,6 +278,23 @@ ok($job_template_id1, "Created job template ($job_template_id1)");
 $t->post_ok(
     '/api/v1/job_templates',
     form => {
+        group_id      => 1001,
+        machine_id    => 1001,
+        test_suite_id => 1002,
+        product_id    => 1,
+        prio          => "30\n",
+    }
+)->status_is(400)->json_is(
+    '' => {
+        error_status => 400,
+        error        => 'wrong parameter: prio'
+    },
+    'setting invalid prio'
+);
+
+$t->post_ok(
+    '/api/v1/job_templates',
+    form => {
         group_name      => 'opensuse',
         machine_name    => '64bit',
         test_suite_name => 'RAID0',


### PR DESCRIPTION
`$` in a regex means

     Match the end of the string or before newline at the end of the string

`\z` really means end of the string.

Also submitting an invalid prio didn't result in the correct error message.