### PR TITLE
Add CLI tool openqa-validate-yaml

### DIFF
--- a/.circleci/dependencies.txt
+++ b/.circleci/dependencies.txt
@@ -96,6 +96,7 @@ perl-File-ShareDir-1.104
 perl-File-Touch-0.11
 perl-File-Which-1.22
 perl-Furl-3.13
+perl-Getopt-Long-Descriptive-0.102
 perl-Hash-Merge-0.200
 perl-HTML-Parser-3.72
 perl-HTML-Tagset-3.20

--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,7 @@ requires 'File::Path';
 requires 'File::Spec';
 requires 'FindBin';
 requires 'Getopt::Long';
+requires 'Getopt::Long::Descriptive';
 requires 'IO::Handle';
 requires 'IO::Socket::SSL';
 requires 'IPC::Run';

--- a/lib/OpenQA/JobTemplates.pm
+++ b/lib/OpenQA/JobTemplates.pm
@@ -1,0 +1,62 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+package OpenQA::JobTemplates;
+
+use strict;
+use warnings;
+
+use Exporter 'import';
+use Carp;
+use Try::Tiny;
+use JSON::Validator;
+
+our $VERSION   = '0.0.1';
+our @EXPORT_OK = qw(
+  &validate_data
+);
+
+sub validate_data {
+    my %args            = @_;
+    my $schema_file     = $args{schema_file};
+    my $data            = $args{data};
+    my $validate_schema = $args{validate_schema};
+    my $validator       = JSON::Validator->new;
+    my $schema;
+    my @errors;
+
+    try {
+        # Note: Using the schema filename; slurp'ed text isn't detected as YAML
+
+        if ($validate_schema) {
+            # Validate the schema: catches errors in type names and definitions
+            $validator = $validator->load_and_validate_schema($schema_file);
+            $schema    = $validator->schema;
+        }
+        else {
+            $schema = $validator->schema($schema_file);
+        }
+    }
+    catch {
+        # The first line of the backtrace gives us the error message we want
+        push @errors, (split /\n/, $_)[0];
+    };
+    if ($schema) {
+        # Note: Don't pass $schema here, that won't work
+        push @errors, $validator->validate($data);
+    }
+    return \@errors;
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -17,7 +17,6 @@
 package OpenQA::WebAPI::Controller::API::V1::JobTemplate;
 use Mojo::Base 'Mojolicious::Controller';
 use Try::Tiny;
-use JSON::Validator;
 
 =pod
 

--- a/openQA.spec
+++ b/openQA.spec
@@ -48,7 +48,7 @@
 %define assetpack_requires perl(Mojolicious::Plugin::AssetPack) >= 1.36, perl(CSS::Minifier::XS) perl(JavaScript::Minifier::XS)
 %define common_requires perl(Config::IniFiles) perl(Cpanel::JSON::XS) perl(Cwd) perl(Data::Dump) perl(Data::Dumper) perl(Digest::MD5) perl(Getopt::Long) perl(Minion) >= 9.09, perl(Mojolicious) >= 8.24, perl(Try::Tiny) perl(Regexp::Common), perl(Storable)
 # runtime requirements for the main package that are not required by other sub-packages
-%define main_requires %assetpack_requires git-core perl(Carp::Always) perl(Date::Format) perl(DateTime::Format::Pg) perl(DBD::Pg) >= 3.7.4, perl(DBI) >= 1.632, perl(DBIx::Class) >= 0.082801, perl(DBIx::Class::DeploymentHandler) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(DBIx::Class::OptimisticLocking) perl(File::Copy::Recursive) perl(Net::OpenID::Consumer) perl(Module::Pluggable) perl(aliased) perl(Config::Tiny) perl(Text::Diff) perl(CommonMark) perl(JSON::Validator) perl(IPC::Run) perl(Archive::Extract) perl(Time::ParseDate) perl(Sort::Versions) perl(BSD::Resource) perl(Pod::POM) perl(Mojo::Pg) perl(Mojo::RabbitMQ::Client) >= 0.2, perl(SQL::Translator) perl(YAML::XS) perl(LWP::UserAgent)
+%define main_requires %assetpack_requires git-core perl(Carp::Always) perl(Date::Format) perl(DateTime::Format::Pg) perl(DBD::Pg) >= 3.7.4, perl(DBI) >= 1.632, perl(DBIx::Class) >= 0.082801, perl(DBIx::Class::DeploymentHandler) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(DBIx::Class::OptimisticLocking) perl(File::Copy::Recursive) perl(Net::OpenID::Consumer) perl(Module::Pluggable) perl(aliased) perl(Config::Tiny) perl(Text::Diff) perl(CommonMark) perl(JSON::Validator) perl(IPC::Run) perl(Archive::Extract) perl(Time::ParseDate) perl(Sort::Versions) perl(BSD::Resource) perl(Pod::POM) perl(Mojo::Pg) perl(Mojo::RabbitMQ::Client) >= 0.2, perl(SQL::Translator) perl(YAML::XS) perl(LWP::UserAgent) perl(Getopt::Long::Descriptive)
 %define client_requires curl jq git-core perl(IO::Socket::SSL) >= 2.009, perl(LWP::UserAgent) perl(IPC::Run)
 %define worker_requires os-autoinst < 5, perl(Mojo::IOLoop::ReadWriteProcess) > 0.19, perl(Minion::Backend::SQLite) perl(Mojo::SQLite) openQA-client optipng
 %define build_requires rubygem(sass) %assetpack_requires
@@ -258,6 +258,7 @@ ln -s %{_datadir}/openqa/script/openqa-clone-job %{buildroot}%{_bindir}/openqa-c
 ln -s %{_datadir}/openqa/script/dump_templates %{buildroot}%{_bindir}/openqa-dump-templates
 ln -s %{_datadir}/openqa/script/load_templates %{buildroot}%{_bindir}/openqa-load-templates
 ln -s %{_datadir}/openqa/script/openqa-clone-custom-git-refspec %{buildroot}%{_bindir}/openqa-clone-custom-git-refspec
+ln -s %{_datadir}/openqa/script/openqa-validate-yaml %{buildroot}%{_bindir}/openqa-validate-yaml
 %if %{with python_scripts}
 ln -s %{_datadir}/openqa/script/openqa-label-all %{buildroot}%{_bindir}/openqa-label-all
 %endif
@@ -494,6 +495,7 @@ fi
 %{_datadir}/openqa/script/load_templates
 %{_datadir}/openqa/script/openqa-clone-job
 %{_datadir}/openqa/script/openqa-clone-custom-git-refspec
+%{_datadir}/openqa/script/openqa-validate-yaml
 %{_datadir}/openqa/script/configure-web-proxy
 %dir %{_datadir}/openqa/lib
 %{_datadir}/openqa/lib/OpenQA/Client.pm
@@ -504,6 +506,7 @@ fi
 %{_bindir}/openqa-dump-templates
 %{_bindir}/openqa-load-templates
 %{_bindir}/openqa-clone-custom-git-refspec
+%{_bindir}/openqa-validate-yaml
 
 %if %{with python_scripts}
 %files python-scripts

--- a/script/openqa-validate-yaml
+++ b/script/openqa-validate-yaml
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+use strict;
+use warnings;
+use 5.010;
+
+use FindBin '$Bin';
+use lib "$Bin/../lib";
+use Getopt::Long::Descriptive;
+use OpenQA::JobTemplates 'validate_data';
+use YAML::XS ();
+$YAML::XS::LoadBlessed = 0;
+
+my ($opt, $usage) = describe_options(
+    <<"EOM",
+$0 %o <yaml-file>
+
+Validate a YAML file against a schema.
+You can pass a YAML file or '-' for STDIN.
+EOM
+    ['validate-schema', 'Validate Schema file itself also'],
+    ['schema-file=s',   "Schema file to validate against (default public/schema/JobTemplates-01.yaml)"],
+    ['help',            'print usage message and exit', {shortcircuit => 1}],
+);
+
+print($usage->text), exit if $opt->help;
+
+my ($file) = @ARGV;
+
+my $default_schema = "$Bin/../public/schema/JobTemplates-01.yaml";
+my $schema         = $opt->schema_file // $default_schema;
+unless (-f $schema) {
+    say "Schema file '$schema' does not exist";
+    exit 1;
+}
+my $data;
+
+unless ($file) {
+    say "Nothing to do";
+    exit;
+}
+if ($file eq '-') {
+    my $yaml = do { local $/; <STDIN> };
+    $data = YAML::XS::Load($yaml);
+}
+else {
+    $data = YAML::XS::LoadFile($file);
+}
+
+if ($opt->validate_schema) {
+    say '# validating schema, too';
+}
+my $errors = validate_data(
+    schema_file     => $schema,
+    data            => $data,
+    validate_schema => $opt->validate_schema,
+);
+
+if (@$errors) {
+    say $_ for @$errors;
+    exit 1;
+}
+else {
+    say "Validated!";
+}

--- a/t/16-utils-job-templates.t
+++ b/t/16-utils-job-templates.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl -w
+
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use strict;
+use warnings;
+
+use FindBin '$Bin';
+use lib "$Bin/lib";
+use OpenQA::JobTemplates qw(validate_data);
+use Test::More;
+use Mojo::File qw(path tempdir tempfile);
+use YAML::XS ();
+
+my $schema          = "$Bin/../public/schema/JobTemplates-01.yaml";
+my $template_openqa = "$Bin/data/job-templates/openqa.yaml";
+my %default_args    = (schema_file => $schema);
+
+my $invalid_schema = "$Bin/data/job-templates/schema-invalid.yaml";
+
+my $template = {
+    scenarios => {},
+    products  => {},
+};
+my $errors = validate_data(%default_args, data => $template,);
+is scalar @$errors, 0, "Empty template - no errors";
+eval { my $errors = validate_data(schema_file => $invalid_schema, data => $template); };
+like($@, qr{JSON::Validator}, "Invalid schema file");
+
+$errors = validate_data(%default_args, data => YAML::XS::LoadFile($template_openqa),);
+if (@$errors) {
+    diag "Error: $_" for @$errors;
+}
+is scalar @$errors, 0, "Valid template - no errors";
+
+done_testing;

--- a/t/data/job-templates/openqa.yaml
+++ b/t/data/job-templates/openqa.yaml
@@ -1,0 +1,34 @@
+defaults:
+  x86_64:
+    machine: 64bit-2G
+    priority: 50
+    settings:
+      INSTALL: '1'
+      INSTALL_ONLY: '1'
+      QEMUCPU: host
+      UPDATE: '0'
+
+products:
+  openqa-*-dev-x86_64:
+    distri: openqa
+    flavor: dev
+    version: '*'
+scenarios:
+  x86_64:
+    openqa-*-dev-x86_64:
+    - openqa_install+publish:
+        testsuite: 'empty'
+        settings:
+          PUBLISH_HDD_1: 'opensuse-Tumbleweed-%ARCH%@%MACHINE%-%BUILD%.qcow2'
+          PUBLISH_PFLASH_VARS: 'opensuse-Tumbleweed-%ARCH%@%MACHINE%-%BUILD%-uefi-vars.qcow2'
+        description: >-
+          Maintainer: okurz@suse.de Test for installation of openQA itself.
+          To be used with "openqa" distri. Publishes an qcow2 image including the openQA installation
+          ready to run as an appliance.
+    - openqa_from_git:
+        testsuite: 'empty'
+        settings:
+          OPENQA_FROM_GIT: '1'
+        description: >-
+          Maintainer: okurz@suse.de Test for running openQA itself from git. To be used with "openqa"
+          distri.

--- a/t/data/job-templates/schema-invalid.yaml
+++ b/t/data/job-templates/schema-invalid.yaml
@@ -1,0 +1,105 @@
+$id: http://open.qa/api/schema/JobTemplates-01.yaml
+$schema: http://json-schema.org/draft-04/schema#
+description: openQA job template
+type: FOO
+additionalProperties: false
+required:
+- products
+- scenarios
+properties:
+  scenarios:
+    description: The scenarios to run, i.e. lists of test suites per architecture and medium
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^[a-z0-9_]+$":
+        type: object
+        description: The architecture of the test suite(s) eg. ppc64le
+        patternProperties:
+          "^.*$":
+            type: array
+            description: The product to run the test suite(s) on
+            items:
+              anyOf:
+              - type: string
+                description: Name of a test suite name
+              - type: object
+                maxProperties: 1
+                description: A test suite with machine and/ or priority specified, or a custom job template name if testsuite was specified
+                additionalProperties: false
+                patternProperties:
+                  "^[A-Za-z\\s0-9_*.+-]+$":
+                    type: object
+                    additionalProperties: false
+                    properties:
+                      machine:
+                        oneOf:
+                          - type: string
+                          - type: array
+                            items:
+                            - type: string
+                      priority:
+                        type: number
+                      settings:
+                        type: object
+                        description: Additional test variables to be set
+                        additionalProperties: false
+                        patternProperties:
+                          "^[A-Z_+]+[A-Z0-9_]*$":
+                            type: string
+                      testsuite:
+                        type: string
+                        pattern: "^[A-Za-z\\s0-9_*.+-]+$"
+                        description: The test suite this scenario is based on if a custom job template name was used
+                      description:
+                        type: string
+                        description: The description of the job template
+  defaults:
+    description: A set of architectures with default configurations
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^[a-z0-9_]+$":
+        type: object
+        description: The architecture to define a default configuration for eg. ppc64le
+        required:
+        - machine
+        - priority
+        additionalProperties: false
+        properties:
+          machine:
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                - type: string
+          priority:
+            type: number
+          settings:
+            type: object
+            description: Additional test variables to be set
+            additionalProperties: false
+            patternProperties:
+              "^[A-Z_]+[A-Z0-9_]*$":
+                type: string
+  products:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^[A-Za-z0-9._*-]+$":
+        type: object
+        description: The name of a product (medium)
+        required:
+          - distri
+          - flavor
+          - version
+        additionalProperties: false
+        properties:
+          distri:
+            type: string
+          flavor:
+            type: string
+          version:
+            oneOf:
+              - type: string
+              - type: number


### PR DESCRIPTION
So one can easily validate local YAML files without having to post to the API.

* Move validation code to OpenQA::JobTemplates
* Add test for invalid schema


Related issue: https://progress.opensuse.org/issues/60329