### PR TITLE
Fix order of arguments in script/openqa-worker-cacheservice-minion

### DIFF
--- a/script/openqa-worker-cacheservice-minion
+++ b/script/openqa-worker-cacheservice-minion
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-exec "$(dirname "$0")"/openqa-workercache -m production run --reset-locks "$@"
+exec "$(dirname "$0")"/openqa-workercache run -m production --reset-locks "$@"


### PR DESCRIPTION
This fixes https://github.com/os-autoinst/openQA/pull/3177
