### PR TITLE
spec: Exclude flaky t/api/14-plugin_obs_rsync_async.t from tests

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -260,9 +260,11 @@ export LC_ALL=en_US.UTF-8
 # Skip tests not working currently, or flaky, and Selenium tests
 # https://progress.opensuse.org/issues/19652
 # 17-labels_carry_over.t: https://progress.opensuse.org/issues/60209
+# api/14-plugin_obs_rsync_async.t: https://progress.opensuse.org/issues/68836
 rm \
     t/17-labels_carry_over.t \
     t/25-cache-service.t \
+    t/api/14-plugin_obs_rsync_async.t \
     t/ui/*.t
 
 make test OBS_RUN=1 PROVE_ARGS='-l -r -v' TEST_PG_PATH=%{buildroot}/DB


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/68836