### PR TITLE
job investigation: test+needle git log+stats, skip merge commits in git log

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -29,7 +29,7 @@ use OpenQA::Utils (
     qw(log_debug log_info log_warning log_error),
     qw(parse_assets_from_settings locate_asset),
     qw(read_test_modules find_bugref random_string),
-    qw(run_cmd_with_log_return_error testcasedir)
+    qw(run_cmd_with_log_return_error needledir testcasedir)
 );
 use OpenQA::Jobs::Constants;
 use OpenQA::JobDependencies::Constants;
@@ -1797,15 +1797,17 @@ sub test_resultfile_list {
 }
 
 sub git_log_diff {
-    my ($self, $before, $after) = @_;
+    my ($self, $dir, $refspec_range) = @_;
     my $res = run_cmd_with_log_return_error(
-        [
-            'git', '-C', testcasedir($self->DISTRI, $self->VERSION),
-            'log', '--pretty=oneline', '--abbrev-commit', '--no-merges',
-            "$before->{TEST_GIT_HASH}..$after->{TEST_GIT_HASH}"
-        ]);
+        ['git', '-C', $dir, 'log', '--pretty=oneline', '--abbrev-commit', '--no-merges', $refspec_range]);
     # regardless of success or not the output contains the information we need
-    return $res->{stderr};
+    return "\n" . $res->{stderr} if $res->{stderr};
+}
+
+sub git_diff {
+    my ($self, $dir, $refspec_range) = @_;
+    my $res = run_cmd_with_log_return_error(['git', '-C', $dir, 'diff', '--stat', $refspec_range]);
+    return "\n" . $res->{stderr} if $res->{stderr};
 }
 
 =head2 investigate
@@ -1818,25 +1820,37 @@ sub investigate {
     my ($self, %args) = @_;
     my @previous = $self->_previous_scenario_jobs;
     return {error => 'No previous job in this scenario, cannot provide hints'} unless @previous;
-    my %investigation;
+    my %inv;
     return {error => 'No result directory available for current job'} unless $self->result_dir();
     my $ignore = $OpenQA::Utils::app->config->{global}->{job_investigate_ignore};
     for my $prev (@previous) {
         next unless $prev->result =~ /(?:passed|softfailed)/;
-        $investigation{last_good} = $prev->id;
+        $inv{last_good} = $prev->id;
         last unless $prev->result_dir;
         # just ignore any problems on generating the diff with eval, e.g.
         # files missing. This is a best-effort approach.
         my @files = map { Mojo::File->new($_->result_dir(), 'vars.json')->slurp } ($prev, $self);
-        my $diff  = eval { diff(\$files[0], \$files[1]) };
-        $investigation{diff_to_last_good} = join("\n", grep { !/$ignore/ } split(/\n/, $diff));
+        my $diff  = eval { diff(\$files[0], \$files[1], {CONTEXT => 0}) };
+        $inv{diff_to_last_good} = join("\n", grep { !/(^@@|$ignore)/ } split(/\n/, $diff));
         my ($before, $after) = map { decode_json($_) } @files;
-        $investigation{git_log} = $self->git_log_diff($before, $after);
-        $investigation{git_log} ||= 'No test changes recorded, test regression unlikely';
+        my $dir           = testcasedir($self->DISTRI, $self->VERSION);
+        my $refspec_range = "$before->{TEST_GIT_HASH}..$after->{TEST_GIT_HASH}";
+        $inv{test_log} = $self->git_log_diff($dir, $refspec_range);
+        $inv{test_log} ||= 'No test changes recorded, test regression unlikely';
+        $inv{test_diff_stat} = $self->git_diff($dir, $refspec_range) if $inv{test_log};
+        # no need for duplicating needles git log if the git repo is the same
+        # as for tests
+        if ($after->{TEST_GIT_HASH} ne $after->{NEEDLES_GIT_HASH}) {
+            $dir = needledir($self->DISTRI, $self->VERSION);
+            my $refspec_needles_range = "$before->{NEEDLES_GIT_HASH}..$after->{NEEDLES_GIT_HASH}";
+            $inv{needles_log} = $self->git_log_diff($dir, $refspec_needles_range);
+            $inv{needles_log} ||= 'No needle changes recorded, test regression due to needles unlikely';
+            $inv{needles_diff_stat} = $self->git_diff($dir, $refspec_needles_range) if $inv{needles_log};
+        }
         last;
     }
-    $investigation{last_good} //= 'not found';
-    return \%investigation;
+    $inv{last_good} //= 'not found';
+    return \%inv;
 }
 
 =head2 done

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1801,7 +1801,8 @@ sub git_log_diff {
     my $res = run_cmd_with_log_return_error(
         [
             'git', '-C', testcasedir($self->DISTRI, $self->VERSION),
-            'log', '--pretty=oneline', '--abbrev-commit', "$before->{TEST_GIT_HASH}..$after->{TEST_GIT_HASH}"
+            'log', '--pretty=oneline', '--abbrev-commit', '--no-merges',
+            "$before->{TEST_GIT_HASH}..$after->{TEST_GIT_HASH}"
         ]);
     # regardless of success or not the output contains the information we need
     return $res->{stderr};

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -824,7 +824,7 @@ sub investigate {
     my $investigation = $job->investigate;
     $self->respond_to(
         json => {json => $investigation},
-        html => {text => join("\n", map { "$_: $investigation->{$_}" } keys %$investigation)});
+        html => {text => join("\n", map { "$_: $investigation->{$_}" } sort keys %$investigation)});
 }
 
 1;

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -415,10 +415,11 @@ subtest 'carry over, including soft-fails' => sub {
         is($inv->{last_good}, 99997, 'previous job identified as last good');
         like($inv->{diff_to_last_good}, qr/^\+.*BUILD.*668/m, 'diff for job settings is shown');
         unlike($inv->{diff_to_last_good}, qr/JOBTOKEN/, 'special variables are not included');
-        is($inv->{git_log}, $fake_git_log, 'git log is evaluated');
+        is($inv->{test_log},    $fake_git_log, 'test git log is evaluated');
+        is($inv->{needles_log}, $fake_git_log, 'needles git log is evaluated');
         $fake_git_log = '';
         ok($inv = $job->investigate, 'job investigation ok for no test changes');
-        is($inv->{git_log}, 'No test changes recorded, test regression unlikely', 'git log with no test changes');
+        is($inv->{test_log}, 'No test changes recorded, test regression unlikely', 'git log with no test changes');
     };
 
 };


### PR DESCRIPTION
A simpler variant of https://github.com/os-autoinst/openQA/pull/2623 without the HTML table changes for now

* job investigation: Ensure consistent output with sorted hash keys
* job investigation: Provide test+needles git log diff and files stat diff
* job investigation: Skip "merge" commits with no helpful information in git log diff