### PR TITLE
Improve the operation of 'jobs post'

### DIFF
--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 
-package OpenQA::ExpandPlaceholder;
+package OpenQA::JobSettings;
 
 use strict;
 use warnings;
@@ -48,6 +48,20 @@ sub _expand_placeholder {
     $value =~ s/%(\w+)%/_expand_placeholder($settings, $1, \%visited_placeholders)/eg;
 
     return $value;
+}
+
+# allow some messing with the usual precedence order. If anything
+# sets +VARIABLE, that setting will be used as VARIABLE regardless
+# (so a product or template +VARIABLE beats a post'ed VARIABLE).
+# if *multiple* things set +VARIABLE, whichever comes highest in
+# the usual precedence order wins.
+sub handle_plus_in_settings {
+    my ($settings) = @_;
+    for (keys %$settings) {
+        if (substr($_, 0, 1) eq '+') {
+            $settings->{substr($_, 1)} = delete $settings->{$_};
+        }
+    }
 }
 
 1;

--- a/lib/OpenQA/Script.pm
+++ b/lib/OpenQA/Script.pm
@@ -42,6 +42,7 @@ sub clone_job_apply_settings {
     my ($argv, $depth, $settings, $options) = @_;
 
     delete $settings->{NAME};    # usually autocreated
+    $settings->{is_clone_job} = 1;    # used to figure out if this is a clone operation
 
     for my $arg (@$argv) {
         # split arg into key and value

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -851,6 +851,12 @@ sub _generate_job_setting {
     $settings{WORKER_CLASS} = join ',', sort @classes if @classes > 0;
     $settings{uc $_} = $args->{$_} for keys %$args;
 
+    # follow the rule that handles '+' in isos post
+    for (keys %settings) {
+        if (substr($_, 0, 1) eq '+') {
+            $settings{substr($_, 1)} = delete $settings{$_};
+        }
+    }
     my $error_message = OpenQA::ExpandPlaceholder::expand_placeholders(\%settings);
     return {error_message => $error_message, settings_result => \%settings};
 }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -17,7 +17,7 @@ package OpenQA::WebAPI::Controller::API::V1::Job;
 use Mojo::Base 'Mojolicious::Controller';
 
 use OpenQA::Utils qw(:DEFAULT assetdir);
-use OpenQA::ExpandPlaceholder;
+use OpenQA::JobSettings;
 use OpenQA::Jobs::Constants;
 use OpenQA::Resource::Jobs;
 use OpenQA::Schema::Result::Jobs;
@@ -239,8 +239,9 @@ is mandatory and should be the name of the test.
 =cut
 
 sub create {
-    my $self   = shift;
-    my $params = $self->req->params->to_hash;
+    my $self         = shift;
+    my $params       = $self->req->params->to_hash;
+    my $is_clone_job = delete $params->{is_clone_job} // 0;
 
     # job_create expects upper case keys
     my %up_params = map { uc $_ => $params->{$_} } keys %$params;
@@ -252,12 +253,15 @@ sub create {
 
     my $json = {};
     my $status;
-    my $result = $self->_generate_job_setting(\%params);
-    return $self->render(json => {error => $result->{error_message}}, status => 400)
-      if defined $result->{error_message};
-
+    my $job_settings = \%params;
+    if (!$is_clone_job) {
+        my $result = $self->_generate_job_setting(\%params);
+        return $self->render(json => {error => $result->{error_message}}, status => 400)
+          if defined $result->{error_message};
+        $job_settings = $result->{settings_result};
+    }
     try {
-        my $job = $self->schema->resultset('Jobs')->create_from_settings($result->{settings_result});
+        my $job = $self->schema->resultset('Jobs')->create_from_settings($job_settings);
         $self->emit_event('openqa_job_create', {id => $job->id, %params});
         $json->{id} = $job->id;
 
@@ -851,13 +855,9 @@ sub _generate_job_setting {
     $settings{WORKER_CLASS} = join ',', sort @classes if @classes > 0;
     $settings{uc $_} = $args->{$_} for keys %$args;
 
-    # follow the rule that handles '+' in isos post
-    for (keys %settings) {
-        if (substr($_, 0, 1) eq '+') {
-            $settings{substr($_, 1)} = delete $settings{$_};
-        }
-    }
-    my $error_message = OpenQA::ExpandPlaceholder::expand_placeholders(\%settings);
+    OpenQA::JobSettings::handle_plus_in_settings(\%settings);
+
+    my $error_message = OpenQA::JobSettings::expand_placeholders(\%settings);
     return {error_message => $error_message, settings_result => \%settings};
 }
 

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -64,12 +64,14 @@ subtest 'clone job apply settings tests' => sub {
     $test_settings{HDD_1}        = 'new.qcow2';
     $test_settings{HDDSIZEGB}    = 40;
     $test_settings{WORKER_CLASS} = 'local';
+    $test_settings{is_clone_job} = 1;
     delete $test_settings{NAME};
     clone_job_apply_settings(\@argv, 0, \%child_settings, \%options);
     is_deeply(\%child_settings, \%test_settings, 'cloned child job with correct global setting and new settings');
 
-    %test_settings = %parent_settings;
+    %test_settings               = %parent_settings;
     $test_settings{WORKER_CLASS} = 'local';
+    $test_settings{is_clone_job} = 1;
     delete $test_settings{NAME};
     clone_job_apply_settings(\@argv, 1, \%parent_settings, \%options);
     is_deeply(\%parent_settings, \%test_settings, 'cloned parent job only take global setting');
@@ -78,16 +80,16 @@ subtest 'clone job apply settings tests' => sub {
 subtest '_GROUP and _GROUP_ID override each other' => sub {
     my %settings = ();
     clone_job_apply_settings([qw(_GROUP=foo _GROUP_ID=bar)], 0, \%settings, \%options);
-    is_deeply(\%settings, {_GROUP_ID => 'bar'}, '_GROUP_ID overrides _GROUP');
+    is_deeply(\%settings, {_GROUP_ID => 'bar', is_clone_job => 1}, '_GROUP_ID overrides _GROUP');
     %settings = ();
     clone_job_apply_settings([qw(_GROUP_ID=bar _GROUP=foo)], 0, \%settings, \%options);
-    is_deeply(\%settings, {_GROUP => 'foo'}, '_GROUP overrides _GROUP_ID');
+    is_deeply(\%settings, {_GROUP => 'foo', is_clone_job => 1}, '_GROUP overrides _GROUP_ID');
 };
 
 subtest 'delete empty setting' => sub {
     my %settings = ();
     clone_job_apply_settings([qw(ISO_1= ADDONS=)], 0, \%settings, \%options);
-    is_deeply(\%settings, {}, 'all empty settings removed');
+    is_deeply(\%settings, {is_clone_job => 1}, 'all empty settings removed');
 };
 
 subtest 'asset download' => sub {

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -20,7 +20,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;
-use OpenQA::ExpandPlaceholder;
+use OpenQA::JobSettings;
 
 my $settings = {
     BUILD_SDK                => '%BUILD_HA%',
@@ -57,7 +57,7 @@ my $settings = {
 };
 
 subtest expand_placeholders => sub {
-    my $error          = OpenQA::ExpandPlaceholder::expand_placeholders($settings);
+    my $error          = OpenQA::JobSettings::expand_placeholders($settings);
     my $match_settings = {
         BUILD_SDK                => '1234',
         BETA                     => 1,
@@ -109,10 +109,21 @@ subtest circular_reference => sub {
         MACHINE       => '64bit',
     };
     like(
-        OpenQA::ExpandPlaceholder::expand_placeholders($circular_settings),
+        OpenQA::JobSettings::expand_placeholders($circular_settings),
         qr/The key (\w+) contains a circular reference, its value is %\w+%/,
         "circular reference exit successfully"
     );
+};
+
+subtest 'handle_plus_in_settings' => sub {
+    my $settings = {
+        'ISO'    => 'foo.iso',
+        '+ISO'   => 'bar.iso',
+        '+ARCH'  => 'x86_64',
+        'DISTRI' => 'opensuse',
+    };
+    OpenQA::JobSettings::handle_plus_in_settings($settings);
+    is_deeply($settings, {ISO => 'bar.iso', ARCH => 'x86_64', DISTRI => 'opensuse'}, 'handle the plus correctly');
 };
 
 done_testing;


### PR DESCRIPTION
In the current code, the settings start with `+` will be added to the job when creating a job using `jobs post` as `{+key => value}`. 
Handle this by following the rule that defined in `schedule_iso`

When we cloning a job, the settings that removed by clone script are added into the job's settings again if the settings are defined in TestSuite or Product or Machine. Because the create job function re-generate the settings.


See: https://progress.opensuse.org/issues/63883
        https://progress.opensuse.org/issues/63565