### PR TITLE
Increase the inactivity timeout of the cache service client

### DIFF
--- a/lib/OpenQA/CacheService/Client.pm
+++ b/lib/OpenQA/CacheService/Client.pm
@@ -27,7 +27,7 @@ use Mojo::File 'path';
 
 has host      => 'http://127.0.0.1:' . service_port('cache_service');
 has cache_dir => sub { $ENV{OPENQA_CACHE_DIR} || OpenQA::Worker::Settings->new->global_settings->{CACHEDIRECTORY} };
-has ua        => sub { Mojo::UserAgent->new };
+has ua        => sub { Mojo::UserAgent->new(inactivity_timeout => 300) };
 
 sub info {
     my $self = shift;


### PR DESCRIPTION
Small change that should help with some cache service issues. The default inactivity timeout of `Mojo::UserAgent` is only 20 seconds. That can be a bit low in cases where the SQLite database is locked by a bigger query. We set 5 minutes for the SQLite busy timeout in the cache service, so using the same value for the client would seem reasonable.

Progress: https://progress.opensuse.org/issues/60866