### PR TITLE
Sumarize results in tab

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -184,8 +184,6 @@ function renderModuleTable(container, response) {
     ])]);
     let tbody = E('tbody');
 
-
-    container.appendChild(E('div', '', {id: 'summary'}));
     container.appendChild(E('table', [thead, tbody],
         {id: 'results', 'class': 'table table-striped'}));
 

--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -169,6 +169,24 @@ function renderModuleRow(module, snippets) {
     return E('tr', [component, result, links], {id: rowid});
 }
 
+function renderTestSummary(data) {
+    var html = data.passed + "<i class='fa module_passed fa-star' title='modules passed'></i>";
+    if (data.softfailed) {
+        html += " " + data.softfailed + "<i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>";
+    }
+    if (data.failed) {
+        html += " " + data.failed + "<i class='far module_failed fa-star' title='modules failed'></i>";
+    }
+    if (data.none) {
+        html += " " + data.none + "<i class='fa module_none fa-ban' title='modules skipped'></i>";
+    }
+    if (data.skipped) {
+        html += " " + data.skipped + "<i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>";
+    }
+
+    return html;
+}
+
 function renderModuleTable(container, response) {
     container.innerHTML = response.snippets.header;
 
@@ -184,8 +202,12 @@ function renderModuleTable(container, response) {
     ])]);
     let tbody = E('tbody');
 
+
+    container.appendChild(E('div', '', {id: 'summary'}));
     container.appendChild(E('table', [thead, tbody],
         {id: 'results', 'class': 'table table-striped'}));
+
+    let summary = {};
 
     for (let idx in response.modules) {
         let module = response.modules[idx];
@@ -198,5 +220,12 @@ function renderModuleTable(container, response) {
         }
 
         tbody.appendChild(renderModuleRow(module, response.snippets));
+
+        if (summary[module.result] === undefined)
+            summary[module.result] = 1;
+        else
+            summary[module.result] ++;
     }
+
+    $('#summary').html(renderTestSummary(summary, 'display'));
 }

--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -207,5 +207,5 @@ function renderModuleTable(container, response) {
             summary[module.result] ++;
     }
 
-    $('#summary').html(renderTestSummary(summary, 'display'));
+    $('#summary_stars').html(renderTestSummary(summary, 'display'));
 }

--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -169,24 +169,6 @@ function renderModuleRow(module, snippets) {
     return E('tr', [component, result, links], {id: rowid});
 }
 
-function renderTestSummary(data) {
-    var html = data.passed + "<i class='fa module_passed fa-star' title='modules passed'></i>";
-    if (data.softfailed) {
-        html += " " + data.softfailed + "<i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>";
-    }
-    if (data.failed) {
-        html += " " + data.failed + "<i class='far module_failed fa-star' title='modules failed'></i>";
-    }
-    if (data.none) {
-        html += " " + data.none + "<i class='fa module_none fa-ban' title='modules skipped'></i>";
-    }
-    if (data.skipped) {
-        html += " " + data.skipped + "<i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>";
-    }
-
-    return html;
-}
-
 function renderModuleTable(container, response) {
     container.innerHTML = response.snippets.header;
 

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -184,6 +184,24 @@ function changeJobPrio(jobId, delta, linkElement) {
     });
 }
 
+function renderTestSummary(data) {
+    var html = data.passed + "<i class='fa module_passed fa-star' title='modules passed'></i>";
+    if (data.softfailed) {
+        html += " " + data.softfailed + "<i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>";
+    }
+    if (data.failed) {
+        html += " " + data.failed + "<i class='far module_failed fa-star' title='modules failed'></i>";
+    }
+    if (data.none) {
+        html += " " + data.none + "<i class='fa module_none fa-ban' title='modules skipped'></i>";
+    }
+    if (data.skipped) {
+        html += " " + data.skipped + "<i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>";
+    }
+
+    return html;
+}
+
 function renderTestResult( data, type, row ) {
     if (type !== 'display') {
         return (parseInt(data.passed) * 10000) + (parseInt(data.softfailed) * 100) + parseInt(data.failed);
@@ -191,19 +209,7 @@ function renderTestResult( data, type, row ) {
 
     var html = '';
     if (row.state === 'done') {
-        html += data.passed + "<i class='fa module_passed fa-star' title='modules passed'></i>";
-        if (data.softfailed) {
-            html += " " + data.softfailed + "<i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>";
-        }
-        if (data.failed) {
-            html += " " + data.failed + "<i class='far module_failed fa-star' title='modules failed'></i>";
-        }
-        if (data.none) {
-            html += " " + data.none + "<i class='fa module_none fa-ban' title='modules skipped'></i>";
-        }
-        if (data.skipped) {
-            html += " " + data.skipped + "<i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>";
-        }
+        html += renderTestSummary(data);
     }
     if (row.state === 'cancelled') {
         html += "<i class='fa fa-times' title='canceled'></i>";

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -185,19 +185,24 @@ function changeJobPrio(jobId, delta, linkElement) {
 }
 
 function renderTestSummary(data) {
-    var html = data.passed + "<i class='fa module_passed fa-star' title='modules passed'></i>";
-    if (data.softfailed) {
+    var html = ''
+
+    if (data.passed)
+        html += data.passed + "<i class='fa module_passed fa-star' title='modules passed'></i>";
+    else
+        html += "0 <i class='fa module_passed fa-star' title='modules passed'></i>";
+        
+    if (data.softfailed)
         html += " " + data.softfailed + "<i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>";
-    }
-    if (data.failed) {
+
+    if (data.failed)
         html += " " + data.failed + "<i class='far module_failed fa-star' title='modules failed'></i>";
-    }
-    if (data.none) {
+
+    if (data.none)
         html += " " + data.none + "<i class='fa module_none fa-ban' title='modules skipped'></i>";
-    }
-    if (data.skipped) {
+
+    if (data.skipped)
         html += " " + data.skipped + "<i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>";
-    }
 
     return html;
 }

--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -173,3 +173,12 @@ h2 .fa {
     margin-bottom: 10px;
     margin-left: 5px;
 }
+
+.top-rigth {
+    top: 0px;
+    right: 0px;
+}
+
+.pt-2-and-half{
+    padding-top: 0.75rem !important;
+}

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -1,9 +1,12 @@
             <div class="card-header">
-                Results for
-                % if (current_route 'latest') {
-                    <%= link_to $job->id => url_for ('test', testid => $job->id) %>:
-                % }
-                %= $job->name
+                <div class="d-inline">
+                    Results for
+                    % if (current_route 'latest') {
+                        <%= link_to $job->id => url_for ('test', testid => $job->id) %>:
+                    % }
+                    %= $job->name
+                </div>
+                <div class="pl-2 d-inline" id="summary_stars"></div>
             </div>
             <div id="info-box-content" class="card-body"
                 % if ($additional_data) {

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -1,12 +1,10 @@
-            <div class="card-header">
-                <div class="d-inline">
-                    Results for
-                    % if (current_route 'latest') {
-                        <%= link_to $job->id => url_for ('test', testid => $job->id) %>:
-                    % }
-                    %= $job->name
-                </div>
-                <div class="pl-2 d-inline" id="summary_stars"></div>
+            <div class="card-header position-relative">
+                Results for
+                % if (current_route 'latest') {
+                    <%= link_to $job->id => url_for ('test', testid => $job->id) %>:
+                % }
+                %= $job->name
+                <div class="position-absolute top-rigth pt-2-and-half pr-3" id="summary_stars"></div>
             </div>
             <div id="info-box-content" class="card-body"
                 % if ($additional_data) {

--- a/templates/webapi/test/result.html.ep
+++ b/templates/webapi/test/result.html.ep
@@ -33,7 +33,10 @@
         <div role="tabpanel">
             <ul class="nav nav-tabs" role="tablist" id="result_tabs">
                 <li role="presentation" class="nav-item" id="nav-item-for-details">
-                    <a href="#details" aria-controls="details" role="tab" data-toggle="tab" class="nav-link">Details</a>
+                    <div class="d-flex flex-row">
+                      <a href="#details" aria-controls="details" role="tab" data-toggle="tab" class="nav-link">Details</a>
+                      <div class="pt-2" id="summary"/>
+                    </div>
                 </li>
                 <li role="presentation" class="nav-item" id="nav-item-for-external">
                     <a href="#external" aria-controls="external" role="tab" data-toggle="tab" class="nav-link">External results</a>

--- a/templates/webapi/test/result.html.ep
+++ b/templates/webapi/test/result.html.ep
@@ -33,10 +33,7 @@
         <div role="tabpanel">
             <ul class="nav nav-tabs" role="tablist" id="result_tabs">
                 <li role="presentation" class="nav-item" id="nav-item-for-details">
-                    <div class="d-flex flex-row">
-                      <a href="#details" aria-controls="details" role="tab" data-toggle="tab" class="nav-link">Details</a>
-                      <div class="pt-2" id="summary"/>
-                    </div>
+                    <a href="#details" aria-controls="details" role="tab" data-toggle="tab" class="nav-link">Details</a>
                 </li>
                 <li role="presentation" class="nav-item" id="nav-item-for-external">
                     <a href="#external" aria-controls="external" role="tab" data-toggle="tab" class="nav-link">External results</a>


### PR DESCRIPTION
https://progress.opensuse.org/issues/44654

To get a quick overview in test details the idea is to show grouped
results in tab on details page.

![image](https://user-images.githubusercontent.com/11134265/84997399-d35eeb00-b14e-11ea-9cd8-70ad98c9437a.png)
