### PR TITLE
systemd: Get rid of obsolete dependency of worker on apache2

### DIFF
--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -4,8 +4,8 @@
 # replace '1' with the instance number you want
 [Unit]
 Description=openQA Worker #%i
-Wants=apache2.service openqa-webui.service network.target
-After=apache2.service openqa-webui.service openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
+Wants=openqa-webui.service network.target
+After=openqa-webui.service openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
 PartOf=openqa-worker.target
 
 [Service]


### PR DESCRIPTION
The dependency on apache2 was added a very long time ago with 5d8bf4eaa
but since we are making full use of websockets for the communication
there is no reliance on apache2 by the worker directly at all.

Related progress issue: https://progress.opensuse.org/issues/66682