### PR TITLE
Use :report_warnings feature of Test::Warnings

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -106,7 +106,7 @@ on 'test' => sub {
     requires 'Test::Output';
     requires 'Test::Pod';
     requires 'Test::Strict';
-    requires 'Test::Warnings';
+    requires 'Test::Warnings', '>= 0.029';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -170,4 +170,4 @@ test_requires:
   perl(Test::MockObject):
   perl(Test::Output):
   perl(Test::Pod):
-  perl(Test::Warnings):
+  perl(Test::Warnings): '>= 0.029'

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -123,7 +123,7 @@ RUN zypper in -y -C \
        'perl(Test::MockObject)' \
        'perl(Test::Output)' \
        'perl(Socket::MsgHdr)' \
-       'perl(Test::Warnings)' \
+       'perl(Test::Warnings) >= 0.029' \
        'perl(Text::Diff)' \
        'perl(CommonMark)' \
        'perl(Time::ParseDate)' \

--- a/openQA.spec
+++ b/openQA.spec
@@ -63,7 +63,7 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) postgresql-server python3-setuptools python3-yamllint
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -15,7 +15,7 @@
 
 use Test::Most;
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 is(system('tools/tidy', '--check'), 0, "tidy");
 

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -27,7 +27,7 @@ use OpenQA::Test::Database;
 use OpenQA::Utils 'assetdir';
 use Test::Mojo;
 use Test::MockModule;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Schema::Result::Jobs;
 
 my $sent = {};

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -25,7 +25,7 @@ use OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use Test::MockModule;
 use DBIx::Class::Timestamps 'now';
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 my $schema = OpenQA::Test::Database->new->create();
 

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -23,7 +23,7 @@ use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Database;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Mojo::Util 'monkey_patch';
 
 my $schema = OpenQA::Test::Database->new->create;

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -23,7 +23,7 @@ use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::WebSockets::Client;
 use OpenQA::Jobs::Constants;
 use OpenQA::Test::FakeWebSocketTransaction;

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -25,7 +25,7 @@ use OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use OpenQA::WebSockets::Client;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 my $schema = OpenQA::Test::Database->new->create();
 my $t      = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -28,7 +28,7 @@ use OpenQA::Test::Case;
 use Test::MockModule 'strict';
 use Test::Mojo;
 use Mojo::JSON 'decode_json';
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Mojo::File qw(path tempdir);
 use Mojo::IOLoop::ReadWriteProcess;
 use OpenQA::Test::Utils 'redirect_output';

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -18,7 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use Test::Output 'stderr_like';
 use OpenQA::Test::Case;
 use OpenQA::WebSockets::Client;

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 use File::Temp qw(tempfile);

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -23,7 +23,7 @@ use OpenQA::Test::Database;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Jobs::Constants;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 
 my $schema = OpenQA::Test::Database->new->create();

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -26,7 +26,7 @@ use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job);
 use Test::MockModule;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Output 'combined_like';
 use OpenQA::Test::Case;
 use File::Which 'which';

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use Test::Mojo;
 use OpenQA::Resource::Jobs 'job_restart';

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -26,7 +26,7 @@ use OpenQA::Test::Case;
 use Mojo::File 'tempdir';
 use Test::MockModule;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Output 'stdout_like';
 
 # allow catching log messages via stdout_like

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::JobGroupDefaults;
 use OpenQA::Schema::Result::JobGroupParents;

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -20,7 +20,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use Mojo::JSON qw(decode_json);
 

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Test::Database;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 my $args;
 

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -20,7 +20,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Output qw(combined_like stderr_like);
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
 use OpenQA::WebSockets;

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -27,7 +27,7 @@ use OpenQA::Task::Needle::Scan;
 use File::Find;
 use Test::Output 'combined_like';
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Date::Format 'time2str';
 
 my %settings = (

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -20,7 +20,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Jobs::Constants;
 

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -25,7 +25,7 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Test::Database;
 use Test::MockModule;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Mojo::File qw(tempdir path);
 use Mojo::JSON qw(decode_json);
 use OpenQA::WebAPI::Plugin::AMQP;

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
 use Test::Fatal;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Worker;
 use Test::MockModule;
 use Test::MockObject;

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -22,7 +22,7 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job collect_coverage_of_gru_jobs);
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
 my $t      = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -37,7 +37,7 @@ CACHELIMIT = 100');
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Utils;
 use IO::Socket::INET;
 use Mojo::Server::Daemon;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -39,7 +39,7 @@ use utf8;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Utils qw(:DEFAULT base_host);
 use OpenQA::CacheService;
 use IO::Socket::INET;

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::WebAPI::Controller::Running;
 use OpenQA::Jobs::Constants;
 use Mojolicious;

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 # init test case

--- a/t/31-api_descriptions.t
+++ b/t/31-api_descriptions.t
@@ -16,7 +16,7 @@
 use Test::Most;
 
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 use_ok('OpenQA::WebAPI::Description', qw(get_pod_from_controllers set_api_desc));
 $ENV{OPENQA_CODEBASE} = ".";

--- a/t/31-client.t
+++ b/t/31-client.t
@@ -21,6 +21,7 @@ use Test::Mojo;
 use Test::MockModule;
 use Test::MockObject;
 use Test::Output;
+use Test::Warnings ':report_warnings';
 use OpenQA::WebAPI;
 use OpenQA::Test::Case;
 use OpenQA::Script::Client;

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -22,7 +22,7 @@ use Date::Format;
 use Data::Dumper 'Dumper';
 use Test::Output 'combined_like';
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use OpenQA::Test::Case;
 use OpenQA::Test::FakeWebSocketTransaction;

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::JobGroupDefaults;
 

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Mojo::File 'path';
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use Test::Output qw(stdout_like stdout_from);
 use OpenQA::Test::Case;

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -20,7 +20,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Jobs::Constants;
 

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use OpenQA::Test::Case;
 use OpenQA::Utils;

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -22,7 +22,7 @@ use Mojo::File qw(path curfile);
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils;
 use Test::Output;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Utils qw(run_cmd test_cmd stop_service);
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -17,7 +17,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Output;
 use OpenQA::Test::Utils qw(run_cmd test_cmd);
 

--- a/t/40-script_openqa-label-all.t
+++ b/t/40-script_openqa-label-all.t
@@ -15,7 +15,7 @@
 
 use Test::Most;
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 is(system('script/openqa-label-all --help'), 0);
 

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Date::Format 'time2str';
 use OpenQA::Test::Case;
 

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -28,7 +28,7 @@ use Mojo::Log;
 use Test::Output 'combined_like';
 use Test::MockModule;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use DateTime;
 
 my $schema           = OpenQA::Test::Database->new->create;

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -16,7 +16,7 @@
 
 use Test::Most;
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use Time::HiRes 'sleep';
 use File::Path 'make_path';

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use Mojo::URL;
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'embed_server_for_testing';

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -20,7 +20,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::Schema::Result::ScheduledProducts;

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::MockModule;
 use Test::Mojo;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use Mojo::URL;
 use Mojo::Util qw(encode hmac_sha1_sum);
 use OpenQA::Test::Case;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/../lib";
 use File::Temp;
 use Test::Mojo;
 use Test::Output;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::App;
 use OpenQA::Events;
 use OpenQA::File;

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use OpenQA::Test::Case;
 use OpenQA::Client;

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -18,7 +18,7 @@ use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -20,7 +20,7 @@ use Date::Format;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 require OpenQA::Schema::Result::Jobs;

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::WebSockets;

--- a/t/basic.t
+++ b/t/basic.t
@@ -15,7 +15,7 @@
 
 use Test::Most;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib";

--- a/t/config.t
+++ b/t/config.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Output 'combined_like';
 use Mojolicious;
 use OpenQA::Setup;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -20,7 +20,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Mojo;
 use DBIx::Class::DeploymentHandler;
 use SQL::Translator;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -34,7 +34,7 @@ BEGIN {
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use autodie ':all';
 use IO::Socket::INET;
 use POSIX '_exit';

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format 'time2str';
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Test::Database;
 

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use Mojo::File 'path';
 

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Test::Database;
 use OpenQA::SeleniumTest;

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -19,7 +19,7 @@ use FindBin;
 use File::Spec;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Mojo::File;
 use OpenQA::Test::Case;
 

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format 'time2str';
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 use OpenQA::Jobs::Constants;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Encode 'encode_utf8';
 use Test::Mojo;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use OpenQA::Test::Case;
 use Cwd 'abs_path';
 use Mojo::File;

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Utils 'assetdir';
 use Date::Format 'time2str';

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -21,7 +21,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format;
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -20,7 +20,7 @@ use Module::Load::Conditional qw(can_load);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Log 'log_debug';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'embed_server_for_testing';

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -19,7 +19,7 @@ use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Log qw(log_debug);
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::SeleniumTest;

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use Date::Format 'time2str';
 

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -21,7 +21,7 @@ use Mojo::JSON 'decode_json';
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 use OpenQA::Test::Case;
 use OpenQA::Client;

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -20,7 +20,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use Mojo::JSON qw(decode_json encode_json);
 use Mojo::File qw(path);
 use Mojo::IOLoop;

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/20-bugzilla-links.t
+++ b/t/ui/20-bugzilla-links.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Date::Format 'time2str';
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use OpenQA::Test::Case;
 use Time::HiRes qw(sleep);
 use OpenQA::SeleniumTest;

--- a/t/ui/22-job_group_order.t
+++ b/t/ui/22-job_group_order.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data;

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 use OpenQA::Test::Case;
 use OpenQA::Client;

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -25,7 +25,7 @@ use Mojo::File qw(path tempdir);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use OpenQA::WebSockets::Client;
 use OpenQA::Test::Case;

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -18,7 +18,7 @@ use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 use OpenQA::JobDependencies::Constants;


### PR DESCRIPTION
It will report all unexpected warnings at the end, to avoid having to search
through the whole output.
