### PR TITLE
Switch from SIGTERM to SIGQUIT for Minion restart

### DIFF
--- a/systemd/openqa-gru.service
+++ b/systemd/openqa-gru.service
@@ -8,6 +8,8 @@ User=geekotest
 ExecStart=/usr/share/openqa/script/openqa-gru
 Nice=19
 Restart=on-failure
+KillSignal=SIGQUIT
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/openqa-worker-cacheservice-minion.service
+++ b/systemd/openqa-worker-cacheservice-minion.service
@@ -8,6 +8,8 @@ PartOf=openqa-worker.target
 Restart=on-failure
 User=_openqa-worker
 ExecStart=/usr/share/openqa/script/openqa-worker-cacheservice-minion
+KillSignal=SIGQUIT
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
By default systemd will send SIGTERM followed by SIGKILL after 90
seconds to the control-group when stopping a service. But Minion expects
a [SIGQUIT](https://metacpan.org/pod/Minion::Command::minion::worker#QUIT) for shutting down cleanly.

systemd docs: https://www.freedesktop.org/software/systemd/man/systemd.kill.html
Progress: https://progress.opensuse.org/issues/68131