### PR TITLE
Fix race condition when on job assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ test-fullstack:
 
 .PHONY: test-scheduler
 test-scheduler:
-	$(MAKE) test-with-database SCHEDULER_FULLSTACK=1 PROVE_ARGS="$$HARNESS t/05-scheduler-full.t" RETRY=3
+	$(MAKE) test-with-database SCHEDULER_FULLSTACK=1 SCALABILITY_TEST=1 PROVE_ARGS="$$HARNESS t/05-scheduler-full.t t/43-scheduling-and-worker-scalability.t" RETRY=3
 
 .PHONY: test-developer
 test-developer:

--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -20,11 +20,18 @@ use constant MAX_TIMER => 100;
 # Time verification to be use with WORKERS_CHECKER_THRESHOLD.
 use constant MIN_TIMER => 20;
 
+# The smallest time difference of database timestamps we usually distinguish in seconds
+# note: PostgreSQL actually provides a higher accuracy for the timestamp type. However,
+#       the automatic timestamp handling provided by DBIx only stores whole seconds. The
+#       openQA code itself only deals with whole seconds as well.
+use constant DB_TIMESTAMP_ACCURACY => 1;
+
 our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION
   WORKERS_CHECKER_THRESHOLD
   MAX_TIMER
   MIN_TIMER
+  DB_TIMESTAMP_ACCURACY
 );
 
 

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -27,6 +27,7 @@ use OpenQA::App;
 use OpenQA::Utils 'log_error';
 use OpenQA::WebSockets::Client;
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
+use OpenQA::Jobs::Constants;
 use Mojo::JSON qw(encode_json decode_json);
 
 use constant COMMANDS =>
@@ -276,6 +277,36 @@ sub unfinished_jobs {
 sub set_current_job {
     my ($self, $job) = @_;
     $self->update({job_id => $job->id});
+}
+
+sub reschedule_assigned_jobs {
+    my ($self, $currently_assigned_jobs) = @_;
+    $currently_assigned_jobs //= [$self->job, $self->unfinished_jobs];
+
+    my %considered_jobs;
+    for my $associated_job (@$currently_assigned_jobs) {
+        next unless defined $associated_job;
+
+        # prevent doing this twice for the same job ($current_job and @unfinished_jobs might overlap)
+        my $job_id = $associated_job->id;
+        next if exists $considered_jobs{$job_id};
+        $considered_jobs{$job_id} = 1;
+
+        # consider only assigned jobs here
+        # note: Running jobs are only marked as incomplete on worker registration (and not here) because that
+        #       operation can be quite costly.
+        next if $associated_job->state ne ASSIGNED;
+
+        # set associated job which was only assigned back to scheduled
+        # note: Using a transaction here so we don't end up with an inconsistent state when an error occurs.
+        try {
+            $self->result_source->schema->txn_do(sub { $associated_job->reschedule_state });
+        }
+        catch {
+            my $worker_id = $self->id;
+            log_warning("Unable to re-schedule job $job_id abandoned by worker $worker_id: $_");
+        };
+    }
 }
 
 1;

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 SUSE Linux GmbH
-#               2016-2018 SUSE LLC
+#               2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ use Try::Tiny;
 use OpenQA::App;
 use OpenQA::Utils 'log_error';
 use OpenQA::WebSockets::Client;
-use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
+use OpenQA::Constants qw(WORKERS_CHECKER_THRESHOLD DB_TIMESTAMP_ACCURACY);
 use OpenQA::Jobs::Constants;
 use Mojo::JSON qw(encode_json decode_json);
 
@@ -144,7 +144,7 @@ sub dead {
     # check for workers active in last WORKERS_CHECKER_THRESHOLD
     # last seen should be updated at least in MAX_TIMER t in worker
     # and should not be greater than WORKERS_CHECKER_THRESHOLD.
-    $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD);
+    $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD - DB_TIMESTAMP_ACCURACY);
 
     $self->t_updated < $dt;
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@ use Mojo::Base 'Mojolicious';
 use Mojolicious 7.18;
 use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
-use OpenQA::Utils qw(log_warning detect_current_version);
+use OpenQA::Utils qw(log_warning detect_current_version service_port);
 use OpenQA::Setup;
 use OpenQA::WebAPI::Description qw(get_pod_from_controllers set_api_desc);
 use Mojo::IOLoop;
@@ -269,11 +269,7 @@ sub startup {
         '/ws/<workerid:num>' => sub {
             my $c        = shift;
             my $workerid = $c->param('workerid');
-            # use port one higher than WebAPI
-            my $port = 9527;
-            if (my $custom = $c->req->url->to_abs->port) {
-                $port = $custom + 1;
-            }
+            my $port     = service_port('websocket');
             $c->redirect_to("http://localhost:$port/ws/$workerid");
         });
     my $api_job_auth = $api_public->under('/')->to(controller => 'API::V1', action => 'auth_jobtoken');
@@ -344,11 +340,7 @@ sub startup {
         '/ws' => sub {
             my $c        = shift;
             my $workerid = $c->param('workerid');
-            # use port one higher than WebAPI
-            my $port = 9527;
-            if (defined $ENV{MOJO_LISTEN} && $ENV{MOJO_LISTEN} =~ /.*:(\d{1,5})\/?$/) {
-                $port = $1 + 1;
-            }
+            my $port     = service_port('websocket');
             $c->redirect_to("http://localhost:$port/ws/$workerid");
         });
 

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -68,6 +68,7 @@ sub _message {
     my $schema        = $app->schema;
     my $worker_status = $app->status->worker_status;
 
+    # find relevant worker
     my $worker = OpenQA::WebSockets::Model::Status->singleton->worker_by_transaction->{$self->tx};
     unless ($worker) {
         $app->log->warn("A message received from unknown worker connection");
@@ -75,74 +76,102 @@ sub _message {
         $self->finish("1008", "Connection terminated from WebSocket server - thought dead");
         return undef;
     }
+    my $worker_id = $worker->{id};
+    my $worker_db = $worker->{db};
+
+    # check whether the job was idle before and unset the idle state (any action by the worker other than
+    # claiming it is not broken and not working on any job revokes the idle flag)
+    my $worker_previously_idle = delete $worker->{idle};
+
     unless (ref($json) eq 'HASH') {
-        log_error(sprintf('Received unexpected WS message "%s from worker %u', dumper($json), $worker->{id}));
+        log_error(sprintf('Received unexpected WS message "%s from worker %u', dumper($json), $worker_id));
         $self->finish(1003 => 'Received unexpected data from worker, forcing close');
         return undef;
     }
 
-    # This is to make sure that no worker can skip the _registration.
-    if (($worker->{db}->websocket_api_version() || 0) != WEBSOCKET_API_VERSION) {
-        log_warning("Received a message from an incompatible worker " . $worker->{id});
-        $self->tx->send({json => {type => 'incompatible'}});
-        $self->finish("1008",
-            "Connection terminated from WebSocket server - incompatible communication protocol version");
+    # make sure no worker can skip the initial registration
+    if (($worker_db->websocket_api_version || 0) != WEBSOCKET_API_VERSION) {
+        log_warning("Received a message from an incompatible worker $worker_id");
+        $self->send({json => {type => 'incompatible'}});
+        $self->finish(
+            1008 => 'Connection terminated from WebSocket server - incompatible communication protocol version');
         return undef;
     }
 
-    if ($json->{type} eq 'quit') {
+    my $message_type = $json->{type};
+    if ($message_type eq 'quit') {
         my $dt = DateTime->now(time_zone => 'UTC');
         $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD);
-        $worker->{db}->update({t_updated => $dt});
+        $worker_db->update({t_updated => $dt});
+        $worker_db->reschedule_assigned_jobs;
     }
-    elsif ($json->{type} eq 'accepted') {
+    elsif ($message_type eq 'rejected') {
+        my $job_ids = $json->{job_ids};
+        my $reason  = $json->{reason} // 'unknown reason';
+        return undef unless ref($job_ids) eq 'ARRAY' && @$job_ids;
+
+        my $job_ids_str = join(', ', @$job_ids);
+        log_debug("Worker $worker_id rejected job(s) $job_ids_str: $reason");
+
+        # re-schedule rejected job if it is still assigned to that worker
+        try {
+            $schema->txn_do(
+                sub {
+                    my @jobs = $schema->resultset('Jobs')
+                      ->search({id => {-in => $job_ids}, assigned_worker_id => $worker_id, state => ASSIGNED});
+                    $_->reschedule_state for @jobs;
+                });
+        }
+        catch {
+            log_warning("Unable to re-schedule job(s) $job_ids_str rejected by worker $worker_id: $_");
+        };
+    }
+    elsif ($message_type eq 'accepted') {
         my $job_id = $json->{jobid};
         return undef unless $job_id;
 
         # verify whether the job has previously been assigned to the worker and can actually be accepted
-        my $job = $worker->{db}->unfinished_jobs->find($job_id);
+        my $job = $worker_db->unfinished_jobs->find($job_id);
         if (!$job) {
             log_warning(
-                "Worker $worker->{id} accepted job $job_id which was never assigned to it or has already finished");
+                "Worker $worker_id accepted job $job_id which was never assigned to it or has already finished");
             return undef;
         }
 
         # assume the job setup is done by the worker
-        # note: Setting the state to something different also prevents that the job is set back to SCHEDULED
-        #       if the worker is slow with the first status update.
         $schema->resultset('Jobs')->search({id => $job_id, state => ASSIGNED, t_finished => undef})
           ->update({state => SETUP});
 
         # update the worker's current job
-        $worker->{db}->update({job_id => $job_id});
-        log_debug("Worker $worker->{id} accepted job $job_id");
+        $worker_db->update({job_id => $job_id});
+        log_debug("Worker $worker_id accepted job $job_id");
     }
-    elsif ($json->{type} eq 'worker_status') {
+    elsif ($message_type eq 'worker_status') {
         my $current_worker_status = $json->{status};
-        my $current_worker_error  = $current_worker_status eq 'broken' ? $json->{reason} : undef;
+        my $worker_is_broken      = $current_worker_status eq 'broken';
+        my $current_worker_error  = $worker_is_broken ? $json->{reason} : undef;
         my $job_info              = $json->{job} // {};
         my $job_status            = $job_info->{state};
         my $job_id                = $job_info->{id};
         my $job_settings          = $job_info->{settings} // {};
         my $job_token             = $job_settings->{JOBTOKEN};
         my $pending_job_ids       = $json->{pending_job_ids} // {};
-        my $wid                   = $worker->{id};
 
-        $worker_status->{$wid} = $json;
-        log_debug(sprintf('Received from worker "%u" worker_status message "%s"', $wid, dumper($json)));
+        $worker_status->{$worker_id} = $json;
+        log_debug(sprintf('Received from worker "%u" worker_status message "%s"', $worker_id, dumper($json)));
 
         # log that we 'saw' the worker
         try {
             $schema->txn_do(
                 sub {
-                    return undef unless my $w = $schema->resultset("Workers")->find($wid);
-                    log_debug("Updating worker seen from worker_status");
+                    return undef unless my $w = $schema->resultset("Workers")->find($worker_id);
+                    log_debug("Updating seen of worker $worker_id from worker_status");
                     $w->seen;
                     $w->update({error => $current_worker_error});
                 });
         }
         catch {
-            log_error("Failed updating worker seen and error status: $_");
+            log_error("Failed updating seen and error status of worker $worker_id: $_");
         };
 
         # send worker population
@@ -152,16 +181,16 @@ sub _message {
             $self->tx->send({json => $msg} => sub { log_debug("Sent population to worker: " . pp($msg)) });
         }
         catch {
-            log_debug("Could not send the population number to worker: $_");
+            log_debug("Could not send the population number to worker $worker_id: $_");
         };
 
         # find the job currently associated with that worker and check whether the worker still
         # executes the job it is supposed to
+        my $current_job_id;
         try {
-            my $worker = $schema->resultset('Workers')->find($wid);
+            my $worker = $schema->resultset('Workers')->find($worker_id);
             return undef unless $worker;
 
-            my $current_job_id;
             my $registered_job_token;
             my $current_job_state;
             my @unfinished_jobs = $worker->unfinished_jobs;
@@ -172,12 +201,12 @@ sub _message {
             }
 
             # log debugging info
-            log_debug("Found job $current_job_id in DB from worker_status update sent by worker $wid")
+            log_debug("Found job $current_job_id in DB from worker_status update sent by worker $worker_id")
               if defined $current_job_id;
             log_debug("Received request has job id: $job_id")
               if defined $job_id;
             $registered_job_token = $worker->get_property('JOBTOKEN');
-            log_debug("Worker $wid for job $current_job_id has token $registered_job_token")
+            log_debug("Worker $worker_id for job $current_job_id has token $registered_job_token")
               if defined $current_job_id && defined $registered_job_token;
             log_debug("Received request has token: $job_token")
               if defined $job_token;
@@ -193,50 +222,25 @@ sub _message {
                 && OpenQA::Jobs::Constants::meta_state($current_job_state) eq OpenQA::Jobs::Constants::EXECUTION)
               && (scalar @unfinished_jobs <= 1);
 
-            # handle the case when the worker does not work on the job(s) it is supposed to work on
-            my @all_jobs_currently_associated_with_worker = ($current_job, @unfinished_jobs);
-            my %considered_jobs;
-            for my $associated_job (@all_jobs_currently_associated_with_worker) {
-                next unless defined $associated_job;
+            # give worker a second chance to process the job assignment
+            # possible situation on the worker: The worker might be sending a status update claiming it is
+            # idle (or has doing that task piled up on the event loop). At the same time a job arrives. The
+            # message regarding that job will be processed after sending the idle status. So let's give the
+            # worker another change to process the message about its assigned job.
+            return undef unless $worker_previously_idle;
 
-                # prevent doing this twice for the same job ($current_job and @unfinished_jobs might overlap)
-                my $job_id = $associated_job->id;
-                next if exists $considered_jobs{$job_id};
-                $considered_jobs{$job_id} = 1;
-
-                # do nothing if the job token is corrent and the worker claims that it is still working on that job
-                # or that the job is still pending
-                if ($job_token_correct) {
-                    next if $job_id eq $current_job_id;
-                    next if exists $pending_job_ids->{$job_id};
-                }
-
-                # set associated job which was only assigned back to scheduled
-                # note: It is not sufficient to do that just on worker registration because if a worker is not taking
-                #       the job we assigned it might just be busy with a job from another web UI. In this case we need
-                #       to assign the job to a different worker.
-                # note: Using a transaction here so we don't end up with an inconsistent state when an error occurs.
-                if ($associated_job->state eq OpenQA::Jobs::Constants::ASSIGNED) {
-                    try {
-                        $schema->txn_do(sub { $associated_job->reschedule_state; });
-                    }
-                    catch {
-                        log_warning("Unable to reschedule jobs abandoned by worker $wid: $_");
-                    };
-                    next;
-                }
-
-                # note: Jobs are only marked as incomplete on worker registration (and not here) because that operation
-                #       can be quite costly. (FIXME: We could just cancel the web socket connection to force the worker
-                #       to re-register.)
-            }
+            log_debug("Rescheduling jobs assigned to worker $worker_id");
+            $worker->reschedule_assigned_jobs([$current_job, @unfinished_jobs]);
         }
         catch {
-            log_warning("Unable to verify whether worker $wid runs its job(s) as expected: $_");
-        }
+            log_warning("Unable to verify whether worker $worker_id runs its job(s) as expected: $_");
+        };
+
+        # consider the worker idle unless it claims to be broken or work on a job
+        $worker->{idle} = !$worker_is_broken && !defined $job_id;
     }
     else {
-        log_error(sprintf('Received unknown message type "%s" from worker %u', $json->{type}, $worker->{id}));
+        log_error(sprintf('Received unknown message type "%s" from worker %u', $message_type, $worker->{id}));
     }
 }
 

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -817,6 +817,24 @@ sub find_current_or_pending_job {
     return _find_job_in_queue($job_id, $self->{_pending_jobs});
 }
 
+sub current_job_ids {
+    my ($self) = @_;
+
+    my @current_job_ids;
+    if (my $current_job = $self->current_job) {
+        push(@current_job_ids, $current_job->id);
+    }
+    push(@current_job_ids, @{$self->pending_job_ids});
+    return \@current_job_ids;
+}
+
+sub is_busy {
+    my ($self) = @_;
+    return 1 if $self->current_job;
+    return 1 if $self->has_pending_jobs;
+    return 0;
+}
+
 # marks a job to be immediately skipped when picking it from the queue
 sub skip_job {
     my ($self, $job_id, $reason) = @_;

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,6 +22,8 @@ use POSIX ':sys_wait_h';
 use Data::Dump 'pp';
 
 has 'client';
+
+my %COMMANDS_SPECIFIC_TO_CURRENT_JOB = map { ($_ => 1) } qw(livelog_start livelog_stop developer_session_start);
 
 sub new {
     my ($class, $client) = @_;
@@ -66,7 +68,7 @@ sub handle_command {
             return undef;
         }
     }
-    elsif ($type ne 'info' && $type ne 'grab_job' && $type ne 'grab_jobs') {
+    elsif (exists $COMMANDS_SPECIFIC_TO_CURRENT_JOB{$type}) {
         # require a job ID and ensure it matches the current job if we're already executing one
         if ($current_job) {
             # ignore messages which do not belong to the current job

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -38,15 +38,14 @@ sub handle_command {
     my $webui_host         = $client->webui_host;
     my $current_webui_host = $worker->current_webui_host // 'unknown web UI host';
 
+    return log_warning("Ignoring invalid json sent by $current_webui_host") unless ref($json) eq 'HASH';
+
     # ignore responses to our own messages which are indicated by 'result'
-    return undef if ($json->{result});
+    return undef if defined $json->{result};
 
     # handle commands of certain types regarding a specific job (which is supposed to be the job we're working on)
     my $type = $json->{type};
-    if (!$type) {
-        log_warning("Ignoring WS message without type from $webui_host:\n" . pp($json));
-        return undef;
-    }
+    return log_warning("Ignoring WS message without type from $webui_host:\n" . pp($json)) unless defined $type;
 
     # match the specified job
     my $job_id       = $json->{jobid};
@@ -67,18 +66,12 @@ sub handle_command {
             return undef;
         }
     }
-    elsif ($type ne 'info') {
+    elsif ($type ne 'info' && $type ne 'grab_job' && $type ne 'grab_jobs') {
         # require a job ID and ensure it matches the current job if we're already executing one
         if ($current_job) {
             # ignore messages which do not belong to the current job
             my $current_job_id = $current_job->id // 'another job';
-            if (!$job_id) {
-                # log a more specific warning in case of the grab_job message from a different web UI
-                if ($type eq 'grab_job' && $webui_host ne $current_webui_host) {
-                    log_warning("Ignoring job assignment from $webui_host "
-                          . "(already busy with job $current_job_id from $current_webui_host).");
-                    return undef;
-                }
+            if (!defined $job_id) {
                 log_warning("Ignoring WS message from $webui_host with type $type but no job ID "
                       . "(currently running $current_job_id for $current_webui_host):\n"
                       . pp($json));
@@ -93,7 +86,7 @@ sub handle_command {
         }
         else {
             # ignore messages which belong to a job
-            if ($job_id) {
+            if (defined $job_id) {
                 log_warning("Ignoring WS message from $webui_host with type $type and job ID $job_id "
                       . "(currently not executing a job):\n"
                       . pp($json));
@@ -157,17 +150,24 @@ sub _handle_command_developer_session_start {
 }
 
 sub _can_grab_job {
-    my ($worker, $webui_host, $current_job) = @_;
+    my ($client, $worker, $webui_host, $current_job, $job_ids_to_grab) = @_;
+
+    my $reason_to_reject_job;
 
     # refuse new job if the worker is
     # * in an error state (this will leave the job to be grabbed in assigned state)
     # * stopping
     if ($worker->is_stopping) {
-        log_debug("Refusing 'grab_job', the worker is currently stopping");
-        return 0;
+        $reason_to_reject_job = 'currently stopping';
+        # note: Not rejecting the job here; declaring the worker as offline which is done in any case
+        #       should be sufficient.
     }
-    if (my $current_error = $worker->current_error) {
-        log_debug("Refusing 'grab_job', we are currently unable to do any work: $current_error");
+    elsif (my $current_error = $worker->current_error) {
+        $reason_to_reject_job = $current_error;
+        $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
+    }
+    if (defined $reason_to_reject_job) {
+        log_debug("Refusing to grab job from $webui_host: $reason_to_reject_job");
         return 0;
     }
 
@@ -175,12 +175,14 @@ sub _can_grab_job {
     my $current_webui_host = $worker->current_webui_host;
     if ($current_job) {
         my $current_job_id = $current_job->id // 'another job';
-        log_warning(
-            "Refusing to grab job from $webui_host, already busy with $current_job_id from $current_webui_host");
-        return 0;
+        $reason_to_reject_job = "already busy with $current_job_id from $current_webui_host";
     }
-    if ($worker->has_pending_jobs) {
-        log_warning("Refusing to grab job from $webui_host, there are still pending jobs from $current_webui_host");
+    elsif ($worker->has_pending_jobs) {
+        $reason_to_reject_job = "there are still pending jobs from $current_webui_host";
+    }
+    if (defined $reason_to_reject_job) {
+        $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
+        log_warning("Refusing to grab job from $webui_host: $reason_to_reject_job");
         return 0;
     }
 
@@ -188,10 +190,13 @@ sub _can_grab_job {
 }
 
 sub _can_accept_job {
-    my ($webui_host, $job_info) = @_;
+    my ($client, $webui_host, $job_info, $job_ids_to_grab) = @_;
 
-    if (!$job_info || ref($job_info) ne 'HASH' || !defined $job_info->{id} || !$job_info->{settings}) {
-        log_error("Refusing to grab job from $webui_host because the provided job is invalid: " . pp($job_info));
+    my $job_id_missing = ref($job_info) ne 'HASH' || !defined $job_info->{id};
+    if ($job_id_missing || !$job_info->{settings}) {
+        $client->reject_jobs($job_ids_to_grab // [$job_info->{id}], 'the provided job is invalid')
+          if defined $job_ids_to_grab || !$job_id_missing;
+        log_error("Refusing to grab job from $webui_host: the provided job is invalid: " . pp($job_info));
         return undef;
     }
 
@@ -199,16 +204,17 @@ sub _can_accept_job {
 }
 
 sub _can_accept_sequence {
-    my ($webui_host, $job_sequence, $job_data) = @_;
+    my ($client, $webui_host, $job_sequence, $job_data, $job_ids_to_grab) = @_;
 
     for my $job_id_or_sub_sequence (@$job_sequence) {
         $job_id_or_sub_sequence //= '?';
         if (ref($job_id_or_sub_sequence) eq 'ARRAY') {
-            return 0 unless _can_accept_sequence($webui_host, $job_id_or_sub_sequence, $job_data);
+            return 0 unless _can_accept_sequence($client, $webui_host, $job_id_or_sub_sequence, $job_data);
         }
         elsif (!exists $job_data->{$job_id_or_sub_sequence}) {
-            log_error(
-                "Refusing to grab job from $webui_host because job data for job $job_id_or_sub_sequence is missing.");
+            my $reason_to_reject_job = "job data for job $job_id_or_sub_sequence is missing";
+            $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
+            log_error("Refusing to grab job from $webui_host: $reason_to_reject_job");
             return 0;
         }
     }
@@ -219,8 +225,9 @@ sub _handle_command_grab_job {
     my ($json, $client, $worker, $webui_host, $current_job) = @_;
 
     my $job_info = $json->{job};
-    return undef unless _can_grab_job($worker, $webui_host, $current_job);
-    return undef unless defined _can_accept_job($webui_host, $job_info);
+    my $job_id   = _can_accept_job($client, $webui_host, $job_info);
+    return undef unless defined $job_id;
+    return undef unless _can_grab_job($client, $worker, $webui_host, $current_job, [$job_id]);
 
     $worker->accept_job($client, $job_info);
 }
@@ -228,23 +235,29 @@ sub _handle_command_grab_job {
 sub _handle_command_grab_jobs {
     my ($json, $client, $worker, $webui_host, $current_job) = @_;
 
-    return undef unless _can_grab_job($worker, $webui_host, $current_job);
-
     # validate input (log error and ignore job on failure)
     my $job_info     = $json->{job_info} // {};
     my $job_data     = $job_info->{data};
     my $job_sequence = $job_info->{sequence};
-    if (ref($job_data) ne 'HASH' || ref($job_sequence) ne 'ARRAY') {
+    if (ref($job_data) ne 'HASH') {
         log_error(
-            "Refusing to grab job from $webui_host because the provided job info lacks job data or execution sequence: "
+            "Refusing to grab jobs from $webui_host: the provided job info lacks job data or execution sequence: "
               . pp($job_info));
         return undef;
     }
-    for my $job_id (keys %$job_data) {
-        my $acceptable_id = _can_accept_job($webui_host, $job_data->{$job_id});
+    my @job_ids_to_grab = keys %$job_data;
+    if (ref($job_sequence) ne 'ARRAY') {
+        log_error(
+            "Refusing to grab jobs from $webui_host: the provided job info lacks execution sequence: " . pp($job_info));
+        $client->reject_jobs(\@job_ids_to_grab, 'job info lacks execution sequence');
+        return undef;
+    }
+    for my $job_id (@job_ids_to_grab) {
+        my $acceptable_id = _can_accept_job($client, $webui_host, $job_data->{$job_id}, \@job_ids_to_grab);
         return undef unless defined $acceptable_id && $acceptable_id eq $job_id;
     }
-    return undef unless _can_accept_sequence($webui_host, $job_sequence, $job_data);
+    return undef unless _can_accept_sequence($client, $webui_host, $job_sequence, $job_data, \@job_ids_to_grab);
+    return undef unless _can_grab_job($client, $worker, $webui_host, $current_job, \@job_ids_to_grab);
 
     $worker->enqueue_jobs_and_accept_first($client, $job_info);
 }

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -793,7 +793,7 @@ sub _upload_results_step_0_prepare {
     }
 
     # mark the currently running test as running
-    $status{result}->{$current_test_module}->{result} = 'running' if ($current_test_module);
+    $status{result}->{$current_test_module}->{result} = 'running' if $current_test_module && !$is_final_upload;
 
     # define steps for uploading status to web UI
     return $self->_upload_results_step_1_post_status(
@@ -1190,7 +1190,7 @@ sub _read_result_file {
             shift(@$test_order);
         }
 
-        last unless ($result);
+        last unless $result;
         $ret{$test} = $result;
 
         if ($result->{extra_test_results}) {
@@ -1211,7 +1211,7 @@ sub _read_module_result {
     my ($self, $test) = @_;
 
     my $result = $self->_read_json_file("result-$test.json");
-    return unless $result;
+    return undef unless ref($result) eq 'HASH';
 
     my $images_to_send = $self->images_to_send;
     my $files_to_send  = $self->files_to_send;

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -494,4 +494,18 @@ sub quit {
     $websocket_connection->send({json => {type => 'quit'}}, $callback);
 }
 
+# send "rejected" message when refusing to take one or more jobs assigned by the web UI
+sub reject_jobs {
+    my ($self, $job_ids, $reason, $callback) = @_;
+
+    # send rejection message via web sockets if connected
+    my $websocket_connection = $self->websocket_connection;
+    return $websocket_connection->send({json => {type => 'rejected', job_ids => $job_ids, reason => $reason}},
+        $callback)
+      if defined $websocket_connection;
+
+    # try sending the message when the web socket connection becomes available again
+    $self->once(connected => sub { $self->reject_jobs($job_ids, $reason, $callback); });
+}
+
 1;

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -56,7 +56,7 @@ my $api_key         = $api_credentials->key;
 my $api_secret      = $api_credentials->secret;
 
 # create web UI and websocket server
-my $mojoport = Mojo::IOLoop::Server->generate_port();
+my $mojoport = $ENV{OPENQA_BASE_PORT} = Mojo::IOLoop::Server->generate_port();
 my $wspid    = create_websocket_server($mojoport + 1, 0, 1, 1);
 my $webapi   = create_webapi($mojoport, sub { });
 

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -40,7 +40,8 @@ use Time::HiRes 'sleep';
 use OpenQA::Test::Utils qw(
   setup_fullstack_temp_dir create_user_for_workers
   create_webapi wait_for_worker setup_share_dir create_websocket_server
-  stop_service unstable_worker client_output unresponsive_worker
+  stop_service unstable_worker client_output
+  unresponsive_worker broken_worker rejective_worker
 );
 use Mojolicious;
 use DateTime;
@@ -107,7 +108,7 @@ subtest 'Scheduler worker job allocation' => sub {
     dead_workers($schema);
 };
 
-subtest 're-scheduling and incompletion of jobs when worker is unresponsive or crashes completely' => sub {
+subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes offline' => sub {
     # avoid wasting time waiting for status updates
     my $web_ui_connection_mock = Test::MockModule->new('OpenQA::Worker::WebUIConnection');
     $web_ui_connection_mock->mock(_calculate_status_update_interval => .1);
@@ -118,9 +119,17 @@ subtest 're-scheduling and incompletion of jobs when worker is unresponsive or c
 
     # try to allocate to previous worker and fail!
     my ($allocated) = scheduler_step();
+    is(@$allocated, 0, 'no jobs allocated');
 
-    # simulate unresponsive worker which will register itself but not grab any jobs
-    my $unstable_w_pid = unresponsive_worker($api_key, $api_secret, "http://localhost:$mojoport", 3);
+    # simulate a worker in broken state; it will register itself but declare itself as broken
+    my $broken_w_pid = broken_worker($api_key, $api_secret, "http://localhost:$mojoport", 3, 'out of order');
+    wait_for_worker($schema, 5);
+    $allocated = scheduler_step();
+    is(@$allocated, 0, 'scheduler does not consider broken worker for allocating job');
+    stop_service($broken_w_pid, 1);
+
+    # simulate a worker in idle state that rejects all jobs assigned to it
+    my $rejective_w_pid = rejective_worker($api_key, $api_secret, "http://localhost:$mojoport", 3, 'rejection reason');
     wait_for_worker($schema, 5);
 
     note('waiting for job to be assigned and set back to re-scheduled');
@@ -143,10 +152,11 @@ subtest 're-scheduling and incompletion of jobs when worker is unresponsive or c
         sleep .2;
     }
     ok($job_scheduled, 'assigned job set back to scheduled if worker reports back again but has abandoned the job');
-    stop_service($unstable_w_pid, 1);
+    stop_service($rejective_w_pid, 1);
 
-    # start unstable worker again
-    $unstable_w_pid = unstable_worker($api_key, $api_secret, "http://localhost:$mojoport", 3, -1);
+    # start an unstable worker; it will register itself but ignore any job assignment (also not explicitely reject
+    # assignments)
+    my $unstable_w_pid = unstable_worker($api_key, $api_secret, "http://localhost:$mojoport", 3, -1);
     wait_for_worker($schema, 5);
 
     ($allocated) = scheduler_step();

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -107,6 +107,7 @@ like(
         my ($self, $reason) = @_;
         $self->stop_current_job_called($reason);
     }
+    sub stop   { shift->is_stopping(1); }
     sub status { {fake_status => 1} }
     sub accept_job {
         my ($self, $client, $job_info) = @_;
@@ -498,19 +499,46 @@ qr/Ignoring WS message from http:\/\/test-host with type livelog_stop and job ID
         qr/Refusing to grab jobs.*: the provided job info lacks execution sequence.*/,
         'ignoring grab multiple jobs if execution sequence missing',
     );
+    $worker->current_job(OpenQA::Worker::Job->new($worker, $client, {id => 43}));
+    combined_like(
+        sub {
+            $command_handler->handle_command(undef, {type => 'grab_job', job => {id => 42, settings => {}}});
+        },
+        qr/Refusing to grab job from .* already busy with 43 from http:\/\/test-host/,
+        'ignoring job grab when busy with another job',
+    );
+    combined_like(
+        sub {
+            $command_handler->handle_command(undef, {type => 'livelog_start'});
+        },
+        qr/Ignoring WS message from .* with type livelog_start but no job ID \(currently running 43 for .*\)/,
+        'warning about receiving job-specific message without job ID',
+    );
+    $worker->current_job(undef);
+    $worker->has_pending_jobs(1);
+    combined_like(
+        sub {
+            $command_handler->handle_command(undef, {type => 'grab_job', job => {id => 42, settings => {}}});
+        },
+        qr/Refusing to grab job from .* there are still pending jobs from http:\/\/test-host/,
+        'ignoring job grab when there are pending jobs',
+    );
+    $worker->has_pending_jobs(0);
     combined_like(
         sub { $command_handler->handle_command(undef, {type => 'foo'}); },
         qr/Ignoring WS message with unknown type foo.*/,
         'ignoring messages of unknown type',
     );
-    my %rejected_message = (json => {job_ids => [42], reason => 'some error', type => 'rejected'});
+    my $rejection = sub { {json => {job_ids => shift, reason => shift, type => 'rejected'}} };
     is_deeply(
         $ws->sent_messages,
         [
-            \%rejected_message,
-            \%rejected_message,
-            {json => {job_ids => ['but no settings'], reason => 'the provided job is invalid', type => 'rejected'}},
-            {json => {job_ids => ['42'], reason => 'job info lacks execution sequence', type => 'rejected'}},
+            $rejection->([42],                'some error'),
+            $rejection->([42],                'some error'),
+            $rejection->(['but no settings'], 'the provided job is invalid'),
+            $rejection->(['42'],              'job info lacks execution sequence'),
+            $rejection->(['42'],              'already busy with 43 from http://test-host'),
+            $rejection->(['42'],              'there are still pending jobs from http://test-host'),
         ],
         'jobs have been rejected in the error cases (when possible)'
     ) or diag explain $ws->sent_messages;
@@ -547,7 +575,6 @@ qr/Ignoring WS message from http:\/\/test-host with type livelog_stop and job ID
     $command_handler->handle_command(undef, {type => 'quit', jobid => 25});
     is($accepted_job->status, 'stopped', 'job has been stopped');
 
-
     # test accepting multiple jobs
     $worker->current_job(undef);
     my %job_info = (
@@ -575,6 +602,17 @@ qr/Ignoring WS message from http:\/\/test-host with type livelog_stop and job ID
     );
     is_deeply($worker->enqueued_job_info, undef, 'no jobs enqueued if validation failed')
       or diag explain $worker->enqueued_job_info;
+
+    # test incompatible (so far the worker stops when receiving this message; there are likely better ways to handle it)
+    is($worker->is_stopping, 0, 'not already stopping');
+    combined_like(
+        sub {
+            $command_handler->handle_command(undef, {type => 'incompatible'});
+        },
+        qr/running a version incompatible with web UI host http:\/\/test-host and therefore stopped/,
+        'problem is logged',
+    );
+    is($worker->is_stopping, 1, 'worker is stopping on incompatible message');
 };
 
 $client->worker_id(undef);

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -175,6 +175,27 @@ subtest 'web socket message handling' => sub {
     };
 
     $schema->txn_rollback;
+    $schema->txn_begin;
+
+    subtest 'quit' => sub {
+        $jobs->create({id => 42, state => ASSIGNED, assigned_worker_id => 1, TEST => 'foo'});
+        ok(!$workers->find(1)->dead, 'worker not considered dead in the first place');
+        combined_like(
+            sub {
+                $t->websocket_ok('/ws/1', 'establish ws connection');
+                $t->send_ok('{"type":"quit"}');
+                $t->finish_ok(1000, 'finished ws connection');
+            },
+            qr/Job 42 reset to state scheduled/s,
+            'info logged when worker rejects job'
+        );
+        is($jobs->find(42)->state, SCHEDULED,
+                'job is immediately set back to scheduled if assigned worker goes offline '
+              . 'gracefully before starting to work on the job');
+        ok($workers->find(1)->dead, 'worker considered immediately dead when it goes offline gracefully');
+    };
+
+    $schema->txn_rollback;
     $t->websocket_ok('/ws/1', 'establish ws connection');
 
     subtest 'worker status' => sub {

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -126,6 +126,8 @@ subtest 'web socket message handling' => sub {
         );
     };
 
+    $schema->txn_begin;
+
     subtest 'accepted' => sub {
         combined_like(
             sub {
@@ -151,6 +153,28 @@ subtest 'web socket message handling' => sub {
         is($workers->find(1)->job_id, 42,    'job is considered the current job of the worker');
     };
 
+    $schema->txn_rollback;
+    $schema->txn_begin;
+
+    subtest 'rejected' => sub {
+        $jobs->create({id => 42, state => ASSIGNED, assigned_worker_id => 1, TEST => 'foo'});
+        $jobs->create({id => 43, state => DONE,     assigned_worker_id => 1, TEST => 'foo'});
+        $workers->find(1)->update({job_id => 42});
+        combined_like(
+            sub {
+                $t->websocket_ok('/ws/1', 'establish ws connection');
+                $t->send_ok('{"type":"rejected","job_ids":[42,43],"reason":"foo"}');
+                $t->finish_ok(1000, 'finished ws connection');
+            },
+            qr/Worker 1 rejected job\(s\) 42, 43: foo.*Job 42 reset to state scheduled/s,
+            'info logged when worker rejects job'
+        );
+        is($jobs->find(42)->state,    SCHEDULED, 'job is again in scheduled state');
+        is($jobs->find(43)->state,    DONE,      'completed job not affected');
+        is($workers->find(1)->job_id, undef,     'job not considered the current job of the worker anymore');
+    };
+
+    $schema->txn_rollback;
     $t->websocket_ok('/ws/1', 'establish ws connection');
 
     subtest 'worker status' => sub {
@@ -161,7 +185,7 @@ subtest 'web socket message handling' => sub {
                 $t->json_message_is({type => 'info', population => $workers->count});
                 is($workers->find($worker_id)->error, 'test', 'broken message set');
             },
-            qr/Received .* worker_status message.*Updating worker seen from worker_status/s,
+            qr/Received.*worker_status message.*Updating seen of worker 1 from worker_status/s,
             'update logged'
         );
 
@@ -174,7 +198,7 @@ subtest 'web socket message handling' => sub {
                 $t->json_message_is({type => 'info', population => $workers->count});
                 is($workers->find($worker_id)->error, undef, 'broken status unset');
             },
-            qr/Received .* worker_status message.*Updating worker seen from worker_status/s,
+            qr/Received.*worker_status message.*Updating seen of worker 1 from worker_status/s,
             'update logged'
         );
     };

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -23,6 +23,7 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
+use OpenQA::Jobs::Constants;
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
@@ -33,6 +34,33 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 my $db      = $t->app->schema;
 my $workers = $db->resultset('Workers');
 my $jobs    = $db->resultset('Jobs');
+
+$db->txn_begin;
+
+subtest 'reschedule assigned jobs' => sub {
+    my $worker_1 = $workers->find({host => 'localhost', instance => 1});
+
+    # assume the jobs 99961, 99963 and 99937 are assigned to the worker and 99961 is the current job
+    $workers->search({})->update({job_id => undef});
+    $worker_1->update({job_id => 99961});
+    $jobs->find($_)->update({state => ASSIGNED, assigned_worker_id => $worker_1->id}) for (99961, 99963);
+    $jobs->find(99937)->update({state => PASSED, assigned_worker_id => $worker_1->id});
+
+    $worker_1->reschedule_assigned_jobs;
+    $worker_1->discard_changes;
+
+    is($worker_1->job_id, undef, 'current job has been un-assigned');
+    for my $job_id ((99961, 99963)) {
+        my $job = $jobs->find($job_id);
+        is($job->state,              SCHEDULED, "job $job_id is scheduled again");
+        is($job->assigned_worker_id, undef,     "job $job_id has no worker assigned anymore");
+    }
+    my $passed_job = $jobs->find(99937);
+    is($passed_job->state,              PASSED,        'passed job not affected');
+    is($passed_job->assigned_worker_id, $worker_1->id, 'passed job still associated with worker');
+};
+
+$db->txn_rollback;
 
 subtest 'delete job which is currently assigned to worker' => sub {
     my $worker_1        = $workers->find({host => 'localhost', instance => 1});

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -1,0 +1,194 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use OpenQA::Scheduler::Model::Jobs;
+use OpenQA::Test::Database;
+use OpenQA::Jobs::Constants;
+use OpenQA::Test::Utils
+  qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
+  qw(stop_service setup_fullstack_temp_dir);
+use Test::More;
+use Test::Warnings;
+use Time::HiRes 'sleep';
+use File::Path 'make_path';
+use Scalar::Util 'looks_like_number';
+use Mojo::File 'path';
+use Mojo::Util 'dumper';
+
+# allow the scheduler to assigns all jobs within one tick (needs to be in BEGIN block because the env variable
+# is assigned to constant)
+BEGIN {
+    $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} = $ENV{SCALABILITY_FULLSTACK_JOB_COUNT}
+      // $ENV{SCALABILITY_FULLSTACK_WORKER_COUNT};
+}
+
+# read number of workers to spawn from environment variable; skip test entirely if variable not present
+# similar to other fullstack tests
+my $worker_count = $ENV{SCALABILITY_FULLSTACK_WORKER_COUNT};
+my $job_count    = $ENV{SCALABILITY_FULLSTACK_JOB_COUNT} // $worker_count;
+plan skip_all => 'set e.g. SCALABILITY_FULLSTACK_WORKER_COUNT=n to run the scalability test for n workers'
+  unless looks_like_number($worker_count) && $worker_count > 0;
+
+# setup basedir, config dir and database
+my $tempdir = setup_fullstack_temp_dir('scalability');
+my $schema  = OpenQA::Test::Database->new->create(skip_fixtures => 1);
+my $workers = $schema->resultset('Workers');
+my $jobs    = $schema->resultset('Jobs');
+
+# create web UI and websocket server
+my $mojoport              = Mojo::IOLoop::Server->generate_port();
+my $web_socket_server_pid = create_websocket_server($mojoport + 1, 0, 1, 1);
+my $webui_pid             = create_webapi($mojoport, sub { });
+
+# prepare spawning workers
+my $sharedir        = setup_share_dir($ENV{OPENQA_BASEDIR});
+my $resultdir       = path($ENV{OPENQA_BASEDIR}, 'openqa', 'testresults')->make_path;
+my $api_credentials = create_user_for_workers;
+my $api_key         = $api_credentials->key;
+my $api_secret      = $api_credentials->secret;
+my $webui_host      = "http://localhost:$mojoport";
+my $worker_path     = path($FindBin::Bin)->child('../script/worker');
+my $isotovideo_path = path($FindBin::Bin)->child('dummy-isotovideo.sh');
+my $worker_flags    = '--verbose --no-cleanup';
+my $worker_args
+  = "--apikey=$api_key --apisecret=$api_secret --host=$webui_host --isotovideo=$isotovideo_path $worker_flags";
+note("share dir: $sharedir");
+note("resultdir: $resultdir");
+
+# spawn workers
+note("Spawning $worker_count workers");
+sub spawn_worker {
+    my ($instance) = @_;
+
+    note("Starting worker '$instance'");
+    my $workerpid = fork();
+    return $workerpid if $workerpid != 0;
+
+    exec("perl $worker_path --instance=$instance $worker_args");
+    die "failed to start worker $instance";
+}
+my %worker_ids;
+my @worker_pids;
+push @worker_pids, spawn_worker($_) for 1 .. $worker_count;
+
+# create jobs
+note("Creating $job_count jobs");
+sub log_jobs {
+    my @job_info
+      = map { sprintf("id: %s, state: %s, result: %s, reason: %s", $_->id, $_->state, $_->result, $_->reason // 'none') }
+      $jobs->search({}, {order_by => 'id'});
+    note("All jobs:\n - " . join("\n - ", @job_info));
+}
+my %job_ids;
+my @job_settings = (
+    BUILD   => '0048@0815',
+    DISTRI  => 'opensuse',
+    VERSION => 'Factory',
+    FLAVOR  => 'tape',
+    ARCH    => 'x86_64',
+    MACHINE => 'xxx',
+);
+$job_ids{$jobs->create({@job_settings, TEST => "dummy-$_"})->id} = 1 for 1 .. $job_count;
+
+# wait one second per worker/job
+my $polling_interval      = 0.1;
+my $polling_tries_workers = 1.0 / $polling_interval * $worker_count;
+my $polling_tries_jobs    = 1.0 / $polling_interval * $job_count;
+
+subtest 'wait for workers to be idle' => sub {
+    for my $try (1 .. $polling_tries_workers) {
+        last if $workers->count == $worker_count;
+        note("Waiting until all workers are registered, try $try");
+        sleep $polling_interval;
+    }
+    is($workers->count, $worker_count, 'all workers registered');
+    my @non_idle_workers;
+    for my $worker ($workers->all) {
+        $worker_ids{$worker->id} = 1;
+        push(@non_idle_workers, $worker->id) if $worker->status ne 'idle';
+    }
+    ok(!@non_idle_workers, 'all workers idling') or diag explain \@non_idle_workers;
+};
+
+subtest 'assign and run jobs' => sub {
+    my $allocated      = OpenQA::Scheduler::Model::Jobs->singleton->schedule;
+    my $remaining_jobs = $job_count - $worker_count;
+    note("Assigned jobs: " . dumper($allocated));
+    note('Remaining ' . ($remaining_jobs > 0 ? ('jobs: ' . $remaining_jobs) : ('workers: ' . -$remaining_jobs)));
+    if ($remaining_jobs > 0) {
+        is(scalar @$allocated, $worker_count, 'each worker has a job assigned');
+    }
+    elsif ($remaining_jobs < 0) {
+        is(scalar @$allocated, $job_count, 'each job has a worker assigned');
+    }
+    else {
+        is(scalar @$allocated, $job_count, 'all jobs assigned and all workers busy');
+        my @allocated_job_ids    = map { $_->{job} } @$allocated;
+        my @allocated_worker_ids = map { $_->{worker} } @$allocated;
+        my @expected_job_ids     = map { int($_) } keys %job_ids;
+        my @expected_worker_ids  = map { int($_) } keys %worker_ids;
+        is_deeply([sort @allocated_job_ids],    [sort @expected_job_ids],    'all jobs allocated');
+        is_deeply([sort @allocated_worker_ids], [sort @expected_worker_ids], 'all workers allocated');
+    }
+    for my $try (1 .. $polling_tries_jobs) {
+        last if $jobs->search({state => DONE})->count == $job_count;
+        if ($jobs->search({state => SCHEDULED})->count > $remaining_jobs) {
+            note('At least one job has been set back to scheduled; aborting to wait until all jobs are done');
+            last;
+        }
+        if ($remaining_jobs > 0) {
+            note("Trying to assign remaining $remaining_jobs jobs");
+            if (my $allocated = OpenQA::Scheduler::Model::Jobs->singleton->schedule) {
+                my $assigned_job_count = scalar @$allocated;
+                $remaining_jobs -= $assigned_job_count;
+                note("Assigned $assigned_job_count more jobs: " . dumper($allocated)) if $assigned_job_count > 0;
+            }
+        }
+        note("Waiting until all jobs are done, try $try");
+        sleep $polling_interval;
+    }
+    my $done   = is($jobs->search({state  => DONE})->count,   $job_count, 'all jobs done');
+    my $passed = is($jobs->search({result => PASSED})->count, $job_count, 'all jobs passed');
+    log_jobs unless $done && $passed;
+};
+
+subtest 'stop all workers' => sub {
+    stop_service $_ for @worker_pids;
+    my @non_offline_workers;
+    for my $try (1 .. $polling_tries_workers) {
+        @non_offline_workers = ();
+        for my $worker ($workers->all) {
+            push(@non_offline_workers, $worker->id) unless $worker->dead;
+        }
+        last unless @non_offline_workers;
+        note("Waiting until all workers are offline, try $try");
+        sleep $polling_interval;
+    }
+    ok(!@non_offline_workers, 'all workers offline') or diag explain \@non_offline_workers;
+};
+
+done_testing;
+
+END {
+    stop_service $_ for @worker_pids;
+    stop_service $web_socket_server_pid;
+    stop_service $webui_pid;
+}

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -54,7 +54,7 @@ my $workers = $schema->resultset('Workers');
 my $jobs    = $schema->resultset('Jobs');
 
 # create web UI and websocket server
-my $mojoport              = Mojo::IOLoop::Server->generate_port();
+my $mojoport              = $ENV{OPENQA_BASE_PORT} = Mojo::IOLoop::Server->generate_port();
 my $web_socket_server_pid = create_websocket_server($mojoport + 1, 0, 1, 1);
 my $webui_pid             = create_webapi($mojoport, sub { });
 

--- a/t/dummy-isotovideo.sh
+++ b/t/dummy-isotovideo.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+echo "dummy isotovideo started with arguments: $*"
+echo "arguments: $*" > autoinst-log.txt
+
+# create fake test results so the web UI thinks we ran at least one test module successfully and considers
+# the test as passed
+mkdir -p testresults
+echo '[{"category":"dummy","name":"fake","script":"none","flags":{}}]' > testresults/test_order.json
+echo '{"dents":0,"details":[],"result":"ok"}' > testresults/result-fake.json
+echo '{"current_test":"fake","status":"finished","test_execution_paused":0}' > autoinst-status.json
+
+# also add a vars.json file for less distracting error messages in the test log
+echo '{"ARCH":"x86_64","NAME":"fake-test"}' > vars.json
+
+exit 0

--- a/t/dummy-isotovideo.sh
+++ b/t/dummy-isotovideo.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -euo pipefail
 
 echo "dummy isotovideo started with arguments: $*"
 echo "arguments: $*" > autoinst-log.txt


### PR DESCRIPTION
For details about the race condition and the fix itself, see the commit message of "Prevent race condition when assigning and sending jobs to a worker".

Change regarding the [first attempt](https://github.com/os-autoinst/openQA/pull/2750): This time the re-scheduling when the worker reports a status update is not completely taken out. It is only omitted on the first status update. That should be sufficient to fix the race condition without risking jobs being stuck in the assigned state. The worst case is that a job is twice as long in the assigned state as it was possible before. However, in the good case jobs are now hopefully even less long assigned because I've kept the "rejection" message from the first attempt.

This also introduces a "scalability test" which allows to reproduce the race condition. With the fix of this PR applied, this test looks now quite stable and is even fast to run. I've executed the test locally with  
```
make test PROVE_ARGS='-v t/43-scheduling-and-worker-scalability.t' KEEP_DB=1 CHECKSTYLE=0 SCALABILITY_FULLSTACK_WORKER_COUNT=50 SCALABILITY_FULLSTACK_JOB_COUNT=100 STABILITY_TEST=1 RETRY=50
```
and with some other variations of `SCALABILITY_FULLSTACK_WORKER_COUNT`/`SCALABILITY_FULLSTACK_JOB_COUNT` and it passes fine.

So we could also enable it in the CI, e.g. using the parameters `SCALABILITY_FULLSTACK_WORKER_COUNT=5` and `SCALABILITY_FULLSTACK_JOB_COUNT=10`. Locally that takes 5 seconds to execute using these parameters.

This is only a draft because I suspect that I've lost some test coverage and need to add more test. Otherwise it is ready to be reviewed.