### PR TITLE
Improve test coverage; remove support for old workers relying on redirection for ws route

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -141,7 +141,7 @@ sub schedule {
             $worker = $schema->resultset('Workers')->find({id => $worker_id});
         }
         catch {
-            log_debug("Failed to retrieve worker ($worker_id) in the DB, reason: $_");
+            log_debug("Failed to retrieve worker ($worker_id) in the DB, reason: $_");    # uncoverable statement
         };
         next unless $worker;
         if ($worker->unfinished_jobs->count) {
@@ -248,7 +248,7 @@ sub schedule {
             $schema->txn_do(sub { $worker->unprepare_for_work; });
         }
         catch {
-            log_debug("Failed resetting unprepare worker, reason: $_");
+            log_debug("Failed resetting unprepare worker, reason: $_");    # uncoverable statement
         };
         for my $job (@jobs) {
             try {
@@ -257,8 +257,8 @@ sub schedule {
             }
             catch {
                 # if we see this, we are in a really bad state
-                my $job_id = $job->id;
-                log_debug("Failed resetting job '$job_id' to scheduled state, reason: $_");
+                my $job_id = $job->id;                                                         # uncoverable statement
+                log_debug("Failed resetting job '$job_id' to scheduled state, reason: $_");    # uncoverable statement
             };
         }
     }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1508,8 +1508,8 @@ sub allocate_network {
                 });
         }
         catch {
-            log_debug("Failed to create new vlan tag: $vlan");
-            next;
+            log_debug("Failed to create new vlan tag: $vlan");    # uncoverable statement
+            next;                                                 # uncoverable statement
         };
         if ($created) {
             # mark it for the whole cluster - so that the vlan only appears

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1938,11 +1938,6 @@ sub result_stats {
     };
 }
 
-sub search_for {
-    my ($self, $result_set, $condition, $attrs) = @_;
-    return $self->$result_set->search($condition, $attrs);
-}
-
 sub blocked_by_parent_job {
     my ($self) = @_;
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1356,18 +1356,7 @@ sub failed_modules {
 
 sub update_status {
     my ($self, $status) = @_;
-
     my $ret = {result => 1};
-    if (!$self->worker) {
-        OpenQA::Utils::log_info(
-            'Got status update for job with no worker assigned (maybe running job already considered dead): '
-              . $self->id);
-        return {
-            result       => 0,
-            error_status => 404,
-            error        => 'No worker assigned'
-        };
-    }
 
     # that is a bit of an abuse as we don't have anything of the
     # other payload
@@ -1392,9 +1381,6 @@ sub update_status {
         }
     }
     $ret->{known_images} = [sort keys %known];
-
-    # mark the worker as alive
-    $self->worker->seen;
 
     # update info used to compose the URL to os-autoinst command server
     if (my $assigned_worker = $self->assigned_worker) {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1097,20 +1097,6 @@ sub custom_module {
     $parser->write_output($self->result_dir);
 }
 
-# check the group comments for tags
-sub part_of_important_build {
-    my ($self) = @_;
-
-    my $build = $self->BUILD;
-
-    # if there is no group, it can't be important
-    if (!$self->group) {
-        return;
-    }
-
-    return grep { $_ eq $build } @{$self->group->important_builds};
-}
-
 sub delete_logs {
     my ($self) = @_;
 

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -102,10 +102,6 @@ sub update_caps {
     }
 }
 
-sub all_properties {
-    map { $_->key => $_->value } shift->properties->all();
-}
-
 sub get_property {
     my ($self, $key) = @_;
 

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -303,8 +303,8 @@ sub reschedule_assigned_jobs {
             $self->result_source->schema->txn_do(sub { $associated_job->reschedule_state });
         }
         catch {
-            my $worker_id = $self->id;
-            log_warning("Unable to re-schedule job $job_id abandoned by worker $worker_id: $_");
+            my $worker_id = $self->id;                                                           # uncoverable statement
+            log_warning("Unable to re-schedule job $job_id abandoned by worker $worker_id: $_"); # uncoverable statement
         };
     }
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -335,15 +335,6 @@ sub startup {
     $worker_r->post('/commands/')->name('apiv1_create_command')->to('command#create');
     $api_ro->delete('/workers/<worker_id:num>')->name('apiv1_worker_delete')->to('worker#delete');
 
-    # redirect for older workers
-    $worker_r->websocket(
-        '/ws' => sub {
-            my $c        = shift;
-            my $workerid = $c->param('workerid');
-            my $port     = service_port('websocket');
-            $c->redirect_to("http://localhost:$port/ws/$workerid");
-        });
-
     # api/v1/mutex
     $api_r_job->post('/mutex')->name('apiv1_mutex_create')->to('locks#mutex_create');
     $api_r_job->post('/mutex/:name')->name('apiv1_mutex_action')->to('locks#mutex_action');

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -123,6 +123,7 @@ sub _message {
                 });
         }
         catch {
+            # uncoverable statement
             log_warning("Unable to re-schedule job(s) $job_ids_str rejected by worker $worker_id: $_");
         };
     }
@@ -171,7 +172,7 @@ sub _message {
                 });
         }
         catch {
-            log_error("Failed updating seen and error status of worker $worker_id: $_");
+            log_error("Failed updating seen and error status of worker $worker_id: $_");    # uncoverable statement
         };
 
         # send worker population
@@ -181,7 +182,7 @@ sub _message {
             $self->tx->send({json => $msg} => sub { log_debug("Sent population to worker: " . pp($msg)) });
         }
         catch {
-            log_debug("Could not send the population number to worker $worker_id: $_");
+            log_debug("Could not send the population number to worker $worker_id: $_");     # uncoverable statement
         };
 
         # find the job currently associated with that worker and check whether the worker still
@@ -233,6 +234,7 @@ sub _message {
             $worker->reschedule_assigned_jobs([$current_job, @unfinished_jobs]);
         }
         catch {
+            # uncoverable statement
             log_warning("Unable to verify whether worker $worker_id runs its job(s) as expected: $_");
         };
 


### PR DESCRIPTION
* Remove uncovered code which was obsolete anyways
* Mark code as uncoverable which we will hardly ever cover
* See particular commit messages