### PR TITLE
Improve log error message from worker when working directory is unusable

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -304,7 +304,7 @@ sub init {
         my ($working_dir) = grep { $_ && -d } @working_dirs;
         unless ($working_dir) {
             $_ and log_debug("Found possible working directory for $host: $_") for @working_dirs;
-            log_error("Ignoring host '$host': Working directory does not exist.");
+            log_error("Ignoring host '$host': Working directory '$_' does not exist.");
             next;
         }
         $client->working_directory($working_dir);


### PR DESCRIPTION
Every log message of a higher log message should have complete
information and not rely on e.g. debug messages to provide context.
Hence we need to output *which* working directory was not usable for a
worker.

Related progress issue: https://progress.opensuse.org/issues/65450