### PR TITLE
Replace all uses of mock with redefine

### DIFF
--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -37,7 +37,7 @@ my $sent = {};
 
 # Mangle worker websocket send, and record what was sent
 my $mock_result = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
-$mock_result->mock(
+$mock_result->redefine(
     ws_send => sub {
         my ($self, $worker) = @_;
         my $hashref = $self->prepare_for_work($worker);
@@ -67,7 +67,7 @@ subtest 'Exception' => sub {
 subtest 'API' => sub {
     my $mock_scheduler = Test::MockModule->new('OpenQA::Scheduler');
     my $awake          = 0;
-    $mock_scheduler->mock(wakeup => sub { $awake++ });
+    $mock_scheduler->redefine(wakeup => sub { $awake++ });
     $t->get_ok('/api/wakeup')->status_is(200)->content_is('ok');
     is $awake, 1, 'scheduler has been woken up';
     $t->get_ok('/api/wakeup')->status_is(200)->content_is('ok');

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -215,7 +215,7 @@ subtest 'parallel parent fails -> children are cancelled (parallel_failed)' => s
     my $mock_server = Test::MockModule->new('OpenQA::WebSockets');
     my $server_called;
     my @sent_commands;
-    $mock_server->mock(
+    $mock_server->redefine(
         ws_send => sub {
             my ($workerid, $command, $jobid) = @_;
             $server_called++;

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -175,7 +175,7 @@ sub schedule {
 # Mangle worker websocket send, and record what was sent
 my $jobs_result_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
 my $mock_send_called;
-$jobs_result_mock->mock(
+$jobs_result_mock->redefine(
     ws_send => sub {
         my ($self, $worker) = @_;
         my $hashref = $self->prepare_for_work($worker);

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -111,7 +111,7 @@ subtest 'Scheduler worker job allocation' => sub {
 subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes offline' => sub {
     # avoid wasting time waiting for status updates
     my $web_ui_connection_mock = Test::MockModule->new('OpenQA::Worker::WebUIConnection');
-    $web_ui_connection_mock->mock(_calculate_status_update_interval => .1);
+    $web_ui_connection_mock->redefine(_calculate_status_update_interval => .1);
 
     my $jobs   = $schema->resultset('Jobs');
     my @latest = $jobs->latest_jobs;

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -32,7 +32,7 @@ OpenQA::Test::Case->new->init_data;
 
 my $mock_client = Test::MockModule->new('OpenQA::WebSockets::Client');
 my ($client_called, $last_command);
-$mock_client->mock(
+$mock_client->redefine(
     send_msg => sub {
         my ($self, $workerid, $command, $jobid) = @_;
         $client_called++;
@@ -40,7 +40,7 @@ $mock_client->mock(
     });
 my $mock_ws = Test::MockModule->new('OpenQA::WebSockets');
 my $last_ws_params;
-$mock_ws->mock(
+$mock_ws->redefine(
     ws_send => sub {
         $last_ws_params = [@_];
         return Mojo::Message->new;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -53,7 +53,7 @@ sub mock_deleted { -e $deleted ? retrieve($deleted) : [] }
 sub mock_removed { -e $removed ? retrieve($removed) : [] }
 sub reset_mocked_asset_deletions { unlink $tempdir->child($_) for qw(removed deleted) }
 my $assets_result_mock = Test::MockModule->new('OpenQA::Schema::Result::Assets');
-$assets_result_mock->mock(
+$assets_result_mock->redefine(
     delete => sub {
         my ($self) = @_;
         $self->remove_from_disk;
@@ -62,7 +62,7 @@ $assets_result_mock->mock(
         push @$array, $self->name;
         store($array, $deleted);
     });
-$assets_result_mock->mock(
+$assets_result_mock->redefine(
     remove_from_disk => sub {
         my ($self) = @_;
         store([], $removed) unless -e $removed;
@@ -70,7 +70,7 @@ $assets_result_mock->mock(
         push @$array, $self->name;
         store($array, $removed);
     });
-$assets_result_mock->mock(refresh_size => sub { });
+$assets_result_mock->redefine(refresh_size => sub { });
 
 # setup test config and database
 my $test_case     = OpenQA::Test::Case->new(config_directory => "$FindBin::Bin/data/41-audit-log");
@@ -90,8 +90,8 @@ $job_groups->search({id => 1002})->update({parent_id => 1});
 # refresh assets only once and prevent adding untracked assets
 my $assets_mock = Test::MockModule->new('OpenQA::Schema::ResultSet::Assets');
 $schema->resultset('Assets')->refresh_assets();
-$assets_mock->mock(scan_for_untracked_assets => sub { });
-$assets_mock->mock(refresh_assets            => sub { });
+$assets_mock->redefine(scan_for_untracked_assets => sub { });
+$assets_mock->redefine(refresh_assets            => sub { });
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -40,7 +40,7 @@ use Mojo::Util 'monkey_patch';
 my $mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
 my $mock_send_called;
 my $sent = {};
-$mock->mock(
+$mock->redefine(
     ws_send => sub {
         my ($self, $worker) = @_;
         my $hashref = $self->prepare_for_work($worker);
@@ -270,7 +270,7 @@ subtest 'asset status' => sub {
 
     my $gru_mock            = Test::MockModule->new('OpenQA::WebAPI::Plugin::Gru');
     my $limit_assets_active = 1;
-    $gru_mock->mock(
+    $gru_mock->redefine(
         is_task_active => sub {
             my ($self, $task) = @_;
             return $limit_assets_active if $task eq 'limit_assets';

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -102,7 +102,7 @@ my %mock_return_value = (
     status => 1,
     stderr => undef,
 );
-$utils_mock->mock(
+$utils_mock->redefine(
     run_cmd_with_log_return_error => sub {
         my ($cmd) = @_;
         push(@executed_commands, $cmd);

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -71,7 +71,7 @@ subtest 'worker with job and not updated in last 120s is considered dead' => sub
 subtest 'exception during stale job detection handled and logged' => sub {
     my $mock_schema = Test::MockModule->new('OpenQA::Schema');
     my $mock_singleton_called;
-    $mock_schema->mock(singleton => sub { $mock_singleton_called++; bless({}); });
+    $mock_schema->redefine(singleton => sub { $mock_singleton_called++; bless({}); });
     combined_like(
         sub { OpenQA::Scheduler::Model::Jobs->singleton->incomplete_and_duplicate_stale_jobs; },
         qr/Failed stale job detection/,

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -35,7 +35,7 @@ use OpenQA::WebAPI::Plugin::AMQP;
 my %published;
 
 my $plugin_mock = Test::MockModule->new('OpenQA::WebAPI::Plugin::AMQP');
-$plugin_mock->mock(
+$plugin_mock->redefine(
     publish_amqp => sub {
         my ($self, $topic, $data) = @_;
         $published{$topic} = $data;
@@ -248,7 +248,7 @@ $plugin_mock->unmock('publish_amqp');
 %published = ();
 # ...but we'll mock the thing it calls.
 my $publisher_mock = Test::MockModule->new('Mojo::RabbitMQ::Client::Publisher');
-$publisher_mock->mock(
+$publisher_mock->redefine(
     publish_p => sub {
         # copied from upstream git master as of 2019-07-24
         my $self    = shift;

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -137,8 +137,8 @@ like(
 
 # mock OpenQA::Worker::Job so it starts/stops the livelog also if the backend isn't running
 my $job_mock = Test::MockModule->new('OpenQA::Worker::Job');
-$job_mock->mock(start_livelog => sub { shift->{_livelog_viewers} = 1 });
-$job_mock->mock(stop_livelog  => sub { shift->{_livelog_viewers} = 0 });
+$job_mock->redefine(start_livelog => sub { shift->{_livelog_viewers} = 1 });
+$job_mock->redefine(stop_livelog  => sub { shift->{_livelog_viewers} = 0 });
 
 subtest 'attempt to register and send a command' => sub {
     # test registration failure
@@ -261,7 +261,7 @@ subtest 'retry behavior' => sub {
     my $web_ui_connection_mock                = Test::MockModule->new('OpenQA::Worker::WebUIConnection');
     my $web_ui_supposed_to_be_considered_busy = 1;
     my $retry_delay_invoked                   = 0;
-    $web_ui_connection_mock->mock(
+    $web_ui_connection_mock->redefine(
         _retry_delay => sub {
             my ($self, $is_webui_busy) = @_;
             is($is_webui_busy, $web_ui_supposed_to_be_considered_busy, 'retry delay applied accordingly');

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -165,11 +165,11 @@ subtest 'Availability check and worker status' => sub {
     $client_mock->mock(error => sub { return {message => 'bar', code => 404}; });
     is($info->availability_error, 'Cache service returned error 404: bar', 'cache service returns an error');
 
-    $client_mock->mock(error             => sub { return undef; });
-    $client_mock->mock(available_workers => sub { return 0; });
+    $client_mock->mock(error => sub { return undef; });
+    $client_mock->redefine(available_workers => sub { return 0; });
     is($info->availability_error, 'No workers active in the cache service', 'nor workers active');
 
-    $client_mock->mock(available_workers => sub { return 1; });
+    $client_mock->redefine(available_workers => sub { return 1; });
     is($info->availability_error, undef, 'no error');
 
     $client_mock->unmock_all();

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -518,12 +518,12 @@ subtest 'Fallback to stderr/stdout' => sub {
     my $utils_mock             = Test::MockModule->new('OpenQA::Log');
     my $log_via_channel_tried  = 0;
     my $log_via_mojo_app_tried = 0;
-    $utils_mock->mock(
+    $utils_mock->redefine(
         _log_to_channel_by_name => sub {
             ++$log_via_channel_tried;
             return 0;
         });
-    $utils_mock->mock(
+    $utils_mock->redefine(
         _log_via_mojo_app => sub {
             ++$log_via_mojo_app_tried;
             return 0;
@@ -557,7 +557,7 @@ subtest 'Fallback to stderr/stdout' => sub {
     is(Mojo::File->new($logging_test_file1)->slurp, '', 'nothing written to logfile');
 
     # check fallback on attempt to log to invalid channel
-    $utils_mock->mock(
+    $utils_mock->redefine(
         _log_to_channel_by_name => sub {
             ++$log_via_channel_tried;
             return $utils_mock->original('_log_to_channel_by_name')->(@_);
@@ -575,7 +575,7 @@ subtest 'Fallback to stderr/stdout' => sub {
     # check fallback when logging to channel throws an exception
     $utils_mock->unmock('_log_to_channel_by_name');
     my $log_mock = Test::MockModule->new('Mojo::Log');
-    $log_mock->mock(
+    $log_mock->redefine(
         error => sub {
             ++$log_via_channel_tried;
             die 'not enough disk space or whatever';

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -37,7 +37,7 @@ use OpenQA::Utils qw(determine_web_ui_web_socket_url get_ws_status_only_url);
 # mock OpenQA::Schema::Result::Jobs::cancel()
 my $jobs_mock_module = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
 my @jobs_cancelled;
-$jobs_mock_module->mock(
+$jobs_mock_module->redefine(
     cancel => sub {
         my ($job) = @_;
         push(@jobs_cancelled, $job->id);
@@ -47,7 +47,7 @@ my @ipc_messages_for_websocket_server;
 my $fake_send_msg_failure;
 my $mock_client = Test::MockModule->new('OpenQA::WebSockets::Client');
 my ($client_called, $last_command);
-$mock_client->mock(
+$mock_client->redefine(
     send_msg => sub {
         my $self = shift;
         $client_called++;
@@ -85,7 +85,7 @@ my $finished_handled;
 sub prepare_waiting_for_finished_handled {
     my $subroutine_name = 'handle_disconnect_from_java_script_client';
     $finished_handled = 0;
-    $finished_handled_mock->mock(
+    $finished_handled_mock->redefine(
         $subroutine_name => sub {
             $finished_handled_mock->original($subroutine_name)->(@_);
             $finished_handled = 1;
@@ -973,7 +973,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
         $t_livehandler->app->log(Mojo::Log->new);
 
         my $live_view_handler_mock = Test::MockModule->new('OpenQA::WebAPI::Controller::LiveViewHandler');
-        $live_view_handler_mock->mock(not_found_http => sub { die 'some error'; });
+        $live_view_handler_mock->redefine(not_found_http => sub { die 'some error'; });
         $t_livehandler->app->mode('development');
         combined_like(sub { $t_livehandler->get_ok('/some/route'); }, qr/some error/, 'error logged');
         $t_livehandler->status_is(500)->content_like(qr/some error/, 'error rendered as plain text');

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -45,7 +45,7 @@ my %settings           = (
 
 # prevent job creation
 my $scheduled_products_mock = Test::MockModule->new('OpenQA::Schema::Result::ScheduledProducts');
-$scheduled_products_mock->mock(_generate_jobs => sub { return undef; });
+$scheduled_products_mock->redefine(_generate_jobs => sub { return undef; });
 
 my $scheduled_product;
 subtest 'handling assets with invalid name' => sub {

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -63,7 +63,7 @@ note('Set SCALABILITY_TEST_WORKER_COUNT/SCALABILITY_TEST_JOB_COUNT to adjust thi
 #        in the other fullstack tests as well.
 my %ports      = (webui => Mojo::IOLoop::Server->generate_port, websocket => Mojo::IOLoop::Server->generate_port);
 my $utils_mock = Test::MockModule->new('OpenQA::Utils');
-$utils_mock->mock(
+$utils_mock->redefine(
     service_port => sub {
         my ($service) = @_;
         my $port = $ports{$service};

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -41,7 +41,7 @@ $t->app($app);
 # whether we're allowed to or not, so let's mock that out
 my $mock_asset_remove_callcount = 0;
 my $mock_asset                  = Test::MockModule->new('OpenQA::Schema::Result::Assets');
-$mock_asset->mock(remove_from_disk => sub { $mock_asset_remove_callcount++; return 1; });
+$mock_asset->redefine(remove_from_disk => sub { $mock_asset_remove_callcount++; return 1; });
 
 subtest 'authentication routes for plugins' => sub {
     my $public = $t->app->routes->find('api_public');

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -283,7 +283,7 @@ subtest 'missing-linebreak' => sub {
     my $orig = OpenQA::Schema::Result::JobGroups->can('to_yaml');
     my $mock = Test::MockModule->new('OpenQA::Schema::Result::JobGroups');
     # Code should be able to deal with YAML missing last linebreak
-    $mock->mock(
+    $mock->redefine(
         to_yaml => sub {
             my ($self) = @_;
             my $yaml = $orig->($self);

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -269,7 +269,7 @@ sub create_websocket_server {
             # mock the scheduler's automatic rescheduling behavior because this test invokes
             # the scheduling logic manually
             my $scheduler_mock = Test::MockModule->new('OpenQA::Scheduler');
-            $scheduler_mock->mock(_reschedule => sub { });
+            $scheduler_mock->redefine(_reschedule => sub { });
         }
 
         OpenQA::WebSockets::run;
@@ -445,7 +445,7 @@ sub c_worker {
     if ($pid == 0) {
         my $command_handler_mock = Test::MockModule->new('OpenQA::Worker::CommandHandler');
         if ($bogus) {
-            $command_handler_mock->mock(
+            $command_handler_mock->redefine(
                 handle_command => sub {
                     my ($self, $tx, $json) = @_;
                     log_debug('Received ws message: ' . Dumper($json));
@@ -462,7 +462,7 @@ sub c_worker {
         }
         my $error       = $options{error};
         my $worker_mock = Test::MockModule->new('OpenQA::Worker');
-        $worker_mock->mock(check_availability => sub { }) if defined $error;
+        $worker_mock->redefine(check_availability => sub { }) if defined $error;
         my $worker = OpenQA::Worker->new(
             {
                 apikey    => $apikey,

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -45,7 +45,7 @@ sub schema_hook {
 
     # make OpenQA::WebSockets::Client::send_msg() a noop (tested in ../34-developer_mode-unit.t anyways)
     my $ipc_mock_module = Test::MockModule->new('OpenQA::WebSockets::Client');
-    $ipc_mock_module->mock(send_msg => sub { });
+    $ipc_mock_module->redefine(send_msg => sub { });
 
     # assign a worker to job 99961
     my $job_id = 99961;


### PR DESCRIPTION
Redefine fails early if a sub is not found in the mocked module.

    ag -l -- '->mock' | xargs sed -i 's@->mock@->redefine@'