### PR TITLE
t: Stabilize and simplify ui/02-list-group.t (again)

### DIFF
--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2018 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@ is(@rows, 1, 'one sheduled job without group');
 ok($driver->get("/tests?groupid=1001"), "list jobs without group 1001");
 @rows = $driver->find_child_elements($driver->find_element('#running tbody'), "tr");
 is(@rows, 1, 'one running job with this group');
-isnt($driver->find_element('#running #job_99963'), undef, '99963 listed');
+ok(wait_for_element(selector => '#running #job_99963'), '99963 listed');
 
 kill_driver();
 done_testing();

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -26,25 +26,23 @@ OpenQA::Test::Case->new->init_data;
 
 use OpenQA::SeleniumTest;
 
-my $t = Test::Mojo->new('OpenQA::WebAPI');
-
-my $driver = call_driver();
+my $t      = Test::Mojo->new('OpenQA::WebAPI');
+my $driver = call_driver;
 unless ($driver) {
     plan skip_all => $OpenQA::SeleniumTest::drivermissing;
     exit(0);
 }
 
-$driver->title_is("openQA", "on main page");
-ok($driver->get('/tests?groupid=0'), 'list jobs without group');
-wait_for_ajax();
+ok $driver->get('/tests?groupid=0'), 'list jobs without group';
+wait_for_ajax(msg => 'wait for test list without group');
+my @rows = $driver->find_child_elements($driver->find_element('#scheduled tbody'), 'tr');
+is @rows, 1, 'one scheduled job without group';
 
-my @rows = $driver->find_child_elements($driver->find_element('#scheduled tbody'), "tr");
-is(@rows, 1, 'one sheduled job without group');
+ok $driver->get('/tests?groupid=1001'), 'list jobs with group 1001';
+wait_for_ajax(msg => 'wait for test list with one group');
+@rows = $driver->find_child_elements($driver->find_element('#running tbody'), 'tr');
+is @rows, 1, 'one running job with this group';
+ok $driver->find_element('#running #job_99963'), '99963 listed';
 
-ok($driver->get("/tests?groupid=1001"), "list jobs without group 1001");
-@rows = $driver->find_child_elements($driver->find_element('#running tbody'), "tr");
-is(@rows, 1, 'one running job with this group');
-ok(wait_for_element(selector => '#running #job_99963'), '99963 listed');
-
-kill_driver();
-done_testing();
+kill_driver;
+done_testing;


### PR DESCRIPTION
The previous fix to wait for an element should be applied before
counting the displayed entries, not only looking for an individual entry
afterwards.

Also simplifying the test module according to common style.

Related progress issue: https://progress.opensuse.org/issues/59043