### PR TITLE
Handle the case where there are no screenshots more gracefully

### DIFF
--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -50,6 +50,7 @@ sub _limit {
     my $storage = $schema->storage;
     my $dbh     = $storage->dbh;
     my ($min_id, $max_id) = $dbh->selectrow_array('select min(id), max(id) from screenshots');
+    return undef unless $min_id && $max_id;
     my $screenshots_with_ref_count_query_limit = 200000;
     my $delete_screenshot_query                = $dbh->prepare('DELETE FROM screenshots WHERE id = ?');
     my $unused_screenshots_query               = $dbh->prepare(


### PR DESCRIPTION
This change gets rid of some test warnings that were no longer hidden since #2736 was applied yesterday.
```
t/14-grutasks.t ................................ 24/? Use of uninitialized value $max_id in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
Use of uninitialized value $i in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
Use of uninitialized value $i in addition (+) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 64.
Use of uninitialized value $max_id in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
t/14-grutasks.t ................................ 27/? Use of uninitialized value $max_id in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
Use of uninitialized value $i in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
Use of uninitialized value $i in addition (+) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 64.
Use of uninitialized value $max_id in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
Use of uninitialized value $max_id in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
Use of uninitialized value $i in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
Use of uninitialized value $i in addition (+) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 64.
Use of uninitialized value $max_id in numeric le (<=) at /home/squamata/project/lib/OpenQA/Task/Job/Limit.pm line 63.
```