### PR TITLE
Remove references to Test::More::Color not adding benefit

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -46,10 +46,6 @@ use OpenQA::Test::Utils
 use OpenQA::Test::FullstackUtils;
 use OpenQA::SeleniumTest;
 
-# optional but very useful
-eval 'use Test::More::Color';
-eval 'use Test::More::Color "foreground"';
-
 plan skip_all => 'set DEVELOPER_FULLSTACK=1 (be careful)'                       unless $ENV{DEVELOPER_FULLSTACK};
 plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -46,9 +46,6 @@ use Mojo::File 'path';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::SeleniumTest;
 session->enable;
-# optional but very useful
-eval 'use Test::More::Color';
-eval 'use Test::More::Color "foreground"';
 
 use File::Path qw(make_path remove_tree);
 use Module::Load::Conditional 'can_load';

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -27,10 +27,6 @@ use OpenQA::Utils 'assetdir';
 use Date::Format 'time2str';
 use IO::Socket::INET;
 
-# optional but very useful
-eval 'use Test::Most::Color';
-eval 'use Test::Most::Color "foreground"';
-
 use File::Path qw(make_path remove_tree);
 use Module::Load::Conditional qw(can_load);
 


### PR DESCRIPTION
prove already provides color by default and Test::More::Color does not
add anything more so we can safely remove this questionable code.