### PR TITLE
Don't have a default size limit on parent group level

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -996,8 +996,8 @@ in the operators menu and select a group. The size limit for assets can be
 configured under 'Edit job group properties'. It also shows the size of
 assets which belong to that group and not to any other group.
 
-The default size limit for job groups and parent job groups can be adjusted
-in the +default_group_limits+ section of the openQA config file.
+The default size limit for job groups can be adjusted in the
++default_group_limits+ section of the openQA config file.
 
 === Configure limit for groupless assets ===
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -120,7 +120,7 @@ blacklist = job_grab job_done
 
 # Default limits for cleanup (sizes are in GiB, durations in days, zero denotes infinity)
 [default_group_limits]
-#asset_size_limit = 100 # enforced on job group level for job groups without parent and on job group parent level
+#asset_size_limit = 100 # only used on job group level (parent groups have no default)
 #log_storage_duration = 30
 #important_log_storage_duration = 120
 #result_storage_duration = 365

--- a/lib/OpenQA/Schema/Result/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/Result/JobGroupParents.pm
@@ -102,11 +102,6 @@ sub _get_column_or_default {
     return $OpenQA::Utils::app->config->{default_group_limits}->{$setting};
 }
 
-around 'size_limit_gb' => sub {
-    my ($orig, $self) = @_;
-    return $self->_get_column_or_default('size_limit_gb', 'asset_size_limit');
-};
-
 around 'default_keep_logs_in_days' => sub {
     my ($orig, $self) = @_;
     return $self->_get_column_or_default('default_keep_logs_in_days', 'log_storage_duration');

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -250,11 +250,13 @@ END_SQL
                 my $parent_id;
                 if (defined $parent) {
                     my $parent_size_limit_gb = $parent->size_limit_gb;
+                    my $parent_size
+                      = (defined $parent_size_limit_gb ? $parent_size_limit_gb * 1024 * 1024 * 1024 : undef);
                     $parent_id = $parent->id;
                     $parent_group_info{$parent_id} = {
                         id            => $parent_id,
                         size_limit_gb => $parent_size_limit_gb,
-                        size          => $parent_size_limit_gb * 1024 * 1024 * 1024,
+                        size          => $parent_size,
                         picked        => 0,
                         group         => $parent->name,
                     };

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -83,7 +83,7 @@ my $assets        = $schema->resultset('Assets');
 # move group 1002 into a parent group
 # note: This shouldn't change much because 1002 will be the only child and the same limit applies.
 #       However, the size of exclusively kept assets is moved to the parent-level.
-$parent_groups->create({id => 1, name => 'parent of "opensuse test"'});
+$parent_groups->create({id => 1, name => 'parent of "opensuse test"', size_limit_gb => 100});
 $job_groups->search({id => 1002})->update({parent_id => 1});
 
 # refresh assets only once and prevent adding untracked assets

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -47,7 +47,7 @@ my $new_job_group    = $job_groups->find($new_job_group_id);
 ok($new_job_group, 'create new job group');
 
 subtest 'defaults of parent group' => sub {
-    is($new_parent_group->size_limit_gb,             OpenQA::Schema::JobGroupDefaults::SIZE_LIMIT_GB);
+    is($new_parent_group->size_limit_gb,             undef);
     is($new_parent_group->default_keep_logs_in_days, OpenQA::Schema::JobGroupDefaults::KEEP_LOGS_IN_DAYS);
     is(
         $new_parent_group->default_keep_important_logs_in_days,
@@ -78,7 +78,7 @@ subtest 'overrideing defaults in settings affects groups' => sub {
     $config->{$_} += 1000 for (@fields);
 
     subtest 'defaults for parent group overridden' => sub {
-        is($new_parent_group->size_limit_gb,             OpenQA::Schema::JobGroupDefaults::SIZE_LIMIT_GB + 1000);
+        is($new_parent_group->size_limit_gb,             undef);
         is($new_parent_group->default_keep_logs_in_days, OpenQA::Schema::JobGroupDefaults::KEEP_LOGS_IN_DAYS + 1000);
         is(
             $new_parent_group->default_keep_important_logs_in_days,
@@ -107,10 +107,10 @@ subtest 'defaults overridden on parent group level' => sub {
     my @columns
       = qw(size_limit_gb default_keep_logs_in_days default_keep_important_logs_in_days default_keep_results_in_days default_keep_important_results_in_days default_priority);
     for my $column (@columns) {
-        $new_parent_group->update({$column => $new_parent_group->$column + 1000});
+        $new_parent_group->update({$column => ($new_parent_group->$column // 0) + 1000});
     }
 
-    is($new_parent_group->size_limit_gb,             OpenQA::Schema::JobGroupDefaults::SIZE_LIMIT_GB + 2000);
+    is($new_parent_group->size_limit_gb,             1000);
     is($new_parent_group->default_keep_logs_in_days, OpenQA::Schema::JobGroupDefaults::KEEP_LOGS_IN_DAYS + 2000);
     is(
         $new_parent_group->default_keep_important_logs_in_days,

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -112,7 +112,7 @@ $mock_limit->mock(_remove_if       => sub { return 0; });
 $t->app->config->{default_group_limits}->{asset_size_limit} = 100;
 
 # move group 1002 into a parent group
-$schema->resultset('JobGroupParents')->create({id => 1, name => 'parent of "opensuse test"'});
+$schema->resultset('JobGroupParents')->create({id => 1, name => 'parent of "opensuse test"', size_limit_gb => 100});
 $schema->resultset('JobGroups')->search({id => 1002})->update({parent_id => 1});
 
 # define helper to prepare the returned asset status for checks


### PR DESCRIPTION
* The default specified in the config file is only used for job groups but not parent groups.
* If no size limit on parent group level is specified the old behavior of only considering limits on job group level is retained.

---

I was convinced that https://github.com/os-autoinst/openQA/pull/2536 already made openQA behave like this. Otherwise the UI commits contained by that PR wouldn't make any sense, too. But I also remember that I implemented this some time ago and quickly reconstructed the changes. Seems like I accidentally dropped the commit when rebasing https://github.com/os-autoinst/openQA/pull/2536.