### PR TITLE
Fix triggering ObsSync using repository

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Gru.pm
@@ -106,13 +106,12 @@ sub run {
     if ($repo) {
         $folder_repo = $project . "::" . $repo;
         $folder_repo = "" unless -d Mojo::File->new($home, $folder_repo);
+        $project     = $folder_repo if $folder_repo;
     }
     # repository may be defined as tail of folder name or inside project's folder
     # thus not obvious checks to make configuration more flexible
-    if (!-d $folder) {
-        return undef if !$folder_repo && $helper->check_and_render_error($project);
-        $project = $folder_repo if $folder_repo;
-    }
+    return undef if !$folder_repo && !-d $folder && $helper->check_and_render_error($project);
+
     if ($repo && !$folder_repo && $helper->get_api_repo($project) ne $repo) {
         return $self->render(json => {message => 'repository ignored'}, status => IGNORED);
     }

--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -29,6 +29,7 @@ $Test::Strict::TEST_SKIP     = [
     't/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm',
     # Skip data file which is supposed to resemble generated output which has no 'use' statements
     't/data/40-templates.pl',
+    't/data/openqa-trigger-from-obs/Proj2::appliances/empty.txt',
     't/data/openqa-trigger-from-obs/Proj3::standard/empty.txt',
 ];
 all_perl_files_ok(qw(lib script t));

--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -73,6 +73,16 @@ subtest 'smoke' => sub {
 
 $t->app->minion->perform_jobs;
 
+subtest 'appliances' => sub {
+    $t->put_ok('/api/v1/obs_rsync/Proj2/runs?repository=images')->status_is(201, "trigger with repository parameter");
+    $t->put_ok('/api/v1/obs_rsync/Proj2/runs?repository=images')
+      ->status_is(208, "trigger with repository parameter again");
+    $t->put_ok('/api/v1/obs_rsync/Proj2/runs?repository=appliances')
+      ->status_is(201, "trigger with different repository");
+};
+
+$t->app->minion->perform_jobs;
+
 sub test_queue {
     my $t = shift;
     $t->put_ok('/api/v1/obs_rsync/Proj2/runs?repository=wrong')


### PR DESCRIPTION
Parameter repository was ignored in Sync request if folder with default repository exists for the same project in ObsRsync Plugin