### PR TITLE
worker: Allow video encoder to finalize the file

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -54,7 +54,7 @@ requires 'Module::Pluggable';
 requires 'Mojo::Base';
 requires 'Mojo::ByteStream';
 requires 'Mojo::IOLoop';
-requires 'Mojo::IOLoop::ReadWriteProcess', '>= 0.20';
+requires 'Mojo::IOLoop::ReadWriteProcess', '>= 0.26';
 requires 'Mojo::JSON';
 requires 'Mojo::Pg';
 requires 'Mojo::RabbitMQ::Client', '>= v0.2';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -149,7 +149,7 @@ worker_requires:
   os-autoinst: '< 5'
   openQA-client:
   optipng:
-  perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.20'
+  perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.26'
   perl(Minion::Backend::SQLite): '>= 5.0.1'
   perl(Mojo::SQLite):
 

--- a/openQA.spec
+++ b/openQA.spec
@@ -55,7 +55,7 @@
 # The following line is generated from dependencies.yaml
 %define client_requires curl git-core jq perl(Getopt::Long::Descriptive) perl(IO::Socket::SSL) >= 2.009 perl(IPC::Run) perl(JSON::Validator) perl(LWP::Protocol::https) perl(LWP::UserAgent) perl(Test::More) perl(YAML::PP) >= 0.020 perl(YAML::XS)
 # The following line is generated from dependencies.yaml
-%define worker_requires openQA-client optipng os-autoinst < 5 perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.20 perl(Mojo::SQLite)
+%define worker_requires openQA-client optipng os-autoinst < 5 perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite)
 # The following line is generated from dependencies.yaml
 %define build_requires %assetpack_requires rubygem(sass)
 


### PR DESCRIPTION
* Do not send SIGTERM repeatedly (without waiting time between the
  attempts) so the video encoder (e.g. ffmpeg) will be able to finalize
  the file (e.g. write the index and total duration).
* SIGKILL is still sent after 10 seconds to deal with stuck processes.
* See https://progress.opensuse.org/issues/67342#note-5