### PR TITLE
Create hardlinks instead of symlinks for cached assets when possible

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -354,10 +354,11 @@ subtest 'Cache tests' => sub {
     ok(!-d path($cache_location, "test_directory"), "Directory within cache, not present after deploy");
     ok(!-e $cache_location->child("test.file"),     "File within cache, not present after deploy");
 
-    my $link = path($ENV{OPENQA_BASEDIR}, 'openqa', 'pool', '1')->child("Core-7.2.iso");
+    my $link = path($ENV{OPENQA_BASEDIR}, 'openqa', 'pool', '1')->child('Core-7.2.iso');
     sleep 5 and note "Waiting for cache service to finish the download" until -e $link;
 
-    like(readlink($link), qr($cache_location/localhost/Core-7.2.iso), "iso is symlinked to cache");
+    my $cached = $cache_location->child('localhost', 'Core-7.2.iso');
+    is $cached->stat->ino, $link->stat->ino, 'iso is hardlinked to cache';
 
     OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/, 'test 5 is passed');
     kill_worker;


### PR DESCRIPTION
Currently it is possible that on a busy worker assets get deleted from the cache before the job that requested them last is finished. By using hardlinks instead of symlinks we can keep using the same cleanup logic we have in the past, but all assets will also be referenced from the pool directory of the job. So from now on assets can only ever vanish from the worker once all references have been purged from `/var/lib/openqa/cache` and `/var/lib/openqa/pool`.

There are two possible solutions, one is to first check if both locations are on the same device and only then create the hardlink, the other is to always try to create a hardlink first and to fall back to symlinks. We've talked about this on Rocket Chat and the former got more votes.

Progress: https://progress.opensuse.org/issues/46742