### PR TITLE
Fix 'openqa-setup-db' on SLE12 builds

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -259,9 +259,9 @@ ln -s %{_datadir}/openqa/script/dump_templates %{buildroot}%{_bindir}/openqa-dum
 ln -s %{_datadir}/openqa/script/load_templates %{buildroot}%{_bindir}/openqa-load-templates
 ln -s %{_datadir}/openqa/script/openqa-clone-custom-git-refspec %{buildroot}%{_bindir}/openqa-clone-custom-git-refspec
 ln -s %{_datadir}/openqa/script/openqa-validate-yaml %{buildroot}%{_bindir}/openqa-validate-yaml
+ln -s %{_datadir}/openqa/script/setup-db %{buildroot}%{_bindir}/openqa-setup-db
 %if %{with python_scripts}
 ln -s %{_datadir}/openqa/script/openqa-label-all %{buildroot}%{_bindir}/openqa-label-all
-ln -s %{_datadir}/openqa/script/setup-db %{buildroot}%{_bindir}/openqa-setup-db
 %endif
 
 cd %{buildroot}


### PR DESCRIPTION
Problem introduced with 833d31513 by incorrectly grouping with python
scripts.