### PR TITLE
Narrow down fixtures needed by api tests

### DIFF
--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -30,7 +30,7 @@ use OpenQA::Jobs::Constants;
 use Date::Format 'time2str';
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema    = $test_case->init_data;
+my $schema    = $test_case->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 my $jobs      = $schema->resultset('Jobs');
 my $workers   = $schema->resultset('Workers');
 

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -24,7 +24,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
@@ -61,7 +61,6 @@ touch_isos [$iso1, $iso2];
 
 my $listing = [
     {
-        id              => 7,
         name            => $iso1,
         type            => "iso",
         size            => undef,
@@ -70,7 +69,6 @@ my $listing = [
         fixed           => 0,
     },
     {
-        id              => 8,
         name            => $iso2,
         type            => "iso",
         size            => undef,
@@ -82,8 +80,8 @@ my $listing = [
 
 la;
 
-$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200, 'iso registered')
-  ->json_is('/id', $listing->[0]->{id}, 'iso has correct id');
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200, 'iso registered');
+$listing->[0]->{id} = $t->tx->res->json->{id};
 $t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso1})->status_is(200, 'register iso again')
   ->json_is('/id' => $listing->[0]->{id}, 'iso has the same ID, no duplicate');
 
@@ -98,8 +96,9 @@ delete $t->tx->res->json->{$_} for qw/t_updated t_created/;
 $t->json_is('' => $listing->[0], "asset correctly entered by id");
 $t->get_ok('/api/v1/assets/iso/' . $iso2)->status_is(404, 'iso does not exist');
 
-$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso2})->status_is(200, 'second asset posted')
-  ->json_is('/id', $listing->[1]->{id}, "asset has corect ID");
+$t->post_ok('/api/v1/assets', form => {type => 'iso', name => $iso2})->status_is(200, 'second asset posted');
+$listing->[1]->{id} = $t->tx->res->json->{id};
+isnt($listing->[0]->{id}, $listing->[1]->{id}, 'new assets has a distinct ID');
 
 # check data
 $t->get_ok('/api/v1/assets/' . $listing->[1]->{id})->status_is(200);

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -27,7 +27,7 @@ use Mojo::IOLoop;
 
 use OpenQA::Utils 'locate_asset';
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -26,7 +26,7 @@ use OpenQA::Client;
 use OpenQA::Schema::Result::ScheduledProducts;
 use Mojo::IOLoop;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -26,7 +26,7 @@ use Mojo::Util qw(encode hmac_sha1_sum);
 use OpenQA::Test::Case;
 use OpenQA::Client;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data((fixtures_glob => '01-jobs.pl 03-users.pl'));
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -24,7 +24,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -24,7 +24,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -23,7 +23,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -27,7 +27,7 @@ use Mojo::File 'path';
 use Mojo::IOLoop;
 use OpenQA::YAML qw(load_yaml dump_yaml);
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
 my $accept_yaml = {Accept => 'text/yaml'};
 my $t           = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -23,7 +23,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use Mojo::IOLoop;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -24,7 +24,7 @@ use OpenQA::Client;
 use Mojo::IOLoop;
 use Mojo::JSON 'decode_json';
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -25,7 +25,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 require OpenQA::Schema::Result::Jobs;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -23,7 +23,7 @@ use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -24,7 +24,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::WebSockets;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 $t->app->config->{global}->{base_url} = 'http://example.com';

--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -23,7 +23,7 @@ use OpenQA::Test::Case;
 use Mojo::File qw(tempdir path);
 use File::Copy::Recursive 'dircopy';
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl');
 
 $ENV{OPENQA_CONFIG} = my $tempdir = tempdir;
 my $home_template = path(__FILE__)->dirname->dirname->child('data', 'openqa-trigger-from-obs');

--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -25,7 +25,7 @@ use Mojo::File qw(tempdir path);
 use Time::HiRes 'sleep';
 use File::Copy::Recursive 'dircopy';
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
 
 $ENV{OPENQA_CONFIG} = my $tempdir = tempdir;
 my $home_template = path(__FILE__)->dirname->dirname->child('data', 'openqa-trigger-from-obs');


### PR DESCRIPTION
Another follow-up for #3214 reducing fixture use in `api` tests.