### PR TITLE
Rely on CircleCI jobs for test re-runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,12 @@ aliases:
     command: |
       export PERL5OPT="$COVEROPT,-db,cover_db_${CIRCLE_JOB}"
       echo PERL5OPT="$PERL5OPT"
-      make test-$CIRCLE_JOB
+      make test-$CIRCLE_JOB RETRY=0
+
+  - &make_test_2
+    name: "Running unit tests (re-run)"
+    when: on_fail
+    <<: *make_test
 
   - &git_token_authentication
     name: "Prepare auth token"
@@ -202,6 +207,7 @@ jobs:
       - run: *install_cached_packages
       - run: *test_junit
       - run: *make_test
+      - run: *make_test_2
       - persist_to_workspace:
           root: .
           paths:
@@ -224,6 +230,7 @@ jobs:
       - run: *build_autoinst
       - run: *test_junit
       - run: *make_test
+      - run: *make_test_2
       - persist_to_workspace:
           root: .
           paths:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RETRY ?= 0
+RETRY ?= 3
 # STABILITY_TEST: Set to 1 to fail as soon as any of the RETRY fails rather
 # than succeed if any of the RETRY succeed
 STABILITY_TEST ?= 0
@@ -139,19 +139,19 @@ test-api:
 # put unstable tests in unstable_tests.txt and uncomment in circle CI to handle unstables with retries
 .PHONY: test-unstable
 test-unstable:
-	for f in $$(cat .circleci/unstable_tests.txt); do $(MAKE) test-with-database TIMEOUT_M=5 PROVE_ARGS="$$HARNESS $f" RETRY=3 || break; done
+	for f in $$(cat .circleci/unstable_tests.txt); do $(MAKE) test-with-database TIMEOUT_M=5 PROVE_ARGS="$$HARNESS $f" || break; done
 
 .PHONY: test-fullstack
 test-fullstack:
-	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=20 PROVE_ARGS="$$HARNESS t/full-stack.t" RETRY=3
+	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=20 PROVE_ARGS="$$HARNESS t/full-stack.t"
 
 .PHONY: test-scheduler
 test-scheduler:
-	$(MAKE) test-with-database SCHEDULER_FULLSTACK=1 SCALABILITY_TEST=1 TIMEOUT_M=5 PROVE_ARGS="$$HARNESS t/05-scheduler-full.t t/43-scheduling-and-worker-scalability.t" RETRY=3
+	$(MAKE) test-with-database SCHEDULER_FULLSTACK=1 SCALABILITY_TEST=1 TIMEOUT_M=5 PROVE_ARGS="$$HARNESS t/05-scheduler-full.t t/43-scheduling-and-worker-scalability.t"
 
 .PHONY: test-developer
 test-developer:
-	$(MAKE) test-with-database DEVELOPER_FULLSTACK=1 TIMEOUT_M=10 PROVE_ARGS="$$HARNESS t/33-developer_mode.t" RETRY=3
+	$(MAKE) test-with-database DEVELOPER_FULLSTACK=1 TIMEOUT_M=10 PROVE_ARGS="$$HARNESS t/33-developer_mode.t"
 
 .PHONY: test-with-database
 test-with-database:


### PR DESCRIPTION
- Using a CIRCLE condition allows CircleCI to show the test runs separately instead of jumbling everything up
- Timeouts are not mixed up
- RETRY is not enforced in the Makefile but a default of 3

This is motivated by #2626 running [for several hours](https://app.circleci.com/pipelines/github/os-autoinst/openQA/2311/workflows/ff152f67-e005-4399-beb0-7fefcfb496d5/jobs/21694) without an apparent limit,

See also CircleCI docs on [when: on_fail](https://support.circleci.com/hc/en-us/articles/360043188514-How-to-Retry-a-Failed-Step-with-when-Attribute-).