### PR TITLE
systemd: Fix premature startup of services when network is not fully up yet

### DIFF
--- a/systemd/openqa-livehandler.service
+++ b/systemd/openqa-livehandler.service
@@ -2,7 +2,7 @@
 Description=Handler for live view in openQA's web UI
 Wants=apache2.service
 Before=apache2.service
-After=postgresql.service
+After=postgresql.service nss-lookup.target remote-fs.target
 Requires=openqa-webui.service
 
 [Service]

--- a/systemd/openqa-scheduler.service
+++ b/systemd/openqa-scheduler.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The openQA Scheduler
-After=postgresql.service openqa-setup-db.service
+After=postgresql.service openqa-setup-db.service nss-lookup.target remote-fs.target
 Wants=openqa-setup-db.service
 
 [Service]

--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -2,7 +2,7 @@
 Description=The openQA WebSockets server
 Wants=apache2.service network.target openqa-setup-db.service
 Before=apache2.service openqa-webui.service
-After=openqa-scheduler.service postgresql.service network.target openqa-setup-db.service
+After=openqa-scheduler.service postgresql.service openqa-setup-db.service network.target nss-lookup.target remote-fs.target
 
 [Service]
 # TODO: define whether we want to run the websockets with the same user

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -2,7 +2,7 @@
 Description=The openQA web UI
 Wants=apache2.service openqa-setup-db.service
 Before=apache2.service
-After=postgresql.service openqa-setup-db.service openqa-scheduler.service
+After=postgresql.service openqa-setup-db.service openqa-scheduler.service nss-lookup.target remote-fs.target
 Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
 
 [Service]


### PR DESCRIPTION
On a system where the network setup is not instantanious, e.g. NetworkManager+DHCP, when openQA systemd services are enabled to automatically startup, they can fail like

```
openqa-scheduler[1282]: Can't create listen socket: Address family for hostname not supported at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop.pm line 124.
openqa-websockets[1283]: Can't create listen socket: Address family for hostname not supported at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop.pm line 124.
openqa-livehandler[1248]: Can't create listen socket: Address family for hostname not supported at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop.pm line 124.
openqa[1284]: Can't create listen socket: Address family for hostname not supported at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop.pm line 124.
```

Theoretically the issue is reproducible on any system, just with slow DHCP it
is more likely to observe unless reproduced differently, e.g. on a system
without any network. Up to now the the systemd services did not depend on the
network being up, just the network controller stack initialized.

This commit introduces additional dependencies, similar to what for
example apache2.service and nginx.service do without going as far as
requiring "network-online.service" which is also discouraged by
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/ . As
the error message encountered is related to setting up the server listen
"nss-lockup" looks like the right, specific requirement.

Related progress issue: https://progress.opensuse.org/issues/62567