### PR TITLE
Further stabilize UI tests, part of #2626

### DIFF
--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -449,9 +449,7 @@ subtest 'job property editor' => sub() {
             undef, 'group properties save button is enabled');
         $driver->find_element_by_id('editor-carry-over-bugrefs')->click();
         $driver->find_element('#properties p.buttons button.btn-primary')->click();
-        # ensure there is no race condition, even though the page is reloaded
-        wait_for_ajax;
-
+        wait_for_ajax(msg => 'ensure there is no race condition, even though the page is reloaded');
         $driver->refresh();
         $driver->title_is('openQA: Job templates for Cool Group has been edited!', 'new name on title');
         $driver->find_element_by_id('toggle-group-properties')->click();

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -122,6 +122,7 @@ isnt(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, "child group 
 
 # back to home and go to another parent group overview
 $driver->find_element_by_class('navbar-brand')->click();
+wait_for_ajax(msg => 'wait until job group results show up');
 $driver->find_element_by_link_text('Test parent 2')->click();
 wait_for_ajax_and_animations;
 isnt(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, "child group 'opensuse' in 'Test parent 2'");

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -103,6 +103,7 @@ like(
 # trigger job next and previous for current job
 $driver->title_is('openQA', 'on main page');
 $driver->find_element_by_link_text('All Tests')->click();
+wait_for_ajax(msg => 'wait for All Tests displayed before looking for 99946');
 wait_for_element(selector => '[href="/tests/99946"]')->click();
 $driver->find_element_by_link_text('Next & previous results')->click();
 wait_for_ajax();
@@ -186,6 +187,7 @@ is(
 
 # check job next and previous of current running/scheduled job
 $driver->find_element_by_link_text('All Tests')->click();
+wait_for_ajax(msg => 'wait for All Tests displayed before looking for 99963');
 $driver->find_element('[href="/tests/99963"]')->click();
 $driver->find_element_by_link_text('Next & previous results')->click();
 wait_for_ajax();
@@ -203,6 +205,7 @@ is((shift @tds)->get_text(),       'Not yet: running', '99963 is not yet finishe
 is(scalar @{$driver->find_elements('#job_next_previous_table #job_result_99962')}, 1, 'found previous job 99962');
 
 $driver->find_element_by_link_text('All Tests')->click();
+wait_for_ajax(msg => 'wait for All Tests displayed before looking for 99928');
 $driver->find_element('[href="/tests/99928"]')->click();
 $driver->find_element_by_link_text('Next & previous results')->click();
 wait_for_ajax();

--- a/tools/retry
+++ b/tools/retry
@@ -15,12 +15,12 @@ else
     while :; do
         if [ "$STABILITY_TEST" = "0" ]; then
             [ $n -lt "$RETRY" ] || exit 1
-            [ $n -eq 0 ] || echo Retrying...
+            [ $n -eq 0 ] || echo "Retrying ($n of $RETRY) …"
             run_once $* && break
         else
             [ $n -lt "$RETRY" ] || exit 0
             run_once $* || exit
-            echo Retrying...
+            echo "Retrying ($n of $RETRY) …"
         fi
         n=$((n+1))
     done


### PR DESCRIPTION
* t: Stabilize ui tests waiting for ajax
* t: Stabilize ui/14-dashboard-parents.t waiting for build results
* t: Use descriptive string in wait_for_ajax rather than comment
* Add output of each try in tools/retry