### PR TITLE
worker: Enhance log output slightly

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -353,9 +353,6 @@ sub engine_workit {
             $ENV{TMPDIR} = $tmpdir;
             log_info("$$: WORKING " . $job_info->{id});
             log_debug('+++ worker notes +++', channels => 'autoinst');
-            my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
-            log_debug(sprintf("Running on $hostname:%d ($sysname $release $version $machine)", $instance),
-                channels => 'autoinst');
             my $handle = get_channel_handle('autoinst');
             STDOUT->fdopen($handle, 'w');
             STDERR->fdopen($handle, 'w');
@@ -371,12 +368,7 @@ sub engine_workit {
         collected => sub {
             my $self = shift;
             eval { log_info("Isotovideo exit status: " . $self->exit_status, channels => 'autoinst'); };
-            if ($self->exit_status != 0) {
-                $job->stop('died');
-            }
-            else {
-                $job->stop('done');
-            }
+            $job->stop($self->exit_status == 0 ? 'done' : 'died');
         });
 
     session->on(

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -201,7 +201,6 @@ sub engine_workit {
 
     my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
     log_info('+++ setup notes +++', channels => 'autoinst');
-    log_info(sprintf("Start time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
     log_info(sprintf("Running on $hostname:%d ($sysname $release $version $machine)", $instance),
         channels => 'autoinst');
 
@@ -353,9 +352,7 @@ sub engine_workit {
             setpgrp(0, 0);
             $ENV{TMPDIR} = $tmpdir;
             log_info("$$: WORKING " . $job_info->{id});
-            log_debug('+++ worker notes +++',                               channels => 'autoinst');
-            log_debug(sprintf("Start time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
-
+            log_debug('+++ worker notes +++', channels => 'autoinst');
             my ($sysname, $hostname, $release, $version, $machine) = POSIX::uname();
             log_debug(sprintf("Running on $hostname:%d ($sysname $release $version $machine)", $instance),
                 channels => 'autoinst');


### PR DESCRIPTION
* worker: Remove redundant worker information log output
* worker: Simplify '->stop' call slightly
* Remove redundant timestamp output in worker log