### PR TITLE
Increase proxy timeout

### DIFF
--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -79,3 +79,7 @@ ServerSignature On
 # TODO: try mojo 7.39 - https://github.com/kraih/mojo/commit/f9ff45e48f606
 SetEnv proxy-nokeepalive 1
 
+# Increase the timeout from 60s (default) to 300s to ensure that the large
+# requests could finish without proxy timeouts problems.
+# This value could be enough but not necessary. More investigation needed
+ProxyTimeout 300


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/63244

Problem: Apache2 proxy sets the timeout by default to 60s. But sometimes
openQA-webui need more than this time to finish parsing and rendering.

Solution: Increase the timeout in the proxy configuration file to 300s.

It indicates that it took around 103 seconds for openQA-webui
to finish parsing, rendering.
Weheras the apache2 proxy waiting timeout defaults to 60s. That was why
my browser couldn't load results page.