### PR TITLE
Test asset download of openqa-clone-job script

### DIFF
--- a/lib/OpenQA/Script.pm
+++ b/lib/OpenQA/Script.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,10 +17,14 @@ package OpenQA::Script;
 use strict;
 use warnings;
 
+use Cpanel::JSON::XS;
 use Exporter 'import';
+use Mojo::File 'path';
 
 our @EXPORT = qw(
   clone_job_apply_settings
+  clone_job_get_job
+  clone_job_download_assets
 );
 
 use constant GLOBAL_SETTINGS => ('WORKER_CLASS');
@@ -59,6 +63,72 @@ sub clone_job_apply_settings {
         $settings->{$key} = $value;
         if (my $override = JOB_SETTING_OVERRIDES->{$key}) {
             delete $settings->{$override};
+        }
+    }
+}
+
+sub clone_job_get_job {
+    my ($jobid, $remote, $remote_url, $options) = @_;
+
+    my $job;
+    my $url = $remote_url->clone;
+    $url->path("jobs/$jobid");
+    my $tx = $remote->max_redirects(3)->get($url);
+    if (!$tx->error) {
+        if ($tx->res->code == 200) {
+            $job = $tx->res->json->{job};
+        }
+        else {
+            warn sprintf("unexpected return code: %s %s", $tx->res->code, $tx->res->message);
+            exit 1;
+        }
+    }
+    else {
+        my $err = $tx->error;
+        # there is no code for some error reasons, e.g. 'connection refused'
+        $err->{code} //= '';
+        warn "failed to get job '$jobid': $err->{code} $err->{message}";
+        exit 1;
+    }
+
+    print Cpanel::JSON::XS->new->pretty->encode($job) if $options->{verbose};
+    return $job;
+}
+
+sub clone_job_download_assets {
+    my ($jobid, $job, $remote, $remote_url, $ua, $options) = @_;
+    my @parents = map { clone_job_get_job($_, $remote, $remote_url, $options) } @{$job->{parents}->{Chained}};
+  ASSET:
+    for my $type (keys %{$job->{assets}}) {
+        next if $type eq 'repo';    # we can't download repos
+        for my $file (@{$job->{assets}->{$type}}) {
+            my $dst = $file;
+            # skip downloading published assets assuming we are also cloning
+            # the generation job or if the only cloned job *is* the generation
+            # job.
+            my $nr_parents = @parents;
+            if ((!$options->{'skip-deps'} && !$options->{'skip-chained-deps'}) || ($nr_parents == 0)) {
+                for my $j (@parents, $job) {
+                    next ASSET if $j->{settings}->{PUBLISH_HDD_1} && $file eq $j->{settings}->{PUBLISH_HDD_1};
+                }
+            }
+            $dst =~ s,.*/,,;
+            $dst = join('/', $options->{dir}, $type, $dst);
+            my $from = $remote_url->clone;
+            $from->path(sprintf '/tests/%d/asset/%s/%s', $jobid, $type, $file);
+            $from = $from->to_string;
+
+            die "can't write $options->{dir}/$type\n" unless -w "$options->{dir}/$type";
+
+            print "downloading\n$from\nto\n$dst\n";
+            my $r = $ua->mirror($from, $dst);
+            unless ($r->is_success || $r->code == 304) {
+                die "$jobid failed: ", $r->status_line, "\n";
+            }
+
+            # ensure the asset cleanup preserves the asset the configured amount of days starting from the time
+            # it has been cloned (otherwise old assets might be cleaned up directly again after cloning)
+            path($dst)->touch;
         }
     }
 }

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -222,72 +222,6 @@ else {
 $remote_url->path('/api/v1/jobs');
 $remote = OpenQA::Client->new(api => $remote_url->host);
 
-sub get_job {
-    my ($jobid) = @_;
-
-    my $job;
-    my $url = $remote_url->clone;
-    $url->path("jobs/$jobid");
-    my $tx = $remote->max_redirects(3)->get($url);
-    if (!$tx->error) {
-        if ($tx->res->code == 200) {
-            $job = $tx->res->json->{job};
-        }
-        else {
-            warn sprintf("unexpected return code: %s %s", $tx->res->code, $tx->res->message);
-            exit 1;
-        }
-    }
-    else {
-        my $err = $tx->error;
-        # there is no code for some error reasons, e.g. 'connection refused'
-        $err->{code} //= '';
-        warn "failed to get job '$jobid': $err->{code} $err->{message}";
-        exit 1;
-    }
-
-    print Cpanel::JSON::XS->new->pretty->encode($job) if ($options{verbose});
-    return $job;
-}
-
-sub download_assets {
-    my ($job, $remote_url, $ua, %options) = @_;
-    my @parents = map { get_job($_) } @{$job->{parents}->{Chained}};
-  ASSET:
-    for my $type (keys %{$job->{assets}}) {
-        next if $type eq 'repo';    # we can't download repos
-        for my $file (@{$job->{assets}->{$type}}) {
-            my $dst = $file;
-            # skip downloading published assets assuming we are also cloning
-            # the generation job or if the only cloned job *is* the generation
-            # job.
-            my $nr_parents = @parents;
-            if ((!$options{'skip-deps'} && !$options{'skip-chained-deps'}) || ($nr_parents == 0)) {
-                for my $j (@parents, $job) {
-                    next ASSET if $j->{settings}->{PUBLISH_HDD_1} && $file eq $j->{settings}->{PUBLISH_HDD_1};
-                }
-            }
-            $dst =~ s,.*/,,;
-            $dst = join('/', $options{dir}, $type, $dst);
-            my $from = $remote_url->clone;
-            $from->path(sprintf '/tests/%d/asset/%s/%s', $jobid, $type, $file);
-            $from = $from->to_string;
-
-            die "can't write $options{dir}/$type\n" unless -w "$options{dir}/$type";
-
-            print "downloading\n$from\nto\n$dst\n";
-            my $r = $ua->mirror($from, $dst);
-            unless ($r->is_success || $r->code == 304) {
-                die "$jobid failed: ", $r->status_line, "\n";
-            }
-
-            # ensure the asset cleanup preserves the asset the configured amount of days starting from the time
-            # it has been cloned (otherwise old assets might be cleaned up directly again after cloning)
-            path($dst)->touch;
-        }
-    }
-}
-
 sub openqa_baseurl {
     my ($local_url) = @_;
     my $port = '';
@@ -307,7 +241,7 @@ sub clone_job {
     $depth     //= 0;
     return $clone_map->{$jobid} if defined $clone_map->{$jobid};
 
-    my $job = get_job($jobid);
+    my $job = clone_job_get_job($jobid, $remote, $remote_url, \%options);
     if ($job->{parents}) {
         my ($chained, $directly_chained, $parallel);
         unless ($options{'skip-deps'}) {
@@ -335,7 +269,8 @@ sub clone_job {
         $job->{settings}->{_START_DIRECTLY_AFTER_JOBS} = join(',', @new_chained)  if @new_directly_chained;
     }
 
-    download_assets($job, $remote_url, $ua, %options) unless $options{'skip-download'};
+    clone_job_download_assets($jobid, $job, $remote, $remote_url, $ua, \%options)
+      unless $options{'skip-download'};
 
     my $url      = $local_url->clone;
     my %settings = %{$job->{settings}};

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE Linux GmbH
+# Copyright (C) 2018-2020 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,28 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;
+use Test::Output 'combined_like';
 use OpenQA::Script;
+use Mojo::URL;
+use Mojo::File 'tempdir';
+
+# define fake client
+{
+    package Test::FakeLWPUserAgentMirrorResult;
+    use Mojo::Base -base;
+    has is_success => 1;
+    has code       => 304;
+}
+{
+    package Test::FakeLWPUserAgent;
+    use Mojo::Base -base;
+    has mirrored => sub { [] };
+    sub mirror {
+        my $self = shift;
+        push(@{$self->mirrored}, @_);
+        return Test::FakeLWPUserAgentMirrorResult->new;
+    }
+}
 
 my @argv           = qw(WORKER_CLASS=local HDD_1=new.qcow2 HDDSIZEGB=40);
 my %options        = ('parental-inheritance' => '');
@@ -68,6 +89,41 @@ subtest 'delete empty setting' => sub {
     my %settings = ();
     clone_job_apply_settings([qw(ISO_1= ADDONS=)], 0, \%settings, \%options);
     is_deeply(\%settings, {}, 'all empty settings removed');
+};
+
+subtest 'asset download' => sub {
+    my $temp_assetdir = tempdir;
+    my $fake_ua       = Test::FakeLWPUserAgent->new;
+    my $remote        = undef;                          # should not be used here (there are no parents)
+    my $remote_url    = Mojo::URL->new('http://foo');
+    my %options       = (dir => $temp_assetdir);
+    my $job_id        = 1;
+    my %job           = (
+        assets => {
+            repo => 'supposed to be skipped',
+            iso  => [qw(foo.iso bar.iso)],
+        },
+    );
+
+    $temp_assetdir->child('iso')->make_path;
+
+    combined_like(
+        sub {
+            clone_job_download_assets($job_id, \%job, $remote, $remote_url, $fake_ua, \%options);
+        },
+        qr{downloading.*http://.*foo.iso.*to.*foo.iso.*downloading.*http://.*bar.iso.*to.*bar.iso}s,
+        'download logged',
+    );
+    is_deeply(
+        $fake_ua->mirrored,
+        [
+            "http://foo/tests/$job_id/asset/iso/foo.iso", "$temp_assetdir/iso/foo.iso",
+            "http://foo/tests/$job_id/asset/iso/bar.iso", "$temp_assetdir/iso/bar.iso",
+        ],
+        'assets downloadeded'
+    ) or diag explain $fake_ua->mirrored;
+    ok(-f "$temp_assetdir/iso/foo.iso", 'foo touched');
+    ok(-f "$temp_assetdir/iso/bar.iso", 'foo touched');
 };
 
 done_testing();


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/62021
* Moves the asset and job download into the `OpenQA::Scripts` module to ease testing