### PR TITLE
Have test_once in clone-custom-git-refspec test report errors correctly

### DIFF
--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -35,6 +35,9 @@ sub run_once {
 }
 
 sub test_once {
+    # Report failure at the callsite instead of the test function
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
     my ($args, $expected, $test_msg, $exit_code, $exit_code_msg) = @_;
     $expected      //= qr//;
     $test_msg      //= 'command line is correct';


### PR DESCRIPTION
Without the local override, failures point to the wrong line.

**Before**

```
not ok 18 - accepts comma-separated list of jobs

#   Failed test 'accepts comma-separated list of jobs'
#   at ./t/40-script_openqa-clone-custom-git-refspec.t line 44.
# STDOUT & STDERR:
# openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 1234 _GROUP=0 TEST=my_test@user/repo#my_branch BUILD=user/repo#9128 CASEDIR=https://github.com/user/repo.git#my_branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles
# openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 1234 _GROUP=0 TEST=my_test@user/repo#my_branch BUILD=user/repo#9128 CASEDIR=https://github.com/user/repo.git#my_branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles
#
# don't match:
# (?^s:openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 1234 _GROUP=0 TEST=my_test@user/repo#my_branchBUILD=user/repo#9128 CASEDIR=https://github.com/user/repo.git#my_branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles.*opensuse.org 1324)
# as expected
```

**After**

```
not ok 18 - accepts comma-separated list of jobs

#   Failed test 'accepts comma-separated list of jobs'
#   at ./t/40-script_openqa-clone-custom-git-refspec.t line 85.
# STDOUT & STDERR:
# openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 1234 _GROUP=0 TEST=my_test@user/repo#my_branch BUILD=user/repo#9128 CASEDIR=https://github.com/user/repo.git#my_branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles
# openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 1234 _GROUP=0 TEST=my_test@user/repo#my_branch BUILD=user/repo#9128 CASEDIR=https://github.com/user/repo.git#my_branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles
#
# don't match:
# (?^s:openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 1234 _GROUP=0 TEST=my_test@user/repo#my_branchBUILD=user/repo#9128 CASEDIR=https://github.com/user/repo.git#my_branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles.*opensuse.org 1324)
# as expected
```