### PR TITLE
Avoid undefined $appname/$api_description errors by using the stash

### DIFF
--- a/templates/layouts/error.html.ep
+++ b/templates/layouts/error.html.ep
@@ -8,7 +8,7 @@
       <meta name="description" content="openQA is a testing framework mainly for distributions">
       <meta name="keywords" content="Testing, Linux, Qemu">
       <meta name="author" content="openQA contributors">
-      % my $appname_safe = defined($appname)? $appname : "Default app";
+      % my $appname_safe = stash('appname') // "Default app";
       % if ($title) {
       <title><%= $appname_safe . ": " . title %></title>
       % } else

--- a/templates/not_found.html.ep
+++ b/templates/not_found.html.ep
@@ -29,6 +29,7 @@ table pre {
             <%= $route->has_custom_name ? qq{"$name"} : $name %>
         </td>
         <td>
+            % my $api_description = stash('api_description') // {};
             % if (my $description = $api_description->{$route->name}) {
                 %= $description
             % }


### PR DESCRIPTION
Otherwise non-existance of these variables raises an exception because templates are evaluted `strict`ly i.e.

```
Global symbol "$appname" requires explicit package name
```

Note: As discussed this still leaves using different templates in our micro services.