### PR TITLE
Use new format to store job module details

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -296,8 +296,8 @@ sub save_details {
     my ($self, $details) = @_;
     my $existent_md5 = [];
     my @dbpaths;
-    $details = ref($details) eq 'HASH' ? $details->{results} : $details;
-    for my $d (@$details) {
+    my $results = ref($details) eq 'HASH' ? $details->{results} : $details;
+    for my $d (@$results) {
         # avoid creating symlinks for text results
         if ($d->{screenshot}) {
             # save the database entry for the screenshot first
@@ -308,7 +308,7 @@ sub save_details {
     }
     $self->result_source->schema->resultset('Screenshots')->populate_images_to_job(\@dbpaths, $self->job_id);
 
-    $self->store_needle_infos($details);
+    $self->store_needle_infos($results);
     path($self->job->result_dir, 'details-' . $self->name . '.json')->spurt(encode_json($details));
     return $existent_md5;
 }

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl -w
 
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ use OpenQA::Test::Case;
 use Test::More;
 use Test::MockModule 'strict';
 use Test::Mojo;
+use Mojo::JSON 'decode_json';
 use Test::Warnings;
 use Mojo::File qw(path tempdir);
 use Mojo::IOLoop::ReadWriteProcess;
@@ -627,6 +628,14 @@ subtest 'modules are unique per job' => sub {
     is $modules[0]->name,   'some_name',  'right name';
     is $modules[0]->script, 'foo/bar.pm', 'right script';
     is $modules[1], undef, 'no second result';
+};
+
+subtest 'saving details' => sub {
+    my %some_test_results    = (results => [], spare => 'me the details');
+    my $arbitrary_job_module = $schema->resultset('JobModules')->first;
+    $arbitrary_job_module->save_details(\%some_test_results);
+    my $details_file = path($arbitrary_job_module->job->result_dir, 'details-' . $arbitrary_job_module->name . '.json');
+    is_deeply(decode_json($details_file->slurp), \%some_test_results, 'overall structure of test results preserved');
 };
 
 done_testing();


### PR DESCRIPTION
This is fixing a mistake within https://github.com/os-autoinst/openQA/pull/2654. Otherwise the execution time would be discarded by openQA and never displayed.