### PR TITLE
Remove dead code from OpenQA::WebAPI::Plugin::ObsRsync

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -278,7 +278,7 @@ sub _read_test_id {
 
 sub _get_test_result {
     my ($c, $id) = @_;
-    return 'unknown' unless my $job = $c->schema->resultset("Jobs")->single({id => $id});
+    return 'unknown' unless my $job = $c->schema->resultset("Jobs")->find($id);
     return $job->result;
 }
 


### PR DESCRIPTION
Small change to remove some dead code from `OpenQA::WebAPI::Plugin::ObsRsync`. I'm a little disappointed that #3052 got approved despite the objections. But this PR will resolve the issues raised.

1) It's bad practice to wrap `->single` calls in an `eval` (confirmed with a second opinion from the `DBIx::Class` author in #3052).
2) Wrapping `readlink` in an `eval` does nothing, the function only throws an exception if the operating system does not support the required syscall (Win32, RISC OS, VMS), normal errors return `undef` and set `$!`.