### PR TITLE
The job result is a string and not a number

### DIFF
--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -39,7 +39,7 @@ sub _cache_tests {
         $job->note(downloading_job => $id);
         $id ||= 'unknown';
         $job->note(output => qq{Sync "$from" to "$to" was performed by #$id, details are therefore unavailable here});
-        return $job->finish(0);
+        return $job->finish;
     }
 
     my $ctx = $app->log->context("[#$job_id]");
@@ -50,7 +50,7 @@ sub _cache_tests {
     $ctx->info("Calling: $cmd");
     my $output = `@cmd`;
     my $status = $? >> 8;
-    $job->finish($status);
+    $job->finish("exit code $status");
     $job->note(output => "[info] [#$job_id] Calling: $cmd\n$output");
     $ctx->info("Finished sync: $status");
 }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -277,21 +277,18 @@ sub engine_workit {
                 }
 
                 # treat "no sync necessary" as success as well
-                my $exit = $status->result // 0;
+                my $result = $status->result // 'exit code 0';
 
-                if (!defined $exit) {
-                    return {error => 'Failed to rsync tests'};
-                }
-                elsif ($exit == 0) {
+                if ($result eq 'exit code 0') {
                     log_info('Finished to rsync tests', channels => 'autoinst');
                     last;
                 }
-                elsif ($remaining_tries > 1 && $exit == 24) {
-                    log_info("Rsync failed due to a vanished source files (exit code 24), trying again",
+                elsif ($remaining_tries > 1 && $result eq 'exit code 24') {
+                    log_info("Rsync failed due to a vanished source files ($result), trying again",
                         channels => 'autoinst');
                 }
                 else {
-                    return {error => "Failed to rsync tests: exit code: $exit"};
+                    return {error => "Failed to rsync tests: $result"};
                 }
             }
 

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -109,7 +109,7 @@ sub test_sync {
     sleep .1 until $cache_client->status($rsync_request)->is_processed;
 
     my $status = $cache_client->status($rsync_request);
-    is $status->result, 0;
+    is $status->result, 'exit code 0';
     ok $status->output;
 
     like $status->output, qr/100\%/ or die diag $status->output;
@@ -468,7 +468,7 @@ subtest 'Test Minion Sync task' => sub {
     $job->perform;
     my $status = $cache_client->status($req);
     ok $status->is_processed;
-    is $status->result, 0;
+    is $status->result, 'exit code 0';
     note $status->output;
 
     ok -e $expected;
@@ -596,7 +596,7 @@ subtest 'Concurrent rsync' => sub {
     $job->perform;
     my $status = $cache_client->status($req);
     ok $status->is_processed, 'is processed';
-    is $status->result, 0, 'expected result';
+    is $status->result, 'exit code 0', 'expected result';
     my $info = $app->minion->job($req->minion_id)->info;
     ok !$info->{notes}{downloading_job}, 'no linked job';
     like $status->output, qr/sending incremental file list/, 'right output';
@@ -614,7 +614,7 @@ subtest 'Concurrent rsync' => sub {
     undef $guard;
     my $status2 = $cache_client->status($req2);
     ok $status2->is_processed, 'is processed';
-    is $status2->result, 0, 'expected result';
+    is $status2->result, undef, 'expected result';
     my $info2 = $app->minion->job($req2->minion_id)->info;
     ok $info2->{notes}{downloading_job}, 'downloading job is linked';
     like $info2->{notes}{output}, qr/Sync ".+" to ".+" was performed by #\d+, details are therefore unavailable here/,
@@ -627,7 +627,7 @@ subtest 'Concurrent rsync' => sub {
     $app->minion->job($req->minion_id)->remove;
     my $status3 = $cache_client->status($req2);
     ok $status3->is_processed, 'is processed';
-    is $status3->result,       0, 'expected result';
+    is $status3->result,       undef, 'expected result';
     like $status3->output,     qr/Sync ".+" to ".+" was performed by #\d+, details are therefore unavailable here/,
       'right output';
 };


### PR DESCRIPTION
Very simple patch, for something that should happen very very rarely.

While the happy path of the sync job always results in an exit code for
the job result, a catastrophic failure in the job will store the
exception as a string. So make sure isotovideo.pm can handle both cases
gracefully.

Progress: https://progress.opensuse.org/issues/64743