### PR TITLE
Fix visual artifact in audio result box

### DIFF
--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -194,6 +194,8 @@ span.resborder {
 
     &.icon_terminal, &.icon_audio {
         background-size: contain;
+        background-repeat: no-repeat;
+        background-position: center center;
     }
     .fa-question, .step_actions {
         padding: 5px;


### PR DESCRIPTION
My job details page performance optimization introduced a minor graphical artifact to audio result boxes: https://openqa.suse.de/tests/4288141#step/firefox_audio/4

Fix the icon position in audio result box.