### PR TITLE
Prevent Perl warning in downloader code

### DIFF
--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -82,8 +82,9 @@ sub _get {
     }
 
     if (!$res->is_success) {
-        my $message = $res->error->{message};
-        $log->info(qq{Download of "$target" failed: $code $message});
+        my $error   = $res->error;
+        my $message = ref $error eq 'HASH' ? " $error->{message}" : '';
+        $log->info(qq{Download of "$target" failed: $code$message});
         return $code;
     }
 


### PR DESCRIPTION
Prevents
```
Can't use an undefined value as a HASH reference at /usr/share/openqa/script/../lib/OpenQA/Downloader.pm line 85.
```
observed on o3.