### PR TITLE
worker: Improve inconsistent reason and logging

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -127,39 +127,24 @@ sub register {
     # register via REST API
     $url->path('workers');
     $url->query($capabilities);
-    my $tx = $ua->post($url, json => $capabilities);
+    my $tx       = $ua->post($url, json => $capabilities);
+    my $json_res = $tx->res->json;
     if (my $error = $tx->error) {
-        my $err_code = $error->{code};
-        if ($err_code) {
-            if ($err_code =~ /^4\d\d$/) {
-                # don't retry when 4xx codes are returned. There is problem with scheduler
-                $self->_set_status(
-                    disabled => {
-                        error_message => sprintf('server refused with code %s: %s', $tx->error->{code}, $tx->res->body)}
-                );
-            }
-            else {
-                $self->_set_status(
-                    failed => {
-                        error_message =>
-                          sprintf('failed to register worker %s - %s:%s', $webui_host, $err_code, $tx->res->body)});
-            }
-        }
-        else {
-            $self->_set_status(
-                failed => {
-                    error_message => "Unable to connect to host $webui_host"
-                });
-        }
+        my $error_code  = $error->{code};
+        my $error_class = $error_code ? "$error_code response" : 'connection error';
+        my $error_message;
+        $error_message = $json_res->{error} if ref($json_res) eq 'HASH';
+        $error_message //= $tx->res->body || $error->{message};
+        $error_message = "Failed to register at $webui_host - $error_class: $error_message";
+        my $status = (defined $error_code && $error_code =~ /^4\d\d$/ ? 'disabled' : 'failed');
+        $self->_set_status($status => {error_message => $error_message});
         return undef;
     }
-    my $worker_id = $tx->res->json->{id};
+    my $worker_id = $json_res->{id};
     $self->worker_id($worker_id);
     if (!defined $worker_id) {
         $self->_set_status(
-            disabled => {
-                error_message => "Host $webui_host did not return a worker ID"
-            });
+            disabled => {error_message => "Failed to register at $webui_host: host did not return a worker ID"});
         return undef;
     }
 

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -137,6 +137,7 @@ sub register {
         $error_message //= $tx->res->body || $error->{message};
         $error_message = "Failed to register at $webui_host - $error_class: $error_message";
         my $status = (defined $error_code && $error_code =~ /^4\d\d$/ ? 'disabled' : 'failed');
+        $self->{_last_error} = $error_message;
         $self->_set_status($status => {error_message => $error_message});
         return undef;
     }

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -226,8 +226,9 @@ subtest 'attempt to register and send a command' => sub {
                 error_message => undef,
             },
             {
-                status        => 'failed',
-                error_message => 'Unable to connect to host http://test-host',
+                status => 'failed',
+                error_message =>
+                  "Failed to register at http://test-host - connection error: Can't connect: Name or service not known",
             }
         ],
         'events emitted'

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -218,21 +218,18 @@ subtest 'attempt to register and send a command' => sub {
     is($client->worker->stop_current_job_called,
         'api-failure', 'attempted to stop current job with reason "api-failure"');
 
-    is_deeply(
-        \@happened_events,
-        [
-            {
-                status        => 'registering',
-                error_message => undef,
-            },
-            {
-                status => 'failed',
-                error_message =>
-                  "Failed to register at http://test-host - connection error: Can't connect: Name or service not known",
-            }
-        ],
-        'events emitted'
-    ) or diag explain \@happened_events;
+    my $error_message = ref($happened_events[1]) eq 'HASH' ? delete $happened_events[1]->{error_message} : undef;
+    (
+        is_deeply(
+            \@happened_events,
+            [{status => 'registering', error_message => undef}, {status => 'failed'}],
+            'events emitted',
+          )
+          and like(
+            $error_message,
+            qr{Failed to register at http://test-host - connection error: Can't connect:.*},
+            'error message',
+          )) or diag explain \@happened_events;
 };
 
 


### PR DESCRIPTION
This helps with incompletes like https://openqa.suse.de/tests/3863913

* The reason for the API failure is consistent with how it is usually provided (e.g. has a details error message).
* If the authentication error only happened once the job wouldn't even be incomplete. The worker would still be restarted after the job is done (e.g. reloading credentials from the config file might help).