### PR TITLE
t: Try to stabilize t/ui/01-list.t

### DIFF
--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -337,7 +337,7 @@ $driver->find_element('#finished_jobs_result_filter_chosen .search-choice-close'
 # enable filter via query parameter, this time disable relevantfilter
 $driver->get('/tests?resultfilter=Failed&foo=bar&resultfilter=Softfailed');
 $driver->find_element_by_id('relevantfilter')->click();
-wait_for_ajax();
+wait_for_ajax_and_animations();
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
 is_deeply(
     \@jobs,


### PR DESCRIPTION
We do not really expect "animations" in this step but it might be the
data table is built not immediately after user actions to provide a more
responsive user interface.

I failed to reliably reproduce the problem so the fix is without actual
verification.

Related progress issue: https://progress.opensuse.org/issues/59043