### PR TITLE
Do not retry downloads with 4xx response

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -90,11 +90,6 @@ sub _download_asset {
         $ret = 520 unless $self->_update_asset_last_use($asset);
     }
 
-    elsif ($res->is_server_error) {
-        $log->info(qq{Downloading "$asset" failed with server error $code});
-        $ret = $code;
-    }
-
     elsif ($res->is_success) {
         my $headers = $tx->res->headers;
         $etag = $headers->etag;
@@ -129,8 +124,8 @@ sub _download_asset {
     }
     else {
         my $message = $res->error->{message};
-        $log->info(qq{Download of "$asset" failed: $code - $message});
-        $ret = 521;
+        $log->info(qq{Download of "$asset" failed: $code $message});
+        $ret = $code;
     }
 
     return $ret;
@@ -154,7 +149,7 @@ sub get_asset {
         eval { $ret = $self->_download_asset($host, $job->{id}, lc($asset_type), $asset, $result->{etag}) };
         last unless $ret;
 
-        if ($ret =~ /^5[0-9]{2}$/ && --$n) {
+        if ($ret =~ /^[45][0-9]{2}$/ && --$n) {
             my $time = $self->sleep_time;
             $log->info("Download error $ret, waiting $time seconds for next try ($n remaining)");
             sleep $time;

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -149,7 +149,7 @@ sub get_asset {
         eval { $ret = $self->_download_asset($host, $job->{id}, lc($asset_type), $asset, $result->{etag}) };
         last unless $ret;
 
-        if ($ret =~ /^[45][0-9]{2}$/ && --$n) {
+        if ($ret =~ /^5[0-9]{2}$/ && --$n) {
             my $time = $self->sleep_time;
             $log->info("Download error $ret, waiting $time seconds for next try ($n remaining)");
             sleep $time;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -158,17 +158,15 @@ like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(3 remai
 like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(2 remaining\)/, '2 tries remaining';
 like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
 like $cache_log, qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
+ok !-e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-200_server_error@64bit.qcow2'), 'Asset does not exist in cache';
 $cache_log = '';
 
-# Retry client error (404)
+# Do not retry client error (404)
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_client_error@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200_client_error\@64bit.qcow2" from/,  'Asset download attempt';
 like $cache_log, qr/Download of ".*0368-200_client_error\@64bit.qcow2" failed: 404 Not Found/, 'Real error is logged';
-like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(4 remaining\)/,       '4 tries remaining';
-like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(3 remaining\)/,       '3 tries remaining';
-like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(2 remaining\)/,       '2 tries remaining';
-like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(1 remaining\)/,       '1 tries remaining';
-like $cache_log, qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
+unlike $cache_log, qr/waiting .* seconds for next try/, 'No retries';
+ok !-e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-200_client_error@64bit.qcow2'), 'Asset does not exist in cache';
 $cache_log = '';
 
 # Retry download error with 200 status (size of asset differs)
@@ -181,6 +179,7 @@ like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(2 remai
 like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
 like $cache_log,   qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
 unlike $cache_log, qr/failed because the asset did not exist/,                'Asset existed';
+ok !-e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-589@64bit.qcow2'), 'Asset does not exist in cache';
 $cache_log = '';
 
 # Retry connection error (closed early)
@@ -195,6 +194,7 @@ like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(1 remai
 like $cache_log, qr/Purging ".*200_close\@64bit.qcow2" because of too many download errors/,
   'Bailing out after too many retries';
 like $cache_log, qr/Purging ".*200_close\@64bit.qcow2" failed because the asset did not exist/, 'Asset was missing';
+ok !-e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-200_close@64bit.qcow2'), 'Asset does not exist in cache';
 $cache_log = '';
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-503@64bit.qcow2');
@@ -204,13 +204,16 @@ like $cache_log, qr/Download of ".*0368-503\@64bit.qcow2" failed: 503 Service Un
 like $cache_log, qr/Download error 503, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
 like $cache_log, qr/Purging ".*-503@64bit.qcow2" because of too many download errors/,
   'Bailing out after too many retries';
+ok !-e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-503@64bit.qcow2'), 'Asset does not exist in cache';
 $cache_log = '';
 
+# Successful download
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200\@64bit.qcow2" from/, 'Asset download attempt';
 like $cache_log, qr/Download of ".*sle-12-SP3-x86_64-0368-200.*" successful, new cache size is 1024/,
   'Full download logged';
 like $cache_log, qr/Size of .* is 1024 Byte, with ETag "andi \$a3, \$t1, 41399"/, 'Etag and size are logged';
+ok -e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-200@64bit.qcow2'), 'Asset exist in cache';
 $cache_log = '';
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -128,7 +128,7 @@ $cache_log = '';
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-textmode@64bit.qcow2');
 my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2" from "$from"/, 'Asset download attempt';
-like $cache_log, qr/failed: 521/, 'Asset download fails with: 521 - Connection refused';
+like $cache_log, qr/failed: 521/, 'Asset download fails with: 521 Connection refused';
 $cache_log = '';
 
 $port = Mojo::IOLoop::Server->generate_port;
@@ -140,15 +140,38 @@ $cache->refresh;
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-404@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-404\@64bit.qcow2" from/, 'Asset download attempt';
-like $cache_log, qr/failed: 404/, 'Asset download fails with: 404 - Not Found';
+like $cache_log, qr/failed: 404/, 'Asset download fails with: 404 Not Found';
 $cache_log = '';
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-400@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-400\@64bit.qcow2" from/, 'Asset download attempt';
-like $cache_log, qr/failed: 400/, 'Asset download fails with 400 - Bad Request';
+like $cache_log, qr/failed: 400/, 'Asset download fails with 400 Bad Request';
 $cache_log = '';
 
-# Server error
+# Retry server error (500)
+$cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_server_error@64bit.qcow2');
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200_server_error\@64bit.qcow2" from/, 'Asset download attempt';
+like $cache_log, qr/Download of ".*0368-200_server_error\@64bit.qcow2" failed: 500 Internal Server Error/,
+  'Real error is logged';
+like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
+like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
+like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(2 remaining\)/, '2 tries remaining';
+like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
+like $cache_log, qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
+$cache_log = '';
+
+# Retry client error (404)
+$cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_client_error@64bit.qcow2');
+like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200_client_error\@64bit.qcow2" from/,  'Asset download attempt';
+like $cache_log, qr/Download of ".*0368-200_client_error\@64bit.qcow2" failed: 404 Not Found/, 'Real error is logged';
+like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(4 remaining\)/,       '4 tries remaining';
+like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(3 remaining\)/,       '3 tries remaining';
+like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(2 remaining\)/,       '2 tries remaining';
+like $cache_log, qr/Download error 404, waiting 1 seconds for next try \(1 remaining\)/,       '1 tries remaining';
+like $cache_log, qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
+$cache_log = '';
+
+# Retry download error with 200 status (size of asset differs)
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-589@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-589\@64bit.qcow2" from/,         'Asset download attempt';
 like $cache_log, qr/Size of .+ differs, expected 10 Byte but downloaded 6 Byte/,         'Incomplete download logged';
@@ -160,10 +183,10 @@ like $cache_log,   qr/Purging ".*qcow2" because of too many download errors/, 'B
 unlike $cache_log, qr/failed because the asset did not exist/,                'Asset existed';
 $cache_log = '';
 
-# Connection error (closed early)
+# Retry connection error (closed early)
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_close@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200_close\@64bit.qcow2" from/, 'Asset download attempt';
-like $cache_log, qr/Download of ".*200_close\@64bit.qcow2" failed: 521 - Premature connection close/,
+like $cache_log, qr/Download of ".*200_close\@64bit.qcow2" failed: 521 Premature connection close/,
   'Real error is logged';
 like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
 like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
@@ -176,7 +199,7 @@ $cache_log = '';
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-503@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-503\@64bit.qcow2" from/, 'Asset download attempt';
-like $cache_log, qr/Downloading ".*0368-503\@64bit.qcow2" failed with server error 503/,
+like $cache_log, qr/Download of ".*0368-503\@64bit.qcow2" failed: 503 Service Unavailable/,
   'Asset download fails with 503 - Server not available';
 like $cache_log, qr/Download error 503, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
 like $cache_log, qr/Purging ".*-503@64bit.qcow2" because of too many download errors/,

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -115,6 +115,14 @@ sub fake_asset_server {
                 }
             }
 
+            elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_client_error/) {
+                $c->render(text => 'Client error!', status => 404);
+            }
+
+            elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_server_error/) {
+                $c->render(text => 'Server error!', status => 500);
+            }
+
             elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_close/) {
                 my $stream = Mojo::IOLoop->stream($c->tx->connection);
                 Mojo::IOLoop->next_tick(sub { $stream->close });


### PR DESCRIPTION
Currently the cache service retries all downloads that result in 4xx and 5xx responses, as well as connection errors. But unless 4xx responses are misused by the server, there should be no chance to ever get a successful response just by retrying 5 times. So i believe it is more efficient to disable that case in the retry logic.

Progress: https://progress.opensuse.org/issues/55529