### PR TITLE
t: Prevent perl warning when 05-scheduler-full fails

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -132,9 +132,9 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
 
     note('waiting for job to be assigned and set back to re-scheduled');
     $allocated = scheduler_step();
-    is(@$allocated,                1,     'one job allocated');
-    is(@{$allocated}[0]->{job},    99982, 'right job allocated');
-    is(@{$allocated}[0]->{worker}, 5,     'job allocated to expected worker');
+    is(@$allocated, 1, 'one job allocated')
+      and is(@{$allocated}[0]->{job},    99982, 'right job allocated')
+      and is(@{$allocated}[0]->{worker}, 5,     'job allocated to expected worker');
     my $job_assigned  = 0;
     my $job_scheduled = 0;
     for (0 .. 100) {
@@ -158,9 +158,9 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
     wait_for_worker($schema, 5);
 
     ($allocated) = scheduler_step();
-    is(@$allocated,                1,     'one job allocated');
-    is(@{$allocated}[0]->{job},    99982, 'right job allocated');
-    is(@{$allocated}[0]->{worker}, 5,     'job allocated to expected worker');
+    is(@$allocated, 1, 'one job allocated')
+      and is(@{$allocated}[0]->{job},    99982, 'right job allocated')
+      and is(@{$allocated}[0]->{worker}, 5,     'job allocated to expected worker');
 
     # kill the worker but assume the job has been actually started and is running
     stop_service($unstable_w_pid, 1);


### PR DESCRIPTION
Instead of

```
    #   Failed test 'one job allocated'
    #   at t/05-scheduler-full.t line 136.
    #          got: '0'
    #     expected: '1'
    # Looks like you failed 1 test of 3.
t/05-scheduler-full.t .. 3/?
Can't use an undefined value as a HASH reference at t/05-scheduler-full.t line 137.
```

get something like

```
    #   Failed test 'scheduler does not consider broken worker for allocating job'
    #   at t/05-scheduler-full.t line 127.
    #          got: '1'
    #     expected: '0'
    # Looks like you failed 1 test of 12.
t/05-scheduler-full.t .. 3/?
t/05-scheduler-full.t .. 5/? # Looks like you failed 1 test of 5.
t/05-scheduler-full.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/5 subtests
```

including the proper test summary.