### PR TITLE
Fix unstable tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,8 @@ aliases:
       t)         make test CHECKSTYLE=1 PROVE_ARGS="$HARNESS t/*.t"     GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
       ui)        make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/ui/*.t"  GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
       api)       make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/api/*.t" GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
-      unstable)  for f in $(cat .circleci/unstable_tests.txt); do make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS $f" RETRY=3 || break; done;;
+      # put unstable tests in unstable_tests.txt and uncomment to handle with retries
+      #unstable)  for f in $(cat .circleci/unstable_tests.txt); do make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS $f" RETRY=3 || break; done;;
       fullstack) make test CHECKSTYLE=0 FULLSTACK=1           PROVE_ARGS="$HARNESS t/full-stack.t" RETRY=3;;
       scheduler) make test CHECKSTYLE=0 SCHEDULER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/05-scheduler-full.t" RETRY=3;;
       developer) make test CHECKSTYLE=0 DEVELOPER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/33-developer_mode.t";;
@@ -315,9 +316,10 @@ workflows:
       - ui:
           requires:
             - cache
-      - unstable:
-          requires:
-            - cache
+      # put unstable tests in unstable_tests.txt and uncomment to handle with retries
+      # - unstable:
+      #     requires:
+      #       - cache
       - cache.fullstack:
           requires:
             - cache
@@ -335,7 +337,7 @@ workflows:
             - t
             - api
             - ui
-            - unstable
+            # - unstable
             - fullstack
             - developer
             - scheduler

--- a/.circleci/unstable_tests.txt
+++ b/.circleci/unstable_tests.txt
@@ -1,3 +1,0 @@
-t/ui/14-dashboard-parents.t
-t/ui/01-list.t
-t/ui/26-jobs_restart.t

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -10,6 +10,7 @@ require OpenQA::Test::Database;
 our @EXPORT = qw($drivermissing check_driver_modules enable_timeout
   disable_timeout start_driver
   call_driver kill_driver wait_for_ajax disable_bootstrap_animations
+  wait_for_ajax_and_animations
   open_new_tab mock_js_functions element_visible element_hidden
   element_not_present javascript_console_has_no_warnings_or_errors
   wait_until wait_until_element_gone wait_for_element);
@@ -251,6 +252,11 @@ sub disable_bootstrap_animations {
     for my $rule (@rules) {
         $_driver->execute_script("document.styleSheets[0].addRule($rule, 1);");
     }
+}
+
+sub wait_for_ajax_and_animations {
+    disable_bootstrap_animations();
+    wait_for_ajax();
 }
 
 sub javascript_console_has_no_warnings_or_errors {

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -106,13 +106,10 @@ is(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, 'link to child 
 $driver->find_element_by_link_text('Build0091')->click();
 my $element = $driver->find_element_by_link_text('opensuse');
 ok($element->is_displayed(), 'link to child group expanded');
-
-# first try of click does not work for unknown reasons
-for (0 .. 10) {
-    $driver->find_element_by_link_text('Build0091')->click();
-    last if $driver->find_element('#group1_build13_1-0091 .h4 a')->is_hidden();
-}
-ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_hidden(), 'link to child group collapsed');
+$driver->find_element_by_link_text('Build0091')->click();
+# Looking for "is_hidden" does not turn out to be reliable so relying on xpath
+# lookup of collapsed entries instead
+ok($driver->find_element_by_xpath('//div[contains(@class,"children-collapsed")]//a'), 'link to child group collapsed');
 
 # go to parent group overview
 $driver->find_element_by_link_text('Test parent')->click();

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -98,8 +98,7 @@ $driver->title_is('openQA', 'on main page');
 my $baseurl = $driver->get_current_url();
 
 $driver->get($baseurl . '?limit_builds=20');
-disable_bootstrap_animations();
-wait_for_ajax();
+wait_for_ajax_and_animations;
 
 # test expanding/collapsing
 is(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, 'link to child group collapsed (in the first place)');
@@ -113,9 +112,7 @@ ok($driver->find_element_by_xpath('//div[contains(@class,"children-collapsed")]/
 
 # go to parent group overview
 $driver->find_element_by_link_text('Test parent')->click();
-disable_bootstrap_animations();
-wait_for_ajax();
-
+wait_for_ajax_and_animations;
 ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_displayed(), 'link to child group displayed');
 my @links = $driver->find_elements('.h4 a', 'css');
 is(scalar @links, 11, 'all links expanded in the first place');
@@ -128,15 +125,13 @@ isnt(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, "child group 
 # back to home and go to another parent group overview
 $driver->find_element_by_class('navbar-brand')->click();
 $driver->find_element_by_link_text('Test parent 2')->click();
-disable_bootstrap_animations();
-wait_for_ajax();
+wait_for_ajax_and_animations;
 isnt(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, "child group 'opensuse' in 'Test parent 2'");
 
 # test filtering for nested groups
 subtest 'filtering subgroups' => sub {
     $driver->get('/');
-    disable_bootstrap_animations();
-    wait_for_ajax();
+    wait_for_ajax_and_animations;
     my $url = $driver->get_current_url;
     $driver->find_element('#filter-panel .card-header')->click();
     $driver->find_element_by_id('filter-group')->send_keys('Test parent / .* test$');

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -126,8 +126,7 @@ is(scalar @{$driver->find_elements('h2', 'css')}, 2, 'a single, empty group para
 
 subtest 'filter form' => sub {
     $driver->get('/');
-    disable_bootstrap_animations;
-    wait_for_ajax;
+    wait_for_ajax_and_animations;
     my $url = $driver->get_current_url;
     $driver->find_element('#filter-panel .card-header')->click();
     $driver->find_element_by_id('filter-group')->send_keys('SLE 12 SP2');

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -381,8 +381,7 @@ sub test_with_error {
     # check whether candidates are displayed as expected
     my $random_number = int(rand(100000));
     $driver->get("/tests/99946?prevent_caching=$random_number#step/yast2_lan/1");
-    disable_bootstrap_animations;
-    wait_for_ajax;
+    wait_for_ajax_and_animations;
     is_deeply(find_candidate_needles, $expect, $test_name // 'candidates displayed as expected');
 }
 


### PR DESCRIPTION
* Treat all previously unstable tests as stable after proof of stability
* t: Extract method for ajax/animation handling
* Stabilize t/ui/14-dashboard-parents.t by relying on "collapsed" only

All previously unstable tests are now proven to be stable, see https://app.circleci.com/jobs/github/os-autoinst/openQA/12038/parallel-runs/0/steps/0-108 for test results.

Related progress issue: https://progress.opensuse.org/issues/53498