### PR TITLE
fetchneedles: Fix "no tracking information for the current branch" on self-repair

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -46,25 +46,27 @@ needlesdir() {
 }
 
 git_update() {
+    branch="${1:-"master"}"
     git gc --auto --quiet
-    git fetch -q
-    git rebase -q
+    git fetch -q origin
+    git rebase -q origin/"$branch"
 }
 
 # For needles repos because of needle saving we might end up in conflict, i.e.
 # detached HEAD so we need to repair this
 git_update_needles() {
-    git_update
+    git_update $needles_branch
     if [ "$(git rev-parse --abbrev-ref --symbolic-full-name HEAD)" = "HEAD" ]; then
-        git branch -D master
-        git checkout -b master
-        git push origin HEAD:master
+        git branch -D $needles_branch
+        git checkout -b $needles_branch
+        git branch --set-upstream-to=origin/$needles_branch $needles_branch
+        git push origin HEAD:$needles_branch
     fi
 }
 
 do_fetch() {
     target=$1
-    git_update
+    git_update "$branch"
     [ "$needles_separate" = 1 ] || return 0
     if test -d products; then
         for nd in products/*/needles; do


### PR DESCRIPTION
2aadd3e56 was probably incomplete in the sense that we recreate the master
branch but never set the upstream information causing the problem:

```
There is no tracking information for the current branch.
Please specify which branch you want to rebase against.
```

To prevent that we can set the upstream branch when recreating a branch.
Additionally it is a safer approach if we specify explicitly which branch to
fetch and rebase against as we already have the branch/needles_branch as
configuration parameters supplied.

Tested manually:

* Test 1: needles repo on valid branch -> fetch+rebase with explicit branch
  works fine

* Test 2: `git co HEAD^^^^` to detach from master -> fetchneedles calls
  self-repair including `git branch --set-upstream-to=origin/master master`

Related progress issue: https://progress.opensuse.org/issues/63133