### PR TITLE
Fix cache service log formatting

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -93,8 +93,8 @@ sub setup_workers {
 sub run {
     my @args = setup_workers(@_);
 
+    local $ENV{MOJO_LOG_SHORT} = 1;
     my $app = __PACKAGE__->new;
-    $app->log->short(1);
     $ENV{MOJO_INACTIVITY_TIMEOUT} //= 300;
     $app->log->debug("Starting cache service: $0 @args");
 


### PR DESCRIPTION
Small patch to turn this
```
Jan 10 17:08:54 openqaworker11 openqa-workercache[15565]: [2020-01-10 17:08:54.15458] [1756] [info] [#10278] Downloading: "SLES-15-SP1-x86_64-Installtest.qcow2"
Jan 10 17:08:54 openqaworker11 openqa-workercache[15565]: [2020-01-10 17:08:54.15815] [1756] [info] [#10278] Cache size of "/var/lib/openqa/cache" is 7.4GiB, with limit 20GiB
```
into this
```
Jan 13 16:48:37 openqaworker11 openqa-workercache[15562]: [15614] [i] [#10281] Downloading: "SLES-15-SP1-x86_64-Installtest.qcow2"
Jan 13 16:48:37 openqaworker11 openqa-workercache[15562]: [15614] [i] [#10281] Cache size of "/var/lib/openqa/cache" is 7.4GiB, with limit 20GiB
```
in the journal.