### PR TITLE
t: Provide info in 43-scheduling-and-worker-scalability.t also in non-verbose

### DIFF
--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -120,7 +120,7 @@ sub log_jobs {
     my @job_info
       = map { sprintf("id: %s, state: %s, result: %s, reason: %s", $_->id, $_->state, $_->result, $_->reason // 'none') }
       $jobs->search({}, {order_by => 'id'});
-    note("All jobs:\n - " . join("\n - ", @job_info));
+    diag("All jobs:\n - " . join("\n - ", @job_info));
 }
 my %job_ids;
 my @job_settings = (


### PR DESCRIPTION
The test 43-scheduling-and-worker-scalability.t calls the internal
output helper function "job_info" only on failure but so far uses "note"
which only logs in verbose mode or into the external harness log files.
In case of failure we can benefit from a more verbose output in both CI
as well as local runs directly next to the test results.

Example output:

```
t/43-scheduling-and-worker-scalability.t .. 1/?
    #   Failed test 'all jobs done'
    #   at t/43-scheduling-and-worker-scalability.t line 196.
    #          got: '5'
    #     expected: '6'
    # All jobs:
    #  - id: 1, state: done, result: passed, reason: none
    #  - id: 2, state: done, result: passed, reason: none
    #  - id: 3, state: done, result: passed, reason: none
    #  - id: 4, state: done, result: passed, reason: none
    #  - id: 5, state: done, result: passed, reason: none
```