### PR TITLE
Cover web UI being down multiple minutes - alternative to #2895 with no 408/425 exception

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -260,7 +260,7 @@ sub send {
     my $params    = $args{params};
     my $json_data = $args{json};
     my $callback  = $args{callback} // sub { };
-    my $tries     = $args{tries} // 3;
+    my $tries     = $args{tries} // $self->worker->settings->global_settings->{RETRIES} // 60;
 
     # if set ignore errors completely and don't retry
     my $ignore_errors = $args{ignore_errors} // 0;

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -314,9 +314,9 @@ sub send {
         $msg //= $err->{message};
         if (my $error_code = $err->{code}) {
             $msg = "$error_code response: $msg";
-            if ($error_code == 404) {
-                # don't retry on 404 errors (in this case we can't expect different
-                # results on further attempts)
+            if (400 <= $error_code && $error_code < 500) {
+                # don't retry on 4xx errors (in this case we should not expect
+                # different results on further attempts)
                 $tries = 0;
             }
             else {

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -329,7 +329,12 @@ qr/502 response: some timeout \(remaining tries: 2\).*502 response: some timeout
         $callback_invoked = $retry_delay_invoked = 0;
         $fake_ua->start_count(0);
         my %codes_4xx = (
+            400 => 'Not found',
+            401 => 'Unauthorized',
+            403 => 'Forbidden',
             404 => 'Not found',
+            418 => 'I\'m a teapot',
+            426 => 'Upgrade Required',
         );
         my $start_count = 1;
         my $callback_count = 1;


### PR DESCRIPTION
* Prevent more useless retries for worker-webui connect
* Extend retry in worker-webui connect to cover rebooting hosts
* t: Extend 24-worker-webui-connection.t to check different retry codes
* t: Extract method for send in 24-worker-webui-connection.t