### PR TITLE
Split 'checkstyle' tests within circle CI to reduce overall runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ images:
       JUNIT_PACKAGE: openQA
       JUNIT_NAME_MANGLE: perl
       PERL_TEST_HARNESS_DUMP_TAP: test-results
-      HARNESS: --harness TAP::Harness::JUnit
+      HARNESS: --harness TAP::Harness::JUnit --timer
       COVEROPT: -MDevel::Cover=-select_re,'^/lib',-ignore_re,'^t/.*',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement
       COMMIT_AUTHOR_EMAIL: skynet@open.qa
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,15 +88,17 @@ aliases:
     command: |
       export PERL5OPT="$COVEROPT,-db,cover_db_${CIRCLE_JOB}"
       echo PERL5OPT="$PERL5OPT"
+      export unstables=$(cat .circleci/unstable_tests.txt | tr '\n' :)
       case "$CIRCLE_JOB" in
-      t)         make test CHECKSTYLE=1 PROVE_ARGS="$HARNESS t/*.t"     GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
-      ui)        make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/ui/*.t"  GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
-      api)       make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/api/*.t" GLOBIGNORE="$(cat .circleci/unstable_tests.txt | tr '\n' :)";;
+      checkstyle) make test CHECKSTYLE=1 PROVE_ARGS="$HARNESS t/*{tidy,compile}*.t" GLOBIGNORE="$unstables";;
+      t)          make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/*.t"               GLOBIGNORE="t/*tidy*:t/*compile*:$unstables";;
+      ui)         make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/ui/*.t"            GLOBIGNORE="t/*tidy*:t/*compile*:$unstables";;
+      api)        make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS t/api/*.t"           GLOBIGNORE="t/*tidy*:t/*compile*:$unstables";;
       # put unstable tests in unstable_tests.txt and uncomment to handle with retries
-      #unstable)  for f in $(cat .circleci/unstable_tests.txt); do make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS $f" RETRY=3 || break; done;;
-      fullstack) make test CHECKSTYLE=0 FULLSTACK=1           PROVE_ARGS="$HARNESS t/full-stack.t" RETRY=3;;
-      scheduler) make test CHECKSTYLE=0 SCHEDULER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/05-scheduler-full.t" RETRY=3;;
-      developer) make test CHECKSTYLE=0 DEVELOPER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/33-developer_mode.t" RETRY=3;;
+      #unstable)   for f in $(cat .circleci/unstable_tests.txt); do make test CHECKSTYLE=0 PROVE_ARGS="$HARNESS $f" RETRY=3 || break; done;;
+      fullstack)  make test CHECKSTYLE=0 FULLSTACK=1           PROVE_ARGS="$HARNESS t/full-stack.t" RETRY=3;;
+      scheduler)  make test CHECKSTYLE=0 SCHEDULER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/05-scheduler-full.t" RETRY=3;;
+      developer)  make test CHECKSTYLE=0 DEVELOPER_FULLSTACK=1 PROVE_ARGS="$HARNESS t/33-developer_mode.t" RETRY=3;;
       esac
 
   - &git_token_authentication
@@ -199,7 +201,7 @@ jobs:
             fi
       - save_cache: *save_fullstack_cache
 
-  t: &test-template
+  checkstyle: &test-template
     docker:
       - <<: *base
     steps:
@@ -239,6 +241,8 @@ jobs:
             - cover_db_*
       - store_test_results: *store_test_results
       - store_artifacts: *store_artifacts
+  t:
+    <<: *test-template
 
   ui:
     <<: *test-template
@@ -307,31 +311,28 @@ workflows:
   test:
     jobs:
       - cache
+      - checkstyle: &requires
+          requires:
+            - cache
       - t:
-          requires:
-            - cache
+          <<: *requires
       - api:
-          requires:
-            - cache
+          <<: *requires
       - ui:
-          requires:
-            - cache
+          <<: *requires
       # put unstable tests in unstable_tests.txt and uncomment to handle with retries
       # - unstable:
       #     requires:
       #       - cache
       - cache.fullstack:
-          requires:
-            - cache
-      - fullstack:
+          <<: *requires
+      - fullstack: &requires_fullstack
           requires:
             - cache.fullstack
       - developer:
-          requires:
-            - cache.fullstack
+          <<: *requires_fullstack
       - scheduler:
-          requires:
-            - cache.fullstack
+          <<: *requires_fullstack
       - codecov:
           requires:
             - t
@@ -342,8 +343,7 @@ workflows:
             - developer
             - scheduler
       - build-docs:
-          requires:
-            - cache
+          <<: *requires
 
   nightly:
     triggers:

--- a/Makefile
+++ b/Makefile
@@ -117,16 +117,16 @@ test: checkstyle test-with-database
 endif
 endif
 
-.PHONY: test-unit-and-integration
-test-unit-and-integration:
-	export GLOBIGNORE="$(GLOBIGNORE)";\
-	script/retry prove ${PROVE_LIB_ARGS} ${PROVE_ARGS}
-
 .PHONY: test-with-database
 test-with-database:
 	test -d $(TEST_PG_PATH) && (pg_ctl -D $(TEST_PG_PATH) -s status >&/dev/null || pg_ctl -D $(TEST_PG_PATH) -s start) || ./t/test_postgresql $(TEST_PG_PATH)
 	PERL5OPT="$(PERL5OPT) -I$(PWD)/t/lib -MOpenQA::Test::PatchDeparse" $(MAKE) test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)"
 	-[ $(KEEP_DB) = 1 ] || pg_ctl -D $(TEST_PG_PATH) stop
+
+.PHONY: test-unit-and-integration
+test-unit-and-integration:
+	export GLOBIGNORE="$(GLOBIGNORE)";\
+	script/retry prove ${PROVE_LIB_ARGS} ${PROVE_ARGS}
 
 # prepares running the tests within Docker (eg. pulls os-autoinst) and then runs the tests considering
 # the test matrix environment variables


### PR DESCRIPTION
Currently 't' is taking longer than 30m whereas all other test
collections take 20m or less. Having 'checkstyle' a separate test
collection should reduce overall runtime with the additional benefit of
identifying style issues earlier without needing to wait for other
tests.

This reduces the overall runtime from about 1h 4m to 48m, e.g. compare
a workflow before:
https://app.circleci.com/github/os-autoinst/openQA/pipelines/6f7ddd8c-30fc-4afc-8255-6e048434d328/workflows/8893b002-0ec9-45be-a3c6-fb4bb64c1ee1
with the new workflow:
https://app.circleci.com/github/os-autoinst/openQA/pipelines/c0c3f8d9-1cd9-43a4-9d00-a222ad1db1a7/workflows/9bc277da-296a-4396-a352-bef188d01d1d