### PR TITLE
t: Use existing dataset as time reference for stability

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -51,8 +51,8 @@ use OpenQA::SeleniumTest;
 eval 'use Test::More::Color';
 eval 'use Test::More::Color "foreground"';
 
-plan skip_all => 'set DEVELOPER_FULLSTACK=1 (be careful)'                      unless $ENV{DEVELOPER_FULLSTACK};
-plan skip_all => 'set TEST_PG to e.g. DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
+plan skip_all => 'set DEVELOPER_FULLSTACK=1 (be careful)'                       unless $ENV{DEVELOPER_FULLSTACK};
+plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 
 # load Selenium::Remote::WDKeys module or skip this test if not available
 unless (can_load(modules => {'Selenium::Remote::WDKeys' => undef})) {

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -33,7 +33,7 @@ use List::Util 'min';
 use Try::Tiny;
 use FindBin;
 
-plan skip_all => 'set TEST_PG to e.g. DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
+plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 
 # find the oldest still supported schema version which is defined by the oldest deploy folder
 # which is still present

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -59,8 +59,8 @@ use OpenQA::Test::Utils
   qw(stop_service);
 use OpenQA::Test::FullstackUtils;
 
-plan skip_all => "set FULLSTACK=1 (be careful)"                                unless $ENV{FULLSTACK};
-plan skip_all => 'set TEST_PG to e.g. DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
+plan skip_all => 'set FULLSTACK=1 (be careful)'                                 unless $ENV{FULLSTACK};
+plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 
 my $workerpid;
 my $wspid;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -367,7 +367,8 @@ subtest 'Cache tests' => sub {
     # the worker ini
     like($result->{filename}, qr/Core-7/, "Core-7.2.iso is the first element");
 
-    my $time = time;
+    # create assets at same time and in the following seconds after the above
+    my $time = $result->{last_use};
     for (1 .. 5) {
         $filename = $cache_location->child("$_.qcow2");
         path($filename)->spurt($filename);

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -112,7 +112,7 @@ $driver->find_element_by_link_text('core@coolone')->click();
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');
 my $job_page_url = $driver->get_current_url();
 like($driver->find_element('#result-row .card-body')->get_text(), qr/State: scheduled/, 'test 1 is scheduled');
-javascript_console_has_no_warnings_or_errors;
+ok javascript_console_has_no_warnings_or_errors, 'no javascript warnings or errors after test 1 was scheduled';
 
 sub start_worker {
     return fail "Unable to start worker, previous worker with PID '$workerpid' is still running" if defined $workerpid;
@@ -234,7 +234,7 @@ $job_name = 'tinycore-1-flavor-i386-Build1-core@noassets';
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');
 like($driver->find_element('#result-row .card-body')->get_text(), qr/State: scheduled/, 'test 4 is scheduled');
 
-javascript_console_has_no_warnings_or_errors;
+ok javascript_console_has_no_warnings_or_errors, 'no javascript warnings or errors after test 4 was scheduled';
 start_worker;
 
 ok OpenQA::Test::FullstackUtils::wait_for_result_panel($driver, qr/Result: incomplete/), 'Test 4 crashed as expected';


### PR DESCRIPTION
As a followup to 6afde4caf I figured that relying on the time of the
already existing last asset can be even more stable rather than getting
another absolute timestamp in t/full-stack.t.