### PR TITLE
Fix `TEST` is not replaced when using `isos post`

### DIFF
--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -42,6 +42,14 @@ sub generate_settings {
         $settings->{BACKEND} = $machine->backend;
         $settings->{MACHINE} = $machine->name;
     }
+
+    # add properties from dedicated database columns to settings
+    if (my $job_template = $params->{job_template}) {
+        $settings->{TEST}            = $job_template->name || $job_template->test_suite->name;
+        $settings->{TEST_SUITE_NAME} = $job_template->test_suite->name;
+        $settings->{JOB_DESCRIPTION} = $job_template->description if length $job_template->description;
+    }
+
     handle_plus_in_settings($settings);
     return expand_placeholders($settings);
 }

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -539,11 +539,6 @@ sub _generate_jobs {
             my $error = OpenQA::JobSettings::generate_settings(\%params);
             $error_message .= $error if defined $error;
 
-            # add properties from dedicated database columns to settings
-            $settings{TEST}            = $job_template->name || $job_template->test_suite->name;
-            $settings{TEST_SUITE_NAME} = $job_template->test_suite->name;
-            $settings{JOB_DESCRIPTION} = $job_template->description if length $job_template->description;
-
             # make sure that the DISTRI is lowercase
             $settings{DISTRI} = lc($settings{DISTRI});
 


### PR DESCRIPTION
`TEST` is set value after replacing the specify values `%TEST%`, so the
`TEST` in setting is not replaced.