### PR TITLE
Use aliases in JobTemplate schema

### DIFF
--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -6,6 +6,7 @@ additionalProperties: false
 required:
 - products
 - scenarios
+
 properties:
   scenarios:
     description: The scenarios to run, i.e. lists of test suites per architecture and medium
@@ -28,19 +29,19 @@ properties:
                 description: A test suite with machine and/ or priority specified, or a custom job template name if testsuite was specified
                 additionalProperties: false
                 patternProperties:
-                  "^[A-Za-z\\s0-9_*.+-]+$":
+                  &testsuite-pattern "^[A-Za-z\\s0-9_*.+-]+$":
                     type: object
                     additionalProperties: false
                     properties:
-                      machine:
+                      machine: &machine-definition
                         oneOf:
                           - type: string
                           - type: array
                             items:
                             - type: string
-                      priority:
+                      priority: &priority-definition
                         type: number
-                      settings:
+                      settings: &settings-definition
                         type: object
                         description: Additional test variables to be set
                         additionalProperties: false
@@ -49,11 +50,12 @@ properties:
                             type: string
                       testsuite:
                         type: [string, 'null']
-                        pattern: "^[A-Za-z\\s0-9_*.+-]+$"
+                        pattern: *testsuite-pattern
                         description: The test suite this scenario is based on if a custom job template name was used
                       description:
                         type: string
                         description: The description of the job template
+
   defaults:
     description: A set of architectures with default configurations
     type: object
@@ -67,21 +69,10 @@ properties:
         - priority
         additionalProperties: false
         properties:
-          machine:
-            oneOf:
-              - type: string
-              - type: array
-                items:
-                - type: string
-          priority:
-            type: number
-          settings:
-            type: object
-            description: Additional test variables to be set
-            additionalProperties: false
-            patternProperties:
-              "^[A-Z_]+[A-Z0-9_]*$":
-                type: string
+          machine: *machine-definition
+          priority: *priority-definition
+          settings: *settings-definition
+
   products:
     type: object
     additionalProperties: false


### PR DESCRIPTION
to avoid duplication

Note that the regex for the settings and for the default settings were
different and I made them the same as I assumed this was an oversight.

Related issue: https://progress.opensuse.org/issues/60371