### PR TITLE
Let Mojo::UserAgent deal with WebSocket redirects

### DIFF
--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -47,6 +47,9 @@ sub startup {
     my $self = shift;
 
     $self->defaults(appname => 'openQA Live Handler');
+
+    $self->ua->max_redirects(3);
+
     # Provide help to users early to prevent failing later on
     # misconfigurations
     return if $ENV{MOJO_HELP};

--- a/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/WebAPI/Controller/LiveViewHandler.pm
@@ -384,18 +384,9 @@ sub connect_to_cmd_srv {
             my ($ua, $tx) = @_;
 
             # upgrade to ws connection if not already a websocket connection
-            if (!$tx->is_websocket) {
-                my $location_header = ($tx->completed ? $tx->res->headers->location : undef);
-                if (!$location_header) {
-                    $self->send_message_to_java_script_clients_and_finish($job_id,
-                        error => 'unable to upgrade ws to command server');
-                    return;
-                }
-                log_debug('following ws redirection to: ' . $location_header);
-                $cmd_srv_url = $cmd_srv_url->parse($location_header);
-                $self->connect_to_cmd_srv($job_id, $cmd_srv_raw_url, $cmd_srv_url);
-                return;
-            }
+            return $self->send_message_to_java_script_clients_and_finish($job_id,
+                error => 'unable to upgrade ws to command server')
+              unless $tx->is_websocket;
 
 # assign transaction: don't do this before to prevent regular HTTP connections to be used in send_message_to_os_autoinst
             $self->cmd_srv_transactions_by_job->{$job_id} = $tx;

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -58,7 +58,7 @@ sub new {
     # disable keep alive to avoid time outs in strange places - we only reach the
     # webapi once in a while so take the price of reopening the connection every time
     # we do
-    $ua->max_connections(0);
+    $ua->max_connections(0)->max_redirects(3);
 
     die "API key and secret are needed for the worker connecting $webui_host\n" unless ($ua->apikey && $ua->apisecret);
 
@@ -180,10 +180,6 @@ sub _setup_websocket_connection {
             # handle case when we've only got a regular HTTP connection
             if (!$tx->is_websocket) {
                 $self->websocket_connection(undef);
-                if (my $location_header = ($tx->completed ? $tx->res->headers->location : undef)) {
-                    log_debug("Following ws redirection to: $location_header");
-                    return $self->_setup_websocket_connection();
-                }
 
                 my $error         = $tx->error;
                 my $error_message = "Unable to upgrade to ws connection via $websocket_url";


### PR DESCRIPTION
While reviewing #3036 i noticed that we had workaround code for handling WebSocket redirects. While WebSocket redirects were not officially supported upstream in Mojolicious (they are an optional feature in RFC 6455), it turned out that they already worked and [just needed some tests](https://github.com/mojolicious/mojo/compare/8fc68f476968...16d8d4c7304b).

So now we can safely rely on `Mojo::UserAgent` to handle redirects for openQA. That also means there is now a limit of 3 redirects, and no risk of circular redirects anymore.