### PR TITLE
Enable NOVIDEO for jobs with increased MAX_JOB_TIME by default

### DIFF
--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -20,6 +20,9 @@ use constant MAX_TIMER => 100;
 # Time verification to be use with WORKERS_CHECKER_THRESHOLD.
 use constant MIN_TIMER => 20;
 
+# The max. time a job is allowed to run by default before the worker kills it.
+use constant DEFAULT_MAX_JOB_TIME => 7200;
+
 # The smallest time difference of database timestamps we usually distinguish in seconds
 # note: PostgreSQL actually provides a higher accuracy for the timestamp type. However,
 #       the automatic timestamp handling provided by DBIx only stores whole seconds. The
@@ -31,8 +34,8 @@ our @EXPORT_OK = qw(
   WORKERS_CHECKER_THRESHOLD
   MAX_TIMER
   MIN_TIMER
+  DEFAULT_MAX_JOB_TIME
   DB_TIMESTAMP_ACCURACY
 );
-
 
 1;

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -189,6 +189,8 @@ sub _compute_max_job_time {
     my $max_job_time  = $job_settings->{MAX_JOB_TIME};
     my $timeout_scale = $job_settings->{TIMEOUT_SCALE};
     $max_job_time = DEFAULT_MAX_JOB_TIME unless looks_like_number $max_job_time;
+    # disable video for long-running scenarios by default
+    $job_settings->{NOVIDEO} = 1 if !exists $job_settings->{NOVIDEO} && $max_job_time > DEFAULT_MAX_JOB_TIME;
     $max_job_time *= $timeout_scale if looks_like_number $timeout_scale;
     return $max_job_time;
 }

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1087,7 +1087,23 @@ subtest 'computing max job time' => sub {
     is(OpenQA::Worker::Job::_compute_max_job_time(\%settings), DEFAULT_MAX_JOB_TIME / 2, 'short scenario');
     $settings{TIMEOUT_SCALE} = '4';
     is(OpenQA::Worker::Job::_compute_max_job_time(\%settings), DEFAULT_MAX_JOB_TIME * 2, 'max job time scaled');
-    is_deeply([sort keys %settings], [qw(MAX_JOB_TIME TIMEOUT_SCALE)], 'no extra settings added');
+    is_deeply([sort keys %settings], [qw(MAX_JOB_TIME TIMEOUT_SCALE)], 'no extra settings added so far');
+    $settings{TIMEOUT_SCALE} = undef;
+    $settings{MAX_JOB_TIME}  = DEFAULT_MAX_JOB_TIME + 1;
+    is(
+        OpenQA::Worker::Job::_compute_max_job_time(\%settings),
+        DEFAULT_MAX_JOB_TIME + 1,
+        'long scenario, NOVIDEO not specified'
+    );
+    is($settings{NOVIDEO}, 1, 'NOVIDEO set to 1 for long scenarios');
+    $settings{NOVIDEO} = 0;
+    is(
+        OpenQA::Worker::Job::_compute_max_job_time(\%settings),
+        DEFAULT_MAX_JOB_TIME + 1,
+        'long scenario, NOVIDEO specified'
+    );
+    is($settings{NOVIDEO}, 0, 'NOVIDEO not overridden if set to 0 explicitely');
+    is_deeply([sort keys %settings], [qw(MAX_JOB_TIME NOVIDEO TIMEOUT_SCALE)], 'only expected settings added');
 };
 
 subtest 'ignoring known images and files' => sub {

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -28,6 +28,7 @@ use Mojo::JSON 'encode_json';
 use Mojo::UserAgent;
 use Mojo::URL;
 use Mojo::IOLoop;
+use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME);
 use OpenQA::Worker::Job;
 use OpenQA::Worker::Settings;
 use OpenQA::Test::FakeWebSocketTransaction;
@@ -1077,6 +1078,16 @@ subtest '_read_result_file' => sub {
     my $extra_res = $ret->{my_extra}->{extra_test_results};
     is $extra_res->[0]->{name}, 'my_extra', 'extra_test_results covered' or diag explain $ret;
     is $extra_test_order, undef, 'the passed reference is not updated (do we need this?)';
+};
+
+subtest 'computing max job time' => sub {
+    my %settings;
+    is(OpenQA::Worker::Job::_compute_max_job_time(\%settings), DEFAULT_MAX_JOB_TIME, 'default scenario');
+    $settings{MAX_JOB_TIME} = sprintf('%d', DEFAULT_MAX_JOB_TIME / 2);
+    is(OpenQA::Worker::Job::_compute_max_job_time(\%settings), DEFAULT_MAX_JOB_TIME / 2, 'short scenario');
+    $settings{TIMEOUT_SCALE} = '4';
+    is(OpenQA::Worker::Job::_compute_max_job_time(\%settings), DEFAULT_MAX_JOB_TIME * 2, 'max job time scaled');
+    is_deeply([sort keys %settings], [qw(MAX_JOB_TIME TIMEOUT_SCALE)], 'no extra settings added');
 };
 
 subtest 'ignoring known images and files' => sub {


### PR DESCRIPTION
The video contributes significantly to the log size. This is especially the
case for long-running results so it makes sense to disable the video there
by default.

See
* https://progress.opensuse.org/issues/66922
* https://progress.opensuse.org/issues/67087#note-3