### PR TITLE
Use CMake to build os-autoinst

### DIFF
--- a/.circleci/build_autoinst.sh
+++ b/.circleci/build_autoinst.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,7 +24,6 @@ echo Building os-autoinst $destdir $sha
 git clone https://github.com/os-autoinst/os-autoinst.git "$destdir"
 ( cd "$destdir"
 [ -z "$sha" ] || git checkout $sha
-autoreconf -f -i
-./configure
-make 
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release .
+ninja symlinks
 )

--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -3,10 +3,10 @@
 FROM opensuse/leap:15.1
 
 # these are autoinst dependencies
-RUN zypper install -y autoconf automake gcc-c++ libtool pkgconfig\(opencv\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) make cmake ninja
+RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\)
 
 # openQA dependencies
-RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo
+RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
 
 # openQA chromedriver for Selenium tests
 RUN zypper install -y chromedriver

--- a/tools/run-tests-within-container
+++ b/tools/run-tests-within-container
@@ -25,7 +25,7 @@ prepare_fullstack_test() {
     else
         cpanm -n --mirror http://no.where/ --installdeps .
     fi
-    sh autogen.sh && make
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release . && ninja -v symlinks
     cd -
     ([ "$INSTALL_FROM_CPAN" -eq 1 ] && eval "$(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)") || true
 }


### PR DESCRIPTION
I suppose this is actually necessary because os-autoinst-devel will now only pull the dependencies for the CMake build.