### PR TITLE
Enhance full-stack test

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -148,7 +148,7 @@ sub start_worker {
 }
 
 start_worker;
-OpenQA::Test::FullstackUtils::wait_for_job_running($driver, 'fail on incomplete');
+ok OpenQA::Test::FullstackUtils::wait_for_job_running($driver), 'fail on incomplete';
 
 sub wait_for_session_info {
     my ($info_regex, $diag_info) = @_;
@@ -450,11 +450,10 @@ subtest 'quit session' => sub {
 subtest 'test cancelled by quitting the session' => sub {
     $driver->switch_to_window($first_tab);
     $driver->get($job_page_url);
-    OpenQA::Test::FullstackUtils::wait_for_result_panel(
-        $driver,
-        qr/(State: cancelled|Result: (user_cancelled|passed))/,
-        'test 1 has been cancelled (if it was fast enough to actually pass that is ok, too)'
-    );
+    ok OpenQA::Test::FullstackUtils::wait_for_result_panel(
+        $driver, qr/(State: cancelled|Result: (user_cancelled|passed))/
+      ),
+      'test 1 has been cancelled (if it was fast enough to actually pass that is ok, too)';
     my $log_file_path = path($resultdir, '00000', "00000001-$job_name")->make_path->child('autoinst-log.txt');
     ok(-s $log_file_path, "log file generated under $log_file_path");
 };

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -113,18 +113,10 @@ is($driver->find_element('#user-action a')->get_text(), 'Login', 'no one initial
 $driver->click_element_ok('Login', 'link_text');
 $driver->title_is('openQA', 'back on main page');
 
-my $JOB_SETUP
-  = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 QEMU_NO_KVM=1 '
-  . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1 '
-  . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2 '
-  . 'TESTING_ASSERT_SCREEN_TIMEOUT=1';
+$OpenQA::Test::FullstackUtils::JOB_SETUP .= 'TESTING_ASSERT_SCREEN_TIMEOUT=1';
 # setting TESTING_ASSERT_SCREEN_TIMEOUT is important here (see os-autoinst/t/data/tests/tests/boot.pm)
 
-subtest 'schedule job' => sub {
-    OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP");
-    OpenQA::Test::FullstackUtils::verify_one_job_displayed_as_scheduled($driver);
-};
-
+OpenQA::Test::FullstackUtils::schedule_one_job_over_api_and_verify($driver);
 my $job_name = 'tinycore-1-flavor-i386-Build1-core@coolone';
 $driver->find_element_by_link_text('core@coolone')->click();
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -105,10 +105,6 @@ $driver->title_is("openQA", "back on main page");
 $driver->click_element_ok('dont-notify', 'id', 'Selected to not notify about tour');
 $driver->click_element_ok('confirm',     'id', 'Clicked confirm about no tour');
 
-# speedup using virtualization support if available, results should be
-# equivalent, just saving some time
-$OpenQA::Test::FullstackUtils::JOB_SETUP .= ' QEMU_NO_KVM=1' unless -r '/dev/kvm';
-
 OpenQA::Test::FullstackUtils::schedule_one_job_over_api_and_verify($driver);
 
 my $job_name = 'tinycore-1-flavor-i386-Build1-core@coolone';
@@ -133,7 +129,7 @@ sub start_worker {
 }
 
 start_worker;
-OpenQA::Test::FullstackUtils::wait_for_job_running($driver, 'fail on incomplete');
+ok OpenQA::Test::FullstackUtils::wait_for_job_running($driver), 'fail on incomplete';
 
 subtest 'wait until developer console becomes available' => sub {
     # open developer console
@@ -175,7 +171,7 @@ subtest 'pause at certain test' => sub {
 };
 
 $driver->get($job_page_url);
-OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/, 'test 1 is passed');
+ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/), 'test 1 is passed';
 
 ok(-s path($resultdir, '00000',   "00000001-$job_name")->make_path->child('autoinst-log.txt'), 'log file generated');
 ok(-s path($sharedir,  'factory', 'hdd')->make_path->child('core-hdd.qcow2'),                  'image of hdd uploaded');
@@ -205,11 +201,11 @@ like($driver->find_element('#result-row .card-body')->get_text(), qr/Cloned as 2
 $driver->click_element_ok('2', 'link_text', 'clicked link to test 2');
 
 OpenQA::Test::FullstackUtils::schedule_one_job;
-OpenQA::Test::FullstackUtils::wait_for_job_running($driver);
+ok OpenQA::Test::FullstackUtils::wait_for_job_running($driver), 'job running';
 
 stop_worker;
 
-OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/, 'test 2 crashed');
+ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/), 'test 2 crashed';
 like(
     $driver->find_element('#result-row .card-body')->get_text(),
     qr/Cloned as 3/,
@@ -225,12 +221,8 @@ subtest 'cancel a scheduled job' => sub {
 
     # it can happen that the test is assigned and needs to wait for the scheduler
     # to detect it as dead before it's moved back to scheduled
-    OpenQA::Test::FullstackUtils::wait_for_result_panel(
-        $driver,
-        qr/State: scheduled/,
-        'Test 3 is scheduled',
-        undef, 0.2,
-    );
+    ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/State: scheduled/, undef, 0.2),
+      'Test 3 is scheduled';
 
     my @cancel_button = $driver->find_elements('cancel_running', 'id');
     $cancel_button[0]->click();
@@ -245,7 +237,7 @@ like($driver->find_element('#result-row .card-body')->get_text(), qr/State: sche
 javascript_console_has_no_warnings_or_errors;
 start_worker;
 
-OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/, 'Test 4 crashed as expected');
+ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/), 'Test 4 crashed as expected';
 
 # Slurp the whole file, it's not that big anyways
 my $filename = $resultdir . "/00000/00000004-$job_name/autoinst-log.txt";
@@ -335,7 +327,7 @@ subtest 'Cache tests' => sub {
     like($driver->find_element('#result-row .card-body')->get_text(), qr/State: scheduled/, 'test 5 is scheduled')
       or die;
     start_worker;
-    OpenQA::Test::FullstackUtils::wait_for_job_running($driver, 1);
+    ok OpenQA::Test::FullstackUtils::wait_for_job_running($driver, 1), 'job running';
     ok(-e $db_file,                                 "cache.sqlite file created");
     ok(!-d path($cache_location, "test_directory"), "Directory within cache, not present after deploy");
     ok(!-e $cache_location->child("test.file"),     "File within cache, not present after deploy");
@@ -346,7 +338,7 @@ subtest 'Cache tests' => sub {
     my $cached = $cache_location->child('localhost', 'Core-7.2.iso');
     is $cached->stat->ino, $link->stat->ino, 'iso is hardlinked to cache';
 
-    OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/, 'test 5 is passed');
+    ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/), 'test 5 is passed';
     stop_worker;
 
     #  The worker is launched with --verbose, so by default in this test the level is always debug
@@ -406,7 +398,7 @@ subtest 'Cache tests' => sub {
     $driver->get('/tests/6');
     like($driver->find_element('#result-row .card-body')->get_text(), qr/State: scheduled/, 'test 6 is scheduled');
     start_worker;
-    OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/, 'test 6 is passed');
+    ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/), 'test 6 is passed';
     stop_worker;
 
     ok(!-e $result->{filename}, "asset 5.qcow2 removed during cache init");
@@ -427,7 +419,7 @@ subtest 'Cache tests' => sub {
     $driver->get('/tests/7');
     like($driver->find_element('#result-row .card-body')->get_text(), qr/State: scheduled/, 'test 7 is scheduled');
     start_worker;
-    OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/, 'test 7 is passed');
+    ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: passed/), 'test 7 is passed';
 
     #  The worker is launched with --verbose, so by default in this test the level is always debug
     if (!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i) {
@@ -450,7 +442,7 @@ subtest 'Cache tests' => sub {
     OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP HDD_1=non-existent.qcow2");
     OpenQA::Test::FullstackUtils::schedule_one_job;
     $driver->get('/tests/8');
-    OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/, 'test 8 is incomplete');
+    ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/), 'test 8 is incomplete';
 
     #  The worker is launched with --verbose, so by default in this test the level is always debug
     if (!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i) {

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -105,20 +105,11 @@ $driver->title_is("openQA", "back on main page");
 $driver->click_element_ok('dont-notify', 'id', 'Selected to not notify about tour');
 $driver->click_element_ok('confirm',     'id', 'Clicked confirm about no tour');
 
-my $JOB_SETUP
-  = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 '
-  . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1 '
-  . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2 '
-  . 'UEFI_PFLASH_VARS=/usr/share/qemu/ovmf-x86_64.bin';
-
 # speedup using virtualization support if available, results should be
 # equivalent, just saving some time
-$JOB_SETUP .= ' QEMU_NO_KVM=1' unless -r '/dev/kvm';
+$OpenQA::Test::FullstackUtils::JOB_SETUP .= ' QEMU_NO_KVM=1' unless -r '/dev/kvm';
 
-subtest 'schedule job' => sub {
-    OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP");
-    OpenQA::Test::FullstackUtils::verify_one_job_displayed_as_scheduled($driver);
-};
+OpenQA::Test::FullstackUtils::schedule_one_job_over_api_and_verify($driver);
 
 my $job_name = 'tinycore-1-flavor-i386-Build1-core@coolone';
 $driver->find_element_by_link_text('core@coolone')->click();
@@ -225,6 +216,7 @@ like(
     'test 2 is restarted by killing worker'
 );
 
+my $JOB_SETUP = $OpenQA::Test::FullstackUtils::JOB_SETUP;
 OpenQA::Test::FullstackUtils::client_call("jobs post $JOB_SETUP MACHINE=noassets HDD_1=nihilist_disk.hda");
 
 subtest 'cancel a scheduled job' => sub {

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -27,6 +27,16 @@ use Time::HiRes 'sleep';
 use OpenQA::SeleniumTest;
 use OpenQA::Scheduler::Model::Jobs;
 
+our $JOB_SETUP
+  = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 QEMU_NO_KVM=1 '
+  . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1 '
+  . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2 '
+  . 'UEFI_PFLASH_VARS=/usr/share/qemu/ovmf-x86_64.bin';
+
+# speedup using virtualization support if available, results should be
+# equivalent, just saving some time
+$JOB_SETUP .= ' QEMU_NO_KVM=1' unless -r '/dev/kvm';
+
 sub get_connect_args {
     my $mojoport = OpenQA::SeleniumTest::get_mojoport;
     return "--apikey=1234567890ABCDEF --apisecret=1234567890ABCDEF --host=http://localhost:$mojoport";
@@ -207,5 +217,11 @@ sub verify_one_job_displayed_as_scheduled {
     wait_for_ajax(msg => $msg);
     is $driver->find_element_by_id('scheduled_jobs_heading')->get_text(), '1 scheduled jobs', $msg;
 }
+
+sub schedule_one_job_over_api_and_verify {
+    my ($driver) = @_;
+    client_call("jobs post $JOB_SETUP");
+    return verify_one_job_displayed_as_scheduled($driver);
+};
 
 1;

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -78,11 +78,11 @@ sub prevent_reload {
 
 # reloads the page manually and prevents further automatic reloads
 sub reload_manually {
-    my ($driver, $desc, $delay) = @_;
+    my ($driver, $delay) = @_;
 
     sleep($delay) if $delay;
     if ($driver->execute_script('return window.wouldHaveReloaded;')) {
-        note("reloading manually ($desc)");
+        note('reloading manually');
         $driver->refresh();
     }
     prevent_reload($driver);
@@ -91,7 +91,7 @@ sub reload_manually {
 sub find_status_text { shift->find_element('#result-row .card-body')->get_text() }
 
 sub wait_for_result_panel {
-    my ($driver, $result_panel, $desc, $fail_on_incomplete, $refresh_interval) = @_;
+    my ($driver, $result_panel, $fail_on_incomplete, $refresh_interval) = @_;
     $refresh_interval //= 1;
 
     prevent_reload($driver);
@@ -100,20 +100,21 @@ sub wait_for_result_panel {
         my $status_text = find_status_text($driver);
         last if ($status_text =~ $result_panel);
         if ($fail_on_incomplete && $status_text =~ qr/Result: (incomplete|timeout_exceeded)/) {
-            fail('test result is incomplete but shouldn\'t');
-            return;
+            diag('test result is incomplete but shouldn\'t');
+            return undef;
         }
         javascript_console_has_no_warnings_or_errors;
-        reload_manually($driver, $desc, $refresh_interval);
+        reload_manually($driver, $refresh_interval);
     }
     javascript_console_has_no_warnings_or_errors;
-    reload_manually($driver, $desc);
-    like(find_status_text($driver), $result_panel, $desc);
+    reload_manually($driver);
+    return find_status_text($driver) =~ $result_panel;
 }
 
 sub wait_for_job_running {
     my ($driver, $fail_on_incomplete) = @_;
-    wait_for_result_panel($driver, qr/State: running/, 'job is running', $fail_on_incomplete);
+    my $success = wait_for_result_panel($driver, qr/State: running/, $fail_on_incomplete);
+    return unless $success;
     $driver->find_element_by_link_text('Live View')->click();
 }
 
@@ -213,15 +214,14 @@ sub verify_one_job_displayed_as_scheduled {
 
     $driver->click_element_ok('All Tests', 'link_text', 'Clicked All Tests to look for scheduled job');
     $driver->title_is('openQA: Test results', 'tests followed');
-    my $msg = 'test displayed as scheduled';
-    wait_for_ajax(msg => $msg);
-    is $driver->find_element_by_id('scheduled_jobs_heading')->get_text(), '1 scheduled jobs', $msg;
+    wait_for_ajax(msg => 'wait before checking for scheduled job');
+    return $driver->find_element_by_id('scheduled_jobs_heading')->get_text() eq '1 scheduled jobs';
 }
 
 sub schedule_one_job_over_api_and_verify {
     my ($driver) = @_;
     client_call("jobs post $JOB_SETUP");
     return verify_one_job_displayed_as_scheduled($driver);
-};
+}
 
 1;


### PR DESCRIPTION
* Improve test stack reporting by avoiding Test::More tests in helper libs
* t: Extract common full stack function "schedule_one_job_over_api_and_verify"
* t: Add timeout for loops in full-stack.t
* t: Speedup full stack test with KVM when available