### PR TITLE
Prevent massive database errors on screenshot insertion

### DIFF
--- a/lib/OpenQA/Schema/Result/Screenshots.pm
+++ b/lib/OpenQA/Schema/Result/Screenshots.pm
@@ -20,11 +20,6 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
-use File::Spec::Functions 'catfile';
-use File::Basename qw(basename dirname);
-use OpenQA::Utils qw(log_debug log_warning);
-use Try::Tiny;
-
 __PACKAGE__->table('screenshots');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime));
 


### PR DESCRIPTION
The previous approach was to catch conflicts on screenshot insertion in
perl context yielding the right functional behaviour but also causing a
log entry for every image object amounting to multiple gigabytes of
postgres database error log files which can cause obvious problems. By
using a similar approach as is already done in
lib/OpenQA/Schema/Result/Jobs.pm with raw SQL we can ask the database
for silent conflict handling and more efficiently not involving perl
exception handling.

Related progress issue: https://progress.opensuse.org/issues/60926