### PR TITLE
Alleviate debugging of test_postgresql

### DIFF
--- a/t/test_postgresql
+++ b/t/test_postgresql
@@ -14,13 +14,18 @@ fi
 if test -d $DIR; then
   rm -r $DIR
 fi
-initdb --auth-local=peer -N $DIR -U $USER
+initdb --auth-local=peer -N $DIR -U $(id -u -n)
 echo "listen_addresses=''" >> $DIR/postgresql.conf
 echo "unix_socket_directories='$DIR'" >> $DIR/postgresql.conf
 echo "fsync=off" >> $DIR/postgresql.conf
 echo "full_page_writes=off" >> $DIR/postgresql.conf
 
-pg_ctl -D $DIR -l log_test_postgresql start -w
+LOGDIR="$DIR/log"
+LOGFILE="${LOGFILE:-"$LOGDIR/postgresql-openqa-test.log"}"
+echo "PostgreSQL logs will be stored in $LOGFILE."
+
+mkdir -p $LOGDIR
+pg_ctl -D $DIR -l $LOGFILE start -w
 createdb -h $DIR openqa_test
 
 echo "Now export TEST_PG like:"


### PR DESCRIPTION
- The `$USER` variable may not be set in a container and thus lead to an  argument error  - `id -u -n` is posix compliant.
- Redirecting the log is problematic if the user can't write the log  file and in turn produces a permission error even in case of success.
- Use overridable $LOGFILE defaulting to shared memory.