### PR TITLE
Improve Perl module search paths of some tests

### DIFF
--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -20,7 +20,7 @@ use warnings;
 use Test::Exception;
 use Test::More;
 use FindBin;
-use lib "$FindBin::Bin/../script";
+use lib "$FindBin::Bin/lib";
 use OpenQA::Test::Utils qw(run_cmd test_cmd);
 
 

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -15,6 +15,8 @@
 
 use Mojo::Base -strict;
 
+use FindBin;
+use lib "$FindBin::Bin/lib";
 use File::Temp qw(tempfile);
 use Mojo::File qw(path curfile);
 use OpenQA::Test::Database;

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -16,6 +16,8 @@
 use strict;
 use warnings;
 
+use FindBin;
+use lib "$FindBin::Bin/lib";
 use Test::More;
 use Test::Warnings;
 use Test::Output;


### PR DESCRIPTION
* The script directory does not contain any Perl modules so it is not useful to add it to the search path
* Add the lib directory to the search path where it was missing so one does not have to care about passing `-Ilib` manually.