### PR TITLE
openqa-clone-custom-git-refspec: Fix curl+jq check for jq < 1.6

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -111,7 +111,7 @@ clone_job() {
         local json_url=${host}/tests/${job}/file/vars.json
         local json_data
         json_data=$(eval "${curl_openqa} -s ${json_url}")
-        echo "$json_data" | jq &>/dev/null || \
+        echo "$json_data" | jq . &>/dev/null || \
             fail "Unreadable openQA job or no valid JSON data encountered. \
 Please try 'curl $json_url' or select another job, e.g. in the same scenario: $host/t$job#next_previous"
         local testsuite="${testsuite:-"$(echo "$json_data" | jq -r '.TEST')"}" || throw_json_error "$json_url" "$json_data"


### PR DESCRIPTION
A problem was observed in jq version 1.5 that the JSON document was
properly evaluated but still jq would return an exit code of 2 instead
of 0 unless a scope is given, e.g. with ".".