### PR TITLE
Show candidate needle's last match/seen in the needle diff view

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -157,6 +157,14 @@ function previewSuccess(data, force) {
       setNeedle(trigger.parents('tr'), trigger.data('diff'));
       event.stopPropagation();
   });
+  // prevent hiding drop down when showing needle info popover
+  $('.show-needle-info').on('click', function (event) {
+      event.stopPropagation();
+  });
+  // hide needle info popover when hiding drop down
+  $('#needlediff_dropdown').on('hide.bs.dropdown', function (event) {
+      $('#needlediff_selector [data-toggle="popover"]').popover('hide');
+  });
 }
 
 function toggleTextPreview(textResultDomElement) {

--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -86,6 +86,11 @@
     }
 }
 
+.needle-info-table th {
+    text-align: right;
+    font-weight: normal;
+}
+
 .candidates-selection {
     min-width: 50%;
 

--- a/lib/OpenQA/Schema/ResultSet/Needles.pm
+++ b/lib/OpenQA/Schema/ResultSet/Needles.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 LLC
+# Copyright (C) 2018-2020 LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,11 @@ use base 'DBIx::Class::ResultSet';
 use OpenQA::Schema::Result::Needles;
 use OpenQA::Schema::Result::NeedleDirs;
 use DateTime::Format::Pg;
+
+sub find_needle {
+    my ($self, $needledir, $needlename) = @_;
+    return $self->find({filename => $needlename, 'directory.path' => $needledir}, {join => 'directory'});
+}
 
 # updates needle information with data from needle editor
 sub update_needle_from_editor {

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -71,24 +71,7 @@ sub _prepare_data_table {
         };
     }
     $n = ($real_dir_id ? $needles_rs->find({dir_id => $real_dir_id, filename => $filename}) : undef) // $n;
-    $hash->{last_seen}  = $n->last_seen_time    || 'never';
-    $hash->{last_match} = $n->last_matched_time || 'never';
-
-    if (my $last_seen_module_id = $n->last_seen_module_id) {
-        $hash->{last_seen_link} = $self->url_for(
-            'admin_needle_module',
-            module_id => $last_seen_module_id,
-            needle_id => $n->id
-        );
-    }
-    if (my $last_matched_module_id = $n->last_matched_module_id) {
-        $hash->{last_match_link} = $self->url_for(
-            'admin_needle_module',
-            module_id => $last_matched_module_id,
-            needle_id => $n->id
-        );
-    }
-    return $hash;
+    return $self->populate_hash_with_needle_timestamps_and_urls($n, $hash);
 }
 
 sub ajax {

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -126,6 +126,7 @@ sub edit {
     my $distri        = $job->DISTRI;
     my $dversion      = $job->VERSION || '';
     my $needle_dir    = $job->needle_dir;
+    my $needles_rs    = $self->app->schema->resultset('Needles');
 
     # Each object in @needles will contain the name, both the url and the local path
     # of the image and 2 lists of areas: 'area' and 'matches'.
@@ -197,7 +198,7 @@ sub edit {
 
     # check whether new needles with matching tags have already been created since the job has been started
     if (@$tags) {
-        my $new_needles = $self->app->schema->resultset('Needles')->new_needles_since($job->t_started, $tags, 5);
+        my $new_needles = $needles_rs->new_needles_since($job->t_started, $tags, 5);
         while (my $new_needle = $new_needles->next) {
             my $new_needle_tags = $new_needle->tags;
             my $joined_tags     = $new_needle_tags ? join(', ', @$new_needle_tags) : 'none';
@@ -359,7 +360,6 @@ sub _extended_needle_info {
     for my $tag (@{$needle_info->{tags}}) {
         push(@$overall_list_of_tags, $tag) unless grep(/^$tag$/, @$overall_list_of_tags);
     }
-
     return $needle_info;
 }
 
@@ -501,6 +501,7 @@ sub viewimg {
     my $needle_dir = $job->needle_dir;
     my $distri     = $job->DISTRI;
     my $dversion   = $job->VERSION || '';
+    my $needles_rs = $self->app->schema->resultset('Needles');
 
     # initialize hash to store needle lists by tags
     my %needles_by_tag;
@@ -511,10 +512,14 @@ sub viewimg {
     my $append_needle_info = sub {
         my ($tags, $needle_info) = @_;
 
+        # add timestamps and URLs from database
+        $self->populate_hash_with_needle_timestamps_and_urls(
+            $needles_rs->find_needle($needle_info->{needledir}, "$needle_info->{name}.json"), $needle_info);
+
         # handle case when the needle has (for some reason) no tags
         if (!$tags) {
             push(@{$needles_by_tag{'tags unknown'} //= []}, $needle_info);
-            return;
+            return undef;
         }
 
         # ensure we have a label assigned
@@ -536,6 +541,7 @@ sub viewimg {
         if ($needleinfo) {
             my $info = {
                 name          => $needle,
+                needledir     => $needleinfo->{needledir},
                 image         => $self->needle_url($distri, $needle . '.png', $dversion, $needleinfo->{json}),
                 areas         => $needleinfo->{area},
                 error         => $module_detail->{error},
@@ -556,11 +562,12 @@ sub viewimg {
             my ($needleinfo) = $self->_basic_needle_info($needlename, $distri, $dversion, $needle->{json}, $needle_dir);
             next unless $needleinfo;
             my $info = {
-                name    => $needlename,
-                image   => $self->needle_url($distri, "$needlename.png", $dversion, $needleinfo->{json}),
-                error   => $needle->{error},
-                areas   => $needleinfo->{area},
-                matches => [],
+                name      => $needlename,
+                needledir => $needleinfo->{needledir},
+                image     => $self->needle_url($distri, "$needlename.png", $dversion, $needleinfo->{json}),
+                error     => $needle->{error},
+                areas     => $needleinfo->{area},
+                matches   => [],
             };
             calc_matches($info, $needle->{area});
             $append_needle_info->($needleinfo->{tags} => $info);

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -331,6 +331,39 @@ sub register {
             );
         });
 
+    $app->helper(
+        populate_hash_with_needle_timestamps_and_urls => sub {
+            my ($c, $needle, $hash) = @_;
+
+            $hash->{last_seen}  = $needle ? $needle->last_seen_time    || 'never' : 'unknown';
+            $hash->{last_match} = $needle ? $needle->last_matched_time || 'never' : 'unknown';
+            return $hash unless $needle;
+            if (my $last_seen_module_id = $needle->last_seen_module_id) {
+                $hash->{last_seen_link} = $c->url_for(
+                    'admin_needle_module',
+                    module_id => $last_seen_module_id,
+                    needle_id => $needle->id
+                );
+            }
+            if (my $last_matched_module_id = $needle->last_matched_module_id) {
+                $hash->{last_match_link} = $c->url_for(
+                    'admin_needle_module',
+                    module_id => $last_matched_module_id,
+                    needle_id => $needle->id
+                );
+            }
+            return $hash;
+        });
+
+    $app->helper(
+        popover_link => sub {
+            my ($c, $text, $url) = @_;
+            return $text unless $url;
+            return "<a href='$url'>$text</a>";
+            # note: This code ends up in an HTML attribute and therefore needs to be escaped by the template
+            #       rendering. Therefore not using link_to here (which would prevent escaping of the "a" tag).
+        });
+
     $app->helper(find_job_or_render_not_found => \&_find_job_or_render_not_found);
 
     $app->helper(

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -61,6 +61,10 @@ sub schema_hook {
             settings => '{}'
         })->id;
     $jobs->find(99937)->update({scheduled_product_id => $scheduled_product_id});
+
+    # store the needle dir's realpath within the database; that is what the lookup for the candidates menu is
+    # expected to use
+    $needle_dir_fixture->update({path => $needle_dir->realpath});
 }
 
 my $driver = call_driver(\&schema_hook);

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -22,9 +22,10 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':all';
 use Mojo::JSON qw(decode_json encode_json);
+use Mojo::File qw(path);
+use Mojo::IOLoop;
 use OpenQA::Test::Case;
 use OpenQA::Client;
-use Mojo::IOLoop;
 use Module::Load::Conditional qw(can_load);
 
 use OpenQA::SeleniumTest;
@@ -32,6 +33,12 @@ use OpenQA::SeleniumTest;
 my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema      = $test_case->init_data(schema_name => $schema_name);
+
+# prepare needles dir
+my $needle_dir_fixture = $schema->resultset('NeedleDirs')->find(1);
+my $needle_dir         = path($needle_dir_fixture->path);
+$needle_dir->remove_tree({keep_root => 1});
+$needle_dir->child('inst-timezone-text.json')->spurt('{"area":[],"tags":["ENV-VIDEOMODE-text","inst-timezone"]}');
 
 sub schema_hook {
     my $jobs = $schema->resultset('Jobs');
@@ -390,8 +397,6 @@ my $ntext = <<EOM;
   ]
 }
 EOM
-my $needle_dir = 't/data/openqa/share/tests/opensuse/needles';
-ok(-d $needle_dir || mkdir($needle_dir), 'create needle directory');
 for my $needle_name (qw(sudo-passwordprompt-lxde sudo-passwordprompt)) {
     ok(open(my $fh, '>', "$needle_dir/$needle_name.json"));
     print $fh $ntext;
@@ -457,6 +462,18 @@ subtest 'test candidate list' => sub {
     );
     test_with_error(0, 0, ['sudo-passwordprompt', 'some-other-tag'],
         \%expected_candidates, 'needles appear twice, each time under different tag');
+
+    $driver->get('/tests/99946#step/installer_timezone/1');
+    wait_for_ajax_and_animations(msg => 'step preview');
+    $driver->find_element_by_id('candidatesMenu')->click();
+    wait_for_element(selector => '#needlediff_selector .show-needle-info', is_displayed => 1)->click();
+    like(
+        $driver->find_element('.needle-info-table')->get_text(),
+        qr/Last match.*T.*Last seen.*T.*/s,
+        'last match and last seen shown',
+    );
+    $driver->find_element_by_id('candidatesMenu')->click();
+    wait_until_element_gone('.needle-info-table');
 };
 
 subtest 'filtering' => sub {

--- a/templates/webapi/step/viewimg.html.ep
+++ b/templates/webapi/step/viewimg.html.ep
@@ -2,7 +2,7 @@
 <div class="aligncenter" data-image="<%= url_for('test_img', filename => $screenshot) %>" id="step_view">
     <span class="candidate_needles">
         Candidate needles and tags:
-        <div class="btn-group candidates-selection dropdown">
+        <div id="needlediff_dropdown" class="btn-group candidates-selection dropdown">
             <button type="button" class="btn btn-light btn-left" onclick="setNeedle($([]));" id="screenshot_button">
                 <i class="fas fa-image" title="Show only screenshot"></i>
             </button>
@@ -63,6 +63,15 @@
                                                 <i class="fas fa-eye trigger-diff"
                                                     title="View full diff"
                                                     data-diff="full-diff">
+                                                </i>
+                                                <i class="fas fa-history show-needle-info"
+                                                    title="Last match and last use"
+                                                    data-toggle="popover" data-placement="right"
+                                                    data-content="
+                                                    <table class='needle-info-table'>
+                                                        <tr><th>Last match:</th><td><%= popover_link $needle->{last_match}, $needle->{last_match_link} %></td></tr>
+                                                        <tr><th>Last seen:</th><td><%= popover_link $needle->{last_seen}, $needle->{last_seen_link} %></td></tr>
+                                                    </table>">
                                                 </i>
                                             </td>
                                         </tr>


### PR DESCRIPTION
* So one does not have to serach for the needle within the needles table
  manually to find out when the needle has been seen or matched the last
  time
* See https://progress.opensuse.org/issues/13740