### PR TITLE
Add UI support for removing users

### DIFF
--- a/assets/javascripts/admin_user.js
+++ b/assets/javascripts/admin_user.js
@@ -1,5 +1,5 @@
 function setup_admin_user() {
-    $('#users').DataTable({order: [[0, 'asc']]});
+    window.admin_user_table = $('#users').DataTable({order: [[0, 'asc']]});
 
     $('#users').on('change', 'input[name="role"]:radio', function() {
         var username = $(this).parents('tr').find('.name').text();
@@ -37,4 +37,25 @@ function setup_admin_user() {
             }
         });
     });
+
+    window.deleteUser = function(id) {
+        if (!confirm("Are you sure you want to delete this user?"))
+            return;
+
+        $.ajax({
+            url: '/api/v1/user/' + id,
+            method: 'DELETE',
+            dataType: 'json',
+            success: function() {
+                addFlash('info', 'The user was deleted successfully.');
+                window.admin_user_table.row($("#user_" + id)).remove().draw();
+            },
+            error: function(xhr, ajaxOptions, thrownError) {
+                if (xhr.responseJSON && xhr.responseJSON.error)
+                    addFlash('danger', xhr.responseJSON.error);
+                else
+                    addFlash('danger', 'An error has ocurred. Maybe there are unsatisfied foreign key restrictions in the DB for this user.');
+            }
+        });
+    };
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -448,6 +448,8 @@ sub startup {
     $api_ra->delete('/parent_groups/<parent_group_id:num>/comments/<comment_id:num>')
       ->name('apiv1_delete_parent_group_comment')->to('comment#delete');
 
+    $api_ra->delete('/user/<id:num>')->name('apiv1_delete_user')->to('user#delete');
+
     # json-rpc methods not migrated to this api: echo, list_commands
     ###
     ## JSON API ends here

--- a/lib/OpenQA/WebAPI/Controller/API/V1/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/User.pm
@@ -1,0 +1,54 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Controller::API::V1::User;
+use Mojo::Base 'Mojolicious::Controller';
+
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::User
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::User;
+
+=head1 DESCRIPTION
+
+Implements User API.
+
+=head1 METHODS
+
+=over 4
+
+=item delete()
+
+Deletes an existing user.
+
+=back
+
+=cut
+
+sub delete {
+    my ($self) = @_;
+    my $user = $self->schema->resultset('Users')->find($self->param('id'));
+    return $self->render(json => {error => 'Not found'}, status => 404) unless $user;
+    my $result = $user->delete();
+    $self->emit_event('openqa_user_deleted', {username => $user->username});
+    $self->render(json => {result => $result});
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -25,11 +25,11 @@ my @job_events   = qw(job_create job_delete job_cancel job_duplicate job_restart
   job_done job_grab job_cancel_by_settings);
 my @jobgroup_events    = qw(jobgroup_create jobgroup_update jobgroup_delete jobgroup_connect);
 my @jobtemplate_events = qw(jobtemplate_create jobtemplate_delete);
-my @user_events        = qw(user_update user_login user_new_comment user_update_comment user_delete_comment);
-my @asset_events       = qw(asset_register asset_delete);
-my @iso_events         = qw(iso_create iso_delete iso_cancel);
-my @worker_events      = qw(command_enqueue worker_register worker_delete);
-my @needle_events      = qw(needle_modify needle_delete);
+my @user_events   = qw(user_update user_login user_new_comment user_update_comment user_delete_comment user_deleted);
+my @asset_events  = qw(asset_register asset_delete);
+my @iso_events    = qw(iso_create iso_delete iso_cancel);
+my @worker_events = qw(command_enqueue worker_register worker_delete);
+my @needle_events = qw(needle_modify needle_delete);
 
 # disabled events:
 # job_grab

--- a/t/api/15-users.t
+++ b/t/api/15-users.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use OpenQA::Client;
+use OpenQA::Test::Case;
+
+OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
+
+my $t   = Test::Mojo->new('OpenQA::WebAPI');
+my $app = $t->app;
+$t->ua(OpenQA::Client->new(apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+
+$t->delete_ok('/api/v1/user/99904')->status_is(200, 'admins can delete users');
+is_deeply(
+    OpenQA::Test::Case::find_most_recent_event($t->app->schema, 'user_deleted'),
+    {username => 'Demo'},
+    'Delete was logged correctly'
+);
+
+$t->delete_ok('/api/v1/user/99999')->status_is(404, 'a non-existent user cannot be deleted');
+
+$t->ua(OpenQA::Client->new(apikey => 'LANCELOTKEY01', apisecret => 'MANYPEOPLEKNOW')->ioloop(Mojo::IOLoop->singleton));
+$t->app($app);
+$t->delete_ok('/api/v1/user/99904')->status_is(403, 'non-admins cannot delete users');
+
+done_testing();

--- a/templates/webapi/admin/user/index.html.ep
+++ b/templates/webapi/admin/user/index.html.ep
@@ -5,6 +5,8 @@
     setup_admin_user();
 % end
 
+% my $show_user_actions = is_admin;
+
 <div class="row">
     <div class="col-sm-12">
         <h2><%= title %></h2>
@@ -19,6 +21,9 @@
                     <th>Name</th>
                     <th>Nick</th>
                     <th>Role</th>
+                    % if ($show_user_actions) {
+                    <th></th>
+                    % }
                 </tr>
             </thead>
             <tbody>
@@ -64,6 +69,13 @@
                 </label>
                             % end
                         </td>
+                        % if ($show_user_actions) {
+                        <td class="text-nowrap">
+                            <a class="btn p-0">
+                                <i class="fa fa-trash" aria-hidden="true" onclick="deleteUser(<%= $user->id %>)"></i>
+                            </a>
+                        </td>
+                        % }
                     </tr>
             % }
             </tbody>


### PR DESCRIPTION
https://progress.opensuse.org/issues/68702

 Add UI support for removing users

- Created API function for removing users
- Created UI elements to perform the action
- Only admins could see the delete button and can delete users
- The table is manipulated by JS instead of reload the page
- Added test to prove that admins can delete users, and other not