### PR TITLE
Consider directly chained dependencies when registering assets

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1426,7 +1426,7 @@ sub register_assets_from_settings {
 
     return unless keys %assets;
 
-    my %cond       = (dependency => OpenQA::JobDependencies::Constants::CHAINED);
+    my %cond       = (dependency => {-in => [OpenQA::JobDependencies::Constants::CHAINED_DEPENDENCIES]});
     my @parents_rs = $self->parents->search(\%cond, {columns => ['parent_job_id']});
     my @parents    = map { $_->parent_job_id } @parents_rs;
 


### PR DESCRIPTION
Considering https://progress.opensuse.org/issues/65627 it seems that directly chained parents need to be taken into account similarly to regularly chained parents when registering assets.

This change implements that and adds and explicit test for both cases.