### PR TITLE
Fix local runs of full-stack test failing on "Content has not changed"

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -430,7 +430,7 @@ subtest 'Cache tests' => sub {
         my $autoinst_log = do { local ($/); <$f> };
         close($f);
 
-        like($autoinst_log,                   qr/Content has not changed/,     'Test 7 Core-7.2.iso has not changed');
+        like($autoinst_log,                   qr/Content.*has not changed/,    'Test 7 Core-7.2.iso has not changed');
         like($autoinst_log,                   qr/\+\+\+\ worker notes \+\+\+/, 'Test 7 correct autoinst worker notes');
         like((split(/\n/, $autoinst_log))[0], qr/\+\+\+ setup notes \+\+\+/,   'Test 7 correct autoinst setup notes');
         like(


### PR DESCRIPTION
Generalize the cache log message we look for to fix local runs of
full-stack test or actually all runs depending on the log level
configured as the relevant tests are only executed if the condition
`!$ENV{MOJO_LOG_LEVEL} || $ENV{MOJO_LOG_LEVEL} =~ /DEBUG|INFO/i` is met,
which does not seem to be the case in circleCI.

The failing test is

```
not ok 33 - Test 7 Core-7.2.iso has not changed
```

As can be seen in the last line the message format is different than the
expected regex, hence generalizing it in the current commit. The commit
that introduced the change in the log message was c4fa5d28d.