### PR TITLE
load_templates: better error handling

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -222,9 +222,11 @@ sub update {
         $yaml .= "\n";
     }
     try {
+        my $template = $self->param('template') or die "No template specified\n";
+
         # No objects (aka SafeYAML)
         $YAML::XS::LoadBlessed = 0;
-        $data                  = YAML::XS::Load($yaml);
+        $data                  = YAML::XS::Load($template);
         $errors = $self->app->validate_yaml($data, $self->param('schema'), $self->app->log->level eq 'debug');
     }
     catch {

--- a/script/load_templates
+++ b/script/load_templates
@@ -75,6 +75,7 @@ use OpenQA::Client;
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 use YAML::XS;
+use Scalar::Util qw(reftype);
 
 use Getopt::Long;
 
@@ -130,11 +131,17 @@ my @tables = (qw(Machines TestSuites Products JobTemplates JobGroups));
 
 sub print_error {
     my ($res) = @_;
-    die 'unknown error code - host ' . $url->host . ' unreachable?' unless $res->code;
-    printf STDERR "ERROR: %s - %s\n", $res->code, $res->message // 'no error message';
-    if ($res->body) {
-        dd($res->json || $res->body);
+    if (my $err = $res->error) {
+        if (my $json = $res->json) {
+            if (my $json_err = $json->{error}) {
+                die "$err->{message}: " . join("\n", @{$json_err})
+                  if reftype $json_err eq 'ARRAY';
+                die "$err->{message}: $json_err";
+            }
+        }
+        die "ERROR: $err->{code} - $err->{message}" if $err->{code};
     }
+    die "unknown error code - host $url->{host} unreachable?";
 }
 
 sub post_entry {

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -65,7 +65,7 @@ my $schema = OpenQA::Test::Database->new->create(skip_schema => 1);
 # Create webapi and websocket server services
 my $mojoport = Mojo::IOLoop::Server->generate_port();
 my $wspid    = create_websocket_server($mojoport + 1, 0, 1, 1);
-my $webapi   = create_webapi($mojoport);
+my $webapi   = create_webapi($mojoport, sub { });
 
 # Setup needed files for workers.
 

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -18,6 +18,8 @@ use Mojo::Base -strict;
 
 use File::Temp qw(tempfile);
 use Mojo::File qw(path curfile);
+use OpenQA::Test::Database;
+use OpenQA::Test::Utils;
 use Test::More;
 use Test::Output;
 use Test::Warnings;
@@ -41,5 +43,42 @@ my $filename = 't/data/40-templates.pl';
 $args = "--host $host $filename";
 combined_like sub { $ret = run_once($args); }, qr/unknown error code - host $host unreachable?/, 'invalid host error';
 is $ret, 22, 'error because host is invalid';
+
+$ENV{MOJO_LOG_LEVEL} = 'fatal';
+my $mojoport = Mojo::IOLoop::Server->generate_port;
+$host = "localhost:$mojoport";
+my $pid = OpenQA::Test::Utils::create_webapi($mojoport, sub { OpenQA::Test::Database->new->create; });
+# Note: See t/fixtures/03-users.pl for test user credentials
+my $apikey    = 'PERCIVALKEY02';
+my $apisecret = 'PERCIVALSECRET02';
+$args = "--host $host --apikey $apikey --apisecret $apisecret $filename";
+combined_like sub { $ret = run_once($args); }, qr/Administrator level required/, 'Operator is not allowed';
+is $ret, 255, 'error because of insufficient permissions';
+
+$apikey    = 'ARTHURKEY01';
+$apisecret = 'EXCALIBUR';
+$args      = "--host $host --apikey $apikey --apisecret $apisecret $filename";
+combined_like sub { $ret = run_once($args); }, qr/Job group.+not found/, 'Invalid job group';
+is $ret, 255, 'failed to load templates with invalid job group';
+kill TERM => $pid;
+
+sub schema_hook {
+    my $schema     = OpenQA::Test::Database->new->create;
+    my $job_groups = $schema->resultset('JobGroups');
+    $job_groups->create({name => 'openSUSE Leap 42.3 Updates'});
+}
+$mojoport = Mojo::IOLoop::Server->generate_port;
+$host     = "localhost:$mojoport";
+$pid      = OpenQA::Test::Utils::create_webapi($mojoport, \&schema_hook);
+$args     = "--host $host --apikey $apikey --apisecret $apisecret $filename";
+stdout_like sub { $ret = run_once($args); }, qr/JobGroups.+=> \{ added => 1, of => 1 \}/, 'Admin may load templates';
+is $ret, 0, 'successfully loaded templates';
+
+$filename = 't/data/40-templates.json';
+$args     = "--host $host --apikey $apikey --apisecret $apisecret $filename";
+combined_like sub { $ret = run_once($args); }, qr/Bad Request: No template specified/,
+  'YAML template is mandatory (JSON)';
+is $ret, 255, 'failed to load templates without YAML (JSON)';
+kill TERM => $pid;
 
 done_testing;

--- a/t/data/40-templates.json
+++ b/t/data/40-templates.json
@@ -1,0 +1,35 @@
+{
+   "Machines" : [
+      {
+         "name" : "32bit",
+         "backend" : "qemu"
+      }
+   ],
+   "JobGroups" : [
+      {
+         "group_name" : "openSUSE Leap 42.3 Updates"
+      }
+   ],
+   "Products" : [
+      {
+         "arch" : "x86_64",
+         "version" : "42.2",
+         "flavor" : "DVD",
+         "distri" : "opensuse"
+      }
+   ],
+   "JobTemplates" : [
+   ],
+   "TestSuites" : [
+      {
+         "description" : "Maintainer: averagea\n\nThat's some test right there",
+         "name" : "uefi",
+         "settings" : [
+            {
+               "key" : "DESKTOP",
+               "value" : "gnome"
+            }
+         ]
+      }
+   ]
+}

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -158,7 +158,7 @@ foreach my $proj (sort { $b cmp $a } keys %params) {
 
     # refresh page and make sure that last sync is gone
     $driver->get("/admin/obs_rsync/$parent");
-    is($driver->find_element("tr#folder_$proj .lastsync")->get_text(), 'no data', "$proj last sync forgotten");
+    is($driver->find_element("tr#folder_$proj .lastsync")->get_text(), 'no data', "$proj last sync absent from web UI");
 
     # Update project status
     $driver->find_element("tr#folder_$proj .dirtystatusupdate")->click();


### PR DESCRIPTION
- The unit test also runs a webui with fixtures to verify how templates are loaded and how errors are handled.
- `SeleniumTest::start_app` is re-based onto `OpenQA::TEST::Utils::create_webapi` since both do the same except the latter was missing the schema hook.
- Fail cleanly in `JobTemplate::update` if not template was specified.
- Make Selenium start helpers internal

Related to: [poo#60118](https://progress.opensuse.org/issues/60118)