### PR TITLE
Show job dependency on the Test overview page

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -46,6 +46,29 @@ function setupOverview() {
                 icon.fadeTo('slow', 0.5).fadeTo('slow', 1.0);
             });
         });
+    var dependencies = document.getElementsByClassName('dependency');
+    for (var i = 0; i < dependencies.length; i++) {
+        var depObject = dependencies[i];
+        var deps = JSON.parse(depObject.getAttribute('data'));
+        var jobid = depObject.getAttribute('jobid');
+        var result = depObject.getAttribute('result');
+        var dependencyResult = showJobDependency(deps);
+        var parentsDepsResult = showDependencyResult(deps.parents, result);
+        if (dependencyResult.title === undefined) { continue; }
+        var elementIClass = 'fa fa-code-branch';
+        var elementATitle = dependencyResult.title;
+        if (parentsDepsResult !== '') {
+            elementIClass += ' result_' + parentsDepsResult;
+            elementATitle += '\ndependency ' + parentsDepsResult;
+        }
+        var elementA = document.createElement('a');
+        elementA.href = '/tests/' + jobid + '#dependencies';
+        elementA.title = elementATitle;
+        var elementI = document.createElement('i');
+        elementI.setAttribute('class', elementIClass);
+        elementA.appendChild(elementI);
+        dependencies[i].appendChild(elementA);
+    }
 
     setupFilterForm();
     $('#filter-todo').prop('checked', false);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -25,6 +25,7 @@ use Mojo::ByteStream;
 use Mojo::Util 'xml_escape';
 use File::Basename;
 use POSIX 'strftime';
+use Mojo::JSON 'to_json';
 
 sub referer_check {
     my ($self) = @_;
@@ -563,6 +564,7 @@ sub prepare_job_results {
         my $test   = $job->TEST;
         my $flavor = $job->FLAVOR || 'sweet';
         my $arch   = $job->ARCH || 'noarch';
+        $result->{deps} = to_json($job->dependencies);
 
         # Append machine name to TEST if it does not match the most frequently used MACHINE
         # for the jobs architecture

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -28,7 +28,7 @@ my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema      = $test_case->init_data(
     schema_name   => $schema_name,
-    fixtures_glob => '01-jobs.pl 02-workers.pl 04-products.pl 05-job_modules.pl'
+    fixtures_glob => '01-jobs.pl 02-workers.pl 04-products.pl 05-job_modules.pl 06-job_dependencies.pl'
 );
 
 sub schema_hook {
@@ -358,6 +358,15 @@ subtest "job template names displayed on 'Test result overview' page" => sub {
     disable_bootstrap_animations;
     $descriptions[0]->click();
     is(wait_for_element(selector => '.popover-header')->get_text, 'kde_variant', 'description popover shows content');
+};
+
+subtest "job dependencies displayed on 'Test result overview' page" => sub {
+    $driver->get($baseurl . 'tests/overview?distri=opensuse&version=13.1&build=0091&groupid=1001');
+    my $deps           = $driver->find_element('td#res_DVD_x86_64_kde .dependency');
+    my @child_elements = $driver->find_child_elements($deps, 'a');
+    my $details        = $child_elements[0];
+    like $details->get_attribute('href'), qr{tests/99963\#dependencies},          'job href is shown correctly';
+    is $details->get_attribute('title'),  "1 parallel parent\ndependency passed", 'dependency is shown correctly';
 };
 
 kill_driver();

--- a/templates/webapi/test/tr_job_result.html.ep
+++ b/templates/webapi/test/tr_job_result.html.ep
@@ -37,5 +37,6 @@
             %= include 'test/tr_job_result_failedmodules', jobid => $jobid, failedmodules => $res->{failures}, resultid => $resultid
          % }
          %= include 'test/tr_job_result_details', jobid => $jobid, res => $res
+         <span class='dependency' data="<%= $res->{deps} %>" jobid="<%= $jobid %>" result="<%= $res->{overall} %>"></span>
      % }
 </td>


### PR DESCRIPTION
Following the way that used in tests page:
1. use a little branch icon to show the related jobs
2. different color of the branch icon means different status:
   a. when the icon is blue, it means the job has no parent job
   b. when the icon is red, it means the job's parent job failed
   c. when the icon is green, it means the job's parent job success

See: https://progress.opensuse.org/issues/15850