### PR TITLE
Highlight dependency jobs in the overview page

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -64,6 +64,9 @@ function setupOverview() {
         var elementA = document.createElement('a');
         elementA.href = '/tests/' + jobid + '#dependencies';
         elementA.title = elementATitle;
+        elementA.className = 'parents_children';
+        elementA.dataset.childrenDeps = "[" + dependencyResult['data-children'].toString() + "]";
+        elementA.dataset.parentsDeps = "[" + dependencyResult['data-parents'].toString() + "]";
         var elementI = document.createElement('i');
         elementI.setAttribute('class', elementIClass);
         elementA.appendChild(elementI);
@@ -126,5 +129,33 @@ function setupOverview() {
         $('#filter-states input').each(function(index, element) {
             element.checked = states[element.id.substr(7)];
         });
+    }
+
+    var parentChild = document.getElementsByClassName('parents_children');
+    for (var i = 0; i < parentChild.length; i++) {
+        parentChild[i].addEventListener('mouseover', highlightDeps);
+        parentChild[i].addEventListener('mouseout', unhighlightDeps);
+    }
+}
+
+function highlightDeps() {
+    var parentData = JSON.parse(this.dataset.parentsDeps);
+    var childData = JSON.parse(this.dataset.childrenDeps);
+    addClassToDependencyJob(parentData, 'highlight_parent');
+    addClassToDependencyJob(childData, 'highlight_child');
+}
+
+function unhighlightDeps() {
+    var parentData = JSON.parse(this.dataset.parentsDeps);
+    var childData = JSON.parse(this.dataset.childrenDeps);
+    addClassToDependencyJob(parentData, '');
+    addClassToDependencyJob(childData, '');
+}
+
+function addClassToDependencyJob(array, className) {
+    for (var i = 0; i < array.length; i++) {
+        var ele = document.getElementsByName("jobid_td_" + array[i])[0];
+        if (ele === undefined) { continue; }
+        ele.parentNode.className = className;
     }
 }

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -84,7 +84,7 @@ function renderTestName(data, type, row) {
         var dependencyResult = showJobDependency(deps);
         var dependencyHtml = '';
         if (dependencyResult['title'] !== undefined) {
-            dependencyHtml = ' <a href="/tests/' + row.id + '" title="' + dependencyResult['title'] + '"' +
+            dependencyHtml = ' <a href="/tests/' + row.id + '" title="' + dependencyResult.title + '"' +
                 highlightJobsHtml(dependencyResult['data-children'], dependencyResult['data-parents']) +
                 '><i class="fa fa-code-branch"></i></a>';
         }

--- a/templates/webapi/test/tr_job_result.html.ep
+++ b/templates/webapi/test/tr_job_result.html.ep
@@ -1,4 +1,4 @@
-<td id="res_<%= $resultid %>">
+<td id="res_<%= $resultid %>" name="jobid_td_<%= $jobid %>">
      % if ($res) {
          % if (is_operator) {
              % if ($state eq "done" || $state eq "cancelled") {


### PR DESCRIPTION
This is a followup for #3287.
1. when putting the mouse over the branch icon:
  a. highlight parent jobs with red color
  b. highlight child jobs with blue color
2. Fix a javascript issue

Related: https://github.com/os-autoinst/openQA/pull/3287#issuecomment-665614031