### PR TITLE
README: Fix circleci badge to master branch

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,4 +1,4 @@
-:circleci: image:https://circleci.com/gh/os-autoinst/openQA.svg?style=svg["CircleCI", link="https://circleci.com/gh/os-autoinst/openQA"]
+:circleci: image:https://circleci.com/gh/os-autoinst/openQA/tree/master.svg?style=svg["CircleCI", link="https://circleci.com/gh/os-autoinst/openQA/tree/master"]
 :codecov: image:https://codecov.io/gh/os-autoinst/openQA/branch/master/graph/badge.svg[link=https://codecov.io/gh/os-autoinst/openQA]
 
 = openQA


### PR DESCRIPTION
Point circeci badge directly to master showing release relevant build
results instead of all the results from arbitrary pull requests which
are most likely not relevant for anyone clicking on the badge. Same as
for codecov we link to the master branch as link target as well.