### PR TITLE
Remove versioned chromedriver install again

### DIFF
--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -9,8 +9,7 @@ RUN zypper install -y autoconf automake gcc-c++ libtool pkgconfig\(opencv\) pkg-
 RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo
 
 # openQA chromedriver for Selenium tests
-# note: Using an old version here on purpose (see https://progress.opensuse.org/issues/68284).
-RUN zypper install -y --oldpackage chromedriver-81.0.4044.138-lp151.2.88.1 chromium-81.0.4044.138-lp151.2.88.1
+RUN zypper install -y chromedriver
 
 ENV LANG en_US.UTF-8
 


### PR DESCRIPTION
Unfortunately this did not work because OBS parses the Dockerfile for zypper invocations and tries to resolve the dependencies.

The suggested alternative is to aggregate the old version in some other repository and add that one as the most important repo.