### PR TITLE
Fix webui host handling in the cache service

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -68,7 +68,7 @@ sub _download_asset {
 
     my $ua   = $self->ua;
     my $file = path($asset)->basename;
-    my $url  = Mojo::URL->new($host)->path("/tests/$id/asset/$type/$file");
+    my $url  = Mojo::URL->new("http://$host")->path("/tests/$id/asset/$type/$file");
     $log->info(qq{Downloading "$file" from "$url"});
 
     # Keep temporary files on the same partition as the cache

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -68,7 +68,7 @@ sub _download_asset {
 
     my $ua   = $self->ua;
     my $file = path($asset)->basename;
-    my $url  = Mojo::URL->new("http://$host")->path("/tests/$id/asset/$type/$file");
+    my $url  = Mojo::URL->new($host =~ m!^/|://! ? $host : "http://$host")->path("/tests/$id/asset/$type/$file");
     $log->info(qq{Downloading "$file" from "$url"});
 
     # Keep temporary files on the same partition as the cache

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -54,7 +54,7 @@ use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server);
 
 my $port = Mojo::IOLoop::Server->generate_port;
-my $host = "http://localhost:$port";
+my $host = "localhost:$port";
 
 # Capture logs
 my $log = Mojo::Log->new;
@@ -71,7 +71,7 @@ $SIG{INT} = sub { session->clean };
 END { session->clean }
 
 my $server_instance = process sub {
-    Mojo::Server::Daemon->new(app => fake_asset_server, listen => [$host], silent => 1)->run;
+    Mojo::Server::Daemon->new(app => fake_asset_server, listen => ["http://$host"], silent => 1)->run;
     _exit(0);
 };
 
@@ -126,13 +126,13 @@ ok(!-e '1.qcow2', 'Oldest asset (1.qcow2) was sucessfully removed');
 $cache_log = '';
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-textmode@64bit.qcow2');
-my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
+my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2" from "$from"/, 'Asset download attempt';
 like $cache_log, qr/failed: 521/, 'Asset download fails with: 521 - Connection refused';
 $cache_log = '';
 
 $port = Mojo::IOLoop::Server->generate_port;
-$host = "http://127.0.0.1:$port";
+$host = "127.0.0.1:$port";
 start_server;
 
 $cache->limit(1024);

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -205,6 +205,18 @@ like $cache_log, qr/Download of ".*sle-12-SP3-x86_64-0368-200_#:.*" successful/,
 like $cache_log, qr/Size of .* is 20 Byte, with ETag "123456789"/, 'Etag and size are logged';
 $cache_log = '';
 
+$cache->get_asset("http://$host", {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200\@64bit.qcow2" from/, 'Asset download attempt';
+like $cache_log, qr/Download of ".*sle-12-SP3-x86_64-0368-200.*" successful, new cache size is 1024/,
+  'Full download logged';
+like $cache_log, qr/Size of .* is 1024 Byte, with ETag "andi \$a3, \$t1, 41399"/, 'Etag and size are logged';
+$cache_log = '';
+
+$cache->get_asset("http://$host", {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200\@64bit.qcow2" from/,             'Asset download attempt';
+like $cache_log, qr/Content of ".*0368-200@64bit.qcow2" has not changed, updating last use/, 'Content has not changed';
+$cache_log = '';
+
 $cache->track_asset('Foobar', 0);
 $cache->sqlite->db->query('delete from assets');
 


### PR DESCRIPTION
This fixes the problem we noticed earlier during the OSD deployment. Unfortunately we allow the webui host to be configured with and without scheme and port. The tests only ever covered one case, so everything seemed fine when we merged #2639.