### PR TITLE
Rename YAMLRenderer plugin to YAML

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -254,7 +254,7 @@ sub load_plugins {
 
     push @{$server->plugins->namespaces}, 'OpenQA::WebAPI::Plugin';
 
-    foreach my $plugin (qw(Helpers MIMETypes CSRF REST HashedParams Gru YAMLRenderer)) {
+    foreach my $plugin (qw(Helpers MIMETypes CSRF REST HashedParams Gru YAML)) {
         $server->plugin($plugin);
     }
 

--- a/lib/OpenQA/WebAPI/Plugin/YAML.pm
+++ b/lib/OpenQA/WebAPI/Plugin/YAML.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-package OpenQA::WebAPI::Plugin::YAMLRenderer;
+package OpenQA::WebAPI::Plugin::YAML;
 use Mojo::Base 'Mojolicious::Plugin';
 use OpenQA::YAML 'validate_data';
 


### PR DESCRIPTION
- The plugin contains a renderer.
- And, too, the helper for validation.
- Other plugins have short base names as well.