### PR TITLE
Revert "t: Stabilize ui/13-admin.t"

### DIFF
--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -406,16 +406,12 @@ subtest 'job property editor' => sub() {
     };
 
     subtest 'update group name with empty or blank' => sub {
-        # the check for the disabled save button always fails reproducibly on
-        # my machine now, sometimes on circle CI, have not understood that yet
-        enable_timeout;
         my $groupname = $driver->find_element_by_id('editor-name');
         # update group name with empty
         $groupname->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $groupname->send_keys(Selenium::Remote::WDKeys->KEYS->{backspace});
-        is $groupname->get_text, '', 'empty group name';
         is($driver->find_element('#properties p.buttons button.btn-primary')->get_attribute('disabled'),
-            'true', 'group properties save button is disabled if name is left empty');
+            'true', 'group properties save button is disabled if leave name is empty');
         is(
             $driver->find_element('#editor-name')->get_attribute('class'),
             'form-control is-invalid',
@@ -429,13 +425,12 @@ subtest 'job property editor' => sub() {
         $groupname->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $groupname->send_keys('   ');
         is($driver->find_element('#properties p.buttons button.btn-primary')->get_attribute('disabled'),
-            'true', 'group properties save button is disabled if name is blank');
+            'true', 'group properties save button is disabled if leave name is empty');
         is(
             $driver->find_element('#editor-name')->get_attribute('class'),
             'form-control is-invalid',
             'editor name input marked as invalid'
         );
-        disable_timeout;
         $driver->refresh();
         $driver->find_element_by_id('toggle-group-properties')->click();
     };


### PR DESCRIPTION
This reverts commit a8078421fde426eff940a914e66aefdc964088be.

CI sees failures with recent commit, e.g. 
https://app.circleci.com/pipelines/github/os-autoinst/openQA/2356/workflows/779837cd-6328-438f-add7-568660a6fa2c/jobs/22131
https://app.circleci.com/pipelines/github/os-autoinst/openQA/2364/workflows/6f1b8468-2e44-4630-bcaf-86fe7bf11acb/jobs/22211

Can reproduce the same locally:
https://gist.github.com/andrii-suse/d0a09e76045f9f1250355e0fbb169fc5

So suggest reverting commit a8078421