### PR TITLE
Simplify Schema::Results::Jobs

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -351,6 +351,8 @@ sub reschedule_state {
     }
 }
 
+sub log_debug_job { log_debug('[Job#' . shift->id . '] ' . shift) }
+
 sub set_assigned_worker {
     my ($self, $worker) = @_;
 
@@ -369,7 +371,7 @@ sub prepare_for_work {
     my ($self, $worker, $worker_properties) = @_;
     return undef unless $worker;
 
-    log_debug("[Job#" . $self->id . "] Prepare for being processed by worker " . $worker->id);
+    $self->log_debug_job('Prepare for being processed by worker ' . $worker->id);
 
     my $job_hashref = {};
     $job_hashref = $self->to_hash(assets => 1);
@@ -936,7 +938,7 @@ sub scheduler_abort {
     my ($self, $worker) = @_;
     return unless $self->worker || $worker;
     $worker = $self->worker unless $worker;
-    log_debug("[Job#" . $self->id . "] Sending scheduler_abort command to worker: " . $worker->id);
+    $self->log_debug_job('Sending scheduler_abort command to worker: ' . $worker->id);
     $worker->send_command(command => 'scheduler_abort', job_id => $self->id);
 }
 
@@ -953,12 +955,11 @@ sub set_running {
     }
 
     if ($self->state eq RUNNING) {
-        log_debug("[Job#" . $self->id . "] is in the running state");
+        $self->log_debug_job('is in the running state');
         return 1;
     }
     else {
-        log_debug(
-            "[Job#" . $self->id . "] is already in state '" . $self->state . "' with result '" . $self->result . "'");
+        $self->log_debug_job("is already in state '" . $self->state . "' with result '" . $self->result . "'");
         return 0;
     }
 }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -256,10 +256,8 @@ sub delete {
     # last step: remove result directory if already existant
     # This must be executed after $self->SUPER::delete because it might fail and result_dir should not be
     # deleted in the error case
-    if ($self->result_dir() && -d $self->result_dir()) {
-        File::Path::rmtree($self->result_dir());
-    }
-
+    my $res_dir = $self->result_dir();
+    File::Path::rmtree($res_dir) if $res_dir && -d $res_dir;
     return $ret;
 }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -463,20 +463,16 @@ sub deps_hash {
 
 sub add_result_dir_prefix {
     my ($self, $rd) = @_;
-
-    return catfile($self->num_prefix_dir, $rd) if $rd;
-    return;
+    return $rd ? catfile($self->num_prefix_dir, $rd) : undef;
 }
 
 sub remove_result_dir_prefix {
     my ($self, $rd) = @_;
-    return basename($rd) if $rd;
-    return;
+    return $rd ? basename($rd) : undef;
 }
 
 sub set_prio {
     my ($self, $prio) = @_;
-
     $self->update({priority => $prio});
 }
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -659,7 +659,9 @@ subtest 'create result dir, delete logs' => sub {
     my $ulogs_dir    = path($result_dir, 'ulogs')->make_path;
     my $file_content = Encode::encode('UTF-8', 'this text is 26 bytes long');
     path($result_dir, $_)->spurt($file_content) for qw(autoinst-log.txt video.ogv serial0.txt serial_terminal.txt);
-    path($ulogs_dir,  $_)->spurt($file_content) for qw(foo.log bar.log);
+    my @ulogs = qw(bar.log foo.log);
+    path($ulogs_dir, $_)->spurt($file_content) for @ulogs;
+    is_deeply $job->test_uploadlog_list, \@ulogs, 'logs linked to job as uploaded';
 
     # delete logs
     $job->delete_logs;

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -76,16 +76,20 @@ sub _job_create {
     return $job;
 }
 
-subtest 'scenario description' => sub {
-    my $minimalx_job = $schema->resultset('Jobs')->find(99926);
-    is($minimalx_job->scenario_description, undef, 'return undef if no description');
+subtest 'name/label/scenario and description' => sub {
+    my $job = $schema->resultset('Jobs')->find(99926);
+    is $job->name,          'opensuse-Factory-staging_e-x86_64-Build87.5011-minimalx@32bit', 'job name';
+    is $job->label,         'minimalx@32bit',                                                'job label';
+    is $job->scenario,      undef,                                                           'test scenario';
+    is $job->scenario_name, 'opensuse-Factory-staging_e-x86_64-minimalx@32bit',              'test scenario name';
+    is $job->scenario_description, undef, 'return undef if no description';
 
     my $minimalx_testsuite = $schema->resultset('TestSuites')->create(
         {
             name        => 'minimalx',
             description => 'foobar',
         });
-    is($minimalx_job->scenario_description, 'foobar', 'description returned');
+    is($job->scenario_description, 'foobar', 'description returned');
     $minimalx_testsuite->delete;
 };
 


### PR DESCRIPTION
I went over the complete file and applied the following changes among
others:

* Use post-condition where feasible to save lines
* Use map rather for-loops with push
* Extract methods for common code
* Use early returns rather than big indented if-blocks

I am open to feedback for all the little details and can easily split my commits or PRs as required.