### PR TITLE
Consistent validation in JobTemplate update route

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -411,8 +411,8 @@ sub startup {
     # api/v1/job_templates
     $api_public_r->get('job_templates')->name('apiv1_job_templates')->to('job_template#list');
     $api_ra->post('job_templates')->to('job_template#create');
-    $api_public_r->get('job_templates/:job_template_id')->name('apiv1_job_template')->to('job_template#list');
-    $api_ra->delete('job_templates/:job_template_id')->to('job_template#destroy');
+    $api_public_r->get('job_templates/<:job_template_id:num>')->name('apiv1_job_template')->to('job_template#list');
+    $api_ra->delete('job_templates/<:job_template_id:num>')->to('job_template#destroy');
 
     # api/v1/job_templates_scheduling
     $api_public_r->get('job_templates_scheduling/<id:num>')->name('apiv1_job_templates_schedules')

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -498,10 +498,21 @@ sub _step_thumbnail {
 }
 
 sub _validation_error {
-    my $c      = shift;
-    my $failed = join ', ', @{$c->validation->failed};
-    my $error  = "Invalid request parameters ($failed)";
-    $c->render(text => $error, status => 400);
+    my ($c, $args) = @_;
+    my $format = $args->{format} // 'text';
+    my @errors;
+    for my $parameter (@{$c->validation->failed}) {
+        if (exists $c->validation->input->{$parameter}) {
+            push @errors, "$parameter invalid";
+        }
+        else {
+            push @errors, "$parameter missing";
+        }
+    }
+    my $failed = join ', ', @errors;
+    my $error  = "Erroneous parameters ($failed)";
+    return $c->render(json => {error => $error}, status => 400) if $format eq 'json';
+    return $c->render(text => $error,            status => 400);
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Plugin/YAMLRenderer.pm
+++ b/lib/OpenQA/WebAPI/Plugin/YAMLRenderer.pm
@@ -47,7 +47,6 @@ sub register {
             my @errors;
 
             try {
-                die "No valid schema specified\n" unless ($schema_filename // '') =~ /^[^.\/]+\.yaml$/;
                 my $schema_abspath = $self->app->home->child('public', 'schema', $schema_filename)->to_string;
                 my $errors         = validate_data(
                     data            => $yaml,

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -356,13 +356,13 @@ set_token_header($t->ua, 'token' . $jC);
 $t->post_ok($b_prefix . '/barrier2', form => {action => 'wait', check_dead_job => 1})->status_is(200);
 
 # input validation
-$t->post_ok($m_prefix)->status_is(400)->content_is('Invalid request parameters (name)');
-$t->post_ok("$m_prefix/foo")->status_is(400)->content_is('Invalid request parameters (action)');
+$t->post_ok($m_prefix)->status_is(400)->content_is('Erroneous parameters (name missing)');
+$t->post_ok("$m_prefix/foo")->status_is(400)->content_is('Erroneous parameters (action missing)');
 $t->post_ok($b_prefix => form => {tasks => 'abc'})->status_is(400)
-  ->content_is('Invalid request parameters (name, tasks)');
+  ->content_is('Erroneous parameters (name missing, tasks invalid)');
 $t->post_ok("$b_prefix/foo" => form => {where => 'abc'})->status_is(400)
-  ->content_is('Invalid request parameters (where)');
+  ->content_is('Erroneous parameters (where invalid)');
 $t->delete_ok("$b_prefix/foo" => form => {where => 'abc'})->status_is(400)
-  ->content_is('Invalid request parameters (where)');
+  ->content_is('Erroneous parameters (where invalid)');
 
 done_testing();

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -62,7 +62,7 @@ $host     = "localhost:$mojoport";
 $pid      = OpenQA::Test::Utils::create_webapi($mojoport, sub { OpenQA::Test::Database->new->create; });
 $filename = 't/data/40-templates.json';
 $args     = "--host $host --apikey $apikey --apisecret $apisecret $filename";
-$expected = qr/Bad Request: No template specified/;
+$expected = qr/Bad Request: Erroneous parameters \(template missing\)/;
 test_once $args, $expected, 'YAML template is mandatory (JSON)', 255, 'failed to load templates without YAML (JSON)';
 kill TERM => $pid;
 


### PR DESCRIPTION
- Schema filename validation should be done in the controller, for that reason the tests are also updated.
- ~With debugging enabled, unknown parameters result in an error.~
- `$validation->param` is used, except params which are part of the path get validated through typed routes.
- The `validation_error` helper now speaks JSON, too, and distinguishes between invalid and missing parameters.

This came up in the context of #2270 where the re-use of the URL object caused unrelated parameters to be merged until it corrupted the response. Disallowing unknown parameters would've caught this.

See [poo#64075](https://progress.opensuse.org/issues/64075)