### PR TITLE
Prevent old but newly cloned assets from being cleaned up immediately

### DIFF
--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -127,6 +127,7 @@ use Data::Dump 'pp';
 use Getopt::Long;
 use LWP::UserAgent;
 Getopt::Long::Configure("no_ignore_case");
+use Mojo::File 'path';
 use Mojo::URL;
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS;
@@ -279,6 +280,10 @@ sub download_assets {
             unless ($r->is_success || $r->code == 304) {
                 die "$jobid failed: ", $r->status_line, "\n";
             }
+
+            # ensure the asset cleanup preserves the asset the configured amount of days starting from the time
+            # it has been cloned (otherwise old assets might be cleaned up directly again after cloning)
+            path($dst)->touch;
         }
     }
 }


### PR DESCRIPTION
The problem has been introducted by https://github.com/os-autoinst/openQA/commit/aab8829739e26b18b52d2691f307cc16c6164f50. This fix simply touches assets after the download so they appear new.