### PR TITLE
Add worker name to reason when stale job detection incompletes job

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -477,9 +477,11 @@ sub incomplete_and_duplicate_stale_jobs {
             sub {
                 my $stale_jobs = $schema->resultset('Jobs')->stale_ones(WORKERS_CHECKER_THRESHOLD);
                 for my $job ($stale_jobs->all) {
+                    my $worker      = $job->assigned_worker // $job->worker;
+                    my $worker_info = defined $worker ? ('worker ' . $worker->name) : 'worker';
                     $job->done(
                         result => OpenQA::Jobs::Constants::INCOMPLETE,
-                        reason => 'abandoned: associated worker has not sent any status updates for too long',
+                        reason => "abandoned: associated $worker_info has not sent any status updates for too long",
                     );
                     my $res = $job->auto_duplicate;
                     if ($res) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -147,11 +147,13 @@ sub _incomplete_previous_job {
     }
 
     # mark jobs which were already beyond assigned as incomplete and duplicate it
+    my $worker      = $job->assigned_worker // $job->worker;
+    my $worker_info = defined $worker ? ('worker ' . $worker->name) : 'worker';
     $job->set_property('JOBTOKEN');
     $job->auto_duplicate;
     $job->done(
         result => OpenQA::Jobs::Constants::INCOMPLETE,
-        reason => 'abandoned: associated worker re-connected but abandoned the job'
+        reason => "abandoned: associated $worker_info re-connected but abandoned the job",
     );
     return 1;
 }

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -182,7 +182,7 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
       'running job set to done if its worker re-connects claiming not to work on it anymore';
     is $job->result, OpenQA::Jobs::Constants::INCOMPLETE,
       'running job incompleted if its worker re-connects claiming not to work on it anymore';
-    is $job->reason, 'abandoned: associated worker re-connected but abandoned the job', 'reason is set';
+    like $job->reason, qr/abandoned: associated worker .+:\d+ re-connected but abandoned the job/, 'reason is set';
 
     stop_service($unstable_w_pid, 1);
     dead_workers($schema);

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -44,9 +44,9 @@ sub _check_job_incomplete {
     my $job = $schema->resultset('Jobs')->find($jobid);
     is($job->state,  OpenQA::Jobs::Constants::DONE,       "job $jobid set as done");
     is($job->result, OpenQA::Jobs::Constants::INCOMPLETE, "job $jobid set as incomplete");
-    is(
+    like(
         $job->reason,
-        'abandoned: associated worker has not sent any status updates for too long',
+        qr/abandoned: associated worker (remote|local)host:1 has not sent any status updates for too long/,
         "job $jobid set as incomplete"
     );
     ok($job->clone, "job $jobid was cloned");


### PR DESCRIPTION
With this change we have the relevant worker name directly available when investigating incomplete jobs without having to do more complicated queries.