### PR TITLE
Fix support for multiple params with the same name in api command

### DIFF
--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -80,7 +80,14 @@ sub parse_headers {
 
 sub parse_params {
     my ($self, @args) = @_;
-    return {map { /^([[:alnum:]_\[\]\.]+)=(.+)$/s ? ($1, $2) : () } @args};
+
+    my %params;
+    for my $arg (@args) {
+        next unless $arg =~ /^([[:alnum:]_\[\]\.]+)=(.*)$/s;
+        push @{$params{$1}}, $2;
+    }
+
+    return \%params;
 }
 
 sub run {

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -105,10 +105,9 @@ is($driver->find_element('#user-action a')->get_text(), 'Login', 'no one initial
 $driver->click_element_ok('Login', 'link_text');
 $driver->title_is('openQA', 'back on main page');
 
-$OpenQA::Test::FullstackUtils::JOB_SETUP .= 'TESTING_ASSERT_SCREEN_TIMEOUT=1';
 # setting TESTING_ASSERT_SCREEN_TIMEOUT is important here (see os-autoinst/t/data/tests/tests/boot.pm)
-
-schedule_one_job_over_api_and_verify($driver);
+schedule_one_job_over_api_and_verify($driver,
+    OpenQA::Test::FullstackUtils::job_setup(TESTING_ASSERT_SCREEN_TIMEOUT => '1'));
 my $job_name = 'tinycore-1-flavor-i386-Build1-core@coolone';
 $driver->find_element_by_link_text('core@coolone')->click();
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -257,6 +257,27 @@ subtest 'Parameters' => sub {
     $data = decode_json $stdout;
     is $data->{method}, 'GET', 'GET request';
     is_deeply $data->{params}, {valid => '1'}, 'params';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http', 'jobs=1611', 'jobs=1610') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {jobs => [1611, 1610]}, 'params';
+    is $data->{body}, 'jobs=1611&jobs=1610', 'request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http', 'test1=', 'test2=3') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {test1 => '', test2 => 3}, 'params';
+    is $data->{body}, 'test1=&test2=3', 'request body';
+
+    ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http', 'jobs=1611', 'foo=bar', 'jobs=1610') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {foo => 'bar', jobs => [1611, 1610]}, 'params';
+    is $data->{body}, 'foo=bar&jobs=1611&jobs=1610', 'request body';
 };
 
 subtest 'JSON' => sub {

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -98,8 +98,7 @@ $driver->title_is('openQA', 'back on main page');
 $driver->click_element_ok('dont-notify', 'id', 'Selected to not notify about tour');
 $driver->click_element_ok('confirm',     'id', 'Clicked confirm about no tour');
 
-my $job_setup = $OpenQA::Test::FullstackUtils::JOB_SETUP;
-schedule_one_job_over_api_and_verify($driver, $job_setup . ' PAUSE_AT=shutdown');
+schedule_one_job_over_api_and_verify($driver, OpenQA::Test::FullstackUtils::job_setup(PAUSE_AT => 'shutdown'));
 
 sub status_text { find_status_text($driver) }
 
@@ -176,8 +175,8 @@ stop_worker;
 ok wait_for_result_panel($driver, qr/Result: incomplete/), 'test 2 crashed';
 like status_text, qr/Cloned as 3/, 'test 2 is restarted by killing worker';
 
-my $JOB_SETUP = $OpenQA::Test::FullstackUtils::JOB_SETUP;
-client_call("-X POST jobs $job_setup MACHINE=noassets HDD_1=nihilist_disk.hda");
+client_call(
+    '-X POST jobs ' . OpenQA::Test::FullstackUtils::job_setup(MACHINE => 'noassets', HDD_1 => 'nihilist_disk.hda'));
 
 subtest 'cancel a scheduled job' => sub {
     $driver->click_element_ok('All Tests', 'link_text', 'Clicked All Tests');
@@ -265,7 +264,7 @@ subtest 'Cache tests' => sub {
     }
     ok $cache_client->info->available_workers, 'cache service worker is available';
     $job_name = 'tinycore-1-flavor-i386-Build1-core@coolone';
-    client_call("-X POST jobs $job_setup PUBLISH_HDD_1=");
+    client_call('-X POST jobs ' . OpenQA::Test::FullstackUtils::job_setup(PUBLISH_HDD_1 => ''));
     $driver->get('/tests/5');
     like status_text, qr/State: scheduled/, 'test 5 is scheduled' or die;
     start_worker_and_schedule;
@@ -351,7 +350,7 @@ subtest 'Cache tests' => sub {
     like $log_content, qr/\+\+\+\ worker notes \+\+\+/, 'Test 7 has worker notes';
     like((split(/\n/, $log_content))[0],  qr/\+\+\+ setup notes \+\+\+/,   'Test 7 has setup notes');
     like((split(/\n/, $log_content))[-1], qr/uploading autoinst-log.txt/i, 'Test 7 uploaded autoinst-log (as last)');
-    client_call("-X POST jobs $job_setup HDD_1=non-existent.qcow2");
+    client_call('-X POST jobs ' . OpenQA::Test::FullstackUtils::job_setup(HDD_1 => 'non-existent.qcow2'));
     schedule_one_job;
     $driver->get('/tests/8');
     ok wait_for_result_panel($driver, qr/Result: incomplete/), 'test 8 is incomplete';

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -32,15 +32,34 @@ use Time::HiRes 'sleep';
 use OpenQA::SeleniumTest;
 use OpenQA::Scheduler::Model::Jobs;
 
-our $JOB_SETUP
-  = 'ISO=Core-7.2.iso DISTRI=tinycore ARCH=i386 QEMU=i386 '
-  . 'FLAVOR=flavor BUILD=1 MACHINE=coolone QEMU_NO_TABLET=1 INTEGRATION_TESTS=1 '
-  . 'QEMU_NO_FDC_SET=1 CDMODEL=ide-cd HDDMODEL=ide-drive VERSION=1 TEST=core PUBLISH_HDD_1=core-hdd.qcow2 '
-  . 'UEFI_PFLASH_VARS=/usr/share/qemu/ovmf-x86_64.bin';
+my $JOB_SETUP = {
+    ISO               => 'Core-7.2.iso',
+    DISTRI            => 'tinycore',
+    ARCH              => 'i386',
+    QEMU              => 'i386',
+    FLAVOR            => 'flavor',
+    BUILD             => '1',
+    MACHINE           => 'coolone',
+    QEMU_NO_TABLET    => '1',
+    INTEGRATION_TESTS => '1',
+    QEMU_NO_FDC_SET   => '1',
+    CDMODEL           => 'ide-cd',
+    HDDMODEL          => 'ide-drive',
+    VERSION           => '1',
+    TEST              => 'core',
+    PUBLISH_HDD_1     => 'core-hdd.qcow2',
+    UEFI_PFLASH_VARS  => '/usr/share/qemu/ovmf-x86_64.bin'
+};
 
 # speedup using virtualization support if available, results should be
 # equivalent, just saving some time
-$JOB_SETUP .= ' QEMU_NO_KVM=1' unless -r '/dev/kvm';
+$JOB_SETUP->{QEMU_NO_KVM} = '1' unless -r '/dev/kvm';
+
+sub job_setup {
+    my %override = @_;
+    my $new      = {%$JOB_SETUP, %override};
+    return join ' ', map { "$_=$new->{$_}" } sort keys %$new;
+}
 
 sub get_connect_args {
     my $mojoport = OpenQA::SeleniumTest::get_mojoport;
@@ -193,7 +212,6 @@ sub verify_one_job_displayed_as_scheduled {
 
 sub schedule_one_job_over_api_and_verify {
     my ($driver, $job_setup) = @_;
-    $job_setup //= $JOB_SETUP;
     client_call("-X POST jobs $job_setup");
     return verify_one_job_displayed_as_scheduled($driver);
 }


### PR DESCRIPTION
Simple fix for a problem @Martchus noticed last week. Makes `openqa-cli api -X POST jobs/restart jobs=1611 jobs=1610` work.