### PR TITLE
t: Use Test::MockModule->redefine in t/28-logging.t

### DIFF
--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -561,7 +561,7 @@ subtest 'Fallback to stderr/stdout' => sub {
 subtest 'Formatting' => sub {
     my $time       = gettimeofday;
     my $hires_mock = Test::MockModule->new('Time::HiRes');
-    $hires_mock->mock(gettimeofday => sub() { $time });
+    $hires_mock->redefine(gettimeofday => sub() { $time });
     my @loglevels = qw(debug info warn error fatal);
     for my $level (@loglevels) {
         like log_format_callback(undef, $level, ("test $level")), qr/\[.+\] \[$level\] test $level\n$/,


### PR DESCRIPTION
This wasn't catched by our CI because it still has
Test::MockModule 0.13, where the strict option is not yet supported.

Test::MockModule didn't warn about that option being unsupported
because it doesn't check for unknown imports.

Created an issue:
https://github.com/geofffranks/test-mockmodule/issues/45