### PR TITLE
Add colors to log output when available

### DIFF
--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -46,6 +46,9 @@ my %LOG_DEFAULTS = (LOG_TO_STANDARD_CHANNEL => 1, CHANNELS => []);
 
 sub log_warning;
 
+my $log_module = "Mojo::Log";
+eval 'use Mojo::Log::Colored; $log_module = "Mojo::Log::Colored"';
+
 # logging helpers - _log_msg wrappers
 
 # log_debug("message"[, param1=>val1, param2=>val2]);
@@ -167,8 +170,7 @@ sub add_log_channel {
         }
         delete $options{default};
     }
-    $CHANNELS{$channel} = Mojo::Log->new(%options);
-
+    $CHANNELS{$channel} = $log_module->new(%options);
     $CHANNELS{$channel}->format(\&log_format_callback);
 }
 
@@ -219,35 +221,37 @@ sub setup_log {
 
     if ($logfile && $logdir) {
         $logfile = catfile($logdir, $logfile);
-        $log     = Mojo::Log->new(
+        $log     = $log_module->new(
             handle => path($logfile)->open('>>'),
-            level  => $app->level,
-            format => \&log_format_callback
+            level  => $app->level
         );
+        $log->format(\&log_format_callback);
     }
     elsif ($logfile) {
-        $log = Mojo::Log->new(
+        $log = $log_module->new(
             handle => path($logfile)->open('>>'),
-            level  => $level,
-            format => \&log_format_callback
+            level  => $level
         );
+        $log->format(\&log_format_callback);
     }
     elsif ($logdir) {
         # So each worker from each host get its own log (as the folder can be shared).
         # Hopefully the machine hostname is already sanitized. Otherwise we need to check
         $logfile
           = catfile($logdir, hostname() . (defined $app->instance ? "-${\$app->instance}" : '') . ".log");
-        $log = Mojo::Log->new(
+        $log = $log_module->new(
             handle => path($logfile)->open('>>'),
-            level  => $app->level,
-            format => \&log_format_callback
+            level  => $app->level
         );
+        $log->format(\&log_format_callback);
     }
     else {
-        $log = Mojo::Log->new(
+        $log = $log_module->new(
             handle => \*STDOUT,
-            level  => $level,
-            format => sub {
+            level  => $level
+        );
+        $log->format(
+            sub {
                 my ($time, $level, @lines) = @_;
                 return "[$level] " . join "\n", @lines, '';
             });

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -67,6 +67,7 @@ subtest 'load correct configs' => sub {
 subtest 'Logging to stdout' => sub {
     local $ENV{OPENQA_WORKER_LOGDIR};
     local $ENV{OPENQA_LOGFILE};
+    $ENV{ANSI_COLORS_DISABLED} = 1;
     my $app = OpenQA::Worker::App->new(
         mode     => 'production',
         log_name => 'worker',

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -67,7 +67,6 @@ subtest 'load correct configs' => sub {
 subtest 'Logging to stdout' => sub {
     local $ENV{OPENQA_WORKER_LOGDIR};
     local $ENV{OPENQA_LOGFILE};
-    $ENV{ANSI_COLORS_DISABLED} = 1;
     my $app = OpenQA::Worker::App->new(
         mode     => 'production',
         log_name => 'worker',
@@ -83,13 +82,13 @@ subtest 'Logging to stdout' => sub {
         log_error('error message');
         log_info('info message');
     };
-
+    note $output;
     my @matches = ($output =~ m/$reStdOut/gm);
 
     like $output, qr/$$/, 'Pid is printed in debug mode';
     is(@matches / 2, 3, 'Worker log matches');
     for (my $i = 0; $i < @matches; $i += 2) {
-        is($matches[$i], $matches[$i + 1], "OK $matches[$i]");
+        like($matches[$i], qr/$matches[$i + 1]/, "OK $matches[$i]");
     }
 };
 


### PR DESCRIPTION
* t: Extend 28-logging.t to cover color codes
* Define custom log color selection compatible with reverse video terminals
* Slightly simplify OpenQA::Log
* Add colors to log output when available
* t: Add trivial test for OpenQA::Log::get_channel_handle coverage
* t: Simplify stdout matching in 28-logging.t
* t: Fix warning "Prototype mismatch: sub Time::HiRes::gettimeofday"

Might not make much of a difference for production but makes debugging from log files also within local tests so much more enjoyable :)