### PR TITLE
Job details rendering performance optimization

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -153,6 +153,7 @@
 < https://raw.githubusercontent.com/sorich87/bootstrap-tour/6a1028fb562f9aa68c451f0901f8cfeb43cad140/build/js/bootstrap-tour.min.js
 
 ! test_result.js
+< javascripts/render.js
 < javascripts/test_result.js
 < javascripts/needlediff.js
 < javascripts/running.js

--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -1,0 +1,202 @@
+// jshint esversion: 6
+
+function createElement(tag, content=[], attrs={}) {
+    let elem = document.createElement(tag);
+
+    for (let key in attrs) {
+        elem.setAttribute(key, attrs[key]);
+    }
+
+    for (let idx in content) {
+        let val = content[idx];
+
+        if ((typeof val) === 'string') {
+            val = document.createTextNode(val);
+        }
+
+        elem.appendChild(val);
+    }
+
+    return elem;
+}
+
+function renderTemplate(template, args={}) {
+    for (let key in args) {
+        template = template.split('$'+key+'$').join(args[key]);
+        template = template.split(encodeURIComponent('$'+key+'$'));
+        template = template.join(encodeURIComponent(args[key]));
+    }
+
+    return template;
+}
+
+function moduleResultCSS(result) {
+    let resmap = {na: '', incomplete: '', softfailed: 'resultsoftfailed',
+        passed: 'resultok', running: 'resultrunning'};
+
+    if (!result) {
+        return 'resultunknown';
+    } else if (result.substr(0, 4) === 'fail') {
+        return 'resultfailed';
+    } else if (resmap[result] !== undefined) {
+        return resmap[result];
+    }
+
+    return 'resultunknown';
+}
+
+function renderModuleRow(module, snippets) {
+    let E = createElement;
+    let rowid = 'module_' + module.name.replace(/[^a-z0-9_-]+/ig, '-');
+    let flags = [];
+    let stepnodes = [];
+
+    if (module.execution_time) {
+        flags.push(E('span', [module.execution_time]));
+        flags.push('\u00a0');
+    }
+
+    if (module.flags.indexOf('fatal') >= 0) {
+        flags.push(E('i', [], {
+            'class': 'flag fa fa-plug',
+            title: 'Fatal: testsuite is aborted if this test fails'
+        }));
+    } else if (module.flags.indexOf('important') < 0) {
+        flags.push(E('i', [], {
+            'class': 'flag fa fa-minus',
+            title: 'Ignore failure: failure or soft failure of this test does not impact overall job result'
+        }));
+    }
+
+    if (module.flags.indexOf('milestone') >= 0) {
+        flags.push(E('i', [], {
+            'class': 'flag fa fa-anchor',
+            title: 'Milestone: snapshot the state after this test for restoring'
+        }));
+    }
+
+    if (module.flags.indexOf('always_rollback') >= 0) {
+        flags.push(E('i', [], {
+            'class': 'flag fa fa-redo',
+            title: 'Always rollback: revert to the last milestone snapshot even if test module is successful'
+        }));
+    }
+
+    let src_url = renderTemplate(snippets.src_url,
+        {MODULE: encodeURIComponent(module.name)});
+    let component = E('td', [
+        E('div', [E('a', [module.name], {href: src_url})]),
+        E('div', flags, {'class': 'flags'})
+    ], {'class': 'component'});
+
+    let result = E('td', [module.result],
+        {'class': 'result ' + moduleResultCSS(module.result)});
+
+    for (let idx in module.details) {
+        let step = module.details[idx];
+        let title = step.display_title;
+        let href = '#step/' + module.name + '/' + step.num;
+        let tplargs = {MODULE: encodeURIComponent(module.name), STEP: step.num};
+        let alt = '';
+
+        if (step.name) {
+            alt = step.name;
+        }
+
+        if (step.is_parser_text_result) {
+            let elem = E('span', [], {'class': 'step_actions'});
+            elem.innerHTML = renderTemplate(snippets.bug_actions,
+                {MODULE: module.name, STEP: step.num});
+            elem = E('span', [elem, step.text_data],
+                {'class': 'resborder ' + step.resborder});
+            elem = E('span', [elem], {title: title, 'data-href': href,
+                'class': 'text-result', onclick: 'toggleTextPreview(this)'});
+            stepnodes.push(E('div', [elem],
+                {'class': 'links_a text-result-container'}));
+            continue;
+        }
+
+        let url = renderTemplate(snippets.module_url, tplargs);
+        let resborder = step.resborder;
+        let box = [];
+
+        if (step.screenshot) {
+            let thumb;
+
+            if (step.md5_dirname) {
+                thumb = renderTemplate(snippets.md5thumb_url,
+                    {DIRNAME: step.md5_dirname, BASENAME: step.md5_basename});
+            } else {
+                thumb = renderTemplate(snippets.thumbnail_url,
+                    {FILENAME: step.screenshot});
+            }
+
+            if (step.properties &&
+                step.properties.indexOf('workaround') >= 0) {
+                resborder = 'resborder_softfailed';
+            }
+
+            box.push(E('img', [], {width: 60, height: 45, src: thumb, alt: alt,
+                'class': 'resborder ' + resborder}));
+        } else if (step.audio) {
+            box.push(E('span', [], {alt: alt,
+                'class': 'icon_audio resborder ' + resborder}));
+        } else if (step.text && title === 'wait_serial') {
+            box.push(E('span', [], {alt: alt,
+                'class':'icon_terminal resborder '+resborder}));
+        } else if (step.text) {
+            box.push(E('span', [step.title ? step.title : 'Text'],
+                {'class': 'resborder ' + resborder}));
+        } else {
+            let content = step.title;
+
+            if (!content) {
+                content = E('i', [], {'class': 'fas fa fa-question'});
+            }
+
+            box.push(E('span', [content], {'class': 'resborder '+resborder}));
+        }
+
+        stepnodes.push(E('div', [
+            E('div', [], {'class': 'fa fa-caret-up'}),
+            E('a', box, {'class': 'no_hover', title: title, href: href,
+                'data-url': url})
+        ], {'class': 'links_a'}));
+        stepnodes.push(' ');
+    }
+
+    let links = E('td', stepnodes, {'class': 'links'});
+    return E('tr', [component, result, links], {id: rowid});
+}
+
+function renderModuleTable(container, response) {
+    container.innerHTML = response.snippets.header;
+
+    if (response.modules === undefined || response.modules === null) {
+        return;
+    }
+
+    let E = createElement;
+    let thead = E('thead', [E('tr', [
+        E('th', ['Test']),
+        E('th', ['Result']),
+        E('th', ['References'], {style: 'width: 100%'})
+    ])]);
+    let tbody = E('tbody');
+
+    container.appendChild(E('table', [thead, tbody],
+        {id: 'results', 'class': 'table table-striped'}));
+
+    for (let idx in response.modules) {
+        let module = response.modules[idx];
+
+        if (module.category) {
+            tbody.appendChild(E('tr', [E('td', [
+                E('i', [], {'class': 'fas fa-folder-open'}),
+                '\u00a0' + module.category
+            ], {colspan: 3})]));
+        }
+
+        tbody.appendChild(renderModuleRow(module, response.snippets));
+    }
+}

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -588,7 +588,7 @@ function setCurrentPreviewFromStepLinkIfPossible(stepLink) {
 
 function renderTestModules(response) {
     this.hasContents = true;
-    this.panelElement.innerHTML = response;
+    renderModuleTable(this.panelElement, response);
 
     // load the embedded logfiles (autoinst-log.txt); assume that in this case no test modules are available and skip further processing
     if (this.panelElement.getElementsByClassName('embedded-logfile').length > 0) {

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -192,6 +192,9 @@ span.resborder {
     font-size: small;
     padding: 1px;
 
+    &.icon_terminal, &.icon_audio {
+        background-size: contain;
+    }
     .fa-question, .step_actions {
         padding: 5px;
     }

--- a/templates/webapi/test/details.html.ep
+++ b/templates/webapi/test/details.html.ep
@@ -13,4 +13,3 @@
         <label for="details-only-failed-filter">Show only failures</label>
     </div>
 </form>
-%= include 'test/module_table'

--- a/templates/webapi/test/result.html.ep
+++ b/templates/webapi/test/result.html.ep
@@ -3,6 +3,14 @@
 
 % content_for 'head' => begin
 %= asset 'test_result.js'
+<style type="text/css">
+    .resborder.icon_terminal {
+        background-image: url("<%= icon_url 'terminal.svg' %>");
+    }
+    .resborder.icon_audio {
+        background-image: url("<%= icon_url 'audio.svg' %>");
+    }
+</style>
 % end
 
 % content_for 'ready_function' => begin


### PR DESCRIPTION
Server-side template rendering is extremely slow with large number of test modules (100+) in a job. Send module results to client as JSON and render HTML on client side using JavaScript. This makes rendering almost 30 times faster.

Currently, rendering of LTP syscalls job results (1112 modules) into HTML in OpenQA takes over 16 seconds. 3 seconds are spent reading and parsing data from storage, 13 seconds are spent rendering the HTML template. With this PR, HTML rendering takes only 700ms on my machine.

The JavaScript generates HTML functionally equivalent to the `test/module_table` template. The only significant change I did was replacing the `<img>` elements for terminal and audio boxes with CSS-defined equivalent `<span>` elements. This little change sped up rendering of syscalls jobs from 2.5 seconds to 700 milliseconds.

There will be a second part of this PR which will optimize `read_test_modules()` and possibly speed up JSON generation by another 2 seconds. But I have another task to take care of first and I don't mind opening a separate PR for part 2.