### PR TITLE
Makefile: Bump timeout for 't' for accepted slow runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test-checkstyle: test-checkstyle-standalone test-tidy-compile
 
 .PHONY: test-t
 test-t:
-	$(MAKE) test-with-database TIMEOUT_M=25 PROVE_ARGS="$$HARNESS t/*.t" GLOBIGNORE="t/*tidy*:t/*compile*:$(unstables)"
+	$(MAKE) test-with-database TIMEOUT_M=35 PROVE_ARGS="$$HARNESS t/*.t" GLOBIGNORE="t/*tidy*:t/*compile*:$(unstables)"
 
 .PHONY: test-ui
 test-ui:


### PR DESCRIPTION
Commonly a complete run of "test-t" within circleci takes 18-20 minutes
as visible on
https://app.circleci.com/pipelines/github/os-autoinst/openQA?branch=master
but sometimes we seem to hit a slow run which does not seem to be linked
to the tested changes at all as in the example
https://app.circleci.com/pipelines/github/os-autoinst/openQA/2790/workflows/e54a972e-c2dd-4e17-9a15-128130a6a702/jobs/26344/steps
where it can be seen that the setup takes longer  as well as each
individual test module takes  around double the normal time despite the
general parameters of the circleci environment still being the same
"Docker Medium, 2 CPU / 4 GB RAM".