### PR TITLE
Fix perlcritic issue

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -385,7 +385,7 @@ sub _for_every_batch {
     return $sub->($project, '') unless @$batches;
 
     my @ret;
-    for $batch (@$batches) {
+    for my $batch (@$batches) {
         @ret = $sub->($project, $batch);
         return @ret if @ret && $ret[0];
     }


### PR DESCRIPTION
I'm getting this:
```
lib/OpenQA/WebAPI/Plugin/ObsRsync.pm: Loop iterator is not lexical at line 388, column 5.  See page 108 of PBP.  (Severity: 4)
```

with Perl::Critic 1.136