### PR TITLE
Improve cache service client exception handling

### DIFF
--- a/lib/OpenQA/CacheService/Client.pm
+++ b/lib/OpenQA/CacheService/Client.pm
@@ -66,19 +66,19 @@ sub enqueue {
 sub _error {
     my ($self, $action, $tx) = @_;
 
-    # Connection or server error
-    if (my $err = $tx->error) {
-        return "Cache service $action error $err->{code}: $err->{message}" if $err->{code};
-        return "Cache service $action error: $err->{message}";
-    }
-
-    # Non-JSON response
     my $res  = $tx->res;
     my $code = $res->code;
-    return "Cache service $action error: $code non-JSON response" unless my $json = $res->json;
+    my $json = $res->json;
 
-    # API error
-    return "Cache service $action error from API: $json->{error}" if $json->{error};
+    # Connection or server error
+    if (my $err = $tx->error) {
+        if ($err->{code}) {
+            return "Cache service $action error from API: $json->{error}" if $json && $json->{error};
+            return "Cache service $action error $err->{code}: $err->{message}";
+        }
+        return "Cache service $action error: $err->{message}";
+    }
+    else { return "Cache service $action error: $code non-JSON response" unless $json }
 
     return undef;
 }

--- a/lib/OpenQA/CacheService/Controller/API.pm
+++ b/lib/OpenQA/CacheService/Controller/API.pm
@@ -55,6 +55,8 @@ sub enqueue {
       unless defined(my $task = $data->{task});
     return $self->render(json => {error => 'No arguments defined'}, status => 400)
       unless defined(my $args = $data->{args});
+    return $self->render(json => {error => 'Arguments need to be an array'}, status => 400)
+      unless ref $args eq 'ARRAY';
     return $self->render(json => {error => 'No lock defined'}, status => 400)
       unless defined(my $lock = $data->{lock});
 

--- a/lib/OpenQA/CacheService/Response.pm
+++ b/lib/OpenQA/CacheService/Response.pm
@@ -18,4 +18,6 @@ use Mojo::Base -base;
 
 has [qw(data error)];
 
+sub has_error { !!shift->error }
+
 1;

--- a/lib/OpenQA/CacheService/Response/Info.pm
+++ b/lib/OpenQA/CacheService/Response/Info.pm
@@ -16,7 +16,7 @@
 package OpenQA::CacheService::Response::Info;
 use Mojo::Base 'OpenQA::CacheService::Response';
 
-sub available { !shift->error }
+sub available { !shift->has_error }
 
 sub available_workers {
     my $self = shift;
@@ -27,7 +27,7 @@ sub available_workers {
 
 sub availability_error {
     my $self = shift;
-    if (my $err = $self->error) { return $err }
+    return $self->error if $self->has_error;
     return 'No workers active in the cache service' unless $self->available_workers;
     return undef;
 }

--- a/lib/OpenQA/CacheService/Response/Info.pm
+++ b/lib/OpenQA/CacheService/Response/Info.pm
@@ -27,10 +27,7 @@ sub available_workers {
 
 sub availability_error {
     my $self = shift;
-    if (my $error = $self->error) {
-        return "Cache service returned error $error->{code}: $error->{message}" if $error->{code};
-        return "Cache service not reachable: $error->{message}";
-    }
+    if (my $err = $self->error) { return $err }
     return 'No workers active in the cache service' unless $self->available_workers;
     return undef;
 }

--- a/lib/OpenQA/CacheService/Response/Status.pm
+++ b/lib/OpenQA/CacheService/Response/Status.pm
@@ -16,8 +16,8 @@
 package OpenQA::CacheService::Response::Status;
 use Mojo::Base 'OpenQA::CacheService::Response';
 
-sub is_downloading { shift->data->{status} eq 'downloading' }
-sub is_processed   { shift->data->{status} eq 'processed' }
+sub is_downloading { (shift->data->{status} // '') eq 'downloading' }
+sub is_processed   { (shift->data->{status} // '') eq 'processed' }
 
 sub output {
     my $self = shift;

--- a/lib/OpenQA/CacheService/Response/Status.pm
+++ b/lib/OpenQA/CacheService/Response/Status.pm
@@ -21,8 +21,7 @@ sub is_processed   { (shift->data->{status} // '') eq 'processed' }
 
 sub output {
     my $self = shift;
-    if (my $err = $self->error) { return $err }
-    return $self->data->{output};
+    return $self->has_error ? $self->error : $self->data->{output};
 }
 
 sub result { shift->data->{result} }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -135,6 +135,7 @@ sub cache_assets {
         until ($status->is_processed) {
             sleep 5;
             return {error => 'Status updates interrupted'} unless $job->post_setup_status;
+            return {error => $status->error} if $status->has_error;
             $status = $cache_client->status($asset_request);
         }
         my $msg = "Download of $asset_uri processed";
@@ -209,6 +210,7 @@ sub sync_tests {
         until ($status->is_processed) {
             sleep 5;
             return {error => 'Status updates interrupted'} unless $job->post_setup_status;
+            return {error => $status->error} if $status->has_error;
             $status = $cache_client->status($rsync_request);
         }
 

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -185,13 +185,13 @@ subtest 'status' => sub {
     $worker->settings->global_settings->{CACHEDIRECTORY} = 'foo';
     my $worker_status;
     combined_like { $worker_status = $worker->status }
-    qr/Worker cache not available: Cache service not reachable: Connection refused/, 'worker cache error logged';
+    qr/Worker cache not available: Cache service info error: Connection refused/, 'worker cache error logged';
     is_deeply(
         $worker_status,
         {
             type   => 'worker_status',
             status => 'broken',
-            reason => 'Cache service not reachable: Connection refused'
+            reason => 'Cache service info error: Connection refused'
         },
         'worker is broken if CACHEDIRECTORY set but worker cache not available'
     );

--- a/t/25-cache-client.t
+++ b/t/25-cache-client.t
@@ -1,0 +1,130 @@
+#!/usr/bin/env perl
+# Copyright (c) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+
+my $tempdir;
+BEGIN {
+    use Mojo::File qw(path tempdir);
+
+    $ENV{OPENQA_CACHE_SERVICE_QUIET} = $ENV{HARNESS_IS_VERBOSE} ? 0 : 1;
+
+    $tempdir = tempdir;
+    my $basedir = $tempdir->child('t', 'cache.d');
+    $ENV{OPENQA_CACHE_DIR} = path($basedir, 'cache');
+    $ENV{OPENQA_BASEDIR}   = $basedir;
+    $ENV{OPENQA_CONFIG}    = path($basedir, 'config')->make_path;
+    path($ENV{OPENQA_CONFIG})->child("workers.ini")->spurt('
+[global]
+CACHEDIRECTORY = ' . $ENV{OPENQA_CACHE_DIR} . '
+CACHEWORKERS = 10
+CACHELIMIT = 100');
+}
+
+use OpenQA::CacheService;
+use OpenQA::CacheService::Client;
+use Mojo::Server::Daemon;
+use Mojo::Log;
+use Test::MockModule;
+
+# Capture logs
+my $log = Mojo::Log->new;
+$log->unsubscribe('message');
+my $cache_log = '';
+$log->on(
+    message => sub {
+        my ($log, $level, @lines) = @_;
+        $cache_log .= "[$level] " . join "\n", @lines, '';
+    });
+
+# Set up application and client
+my $client = OpenQA::CacheService::Client->new;
+my $app    = OpenQA::CacheService->new(log => $log);
+my $daemon = Mojo::Server::Daemon->new(
+    silent => 1,
+    listen => ['http://127.0.0.1'],
+    ioloop => $client->ua->ioloop,
+    app    => $app
+)->start;
+my $host = 'http://127.0.0.1:' . $daemon->ports->[0];
+$client->host($host);
+like $cache_log, qr/Creating cache directory tree for/,             'directory initialized';
+like $cache_log, qr/Cache size of .+ is 0 Byte, with limit 100GiB/, 'empty cache';
+
+subtest 'Enqueue' => sub {
+    my $request
+      = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
+    ok !$client->enqueue($request), 'no error';
+    ok $request->minion_id, 'has Minion id';
+    ok my $job = $app->minion->job($request->minion_id), 'is Minion job';
+    is $job->task, 'cache_asset', 'right task';
+    is_deeply $job->args, [9999, 'hdd', 'asset_name.qcow2', 'openqa.opensuse.org'], 'right arguments';
+
+    $request = $client->rsync_request(from => '/test/a', to => '/test/b');
+    ok !$client->enqueue($request), 'no error';
+    ok $request->minion_id, 'has Minion id';
+    ok $job = $app->minion->job($request->minion_id), 'is Minion job';
+    is $job->task, 'cache_tests', 'right task';
+    is_deeply $job->args, ['/test/a', '/test/b'], 'right arguments';
+};
+
+subtest 'Enqueue error' => sub {
+    my $request
+      = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
+    $request->task(undef);
+    like $client->enqueue($request), qr/Cache service enqueue error from API: No task defined/, 'error';
+    ok !$request->minion_id, 'no Minion id';
+
+    $request = $client->rsync_request(from => '/test/a', to => '/test/b');
+    $request->task(undef);
+    like $client->enqueue($request), qr/Cache service enqueue error from API: No task defined/, 'error';
+    ok !$request->minion_id, 'no Minion id';
+
+    my $mock = Test::MockModule->new('OpenQA::CacheService::Request::Asset');
+    $mock->redefine(to_array => sub { undef });
+    $request
+      = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
+    like $client->enqueue($request), qr/Cache service enqueue error from API: No arguments defined/, 'error';
+    ok !$request->minion_id, 'no Minion id';
+
+    $mock->redefine(to_array => sub { 'test' });
+    $request
+      = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
+    like $client->enqueue($request), qr/Cache service enqueue error from API: Arguments need to be an array/, 'error';
+    ok !$request->minion_id, 'no Minion id';
+
+    $mock->unmock('to_array');
+    $mock->redefine(lock => sub { undef });
+    $request
+      = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
+    like $client->enqueue($request), qr/Cache service enqueue error from API: No lock defined/, 'error';
+    ok !$request->minion_id, 'no Minion id';
+
+    $mock->unmock('lock');
+    $app->plugins->once(before_dispatch => sub { shift->render(text => 'Howdy!', status => 500) });
+    $request
+      = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
+    like $client->enqueue($request), qr/Cache service enqueue error 500: Internal Server Error/, 'error';
+    ok !$request->minion_id, 'no Minion id';
+
+    $app->plugins->once(before_dispatch => sub { shift->render(text => 'Howdy!') });
+    $request
+      = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
+    like $client->enqueue($request), qr/Cache service enqueue error: 200 non-JSON response/, 'error';
+    ok !$request->minion_id, 'no Minion id';
+};
+
+done_testing();

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -53,7 +53,6 @@ use OpenQA::CacheService::Request;
 use OpenQA::CacheService::Client;
 
 my $cachedir = $ENV{OPENQA_CACHE_DIR};
-my $db_file  = "$cachedir/cache.sqlite";
 my $port     = Mojo::IOLoop::Server->generate_port;
 my $host     = "http://localhost:$port";
 


### PR DESCRIPTION
There were quite a few error conditions that could result in the cache service client breaking workers. This PR adds lots of tests for them and will allow the worker to handle all of them gracefully.

Progress: https://progress.opensuse.org/issues/66988