### PR TITLE
Provide enqueue convenience scripts rather than systemd

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -422,6 +422,10 @@ fi
 %{_datadir}/openqa/script/openqa-scheduler
 %{_datadir}/openqa/script/openqa-websockets
 %{_datadir}/openqa/script/openqa-livehandler
+%{_datadir}/openqa/script/openqa-enqueue-asset-cleanup
+%{_datadir}/openqa/script/openqa-enqueue-audit-event-cleanup
+%{_datadir}/openqa/script/openqa-enqueue-bug-cleanup
+%{_datadir}/openqa/script/openqa-enqueue-result-cleanup
 %{_datadir}/openqa/script/upgradedb
 %{_datadir}/openqa/script/modify_needle
 # TODO: define final user

--- a/script/openqa-enqueue-asset-cleanup
+++ b/script/openqa-enqueue-asset-cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec "$(dirname "$0")"/openqa eval -m production -V 'app->gru->enqueue_limit_assets()' "$@"

--- a/script/openqa-enqueue-audit-event-cleanup
+++ b/script/openqa-enqueue-audit-event-cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec "$(dirname "$0")"/openqa minion -m production job -e limit_audit_events "$@"

--- a/script/openqa-enqueue-bug-cleanup
+++ b/script/openqa-enqueue-bug-cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec "$(dirname "$0")"/openqa minion -m production job -e limit_bugs "$@"

--- a/script/openqa-enqueue-result-cleanup
+++ b/script/openqa-enqueue-result-cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec "$(dirname "$0")"/openqa eval -m production -V 'app->gru->enqueue(limit_results_and_logs => [], {priority => 5, ttl => 172800, limit => 1})' "$@"

--- a/systemd/openqa-enqueue-asset-cleanup.service
+++ b/systemd/openqa-enqueue-asset-cleanup.service
@@ -6,4 +6,4 @@ Wants=openqa-setup-db.service
 [Service]
 Type=oneshot
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa eval -m production -V 'app->gru->enqueue_limit_assets()'
+ExecStart=/usr/share/openqa/script/openqa-enqueue-asset-cleanup

--- a/systemd/openqa-enqueue-audit-event-cleanup.service
+++ b/systemd/openqa-enqueue-audit-event-cleanup.service
@@ -6,4 +6,4 @@ Wants=openqa-setup-db.service
 [Service]
 Type=oneshot
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa minion -m production job -e limit_audit_events
+ExecStart=/usr/share/openqa/script/openqa-audit-event-cleanup

--- a/systemd/openqa-enqueue-bug-cleanup.service
+++ b/systemd/openqa-enqueue-bug-cleanup.service
@@ -6,4 +6,4 @@ Wants=openqa-setup-db.service
 [Service]
 Type=oneshot
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa minion -m production job -e limit_bugs
+ExecStart=/usr/share/openqa/script/openqa-enqueue-bug-cleanup

--- a/systemd/openqa-enqueue-result-cleanup.service
+++ b/systemd/openqa-enqueue-result-cleanup.service
@@ -6,4 +6,4 @@ Wants=openqa-setup-db.service
 [Service]
 Type=oneshot
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa eval -m production -V 'app->gru->enqueue(limit_results_and_logs => [], {priority => 5, ttl => 172800, limit => 1})'
+ExecStart=/usr/share/openqa/script/openqa-enqueue-result-cleanup


### PR DESCRIPTION
systemd startup scripts should not have too much business logic and not
duplicate what a startup in other environments e.g. containers would
need as well. This can simplify containerization of services at least
regarding the job enqueue services we have.