### PR TITLE
t: Save 5s test execution time in full-stack.t with smarter timestamps

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -367,15 +367,16 @@ subtest 'Cache tests' => sub {
     # the worker ini
     like($result->{filename}, qr/Core-7/, "Core-7.2.iso is the first element");
 
+    my $time = time;
     for (1 .. 5) {
         $filename = $cache_location->child("$_.qcow2");
-        open(my $tmpfile, '>', $filename);
-        print $tmpfile $filename;
-        $sql = "INSERT INTO assets (filename,etag,last_use) VALUES ( ?, 'Not valid', strftime('%s','now'));";
+        path($filename)->spurt($filename);
+        # so that last_use is not the same for every item
+        $time++;
+        $sql = "INSERT INTO assets (filename,etag,last_use) VALUES ( ?, 'Not valid', $time);";
         $sth = $dbh->prepare($sql);
         $sth->bind_param(1, $filename);
         $sth->execute();
-        sleep 1;    # so that last_use is not the same for every item
     }
 
     $sql    = "SELECT * from assets order by last_use desc";

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -244,7 +244,6 @@ sub create_websocket_server {
         use OpenQA::WebSockets::Controller::Worker;
         use OpenQA::WebSockets::Plugin::Helpers;
 
-        # TODO: Kill it with fire!
         if ($bogus) {
             monkey_patch 'OpenQA::WebSockets::Controller::Worker', _get_worker => sub { return };
             monkey_patch 'OpenQA::WebSockets::Controller::Worker', ws          => sub {
@@ -293,9 +292,7 @@ sub create_websocket_server {
 
 sub create_scheduler {
     my ($port, $no_stale_job_detection) = @_;
-
     note("Starting Scheduler service");
-
     OpenQA::Scheduler::Client->singleton->port($port);
     my $pid = fork();
     if ($pid == 0) {


### PR DESCRIPTION
Instead of sleeping and wasting 1s five times for generating fake assets
with differing timestamps instead we can simply increment the timestamp with
which we create assets in the cache database with no sleep time at all.