### PR TITLE
Move job incompletion code on worker connect to one place

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -61,7 +61,6 @@ sub startup {
     $ca->get('/' => {json => {name => $self->defaults('appname')}});
     my $api = $ca->any('/api');
     $api->get('/wakeup')->to('API#wakeup');
-    $api->post('/worker_reported_back')->to('API#handle_worker_reported_back');
     $r->any('/*whatever' => {whatever => ''})->to(status => 404, text => 'Not found');
 
     OpenQA::Setup::setup_plain_exception_handler($self);

--- a/lib/OpenQA/Scheduler/Client.pm
+++ b/lib/OpenQA/Scheduler/Client.pm
@@ -41,13 +41,6 @@ sub wakeup {
       ->finally(sub { delete $self->{wakeup} })->wait;
 }
 
-sub inform_scheduler_that_worker_reported_back {
-    my ($self, $worker_info, $callback) = @_;
-
-    $self->client->max_connections(20)->request_timeout(60)
-      ->post($self->_api('worker_reported_back'), json => $worker_info, $callback);
-}
-
 sub singleton { state $client ||= __PACKAGE__->new }
 
 sub _api {

--- a/lib/OpenQA/Scheduler/Controller/API.pm
+++ b/lib/OpenQA/Scheduler/Controller/API.pm
@@ -16,97 +16,11 @@
 package OpenQA::Scheduler::Controller::API;
 use Mojo::Base 'Mojolicious::Controller';
 
-use OpenQA::Schema;
-use OpenQA::Jobs::Constants;
-use OpenQA::Utils qw(log_info log_warning);
-use Scalar::Util 'looks_like_number';
-use Try::Tiny;
+use OpenQA::Scheduler;
 
 sub wakeup {
     my $self = shift;
     OpenQA::Scheduler::wakeup();
-    $self->render(text => 'ok');
-}
-
-sub handle_worker_reported_back {
-    my $self = shift;
-
-    # get and validate IDs from JSON
-    my $json = $self->req->json;
-    return $self->render(text => 'no JSON with worker and job IDs submitted', status => 400)
-      unless ref($json) eq 'HASH';
-    my $worker_id = $json->{worker_id};
-    return $self->render(text => 'worker ID is missing/invalid', status => 400)
-      unless defined $worker_id && looks_like_number($worker_id);
-    my $worker_status      = $json->{worker_status}      // '';
-    my $current_job_id     = $json->{current_job_id}     // '';
-    my $current_job_status = $json->{current_job_status} // '';
-    my $pending_job_ids    = $json->{pending_job_ids}    // {};
-    my $job_token          = $json->{job_token}          // '';
-
-    # ensure the worker's current job is considered running
-    # note: Not sure whether this is actually required. Just moving the code from the web socket server here for now.
-    my $schema = OpenQA::Schema->singleton;
-    if (   looks_like_number($current_job_id)
-        && defined $current_job_status
-        && $current_job_status eq OpenQA::Jobs::Constants::RUNNING)
-    {
-        try {
-            $schema->txn_do(
-                sub {
-                    my $job = $schema->resultset('Jobs')->find($current_job_id);
-                    return undef unless $job;
-                    return undef if $job->state eq RUNNING || $job->result ne NONE;
-                    $job->set_running;
-                    log_debug("Job $current_job_id set to running when worker reported back.");
-                });
-        }
-        catch {
-            log_warning(
-                "Unable to set the status of the current job $current_job_id of worker $worker_id to running: $_");
-        };
-    }
-
-# set status of unfinished jobs according to what the worker has reported (e.g. if worker says it is idling we want to set
-# the job it was supposed to run to "incomplete" and duplicate it)
-    try {
-        $schema->txn_do(
-            sub {
-                my $worker = $schema->resultset('Workers')->find($worker_id);
-                return undef unless $worker;
-
-                my $supposed_job_token = $worker->get_property('JOBTOKEN');
-                my $job_token_correct  = $job_token eq $supposed_job_token;
-
-                # take any unfinished jobs of that worker into account
-                for my $job ($worker->unfinished_jobs) {
-                    my $job_id = $job->id;
-
-                    if ($job_token_correct) {
-                        # do nothing if the worker claims that it is still working on that job
-                        next if $job_id eq $current_job_id;
-
-                        # do nothing if the worker claims that the job is still pending
-                        next if exists $pending_job_ids->{$job->id};
-                    }
-
-                    # set jobs which were only assigned anyways back to scheduled
-                    my $job_state = $job->state;
-                    return $job->reschedule_state
-                      if $job_state eq OpenQA::Jobs::Constants::ASSIGNED;
-
-                    # mark jobs which were already beyond assigned as incomplete and duplicate it
-                    return $job->incomplete_and_duplicate
-                      if $job_state eq OpenQA::Jobs::Constants::RUNNING
-                      || $job_state eq OpenQA::Jobs::Constants::UPLOADING
-                      || $job_state eq OpenQA::Jobs::Constants::SETUP;
-                }
-            });
-    }
-    catch {
-        log_warning("Unable to incomplete/duplicate or reschedule jobs abandoned by worker $worker_id: $_");
-    };
-
     $self->render(text => 'ok');
 }
 

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -236,7 +236,7 @@ sub schedule {
                     }
                     else {
                         # Send abort and reschedule if we fail associating the job to the worker
-                        die "Failed rollback of job" unless $jobs[0]->reschedule_rollback($worker);
+                        $jobs[0]->reschedule_rollback($worker);
                     }
                 }
             }
@@ -256,7 +256,7 @@ sub schedule {
             for my $job (@jobs) {
                 try {
                     # Remove the associated worker and be sure to be in scheduled state.
-                    die "failed reset" unless $job->reschedule_state;
+                    $job->reschedule_state;
                 }
                 catch {
                     # Again: If we see this, we are in a really bad state.

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -156,8 +156,12 @@ subtest 'Simulation of unstable workers' => sub {
     is(@{$allocated}[0]->{job},    99982, 'right job allocated');
     is(@{$allocated}[0]->{worker}, 5,     'job allocated to expected worker');
 
+    for (0 .. 100) {
+        last if $schema->resultset("Jobs")->find(99982)->state eq OpenQA::Jobs::Constants::RUNNING;
+        sleep 2;
+    }
+    is $schema->resultset("Jobs")->find(99982)->state, OpenQA::Jobs::Constants::RUNNING, 'job is running';
     kill_service($unstable_w_pid, 1);
-    is $schema->resultset("Jobs")->find(99982)->state, OpenQA::Jobs::Constants::ASSIGNED;
 
     $unstable_w_pid = unstable_worker($k->key, $k->secret, "http://localhost:$mojoport", 3, 8);
 


### PR DESCRIPTION
Marking previous jobs of a worker as incomplete when it shows up again is so far handled within the web socket server and the registration API route. This change moves all aspects of handling this to the API. This will hopefully scale better because the regular API can use preforking.

See https://progress.opensuse.org/issues/60866