### PR TITLE
Add --verbose option to "openqa-cli api"

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -36,7 +36,8 @@ sub command {
       'j|json'        => \my $json,
       'p|pretty'      => \my $pretty,
       'q|quiet'       => \my $quiet,
-      'X|method=s'    => \(my $method = 'GET');
+      'X|method=s'    => \(my $method = 'GET'),
+      'v|verbose'     => \my $verbose;
 
     @args = $self->decode_args(@args);
     die $self->usage unless my $path = shift @args;
@@ -54,7 +55,7 @@ sub command {
     my $client = $self->client($url);
     my $tx     = $client->build_tx($method, $url, $headers, @data);
     $tx = $client->start($tx);
-    $self->handle_result($tx, {pretty => $pretty, quiet => $quiet});
+    $self->handle_result($tx, {pretty => $pretty, quiet => $quiet, verbose => $verbose});
 
     return 0;
 }
@@ -122,5 +123,6 @@ sub command {
     -p, --pretty                Pretty print JSON content
     -q, --quiet                 Do not print error messages to STDERR
     -X, --method <method>       HTTP method to use, defaults to GET
+    -v, --verbose               Print HTTP response headers
 
 =cut

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -52,7 +52,15 @@ sub handle_result {
     my $res     = $tx->res;
     my $is_json = ($res->headers->content_type // '') =~ m!application/json!;
 
-    if (!$options->{quiet} && (my $err = $res->error)) {
+    my $err = $res->error;
+    if ($options->{verbose} && (!$err || $err->{code})) {
+        my $version = $res->version;
+        my $code    = $res->code;
+        my $msg     = $res->message;
+        print "HTTP/$version $code $msg\n", $res->headers->to_string, "\n\n";
+    }
+
+    elsif (!$options->{quiet} && $err) {
         my $code = $err->{code} // '';
         $code .= ' ' if length $code;
         my $msg = $err->{message};

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -52,8 +52,10 @@ sub handle_result {
     my $res     = $tx->res;
     my $is_json = ($res->headers->content_type // '') =~ m!application/json!;
 
-    my $err = $res->error;
-    if ($options->{verbose} && (!$err || $err->{code})) {
+    my $err                 = $res->error;
+    my $is_connection_error = $err && !$err->{code};
+
+    if ($options->{verbose} && !$is_connection_error) {
         my $version = $res->version;
         my $code    = $res->code;
         my $msg     = $res->message;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -137,7 +137,16 @@ subtest 'Simple request with authentication' => sub {
     like $stdout, qr/403/, 'not authenticated';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@auth, 'test/op/hello') };
-    like $stdout, qr/Hello operator!/, 'operator response';
+    unlike $stdout, qr/200 OK.*Content-Type:/s, 'not verbose';
+    like $stdout,   qr/Hello operator!/,        'operator response';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@auth, '--verbose', 'test/op/hello') };
+    like $stdout, qr/200 OK.*Content-Type:/s, 'verbose';
+    like $stdout, qr/Hello operator!/,        'operator response';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@auth, '--v', 'test/op/hello') };
+    like $stdout, qr/200 OK.*Content-Type:/s, 'verbose';
+    like $stdout, qr/Hello operator!/,        'operator response';
 };
 
 subtest 'HTTP features' => sub {


### PR DESCRIPTION
Small change to add a `--verbose` option to `openqa-cli api`. This was suggested by @perlpunk as a debug feature, and i find it quite useful.

Instead of:
```
{"error":"no api key","error_status":403}
```
You can now also use the `--verbose` option to get:
```
HTTP/1.1 403 Forbidden
Content-Type: application/json;charset=UTF-8
Strict-Transport-Security: max-age=31536000; includeSubDomains
Server: Mojolicious (Perl)
Content-Length: 41
Date: Wed, 29 Apr 2020 12:03:11 GMT

{"error":"no api key","error_status":403}
```
And the `--pretty` option still works independently on the JSON:
```
HTTP/1.1 403 Forbidden
Content-Type: application/json;charset=UTF-8
Strict-Transport-Security: max-age=31536000; includeSubDomains
Server: Mojolicious (Perl)
Content-Length: 41
Date: Wed, 29 Apr 2020 12:03:11 GMT

{
   "error" : "no api key",
   "error_status" : 403
}
```