### PR TITLE
Only rebless gru jobs once

### DIFF
--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -17,7 +17,6 @@ package OpenQA::WebAPI::Command::gru::run;
 use Mojo::Base 'Minion::Command::minion::worker';
 
 use Mojo::Util 'getopt';
-use OpenQA::WebAPI::GruJob;
 
 has description => 'Start Gru worker';
 has usage       => sub { shift->extract_usage };
@@ -28,19 +27,6 @@ sub run {
     getopt \@args, 'o|oneshot' => \my $oneshot, 'reset-locks' => \my $reset_locks;
 
     my $minion = $self->app->minion;
-    $minion->on(
-        worker => sub {
-            my ($minion, $worker) = @_;
-            $worker->on(
-                dequeue => sub {
-                    my ($worker, $job) = @_;
-
-                    # Reblessing the job is fine for now, but in the future it would be nice
-                    # to use a role instead
-                    bless $job, 'OpenQA::WebAPI::GruJob';
-                });
-        });
-
     return $minion->perform_jobs if $oneshot;
 
     if ($reset_locks) {

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -334,7 +334,7 @@ subtest 'no cleanup of important builds' => sub {
     close $fh;
 
     $t->app->gru->enqueue('limit_results_and_logs');
-    $t->app->start('gru', 'run', '--oneshot');
+    $t->app->minion->perform_jobs;
     ok(-e $filename, 'file still exists');
 };
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -996,7 +996,7 @@ subtest 'async flag' => sub {
     is_deeply($json->{settings}, \%scheduling_params, 'settings stored correctly');
 
     # run gru and check whether scheduled product has actually been scheduled
-    $t->app->start('gru', 'run', '--oneshot');
+    $t->app->minion->perform_jobs;
     $t->get_ok("/api/v1/isos/$scheduled_product_id?include_job_ids=1")->status_is(200);
     $json = $t->tx->res->json;
     my $ok = 1;

--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -67,7 +67,7 @@ subtest 'smoke' => sub {
     $t->put_ok('/admin/obs_rsync/Proj1/runs')->status_is(404, "trigger rsync non-api path");
 };
 
-$t->app->start('gru', 'run', '--oneshot');
+$t->app->minion->perform_jobs;
 
 sub test_queue {
     my $t = shift;
@@ -83,7 +83,7 @@ sub test_queue {
     $t->put_ok('/api/v1/obs_rsync/Proj3/runs')->status_is(208, "Proj3 is still in queue");
     $t->put_ok('/api/v1/obs_rsync/WRONGPROJECT/runs')->status_is(404, "wrong project still returns error");
 
-    $t->app->start('gru', 'run', '--oneshot');
+    $t->app->minion->perform_jobs;
 
     $t->put_ok('/api/v1/obs_rsync/Proj1/runs')->status_is(201, "Proj1 just starts as queue is empty now");
 }
@@ -91,13 +91,13 @@ sub test_queue {
 subtest 'test queue' => sub {
     test_queue($t);
 };
-$t->app->start('gru', 'run', '--oneshot');
+$t->app->minion->perform_jobs;
 
 subtest 'test queue again' => sub {
     test_queue($t);
 };
 
-$t->app->start('gru', 'run', '--oneshot');
+$t->app->minion->perform_jobs;
 
 sub lock_test() {
     my $helper = $t->app->obs_rsync;
@@ -119,7 +119,7 @@ subtest 'test lock after failure' => sub {
     # now similate error by deleting the script
     unlink(Mojo::File->new($home, 'script', 'rsync.sh'));
     $t->put_ok('/api/v1/obs_rsync/Proj1/runs')->status_is(201, "trigger rsync");
-    $t->app->start('gru', 'run', '--oneshot');
+    $t->app->minion->perform_jobs;
 
     lock_test();
 };

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -194,7 +194,7 @@ $t->get_ok('/admin/obs_rsync/')->status_is(200, 'project list')->content_like(qr
 $t->get_ok('/admin/obs_rsync/queue')->status_is(200, 'jobs list')->content_like(qr/inactive/)
   ->content_unlike(qr/\bactive\b/)->content_like(qr/Proj1/)->content_like(qr/Proj2/)->content_like(qr/Proj3/);
 
-$t->app->start('gru', 'run', '--oneshot');
+$t->app->minion->perform_jobs;
 
 # Proj1 and Proj2 must be still in queue, but Proj3 must gone now
 $t->get_ok('/admin/obs_rsync/queue')->status_is(200, 'jobs list')->content_like(qr/inactive/)


### PR DESCRIPTION
Every time the "--oneshot" command runs it registers yet another worker
event handler. Causing more and more overhead each time. But we don't
actually need to use commands to run jobs in tests. Minion already has
method for that we can use instead.