### PR TITLE
Remove "Jump to video" icon from "needle view" when video is unavailable

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -598,7 +598,7 @@ sub viewimg {
     }
 
     $self->stash('screenshot',     $screenshot);
-    $self->stash('frametime',      $module_detail->{frametime});
+    $self->stash('frametime',      $module_detail->{frametime}) if grep { /video.ogv$/ } @{$job->test_resultfile_list};
     $self->stash('default_label',  $primary_match ? $primary_match->{label} : 'Screenshot');
     $self->stash('needles_by_tag', \%needles_by_tag);
     $self->stash('tag_count',      scalar %needles_by_tag);


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/39917