### PR TITLE
Extract duplicated code from generating job settings

### DIFF
--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -17,6 +17,30 @@ package OpenQA::JobSettings;
 use strict;
 use warnings;
 
+sub generate_settings {
+    my ($params) = @_;
+    my $settings = $params->{settings};
+    my @worker_class;
+    for my $entity (qw (product machine test_suite job_template)) {
+        next unless $params->{$entity};
+        my @entity_settings = $params->{$entity}->settings;
+        for my $setting (@entity_settings) {
+            if ($setting->key eq 'WORKER_CLASS') {
+                push @worker_class, $setting->value;
+                next;
+            }
+            $settings->{$setting->key} = $setting->value;
+        }
+        $settings->{BACKEND} = $params->{$entity}->backend if ($entity eq 'machine');
+    }
+    $settings->{WORKER_CLASS} = join ',', sort @worker_class if @worker_class > 0;
+    if (my $input_args = $params->{input_args}) {
+        $settings->{uc $_} = $input_args->{$_} for keys %$input_args;
+    }
+    handle_plus_in_settings($settings);
+    return expand_placeholders($settings);
+}
+
 # replace %NAME% with $settings{NAME}
 sub expand_placeholders {
     my ($settings) = @_;

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -528,14 +528,16 @@ sub _generate_jobs {
            # note: That order also defines the precedence from lowest to highest. The only exception is the WORKER_CLASS
            #       variable where all occurrences are merged.
             my %settings;
-            my @worker_classes;
-            for my $entity ($product, $job_template->machine, $job_template->test_suite, $job_template) {
-                my %settings_of_entity = map { $_->key => $_->value } $entity->settings;
-                if (my $worker_class = delete $settings_of_entity{WORKER_CLASS}) {
-                    push(@worker_classes, $worker_class);
-                }
-                @settings{keys %settings_of_entity} = values %settings_of_entity;
-            }
+            my %params = (
+                settings     => \%settings,
+                input_args   => $args,
+                product      => $product,
+                machine      => $job_template->machine,
+                test_suite   => $job_template->test_suite,
+                job_template => $job_template,
+            );
+            my $error = OpenQA::JobSettings::generate_settings(\%params);
+            $error_message .= $error if defined $error;
 
             # add properties from dedicated database columns to settings
             $settings{TEST}            = $job_template->name || $job_template->test_suite->name;
@@ -544,27 +546,11 @@ sub _generate_jobs {
             $settings{TEST_SUITE_NAME} = $job_template->test_suite->name;
             $settings{JOB_DESCRIPTION} = $job_template->description if length $job_template->description;
 
-            # merge worker classes
-            $settings{WORKER_CLASS} = @worker_classes ? join(',', sort(@worker_classes)) : "qemu_$args->{ARCH}";
-
-            # add upper-case versions of keys
-            for my $key (keys %$args) {
-                next if $key eq 'TEST' || $key eq 'MACHINE';
-                $settings{uc $key} = $args->{$key};
-            }
-
             # make sure that the DISTRI is lowercase
             $settings{DISTRI} = lc($settings{DISTRI});
 
             $settings{PRIO}     = defined($priority) ? $priority : $job_template->prio;
             $settings{GROUP_ID} = $job_template->group_id;
-
-            OpenQA::JobSettings::handle_plus_in_settings(\%settings);
-
-            # variable expansion
-            # replace %NAME% with $settings{NAME}
-            my $error = OpenQA::JobSettings::expand_placeholders(\%settings);
-            $error_message .= $error if defined $error;
 
             if (!$args->{MACHINE} || $args->{MACHINE} eq $settings{MACHINE}) {
                 if (!@tests) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -794,6 +794,7 @@ sub _generate_job_setting {
 
     my %settings;    # Machines, product and test suite settings for the job
     my @classes;     # Populated with WORKER_CLASS settings from machines and products
+    my %params = (input_args => $args, settings => \%settings);
 
     # Populated with Product settings if there are DISTRI, VERSION, FLAVOR, ARCH in arguments.
     if (   defined $args->{DISTRI}
@@ -808,14 +809,8 @@ sub _generate_job_setting {
                 arch    => $args->{ARCH},
                 flavor  => $args->{FLAVOR},
             });
-
         if (my $product = $products->next) {
-            my %tmp_setting = map { $_->key => $_->value } $product->settings;
-
-            if (my $class = delete $tmp_setting{WORKER_CLASS}) {
-                push @classes, $class;
-            }
-            @settings{keys %tmp_setting} = values %tmp_setting;
+            $params{product} = $product;
         }
     }
 
@@ -825,14 +820,8 @@ sub _generate_job_setting {
             {
                 name => $args->{MACHINE},
             });
-
         if (my $machine = $machines->next) {
-            my %tmp_setting = map { $_->key => $_->value } $machine->settings;
-
-            if (my $class = delete $tmp_setting{WORKER_CLASS}) {
-                push @classes, $class;
-            }
-            @settings{keys %tmp_setting} = values %tmp_setting;
+            $params{machine} = $machine;
         }
     }
 
@@ -841,22 +830,11 @@ sub _generate_job_setting {
         {
             name => $args->{TEST},
         });
-
     if (my $test_suite = $test_suites->next) {
-        my %test_suite_setting = map { $_->key => $_->value } $test_suite->settings;
-
-        if (my $test_suite_class = delete $test_suite_setting{WORKER_CLASS}) {
-            push @classes, $test_suite_class;
-        }
-        @settings{keys %test_suite_setting} = values %test_suite_setting;
+        $params{test_suite} = $test_suite;
     }
 
-    $settings{WORKER_CLASS} = join ',', sort @classes if @classes > 0;
-    $settings{uc $_} = $args->{$_} for keys %$args;
-
-    OpenQA::JobSettings::handle_plus_in_settings(\%settings);
-
-    my $error_message = OpenQA::JobSettings::expand_placeholders(\%settings);
+    my $error_message = OpenQA::JobSettings::generate_settings(\%params);
     return {error_message => $error_message, settings_result => \%settings};
 }
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -891,6 +891,7 @@ subtest 'Expand specified Machine, Testsuite, Product variables' => sub {
             'PUBLISH_HDD_1'       => 'SLES-15-SP1-x86_64-1234@64bit-minimal_with_sdk1234_installed.qcow2',
             'ANOTHER_JOB'         => 'SLES-15-SP1-x86_64-1234@64bit-minimal_with_sdk1234_installed.qcow2',
             'HDD_1'               => 'SLES-15-SP1-x86_64-1234@64bit-minimal_with_sdk1234_installed.qcow2',
+            'BACKEND'             => 'qemu',
         },
         'Job post method expand specified MACHINE, PRODUCT, TESTSUITE variable',
     );


### PR DESCRIPTION
Both in the operation `isos post` and `jobs post`, there are some code used to generate job settings, this pr used to reduce the duplicated code.