### PR TITLE
Optimize _optimize_image

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -1281,8 +1281,10 @@ sub _log_snippet {
 
 sub _optimize_image {
     my ($image) = @_;
-    if (which('optipng')) {
-        log_debug("Optimizing $image");
+    log_debug("Optimizing $image");
+    {
+        # treat as "best-effort". If optipng is not found, ignore
+        no warnings;
         system('optipng', '-quiet', '-o2', $image);
     }
     return undef;


### PR DESCRIPTION
I consider a "which" call for every "system" to be wasteful as we ignore
the fact if optipng is not found anyway. So just ignore any problem
encountered with the system call instead.

The additional difference would be that the debug log message would be
printed regardless in before.