### PR TITLE
Job templates test: update check for error message

### DIFF
--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -803,12 +803,15 @@ $t->post_ok(
         template => $template_yaml,
     },
 )->status_is(400)->json_is(
-    '' => {
-        error_status => 400,
-        error =>
-          [{path => '/scenarios/i586/opensuse-13.1-DVD-i586/0', message => '/anyOf/1 Too many properties: 2/1.'},],
-    },
-    'posting invalid YAML template results in error'
+    '/error_status' => 400,
+    'posting invalid YAML template - error_status',
+)->json_is(
+    '/error/0/path' => '/scenarios/i586/opensuse-13.1-DVD-i586/0',
+    'posting invalid YAML template - error path',
+)->json_like(
+    # Depends on JSON::Validator version; started to change in JSON::Validator 3.24
+    '/error/0/message' => qr{/anyOf/1 Too many properties: 2/1.|/anyOf/0 Expected string - got object.},
+    'posting invalid YAML template - error content',
 );
 
 subtest 'Create and modify groups with YAML' => sub {


### PR DESCRIPTION
The behaviour of JSON::Validator changed (presumably in 3.24), and it
reports the first of the anyOf rule now.

Issue: https://progress.opensuse.org/issues/64454

Tested with JSON::Validator 3.17 and 3.24