### PR TITLE
Generalize handling the video

### DIFF
--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -29,6 +29,11 @@ use constant DEFAULT_MAX_JOB_TIME => 7200;
 #       openQA code itself only deals with whole seconds as well.
 use constant DB_TIMESTAMP_ACCURACY => 1;
 
+# Define constants related to the video file
+# note: All artefacts starting with VIDEO_FILE_NAME_START are considered videos.
+use constant VIDEO_FILE_NAME_START => 'video.';
+use constant VIDEO_FILE_NAME_REGEX => qr/^.*\/video\.[^\/]*$/;
+
 our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION
   WORKERS_CHECKER_THRESHOLD
@@ -36,6 +41,8 @@ our @EXPORT_OK = qw(
   MIN_TIMER
   DEFAULT_MAX_JOB_TIME
   DB_TIMESTAMP_ACCURACY
+  VIDEO_FILE_NAME_START
+  VIDEO_FILE_NAME_REGEX
 );
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -33,6 +33,7 @@ use Mojo::Log;
 use Scalar::Util qw(blessed reftype);
 use Exporter 'import';
 use OpenQA::App;
+use OpenQA::Constants qw(VIDEO_FILE_NAME_START VIDEO_FILE_NAME_REGEX);
 use OpenQA::Log qw(log_info log_debug log_warning log_error);
 
 # avoid boilerplate "$VAR1 = " in dumper output
@@ -82,6 +83,7 @@ our @EXPORT = qw(
   set_listen_address
   service_port
   change_sec_to_word
+  find_video_files
 );
 
 our @EXPORT_OK = qw(
@@ -903,5 +905,7 @@ sub change_sec_to_word {
     $time_word =~ s/\s$//g;
     return $time_word;
 }
+
+sub find_video_files { path(shift)->list_tree->grep(VIDEO_FILE_NAME_REGEX) }
 
 1;

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -599,11 +599,21 @@ sub viewimg {
         $self->stash(textresult => 'Seems like os-autoinst has produced a result which openQA can not display.');
         return $self->render('step/viewtext');
     }
-    $self->stash('screenshot',     $screenshot);
-    $self->stash('frametime',      grep(/video.ogv$/, @{$job->test_resultfile_list}) ? $module_detail->{frametime} : 0);
-    $self->stash('default_label',  $primary_match ? $primary_match->{label} : 'Screenshot');
-    $self->stash('needles_by_tag', \%needles_by_tag);
-    $self->stash('tag_count',      scalar %needles_by_tag);
+    my %stash = (
+        screenshot      => $screenshot,
+        default_label   => $primary_match ? $primary_match->{label} : 'Screenshot',
+        needles_by_tag  => \%needles_by_tag,
+        tag_count       => scalar %needles_by_tag,
+        video_file_name => undef,
+        frametime       => 0,
+    );
+    my $videos    = $job->video_file_paths;
+    my $frametime = $module_detail->{frametime};
+    if ($videos->size) {
+        $stash{video_file_name} = $videos->first->basename;
+        $stash{frametime}       = ref $frametime eq 'ARRAY' ? $frametime : 0;
+    }
+    $self->stash(\%stash);
     return $self->render('step/viewimg');
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -89,12 +89,12 @@ sub register {
 
     $app->helper(
         stepvideolink_for => sub {
-            my ($c, $testid, $frametime) = @_;
-            my $t     = sprintf("?t=%s,%s", ${$frametime}[0], ${$frametime}[1]);
-            my $url   = $c->url_for('video', testid => $testid) . $t;
-            my $icon  = $c->t(i => (class => "step_action far fa-video-file fa-lg"));
-            my $class = "step_action far fa-file-video fa-lg";
-            return $c->link_to($url => (title => "Jump to video", class => $class) => sub { "" });
+            my ($c, $testid, $file_name, $frametime) = @_;
+            my $t     = sprintf('&t=%s,%s', $frametime->[0], $frametime->[1]);
+            my $url   = $c->url_for('video', testid => $testid)->query(filename => $file_name) . $t;
+            my $icon  = $c->t(i => (class => 'step_action far fa-video-file fa-lg'));
+            my $class = 'step_action far fa-file-video fa-lg';
+            return $c->link_to($url => (title => 'Jump to video', class => $class) => sub { '' });
         });
 
     $app->helper(

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -118,6 +118,8 @@ is($t->tx->res->dom->at('#asset_1')->{href}, '/tests/99946/asset/iso/openSUSE-13
 $res = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#asset_5')->text);
 is($res,                                     'openSUSE-13.1-x86_64.hda');
 is($t->tx->res->dom->at('#asset_5')->{href}, '/tests/99946/asset/hdd/openSUSE-13.1-x86_64.hda');
+$t->get_ok('/tests/99938/downloads_ajax')->status_is(200)
+  ->element_exists('a[href=/tests/99938/video?filename=video.ogv]', 'link to video player contains filename');
 
 # downloads are currently redirects
 $t->get_ok('/tests/99946/asset/1')->status_is(302)

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -335,9 +335,17 @@ subtest 'render video link if frametime is available' => sub {
     wait_for_ajax(msg => 'second step of bootloader test module loaded');
     my @video_link_elems = $driver->find_elements('.step_actions .fa-file-video');
     is($video_link_elems[0]->get_attribute('title'), 'Jump to video', 'video link exists');
-    like($video_link_elems[0]->get_attribute('href'), qr!/tests/99946/video\?t=0\.00,1\.00!, 'video href correct');
+    like(
+        $video_link_elems[0]->get_attribute('href'),
+        qr!/tests/99946/video\?filename=video\.ogv&t=0\.00,1\.00!,
+        'video href correct'
+    );
     $video_link_elems[0]->click();
-    like($driver->find_element('video')->get_attribute('src'), qr!#t=0!, 'video starts on timestamp');
+    like(
+        $driver->find_element('video')->get_attribute('src'),
+        qr!/tests/99946/file/video\.ogv#t=0!,
+        'video src correct and starts on timestamp'
+    );
 };
 
 subtest 'route to latest' => sub {

--- a/templates/webapi/step/viewimg.html.ep
+++ b/templates/webapi/step/viewimg.html.ep
@@ -89,8 +89,8 @@
             %= stepaction_for 'Create new needle' => url_for('edit_step'), 'fa-thumbtack', 'create_new_needle'
         % }
         %= bug_report_actions
-        % if ($frametime) {
-            %= stepvideolink_for $testid, $frametime
+        % if ($video_file_name && $frametime) {
+            %= stepvideolink_for $testid, $video_file_name, $frametime
         % }
     </span>
 </div>

--- a/templates/webapi/test/downloads.html.ep
+++ b/templates/webapi/test/downloads.html.ep
@@ -1,13 +1,14 @@
+% use OpenQA::Constants 'VIDEO_FILE_NAME_START';
 % if(@$resultfiles) {
     <div class="h5">Result Files</div>
     <ul>
         % for my $resultfile (@$resultfiles) {
             <li>
-                % if($resultfile =~ /video.ogv$/) {
-                    %= link_to url_for('video', testid => $testid) => begin
-                        <i title="ogg/theora video of this testrun" class="far fa-file-video"></i> Video
+                % if (rindex($resultfile, VIDEO_FILE_NAME_START, 0) == 0) {
+                    %= link_to url_for('video', testid => $testid)->query(filename => $resultfile) => begin
+                        <i title="Video of this testrun" class="far fa-file-video"></i> Video
                     %= end
-                    %= link_to '(download)' => url_for('test_file', testid => $testid, filename => 'video.ogv')
+                    %= link_to '(download)' => url_for('test_file', testid => $testid, filename => $resultfile)
                 % } else
                 % {
                     <a href="<%= url_for('test_file', testid => $testid,

--- a/templates/webapi/test/video.html.ep
+++ b/templates/webapi/test/video.html.ep
@@ -1,11 +1,12 @@
-% title 'Video';
+% return unless my $filename = param 'filename'; # return 404 unless filename query parameter specified
 
+% title 'Video';
 % content_for 'head' => begin
   %= asset 'video.css'
 % end
 
 <figure id="video_viewer">
-    <video id="video" src="<%= url_for('test_file', testid => $testid, filename => 'video.ogv')->fragment('t=' . (param('t') // 0)) %>" controls>
+    <video id="video" src="<%= url_for('test_file', testid => $testid, filename => $filename)->fragment('t=' . (param('t') // 0)) %>" controls>
         <track default="" kind="subtitles" srclang="en" label="Timestamps" src="<%= url_for('test_file', testid => $testid, filename => 'video_time.vtt') %>">
     </video>
 </figure>


### PR DESCRIPTION
* Nothing changes for regular jobs producing `video.ogv` or no video at all.
* Settings influencing the video encoding are only passed from the worker
  config to isotovideo but not from job settings to avoid running arbitrary
  commands on the worker.
* All artefacts named like `video.*` will be considered videos. This affects
    * files considered to be uploaded by the worker.
    * cleanup of results.
    * the list in the 'Logs & Assets' tab.
* See https://progress.opensuse.org/issues/67342