### PR TITLE
Remove debug message leading to "Use of uninitialized value [...]" warnings

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -342,11 +342,6 @@ sub job_next_previous_ajax {
     my (@jobs, @data);
     my $latest = 1;
     while (my $each = $jobs_rs->next) {
-        # Output fetched job next and previous for future debug
-        $self->app->log->debug("Fetched job next and previous "
-              . $each->id . ": "
-              . join('-', map { $each->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS));
-
         $latest = $each->id > $latest ? $each->id : $latest;
         push @jobs, $each;
         push(


### PR DESCRIPTION
The machine is nullable and hence might be undef wich is not taken into account. I like to remove the code completely because the debug message does not seem to be generally useful anyways.