### PR TITLE
Prevent flooding PostgreSQL logs with errors when inserting job modules

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,84 +98,6 @@ sub sqlt_deploy_hook {
     $sqlt_table->add_index(name => 'idx_job_modules_result', fields => ['result']);
 }
 
-my %columns_by_result = (
-    OpenQA::Jobs::Constants::PASSED     => 'passed_module_count',
-    OpenQA::Jobs::Constants::SOFTFAILED => 'softfailed_module_count',
-    OpenQA::Jobs::Constants::FAILED     => 'failed_module_count',
-    OpenQA::Jobs::Constants::NONE       => 'skipped_module_count',
-    OpenQA::Jobs::Constants::SKIPPED    => 'externally_skipped_module_count',
-);
-
-# override to update job module stats in jobs table
-sub store_column {
-    my ($self, $name, $value) = @_;
-
-    # only updates of result relevant here
-    return $self->next::method($name, $value) unless ($name eq 'result' || $name eq 'job_id');
-
-    # set default result to 'none'
-    $value //= OpenQA::Jobs::Constants::NONE if ($name eq 'result');
-
-    # remember previous value before updating
-    my $previous_value = $self->get_column($name);
-    my $res            = $self->next::method($name, $value);
-
-    # skip this when the value does not change
-    return $res if ($value && $previous_value && $value eq $previous_value);
-
-    # update statistics in relevant job(s)
-    if ($name eq 'result') {
-        # update assigned job on result change
-        my $job = $self->job or return $res;
-        my %job_update;
-        if (my $value_column = $columns_by_result{$value}) {
-            $job_update{$value_column} = $job->get_column($value_column) + 1;
-        }
-        if ($previous_value) {
-            if (my $previous_value_column = $columns_by_result{$previous_value}) {
-                $job_update{$previous_value_column} = $job->get_column($previous_value_column) - 1;
-            }
-        }
-        $job->update(\%job_update);
-
-    }
-    elsif ($name eq 'job_id') {
-        # update previous job and new job on job assignment
-        # handling previous job might not be neccassary because once a job is assigned, it shouldn't
-        # change anymore, right?
-        my $result        = $self->result               or return $res;
-        my $result_column = $columns_by_result{$result} or return $res;
-        if ($previous_value) {
-            if (my $previous_job = $self->result_source->schema->resultset('Jobs')->find($previous_value)) {
-                $previous_job->update({$result_column => $previous_job->get_column($result_column) - 1});
-            }
-        }
-        if ($value) {
-            if (my $job = $self->result_source->schema->resultset('Jobs')->find($value)) {
-                $job->update({$result_column => $job->get_column($result_column) + 1});
-            }
-        }
-    }
-
-    return $res;
-}
-
-# override to update job module stats in jobs table
-sub insert {
-    my ($self, @args) = @_;
-    $self->next::method(@args);
-
-    # count modules which are initially skipped (default value for the result) in statistics of associated job
-    # doing this explicitely is required because in this case store_column does not seem to be called
-    my $job    = $self->job;
-    my $result = $self->result;
-    if ($job && (!$result || $result eq OpenQA::Jobs::Constants::NONE)) {
-        $job->update({skipped_module_count => $job->skipped_module_count + 1});
-    }
-
-    return $self;
-}
-
 sub details {
     my ($self) = @_;
 
@@ -239,6 +161,7 @@ sub update_result {
     $result =~ s,^skip,skipped,;
     $result = 'softfailed' if ($r->{dents} && $result eq 'passed');
     $self->update({result => $result});
+    return $result;
 }
 
 # if you give a needle_cache, make sure to call

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -193,10 +193,15 @@ subtest 'Create custom job module' => sub {
         test    => OpenQA::Parser::Result::Test->new(name => 'CUSTOM', category => 'w00t!'));
     my $output = OpenQA::Parser::Result::Output->new(file => 'Test-CUSTOM.txt', content => 'Whatever!');
 
+    is($job->failed_module_count, 0, 'no failed modules before');
     $job->custom_module($result => $output);
     $job->update;
     $job->discard_changes;
-    is($job->result, OpenQA::Jobs::Constants::NONE, 'result is not yet set');
+    is($job->passed_module_count,     0,                             'number of passed modules not incremented');
+    is($job->softfailed_module_count, 0,                             'number of softfailed modules not incremented');
+    is($job->failed_module_count,     1,                             'number of failed modules incremented');
+    is($job->skipped_module_count,    0,                             'number of skipped modules not incremented');
+    is($job->result,                  OpenQA::Jobs::Constants::NONE, 'result is not yet set');
     $job->done;
     $job->discard_changes;
     is($job->result, OpenQA::Jobs::Constants::FAILED, 'job result is failed');

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -22,6 +22,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use autodie ':all';
 use File::Copy;
+use OpenQA::Jobs::Constants;
 use OpenQA::Utils;
 use OpenQA::Test::Case;
 use Test::More;
@@ -87,15 +88,13 @@ subtest 'scenario description' => sub {
     $minimalx_testsuite->delete;
 };
 
-subtest 'initial job module statistics' => sub {
-    # Those counters are not directly hardcoded in the jobs table of the fixtures.
-    # Instead, the counters are automatically incremented when initializing the
-    # job module fixtures.
-    my $job = $rs->find(99946);
-    is($job->passed_module_count,     28, 'number of passed modules');
-    is($job->softfailed_module_count, 1,  'number of softfailed modules');
-    is($job->failed_module_count,     1,  'number of failed modules');
-    is($job->skipped_module_count,    0,  'number of skipped modules');
+subtest 'hard-coded initial job module statistics consistent; no automatic handling via DBIx hooks interferes' => sub {
+    my $job     = $rs->find(99946);
+    my $modules = $job->modules;
+    is($job->passed_module_count,     $modules->search({result => PASSED})->count,     'number of passed modules');
+    is($job->softfailed_module_count, $modules->search({result => SOFTFAILED})->count, 'number of softfailed modules');
+    is($job->failed_module_count,     $modules->search({result => FAILED})->count,     'number of failed modules');
+    is($job->skipped_module_count,    $modules->search({result => SKIPPED})->count,    'number of skipped modules');
 };
 
 subtest 'job with all modules passed => overall is passsed' => sub {

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -298,7 +298,12 @@ use warnings;
         backend     => 'qemu',
         jobs_assets => [{asset_id => 1}, {asset_id => 5}],
         result_dir  => '00099946-opensuse-13.1-DVD-i586-Build0091-textmode',
-        settings    => [
+        # job module statistics are hard-coded in accordance with t/fixtures/05-job_modules.pl
+        passed_module_count     => 28,
+        softfailed_module_count => 1,
+        failed_module_count     => 1,
+        skipped_module_count    => 0,
+        settings                => [
             {key => 'QEMUCPU',     value => 'qemu32'},
             {key => 'DVD',         value => '1'},
             {key => 'VIDEOMODE',   value => 'text'},

--- a/t/fixtures/05-job_modules.pl
+++ b/t/fixtures/05-job_modules.pl
@@ -1,6 +1,9 @@
 use strict;
 use warnings;
 
+# note: Only job module statistics for job 99946 are set in `t/fixtures/01-jobs.pl`. Statistics for
+#       other jobs are *not* consistent in the fixtures database.
+
 [
     JobModules => {
         script   => 'tests/installation/isosize.pm',


### PR DESCRIPTION
For https://progress.opensuse.org/issues/64298. Let's see what tests this breaks (hopefully none).