### PR TITLE
t: Make process handling more robust with IPC::Run

### DIFF
--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -95,7 +95,7 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # launch an additional app to serve some file for testing blocking downloads
 my $mojo_port = Mojo::IOLoop::Server->generate_port;
-my $pid       = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
+my $webapi    = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
 
 # define a fix asset_size_limit configuration for this test to be independent of the default value
 # we possibly want to adjust without going into the details of this test
@@ -608,7 +608,8 @@ subtest 'download assets with correct permissions' => sub {
     ok -f $assetpath, 'asset downloaded';
 };
 
-kill TERM => $pid;
+$webapi->signal('TERM');
+$webapi->finish;
 
 done_testing();
 

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -56,12 +56,12 @@ unless (can_load(modules => {'Selenium::Remote::WDKeys' => undef})) {
     exit(0);
 }
 
-my $workerpid;
-my $wspid;
-my $livehandlerpid;
-my $schedulerpid;
+my $worker;
+my $ws;
+my $livehandler;
+my $scheduler;
 sub turn_down_stack {
-    stop_service($_) for ($workerpid, $wspid, $livehandlerpid, $schedulerpid);
+    stop_service($_) for ($worker, $ws, $livehandler, $scheduler);
 }
 
 # skip if appropriate modules aren't available
@@ -94,9 +94,9 @@ ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'));
 # start Selenium test driver and other daemons
 my $mojoport = Mojo::IOLoop::Server->generate_port;
 my $driver   = call_driver(sub { }, {mojoport => $mojoport});
-$wspid          = create_websocket_server($mojoport + 1, 0, 0);
-$schedulerpid   = create_scheduler($mojoport + 3);
-$livehandlerpid = create_live_view_handler($mojoport);
+$ws          = create_websocket_server($mojoport + 1, 0, 0);
+$scheduler   = create_scheduler($mojoport + 3);
+$livehandler = create_live_view_handler($mojoport);
 
 # login
 $driver->title_is('openQA', 'on main page');
@@ -128,7 +128,7 @@ for my $ext (qw(.json .png)) {
         'can rename needle ' . $ext);
 }
 
-$workerpid = start_worker(get_connect_args());
+$worker = start_worker(get_connect_args());
 ok wait_for_job_running($driver), 'test 1 is running';
 
 sub wait_for_session_info {

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -55,8 +55,8 @@ $ENV{MOJO_LOG_LEVEL} = 'fatal';
 my $mojoport = Mojo::IOLoop::Server->generate_port;
 $host = "localhost:$mojoport";
 my $schema = OpenQA::Test::Database->new->create;
-my $pid    = OpenQA::Test::Utils::create_webapi($mojoport, sub { });
-END { stop_service $pid; }
+my $webapi = OpenQA::Test::Utils::create_webapi($mojoport, sub { });
+END { stop_service $webapi; }
 # Note: See t/fixtures/03-users.pl for test user credentials
 my $apikey    = 'PERCIVALKEY02';
 my $apisecret = 'PERCIVALSECRET02';

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -44,13 +44,13 @@ $JOB_SETUP .= ' QEMU_NO_KVM=1' unless -r '/dev/kvm';
 
 sub get_connect_args {
     my $mojoport = OpenQA::SeleniumTest::get_mojoport;
-    return "--apikey 1234567890ABCDEF --apisecret 1234567890ABCDEF --host http://localhost:$mojoport";
+    return ["--apikey=1234567890ABCDEF", "--apisecret=1234567890ABCDEF", "--host=http://localhost:$mojoport"];
 }
 
 sub client_output {
     my ($args) = @_;
-    my $connect_args = get_connect_args();
-    open(my $client, "-|", "perl ./script/openqa-cli api $connect_args $args");
+    my @connect_args = @{get_connect_args()};
+    open(my $client, "-|", "perl ./script/openqa-cli api @connect_args $args");
     my $out;
     while (<$client>) {
         $out .= $_;


### PR DESCRIPTION
Whenever processes are spawned they need to be tracked properly for
cleanup. This posed problems of sometimes leaking orphans when tests are
aborted or crashed. As we already use IPC::Run we can use the same for
other cases where we spawn processes with fork by using IPC::Run::start
instead. Additional benefits are that we can debug the process handling
and IPC going with https://metacpan.org/pod/IPC::Run#Debugging-Tip as
well as be able to catch output of the processes.

One example of a recent problem that should be fixed by this is
t/05-scheduler-full.t failing to stop completely when individual test
steps fail. This prevents the RETRY on the level of tools/retry and the
Makefile to work as the former test never completely finishes and is
stuck until the CI aborts the complete test run without further retries.

https://progress.opensuse.org/issues/59043