### PR TITLE
Add OAuth2 auth method with GitHub provider

### DIFF
--- a/.circleci/ci-packages.txt
+++ b/.circleci/ci-packages.txt
@@ -140,6 +140,7 @@ perl-Module-Runtime-Conflicts-0.003
 perl-Mojo-IOLoop-ReadWriteProcess-0.25
 perl-Mojolicious-8.56
 perl-Mojolicious-Plugin-AssetPack-2.08
+perl-Mojolicious-Plugin-OAuth2
 perl-Mojo-Pg-4.19
 perl-Mojo-RabbitMQ-Client-0.3.1
 perl-Mojo-SQLite-3.003

--- a/cpanfile
+++ b/cpanfile
@@ -93,6 +93,7 @@ requires 'warnings';
 
 on 'test' => sub {
     requires 'App::cpanminus';
+    requires 'Mojolicious::Plugin::OAuth2';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Freenode';
     requires 'Selenium::Remote::Driver', '>= 1.23';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -161,6 +161,7 @@ test_requires:
   python3-setuptools:
   python3-yamllint:
   perl(App::cpanminus):
+  perl(Mojolicious::Plugin::OAuth2):
   perl(Perl::Critic):
   perl(Perl::Critic::Freenode):
   perl(Selenium::Remote::Driver): '>= 1.23'

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -268,14 +268,15 @@ according to
 [[authentication]]
 === User authentication
 
-OpenQA supports two different authentication methods - OpenID (default) and
-Fake. See `auth` section in `/etc/openqa/openqa.ini`.
+OpenQA supports three different authentication methods - OpenID (default),
+Fake (for development) and OAuth2 (currently limited to GitHub).
+See `auth` section in `/etc/openqa/openqa.ini`.
 
 [source,ini]
 --------------------------------------------------------------------------------
 [auth]
 # method name is case sensitive!
-method = OpenID|Fake
+method = OpenID
 --------------------------------------------------------------------------------
 
 Independently of method used, the first user that logs in (if there is no admin yet)
@@ -288,6 +289,10 @@ OpenID method has its own `openid` section in `/etc/openqa/openqa.ini`:
 
 [source,ini]
 --------------------------------------------------------------------------------
+[auth]
+# method name is case sensitive!
+method = OpenID
+
 [openid]
 ## base url for openid provider
 provider = https://www.opensuse.org/openid/user/
@@ -295,8 +300,35 @@ provider = https://www.opensuse.org/openid/user/
 httpsonly = 1
 --------------------------------------------------------------------------------
 
-OpenQA supports only OpenID version up to 2.0. Newer OpenID-Connect and OAuth is
-not supported currently.
+This method supports OpenID version up to 2.0.
+
+=== OAuth2
+
+Login via OAuth 2.0 is currently limited to GitHub.
+
+[source,ini]
+--------------------------------------------------------------------------------
+[auth]
+# method name is case sensitive!
+method = OAuth2
+
+[oauth2]
+provider = github
+key = mykey
+secret = mysecret
+--------------------------------------------------------------------------------
+
+In order to use GitHub for authorization, the instance needs to be
+https://github.com/settings/applications/new[registered on GitHub]. Afterwards
+the key and secret will be visible to the application owner(s).
+
+Note: An additional Mojolicious plugin is required to use this feature:
+
+[source,sh]
+-------------------------------------------------------------------------------
+# openSUSE
+zypper in 'perl(Mojolicious::Plugin::OAuth2)'
+-------------------------------------------------------------------------------
 
 === Fake
 
@@ -308,6 +340,10 @@ You can then use following as `/etc/openqa/client.conf`:
 
 [source,ini]
 --------------------------------------------------------------------------------
+[auth]
+# method name is case sensitive!
+method = Fake
+
 [localhost]
 key = 1234567890ABCDEF
 secret = 1234567890ABCDEF

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -68,6 +68,11 @@ sub read_config {
             provider  => 'https://www.opensuse.org/openid/user/',
             httpsonly => 1,
         },
+        oauth2 => {
+            provider => '',
+            key      => '',
+            secret   => '',
+        },
         hypnotoad => {
             listen => ['http://localhost:9526/'],
             proxy  => 1,
@@ -286,6 +291,10 @@ sub load_plugins {
     if (my $err = load_class $auth_module) {
         $err = 'Module not found' unless ref $err;
         die "Unable to load auth module $auth_module: $err";
+    }
+    # Optional initialization with access to the app
+    if (my $sub = $auth_module->can('auth_setup')) {
+        $server->$sub;
     }
 
     # Read configurations expected by plugins.

--- a/lib/OpenQA/Shared/Controller/Session.pm
+++ b/lib/OpenQA/Shared/Controller/Session.pm
@@ -67,6 +67,7 @@ sub create {
 
     return $self->render(text => 'Forbidden', status => 403) unless %res;
     return $self->render(text => $res{error}, status => 403) if $res{error};
+    return if $res{manual};
     if ($res{redirect}) {
         $self->flash(ref => $ref);
         return $self->redirect_to($res{redirect});

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -1,0 +1,71 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Auth::OAuth2;
+use Mojo::Base -base;
+
+use Carp 'croak';
+
+has config => undef;
+
+sub auth_setup {
+    my ($self) = @_;
+    $self->config($self->app->config->{oauth2});
+    croak 'No OAuth2 provider selected' unless my $provider = $self->config->{provider};
+    croak "Provider $provider not supported" unless $provider eq 'github';
+
+    $self->app->plugin(
+        OAuth2 => {
+            $provider => {
+                key    => $self->config->{key},
+                secret => $self->config->{secret},
+            }});
+}
+
+sub auth_login {
+    my ($self) = @_;
+    croak 'Setup was not called' unless $self->config;
+
+    my $get_token_args = {redirect_uri => $self->url_for('login')->userinfo(undef)->to_abs};
+    # Note: user:email is GitHub-specific, email may be empty
+    $get_token_args->{scope} = 'user:email';
+    $self->oauth2->get_token_p($self->config->{provider} => $get_token_args)->then(
+        sub {
+            return unless my $data = shift;
+
+            # Get or update user details via GitHub-specific API
+            my $ua    = Mojo::UserAgent->new;
+            my $token = $data->{access_token};
+            my $res   = $ua->get('https://api.github.com/user', {Authorization => "token $token"})->result;
+            if (my $err = $res->error) {
+                # Note: Using 403 for consistency
+                return $self->render(text => "$err->{code}: $err->{message}", status => 403);
+            }
+            my $details = $res->json;
+            my $user    = $self->schema->resultset('Users')->create_user(
+                $details->{id},
+                {
+                    nickname => $details->{login},
+                    fullname => $details->{name},
+                    email    => $details->{email},
+                });
+
+            $self->session->{user} = $user->username;
+            $self->redirect_to('index');
+        })->catch(sub { $self->render(text => shift, status => 403) });
+    return (manual => 1);
+}
+
+1;

--- a/openQA.spec
+++ b/openQA.spec
@@ -63,7 +63,7 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Mojolicious::Plugin::OAuth2) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else
@@ -100,6 +100,8 @@ Recommends:     apache2
 Recommends:     apparmor-profiles
 Recommends:     apparmor-utils
 Recommends:     logrotate
+# the plugin is needed if the auth method is set to "oauth2"
+Recommends:     perl(Mojolicious::Plugin::OAuth2)
 # server needs to run an rsync server if worker caching is used
 Recommends:     rsync
 BuildArch:      noarch

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -25,12 +25,12 @@ use OpenQA::Test::Database;
 use Mojo::File qw(tempdir path);
 
 my $t;
-my $tempdir = tempdir;
+my $tempdir = tempdir("/tmp/$FindBin::Script-XXXX")->make_path;
+$ENV{OPENQA_CONFIG} = $tempdir;
 
 sub test_auth_method_startup {
     my ($auth, @options) = @_;
     my @conf = ("[auth]\n", "method = \t  $auth \t\n");
-    $ENV{OPENQA_CONFIG} = $tempdir;
     $tempdir->child("openqa.ini")->spurt(@conf, @options);
 
     $t = Test::Mojo->new('OpenQA::WebAPI');
@@ -40,12 +40,14 @@ sub test_auth_method_startup {
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 
-test_auth_method_startup('Fake')->status_is(302);
+combined_like { test_auth_method_startup('Fake')->status_is(302) } qr/302 Found/, 'Plugin loaded';
+
 # openid relies on external server which we mock to not rely on external
 # dependencies
 my $openid_mock = Test::MockModule->new('Net::OpenID::Consumer');
 $openid_mock->redefine(claimed_identity => undef);
-test_auth_method_startup('OpenID')->status_is(403);
+combined_like { test_auth_method_startup('OpenID')->status_is(403) } qr/Claiming OpenID identity for URL.+failed/,
+  'Plugin loaded, identity denied';
 
 subtest OAuth2 => sub {
     lives_ok {
@@ -64,7 +66,7 @@ subtest OAuth2 => sub {
       'Plugin loaded';
 };
 
-eval { test_auth_method_startup('nonexistant') };
-ok $@, 'refused to start with non existant auth module';
+throws_ok { test_auth_method_startup('nonexistant') } qr/Unable to load auth module/,
+  'refused to start with non existant auth module';
 
 done_testing;

--- a/t/config.t
+++ b/t/config.t
@@ -69,6 +69,11 @@ subtest 'Test configuration default modes' => sub {
             provider  => 'https://www.opensuse.org/openid/user/',
             httpsonly => 1,
         },
+        oauth2 => {
+            provider => '',
+            key      => '',
+            secret   => '',
+        },
         hypnotoad => {
             listen => ['http://localhost:9526/'],
             proxy  => 1,


### PR DESCRIPTION
- The new method needs to be enabled in the config file, which is described in the installation doc.
- Currently `github` is the only accepted value because authorization with GitHub doesn't follow the _OpenID Connect_ spec. Although adding other providers will be straightforward.

Fixes: [poo#67576](https://progress.opensuse.org/issues/67576)