### PR TITLE
Use defaults already in startup scripts rather than systemd

### DIFF
--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -94,7 +94,7 @@ sub startup {
     OpenQA::Setup::setup_validator_check_for_datetime($self);
 }
 
-sub run { __PACKAGE__->new->start }
+sub run { __PACKAGE__->new->start(@_) }
 
 sub schema { OpenQA::Schema->singleton }
 

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -68,7 +68,7 @@ sub startup {
 
 sub run {
     local $RUNNING = 1;
-    __PACKAGE__->new->start;
+    __PACKAGE__->new->start(@_);
 }
 
 sub wakeup { _reschedule(0) }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -469,6 +469,6 @@ sub startup {
 
 sub schema { OpenQA::Schema->singleton }
 
-sub run { __PACKAGE__->new->start }
+sub run { __PACKAGE__->new->start(@_) }
 
 1;

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -56,7 +56,7 @@ sub startup {
 
 sub run {
     local $RUNNING = 1;
-    __PACKAGE__->new->start;
+    __PACKAGE__->new->start(@_);
 }
 
 sub ws_send {

--- a/openQA.spec
+++ b/openQA.spec
@@ -433,6 +433,7 @@ fi
 %{_datadir}/openqa/script/openqa-enqueue-audit-event-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-bug-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-result-cleanup
+%{_datadir}/openqa/script/openqa-gru
 %{_datadir}/openqa/script/upgradedb
 %{_datadir}/openqa/script/modify_needle
 # TODO: define final user
@@ -498,6 +499,9 @@ fi
 %{_unitdir}/openqa-worker-no-cleanup@.service
 %{_unitdir}/openqa-slirpvde.service
 %{_unitdir}/openqa-vde_switch.service
+%{_datadir}/openqa/script/openqa-worker-cacheservice-minion
+%{_datadir}/openqa/script/openqa-slirpvde
+%{_datadir}/openqa/script/openqa-vde_switch
 %{_tmpfilesdir}/openqa.conf
 %ghost %dir %{_rundir}/openqa
 # worker libs

--- a/script/openqa
+++ b/script/openqa
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,5 +32,5 @@ $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
 $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
 
 set_listen_address(service_port('webui'));
-OpenQA::WebAPI::run;
-
+# Our API commands are very expensive, so the default timeouts are too tight
+OpenQA::WebAPI::run(@ARGV ? @_ : qw(prefork -m production --proxy -i 100 -H 400 -w 30 -c 1 -G 800));

--- a/script/openqa-gru
+++ b/script/openqa-gru
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright (C) 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,13 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use warnings;
 use Mojo::Base -strict;
 
 use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
-use OpenQA::CacheService;
-use OpenQA::Utils qw(service_port set_listen_address);
-
-set_listen_address(service_port('cache_service'));
-OpenQA::CacheService::run(@ARGV ? @_ : qw(prefork -m production -i 100 -H 400 -w 4 -G 80));
+use OpenQA::WebAPI;
+OpenQA::WebAPI::run('gru', (@ARGV ? @_ : qw(-m production run --reset-locks)));

--- a/script/openqa-livehandler
+++ b/script/openqa-livehandler
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,4 +27,5 @@ use OpenQA::Utils qw(service_port set_listen_address);
 $ENV{MOJO_INACTIVITY_TIMEOUT} ||= 15 * 60;
 
 set_listen_address(service_port('livehandler'));
-OpenQA::LiveHandler::run;
+# Our API commands are very expensive, so the default timeouts are too tight
+OpenQA::LiveHandler::run(@ARGV ? @_ : qw(daemon -m production --proxy -i 100));

--- a/script/openqa-scheduler
+++ b/script/openqa-scheduler
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,4 +24,4 @@ use OpenQA::Scheduler;
 use OpenQA::Utils qw(service_port set_listen_address);
 
 set_listen_address(service_port('scheduler'));
-OpenQA::Scheduler::run;
+OpenQA::Scheduler::run(@ARGV ? @_ : qw(daemon -m production));

--- a/script/openqa-slirpvde
+++ b/script/openqa-slirpvde
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec /usr/bin/slirpvde -D -s /run/openqa/vde.ctl "$@"

--- a/script/openqa-vde_switch
+++ b/script/openqa-vde_switch
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec /usr/bin/vde_switch -F -s /run/openqa/vde.ctl -M /run/openqa/vde.mgmt "$@"

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,4 +27,4 @@ use OpenQA::Utils qw(service_port set_listen_address);
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 1024 * 1024 * 1024 * 20;
 
 set_listen_address(service_port('websocket'));
-OpenQA::WebSockets::run;
+OpenQA::WebSockets::run(@ARGV ? @_ : qw(daemon -m production));

--- a/script/openqa-worker-cacheservice-minion
+++ b/script/openqa-worker-cacheservice-minion
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec "$(dirname "$0")"/openqa-workercache minion worker -m production "$@"

--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -5,7 +5,7 @@ Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa gru -m production run --reset-locks
+ExecStart=/usr/share/openqa/script/openqa-gru
 Nice=19
 Restart=on-failure
 

--- a/systemd/openqa-livehandler.service
+++ b/systemd/openqa-livehandler.service
@@ -6,10 +6,8 @@ After=postgresql.service nss-lookup.target remote-fs.target
 Requires=openqa-webui.service
 
 [Service]
-# TODO: define whether we want to run the web ui with the same user
 User=geekotest
-# Our API commands are very expensive, so the default timeouts are too tight
-ExecStart=/usr/share/openqa/script/openqa-livehandler daemon -m production --proxy -i 100
+ExecStart=/usr/share/openqa/script/openqa-livehandler
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-scheduler.service
+++ b/systemd/openqa-scheduler.service
@@ -5,7 +5,7 @@ Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-scheduler daemon -m production
+ExecStart=/usr/share/openqa/script/openqa-scheduler
 TimeoutStopSec=120
 
 [Install]

--- a/systemd/openqa-slirpvde.service
+++ b/systemd/openqa-slirpvde.service
@@ -4,7 +4,7 @@ PartOf=openqa-worker.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/slirpvde -D -s /run/openqa/vde.ctl
+ExecStart=/usr/share/openqa/script/openqa-slirpvde
 User=_openqa-worker
 
 [Install]

--- a/systemd/openqa-vde_switch.service
+++ b/systemd/openqa-vde_switch.service
@@ -5,7 +5,7 @@ Requires=openqa-vde_switch.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/vde_switch -F -s /run/openqa/vde.ctl -M /run/openqa/vde.mgmt
+ExecStart=/usr/share/openqa/script/openqa-vde_switch
 User=_openqa-worker
 
 [Install]

--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -5,9 +5,8 @@ Before=apache2.service openqa-webui.service
 After=openqa-scheduler.service postgresql.service openqa-setup-db.service network.target nss-lookup.target remote-fs.target
 
 [Service]
-# TODO: define whether we want to run the websockets with the same user
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-websockets daemon -m production
+ExecStart=/usr/share/openqa/script/openqa-websockets
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -6,10 +6,8 @@ After=postgresql.service openqa-setup-db.service openqa-scheduler.service nss-lo
 Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
 
 [Service]
-# TODO: define whether we want to run the web ui with the same user
 User=geekotest
-# Our API commands are very expensive, so the default timeouts are too tight
-ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 30 -c 1 -G 800
+ExecStart=/usr/share/openqa/script/openqa
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-worker-cacheservice-minion.service
+++ b/systemd/openqa-worker-cacheservice-minion.service
@@ -7,7 +7,7 @@ PartOf=openqa-worker.target
 [Service]
 Restart=on-failure
 User=_openqa-worker
-ExecStart=/usr/share/openqa/script/openqa-workercache minion worker -m production
+ExecStart=/usr/share/openqa/script/openqa-worker-cacheservice-minion
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-worker-cacheservice.service
+++ b/systemd/openqa-worker-cacheservice.service
@@ -7,7 +7,7 @@ PartOf=openqa-worker.target
 [Service]
 Restart=on-failure
 User=_openqa-worker
-ExecStart=/usr/share/openqa/script/openqa-workercache prefork -m production -i 100 -H 400 -w 4 -G 80
+ExecStart=/usr/share/openqa/script/openqa-workercache
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd startup scripts should not have too much business logic and not
duplicate what a startup in other environments e.g. containers would
need as well. This can simplify containerization of services.