### PR TITLE
Add pointer to log details for incomplete jobs with reason "died"

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -368,7 +368,7 @@ sub engine_workit {
         collected => sub {
             my $self = shift;
             eval { log_info("Isotovideo exit status: " . $self->exit_status, channels => 'autoinst'); };
-            $job->stop($self->exit_status == 0 ? 'done' : 'died');
+            $job->stop($self->exit_status == 0 ? 'done' : 'died: terminated prematurely, see log output for details');
         });
 
     session->on(


### PR DESCRIPTION
In the case of a job incompleting with "died" most likely a problem
within the backend triggered the premature termination.
Results (up to that point) and logs are usually available. These can
provide further information. As it is not feasible to provide only the
"relevant lines" from the log easily an easy thing we can do is provide
a pointer for test reviewers in the reason itself pointing to the
details from log files which are either available in the attached logs
of a job or already directly output in the "details" tab of the web view
when there are no module results at all.

Related progress issue: https://progress.opensuse.org/issues/63718