### PR TITLE
spec: Prevent unresolvable on ppc64le with no-selenium-devel subpackage

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,11 +8,12 @@
 #######################################################
 ---
 targets:
-  cpanfile: [ assetpack,        client, common, cover, devel, main, test, worker ]
-  spec:     [ assetpack, build, client, common,        devel, main, test, worker ]
+  cpanfile: [ assetpack,        client, common, cover, devel, devel_no_selenium, main, test, worker ]
+  spec:     [ assetpack, build, client, common,        devel, devel_no_selenium, main, test, worker ]
   cpanfile-targets:
     # target: cpanfile target type (default main)
     devel: devel
+    devel_no_selenium: devel
     cover: cover
     test: test
 
@@ -58,11 +59,10 @@ client_requires:
   perl(YAML::PP): '>= 0.020'
   perl(YAML::XS):
 
-devel_requires:
+devel_no_selenium_requires:
   '%build_requires':
   '%test_requires':
   '%qemu':
-  chromedriver:
   curl:
   rsync:
   postgresql-devel:
@@ -72,6 +72,10 @@ devel_requires:
   perl(Devel::Cover):
   perl(Devel::Cover::Report::Codecov):
   perl(Perl::Tidy): '== 20200619'
+
+devel_requires:
+  '%devel_no_selenium_requires':
+  chromedriver:
 
 main_requires:
   '%assetpack_requires':

--- a/openQA.spec
+++ b/openQA.spec
@@ -70,7 +70,11 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define devel_requires %build_requires %qemu %test_requires chromedriver curl perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy) postgresql-devel rsync sudo tar xorg-x11-fonts
+%define devel_no_selenium_requires %build_requires %qemu %test_requires curl perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy) postgresql-devel rsync sudo tar xorg-x11-fonts
+%ifarch x86_64 aarch64
+# The following line is generated from dependencies.yaml
+%define devel_requires %devel_no_selenium_requires chromedriver
+%endif
 
 Name:           openQA
 Version:        4.6
@@ -133,6 +137,15 @@ revision of the operating system, reporting the errors detected for each
 combination of hardware configuration, installation options and variant of the
 operating system.
 
+%package no-selenium-devel
+Summary:        Development package pulling in all build+test dependencies except chromedriver for Selenium based tests
+Group:          Development/Tools/Other
+Requires:       %{devel_no_selenium_requires}
+
+%description no-selenium-devel
+Development package pulling in all build+test dependencies except chromedriver for Selenium based tests.
+
+%ifarch x86_64 aarch64
 %package devel
 Summary:        Development package pulling in all build+test dependencies
 Group:          Development/Tools/Other
@@ -140,6 +153,7 @@ Requires:       %{devel_requires}
 
 %description devel
 Development package pulling in all build+test dependencies.
+%endif
 
 %package common
 Summary:        The openQA common tools for web-frontend and workers


### PR DESCRIPTION
Split subpackage "no-selenium-devel" out of "devel" so that we can
provide a sensible variant for cases when chromedriver is not available,
e.g. as is the case for ppc64le on openSUSE/SLE.