### PR TITLE
Implement test search route and results view

### DIFF
--- a/assets/stylesheets/navigation.scss
+++ b/assets/stylesheets/navigation.scss
@@ -34,6 +34,9 @@
         }
     }
 }
+.navbar-input {
+    margin: 1em 0;
+}
 .dropdown-menu {
     font-size: inherit;
     margin-top: 0;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -51,6 +51,9 @@ sub read_config {
             job_investigate_ignore      => '"(JOBTOKEN|NAME)"',
             job_investigate_git_timeout => 20,
         },
+        rate_limits => {
+            search => 5,
+        },
         auth => {
             method => 'OpenID',
         },

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -148,6 +148,7 @@ sub testcasedir {
     for my $dir (catdir($prjdir, 'share', 'tests'), catdir($prjdir, 'tests')) {
         $rootfortests ||= $dir if -d $dir;
     }
+    $distri //= '';
     # TODO actually "distri" is misused here. It should rather be something
     # like the name of the repository with all tests
     my $dir = catdir($rootfortests, $distri);

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -129,6 +129,8 @@ sub startup {
     $apik_auth->post('/')->to('api_key#create');
     $apik_auth->delete('/:apikeyid')->name('api_key')->to('api_key#destroy');
 
+    $r->get('/search')->name('search')->to('search#search');
+
     $r->get('/tests')->name('tests')->to('test#list');
     $r->get('/tests/overview')->name('tests_overview')->to('test#overview');
     $r->get('/tests/latest')->name('latest')->to('test#latest');
@@ -449,6 +451,9 @@ sub startup {
       ->name('apiv1_delete_parent_group_comment')->to('comment#delete');
 
     $api_ra->delete('/user/<id:num>')->name('apiv1_delete_user')->to('user#delete');
+
+    # api/v1/search
+    $api_public_r->get('/experimental/search')->name('apiv1_search_query')->to('search#query');
 
     # json-rpc methods not migrated to this api: echo, list_commands
     ###

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -1,0 +1,111 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Controller::API::V1::Search;
+use Mojo::Base 'Mojolicious::Controller';
+
+use OpenQA::Utils;
+use Mojo::File 'path';
+use IPC::Run;
+
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Search
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Search;
+
+=head1 DESCRIPTION
+
+Implements API methods to search (for) tests.
+
+=head1 METHODS
+
+=cut
+
+# Helper methods
+
+=over 4
+
+=item query()
+
+Renders an array of search results.
+
+=over 8
+
+=item q
+
+One or multiple keywords, treated as literal strings.
+
+=back
+
+The response will have these fields:
+
+=over
+
+=item B<data>: the array of search results, with B<occurrence> and B<contents> in case of a fulltext match
+
+=item B<error>: an array of errors if validation or retrieving results failed
+
+=back
+
+The B<data> and B<error> fields are mutually exclusive.
+
+=back
+
+=cut
+
+sub query {
+    my ($self) = @_;
+
+    my $validation = $self->validation;
+    $validation->required('q');
+    return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
+
+    # Allow n queries per minute, per user (if logged in)
+    my $lockname = 'webui_query_rate_limit';
+    if (my $user = $self->current_user) { $lockname .= $user }
+    return $self->render(json => {error => 'Rate limit exceeded'}, status => 400)
+      unless $self->app->minion->lock($lockname, 60, {limit => $self->app->config->{'rate_limits'}->{'search'}});
+
+    my @results;
+    my $keywords = $validation->param('q');
+    my $distris  = path(OpenQA::Utils::testcasedir);
+    for my $distri ($distris->list({dir => 1})->each) {
+        # Perl module filenames
+        for my $filename ($distri->list_tree()->map('to_rel', $distris)->grep(qr/.*\Q$keywords\E.*\.pm$/)->each) {
+            push(@results, {occurrence => $filename});
+        }
+
+        # Contents of Perl modules
+        my @cmd = ('git', '-C', $distri, 'grep', '--no-index', '-F', $keywords, '--', '*.pm');
+        my $stdout;
+        my $stderr;
+        IPC::Run::run(\@cmd, \undef, \$stdout, \$stderr);
+        return $self->render(json => {error => "Grep failed: $stderr"}, status => 400) if $stderr;
+
+        foreach my $match (split("\n", $stdout)) {
+            my ($filename, $occurrence) = split(':', $match);
+            push(@results, {occurrence => $distri->basename . '/' . $filename, contents => $occurrence});
+        }
+    }
+
+    $self->render(json => {data => \@results});
+}
+
+1;

--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+# Copyright (C) 2017-2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+use Test::Mojo;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use OpenQA::Test::Case;
+
+OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+subtest 'Perl modules' => sub {
+    $t->get_ok('/api/v1/experimental/search?q=timezone', 'search successful');
+    $t->json_is('/error'  => undef,                                                               'no errors');
+    $t->json_is('/data/0' => {occurrence => 'opensuse/tests/installation/installer_timezone.pm'}, 'module found');
+    $t->json_is(
+        '/data/1' => {
+            occurrence => 'opensuse/tests/installation/installer_timezone.pm',
+            contents   => qq{    assert_screen "inst-timezone", 125 || die 'no timezone';}
+        },
+        'contents found'
+    );
+};
+
+subtest 'Errors' => sub {
+    $t->get_ok('/api/v1/experimental/search', 'Search succesful');
+    $t->json_is('/error' => 'Erroneous parameters (q missing)', 'no search terms results in error');
+
+    $t->get_ok('/api/v1/experimental/search?q=*', 'wildcard is interpreted literally');
+    $t->json_is('/data' => [], 'no result for *');
+
+    $t->app->config->{rate_limits}->{search} = 3;
+    $t->get_ok('/api/v1/experimental/search?q=timezone', 'Search succesful') for (1 .. 3);
+    $t->json_is('/error' => 'Rate limit exceeded', 'rate limit triggered');
+};
+
+done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -57,6 +57,9 @@ subtest 'Test configuration default modes' => sub {
             job_investigate_ignore      => '"(JOBTOKEN|NAME)"',
             job_investigate_git_timeout => 20,
         },
+        rate_limits => {
+            search => 5,
+        },
         auth => {
             method => 'Fake',
         },

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -288,7 +288,7 @@ subtest 'add test suite' => sub() {
     $elem = $driver->find_element('.admintable tbody tr:nth-child(7)');
     is($elem->get_text(), "$suiteName testKey=$suiteValue", 'stored text is the same except key');
 
-    $elem = $driver->find_element('input[type=search]');
+    $elem = $driver->find_element('#test-suites_filter input[type=search]');
     $elem->send_keys("^kde");
     @fields = $driver->find_elements('.admintable tbody tr');
     is(@fields, 1, "search using regex");

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -1,0 +1,69 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use OpenQA::Test::Case;
+use OpenQA::Client;
+
+use OpenQA::SeleniumTest;
+
+OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
+
+my $driver = call_driver();
+if (!$driver) {
+    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
+    exit(0);
+}
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+# we need to talk to the phantom instance or else we're using wrong database
+my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+
+subtest 'Perl modules' => sub {
+    my $search = $driver->find_element_by_id('global-search');
+    $search->click();
+    is $search->get_text(), '', 'empty search entry by default';
+
+    $search->send_keys('timezone');
+    $search->send_keys(Selenium::Remote::WDKeys->KEYS->{'enter'});
+    wait_for_element(selector => '#results .list-group-item');
+
+    like $driver->get_title(), qr/Search/, 'search shown' or return;
+    my $header = $driver->find_element_by_id('results-heading');
+    is $header->get_text(), 'Search results: 2 matches found', 'number of results in header';
+    my $results = $driver->find_element_by_id('results');
+    my @entries = $results->children('.list-group-item');
+    is scalar @entries, 2, 'two elements' or return;
+
+    my $first = $entries[0];
+    is $first->child('.occurrence')->get_text(), 'opensuse/tests/installation/installer_timezone.pm',
+      'expected occurrence';
+
+    my $second = $entries[1];
+    is $second->child('.occurrence')->get_text(), 'opensuse/tests/installation/installer_timezone.pm',
+      'expected occurrence';
+    is $second->child('.contents')->get_text(), qq{    assert_screen "inst-timezone", 125 || die 'no timezone';},
+      'expected contents';
+};
+
+END { kill_driver() }
+done_testing();

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -64,7 +64,7 @@ my $table = $driver->find_element_by_id('audit_log_table');
 ok($table, 'audit table found');
 
 # search for name, event, date and combination
-my $search = $driver->find_element('input.form-control');
+my $search = $driver->find_element('#audit_log_table_filter input.form-control');
 ok($search, 'search box found');
 
 my @entries = $driver->find_child_elements($table, 'tbody/tr', 'xpath');

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -35,6 +35,11 @@
           </li>
         </ul>
         <ul class="navbar-nav ml-auto">
+            <li class="nav-item">
+                <form method="get" action="<%= url_for('search') %>">
+                    <input type="search" name="q" id="global-search" class="form-control navbar-input" value="<%= $self->param('q') %>" placeholder="Type to search" aria-label="Global search input"/>
+                </form>
+            </li>
         % if (current_user) {
             <li class="nav-item dropdown" id="user-action">
                 <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" >Logged in as

--- a/templates/webapi/search/search.html.ep
+++ b/templates/webapi/search/search.html.ep
@@ -1,0 +1,15 @@
+% layout 'bootstrap';
+% title 'Search';
+
+% content_for ready_function => begin
+  renderSearchResults(document.getElementById('global-search').value);
+% end
+
+<div>
+    <h2 id="results-heading">Search results</h2>
+    <p>The search currently finds Perl modules within the test distributions,
+       either by <b>filename</b> or <b>source code</b>.</p>
+    <div id="flash-messages"></div>
+    <div id="results" class="list-group">
+    </div>
+</div>


### PR DESCRIPTION
- Global search field
- A new search template to render results
- New "Search" controller
- AT3-4 - Search for Perl modules by filename
- AT3-5 - Search Perl module contents
- Results are rendered via a new REST API route

![Screenshot from 2020-07-09 13-25-05](https://user-images.githubusercontent.com/1204189/87035385-8e782280-c1e9-11ea-8a35-b6182ac0187a.png)

Related: [poo#34486](https://progress.opensuse.org/issues/34486)