### PR TITLE
JUnit log parser should support softfail overall

### DIFF
--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -575,6 +575,15 @@ subtest junit_parse => sub {
     is scalar @{$parser->results->first->details}, 33, '33 test cases details';
     is $_->{result}, 'fail', 'All testcases are failing' for @{$parser->results->first->details};
 
+    $parser = OpenQA::Parser::Format::JUnit->new;
+
+    $junit_test_file = path($FindBin::Bin, "data")->child("junit-results-output-softfail.xml");
+
+    $parser->load($junit_test_file);
+
+    is $parser->results->first->result, 'softfail', 'First testsuite softfails as testcases are softfailing';
+    is scalar @{$parser->results->first->details}, 1, '1 test cases details';
+    is $_->{result}, 'softfail', 'All testcases are softfailing' for @{$parser->results->first->details};
 };
 
 sub test_tap_file {

--- a/t/data/junit-results-output-softfail.xml
+++ b/t/data/junit-results-output-softfail.xml
@@ -1,0 +1,10 @@
+<testsuites id="0" error="n/a" failures="0" softfailures="1" name="hotplugging" skipped="0" tests="1" time="02:03:56">
+  <testsuite id="0" error="n/a" failures="0" softfailures="1" hostname="localhost" name="SUSE Linux Enterprise Server 15 SP2 Snapshot9 (x86_64)" package="hotplugging" skipped="0" tests="1" time="02:03:56" timestamp="Tue Mar 31 05:03:00 2020">
+    <testcase classname="bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning" name="bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning" status="softfail" time="n/a">
+      <system-err>n/a</system-err>
+      <system-out>n/a time cost: n/a</system-out>
+      <failure>affected subject: sles-11-sp4-64-pv-def-net</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+

--- a/t/data/slenkins_control-junit-results-fail.xml
+++ b/t/data/slenkins_control-junit-results-fail.xml
@@ -1,5 +1,5 @@
 <testsuites>
-  <testsuite package="Scenario-1" hostname="localhost" timestamp="2018-02-13T10:17:36" name="Default configuration">
+  <testsuite failures="33" softfailures="0" package="Scenario-1" hostname="localhost" timestamp="2018-02-13T10:17:36" name="Default configuration">
     <properties/>
     <testcase classname="server.default-configuration" status="failure" name="server.default-configuration" time="0.015">
       <failure message="(unknown)" type="randomError"><![CDATA[Error while initializing library: Unknown plugin.


### PR DESCRIPTION
At the test suite level if there is counter that indicates soft failures exist and at the same time no failures exist, the overall test result should be softfail.

At the test case level if individual test case status indicates soft falure judging by leading 'softfail' string, it will be replaced by status 'softfail'. And if the overall test result had not been determined by then, it still can be decided by the status of individual test case, for example, the overall test result should be 'softfail' if it is not 'fail' and 'softfail' test case exists.

Also added new JUnit parser unit test into t/30-test_parser.t, including slenkins_control-junit-results-fail and junit-results-output-softfail to make test and coverage test. So the changed part has been tested and the coverage percentage also increases to 98.6% from its previous 95% for JUnit module.

- Related test scenarios: All test suites that have soft failed modules and, at the same time generate corresponding JUnit log output.
- Needles: n/a
- Verification run: http://10.67.133.40/tests/21
