### PR TITLE
Make "last good" a link to a job instead of plain job ID

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -748,40 +748,60 @@ function renderInvestigationTab(response) {
 
     var tbodyElement = document.createElement('tbody');
     Object.keys(response).forEach(key => {
+        var value = response[key];
+        var type = 'pre';
+
+        // The value can be an object with attribute "type" to determine the
+        // behavior. The accepted types are:
+        // - link: adds a link reference using an anchor <a>
+        //   additional required attributes:
+        //     - link: the url
+        //     - text: the text to show instead of the url
+
+        if (typeof value === 'object' && value.type)
+            type = value.type;
+
         var keyElement = document.createElement('td');
         keyElement.style.verticalAlign = 'top';
         keyElement.appendChild(document.createTextNode(key));
 
-        var text = response[key];
-        var textLines = typeof text === 'string' ? text.split('\n') : [text];
-        var textLinesRest;
-
-        var lineLimit = 10;
-        if (textLines.length > lineLimit) {
-            textLinesRest = textLines.slice(lineLimit, textLines.length);
-            textLines = textLines.slice(0, lineLimit);
-        }
-
         var valueElement = document.createElement('td');
-        var preElement = document.createElement('pre');
-        preElement.appendChild(document.createTextNode(textLines.join('\n')));
-        valueElement.appendChild(preElement);
 
-        if (textLinesRest) {
-            var preElementMore = document.createElement('pre');
-            preElementMore.appendChild(document.createTextNode(textLinesRest.join('\n')));
-            preElementMore.style = "display: none";
+        if (type === "link") {
+            var html = document.createElement("a");
+            html.href = value.link;
+            html.innerHTML = value.text;
+            valueElement.appendChild(html);
+        } else {
+            var textLines = typeof value === 'string' ? value.split('\n') : [value];
+            var textLinesRest;
 
-            var moreLink = document.createElement('a');
-            moreLink.style = "cursor:pointer";
-            moreLink.innerHTML = "Show more";
-            moreLink.onclick = function() {
-                preElementMore.style = "";
-                moreLink.style = "display:none";
-            };
+            var lineLimit = 10;
+            if (textLines.length > lineLimit) {
+                textLinesRest = textLines.slice(lineLimit, textLines.length);
+                textLines = textLines.slice(0, lineLimit);
+            }
 
-            valueElement.appendChild(moreLink);
-            valueElement.appendChild(preElementMore);
+            var preElement = document.createElement('pre');
+            preElement.appendChild(document.createTextNode(textLines.join('\n')));
+            valueElement.appendChild(preElement);
+
+            if (textLinesRest) {
+                var preElementMore = document.createElement('pre');
+                preElementMore.appendChild(document.createTextNode(textLinesRest.join('\n')));
+                preElementMore.style = "display: none";
+
+                var moreLink = document.createElement('a');
+                moreLink.style = "cursor:pointer";
+                moreLink.innerHTML = "Show more";
+                moreLink.onclick = function() {
+                    preElementMore.style = "";
+                    moreLink.style = "display:none";
+                };
+
+                valueElement.appendChild(moreLink);
+                valueElement.appendChild(preElementMore);
+            }
         }
 
         var trElement = document.createElement('tr');

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1831,7 +1831,7 @@ sub investigate {
     my $ignore = OpenQA::App->singleton->config->{global}->{job_investigate_ignore};
     for my $prev (@previous) {
         next unless $prev->result =~ /(?:passed|softfailed)/;
-        $inv{last_good} = $prev->id;
+        $inv{last_good} = {type => 'link', link => '/test/' . $prev->id, text => $prev->id};
         last unless $prev->result_dir;
         # just ignore any problems on generating the diff with eval, e.g.
         # files missing. This is a best-effort approach.

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -450,7 +450,10 @@ subtest 'carry over, including soft-fails' => sub {
         is($job->result, OpenQA::Jobs::Constants::FAILED, 'job result is failed');
         ok(my $inv = $job->investigate, 'job can provide investigation details');
         ok($inv,                        'job provides failure investigation');
-        is($inv->{last_good}, 99998, 'previous job identified as last good');
+        is(ref(my $last_good = $inv->{last_good}), 'HASH', 'previous job identified as last good and it is a hash');
+        is($last_good->{text},                     99998,  'last_good hash has the text');
+        is($last_good->{type},                     'link', 'last_good hash has the type');
+        is($last_good->{link}, '/test/99998', 'last_good hash has the correct link');
         like($inv->{diff_to_last_good}, qr/^\+.*BUILD.*668/m, 'diff for job settings is shown');
         unlike($inv->{diff_to_last_good}, qr/JOBTOKEN/, 'special variables are not included');
         is($inv->{test_log},    $fake_git_log, 'test git log is evaluated');


### PR DESCRIPTION
https://progress.opensuse.org/issues/19720

If a valid last_good job ID is present in the investigation result
set, then it is replaced by html code <a> to link directly to this job.

In order to tell to the JS that this is a link, the value is a hash
where a type => link is set.

In JS detects if it is an object and if the type has being defined
or not. If is link then creates a link with the information.
In other cases, now only traditional use, then creates a \<pre\> element.

This allows to add typed information like links to files,
tables, but also colorize the values is needed.

Alternative to https://github.com/os-autoinst/openQA/pull/3261 without adding extra information to the name of the variables