### PR TITLE
t: Use explicit wait functions where needed

### DIFF
--- a/script/retry
+++ b/script/retry
@@ -19,7 +19,7 @@ else
             run_once $* && break
         else
             [ $n -lt "$RETRY" ] || exit 0
-            run_once $* || break
+            run_once $* || exit
             echo Retrying...
         fi
         n=$((n+1))

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -185,6 +185,7 @@ sub _default_check_interval {
 sub wait_for_ajax {
     my $check_interval = _default_check_interval(shift);
     my $timeout        = 60 * 5;
+    my $slept          = 0;
 
     while (!$_driver->execute_script('return window.jQuery && jQuery.active === 0')) {
         if ($timeout <= 0) {
@@ -194,8 +195,10 @@ sub wait_for_ajax {
 
         $timeout -= $check_interval;
         sleep $check_interval;
+        $slept = 1;
     }
     pass("Wait for jQuery successful");
+    return $slept;
 }
 
 sub disable_bootstrap_animations {
@@ -328,7 +331,7 @@ sub wait_until {
             return 0;
         }
         $timeout -= $check_interval;
-        sleep $check_interval;
+        wait_for_ajax or sleep $check_interval;
     }
 }
 

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -147,12 +146,8 @@ subtest 'worker overview' => sub {
 # test delete offline worker function
 subtest 'delete offline worker' => sub {
     $driver->find_element("tr#worker_$offline_worker_id .btn")->click();
-    is(
-        $driver->find_element("div#flash-messages .alert span")->get_text(),
-        'Delete worker offline_test:1 successfully.',
-        'delete offline worker successfully'
-    );
-
+    my $e = wait_for_element(selector => 'div#flash-messages .alert span', description => 'delete message displayed');
+    is($e->get_text(), 'Delete worker offline_test:1 successfully.', 'delete offline worker successfully');
     is(scalar @{$driver->find_elements('table#workers tbody tr')}, 4, 'worker deleted not shown');
 };
 

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 SUSE Linux GmbH
+# Copyright (C) 2016-2020 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -103,7 +103,7 @@ like(
 # trigger job next and previous for current job
 $driver->title_is('openQA', 'on main page');
 $driver->find_element_by_link_text('All Tests')->click();
-$driver->find_element('[href="/tests/99946"]')->click();
+wait_for_element(selector => '[href="/tests/99946"]')->click();
 $driver->find_element_by_link_text('Next & previous results')->click();
 wait_for_ajax();
 $driver->find_element_by_class('dataTables_wrapper');

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -39,7 +39,7 @@ $driver->find_element_by_link_text('Login')->click();
 # we're back on the main page
 $driver->title_is("openQA", "back on main page");
 
-my @texts = map { $_->get_text() } $driver->find_elements('.progress-bar-softfailed', 'css');
+my @texts = map { $_->get_text() } wait_for_element(selector => '.progress-bar-softfailed');
 is_deeply(\@texts, ['2 softfailed'], 'Progress bars show soft fails');
 
 is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
@@ -55,7 +55,7 @@ $driver->title_is('openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test 
 
 # expect the failure to be displayed
 is(
-    $driver->find_element_by_id('step_view')->get_attribute('data-image'),
+    wait_for_element(selector => '#step_view')->get_attribute('data-image'),
     '/tests/99938/images/logpackages-1.png',
     'Failure displayed'
 );


### PR DESCRIPTION
To not rely on a global Selenium timeout in test functions we should use
our explicit wait functions where they are needed.