### PR TITLE
fetchneedles: Do not fail the script when we are on the correct branch

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -55,7 +55,11 @@ git_update() {
 # detached HEAD so we need to repair this
 git_update_needles() {
     git_update
-    test "$(git rev-parse --abbrev-ref --symbolic-full-name HEAD)" = "HEAD" && git branch -D master && git checkout -b master && git push origin HEAD:master
+    if [ "$(git rev-parse --abbrev-ref --symbolic-full-name HEAD)" = "HEAD" ]; then
+        git branch -D master
+        git checkout -b master
+        git push origin HEAD:master
+    fi
 }
 
 do_fetch() {

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -59,8 +59,8 @@ fi
 /usr/share/openqa/script/fetchneedles
 
 if ping -c1 gitlab.suse.de. ; then
-        sles_needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git"
-        sles_needles_directory="/var/lib/openqa/tests/opensuse/products/sle/needles"
+    sles_needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git"
+    sles_needles_directory="/var/lib/openqa/tests/opensuse/products/sle/needles"
     # clone SLE needles if run from within SUSE network
     if [ ! -d $sles_needles_directory ]; then
         echo "cloning $sles_needles_giturl shallow. Call 'git fetch --unshallow' for full history"


### PR DESCRIPTION
Seems I ran into https://github.com/koalaman/shellcheck/wiki/SC2015

Related progress issue: https://progress.opensuse.org/issues/62549