### PR TITLE
Extract a script "openqa-setup-db" for local database setup

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -218,6 +218,8 @@ One also needs to setup a PostgreSQL database for openQA manually owned by your 
    User name and password are not required.
 7. openQA will default-initialize the new database on the next startup.
 
+The script `openqa-setup-db` can be used to conduct step 4 and 5.
+
 ==== Importing production data
 Assuming you have already followed steps 1. to 4. above:
 

--- a/openQA.spec
+++ b/openQA.spec
@@ -261,6 +261,7 @@ ln -s %{_datadir}/openqa/script/openqa-clone-custom-git-refspec %{buildroot}%{_b
 ln -s %{_datadir}/openqa/script/openqa-validate-yaml %{buildroot}%{_bindir}/openqa-validate-yaml
 %if %{with python_scripts}
 ln -s %{_datadir}/openqa/script/openqa-label-all %{buildroot}%{_bindir}/openqa-label-all
+ln -s %{_datadir}/openqa/script/setup-db %{buildroot}%{_bindir}/openqa-setup-db
 %endif
 
 cd %{buildroot}
@@ -523,6 +524,8 @@ fi
 
 %files local-db
 %{_unitdir}/openqa-setup-db.service
+%{_datadir}/openqa/script/setup-db
+%{_bindir}/openqa-setup-db
 
 %files bootstrap
 %{_datadir}/openqa/script/openqa-bootstrap

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -22,15 +22,7 @@ fi
 
 # setup database
 systemctl enable --now postgresql
-if ! su postgres -c "psql -qt <<< '\du'" | cut -d '|' -f1 | grep -q $dbuser ; then
-    # create db user if not existing
-    su postgres -c "createuser -D $dbuser"
-fi
-if ! su postgres -c "psql -lqt" | cut -d '|' -f1 | grep -q $dbname ; then
-    # create db if not existing
-    su postgres -c "createdb -O $dbuser $dbname"
-fi
-
+su postgres -c "/usr/share/openqa/script/setup-db" $dbuser $dbname
 
 # setup webserver and fake-auth
 setup=/usr/share/openqa/script/configure-web-proxy

--- a/script/setup-db
+++ b/script/setup-db
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+dbuser="${1:-"geekotest"}"
+dbname="${2:-"openqa"}"
+psql -t -c '\du' | grep -q "$dbuser" || createuser -D "$dbuser"
+psql -l -t | grep -q "$dbname" || createdb -O "$dbuser" "$dbname"

--- a/systemd/openqa-setup-db.service
+++ b/systemd/openqa-setup-db.service
@@ -6,8 +6,7 @@ After=postgresql.service
 [Service]
 User=postgres
 Type=oneshot
-ExecStart=-/bin/sh -c ' psql -t -c '\du' | grep -q geekotest || /usr/bin/createuser -D geekotest'
-ExecStart=-/bin/sh -c 'psql -l -t | grep -q openqa || /usr/bin/createdb -O geekotest openqa'
+ExecStart=/usr/share/openqa/script/setup-db
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-setup-db.service
+++ b/systemd/openqa-setup-db.service
@@ -6,8 +6,8 @@ After=postgresql.service
 [Service]
 User=postgres
 Type=oneshot
-ExecStart=-/usr/bin/createuser -D geekotest
-ExecStart=-/usr/bin/createdb -O geekotest openqa
+ExecStart=-/bin/sh -c ' psql -t -c '\du' | grep -q geekotest || /usr/bin/createuser -D geekotest'
+ExecStart=-/bin/sh -c 'psql -l -t | grep -q openqa || /usr/bin/createdb -O geekotest openqa'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This reduces the duplication among bootstrap script and systemd service
and can help in other environments, e.g. without systemd.