### PR TITLE
Allow skipping passed children when restarting a job

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -861,6 +861,7 @@ function renderDependencyGraph(container, nodes, edges, cluster, currentNode) {
     });
 
     // insert nodes
+    const nodeIDs = {};
     nodes.forEach(node => {
         var testResultId;
         if (node.result !== 'none') {
@@ -903,18 +904,23 @@ function renderDependencyGraph(container, nodes, edges, cluster, currentNode) {
             startDirectlyAfter: node.directly_chained,
             parallelWith: node.parallel,
         });
+        nodeIDs[node.id] = true;
     });
 
     // insert edges
     edges.forEach(edge => {
-        g.setEdge(edge.from, edge.to, {});
+        if (nodeIDs[edge.from] && nodeIDs[edge.to]) {
+            g.setEdge(edge.from, edge.to, {});
+        }
     });
 
     // insert clusters
     Object.keys(cluster).forEach(clusterId => {
         g.setNode(clusterId, {});
         cluster[clusterId].forEach(child => {
-            g.setParent(child, clusterId);
+            if (nodeIDs[child]) {
+                g.setParent(child, clusterId);
+            }
         });
     });
 

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -329,9 +329,18 @@ have been explicitly defined in a variable for each dependent test suite.
 Checkout the following example sections to get a better understanding.
 
 ===== Handling of related jobs on failure / cancellation / restart
-openQA tries to handle things sensibly when jobs with relations like this either fail, or are manually cancelled or restarted. When a chained or parallel parent fails or is cancelled, all children will be cancelled; if the parent is restarted, all children are also restarted. When a parallel child is restarted, the parent and any other children will also be restarted. When a chained child is restarted, the parent is not restarted; this will usually be fine, but be aware that if an asset uploaded by the chained parent has been cleaned up, the child may fail immediately. To deal with this case, just restart the parent.
+openQA tries to handle things sensibly when jobs with dependencies either fail, or are manually cancelled or restarted:
 
-By default, when a parallel *child* fails or is cancelled, the parent and all other children are also cancelled. This behaviour is intended for closely-related clusters of jobs, e.g. high availability tests, where it's sensible to assume the entire test is invalid if any of its components fails. A special variable can be used to change this behaviour. Setting a parallel parent job's PARALLEL_CANCEL_WHOLE_CLUSTER to any truth-y value (e.g. 1 or 'true') changes this so that, if one of its children fails or is cancelled but the parent has other pending or active children, the parent and the other children will not be cancelled. This behaviour makes more sense if the parent is providing services to the various children but the children themselves are not closely related and a failure of one does not imply that the tests run by the other children and the parent are invalid.
+* When a chained or parallel parent fails or is cancelled, all children will be cancelled.
+* When a parent is restarted, all children are also restarted recursively.
+* When a parallel child is restarted, the parent and siblings will also be restarted.
+* When a *regularly* chained child is restarted, the parent is not restarted. This will usually be fine, but be aware that if an asset uploaded by the chained parent has been cleaned up, the child may fail immediately. To deal with this case, just restart the parent to recreate the asset.
+* When a *directly* chained child is restarted, all directly chained parents are recursively restarted (but not directly chained siblings). Otherwise it would not be possible to guarantee that the jobs run directly after each other on the same worker.
+* When a parallel *child* fails or is cancelled, the parent and all other children are also cancelled. This behaviour is intended for closely-related clusters of jobs, e.g. high availability tests, where it's sensible to assume the entire test is invalid if any of its components fails. A special variable can be used to change this behaviour. Setting a parallel parent job's PARALLEL_CANCEL_WHOLE_CLUSTER to any truth-y value (e.g. 1 or 'true') changes this so that, if one of its children fails or is cancelled but the parent has other pending or active children, the parent and the other children will not be cancelled. This behaviour makes more sense if the parent is providing services to the various children but the children themselves are not closely related and a failure of one does not imply that the tests run by the other children and the parent are invalid.
+
+====== Further notes
+* The API also allows to skip restarting parents via `skip_parents=1` and to skip restarting children via `skip_children=1`. It is also possible to skip restarting only passed/softfailed children via `skip_passed_children=1`.
+* Restarting multiple directly chained children individually is not possible because the parent would be restarted twice which is not possible. So one needs to restart the parent job instead. Use the mentioned `skip_passed_children=1` to restart only failures.
 
 ===== Examples
 ====== Specify machine explicitly

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -339,8 +339,8 @@ openQA tries to handle things sensibly when jobs with dependencies either fail, 
 * When a parallel *child* fails or is cancelled, the parent and all other children are also cancelled. This behaviour is intended for closely-related clusters of jobs, e.g. high availability tests, where it's sensible to assume the entire test is invalid if any of its components fails. A special variable can be used to change this behaviour. Setting a parallel parent job's PARALLEL_CANCEL_WHOLE_CLUSTER to any truth-y value (e.g. 1 or 'true') changes this so that, if one of its children fails or is cancelled but the parent has other pending or active children, the parent and the other children will not be cancelled. This behaviour makes more sense if the parent is providing services to the various children but the children themselves are not closely related and a failure of one does not imply that the tests run by the other children and the parent are invalid.
 
 ====== Further notes
-* The API also allows to skip restarting parents via `skip_parents=1` and to skip restarting children via `skip_children=1`. It is also possible to skip restarting only passed/softfailed children via `skip_passed_children=1`.
-* Restarting multiple directly chained children individually is not possible because the parent would be restarted twice which is not possible. So one needs to restart the parent job instead. Use the mentioned `skip_passed_children=1` to restart only failures.
+* The API also allows to skip restarting parents via `skip_parents=1` and to skip restarting children via `skip_children=1`. It is also possible to skip restarting only passed and softfailed children via `skip_ok_result_children=1`.
+* Restarting multiple directly chained children individually is not possible because the parent would be restarted twice which is not possible. So one needs to restart the parent job instead. Use the mentioned `skip_ok_result_children=1` to restart only jobs which are not ok.
 
 ===== Examples
 ====== Specify machine explicitly

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -40,12 +40,15 @@ or done. Scheduled jobs can't be restarted.
 =cut
 sub job_restart {
     my ($jobids, %args) = @_;
-    my $force        = $args{force};
-    my $skip_parents = $args{skip_parents};
     my (@duplicated, @processed, @errors, @warnings, $enforceable);
     return (\@duplicated, ['No job IDs specified'], \@warnings) unless ref $jobids eq 'ARRAY' && @$jobids;
 
     # duplicate all jobs that are either running or done
+    my $force             = $args{force};
+    my %duplication_flags = (
+        skip_parents         => $args{skip_parents},
+        skip_children        => $args{skip_children},
+        skip_passed_children => $args{skip_passed_children});
     my $schema = OpenQA::Schema->singleton;
     my $jobs   = $schema->resultset("Jobs")->search(
         {
@@ -73,9 +76,14 @@ sub job_restart {
                 next;
             }
         }
-        my $dup = $job->auto_duplicate({skip_parents => $skip_parents});
-        push @duplicated, $dup->{cluster_cloned} if $dup;
-        push @processed,  $job_id;
+        if (my $dup = $job->auto_duplicate(\%duplication_flags)) {
+            push @duplicated, $dup->{cluster_cloned};
+        }
+        else {
+            push @errors,
+              "It is not possible to restart $job_id. The job (or a dependent job) might have already a clone.";
+        }
+        push @processed, $job_id;
     }
 
     # abort running jobs

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -46,9 +46,9 @@ sub job_restart {
     # duplicate all jobs that are either running or done
     my $force             = $args{force};
     my %duplication_flags = (
-        skip_parents         => $args{skip_parents},
-        skip_children        => $args{skip_children},
-        skip_passed_children => $args{skip_passed_children});
+        skip_parents            => $args{skip_parents},
+        skip_children           => $args{skip_children},
+        skip_ok_result_children => $args{skip_ok_result_children});
     my $schema = OpenQA::Schema->singleton;
     my $jobs   = $schema->resultset("Jobs")->search(
         {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -778,8 +778,9 @@ sub cluster_jobs {
         elsif ($pd->dependency eq OpenQA::JobDependencies::Constants::DIRECTLY_CHAINED) {
             push(@{$job->{directly_chained_parents}}, $p->id);
             # duplicate also up the chain to ensure this job ran directly after its directly chained parent
-            # note: We skip the children here to avoid considering "direct siblings".
-            $p->cluster_jobs(jobs => $jobs, skip_children => 1) unless $skip_parents;
+            # notes: - We skip the children here to avoid considering "direct siblings".
+            #        - Going up the chain is not required/wanted when cancelling.
+            $p->cluster_jobs(jobs => $jobs, skip_children => 1) unless $skip_parents || $args{cancelmode};
             next;
         }
         elsif ($pd->dependency eq OpenQA::JobDependencies::Constants::PARALLEL) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -698,11 +698,11 @@ Used for both apiv1_restart and apiv1_restart_jobs
 sub restart {
     my ($self) = @_;
 
+    my @flags      = qw(force skip_parents skip_children skip_passed_children);
     my $validation = $self->validation;
     $validation->optional('jobid')->num(0);
     $validation->optional('jobs');
-    $validation->optional('force')->num(1);
-    $validation->optional('skip_parents')->num(1);
+    $validation->optional($_)->num(1) for @flags;
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
 
     my $jobs = $self->param('jobid');
@@ -715,11 +715,8 @@ sub restart {
         $self->app->log->debug("Restarting jobs @$jobs");
     }
 
-    my ($duplicated, $errors, $warnings, $enforceable) = OpenQA::Resource::Jobs::job_restart(
-        $jobs,
-        defined $validation->param('force')        ? (force        => 1) : (),
-        defined $validation->param('skip_parents') ? (skip_parents => 1) : (),
-    );
+    my @params = map { defined $validation->param($_) ? ($_ => 1) : () } @flags;
+    my ($duplicated, $errors, $warnings, $enforceable) = OpenQA::Resource::Jobs::job_restart($jobs, @params);
     OpenQA::Scheduler::Client->singleton->wakeup;
 
     my @urls;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -688,6 +688,8 @@ Restart job(s).
 
 Use force=1 to force the restart (e.g. despite missing assets).
 Use skip_parents=1 to prevent restarting parent jobs.
+Use skip_children=1 to prevent restarting child jobs.
+Use skip_passed_children=1 to prevent restarting passed child jobs.
 
 Used for both apiv1_restart and apiv1_restart_jobs
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -689,7 +689,7 @@ Restart job(s).
 Use force=1 to force the restart (e.g. despite missing assets).
 Use skip_parents=1 to prevent restarting parent jobs.
 Use skip_children=1 to prevent restarting child jobs.
-Use skip_passed_children=1 to prevent restarting passed child jobs.
+Use skip_ok_result_children=1 to prevent restarting passed/softfailed child jobs.
 
 Used for both apiv1_restart and apiv1_restart_jobs
 
@@ -700,7 +700,7 @@ Used for both apiv1_restart and apiv1_restart_jobs
 sub restart {
     my ($self) = @_;
 
-    my @flags      = qw(force skip_parents skip_children skip_passed_children);
+    my @flags      = qw(force skip_parents skip_children skip_ok_result_children);
     my $validation = $self->validation;
     $validation->optional('jobid')->num(0);
     $validation->optional('jobs');

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -47,6 +47,7 @@ is_deeply(
     {
         99961 => {
             is_parent_or_initial_job  => 1,
+            ok                        => 0,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -56,6 +57,7 @@ is_deeply(
         },
         99963 => {
             is_parent_or_initial_job  => 1,
+            ok                        => 0,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -75,6 +77,7 @@ is_deeply(
     {
         99982 => {
             is_parent_or_initial_job  => 1,
+            ok                        => 0,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -84,6 +87,7 @@ is_deeply(
         },
         99983 => {
             is_parent_or_initial_job  => 1,
+            ok                        => 0,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -46,6 +46,7 @@ is_deeply(
     $job->cluster_jobs,
     {
         99961 => {
+            is_parent_or_initial_job  => 1,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -54,6 +55,7 @@ is_deeply(
             parallel_parents          => [],
         },
         99963 => {
+            is_parent_or_initial_job  => 1,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -72,6 +74,7 @@ is_deeply(
     $new_job->cluster_jobs,
     {
         99982 => {
+            is_parent_or_initial_job  => 1,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -80,6 +83,7 @@ is_deeply(
             parallel_parents          => [],
         },
         99983 => {
+            is_parent_or_initial_job  => 1,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -412,7 +412,7 @@ sub exp_cluster_jobs_for {
 
     # note: The actual dependency info is the same for every job within the cluster.
     #       The only difference is the 'is_parent_or_initial_job' flag (which is used
-    #       for the feature to skip passed children).
+    #       to implement the 'skip_ok_result_children' parameter).
 
     # C is only a child when starting from B
     $exp_cluster_jobs{$jobC->id}{is_parent_or_initial_job} = ($job ne 'B') ? 1 : 0;
@@ -1388,7 +1388,7 @@ subtest 'WORKER_CLASS validated when creating directly chained dependencies' => 
     );
 };
 
-subtest 'skip passed children' => sub {
+subtest 'skip "ok" children' => sub {
     # create a cluster
     #                -> child-1-passed
     #               /
@@ -1407,13 +1407,13 @@ subtest 'skip passed children' => sub {
     $_->discard_changes for @all_jobs;
 
     # duplicate parent
-    $parent->auto_duplicate({skip_passed_children => 1});
+    $parent->auto_duplicate({skip_ok_result_children => 1});
     $_->discard_changes for @all_jobs;
 
     my $clone = $parent->clone;
     subtest 'jobs have been cloned/skipped as expected' => sub {
         isnt($clone, undef, 'parent has been cloned because it is the direct job to be restarted');
-        is($child_1->clone_id, undef, 'child-1 has not been cloned because it is passed');
+        is($child_1->clone_id, undef, 'child-1 has not been cloned because it is ok');
         isnt($child_2->clone_id,         undef, 'child-2 has been cloned because its child failed');
         isnt($child_2_child_1->clone_id, undef, 'child-2-child-1 has been cloned because it failed');
         isnt($child_3->clone_id,         undef, 'child-3 has been cloned because it failed');

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -354,6 +354,7 @@ my %exp_cluster_jobs = (
         directly_chained_children => [],
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 1,
+        ok                        => 0,
     },
     $jobB->id => {
         chained_children          => [],
@@ -363,6 +364,7 @@ my %exp_cluster_jobs = (
         directly_chained_children => [],
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 1,
+        ok                        => 0,
     },
     $jobC->id => {
         chained_children          => [],
@@ -372,6 +374,7 @@ my %exp_cluster_jobs = (
         directly_chained_children => [],
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
+        ok                        => 0,
     },
     $jobD->id => {
         chained_children          => [],
@@ -381,6 +384,7 @@ my %exp_cluster_jobs = (
         directly_chained_children => [],
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
+        ok                        => 0,
     },
     $jobE->id => {
         chained_children          => [],
@@ -390,6 +394,7 @@ my %exp_cluster_jobs = (
         directly_chained_children => [],
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
+        ok                        => 0,
     },
     $jobF->id => {
         chained_children          => [],
@@ -399,6 +404,7 @@ my %exp_cluster_jobs = (
         directly_chained_children => [],
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
+        ok                        => 0,
     },
 );
 sub exp_cluster_jobs_for {

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -73,6 +73,7 @@ is_deeply(
             parallel_children         => [],
             chained_children          => [],
             directly_chained_children => [],
+            is_parent_or_initial_job  => 1,
         },
     },
     '99926 has no siblings'
@@ -97,11 +98,15 @@ for my $job ($job1, $job2) {
 }
 is_deeply($job1, $job2, 'duplicated job equal');
 
-subtest 'restart jobs' => sub {
+subtest 'restart job which has already been cloned' => sub {
     my ($duplicated, $errors, $warnings) = OpenQA::Resource::Jobs::job_restart([99926]);
     is_deeply($duplicated, [], 'no job ids returned') or diag explain $duplicated;
-    is_deeply($errors,     [], 'no errors')           or diag explain $errors;
-    is_deeply($warnings,   [], 'no warnings')         or diag explain $warnings;
+    is_deeply(
+        $errors,
+        ['It is not possible to restart 99926. The job (or a dependent job) might have already a clone.'],
+        'error returned'
+    ) or diag explain $errors;
+    is_deeply($warnings, [], 'no warnings') or diag explain $warnings;
 };
 
 $jobs = list_jobs();
@@ -132,6 +137,7 @@ subtest 'restart with (directly) chained child' => sub {
         job_get_rs(99937)->cluster_jobs,
         {
             99937 => {
+                is_parent_or_initial_job  => 1,
                 chained_parents           => [99926],
                 chained_children          => [99938],
                 parallel_parents          => [],
@@ -140,6 +146,7 @@ subtest 'restart with (directly) chained child' => sub {
                 directly_chained_children => [],
             },
             99938 => {
+                is_parent_or_initial_job  => 0,
                 chained_parents           => [99937],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -179,6 +186,7 @@ subtest 'restart with (directly) chained child' => sub {
         {
             99926 => {
                 children_skipped          => 1,
+                is_parent_or_initial_job  => 1,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -187,6 +195,7 @@ subtest 'restart with (directly) chained child' => sub {
                 directly_chained_children => [],
             },
             99937 => {
+                is_parent_or_initial_job  => 1,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -195,6 +204,7 @@ subtest 'restart with (directly) chained child' => sub {
                 directly_chained_children => [99938],
             },
             99938 => {
+                is_parent_or_initial_job  => 0,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -235,6 +245,7 @@ is_deeply(
     job_get_rs(99963)->cluster_jobs,
     {
         99963 => {
+            is_parent_or_initial_job  => 1,
             chained_parents           => [],
             chained_children          => [],
             parallel_parents          => [99961],
@@ -243,6 +254,7 @@ is_deeply(
             directly_chained_children => [],
         },
         99961 => {
+            is_parent_or_initial_job  => 1,
             chained_parents           => [],
             chained_children          => [],
             parallel_parents          => [],

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -74,6 +74,7 @@ is_deeply(
             chained_children          => [],
             directly_chained_children => [],
             is_parent_or_initial_job  => 1,
+            ok                        => 0,
         },
     },
     '99926 has no siblings'
@@ -138,6 +139,7 @@ subtest 'restart with (directly) chained child' => sub {
         {
             99937 => {
                 is_parent_or_initial_job  => 1,
+                ok                        => 0,
                 chained_parents           => [99926],
                 chained_children          => [99938],
                 parallel_parents          => [],
@@ -147,6 +149,7 @@ subtest 'restart with (directly) chained child' => sub {
             },
             99938 => {
                 is_parent_or_initial_job  => 0,
+                ok                        => 0,
                 chained_parents           => [99937],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -187,6 +190,7 @@ subtest 'restart with (directly) chained child' => sub {
             99926 => {
                 children_skipped          => 1,
                 is_parent_or_initial_job  => 1,
+                ok                        => 0,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -196,6 +200,7 @@ subtest 'restart with (directly) chained child' => sub {
             },
             99937 => {
                 is_parent_or_initial_job  => 1,
+                ok                        => 0,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -205,6 +210,7 @@ subtest 'restart with (directly) chained child' => sub {
             },
             99938 => {
                 is_parent_or_initial_job  => 0,
+                ok                        => 0,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -246,6 +252,7 @@ is_deeply(
     {
         99963 => {
             is_parent_or_initial_job  => 1,
+            ok                        => 0,
             chained_parents           => [],
             chained_children          => [],
             parallel_parents          => [99961],
@@ -255,6 +262,7 @@ is_deeply(
         },
         99961 => {
             is_parent_or_initial_job  => 1,
+            ok                        => 0,
             chained_parents           => [],
             chained_children          => [],
             parallel_parents          => [],

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -222,15 +222,15 @@ subtest 'job overview' => sub {
 
 $schema->txn_begin;
 
-subtest 'restart jobs' => sub {
-    $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})
-      ->status_is(200);
+subtest 'restart jobs, error handling' => sub {
+    $t->post_ok('/api/v1/jobs/restart', form => {jobs => [99981, 99963, 99946, 99945, 99927, 99939]})->status_is(200);
     $t->json_is(
         '/errors' => [
-                "Job 99939 misses the following mandatory assets: iso/openSUSE-Factory-DVD-x86_64-Build0048-Media.iso\n"
-              . 'Ensure to provide mandatory assets and/or force retriggering if necessary.'
+            "Job 99939 misses the following mandatory assets: iso/openSUSE-Factory-DVD-x86_64-Build0048-Media.iso\n"
+              . 'Ensure to provide mandatory assets and/or force retriggering if necessary.',
+            'It is not possible to restart 99945. The job (or a dependent job) might have already a clone.'
         ],
-        'error for missing asset'
+        'error for missing asset of 99939, error for 99945 being already duplicated'
     );
 };
 
@@ -264,7 +264,7 @@ subtest 'prevent restarting parents' => sub {
 $schema->txn_rollback;
 
 subtest 'restart jobs (forced)' => sub {
-    $t->post_ok('/api/v1/jobs/restart?force=1', form => {jobs => [99981, 99963, 99962, 99946, 99945, 99927, 99939]})
+    $t->post_ok('/api/v1/jobs/restart?force=1', form => {jobs => [99981, 99963, 99946, 99945, 99927, 99939]})
       ->status_is(200);
     $t->json_is(
         '/warnings' => [

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -69,7 +69,7 @@
                                 <li>Any kind of chained child jobs are restarted.</li>
                                 <li>Directly chained parent jobs are restarted.</li>
                             </ul>
-                            All rules are applied recursively. Direct use of the REST-API allows excluding parents.', undef, undef, 'bottom');
+                            All rules are applied recursively. Direct use of the REST-API allows excluding parents and (passed) children.', undef, undef, 'bottom');
                         %>
                     % }
                     % if (is_operator && ($job->state eq 'running' || $job->state eq 'scheduled')) {

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -69,7 +69,8 @@
                                 <li>Any kind of chained child jobs are restarted.</li>
                                 <li>Directly chained parent jobs are restarted.</li>
                             </ul>
-                            All rules are applied recursively. Direct use of the REST-API allows excluding parents and (passed) children.', undef, undef, 'bottom');
+                            All rules are applied recursively. Direct use of the REST-API allows excluding parents and (passed/softfailed) children.',
+                            'https://open.qa/docs/#_handling_of_related_jobs_on_failure_cancellation_restart', 'documentation', 'bottom');
                         %>
                     % }
                     % if (is_operator && ($job->state eq 'running' || $job->state eq 'scheduled')) {


### PR DESCRIPTION
* This is particularly useful for directly chained dependencies where it
  does not make sense to restart failed children on-by-one.
* For consistency, expose the ability to skip children generally via the
  API as well. That means it is now possible to skip restarting parents and
  children and only passed children.
* Also improve the error message when restarting is not possible.
* See https://progress.opensuse.org/issues/68956#note-22