### PR TITLE
Convert DISTRI into lowercase before replacing variables

### DIFF
--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -43,6 +43,9 @@ sub generate_settings {
         $settings->{MACHINE} = $machine->name;
     }
 
+    # make sure that the DISTRI is lowercase
+    $settings->{DISTRI} = lc($settings->{DISTRI}) if $settings->{DISTRI};
+
     # add properties from dedicated database columns to settings
     if (my $job_template = $params->{job_template}) {
         $settings->{TEST}            = $job_template->name || $job_template->test_suite->name;

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -539,9 +539,6 @@ sub _generate_jobs {
             my $error = OpenQA::JobSettings::generate_settings(\%params);
             $error_message .= $error if defined $error;
 
-            # make sure that the DISTRI is lowercase
-            $settings{DISTRI} = lc($settings{DISTRI});
-
             $settings{PRIO}     = defined($priority) ? $priority : $job_template->prio;
             $settings{GROUP_ID} = $job_template->group_id;
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -977,6 +977,8 @@ subtest 'Expand specified variables when scheduling iso' => sub {
     );
     my $res = schedule_iso({%iso, _GROUP_ID => '1002', TEST => 'foo', BUILD => '176.6'}, 200);
     is($res->json->{count}, 2, 'two job templates were scheduled');
+
+    $iso{DISTRI} = 'OPENSUSE';
     $res = schedule_iso({%iso, _GROUP_ID => '1002', BUILD => '176.6', MACHINE => '64bit'}, 200);
     is($res->json->{count}, 1, 'only the job template which machine is 64bit was scheduled');
     my $result = $jobs->find($res->json->{ids}->[0])->settings_hash;


### PR DESCRIPTION
PR https://github.com/os-autoinst/openQA/pull/2959 caused a regression
issue that the `DISTRI` is not converted into lowercase.

Here is the comments and example: https://github.com/os-autoinst/openQA/pull/2959/files#r420928584