### PR TITLE
Revert "Use defaults already in startup scripts rather than systemd (alternative to #2864 with shell wrappers)"

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -435,17 +435,12 @@ fi
 %{_datadir}/openqa/script/initdb
 %{_datadir}/openqa/script/openqa
 %{_datadir}/openqa/script/openqa-scheduler
-%{_datadir}/openqa/script/openqa-scheduler-daemon
 %{_datadir}/openqa/script/openqa-websockets
-%{_datadir}/openqa/script/openqa-websockets-daemon
 %{_datadir}/openqa/script/openqa-livehandler
-%{_datadir}/openqa/script/openqa-livehandler-daemon
 %{_datadir}/openqa/script/openqa-enqueue-asset-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-audit-event-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-bug-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-result-cleanup
-%{_datadir}/openqa/script/openqa-gru
-%{_datadir}/openqa/script/openqa-webui-daemon
 %{_datadir}/openqa/script/upgradedb
 %{_datadir}/openqa/script/modify_needle
 # TODO: define final user
@@ -511,8 +506,6 @@ fi
 %{_unitdir}/openqa-worker-no-cleanup@.service
 %{_unitdir}/openqa-slirpvde.service
 %{_unitdir}/openqa-vde_switch.service
-%{_datadir}/openqa/script/openqa-slirpvde
-%{_datadir}/openqa/script/openqa-vde_switch
 %{_tmpfilesdir}/openqa.conf
 %ghost %dir %{_rundir}/openqa
 # worker libs
@@ -520,8 +513,6 @@ fi
 %dir %{_datadir}/openqa/script
 %{_datadir}/openqa/script/worker
 %{_datadir}/openqa/script/openqa-workercache
-%{_datadir}/openqa/script/openqa-workercache-daemon
-%{_datadir}/openqa/script/openqa-worker-cacheservice-minion
 %dir %{_localstatedir}/lib/openqa/pool
 %defattr(-,_openqa-worker,root)
 %dir %{_localstatedir}/lib/openqa/cache

--- a/script/openqa-gru
+++ b/script/openqa-gru
@@ -1,1 +1,0 @@
-exec $(dirname $0)/openqa gru -m production run --reset-locks "$@"

--- a/script/openqa-livehandler-daemon
+++ b/script/openqa-livehandler-daemon
@@ -1,2 +1,0 @@
-# Our API commands are very expensive, so the default timeouts are too tight
-exec $(dirname $0)/openqa-livehandler daemon -m production --proxy -i 100 "$@"

--- a/script/openqa-scheduler-daemon
+++ b/script/openqa-scheduler-daemon
@@ -1,1 +1,0 @@
-exec $(dirname $0)/openqa-scheduler -m production "$@"

--- a/script/openqa-slirpvde
+++ b/script/openqa-slirpvde
@@ -1,1 +1,0 @@
-exec /usr/bin/slirpvde -D -s /run/openqa/vde.ctl "$@"

--- a/script/openqa-vde_switch
+++ b/script/openqa-vde_switch
@@ -1,1 +1,0 @@
-exec /usr/bin/vde_switch -F -s /run/openqa/vde.ctl -M /run/openqa/vde.mgmt "$@"

--- a/script/openqa-websockets-daemon
+++ b/script/openqa-websockets-daemon
@@ -1,1 +1,0 @@
-exec $(dirname $0)/openqa-websockets daemon -m production "$@"

--- a/script/openqa-webui-daemon
+++ b/script/openqa-webui-daemon
@@ -1,2 +1,0 @@
-# Our API commands are very expensive, so the default timeouts are too tight
-exec $(dirname $0)/openqa prefork -m production --proxy -i 100 -H 400 -w 30 -c 1 -G 800 "$@"

--- a/script/openqa-worker-cacheservice-minion
+++ b/script/openqa-worker-cacheservice-minion
@@ -1,1 +1,0 @@
-exec $(dirname $0)/openqa-workercache minion worker -m production "$@"

--- a/script/openqa-workercache-daemon
+++ b/script/openqa-workercache-daemon
@@ -1,1 +1,0 @@
-exec $(dirname $0)/openqa-workercache prefork -m production -i 100 -H 400 -w 4 -G 80 "$@"

--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -5,7 +5,7 @@ Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-gru
+ExecStart=/usr/share/openqa/script/openqa gru -m production run --reset-locks
 Nice=19
 Restart=on-failure
 

--- a/systemd/openqa-livehandler.service
+++ b/systemd/openqa-livehandler.service
@@ -6,8 +6,10 @@ After=postgresql.service nss-lookup.target remote-fs.target
 Requires=openqa-webui.service
 
 [Service]
+# TODO: define whether we want to run the web ui with the same user
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-livehandler-daemon
+# Our API commands are very expensive, so the default timeouts are too tight
+ExecStart=/usr/share/openqa/script/openqa-livehandler daemon -m production --proxy -i 100
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-scheduler.service
+++ b/systemd/openqa-scheduler.service
@@ -5,7 +5,7 @@ Wants=openqa-setup-db.service
 
 [Service]
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-scheduler-daemon
+ExecStart=/usr/share/openqa/script/openqa-scheduler daemon -m production
 TimeoutStopSec=120
 
 [Install]

--- a/systemd/openqa-slirpvde.service
+++ b/systemd/openqa-slirpvde.service
@@ -4,7 +4,7 @@ PartOf=openqa-worker.target
 
 [Service]
 Type=simple
-ExecStart=/usr/share/openqa/script/openqa-slirpvde
+ExecStart=/usr/bin/slirpvde -D -s /run/openqa/vde.ctl
 User=_openqa-worker
 
 [Install]

--- a/systemd/openqa-vde_switch.service
+++ b/systemd/openqa-vde_switch.service
@@ -5,7 +5,7 @@ Requires=openqa-vde_switch.service
 
 [Service]
 Type=simple
-ExecStart=/usr/share/openqa/script/openqa-vde_switch
+ExecStart=/usr/bin/vde_switch -F -s /run/openqa/vde.ctl -M /run/openqa/vde.mgmt
 User=_openqa-worker
 
 [Install]

--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -5,8 +5,9 @@ Before=apache2.service openqa-webui.service
 After=openqa-scheduler.service postgresql.service openqa-setup-db.service network.target nss-lookup.target remote-fs.target
 
 [Service]
+# TODO: define whether we want to run the websockets with the same user
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-websockets-daemon
+ExecStart=/usr/share/openqa/script/openqa-websockets daemon -m production
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -6,8 +6,10 @@ After=postgresql.service openqa-setup-db.service openqa-scheduler.service nss-lo
 Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
 
 [Service]
+# TODO: define whether we want to run the web ui with the same user
 User=geekotest
-ExecStart=/usr/share/openqa/script/openqa-webui
+# Our API commands are very expensive, so the default timeouts are too tight
+ExecStart=/usr/share/openqa/script/openqa prefork -m production --proxy -i 100 -H 400 -w 30 -c 1 -G 800
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-worker-cacheservice-minion.service
+++ b/systemd/openqa-worker-cacheservice-minion.service
@@ -7,7 +7,7 @@ PartOf=openqa-worker.target
 [Service]
 Restart=on-failure
 User=_openqa-worker
-ExecStart=/usr/share/openqa/script/openqa-worker-cacheservice-minion
+ExecStart=/usr/share/openqa/script/openqa-workercache minion worker -m production
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-worker-cacheservice.service
+++ b/systemd/openqa-worker-cacheservice.service
@@ -7,7 +7,7 @@ PartOf=openqa-worker.target
 [Service]
 Restart=on-failure
 User=_openqa-worker
-ExecStart=/usr/share/openqa/script/openqa-workercache-daemon
+ExecStart=/usr/share/openqa/script/openqa-workercache prefork -m production -i 100 -H 400 -w 4 -G 80
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Completely broke all services due to a broken path in `openqa-webui.service` and missing `#!/bin/sh` in all scripts.