### PR TITLE
Package installation enhancements; 'openQA-single-instance' package

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -138,7 +138,7 @@ zypper dup --from devel_openQA_Leap --allow-vendor-change
 
 
 === Installation
-You can install the packages using these commands.
+You can install the main openQA server package using these commands.
 
 [source,sh]
 -------------------------------------------------------------------------------

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -149,6 +149,14 @@ zypper in openQA
 dnf install openqa openqa-httpd
 -------------------------------------------------------------------------------
 
+To install the openQA worker package use the following.
+
+[source,sh]
+-------------------------------------------------------------------------------
+# openSUSE
+zypper in openQA-worker
+-------------------------------------------------------------------------------
+
 
 == Basic configuration
 

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -157,6 +157,12 @@ To install the openQA worker package use the following.
 zypper in openQA-worker
 -------------------------------------------------------------------------------
 
+Different convenience packages exist for convenience in openSUSE, for example:
+`openQA-local-db` to install the server including the setup of a local
+PostgreSQL database or `openQA-single-instance` which sets up a web UI server,
+a web proxy as well as a local worker. Install `openQA-client` if you only
+want to interact with existing, external openQA instances.
+
 
 == Basic configuration
 
@@ -644,7 +650,7 @@ and
 systemctl enable --now rsyncd
 --------------------------------------------------------------------------------
 
-This will allow the workers to download the assets from the webUI and use them
+This will allow the workers to download the assets from the web UI and use them
 locally. If `TESTPOOLSERVER` is set tests and needles will also be cached by the
 worker.
 

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -142,11 +142,10 @@ You can install the packages using these commands.
 
 [source,sh]
 -------------------------------------------------------------------------------
-# openSUSE Leap 42.3+
+# openSUSE
 zypper in openQA
 
-
-# Fedora 23+
+# Fedora
 dnf install openqa openqa-httpd
 -------------------------------------------------------------------------------
 

--- a/openQA.spec
+++ b/openQA.spec
@@ -199,6 +199,16 @@ Supplements:    packageand(%name:postgresql-server)
 You only need this package if you have a local postgresql server
 next to the webui.
 
+%package single-instance
+Summary:        Convenience package for a single-instance setup
+Group:          Development/Tools/Other
+Requires:       %{name}-local-db
+Requires:       %{name}-worker
+Requires:       apache2
+
+%description single-instance
+Use this package to setup a local instance with all services provided together.
+
 %package bootstrap
 Summary:        Automated openQA setup
 Group:          Development/Tools/Other
@@ -556,6 +566,8 @@ fi
 %{_unitdir}/openqa-setup-db.service
 %{_datadir}/openqa/script/setup-db
 %{_bindir}/openqa-setup-db
+
+%files single-instance
 
 %files bootstrap
 %{_datadir}/openqa/script/openqa-bootstrap

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -14,7 +14,7 @@ fi
 
 
 # install packages
-zypper -n install --no-recommends openQA-local-db apache2 openQA-worker qemu-arm qemu-ppc qemu-x86 qemu-tools sudo os-autoinst-distri-opensuse-deps
+zypper -n install --no-recommends openQA-single-instance qemu-arm qemu-ppc qemu-x86 qemu-tools sudo os-autoinst-distri-opensuse-deps
 
 if [ "$(uname -m)" = "aarch64" ]; then
     zypper -n install --no-recommends qemu-uefi-aarch64

--- a/script/openqa-bootstrap-container
+++ b/script/openqa-bootstrap-container
@@ -21,7 +21,7 @@ else
     DEFAULT_REPO="${DEFAULT_REPO:="http://download.opensuse.org/ports/$ARCH/tumbleweed/repo/oss/"}"
 fi
 
-PKGS_TO_INSTALL="aaa_base systemd shadow zypper openSUSE-release vim iproute2 iputils openQA-local-db openQA-worker sudo apache2 net-tools curl wget ca-certificates-mozilla qemu-arm qemu-ppc qemu-x86 openQA-bootstrap"
+PKGS_TO_INSTALL="aaa_base systemd shadow zypper openSUSE-release vim iproute2 iputils openQA-single-instance sudo net-tools curl wget ca-certificates-mozilla qemu-arm qemu-ppc qemu-x86 openQA-bootstrap"
 
 zypper -n install systemd-container
 mkdir -p /var/lib/machines/


### PR DESCRIPTION
* Add convenience sub-package 'openQA-single-instance'
* docs: Mention installation of openQA-worker explicitly
* docs: Correct reference to main package as "openQA server package"
* docs: Simplify reference to minimum Leap/Fedora version