### PR TITLE
Fix extra arg escaping on clone_custom_git_refspec

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -107,7 +107,8 @@ clone_job() {
     local casedir="${casedir:-"$repo#$branch"}"
     local GROUP="${GROUP:-0}"
     local dry_run="${dry_run:-""}"
-    local cmd="$dry_run openqa-clone-job --skip-chained-deps --within-instance \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST=\"$test\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\" $args"
+    local cmd="$dry_run openqa-clone-job --skip-chained-deps --within-instance \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST=\"$test\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\""
+    cmd=$cmd"$(printf " '%s'" "${args[@]}")"
     if [[ -n "$MARKDOWN" ]]; then
         eval "$cmd" | sed 's/^Created job.*: \([^ ]*\) -> \(.*\)$/* [\1](\2)/'
     else
@@ -118,7 +119,7 @@ clone_job() {
 if [[ -z "$host" ]] || [[ -z "$job" ]]; then
     job_list="${2:?"Need 'job_url' as parameter pointing to the openQA job to clone or 'host' and 'job' variables, e.g. either 'https://openqa.opensuse.org/tests/123456' or 'https://openqa.opensuse.org' and '123456'. Argument can also be a comma-separated list of job URLs or a single host and multiple ids."}"
 fi
-args=${*:3}
+args=("${@:3}")
 IFS=',' ; for i in $job $job_list; do
     clone_job "$i"
 done

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -87,6 +87,13 @@ $args .= ' FOO=bar';
 $expected_re = qr/${expected} FOO=bar.*opensuse.org 1234.*FOO=bar/s;
 test_once $args, $expected_re, 'additional arguments are passed as test parameters for each job';
 
+my $args_escape
+  = q(https://github.com/me/repo/pull/1/ https://openqa.opensuse.org/tests/1 TEST1=$FOO_BAR 'TEST2=$VAR' TEST3=space\\ space 'TEST4=(!?bla)');
+$ENV{FOO_BAR} = 'BLUB';
+$expected_re = qr/TEST1=BLUB\r?\nTEST2=\$VAR\r?\nTEST3=space space\r?\nTEST4=\(!\?bla\)$/m;
+combined_like sub { run_once($args_escape, q(dry_run='printf "%s\n"')) }, $expected_re,
+  'Custom variables has proper bash escaping';
+
 TODO: {
     local $TODO = 'not implemented';
     $args = 'https://github.com/user/repo/pull/9128 https://openqa.opensuse.org/t1234';


### PR DESCRIPTION
When running openqa-clone-custom-git-refspec with arguments containing
bash special chars like '(' we get an syntax error.

e.g:
```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9253 https://openqa.suse.de/tests/3851992 'COMMAND_EXCLUDE=^(?!abort01)'
```