### PR TITLE
systemd: Prevent worker erroneously pulling in any local openQA webUI service

### DIFF
--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -4,8 +4,8 @@
 # replace '1' with the instance number you want
 [Unit]
 Description=openQA Worker #%i
-Wants=openqa-webui.service network.target
-After=openqa-webui.service openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
+Wants=network.target
+After=openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
 PartOf=openqa-worker.target
 
 [Service]


### PR DESCRIPTION
The dependencies of the openQA worker including the openqa-webui.service have
been added a very long time ago in commit 55a8d9be1 but unfortunately from the
git commit messages we do not know the reason. Likely the use case was for a
single-instance setup to synchronise the services. However in general the
systemd service definition does not know for which openQA webUI instance the
worker is configured, if it is remote or local, so pulling in and waiting for
the local webUI regardless of the configuration is incorrect.

This commit removes both the "Wants=" and "After=" dependency on
openqa-webui.service. The prerequisite to be able to remove the dependency is
that the worker automatically reconnects until it can connect to the configured
webui.  The argument about "the user can configure systemd anyway" still counts
in any case: When we do not specify the dependency one can add it additionally
in an override. And actually adding is always easier than overriding in a way
that the original ones are not there anymore because then you need to replicate
the parts you still want in. Our documentation already promimently describes
that the openQA webUI service should be enabled and start to be able to be used
so there should be no problem to not make the workers pull in webUI services.

Related progress issue: https://progress.opensuse.org/issues/66682