### PR TITLE
Keep the menu always visible

### DIFF
--- a/assets/stylesheets/navigation.scss
+++ b/assets/stylesheets/navigation.scss
@@ -3,6 +3,7 @@
     border: none;
     -webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    background-color: $default-bg-color;
     padding-top: 0px;
     padding-bottom: 0px;
     margin-bottom: 30px;

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light">
+<nav class="navbar navbar-expand-lg navbar-light sticky-top">
   <div class="container-fluid">
      <a class="navbar-brand" href="/"><img src="<%= icon_url 'logo.svg'%>" alt="openQA"></a>
      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Scroll endlessly just to get to the menu is annoying. Let's fix that.

Before:

![image](https://user-images.githubusercontent.com/74432/81096572-e56e2c80-8f06-11ea-9955-9d876aea3efd.png)

After:

![image](https://user-images.githubusercontent.com/74432/81096608-ef902b00-8f06-11ea-8d85-3eb35c8156f5.png)
