### PR TITLE
load_templates: Remove query uses from table requests

### DIFF
--- a/script/load_templates
+++ b/script/load_templates
@@ -201,19 +201,16 @@ sub post_entry {
         }
     }
 
+    my $table_url = $url->clone->path($options{'apibase'} . '/' . decamelize($table));
     if (!$options{'clean'}) {    # with --clean the entry should not exist at this point, no need to check
-        my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table))->query(%param))->res;
-        if ($res->code && $res->code == 200 && @{$res->json->{$table}} > 0 && $res->json->{$table}[0]{id}) {
+        my $res = $client->get($table_url, form => \%param)->res;
+        if ($res->is_success && @{$res->json->{$table}} > 0 && $res->json->{$table}[0]{id}) {
             if ($options{'update'} && $table ne 'JobTemplates')
             {                    # there is nothing to update in JobTemplates, the entry just exists or not
-                my $id = $res->json->{$table}[0]{id};
-                my $res
-                  = $client->put($url->path($options{'apibase'} . '/' . decamelize($table) . "/$id")->query(%param))
-                  ->res;
-                if (!($res->code && $res->code == 200)) {
-                    print_error($res);
-                    return 0;
-                }
+                my $id           = $res->json->{$table}[0]{id};
+                my $table_url_id = $url->clone->path($options{'apibase'} . '/' . decamelize($table) . "/$id");
+                my $res          = $client->put($table_url_id, form => \%param)->res;
+                print_error $res unless $res->is_success;
                 return 1;
             }
             else {
@@ -222,12 +219,8 @@ sub post_entry {
         }
     }
 
-    my $res = $client->post($url->path($options{'apibase'} . '/' . decamelize($table))->query(%param))->res;
-
-    if (!($res->code && $res->code == 200)) {
-        print_error($res);
-        return 0;
-    }
+    my $res = $client->post($table_url, form => \%param)->res;
+    print_error $res unless $res->is_success;
     return 1;
 }
 
@@ -235,20 +228,19 @@ if ($options{'clean'}) {
     for my $table (@tables) {
         # we can't clean job groups as they're not deletable unless empty
         next if ($table eq "JobGroups");
-        my $res = $client->get($url->path($options{'apibase'} . '/' . decamelize($table)))->res;
-        if ($res->code && $res->code == 200) {
+        my $table_url = $url->clone->path($options{'apibase'} . '/' . decamelize($table));
+        my $res       = $client->get($table_url)->res;
+        if ($res->is_success) {
             my $result = $res->json;
             for my $i (0 .. $#{$result->{$table}}) {
-                my $id = $result->{$table}->[$i]->{id};
-                $res = $client->delete($url->path($options{'apibase'} . '/' . decamelize($table) . "/$id"))->res;
-                last if !($res->code && $res->code == 200);
+                my $id           = $result->{$table}->[$i]->{id};
+                my $table_url_id = $url->clone->path($options{'apibase'} . '/' . decamelize($table) . "/$id");
+                $res = $client->delete($table_url_id)->res;
+                last if $res->is_success;
             }
         }
 
-        if (!($res->code && $res->code == 200)) {
-            print_error($res);
-            exit(1);
-        }
+        print_error $res unless $res->is_success;
     }
 }
 


### PR DESCRIPTION
This is a follow-up to #2770. Re-using the URL can lead to problems which are difficult to diagnose. Instead we should always use the form style which works for get, put and post.