### PR TITLE
t: Make test database inserts fatal to detect early

### DIFF
--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -14,7 +14,6 @@ use OpenQA::Schema;
 use OpenQA::Log 'log_info';
 use OpenQA::Utils 'random_string';
 use Mojo::File 'path';
-use Try::Tiny;
 
 has fixture_path => 't/fixtures';
 
@@ -65,7 +64,6 @@ sub insert_fixtures {
     my %ids;
 
     foreach my $fixture (glob "*.pl") {
-
         my $info = eval path($fixture)->slurp;    ## no critic
         chdir $cwd, croak "Could not insert fixture $fixture: $@" if $@;
 
@@ -84,13 +82,8 @@ sub insert_fixtures {
         for (my $i = 0; $i < @$info; $i++) {
             my $class = $info->[$i];
             my $ri    = $info->[++$i];
-            try {
-                my $row = $schema->resultset($class)->create($ri);
-                $ids{$row->result_source->from} = $ri->{id} if $ri->{id};
-            }
-            catch {
-                croak "Could not insert fixture " . path($fixture)->to_rel($cwd) . ": $_";
-            };
+            my $row = $schema->resultset($class)->create($ri);
+            $ids{$row->result_source->from} = $ri->{id} if $ri->{id};
         }
     }
 


### PR DESCRIPTION
Previously the error message could look like this for invalid data in
the fixtures:

```
$ prove -l t/10-jobs.t
t/10-jobs.t .. Could not insert fixture t/fixtures/01-jobs.pl: DBIx::Class::Row::store_column(): No such column 'foo' on OpenQA::Schema::Result::Assets at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/Test/Database.pm line 88
 at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/Test/Database.pm line 93.
t/10-jobs.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run

…
Result: FAIL
```

The new format is like this:

```
$ prove -l t/10-jobs.t
t/10-jobs.t .. DBIx::Class::Row::store_column(): No such column 'foo' on OpenQA::Schema::Result::Assets at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/Test/Database.pm line 85
t/10-jobs.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run

…
Result: FAIL
```
