### PR TITLE
Clone directly chained parents when restarting jobs

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -364,11 +364,13 @@ function refreshInfoPanel() {
             if (!infoBoxContent) {
                 return;
             }
-            // update favicon, class of info panel and timeago elements
+            // update favicon, class of info panel, timeago and popover elements
             document.getElementById('favicon-16').href = infoBoxContent.dataset['faviconUrl-16'];
             document.getElementById('favicon-svg').href = infoBoxContent.dataset.faviconUrlSvg;
             setInfoPanelClassName(testStatus.state, testStatus.result);
-            $(infoBoxContent).find('.timeago').timeago();
+            const infoBoxJQuery = $(infoBoxContent);
+            infoBoxJQuery.find('.timeago').timeago();
+            infoBoxJQuery.find('[data-toggle="popover"]').popover({ html: true });
             setupResultButtons();
         },
         error: function(xhr, ajaxOptions, thrownError) {

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -3,6 +3,15 @@
     background-color: $color-softfailed;
     color: $color-result;
 }
+#restart-result + .help_popover {
+    font-size: 80%;
+    position: relative;
+    top: 5px;
+    left: -3px;
+    margin-left: 0px;
+    padding-left: 0px;
+    opacity: 0.75;
+}
 
 // test result
 .resultok { background-color: $color-ok; color: $color-result; }

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -39,7 +39,9 @@ or done. Scheduled jobs can't be restarted.
 
 =cut
 sub job_restart {
-    my ($jobids, $force) = @_;
+    my ($jobids, %args) = @_;
+    my $force        = $args{force};
+    my $skip_parents = $args{skip_parents};
     my (@duplicated, @processed, @errors, @warnings, $enforceable);
     return (\@duplicated, ['No job IDs specified'], \@warnings) unless ref $jobids eq 'ARRAY' && @$jobids;
 
@@ -71,7 +73,7 @@ sub job_restart {
                 next;
             }
         }
-        my $dup = $job->auto_duplicate;
+        my $dup = $job->auto_duplicate({skip_parents => $skip_parents});
         push @duplicated, $dup->{cluster_cloned} if $dup;
         push @processed,  $job_id;
     }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -620,13 +620,13 @@ sub create_clone {
             # assets are re-created in job_grab
             priority => $prio || $self->priority
         });
+
     # Perform optimistic locking on clone_id. If the job is not longer there
     # or it already has a clone, rollback the transaction (new_job should
     # not be created, somebody else was faster at cloning)
-    my $upd = $rset->search({clone_id => undef, id => $self->id})->update({clone_id => $new_job->id});
-
-    # One row affected
-    die('There is already a clone!') unless ($upd == 1);
+    my $id            = $self->id;
+    my $affected_rows = $rset->search({id => $id, clone_id => undef})->update({clone_id => $new_job->id});
+    die "Job $id has already been cloned as " . $self->clone_id unless $affected_rows == 1;
 
     # Needed to load default values from DB
     $new_job->discard_changes;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -721,9 +721,22 @@ sub cluster_jobs {
         @_
     );
 
-    my $jobs = $args{jobs};
-    return $jobs if defined $jobs->{$self->id};
-    $jobs->{$self->id} = {
+    my $jobs          = $args{jobs};
+    my $job_id        = $self->id;
+    my $job           = $jobs->{$job_id};
+    my $skip_children = $args{skip_children};
+
+    # handle re-visiting job
+    if (defined $job) {
+        # checkout the children after all when revisiting this job without $skip_children but children
+        # have previously been skipped
+        return $self->_cluster_children($jobs) if !$skip_children && delete $job->{children_skipped};
+        # otherwise skip the already visisted job
+        return $jobs;
+    }
+
+    # make empty dependency data for the job
+    $job = $jobs->{$job_id} = {
         parallel_parents          => [],
         chained_parents           => [],
         directly_chained_parents  => [],
@@ -732,23 +745,25 @@ sub cluster_jobs {
         directly_chained_children => [],
     };
 
-    ## if we have a parallel parent, go up recursively
+    # fill dependency data; go up recursively if we have a directly chained or parallel parent
     my $parents = $self->parents;
   PARENT: while (my $pd = $parents->next) {
         my $p = $pd->parent;
 
         if ($pd->dependency eq OpenQA::JobDependencies::Constants::CHAINED) {
-            push(@{$jobs->{$self->id}->{chained_parents}}, $p->id);
+            push(@{$job->{chained_parents}}, $p->id);
             # we don't duplicate up the chain, only down
             next;
         }
         elsif ($pd->dependency eq OpenQA::JobDependencies::Constants::DIRECTLY_CHAINED) {
-            push(@{$jobs->{$self->id}->{directly_chained_parents}}, $p->id);
-            # we don't duplicate up the chain, only down
+            push(@{$job->{directly_chained_parents}}, $p->id);
+            # duplicate also up the chain to ensure this job ran directly after its directly chained parent
+            # note: We skip the children here to avoid considering "direct siblings".
+            $p->cluster_jobs(jobs => $jobs, skip_children => 1);
             next;
         }
         elsif ($pd->dependency eq OpenQA::JobDependencies::Constants::PARALLEL) {
-            push(@{$jobs->{$self->id}->{parallel_parents}}, $p->id);
+            push(@{$job->{parallel_parents}}, $p->id);
             my $cancelwhole = 1;
             # check if the setting to disable cancelwhole is set: the var
             # must exist and be set to something false-y
@@ -769,11 +784,15 @@ sub cluster_jobs {
         }
     }
 
-    return $self->cluster_children($jobs);
+    return $self->_cluster_children($jobs) unless $skip_children;
+
+    # flag this job as "children_skipped" to be able to distinguish when re-visiting the job
+    $job->{children_skipped} = 1;
+    return $jobs;
 }
 
-# internal (recursive) function to cluster_jobs
-sub cluster_children {
+# internal (recursive) function used by cluster_jobs to invoke itself for all children
+sub _cluster_children {
     my ($self, $jobs) = @_;
 
     my $schema = $self->result_source->schema;
@@ -792,6 +811,7 @@ sub cluster_children {
     }
     return $jobs;
 }
+
 
 =head2 duplicate
 
@@ -820,6 +840,12 @@ for PARALLEL dependencies:
 for CHAINED dependencies:
 - do NOT clone parents
  + create new dependency - duplicit cloning is prevented by ignorelist, webui will show multiple chained deps though
+- clone children
+ + if child is clone, find the latest clone and clone it
+
+for DIRECTLY_CHAINED dependencies:
+- clone parents recursively but ignore their children (our siblings)
+ + if parent is clone, find the latest clone and clone it
 - clone children
  + if child is clone, find the latest clone and clone it
 

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -59,8 +59,18 @@
                     % }
                     % if (is_operator && $job->can_be_duplicated) {
                         %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result', 'data-jobid' => $testid) => begin
-                            <i class="fa fa-2 fa-redo" title="Restart Job"></i>
+                            <i class="fa fa-2 fa-redo" title="Restart job"></i>
                         %= end
+                        <%= help_popover('Restart job' => '
+                            <p>Restarts the job and certain dependent jobs.</p>
+                            <p>Rules for restarting dependencies:</p>
+                            <ul>
+                                <li>If the job is part of a parallel cluster, all jobs within that cluster are restarted.</li>
+                                <li>Any kind of chained child jobs are restarted.</li>
+                                <li>Directly chained parent jobs are restarted.</li>
+                            </ul>
+                            All rules are applied recursively. Direct use of the REST-API allows excluding parents.', undef, undef, 'bottom');
+                        %>
                     % }
                     % if (is_operator && ($job->state eq 'running' || $job->state eq 'scheduled')) {
                         %= link_post url_for('apiv1_cancel', jobid => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin


### PR DESCRIPTION
It makes sense to restart directly chained parents because otherwise it is
not ensured that the child actually directly after its parent on the same
worker.

See https://progress.opensuse.org/issues/68956