### PR TITLE
Avoid race condition in job scheduling

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -872,7 +872,7 @@ sub auto_duplicate {
 
     while (my $j = $jobs->next) {
         next if $j->abort;
-        next unless $j->state eq SCHEDULED;
+        next unless $j->state eq SCHEDULED || $j->state eq ASSIGNED;
         $j->release_networks;
         $j->update({state => CANCELLED});
     }

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -272,4 +272,9 @@ sub unfinished_jobs {
     return $self->previous_jobs->search({t_finished => undef});
 }
 
+sub set_current_job {
+    my ($self, $job) = @_;
+    $self->update({job_id => $job->id});
+}
+
 1;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -332,8 +332,9 @@ is(scalar(@{$rjobs_before}) + 1,             scalar(@{$rjobs_after}), "number of
 is($rjobs_after->[-1]->{assigned_worker_id}, 1,                       'assigned worker set');
 
 $grabbed = job_get($job->id);
-is($grabbed->worker->id, $worker->{id}, 'correct worker assigned');
-is($grabbed->state,      ASSIGNED,      'job is in assigned state');
+is($grabbed->assigned_worker_id, $worker->{id}, 'worker assigned to job');
+is($grabbed->worker->id,         $worker->{id}, 'job assigned to worker');
+is($grabbed->state,              ASSIGNED,      'job is in assigned state');
 
 # register worker again with no job while the web UI thinks it has an assigned job
 is(register_worker, $id, 'worker re-registered');

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -24,14 +24,14 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Database;
+use OpenQA::WebAPI::Controller::API::V1::Worker;
 use Test::Mojo;
 use Test::More;
 use Test::Warnings;
 use Mojo::Util 'monkey_patch';
 
-my $schema = OpenQA::Test::Database->new->create;    #(skip_fixtures => 1);
-
-my $sent = {};
+my $schema = OpenQA::Test::Database->new->create;
+my $sent   = {};
 
 OpenQA::Scheduler::Model::Jobs->singleton->shuffle_workers(0);
 
@@ -55,18 +55,13 @@ monkey_patch 'OpenQA::Schema::Result::Jobs', ws_send => sub {
     return {state => {msg_sent => 1}};
 };
 
-
-#my $t = Test::Mojo->new('OpenQA::WebAPI');
-
 sub list_jobs {
     my %args = @_;
     [map { $_->to_hash(assets => 1) } $schema->resultset('Jobs')->complex_query(%args)->all];
 }
 
-my $current_jobs = list_jobs();
-#diag explain $current_jobs;
-
-my %settings = (
+my $current_jobs = list_jobs;
+my %settings     = (
     DISTRI      => 'Unicorn',
     FLAVOR      => 'pink',
     VERSION     => '42',
@@ -174,9 +169,7 @@ $jobH->set_prio(8);
 $jobI->set_prio(10);
 $jobJ->set_prio(9);
 
-use OpenQA::WebAPI::Controller::API::V1::Worker;
-my $c = OpenQA::WebAPI::Controller::API::V1::Worker->new;
-
+my $c     = OpenQA::WebAPI::Controller::API::V1::Worker->new;
 my $w1_id = $c->_register($schema, "host", "1", \%workercaps64_client);
 my $w2_id = $c->_register($schema, "host", "2", \%workercaps64_server);
 my $w3_id = $c->_register($schema, "host", "3", \%workercaps32);
@@ -219,7 +212,6 @@ is($job->{id}, $jobJ->id,
 
 $job = $sent->{$w9_id}->{job}->to_hash;
 is($job->{id}, $jobI->id, "this worker can do jobI, child - client");
-
 
 # job G is not grabbed because there is no worker with class 'special'
 

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -199,7 +199,11 @@ subtest 'Simulation of heavy unstable load' => sub {
     dead_workers($schema);
     my @duplicated;
 
-    push(@duplicated, $_->auto_duplicate()) for $schema->resultset("Jobs")->latest_jobs;
+    # duplicate latest jobs ignoring failures
+    for my $job ($schema->resultset('Jobs')->latest_jobs) {
+        my $duplicate = $job->auto_duplicate;
+        push(@duplicated, $duplicate) if defined $duplicate;
+    }
 
     push(@workers, unresponsive_worker($k->key, $k->secret, "http://localhost:$mojoport", $_)) for (1 .. 50);
     my $i = 4;

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -90,30 +90,30 @@ sub create_worker {
 }
 
 subtest 'Scheduler worker job allocation' => sub {
-    # Step 1
-    my $allocated = scheduler_step();    # Will try to allocate to previous worker and fail!
+    note('try to allocate to previous worker (supposed to fail)');
+    my $allocated = scheduler_step();
     is @$allocated, 0;
 
+    note('starting two workers');
     my $w1_pid = create_worker($k->key, $k->secret, "http://localhost:$mojoport", 1);
     my $w2_pid = create_worker($k->key, $k->secret, "http://localhost:$mojoport", 2);
     wait_for_worker($schema, 3);
     wait_for_worker($schema, 4);
 
-    ($allocated) = scheduler_step();     # Will try to allocate to previous worker and fail!
-
-    my $job_id1 = $allocated->[0]->{job};
-    my $job_id2 = $allocated->[1]->{job};
-    my $wr_id1  = $allocated->[0]->{worker};
-    my $wr_id2  = $allocated->[1]->{worker};
-    ok $wr_id1 != $wr_id2,   "Jobs dispatched to different workers";
-    ok $job_id1 != $job_id2, "Jobs dispatched to different workers";
-
+    note('assigning one job to each worker');
+    ($allocated) = scheduler_step();
+    my $job_id1           = $allocated->[0]->{job};
+    my $job_id2           = $allocated->[1]->{job};
+    my $wr_id1            = $allocated->[0]->{worker};
+    my $wr_id2            = $allocated->[1]->{worker};
+    my $different_workers = isnt($wr_id1, $wr_id2, 'jobs dispatched to different workers');
+    my $different_jobs    = isnt($job_id1, $job_id2, 'each of the two jobs allocated to one of the workers');
+    diag explain $allocated unless $different_workers && $different_jobs;
 
     ($allocated) = scheduler_step();
     is @$allocated, 0;
 
     kill_service($_, 1) for ($w1_pid, $w2_pid);
-
     dead_workers($schema);
 };
 


### PR DESCRIPTION
* Associate workers and jobs before sending the job to the worker
* Set the worker's current job only when the worker reports it
* Consider all unfinished jobs in stale job handling on worker status updates via web sockets

This should help to avoid the problems mentioned in the ticket https://progress.opensuse.org/issues/62015.

---

In overall this change is actually a simplification (also in terms of lines of code; 54 additions, 81 deletions). So things should work as before but with less effort and of course avoiding the race condition from the issue.

I've tested this locally by simulating a slow scheduler, a worker which doesn't accept jobs and other problems which cause the changed code to be executed. It seems to work although I've once managed to have an assigned job which had `t_finished` set and was therefore considered finished. That seems to be an additional problem so I still want to find out why that could have happened and fix it, too.