### PR TITLE
Rename the JobTemplates module to YAML

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -26,7 +26,7 @@ use OpenQA::Schema::JobGroupDefaults;
 use Class::Method::Modifiers;
 use OpenQA::Utils qw(log_debug parse_tags_from_comments);
 use Date::Format 'time2str';
-use OpenQA::JobTemplates 'dump_yaml';
+use OpenQA::YAML 'dump_yaml';
 use Storable 'dclone';
 use Text::Diff 'diff';
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -16,7 +16,7 @@
 package OpenQA::WebAPI::Controller::API::V1::JobTemplate;
 use Mojo::Base 'Mojolicious::Controller';
 use Try::Tiny;
-use OpenQA::JobTemplates 'load_yaml';
+use OpenQA::YAML 'load_yaml';
 
 =pod
 

--- a/lib/OpenQA/WebAPI/Plugin/YAMLRenderer.pm
+++ b/lib/OpenQA/WebAPI/Plugin/YAMLRenderer.pm
@@ -15,7 +15,7 @@
 
 package OpenQA::WebAPI::Plugin::YAMLRenderer;
 use Mojo::Base 'Mojolicious::Plugin';
-use OpenQA::JobTemplates 'validate_data';
+use OpenQA::YAML 'validate_data';
 
 use Try::Tiny;
 

--- a/lib/OpenQA/YAML.pm
+++ b/lib/OpenQA/YAML.pm
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 
-package OpenQA::JobTemplates;
+package OpenQA::YAML;
 
 use strict;
 use warnings;

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -116,7 +116,7 @@ use Getopt::Long;
 use Mojo::Util qw(decamelize);
 use Mojo::URL;
 use OpenQA::Client;
-use OpenQA::JobTemplates 'load_yaml';
+use OpenQA::YAML 'load_yaml';
 
 Getopt::Long::Configure("no_ignore_case");
 

--- a/script/openqa-validate-yaml
+++ b/script/openqa-validate-yaml
@@ -26,8 +26,7 @@ use 5.010;
 use FindBin '$RealBin';
 use lib "$RealBin/../lib";
 use Getopt::Long::Descriptive;
-use OpenQA::JobTemplates 'validate_data';
-use OpenQA::JobTemplates 'load_yaml';
+use OpenQA::YAML qw(load_yaml validate_data);
 
 my ($opt, $usage) = describe_options(
     <<"EOM",

--- a/t/16-utils-job-templates.t
+++ b/t/16-utils-job-templates.t
@@ -20,10 +20,9 @@ use warnings;
 
 use FindBin '$Bin';
 use lib "$Bin/lib";
-use OpenQA::JobTemplates qw(validate_data);
+use OpenQA::YAML qw(load_yaml validate_data);
 use Test::More;
 use Mojo::File qw(path tempdir tempfile);
-use OpenQA::JobTemplates 'load_yaml';
 
 my $schema               = "$Bin/../public/schema/JobTemplates-01.yaml";
 my $template_openqa      = "$Bin/data/job-templates/openqa.yaml";

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -26,7 +26,7 @@ use OpenQA::Client;
 use OpenQA::WebAPI::Controller::API::V1::JobTemplate;
 use Mojo::File 'path';
 use Mojo::IOLoop;
-use OpenQA::JobTemplates qw(load_yaml dump_yaml);
+use OpenQA::YAML qw(load_yaml dump_yaml);
 
 OpenQA::Test::Case->new->init_data;
 


### PR DESCRIPTION
Whilst the code originated in the JobTemplates controller there is not a single reference to job templates. The module provides YAML support.