### PR TITLE
asset cleanup: Consider all jobs which are not done or cancelled as pending

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -149,7 +149,7 @@ sub status {
                 a.id as id, a.name as name, a.t_created as t_created, a.size as size, a.type as type,
                 a.fixed as fixed,
                 coalesce(max(j.id), -1) as max_job,
-                max(case when j.id is not null and j.result='none' then 1 else 0 end) as pending
+                max(case when j.id is not null and j.state!='done' and j.state!='cancelled' then 1 else 0 end) as pending
             from assets a
                 left join jobs_assets ja on a.id=ja.asset_id
                 left join jobs j on j.id=ja.job_id


### PR DESCRIPTION
Checking for the result is slightly wrong, e.g. a job can be in state cancelled with no result and should not be considered pending anymore.