### PR TITLE
Prevent search popover icons from appearing on top of menus

### DIFF
--- a/assets/stylesheets/admin-pages.scss
+++ b/assets/stylesheets/admin-pages.scss
@@ -12,7 +12,7 @@
 .search-popover {
     position: relative;
     left: -15px;
-    z-index: 1000;
+    z-index: 10;
     float: right;
     margin-top: 5px;
     margin-left: 5px;


### PR DESCRIPTION
* The z-index of those menus is 1000 so the z-index of the the icons must be lower
* See https://progress.opensuse.org/issues/63856