### PR TITLE
systemd: Make worker also only depend necessary network related targets

### DIFF
--- a/systemd/openqa-worker-cacheservice.service
+++ b/systemd/openqa-worker-cacheservice.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OpenQA Worker Cache Service
-After=network-online.target
-Wants=network-online.target
+After=network.target nss-lookup.target remote-fs.target
+Wants=network.target nss-lookup.target remote-fs.target
 PartOf=openqa-worker.target
 
 [Service]

--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -5,7 +5,7 @@
 [Unit]
 Description=openQA Worker #%i
 Wants=apache2.service openqa-webui.service network.target
-After=apache2.service openqa-webui.service network.target openqa-slirpvde.service
+After=apache2.service openqa-webui.service openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
 PartOf=openqa-worker.target
 
 [Service]


### PR DESCRIPTION
Following a066ce630 for the webUI related services we can use the same
dependencies for worker and cacheservice to be more correct and
potentially save some seconds of service startup time while still
ensuring all required dependencies are fulfilled.

Related progress issue: https://progress.opensuse.org/issues/62567