### PR TITLE
Turn warning about missing assets when restarting jobs into error

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -16,7 +16,7 @@ function setupOverview() {
                 addFlash('danger', '<strong>Unable to restart job.</strong>');
                 return;
             }
-            showWarningsFromJobRestart(xhr);
+            showJobRestartResults(xhr);
             var newId = xhr.result[0];
             $.each(newId, function(key, value) {
                 if (!$('.restart[data-jobid="' + key + '"]').length) {

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -425,7 +425,7 @@ function setupTestButtons() {
                 addFlash('danger', '<strong>Unable to restart job.</strong>', flashTarget);
                 return;
             }
-            showWarningsFromJobRestart(responseJSON, undefined, flashTarget);
+            showJobRestartResults(responseJSON, undefined, flashTarget);
             var urls = responseJSON.test_url[0];
             $.each(urls , function(key, value) {
                 // Skip to mark the job that is not shown in current page


### PR DESCRIPTION
* Allow forcing the restart via API
* Suggest restarting parent job if there is one
* See https://progress.opensuse.org/issues/34783
---
![screenshot_20200401_113614](https://user-images.githubusercontent.com/10248953/78122447-0d9cd400-740d-11ea-8d3e-7d8638c1bcc4.png)