### PR TITLE
t: Make output nicer on time limit

### DIFF
--- a/t/lib/OpenQA/Test/TimeLimit.pm
+++ b/t/lib/OpenQA/Test/TimeLimit.pm
@@ -14,13 +14,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Test::TimeLimit;
-use strict;
-use warnings;
+use Test::Most;
 
 sub import {
     my ($package, $limit) = @_;
     die "$package: Need argument on import, e.g. use: use OpenQA::Test::TimeLimit '42';" unless $limit;
-    $SIG{ALRM} = sub { die "test exceeds runtime limit of '$limit' seconds\n" };
+    $SIG{ALRM} = sub { BAIL_OUT "test exceeds runtime limit of '$limit' seconds\n" };
     alarm $limit;
 }
 


### PR DESCRIPTION
Instead of

```
t/basic.t .. run(/usr/bin/sass) failed: test exceeds runtime limit of '1' seconds
 ($?=0, $!=29, PATH=/home/okurz/.gem/ruby/2.5.0/bin:/home/okurz/perl5.26/bin:/home/okurz/perl5.26/perlbrew/bin:/home/okurz/perl5.26/bin:/home/okurz/local/os-autoinst/scripts:/suse/bin:/usr/lib/ccache:/home/okurz/local/python_venv-linux-28d6.suse/bin:/home/okurz/.npm-packages/bin:/home/okurz/node_modules/.bin:/opt/bin:/home/okurz/bin:/home/okurz/bin:/usr/local/bin:/usr/bin:/bin:/opt/bin:/usr/lib/mit/sbin:/home/okurz/.neo:/home/krz/.neo/:/home/okurz/documents/Computer/todo.txt/todo.txt-cli) at /usr/lib/perl5/vendor_perl/5.26.1/Mojolicious/Plugin/AssetPack/Pipe.pm line 30.
t/basic.t .. Dubious, test returned 29 (wstat 7424, 0x1d00)
No subtests run

Test Summary Report
-------------------
t/basic.t (Wstat: 7424 Tests: 0 Failed: 0)
  Non-zero exit status: 29
  Parse errors: No plan found in TAP output
Files=1, Tests=0, 2.72359 wallclock secs ( 0.01 usr  0.00 sys +  1.45 cusr  0.10 csys =  1.56 CPU)
Result: FAIL
```

make it

```
t/basic.t .. Bailout called.  Further testing stopped:  test exceeds runtime limit of '1' seconds
FAILED--Further testing stopped: test exceeds runtime limit of '1' seconds
```