### PR TITLE
Speed up dashboard tests

### DIFF
--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -24,14 +24,11 @@ use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
+use OpenQA::SeleniumTest;
 
 my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema      = $test_case->init_data(schema_name => $schema_name);
-
-use OpenQA::SeleniumTest;
-
-my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 sub schema_hook {
     my $parent_groups = $schema->resultset('JobGroupParents');


### PR DESCRIPTION
Avoid instantiating `Test::Mojo->new('OpenQA::WebAPI')` in these tests. This also avoids initializing the database twice in `t/ui/14-dashboard.t`.