### PR TITLE
Capture base_state.json JSON error warning in worker jobs test

### DIFF
--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -406,11 +406,15 @@ subtest 'Job aborted, broken state file' => sub {
         'died: terminated prematurely with corrupted state file, see log output for details',
         'reason propagated'
     ) or diag explain $client->sent_messages;
-    is(
-        $job->_format_reason(PASSED, 'done'),
-        'done: terminated with corrupted state file',
-        'reason in case the job is nevertheless done'
-    ) or diag explain $client->sent_messages;
+    combined_like {
+        is(
+            $job->_format_reason(PASSED, 'done'),
+            'done: terminated with corrupted state file',
+            'reason in case the job is nevertheless done'
+          )
+          or diag explain $client->sent_messages
+    }
+    qr/but failed to parse the JSON/, 'JSON error logged';
 
     $state_file->remove;
     $client->sent_messages([]);


### PR DESCRIPTION
    [WARN] Found poolr3UU/base_state.json but failed to parse the JSON: '"' expected, at character offset 16 (before "(end of string)") at /usr