### PR TITLE
Provide a '--help' option to all our scripts

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +28,9 @@ sub startup {
     my $self = shift;
 
     $self->defaults(appname => 'openQA Cache Service');
+    # Provide help to users early to prevent failing later on
+    # misconfigurations
+    return if $ENV{MOJO_HELP};
 
     # Worker settings
     my $global_settings = OpenQA::Worker::Settings->new->global_settings;

--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -47,6 +47,9 @@ sub startup {
     my $self = shift;
 
     $self->defaults(appname => 'openQA Live Handler');
+    # Provide help to users early to prevent failing later on
+    # misconfigurations
+    return if $ENV{MOJO_HELP};
     OpenQA::Setup::read_config($self);
     setup_log($self);
     OpenQA::Setup::setup_mojo_tmpdir();

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -42,6 +42,9 @@ sub log_name {
 # This method will run once at server start
 sub startup {
     my $self = shift;
+    # Provide help to users early to prevent failing later on
+    # misconfigurations
+    return if $ENV{MOJO_HELP};
 
     # "templates/webapi" prefix
     $self->renderer->paths->[0] = path($self->renderer->paths->[0])->child('webapi')->to_string;

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -32,12 +32,6 @@ for my $key (keys %types) {
     delete $types{$key} unless $allowed_types{$types{$key}};
 }
 
-# scripts without --help
-for (qw(openqa-workercache openqa openqa-livehandler)) {
-    delete $types{$_};
-    diag "TODO $_";
-}
-
 for my $script (sort keys %types) {
     my $out = qx{$Bin/../script/$script --help 2>&1};
     my $rc  = $?;


### PR DESCRIPTION
Mojo services already have an internal help options but in some cases we
could not reach it so we should treat '--help' in a special way to allow
users to reach help :)

This also removes all TODOs from t/44-scripts.t