### PR TITLE
Extend reason quit

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -551,6 +551,9 @@ sub _format_reason {
             return 'api failure';
         }
     }
+    elsif ($reason eq 'quit') {
+        return 'quit: worker has been stopped or restarted';
+    }
     elsif ($reason eq 'cancel') {
         return undef;    # the result is sufficient here
     }

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -376,7 +376,7 @@ subtest 'Job aborted during setup' => sub {
                 json   => undef,
                 path   => 'jobs/8/set_done',
                 result => 'incomplete',
-                reason => 'quit',
+                reason => 'quit: worker has been stopped or restarted',
             }
         ],
         'expected REST-API calls happened'


### PR DESCRIPTION
I've marked it as "not-ready" because we need to adjust our monitoring queries before merging.