### PR TITLE
Allow flock on temporary files to fix support for monitoring

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -21,7 +21,7 @@
   /etc/openqa/templates/ r,
   /etc/openqa/templates/** r,
   /proc/meminfo r,
-  /tmp/** rw,
+  /tmp/** rwk,
   /usr/bin/perl ix,
   /usr/bin/ssh rcx,
   /usr/bin/timeout rix,
@@ -69,7 +69,7 @@
   /var/lib/openqa/testresults/** rw,
   /var/lib/openqa/webui/** rw,
   /var/log/openqa rwk,
-  /var/tmp/* rw,
+  /var/tmp/* rwk,
   owner /var/lib/openqa/share/tests/** rwl,
 
 


### PR DESCRIPTION
For some time now we had the problem that the monitoring feature didn't work because its data would get corrupted after some time, resulting in webui processes crashing. The cause is twofold, first `Mojolicious::Plugin::Status` had [a bug](https://github.com/mojolicious/mojo-status/commit/b53759ca0fc2602352ebde377aaa08f9049258d5) causing it to silently ignore `flock` errors, and second our apparmor profile did not allow `flock` on temporary files. This PR fixes the second problem and should make monitoring work again.