### PR TITLE
Narrow down fixtures needed by toplevel tests

### DIFF
--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -36,9 +36,10 @@ use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;
 use OpenQA::Parser::Result::Output;
 
-my $schema = OpenQA::Test::Case->new->init_data;
+my $schema = OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl 06-job_dependencies.pl');
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
 my $jobs   = $t->app->schema->resultset("Jobs");
+my $users  = $t->app->schema->resultset("Users");
 
 # for "investigation" tests
 my $job_mock     = Test::MockModule->new('OpenQA::Schema::Result::Jobs', no_auto => 1);
@@ -412,7 +413,8 @@ subtest 'carry over, including soft-fails' => sub {
     $job->done;
     $job->discard_changes;
     is($job->result, OpenQA::Jobs::Constants::SOFTFAILED, 'job result is softfailed');
-    $job->comments->create({text => 'bsc#101', user_id => 99901});
+    my $user = $users->create_user('foo');
+    $job->comments->create({text => 'bsc#101', user_id => $user->id});
 
     $_settings{BUILD} = '667';
     $job = _job_create(\%_settings);
@@ -475,7 +477,8 @@ subtest 'carry over for ignore_failure modules' => sub {
     $job->done;
     $job->discard_changes;
     is($job->result, OpenQA::Jobs::Constants::PASSED, 'job result is passed');
-    $job->comments->create({text => 'bsc#101', user_id => 99901});
+    my $user = $users->create_user('foo');
+    $job->comments->create({text => 'bsc#101', user_id => $user->id});
 
     $_settings{BUILD} = '670';
     $job = _job_create(\%_settings);

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -22,7 +22,7 @@ use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
 
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
 my $schema = $t->app->schema;
@@ -104,9 +104,7 @@ $t->element_exists('#res_DVD_x86_64_kde .result_softfailed');
 $t->element_exists_not('#res_DVD_i586_doc');
 $t->element_exists_not('#res_DVD_i686_doc');
 
-my $failedmodules
-  = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#res_DVD_x86_64_doc .failedmodule')->all_text);
-like($failedmodules, qr/logpackages/i, "failed modules are listed");
+$t->text_is('#res_DVD_x86_64_doc .failedmodule *' => 'logpackages', 'failed modules are listed');
 
 #
 # Default overview for 13.1
@@ -320,8 +318,7 @@ $t->get_ok(
         failed_modules => 'failing_module,logpackages',
     })->status_is(200);
 like(get_summary, qr/Passed: 0 Failed: 1/i, 'expected job failures matches');
-$failedmodules = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#res_DVD_x86_64_doc')->all_text);
-is($failedmodules, 'failing_module', 'failing_module module failed');
+$t->text_is('#res_DVD_x86_64_doc .failedmodule *' => 'failing_module', 'failing_module module failed');
 
 # Check if failed_modules hides successful jobs even if a (fake) module failure is there
 $failing_module = $schema->resultset('JobModules')->create(

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -26,7 +26,7 @@ use Test::MockModule;
 use Mojolicious;
 use Mojo::Message;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data((fixtures_glob => '01-jobs.pl 02-workers.pl'));
 
 my $mock_client = Test::MockModule->new('OpenQA::WebSockets::Client');
 my ($client_called, $last_command);

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -29,7 +29,7 @@ $ENV{MOJO_LOG_LEVEL}   = 'debug';
 $ENV{OPENQA_SQL_DEBUG} = 'true';
 $ENV{OPENQA_LOGFILE}   = $filename;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -72,7 +72,7 @@ $assets_result_mock->redefine(refresh_size => sub { });
 
 # setup test config and database
 my $test_case     = OpenQA::Test::Case->new(config_directory => "$FindBin::Bin/data/41-audit-log");
-my $schema        = $test_case->init_data;
+my $schema        = $test_case->init_data(fixtures_glob => '01-jobs.pl 04-products.pl');
 my $jobs          = $schema->resultset('Jobs');
 my $job_groups    = $schema->resultset('JobGroups');
 my $parent_groups = $schema->resultset('JobGroupParents');

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -32,7 +32,7 @@ use OpenQA::Jobs::Constants;
 =cut
 
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # Allow Devel::Cover to collect stats for background jobs

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -26,7 +26,7 @@ use OpenQA::Jobs::Constants;
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
 my $t    = Test::Mojo->new('OpenQA::WebAPI');
 my $auth = {'X-CSRF-Token' => $t->ua->get('/tests')->res->dom->at('meta[name=csrf-token]')->attr('content')};
 $test_case->login($t, 'percival');

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -23,7 +23,7 @@ use OpenQA::Test::Case;
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 subtest '404 error page' => sub {

--- a/t/31-client_archive.t
+++ b/t/31-client_archive.t
@@ -25,7 +25,7 @@ use Mojo::File qw(tempdir path);
 use OpenQA::Test::Case;
 
 # init test case
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # XXX: Test::Mojo loses it's app when setting a new ua

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -29,7 +29,7 @@ use OpenQA::Test::Case;
 
 require OpenQA::Schema::Result::Jobs;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 my $chunk_size = 10000000;
 
 # allow up to 200MB - videos mostly

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -57,7 +57,7 @@ $mock_client->redefine(
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl 05-job_modules.pl 07-needles.pl');
 
 my $t             = Test::Mojo->new('OpenQA::WebAPI');
 my $t_livehandler = Test::Mojo->new('OpenQA::LiveHandler');

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -25,7 +25,7 @@ use OpenQA::JobGroupDefaults;
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(skip_fixtures => 1);
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # get resultsets

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -41,7 +41,7 @@ delete $ENV{OPENQA_LOGFILE};
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl 06-job_dependencies.pl');
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
 my $schema = $t->app->schema;
 

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -26,7 +26,7 @@ use OpenQA::Jobs::Constants;
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl');
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # get resultsets

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -26,11 +26,13 @@ use OpenQA::Utils;
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data;
+$test_case->init_data(skip_fixtures => 1);
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $schema             = $t->app->schema;
 my $scheduled_products = $schema->resultset('ScheduledProducts');
+my $users              = $schema->resultset('Users');
+my $user               = $users->create_user('foo');
 my %settings           = (
     distri   => 'openSUSE',
     version  => '15.1',
@@ -38,7 +40,7 @@ my %settings           = (
     arch     => 'x86_64',
     build    => 'foo',
     settings => {some => 'settings'},
-    user_id  => 99901,
+    user_id  => $user->id,
 );
 
 # prevent job creation

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -25,7 +25,7 @@ use OpenQA::Test::Case;
 
 # init test case
 my $test_case = OpenQA::Test::Case->new(config_directory => "$FindBin::Bin/data/41-audit-log");
-my $schema    = $test_case->init_data;
+my $schema    = $test_case->init_data(skip_fixtures => 1);
 my $t         = Test::Mojo->new('OpenQA::WebAPI');
 
 # get resultsets
@@ -52,10 +52,11 @@ my %fake_events = (
     1080 => 'other_event',
     1081 => 'yet_other_event',
 );
+my $user = $schema->resultset('Users')->create_user('foo');
 $events->create(
     {
         id            => $_,
-        user_id       => 99901,
+        user_id       => $user->id,
         connection_id => 'foo',
         event         => $fake_events{$_},
         event_data    => '{"foo" => "bar"}',

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -28,7 +28,7 @@ use OpenQA::CLI;
 use OpenQA::CLI::api;
 use OpenQA::Test::Case;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
 
 # Mock WebAPI with extra test routes
 my $daemon = Mojo::Server::Daemon->new(listen => ['http://127.0.0.1']);

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -26,7 +26,7 @@ use OpenQA::CLI;
 use OpenQA::CLI::archive;
 use OpenQA::Test::Case;
 
-OpenQA::Test::Case->new->init_data;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
 
 # Mock WebAPI with extra test routes
 my $daemon = Mojo::Server::Daemon->new(listen => ['http://127.0.0.1']);


### PR DESCRIPTION
Another follow-up for #3214 reducing fixture use in uncategorized tests.