### PR TITLE
Fix missing_assets to ignore repos, not 'hidden assets'

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -572,8 +572,10 @@ sub missing_assets {
     delete $assets->{UEFI_PFLASH_VARS};
 
     my $parent_job_ids = $self->_parent_job_ids;
+    # ignore repos, as they're not really clonable: see
+    # https://github.com/os-autoinst/openQA/pull/2676#issuecomment-616312026
     my @relevant_assets
-      = grep { $_->{name} ne '' && !OpenQA::Schema::Result::Assets::is_type_hidden($_->{type}) } values %$assets;
+      = grep { $_->{name} ne '' && $_->{type} ne 'repo' } values %$assets;
     my @assets_query = map {
         {
             type => $_->{type},

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -320,11 +320,10 @@ subtest 'check for missing assets' => sub {
         is_deeply($job_with_2_assets->missing_assets,
             ['hdd/not_existent'], 'assets are considered missing if at least one is missing');
     };
-    subtest 'hidden assets are ignored' => sub {
+    subtest 'repo assets are ignored' => sub {
         $settings{REPO_0} = delete $settings{HDD_1};
-        diag explain $t->app->config->{global}->{hide_asset_types};
         my $job_with_2_assets = $jobs->create_from_settings(\%settings);
-        is_deeply($job_with_2_assets->missing_assets, [], 'hidden asset not considered so no asset missing');
+        is_deeply($job_with_2_assets->missing_assets, [], 'repo asset not considered so no asset missing');
     };
     subtest 'empty assets are ignored' => sub {
         delete $settings{REPO_0};


### PR DESCRIPTION
As discussed in
https://github.com/os-autoinst/openQA/pull/2676#issuecomment-615951653
and follow-ups, this check misunderstands the "hidden" attribute.
The code assumes that "hidden" assets are the same thing as
"assets we don't really want to copy down when cloning jobs",
but they are not. The "hidden" attribute was written (by me) to
mean "asset types not to be shown for downloading in the web UI".

For SUSE, it happens to be the case that ["repo"] would be the
right array of both "not-to-be-shown-in-the-web-ui assets" and
"non-clonable assets", so this bug wasn't apparent, as SUSE
deployments leave the `hide_asset_types` config setting at its
default value of just 'repo'. But on Fedora deployments, this
setting is changed to 'repo iso hdd' (because we don't want to
show those asset types for download in the web UI), so this code
also ignored ISO and HDD assets when checking for "missing"
assets, which we don't want.

As discussed in the pull request we could potentially make this
a configurable attribute and have the clone_job script use it
too, but doing that is a bit harder, and I don't think for now
anyone wants a different definition of "non-clonable assets", so
it doesn't seem really necessary.

Signed-off-by: Adam Williamson <awilliam@redhat.com>