### PR TITLE
t: Use proper copyright header for OpenQA::Test::Database

### DIFF
--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -1,7 +1,17 @@
+# Copyright (C) 2014-2020 SUSE LLC
 #
-# Stolen from https://github.com/tempire/MojoExample
-# TODO: Contact author to make sure that's OK
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Test::Database;
 use Mojo::Base -base;


### PR DESCRIPTION
The original project https://github.com/tempire/MojoExample describes
that code is usable under same terms and license as Perl, which is GPL,
so we are good.