### PR TITLE
Simplify OpenQA::WebAPI::Controller::Admin::Needle and enhance tests

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -100,9 +100,12 @@ sub start_driver {
                 map { $_ => {args => []} } @chrome_option_keys,
             },
             error_handler => sub {
-                # generate Test::More failure instead of croaking to preserve context
+                # generate Test::More failure instead of croaking to preserve
+                # context but bail out to not have repeated entries for the
+                # same problem exceeded console scrollback buffers easily
                 my ($driver, $exception, $args) = @_;
-                fail((split /\n/, $exception)[0] =~ s/Error while executing command: //r);
+                my $err = (split /\n/, $exception)[0] =~ s/Error while executing command: //r;
+                BAIL_OUT($err . ' at ' . __FILE__ . ':' . __LINE__);
             },
         );
 


### PR DESCRIPTION
* Simplify update of seen/match in OpenQA::WebAPI::Controller::Admin::Needle
* Simplify 'prepare_data_function' as followup to #2793
* t: Bail out early on Selenium reported errors for concise log
* t: Ensure necessary test dirs exist for ui/21-admin-needles.t