### PR TITLE
Use a shared downloader for cache service and webui

### DIFF
--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -1,0 +1,107 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Downloader;
+use Mojo::Base -base;
+
+use Mojo::UserAgent;
+use Mojo::File 'path';
+use OpenQA::Utils 'human_readable_size';
+
+has attempts => 5;
+has [qw(log tmpdir)];
+has sleep_time => 5;
+has ua         => sub { Mojo::UserAgent->new(max_redirects => 2, max_response_size => 0) };
+
+sub download {
+    my ($self, $url, $target, $options) = (shift, shift, shift, shift // {});
+
+    my $log = $self->log;
+
+    local $ENV{MOJO_TMPDIR} = $self->tmpdir;
+
+    my $n = $self->attempts;
+    while (1) {
+        $options->{on_attempt}->() if $options->{on_attempt};
+
+        my $ret;
+        eval { $ret = $self->_get($url, $target, $options) };
+        return 1 unless $ret;
+
+        if ($ret =~ /^5[0-9]{2}$/ && --$n) {
+            my $time = $self->sleep_time;
+            $log->info("Download error $ret, waiting $time seconds for next try ($n remaining)");
+            sleep $time;
+            next;
+        }
+        elsif (!$n) {
+            $options->{on_failed}->() if $options->{on_failed};
+            last;
+        }
+
+        last;
+    }
+
+    return undef;
+}
+
+sub _get {
+    my ($self, $url, $target, $options) = @_;
+
+    my $ua  = $self->ua;
+    my $log = $self->log;
+
+    my $file = path($target)->basename;
+    $log->info(qq{Downloading "$file" from "$url"});
+
+    # Assets might be deleted by a sysadmin
+    my $tx   = $ua->build_tx(GET => $url);
+    my $etag = $options->{etag};
+    $tx->req->headers->header('If-None-Match' => $etag) if $etag && -e $target;
+    $tx = $ua->start($tx);
+    my $res = $tx->res;
+
+    my $ret;
+    my $code = $res->code // 521;    # Used by cloudflare to indicate web server is down.
+    if ($code eq 304) {
+        $options->{on_unchanged}->() if $options->{on_unchanged};
+        $ret = 520 unless -e $target;    # Avoid race condition between check and removal
+    }
+
+    elsif ($res->is_success) {
+        unlink $target;
+        $options->{on_downloaded}->() if $options->{on_downloaded};
+        my $headers = $res->headers;
+        my $size    = $res->content->asset->move_to($target)->size;
+        if ($size == $headers->content_length) {
+            $options->{on_success}->($res) if $options->{on_success};
+        }
+        else {
+            my $header_size = human_readable_size($headers->content_length);
+            my $actual_size = human_readable_size($size);
+            $log->info(qq{Size of "$target" differs, expected $header_size but downloaded $actual_size});
+            $ret = 598;    # 598 (Informal convention) Network read timeout error
+        }
+    }
+    else {
+        my $message = $res->error->{message};
+        $log->info(qq{Download of "$target" failed: $code $message});
+        $ret = $code;
+    }
+
+    return $ret;
+}
+
+1;

--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -63,7 +63,10 @@ sub _download {
     my $downloader = OpenQA::Downloader->new(log => $ctx, tmpdir => $ENV{MOJO_TMPDIR});
     my $options    = {
         extract    => $do_extract,
-        on_success => sub { chmod 0644, $assetpath }
+        on_success => sub {
+            chmod 0644, $assetpath;
+            $ctx->debug(qq{Download of "$assetpath" successful});
+        }
     };
     unless ($downloader->download($url, $assetpath, $options)) {
         $ctx->error(my $msg = qq{Downloading "$url" failed because of too many download errors});

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -536,7 +536,7 @@ subtest 'download assets with correct permissions' => sub {
 
     $t->app->config->{global}->{download_domains} .= " $local_domain";
     $output = run_gru_job($t->app, 'download_asset' => [$assetsource . '.foo', $assetpath, 0])->{notes}{output};
-    like $output, qr/404 response\:/, 'error code logged';
+    like $output, qr/failed: 404 Not Found/, 'error code logged';
 
     run_gru_job($t->app, 'download_asset' => [$assetsource, $assetpath, 0]);
     ok(-f $assetpath, 'asset downloaded');

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -527,12 +527,12 @@ subtest 'download assets with correct permissions' => sub {
     unlink($assetpath);
 
     my $output = run_gru_job($t->app, 'download_asset' => [$assetsource, $assetpath, 0])->{notes}{output};
-    like $output, qr/host $local_domain .* is not on the whitelist \(which is empty\)/,
+    like $output, qr/Host "$local_domain" .* is not on the whitelist \(which is empty\)/,
       'download refused if whitelist empty';
 
     $t->app->config->{global}->{download_domains} = 'foo';
     $output = run_gru_job($t->app, 'download_asset' => [$assetsource, $assetpath, 0])->{notes}{output};
-    like $output, qr/host $local_domain .* is not on the whitelist/, 'download refused if host not on whitelist';
+    like $output, qr/Host "$local_domain" .* is not on the whitelist/, 'download refused if host not on whitelist';
 
     $t->app->config->{global}->{download_domains} .= " $local_domain";
     $output = run_gru_job($t->app, 'download_asset' => [$assetsource . '.foo', $assetpath, 0])->{notes}{output};

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -176,8 +176,7 @@ like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(4 remai
 like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
 like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(2 remaining\)/, '2 tries remaining';
 like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
-like $cache_log,   qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
-unlike $cache_log, qr/failed because the asset did not exist/,                'Asset existed';
+like $cache_log, qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
 ok !-e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-589@64bit.qcow2'), 'Asset does not exist in cache';
 $cache_log = '';
 

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -104,7 +104,7 @@ for my $i (1 .. 3) {
     }
 }
 
-$cache->sleep_time(1);
+$cache->downloader->sleep_time(1);
 $cache->init;
 is $cache->sqlite->migrations->active, 2, 'version 2 is still the active version';
 like $cache_log, qr/Cache size of "$cachedir" is 168 Byte, with limit 50GiB/,
@@ -314,7 +314,7 @@ subtest 'cache directory is symlink' => sub {
 subtest 'cache tmp directory is used for downloads' => sub {
     $cache->location($cachedir);
     my $tmpfile;
-    $cache->ua->on(
+    $cache->downloader->ua->on(
         start => sub {
             my ($ua, $tx) = @_;
             $tx->res->on(

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -1,0 +1,191 @@
+#! /usr/bin/perl
+
+# Copyright (c) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Mojo::Base -strict;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+use OpenQA::Downloader;
+use IO::Socket::INET;
+use Mojo::Server::Daemon;
+use Mojo::IOLoop::Server;
+use Mojo::Log;
+use POSIX '_exit';
+use Mojo::IOLoop::ReadWriteProcess 'process';
+use Mojo::IOLoop::ReadWriteProcess::Session 'session';
+use OpenQA::Test::Utils qw(fake_asset_server);
+use Mojo::File qw(tempdir);
+
+my $port = Mojo::IOLoop::Server->generate_port;
+my $host = "127.0.0.1:$port";
+
+# Capture logs
+my $log = Mojo::Log->new;
+$log->unsubscribe('message');
+my $cache_log = '';
+$log->on(
+    message => sub {
+        my ($log, $level, @lines) = @_;
+        $cache_log .= "[$level] " . join "\n", @lines, '';
+    });
+
+$SIG{INT} = sub { session->clean };
+
+END { session->clean }
+
+my $server_instance = process sub {
+    Mojo::Server::Daemon->new(app => fake_asset_server, listen => ["http://$host"], silent => 1)->run;
+    _exit(0);
+};
+
+sub start_server {
+    $server_instance->set_pipes(0)->start;
+    sleep 1 while !IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port);
+    return;
+}
+
+sub stop_server {
+    # now kill the worker
+    $server_instance->stop();
+}
+
+my $mojo_tmpdir = tempdir;
+my $downloader  = OpenQA::Downloader->new(log => $log, sleep_time => 1, tmpdir => $mojo_tmpdir);
+my $tempdir     = tempdir;
+my $to          = $tempdir->child('test.qcow');
+
+subtest 'Connection refused' => sub {
+    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
+    ok !$downloader->download($from, $to), 'Failed';
+
+    ok !-e $to, 'File not downloaded';
+
+    like $cache_log, qr/Downloading "test.qcow" from "$from"/,                               'Download attempt';
+    like $cache_log, qr/Download of "$to" failed: 521/,                                      'Real error is logged';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(2 remaining\)/, '2 tries remaining';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
+    $cache_log = '';
+};
+
+$port = Mojo::IOLoop::Server->generate_port;
+$host = "127.0.0.1:$port";
+start_server;
+
+subtest 'Not found' => sub {
+    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-404@64bit.qcow2";
+    ok !$downloader->download($from, $to), 'Failed';
+
+    ok !-e $to, 'File not downloaded';
+
+    like $cache_log,   qr/Downloading "test.qcow" from "$from"/,    'Download attempt';
+    like $cache_log,   qr/Download of "$to" failed: 404 Not Found/, 'Real error is logged';
+    unlike $cache_log, qr/waiting .* seconds for next try/,         'No retries';
+    $cache_log = '';
+};
+
+subtest 'Success' => sub {
+    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200@64bit.qcow2";
+    ok $downloader->download($from, $to), 'Success';
+
+    ok -e $to, 'File downloaded';
+    is -s $to, 1024, 'File size is 1024 bytes';
+    unlink $to;
+
+    like $cache_log,   qr/Downloading "test.qcow" from "$from"/, 'Download attempt';
+    unlike $cache_log, qr/waiting .* seconds for next try/,      'No retries';
+    $cache_log = '';
+};
+
+subtest 'Connection closed early' => sub {
+    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_close@64bit.qcow2";
+    ok !$downloader->download($from, $to), 'Failed';
+
+    ok !-e $to, 'File not downloaded';
+
+    like $cache_log, qr/Downloading "test.qcow" from "$from"/,                               'Download attempt';
+    like $cache_log, qr/Download of "$to" failed: 521 Premature connection close/,           'Real error is logged';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(2 remaining\)/, '2 tries remaining';
+    like $cache_log, qr/Download error 521, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
+    $cache_log = '';
+};
+
+subtest 'Server error' => sub {
+    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_server_error@64bit.qcow2";
+    ok !$downloader->download($from, $to), 'Failed';
+
+    ok !-e $to, 'File not downloaded';
+
+    like $cache_log, qr/Downloading "test.qcow" from "$from"/,                               'Download attempt';
+    like $cache_log, qr/Download of "$to" failed: 500 Internal Server Error/,                'Real error is logged';
+    like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
+    like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
+    like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(2 remaining\)/, '2 tries remaining';
+    like $cache_log, qr/Download error 500, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
+    $cache_log = '';
+};
+
+subtest 'Size differs' => sub {
+    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-589@64bit.qcow2";
+    ok !$downloader->download($from, $to), 'Failed';
+
+    ok !-e $to, 'File not downloaded';
+
+    like $cache_log, qr/Downloading "test.qcow" from "$from"/,                       'Download attempt';
+    like $cache_log, qr/Size of .+ differs, expected 10 Byte but downloaded 6 Byte/, 'Incomplete download logged';
+    like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(4 remaining\)/, '4 tries remaining';
+    like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(3 remaining\)/, '3 tries remaining';
+    like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(2 remaining\)/, '2 tries remaining';
+    like $cache_log, qr/Download error 598, waiting 1 seconds for next try \(1 remaining\)/, '1 tries remaining';
+    $cache_log = '';
+};
+
+subtest 'Decompressing archive failed' => sub {
+    $to = $tempdir->child('test');
+    my $from = "http://$host/test.gz";
+    ok !$downloader->download($from, $to, {extract => 1}), 'Failed';
+
+    ok !-e $to, 'File not downloaded';
+
+    like $cache_log, qr/Downloading "test" from "$from"/,                              'Download attempt';
+    like $cache_log, qr/Extracting ".*test" to ".*test"/,                              'Extracting download';
+    like $cache_log, qr/Extracting ".*test" failed: Could not determine archive type/, 'Extracting failed';
+    $cache_log = '';
+};
+
+subtest 'Decompressing archive' => sub {
+    $to = $tempdir->child('test.gz');
+    my $from = "http://$host/test.gz";
+    ok $downloader->download($from, $to, {extract => 1}), 'Success';
+
+    ok -e $to, 'File downloaded';
+    is $to->slurp, 'This file was compressed!', 'File was decompressed';
+
+    like $cache_log,   qr/Downloading "test.gz" from "$from"/,    'Download attempt';
+    like $cache_log,   qr/Extracting ".*test.gz" to ".*test.gz"/, 'Extracting download';
+    unlike $cache_log, qr/Extracting ".*test" failed:/,           'Extracting did not fail';
+    $cache_log = '';
+};
+
+stop_server;
+
+done_testing();

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -17,6 +17,7 @@ use OpenQA::Scheduler::Client;
 use Mojo::Home;
 use Mojo::File qw(path tempfile);
 use Cwd qw(abs_path getcwd);
+use Mojo::Util 'gzip';
 use Test::More;
 use Mojo::IOLoop;
 use Mojo::IOLoop::ReadWriteProcess 'process';
@@ -74,7 +75,14 @@ sub cache_worker_service {
 sub fake_asset_server {
     my $mock = Mojolicious->new;
     $mock->mode('test');
-    $mock->routes->get(
+    my $r = $mock->routes;
+    $r->get(
+        '/test.gz' => sub {
+            my $c       = shift;
+            my $archive = gzip 'This file was compressed!';
+            $c->render(data => $archive);
+        });
+    $r->get(
         '/tests/:job/asset/:type/:filename' => sub {
             my $c        = shift;
             my $id       = $c->stash('job');


### PR DESCRIPTION
This makes all the features the cache service currently has, such as retries, available for asset downloads in the webui. Just need to make sure test coverage is good enough. As it turns out, features like auto-extract did not have any tests at all.

Progress: https://progress.opensuse.org/issues/62459