### PR TITLE
worker: Improve retrieving extended reason from os-autoinst

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -366,7 +366,7 @@ sub engine_workit {
         collected => sub {
             my $self = shift;
             eval { log_info("Isotovideo exit status: " . $self->exit_status, channels => 'autoinst'); };
-            $job->stop($self->exit_status == 0 ? 'done' : 'died: terminated prematurely, see log output for details');
+            $job->stop($self->exit_status == 0 ? 'done' : 'died');
         });
 
     session->on(

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -574,7 +574,8 @@ sub _format_reason {
             }
             if (my $msg = $state->{msg}) {
                 # append additional information, e.g. turn "backend died" into "backend died: qemu crashed"
-                $reason = "$reason: $msg" unless $msg =~ /\n/;
+                my $first_line = ($msg =~ /\A(.*?)$/ms)[0];
+                $reason = "$reason: $first_line";
             }
         }
     }

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -542,8 +542,8 @@ sub _stop_step_5_1_upload {
 
 sub _format_reason {
     my ($self, $result, $reason) = @_;
-    return undef unless $reason ne 'done' && (!defined $result || $result ne $reason);
 
+    # format stop reasons from the worker itself
     if ($reason eq 'setup failure') {
         return "setup failure: $self->{_setup_error}";
     }
@@ -561,27 +561,40 @@ sub _format_reason {
     elsif ($reason eq 'cancel') {
         return undef;    # the result is sufficient here
     }
-    else {
-        return $reason;
+
+    # consider other reasons as os-autoinst specific; retrieve extended reason if available
+    my $state_file = path($self->worker->pool_directory)->child(BASE_STATEFILE);
+    try {
+        if (-e $state_file) {
+            my $state = decode_json($state_file->slurp);
+            die 'top-level element is not a hash' unless ref $state eq 'HASH';
+            if (my $component = $state->{component}) {
+                # prepent the relevant component, e.g. turn "died" into "backend died" or "tests died"
+                $reason = "$component $reason" unless $component =~ qr/$[\w\d]^/;
+            }
+            if (my $msg = $state->{msg}) {
+                # append additional information, e.g. turn "backend died" into "backend died: qemu crashed"
+                $reason = "$reason: $msg" unless $msg =~ /\n/;
+            }
+        }
     }
+    catch {
+        if ($reason eq 'done') {
+            $reason = "$reason: terminated with corrupted state file";
+        }
+        else {
+            $reason = "$reason: terminated prematurely with corrupted state file, see log output for details";
+        }
+        log_warning("Found $state_file but failed to parse the JSON: $_");
+    };
+
+    # discard the reason if it is just 'done' or the same as the result; otherwise return it
+    return undef unless $reason ne 'done' && (!defined $result || $result ne $reason);
+    return $reason;
 }
 
 sub _set_job_done {
     my ($self, $reason, $params, $callback) = @_;
-
-    # Retrieve extended reason if available
-    my $pooldir    = $self->worker->pool_directory;
-    my $state_file = path($pooldir)->child(BASE_STATEFILE);
-    try {
-        if (-e $state_file) {
-            my $msg = decode_json($state_file->slurp)->{msg};
-            $reason = "$reason: " . $msg unless $msg =~ /\n/;
-        }
-    }
-    catch {
-        $reason = "$reason: Corrupted state file could not be read";
-        log_warning("Found $state_file but failed to parse the JSON: $_");
-    };
 
     # pass the reason if it is an additional specification of the result
     my $formatted_reason = $self->_format_reason($params->{result}, $reason);

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -377,7 +377,7 @@ subtest 'Job aborted because backend process died, multiple lines' => sub {
     $job->start;
     wait_until_job_status_ok($job, 'stopped');
 
-    is(@{$client->sent_messages}[-1]->{reason}, 'died', 'extended reason ignored')
+    is(@{$client->sent_messages}[-1]->{reason}, 'died: Lorem ipsum', 'only first line added to reason')
       or diag explain $client->sent_messages;
 
     $state_file->remove;


### PR DESCRIPTION
* Take the relevant component into account because for
  https://progress.opensuse.org/issues/64884 we need to distinguish
  between test crashes and backend crashes
* Ensure retrieving the extended reason does not interfere with stop
  reasons from the worker itself by handling worker-specific stop reasons
  first

With a change in os-autoinst to propagate the relevant component it will
look like this:
```
Reason: tests died: unable to load, check the log for the cause (e.g. syntax error)
Reason: backend died: Migrate to file failed
```