### PR TITLE
Fail in Selenium error handler before bailing out

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -100,7 +100,9 @@ sub start_driver {
                 # same problem exceeded console scrollback buffers easily
                 my ($driver, $exception, $args) = @_;
                 my $err = (split /\n/, $exception)[0] =~ s/Error while executing command: //r;
-                BAIL_OUT($err . ' at ' . __FILE__ . ':' . __LINE__);
+                fail($err);
+                done_testing;
+                exit 255;
             },
         );
 


### PR DESCRIPTION
This should address the test plan lacking the failure whilst the test run exists with an error code.

Example of the problem: https://app.circleci.com/pipelines/github/os-autoinst/openQA/3299/workflows/22ca016b-41f6-41d5-8c26-3ae33d15fcb2/jobs/31534/tests