### PR TITLE
Allow more than one keepalive connection per cache service worker

### DIFF
--- a/systemd/openqa-worker-cacheservice.service
+++ b/systemd/openqa-worker-cacheservice.service
@@ -7,7 +7,7 @@ PartOf=openqa-worker.target
 [Service]
 Restart=on-failure
 User=_openqa-worker
-ExecStart=/usr/share/openqa/script/openqa-workercache prefork -m production -i 100 -H 400 -w 4 -c 1 -G 80
+ExecStart=/usr/share/openqa/script/openqa-workercache prefork -m production -i 100 -H 400 -w 4 -G 80
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I made a small mistake when i copied the prefork parameters from the webui to the cache service API server. The webui has an Apache reverse proxy to handle HTTP keep-alive connections, but the cache service does not.

That means when a worker is under heavy load you can start seeing errors like `[2020-01-17T11:29:56.0370 CET] [error] [pid:47664] Unable to setup job 3801895: Cache service not reachable: Inactivity timeout`, because other workers were blocking access to the API server with their keep-alive connections.