### PR TITLE
Mark unstable/flaky t/ui/27-plugin_obs_rsync_status_details.t as such

### DIFF
--- a/.circleci/unstable_tests.txt
+++ b/.circleci/unstable_tests.txt
@@ -1,1 +1,2 @@
 t/ui/01-list.t
+t/ui/27-plugin_obs_rsync_status_details.t


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/os-autoinst/openQA/2827/workflows/13672907-1ad3-48d0-a1b2-e210991ed1f8/jobs/26708/steps :

```
[22:54:20] t/ui/27-plugin_obs_rsync_status_details.t .. 19/? [22:54:20] t/ui/27-plugin_obs_rsync_status_details.t .. 24/?
[22:54:20] t/ui/27-plugin_obs_rsync_status_details.t .. 27/? [22:54:20] t/ui/27-plugin_obs_rsync_status_details.t .. 28/? [22:54:20] t/ui/27-plugin_obs_rsync_status_details.t .. …60/? # Looks like you failed 1 test of 60.
                                                              [22:54:20] t/ui/27-plugin_obs_rsync_status_details.t .. Dubious, test returned 1 (wstat 256, 0x100)

Failed 1/60 subtests
```

t/ui/27-plugin_obs_rsync_status_details.t failed in 1/2 runs within a stability test

Related progress issue: https://progress.opensuse.org/issues/66718