### PR TITLE
Fix a very sporadic issue of a wrong comment header applied

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -34,7 +34,8 @@ function renderCommentHeading(comment, commentId) {
     abbr_link.prop('class', 'comment-anchor');
     abbr_link.append(renderDate(comment.created));
     heading.append(comment.userName, ' wrote ', abbr_link);
-    if(comment.created !== comment.updated) {
+    // add a margin of 1000ms to prevent erroneous update detected if off by 1
+    if((new Date(comment.updated).getTime() - 1000) >= (new Date(comment.created))) {
         heading.append(' (last edited ', renderDate(comment.updated), ')');
     }
     return heading;


### PR DESCRIPTION
From time to time our CI tests show a problem like the following:

```
not ok 4 - heading text
```

I managed to reproduce it locally although this was really hard.  One of two
runs of

```
STABILITY_TEST=1 RETRY=200 tools/retry prove -v -l t/ui/15-comments.t
```

could reproduce it in "Rerun 125 of 200 …" for the first time.

The problem most likely appears in javascript when we want to update the
comment header line but there is an incorrect "edited" appended as the creation
and update time might not be set to exactly the same in the database row.

To verify a fix I ran:

```
STABILITY_TEST=1 RETRY=500 tools/retry prove -l t/ui/15-comments.t
```

successfully with no failed tests.

Related progress issue: https://progress.opensuse.org/issues/53771