### PR TITLE
Cover web UI being down multiple minutes in worker connection retries

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -314,9 +314,9 @@ sub send {
         $msg //= $err->{message};
         if (my $error_code = $err->{code}) {
             $msg = "$error_code response: $msg";
-            if ($error_code == 404) {
-                # don't retry on 404 errors (in this case we can't expect different
-                # results on further attempts)
+            if (400 <= $error_code && $error_code < 500) {
+                # don't retry on most 4xx errors (in this case we can't expect
+                # different results on further attempts)
                 $tries = 0;
             }
             else {

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -240,7 +240,7 @@ sub finish_websocket_connection {
 
 # define list of HTTP error codes which indicate that the web UI is overloaded or down for maintenance
 # (in these cases the re-try delay should be increased)
-my %BUSY_ERROR_CODES = map { $_ => 1 } 502, 503, 504, 598;
+my %BUSY_ERROR_CODES = map { $_ => 1 } 408, 425, 502, 503, 504, 598;
 
 sub _retry_delay {
     my ($self, $is_webui_busy) = @_;
@@ -314,7 +314,7 @@ sub send {
         $msg //= $err->{message};
         if (my $error_code = $err->{code}) {
             $msg = "$error_code response: $msg";
-            if (400 <= $error_code && $error_code < 500) {
+            if (400 <= $error_code && $error_code < 500 && $error_code != 408 && $error_code != 425) {
                 # don't retry on most 4xx errors (in this case we can't expect
                 # different results on further attempts)
                 $tries = 0;

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -260,7 +260,7 @@ sub send {
     my $params    = $args{params};
     my $json_data = $args{json};
     my $callback  = $args{callback} // sub { };
-    my $tries     = $args{tries} // 3;
+    my $tries     = $args{tries} // $self->worker->settings->global_settings->{RETRIES} // 60;
 
     # if set ignore errors completely and don't retry
     my $ignore_errors = $args{ignore_errors} // 0;

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -302,13 +302,17 @@ qr/Connection error: some timeout \(remaining tries: 2\).*Connection error: some
 
         $callback_invoked = $retry_delay_invoked = 0;
         $fake_ua->start_count(0);
-        $fake_error->{code} = 502;
-        send_once(\@send_args,
-qr/502 response: some timeout \(remaining tries: 2\).*502 response: some timeout \(remaining tries: 1\).*502 response: some timeout \(remaining tries: 0\)/s
+        my %codes_retry_ok = (
+            502 => 'Bad Gateway (some timeout)',
         );
-        is($fake_ua->start_count, 3, 'tried 3 times');
-        is($callback_invoked,     1, 'callback invoked exactly one time');
-        is($retry_delay_invoked,  2, 'retry delay queried');
+        for (sort keys %codes_retry_ok) {
+            my $code = $fake_error->{code} = $_;
+            send_once(\@send_args,
+                qr/$code response: some timeout \(remaining tries: 2\).*$code response: some timeout \(remaining tries: 1\).*$code response: some timeout \(remaining tries: 0\)/s);
+            is($fake_ua->start_count, 3, "tried 3 times for $code");
+            is($callback_invoked,     1, "callback invoked exactly one time for $code");
+            is($retry_delay_invoked,  2, "retry delay queried for $code");
+        }
     };
 
     subtest 'retry after unknown API error' => sub {
@@ -325,15 +329,24 @@ qr/502 response: some timeout \(remaining tries: 2\).*502 response: some timeout
         is($retry_delay_invoked,  1, 'retry delay queried');
     };
 
-    subtest 'no retry after 404' => sub {
+    subtest 'no retry after 4XX (with exceptions)' => sub {
         $callback_invoked = $retry_delay_invoked = 0;
         $fake_ua->start_count(0);
-        $fake_error->{message} = 'Not found';
-        $fake_error->{code}    = 404;
-        send_once(\@send_args, qr/404 response: Not found \(remaining tries: 0\)/, '404 logged');
-        is($fake_ua->start_count, 1, 'tried 1 time');
-        is($callback_invoked,     1, 'callback invoked exactly one time');
-        is($retry_delay_invoked,  0, 'retry delay not queried');
+        my %codes_4xx = (
+            404 => 'Not found',
+        );
+        my $start_count = 1;
+        my $callback_count = 1;
+        for (sort keys %codes_4xx) {
+            $fake_error->{code}    = $_;
+            $fake_error->{message} = $codes_4xx{$_};
+            send_once(\@send_args,
+                qr/$fake_error->{code} response: $fake_error->{message} \(remaining tries: 0\)/,
+                "$fake_error->{code} logged");
+            is($fake_ua->start_count, $start_count++, "tried 1 time for $fake_error->{code}");
+            is($callback_invoked,     $callback_count++, "callback invoked exactly one time for $fake_error->{code}");
+            is($retry_delay_invoked,  0, "retry delay not queried $fake_error->{code}");
+        }
     };
 
     subtest 'no retry if ignoring errors' => sub {

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -333,7 +333,12 @@ qr/Connection error: some timeout \(remaining tries: 2\).*Connection error: some
         $callback_invoked = $retry_delay_invoked = 0;
         $fake_ua->start_count(0);
         my %codes_4xx = (
+            400 => 'Not found',
+            401 => 'Unauthorized',
+            403 => 'Forbidden',
             404 => 'Not found',
+            418 => 'I\'m a teapot',
+            426 => 'Upgrade Required',
         );
         my $start_count = 1;
         my $callback_count = 1;


### PR DESCRIPTION
Retry connection attempts to web UI for multiple minutes to ensure we
can continue jobs when for example the web UI host reboots.

Related progress issue: https://progress.opensuse.org/issues/57620