### PR TITLE
Various, minor enhancement

### DIFF
--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -78,9 +78,6 @@ __PACKAGE__->inflate_column(
         deflate => sub { encode_json(shift) },
     });
 
-# TODO
-# INSERT INTO workers (id, t_created) VALUES(0, datetime('now'));
-
 sub name {
     my ($self) = @_;
     return $self->host . ":" . $self->instance;

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -86,6 +86,8 @@ sub name {
     return $self->host . ":" . $self->instance;
 }
 
+sub to_string { name(@_) }
+
 sub seen {
     my ($self, $workercaps, $error) = @_;
     $self->update({t_updated => now()});
@@ -256,12 +258,6 @@ sub send_command {
         return undef;
     };
     return 1;
-}
-
-sub to_string {
-    my ($self) = @_;
-
-    return $self->host . ':' . $self->instance;
 }
 
 sub unfinished_jobs {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -21,7 +21,6 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use DBIx::Class::Timestamps 'now';
 use Try::Tiny;
-use Scalar::Util 'looks_like_number';
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 
 =pod

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -16,6 +16,13 @@
 
 use Test::Most;
 
+use Test::Warnings;
+use Test::MockModule;
+use Time::HiRes 'sleep';
+use File::Path 'make_path';
+use Scalar::Util 'looks_like_number';
+use Mojo::File 'path';
+use Mojo::Util 'dumper';
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Scheduler::Model::Jobs;
@@ -24,13 +31,6 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Test::Utils
   qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
   qw(stop_service setup_fullstack_temp_dir);
-use Test::Warnings;
-use Test::MockModule;
-use Time::HiRes 'sleep';
-use File::Path 'make_path';
-use Scalar::Util 'looks_like_number';
-use Mojo::File 'path';
-use Mojo::Util 'dumper';
 
 BEGIN {
     # set default worker and job count

--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -55,6 +55,7 @@ $t->app($app);
 sub start_gru {
     start sub {
         note('starting gru');
+        $0 = 'openqa-gru';
         $ENV{MOJO_MODE} = 'test';
         Mojolicious::Commands->start_app('OpenQA::WebAPI', 'gru', 'run', '-m', 'test');
     };

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -49,6 +49,7 @@ sub _start_app {
 sub _start_gru {
     $gru_pid = fork();
     if ($gru_pid == 0) {
+        $0 = 'openqa-gru';
         log_info("starting gru\n");
         $ENV{MOJO_MODE} = 'test';
         my $app = Mojo::Server->new->build_app('OpenQA::WebAPI');

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -199,6 +199,7 @@ sub create_webapi {
 
     my $mojopid = fork();
     if ($mojopid == 0) {
+        $0 = 'openqa-webapi';
         $schema_hook->();
 
         local $ENV{MOJO_MODE} = 'test';
@@ -235,6 +236,7 @@ sub create_websocket_server {
     OpenQA::WebSockets::Client->singleton->port($port);
     my $wspid = fork();
     if ($wspid == 0) {
+        $0 = 'openqa-websocket';
         local $ENV{MOJO_LISTEN}             = "http://127.0.0.1:$port";
         local $ENV{MOJO_INACTIVITY_TIMEOUT} = 9999;
 
@@ -298,6 +300,7 @@ sub create_scheduler {
     OpenQA::Scheduler::Client->singleton->port($port);
     my $pid = fork();
     if ($pid == 0) {
+        $0 = 'openqa-scheduler';
         local $ENV{MOJO_LISTEN}             = "http://127.0.0.1:$port";
         local $ENV{MOJO_INACTIVITY_TIMEOUT} = 9999;
         local @ARGV                         = ('daemon');
@@ -316,6 +319,7 @@ sub create_live_view_handler {
     if ($pid == 0) {
         my $livehandlerport = $mojoport + 2;
         my $daemon          = Mojo::Server::Daemon->new(listen => ["http://127.0.0.1:$livehandlerport"], silent => 1);
+        $0 = 'openqa-livehandler';
         $daemon->build_app('OpenQA::LiveHandler');
         $daemon->run;
         Devel::Cover::report() if Devel::Cover->can('report');
@@ -398,6 +402,7 @@ sub unstable_worker {
 
     my $pid = fork();
     if ($pid == 0) {
+        $0 = 'openqa-worker-unstable';
         my $worker = OpenQA::Worker->new(
             {
                 apikey    => $apikey,
@@ -455,6 +460,7 @@ sub c_worker {
 
     my $pid = fork();
     if ($pid == 0) {
+        $0 = 'openqa-worker-rejecting';
         my $command_handler_mock = Test::MockModule->new('OpenQA::Worker::CommandHandler');
         if ($bogus) {
             $command_handler_mock->redefine(

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -229,7 +229,7 @@ sub create_webapi {
 sub create_websocket_server {
     my ($port, $bogus, $nowait, $with_embedded_scheduler) = @_;
 
-    note("Starting WebSocket service");
+    note("Starting WebSocket service. Port: $port");
     note("Bogus: $bogus | No wait: $nowait");
 
     OpenQA::WebSockets::Client->singleton->port($port);

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -275,7 +275,8 @@ sub create_websocket_server {
     }
     elsif (!defined $nowait) {
         # wait for websocket server
-        my $wait = time + 20;
+        my $limit = 20;
+        my $wait  = time + $limit;
         while (time < $wait) {
             my $t      = time;
             my $socket = IO::Socket::INET->new(
@@ -286,6 +287,7 @@ sub create_websocket_server {
             last    if $socket;
             sleep 1 if time - $t < 1;
         }
+        die("websocket server is not responsive after '$limit' seconds") unless time < $wait;
     }
     return $wspid;
 }


### PR DESCRIPTION
* Delete unused import in WebAPI::Controller::API::V1::Worker
* Delete obsolete TODO in worker schema implementation
* DRY in name/to_string within worker schema implementation
* t: Provide unique process name for all forked processes
* t: Use IPC::Run for gru service in t/api/14-plugin_obs_rsync_async.t
* t: Simplify sleep, retry and loops in t/api/14-plugin_obs_rsync_async.t
* t: Output port for websocket server same as we do for webapi
* t: Ensure unavailable websocket server is seen by throwing exception
* t: Sort external imports first in 43-scheduling-and-worker-scalability.t