### PR TITLE
Reset locks when restarting the cache service Minion worker

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -39,6 +39,9 @@ sub startup {
       unless defined $location;
     my $limit = $global_settings->{CACHELIMIT};
 
+    # commands
+    push @{$self->commands->namespaces}, 'OpenQA::CacheService::Command';
+
     # Allow for very quiet tests
     $self->hook(
         before_server_start => sub {
@@ -84,7 +87,7 @@ sub startup {
 }
 
 sub setup_workers {
-    return @_ unless grep { $_ eq 'worker' } @_;
+    return @_ unless grep { $_ eq 'run' } @_;
     my @args = @_;
 
     my $global_settings = OpenQA::Worker::Settings->new->global_settings;
@@ -122,7 +125,7 @@ OpenQA::CacheService - OpenQA Cache Service
     OpenQA::CacheService::run(qw(daemon));
 
     # Start one or more Minions
-    OpenQA::CacheService::run(qw(minion worker))
+    OpenQA::CacheService::run(qw(run))
 
 =head1 DESCRIPTION
 

--- a/lib/OpenQA/CacheService/Command/run.pm
+++ b/lib/OpenQA/CacheService/Command/run.pm
@@ -1,0 +1,62 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::CacheService::Command::run;
+use Mojo::Base 'Minion::Command::minion::worker';
+
+use Mojo::Util 'getopt';
+
+has description => 'Start Minion worker';
+has usage       => sub { shift->extract_usage };
+
+sub run {
+    my ($self, @args) = @_;
+
+    getopt \@args, ['pass_through'], 'reset-locks' => \my $reset_locks;
+
+    if ($reset_locks) {
+        my $app = $self->app;
+        $app->log->info('Resetting all leftover locks after restart');
+        $app->minion->reset({locks => 1});
+    }
+    $self->SUPER::run(@args);
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenQA::CacheService::Command::run - Cache service run command
+
+=head1 SYNOPSIS
+
+  Usage: APPLICATION run [OPTIONS]
+
+    script/openqa-workercache run
+
+  Options:
+    --reset-locks   Reset all remaining locks before startup
+
+    See 'script/openqa-workercache minion worker -h' for all available options.
+
+
+=head1 DESCRIPTION
+
+L<OpenQA::CacheService::Command::run> is a subclass of
+L<Minion::Command::minion::worker> that adds cache service features.
+
+=cut

--- a/script/openqa-worker-cacheservice-minion
+++ b/script/openqa-worker-cacheservice-minion
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-exec "$(dirname "$0")"/openqa-workercache minion worker -m production "$@"
+exec "$(dirname "$0")"/openqa-workercache -m production run --reset-locks "$@"

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -183,8 +183,7 @@ subtest 'Availability check and worker status' => sub {
 subtest 'Configurable minion workers' => sub {
     is_deeply([OpenQA::CacheService::setup_workers(qw(minion test))],
         [qw(minion test)], 'minion worker setup with test');
-    is_deeply([OpenQA::CacheService::setup_workers(qw(minion worker))],
-        [qw(minion worker -j 10)], 'minion worker setup with worker');
+    is_deeply([OpenQA::CacheService::setup_workers(qw(run))], [qw(run -j 10)], 'minion worker setup with worker');
     is_deeply([OpenQA::CacheService::setup_workers(qw(minion daemon))],
         [qw(minion daemon)], 'minion worker setup with daemon');
 
@@ -193,8 +192,7 @@ subtest 'Configurable minion workers' => sub {
 CACHEDIRECTORY = $cachedir
 CACHELIMIT = 100");
 
-    is_deeply([OpenQA::CacheService::setup_workers(qw(minion worker))],
-        [qw(minion worker -j 5)], 'minion worker setup with parallel jobs');
+    is_deeply([OpenQA::CacheService::setup_workers(qw(run))], [qw(run -j 5)], 'minion worker setup with parallel jobs');
 };
 
 subtest 'Cache Requests' => sub {

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -83,7 +83,7 @@ sub cache_minion_worker {
             require OpenQA::CacheService;
             local $ENV{MOJO_MODE} = 'test';
             note('Starting cache minion worker');
-            OpenQA::CacheService::run(qw(minion worker));
+            OpenQA::CacheService::run(qw(run));
             note('Cache minion worker stopped');
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);


### PR DESCRIPTION
Otherwise there might be leftover locks that will cause new downloads
for the same files to wait for non-existing download jobs. The
implementation is almost the same as the Gru --reset-locks feature. So
it will be very easy to add more features in the future.

Gru feature: https://github.com/os-autoinst/openQA/commit/040083a1f446653e826c094dd734666424897255
Progress: https://progress.opensuse.org/issues/68131