### PR TITLE
Fix logic for changed schedule

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -740,13 +740,13 @@ sub _upload_results_step_0_prepare {
     if ($self->{_has_uploaded_logs_and_assets} || $running_or_finished) {
         my @file_info = stat $self->_result_file_path('test_order.json');
         my $test_order;
-        if (   !$current_test_module
-            or !$file_info[9]
-            or $file_info[9] != $self->{_test_order_mtime}
-            or !$file_info[7]
-            or $file_info[7] != $self->{_test_order_fsize})
-        {
-            log_info('Test schedule has changed, reloading test_order.json') if $self->{_test_order_mtime};
+        my $changed_schedule = (
+            $self->{_test_order_mtime} and ($file_info[9] != $self->{_test_order_mtime}
+                or $file_info[7] != $self->{_test_order_fsize}));
+        if (not $current_test_module or $changed_schedule) {
+            log_info('Test schedule has changed, reloading test_order.json') if $changed_schedule;
+            # We need to reread the schedule when $current_test_module is not set
+            # Not clear why
             $test_order                = $self->_read_json_file('test_order.json');
             $status{test_order}        = $test_order;
             $self->{_test_order}       = $test_order;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1084,6 +1084,15 @@ subtest 'Dynamic schedule' => sub {
     $job->_upload_results_step_0_prepare(sub { });
     is_deeply $job->{_test_order}, $test_order, 'Initial test schedule';
 
+    # do not log that test_order.json has changed when it didn't
+    $autoinst_status->{current_test} = '';
+    $status_file->spurt(encode_json($autoinst_status));
+    $job->_upload_results_step_0_prepare(sub { });
+
+    combined_unlike {
+        $job->_upload_results_step_0_prepare(sub { })
+    }
+    qr/Test schedule has changed, reloading test_order\.json/, 'Did not report that schedule changed';
     # Write updated test schedule and test it'll be reloaded
     push @$test_order,
       {


### PR DESCRIPTION
It was reporting that the schedule changed too often.

Issue: https://progress.opensuse.org/issues/58700

It's still not clear why we need to reread the schedule whenever
$current_test_module is unset, see code comment.