### PR TITLE
load_templates: Create groups that do not exist

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -230,7 +230,7 @@ sub create {
     $check = $self->check_top_level_group;
     if ($check != 0) {
         return $self->render(
-            json   => {error => 'Unable to create group due to not allow duplicated job group on top level'},
+            json   => {error => 'Unable to create group with existing name ' . $self->param('name')},
             status => 500
         );
     }

--- a/script/load_templates
+++ b/script/load_templates
@@ -149,13 +149,18 @@ sub post_entry {
     my %param;
 
     if ($table eq 'JobGroups') {
-        $url->path($options{'apibase'} . '/job_templates_scheduling');
-        $url->query({name => $entry->{group_name}, template => $entry->{template}, schema => 'JobTemplates-01.yaml'});
-        my $res = $client->post($url)->res;
-        if (!($res->code && $res->code == 200)) {
-            print_error($res);
-            return 0;
-        }
+        # Create the group first
+        my $job_groups_url = $url->clone->path($options{'apibase'} . '/job_groups');
+        my $res            = $client->post($job_groups_url, form => {name => $entry->{group_name}})->res;
+        print_error $res unless $res->is_success;
+
+        # Post the job template YAML
+        my $job_templates_url = $url->clone->path($options{'apibase'} . '/job_templates_scheduling');
+        $res
+          = $client->post($job_templates_url,
+            form => {name => $entry->{group_name}, template => $entry->{template}, schema => 'JobTemplates-01.yaml'})
+          ->res;
+        print_error $res unless $res->is_success;
         return 1;
     }
 


### PR DESCRIPTION
The new code uses `form =>` syntax to post without making use of the query and also `is_success` to bail out.

Fixes: [poo#60118](https://progress.opensuse.org/issues/60118)