### PR TITLE
Allow to overwrite 'worker connect retries' by environment variable

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -257,11 +257,12 @@ sub _retry_delay {
 sub send {
     my ($self, $method, $path, %args) = @_;
 
-    my $host      = $self->webui_host;
-    my $params    = $args{params};
-    my $json_data = $args{json};
-    my $callback  = $args{callback} // sub { };
-    my $tries     = $args{tries} // $self->worker->settings->global_settings->{RETRIES} // 60;
+    my $host           = $self->webui_host;
+    my $params         = $args{params};
+    my $json_data      = $args{json};
+    my $callback       = $args{callback} // sub { };
+    my $global_retries = $self->worker->settings->global_settings->{RETRIES};
+    my $tries          = $args{tries} // $ENV{OPENQA_WORKER_CONNECT_RETRIES} // $global_retries // 60;
 
     # if set ignore errors completely and don't retry
     my $ignore_errors = $args{ignore_errors} // 0;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -119,6 +119,9 @@ sub start_worker {
 
     $workerpid = fork();
     if ($workerpid == 0) {
+        # save testing time as we do not test a webUI host being down for
+        # multiple minutes
+        $ENV{OPENQA_WORKER_CONNECT_RETRIES} = 1;
         exec("perl ./script/worker --instance=1 $connect_args --isotovideo=../os-autoinst/isotovideo --verbose");
         die "FAILED TO START WORKER";
     }


### PR DESCRIPTION
This commit adds the possibility to override the worker config setting
'RETRIES' with an optional environment variable
'OPENQA_WORKER_CONNECT_RETRIES' that the full stack test can immediately
use to significantly reduce runtime from 4m for just the *first*
internal job runs to about 2m.