### PR TITLE
Return JSON for all API routes

### DIFF
--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -366,7 +366,10 @@ function toggleTemplateEditor() {
             $('.CodeMirror').css('width', window.innerWidth * 0.9 - guide_width + 'px');
         });
     }
-    $.ajax(form.data('put-url')).done(prepareTemplateEditor);
+    $.ajax({
+      url: form.data('put-url'),
+      dataType: 'json'
+    }).done(prepareTemplateEditor);
 }
 
 function prepareTemplateEditor(data) {

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -70,15 +70,17 @@ sub _add_auth_headers {
     my $timestamp = time;
     my %headers   = (
         Accept            => 'application/json',
-        'X-API-Microtime' => $timestamp
+        'X-API-Microtime' => $timestamp,
     );
     if ($self->apisecret && $self->apikey) {
         $headers{'X-API-Key'}  = $self->apikey;
         $headers{'X-API-Hash'} = hmac_sha1_sum($self->_path_query($tx) . $timestamp, $self->apisecret);
     }
 
+    my $set_headers = $tx->req->headers;
     foreach my $key (keys %headers) {
-        $tx->req->headers->header($key, $headers{$key});
+        # don't overwrite headers that were set manually
+        $set_headers->header($key, $headers{$key}) unless defined $set_headers->header($key);
     }
 }
 

--- a/script/client
+++ b/script/client
@@ -45,7 +45,20 @@ Set API base URL component, default: '/api/v1'
 
 =item B<--json-output>
 
-Output JSON instead of perl structures.
+Output JSON instead of Perl structures.
+
+=item B<--yaml-output>
+
+Output YAML instead of Perl structures.
+
+=item B<accept> (json|yaml)
+
+Send Accept header to explicitly tell the API what format is accepted
+
+Note that currently only one endpoint (job_templates_scheduling) is able
+to return YAML, and it's deprecated.
+
+By default, C<Accept: */*> is sent.
 
 =item B<--verbose, -v>
 
@@ -148,6 +161,7 @@ use Mojo::URL;
 use OpenQA::Client;
 use Getopt::Long;
 use OpenQA::Client::Archive;
+use OpenQA::YAML qw(dump_yaml load_yaml);
 
 Getopt::Long::Configure("no_ignore_case");
 
@@ -169,12 +183,34 @@ sub handle_result {
 
     if ($rescode >= 200 && $rescode <= 299) {
         printf(STDERR "%s - %s\n", $rescode, $message) if $rescode > 200;
-        my $json = $res->json;
+        my $content_type = $res->headers->content_type;
+        my $json         = $res->json;
+        my $body         = $res->body;
         if ($options{'json-output'}) {
-            print Cpanel::JSON::XS->new->pretty->encode($json);
+            if ($content_type =~ m{text/yaml}) {
+                print Cpanel::JSON::XS->new->pretty->encode(load_yaml(string => $body));
+            }
+            else {
+                print Cpanel::JSON::XS->new->allow_nonref->pretty->encode($json);
+            }
+        }
+        elsif ($options{'yaml-output'}) {
+            if ($content_type =~ m{text/yaml}) {
+                # avoid messy prompt when missing final linebreak
+                $body .= "\n" unless $body =~ m/\n\z/;
+                print $body;
+            }
+            else {
+                print dump_yaml(string => $json);
+            }
         }
         else {
-            dd($json || $res->body);
+            if ($content_type =~ m{text/yaml}) {
+                dd(load_yaml(string => $body));
+            }
+            else {
+                dd($json);
+            }
         }
         return $json;
     }
@@ -202,10 +238,10 @@ sub prepend_api_base {
 }
 
 GetOptions(
-    \%options,            'host=s',      'apibase=s',   'json-output',
-    'verbose|v',          'apikey:s',    'apisecret:s', 'params=s',
-    'form',               'json-data:s', 'help|h|?',    'archive|a:s',
-    'asset-size-limit:i', 'with-thumbnails'
+    \%options,            'host=s',          'apibase=s',   'json-output',
+    'verbose|v',          'apikey:s',        'apisecret:s', 'params=s',
+    'form',               'json-data:s',     'help|h|?',    'archive|a:s',
+    'asset-size-limit:i', 'with-thumbnails', 'accept=s',    'yaml-output',
 ) or usage(1);
 
 usage(1) unless @ARGV;
@@ -271,6 +307,14 @@ else {
     %params = %form;
 }
 
+my $accept = $options{accept} || '';
+my %accept = (
+    yaml => 'text/yaml',
+    json => 'application/json',
+);
+# We accept any content-type by default
+my $accept_header = $accept{$accept} || '*/*';
+
 my $client = OpenQA::Client->new(apikey => $options{apikey}, apisecret => $options{apisecret}, api => $url->host);
 
 if ($options{form}) {
@@ -300,10 +344,10 @@ else {
         $url->query(Mojo::Parameters->new);
         $url->query(jobs => \@job_ids);
         print("$url\n");
-        handle_result($client->post($url)->res);
+        handle_result($client->post($url, {Accept => $accept_header})->res);
     }
     else {
-        handle_result($client->$method($url)->res);
+        handle_result($client->$method($url, {Accept => $accept_header})->res);
     }
 }
 

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -197,10 +197,10 @@ if ($tables{'JobGroups'}) {
     if ($res->code && $res->code == 200) {
         if ($group) {
             # This is already the YAML document of a single group
-            push @{$result{'JobGroups'}}, {group_name => $group, template => $res->body};
+            push @{$result{'JobGroups'}}, {group_name => $group, template => $res->json};
         }
         else {
-            my $yaml = load_yaml(string => $res->body);
+            my $yaml = $res->json;
             foreach my $group (sort keys %$yaml) {
                 push @{$result{'JobGroups'}}, {group_name => $group, template => $yaml->{$group}};
             }


### PR DESCRIPTION
This commit changes the response of the `job_templates_scheduling` endpoint,
if `Accept: application/json` was requested explicitly, it will return the
job template YAML encoded in a JSON string.

With an unspecific request header (or explicitly text/yaml) it will return
YAML as before.

OpenQA::UserAgent allows overriding the Accept header now.

The command line client can deal with different combinations of response type
and output options.

Issue: https://progress.opensuse.org/issues/64496

I did not add tests for the new `script/client` options. Any hints on how to test that appreciated.