### PR TITLE
Revert "Trigger tasks for limiting assets and results/logs hourly" due to never finishing cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,6 @@ install:
 	install -m 644 systemd/openqa-scheduler.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-enqueue-audit-event-cleanup.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-enqueue-audit-event-cleanup.timer "$(DESTDIR)"/usr/lib/systemd/system
-	install -m 644 systemd/openqa-enqueue-asset-and-result-cleanup.service "$(DESTDIR)"/usr/lib/systemd/system
-	install -m 644 systemd/openqa-enqueue-asset-and-result-cleanup.timer "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 644 systemd/openqa-setup-db.service "$(DESTDIR)"/usr/lib/systemd/system
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -337,6 +337,10 @@ sub _schedule_iso {
         @successful_job_ids = ();
     };
 
+    # enqueue cleanup task
+    $gru->enqueue_limit_assets();
+    $gru->enqueue(limit_results_and_logs => [], {priority => 5, ttl => 172800, limit => 1});
+
     # emit events
     for my $succjob (@successful_job_ids) {
         OpenQA::Events->singleton->emit_event('openqa_job_create', data => {id => $succjob}, user_id => $user_id);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -263,6 +263,7 @@ sub create {
         my $downloads = create_downloads_list(\%params);
         my $gru       = $self->gru;
         $gru->enqueue_download_jobs($downloads, [$job->id]);
+        $gru->enqueue_limit_assets;
         $job->calculate_blocked_by;
         OpenQA::Scheduler::Client->singleton->wakeup;
     }

--- a/openQA.spec
+++ b/openQA.spec
@@ -17,7 +17,7 @@
 
 
 # can't use linebreaks here!
-%define openqa_services openqa-webui.service openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer openqa-enqueue-asset-and-result-cleanup.service openqa-enqueue-asset-and-result-cleanup.timer
+%define openqa_services openqa-webui.service openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer
 %define openqa_worker_services openqa-worker.target openqa-slirpvde.service openqa-vde_switch.service openqa-worker-cacheservice.service openqa-worker-cacheservice-minion.service
 %if %{undefined tmpfiles_create}
 %define tmpfiles_create() \
@@ -398,8 +398,6 @@ fi
 %{_unitdir}/openqa-websockets.service
 %{_unitdir}/openqa-enqueue-audit-event-cleanup.service
 %{_unitdir}/openqa-enqueue-audit-event-cleanup.timer
-%{_unitdir}/openqa-enqueue-asset-and-result-cleanup.service
-%{_unitdir}/openqa-enqueue-asset-and-result-cleanup.timer
 # web libs
 %dir %{_datadir}/openqa
 %{_datadir}/openqa/templates

--- a/systemd/openqa-enqueue-asset-and-result-cleanup.service
+++ b/systemd/openqa-enqueue-asset-and-result-cleanup.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Enqueues an asset cleanup and a result/logs cleanup task for the openQA.
-After=postgresql.service openqa-setup-db.service
-Wants=openqa-setup-db.service
-
-[Service]
-Type=oneshot
-User=geekotest
-ExecStart=/usr/share/openqa/script/openqa eval -m production -V '[app->gru->enqueue_limit_assets(), app->gru->enqueue(limit_results_and_logs => [], {priority => 5, ttl => 172800, limit => 1})]'

--- a/systemd/openqa-enqueue-asset-and-result-cleanup.timer
+++ b/systemd/openqa-enqueue-asset-and-result-cleanup.timer
@@ -1,9 +1,0 @@
-[Unit]
-Description=Enqueues an asset cleanup and a result/logs cleanup task for the openQA every hour.
-
-[Timer]
-OnCalendar=hourly
-Persistent=true
-
-[Install]
-WantedBy=timers.target

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -3,7 +3,7 @@ Description=The openQA web UI
 Wants=apache2.service openqa-setup-db.service
 Before=apache2.service
 After=postgresql.service openqa-setup-db.service openqa-scheduler.service
-Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-and-result-cleanup.timer
+Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service
 
 [Service]
 # TODO: define whether we want to run the web ui with the same user


### PR DESCRIPTION
Reverts os-autoinst/openQA#2491 as there were problems reported.
It seems that the cleanup blocked the /admin/assets view for way longer
than usual, the cleanup job was triggered but never finished traversing
directories.

See https://progress.opensuse.org/issues/55241#note-11 for details.