### PR TITLE
Fix local livehandler

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -386,13 +386,15 @@ sub connect_to_cmd_srv {
             # upgrade to ws connection if not already a websocket connection
             if (!$tx->is_websocket) {
                 my $location_header = ($tx->completed ? $tx->res->headers->location : undef);
-                if (!$location_header) {
+                if (!$location_header && !$tx->res->headers->upgrade) {
                     $self->send_message_to_java_script_clients_and_finish($job_id,
                         error => 'unable to upgrade ws to command server');
                     return;
                 }
-                log_debug('following ws redirection to: ' . $location_header);
-                $cmd_srv_url = $cmd_srv_url->parse($location_header);
+                if ($location_header) {
+                    log_debug('following ws redirection to: ' . $location_header);
+                    $cmd_srv_url = $cmd_srv_url->parse($location_header);
+                }
                 $self->connect_to_cmd_srv($job_id, $cmd_srv_raw_url, $cmd_srv_url);
                 return;
             }


### PR DESCRIPTION
While using developer mode locally, error message "unable to upgrade ws to command server" was popping up every second.
Debugging revealed that Controller was expecting `header->location` to be present in reply from WS, which wasn't the case:

```bless( { 'raw_size' => 194, 'max_message_size' => 2147483648, 'max_line_size' => 8192, 'content' => bless( { 'auto_relax' => 1, 'pre_buffer' => '', 'auto_decompress' => 1, 'body' => 2, 'headers' => bless( { 'cache' => [], 'headers' => { 'upgrade' => [ 'websocket' ], 'connection' => [ 'Upgrade' ], 'sec-websocket-accept' => [ 'jw5h2qP/usDGEUeXxVwzZ2KkOMI=' ], 'server' => [ 'Mojolicious (Perl)' ], 'date' => [ 'Wed, 06 May 2020 02:58:56 GMT' ] }, 'max_line_size' => 8192, 'state' => 'finished', 'max_lines' => 100 }, 'Mojo::Headers' ), 'buffer' => '', 'auto_upgrade' => 1, 'real_size' => 0, 'state' => 'finished', 'raw_size' => 160, 'read' => sub { "DUMMY" }, 'skip_body' => 1, 'events' => { 'read' => [ $VAR1->{'content'}{'read'} ] }, 'header_size' => 160 }, 'Mojo::Content::Single' ), 'events' => {}, 'finished' => 2, 'message' => 'Switching Protocols', 'code' => '101', 'state' => 'finished', 'version' => '1.1' }, 'Mojo::Message::Response' ) ```

This commit fixes the problem.