### PR TITLE
Fix pagination in the group overview

### DIFF
--- a/templates/webapi/comments/pagination.html.ep
+++ b/templates/webapi/comments/pagination.html.ep
@@ -1,54 +1,100 @@
-<nav class="comments-pagination" aria-label="Comments pagination">
-  <ul class="pagination">
-    % if ($comments_pager->current_page == $comments_pager->first_page) {
-        <li class="disabled"><span
-    % }
-    % else {
-        <li><a href="<%= url_with->query([ comments_page => $comments_pager->current_page - 1 ]) %>"
-    % }
-      class="page-link" aria-label="Previous">
-        <span aria-hidden="true">&laquo;</span>
-        <span class="sr-only">Previous</span>
-    % if ($comments_pager->current_page == $comments_pager->first_page) {
-        </span>
-    % }
-    % else {
-        </a>
-    % }
-
-    % my $skipped = 0;
-    % my $skipping_range = 5;
-    % for (my $i = $comments_pager->first_page; $i <= $comments_pager->last_page; $i++) {
-        % # skip rendering page buttons which are too far from the beginning, the end or the current page
-        % unless ($i < $skipping_range || $i + $skipping_range >= $comments_pager->last_page || (abs($comments_pager->current_page - $i) < $skipping_range)) {
-            % # render … between gaps
-            % unless ($skipped) {
-                <li class="disabled"><span class="page-link">…</span></li>
-                % $skipped = 1;
+<div class="row">
+    <div class="col-sm-1"></div>
+    <div class="col-sm-11">
+        <nav class="comments-pagination" aria-label="Comments pagination">
+            <ul class="pagination">
+            % if ($comments_pager->current_page == $comments_pager->first_page) {
+                <li class="disabled"><span
+            % } else {
+                <li><a href="<%= url_with->query([ comments_page => $comments_pager->current_page - 1 ]) %>"
             % }
-            % next;
-        % }
-        % $skipped = 0;
-        %= tag 'li', class => ($i == $comments_pager->current_page ? 'active' : undef) => sub {
-        %    link_to $i => url_with->query([ comments_page => $i ]) => (class => 'page-link')
-        % };
-    % }
+                class="page-link" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                    <span class="sr-only">Previous</span>
+            % if ($comments_pager->current_page == $comments_pager->first_page) {
+                </span>
+            % } else {
+                </a>
+            % }
 
-    % if ($comments_pager->current_page == $comments_pager->last_page) {
-        <li class="disabled"><span
-    % }
-    % else {
-        <li><a href="<%= url_with->query([ comments_page => $comments_pager->current_page + 1 ]) %>"
-    % }
-        class="page-link" aria-label="Next">
-          <span aria-hidden="true">&raquo;</span>
-          <span class="sr-only">Next</span>
-    % if ($comments_pager->current_page == $comments_pager->last_page) {
-        </span>
-    % }
-    % else {
-        </a>
-    % }
-    </li>
-  </ul>
-</nav>
+            % my @sizes = (5, 10, 12, 16, 20);
+            % my @media_classes = ('d-block d-sm-none', 'd-none d-sm-block d-md-none', 'd-none d-md-block d-lg-none', 'd-none d-lg-block d-xl-none', 'd-none d-xl-block');
+            % my @media_classes_full = ('d-block', 'd-none d-sm-block', 'd-none d-md-block', 'd-none d-lg-block', 'd-none');
+            % my $simple_pager_already_painted = 0;
+
+            % for (my $size = 0; $size < 5; $size++) {
+                % my $max = $sizes[$size];
+
+                % if ($comments_pager->last_page <= $max) {
+                    % my $media_class = $media_classes_full[$size];
+
+                    % if ( $simple_pager_already_painted == 0 ) {
+                        % for (my $i = 1; $i <= $comments_pager->last_page; $i++){
+                            %= tag 'li', class => ($i == $comments_pager->current_page ? 'active' : undef) => sub {
+                            %    link_to $i => url_with->query([ comments_page => $i ]) => (class => "page-link $media_class")
+                            % };
+                        % }
+
+                        % $simple_pager_already_painted = 1;
+                    % }
+                % } else {
+                    % my $media_class = $media_classes[$size];
+
+                    %= tag 'li', class => (1 == $comments_pager->current_page ? 'active' : undef) => sub {
+                    %    link_to 1 => url_with->query([ comments_page => 1 ]) => (class => "page-link $media_class")
+                    % };
+
+                    % my $surround = int(($max - 3) / 2);
+                    % my $from = $comments_pager->current_page - $surround;
+                    % my $to =  $comments_pager->current_page + $surround;
+
+                    % if ($from <= 1) {
+                        % $to += ( -1 * $from + 2 );
+                        % $from = 2;
+                    % }
+
+                    % if ($from > 2){
+                        <li class="page-link disabled <%= $media_class %>">..</li>
+                        % $from++;
+                    %}
+
+                    % if ($to >= $comments_pager->last_page - 1){
+                        % $from -= ( $to - $comments_pager->last_page + 1 );
+                        % $to = $comments_pager->last_page;
+                    % }
+
+                    % for (my $i = $from; $i< $to; $i++) {
+                        % if ($i > 1 && $i< $comments_pager->last_page){
+                            %= tag 'li', class => ($i == $comments_pager->current_page ? 'active' : undef) => sub {
+                                % link_to $i => url_with->query([ comments_page => $i ]) => (class => "page-link $media_class")
+                                % };
+                        % }
+                    % }
+
+                    % if ( $to != $comments_pager->last_page - 1) {
+                        <li class="page-link disabled <%= $media_class %>">..</li>
+                    % }
+
+                    %= tag 'li', class => ($comments_pager->last_page == $comments_pager->current_page ? 'active' : undef) => sub {
+                    % link_to $comments_pager->last_page => url_with->query([ comments_page => $comments_pager->last_page ]) => (class => "page-link $media_class")
+                    % };
+                % }
+            % }
+
+            % if ($comments_pager->current_page == $comments_pager->last_page) {
+                <li class="disabled"><span
+            % } else {
+                <li><a href="<%= url_with->query([ comments_page => $comments_pager->current_page + 1 ]) %>"
+            % }
+                class="page-link" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                    <span class="sr-only">Next</span>
+            % if ($comments_pager->current_page == $comments_pager->last_page) {
+                </span>
+            % } else {
+                </a>
+            % }
+            </ul>
+        </nav>
+    </div>
+</div>


### PR DESCRIPTION
https://progress.opensuse.org/issues/52745

Pagination is not responsive and breaks the screen adding scrollbars
A solution based on media size is provided. This shows a max number of pages in the page bar depending on the media size

Alternative in #3079