### PR TITLE
Make "last good" a link to a job instead of plain job ID

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -745,40 +745,56 @@ function renderInvestigationTab(response) {
 
     var tbodyElement = document.createElement('tbody');
     Object.keys(response).forEach(key => {
+        var spl = key.split(':');
+        var value = response[key];
+        var type = "pre";
+
+        if (spl.length == 2) {
+            key = spl[0];
+            type = spl[1];
+        }
+
         var keyElement = document.createElement('td');
         keyElement.style.verticalAlign = 'top';
         keyElement.appendChild(document.createTextNode(key));
 
-        var text = response[key];
-        var textLines = typeof text === 'string' ? text.split('\n') : [text];
-        var textLinesRest;
-
-        var lineLimit = 10;
-        if (textLines.length > lineLimit) {
-            textLinesRest = textLines.slice(lineLimit, textLines.length);
-            textLines = textLines.slice(0, lineLimit);
-        }
-
         var valueElement = document.createElement('td');
-        var preElement = document.createElement('pre');
-        preElement.appendChild(document.createTextNode(textLines.join('\n')));
-        valueElement.appendChild(preElement);
 
-        if (textLinesRest) {
-            var preElementMore = document.createElement('pre');
-            preElementMore.appendChild(document.createTextNode(textLinesRest.join('\n')));
-            preElementMore.style = "display: none";
+        if (type === "link") {
+            var html = document.createElement("a");
+            html.href = value.link;
+            html.innerHTML = value.text;
+            valueElement.appendChild(html);
+        } else {
+            var textLines = typeof value === 'string' ? value.split('\n') : [value];
+            var textLinesRest;
 
-            var moreLink = document.createElement('a');
-            moreLink.style = "cursor:pointer";
-            moreLink.innerHTML = "Show more";
-            moreLink.onclick = function() {
-                preElementMore.style = "";
-                moreLink.style = "display:none";
-            };
+            var lineLimit = 10;
+            if (textLines.length > lineLimit) {
+                textLinesRest = textLines.slice(lineLimit, textLines.length);
+                textLines = textLines.slice(0, lineLimit);
+            }
 
-            valueElement.appendChild(moreLink);
-            valueElement.appendChild(preElementMore);
+            var preElement = document.createElement('pre');
+            preElement.appendChild(document.createTextNode(textLines.join('\n')));
+            valueElement.appendChild(preElement);
+
+            if (textLinesRest) {
+                var preElementMore = document.createElement('pre');
+                preElementMore.appendChild(document.createTextNode(textLinesRest.join('\n')));
+                preElementMore.style = "display: none";
+
+                var moreLink = document.createElement('a');
+                moreLink.style = "cursor:pointer";
+                moreLink.innerHTML = "Show more";
+                moreLink.onclick = function() {
+                    preElementMore.style = "";
+                    moreLink.style = "display:none";
+                };
+
+                valueElement.appendChild(moreLink);
+                valueElement.appendChild(preElementMore);
+            }
         }
 
         var trElement = document.createElement('tr');

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1831,7 +1831,7 @@ sub investigate {
     my $ignore = OpenQA::App->singleton->config->{global}->{job_investigate_ignore};
     for my $prev (@previous) {
         next unless $prev->result =~ /(?:passed|softfailed)/;
-        $inv{last_good} = $prev->id;
+        $inv{'last_good:link'} = {'link' => '/test/'.$prev->id, 'text' => $prev->id};
         last unless $prev->result_dir;
         # just ignore any problems on generating the diff with eval, e.g.
         # files missing. This is a best-effort approach.


### PR DESCRIPTION
https://progress.opensuse.org/issues/19720

If a valid last_good job ID is present in the investigation result
set, then it is replaced by html code <a> to link directly to this job.

In order to tell to the JS that this is a piece of HTML, backend adds
the type of this variable. Using ':' to split <name>[:<type>].
In this case the type is html. The key will be now 'last_good:html'

In JS detects if a type has being defined or not. If is html then
use this html. In other cases, now only traditional use, then creates
a < pre > element.

This allows to add typed information like links to files,
tables, but also colorize the values is needed.

Alternative to https://github.com/os-autoinst/openQA/pull/3259