### PR TITLE
t: Prevent use of occupied port in all full-stack/scalability tests

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -38,6 +38,7 @@ use Mojo::IOLoop::Server;
 use Mojo::File qw(path tempfile);
 use Time::HiRes 'sleep';
 use OpenQA::Test::Utils qw(
+  mock_service_ports
   setup_fullstack_temp_dir create_user_for_workers
   create_webapi wait_for_worker setup_share_dir create_websocket_server
   stop_service unstable_worker
@@ -57,8 +58,9 @@ my $api_key         = $api_credentials->key;
 my $api_secret      = $api_credentials->secret;
 
 # create web UI and websocket server
-my $mojoport = $ENV{OPENQA_BASE_PORT} = Mojo::IOLoop::Server->generate_port();
-my $ws       = create_websocket_server($mojoport + 1, 0, 1, 1);
+mock_service_ports;
+my $mojoport = service_port 'webui';
+my $ws       = create_websocket_server(undef, 0, 1, 1);
 my $webapi   = create_webapi($mojoport, sub { });
 my @workers;
 
@@ -258,7 +260,7 @@ subtest 'Websocket server - close connection test' => sub {
 
     my $log;
     # create unstable ws
-    $ws      = create_websocket_server($mojoport + 1, 1, 0);
+    $ws      = create_websocket_server(undef, 1, 0);
     @workers = create_worker($api_key, $api_secret, "http://localhost:$mojoport", 2, \$log);
 
     my $found_connection_closed_in_log = 0;

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -40,6 +40,7 @@ use Fcntl ':mode';
 use DBI;
 use File::Path qw(make_path remove_tree);
 use Module::Load::Conditional 'can_load';
+use OpenQA::Utils qw(service_port);
 use OpenQA::Test::Utils qw(
   create_websocket_server create_scheduler create_live_view_handler setup_share_dir setup_fullstack_temp_dir
   start_worker stop_service
@@ -92,11 +93,11 @@ $users->create(
 ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'));
 
 # start Selenium test driver and other daemons
-my $mojoport = Mojo::IOLoop::Server->generate_port;
-my $driver   = call_driver(sub { }, {mojoport => $mojoport});
-$ws          = create_websocket_server($mojoport + 1, 0, 0);
-$scheduler   = create_scheduler($mojoport + 3);
-$livehandler = create_live_view_handler($mojoport);
+my $port   = service_port 'webui';
+my $driver = call_driver(sub { }, {mojoport => $port});
+$ws          = create_websocket_server(undef, 0, 0);
+$scheduler   = create_scheduler;
+$livehandler = create_live_view_handler;
 
 # login
 $driver->title_is('openQA', 'on main page');


### PR DESCRIPTION
Sporadically tests can fail with "Connection refused" when already
occupied ports have been selected for services in tests as we only
looked for a single free port and tried to use the ports next to it
without checking if they are actually free.

This commit is inspired from the idea in the scalability test extended
to all services and used in all relevant full-stack and scalability
tests. By mocking the function "service_port" from OpenQA::Utils
whenever the new function "mock_service_ports" is called we can provide
a consistent but dynamically defined set of ports that should all be
free to use during the course of each test.

Related progress issue: https://progress.opensuse.org/issues/59043