### PR TITLE
Remove an old workaround for Mojolicious 6

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -75,14 +75,7 @@ sub auth_login {
 sub auth_response {
     my ($self) = @_;
 
-    # FIXME: Mojo6 hack, remove after version bump
-    my %params;
-    if ($self->req->query_params->can('params')) {
-        %params = @{$self->req->query_params->params};
-    }
-    else {
-        %params = @{$self->req->query_params->pairs};
-    }
+    my %params = @{$self->req->query_params->params};
 
     my $url = $self->app->config->{global}->{base_url} || $self->req->url->base;
 


### PR DESCRIPTION
This should be pretty harmless. Just removing an old forgotten workaround.