### PR TITLE
Return error when creating a needle only contains ocr area

### DIFF
--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -43,6 +43,8 @@ sub _json_validation {
     if (!exists $djson->{tags} || !exists $djson->{tags}[0]) {
         die 'no tag defined';
     }
+    my @not_ocr_area = grep { $_->{type} ne 'ocr' } @{$djson->{area}};
+    die 'Cannot create a needle with only OCR areas' if scalar(@not_ocr_area) == 0;
 
     my $areas = $djson->{area};
     foreach my $area (@$areas) {

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -406,6 +406,23 @@ subtest 'Saving needle when "taking matches" not selected' => sub {
     check_flash_for_saving_logpackages();
 };
 
+subtest 'Saving needle with only OCR areas' => sub {
+    $driver->get('/tests/99938/modules/logpackages/steps/1/edit');
+    $driver->execute_script('$(\'#modal-overwrite\').removeClass(\'fade\');');
+    $driver->find_element_by_id('tag_ENV-DESKTOP-kde')->click();
+    create_needle(200, 250);
+    $driver->double_click;
+    $driver->double_click;    # the match tpye change to ocr
+    $driver->find_element_by_id('save')->click();
+    wait_for_ajax(msg => 'wait for needle with only OCR areas created');
+    like(
+        $driver->find_element('#flash-messages span')->get_text(),
+        qr/Cannot create a needle with only OCR areas/,
+        'error displayed for OCR-only needle'
+    );
+    $driver->find_element('#flash-messages .close')->click();
+};
+
 subtest 'Verify new needle\'s JSON' => sub {
     # parse new needle json
     my $new_needle_file = Mojo::File->new($dir, "$needlename.json");


### PR DESCRIPTION
Since openQA does not support OCR, so forbidden users to create a needle
only contains ocr type area, which will cause the test case to failed.

See: https://progress.opensuse.org/issues/65579