### PR TITLE
Fix tab-handling related issues on test details page

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -383,9 +383,16 @@ function handleJobStateTransition(oldJobState, newJobState, newJobResult) {
     testStatus.state = newJobState;
     testStatus.result = newJobResult;
 
-    // show the live tab by default for running jobs
+    // show the live tab by default for running jobs (instead of details)
     if (newJobState === 'running') {
-        $("[href='#live']").tab('show');
+        // avoid overriding explicitly specified tab/step
+        if (!location.hash || location.hash === '#') {
+            $("[href='#live']").tab('show');
+        } else {
+            // ensure the live tab is loaded even when not showing it initially because it is needed to
+            // process the test status updates
+            activateTab('live');
+        }
         // load contents of the details tab as well as it is updated continuously while the test is running
         activateTab('details');
     }

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -815,7 +815,16 @@ function renderDependencyTab(response) {
                                  The current job is highlighted with a bolder border and yellow background.</p> \
                                  <p>The graph shows only the latest jobs. That means jobs which have been cloned will \
                                  never show up.</p><svg id="dependencygraph"></svg>';
-    renderDependencyGraph(tabPanelElement, nodes, edges, cluster, tabPanelElement.dataset.currentJobId);
+
+    // render the graph only while the tab panel element is visible; otherwise delay the rendering until it becomes visible
+    // note: This is required because otherwise the initialization does not seem to work (e.g. in Chromium only the arrows
+    //       are rendered and in Firefox nothing at all).
+    const renderGraph = renderDependencyGraph.bind(this, tabPanelElement, nodes, edges, cluster, tabPanelElement.dataset.currentJobId);
+    if (tabPanelElement.classList.contains('active')) {
+        renderGraph();
+    } else {
+        $("[href='#dependencies']").on('shown.bs.tab', renderGraph);
+    }
 }
 
 function renderDependencyGraph(container, nodes, edges, cluster, currentNode) {


### PR DESCRIPTION
These two issues are actually distinct but are observed at the same time when showing job details for a running job with the hash '#dependencies'. As the particular commit message state this change avoids overriding the explicitly specified tab/step when loading a running job. It also ensures that the dependency graph is only rendered while its tab is active to avoid rendering problems.