### PR TITLE
Summarize results in test details tab (alternative)

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -184,6 +184,19 @@ function changeJobPrio(jobId, delta, linkElement) {
     });
 }
 
+function renderTestSummary(data) {
+    var html = (data.passed || 0) + "<i class='fa module_passed fa-star' title='modules passed'></i>";
+    if (data.softfailed)
+        html += " " + data.softfailed + "<i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>";
+    if (data.failed)
+        html += " " + data.failed + "<i class='far module_failed fa-star' title='modules failed'></i>";
+    if (data.none)
+        html += " " + data.none + "<i class='fa module_none fa-ban' title='modules skipped'></i>";
+    if (data.skipped)
+        html += " " + data.skipped + "<i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>";
+    return html;
+}
+
 function renderTestResult( data, type, row ) {
     if (type !== 'display') {
         return (parseInt(data.passed) * 10000) + (parseInt(data.softfailed) * 100) + parseInt(data.failed);
@@ -191,19 +204,7 @@ function renderTestResult( data, type, row ) {
 
     var html = '';
     if (row.state === 'done') {
-        html += data.passed + "<i class='fa module_passed fa-star' title='modules passed'></i>";
-        if (data.softfailed) {
-            html += " " + data.softfailed + "<i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>";
-        }
-        if (data.failed) {
-            html += " " + data.failed + "<i class='far module_failed fa-star' title='modules failed'></i>";
-        }
-        if (data.none) {
-            html += " " + data.none + "<i class='fa module_none fa-ban' title='modules skipped'></i>";
-        }
-        if (data.skipped) {
-            html += " " + data.skipped + "<i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>";
-        }
+        html += renderTestSummary(data);
     }
     if (row.state === 'cancelled') {
         html += "<i class='fa fa-times' title='canceled'></i>";

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -347,3 +347,12 @@ ul.modcategory {
         background-color: $color-softfailed;
     }
 }
+
+.top-right {
+    top: 0px;
+    right: 0px;
+}
+
+.pt-2-and-half {
+    padding-top: 0.75rem !important;
+}

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -12,6 +12,27 @@
             >
                 <div>
                     % if ($job->state eq 'done') {
+                        <div class="position-absolute top-right pt-2-and-half pr-3">
+                            %= $job->passed_module_count
+                            <i class='fa module_passed fa-star' title='modules passed'></i>
+                            % if ($job->softfailed_module_count) {
+                                %= $job->softfailed_module_count
+                                <i class='fa module_softfailed fa-star-half' title='modules with warnings'></i>
+                            % }
+                            % if ($job->failed_module_count) {
+                                %= $job->failed_module_count
+                                <i class='far module_failed fa-star' title='modules failed'></i>
+                            % }
+                            % if ($job->skipped_module_count) {
+                                %= $job->skipped_module_count
+                                <i class='fa module_none fa-ban' title='modules skipped'></i>
+                            % }
+                            % if ($job->externally_skipped_module_count) {
+                                %= $job->externally_skipped_module_count
+                                <i class='fa module_skipped fa-angle-double-right' title='modules externally skipped'></i>
+                            % }
+                        </div>
+
                         Result: <b><%= $job->result %></b>
                     % }
                     % else {


### PR DESCRIPTION
https://progress.opensuse.org/issues/44654

This helps to get a quick overview in test details showing grouped results in tab on details page.

![image](https://user-images.githubusercontent.com/11134265/86089118-e0ad9b00-baa7-11ea-9aa5-9c1aef33441f.png)

unlike in https://github.com/os-autoinst/openQA/pull/3184 this approach used the backend to render the summary