### PR TITLE
Maintain pagination when an user role changes

### DIFF
--- a/assets/javascripts/admin_user.js
+++ b/assets/javascripts/admin_user.js
@@ -7,11 +7,35 @@ function setup_admin_user() {
         var username = $(this).parents('tr').find('.name').text();
         var role = $(this).attr('id');
         role = $('label[for="' + role + '"]').text();
-        if (confirm("Are you sure to put " + username + " into role: " + $.trim(role) + "?")) {
-            $(this).parent('form').submit();
-        } else {
-            $(this).parent('form').find('input[class="default"]').first().prop('checked', 'checked');
-        }
-    });
 
+        function findDefault(form) {
+            return form.find('input[class="default"]').first();
+        }
+
+        function rollback(form) {
+            findDefault(form).prop('checked', 'checked');
+        }
+
+        var form = $(this).parent('form');
+
+        if (confirm("Are you sure to put " + username + " into role: " + $.trim(role) + "?")) {
+            var data = form.serializeArray();
+            var newRole = data[1].value;
+
+            $.ajax({
+                type: 'POST',
+                url: form.attr('action'),
+                data: jQuery.param(data),
+                success: function(data){
+                    findDefault(form).removeClass('default');
+                    form.find('input[value="' + newRole + '"]').addClass('default');
+                },
+                error: function(err){
+                    rollback(form);
+                    addFlash('danger', 'An error occurred when changing the user role');
+                }
+            });
+        } else
+            rollback(form);
+    });
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/47210

Problem: In the user administration page. When a role is changed
the page is reloaded loosing the page in the paginator.

Solution: Programmatically summit the form to prevent the page
reload. This solves the problem