### PR TITLE
load_templates: fail early if host is unreachable

### DIFF
--- a/script/load_templates
+++ b/script/load_templates
@@ -130,8 +130,8 @@ my @tables = (qw(Machines TestSuites Products JobTemplates JobGroups));
 
 sub print_error {
     my ($res) = @_;
-    printf STDERR "ERROR: %s - %s\n", $res->code // 'unknown error code - host ' . $url->host . ' unreachable?',
-      $res->message // 'no error message';
+    die 'unknown error code - host ' . $url->host . ' unreachable?' unless $res->code;
+    printf STDERR "ERROR: %s - %s\n", $res->code, $res->message // 'no error message';
     if ($res->body) {
         dd($res->json || $res->body);
     }

--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -26,6 +26,8 @@ $Test::Strict::TEST_STRICT   = 1;
 $Test::Strict::TEST_WARNINGS = 1;
 $Test::Strict::TEST_SKIP     = [
     # skip test module which would require test API from os-autoinst to be present
-    't/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm'
+    't/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm',
+    # Skip data file which is supposed to resemble generated output which has no 'use' statements
+    't/data/40-templates.pl',
 ];
 all_perl_files_ok(qw(lib script t));

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 SUSE Software Solutions Germany GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Mojo::Base -strict;
+
+use File::Temp qw(tempfile);
+use Mojo::File qw(path curfile);
+use Test::More;
+use Test::Output;
+use Test::Warnings;
+
+sub run_once {
+    my ($args) = @_;
+    my $script = path(curfile->dirname, '../script/load_templates')->realpath;
+    system("$script $args") >> 8;
+}
+
+my $ret;
+my $args = '';
+combined_like(sub { $ret = run_once($args) }, qr/Usage:/, 'help text shown');
+is $ret, 1, 'load_templates with no arguments shows usage';
+
+$args = "--host";
+combined_like(sub { $ret = run_once($args) }, qr/Option host requires an argument/, 'host argument error shown');
+
+my $host     = 'testhost:1234';
+my $filename = 't/data/40-templates.pl';
+$args = "--host $host $filename";
+combined_like sub { $ret = run_once($args); }, qr/unknown error code - host $host unreachable?/, 'invalid host error';
+is $ret, 22, 'error because host is invalid';
+
+done_testing;

--- a/t/data/40-templates.pl
+++ b/t/data/40-templates.pl
@@ -1,0 +1,32 @@
+{
+    JobGroups => [
+        {
+            group_name => "openSUSE Leap 42.3 Updates",
+            template   => "scenarios: {}\nproducts: {}\n",
+        },
+    ],
+    JobTemplates => [],
+    Machines     => [
+        {
+            backend  => "qemu",
+            name     => "32bit",
+            settings => [],
+        },
+    ],
+    Products => [
+        {
+            arch     => "x86_64",
+            distri   => "opensuse",
+            flavor   => "DVD",
+            settings => [],
+            version  => 42.2,
+        },
+    ],
+    TestSuites => [
+        {
+            name => "uefi",
+            settings =>
+              [{key => "DESKTOP", value => "kde"}, {key => "INSTALLONLY", value => 1}, {key => "UEFI", value => 1},],
+        },
+    ],
+}


### PR DESCRIPTION
It makes no sense to run other commands in this case lest we end up with inconsistent changes on the off chance that it comes up again.

Add an initial unit test for load_templates.

Related to: [poo#60118](https://progress.opensuse.org/issues/60118)