### PR TITLE
Fix load_templates --clean to wipe more than one entry per table

### DIFF
--- a/script/load_templates
+++ b/script/load_templates
@@ -241,7 +241,7 @@ if ($options{'clean'}) {
                 my $id           = $result->{$table}->[$i]->{id};
                 my $table_url_id = $url->clone->path($options{'apibase'} . '/' . decamelize($table) . "/$id");
                 $res = $client->delete($table_url_id)->res;
-                last if $res->is_success;
+                last unless $res->is_success;
             }
         }
 

--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -27,8 +27,9 @@ $Test::Strict::TEST_WARNINGS = 1;
 $Test::Strict::TEST_SKIP     = [
     # skip test module which would require test API from os-autoinst to be present
     't/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm',
-    # Skip data file which is supposed to resemble generated output which has no 'use' statements
+    # Skip data files which are supposed to resemble generated output which has no 'use' statements
     't/data/40-templates.pl',
+    't/data/40-templates-more.pl',
     't/data/openqa-trigger-from-obs/Proj2::appliances/empty.txt',
     't/data/openqa-trigger-from-obs/Proj3::standard/empty.txt',
 ];

--- a/t/data/40-templates-more.pl
+++ b/t/data/40-templates-more.pl
@@ -1,0 +1,37 @@
+{
+    JobGroups => [
+        {
+            group_name => "openSUSE Leap 42.3 Updates",
+            template   => "scenarios: {}\nproducts: {}\n",
+        },
+    ],
+    JobTemplates => [],
+    Machines     => [
+        {
+            backend  => "qemu",
+            name     => "32bit",
+            settings => [],
+        },
+        {
+            backend  => "qemu",
+            name     => "64bit",
+            settings => [],
+        },
+    ],
+    Products => [
+        {
+            arch     => "x86_64",
+            distri   => "opensuse",
+            flavor   => "DVD",
+            settings => [],
+            version  => 42.2,
+        },
+    ],
+    TestSuites => [
+        {
+            name => "uefi",
+            settings =>
+              [{key => "DESKTOP", value => "kde"}, {key => "INSTALLONLY", value => 1}, {key => "UEFI", value => 1},],
+        },
+    ],
+}


### PR DESCRIPTION
1400d8a8dd inverted the logic here - instead of exiting the loop
on a *failure* we now exit it on *success*. So each time --clean
is run it will only wipe one entry per table. This obviously
breaks things badly (the clean phase doesn't clean things right
at all, so the subsequent load phase fails because we try to add
entries that already exist, and you wind up with a mess).

This flips the logic back, and adds a test.

Signed-off-by: Adam Williamson <awilliam@redhat.com>