### PR TITLE
Remove registered assets regardless of the type

### DIFF
--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -111,7 +111,7 @@ sub _limit {
             else {
                 my $limit          = $age->add(days => $limit_in_days);
                 my $remaining_days = $now->delta_days($limit)->in_units('days');
-                OpenQA::Utils::log_warning(
+                OpenQA::Utils::log_info(
                     "Asset $asset_name is not in any job group and will be deleted in $remaining_days days");
             }
         }

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -25,7 +25,7 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::MockModule;
-use Test::Output qw(stdout_like stdout_from combined_like);
+use Test::Output qw(stdout_like stdout_from);
 use OpenQA::Test::Case;
 use OpenQA::Task::Asset::Limit;
 use OpenQA::Utils;


### PR DESCRIPTION
* Log exactly one message per removal attempts (either asset does
  not exist, can not be removed or the removal failed)
* Don't distinguish assets by their type; just remove files
  via unlink() and try remove_tree() otherwise
* Add tests