### PR TITLE
Minor cleanups for job settings

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/JobTemplates.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobTemplates.pm
@@ -65,8 +65,10 @@ sub create_or_update_job_template {
       . $job_template->group->name . "'\n"
       if $job_template->group_id != $group_id;
     my $job_template_id = $job_template->id;
-    $job_template->update({prio        => $args->{prio}}) if defined $args->{prio};
-    $job_template->update({description => $args->{description} // ''});
+    $job_template->update(
+        {
+            (defined $args->{prio}) ? (prio => $args->{prio}) : (), description => $args->{description} // '',
+        });
 
     # Add/update/remove parameter
     my @setting_ids;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -483,11 +483,10 @@ sub prepare_job_results {
       ->search({job_id => [map { $_->id } @$jobs], key => [qw(TEST_SUITE_DESCRIPTION TEST_SUITE_NAME)]});
     my %settings_by_job_id;
     for my $js ($job_settings->all) {
-        $settings_by_job_id{$js->key}->{$js->job_id} = $js->value;
+        $settings_by_job_id{$js->job_id}->{$js->key} = $js->value;
     }
-    my $test_suite_descr_by_job_id = $settings_by_job_id{TEST_SUITE_DESCRIPTION};
 
-    my %test_suite_names = map { $_->id => ($settings_by_job_id{TEST_SUITE_NAME}->{$_->id} // $_->TEST) } @$jobs;
+    my %test_suite_names = map { $_->id => ($settings_by_job_id{$_->id}->{TEST_SUITE_NAME} // $_->TEST) } @$jobs;
 
     # prefetch descriptions from test suites
     my %desc_args = (in => [values %test_suite_names]);
@@ -536,7 +535,7 @@ sub prepare_job_results {
 
         # add description
         my $id          = $job->id;
-        my $description = $settings_by_job_id{TEST_SUITE_DESCRIPTION}->{$id} // $descriptions{$test_suite_names{$id}};
+        my $description = $settings_by_job_id{$id}->{TEST_SUITE_DESCRIPTION} // $descriptions{$test_suite_names{$id}};
         $results{$distri}{$version}{$flavor}{$test}{description} //= $description;
     }
     return (\%archs, \%results, $aggregated);


### PR DESCRIPTION
- Do only one `update` call
- Restructure `%settings_by_job_id`

Followup-To: https://github.com/os-autoinst/openQA/pull/2602

Issue: https://progress.opensuse.org/issues/60782