### PR TITLE
The exporter is not needed for authentication modules

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -18,6 +18,7 @@ use Mojo::Base -strict;
 
 use Mojo::File 'path';
 use Mojo::Util 'trim';
+use Mojo::Loader 'load_class';
 use Config::IniFiles;
 use OpenQA::App;
 use OpenQA::Log 'log_format_callback';
@@ -280,9 +281,9 @@ sub load_plugins {
     # load auth module
     my $auth_method = $server->config->{auth}->{method};
     my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";
-    eval "require $auth_module";    ## no critic
-    if ($@) {
-        die sprintf('Unable to load auth module %s for method %s', $auth_module, $auth_method);
+    if (my $err = load_class $auth_module) {
+        $err = 'Module not found' unless ref $err;
+        die "Unable to load auth module $auth_module: $err";
     }
 
     # Read configurations expected by plugins.

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -14,13 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Auth::Fake;
-
-use strict;
-use warnings;
-
-use Exporter 'import';
-
-our @EXPORT_OK = qw(auth_login auth_logout);
+use Mojo::Base -base;
 
 sub auth_logout {
     return;

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -14,15 +14,10 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Auth::OpenID;
-
-use strict;
-use warnings;
+use Mojo::Base -base;
 
 use LWP::UserAgent;
 use Net::OpenID::Consumer;
-use Exporter 'import';
-
-our @EXPORT_OK = qw(auth_login auth_response);
 
 sub auth_login {
     my ($self) = @_;


### PR DESCRIPTION
This is a followup to #3019 and finishes the transition from `->import` to `->can`. That's quite a bit more efficient and also means the auth modules no longer need to export anything.