### PR TITLE
docs: Describe the possibility for cloud instances explicitly

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -55,26 +55,25 @@ several components that are hosted in separate repositories as shown in
 .openQA architecture
 image::images/openqa_architecture.png[openQA architecture]
 
-The heart of the test engine is a standalone application called
-'os-autoinst' (blue). In each execution, this application creates a
-virtual machine and uses it to run a set of test scripts (red).
-'os-autoinst' generates a video, screenshots and a JSON file with
-detailed results.
+The heart of the test engine is a standalone application called 'os-autoinst'
+(blue). In each execution, this application creates a virtual machine and uses
+it to run a set of test scripts (red).  'os-autoinst' generates a video,
+screenshots and a JSON file with detailed results.
 
-'openQA' (green) on the other hand provides a web based user
-interface and infrastructure to run 'os-autoinst' in a distributed
-way. The web interface also provides a JSON based REST-like API for
-external scripting and for use by the worker program. Workers
-fetch data and input files from openQA for os-autoinst to run the
-tests. A host system can run several workers. The openQA web
-application takes care of distributing test jobs among workers. Web
-application and workers don't have to run on the same machine but
-can be connected via network instead.
+'openQA' (green) on the other hand provides a web based user interface and
+infrastructure to run 'os-autoinst' in a distributed way. The web interface
+also provides a JSON based REST-like API for external scripting and for use by
+the worker program. Workers fetch data and input files from openQA for
+os-autoinst to run the tests. A host system can run several workers. The openQA
+web application takes care of distributing test jobs among workers. Web
+application and workers can run on the same machine as well as connected via
+network on multiple machines within the same network or distributed. Running
+the web application as well as the workers in the cloud is perfectly possible.
 
 Note that the diagram shown above is simplified. There exists
-link:images/architecture.svg[a more sophisticated version]
-which is more complete and detailed. (The diagram can be edited via
-its underlying link:images/architecture.graphml[GraphML file].)
+link:images/architecture.svg[a more sophisticated version] which is more
+complete and detailed. (The diagram can be edited via its underlying
+link:images/architecture.graphml[GraphML file].)
 
 == Basic concepts
 [id="concepts"]

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -339,11 +339,18 @@ start` instead.
 
 == Run openQA workers
 
-Workers are services running backends to perform the actual testing.  The
+Workers are services running backends to perform the actual testing. The
 testing is commonly performed by running virtual machines but depending on the
-specific backend configuration different options exist. The openQA worker is
-distributed as a separate package which be installed on multiple machines
-while still using only one web UI.
+specific backend configuration different options exist.
+
+It is possible to run openQA workers on the same machine as the web UI as well
+as on different machines, even in different networks, for example instances in
+public cloud. The only requirement is access to the web UI host over
+HTTP/HTTPS. For running tests based on virtual machines KVM support is
+recommended.
+
+The openQA worker is distributed as a separate package which be installed on
+multiple machines while still using only one web UI.
 
 [source,sh]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Previously our documentation was already correct stating the
requirements but to make it more obvious that running the openQA web UI
as well as the openQA worker instances is also perfectly possible in the
cloud we can rephrase in a positive notion and mention "cloud"
explicitly as an option as well.