### PR TITLE
Cover broken needle code path in a unit test

### DIFF
--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -29,7 +29,7 @@ use OpenQA::App;
 use OpenQA::Git;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
-use OpenQA::Utils qw(log_error locate_needle);
+use OpenQA::Utils qw(locate_needle);
 
 __PACKAGE__->table('needles');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -168,14 +168,9 @@ sub serve_static_ {
     my ($self, $asset) = @_;
 
     $self->app->log->debug("looking for " . pp($asset) . " in " . pp($self->{static}->paths));
-    if ($asset && !ref($asset)) {
-        # TODO: check for plain file name
-        $asset = $self->{static}->file($asset);
-    }
-
-    $self->app->log->debug("found " . pp($asset));
-
+    $asset = $self->{static}->file($asset) if $asset && !ref($asset);
     return $self->reply->not_found unless $asset;
+    $self->app->log->debug("found " . pp($asset));
 
     if (ref($asset) eq "Mojo::Asset::File") {
         my $filename = basename($asset->path);


### PR DESCRIPTION
- Distinguish parsing errors from "Not found"
- Failure to parse the JSON was not covered
- The found log should appear only when it was found
- Use refresh API in webdriver