### PR TITLE
 Add "by groups name" as option to organize the builds in parent group overview

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -144,6 +144,7 @@
 < javascripts/feature.js
 < javascripts/fullscreen.js
 < javascripts/obs_rsync.js
+< javascripts/parent_group_overview.js
 < https://raw.githubusercontent.com/bootstrapthemesco/bootstrap-4-multi-dropdown-navbar/beta2.0/js/bootstrap-4-navbar.js
 < https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.js
 < https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.js

--- a/assets/javascripts/parent_group_overview.js
+++ b/assets/javascripts/parent_group_overview.js
@@ -1,0 +1,86 @@
+function setupParentGroupOverviewAssets(group_id) {
+    var cookieProductName = '_product_' + group_id + '_grouped_by';
+    var cookieAllProductsName = 'product_all_grouped_by';
+
+    function setCookie(name, value) {
+        document.cookie = name + "=" + value;
+    }
+
+    function getCookie(name) {
+        var value = "; " + document.cookie;
+        var parts = value.split("; " + name + "=");
+        if (parts.length == 2) return parts.pop().split(";").shift();
+    }
+
+    function updateGroupedByDefaultLinks() {
+        if (window.location.hash !== getCookie(cookieProductName))
+            $('#grouped_by_default').show();
+        else
+            $('#grouped_by_default').hide();
+
+        if (window.location.hash !== getCookie(cookieAllProductsName))
+            $('#grouped_by_default_all').show();
+        else
+            $('#grouped_by_default_all').hide();
+    }
+
+    function updateView() {
+        if (window.location.hash === '#grouped_by_build'){
+            $('#grouped_by_group').hide();
+            $('#grouped_by_build').show();
+        } else {
+            $('#grouped_by_group').show();
+            $('#grouped_by_build').hide();
+        }
+    }
+
+    function updateGroupedByClasses() {
+        if (window.location.hash === undefined || window.location.hash === '#grouped_by_build'){
+            document.getElementById('grouped_by_group_tab').classList.remove('active', 'parent_group_overview_grouping_active');
+            document.getElementById('grouped_by_build_tab').classList.add('active', 'parent_group_overview_grouping_active');
+        } else {
+            document.getElementById('grouped_by_build_tab').classList.remove('active', 'show', 'parent_group_overview_grouping_active');
+            document.getElementById('grouped_by_group_tab').classList.add('active', 'parent_group_overview_grouping_active');
+        }
+    }
+
+    $(document).ready(function() {
+
+        var defaultHash = '#grouped_by_build';
+        var hash = window.location.hash;
+
+        if (hash === undefined || hash === '')
+            hash = getCookie(cookieProductName);
+
+        if (hash === undefined || hash === '')
+            hash = getCookie(cookieAllProductsName);
+
+        if (hash === undefined || hash === '')
+            hash = defaultHash;
+
+        window.location.hash = hash;
+
+        updateGroupedByClasses();
+        updateGroupedByDefaultLinks();
+        updateView();
+
+        $('.nav-tabs a').click(function(event){
+            var hash = $(this).attr('href');
+            window.location.hash = hash;
+            updateGroupedByDefaultLinks();
+            updateGroupedByClasses();
+            updateView();
+            event.preventDefault();
+        });
+
+        $('#grouped_by_default').click(function(){
+            setCookie(cookieProductName, window.location.hash || defaultHash);
+            updateGroupedByDefaultLinks();
+        });
+
+        $('#grouped_by_default_all').click(function(){
+            setCookie(cookieAllProductsName, window.location.hash || defaultHash);
+            updateGroupedByDefaultLinks();
+        });
+    });
+}

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -20,3 +20,4 @@
 @import "admin-pages.scss";
 @import "comments.scss";
 @import "overview.scss";
+@import "parent_group_overview.scss";

--- a/assets/stylesheets/parent_group_overview.scss
+++ b/assets/stylesheets/parent_group_overview.scss
@@ -1,0 +1,12 @@
+.parent_group_overview_grouping_active {
+    font-weight: bold;
+    color: $default-font-color;
+}
+
+.parent_group_overview_grouping_by_default {
+    cursor: pointer;
+}
+
+.parent_group_overview_grouping_by_default:hover{
+    text-decoration: underline;
+}

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -238,6 +238,8 @@ subtest 'tagging builds via parent group comments' => sub {
     @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 4,            'four builds tagged');
     is($tags[-1],    'fromparent', 'tag from parent visible on parent-level');
+    @tags = $t->tx->res->dom->find('.tag-byGroup')->map('text')->each;
+    is(scalar @tags, 4, 'four builds tagged');
 
     # check whether the build is considered important now
     $expected_important_builds{1001} = [qw(0048 0066 08 20170329.n.0 3456ba4c93)];
@@ -258,6 +260,9 @@ subtest 'tagging builds via parent group comments' => sub {
     @tags = $t->tx->res->dom->find('.tag')->map('text')->each;
     is(scalar @tags, 4,           'still four builds tagged');
     is($tags[-1],    'fromchild', 'overriding tag from parent on child-level visible on parent-level');
+    $t->get_ok('/parent_group_overview/' . $parent_group_id)->status_is(200);
+    @tags = $t->tx->res->dom->find('.tag-byGroup')->map('text')->each;
+    is(scalar @tags, 4, 'still four builds tagged');
 
     $important_builds = query_important_builds;
     is_deeply($important_builds, \%expected_important_builds, 'build is still considered important')

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -110,7 +110,7 @@ $driver->find_element_by_link_text('Test parent')->click();
 wait_for_ajax_and_animations;
 ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_displayed(), 'link to child group displayed');
 my @links = $driver->find_elements('.h4 a', 'css');
-is(scalar @links, 11, 'all links expanded in the first place');
+is(scalar @links, 19, 'all links expanded in the first place');
 $driver->find_element_by_link_text('Build0091')->click();
 ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_hidden(), 'link to child group collapsed');
 
@@ -144,6 +144,27 @@ subtest 'filtering subgroups' => sub {
     is($driver->get_current_url,                                  $url, 'URL parameters for filter are correct');
     is(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0,    "child group 'opensuse' filtered out");
     isnt(scalar @{$driver->find_elements('opensuse test', 'link_text')}, 0, "child group 'opensuse test' present'");
+};
+
+subtest 'View grouped by group' => sub {
+    my $parent_group_id = $schema->resultset('JobGroupParents')->find({name => 'Test parent'})->id;
+    $driver->get('/parent_group_overview/'. $parent_group_id);
+    
+    $driver->find_element_by_id('grouped_by_group_tab')->click();
+
+    is(
+        $driver->find_element_by_id('grouped_by_group_tab')->get_attribute('class'),
+        'active parent_group_overview_grouping_active',
+        'grouped by group link not active'
+    );
+
+    isnt(
+        $driver->find_element_by_id('grouped_by_build_tab')->get_attribute('class'),
+        'active parent_group_overview_grouping_active',
+        'grouped by group link remains active'
+    );
+
+    $driver->find_element_by_id('grouped_by_group')->is_displayed();
 };
 
 kill_driver();

--- a/templates/webapi/main/build_progressbar.html.ep
+++ b/templates/webapi/main/build_progressbar.html.ep
@@ -1,4 +1,6 @@
-<div class="progress build-dashboard" title="<%= build_progress_bar_title($result) %>">
+% my $class = stash '';
+
+<div class="progress build-dashboard <%= $class %>" title="<%= build_progress_bar_title($result) %>">
     %= build_progress_bar_section(passed => $result->{passed}, $max_jobs)
     %= build_progress_bar_section(unfinished => $result->{unfinished}, $max_jobs, 'progress-bar-striped')
     %= build_progress_bar_section(softfailed => $result->{softfailed}, $max_jobs)

--- a/templates/webapi/main/group_builds_functionality_view.html.ep
+++ b/templates/webapi/main/group_builds_functionality_view.html.ep
@@ -1,0 +1,59 @@
+% for my $child (@{$children}) {
+  % my $has_jobs = 0;
+  % my $title_class_mod = "text-muted";
+
+  % for my $build_res (@$build_results) {
+    % my $child_res = $build_res->{children}->{$child->{id}};
+    % my $jobs = $child_res->{passed} + $child_res->{unfinished} + $child_res->{softfailed} + $child_res->{failed} + $child_res->{skipped};
+
+    % if ($jobs) {
+      % $has_jobs = 1;
+      % $title_class_mod = "";
+    % }
+  % }
+
+  <div class="mb-2">
+    <div class="h4 <%= $title_class_mod %> mb-2">
+      %= link_to $child->{name} => url_for('group_overview', groupid => $child->{id})
+    </div>
+
+    % for my $build_res (@$build_results) {
+      % my $build = $build_res->{build};
+      % my $child_res = $build_res->{children}->{$child->{id}};
+      % my $jobs = $child_res->{passed} + $child_res->{unfinished} + $child_res->{softfailed} + $child_res->{failed} + $child_res->{skipped};
+
+      % if ($jobs) {
+        % my $group_build_id = $group->{id} . '-' . $build_res->{escaped_id};
+
+          <div class="d-md-flex flex-row build-row">
+              <div class="px-2 build-label text-nowrap">
+                  <span class="h4 m-0 d-inline">
+                      %= link_to $build_res->{build} => url_for('tests_overview')->query(distri => [sort keys %{$child_res->{distris}}], version => $child_res->{version}, build => $build, groupid => $child->{id})
+                  </span>
+
+                  %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $child_res, id_prefix => 'child-byGroup-'
+
+                  % if (my $tag = $build_res->{tag}) {
+                      <span id="tag-byGroup-<%= $group_build_id %>">
+                          <i class="tag-byGroup fa fa-tag" title="<%= $tag->{type}; %>"><%= $tag->{description} %></i>
+                      </span>
+                  % }
+              </div>
+              <div class="px-2 text-nowrap smaller-font pl-4">
+                  <abbr class="timeago" title="<%= $build_res->{oldest}->datetime() %>Z">
+                      %= $build_res->{oldest}
+                  </abbr>
+              </div>
+              <div class="px-2 align-self-end flex-grow-1">
+                  %= include 'main/build_progressbar', max_jobs => $jobs, result => $child_res, class => "mt-0"
+              </div>
+          </div>
+      % }
+    % }
+    % if ($has_jobs eq 0) {
+      <div class="ml-3 text-muted">
+        No builds
+      </div>
+    % }
+  </div>
+% }

--- a/templates/webapi/main/parent_group_overview.html.ep
+++ b/templates/webapi/main/parent_group_overview.html.ep
@@ -6,6 +6,7 @@
 % content_for 'ready_function' => begin
     $('.timeago').timeago();
     alignBuildLabels();
+    setupParentGroupOverviewAssets('<%= $group->{id} %>');
 % end
 
 % if (is_admin) {
@@ -15,27 +16,48 @@
         </button>
     </form>
 % }
-<h2>
+
+<h2 class="mb-4">
     Last Builds for <%= $group->{name} %>
 </h2>
+
+%= include 'main/pinned_comments'
+
 <div class="well well-lg" id="group_description">
     % if (my $description = $group->{rendered_description}) {
         %= $description
     % }
-    <div id="child_groups">
-        <h3>Accumulated results for</h3>
-        <ul>
-        % for my $child_group (@$child_groups) {
-            <li>
-                %= link_to $child_group->name => url_for('group_overview', groupid => $child_group->id)
-            </l>
-        % }
-        </ul>
-    </div>
 </div>
-%= include 'main/pinned_comments'
 
 <div id="build-results"></div>
-%= include 'main/group_builds', build_results => $build_results, group => $group, children => $children, default_expanded => 1
+
+<div id="grouped_by_build">
+    %= include 'main/group_builds', build_results => $build_results, group => $group, children => $children, default_expanded => 1
+</div>
+
+<div id="grouped_by_group">
+    %= include 'main/group_builds_functionality_view', build_results => $build_results, group => $group, children => $children, default_expanded => 1
+</div>
+
 %= include 'main/more_builds', limit_builds => $limit_builds
+
+<div class="d-flex flex-row bd-highlight mb-3">
+  <div class="bd-highlight">
+    <ul class="nav nav-pills">
+      <li>Grouped</li>
+      <li class="nav-tabs" style="padding: 0px 0.3em; border-bottom: 0px">
+        <a id="grouped_by_build_tab" data-toggle="pill" href="#grouped_by_build" role="tab" aria-controls="grouped_by_build">by build</a>
+      </li>
+      <li>/</li>
+      <li class="nav-tabs" style="padding: 0px 0.3em; border-bottom: 0px">
+        <a id="grouped_by_group_tab" data-toggle="pill" href="#grouped_by_group" role="tab" aria-controls="grouped_by_group">by group</a>
+      </li>
+    </ul>
+  </div>
+  <div class="bd-highlight">
+    <a id="grouped_by_default" class="parent_group_overview_grouping_by_default">- Set default for this product</a>
+    <a id="grouped_by_default_all" class="parent_group_overview_grouping_by_default">- Set default to all products</a>
+  </div>
+</div>
+
 %= include 'main/comment_area'


### PR DESCRIPTION

https://progress.opensuse.org/issues/33676

- Allows to select how the builds are grouped:
-- By build (is by default): shows a tree grouping first the builds and
its groups results
-- By group (the new view): Shows a tree grouping first the groups and then the builds
- Allows to the user to store the preference in cookies for this product
and for all products
- Allows to select the view through the url