### PR TITLE
Mergify: configuration update, alt 2, rely on github branch protection

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,6 @@
+pull_request_rules:
+  - name: automatic merge when GitHub branch protection passes
+    conditions: []
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
This change has been made by @okurz from https://mergify.io simulator.

This relies on GitHub branch protection rules, i.e. currently needing at least one approving review and requiring status checks to pass before merging, preventing drafts to be merged as well as anything detected as "work in progress" by the WIP bot.

As an alternative explicit rules can be used like proposed in
https://github.com/os-autoinst/openQA/pull/3208

As it can happen that sometimes services do not report in I now set "codecov/project" to be an explicitly required status check in https://github.com/os-autoinst/openQA/settings/branch_protection_rules/2534118

---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://doc.mergify.io/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR on its base branch
- `@Mergifyio update` will merge the base branch into this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
