### PR TITLE
Move log setup into log module

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -568,7 +568,7 @@ test locally under the same condition set the environment variable
 `OPENQA_LOGFILE`.
 
 Note that redirecting the logs to a logfile only works for tests which run
-`OpenQA::Setup::setup_log`. In other tests the log is just printed to the
+`OpenQA::Log::setup_log`. In other tests the log is just printed to the
 standard output. This makes use of `Test::Output` simple but it should be
 taken care that the test output is not cluttered by log messages which can be
 quite irritating.

--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -19,6 +19,7 @@ use Mojo::Base 'Mojolicious';
 use Mojolicious 7.18;
 use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
+use OpenQA::Log 'setup_log';
 use OpenQA::Setup;
 use Mojo::IOLoop;
 use Mojolicious::Commands;
@@ -47,7 +48,7 @@ sub startup {
 
     $self->defaults(appname => 'openQA Live Handler');
     OpenQA::Setup::read_config($self);
-    OpenQA::Setup::setup_log($self);
+    setup_log($self);
     OpenQA::Setup::setup_mojo_tmpdir();
     OpenQA::Setup::add_build_tx_time_header($self);
 

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -18,7 +18,7 @@ use Mojo::Base 'Mojolicious';
 
 use OpenQA::Setup;
 use Mojo::IOLoop;
-use OpenQA::Log 'log_debug';
+use OpenQA::Log qw(log_debug setup_log);
 use Mojo::Server::Daemon;
 use OpenQA::Schema;
 use OpenQA::Scheduler::Model::Jobs;
@@ -95,7 +95,7 @@ sub _setup {
     my $self = shift;
 
     OpenQA::Setup::read_config($self);
-    OpenQA::Setup::setup_log($self);
+    setup_log($self);
 
     # check for stale jobs every 2 minutes
     Mojo::IOLoop->recurring(

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -19,6 +19,7 @@ use Mojo::Base 'Mojolicious';
 use Mojolicious 7.18;
 use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
+use OpenQA::Log 'setup_log';
 use OpenQA::Utils qw(detect_current_version service_port);
 use OpenQA::Setup;
 use OpenQA::WebAPI::Description qw(get_pod_from_controllers set_api_desc);
@@ -46,7 +47,7 @@ sub startup {
     $self->renderer->paths->[0] = path($self->renderer->paths->[0])->child('webapi')->to_string;
 
     OpenQA::Setup::read_config($self);
-    OpenQA::Setup::setup_log($self);
+    setup_log($self);
     OpenQA::Setup::setup_app_defaults($self);
     OpenQA::Setup::setup_mojo_tmpdir();
     OpenQA::Setup::add_build_tx_time_header($self);

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -18,7 +18,7 @@ use Mojo::Base 'Mojolicious';
 
 use Mojo::Server::Daemon;
 use OpenQA::Setup;
-use OpenQA::Log qw(log_debug log_warning log_info);
+use OpenQA::Log qw(log_debug log_warning log_info setup_log);
 use OpenQA::WebSockets::Model::Status;
 
 our $RUNNING;
@@ -115,7 +115,7 @@ sub _setup {
     my $self = shift;
 
     OpenQA::Setup::read_config($self);
-    OpenQA::Setup::setup_log($self);
+    setup_log($self);
 
     Mojo::IOLoop->recurring(
         380 => sub {

--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -18,7 +18,7 @@ use Mojo::Base -base;
 
 use Mojo::Util 'trim';
 use Config::IniFiles;
-use OpenQA::Setup;
+use OpenQA::Log 'setup_log';
 
 has 'global_settings';
 has 'webui_hosts';
@@ -101,7 +101,7 @@ sub apply_to_app {
     my $global_settings = $self->global_settings;
     $app->log_dir($global_settings->{LOG_DIR});
     $app->level($global_settings->{LOG_LEVEL}) if $global_settings->{LOG_LEVEL};
-    OpenQA::Setup::setup_log($app);
+    setup_log($app, undef, $app->log_dir, $app->level);
 }
 
 sub file_path { shift->{_file_path} }

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -61,8 +61,8 @@ is_deeply(
 
 subtest 'apply settings to app' => sub {
     my ($setup_log_called, $setup_log_app);
-    my $mock = Test::MockModule->new('OpenQA::Setup');
-    $mock->mock(
+    my $mock = Test::MockModule->new('OpenQA::Worker::Settings');
+    $mock->redefine(
         setup_log => sub {
             $setup_log_app    = shift;
             $setup_log_called = 1;

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -30,6 +30,7 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
+use OpenQA::Log 'setup_log';
 use OpenQA::Setup;
 use OpenQA::Utils;
 use Test::More;
@@ -40,7 +41,7 @@ subtest 'Setup logging to file' => sub {
     local $ENV{OPENQA_LOGFILE} = undef;
     my $tempfile = tempfile;
     my $app      = Mojolicious->new(config => {logging => {file => $tempfile}});
-    OpenQA::Setup::setup_log($app);
+    setup_log($app);
     $app->attr('log_name', sub { return "test"; });
 
     my $log = $app->log;
@@ -61,7 +62,7 @@ subtest 'Setup logging to STDOUT' => sub {
     local $ENV{OPENQA_LOGFILE} = undef;
     my $buffer = '';
     my $app    = Mojolicious->new();
-    OpenQA::Setup::setup_log($app);
+    setup_log($app);
     $app->attr('log_name', sub { return "test"; });
     {
         open my $handle, '>', \$buffer;
@@ -82,7 +83,7 @@ subtest 'Setup logging to STDOUT' => sub {
 subtest 'Setup logging to file (ENV)' => sub {
     local $ENV{OPENQA_LOGFILE} = tempfile;
     my $app = Mojolicious->new(config => {logging => {file => "/tmp/ignored_foo_bar"}});
-    OpenQA::Setup::setup_log($app);
+    setup_log($app);
     $app->attr('log_name', sub { return "test"; });
 
     my $log = $app->log;
@@ -100,7 +101,7 @@ subtest 'Setup logging to file (ENV)' => sub {
     ok !-e "/tmp/ignored_foo_bar";
 
     $app = Mojolicious->new();
-    OpenQA::Setup::setup_log($app);
+    setup_log($app);
     $app->attr('log_name', sub { return "test"; });
 
     $log = $app->log;

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -21,9 +21,9 @@ use Time::HiRes 'gettimeofday';
 use Test::More;
 use Mojo::File qw(tempdir tempfile);
 use OpenQA::App;
-use OpenQA::Log
-  qw(log_error log_warning log_fatal log_info log_debug add_log_channel remove_log_channel log_format_callback get_channel_handle);
 use OpenQA::Setup;
+use OpenQA::Log
+  qw(log_error log_warning log_fatal log_info log_debug add_log_channel remove_log_channel log_format_callback get_channel_handle setup_log);
 use OpenQA::Worker::App;
 use File::Path qw(make_path remove_tree);
 use Test::MockModule;
@@ -50,7 +50,7 @@ subtest 'load correct configs' => sub {
     is($app->mode,                     'production');
     is($app->config->{logging}{level}, 'warning');
     is($app->log->level,               'info');
-    OpenQA::Setup::setup_log($app);
+    setup_log($app, undef, $app->log_dir, $app->level);
     is($app->level,      'debug');
     is($app->log->level, 'debug');
 
@@ -60,7 +60,7 @@ subtest 'load correct configs' => sub {
     is($app->mode,                     'production');
     is($app->config->{logging}{level}, 'warning');
     is($app->log->level,               'info');
-    OpenQA::Setup::setup_log($app);
+    setup_log($app);
     is($app->level,      undef);
     is($app->log->level, 'warning');
 
@@ -87,7 +87,7 @@ subtest 'Logging to stdout' => sub {
         level    => 'debug'
     );
 
-    OpenQA::Setup::setup_log($app);
+    setup_log($app, undef, $app->log_dir, $app->level);
 
     log_debug('debug message');
     log_error('error message');
@@ -119,7 +119,7 @@ subtest 'Logging to file' => sub {
         level    => 'debug'
     );
     my $output_logfile = catfile($ENV{OPENQA_WORKER_LOGDIR}, hostname() . '-1.log');
-    OpenQA::Setup::setup_log($app);
+    setup_log($app, undef, $app->log_dir, $app->level);
     log_debug('debug message');
     log_error('error message');
     log_info('info message');
@@ -153,8 +153,8 @@ subtest 'log fatal to stderr' => sub {
         level    => 'debug'
     );
 
-    OpenQA::Setup::setup_log($app);
-    OpenQA::App->set_singleton(undef);    # To make sure we don't are setting it in other tests
+    setup_log($app);
+    OpenQA::App->set_singleton(undef);    # To make sure we are not setting it in other tests
     eval { log_fatal('fatal message'); };
     my $eval_error       = $@;
     my $exception_raised = 0;
@@ -191,7 +191,7 @@ subtest 'Checking log level' => sub {
             level    => $level
         );
 
-        OpenQA::Setup::setup_log($app);
+        setup_log($app, undef, $app->log_dir, $app->level);
 
         log_debug('debug message');
         log_info('info message');
@@ -258,7 +258,7 @@ subtest 'Logging to right place' => sub {
         level    => 'debug'
     );
     my $output_logfile = catfile($ENV{OPENQA_WORKER_LOGDIR}, hostname() . '-1.log');
-    OpenQA::Setup::setup_log($app);
+    setup_log($app, undef, $app->log_dir, $app->level);
     log_debug('debug message');
     log_error('error message');
     log_info('info message');
@@ -272,7 +272,7 @@ subtest 'Logging to right place' => sub {
         log_dir  => $ENV{OPENQA_WORKER_LOGDIR},
         level    => 'debug'
     );
-    OpenQA::Setup::setup_log($app);
+    setup_log($app, undef, $app->log_dir, $app->level);
     log_debug('debug message');
     log_error('error message');
     log_info('info message');
@@ -289,7 +289,7 @@ subtest 'Logging to right place' => sub {
         instance => 1,
         level    => 'debug'
     );
-    OpenQA::Setup::setup_log($app);
+    setup_log($app);
     log_debug('debug message');
     log_error('error message');
     log_info('info message');
@@ -315,7 +315,7 @@ subtest 'Logs to multiple channels' => sub {
             log_dir  => $ENV{OPENQA_WORKER_LOGDIR},
             level    => $level
         );
-        OpenQA::Setup::setup_log($app);
+        setup_log($app, undef, $app->log_dir, $app->level);
 
         for my $channel_tupple (@channel_tupples) {
             my $logging_test_file1 = tempfile;
@@ -362,7 +362,7 @@ subtest 'Logs to bogus channels' => sub {
             log_dir  => $ENV{OPENQA_WORKER_LOGDIR},
             level    => $level
         );
-        OpenQA::Setup::setup_log($app);
+        setup_log($app, undef, $app->log_dir, $app->level);
 
         for my $channel_tupple (@channel_tupples) {
             my $logging_test_file1 = tempfile;
@@ -412,7 +412,7 @@ subtest 'Logs to default channels' => sub {
             log_dir  => $ENV{OPENQA_WORKER_LOGDIR},
             level    => $level
         );
-        OpenQA::Setup::setup_log($app);
+        setup_log($app, undef, $app->log_dir, $app->level);
 
         my $logging_test_file1 = tempfile;
         my $logging_test_file2 = tempfile;


### PR DESCRIPTION
This is the additional step to stop requiring Setup to use logs.

Fixes: https://progress.opensuse.org/issues/27868