### PR TITLE
Revert "Rewrite asset list generation for cache service"

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -18,8 +18,7 @@ package OpenQA::Worker::Engines::isotovideo;
 use strict;
 use warnings;
 
-use OpenQA::Utils qw(base_host locate_asset log_error log_info log_debug
-  log_warning get_channel_handle asset_type_from_setting);
+use OpenQA::Utils qw(base_host locate_asset log_error log_info log_debug log_warning get_channel_handle);
 use POSIX qw(:sys_wait_h strftime uname _exit);
 use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();
@@ -78,29 +77,30 @@ sub _save_vars {
     close($fd);
 }
 
+# When changing something here, also take a look at OpenQA::Utils::asset_type_from_setting
 sub detect_asset_keys {
     my ($vars) = @_;
 
     my %res;
-
-    for my $key (keys(%$vars)) {
-        my $value = $vars->{$key};
-
-        # UEFI_PFLASH_VARS may point to an image uploaded by a previous
-        # test (which we should treat as an hdd asset), or it may point
-        # to an absolute filesystem location of e.g. a template file from
-        # edk2 (which we shouldn't).
-        next if $key eq 'UEFI_PFLASH_VARS' && $value =~ m,^/,;
-
-        # Skip external assets, they're handled elsewhere.
-        next if $vars->{$key . '_URL'} || $vars->{$key . '_DECOMPRESS_URL'};
-        my $type = asset_type_from_setting($key, $value);
-
-        # Exclude repo assets for now because the cache service does not
-        # handle directories
-        next if $type eq 'repo' || !$type;
-        $res{$key} = $type;
+    for my $isokey (qw(ISO), map { "ISO_$_" } (1 .. 9)) {
+        $res{$isokey} = 'iso' if $vars->{$isokey};
     }
+
+    for my $otherkey (qw(KERNEL INITRD)) {
+        $res{$otherkey} = 'other' if $vars->{$otherkey};
+    }
+
+    my $nd = $vars->{NUMDISKS} || 2;
+    for my $i (1 .. $nd) {
+        my $hddkey = "HDD_$i";
+        $res{$hddkey} = 'hdd' if $vars->{$hddkey};
+    }
+
+    # UEFI_PFLASH_VARS may point to an image uploaded by a previous
+    # test (which we should treat as an hdd asset), or it may point
+    # to an absolute filesystem location of e.g. a template file from
+    # edk2 (which we shouldn't).
+    $res{UEFI_PFLASH_VARS} = 'hdd' if ($vars->{UEFI_PFLASH_VARS} && $vars->{UEFI_PFLASH_VARS} !~ m,^/,);
 
     return \%res;
 }

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -48,29 +48,23 @@ subtest 'isotovideo version' => sub {
 
 subtest 'asset settings' => sub {
     my $settings = {
-        DISTRI                 => 'Unicorn',
-        FLAVOR                 => 'pink',
-        VERSION                => '42',
-        BUILD                  => '666',
-        ISO                    => 'whatever.iso',
-        ISO_1                  => 'another.iso',
-        ISO_2_URL              => 'http://example.net/third.iso',
-        KERNEL                 => 'linux',
-        INITRD                 => 'initrd',
-        ASSET_1                => 'data.tar.gz',
-        ASSET_2_URL            => 'https://example.net/file.dat',
-        ASSET_2                => 'renamed.dat',
-        ASSET_3_DECOMPRESS_URL => 'https://example.net/packed.dat.gz',
-        ASSET_3                => 'unpacked.dat',
-        DESKTOP                => 'DESKTOP',
-        KVM                    => 'KVM',
-        ISO_MAXSIZE            => 1,
-        MACHINE                => 'RainbowPC',
-        ARCH                   => 'x86_64',
-        TEST                   => 'testA',
-        NUMDISKS               => 3,
-        WORKER_CLASS           => 'testAworker',
-        UEFI_PFLASH_VARS       => 'however.qcow2'
+        DISTRI           => 'Unicorn',
+        FLAVOR           => 'pink',
+        VERSION          => '42',
+        BUILD            => '666',
+        ISO              => 'whatever.iso',
+        ISO_1            => 'another.iso',
+        KERNEL           => 'linux',
+        INITRD           => 'initrd',
+        DESKTOP          => 'DESKTOP',
+        KVM              => 'KVM',
+        ISO_MAXSIZE      => 1,
+        MACHINE          => 'RainbowPC',
+        ARCH             => 'x86_64',
+        TEST             => 'testA',
+        NUMDISKS         => 3,
+        WORKER_CLASS     => 'testAworker',
+        UEFI_PFLASH_VARS => 'however.qcow2'
     };
 
     my $expected = {
@@ -79,7 +73,6 @@ subtest 'asset settings' => sub {
         'UEFI_PFLASH_VARS' => 'hdd',
         'KERNEL'           => 'other',
         'INITRD'           => 'other',
-        'ASSET_1'          => 'other',
     };
 
     my $got = OpenQA::Worker::Engines::isotovideo::detect_asset_keys($settings);


### PR DESCRIPTION
Reverts os-autoinst/openQA#2860 due to
https://progress.opensuse.org/issues/64866
breaking jobs using dynamic asset downloading.