### PR TITLE
Redirect to remote code location for source view when using CASEDIR

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -371,7 +371,6 @@ sub _extended_needle_info {
 
 sub src {
     my ($self) = @_;
-
     return $self->reply->not_found unless $self->init();
 
     my $job    = $self->stash('job');
@@ -379,18 +378,11 @@ sub src {
 
     my $testcasedir = testcasedir($job->DISTRI, $job->VERSION);
     my $scriptpath  = "$testcasedir/" . $module->script;
-    if (!$scriptpath || !-e $scriptpath) {
-        $scriptpath ||= "";
-        return $self->reply->not_found;
-    }
+    return $self->reply->not_found unless $scriptpath && -e $scriptpath;
     my $script_h = path($scriptpath)->open('<:encoding(UTF-8)');
-    my @script_content;
-    if (defined $script_h) {
-        @script_content = <$script_h>;
-    }
-    my $script = "@script_content";
-
-    $self->stash('script',     $script);
+    return $self->reply->not_found unless defined $script_h;
+    my @script_content = <$script_h>;
+    $self->stash('script',     "@script_content");
     $self->stash('scriptpath', $scriptpath);
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -382,8 +382,7 @@ sub src {
     my $script_h = path($scriptpath)->open('<:encoding(UTF-8)');
     return $self->reply->not_found unless defined $script_h;
     my @script_content = <$script_h>;
-    $self->stash('script',     "@script_content");
-    $self->stash('scriptpath', $scriptpath);
+    $self->render(script => "@script_content", scriptpath => $scriptpath);
 }
 
 sub save_needle_ajax {

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,18 +23,12 @@ use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
 
-SKIP: {
-    skip "breaks package build", 4;
+OpenQA::Test::Case->new->init_data;
 
-    OpenQA::Test::Case->new->init_data;
+my $t    = Test::Mojo->new('OpenQA::WebAPI');
+my $name = 'installer_timezone';
+$t->get_ok("/tests/99938/modules/$name/steps/1/src")->status_is(200)
+  ->content_like(qr|installation/.*$name.pm|i, "$name test source found")
+  ->content_like(qr/assert_screen.*timezone/i, "$name test source shown");
 
-    my $t = Test::Mojo->new('OpenQA::WebAPI');
-
-    my $test_name = 'isosize';
-
-    $t->get_ok("/tests/99938/modules/$test_name/steps/1/src")->status_is(200)
-      ->content_like(qr|inst\.d/.*$test_name.pm|i, "$test_name test source found")
-      ->content_like(qr/ISO_MAXSIZE/i,             "$test_name test source shown");
-}
-
-done_testing();
+done_testing;


### PR DESCRIPTION
The source code view always referenced the current state of test code in
a local path rather than the code that was actually used during test
execution. Any use of remote code locations would in many cases be
incorrectly mapped to local paths which might not even exist.

This commit extends the behaviour to redirect to remote code locations in
case if the variable CASEDIR is specified with a URL pointing to a remote
location.

Related progress issue: https://progress.opensuse.org/issues/54965