### PR TITLE
Use BAIL_OUT instead of die on TimeLimit alarm

### DIFF
--- a/t/lib/OpenQA/Test/TimeLimit.pm
+++ b/t/lib/OpenQA/Test/TimeLimit.pm
@@ -17,10 +17,15 @@ package OpenQA::Test::TimeLimit;
 use strict;
 use warnings;
 
+use Test::More;
+
 sub import {
     my ($package, $limit) = @_;
     die "$package: Need argument on import, e.g. use: use OpenQA::Test::TimeLimit '42';" unless $limit;
-    $SIG{ALRM} = sub { die "test exceeds runtime limit of '$limit' seconds\n" };
+    $SIG{ALRM} = sub {
+        eval { die "test exceeds runtime limit of '$limit' seconds\n" };
+        BAIL_OUT;
+    };
     alarm $limit;
 }
 


### PR DESCRIPTION
This way the testplan is not broken.

The `eval` here is used to avoid causing parsing errors on the testplan. I found this out experimentally.