### PR TITLE
Retry cache service downloads for many more errors

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -129,8 +129,8 @@ sub _download_asset {
     }
     else {
         my $message = $res->error->{message};
-        $log->info(qq{Purging "$asset" because the download failed: $code - $message});
-        $self->purge_asset($asset);
+        $log->info(qq{Download of "$asset" failed: $code - $message});
+        $ret = 521;
     }
 
     return $ret;
@@ -161,7 +161,8 @@ sub get_asset {
             next;
         }
         elsif (!$n) {
-            $log->info('Too many download errors, aborting');
+            $log->info(qq{Purging "$asset" because of too many download errors});
+            $self->purge_asset($asset);
             last;
         }
 

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -115,6 +115,11 @@ sub fake_asset_server {
                 }
             }
 
+            elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_close/) {
+                my $stream = Mojo::IOLoop->stream($c->tx->connection);
+                Mojo::IOLoop->next_tick(sub { $stream->close });
+            }
+
             elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_#:/) {
                 $c->res->headers->content_length(20);
                 $c->res->headers->content_type('text/plain');


### PR DESCRIPTION
This patch makes the cache service retry downloads for almost every error type 5 times (with a small sleep in between each attempt). Server as well as network errors.

Progress: https://progress.opensuse.org/issues/55529