### PR TITLE
Test client in OBS

### DIFF
--- a/openQA-client-test.spec
+++ b/openQA-client-test.spec
@@ -1,0 +1,25 @@
+%define         short_name openQA-client
+Name:           %{short_name}-test
+Version:        4.6
+Release:        0
+Summary:        Test package for %{short_name}
+License:        GPL-2.0-or-later
+BuildRequires:  %{short_name} == %{version}
+ExcludeArch:    i586
+
+%description
+.
+
+%prep
+# workaround to prevent post/install failing assuming this file for whatever
+# reason
+touch %{_sourcedir}/%{short_name}
+
+%build
+openqa-client --help
+
+%install
+# disable debug packages in package test to prevent error about missing files
+%define debug_package %{nil}
+
+%changelog

--- a/openQA.spec
+++ b/openQA.spec
@@ -49,7 +49,7 @@
 %define common_requires perl(Archive::Extract) perl(Config::IniFiles) perl(Cpanel::JSON::XS) perl(Cwd) perl(Data::Dump) perl(Data::Dumper) perl(Digest::MD5) perl(Getopt::Long) perl(Minion) >= 10.04, perl(Mojolicious) >= 8.24, perl(Try::Tiny) perl(Regexp::Common), perl(Storable)
 # runtime requirements for the main package that are not required by other sub-packages
 %define main_requires %assetpack_requires git-core perl(Carp::Always) perl(Date::Format) perl(DateTime::Format::Pg) perl(DBD::Pg) >= 3.7.4, perl(DBI) >= 1.632, perl(DBIx::Class) >= 0.082801, perl(DBIx::Class::DeploymentHandler) perl(DBIx::Class::DynamicDefault) perl(DBIx::Class::Schema::Config) perl(DBIx::Class::Storage::Statistics) perl(DBIx::Class::OptimisticLocking) perl(File::Copy::Recursive) perl(Net::OpenID::Consumer) perl(Module::Pluggable) perl(aliased) perl(Config::Tiny) perl(Text::Diff) perl(CommonMark) perl(JSON::Validator) perl(IPC::Run) perl(Time::ParseDate) perl(Sort::Versions) perl(BSD::Resource) perl(Pod::POM) perl(Mojo::Pg) perl(Mojo::RabbitMQ::Client) >= 0.2, perl(SQL::Translator) perl(YAML::PP) >= 0.020 perl(YAML::XS) perl(LWP::UserAgent) perl(Getopt::Long::Descriptive)
-%define client_requires curl jq git-core perl(IO::Socket::SSL) >= 2.009, perl(LWP::UserAgent) perl(LWP::Protocol::https) perl(IPC::Run)
+%define client_requires curl jq git-core perl(IO::Socket::SSL) >= 2.009, perl(JSON::Validator) perl(LWP::UserAgent) perl(LWP::Protocol::https) perl(IPC::Run) perl(YAML::PP) >= 0.020 perl(YAML::XS)
 %define worker_requires os-autoinst < 5, perl(Mojo::IOLoop::ReadWriteProcess) > 0.19, perl(Minion::Backend::SQLite) perl(Mojo::SQLite) openQA-client optipng
 %define build_requires rubygem(sass) %assetpack_requires
 

--- a/script/client
+++ b/script/client
@@ -169,7 +169,7 @@ my %options;
 
 sub usage($) {
     my $r = shift;
-    eval { use Pod::Usage; pod2usage(1); };
+    eval { require Pod::Usage; Pod::Usage::pod2usage($r); };
     if ($@) {
         die "cannot display help, install perl(Pod::Usage)\n";
     }
@@ -244,6 +244,7 @@ GetOptions(
     'asset-size-limit:i', 'with-thumbnails', 'accept=s',    'yaml-output',
 ) or usage(1);
 
+usage(0) if $options{help};
 usage(1) unless @ARGV;
 
 if ($options{form} && $options{'json-data'}) {

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -146,7 +146,7 @@ my $remote_url;
 
 sub usage($) {
     my $r = shift;
-    eval "use Pod::Usage; pod2usage($r);";
+    eval { require Pod::Usage; Pod::Usage::pod2usage($r); };
     if ($@) {
         die "cannot display help, install perl(Pod::Usage)\n";
     }
@@ -172,6 +172,7 @@ sub parse_options {
         "skip-chained-deps", "skip-download", "parental-inheritance", "help|h",
         "show-progress",     "within-instance|w=s",
     ) or usage(1);
+    usage(0) if $options{help};
 
     usage(1) if $options{help} || ($options{'within-instance'} && $options{from});
     if ($options{'within-instance'}) {

--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -32,7 +32,7 @@ sub test_once {
 }
 
 test_once '', qr/missing.*help for usage/, 'hint shown for mandatory parameter missing', 255, 'needs parameters';
-test_once '--help',        qr/Usage:/, 'help text shown',              1, 'help screen is not success';
+test_once '--help',        qr/Usage:/, 'help text shown',              0, 'help screen is success';
 test_once '--invalid-arg', qr/Usage:/, 'invalid args also yield help', 1, 'help screen on invalid not success';
 my $args = 'http://openqa.opensuse.org/t1';
 test_once $args, qr/failed to get job '1'/, 'fails without network', 1, 'fail';


### PR DESCRIPTION
So we can test if the client package has all dependencies

* Add openQA-client-test.spec
* Add JSON::Validator, YAML::PP, YAML::XS to client_requires
* Fix `script/client` to exit with 0 when called with `--help`

Currently testing in https://build.opensuse.org/package/show/home:tinita:branches:devel:openQA/openQA

