### PR TITLE
Add .jsbeautifyrc for editor support

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,3 @@
+{
+    "brace_style": "collapse,preserve-inline"
+}

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PROVE_LIB_ARGS ?= -l
 DOCKER_IMG ?= openqa:latest
 # python-jsbeautifier does not support reading config file
 # https://github.com/beautify-web/js-beautify/issues/1074
+# Note: Keep in sync with .jsbeautifyrc
 JSBEAUTIFIER_OPTS ?= --brace-style=collapse,preserve-inline
 TEST_PG_PATH ?= /dev/shm/tpg
 # TIMEOUT_M: Timeout for one retry of tests in minutes


### PR DESCRIPTION
Although the makefile relies on the command line, a config file is required for editor plugins.

In case you're wondering "what editor" I'm using [VSCodeBeautify](https://github.com/HookyQR/VSCodeBeautify#how-we-determine-what-settings-to-use) which without this will produce the wrong results.