### PR TITLE
Fix user creation in OAuth2 plugin

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -56,11 +56,9 @@ sub auth_login {
             my $details = $res->json;
             my $user    = $self->schema->resultset('Users')->create_user(
                 $details->{id},
-                {
-                    nickname => $details->{login},
-                    fullname => $details->{name},
-                    email    => $details->{email},
-                });
+                nickname => $details->{login},
+                fullname => $details->{name},
+                email    => $details->{email});
 
             $self->session->{user} = $user->username;
             $self->redirect_to('index');


### PR DESCRIPTION
create_user takes hash keys without parens.