### PR TITLE
Improvements for '$sth' and t/42-screenshots.t

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1227,10 +1227,9 @@ sub store_image {
         # this is actually meant to cause a conflict - the worker uploads symlinks first.
         # But to be sure we have a DB entry in case this was missed, we still force create it
         # using postgresql's "do nothing"
-        my $statement
+        my $sth
           = $dbh->prepare('INSERT INTO screenshots (filename, t_created) VALUES(?, now()) ON CONFLICT DO NOTHING');
-
-        $statement->execute($dbpath);
+        $sth->execute($dbpath);
         log_debug("store_image: $storepath");
     }
     return $storepath;

--- a/lib/OpenQA/Schema/ResultSet/Screenshots.pm
+++ b/lib/OpenQA/Schema/ResultSet/Screenshots.pm
@@ -30,11 +30,11 @@ sub populate_images_to_job {
     my %ids;
     for my $img (@$imgs) {
         log_debug "creating $img";
-        my $dbh       = $self->result_source->schema->storage->dbh;
-        my $statement = $dbh->prepare(
+        my $dbh = $self->result_source->schema->storage->dbh;
+        my $sth = $dbh->prepare(
             'INSERT INTO screenshots (filename, t_created) VALUES(?, now()) ON CONFLICT DO NOTHING RETURNING id');
-        $statement->execute($img);
-        my $res = $statement->fetchrow_arrayref;
+        $sth->execute($img);
+        my $res = $sth->fetchrow_arrayref;
         $ids{$img} = $res ? $res->[0] : $self->find({filename => $img})->id;
     }
     my @data = map { [$_, $job_id] } values %ids;


### PR DESCRIPTION
* t: Use more concise code in t/42-screenshots.t
* Use more conventional variable name '' for raw db calls