### PR TITLE
`make test-with-database`: add -I$(PWD)/t/lib back to PERL5OPT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,10 +161,12 @@ test-scheduler:
 test-developer:
 	$(MAKE) test-with-database DEVELOPER_FULLSTACK=1 TIMEOUT_M=10 PROVE_ARGS="$$HARNESS t/33-developer_mode.t" RETRY=3
 
+# we have apparently-redundant -I args in PERL5OPT here because Docker
+# only works with one and Fedora's build system only works with the other
 .PHONY: test-with-database
 test-with-database:
 	test -d $(TEST_PG_PATH) && (pg_ctl -D $(TEST_PG_PATH) -s status >&/dev/null || pg_ctl -D $(TEST_PG_PATH) -s start) || ./t/test_postgresql $(TEST_PG_PATH)
-	PERL5OPT="$(PERL5OPT) -It/lib -MOpenQA::Test::PatchDeparse" $(MAKE) test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)"
+	PERL5OPT="$(PERL5OPT) -It/lib -I$(PWD)/t/lib -MOpenQA::Test::PatchDeparse" $(MAKE) test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)"
 	-[ $(KEEP_DB) = 1 ] || pg_ctl -D $(TEST_PG_PATH) stop
 
 .PHONY: test-unit-and-integration


### PR DESCRIPTION
As discussed in https://github.com/os-autoinst/openQA/pull/3194
while changing `-I$(PWD)/t/lib` to `-It/lib` made things work in
Docker, it broke them in Fedora's build system. We really don't
know why and it's a bit of a mystery, but it seems easier to just
have both than try and figure out the causes.

Signed-off-by: Adam Williamson <awilliam@redhat.com>