### PR TITLE
Improve the operation of 'jobs post'

### DIFF
--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 
-package OpenQA::ExpandPlaceholder;
+package OpenQA::JobSettings;
 
 use strict;
 use warnings;
@@ -48,6 +48,20 @@ sub _expand_placeholder {
     $value =~ s/%(\w+)%/_expand_placeholder($settings, $1, \%visited_placeholders)/eg;
 
     return $value;
+}
+
+# allow some messing with the usual precedence order. If anything
+# sets +VARIABLE, that setting will be used as VARIABLE regardless
+# (so a product or template +VARIABLE beats a post'ed VARIABLE).
+# if *multiple* things set +VARIABLE, whichever comes highest in
+# the usual precedence order wins.
+sub handle_plus_in_settings {
+    my ($settings) = @_;
+    for (keys %$settings) {
+        if (substr($_, 0, 1) eq '+') {
+            $settings->{substr($_, 1)} = delete $settings->{$_};
+        }
+    }
 }
 
 1;

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -26,7 +26,7 @@ use Try::Tiny;
 use OpenQA::App;
 use OpenQA::Log qw(log_debug log_warning);
 use OpenQA::Utils;
-use OpenQA::ExpandPlaceholder;
+use OpenQA::JobSettings;
 use OpenQA::JobDependencies::Constants;
 use OpenQA::Scheduler::Client;
 use Mojo::JSON qw(encode_json decode_json);
@@ -559,20 +559,11 @@ sub _generate_jobs {
             $settings{PRIO}     = defined($priority) ? $priority : $job_template->prio;
             $settings{GROUP_ID} = $job_template->group_id;
 
-            # allow some messing with the usual precedence order. If anything
-            # sets +VARIABLE, that setting will be used as VARIABLE regardless
-            # (so a product or template +VARIABLE beats a post'ed VARIABLE).
-            # if *multiple* things set +VARIABLE, whichever comes highest in
-            # the usual precedence order wins.
-            for (keys %settings) {
-                if (substr($_, 0, 1) eq '+') {
-                    $settings{substr($_, 1)} = delete $settings{$_};
-                }
-            }
+            OpenQA::JobSettings::handle_plus_in_settings(\%settings);
 
             # variable expansion
             # replace %NAME% with $settings{NAME}
-            my $error = OpenQA::ExpandPlaceholder::expand_placeholders(\%settings);
+            my $error = OpenQA::JobSettings::expand_placeholders(\%settings);
             $error_message .= $error if defined $error;
 
             if (!$args->{MACHINE} || $args->{MACHINE} eq $settings{MACHINE}) {

--- a/lib/OpenQA/Script.pm
+++ b/lib/OpenQA/Script.pm
@@ -42,6 +42,7 @@ sub clone_job_apply_settings {
     my ($argv, $depth, $settings, $options) = @_;
 
     delete $settings->{NAME};    # usually autocreated
+    $settings->{is_clone_job} = 1;    # used to figure out if this is a clone operation
 
     for my $arg (@$argv) {
         # split arg into key and value

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -17,7 +17,7 @@ package OpenQA::WebAPI::Controller::API::V1::Job;
 use Mojo::Base 'Mojolicious::Controller';
 
 use OpenQA::Utils qw(:DEFAULT assetdir);
-use OpenQA::ExpandPlaceholder;
+use OpenQA::JobSettings;
 use OpenQA::Jobs::Constants;
 use OpenQA::Resource::Jobs;
 use OpenQA::Schema::Result::Jobs;
@@ -239,8 +239,9 @@ is mandatory and should be the name of the test.
 =cut
 
 sub create {
-    my $self   = shift;
-    my $params = $self->req->params->to_hash;
+    my $self         = shift;
+    my $params       = $self->req->params->to_hash;
+    my $is_clone_job = delete $params->{is_clone_job} // 0;
 
     # job_create expects upper case keys
     my %up_params = map { uc $_ => $params->{$_} } keys %$params;
@@ -252,12 +253,15 @@ sub create {
 
     my $json = {};
     my $status;
-    my $result = $self->_generate_job_setting(\%params);
-    return $self->render(json => {error => $result->{error_message}}, status => 400)
-      if defined $result->{error_message};
-
+    my $job_settings = \%params;
+    if (!$is_clone_job) {
+        my $result = $self->_generate_job_setting(\%params);
+        return $self->render(json => {error => $result->{error_message}}, status => 400)
+          if defined $result->{error_message};
+        $job_settings = $result->{settings_result};
+    }
     try {
-        my $job = $self->schema->resultset('Jobs')->create_from_settings($result->{settings_result});
+        my $job = $self->schema->resultset('Jobs')->create_from_settings($job_settings);
         $self->emit_event('openqa_job_create', {id => $job->id, %params});
         $json->{id} = $job->id;
 
@@ -850,13 +854,9 @@ sub _generate_job_setting {
     $settings{WORKER_CLASS} = join ',', sort @classes if @classes > 0;
     $settings{uc $_} = $args->{$_} for keys %$args;
 
-    # follow the rule that handles '+' in isos post
-    for (keys %settings) {
-        if (substr($_, 0, 1) eq '+') {
-            $settings{substr($_, 1)} = delete $settings{$_};
-        }
-    }
-    my $error_message = OpenQA::ExpandPlaceholder::expand_placeholders(\%settings);
+    OpenQA::JobSettings::handle_plus_in_settings(\%settings);
+
+    my $error_message = OpenQA::JobSettings::expand_placeholders(\%settings);
     return {error_message => $error_message, settings_result => \%settings};
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -850,6 +850,12 @@ sub _generate_job_setting {
     $settings{WORKER_CLASS} = join ',', sort @classes if @classes > 0;
     $settings{uc $_} = $args->{$_} for keys %$args;
 
+    # follow the rule that handles '+' in isos post
+    for (keys %settings) {
+        if (substr($_, 0, 1) eq '+') {
+            $settings{substr($_, 1)} = delete $settings{$_};
+        }
+    }
     my $error_message = OpenQA::ExpandPlaceholder::expand_placeholders(\%settings);
     return {error_message => $error_message, settings_result => \%settings};
 }

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -64,12 +64,14 @@ subtest 'clone job apply settings tests' => sub {
     $test_settings{HDD_1}        = 'new.qcow2';
     $test_settings{HDDSIZEGB}    = 40;
     $test_settings{WORKER_CLASS} = 'local';
+    $test_settings{is_clone_job} = 1;
     delete $test_settings{NAME};
     clone_job_apply_settings(\@argv, 0, \%child_settings, \%options);
     is_deeply(\%child_settings, \%test_settings, 'cloned child job with correct global setting and new settings');
 
-    %test_settings = %parent_settings;
+    %test_settings               = %parent_settings;
     $test_settings{WORKER_CLASS} = 'local';
+    $test_settings{is_clone_job} = 1;
     delete $test_settings{NAME};
     clone_job_apply_settings(\@argv, 1, \%parent_settings, \%options);
     is_deeply(\%parent_settings, \%test_settings, 'cloned parent job only take global setting');
@@ -78,16 +80,16 @@ subtest 'clone job apply settings tests' => sub {
 subtest '_GROUP and _GROUP_ID override each other' => sub {
     my %settings = ();
     clone_job_apply_settings([qw(_GROUP=foo _GROUP_ID=bar)], 0, \%settings, \%options);
-    is_deeply(\%settings, {_GROUP_ID => 'bar'}, '_GROUP_ID overrides _GROUP');
+    is_deeply(\%settings, {_GROUP_ID => 'bar', is_clone_job => 1}, '_GROUP_ID overrides _GROUP');
     %settings = ();
     clone_job_apply_settings([qw(_GROUP_ID=bar _GROUP=foo)], 0, \%settings, \%options);
-    is_deeply(\%settings, {_GROUP => 'foo'}, '_GROUP overrides _GROUP_ID');
+    is_deeply(\%settings, {_GROUP => 'foo', is_clone_job => 1}, '_GROUP overrides _GROUP_ID');
 };
 
 subtest 'delete empty setting' => sub {
     my %settings = ();
     clone_job_apply_settings([qw(ISO_1= ADDONS=)], 0, \%settings, \%options);
-    is_deeply(\%settings, {}, 'all empty settings removed');
+    is_deeply(\%settings, {is_clone_job => 1}, 'all empty settings removed');
 };
 
 subtest 'asset download' => sub {

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -20,7 +20,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::More;
-use OpenQA::ExpandPlaceholder;
+use OpenQA::JobSettings;
 
 my $settings = {
     BUILD_SDK                => '%BUILD_HA%',
@@ -57,7 +57,7 @@ my $settings = {
 };
 
 subtest expand_placeholders => sub {
-    my $error          = OpenQA::ExpandPlaceholder::expand_placeholders($settings);
+    my $error          = OpenQA::JobSettings::expand_placeholders($settings);
     my $match_settings = {
         BUILD_SDK                => '1234',
         BETA                     => 1,
@@ -109,10 +109,21 @@ subtest circular_reference => sub {
         MACHINE       => '64bit',
     };
     like(
-        OpenQA::ExpandPlaceholder::expand_placeholders($circular_settings),
+        OpenQA::JobSettings::expand_placeholders($circular_settings),
         qr/The key (\w+) contains a circular reference, its value is %\w+%/,
         "circular reference exit successfully"
     );
+};
+
+subtest 'handle_plus_in_settings' => sub {
+    my $settings = {
+        'ISO'    => 'foo.iso',
+        '+ISO'   => 'bar.iso',
+        '+ARCH'  => 'x86_64',
+        'DISTRI' => 'opensuse',
+    };
+    OpenQA::JobSettings::handle_plus_in_settings($settings);
+    is_deeply($settings, {ISO => 'bar.iso', ARCH => 'x86_64', DISTRI => 'opensuse'}, 'handle the plus correctly');
 };
 
 done_testing;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1367,6 +1367,46 @@ subtest 'marking job as done' => sub {
     };
 };
 
+subtest 'handle + in settings when creating a job' => sub {
+    $t->app->schema->resultset('Products')->create(
+        {
+            version     => '12-SP5',
+            name        => '',
+            distri      => 'sle',
+            arch        => 'x86_64',
+            description => '',
+            flavor      => 'DVD',
+            settings    => [
+                {key => 'BETA',         value => '1'},
+                {key => '+ISO_MAXSIZE', value => '4700372992'},
+                {key => '+ISO',         value => 'foo.iso'}
+            ],
+        });
+    $t->app->schema->resultset('TestSuites')->create(
+        {
+            name        => 'handle_plus',
+            description => '',
+            settings    => [{key => 'DESKTOP', value => 'gnome'}, {key => 'ISO_MAXSIZE', value => '50000000'},],
+        });
+    my $params = {
+        VERSION => '12-SP5',
+        DISTRI  => 'sle',
+        ARCH    => 'x86_64',
+        FLAVOR  => 'DVD',
+        TEST    => 'handle_plus',
+        ISO     => 'SLE-12-SP5-Server-DVD-x86_64-GM-DVD1.iso'
+    };
+    $t->post_ok('/api/v1/jobs', form => $params)->status_is(200);
+    my $result = $jobs->find($t->tx->res->json->{id})->settings_hash;
+    $params->{ISO}          = 'foo.iso';
+    $params->{ISO_MAXSIZE}  = '4700372992';
+    $params->{BETA}         = '1';
+    $params->{DESKTOP}      = 'gnome';
+    $params->{WORKER_CLASS} = 'qemu_x86_64';
+    delete $result->{NAME};
+    is_deeply($result, $params, 'handle + in settings correctly');
+};
+
 # delete the job with a registered job module
 $t->delete_ok('/api/v1/jobs/99937')->status_is(200);
 $t->get_ok('/api/v1/jobs/99937')->status_is(404);

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -31,6 +31,7 @@ use OpenQA::Test::Case;
 use OpenQA::Jobs::Constants;
 use OpenQA::Client;
 use OpenQA::Log 'log_debug';
+use OpenQA::Script;
 use Mojo::IOLoop;
 use Mojo::File qw(path tempfile tempdir);
 use Digest::MD5;
@@ -1405,6 +1406,16 @@ subtest 'handle + in settings when creating a job' => sub {
     $params->{WORKER_CLASS} = 'qemu_x86_64';
     delete $result->{NAME};
     is_deeply($result, $params, 'handle + in settings correctly');
+};
+
+subtest 'do not re-generate settings when cloning job' => sub {
+    my $job_settings = $jobs->search({test => 'handle_plus'})->first->settings_hash;
+    clone_job_apply_settings([qw(BETA= DESKTOP=)], 0, $job_settings, {});
+    $t->post_ok('/api/v1/jobs', form => $job_settings)->status_is(200);
+    my $new_job_settings = $jobs->find($t->tx->res->json->{id})->settings_hash;
+    delete $job_settings->{is_clone_job};
+    delete $new_job_settings->{NAME};
+    is_deeply($new_job_settings, $job_settings, 'did not re-generate settings');
 };
 
 # delete the job with a registered job module


### PR DESCRIPTION
In the current code, the settings start with + will be added to the job when creating a job using `jobs post` as `{+key => value}`.
Handle this by following the rule that defined in `schedule_iso`

When we cloning a job, the settings that removed by clone script are added into the job's settings again if the settings are defined in TestSuite or Product or Machine. Because the create job function re-generate the settings.

See: https://progress.opensuse.org/issues/63883
https://progress.opensuse.org/issues/63565