### PR TITLE
Workaround api request in ObsRsync Plugin

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -131,6 +131,11 @@ sub _is_obs_project_status_dirty {
     $url =~ s/%%PROJECT/$project/g;
     my $ua  = $self->{ua} ||= Mojo::UserAgent->new;
     my $res = $ua->get($url)->result;
+
+    if (!$res->is_success) {
+        # this is OBS-specific hack, which must be moved to config somehow
+        $res = $ua->get($url)->result if $url =~ s/\?package=000product//;
+    }
     return undef unless $res->is_success;
 
     return _parse_obs_response_dirty($res);

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -98,7 +98,10 @@ sub fake_api_server {
     for my $project (sort keys %fake_response_by_project) {
         $mock->routes->get(
             "/public/build/$project/_result" => sub {
-                shift->render(status => 200, text => $fake_response_by_project{$project});
+                my $c   = shift;
+                my $pkg = $c->param('package');
+                return $c->render(status => 404) if $pkg;
+                return $c->render(status => 200, text => $fake_response_by_project{$project});
             });
     }
     return $mock;


### PR DESCRIPTION
Current implementation doesnt support configuration of api url per project jet, so needs a workaround