### PR TITLE
Fix tidy in night job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,18 +145,12 @@ jobs:
             bash .circleci/build_dependencies.sh
 
             git --no-pager diff .circleci/dependencies.txt
-            set -x
-            # let's tidy if Tidy version changes
-            newtidyver="$(git diff .circleci/dependencies.txt | grep perl-Perl-Tidy | grep '^+' | grep -o '[0-9]*' || :)"
-            [ -z "$newtidyver" ] || {
-                sed -i -e "s/\('Perl::Tidy',\s\+'==\s\)\([0-9]\+\)\(.*\)/\1$newtidyver\3/g" cpanfile
-                script/tidy
-                git add cpanfile script/* lib/* t/*
-            }
             git diff --quiet .circleci/dependencies.txt || (
                 set +o pipefail
                 curl -s https://api.github.com/repos/os-autoinst/os-autoinst/commits | grep sha | head -n 1 | grep -o -E '[0-9a-f]{40}' > .circleci/autoinst.sha
                 git add .circleci/dependencies.txt .circleci/autoinst.sha
+                # these might have changed by tidy in .circleci/build_dependencies.sh
+                git add cpanfile script/* lib/* t/*
                 git commit -m "Dependency cron $depid"
                 git push -q -f https://token@github.com/openqabot/openQA.git dependency_$depid
                 hub pull-request -m "Dependency cron $depid" --base "$CIRCLE_PROJECT_USERNAME":"$CIRCLE_BRANCH" --head "openqabot:dependency_$depid"


### PR DESCRIPTION
Previous implementation tried to run tidy inside dependency_bot container which is only suitable to run docker. This PR moves tidy logic inside proper container.