### PR TITLE
New openQA client

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -411,7 +411,7 @@ the following commands:
 [source,sh]
 --------------------------------------------------------------------------------
 # Run the first test
-openqa-client isos post \
+openqa-cli api -X POST isos \
          ISO=openSUSE-Factory-NET-x86_64-Build0053-Media.iso \
          DISTRI=opensuse \
          VERSION=Factory \
@@ -433,7 +433,7 @@ For Fedora, a sample run might be:
 [source,sh]
 --------------------------------------------------------------------------------
 # Run the first test
-openqa-client isos post \
+openqa-cli api -X POST isos \
          ISO=Fedora-Everything-boot-x86_64-Rawhide-20160308.n.0.iso \
          DISTRI=fedora \
          VERSION=Rawhide \

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -595,7 +595,7 @@ For example for all job groups in the old format:
 [source,sh]
 ----
 for i in $(ssh openqa.example.com "sudo -u geekotest psql --no-align --tuples-only --command=\"select id from job_groups where template is null order by id;\" openqa") ; do
-    curl -s http://openqa.example.com/api/v1/job_templates_scheduling/$i | openqa-client --json-output --host http://openqa.example.com job_templates_scheduling/$i post --form schema=JobTemplates-01.yaml template="$(cat -)"
+    curl -s http://openqa.example.com/api/v1/job_templates_scheduling/$i | openqa-cli api --host http://openqa.example.com -X POST job_templates_scheduling/$i schema=JobTemplates-01.yaml template="$(cat -)"
 done
 ----
 
@@ -859,8 +859,8 @@ settings), you have to quote it.
 
 openQA includes a _client_ script which - depending on the distribution - is
 packaged independantly if you just want to interface with an existing openQA
-instance without needing to install the full package. Call `openqa-client
---help` for help.
+instance without needing to install the full package. Call `openqa-cli --help`
+for help.
 
 Basics are described in the
 <<GettingStarted.asciidoc#gettingstarted,Getting Started>> guide.
@@ -937,7 +937,7 @@ Example for `_DEPRIORITIZEBUILD` and `_DEPRIORITIZE_LIMIT`.
 
 [source,sh]
 --------------------------------------------------------------------------------
-openqa-client isos post ISO=my_iso.iso DISTRI=my_distri FLAVOR=sweet \
+openqa-cli api -X POST isos ISO=my_iso.iso DISTRI=my_distri FLAVOR=sweet \
          ARCH=my_arch VERSION=42 BUILD=1234 \
          _DEPRIORITIZEBUILD=1 _DEPRIORITIZE_LIMIT=120 \
 --------------------------------------------------------------------------------

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1192,7 +1192,7 @@ stop them outputting non-printable characters.
 === Trigger new tests by modifying settings from existing test runs
 
 To trigger new tests with custom settings the command line client
-`openqa-client` can be used. To trigger new tests relying on all settings from
+`openqa-cli` can be used. To trigger new tests relying on all settings from
 existing tests runs but modifying specific settings the `openqa-clone-job`
 script can be used. Within the openQA repository the script is located at
 `/usr/share/openqa/script/`.  This tool can be used to create a new job that

--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::CLI;
 use Mojo::Base 'Mojolicious::Commands';

--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -1,0 +1,22 @@
+# Copyright (C) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::CLI;
+use Mojo::Base 'Mojolicious::Commands';
+
+has namespaces => sub { ['OpenQA::CLI'] };
+
+1;

--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -34,8 +34,8 @@ has namespaces => sub { ['OpenQA::CLI'] };
     # Show details for job from localhost
     openqa-cli api jobs/4160811
 
-    # Show details for job from one of the staging machines
-    openqa-cli api --host http://openqa-staging-1.qa.suse.de jobs/408
+    # Show details for job from arbitrary host
+    openqa-cli api --host http://openqa.example.com jobs/408
 
     # Show details for OSD job (prettified JSON)
     openqa-cli api --osd --pretty jobs/4160811

--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -16,6 +16,40 @@
 package OpenQA::CLI;
 use Mojo::Base 'Mojolicious::Commands';
 
+has hint => <<EOF;
+
+See 'openqa-cli help COMMAND' for more information on a specific command.
+EOF
+has message    => sub { shift->extract_usage . "\nCommands:\n" };
 has namespaces => sub { ['OpenQA::CLI'] };
 
 1;
+
+=encoding utf8
+
+=head1 SYNOPSIS
+
+  Usage: openqa-cli COMMAND [OPTIONS]
+
+    # Show details for job from localhost
+    openqa-cli api jobs/4160811
+
+    # Show details for job from one of the staging machines
+    openqa-cli api --host http://openqa-staging-1.qa.suse.de jobs/408
+
+    # Show details for OSD job (prettified JSON)
+    openqa-cli api --osd --pretty jobs/4160811
+
+    # Archive job from O3
+    openqa-cli archive --o3 408 /tmp/job_408
+
+  Options (for all commands):
+        --apibase <path>        API base, defaults to /api/v1
+        --apikey <key>          API key
+        --apisecret <secret>    API secret
+        --host <host>           Target host, defaults to http://localhost
+    -h, --help                  Get more information on a specific command
+        --osd                   Set target host to http://openqa.suse.de
+        --o3                    Set target host to https://openqa.opensuse.org
+
+=cut

--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -31,6 +31,9 @@ has namespaces => sub { ['OpenQA::CLI'] };
 
   Usage: openqa-cli COMMAND [OPTIONS]
 
+    # Show api command help with all available options
+    openqa-cli api --help
+
     # Show details for job from localhost
     openqa-cli api jobs/4160811
 

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -38,11 +38,9 @@ sub run {
 
     @args = map { decode 'UTF-8', $_ } @args;
     die $self->usage unless my $path = shift @args;
-    $path = "/$path" unless $path =~ m!^/!;
-    $path = "$base$path";
 
     my $url = Mojo::URL->new($host);
-    $url->path($path);
+    $url->path($self->prepend_apibase($base, $path));
 
     my $client  = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
     my $headers = $self->parse_headers(@headers);

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::CLI::api;
 use Mojo::Base 'OpenQA::Command';

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -1,0 +1,76 @@
+# Copyright (C) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::CLI::api;
+use Mojo::Base 'OpenQA::Command';
+
+use Mojo::URL;
+use Mojo::Util qw(decode getopt);
+
+has description => 'Issue an arbitrary request to the API';
+has usage       => sub { shift->extract_usage };
+
+sub run {
+    my ($self, @args) = @_;
+
+    my $data = $self->data_from_stdin;
+
+    getopt \@args,
+      'a|header=s'  => \my @headers,
+      'apibase=s'   => \(my $base = '/api/v1'),
+      'apikey=s'    => \my $key,
+      'apisecret=s' => \my $secret,
+      'd|data=s'    => \$data,
+      'H|host=s'    => \(my $host = 'http://localhost'),
+      'X|method=s'  => \(my $method = 'GET');
+
+    @args = map { decode 'UTF-8', $_ } @args;
+    die $self->usage unless my $path = shift @args;
+    $path = "/$path" unless $path =~ m!^/!;
+    $path = "$base$path";
+
+    my $url = Mojo::URL->new($host);
+    $url->path($path);
+
+    my $client  = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
+    my $headers = $self->parse_headers(@headers);
+    my $tx      = $client->build_tx($method, $url, $headers, $data);
+    $tx = $client->start($tx);
+    $self->handle_result($tx);
+}
+
+1;
+
+=encoding utf8
+
+=head1 SYNOPSIS
+
+  Usage: openqa-cli api [OPTIONS] PATH
+
+    openqa-cli api -H https://openqa.opensuse.org job_templates_scheduling/24
+
+  Options:
+        --apibase <path>        API base, defaults to /api/v1
+        --apikey <key>          API key
+        --apisecret <secret>    API secret
+    -a, --header <name:value>   One or more additional HTTP headers
+    -d, --data <string>         Content to send with request, alternatively you
+                                can also pipe data to openqa-cli
+    -H, --host <host>           Target host, defaults to http://localhost
+    -h, --help                  Show this summary of available options
+    -X, --method <method>       HTTP method to use, defaults to GET
+
+=cut

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -37,14 +37,18 @@ sub run {
       'X|method=s'  => \(my $method = 'GET');
 
     @args = map { decode 'UTF-8', $_ } @args;
-    die $self->usage unless my $path = shift @args;
 
+    die $self->usage unless my $path = shift @args;
     my $url = Mojo::URL->new($host);
     $url->path($self->prepend_apibase($base, $path));
 
+    my @data   = ($data);
+    my $params = $self->parse_params(@args);
+    @data = (form => $params) if keys %$params;
+
     my $client  = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
     my $headers = $self->parse_headers(@headers);
-    my $tx      = $client->build_tx($method, $url, $headers, $data);
+    my $tx      = $client->build_tx($method, $url, $headers, @data);
     $tx = $client->start($tx);
     $self->handle_result($tx);
 }
@@ -55,7 +59,7 @@ sub run {
 
 =head1 SYNOPSIS
 
-  Usage: openqa-cli api [OPTIONS] PATH
+  Usage: openqa-cli api [OPTIONS] PATH [PARAMS]
 
     openqa-cli api -H https://openqa.opensuse.org job_templates_scheduling/24
 

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -34,6 +34,7 @@ sub run {
       'apisecret=s' => \my $secret,
       'd|data=s'    => \$data,
       'H|host=s'    => \(my $host = 'http://localhost'),
+      'j|json'      => \my $json,
       'X|method=s'  => \(my $method = 'GET');
 
     @args = map { decode 'UTF-8', $_ } @args;
@@ -46,9 +47,12 @@ sub run {
     my $params = $self->parse_params(@args);
     @data = (form => $params) if keys %$params;
 
-    my $client  = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
     my $headers = $self->parse_headers(@headers);
-    my $tx      = $client->build_tx($method, $url, $headers, @data);
+    $headers->{Accept} //= 'application/json';
+    $headers->{'Content-Type'} = 'application/json' if $json;
+
+    my $client = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
+    my $tx     = $client->build_tx($method, $url, $headers, @data);
     $tx = $client->start($tx);
     $self->handle_result($tx);
 }
@@ -72,6 +76,7 @@ sub run {
                                 can also pipe data to openqa-cli
     -H, --host <host>           Target host, defaults to http://localhost
     -h, --help                  Show this summary of available options
+    -j, --json                  Request content is JSON
     -X, --method <method>       HTTP method to use, defaults to GET
 
 =cut

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -18,26 +18,21 @@ use Mojo::Base 'OpenQA::Command';
 
 use Mojo::File 'path';
 use Mojo::JSON qw(decode_json);
-use Mojo::URL;
 use Mojo::Util qw(getopt);
 
 has description => 'Issue an arbitrary request to the API';
 has usage       => sub { shift->extract_usage };
 
-sub run {
+sub command {
     my ($self, @args) = @_;
 
     my $data = $self->data_from_stdin;
 
     getopt \@args,
       'a|header=s'    => \my @headers,
-      'apibase=s'     => \(my $base = '/api/v1'),
-      'apikey=s'      => \my $key,
-      'apisecret=s'   => \my $secret,
       'D|data-file=s' => \my $data_file,
       'd|data=s'      => \$data,
       'f|form'        => \my $form,
-      'H|host=s'      => \(my $host = 'http://localhost'),
       'j|json'        => \my $json,
       'p|pretty'      => \my $pretty,
       'q|quiet'       => \my $quiet,
@@ -45,9 +40,6 @@ sub run {
 
     @args = $self->decode_args(@args);
     die $self->usage unless my $path = shift @args;
-
-    my $url = Mojo::URL->new($host);
-    $url->path($self->prepend_apibase($base, $path));
 
     $data = path($data_file)->slurp if $data_file;
     my @data   = ($data);
@@ -58,10 +50,13 @@ sub run {
     $headers->{Accept} //= 'application/json';
     $headers->{'Content-Type'} = 'application/json' if $json;
 
-    my $client = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
+    my $url    = $self->url_for($path);
+    my $client = $self->client($url);
     my $tx     = $client->build_tx($method, $url, $headers, @data);
     $tx = $client->start($tx);
     $self->handle_result($tx, {pretty => $pretty, quiet => $quiet});
+
+    return 0;
 }
 
 1;
@@ -72,7 +67,43 @@ sub run {
 
   Usage: openqa-cli api [OPTIONS] PATH [PARAMS]
 
-    openqa-cli api -H https://openqa.opensuse.org job_templates_scheduling/24
+    # Show details for job from localhost
+    openqa-cli api jobs/4160811
+
+    # Show details for job from one of the staging machines
+    openqa-cli api --host http://openqa-staging-1.qa.suse.de jobs/408
+
+    # Show details for job from OSD (prettified JSON)
+    openqa-cli api --osd --pretty jobs/4160811
+
+    # List all jobs (CAUTION: this might time out for a large instance)
+    openqa-cli api --host openqa.example.com jobs
+
+    # List all jobs matching the search criteria
+    openqa-cli api --osd jobs groupid=135 distri=caasp version=3.0 latest=1
+
+    # List the latest jobs matching the search criteria
+    openqa-cli api --osd jobs/overview groupid=135 distri=caasp version=3.0
+
+    # Delete job (CAUTION: destructive operation)
+    openqa-cli api --host openqa.example.com -X DELETE jobs/1
+
+    # Trigger jobs on ISO "foo.iso"
+    openqa-cli api --o3 -X POST isos ISO=foo.iso DISTRI=my-distri \
+      FLAVOR=my-flavor ARCH=my-arch VERSION=42 BUILD=1234
+
+    # Change group id for job
+    openqa-cli api --json --data '{"group_id":1}' -X PUT jobs/639172
+
+    # Change group id for job (pipe JSON data)
+    echo '{"group_id":1}' | openqa-cli api --json -X PUT jobs/639172
+
+    # Post job template
+    openqa-cli api -X POST job_templates_scheduling/1 \
+      schema=JobTemplates-01.yaml preview=0 template="$(cat foo.yaml)"
+
+    # Post job template (from JSON file)
+    openqa-cli api --data-file form.json -X POST job_templates_scheduling/1
 
   Options:
         --apibase <path>        API base, defaults to /api/v1
@@ -83,9 +114,11 @@ sub run {
     -d, --data <string>         Content to send with request, alternatively you
                                 can also pipe data to openqa-cli
     -f, --form                  Turn JSON object into form parameters
-    -H, --host <host>           Target host, defaults to http://localhost
+        --host <host>           Target host, defaults to http://localhost
     -h, --help                  Show this summary of available options
     -j, --json                  Request content is JSON
+        --osd                   Set target host to http://openqa.suse.de
+        --o3                    Set target host to https://openqa.opensuse.org
     -p, --pretty                Pretty print JSON content
     -q, --quiet                 Do not print error messages to STDERR
     -X, --method <method>       HTTP method to use, defaults to GET

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'OpenQA::Command';
 use Mojo::File 'path';
 use Mojo::JSON qw(decode_json);
 use Mojo::URL;
-use Mojo::Util qw(decode getopt);
+use Mojo::Util qw(getopt);
 
 has description => 'Issue an arbitrary request to the API';
 has usage       => sub { shift->extract_usage };
@@ -43,9 +43,9 @@ sub run {
       'q|quiet'       => \my $quiet,
       'X|method=s'    => \(my $method = 'GET');
 
-    @args = map { decode 'UTF-8', $_ } @args;
-
+    @args = $self->decode_args(@args);
     die $self->usage unless my $path = shift @args;
+
     my $url = Mojo::URL->new($host);
     $url->path($self->prepend_apibase($base, $path));
 

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -16,6 +16,7 @@
 package OpenQA::CLI::api;
 use Mojo::Base 'OpenQA::Command';
 
+use Mojo::JSON 'decode_json';
 use Mojo::URL;
 use Mojo::Util qw(decode getopt);
 
@@ -33,6 +34,7 @@ sub run {
       'apikey=s'    => \my $key,
       'apisecret=s' => \my $secret,
       'd|data=s'    => \$data,
+      'f|form'      => \my $form,
       'H|host=s'    => \(my $host = 'http://localhost'),
       'j|json'      => \my $json,
       'X|method=s'  => \(my $method = 'GET');
@@ -44,7 +46,7 @@ sub run {
     $url->path($self->prepend_apibase($base, $path));
 
     my @data   = ($data);
-    my $params = $self->parse_params(@args);
+    my $params = $form ? decode_json($data) : $self->parse_params(@args);
     @data = (form => $params) if keys %$params;
 
     my $headers = $self->parse_headers(@headers);
@@ -74,6 +76,7 @@ sub run {
     -a, --header <name:value>   One or more additional HTTP headers
     -d, --data <string>         Content to send with request, alternatively you
                                 can also pipe data to openqa-cli
+    -f, --form                  Turn JSON object into form parameters
     -H, --host <host>           Target host, defaults to http://localhost
     -h, --help                  Show this summary of available options
     -j, --json                  Request content is JSON

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -16,7 +16,8 @@
 package OpenQA::CLI::api;
 use Mojo::Base 'OpenQA::Command';
 
-use Mojo::JSON 'decode_json';
+use Mojo::File 'path';
+use Mojo::JSON qw(decode_json);
 use Mojo::URL;
 use Mojo::Util qw(decode getopt);
 
@@ -29,15 +30,16 @@ sub run {
     my $data = $self->data_from_stdin;
 
     getopt \@args,
-      'a|header=s'  => \my @headers,
-      'apibase=s'   => \(my $base = '/api/v1'),
-      'apikey=s'    => \my $key,
-      'apisecret=s' => \my $secret,
-      'd|data=s'    => \$data,
-      'f|form'      => \my $form,
-      'H|host=s'    => \(my $host = 'http://localhost'),
-      'j|json'      => \my $json,
-      'X|method=s'  => \(my $method = 'GET');
+      'a|header=s'    => \my @headers,
+      'apibase=s'     => \(my $base = '/api/v1'),
+      'apikey=s'      => \my $key,
+      'apisecret=s'   => \my $secret,
+      'D|data-file=s' => \my $data_file,
+      'd|data=s'      => \$data,
+      'f|form'        => \my $form,
+      'H|host=s'      => \(my $host = 'http://localhost'),
+      'j|json'        => \my $json,
+      'X|method=s'    => \(my $method = 'GET');
 
     @args = map { decode 'UTF-8', $_ } @args;
 
@@ -45,6 +47,7 @@ sub run {
     my $url = Mojo::URL->new($host);
     $url->path($self->prepend_apibase($base, $path));
 
+    $data = path($data_file)->slurp if $data_file;
     my @data   = ($data);
     my $params = $form ? decode_json($data) : $self->parse_params(@args);
     @data = (form => $params) if keys %$params;
@@ -74,6 +77,7 @@ sub run {
         --apikey <key>          API key
         --apisecret <secret>    API secret
     -a, --header <name:value>   One or more additional HTTP headers
+    -D, --data-file <path>      Load content to send with request from file
     -d, --data <string>         Content to send with request, alternatively you
                                 can also pipe data to openqa-cli
     -f, --form                  Turn JSON object into form parameters

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -39,6 +39,8 @@ sub run {
       'f|form'        => \my $form,
       'H|host=s'      => \(my $host = 'http://localhost'),
       'j|json'        => \my $json,
+      'p|pretty'      => \my $pretty,
+      'q|quiet'       => \my $quiet,
       'X|method=s'    => \(my $method = 'GET');
 
     @args = map { decode 'UTF-8', $_ } @args;
@@ -59,7 +61,7 @@ sub run {
     my $client = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
     my $tx     = $client->build_tx($method, $url, $headers, @data);
     $tx = $client->start($tx);
-    $self->handle_result($tx);
+    $self->handle_result($tx, {pretty => $pretty, quiet => $quiet});
 }
 
 1;
@@ -84,6 +86,8 @@ sub run {
     -H, --host <host>           Target host, defaults to http://localhost
     -h, --help                  Show this summary of available options
     -j, --json                  Request content is JSON
+    -p, --pretty                Pretty print JSON content
+    -q, --quiet                 Do not print error messages to STDERR
     -X, --method <method>       HTTP method to use, defaults to GET
 
 =cut

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -70,8 +70,8 @@ sub command {
     # Show details for job from localhost
     openqa-cli api jobs/4160811
 
-    # Show details for job from one of the staging machines
-    openqa-cli api --host http://openqa-staging-1.qa.suse.de jobs/408
+    # Show details for job from arbitrary host
+    openqa-cli api --host http://openqa.example.com jobs/408
 
     # Show details for job from OSD (prettified JSON)
     openqa-cli api --osd --pretty jobs/4160811

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -1,0 +1,44 @@
+# Copyright (C) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::CLI::archive;
+use Mojo::Base 'OpenQA::Command';
+
+has description => 'Download assets and test results from a job';
+has usage       => sub { shift->extract_usage };
+
+sub run {
+    my ($self, @args) = @_;
+
+    die "Not yet implemented!\n";
+}
+
+1;
+
+=encoding utf8
+
+=head1 SYNOPSIS
+
+  Usage: openqa-cli archive [OPTIONS]
+
+    openqa-cli archive ...
+
+  Options:
+        --apikey <key>          API key
+        --apisecret <secret>    API secret
+    -h, --help                  Show this summary of available options
+
+=cut

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::CLI::archive;
 use Mojo::Base 'OpenQA::Command';

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -16,13 +16,32 @@
 package OpenQA::CLI::archive;
 use Mojo::Base 'OpenQA::Command';
 
+use Mojo::Util qw(getopt);
+
 has description => 'Download assets and test results from a job';
 has usage       => sub { shift->extract_usage };
 
 sub run {
     my ($self, @args) = @_;
 
-    die "Not yet implemented!\n";
+    getopt \@args,
+      'apibase=s'            => \(my $base = '/api/v1'),
+      'apikey=s'             => \my $key,
+      'apisecret=s'          => \my $secret,
+      'H|host=s'             => \(my $host = 'http://localhost'),
+      'l|asset-size-limit=i' => \(my $limit),
+      't|with-thumbnails'    => \my $thumbnails;
+
+    @args = $self->decode_args(@args);
+    die $self->usage unless my $job  = shift @args;
+    die $self->usage unless my $path = shift @args;
+
+    my $url = Mojo::URL->new($host);
+    $url->path($self->prepend_apibase($base, "jobs/$job/details"));
+
+    my $client = $self->client(apikey => $key, apisecret => $secret, api => $url->host);
+    $client->archive->run(
+        {url => $url, archive => $path, 'with-thumbnails' => $thumbnails, 'asset-size-limit' => $limit});
 }
 
 1;
@@ -31,13 +50,18 @@ sub run {
 
 =head1 SYNOPSIS
 
-  Usage: openqa-cli archive [OPTIONS]
+  Usage: openqa-cli archive [OPTIONS] JOB PATH
 
-    openqa-cli archive ...
+    openqa-cli archive --host http://openqa-staging-1.qa.suse.de 407 /tmp/foo
+    openqa-cli archive -l 1048576000 -t 408 /tmp/bar
 
   Options:
-        --apikey <key>          API key
-        --apisecret <secret>    API secret
-    -h, --help                  Show this summary of available options
+        --apibase <path>           API base, defaults to /api/v1
+        --apikey <key>             API key
+        --apisecret <secret>       API secret
+    -H, --host <host>              Target host, defaults to http://localhost
+    -h, --help                     Show this summary of available options
+    -l, --asset-size-limit <num>   Asset size limit in bytes
+    -t, --with-thumbnails          Download thumbnails as well
 
 =cut

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -51,8 +51,8 @@ sub command {
     # Download assets and test results from OSD to /tmp/job_416081
     openqa-cli archive --osd 416081 /tmp/job_416081
 
-    # Download assets and test results from one of the staging machines
-    openqa-cli archive --host http://openqa-staging-1.qa.suse.de 407 /tmp/foo
+    # Download assets and test results from arbitrary host
+    openqa-cli archive --host http://openqa.example.com 407 /tmp/foo
 
     # Download assets and test results from localhost (including thumbnails and
     # very large assets)

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -39,6 +39,11 @@ sub parse_headers {
     return {map { /^\s*([^:]+)\s*:\s*(.*+)$/ ? ($1, $2) : () } @headers};
 }
 
+sub parse_params {
+    my ($self, @args) = @_;
+    return {map { /^([[:alnum:]_\[\]\.]+)=(.+)$/s ? ($1, $2) : () } @args};
+}
+
 sub prepend_apibase {
     my ($self, $base, $path) = @_;
     $path = "/$path" unless $path =~ m!^/!;

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package OpenQA::Command;
+use Mojo::Base 'Mojolicious::Command';
+
+use OpenQA::Client;
+use Mojo::IOLoop;
+
+sub client {
+    my $self = shift;
+    return OpenQA::Client->new(@_)->ioloop(Mojo::IOLoop->singleton);
+}
+
+sub data_from_stdin {
+    vec(my $r = '', fileno(STDIN), 1) = 1;
+    return !-t STDIN && select($r, undef, undef, 0) ? join '', <STDIN> : '';
+}
+
+sub handle_result {
+    my ($self, $tx) = @_;
+    say $tx->res->body;
+}
+
+sub parse_headers {
+    my ($self, @headers) = @_;
+    return {map { /^\s*([^:]+)\s*:\s*(.*+)$/ ? ($1, $2) : () } @headers};
+}
+
+1;

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Command;
 use Mojo::Base 'Mojolicious::Command';

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -39,4 +39,10 @@ sub parse_headers {
     return {map { /^\s*([^:]+)\s*:\s*(.*+)$/ ? ($1, $2) : () } @headers};
 }
 
+sub prepend_apibase {
+    my ($self, $base, $path) = @_;
+    $path = "/$path" unless $path =~ m!^/!;
+    return "$base$path";
+}
+
 1;

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -19,6 +19,7 @@ use Mojo::Base 'Mojolicious::Command';
 use Cpanel::JSON::XS ();
 use OpenQA::Client;
 use Mojo::IOLoop;
+use Mojo::Util qw(decode);
 use Term::ANSIColor qw(colored);
 
 my $JSON = Cpanel::JSON::XS->new->utf8->canonical->allow_nonref->allow_unknown->allow_blessed->convert_blessed
@@ -32,6 +33,11 @@ sub client {
 sub data_from_stdin {
     vec(my $r = '', fileno(STDIN), 1) = 1;
     return !-t STDIN && select($r, undef, undef, 0) ? join '', <STDIN> : '';
+}
+
+sub decode_args {
+    my ($self, @args) = @_;
+    return map { decode 'UTF-8', $_ } @args;
 }
 
 sub handle_result {

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -80,7 +80,7 @@ sub run {
       'apibase=s'   => sub { $self->apibase($_[1]) },
       'apikey=s'    => sub { $self->apikey($_[1]) },
       'apisecret=s' => sub { $self->apisecret($_[1]) },
-      'host=s'      => sub { $self->host($_[1]) },
+      'host=s'      => sub { $self->host($_[1] =~ m!^/|://! ? $_[1] : "https://$_[1]") },
       'o3'          => sub { $self->host('https://openqa.opensuse.org') },
       'osd'         => sub { $self->host('http://openqa.suse.de') };
 

--- a/openQA-client-test.spec
+++ b/openQA-client-test.spec
@@ -17,6 +17,7 @@ touch %{_sourcedir}/%{short_name}
 
 %build
 openqa-client --help
+openqa-cli --help
 
 %install
 # disable debug packages in package test to prevent error about missing files

--- a/openQA.spec
+++ b/openQA.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package openQA
 #
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -260,6 +260,7 @@ ln -s %{_sysconfdir}/openqa/openqa.ini %{buildroot}%{_datadir}/openqa%{_sysconfd
 ln -s %{_sysconfdir}/openqa/database.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 mkdir -p %{buildroot}%{_bindir}
 ln -s %{_datadir}/openqa/script/client %{buildroot}%{_bindir}/openqa-client
+ln -s %{_datadir}/openqa/script/openqa-cli %{buildroot}%{_bindir}/openqa-cli
 ln -s %{_datadir}/openqa/script/openqa-clone-job %{buildroot}%{_bindir}/openqa-clone-job
 ln -s %{_datadir}/openqa/script/dump_templates %{buildroot}%{_bindir}/openqa-dump-templates
 ln -s %{_datadir}/openqa/script/load_templates %{buildroot}%{_bindir}/openqa-load-templates
@@ -526,6 +527,7 @@ fi
 %{_datadir}/openqa/script/clone_job.pl
 %{_datadir}/openqa/script/dump_templates
 %{_datadir}/openqa/script/load_templates
+%{_datadir}/openqa/script/openqa-cli
 %{_datadir}/openqa/script/openqa-clone-job
 %{_datadir}/openqa/script/openqa-clone-custom-git-refspec
 %{_datadir}/openqa/script/openqa-validate-yaml
@@ -535,6 +537,7 @@ fi
 %{_datadir}/openqa/lib/OpenQA/Client
 %{_datadir}/openqa/lib/OpenQA/UserAgent.pm
 %{_bindir}/openqa-client
+%{_bindir}/openqa-cli
 %{_bindir}/openqa-clone-job
 %{_bindir}/openqa-dump-templates
 %{_bindir}/openqa-load-templates

--- a/script/openqa-cli
+++ b/script/openqa-cli
@@ -1,23 +1,18 @@
 #!/usr/bin/env perl
-# Copyright (c) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use strict;
 use warnings;

--- a/script/openqa-cli
+++ b/script/openqa-cli
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+# Copyright (c) 2020 SUSE Linux Products GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::RealBin/../lib";
+
+use OpenQA::CLI;
+
+OpenQA::CLI->new->run(@ARGV);

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -40,7 +40,7 @@ use Time::HiRes 'sleep';
 use OpenQA::Test::Utils qw(
   setup_fullstack_temp_dir create_user_for_workers
   create_webapi wait_for_worker setup_share_dir create_websocket_server
-  stop_service unstable_worker client_output
+  stop_service unstable_worker
   unresponsive_worker broken_worker rejective_worker
 );
 use Mojolicious;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -68,65 +68,63 @@ subtest 'Client' => sub {
 };
 
 subtest 'Simple request with authentication' => sub {
-    my ($stdout, @result) = capture_stdout sub { $api->run(@host, '/api/v1/test/op/hello') };
+    my ($stdout, @result) = capture_stdout sub { $api->run(@host, 'test/op/hello') };
     like $stdout, qr/403/, 'not authenticated';
 
-    ($stdout, @result) = capture_stdout sub { $api->run(@auth, '/api/v1/test/op/hello') };
+    ($stdout, @result) = capture_stdout sub { $api->run(@auth, 'test/op/hello') };
     like $stdout, qr/Hello operator!/, 'operator response';
 };
 
 subtest 'HTTP features' => sub {
-    my ($stdout, @result) = capture_stdout sub { $api->run('--host', $host, '/api/v1/test/pub/http') };
+    my ($stdout, @result) = capture_stdout sub { $api->run('--host', $host, 'test/pub/http') };
     my $data = decode_json $stdout;
     is $data->{method}, 'GET', 'GET request';
 
-    ($stdout, @result) = capture_stdout sub { $api->run(@host, '/api/v1/test/pub/http') };
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{method}, 'GET', 'GET request';
 
-    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X', 'POST', '/api/v1/test/pub/http') };
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{method}, 'POST', 'POST request';
 
-    ($stdout, @result) = capture_stdout sub { $api->run(@host, '--method', 'POST', '/api/v1/test/pub/http') };
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '--method', 'POST', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{method}, 'POST', 'POST request';
 
-    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-d', 'Hello openQA!', '/api/v1/test/pub/http') };
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-d', 'Hello openQA!', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{body}, 'Hello openQA!', 'request body';
 
-    ($stdout, @result) = capture_stdout sub { $api->run(@host, '--data', 'Hello openQA!', '/api/v1/test/pub/http') };
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '--data', 'Hello openQA!', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{body}, 'Hello openQA!', 'request body';
 
     ($stdout, @result)
-      = capture_stdout sub { $api->run(@host, '-a', 'X-Test: works', '/api/v1/test/pub/http') };
+      = capture_stdout sub { $api->run(@host, '-a', 'X-Test: works', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
 
     ($stdout, @result)
-      = capture_stdout sub { $api->run(@host, '--header', 'X-Test: works', '/api/v1/test/pub/http') };
+      = capture_stdout sub { $api->run(@host, '--header', 'X-Test: works', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
 
     ($stdout, @result)
-      = capture_stdout
-      sub { $api->run(@host, '-a', 'X-Test: works', '-a', 'X-Test2: works too', '/api/v1/test/pub/http') };
+      = capture_stdout sub { $api->run(@host, '-a', 'X-Test: works', '-a', 'X-Test2: works too', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{headers}{'X-Test'},  'works',     'X-Test header';
     is $data->{headers}{'X-Test2'}, 'works too', 'X-Test2 header';
 
     ($stdout, @result)
       = capture_stdout
-      sub { $api->run(@host, '--header', 'X-Test: works', '--header', 'X-Test2: works too', '/api/v1/test/pub/http') };
+      sub { $api->run(@host, '--header', 'X-Test: works', '--header', 'X-Test2: works too', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{headers}{'X-Test'},  'works',     'X-Test header';
     is $data->{headers}{'X-Test2'}, 'works too', 'X-Test2 header';
 
     ($stdout, @result)
-      = capture_stdout
-      sub { $api->run(@host, '-X', 'POST', '-a', 'Accept: application/json', '/api/v1/test/pub/http') };
+      = capture_stdout sub { $api->run(@host, '-X', 'POST', '-a', 'Accept: application/json', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{method}, 'POST', 'POST request';
     is $data->{headers}{'Accept'}, 'application/json', 'Accept header';
@@ -136,7 +134,7 @@ subtest 'PIPE input' => sub {
     my $file = tempfile;
     my $fh   = $file->spurt('Hello openQA!')->open('<');
     local *STDIN = $fh;
-    my ($stdout, @result) = capture_stdout sub { $api->run(@host, '/api/v1/test/pub/http') };
+    my ($stdout, @result) = capture_stdout sub { $api->run(@host, 'test/pub/http') };
     my $data = decode_json $stdout;
     is $data->{body}, 'Hello openQA!', 'request body';
 };

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -1,0 +1,144 @@
+# Copyright (C) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Mojo::Base -strict;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+use Capture::Tiny qw(capture_stdout);
+use Mojo::Server::Daemon;
+use Mojo::JSON 'decode_json';
+use Mojo::File 'tempfile';
+use OpenQA::CLI;
+use OpenQA::CLI::api;
+use OpenQA::Test::Case;
+
+OpenQA::Test::Case->new->init_data;
+
+# Mock WebAPI with extra test routes
+my $daemon = Mojo::Server::Daemon->new(listen => ['http://127.0.0.1']);
+my $app    = $daemon->build_app('OpenQA::WebAPI');
+$app->log->level('error');
+my $port = $daemon->start->ports->[0];
+my $host = "http://127.0.0.1:$port";
+
+# Test routes
+my $op = $app->routes->find('api_ensure_operator');
+$op->get('/test/op/hello' => sub { shift->render(text => 'Hello operator!') });
+my $pub = $app->routes->find('api_public');
+$pub->any(
+    '/test/pub/http' => sub {
+        my $c    = shift;
+        my $req  = $c->req;
+        my $data = {method => $req->method, headers => $req->headers->to_hash, body => $req->body};
+        $c->render(json => $data);
+    });
+
+# Default options for mock server
+my @host = ('-H', $host);
+
+# Default options for authentication tests
+my @auth = ('--apikey', 'ARTHURKEY01', '--apisecret', 'EXCALIBUR', @host);
+
+my $cli = OpenQA::CLI->new;
+my $api = OpenQA::CLI::api->new;
+
+subtest 'Help' => sub {
+    my ($stdout, @result) = capture_stdout sub { $cli->run('help', 'api') };
+    like $stdout, qr/Usage: openqa-cli api/, 'help';
+};
+
+subtest 'Client' => sub {
+    isa_ok $api->client, 'OpenQA::Client', 'right class';
+};
+
+subtest 'Simple request with authentication' => sub {
+    my ($stdout, @result) = capture_stdout sub { $api->run(@host, '/api/v1/test/op/hello') };
+    like $stdout, qr/403/, 'not authenticated';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@auth, '/api/v1/test/op/hello') };
+    like $stdout, qr/Hello operator!/, 'operator response';
+};
+
+subtest 'HTTP features' => sub {
+    my ($stdout, @result) = capture_stdout sub { $api->run('--host', $host, '/api/v1/test/pub/http') };
+    my $data = decode_json $stdout;
+    is $data->{method}, 'GET', 'GET request';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'GET', 'GET request';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X', 'POST', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '--method', 'POST', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-d', 'Hello openQA!', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{body}, 'Hello openQA!', 'request body';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '--data', 'Hello openQA!', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{body}, 'Hello openQA!', 'request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-a', 'X-Test: works', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '--header', 'X-Test: works', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
+
+    ($stdout, @result)
+      = capture_stdout
+      sub { $api->run(@host, '-a', 'X-Test: works', '-a', 'X-Test2: works too', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{headers}{'X-Test'},  'works',     'X-Test header';
+    is $data->{headers}{'X-Test2'}, 'works too', 'X-Test2 header';
+
+    ($stdout, @result)
+      = capture_stdout
+      sub { $api->run(@host, '--header', 'X-Test: works', '--header', 'X-Test2: works too', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{headers}{'X-Test'},  'works',     'X-Test header';
+    is $data->{headers}{'X-Test2'}, 'works too', 'X-Test2 header';
+
+    ($stdout, @result)
+      = capture_stdout
+      sub { $api->run(@host, '-X', 'POST', '-a', 'Accept: application/json', '/api/v1/test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is $data->{headers}{'Accept'}, 'application/json', 'Accept header';
+};
+
+subtest 'PIPE input' => sub {
+    my $file = tempfile;
+    my $fh   = $file->spurt('Hello openQA!')->open('<');
+    local *STDIN = $fh;
+    my ($stdout, @result) = capture_stdout sub { $api->run(@host, '/api/v1/test/pub/http') };
+    my $data = decode_json $stdout;
+    is $data->{body}, 'Hello openQA!', 'request body';
+};
+
+done_testing();

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>..
 
 use Mojo::Base -strict;
 

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -86,6 +86,14 @@ subtest 'Defaults' => sub {
 
 subtest 'Host' => sub {
     my $api = OpenQA::CLI::api->new;
+    eval { $api->run('--host', 'openqa.example.com') };
+    like $@, qr/Usage: openqa-cli api/, 'usage';
+    is $api->host, 'https://openqa.example.com', 'host';
+
+    eval { $api->run('--host', 'http://openqa.example.com') };
+    like $@, qr/Usage: openqa-cli api/, 'usage';
+    is $api->host, 'http://openqa.example.com', 'host';
+
     eval { $api->run('--osd') };
     like $@, qr/Usage: openqa-cli api/, 'usage';
     is $api->host, 'http://openqa.suse.de', 'host';
@@ -138,6 +146,10 @@ subtest 'HTTP features' => sub {
     is $data->{method}, 'GET', 'GET request';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@host, 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'GET', 'GET request';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '/test/pub/http') };
     $data = decode_json $stdout;
     is $data->{method}, 'GET', 'GET request';
 

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -23,6 +23,7 @@ use Capture::Tiny qw(capture capture_stdout);
 use Mojo::Server::Daemon;
 use Mojo::JSON qw(decode_json);
 use Mojo::File qw(tempfile);
+use Mojo::Util qw(encode);
 use OpenQA::CLI;
 use OpenQA::CLI::api;
 use OpenQA::Test::Case;
@@ -157,6 +158,13 @@ subtest 'Parameters' => sub {
     is $data->{method}, 'GET', 'GET request';
     is_deeply $data->{params}, {FOO => 'bar', BAR => 'baz'}, 'params';
     is $data->{body}, '', 'no request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http', encode('UTF-8', 'foo=some täst')) };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {foo => 'some täst'}, 'params';
+    is $data->{body}, 'foo=some+t%C3%A4st', 'request body';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http', 'FOO=bar', 'BAR=baz') };
     $data = decode_json $stdout;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -163,6 +163,33 @@ subtest 'Parameters' => sub {
     is_deeply $data->{params}, {valid => '1'}, 'params';
 };
 
+subtest 'JSON' => sub {
+    my ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-d', '{"foo":"bar"}', '-X', 'PUT', 'test/pub/http') };
+    my $data = decode_json $stdout;
+    is $data->{method}, 'PUT', 'PUT request';
+    is $data->{headers}{Accept},         'application/json', 'Accept header';
+    is $data->{headers}{'Content-Type'}, undef,              'no Content-Type header';
+    is $data->{body}, '{"foo":"bar"}', 'request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-j', '-d', '{"foo":"bar"}', '-X', 'PUT', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'PUT', 'PUT request';
+    is $data->{headers}{Accept},         'application/json', 'Accept header';
+    is $data->{headers}{'Content-Type'}, 'application/json', 'Content-Type header';
+    is $data->{body}, '{"foo":"bar"}', 'request body';
+
+    ($stdout, @result)
+      = capture_stdout
+      sub { $api->run(@host, '-j', '-d', '{"foo":"bar"}', '-a', 'Accept: text/plain', '-X', 'PUT', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'PUT', 'PUT request';
+    is $data->{headers}{Accept},         'text/plain',       'Accept header';
+    is $data->{headers}{'Content-Type'}, 'application/json', 'Content-Type header';
+    is $data->{body}, '{"foo":"bar"}', 'request body';
+};
+
 subtest 'PIPE input' => sub {
     my $file = tempfile;
     my $fh   = $file->spurt('Hello openQA!')->open('<');

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -181,6 +181,14 @@ subtest 'JSON' => sub {
     is $data->{body}, '{"foo":"bar"}', 'request body';
 
     ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '--json', '-d', '{"foo":"bar"}', '-X', 'PUT', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'PUT', 'PUT request';
+    is $data->{headers}{Accept},         'application/json', 'Accept header';
+    is $data->{headers}{'Content-Type'}, 'application/json', 'Content-Type header';
+    is $data->{body}, '{"foo":"bar"}', 'request body';
+
+    ($stdout, @result)
       = capture_stdout
       sub { $api->run(@host, '-j', '-d', '{"foo":"bar"}', '-a', 'Accept: text/plain', '-X', 'PUT', 'test/pub/http') };
     $data = decode_json $stdout;
@@ -188,6 +196,36 @@ subtest 'JSON' => sub {
     is $data->{headers}{Accept},         'text/plain',       'Accept header';
     is $data->{headers}{'Content-Type'}, 'application/json', 'Content-Type header';
     is $data->{body}, '{"foo":"bar"}', 'request body';
+};
+
+subtest 'JSON form data' => sub {
+    my ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-d', '{"foo":"bar"}', '-X', 'POST', 'test/pub/http') };
+    my $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {}, 'no params';
+    is $data->{body}, '{"foo":"bar"}', 'request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-f', '-d', '{"foo":"bar"}', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'GET', 'GET request';
+    is_deeply $data->{params}, {foo => 'bar'}, 'params';
+    is $data->{body}, '', 'no request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-f', '-d', '{"foo":"bar"}', '-X', 'POST', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {foo => 'bar'}, 'params';
+    is $data->{body}, 'foo=bar', 'request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '--form', '-d', '{"foo":"bar"}', '-X', 'PUT', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'PUT', 'PUT request';
+    is_deeply $data->{params}, {foo => 'bar'}, 'params';
+    is $data->{body}, 'foo=bar', 'request body';
 };
 
 subtest 'PIPE input' => sub {

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use Mojo::Base -strict;
 

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -1,0 +1,54 @@
+# Copyright (C) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Mojo::Base -strict;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+use Capture::Tiny qw(capture_stdout);
+use Mojo::Server::Daemon;
+use Mojo::JSON 'decode_json';
+use Mojo::File 'tempfile';
+use OpenQA::CLI;
+use OpenQA::CLI::archive;
+use OpenQA::Test::Case;
+
+OpenQA::Test::Case->new->init_data;
+
+# Mock WebAPI with extra test routes
+my $daemon = Mojo::Server::Daemon->new(listen => ['http://127.0.0.1']);
+my $app    = $daemon->build_app('OpenQA::WebAPI');
+$app->log->level('error');
+my $port = $daemon->start->ports->[0];
+my $host = "http://127.0.0.1:$port";
+
+# Default options for mock server
+my @host = ('-H', $host);
+
+# Default options for authentication tests
+my @auth = ('--apikey', 'ARTHURKEY01', '--apisecret', 'EXCALIBUR', @host);
+
+my $cli     = OpenQA::CLI->new;
+my $archive = OpenQA::CLI::archive->new;
+
+subtest 'Help' => sub {
+    my ($stdout, @result) = capture_stdout sub { $cli->run('help', 'archive') };
+    like $stdout, qr/Usage: openqa-cli archive/, 'help';
+};
+
+done_testing();

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -36,7 +36,7 @@ my $port = $daemon->start->ports->[0];
 my $host = "http://127.0.0.1:$port";
 
 # Default options for mock server
-my @host = ('-H', $host);
+my @host = ('--host', $host);
 
 # Default options for authentication tests
 my @auth = ('--apikey', 'ARTHURKEY01', '--apisecret', 'EXCALIBUR', @host);
@@ -97,7 +97,7 @@ subtest 'Archive job with thumbnails' => sub {
     ($stdout, $stderr, @result)
       = capture_stdout sub { $cli->run('archive', @host, '--with-thumbnails', 99937, $target->to_string) };
     like $stdout, qr/Downloading test details and screenshots to $target/, 'downloading details';
-    my $results = $target->child('testresults');
+    $results = $target->child('testresults');
     ok -d $results, 'testresults directory exists';
     ok -f $results->child('details-isosize.json'), 'details-isosize.json exists';
     ok -f $results->child('autoinst-log.txt'),     'autoinst-log.txt exists';

--- a/t/43-cli.t
+++ b/t/43-cli.t
@@ -1,0 +1,28 @@
+# Copyright (C) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Mojo::Base -strict;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+use OpenQA::CLI;
+
+my $cli = OpenQA::CLI->new;
+is_deeply $cli->namespaces, ['OpenQA::CLI'], 'right namespaces';
+
+done_testing();

--- a/t/43-cli.t
+++ b/t/43-cli.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE Linux Products GmbH
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use Mojo::Base -strict;
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -180,19 +180,16 @@ my @core_hdd_stat = stat($core_hdd_path);
 ok(@core_hdd_stat, 'can stat ' . $core_hdd_path);
 is(S_IMODE($core_hdd_stat[2]), 420, 'exported image has correct permissions (420 -> 0644)');
 
-my $post_group_res = OpenQA::Test::FullstackUtils::client_output "job_groups post name='New job group'";
-my $group_id       = ($post_group_res =~ qr/{ *id *=> *([0-9]*) *}\n/);
+my $post_group_res = OpenQA::Test::FullstackUtils::client_output "-X POST job_groups name='New job group'";
+my $group_id       = ($post_group_res =~ qr/id.+([0-9]+)/);
 ok($group_id, 'regular post via client script');
-OpenQA::Test::FullstackUtils::client_call(
-    "jobs/1 put --json-data '{\"group_id\": $group_id}'",
-    qr/\Q{ job_id => 1 }\E/,
-    'send JSON data via client script'
-);
-OpenQA::Test::FullstackUtils::client_call('jobs/1', qr/group_id *=> *$group_id/, 'group has been altered correctly');
+OpenQA::Test::FullstackUtils::client_call(qq{-X PUT jobs/1 --json --data '{"group_id":$group_id}'},
+    qr/job_id.+1/, 'send JSON data via client script');
+OpenQA::Test::FullstackUtils::client_call('jobs/1', qr/group_id.+$group_id/, 'group has been altered correctly');
 
 OpenQA::Test::FullstackUtils::client_call(
-    'jobs/1/restart post',
-    qr|\Qtest_url => [{ 1 => "/tests/2\E|,
+    '-X POST jobs/1/restart',
+    qr|test_url.+1.+tests.+2|,
     'client returned new test_url'
 );
 #]| restore syntax highlighting
@@ -213,7 +210,7 @@ like(
 );
 
 my $JOB_SETUP = $OpenQA::Test::FullstackUtils::JOB_SETUP;
-OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP MACHINE=noassets HDD_1=nihilist_disk.hda");
+OpenQA::Test::FullstackUtils::client_call("-X POST jobs $JOB_SETUP MACHINE=noassets HDD_1=nihilist_disk.hda");
 
 subtest 'cancel a scheduled job' => sub {
     $driver->click_element_ok('All Tests',    'link_text', 'Clicked All Tests');
@@ -317,8 +314,8 @@ subtest 'Cache tests' => sub {
 
     my $job_name = 'tinycore-1-flavor-i386-Build1-core@coolone';
     OpenQA::Test::FullstackUtils::client_call(
-        'jobs/3/restart post',
-        qr|\Qtest_url => [{ 3 => "/tests/5\E|,
+        '-X POST jobs/3/restart',
+        qr|test_url.+3.+tests.+5|,
         'client returned new test_url'
     );
     #]| restore syntax highlighting in Kate
@@ -389,8 +386,8 @@ subtest 'Cache tests' => sub {
 
     #simple limit testing.
     OpenQA::Test::FullstackUtils::client_call(
-        'jobs/5/restart post',
-        qr|\Qtest_url => [{ 5 => "/tests/6\E|,
+        '-X POST jobs/5/restart',
+        qr|test_url.+5.+tests.+6|,
         'client returned new test_url'
     );
     #]| restore syntax highlighting in Kate
@@ -411,8 +408,8 @@ subtest 'Cache tests' => sub {
 
     #simple limit testing.
     OpenQA::Test::FullstackUtils::client_call(
-        'jobs/6/restart post',
-        qr|\Qtest_url => [{ 6 => "/tests/7\E|,
+        '-X POST jobs/6/restart',
+        qr|test_url.+6.+tests.+7|,
         'client returned new test_url'
     );
     #]| restore syntax highlighting in Kate
@@ -439,7 +436,7 @@ subtest 'Cache tests' => sub {
             'Test 7 correct autoinst uploading autoinst'
         );
     }
-    OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP HDD_1=non-existent.qcow2");
+    OpenQA::Test::FullstackUtils::client_call("-X POST jobs $JOB_SETUP HDD_1=non-existent.qcow2");
     OpenQA::Test::FullstackUtils::schedule_one_job;
     $driver->get('/tests/8');
     ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/), 'test 8 is incomplete';

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -39,13 +39,13 @@ $JOB_SETUP .= ' QEMU_NO_KVM=1' unless -r '/dev/kvm';
 
 sub get_connect_args {
     my $mojoport = OpenQA::SeleniumTest::get_mojoport;
-    return "--apikey=1234567890ABCDEF --apisecret=1234567890ABCDEF --host=http://localhost:$mojoport";
+    return "--apikey 1234567890ABCDEF --apisecret 1234567890ABCDEF --host http://localhost:$mojoport";
 }
 
 sub client_output {
     my ($args) = @_;
     my $connect_args = get_connect_args();
-    open(my $client, "-|", "perl ./script/client $connect_args $args");
+    open(my $client, "-|", "perl ./script/openqa-cli api $connect_args $args");
     my $out;
     while (<$client>) {
         $out .= $_;
@@ -220,7 +220,7 @@ sub verify_one_job_displayed_as_scheduled {
 
 sub schedule_one_job_over_api_and_verify {
     my ($driver) = @_;
-    client_call("jobs post $JOB_SETUP");
+    client_call("-X POST jobs $JOB_SETUP");
     return verify_one_job_displayed_as_scheduled($driver);
 }
 

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -44,7 +44,7 @@ our (@EXPORT, @EXPORT_OK);
     qw(redirect_output standard_worker create_user_for_workers),
     qw(create_webapi create_websocket_server create_scheduler create_live_view_handler),
     qw(unresponsive_worker broken_worker rejective_worker wait_for_worker setup_share_dir setup_fullstack_temp_dir run_gru_job),
-    qw(collect_coverage_of_gru_jobs stop_service unstable_worker client_output fake_asset_server),
+    qw(collect_coverage_of_gru_jobs stop_service unstable_worker fake_asset_server),
     qw(cache_minion_worker cache_worker_service shared_hash embed_server_for_testing),
     qw(run_cmd test_cmd)
 );
@@ -477,18 +477,6 @@ sub c_worker {
     }
 
     return $pid;
-}
-
-sub client_output {
-    my ($apikey, $apisecret, $host, $args) = @_;
-    my $connect_args = "--apikey=${apikey} --apisecret=${apisecret} --host=${host}";
-    open(my $client, "perl ./script/client $connect_args $args|");
-    my $out;
-    while (<$client>) {
-        $out .= $_;
-    }
-    close($client);
-    return $out;
 }
 
 sub shared_hash {


### PR DESCRIPTION
A first proof of concept for a new openQA client with extensions and full test coverage.

**Todo:**
- [x] Fix tests on Circle CI (works locally)
- [x] Add form building (`openqa-cli api -X POST isos ISO=bar.iso DISTRI=my-distri`)
- [x] Add `-f`/`--form` flag to turn JSON data into form parameters
- [x] Add `-j`/`--json` flag for sending a JSON request body
- [x] Load form parameters from JSON file (old `--params test.json`)
- [x] Update usage message for `openqa-cli` (easy navigation to `openqa-cli api`/`openqa-cli archive`)
- [x] Graceful handling of non-200 responses (user friendly output)
- [x] `--quiet` option to hide STDERR messages
- [x] Implement `openqa-cli archive` extension (the first extension of the new client)
- [x] Add tests for archive feature (previously unfortunately untested)
- [x] Optional pretty printing of returned data structures (JSON)
- [x] Content negotiation support (added after work on the new client began)
- [x] Double check UTF-8 handling and make sure it is tested for all features
- [x] Update spec files
- [x] Fix fullstack tests to use `openqa-cli` instead of `client`
- [x] Look into sharing common argument handling between subcommands (`--host`)
- [x] Add `--osd` and `--o3` flags (to avoid repetitive `--host` use)

**Bonus:**
- [x] Collect examples for `openqa-cli` uses and add them to the docs
- [x] Add `-D`/`--data-file` option to make backwards compatibility easier

**Up for discussion**
We need to decide what to do with the legacy client, we could:
- Deprecate it for a few months/years and then just remove it completely
- Try to replace it with a wrapper script around `openqa-cli`, translating arguments as best as possible (some things would break immediately though, like output formatting)

Progress: https://progress.opensuse.org/issues/10316