### PR TITLE
Makefile: Add convenience variable "TESTS" for easier selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-PROVE_ARGS ?= -r -v
-PROVE_LIB_ARGS ?= -l
-DOCKER_IMG ?= openqa:latest
-TEST_PG_PATH ?= /dev/shm/tpg
 RETRY ?= 0
 # STABILITY_TEST: Set to 1 to fail as soon as any of the RETRY fails rather
 # than succeed if any of the RETRY succeed
@@ -9,6 +5,19 @@ STABILITY_TEST ?= 0
 # KEEP_DB: Set to 1 to keep the test database process spawned for tests. This
 # can help with faster re-runs of tests but might yield inconsistent results
 KEEP_DB ?= 0
+# TESTS: Specify individual test files in a space separated lists. As the user
+# most likely wants only the mentioned tests to be executed and no other
+# checks this implicitly disables CHECKSTYLE
+TESTS ?=
+ifeq ($(TESTS),)
+PROVE_ARGS ?= -r -v
+else
+CHECKSTYLE ?= 0
+PROVE_ARGS ?= -v $(TESTS)
+endif
+PROVE_LIB_ARGS ?= -l
+DOCKER_IMG ?= openqa:latest
+TEST_PG_PATH ?= /dev/shm/tpg
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 docker_env_file := "$(current_dir)/docker.env"

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -288,10 +288,6 @@ workers need to be configured to connect to the main web UI port (add `HOST = ht
   read out the dependencies from the spec file for the rest.
 
 === Remarks
-* New dependencies are only available in the Docker container which is used to run
-  CI tests *after* the PR adding these dependencies has been merged. Besides, the
-  build of that container must not be broken (see
-  https://build.opensuse.org/package/show/devel:openQA/openQA[build results on OBS]).
 * The os-autoinst repository uses the container made using
   `docker/travis_test/Dockerfile` within the openQA repository.
 

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -71,12 +71,24 @@ make test
 
 for style checks, unit and integration tests.
 
-To execute a single test, one can tweak the test execution with the variables
-in the Makefile or use `prove` after pointing to a local test database in the
-environment variable `TEST_PG`. Also, If you set a custom base directory, be
-sure to unset it when running tests.
+To execute single tests call `make` with the selected tests in the `TESTS`
+variable specified as a white-space separated list, for example:
 
-Example:
+[source,sh]
+----
+make test TEST=t/config.t
+----
+
+or
+
+[source,sh]
+----
+make test TEST="t/foo.t t/bar.t"
+----
+
+Or use `prove` after pointing to a local test database in the environment
+variable `TEST_PG`. Also, If you set a custom base directory, be sure to unset
+it when running tests. Example:
 
 [source,sh]
 ----
@@ -96,7 +108,7 @@ To check the coverage by individual test files easily call e.g.
 
 [source,sh]
 ----
-env CHECKSTYLE=0 PROVE_ARGS=t/24-worker-engine.t make coverage
+make coverage TESTS=t/24-worker-engine.t
 ----
 
 and take a look into the generated coverage HTML report in

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -61,64 +61,9 @@ i.e. before every commit call:
 
 to ensure your Perl code changes are consistent with the style rules.
 
-* You *may* also run local tests on your machine or in your own development
-environment to verify everything works as expected. Call:
-
-[source,sh]
-----
-make test
-----
-
-for style checks, unit and integration tests.
-
-To execute single tests call `make` with the selected tests in the `TESTS`
-variable specified as a white-space separated list, for example:
-
-[source,sh]
-----
-make test TEST=t/config.t
-----
-
-or
-
-[source,sh]
-----
-make test TEST="t/foo.t t/bar.t"
-----
-
-Or use `prove` after pointing to a local test database in the environment
-variable `TEST_PG`. Also, If you set a custom base directory, be sure to unset
-it when running tests. Example:
-
-[source,sh]
-----
-TEST_PG='DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg' OPENQA_BASEDIR= prove -v t/14-grutasks.t
-----
-
-In the case of wanting to tweak the tests as above, to speed up the test
-initialization, start PostgreSQL using `t/test_postgresql` instead of using
-the system service. E.g.
-
-[source,sh]
-----
-t/test_postgresql /dev/shm/tpg
-----
-
-To check the coverage by individual test files easily call e.g.
-
-[source,sh]
-----
-make coverage TESTS=t/24-worker-engine.t
-----
-
-and take a look into the generated coverage HTML report in
-`cover_db/coverage.html`.
-
-We use annotations in some places to mark "uncoverable" code such as this:
-
-    # uncoverable subroutine
-
-See the docs for details https://metacpan.org/pod/Devel::Cover
+* All tests are passed. This is ensured by a CI system. You can also run local
+tests in your development environment to verify everything works as
+expected, see <<Contributing.asciidoc#testing,Conducting tests>>)
 
 * For git commit messages use the rules stated on
 http://chris.beams.io/posts/git-commit/[How to Write a Git Commit Message] as
@@ -202,10 +147,70 @@ follows the most common Perl style conventions.
 [[development-setup]]
 == Development setup
 For developing openQA and os-autoinst itself it makes sense to checkout the
-<<Contributing.asciidoc#repo-urls,Git repositories>> and to start the daemons manually.
+<<Contributing.asciidoc#repo-urls,Git repositories>> and either execute
+existing tests or start the daemons manually.
 
-This section should give you a general idea how to do that. For a concrete example some developers
-use under openSUSE Tumbleweed have a look at the https://github.com/Martchus/openQA-helper[openQA-helper repository].
+[[testing]]
+=== Conducting tests
+
+To execute all existing checks and tests simply call:
+
+[source,sh]
+----
+make test
+----
+
+for style checks, unit and integration tests.
+
+To execute single tests call `make` with the selected tests in the `TESTS`
+variable specified as a white-space separated list, for example:
+
+[source,sh]
+----
+make test TEST=t/config.t
+----
+
+or
+
+[source,sh]
+----
+make test TEST="t/foo.t t/bar.t"
+----
+
+Or use `prove` after pointing to a local test database in the environment
+variable `TEST_PG`. Also, If you set a custom base directory, be sure to unset
+it when running tests. Example:
+
+[source,sh]
+----
+TEST_PG='DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg' OPENQA_BASEDIR= prove -v t/14-grutasks.t
+----
+
+In the case of wanting to tweak the tests as above, to speed up the test
+initialization, start PostgreSQL using `t/test_postgresql` instead of using
+the system service. E.g.
+
+[source,sh]
+----
+t/test_postgresql /dev/shm/tpg
+----
+
+To check the coverage by individual test files easily call e.g.
+
+[source,sh]
+----
+make coverage TESTS=t/24-worker-engine.t
+----
+
+and take a look into the generated coverage HTML report in
+`cover_db/coverage.html`.
+
+We use annotations in some places to mark "uncoverable" code such as this:
+
+    # uncoverable subroutine
+
+See the docs for details https://metacpan.org/pod/Devel::Cover
+
 
 === Dependencies
 Have a look at the packaged version (e.g. `openQA.spec` within the root of the openQA repository)
@@ -245,10 +250,16 @@ Assuming you have already followed steps 1. to 4. above:
    Everything will be owned by `your_username`.
 4. Configure openQA to use that database as in step 7. above.
 
-=== Starting daemons
-To start the webserver for development, use the `scripts/openqa daemon`. The other daemons (mentioned in
-the link:images/architecture.svg[architecture diagram]) are started in the same way,
-e.g. `script/openqa-scheduler daemon`.
+=== Manual daemon setup
+
+This section should give you a general idea how to start up daemons manually
+for development. For a concrete example some developers use under openSUSE
+Tumbleweed have a look at the
+https://github.com/Martchus/openQA-helper[openQA-helper repository].
+
+To start the webserver for development, use `scripts/openqa daemon`. The other
+daemons (mentioned in the link:images/architecture.svg[architecture diagram])
+are started in the same way, e.g. `script/openqa-scheduler daemon`.
 
 You can also have a look at the systemd unit files. Although it likely makes not much sense to use them directly
 you can have a look at them to see how the different daemons are started. They are found in the `systemd` directory


### PR DESCRIPTION
Up to now one could use:

```
make test CHECKSTYLE=0 PROVE_ARGS=t/42-my-test.t
```

to run just a single test. Of course one can just use

```
make test-with-database PROVE_ARGS=t/42-my-test.t
```

instead but it's not less typing :)

This commit adds a new test variable TESTS with which we can now do

```
make test TESTS=t/42-my-test.t
```

which internally switches off CHECKSTYLE by default.

Test runs:

* We can select individual test modules with TESTS

```
$ make -n test TESTS=t/config.t
test -d /dev/shm/tpg && (pg_ctl -D /dev/shm/tpg -s status >&/dev/null || pg_ctl -D /dev/shm/tpg -s start) || ./t/test_postgresql /dev/shm/tpg
PERL5OPT=" -I/home/okurz/local/os-autoinst/openQA/t/lib -MOpenQA::Test::PatchDeparse" make test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg"
make[1]: Entering directory '/home/okurz/local/os-autoinst/openQA'
export GLOBIGNORE="";\
script/retry prove -l -v t/config.t
make[1]: Leaving directory '/home/okurz/local/os-autoinst/openQA'
[ 0 = 1 ] || pg_ctl -D /dev/shm/tpg stop
```

* Not specifying TESTS still executes all checks and all test modules

```
$ make -n test
which shellcheck >/dev/null 2>&1 || echo "Command 'shellcheck' not found, can not execute shell script checks"
shellcheck -x $(file --mime-type script/* t/* | sed -n 's/^\(.*\):.*text\/x-shellscript.*$/\1/p')
which yamllint >/dev/null 2>&1 || echo "Command 'yamllint' not found, can not execute YAML syntax checks"
yamllint --strict $(git ls-files "*.yml" "*.yaml" | grep -v ^dbicdh)
PERL5LIB=lib/perlcritic:$PERL5LIB perlcritic lib
test -d /dev/shm/tpg && (pg_ctl -D /dev/shm/tpg -s status >&/dev/null || pg_ctl -D /dev/shm/tpg -s start) || ./t/test_postgresql /dev/shm/tpg
PERL5OPT=" -I/home/okurz/local/os-autoinst/openQA/t/lib -MOpenQA::Test::PatchDeparse" make test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg"
make[1]: Entering directory '/home/okurz/local/os-autoinst/openQA'
export GLOBIGNORE="";\
script/retry prove -l -r -v
make[1]: Leaving directory '/home/okurz/local/os-autoinst/openQA'
[ 0 = 1 ] || pg_ctl -D /dev/shm/tpg stop
```

* TESTS parameter can also be applied for the "coverage" target

```
$ make coverage TESTS=t/config.t
cover -select_re '^/lib' -ignore_re '^t/.*' +ignore_re lib/perlcritic/Perl/Critic/Policy -coverage statement -test
cover: running make test "OPTIMIZE=-O0 -fprofile-arcs -ftest-coverage" "OTHERLDFLAGS=-fprofile-arcs -ftest-coverage"
...
script/retry prove -l -v t/config.t
...
Reading database from /home/okurz/local/os-autoinst/openQA/cover_db


------------------------------------- ------ ------
File                                    stmt  total
------------------------------------- ------ ------
lib/OpenQA/App.pm                       50.0   50.0
lib/OpenQA/Schema/JobGroupDefaults.pm  100.0  100.0
lib/OpenQA/Setup.pm                     37.5   37.5
lib/OpenQA/Task/Job/Limit.pm            30.3   30.3
lib/OpenQA/Utils.pm                     16.8   16.8
Total                                   23.9   23.9
------------------------------------- ------ ------


HTML output written to cover_db/coverage.html
done.
```