### PR TITLE
Add error message when openqa-clone-custom-git-refspec is called on invalid job

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -33,6 +33,11 @@ fi
 curl_github="${curl_github:-"curl${AUTHENTICATED_REQUEST}"}"
 curl_openqa="${curl_openqa:-"curl"}"
 
+fail() {
+    echo "$*" >&2
+    exit 1
+}
+
 throw_json_error() {
     echo "in contents queried from $1:"
     echo "$2"
@@ -106,6 +111,7 @@ clone_job() {
         local json_url=${host}/tests/${job}/file/vars.json
         local json_data
         json_data=$(eval "${curl_openqa} -s ${json_url}")
+        echo "$json_data" | jq &>/dev/null || fail "openQA job with no valid JSON data encountered. Please select another job, e.g. in the same scenario: $host/t$job#next_previous"
         local testsuite="${testsuite:-"$(echo "$json_data" | jq -r '.TEST')"}" || throw_json_error "$json_url" "$json_data"
         local old_productdir
         old_productdir=$(echo "$json_data" | jq -r '.PRODUCTDIR') || throw_json_error "$json_url" "$json_data"


### PR DESCRIPTION
We can not read out necessary configuration data in any case of
selecting a job that does not exist, is a completely wrong URL or job
without vars.json, e.g. very old job with deleted results or scheduled
or still running job. This commit adds an explanatory error message
including a suggestion with a URL pointing to the "Next & previous" jobs
in the same test scenario.

Related progress issue: https://progress.opensuse.org/issues/67888