### PR TITLE
Add Test::MockObject and Test::Exception to test dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -96,8 +96,10 @@ on 'test' => sub {
     requires 'Perl::Critic::Freenode';
     requires 'Selenium::Remote::Driver', '>= 1.23';
     requires 'Selenium::Remote::WDKeys';
+    requires 'Test::Exception';
     requires 'Test::Fatal';
     requires 'Test::MockModule';
+    requires 'Test::MockObject';
     requires 'Test::Mojo';
     requires 'Test::More';
     requires 'Test::Output';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -159,11 +159,13 @@ test_requires:
   perl(Perl::Critic::Freenode):
   perl(Selenium::Remote::Driver): '>= 1.23'
   perl(Selenium::Remote::WDKeys):
+  perl(Test::Exception):
   perl(Test::Mojo):
   perl(Test::More):
   perl(Test::Strict):
   perl(Test::Fatal):
   perl(Test::MockModule):
+  perl(Test::MockObject):
   perl(Test::Output):
   perl(Test::Pod):
   perl(Test::Warnings):

--- a/openQA.spec
+++ b/openQA.spec
@@ -63,7 +63,7 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Fatal) perl(Test::MockModule) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) postgresql-server python3-setuptools python3-yamllint
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) postgresql-server python3-setuptools python3-yamllint
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else


### PR DESCRIPTION
A couple of the tests use these, but they were never added to the
RPM spec dependencies.

Signed-off-by: Adam Williamson <awilliam@redhat.com>