### PR TITLE
Allow OpenID login via POST request

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -112,6 +112,7 @@ sub startup {
     $r->delete('/logout')->name('logout')->to('session#destroy');
     $r->get('/logout')->to('session#destroy');
     $r->get('/response')->to('session#response');
+    $r->post('/response')->to('session#response');
     $auth->get('/session/test')->to('session#test');
 
     my $apik_auth = $auth->any('/api_keys');

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -70,7 +70,7 @@ sub auth_login {
 sub auth_response {
     my ($self) = @_;
 
-    my %params = @{$self->req->query_params->pairs};
+    my %params = @{$self->req->params->pairs};
     my $url    = $self->app->config->{global}->{base_url} || $self->req->url->base;
     return (error => 'Got response on http but https is forced. MOJO_REVERSE_PROXY not set?')
       if ($self->app->config->{openid}->{httpsonly} && $url !~ /^https:\/\//);
@@ -142,7 +142,7 @@ sub auth_response {
         },
     );
 
-    return (error => 0);
+    return (redirect => 'index', error => 0);
 }
 
 1;


### PR DESCRIPTION
Allow OpenID login via POST request

This is needed because our new ipsilon-based OpenID provider
(sometimes?) sends the response via POST instead of GET.