### PR TITLE
Make parameters for splitting screenshot cleanup configurable

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -128,3 +128,8 @@ blacklist = job_grab job_done
 
 [misc_limits]
 #untracked_assets_storage_duration = 14
+# Specify the screenshot ID range to query at once from the database (reduce to avoid big queries, increase to lower query overhead)
+#screenshot_cleanup_batch_size = 200000
+# Specify the number of screenshot ID ranges (with a size as configured by screenshot_cleanup_batch_size) to process in a single Minion
+# job (reduce to avoid Minion jobs from running very long and possibly being interrupted, increase to reduce the number of Minion jobs)
+#screenshot_cleanup_batches_per_minion_job = 450

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,6 +27,7 @@ use File::Path 'make_path';
 use POSIX 'strftime';
 use Time::HiRes 'gettimeofday';
 use OpenQA::Schema::JobGroupDefaults;
+use OpenQA::Task::Job::Limit;
 
 sub setup_log {
     my ($app) = @_;
@@ -179,7 +180,9 @@ sub read_config {
             important_result_storage_duration => OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS,
         },
         misc_limits => {
-            untracked_assets_storage_duration => 14,
+            untracked_assets_storage_duration         => 14,
+            screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
+            screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
         },
         'assets/storage_duration' => {
             # intentionally left blank for overview

--- a/t/config.t
+++ b/t/config.t
@@ -23,6 +23,7 @@ use Test::Warnings;
 use Mojolicious;
 use OpenQA::Setup;
 use OpenQA::Schema::JobGroupDefaults;
+use OpenQA::Task::Job::Limit;
 use Mojo::File 'tempdir';
 
 subtest 'Test configuration default modes' => sub {
@@ -92,7 +93,9 @@ subtest 'Test configuration default modes' => sub {
             important_result_storage_duration => OpenQA::Schema::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS,
         },
         misc_limits => {
-            untracked_assets_storage_duration => 14,
+            untracked_assets_storage_duration         => 14,
+            screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
+            screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
         },
     };
 


### PR DESCRIPTION
On different production instances the runtime of the splitted cleanup tasks differs a lot so it makes sense to make the parameters for splitting configurable.

---

See https://progress.opensuse.org/issues/55922#note-18