### PR TITLE
t: Change javascript_console_has_no_warnings_or_errors to only output once

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -249,17 +249,17 @@ sub javascript_console_has_no_warnings_or_errors {
         elsif ($source eq 'javascript') {
             # FIXME: ignore WebSocket error for now (connection errors are tracked via devel console anyways)
             next if ($msg =~ qr/ws\-proxy.*Close received/);
-   # FIXME: find the reason why Chromium says we're trying to send something over an already closed WebSocket connection
+            # FIXME: find the reason why Chromium says we are trying to send something over an already closed
+            # WebSocket connection
             next if ($msg =~ qr/Data frame received after close/);
         }
         push(@errors, $log_entry);
     }
 
     if (@errors) {
-        diag('javascript console output: ' . pp(\@errors));
-        ok(scalar @errors eq 0, 'no errors or warnings on javascript console' . $test_name_suffix);
+        diag('javascript console output' . $test_name_suffix . ': ' . pp(\@errors));
     }
-    return scalar @errors eq 0;    #TODO: fix this return value
+    return scalar @errors eq 0;
 }
 
 # mocks the specified JavaScript functions (reverted when navigating to another page)


### PR DESCRIPTION
A test failure with a line reported in a helper lib and not the calling
place is not more helpful than the already existing diag line.

Instead of

```
t/full-stack.t .. 15/?     # javascript console output: [
    #   {
    #     level     => "SEVERE",
    #     message   => "http://localhost:53585/asset/e27d1d8f48/ws_console.js 8 WebSocket connection to 'ws://127.0.0.1:20013/tjojo3uIh9nP2pn4/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED",
    #     source    => "javascript",
    #     timestamp => 1588332786878,
    #   },
    # ]

    #   Failed test 'no errors or warnings on javascript console, waiting for paused'
    #   at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/SeleniumTest.pm line 262.
    # javascript console output: [
    #   {
    #     level     => "SEVERE",
    #     message   => "http://localhost:53585/asset/e27d1d8f48/ws_console.js 8 WebSocket connection to 'ws://127.0.0.1:20013/tjojo3uIh9nP2pn4/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED",
    #     source    => "javascript",
    #     timestamp => 1588332788056,
    #   },
    # ]

    #   Failed test 'no errors or warnings on javascript console, waiting for resume'
    #   at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/SeleniumTest.pm line 262.
    # Looks like you failed 2 tests of 5.
```

no one can get:

```
t/full-stack.t .. 16/?     # javascript console output, waiting for paused: [
    #   {
    #     level     => "SEVERE",
    #     message   => "http://localhost:49041/asset/e27d1d8f48/ws_console.js 8 WebSocket connection to 'ws://127.0.0.1:20013/sLONnsXFW8GLHn19/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED",
    #     source    => "javascript",
    #     timestamp => 1588332831030,
    #   },
    # ]
    # javascript console output, waiting for resume: [
    #   {
    #     level     => "SEVERE",
    #     message   => "http://localhost:49041/asset/e27d1d8f48/ws_console.js 8 WebSocket connection to 'ws://127.0.0.1:20013/sLONnsXFW8GLHn19/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED",
    #     source    => "javascript",
    #     timestamp => 1588332832242,
    #   },
    # ]
```