### PR TITLE
Add tests for GNU style arguments

### DIFF
--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -166,7 +166,15 @@ subtest 'HTTP features' => sub {
     $data = decode_json $stdout;
     is $data->{method}, 'POST', 'POST request';
 
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X=POST', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+
     ($stdout, @result) = capture_stdout sub { $api->run(@host, '--method', 'POST', 'test/pub/http') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '--method=POST', 'test/pub/http') };
     $data = decode_json $stdout;
     is $data->{method}, 'POST', 'POST request';
 


### PR DESCRIPTION
Just to make sure GNU style options actually work (since it's an extra option in `Getopt::Long`).