### PR TITLE
Use Test::Most instead of Test::More for convenience

### DIFF
--- a/.circleci/dependencies.txt
+++ b/.circleci/dependencies.txt
@@ -213,6 +213,7 @@ perl-Test-LongString-0.17
 perl-Test-MockModule-0.13
 perl-Test-MockObject-1.20161202
 perl-Test-Mock-Time-0.1.7
+perl-Test-Most
 perl-Test-Output-1.031
 perl-Test-Strict-0.40
 perl-Test-Warnings-0.026

--- a/cpanfile
+++ b/cpanfile
@@ -102,7 +102,7 @@ on 'test' => sub {
     requires 'Test::MockModule';
     requires 'Test::MockObject';
     requires 'Test::Mojo';
-    requires 'Test::More';
+    requires 'Test::Most';
     requires 'Test::Output';
     requires 'Test::Pod';
     requires 'Test::Strict';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -163,7 +163,7 @@ test_requires:
   perl(Selenium::Remote::WDKeys):
   perl(Test::Exception):
   perl(Test::Mojo):
-  perl(Test::More):
+  perl(Test::Most):
   perl(Test::Strict):
   perl(Test::Fatal):
   perl(Test::MockModule):

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -138,7 +138,7 @@ but that is no longer possible.
 
 As stated in the previous section, every feature implemented in both packages
 should be backed by proper tests.
-http://perldoc.perl.org/Test/More.html[Test::More] is used to implement those
+http://perldoc.perl.org/Test/Most.html[Test::Most] is used to implement those
 tests. As usual, tests are located under the `/t/` directory. In the openQA
 package, one of the tests consists of a call to
 http://perltidy.sourceforge.net/[Perltidy] to ensure that the contributed code

--- a/openQA.spec
+++ b/openQA.spec
@@ -63,7 +63,7 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) postgresql-server python3-setuptools python3-yamllint
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) postgresql-server python3-setuptools python3-yamllint
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
-use Test::More;
 use Test::Warnings;
 
 is(system('tools/tidy', '--check'), 0, "tidy");

--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,9 @@ use FindBin;
 unshift @INC, "$FindBin::Bin/lib", "$FindBin::Bin/../lib";
 
 use Test::Strict;
+
+push @Test::Strict::MODULES_ENABLING_STRICT,   'Test::Most';
+push @Test::Strict::MODULES_ENABLING_WARNINGS, 'Test::Most';
 
 $Test::Strict::TEST_SYNTAX   = 1;
 $Test::Strict::TEST_STRICT   = 1;

--- a/t/02-pod.t
+++ b/t/02-pod.t
@@ -1,7 +1,5 @@
-use strict;
-use warnings;
+use Test::Most;
 
-use Test::More;
 eval 'use Test::Pod';
 plan skip_all => "Test::Pod required for testing POD" if $@;
 

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -13,12 +13,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::MockModule;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Database;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -28,7 +27,6 @@ use OpenQA::Test::Database;
 use OpenQA::Utils 'assetdir';
 use Test::Mojo;
 use Test::MockModule;
-use Test::More;
 use Test::Warnings;
 use Test::Output qw(stderr_like);
 use OpenQA::Schema::Result::Jobs;

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -26,7 +25,6 @@ use OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use Test::MockModule;
 use DBIx::Class::Timestamps 'now';
-use Test::More;
 use Test::Warnings;
 
 my $schema = OpenQA::Test::Database->new->create();

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -24,7 +23,6 @@ use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Database;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use Test::Mojo;
-use Test::More;
 use Test::Warnings;
 use Mojo::Util 'monkey_patch';
 

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -15,17 +15,14 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Database;
-use Test::Exception;
 use Test::Mojo;
-use Test::More;
 use Test::Warnings;
 use OpenQA::WebSockets::Client;
 use OpenQA::Jobs::Constants;

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing
@@ -32,7 +31,6 @@ use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Worker::WebUIConnection;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
 use Test::MockModule;
 use Mojo::IOLoop::Server;
 use Mojo::File qw(path tempfile);

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -25,7 +24,6 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use OpenQA::WebSockets::Client;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::Output qw(stderr_like);

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -14,14 +14,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -14,14 +14,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -14,15 +14,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -14,14 +14,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -26,7 +25,6 @@ use File::Copy;
 use OpenQA::Jobs::Constants;
 use OpenQA::Utils 'resultdir';
 use OpenQA::Test::Case;
-use Test::More;
 use Test::MockModule 'strict';
 use Test::Mojo;
 use Mojo::JSON 'decode_json';

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Warnings ':all';
 use Test::Output 'stderr_like';
 use OpenQA::Test::Case;

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -13,12 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -23,7 +22,6 @@ use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Jobs::Constants;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -26,7 +25,6 @@ use File::Copy;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job);
 use Test::MockModule;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::Output 'combined_like';

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -14,14 +14,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';
-use Test::More;
 use Test::Warnings;
 use Test::MockModule;
 use Test::Mojo;

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 BEGIN { unshift @INC, 'lib' }
 
-use Test::More;
 use OpenQA::Markdown qw(bugref_to_markdown is_light_color markdown_to_html);
 
 subtest 'standard markdown' => sub {

--- a/t/16-utils-job-templates.t
+++ b/t/16-utils-job-templates.t
@@ -15,13 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin '$Bin';
 use lib "$Bin/lib";
 use OpenQA::YAML qw(load_yaml validate_data);
-use Test::More;
 use Mojo::File qw(path tempdir tempfile);
 
 my $schema               = "$Bin/../public/schema/JobTemplates-01.yaml";

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -25,8 +24,6 @@ use OpenQA::Utils;
 use OpenQA::Task::Needle::Save;
 use OpenQA::Test::Case;
 use Mojo::File 'tempdir';
-use Test::Exception;
-use Test::More;
 use Test::MockModule;
 use Test::Mojo;
 use Test::Warnings;
@@ -193,8 +190,8 @@ subtest 'saving needle via Git' => sub {
         sub finish {
         }
         sub fail {
-            Test::More::fail("Minion job shouldn't have failed.");
-            Test::More::note(Data::Dumper::Dumper(\@_));
+            Test::Most::fail("Minion job shouldn't have failed.");
+            Test::Most::note(Data::Dumper::Dumper(\@_));
         }
     }
 

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -14,14 +14,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils qw(:DEFAULT prjdir sharedir resultdir assetdir imagesdir base_host random_string random_hex);
 use OpenQA::Test::Utils 'redirect_output';
-use Test::More;
 use Scalar::Util 'reftype';
 use Mojo::File qw(path tempdir tempfile);
 
@@ -247,11 +245,11 @@ subtest 'Plugins handling' => sub {
     is path_to_class('foo/bar/baz.pm'), "foo::bar::baz";
 
     ok grep("OpenQA::Utils", loaded_modules), "Can detect loaded modules";
-    ok grep("Test::More",    loaded_modules), "Can detect loaded modules";
+    ok grep("Test::Most",    loaded_modules), "Can detect loaded modules";
 
-    is_deeply [loaded_plugins("OpenQA::Utils", "Test::More")], ["OpenQA::Utils", "Test::More"],
+    is_deeply [loaded_plugins('OpenQA::Utils', 'Test::Most')], ['OpenQA::Utils', 'Test::Most', 'Test::Most::Exception'],
       "Can detect loaded plugins, filtering by namespace";
-    ok grep("Test::More", loaded_plugins),
+    ok grep("Test::Most", loaded_plugins),
       "loaded_plugins() behave like loaded_modules() when no arguments are supplied";
 
     my $test_hash = {

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -13,13 +13,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Test::Database;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -15,13 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;
-use Test::More;
 use Test::Warnings;
 use Test::Output qw(combined_like stderr_like);
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -27,7 +26,6 @@ use OpenQA::Test::Database;
 use OpenQA::Task::Needle::Scan;
 use File::Find;
 use Test::Output 'combined_like';
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Date::Format 'time2str';

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -15,11 +15,10 @@
 
 # see also t/ui/14-dashboard.t and t/ui/14-dashboard-parents.t for Selenium test
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use Mojo::IOLoop;
 
@@ -23,9 +23,7 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Client;
 use OpenQA::Jobs::Constants;
 use OpenQA::Test::Database;
-use Test::Exception;
 use Test::MockModule;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Mojo::File qw(tempdir path);

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -13,14 +13,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
-use Test::Exception;
 use Test::Fatal;
-use Test::More;
 use Test::Output qw(stdout_like stderr_like);
 use Test::Warnings;
 use OpenQA::Worker;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -15,12 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::More;
 use Test::Fatal;
 use Test::Output 'combined_like';
 use Test::MockModule;

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -14,18 +14,16 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
-use Mojo::Base -strict;
+use Test::Most;
 use Mojo::File 'tempdir';
 use Mojolicious;
 use Test::Fatal;
 use Test::Output qw(combined_like combined_from);
 use Test::MockModule;
-use Test::More;
 use OpenQA::Worker;
 use OpenQA::Worker::Job;
 use OpenQA::Worker::WebUIConnection;

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
-use Test::More;
 use OpenQA::Worker::Settings;
 use OpenQA::Worker::App;
 use Test::MockModule;

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -15,17 +15,15 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
-use Mojo::Base -strict;
+use Test::Most;
 use Mojo::IOLoop;
 use Mojolicious;
 use Test::Output 'combined_like';
 use Test::Fatal;
-use Test::More;
 use Test::Mojo;
 use Test::MockModule;
 use OpenQA::App;

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -14,15 +14,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job collect_coverage_of_gru_jobs);
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 my $tempdir;
 BEGIN {
@@ -37,7 +37,6 @@ CACHELIMIT = 100');
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::More;
 use Test::Warnings;
 use OpenQA::Utils;
 use IO::Socket::INET;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 my ($tempdir, $cached, $cachedir, $db_file);
 BEGIN {
@@ -34,10 +34,11 @@ CACHEWORKERS = 10
 CACHELIMIT = 50");
 }
 
+use utf8;
+
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::More;
 use Test::Warnings;
 use OpenQA::Utils qw(:DEFAULT base_host);
 use OpenQA::CacheService;

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -15,12 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Test::Most;
+use utf8;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::More;
 use OpenQA::Downloader;
 use IO::Socket::INET;
 use Mojo::Server::Daemon;

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 BEGIN {
     package OpenQA::FakePlugin::Fuzz;
@@ -33,7 +32,6 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Log 'setup_log';
 use OpenQA::Setup;
 use OpenQA::Utils;
-use Test::More;
 use Mojolicious;
 use Mojo::File qw(tempfile path);
 

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -14,13 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;
-use Test::More;
 use Test::Warnings;
 use OpenQA::WebAPI::Controller::Running;
 use Mojolicious;

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -15,11 +15,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use 5.018;
-use Test::More;
 use POSIX;
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -14,11 +14,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use Time::HiRes 'gettimeofday';
-use Test::More;
 use Mojo::File qw(tempdir tempfile);
 use OpenQA::App;
 use OpenQA::Setup;

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
-use Test::More;
 use OpenQA;
 use Test::Output 'combined_like';
 use OpenQA::Parser qw(parser p);

--- a/t/31-api_descriptions.t
+++ b/t/31-api_descriptions.t
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/31-client.t
+++ b/t/31-client.t
@@ -12,14 +12,11 @@
 #
 # You should have received a copy of the GNU General Public License
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "lib";
 
-use Test::Exception;
-use Test::More;
 use Test::Mojo;
 use Test::MockModule;
 use Test::MockObject;

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
-use Test::More;
 use OpenQA::Client;
 use OpenQA::File;
 use Digest::SHA 'sha1_base64';

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
-use Test::More;
 use OpenQA::Client;
 use Test::Mojo;
 use OpenQA::WebAPI;

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -19,7 +19,7 @@
 #  * a qemu instance is still running (maybe leftover from last failed test
 #    execution)
 
-use Mojo::Base -strict;
+use Test::Most;
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing
@@ -32,7 +32,6 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Output 'stderr_like';
 use IO::Socket::INET;

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -14,14 +14,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Date::Format;
 use Data::Dumper 'Dumper';
 use Test::Output 'combined_like';
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::MockModule;

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -13,12 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Output 'combined_like';
 use OpenQA::Script::CloneJob;
 use Mojo::URL;

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use Mojo::File 'path';
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::MockModule;

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -14,15 +14,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::MockModule;
-use Test::Exception;
 use OpenQA::Test::Case;
 use OpenQA::Utils;
 

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use OpenQA::JobSettings;
 
 my $settings = {

--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -15,10 +15,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use strict;
-use warnings;
-use Test::Exception;
-use Test::More;
+use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Test::Utils qw(run_cmd test_cmd);

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -21,7 +21,6 @@ use File::Temp qw(tempfile);
 use Mojo::File qw(path curfile);
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils;
-use Test::More;
 use Test::Output;
 use Test::Warnings;
 use OpenQA::Test::Utils qw(run_cmd test_cmd stop_service);

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -13,12 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Warnings;
 use Test::Output;
 use OpenQA::Test::Utils qw(run_cmd test_cmd);

--- a/t/40-script_openqa-label-all.t
+++ b/t/40-script_openqa-label-all.t
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
-use Test::More;
 use Test::Warnings;
 
 is(system('script/openqa-label-all --help'), 0);

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Date::Format 'time2str';

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -27,7 +26,6 @@ use OpenQA::Test::Utils qw(run_gru_job collect_coverage_of_gru_jobs);
 use Mojo::File 'path';
 use Mojo::Log;
 use Test::Output 'combined_like';
-use Test::More;
 use Test::MockModule;
 use Test::Mojo;
 use Test::Warnings;

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -25,7 +24,6 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Test::Utils
   qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
   qw(stop_service setup_fullstack_temp_dir);
-use Test::More;
 use Test::Warnings;
 use Test::MockModule;
 use Time::HiRes 'sleep';

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -14,11 +14,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin '$Bin';
-use Test::More;
 my %allowed_types = (
     'text/x-perl'   => 1,
     'text/x-python' => 1,

--- a/t/45-make-update-deps.t
+++ b/t/45-make-update-deps.t
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
-
-use Test::More;
+use Test::Most;
 use Test::Warnings;
 
 my $make = "make update-deps";

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
 use Mojo::URL;

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
 use OpenQA::Test::Case;

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::MockModule;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
 use Mojo::URL;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -15,12 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Test::Most;
+use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use File::Temp;
-use Test::More;
 use Test::Mojo;
 use Test::Output;
 use Test::Warnings;

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::MockModule;

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 SUSE LLC
+# Copyright (C) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Test::Most;
+use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use Date::Format;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;

--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
@@ -55,7 +54,7 @@ $t->app($app);
 sub start_gru {
     die 'Cannot fork gru' unless defined(my $gru_pid = fork());
     if ($gru_pid == 0) {
-        Test::More::note('starting gru');
+        Test::Most::note('starting gru');
         $ENV{MOJO_MODE} = 'test';
         Mojolicious::Commands->start_app('OpenQA::WebAPI', 'gru', 'run', '-m', 'test');
         exit(0);

--- a/t/basic.t
+++ b/t/basic.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Database;

--- a/t/config.t
+++ b/t/config.t
@@ -13,12 +13,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::More;
 use Test::Warnings;
 use Mojolicious;
 use OpenQA::Setup;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -15,13 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Test::More;
 use Test::Warnings;
 use Test::Mojo;
 use DBIx::Class::DeploymentHandler;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -20,7 +20,7 @@
 #  * a qemu instance is still running (maybe leftover from last failed test
 #    execution)
 
-use Mojo::Base -strict;
+use Test::Most;
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing
@@ -33,7 +33,6 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use Test::More;
 use Test::Mojo;
 use Test::Output 'stderr_like';
 use Test::Warnings;

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -1,7 +1,6 @@
 package OpenQA::SeleniumTest;
 
-use strict;
-use warnings;
+use Test::Most;
 
 use base 'Exporter';
 
@@ -18,7 +17,6 @@ our @EXPORT = qw($drivermissing check_driver_modules enable_timeout
 use Data::Dump 'pp';
 use Mojo::IOLoop::Server;
 use Mojo::Server::Daemon;
-use Test::More;
 use Try::Tiny;
 use Time::HiRes qw(time sleep);
 use OpenQA::WebAPI;
@@ -101,7 +99,7 @@ sub start_driver {
                 map { $_ => {args => []} } @chrome_option_keys,
             },
             error_handler => sub {
-                # generate Test::More failure instead of croaking to preserve
+                # generate Test::Most failure instead of croaking to preserve
                 # context but bail out to not have repeated entries for the
                 # same problem exceeded console scrollback buffers easily
                 my ($driver, $exception, $args) = @_;

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -14,6 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Test::Database;
+use Test::Most;
 use Mojo::Base -base;
 
 use Date::Format;    # To allow fixtures with relative dates
@@ -28,7 +29,6 @@ use Try::Tiny;
 
 has fixture_path => 't/fixtures';
 
-use Test::More;
 plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 
 sub generate_schema_name {

--- a/t/lib/OpenQA/Test/FakeWebSocketTransaction.pm
+++ b/t/lib/OpenQA/Test/FakeWebSocketTransaction.pm
@@ -16,7 +16,6 @@
 package OpenQA::Test::FakeWebSocketTransaction;
 use Mojo::Base 'Mojo::EventEmitter';
 
-use Test::More;
 use Mojo::IOLoop;
 use Mojo::Message::Response;
 

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -15,14 +15,12 @@
 
 package OpenQA::Test::FullstackUtils;
 
-use strict;
-use warnings;
+use Test::Most;
 
 use base 'Exporter';
 
 use Mojolicious;
 use Mojo::Home;
-use Test::More;
 use Time::HiRes 'sleep';
 use OpenQA::SeleniumTest;
 use OpenQA::Scheduler::Model::Jobs;

--- a/t/lib/OpenQA/Test/PatchDeparse.pm
+++ b/t/lib/OpenQA/Test/PatchDeparse.pm
@@ -1,7 +1,5 @@
 package OpenQA::Test::PatchDeparse;
-use strict;
-use warnings;
-use Test::More;
+use Test::Most;
 
 # Monkeypatch B::Deparse
 # https://progress.opensuse.org/issues/40895

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -1,5 +1,6 @@
 package OpenQA::Test::Utils;
-use Mojo::Base -strict;
+use Test::Most;
+use Mojo::Base -base;
 
 use Exporter 'import';
 use FindBin;
@@ -20,7 +21,6 @@ use Mojo::Home;
 use Mojo::File qw(path tempfile tempdir);
 use Cwd qw(abs_path getcwd);
 use Mojo::Util 'gzip';
-use Test::More;
 use Test::Output 'combined_like';
 use Mojo::IOLoop;
 use Mojo::IOLoop::ReadWriteProcess 'process';

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format 'time2str';
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use OpenQA::Test::Case;
 

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -13,12 +13,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use File::Spec;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Mojo::File;

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -13,12 +13,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format 'time2str';
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Encode 'encode_utf8';
-use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
 use OpenQA::Test::Case;

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -14,13 +14,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;
@@ -29,8 +28,8 @@ use Date::Format 'time2str';
 use IO::Socket::INET;
 
 # optional but very useful
-eval 'use Test::More::Color';
-eval 'use Test::More::Color "foreground"';
+eval 'use Test::Most::Color';
+eval 'use Test::Most::Color "foreground"';
 
 use File::Path qw(make_path remove_tree);
 use Module::Load::Conditional qw(can_load);

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -14,13 +14,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use Module::Load::Conditional qw(can_load);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Date::Format;
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use Module::Load::Conditional qw(can_load);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Log 'log_debug';

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Constants 'WORKERS_CHECKER_THRESHOLD';

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Test::Most;
+use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Log qw(log_debug);

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -15,12 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use Mojo::JSON 'decode_json';
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
 use Mojo::JSON qw(decode_json encode_json);

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings ':all';
 use OpenQA::Test::Case;

--- a/t/ui/20-bugzilla-links.t
+++ b/t/ui/20-bugzilla-links.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Date::Format 'time2str';
 use Test::Warnings ':all';

--- a/t/ui/22-job_group_order.t
+++ b/t/ui/22-job_group_order.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -18,13 +18,12 @@
 #       web socket connection to the live view handler is established here.
 #       Instead, the state is injected via JavaScript commands.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use Module::Load::Conditional qw(can_load);
 use Mojo::File qw(path tempdir);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use Test::MockModule;

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Test::Most;
+use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use Test::Warnings;
 use OpenQA::Test::Case;

--- a/t/ui/27-plugin_obs_rsync.t
+++ b/t/ui/27-plugin_obs_rsync.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;

--- a/t/ui/27-plugin_obs_rsync_gru.t
+++ b/t/ui/27-plugin_obs_rsync_gru.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Mojo;
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use Test::More;
 use Test::Warnings;
 use Test::Mojo;
 use OpenQA::Test::Database;


### PR DESCRIPTION
Test::Most provides a superset of Test::More. This simplifies our
includes as we can strip the boilerplate

```
use strict;
use warnings;
```

from tests but also benefit from additional features, for example being
able to use environment variables to abort testing on the first failure.
This can help for manual investigation of failures, for example with

```
DIE_ON_FAIL=1 prove t/
```

Test::Most is included in our common openSUSE and SLE distribution
versions since at least openSUSE Leap 15.1.