### PR TITLE
Fix scheduler ws race condition

### DIFF
--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -20,11 +20,15 @@ use constant MAX_TIMER => 100;
 # Time verification to be use with WORKERS_CHECKER_THRESHOLD.
 use constant MIN_TIMER => 20;
 
+# The smallest distinguishable time difference of timestamps in the database in seconds
+use constant DB_TIMESTAMP_ACCURACY => 1;
+
 our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION
   WORKERS_CHECKER_THRESHOLD
   MAX_TIMER
   MIN_TIMER
+  DB_TIMESTAMP_ACCURACY
 );
 
 

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -235,6 +235,8 @@ sub schedule {
         };
 
         if (ref($res) eq 'HASH' && $res->{state} && $res->{state}->{msg_sent} == 1) {
+            # note: That only means the websocket server could *start* sending the message but not that the message
+            #       has been received and acknowledged by the worker.
             log_debug("Sent job(s) '$job_ids_str' to worker '$worker_id'");
             push(@successfully_allocated, map { {job => $_, worker => $worker_id} } @$job_ids);
             next;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -340,7 +340,7 @@ sub reschedule_state {
             result             => NONE
         });
 
-    log_debug('Job  ' . $self->id . " reset to state $state");
+    log_debug('Job ' . $self->id . " reset to state $state");
 
     # free the worker
     if (my $worker = $self->worker) {

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 SUSE Linux GmbH
-#               2016-2018 SUSE LLC
+#               2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@ use Try::Tiny;
 use OpenQA::App;
 use OpenQA::Utils 'log_error';
 use OpenQA::WebSockets::Client;
-use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
+use OpenQA::Constants qw(WORKERS_CHECKER_THRESHOLD DB_TIMESTAMP_ACCURACY);
 use OpenQA::Jobs::Constants;
 use Mojo::JSON qw(encode_json decode_json);
 
@@ -145,7 +145,7 @@ sub dead {
     # check for workers active in last WORKERS_CHECKER_THRESHOLD
     # last seen should be updated at least in MAX_TIMER t in worker
     # and should not be greater than WORKERS_CHECKER_THRESHOLD.
-    $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD);
+    $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD - DB_TIMESTAMP_ACCURACY);
 
     $self->t_updated < $dt;
 }

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -28,6 +28,7 @@ use OpenQA::App;
 use OpenQA::Utils 'log_error';
 use OpenQA::WebSockets::Client;
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
+use OpenQA::Jobs::Constants;
 use Mojo::JSON qw(encode_json decode_json);
 
 use constant COMMANDS =>
@@ -277,6 +278,36 @@ sub unfinished_jobs {
 sub set_current_job {
     my ($self, $job) = @_;
     $self->update({job_id => $job->id});
+}
+
+sub reschedule_assigned_jobs {
+    my ($self) = @_;
+
+    my @all_jobs_currently_associated_with_worker = ($self->job, $self->unfinished_jobs);
+    my %considered_jobs;
+    for my $associated_job (@all_jobs_currently_associated_with_worker) {
+        next unless defined $associated_job;
+
+        # prevent doing this twice for the same job ($current_job and @unfinished_jobs might overlap)
+        my $job_id = $associated_job->id;
+        next if exists $considered_jobs{$job_id};
+        $considered_jobs{$job_id} = 1;
+
+        # consider only assigned jobs here
+        # note: Running jobs are only marked as incomplete on worker registration (and not here) because that
+        #       operation can be quite costly.
+        next if $associated_job->state ne ASSIGNED;
+
+        # set associated job which was only assigned back to scheduled
+        # note: Using a transaction here so we don't end up with an inconsistent state when an error occurs.
+        try {
+            $self->result_source->schema->txn_do(sub { $associated_job->reschedule_state });
+        }
+        catch {
+            my $worker_id = $self->id;
+            log_warning("Unable to re-schedule job $job_id abandoned by worker $worker_id: $_");
+        };
+    }
 }
 
 1;

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -103,9 +103,10 @@ sub ws_send_job {
         return $result;
     }
 
+    my $job_ids = ref($job_info->{ids}) eq 'ARRAY' ? $job_info->{ids} : [$job_info->{id} // ()];
     $tx->send({json => $message});
-    my $id_string = ref($job_info->{ids}) eq 'ARRAY' ? join(', ', @{$job_info->{ids}}) : $job_info->{id} // '?';
-    log_debug("Started to send message to $worker_id for job $id_string");
+    my $id_string = join(', ', @$job_ids) || '?';
+    log_debug("Started to send message to $worker_id for job(s) $id_string");
     $result->{state}->{msg_sent} = 1;
     return $result;
 }

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -69,6 +69,7 @@ sub _message {
     my $schema        = $app->schema;
     my $worker_status = $app->status->worker_status;
 
+    # find relevant worker
     my $worker = OpenQA::WebSockets::Model::Status->singleton->worker_by_transaction->{$self->tx};
     unless ($worker) {
         $app->log->warn("A message received from unknown worker connection");
@@ -76,49 +77,73 @@ sub _message {
         $self->finish("1008", "Connection terminated from WebSocket server - thought dead");
         return undef;
     }
+    my $worker_id = $worker->{id};
+    my $worker_db = $worker->{db};
+
     unless (ref($json) eq 'HASH') {
-        log_error(sprintf('Received unexpected WS message "%s from worker %u', Dumper($json), $worker->{id}));
-        $self->finish("1003", "Received unexpected data from worker, forcing close");
+        log_error(sprintf('Received unexpected WS message "%s from worker %u', Dumper($json), $worker_id));
+        $self->finish(1003 => 'Received unexpected data from worker, forcing close');
         return undef;
     }
 
-    # This is to make sure that no worker can skip the _registration.
-    if (($worker->{db}->websocket_api_version() || 0) != WEBSOCKET_API_VERSION) {
-        log_warning("Received a message from an incompatible worker " . $worker->{id});
-        $self->tx->send({json => {type => 'incompatible'}});
-        $self->finish("1008",
-            "Connection terminated from WebSocket server - incompatible communication protocol version");
+    # make sure no worker can skip the initial registration
+    if (($worker_db->websocket_api_version || 0) != WEBSOCKET_API_VERSION) {
+        log_warning("Received a message from an incompatible worker $worker_id");
+        $self->send({json => {type => 'incompatible'}});
+        $self->finish(
+            1008 => 'Connection terminated from WebSocket server - incompatible communication protocol version');
         return undef;
     }
 
-    if ($json->{type} eq 'quit') {
+    my $message_type = $json->{type};
+    if ($message_type eq 'quit') {
         my $dt = DateTime->now(time_zone => 'UTC');
         $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD);
-        $worker->{db}->update({t_updated => $dt});
+        $worker_db->update({t_updated => $dt});
+        $worker_db->reschedule_assigned_jobs;
     }
-    elsif ($json->{type} eq 'accepted') {
+    elsif ($message_type eq 'rejected') {
+        my $job_ids = $json->{job_ids};
+        my $reason  = $json->{reason} // 'unknown reason';
+        return undef unless ref($job_ids) eq 'ARRAY' && @$job_ids;
+
+        my $job_ids_str = join(', ', @$job_ids);
+        log_debug("Worker $worker_id rejected job(s) $job_ids_str: $reason");
+
+        # re-schedule rejected job if it is still assigned to that worker
+        try {
+            $schema->txn_do(
+                sub {
+                    my @jobs = $schema->resultset('Jobs')
+                      ->search({id => {-in => $job_ids}, assigned_worker_id => $worker_id, state => ASSIGNED});
+                    $_->reschedule_state for @jobs;
+                });
+        }
+        catch {
+            log_warning("Unable to re-schedule job(s) $job_ids_str rejected by worker $worker_id: $_");
+        };
+    }
+    elsif ($message_type eq 'accepted') {
         my $job_id = $json->{jobid};
         return undef unless $job_id;
 
         # verify whether the job has previously been assigned to the worker and can actually be accepted
-        my $job = $worker->{db}->unfinished_jobs->find($job_id);
+        my $job = $worker_db->unfinished_jobs->find($job_id);
         if (!$job) {
             log_warning(
-                "Worker $worker->{id} accepted job $job_id which was never assigned to it or has already finished");
+                "Worker $worker_id accepted job $job_id which was never assigned to it or has already finished");
             return undef;
         }
 
         # assume the job setup is done by the worker
-        # note: Setting the state to something different also prevents that the job is set back to SCHEDULED
-        #       if the worker is slow with the first status update.
         $schema->resultset('Jobs')->search({id => $job_id, state => ASSIGNED, t_finished => undef})
           ->update({state => SETUP});
 
         # update the worker's current job
-        $worker->{db}->update({job_id => $job_id});
-        log_debug("Worker $worker->{id} accepted job $job_id");
+        $worker_db->update({job_id => $job_id});
+        log_debug("Worker $worker_id accepted job $job_id");
     }
-    elsif ($json->{type} eq 'worker_status') {
+    elsif ($message_type eq 'worker_status') {
         my $current_worker_status = $json->{status};
         my $current_worker_error  = $current_worker_status eq 'broken' ? $json->{reason} : undef;
         my $job_info              = $json->{job} // {};
@@ -155,89 +180,9 @@ sub _message {
         catch {
             log_debug("Could not send the population number to worker: $_");
         };
-
-        # find the job currently associated with that worker and check whether the worker still
-        # executes the job it is supposed to
-        try {
-            my $worker = $schema->resultset('Workers')->find($wid);
-            return undef unless $worker;
-
-            my $current_job_id;
-            my $registered_job_token;
-            my $current_job_state;
-            my @unfinished_jobs = $worker->unfinished_jobs;
-            my $current_job     = $worker->job // $unfinished_jobs[0];
-            if ($current_job) {
-                $current_job_id    = $current_job->id;
-                $current_job_state = $current_job->state;
-            }
-
-            # log debugging info
-            log_debug("Found job $current_job_id in DB from worker_status update sent by worker $wid")
-              if defined $current_job_id;
-            log_debug("Received request has job id: $job_id")
-              if defined $job_id;
-            $registered_job_token = $worker->get_property('JOBTOKEN');
-            log_debug("Worker $wid for job $current_job_id has token $registered_job_token")
-              if defined $current_job_id && defined $registered_job_token;
-            log_debug("Received request has token: $job_token")
-              if defined $job_token;
-
-            # skip any further actions if worker just does the one job we expected it to do
-            return undef
-              if ( defined $job_id
-                && defined $current_job_id
-                && defined $job_token
-                && defined $registered_job_token
-                && $job_id eq $current_job_id
-                && (my $job_token_correct = $job_token eq $registered_job_token)
-                && OpenQA::Jobs::Constants::meta_state($current_job_state) eq OpenQA::Jobs::Constants::EXECUTION)
-              && (scalar @unfinished_jobs <= 1);
-
-            # handle the case when the worker does not work on the job(s) it is supposed to work on
-            my @all_jobs_currently_associated_with_worker = ($current_job, @unfinished_jobs);
-            my %considered_jobs;
-            for my $associated_job (@all_jobs_currently_associated_with_worker) {
-                next unless defined $associated_job;
-
-                # prevent doing this twice for the same job ($current_job and @unfinished_jobs might overlap)
-                my $job_id = $associated_job->id;
-                next if exists $considered_jobs{$job_id};
-                $considered_jobs{$job_id} = 1;
-
-                # do nothing if the job token is corrent and the worker claims that it is still working on that job
-                # or that the job is still pending
-                if ($job_token_correct) {
-                    next if $job_id eq $current_job_id;
-                    next if exists $pending_job_ids->{$job_id};
-                }
-
-                # set associated job which was only assigned back to scheduled
-                # note: It is not sufficient to do that just on worker registration because if a worker is not taking
-                #       the job we assigned it might just be busy with a job from another web UI. In this case we need
-                #       to assign the job to a different worker.
-                # note: Using a transaction here so we don't end up with an inconsistent state when an error occurs.
-                if ($associated_job->state eq OpenQA::Jobs::Constants::ASSIGNED) {
-                    try {
-                        $schema->txn_do(sub { $associated_job->reschedule_state; });
-                    }
-                    catch {
-                        log_warning("Unable to reschedule jobs abandoned by worker $wid: $_");
-                    };
-                    next;
-                }
-
-                # note: Jobs are only marked as incomplete on worker registration (and not here) because that operation
-                #       can be quite costly. (FIXME: We could just cancel the web socket connection to force the worker
-                #       to re-register.)
-            }
-        }
-        catch {
-            log_warning("Unable to verify whether worker $wid runs its job(s) as expected: $_");
-        }
     }
     else {
-        log_error(sprintf('Received unknown message type "%s" from worker %u', $json->{type}, $worker->{id}));
+        log_error(sprintf('Received unknown message type "%s" from worker %u', $message_type, $worker->{id}));
     }
 }
 

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -267,10 +267,10 @@ sub _handle_command_grab_jobs {
 sub _handle_command_incompatible {
     my ($json, $client, $worker, $webui_host, $current_job) = @_;
 
-    # FIXME: This handler has been copied as-is when refactoring. It would make more sense to disable
-    #        only the particular web UI host which is incompatible instead of just stopping everything.
+    # FIXME: It would make more sense to disable only the particular web UI host which is incompatible instead of
+    #        just stopping everything.
     log_error("The worker is running a version incompatible with web UI host $webui_host and therefore stopped");
-    Mojo::IOLoop->singleton->stop_gracefully;
+    $worker->stop;
 }
 
 1;

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,6 +22,8 @@ use POSIX ':sys_wait_h';
 use Data::Dump 'pp';
 
 has 'client';
+
+my %COMMANDS_SPECIFIC_TO_CURRENT_JOB = map { ($_ => 1) } qw(livelog_start livelog_stop developer_session_start);
 
 sub new {
     my ($class, $client) = @_;
@@ -66,7 +68,7 @@ sub handle_command {
             return undef;
         }
     }
-    elsif ($type ne 'info' && $type ne 'grab_job' && $type ne 'grab_jobs') {
+    elsif (exists $COMMANDS_SPECIFIC_TO_CURRENT_JOB{$type}) {
         # require a job ID and ensure it matches the current job if we're already executing one
         if ($current_job) {
             # ignore messages which do not belong to the current job

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -38,15 +38,14 @@ sub handle_command {
     my $webui_host         = $client->webui_host;
     my $current_webui_host = $worker->current_webui_host // 'unknown web UI host';
 
+    return log_warning("Ignoring invalid json sent by $current_webui_host") unless ref($json) eq 'HASH';
+
     # ignore responses to our own messages which are indicated by 'result'
-    return undef if ($json->{result});
+    return undef if defined $json->{result};
 
     # handle commands of certain types regarding a specific job (which is supposed to be the job we're working on)
     my $type = $json->{type};
-    if (!$type) {
-        log_warning("Ignoring WS message without type from $webui_host:\n" . pp($json));
-        return undef;
-    }
+    return log_warning("Ignoring WS message without type from $webui_host:\n" . pp($json)) unless defined $type;
 
     # match the specified job
     my $job_id       = $json->{jobid};
@@ -67,18 +66,12 @@ sub handle_command {
             return undef;
         }
     }
-    elsif ($type ne 'info') {
+    elsif ($type ne 'info' && $type ne 'grab_job' && $type ne 'grab_jobs') {
         # require a job ID and ensure it matches the current job if we're already executing one
         if ($current_job) {
             # ignore messages which do not belong to the current job
             my $current_job_id = $current_job->id // 'another job';
-            if (!$job_id) {
-                # log a more specific warning in case of the grab_job message from a different web UI
-                if ($type eq 'grab_job' && $webui_host ne $current_webui_host) {
-                    log_warning("Ignoring job assignment from $webui_host "
-                          . "(already busy with job $current_job_id from $current_webui_host).");
-                    return undef;
-                }
+            if (!defined $job_id) {
                 log_warning("Ignoring WS message from $webui_host with type $type but no job ID "
                       . "(currently running $current_job_id for $current_webui_host):\n"
                       . pp($json));
@@ -93,7 +86,7 @@ sub handle_command {
         }
         else {
             # ignore messages which belong to a job
-            if ($job_id) {
+            if (defined $job_id) {
                 log_warning("Ignoring WS message from $webui_host with type $type and job ID $job_id "
                       . "(currently not executing a job):\n"
                       . pp($json));
@@ -157,17 +150,24 @@ sub _handle_command_developer_session_start {
 }
 
 sub _can_grab_job {
-    my ($worker, $webui_host, $current_job) = @_;
+    my ($client, $worker, $webui_host, $current_job, $job_ids_to_grab) = @_;
+
+    my $reason_to_reject_job;
 
     # refuse new job if the worker is
     # * in an error state (this will leave the job to be grabbed in assigned state)
     # * stopping
     if ($worker->is_stopping) {
-        log_debug("Refusing 'grab_job', the worker is currently stopping");
-        return 0;
+        $reason_to_reject_job = 'currently stopping';
+        # note: Not rejecting the job here; declaring the worker as offline which is done in any case
+        #       should be sufficient.
     }
-    if (my $current_error = $worker->current_error) {
-        log_debug("Refusing 'grab_job', we are currently unable to do any work: $current_error");
+    elsif (my $current_error = $worker->current_error) {
+        $reason_to_reject_job = $current_error;
+        $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
+    }
+    if (defined $reason_to_reject_job) {
+        log_debug("Refusing to grab job from $webui_host: $reason_to_reject_job");
         return 0;
     }
 
@@ -175,12 +175,14 @@ sub _can_grab_job {
     my $current_webui_host = $worker->current_webui_host;
     if ($current_job) {
         my $current_job_id = $current_job->id // 'another job';
-        log_warning(
-            "Refusing to grab job from $webui_host, already busy with $current_job_id from $current_webui_host");
-        return 0;
+        $reason_to_reject_job = "already busy with $current_job_id from $current_webui_host";
     }
-    if ($worker->has_pending_jobs) {
-        log_warning("Refusing to grab job from $webui_host, there are still pending jobs from $current_webui_host");
+    elsif ($worker->has_pending_jobs) {
+        $reason_to_reject_job = "there are still pending jobs from $current_webui_host";
+    }
+    if (defined $reason_to_reject_job) {
+        $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
+        log_warning("Refusing to grab job from $webui_host: $reason_to_reject_job");
         return 0;
     }
 
@@ -188,10 +190,13 @@ sub _can_grab_job {
 }
 
 sub _can_accept_job {
-    my ($webui_host, $job_info) = @_;
+    my ($client, $webui_host, $job_info, $job_ids_to_grab) = @_;
 
-    if (!$job_info || ref($job_info) ne 'HASH' || !defined $job_info->{id} || !$job_info->{settings}) {
-        log_error("Refusing to grab job from $webui_host because the provided job is invalid: " . pp($job_info));
+    my $job_id_missing = ref($job_info) ne 'HASH' || !defined $job_info->{id};
+    if ($job_id_missing || !$job_info->{settings}) {
+        $client->reject_jobs($job_ids_to_grab // [$job_info->{id}], 'the provided job is invalid')
+          if defined $job_ids_to_grab || !$job_id_missing;
+        log_error("Refusing to grab job from $webui_host: the provided job is invalid: " . pp($job_info));
         return undef;
     }
 
@@ -199,16 +204,17 @@ sub _can_accept_job {
 }
 
 sub _can_accept_sequence {
-    my ($webui_host, $job_sequence, $job_data) = @_;
+    my ($client, $webui_host, $job_sequence, $job_data, $job_ids_to_grab) = @_;
 
     for my $job_id_or_sub_sequence (@$job_sequence) {
         $job_id_or_sub_sequence //= '?';
         if (ref($job_id_or_sub_sequence) eq 'ARRAY') {
-            return 0 unless _can_accept_sequence($webui_host, $job_id_or_sub_sequence, $job_data);
+            return 0 unless _can_accept_sequence($client, $webui_host, $job_id_or_sub_sequence, $job_data);
         }
         elsif (!exists $job_data->{$job_id_or_sub_sequence}) {
-            log_error(
-                "Refusing to grab job from $webui_host because job data for job $job_id_or_sub_sequence is missing.");
+            my $reason_to_reject_job = "job data for job $job_id_or_sub_sequence is missing";
+            $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
+            log_error("Refusing to grab job from $webui_host: $reason_to_reject_job");
             return 0;
         }
     }
@@ -219,8 +225,9 @@ sub _handle_command_grab_job {
     my ($json, $client, $worker, $webui_host, $current_job) = @_;
 
     my $job_info = $json->{job};
-    return undef unless _can_grab_job($worker, $webui_host, $current_job);
-    return undef unless defined _can_accept_job($webui_host, $job_info);
+    my $job_id   = _can_accept_job($client, $webui_host, $job_info);
+    return undef unless defined $job_id;
+    return undef unless _can_grab_job($client, $worker, $webui_host, $current_job, [$job_id]);
 
     $worker->accept_job($client, $job_info);
 }
@@ -228,23 +235,29 @@ sub _handle_command_grab_job {
 sub _handle_command_grab_jobs {
     my ($json, $client, $worker, $webui_host, $current_job) = @_;
 
-    return undef unless _can_grab_job($worker, $webui_host, $current_job);
-
     # validate input (log error and ignore job on failure)
     my $job_info     = $json->{job_info} // {};
     my $job_data     = $job_info->{data};
     my $job_sequence = $job_info->{sequence};
-    if (ref($job_data) ne 'HASH' || ref($job_sequence) ne 'ARRAY') {
+    if (ref($job_data) ne 'HASH') {
         log_error(
-            "Refusing to grab job from $webui_host because the provided job info lacks job data or execution sequence: "
+            "Refusing to grab jobs from $webui_host: the provided job info lacks job data or execution sequence: "
               . pp($job_info));
         return undef;
     }
-    for my $job_id (keys %$job_data) {
-        my $acceptable_id = _can_accept_job($webui_host, $job_data->{$job_id});
+    my @job_ids_to_grab = keys %$job_data;
+    if (ref($job_sequence) ne 'ARRAY') {
+        log_error(
+            "Refusing to grab jobs from $webui_host: the provided job info lacks execution sequence: " . pp($job_info));
+        $client->reject_jobs(\@job_ids_to_grab, 'job info lacks execution sequence');
+        return undef;
+    }
+    for my $job_id (@job_ids_to_grab) {
+        my $acceptable_id = _can_accept_job($client, $webui_host, $job_data->{$job_id}, \@job_ids_to_grab);
         return undef unless defined $acceptable_id && $acceptable_id eq $job_id;
     }
-    return undef unless _can_accept_sequence($webui_host, $job_sequence, $job_data);
+    return undef unless _can_accept_sequence($client, $webui_host, $job_sequence, $job_data, \@job_ids_to_grab);
+    return undef unless _can_grab_job($client, $worker, $webui_host, $current_job, \@job_ids_to_grab);
 
     $worker->enqueue_jobs_and_accept_first($client, $job_info);
 }

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -505,4 +505,18 @@ sub quit {
     $websocket_connection->send({json => {type => 'quit'}}, $callback);
 }
 
+# send "rejected" message when refusing to take one or more jobs assigned by the web UI
+sub reject_jobs {
+    my ($self, $job_ids, $reason, $callback) = @_;
+
+    # send rejection message via web sockets if connected
+    my $websocket_connection = $self->websocket_connection;
+    return $websocket_connection->send({json => {type => 'rejected', job_ids => $job_ids, reason => $reason}},
+        $callback)
+      if defined $websocket_connection;
+
+    # try sending the message when the web socket connection becomes available again
+    $self->once(connected => sub { $self->reject_jobs($job_ids, $reason, $callback); });
+}
+
 1;

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -407,9 +407,43 @@ subtest 'quit' => sub {
     };
 };
 
+subtest 'rejecting jobs' => sub {
+    my $ws              = OpenQA::Test::FakeWebSocketTransaction->new;
+    my $callback_called = 0;
+    my $callback        = sub { $callback_called = 1; };
+
+    subtest 'rejecting job postponed while not connected' => sub {
+        $client->websocket_connection(undef);
+        $client->reject_jobs([1, 2, 3], 'just a test', $callback);
+        is_deeply($ws->sent_messages, [], 'no message send when not connected')
+          or diag explain $ws->sent_messages;
+        ok(!$callback_called, 'callback not invoked so far');
+    };
+    subtest 'job rejected when connected' => sub {
+        $client->websocket_connection($ws);
+        $client->emit('connected');
+        Mojo::IOLoop->one_tick;
+        is_deeply(
+            $ws->sent_messages,
+            [
+                {
+                    json => {
+                        type    => 'rejected',
+                        job_ids => [1, 2, 3],
+                        reason  => 'just a test',
+                    }}
+            ],
+            'rejected sent when connected again'
+        ) or diag explain $ws->sent_messages;
+        ok($callback_called, 'callback invoked');
+    };
+};
+
 subtest 'command handler' => sub {
     my $command_handler = OpenQA::Worker::CommandHandler->new($client);
+    my $ws              = OpenQA::Test::FakeWebSocketTransaction->new;
     my $worker          = $client->worker;
+    $client->websocket_connection($ws);
 
     # test at least some of the error cases
     combined_like(
@@ -424,14 +458,18 @@ qr/Ignoring WS message from http:\/\/test-host with type livelog_stop and job ID
     );
     $worker->current_error('some error');
     $app->log->level('debug');
+    my %job = (id => 42, settings => {});
     combined_like(
-        sub { $command_handler->handle_command(undef, {type => 'grab_job'}); },
-        qr/Refusing 'grab_job', we are currently unable to do any work: some error/,
+        sub { $command_handler->handle_command(undef, {type => 'grab_job', job => \%job}); },
+        qr/Refusing to grab job.*: some error/,
         'ignoring grab_job while in error-state',
     );
+
+
+    my %job_info = (sequence => [$job{id}], data => {42 => \%job});
     combined_like(
-        sub { $command_handler->handle_command(undef, {type => 'grab_jobs'}); },
-        qr/Refusing 'grab_job', we are currently unable to do any work: some error/,
+        sub { $command_handler->handle_command(undef, {type => 'grab_jobs', job_info => \%job_info}); },
+        qr/Refusing to grab job.*: some error/,
         'ignoring grab_jobs while in error-state',
     );
     is($worker->current_job, undef, 'no job has been accepted while in error-state');
@@ -439,8 +477,8 @@ qr/Ignoring WS message from http:\/\/test-host with type livelog_stop and job ID
     $worker->current_error(undef);
     $worker->is_stopping(1);
     combined_like(
-        sub { $command_handler->handle_command(undef, {type => 'grab_job'}); },
-        qr/Refusing 'grab_job', the worker is currently stopping/,
+        sub { $command_handler->handle_command(undef, {type => 'grab_job', job => \%job}); },
+        qr/Refusing to grab job.*: currently stopping/,
         'ignoring grab_job while stopping',
     );
 
@@ -455,14 +493,60 @@ qr/Ignoring WS message from http:\/\/test-host with type livelog_stop and job ID
                     type => 'grab_job',
                     job  => {id => 'but no settings'}});
         },
-        qr/Refusing to grab job.*because the provided job is invalid.*/,
+        qr/Refusing to grab job.*: the provided job is invalid.*/,
         'ignoring grab job if no valid job info provided',
+    );
+    combined_like(
+        sub {
+            $command_handler->handle_command(
+                undef,
+                {
+                    type     => 'grab_jobs',
+                    job_info => {sequence => ['foo']},
+                });
+        },
+        qr/Refusing to grab jobs.*: the provided job info lacks job data or execution sequence.*/,
+        'ignoring grab multiple jobs if job data',
+    );
+    combined_like(
+        sub {
+            $command_handler->handle_command(
+                undef,
+                {
+                    type     => 'grab_jobs',
+                    job_info => {sequence => 'not an array', data => {42 => 'foo'}},
+                });
+        },
+        qr/Refusing to grab jobs.*: the provided job info lacks execution sequence.*/,
+        'ignoring grab multiple jobs if execution sequence missing',
     );
     combined_like(
         sub { $command_handler->handle_command(undef, {type => 'foo'}); },
         qr/Ignoring WS message with unknown type foo.*/,
         'ignoring messages of unknown type',
     );
+
+    is_deeply(
+        $ws->sent_messages,
+        [
+            {json => {job_ids => [42], reason => 'some error', type => 'rejected'}},
+            {json => {job_ids => [42], reason => 'some error', type => 'rejected'}},
+            {
+                json => {
+                    job_ids => ['but no settings'],
+                    reason  => 'the provided job is invalid',
+                    type    => 'rejected',
+                }
+            },
+            {
+                json => {
+                    job_ids => ['42'],
+                    reason  => 'job info lacks execution sequence',
+                    type    => 'rejected',
+                }}
+        ],
+        'jobs have been rejected in the error cases (when possible)'
+    ) or diag explain $ws->sent_messages;
 
     # test setting population
     $command_handler->handle_command(undef, {type => 'info', population => -42});
@@ -523,7 +607,7 @@ qr/Ignoring WS message from http:\/\/test-host with type livelog_stop and job ID
         sub {
             $command_handler->handle_command(undef, {type => 'grab_jobs', job_info => \%job_info});
         },
-        qr/Refusing to grab job.*because job data for job 28 is missing/,
+        qr/Refusing to grab job.*: job data for job 28 is missing/,
         'ignoring grab job if no valid job info provided',
     );
     is_deeply($worker->enqueued_job_info, undef, 'no jobs enqueued if validation failed')

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -175,6 +175,27 @@ subtest 'web socket message handling' => sub {
     };
 
     $schema->txn_rollback;
+    $schema->txn_begin;
+
+    subtest 'quit' => sub {
+        $jobs->create({id => 42, state => ASSIGNED, assigned_worker_id => 1, TEST => 'foo'});
+        ok(!$workers->find(1)->dead, 'worker not considered dead in the first place');
+        combined_like(
+            sub {
+                $t->websocket_ok('/ws/1', 'establish ws connection');
+                $t->send_ok('{"type":"quit"}');
+                $t->finish_ok(1000, 'finished ws connection');
+            },
+            qr/Job 42 reset to state scheduled/s,
+            'info logged when worker rejects job'
+        );
+        is($jobs->find(42)->state, SCHEDULED,
+                'job is immediately set back to scheduled if assigned worker goes offline '
+              . 'gracefully before starting to work on the job');
+        ok($workers->find(1)->dead, 'worker considered immediately dead when it goes offline gracefully');
+    };
+
+    $schema->txn_rollback;
     $t->websocket_ok('/ws/1', 'establish ws connection');
 
     subtest 'worker status' => sub {

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -40,8 +40,8 @@ our (@EXPORT, @EXPORT_OK);
 @EXPORT_OK = (
     qw(redirect_output standard_worker),
     qw(create_webapi create_websocket_server create_scheduler create_live_view_handler),
-    qw(unresponsive_worker wait_for_worker setup_share_dir run_gru_job),
-    qw(kill_service unstable_worker client_output fake_asset_server),
+    qw(unresponsive_worker broken_worker rejective_worker wait_for_worker setup_share_dir),
+    qw(run_gru_job kill_service unstable_worker client_output fake_asset_server),
     qw(cache_minion_worker cache_worker_service shared_hash embed_server_for_testing)
 );
 
@@ -382,9 +382,21 @@ sub unresponsive_worker {
     note("Starting unresponsive worker. Instance: $instance for host $host");
     c_worker($apikey, $apisecret, $host, $instance, 1);
 }
+sub broken_worker {
+    my ($apikey, $apisecret, $host, $instance, $error) = @_;
+
+    note("Starting broken worker. Instance: $instance for host $host");
+    c_worker($apikey, $apisecret, $host, $instance, 0, error => $error);
+}
+sub rejective_worker {
+    my ($apikey, $apisecret, $host, $instance, $reason) = @_;
+
+    note("Starting rejective worker. Instance: $instance for host $host");
+    c_worker($apikey, $apisecret, $host, $instance, 1, rejection_reason => $reason);
+}
 
 sub c_worker {
-    my ($apikey, $apisecret, $host, $instance, $bogus) = @_;
+    my ($apikey, $apisecret, $host, $instance, $bogus, %options) = @_;
     $bogus //= 1;
 
     my $pid = fork();
@@ -395,9 +407,20 @@ sub c_worker {
                 handle_command => sub {
                     my ($self, $tx, $json) = @_;
                     log_debug('Received ws message: ' . Dumper($json));
+
+                    # if we've got a single job ID and a rejection reason simulate a worker
+                    # which rejects the job
+                    my $rejection_reason = $options{rejection_reason};
+                    return undef unless defined $rejection_reason;
+                    my $job_id = $json->{job}->{id};
+                    return undef unless defined $job_id;
+                    log_debug("Rejecting job $job_id");
+                    $self->client->reject_jobs([$job_id], $rejection_reason);
                 });
         }
-
+        my $error       = $options{error};
+        my $worker_mock = Test::MockModule->new('OpenQA::Worker');
+        $worker_mock->mock(check_availability => sub { }) if defined $error;
         my $worker = OpenQA::Worker->new(
             {
                 apikey    => $apikey,
@@ -405,6 +428,7 @@ sub c_worker {
                 instance  => $instance,
                 verbose   => 1
             });
+        $worker->current_error($error) if defined $error;
         $worker->settings->clear_webui_hosts;
         $worker->settings->add_webui_host($host);
         $worker->log_setup_info;


### PR DESCRIPTION
This change is again a little bit bigger for "just" fixing a race condition. However, it involves changing the protocol a little bit (see commit messages for a description of the actual changes).

But now there should be tests for all relevant communication bits between the worker and the web UI so this likely works as expected. However, the race condition I'm trying to fix here might have become even worse by previously [fixing another race condition](https://github.com/os-autoinst/openQA/commit/f3ea708082fac95684ca5f925bb356ced1c1705e). So who knows which race condition I'm now overlooking. But when this is merged at least 2 problems should be finally addressed:

1. The worker takes the job faster than the web UI fully processes the job-worker assignment. (That was https://github.com/os-autoinst/openQA/commit/f3ea708082fac95684ca5f925bb356ced1c1705e.)
2. The worker takes the job tool slow and the web UI already "re-schedules" the job. (This PR, see https://progress.opensuse.org/issues/62984#note-19).