### PR TITLE
Fix script/retry for STABILITY_TEST preventing false-negatives

### DIFF
--- a/script/retry
+++ b/script/retry
@@ -19,7 +19,7 @@ else
             run_once $* && break
         else
             [ $n -lt "$RETRY" ] || exit 0
-            run_once $* || break
+            run_once $* || exit
             echo Retrying...
         fi
         n=$((n+1))


### PR DESCRIPTION
When the command within "run_once" fails we must not only break the loop
but also preserve the exit code. This was observed when trying out
STABILITY_TEST in more cases which is not affecting our current circle
CI based tests as they do not use STABILITY_TEST anywhere in the current
state.