### PR TITLE
Add script directory to coverage; test all scripts with --help

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,9 +261,9 @@ jobs:
       - attach_workspace:
           at: .
       - run: cover -write cover_db cover_db*
-      - run: cover -select_re '^lib/' -report html_minimal
+      - run: cover -select_re '^(lib|script)/' -report html_minimal
       - store_artifacts: *store_cover_db
-      - run: cover -select_re '^lib/' -report codecov
+      - run: cover -select_re '^(lib|script)/' -report codecov
 
   build-docs: &docs-template
     name: "Generating docs"

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,7 @@ coverage:
     changes: false
     project:
       default:
-        target: 93.0
+        target: 91.5
         threshold: 0.1
     patch:
       default:

--- a/script/load_templates
+++ b/script/load_templates
@@ -92,7 +92,8 @@ sub usage($) {
 
 GetOptions(\%options, "apibase=s", "apikey=s", "apisecret=s", "clean", "host=s", "update", "help|h",) or usage(1);
 
-usage(1) if $options{help} || $#ARGV;
+usage(0) if $options{help};
+usage(1) if $#ARGV;
 
 # Slurp file specified as an argument or STDIN in case of "-"
 my $datafile = join("", <>);

--- a/script/modify_needle
+++ b/script/modify_needle
@@ -59,7 +59,7 @@ sub usage($) {
 my %options;
 GetOptions(\%options, "add-tags=s", "help|h",) or usage(1);
 
-usage(1) if $options{help};
+usage(0) if $options{help};
 
 my @add_tags = split(q{,}, $options{'add-tags'});
 

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -43,7 +43,7 @@ sub dump_templates {
 
 sub decode { Cpanel::JSON::XS->new->relaxed->decode(path(shift)->slurp); }
 
-test_once '--help', qr/Usage:/, 'help text shown', 1, 'load_templates with no arguments shows usage';
+test_once '--help', qr/Usage:/, 'help text shown', 0, 'load_templates with no arguments shows usage';
 test_once '--host', qr/Option host requires an argument/, 'host argument error shown', 1, 'required arguments missing';
 
 my $host         = 'testhost:1234';

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+use FindBin '$Bin';
+use Test::More;
+my %allowed_types = (
+    'text/x-perl'   => 1,
+    'text/x-python' => 1,
+);
+
+# Could also use MIME::Types, would be new dependency
+chomp(my @types = qx{cd $Bin/../script; for i in *; do echo \$i; file --mime-type --brief \$i; done});
+
+my %types = @types;
+for my $key (keys %types) {
+    delete $types{$key} unless $allowed_types{$types{$key}};
+}
+
+# scripts without --help
+for (qw(check_dependencies openqa-workercache openqa openqa-livehandler)) {
+    delete $types{$_};
+    diag "TODO $_";
+}
+
+for my $script (sort keys %types) {
+    my $out = qx{$Bin/../script/$script --help 2>&1};
+    my $rc  = $?;
+    is($rc, 0, "Calling '$script --help' returns exit code 0")
+      or diag "Output: $out";
+}
+
+done_testing;


### PR DESCRIPTION
I excluded the following scripts:
* `check_dependencies`, `openqa-workercache` All our other scripts use `pod2usage` for `--help` but those script have no pod yet.
* `openqa`, `openqa-livehandler` these scripts are failing in CI (https://app.circleci.com/pipelines/github/os-autoinst/openQA/2406/workflows/6a8c5689-a0aa-40e1-a8c9-f2107b493c35/jobs/22618):
```
[13:01:59] t/44-scripts.t ................................. 7/? m
#   Failed test 'Calling 'openqa --help' returns exit code 0'
#   at t/44-scripts.t line 42.
#          got: '512'
#     expected: '0'
# Output: Can not create MOJO_TMPDIR : mkdir /var/lib/openqa: Permission denied at /home/squamata/project/script/../lib/OpenQA/Setup.pm line 243.
# 
# Can't open database lock file /var/lib/openqa/db/db.lock! at /home/squamata/project/script/../lib/OpenQA/Schema.pm line 87.
[13:01:59] t/44-scripts.t ................................. 9/? 
#   Failed test 'Calling 'openqa-livehandler --help' returns exit code 0'
#   at t/44-scripts.t line 42.
#          got: '512'
#     expected: '0'
# Output: Can not create MOJO_TMPDIR : mkdir /var/lib/openqa: Permission denied at /home/squamata/project/script/../lib/OpenQA/Setup.pm line 243.
# 
# Can't open database lock file /var/lib/openqa/db/db.lock! at /home/squamata/project/script/../lib/OpenQA/Schema.pm line 87.
```