### PR TITLE
Mark "25-cache-service.t" as unstable test as observed in circleci

### DIFF
--- a/.circleci/unstable_tests.txt
+++ b/.circleci/unstable_tests.txt
@@ -1,2 +1,3 @@
+t/25-cache-service.t
 t/ui/01-list.t
 t/ui/27-plugin_obs_rsync_status_details.t


### PR DESCRIPTION
For example see
https://app.circleci.com/pipelines/github/os-autoinst/openQA/3103/workflows/65a02451-f06f-470b-a677-5cb7d0201f4e/jobs/29589/steps