### PR TITLE
Make a few small optimizations to speed up the deletion of screenshots

### DIFF
--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -25,7 +25,7 @@ use OpenQA::Task::Job::Limit;
 use OpenQA::Test::Utils qw(run_gru_job collect_coverage_of_gru_jobs);
 use Mojo::File 'path';
 use Mojo::Log;
-use Test::Output 'combined_like';
+use Test::Output qw(combined_like);
 use Test::MockModule;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
@@ -78,7 +78,7 @@ my %args = (
     screenshots_per_batch => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
 );
 combined_like { run_gru_job($app, limit_screenshots => \%args) }
-qr/removing screenshot bar/, 'removing screenshot logged';
+qr/Removing screenshot batch 1/, 'removing screenshot logged';
 @screenshots     = $screenshots->search({id => {-in => \@screenshot_ids}})->search({}, {order_by => 'id'});
 @screenshot_data = map { {filename => $_->filename} } @screenshots;
 is_deeply(\@screenshot_data, [{filename => 'foo'}], 'foo still present (used in 99927), bar removed (no longer used)')
@@ -143,7 +143,7 @@ subtest 'limiting screenshots splitted into multiple Minion jobs' => sub {
     my $worker = $minion->worker->register;
     my $args   = $enququed_minion_job_args->[1]->[0];
     combined_like { $worker->dequeue(0, {id => $enququed_minion_job_ids->[1]})->perform }
-    qr/removing screenshot/, 'screenshots being removed';
+    qr/Removing screenshot batch 1/, 'screenshots being removed';
     is($screenshots->search({id => {-between => [$args->{min_screenshot_id}, $args->{max_screenshot_id}]}})->count,
         0, 'all screenshots in the range deleted');
     is($screenshots->search({filename => {-like => 'test-%'}})->count,
@@ -153,7 +153,7 @@ subtest 'limiting screenshots splitted into multiple Minion jobs' => sub {
     combined_like {
         $worker->dequeue(0, {id => $_})->perform for ($enququed_minion_job_ids->[0], $enququed_minion_job_ids->[2])
     }
-    qr/removing screenshot/, 'screenshots being removed';
+    qr/Removing screenshot batch 1/, 'screenshots being removed';
     $worker->unregister;
 
     my @remaining_screenshots = map { $_->filename } $screenshots->search(undef, {order_by => 'filename'});


### PR DESCRIPTION
These are mostly micro optimizations to speed up the screenshot deletion loop a bit. Just in case the `unlink` syscalls are not the sole bottleneck in the `limit_screenshots` job.

1. `imagesdir()` call has been moved out of the loops.
2. `log_debug` call has been moved out of the inner loop into the outer loop (less function call, but still an indication for the job still being active in the logs).
3. Change `fetchrow_arrayref` loop to `fetchall_arrayref` call (`DBD::Pg` always retrieves all results at once anyway, so repetitive `fetchrow_arrayref` calls only cause overhead).
4. Combine two `unlink` calls to one (does not reduce the number of syscalls unfortunately, but is a little faster).