### PR TITLE
Align jobtemplate inline help to left

### DIFF
--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -124,3 +124,8 @@ select.form-control {
 .img-circle {
     border-radius: 50%;
 }
+
+.editor-yaml-guide {
+    display: none;
+    text-align: left !important;
+}

--- a/templates/webapi/admin/job_template/index.html.ep
+++ b/templates/webapi/admin/job_template/index.html.ep
@@ -103,7 +103,7 @@
         <form action="#" id="editor-form" class="form-horizontal" style="display: none;"
               data-put-url="<%= url_for('apiv1_job_templates_schedules' => (id => $group->id)) %>" data-reference="<%= $yaml_template %>">
             <div class="form-group row">
-                <label for="editor-template" class="col-sm-5 control-label editor-yaml-guide" style="display: none;">
+                <label for="editor-template" class="col-sm-5 control-label editor-yaml-guide">
                     <div>
                         <div>Basic YAML structure for defining job templates:</div>
 <code>defaults:
@@ -186,7 +186,7 @@ scenarios:
                 </div>
             </div>
             <div class="form-group row">
-                <div class="col-sm-5 editor-yaml-guide" style="display: none; text-align: right;">
+                <div class="col-sm-5 editor-yaml-guide">
                     <p class="buttons">
                         <a href="http://open.qa/docs/#_job_group_editor_gh2111" target="blank" class="btn">
                             <i class="fas fa-book"></i>YAML editor documentation


### PR DESCRIPTION
Currently it's aligned to the right, so all YAML examples start at different columns.
I find it more readable at the left.