### PR TITLE
Check if there is a recent event before returning it

### DIFF
--- a/t/lib/OpenQA/Test/Case.pm
+++ b/t/lib/OpenQA/Test/Case.pm
@@ -81,7 +81,11 @@ sub find_most_recent_event {
 
     my $results
       = $schema->resultset('AuditEvents')->search({event => $event}, {limit => 1, order_by => {-desc => 'id'}});
-    return $results ? decode_json($results->next->event_data) : undef;
+    return undef unless $results;
+    if (my $result = $results->next) {
+        return decode_json($result->event_data);
+    }
+    return undef;
 }
 
 1;


### PR DESCRIPTION
Unit tests using `find_most_recent_event` may log this message:

    Can't call method "event_data" on an undefined value[...]

This happens when there is no event of that type.