### PR TITLE
Harmonize shebang style

### DIFF
--- a/dbicdh/_common/upgrade/86-87/001-migrate-jobs.pl
+++ b/dbicdh/_common/upgrade/86-87/001-migrate-jobs.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2018 SUSE LLC
 #

--- a/script/check_dependencies
+++ b/script/check_dependencies
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # Copyright (C) 2014-2017 SUSE LLC
 #
@@ -16,6 +16,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use strict;
+use warnings;
 use FindBin qw($Bin);
 
 open my $fd, '<', "$Bin/../cpanfile" or die "$!";

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -1,6 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
-# Copyright (C) 2015-2019 SUSE Linux GmbH
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/modify_needle
+++ b/script/modify_needle
@@ -1,4 +1,4 @@
-#! /usr/bin/env perl
+#!/usr/bin/env perl
 
 # Copyright © 2015 SUSE LLC
 #

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014 SUSE Linux Products GmbH
 #

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE LLC
 #

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014 SUSE Linux Products GmbH
 #

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2020 SUSE LLC
 #

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2020 SUSE LLC
 #

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE Linux Products GmbH
 #

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014 SUSE Linux Products GmbH
 #

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
 #

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014 SUSE Linux Products GmbH
 #

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014 SUSE Linux Products GmbH
 #

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2020 SUSE LLC
 #

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2017 SUSE Linux Products GmbH
 #

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2017 SUSE Linux Products GmbH
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
 #

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (c) 2016-2019 SUSE LLC
+# Copyright (c) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (c) 2016-2019 SUSE LLC
 #

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (c) 2015-2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (c) 2015-2018 SUSE LINUX GmbH, Nuernberg, Germany.
 #

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2019 SUSE LLC
 #

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/16-utils-job-templates.t
+++ b/t/16-utils-job-templates.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2020 SUSE LLC
 #

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2015-2019 SUSE LLC
 #

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2016 SUSE LLC
 #

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2016 SUSE LLC
+# Copyright (C) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2018 SUSE LLC
 #

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2020 SUSE LLC
 #

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2016 Red Hat
 # Copyright (C) 2019 SUSE LLC

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 # Copyright (C) 2016 Red Hat
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2019 SUSE LLC
 #

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright (C) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019-2020 SUSE LLC
 #

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019 SUSE LLC
 #

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019 SUSE LLC
 #

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019-2020 SUSE LLC
 #

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2017-2019 SUSE Linux LLC
+# Copyright (C) 2017-2020 SUSE Linux LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2017-2019 SUSE Linux LLC
 #

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (c) 2018-2019 SUSE LLC
 #

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (c) 2018-2019 SUSE LLC
 #

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (c) 2020 SUSE LLC
 #

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # Copyright (C) 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2017-2020 SUSE LLC
 #

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2017 SUSE LLC
 #

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # Copyright (C) 2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # Copyright (C) 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # Copyright (C) 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2018-2020 SUSE LLC
 #

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 # Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2018 SUSE LLC
 #

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2018-2019 SUSE LLC
 #

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2018-2019 SUSE LLC
 #

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019-2020 SUSE LLC
 #

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019 SUSE LLC
 #

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/40-expand_placeholders.t
+++ b/t/40-expand_placeholders.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019 SUSE LLC
 #

--- a/t/40-expand_placeholders.t
+++ b/t/40-expand_placeholders.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2019 SUSE LLC
 #

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2019 SUSE Linux LLC
 #

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2019 SUSE Linux LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE LLC
 #

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2017 SUSE LLC
 #

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE LLC
 # Copyright (C) 2016 Red Hat

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 # Copyright (C) 2016 Red Hat
 #
 # This program is free software; you can redistribute it and/or modify

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2017 SUSE LLC
 #

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2015-2020 SUSE LLC
 #

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2017 SUSE LLC
 #

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2017 SUSE LLC
 #

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2017 SUSE Linux LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2017 SUSE Linux LLC
 #

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2017 SUSE LLC
 #

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2018 SUSE LLC
 #

--- a/t/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm
+++ b/t/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2020 SUSE LLC
 #

--- a/t/fake-isotovideo.pl
+++ b/t/fake-isotovideo.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/t/fake-isotovideo.pl
+++ b/t/fake-isotovideo.pl
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2020 SUSE LLC
 #

--- a/t/test_postgresql
+++ b/t/test_postgresql
@@ -7,7 +7,7 @@ else
     DIR=$(readlink -f "$DIR")
 fi
 if test -e "$DIR"/postmaster.pid; then
-  pg_ctl -D "$DIR" stop -w
+  pg_ctl -D "$DIR" stop
 fi
 if test -d "$DIR"; then
   rm -r "$DIR"
@@ -23,7 +23,7 @@ LOGFILE="${LOGFILE:-"$LOGDIR/postgresql-openqa-test.log"}"
 echo "PostgreSQL logs will be stored in $LOGFILE."
 
 mkdir -p "$LOGDIR"
-pg_ctl -D "$DIR" -l "$LOGFILE" start -w
+pg_ctl -D "$DIR" -l "$LOGFILE" start
 createdb -h "$DIR" openqa_test
 
 echo "Now export TEST_PG like:"

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE LLC
 #

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE LLC
 #

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2018-2019 SUSE LLC
 #

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2015-2019 SUSE LLC
 #

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2019 SUSE LLC
 #

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright (C) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE LLC
 #

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2015-2019 SUSE LLC
 #

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2015-2019 SUSE LLC
 #

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2020 SUSE LLC
 #

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2020 SUSE LLC
 #
@@ -115,7 +115,7 @@ like(
     "on src page for installer_timezone test"
 );
 
-is($driver->find_element('.cm-comment')->get_text(), '#!/usr/bin/perl -w', "we have a perl comment");
+is($driver->find_element('.cm-comment')->get_text(), '#!/usr/bin/env perl', "we have a perl comment");
 
 $driver->get("/tests/99937");
 disable_bootstrap_animations;

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2019 SUSE LLC
 #

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2014-2017 SUSE LLC
 #

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2016-2017 SUSE LLC
+# Copyright (C) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2017 SUSE LLC
 #

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2015-2019 SUSE LLC
 #

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2018-2019 SUSE LLC
 #

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
-
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
We use 'warnings' in all our common perl files and modules hence we do
not need the parameter '-w' which would not include e.g. strict anyway.
Also for development environment '/usr/bin/env perl' is more helpful as
the environment can override which specific perl interpreter to use.

Used some interactive and some non-interactive commands to do the
change, e.g.:

 ```
find t/ -name '*.t' -exec sed -i -e 's@/usr/bin/perl@/usr/bin/env perl@' '{}' \;
git grep -l '\-w$' | xargs sed -i -e 's@ \-w$@@'
git grep -l '^#! /' | xargs sed -i -e 's@^#! /@#!/@'
```