### PR TITLE
t: Ensure full stack test run has not passed "shutdown" module

### DIFF
--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -220,8 +220,9 @@ sub verify_one_job_displayed_as_scheduled {
 }
 
 sub schedule_one_job_over_api_and_verify {
-    my ($driver) = @_;
-    client_call("-X POST jobs $JOB_SETUP");
+    my ($driver, $job_setup) = @_;
+    $job_setup //= $JOB_SETUP;
+    client_call("-X POST jobs $job_setup");
     return verify_one_job_displayed_as_scheduled($driver);
 }
 


### PR DESCRIPTION
Given that with https://github.com/os-autoinst/os-autoinst/pull/1390 the
os-autoinst full stack test was made way faster it can happen that the
"shutdown" module was already passed. This happened when executing the
full stack test locally at least once. With this we are most likely not
loosing functional test coverage as t/33-developer_mode.t uses the
"pause" command as well without PAUSE_AT.