### PR TITLE
Validate result and cut reason after 300 characters

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1901,7 +1901,19 @@ test modules
 =cut
 sub done {
     my ($self, %args) = @_;
-    $args{result} = OBSOLETED if $args{newbuild};
+
+    # read specified result or calculate result from module results if none specified
+    my $result;
+    if ($args{newbuild}) {
+        $result = OBSOLETED;
+    }
+    elsif ($result = $args{result}) {
+        $result = lc($result);
+        die "Erroneous parameters (result invalid)\n" unless grep { $result eq $_ } RESULTS;
+    }
+    else {
+        $result = $self->calculate_result;
+    }
 
     # cleanup
     $self->set_property('JOBTOKEN');
@@ -1915,7 +1927,6 @@ sub done {
 
     # update result unless already known (it is already known for CANCELLED jobs)
     # update the reason if updating the result or if there is no reason yet
-    my $result         = lc($args{result} || $self->calculate_result);
     my $reason         = $args{reason};
     my $result_unknown = $self->result eq NONE;
     my $reason_unknown = !$self->reason;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -648,7 +648,14 @@ sub done {
     my $result   = $self->param('result');
     my $reason   = $self->param('reason');
     my $newbuild = defined $self->param('newbuild') ? 1 : undef;
-    my $res      = $job->done(result => $result, reason => $reason, newbuild => $newbuild);
+    my $res;
+    try {
+        $res = $job->done(result => $result, reason => $reason, newbuild => $newbuild);
+    }
+    catch {
+        $self->render(status => 400, json => {error => $_});
+    };
+    return undef unless $res;
 
     # use $res as a result, it is recomputed result by scheduler
     $self->emit_event('openqa_job_done', {id => $job->id, result => $res, reason => $reason, newbuild => $newbuild});

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1336,6 +1336,8 @@ subtest 'marking job as done' => sub {
     };
     subtest 'job is currently running' => sub {
         $jobs->find(99961)->update({state => RUNNING, result => NONE, reason => undef});
+        $t->post_ok('/api/v1/jobs/99961/set_done?result=incomplet')->status_is(400)
+          ->json_like('/error', qr/result invalid/);
         $t->post_ok('/api/v1/jobs/99961/set_done?result=incomplete&reason=test')->status_is(200);
         $t->get_ok('/api/v1/jobs/99961')->status_is(200);
         my $json = $t->tx->res->json;


### PR DESCRIPTION
This limits the length of the reason as mentioned in https://progress.opensuse.org/issues/25814#note-15. It felt a bit weird to limit the reason but allow the result to be of any length. So I also added a commit to validate the result.