### PR TITLE
Fix ARRAY in loaded job template settings

### DIFF
--- a/script/dump_templates
+++ b/script/dump_templates
@@ -201,7 +201,7 @@ if ($tables{'JobGroups'}) {
         }
         else {
             my $yaml = load_yaml(string => $res->body);
-            foreach my $group (keys %$yaml) {
+            foreach my $group (sort keys %$yaml) {
                 push @{$result{'JobGroups'}}, {group_name => $group, template => $yaml->{$group}};
             }
         }

--- a/script/load_templates
+++ b/script/load_templates
@@ -208,7 +208,7 @@ sub post_entry {
 
     my $table_url = $url->clone->path($options{'apibase'} . '/' . decamelize($table));
     if (!$options{'clean'}) {    # with --clean the entry should not exist at this point, no need to check
-        my $res = $client->get($table_url, form => \%param)->res;
+        my $res = $client->get($table_url->clone, form => \%param)->res;
         if ($res->is_success && @{$res->json->{$table}} > 0 && $res->json->{$table}[0]{id}) {
             if ($options{'update'} && $table ne 'JobTemplates')
             {                    # there is nothing to update in JobTemplates, the entry just exists or not


### PR DESCRIPTION
- `get` apparently modifies the URL even with `form` so we need to clone the URL before using it.
- We should always sort the keys from the YAML.
- A new test checks that a re-import has the expected contents.

Fixes: [poo#64361](https://progress.opensuse.org/issues/64361)