### PR TITLE
openqa-clone-custom-git-refspec: fix curl_github

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -11,7 +11,7 @@
 set -o pipefail
 
 if [[ -n "$GITHUB_TOKEN" ]]; then
-    AUTHENTICATED_REQUEST="-u $GITHUB_TOKEN:x-oauth-basic"
+    AUTHENTICATED_REQUEST=" -u $GITHUB_TOKEN:x-oauth-basic"
     echo "Github oauth token provided, peforming authenticated requests"
 fi
 


### PR DESCRIPTION
Add a space between `curl` and options. This fixes usage of requests with a github token.