### PR TITLE
openQA.spec: Run style checks in %check to detect issues in other products

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,4 +250,5 @@ test-shellcheck:
 .PHONY: test-yaml
 test-yaml:
 	@which yamllint >/dev/null 2>&1 || echo "Command 'yamllint' not found, can not execute YAML syntax checks"
-	yamllint --strict $$(git ls-files "*.yml" "*.yaml" | grep -v ^dbicdh)
+	@# Fall back to find if there is no git, e.g. in package builds
+	yamllint --strict $$((git ls-files "*.yml" "*.yaml" 2>/dev/null || find -name '*.y*ml') | grep -v ^dbicdh)

--- a/openQA.spec
+++ b/openQA.spec
@@ -225,7 +225,6 @@ cpanm --installdeps --with-feature=test .
 rm -f t/00-tidy.t
 
 %if %{with tests}
-#make test
 rm -rf %{buildroot}/DB
 export LC_ALL=en_US.UTF-8
 # Skip tests not working currently, or flaky, and Selenium tests
@@ -236,8 +235,7 @@ rm \
     t/25-cache-service.t \
     t/ui/*.t
 
-
-make test-with-database OBS_RUN=1 PROVE_ARGS='-l -r -v' TEST_PG_PATH=%{buildroot}/DB
+make test OBS_RUN=1 PROVE_ARGS='-l -r -v' TEST_PG_PATH=%{buildroot}/DB
 rm -rf %{buildroot}/DB
 %endif
 

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -4,6 +4,7 @@ dbname="${dbname:="openqa"}"
 dbuser="${dbuser:="geekotest"}"
 
 # add extra repos for leap
+# shellcheck disable=SC1091
 . /etc/os-release
 if [ "$NAME" = "openSUSE Leap" ]; then
     zypper -n addrepo -p 90 obs://devel:openQA devel:openQA

--- a/t/dummy-isotovideo.sh
+++ b/t/dummy-isotovideo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 echo "dummy isotovideo started with arguments: $*"


### PR DESCRIPTION
As shown in https://github.com/os-autoinst/openQA/pull/2831
more recent versions of perlcritic can find different issues and the
same can happen for other style checks.

This commit enables all the common style checks additionally.
Some tests are still excluded as in before, e.g. t/00-tidy.t