### PR TITLE
Fix warning about undefined empty arg on clone

### DIFF
--- a/lib/OpenQA/Script.pm
+++ b/lib/OpenQA/Script.pm
@@ -47,7 +47,7 @@ sub clone_job_apply_settings {
     for my $arg (@$argv) {
         # split arg into key and value
         unless ($arg =~ /([A-Z0-9_]+)=(.*)/) {
-            warn "arg $arg doesn't match";
+            warn "arg '$arg' does not match";
             next;
         }
         my ($key, $value) = ($1, $2);

--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -124,7 +124,7 @@ clone_job() {
     local GROUP="${GROUP:-0}"
     local dry_run="${dry_run:-""}"
     local cmd="$dry_run openqa-clone-job $clone_args \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST=\"$test\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\""
-    cmd=$cmd"$(printf " '%s'" "${args[@]}")"
+    [[ ${#args[@]} -ne 0 ]] && cmd=$cmd"$(printf " '%s'" "${args[@]}")"
     if [[ -n "$MARKDOWN" ]]; then
         eval "$cmd" | sed 's/^Created job.*: \([^ ]*\) -> \(.*\)$/* [\1](\2)/'
     else


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/66013