### PR TITLE
Share Cache Service logs between multiple concurrent downloads

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -21,59 +21,42 @@ use File::Basename;
 use Fcntl ':flock';
 use Mojo::UserAgent;
 use OpenQA::Utils qw(base_host human_readable_size);
-use OpenQA::Worker::Settings;
-use Mojo::SQLite;
 use Mojo::File 'path';
-use Mojo::Log;
 use POSIX;
 
-has [qw(cache location dsn)];
+has [qw(location log sqlite)];
 has limit      => 50 * (1024**3);
-has log        => sub { Mojo::Log->new };
 has sleep_time => 5;
-has sqlite     => sub { Mojo::SQLite->new };
 has ua         => sub { Mojo::UserAgent->new(max_redirects => 2, max_response_size => 0) };
-
-sub from_worker {
-    my $class = shift;
-
-    my $global_settings = OpenQA::Worker::Settings->new->global_settings;
-    return $class->new(
-        host     => 'localhost',
-        location => ($ENV{OPENQA_CACHE_DIR} || $global_settings->{CACHEDIRECTORY}),
-        exists $global_settings->{CACHELIMIT} ? (limit => int($global_settings->{CACHELIMIT}) * (1024**3)) : (), @_
-    );
-}
-
-sub _deploy_cache {
-    my $self = shift;
-
-    my $location = $self->location;
-    $self->log->info(qq{Creating cache directory tree for "$location"});
-    path($location)->remove_tree({keep_root => 1});
-    path($location, 'tmp')->make_path;
-}
 
 sub init {
     my $self = shift;
 
     my $location = $self->location;
-    my $log      = $self->log;
-
-    my $db_file = path($location, 'cache.sqlite');
-    $self->sqlite->from_string("sqlite:$db_file");
-    $self->_deploy_cache unless -e $db_file;
+    my $db_file  = path($location, 'cache.sqlite');
+    unless (-e $db_file) {
+        $self->log->info(qq{Creating cache directory tree for "$location"});
+        path($location)->remove_tree({keep_root => 1});
+        path($location, 'tmp')->make_path;
+    }
     eval { $self->sqlite->migrations->migrate };
     if (my $err = $@) {
         croak qq{Deploying cache database to "$db_file" failed}
           . qq{ (Maybe the file is corrupted and needs to be deleted?): $err};
     }
 
+    return $self->refresh;
+}
+
+sub refresh {
+    my $self = shift;
+
     $self->cache_sync;
     $self->_check_limits(0);
     my $cache_size = human_readable_size($self->{cache_real_size});
     my $limit_size = human_readable_size($self->limit);
-    $log->info(qq{Cache size of "$location" is $cache_size, with limit $limit_size});
+    my $location   = $self->location;
+    $self->log->info(qq{Cache size of "$location" is $cache_size, with limit $limit_size});
 
     return $self;
 }

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -63,7 +63,7 @@ sub init {
     my $db_file = path($location, 'cache.sqlite');
     $self->sqlite->from_string("sqlite:$db_file");
     $self->_deploy_cache unless -e $db_file;
-    eval { $self->sqlite->migrations->name('cache_service')->from_data->migrate };
+    eval { $self->sqlite->migrations->migrate };
     if (my $err = $@) {
         croak qq{Deploying cache database to "$db_file" failed}
           . qq{ (Maybe the file is corrupted and needs to be deleted?): $err};
@@ -319,17 +319,3 @@ sub _check_limits {
 }
 
 1;
-
-__DATA__
-@@ cache_service
--- 1 up
-CREATE TABLE IF NOT EXISTS assets (
-    `etag` TEXT,
-    `size` INTEGER,
-    `last_use` DATETIME NOT NULL,
-    `filename` TEXT NOT NULL UNIQUE,
-    PRIMARY KEY(`filename`)
-);
-
--- 1 down
-DROP TABLE assets;

--- a/lib/OpenQA/CacheService/Model/Downloads.pm
+++ b/lib/OpenQA/CacheService/Model/Downloads.pm
@@ -1,0 +1,41 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::CacheService::Model::Downloads;
+use Mojo::Base -base;
+
+# Two days
+use constant CLEANUP_AFTER => 172800;
+
+has 'sqlite';
+
+sub add {
+    my ($self, $lock, $job_id) = @_;
+    my $db = $self->sqlite->db;
+
+    # Clean up entries that are older than 2 days
+    $db->query(q{delete from downloads where created < datetime('now', '-' || ? || ' seconds')}, CLEANUP_AFTER);
+
+    $db->insert('downloads', {lock => $lock, job_id => $job_id});
+}
+
+sub find {
+    my ($self, $lock) = @_;
+    return undef
+      unless my $hash = $self->sqlite->db->select('downloads', ['job_id'], {lock => $lock}, {-desc => 'id'})->hash;
+    return $hash->{job_id};
+}
+
+1;

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -25,19 +25,22 @@ sub register {
 sub _cache_asset {
     my ($job, $id, $type, $asset_name, $host) = @_;
 
-    my $app = $job->app;
+    my $app    = $job->app;
+    my $job_id = $job->id;
 
     my $lock = $job->info->{notes}{lock};
     return $job->finish unless defined $asset_name && defined $type && defined $host && defined $lock;
-    my $guard = $app->progress->guard($lock);
+    my $guard = $app->progress->guard($lock, $job_id);
     unless ($guard) {
-        $job->note(
-            output => qq{Asset "$asset_name" was downloaded by another job, details are therefore unavailable here});
+        my $id = $app->progress->downloading_job($lock);
+        $job->note(downloading_job => $id);
+        $id ||= 'unknown';
+        $job->note(output => qq{Asset "$asset_name" was downloaded by #$id, details are therefore unavailable here});
         return $job->finish;
     }
 
     my $log = $app->log;
-    my $ctx = $log->context('[#' . $job->id . ']');
+    my $ctx = $log->context("[#$job_id]");
     $ctx->info(qq{Downloading: "$asset_name"});
 
     # Log messages need to be logged by this service as well as captured and

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -52,7 +52,7 @@ sub _cache_asset {
             $output .= "[$level] " . join "\n", @lines, '';
         });
 
-    my $cache = $app->cache->log($ctx)->init;
+    my $cache = $app->cache->log($ctx)->refresh;
     $cache->get_asset($host, {id => $id}, $type, $asset_name);
     $job->note(output => $output);
     $ctx->info('Finished download');

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -27,9 +27,10 @@ sub _cache_asset {
 
     my $app    = $job->app;
     my $job_id = $job->id;
-
-    my $lock = $job->info->{notes}{lock};
+    my $lock   = $job->info->{notes}{lock};
     return $job->finish unless defined $asset_name && defined $type && defined $host && defined $lock;
+
+    # Handle concurrent requests gracefully and try to share logs
     my $guard = $app->progress->guard($lock, $job_id);
     unless ($guard) {
         my $id = $app->progress->downloading_job($lock);

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -80,7 +80,7 @@ sub start_server {
     $server_instance->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0)->restart;
     $cache_service->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0)->restart->restart;
     $worker_cache_service->restart;
-    sleep 2 and note 'Wait server to be reachable.' until $cache_client->info->available;
+    sleep 2 and note 'Wait for server to be reachable' until $cache_client->info->available;
     return;
 }
 

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -115,7 +115,7 @@ like $cache_log,   qr/Purging ".*2.qcow2" because the asset is not registered/, 
 $cache_log = '';
 
 $cache->limit(100);
-$cache->init;
+$cache->refresh;
 like $cache_log, qr/Cache size of "$cachedir" is 84 Byte, with limit 100 Byte/,
   'Cache limit/size match the expected 100/84)';
 like $cache_log, qr/Cache size 168 Byte \+ needed 0 Byte exceeds limit of 100 Byte, purging least used assets/,
@@ -136,7 +136,7 @@ $host = "http://127.0.0.1:$port";
 start_server;
 
 $cache->limit(1024);
-$cache->init;
+$cache->refresh;
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-404@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-404\@64bit.qcow2" from/, 'Asset download attempt';

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -58,8 +58,8 @@ sub la {
     return unless $ENV{HARNESS_IS_VERBOSE};
     $t->get_ok('/api/v1/assets')->status_is(200);
     my @assets = @{$t->tx->res->json->{assets}};
-    for my $a (@assets) {
-        printf "%d %-5s %s\n", $a->{id}, $a->{type}, $a->{name};
+    for my $asset (@assets) {
+        printf "%d %-5s %s\n", $asset->{id}, $asset->{type}, $asset->{name};
     }
 }
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -44,8 +44,8 @@ sub test_auth_method_startup {
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
-for my $a (qw(Fake OpenID iChain)) {
-    test_auth_method_startup($a);
+for my $auth (qw(Fake OpenID iChain)) {
+    test_auth_method_startup($auth);
 }
 
 eval { test_auth_method_startup('nonexistant') };

--- a/templates/test/downloads.html.ep
+++ b/templates/test/downloads.html.ep
@@ -35,13 +35,13 @@
 % }
 
 % my $assets = $job->jobs_assets;
-% while (my $a = $assets->next) {
-    % $a = $a->asset;
-    % unless ($a->hidden) {
+% while (my $asset = $assets->next) {
+    % $asset = $asset->asset;
+    % unless ($asset->hidden) {
         % content_for 'asset_box' => begin
             <li>
-                %= link_to url_for('test_asset_name', testid => $testid, assettype => $a->type, assetname => $a->name) => (id => "asset_".$a->id) => begin
-                    <%= $a->name %>
+                %= link_to url_for('test_asset_name', testid => $testid, assettype => $asset->type, assetname => $asset->name) => (id => "asset_".$asset->id) => begin
+                    <%= $asset->name %>
                 % end
             </li>
         % end


### PR DESCRIPTION
This fixes the problem where only the first job requesting an asset from the Cache Service gets the logs. Every other job requesting the same asset would have gotten `Asset "..." was downloaded by another job, details are therefore unavailable here` previously. Making it non-trivial for test developers to find the cause for many cache service problems.

There was also a race condition in `25-cache-service.t`, so that test should be much more stable now.