### PR TITLE
Collapse content of in investigation when content is too big

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -749,12 +749,14 @@ function renderInvestigationTab(response) {
         keyElement.style.verticalAlign = 'top';
         keyElement.appendChild(document.createTextNode(key));
 
-        var textLines = response[key].split('\n');
+        var text = response[key];
+        var textLines = typeof text === 'string' ? text.split('\n') : [text];
         var textLinesRest;
 
-        if (textLines.length > 10) {
-            textLinesRest = textLines.slice(10, textLines.length);
-            textLines = textLines.slice(0, 10);
+        var lineLimit = 10;
+        if (textLines.length > lineLimit) {
+            textLinesRest = textLines.slice(lineLimit, textLines.length);
+            textLines = textLines.slice(0, lineLimit);
         }
 
         var valueElement = document.createElement('td');
@@ -770,7 +772,7 @@ function renderInvestigationTab(response) {
             var moreLink = document.createElement('a');
             moreLink.style = "cursor:pointer";
             moreLink.innerHTML = "Show more";
-            moreLink.onclick = function(){
+            moreLink.onclick = function() {
                 preElementMore.style = "";
                 moreLink.style = "display:none";
             };

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -749,10 +749,35 @@ function renderInvestigationTab(response) {
         keyElement.style.verticalAlign = 'top';
         keyElement.appendChild(document.createTextNode(key));
 
+        var textLines = response[key].split('\n');
+        var textLinesRest;
+
+        if (textLines.length > 10) {
+            textLinesRest = textLines.slice(10, textLines.length);
+            textLines = textLines.slice(0, 10);
+        }
+
         var valueElement = document.createElement('td');
         var preElement = document.createElement('pre');
-        preElement.appendChild(document.createTextNode(response[key]));
+        preElement.appendChild(document.createTextNode(textLines.join('\n')));
         valueElement.appendChild(preElement);
+
+        if (textLinesRest) {
+            var preElementMore = document.createElement('pre');
+            preElementMore.appendChild(document.createTextNode(textLinesRest.join('\n')));
+            preElementMore.style = "display: none";
+
+            var moreLink = document.createElement('a');
+            moreLink.style = "cursor:pointer";
+            moreLink.innerHTML = "Show more";
+            moreLink.onclick = function(){
+                preElementMore.style = "";
+                moreLink.style = "display:none";
+            };
+
+            valueElement.appendChild(moreLink);
+            valueElement.appendChild(preElementMore);
+        }
 
         var trElement = document.createElement('tr');
         trElement.appendChild(keyElement);


### PR DESCRIPTION
Collapse content of initial rows in investigation tab when content becomes too big, e.g. more than 10 lines

https://progress.opensuse.org/issues/19720

- Shows only the 10 initial lines
- Add a link to show the rest of lines

![image](https://user-images.githubusercontent.com/11134265/87320752-99a1ba00-c52b-11ea-9264-1bdbdeba0607.png)
