### PR TITLE
Allow to force restarting jobs

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -192,7 +192,7 @@ function showJobRestartResults(responseJSON, newJobUrl, retryFunction, targetEle
     if (hasResponse && responseJSON.enforceable && retryFunction) {
         var button = document.createElement('button');
         button.onclick = retryFunction;
-        button.className = 'btn btn-danger';
+        button.className = 'btn btn-danger force-restart';
         button.style.float = 'right';
         button.appendChild(document.createTextNode('Force restart'));
         container.appendChild(button);

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -179,7 +179,7 @@ function renderList(items)
     return  ul;
 }
 
-function showJobRestartResults(responseJSON, url, targetElement) {
+function showJobRestartResults(responseJSON, newJobUrl, retryFunction, targetElement) {
     var hasResponse = typeof responseJSON === 'object';
     var errors = hasResponse ? responseJSON.errors : ['Server returned invalid response'];
     var warnings = hasResponse ? responseJSON.warnings : undefined;
@@ -189,6 +189,14 @@ function showJobRestartResults(responseJSON, url, targetElement) {
         return false;
     }
     var container = document.createElement('div');
+    if (hasResponse && responseJSON.enforceable && retryFunction) {
+        var button = document.createElement('button');
+        button.onclick = retryFunction;
+        button.className = 'btn btn-danger';
+        button.style.float = 'right';
+        button.appendChild(document.createTextNode('Force restart'));
+        container.appendChild(button);
+    }
     if (hasWarnings) {
         container.appendChild(document.createTextNode('Warnings occurred when restarting jobs:'));
         container.appendChild(renderList(warnings));
@@ -197,9 +205,9 @@ function showJobRestartResults(responseJSON, url, targetElement) {
         container.appendChild(document.createTextNode('Errors occurred when restarting jobs:'));
         container.appendChild(renderList(errors));
     }
-    if (url !== undefined) {
+    if (newJobUrl !== undefined) {
         var link = document.createElement('a');
-        link.href = url;
+        link.href = newJobUrl;
         link.appendChild(document.createTextNode('new job'));
         container.appendChild(document.createTextNode('Go to '));
         container.appendChild(link);
@@ -209,7 +217,12 @@ function showJobRestartResults(responseJSON, url, targetElement) {
     return true;
 }
 
-function restartJob(url, jobId) {
+function forceJobRestartViaRestartLink(restartLink) {
+    restartLink.href += '?force=1';
+    restartLink.click();
+}
+
+function restartJob(ajaxUrl, jobId) {
     var showError = function(reason) {
         var errorMessage = '<strong>Unable to restart job';
         if (reason) {
@@ -222,19 +235,20 @@ function restartJob(url, jobId) {
 
     return $.ajax({
         type: 'POST',
-        url: url,
+        url: ajaxUrl,
         success: function(data, res, xhr) {
             var responseJSON = xhr.responseJSON;
-            if (showJobRestartResults(responseJSON, url)) {
+            var newJobUrl;
+            try {
+                newJobUrl = responseJSON.test_url[0][jobId];
+            }
+            catch {}
+            if (showJobRestartResults(responseJSON, newJobUrl, restartJob.bind(undefined, ajaxUrl + '?force=1', jobId))) {
                 return;
             }
-            try {
-                var url = responseJSON.test_url[0][jobId];
-                if (!url) {
-                    throw url;
-                }
-                window.location.replace(url);
-            } catch {
+            if (newJobUrl) {
+                window.location.replace(newJobUrl);
+            } else {
                 showError('URL for new job not available');
             }
         },

--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -11,13 +11,13 @@ function setupOverview() {
     });
     $('.restart')
         .bind("ajax:success", function(event, xhr, status) {
-            var oldId = 0;
             if (typeof xhr !== 'object' || !Array.isArray(xhr.result)) {
                 addFlash('danger', '<strong>Unable to restart job.</strong>');
                 return;
             }
-            showJobRestartResults(xhr);
+            showJobRestartResults(xhr, undefined, forceJobRestartViaRestartLink.bind(undefined, event.currentTarget));
             var newId = xhr.result[0];
+            var oldId = 0;
             $.each(newId, function(key, value) {
                 if (!$('.restart[data-jobid="' + key + '"]').length) {
                     return true;

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -416,16 +416,17 @@ function renderTestLists() {
 }
 
 function setupTestButtons() {
-    $(document).on("click", '.restart', function(event) {
+    $(document).on('click', '.restart', function(event) {
         event.preventDefault();
-        $.post(this.href).done( function(data, res, xhr) {
+        var restartLink = this;
+        $.post(restartLink.href).done(function(data, res, xhr) {
             var responseJSON = xhr.responseJSON;
             var flashTarget = $('#flash-messages-finished-jobs');
             if (typeof responseJSON !== 'object' || !Array.isArray(responseJSON.test_url)) {
                 addFlash('danger', '<strong>Unable to restart job.</strong>', flashTarget);
                 return;
             }
-            showJobRestartResults(responseJSON, undefined, flashTarget);
+            showJobRestartResults(responseJSON, undefined, forceJobRestartViaRestartLink.bind(undefined, restartLink), flashTarget);
             var urls = responseJSON.test_url[0];
             $.each(urls , function(key, value) {
                 // Skip to mark the job that is not shown in current page

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@ or done. Scheduled jobs can't be restarted.
 =cut
 sub job_restart {
     my ($jobids, $force) = @_;
-    my (@duplicated, @processed, @errors, @warnings);
+    my (@duplicated, @processed, @errors, @warnings, $enforceable);
     return (\@duplicated, ['No job IDs specified'], \@warnings) unless ref $jobids eq 'ARRAY' && @$jobids;
 
     # duplicate all jobs that are either running or done
@@ -60,13 +60,14 @@ sub job_restart {
                   .= "\nYou may try to retrigger the parent job that should create the assets and will implicitly retrigger this job as well.";
             }
             else {
-                $message .= "\nEnsure to provide mandatory assets and/or force retriggering over API if necessary.";
+                $message .= "\nEnsure to provide mandatory assets and/or force retriggering if necessary.";
             }
             if ($force) {
                 push @warnings, $message;
             }
             else {
                 push @errors, $message;
+                $enforceable = 1;
                 next;
             }
         }
@@ -88,7 +89,7 @@ sub job_restart {
         $j->abort;
     }
 
-    return (\@duplicated, \@errors, \@warnings);
+    return (\@duplicated, \@errors, \@warnings, $enforceable);
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -691,7 +691,8 @@ sub restart {
         $self->app->log->debug("Restarting jobs @$jobs");
     }
 
-    my ($duplicated, $errors, $warnings) = OpenQA::Resource::Jobs::job_restart($jobs, !!$self->param('force'));
+    my ($duplicated, $errors, $warnings, $enforceable)
+      = OpenQA::Resource::Jobs::job_restart($jobs, !!$self->param('force'));
     OpenQA::Scheduler::Client->singleton->wakeup;
 
     my @urls;
@@ -704,8 +705,9 @@ sub restart {
         json => {
             result   => $duplicated,
             test_url => \@urls,
-            @$warnings ? (warnings => $warnings) : (),
-            @$errors   ? (errors   => $errors)   : (),
+            @$warnings   ? (warnings    => $warnings) : (),
+            @$errors     ? (errors      => $errors)   : (),
+            $enforceable ? (enforceable => 1)         : (),
         });
 }
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -228,7 +228,7 @@ subtest 'restart jobs' => sub {
     $t->json_is(
         '/errors' => [
                 "Job 99939 misses the following mandatory assets: iso/openSUSE-Factory-DVD-x86_64-Build0048-Media.iso\n"
-              . 'Ensure to provide mandatory assets and/or force retriggering over API if necessary.'
+              . 'Ensure to provide mandatory assets and/or force retriggering if necessary.'
         ],
         'error for missing asset'
     );
@@ -242,7 +242,7 @@ subtest 'restart jobs (forced)' => sub {
     $t->json_is(
         '/warnings' => [
                 "Job 99939 misses the following mandatory assets: iso/openSUSE-Factory-DVD-x86_64-Build0048-Media.iso\n"
-              . 'Ensure to provide mandatory assets and/or force retriggering over API if necessary.'
+              . 'Ensure to provide mandatory assets and/or force retriggering if necessary.'
         ],
         'warning for missing asset'
     );


### PR DESCRIPTION
Even when https://github.com/os-autoinst/openQA/pull/2676#issuecomment-615926604 is sorted out it makes sense to be able to force a job restart conveniently via the web UI (and not only via the API).