### PR TITLE
Consistently store gru job output as a note

### DIFF
--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -39,7 +39,7 @@ our (@EXPORT, @EXPORT_OK);
 @EXPORT_OK = (
     qw(redirect_output standard_worker),
     qw(create_webapi create_websocket_server create_scheduler create_live_view_handler),
-    qw(unresponsive_worker wait_for_worker setup_share_dir),
+    qw(unresponsive_worker wait_for_worker setup_share_dir run_gru_job),
     qw(kill_service unstable_worker client_output fake_asset_server),
     qw(cache_minion_worker cache_worker_service shared_hash embed_server_for_testing)
 );
@@ -448,6 +448,16 @@ sub embed_server_for_testing {
     }
 
     return $server;
+}
+
+sub run_gru_job {
+    my $app    = shift;
+    my $id     = $app->gru->enqueue(@_)->{minion_id};
+    my $worker = $app->minion->worker->register;
+    my $job    = $worker->dequeue(0, {id => $id});
+    $job->perform;
+    $worker->unregister;
+    return $job->info;
 }
 
 1;


### PR DESCRIPTION
Previously gru would always capture STDOUT/STDERR for every job, but
often just throw it away without storing it anywhere. This made
debugging often rather problematic. Now it is always available in the
"output" note, which is easily introspectable from the Minion ui.

Additionally there is now also a "run_gru_job" test utility, that will
enqueue and perform a single job safely. There was a possible race
condition before, because the previously used "--oneshot" feature does
not run jobs selectively with id.