### PR TITLE
Hide livestream when loading test details and job is currently uploading

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -341,8 +341,8 @@ function disableLivestream() {
     if (livestreamElement && livestreamElement.log.attr('id') === 'livestream') {
         removeDataListener(livestreamElement.log);
         liveViewElements.pop();
-        document.getElementById('canholder').remove();
     }
+    document.getElementById('canholder').remove();
 }
 
 // does further initialization for jobs which are not done (and therefore the status might still change)
@@ -393,7 +393,6 @@ function handleJobStateTransition(oldJobState, newJobState, newJobResult) {
     // disable the developer mode and livestream (but *not* livelog) if the job is not running anymore
     if (oldJobState === 'running') {
         disableDeveloperMode();
-        disableLivestream();
     }
 
     // add/remove tabs to show only tabs relevant for the current job state

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -719,7 +719,11 @@ function renderLiveTab(response) {
     this.hasContents = true;
     this.panelElement.innerHTML = response;
     initLivelogAndTerminal();
-    initLivestream();
+    if (testStatus.state === 'uploading' || testStatus.state === 'done') {
+        disableLivestream();
+    } else {
+        initLivestream();
+    }
     setupDeveloperPanel();
     resumeLiveView();
 }

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -833,16 +833,12 @@ sub _upload_results_step_0_prepare {
             $self->_ignore_known_images($status_post_res->{known_images});
             $self->_ignore_known_files($status_post_res->{known_files});
 
-            # inform liveviewhandler about upload progress if developer session opened
+            # upload images; inform liveviewhandler before and after about the progress if developer session opened
             return $self->post_upload_progress_to_liveviewhandler(
                 $upload_up_to,
                 sub {
-
-                    # upload images (not an async operation)
                     $self->_upload_results_step_2_upload_images(
                         sub {
-
-                            # inform liveviewhandler about upload progress if developer session opened
                             return $self->post_upload_progress_to_liveviewhandler(
                                 $upload_up_to,
                                 sub {


### PR DESCRIPTION
This is an additional tweak for https://progress.opensuse.org/issues/56591.