### PR TITLE
Have openqa-clone-custom-git-refspec parse PR for test URLs

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -27,11 +27,19 @@ fi
 
 curl_github="${curl_github:-"curl${AUTHENTICATED_REQUEST}"}"
 curl_openqa="${curl_openqa:-"curl"}"
+job_list="${job:-"$2"}"
 
 throw_json_error() {
     echo "in contents queried from $1:"
     echo "$2"
     exit 2
+}
+
+extract_urls_from_pr() {
+    urls=$(echo "$1" | jq -r '.body | sub("^(?<marker>@openqa: Clone )(?<url>http.*[0-9]*)"; "\(.url)")')
+    if [[ $urls == *"http"* ]]; then
+      echo "$urls"
+    fi
 }
 
 opts=$(getopt -o vhn --long verbose,dry-run,help -n 'parse-options' -- "$@") || usage
@@ -62,7 +70,6 @@ if [[ -z "$repo_name" ]] || [[ -z "$pr" ]]; then
         casedir="${casedir:-"${forked_repo_part}.git#${branch}"}"
         build="${build:-"$repo_name#$branch"}"
     fi
-
 fi
 if [[ -z "$branch" ]] || [[ -z "$repo_name" ]]; then
     pr_url=${target_repo_part/github.com/api.github.com/repos}/pulls/$pr
@@ -78,14 +85,17 @@ if [[ -z "$branch" ]] || [[ -z "$repo_name" ]]; then
     repo_name="${repo_name:-"${label%:*}/${target_repo_part##*/}"}"
     branch="${branch:-"${label##*:}"}"
     repo="${repo:-"https://github.com/${repo_name}.git"}"
+    pr_urls=$(extract_urls_from_pr "$pr_content")
+    job_list=${pr_urls:-"$job_list"}
 fi
 
 clone_job() {
     if [[ -z "$host" ]] || [[ -z "$job" ]]; then
-        local job_url="${1:?"Need 'job_url' parameter"}"
+        local job_url="${1:?"Need 'job_url' parameter (\$1)"}"
         local host=${job_url%%/t*}
         local job=${job_url##*/}
     fi
+
     if [[ -z "$testsuite" ]] || [[ -z "$needles_dir" ]] || [[ -z "$productdir" ]]; then
         local json_url=${host}/tests/${job}/file/vars.json
         local json_data
@@ -115,10 +125,11 @@ clone_job() {
     fi
 }
 
-if [[ -z "$host" ]] || [[ -z "$job" ]]; then
-    job_list="${2:?"Need 'job_url' as parameter pointing to the openQA job to clone or 'host' and 'job' variables, e.g. either 'https://openqa.opensuse.org/tests/123456' or 'https://openqa.opensuse.org' and '123456'. Argument can also be a comma-separated list of job URLs or a single host and multiple ids."}"
+if [[ -z "$host" ]] && [[ -z "$job_list" ]]; then
+    echo "Need 'job_url' as parameter pointing to the openQA job to clone or 'host' and 'job' variables, e.g. either 'https://openqa.opensuse.org/tests/123456' or 'https://openqa.opensuse.org' and '123456'. Argument can also be a comma-separated list of job URLs or a single host and multiple ids."
+    exit 1
 fi
 args=${*:3}
-IFS=',' ; for i in $job $job_list; do
+IFS=',' ; for i in $job_list; do
     clone_job "$i"
 done

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -57,7 +57,7 @@ test_once '--invalid-arg', qr/Usage:/, 'invalid args also yield help', 0, 'help 
 my $args = 'https://github.com/user/repo/pull/9128 https://openqa.opensuse.org/tests/1234';
 isnt run_once($args), 0, 'without network we fail (without error)';
 # mock any external access with all arguments
-$ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my_branch"}}'; true};
+$ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my_branch"}, "body": "Lorem ipsum"}'; true};
 $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/my/case/dir", "PRODUCTDIR": "/my/case/dir/product", "NEEDLES_DIR": "/my/case/dir/product/needles"}'; true};
 my $clone_job = 'openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org ';
@@ -94,5 +94,12 @@ TODO: {
     $args .= ',https://openqa.suse.de/t1234';
     test_once $args, qr/${expected}.* 1234/s, 'multiple short URLs from different hosts point to individual hosts';
 }
+
+my $test_url = 'https://openqa.opensuse.org/tests/1107158';
+$ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my_branch"}, "body": "\@openqa: Clone ${test_url}"}'; true};
+$args             = 'https://github.com/user/repo/pull/9128';
+$expected         = $clone_job . '1107158 _GROUP=0 TEST=my_test@user/repo#my_branch BUILD=user/repo#9128 ';
+$expected_re      = qr/${expected}/s;
+test_once $args, $expected_re, 'clone-job command with test from PR description';
 
 done_testing;


### PR DESCRIPTION
Given a PR on GitHub, having one or more tests in the description should be sufficient to run them without having to specify them on the command line.

This is a prerequisite to automated test runs for PRs in CI.