### PR TITLE
Move worker reported back from scheduler to webui

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -61,7 +61,6 @@ sub startup {
     $ca->get('/' => {json => {name => $self->defaults('appname')}});
     my $api = $ca->any('/api');
     $api->get('/wakeup')->to('API#wakeup');
-    $api->post('/worker_reported_back')->to('API#handle_worker_reported_back');
     $r->any('/*whatever' => {whatever => ''})->to(status => 404, text => 'Not found');
 
     OpenQA::Setup::setup_plain_exception_handler($self);

--- a/lib/OpenQA/Scheduler/Client.pm
+++ b/lib/OpenQA/Scheduler/Client.pm
@@ -41,13 +41,6 @@ sub wakeup {
       ->finally(sub { delete $self->{wakeup} })->wait;
 }
 
-sub inform_scheduler_that_worker_reported_back {
-    my ($self, $worker_info, $callback) = @_;
-
-    $self->client->max_connections(20)->request_timeout(60)
-      ->post($self->_api('worker_reported_back'), json => $worker_info, $callback);
-}
-
 sub singleton { state $client ||= __PACKAGE__->new }
 
 sub _api {

--- a/lib/OpenQA/Scheduler/Controller/API.pm
+++ b/lib/OpenQA/Scheduler/Controller/API.pm
@@ -16,97 +16,11 @@
 package OpenQA::Scheduler::Controller::API;
 use Mojo::Base 'Mojolicious::Controller';
 
-use OpenQA::Schema;
-use OpenQA::Jobs::Constants;
-use OpenQA::Utils qw(log_info log_warning);
-use Scalar::Util 'looks_like_number';
-use Try::Tiny;
+use OpenQA::Scheduler;
 
 sub wakeup {
     my $self = shift;
     OpenQA::Scheduler::wakeup();
-    $self->render(text => 'ok');
-}
-
-sub handle_worker_reported_back {
-    my $self = shift;
-
-    # get and validate IDs from JSON
-    my $json = $self->req->json;
-    return $self->render(text => 'no JSON with worker and job IDs submitted', status => 400)
-      unless ref($json) eq 'HASH';
-    my $worker_id = $json->{worker_id};
-    return $self->render(text => 'worker ID is missing/invalid', status => 400)
-      unless defined $worker_id && looks_like_number($worker_id);
-    my $worker_status      = $json->{worker_status}      // '';
-    my $current_job_id     = $json->{current_job_id}     // '';
-    my $current_job_status = $json->{current_job_status} // '';
-    my $pending_job_ids    = $json->{pending_job_ids}    // {};
-    my $job_token          = $json->{job_token}          // '';
-
-    # ensure the worker's current job is considered running
-    # note: Not sure whether this is actually required. Just moving the code from the web socket server here for now.
-    my $schema = OpenQA::Schema->singleton;
-    if (   looks_like_number($current_job_id)
-        && defined $current_job_status
-        && $current_job_status eq OpenQA::Jobs::Constants::RUNNING)
-    {
-        try {
-            $schema->txn_do(
-                sub {
-                    my $job = $schema->resultset('Jobs')->find($current_job_id);
-                    return undef unless $job;
-                    return undef if $job->state eq RUNNING || $job->result ne NONE;
-                    $job->set_running;
-                    log_debug("Job $current_job_id set to running when worker reported back.");
-                });
-        }
-        catch {
-            log_warning(
-                "Unable to set the status of the current job $current_job_id of worker $worker_id to running: $_");
-        };
-    }
-
-# set status of unfinished jobs according to what the worker has reported (e.g. if worker says it is idling we want to set
-# the job it was supposed to run to "incomplete" and duplicate it)
-    try {
-        $schema->txn_do(
-            sub {
-                my $worker = $schema->resultset('Workers')->find($worker_id);
-                return undef unless $worker;
-
-                my $supposed_job_token = $worker->get_property('JOBTOKEN');
-                my $job_token_correct  = $job_token eq $supposed_job_token;
-
-                # take any unfinished jobs of that worker into account
-                for my $job ($worker->unfinished_jobs) {
-                    my $job_id = $job->id;
-
-                    if ($job_token_correct) {
-                        # do nothing if the worker claims that it is still working on that job
-                        next if $job_id eq $current_job_id;
-
-                        # do nothing if the worker claims that the job is still pending
-                        next if exists $pending_job_ids->{$job->id};
-                    }
-
-                    # set jobs which were only assigned anyways back to scheduled
-                    my $job_state = $job->state;
-                    return $job->reschedule_state
-                      if $job_state eq OpenQA::Jobs::Constants::ASSIGNED;
-
-                    # mark jobs which were already beyond assigned as incomplete and duplicate it
-                    return $job->incomplete_and_duplicate
-                      if $job_state eq OpenQA::Jobs::Constants::RUNNING
-                      || $job_state eq OpenQA::Jobs::Constants::UPLOADING
-                      || $job_state eq OpenQA::Jobs::Constants::SETUP;
-                }
-            });
-    }
-    catch {
-        log_warning("Unable to incomplete/duplicate or reschedule jobs abandoned by worker $worker_id: $_");
-    };
-
     $self->render(text => 'ok');
 }
 

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -236,7 +236,7 @@ sub schedule {
                     }
                     else {
                         # Send abort and reschedule if we fail associating the job to the worker
-                        die "Failed rollback of job" unless $jobs[0]->reschedule_rollback($worker);
+                        $jobs[0]->reschedule_rollback($worker);
                     }
                 }
             }
@@ -256,7 +256,7 @@ sub schedule {
             for my $job (@jobs) {
                 try {
                     # Remove the associated worker and be sure to be in scheduled state.
-                    die "failed reset" unless $job->reschedule_state;
+                    $job->reschedule_state;
                 }
                 catch {
                     # Again: If we see this, we are in a really bad state.

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -88,7 +88,8 @@ sub _register {
     die 'Incompatible websocket API version'
       if WEBSOCKET_API_VERSION != ($caps->{websocket_api_version} // 0);
 
-    my $worker = $schema->resultset('Workers')->search(
+    my $workers = $schema->resultset('Workers');
+    my $worker  = $workers->search(
         {
             host     => $host,
             instance => int($instance),
@@ -99,7 +100,7 @@ sub _register {
         $worker->update({t_updated => now()});
     }
     else {
-        $worker = $schema->resultset('Workers')->create(
+        $worker = $workers->create(
             {
                 host     => $host,
                 instance => $instance,
@@ -113,19 +114,44 @@ sub _register {
     # mark the jobs the worker is currently supposed to run as incomplete unless the worker claims
     # to still work on these jobs (which might be the case when the worker hasn't actually crashed but
     # just re-registered due to network issues)
+    # note: Using a transaction here so we don't end up with an inconsistent state when an error occurs.
     my %jobs_worker_says_it_works_on = map { ($_ => 1) } @$jobs_worker_says_it_works_on;
-    $worker->update({job_id => undef}) if _incomplete_previous_job(\%jobs_worker_says_it_works_on, $worker->job);
-    _incomplete_previous_job(\%jobs_worker_says_it_works_on, $_) for $worker->unfinished_jobs->all;
+    my $worker_id                    = $worker->id;
+    try {
+        $schema->txn_do(
+            sub {
+                $worker->update({job_id => undef})
+                  if _incomplete_previous_job(\%jobs_worker_says_it_works_on, $worker->job);
+                _incomplete_previous_job(\%jobs_worker_says_it_works_on, $_) for $worker->unfinished_jobs->all;
+            });
+    }
+    catch {
+        log_warning("Unable to incomplete/duplicate or reschedule jobs abandoned by worker $worker_id: $_");
+    };
 
-    return $worker->id;
+    return $worker_id;
 }
 
 sub _incomplete_previous_job {
     my ($jobs_worker_says_it_works_on, $job) = @_;
-    return 0 if !defined $job || $jobs_worker_says_it_works_on->{$job->id};
+    return 0 unless defined $job;
 
+    my $job_id = $job->id;
+    return 0 if $jobs_worker_says_it_works_on->{$job_id};
+    my $job_state = $job->state;
+    return 1 if $job_state eq OpenQA::Jobs::Constants::SCHEDULED;
+
+    # set jobs which were only assigned anyways back to scheduled
+    if ($job_state eq OpenQA::Jobs::Constants::ASSIGNED) {
+        $job->reschedule_state;
+        return 1;
+    }
+
+    # mark jobs which were already beyond assigned as incomplete and duplicate it
     $job->set_property('JOBTOKEN');
-    $job->auto_duplicate;
+    if (my $duplicate = $job->auto_duplicate) {
+        log_debug("Job $job_id duplicated as " . $duplicate->id);
+    }
     $job->done(result => OpenQA::Jobs::Constants::INCOMPLETE);
     return 1;
 }
@@ -184,6 +210,7 @@ sub create {
         }
         return undef;
     };
+    return unless defined $id;
 
     my %event_data = (id => $id, host => $host, instance => $instance, caps => $caps);
     $event_data{job_ids} = $job_ids if @$job_ids;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -25,6 +25,7 @@ use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Resource::Locks;
 use OpenQA::Resource::Jobs;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
+use OpenQA::Jobs::Constants;
 use OpenQA::Test::Database;
 use Test::Mojo;
 use Test::MockModule;
@@ -119,19 +120,22 @@ $workercaps->{isotovideo_interface_version} = WEBSOCKET_API_VERSION;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 my $c = OpenQA::WebAPI::Controller::API::V1::Worker->new;
 
-# this really should be an integration test
-my $id = $c->_register($schema, "host", "1", $workercaps);
-ok($id == 1, "New worker registered");
-my $worker_db_obj = $schema->resultset("Workers")->find($id);
-my $worker        = $worker_db_obj->info();
-ok($worker->{id} == $id && $worker->{host} eq "host" && $worker->{instance} eq "1", "New worker_get");
+sub register_worker {
+    return $c->_register($schema, 'host', '1', $workercaps);
+}
 
-# Update worker
-sleep(1);
-my $id2 = $c->_register($schema, "host", "1", $workercaps);
-ok($id == $id2, "Known worker_register");
-my $worker2 = $schema->resultset("Workers")->find($id2)->info();
-ok($worker2->{id} == $id2 && $worker2->{host} eq "host" && $worker2->{instance} == 1, "Known worker_get");
+my ($id, $worker, $worker_db_obj);
+subtest 'worker registration' => sub {
+    is($id = register_worker, 1, 'new worker registered');
+
+    $worker_db_obj = $schema->resultset('Workers')->find($id);
+    $worker        = $worker_db_obj->info;
+
+    is($worker->{id},       $id,    'id set');
+    is($worker->{host},     'host', 'host set');
+    is($worker->{instance}, '1',    'instance set');
+    is(register_worker,     $id,    're-registered worker got same id');
+};
 
 # Testing job_create and job_get
 my %settings = (
@@ -328,22 +332,33 @@ is(scalar(@{$rjobs_before}) + 1,             scalar(@{$rjobs_after}), "number of
 is($rjobs_after->[-1]->{assigned_worker_id}, 1,                       'assigned worker set');
 
 $grabbed = job_get($job->id);
-is($grabbed->worker->id, $worker->{id}, "correct worker assigned");
-ok($grabbed->state eq "assigned", "Job is in assigned state");    # After job_grab the job is in running state.
+is($grabbed->worker->id, $worker->{id}, 'correct worker assigned');
+is($grabbed->state,      ASSIGNED,      'job is in assigned state');
 
-# register worker again while it has a running job
-$id2 = $c->_register($schema, "host", "1", $workercaps);
-ok($id == $id2, "re-register worker got same id");
+# register worker again with no job while the web UI thinks it has an assigned job
+is(register_worker, $id, 'worker re-registered');
 
-# Now it's previous job must be set to done
+# the assigned job is supposed to be re-scheduled
 $grabbed = job_get($job->id);
-is($grabbed->state,  "done",       "Previous job is in done state");
-is($grabbed->result, "incomplete", "result is incomplete");
-ok(!$grabbed->settings_hash->{JOBTOKEN}, "job token no longer present");
+is($grabbed->state,                     SCHEDULED, 'previous job has been re-scheduled');
+is($grabbed->result,                    NONE,      'previous job has no result yet');
+is($grabbed->settings_hash->{JOBTOKEN}, undef,     'the job token of the previous job has been cleared');
+
+# register worker again with no job while the web UI thinks it as a running job
+$grabbed->update({state => RUNNING});
+$worker_db_obj->update({job_id => $grabbed->id});
+$worker_db_obj->set_property(JOB_TOKEN => 'assume we have a token');
+is(register_worker, $id, 'worker re-registered');
+
+# the assigned job is supposed to be incompleted
+$grabbed = job_get($job->id);
+is($grabbed->state,                     DONE,       'previous job has is considered done');
+is($grabbed->result,                    INCOMPLETE, 'previous job been incompleted');
+is($grabbed->settings_hash->{JOBTOKEN}, undef,      'the job token of the previous job has been cleared');
 
 OpenQA::Scheduler::Model::Jobs->singleton->schedule();
 $grabbed = $sent->{$worker->{id}}->{job}->to_hash;
-isnt($job->id, $grabbed->{id}, "new job grabbed") or die diag explain $grabbed->to_hash;
+isnt($job->id, $grabbed->{id}, "new job grabbed") or die diag explain $grabbed;
 isnt($grabbed->{settings}->{JOBTOKEN}, $job_ref->{settings}->{JOBTOKEN}, "job token differs")
   or die diag explain $grabbed->to_hash;
 
@@ -355,7 +370,6 @@ is_deeply($grabbed->{settings}, $job_ref->{settings}, "settings correct");
 my $job3_id = $job->id;
 my $job_id  = $grabbed->{id};
 
-sleep 1;
 # Testing job_set_done
 $job    = job_get($job_id);
 $result = $job->done(result => 'passed');


### PR DESCRIPTION
Same as https://github.com/os-autoinst/openQA/pull/2595 which was buggy.

Marking previous jobs of a worker as incomplete when it shows up again is so far handled within the web socket server and the registration API route. This change moves all aspects of handling this to the API. This will hopefully scale better because the regular API can use preforking.

See https://progress.opensuse.org/issues/60866