### PR TITLE
Split YAML out of JobTemplate API tests

### DIFF
--- a/t/data/08-create-modify-group.yaml
+++ b/t/data/08-create-modify-group.yaml
@@ -1,0 +1,20 @@
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+    - foobar  # Test names shouldn't conflict across groups
+    - spam
+    - eggs:
+        machine: 32bit
+        priority: 20
+        settings:
+          FOO: removed later
+          BAR: updated later
+defaults:
+  i586:
+    machine: 64bit
+    priority: 40
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: 13.1

--- a/t/data/08-merge-expanded.yaml
+++ b/t/data/08-merge-expanded.yaml
@@ -1,0 +1,28 @@
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+    - lala:
+        settings:
+          A: default A
+          B: default B
+        testsuite: null
+        machine: 32bit
+    - lala2:
+        settings:
+          B: default2 B
+          C: default C
+        testsuite: null
+        machine: 32bit
+    - lala3:
+        settings:
+          A: default A
+          B: b
+          C: default C
+          D: d
+        testsuite: null
+        machine: 32bit
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: '13.1'

--- a/t/data/08-merge.yaml
+++ b/t/data/08-merge.yaml
@@ -1,0 +1,27 @@
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+    - lala:
+        settings: &common1
+          A: default A
+          B: default B
+        testsuite: null
+        machine: 32bit
+    - lala2:
+        settings: &common2
+          B: default2 B
+          C: default C
+        testsuite: null
+        machine: 32bit
+    - lala3:
+        settings:
+          <<: [*common1, *common2]
+          B: b
+          D: d
+        testsuite: null
+        machine: 32bit
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: '13.1'

--- a/t/data/08-opensuse-2.yaml
+++ b/t/data/08-opensuse-2.yaml
@@ -1,0 +1,39 @@
+defaults:
+  i586:
+    machine: 64bit
+    priority: 40
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: '13.1'
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+    - textmode:
+        machine: 64bit
+    - textmode:
+        description: 32bit textmode prio 40
+        machine: 32bit
+    - kde:
+        machine: 32bit
+    - kde:
+        machine: 64bit
+    - RAID0:
+        priority: 20
+    - client1:
+        machine: 32bit
+    - client1:
+        machine: 64bit
+    - server:
+        machine: 64bit
+    - server:
+        machine: 32bit
+    - client2:
+        machine: 32bit
+    - client2:
+        machine: 64bit
+    - advanced_kde:
+        settings:
+          ADVANCED: '1'
+          DESKTOP: advanced_kde

--- a/t/data/08-opensuse-test.yaml
+++ b/t/data/08-opensuse-test.yaml
@@ -1,0 +1,2 @@
+products: {}
+scenarios: {}

--- a/t/data/08-opensuse.yaml
+++ b/t/data/08-opensuse.yaml
@@ -1,0 +1,44 @@
+defaults:
+  i586:
+    machine: 64bit
+    priority: 50
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: '13.1'
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+    - textmode:
+        description: 32bit textmode prio 40
+        machine: 32bit
+        priority: 40
+    - textmode:
+        machine: 64bit
+        priority: 40
+    - kde:
+        priority: 40
+    - client1:
+        machine: 32bit
+        priority: 40
+    - client1:
+        machine: 64bit
+        priority: 40
+    - server:
+        machine: 32bit
+        priority: 40
+    - server:
+        machine: 64bit
+        priority: 40
+    - client2:
+        machine: 64bit
+        priority: 40
+    - client2:
+        machine: 32bit
+        priority: 40
+    - advanced_kde:
+        priority: 40
+        settings:
+          ADVANCED: '1'
+          DESKTOP: advanced_kde

--- a/t/data/08-refs-vars.yaml
+++ b/t/data/08-refs-vars.yaml
@@ -1,0 +1,179 @@
+defaults:
+  x86_64:
+    machine: 64bit-staging
+    priority: 20
+    settings:
+      YAML_SCHEDULE: schedule/staging/%TEST%@64bit-staging.yaml
+products:
+  sle-12-SP5-Server-DVD-A-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-A-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-B-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-B-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-C-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-C-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-D-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-D-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-E-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-E-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-H-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-H-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-S-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-S-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-V-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-V-Staging
+    version: 12-SP5
+  sle-12-SP5-Server-DVD-Y-Staging-x86_64:
+    distri: sle
+    flavor: Server-DVD-Y-Staging
+    version: 12-SP5
+scenarios:
+  x86_64:
+    sle-12-SP5-Server-DVD-A-Staging-x86_64:
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install: &default_install
+        settings:
+          INSTALLONLY: ""
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging: &zdup
+        priority: 50
+    - rescue_system_sle11sp4
+    - RAID1: &raid1
+        settings:
+          INSTALLATION_VALIDATION: ""
+          INSTALLONLY: ""
+    - ext4_uefi-staging: &ext4
+        machine: uefi-staging
+    - minimal+base
+    sle-12-SP5-Server-DVD-B-Staging-x86_64:
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        *ext4
+    - minimal+base
+    sle-12-SP5-Server-DVD-C-Staging-x86_64:
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        *ext4
+    - minimal+base
+    sle-12-SP5-Server-DVD-D-Staging-x86_64:
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        *ext4
+    - minimal+base
+    sle-12-SP5-Server-DVD-E-Staging-x86_64:
+    - cryptlvm
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        *ext4
+    - minimal+base
+    sle-12-SP5-Server-DVD-H-Staging-x86_64:
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        *ext4
+    - minimal+base
+    sle-12-SP5-Server-DVD-S-Staging-x86_64:
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        *ext4
+    - minimal+base
+    sle-12-SP5-Server-DVD-V-Staging-x86_64:
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        machine: uefi-virtio-vga
+        settings:
+          YAML_SCHEDULE: schedule/staging/%TEST%@uefi-staging.yaml
+          INSTALLONLY: ""
+    - minimal+base
+    sle-12-SP5-Server-DVD-Y-Staging-x86_64:
+    - autoyast_mini_no_product
+    - gnome
+    - cryptlvm_minimal_x
+    - default_install:
+        *default_install
+    - installcheck
+    - migration_zdup_offline_sle12sp2_64bit-staging:
+        *zdup
+    - rescue_system_sle11sp4
+    - RAID1:
+        *raid1
+    - ext4_uefi-staging:
+        *ext4
+    - minimal+base

--- a/t/data/08-refs.yaml
+++ b/t/data/08-refs.yaml
@@ -1,0 +1,32 @@
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586: &tests
+    - spam
+    - eggs
+  ppc64:
+    opensuse-13.1-DVD-ppc64:
+      *tests
+  x86_64:
+    sle-12-SP1-Server-DVD-Updates-x86_64:
+      *tests
+defaults:
+  i586:
+    machine: 32bit
+    priority: 50
+  ppc64:
+    machine: 64bit
+    priority: 50
+  x86_64:
+    machine: 64bit
+    priority: 50
+products:
+  opensuse-13.1-DVD-i586: &opensuse13
+    distri: opensuse
+    flavor: DVD
+    version: 13.1
+  opensuse-13.1-DVD-ppc64:
+    *opensuse13
+  sle-12-SP1-Server-DVD-Updates-x86_64:
+    distri: sle
+    flavor: Server-DVD-Updates
+    version: 12-SP1

--- a/t/data/08-testsuite-multiple-keys.yaml
+++ b/t/data/08-testsuite-multiple-keys.yaml
@@ -1,0 +1,12 @@
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+      - x:
+          machine: 32bit
+        y:
+          machine: 32bit
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: '13.1'

--- a/t/data/08-testsuite-null.yaml
+++ b/t/data/08-testsuite-null.yaml
@@ -1,0 +1,13 @@
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+    - lala:
+        testsuite: null
+        description: Testsuite null
+        machine: 32bit
+        priority: 97
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: '13.1'


### PR DESCRIPTION
- YAML snippets should be kept in separate files.
- Early explain and returns can be one-liners

This is a follow-up to #2781.