### PR TITLE
overview: Show version when DISTRI differs

### DIFF
--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -137,7 +137,7 @@
         % my $version_results = $results->{$distri};
         % my $only_version = scalar keys %$version_results == 1;
         % for my $version (sort keys %$version_results) {
-            % my $type_prefix = $type_prefix_distri . ($only_version ? '' : " Version: $version / ");
+            % my $type_prefix = $type_prefix_distri . ($only_version && $only_distri ? '' : " Version: $version / ");
             % my $type_archs = $archs->{$distri}{$version};
             % for my $type (sort keys %$type_archs) {
                 % my $type_result = $version_results->{$version}{$type};


### PR DESCRIPTION
When accessing the `overview` page and give only `build=XYZ` as parameter, I do
get all expected jobs listed, but if there is only _one_ version per
`DISTRI` then the `VERSION` isn't displayed even if I have multiple
`DISTRI`'s.

Example:
 You have multiple products configured like openSUSE_15.2, SLE-15-SP2 and
 SLE-12-SP5.
 Then run a `isos post` within each medium and give all them the same
 `BUILD` value (e.g. `wip-ifreload-1_sle15-sp2-b34fe756`). Then it would
 be nice to see all of them on such a overview page.

Why I would choose the same `BUILD` among different products. Cause I
just don't care about the real `BUILD` what ever that mean. What I'm
going to test is a application (here it is wicked) within different
products. And this application is running with the "BUILD"
`wip-ifreload-1_sle15-sp2-b34fe756`, which describes the current git
version I need to check.

