### PR TITLE
Show warning when restarting job and assets are missing

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -12,9 +12,13 @@ function setupOverview() {
     $('.restart')
         .bind("ajax:success", function(event, xhr, status) {
             var oldId = 0;
+            if (typeof xhr !== 'object' || !Array.isArray(xhr.result)) {
+                addFlash('danger', '<strong>Unable to restart job.</strong>');
+                return;
+            }
+            showWarningsFromJobRestart(xhr);
             var newId = xhr.result[0];
-
-            $.each( newId, function( key, value ) {
+            $.each(newId, function(key, value) {
                 if (!$('.restart[data-jobid="' + key + '"]').length) {
                     return true;
                 }

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -418,9 +418,16 @@ function renderTestLists() {
 function setupTestButtons() {
     $(document).on("click", '.restart', function(event) {
         event.preventDefault();
-        $.post($(this).attr("href")).done( function( data, res, xhr ) {
-            var urls = xhr.responseJSON.test_url[0];
-            $.each( urls , function( key, value ) {
+        $.post(this.href).done( function(data, res, xhr) {
+            var responseJSON = xhr.responseJSON;
+            var flashTarget = $('#flash-messages-finished-jobs');
+            if (typeof responseJSON !== 'object' || !Array.isArray(responseJSON.test_url)) {
+                addFlash('danger', '<strong>Unable to restart job.</strong>', flashTarget);
+                return;
+            }
+            showWarningsFromJobRestart(responseJSON, undefined, flashTarget);
+            var urls = responseJSON.test_url[0];
+            $.each(urls , function(key, value) {
                 // Skip to mark the job that is not shown in current page
                 if (!$('#job_' + key).length) {
                     return true;

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -165,13 +165,16 @@ sub refresh_size {
     return $new_size;
 }
 
-sub hidden {
+# returns whether the specified asset type is considered hidden so it will not be linked by the
+# web UI; configured via 'hide_asset_types' setting
+sub is_type_hidden {
+    my ($type) = @_;
+    return grep { $_ eq $type } split(/ /, OpenQA::App->singleton->config->{global}->{hide_asset_types});
+}
 
-    # 1 if asset should not be linked from the web UI (as set by
-    # 'hide_asset_types' config setting), otherwise 0
+sub hidden {
     my ($self) = @_;
-    my @types = split(/ /, OpenQA::App->singleton->config->{global}->{hide_asset_types});
-    return grep { $_ eq $self->type } @types;
+    return is_type_hidden($self->type);
 }
 
 1;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -563,13 +563,17 @@ sub can_be_duplicated {
     return 1;
 }
 
-sub assets_missing {
+sub missing_assets {
     my ($self) = @_;
 
-    my $assets       = parse_assets_from_settings($self->settings_hash);
-    my @assets_query = map { {type => $_->{type}, name => $_->{name}} }
-      grep { !OpenQA::Schema::Result::Assets::is_type_hidden($_->{type}) } values %$assets;
-    return $self->result_source->schema->resultset('Assets')->search(\@assets_query)->count < @assets_query ? 1 : 0;
+    my $assets          = parse_assets_from_settings($self->settings_hash);
+    my @relevant_assets = grep { !OpenQA::Schema::Result::Assets::is_type_hidden($_->{type}) } values %$assets;
+    my @assets_query    = map { {type => $_->{type}, name => $_->{name}} } @relevant_assets;
+    my @existing_assets = $self->result_source->schema->resultset('Assets')->search(\@assets_query);
+    return [] if scalar @assets_query == scalar @existing_assets;
+    my %missing_assets = map { ("$_->{type}/$_->{name}" => 1) } @relevant_assets;
+    delete $missing_assets{$_->type . '/' . $_->name} for @existing_assets;
+    return [sort keys %missing_assets];
 }
 
 =head2 create_clone

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -563,6 +563,14 @@ sub can_be_duplicated {
     return 1;
 }
 
+sub assets_missing {
+    my ($self) = @_;
+
+    my $assets       = parse_assets_from_settings($self->settings_hash);
+    my @assets_query = map { {type => $_->{type}, name => $_->{name}} }
+      grep { !OpenQA::Schema::Result::Assets::is_type_hidden($_->{type}) } values %$assets;
+    return $self->result_source->schema->resultset('Assets')->search(\@assets_query)->count < @assets_query ? 1 : 0;
+}
 
 =head2 create_clone
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -661,7 +661,8 @@ sub restart {
         $self->app->log->debug("Restarting jobs @$jobs");
     }
 
-    my @res = OpenQA::Resource::Jobs::job_restart($jobs);
+    my @warnings;
+    my @res = OpenQA::Resource::Jobs::job_restart($jobs, \@warnings);
     OpenQA::Scheduler::Client->singleton->wakeup;
 
     my @urls;
@@ -676,7 +677,7 @@ sub restart {
         }
         push @urls, $url;
     }
-    $self->render(json => {result => \@res, test_url => \@urls});
+    $self->render(json => {result => \@res, test_url => \@urls, @warnings ? (warnings => \@warnings) : ()});
 }
 
 =over 4

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -215,6 +215,10 @@ subtest 'job overview' => sub {
 # Test /jobs/restart
 $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})
   ->status_is(200);
+$t->json_is(
+    '/warnings' => ['Job 99939 misses the following assets: iso/openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'],
+    'warning for missing asset'
+);
 
 $t->get_ok('/api/v1/jobs');
 my @new_jobs = @{$t->tx->res->json->{jobs}};
@@ -236,6 +240,7 @@ is(scalar(@{$t->tx->res->json->{jobs}}), 15, 'job count stay the same');
 $t->get_ok('/api/v1/jobs/99926')->status_is(200);
 ok(!$t->tx->res->json->{job}->{clone_id}, 'job is not a clone');
 $t->post_ok('/api/v1/jobs/99926/restart')->status_is(200);
+$t->json_is('/warnings' => undef, 'no warnings generated');
 $t->get_ok('/api/v1/jobs/99926')->status_is(200);
 like($t->tx->res->json->{job}->{clone_id}, qr/\d/, 'job cloned');
 

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -255,5 +255,17 @@ subtest 'check job restart from infopanel in test results' => sub {
     like($driver->find_element('#info_box .card-header')->get_text(), qr/minimalx\@32bit/, 'restarted job is correct');
 };
 
+subtest 'check rendering warnings in flash message' => sub {
+    is($driver->get('/tests/99939'), 1, 'go to job 99939');
+    $driver->find_element('#restart-result')->click();
+    wait_for_ajax();
+    like($driver->get_current_url, qr|tests/99939|, 'no auto refresh when there are warnings');
+    like(
+        $driver->find_element('#flash-messages')->get_text,
+        qr/Warnings occurred when restarting jobs.*misses.*assets.*Go to new job/s,
+        'warning shown'
+    );
+};
+
 kill_driver();
 done_testing();

--- a/templates/webapi/test/list.html.ep
+++ b/templates/webapi/test/list.html.ep
@@ -42,6 +42,7 @@
 
 <div>
   <h2 id="finished_jobs_heading">Finished jobs</h2>
+  <div id="flash-messages-finished-jobs"></div>
     <div class="row" style="margin-bottom: 10px;">
             <div class="col-sm-12 col-md-6">
                 %= check_box relevant => '1', 'checked' => 'checked' => (id => 'relevantfilter')

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -131,6 +131,7 @@
             </form>
         </div>
     </div>
+    <div id="flash-messages"></div>
     % for my $distri (sort keys %$results) {
         % my $type_prefix_distri = $only_distri ? '' : "Distri: $distri / ";
         % my $version_results = $results->{$distri};


### PR DESCRIPTION
**See https://github.com/os-autoinst/openQA/pull/2676#issuecomment-578792752 for the current state.**

---

Related issue: https://progress.opensuse.org/issues/34783

This is WIP as it turns out to be not so easy as expected:

* The required assets need to be parsed from the settings again because the assets of the job might have already been deleted from the database.
* "Hidden" assets such as repositories need to be ignored.
* So far the error is thrown in the duplicate function which means that this change would prevent any job duplication unless the assets are present.

Note that this is only about restarting assets to prevent the creation of a clone in the first place.