### PR TITLE
Prevent race condition when assigning and sending jobs to a worker

### DIFF
--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -79,9 +79,8 @@ sub _message {
     my $worker_id = $worker->{id};
     my $worker_db = $worker->{db};
 
-    # check whether the job was idle before and unset the idle state (any action by the worker other than
-    # claiming it is not broken and not working on any job revokes the idle flag)
-    my $worker_previously_idle = delete $worker->{idle};
+    # check whether the worker/job had was idle before despite a job assignment and unset that flag
+    my $worker_previously_idle = delete $worker->{idle_despite_job_assignment};
 
     unless (ref($json) eq 'HASH') {
         log_error(sprintf('Received unexpected WS message "%s from worker %u', dumper($json), $worker_id));
@@ -237,7 +236,7 @@ sub _message {
         };
 
         # consider the worker idle unless it claims to be broken or work on a job
-        $worker->{idle} = !$worker_is_broken && !defined $job_id;
+        $worker->{idle_despite_job_assignment} = !$worker_is_broken && !defined $job_id && defined $current_job_id;
     }
     else {
         log_error(sprintf('Received unknown message type "%s" from worker %u', $message_type, $worker->{id}));


### PR DESCRIPTION
This is an amendment for the original fix 74f41436. The original fix was not sufficient because it did not take into account that workers might be actually idling for a while. These status updates should not already count as first chance for the worker to process a job assignment.