### PR TITLE
Asset download: fix return statement broken in f0d70f1

### DIFF
--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -34,7 +34,7 @@ sub _download {
 
     # prevent multiple asset download tasks for the same asset to run
     # in parallel
-    return undef $job->retry({delay => 30})
+    return $job->retry({delay => 30})
       unless my $guard = $app->minion->guard("limit_asset_download_${assetpath}_task", 7200);
 
     # bail if the dest file exists (in case multiple downloads of same ISO are scheduled)


### PR DESCRIPTION
It looks like @Martchus just did a search-and-replace on all
occurrences of `return`, changing them to `return undef`, but
that broke this line which actually returns something. It causes
test failures with this error:

Gru job failed
Reason: Can't modify non-lvalue subroutine call of &Minion::Job::retry at /usr/share/openqa/script/../lib/OpenQA/Task/Asset/Download.pm line 37.

Signed-off-by: Adam Williamson <awilliam@redhat.com>