### PR TITLE
t: Fix 'QEMU_NO_KVM' incorrectly added in QEMU_NO_KVM=1

### DIFF
--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -28,7 +28,7 @@ use OpenQA::SeleniumTest;
 use OpenQA::Scheduler::Model::Jobs;
 
 our $JOB_SETUP
-  = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 QEMU_NO_KVM=1 '
+  = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 '
   . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1 '
   . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2 '
   . 'UEFI_PFLASH_VARS=/usr/share/qemu/ovmf-x86_64.bin';


### PR DESCRIPTION
Seems I made a mistake rebasing on my own commits :)