### PR TITLE
Add proxy detect for OpenQA::Client

### DIFF
--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -60,6 +60,8 @@ sub new {
         start => sub {
             $self->_add_auth_headers(@_);
         });
+    #read proxy environment variables
+    $self->proxy->detect;
 
     return $self;
 }


### PR DESCRIPTION
 I have to use `http_proxy` environment variable to access some of the webs in an isolated network.
But openqa-clone-job didn't understand this environment variable.
It will report the following words:
`failed to get job '1255533':  Connect timeout at /usr/share/openqa/script/../lib/OpenQA/Script/CloneJob.pm line 92.
`

Signed-off-by: James.W <jnwang@linux-alibaba.com>