### PR TITLE
job investigation: Give explanation on no test changes

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1829,6 +1829,7 @@ sub investigate {
         $investigation{diff_to_last_good} = join("\n", grep { !/$ignore/ } split(/\n/, $diff));
         my ($before, $after) = map { decode_json($_) } @files;
         $investigation{git_log} = $self->git_log_diff($before, $after);
+        $investigation{git_log} ||= 'No test changes recorded, test regression unlikely';
         last;
     }
     $investigation{last_good} //= 'not found';


### PR DESCRIPTION
Looking up the git log diff between "last good" and "first bad" of a
scenario history can yield an empty result meaning that there are no
changes, i.e. both git hashes most likely match. If this is the case we
can point the reviewer to the likely hypothesis that test changes are
not the cause of a job failure.

Related progress issue: https://progress.opensuse.org/issues/19720
