### PR TITLE
Fix missing import 'log_error' in WebAPI::Controller::Running

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'Mojolicious::Controller';
 use Mojo::Util 'b64_encode';
 use Mojo::File 'path';
 use Mojo::JSON qw(encode_json decode_json);
-use OpenQA::Log 'log_debug';
+use OpenQA::Log qw(log_debug log_error);
 use OpenQA::Utils;
 use OpenQA::WebSockets::Client;
 use OpenQA::Jobs::Constants;


### PR DESCRIPTION
Seen in test output 't/ui/25-developer_mode.t ................... 1/? Mojo::Reactor::EV: I/O watcher failed: Undefined subroutine &OpenQA::WebAPI::Controller::Running::log_error called at /home/okurz/local/os-autoinst/openQA/lib/OpenQA/WebAPI/Controller/Running.pm line 235.'