### PR TITLE
Set text mime in ObsRsync download

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Folders.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Folders.pm
@@ -118,6 +118,7 @@ sub download_file {
     return undef if $helper->check_and_render_error($folder, $subfolder, $filename);
 
     my $full = Mojo::File->new($helper->home, $folder, $subfolder);
+    $self->res->headers->content_type('text/plain');
     $self->reply->file($full->child($filename));
 }
 


### PR DESCRIPTION
ObsRsync Plugin UI allows downloading logs and scripts used in synchronization.
It will be more practical if correct MIME is set for that.