### PR TITLE
Prefetch parent job in JobModules::job_modules()

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -160,7 +160,8 @@ sub job_modules {
     my ($job) = @_;
 
     my $schema = OpenQA::Schema->singleton;
-    return $schema->resultset("JobModules")->search({job_id => $job->id}, {order_by => 'id'})->all;
+    return $schema->resultset("JobModules")->search({job_id => $job->id}, {prefetch => 'job', order_by => 'me.id'})
+      ->all;
 }
 
 sub update_result {


### PR DESCRIPTION
The `JobModules` class sometimes needs to access the parent job internally. If the job wasn't prefetched, this can lead to hundreds or even thousands of unnecessary DB queries. This patch speeds up server-side generation of job details JSON up to 5 times for ltp_syscalls jobs (1100+ test modules).

You can measure performance improvement on these jobs:
- [ltp_openposix](https://openqa.suse.de/tests/4287498) (1608 modules)
- [ltp_syscalls](https://openqa.suse.de/tests/4287479) (1165 modules)