### PR TITLE
Missing assets should not result in a connection timeout

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -23,7 +23,7 @@ use File::Basename;
 use File::Spec;
 use File::Spec::Functions 'catfile';
 use Data::Dump 'pp';
-use Mojolicious::Static;
+use Mojo::File 'path';
 
 sub needle {
     my $self = shift;
@@ -126,9 +126,9 @@ sub download_asset {
     my $path = $self->param('assetpath');
     return $self->reply->not_found if $path =~ qr/\.\./;
 
-    my $static = Mojolicious::Static->new;
-    $static->paths([$OpenQA::Utils::assetdir]);
-    return $self->rendered if $static->serve($self, $path);
+    my $file = path($OpenQA::Utils::assetdir, $path)->to_string;
+    return $self->reply->not_found unless -f $file && -r _;
+    $self->reply->file($file);
 }
 
 sub test_asset {

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -143,6 +143,8 @@ $t->get_ok('/tests/99961/asset/repo/testrepo/README/../README')->status_is(400)
 # download_asset is handled by apache normally, but make sure it works - important for fullstack test
 $t->get_ok('/assets/repo/testrepo/README')->status_is(200);
 $t->get_ok('/assets/iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(200);
+$t->get_ok('/assets/iso/../iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->status_is(404);
+$t->get_ok('/assets/repo/testrepo/doesnotexist')->status_is(404);
 
 
 # TODO: also test repos


### PR DESCRIPTION
This fixes the problem @Martchus ran into yesterday where requesting a non-existing asset results in a connection timeout without any response at all.