### PR TITLE
Add gru download assets by using job settings

### DIFF
--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -49,7 +49,9 @@ $t->ua(
     OpenQA::Client->new(apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02')->ioloop(Mojo::IOLoop->singleton));
 $t->app($app);
 
-my $gru_tasks = $t->app->schema->resultset('GruTasks');
+my $gru_tasks        = $t->app->schema->resultset('GruTasks');
+my $gru_dependencies = $t->app->schema->resultset('GruDependencies');
+my $test_suites      = $t->app->schema->resultset('TestSuites');
 
 sub schedule_iso {
     my ($args, $status, $query_params) = @_;
@@ -111,7 +113,7 @@ sub check_job_setting {
 
 sub job_gru {
     my $job_id = shift;
-    return $t->app->schema->resultset('GruDependencies')->search({job_id => $job_id})->single->gru_task->id;
+    return $gru_dependencies->search({job_id => $job_id})->single->gru_task->id;
 }
 
 my $expected_job_count = 10;
@@ -129,20 +131,20 @@ my %params = (DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 
 $rsp = schedule_iso({%params, ISO_URL => 'http://localhost/nonexistent.iso'});
 is($rsp->json->{count}, $expected_job_count, 'a regular ISO post creates the expected number of jobs');
 check_download_asset('non-existent ISO',
-    ['http://localhost/nonexistent.iso', locate_asset('iso', 'nonexistent.iso', mustexist => 0), 0]);
+    ['http://localhost/nonexistent.iso', [locate_asset('iso', 'nonexistent.iso', mustexist => 0)], 0]);
 check_job_setting($t, $rsp, 'ISO', 'nonexistent.iso', 'parameter ISO is correctly set from ISO_URL');
 
 # Schedule download and uncompression of a non-existing HDD
 $rsp = schedule_iso({%iso, HDD_1_DECOMPRESS_URL => 'http://localhost/nonexistent.hda.xz'});
 is($rsp->json->{count}, $expected_job_count, 'a regular ISO post creates the expected number of jobs');
 check_download_asset('non-existent HDD (with uncompression)',
-    ['http://localhost/nonexistent.hda.xz', locate_asset('hdd', 'nonexistent.hda', mustexist => 0), 1]);
+    ['http://localhost/nonexistent.hda.xz', [locate_asset('hdd', 'nonexistent.hda', mustexist => 0)], 1]);
 check_job_setting($t, $rsp, 'HDD_1', 'nonexistent.hda', 'parameter HDD_1 correctly set from HDD_1_DECOMPRESS_URL');
 
 # Schedule download of a non-existing ISO with a custom target name
 $rsp = schedule_iso({%iso, ISO_URL => 'http://localhost/nonexistent2.iso', ISO => 'callitthis.iso'});
 check_download_asset('non-existent ISO (with custom name)',
-    ['http://localhost/nonexistent2.iso', locate_asset('iso', 'callitthis.iso', mustexist => 0), 0]);
+    ['http://localhost/nonexistent2.iso', [locate_asset('iso', 'callitthis.iso', mustexist => 0)], 0]);
 check_job_setting($t, $rsp, 'ISO', 'callitthis.iso', 'parameter ISO is not overwritten when ISO_URL is set');
 
 # Schedule download and uncompression of a non-existing kernel with a custom target name
@@ -154,7 +156,7 @@ $rsp = schedule_iso(
     });
 is($rsp->json->{count}, $expected_job_count, 'a regular ISO post creates the expected number of jobs');
 check_download_asset('non-existent kernel (with uncompression, custom name',
-    ['http://localhost/nonexistvmlinuz', locate_asset('other', 'callitvmlinuz', mustexist => 0), 1]);
+    ['http://localhost/nonexistvmlinuz', [locate_asset('other', 'callitvmlinuz', mustexist => 0)], 1]);
 check_job_setting($t, $rsp, 'KERNEL', 'callitvmlinuz',
     'parameter KERNEL is not overwritten when KERNEL_DECOMPRESS_URL is set');
 
@@ -205,5 +207,85 @@ foreach my $j (@{$rsp->json->{ids}}) {
     is $ret->{state}, 'done';
     like $ret->{result}, qr/incomplete|skipped/, 'Job skipped/incompleted';
 }
+
+sub get_gru_tasks {
+    my $job_ids = shift;
+    my %gru_task_ids;
+    foreach my $job_id (@$job_ids) {
+        my @gru_dependencies = $gru_dependencies->search({job_id => $job_id});
+        foreach my $gru_dependency (@gru_dependencies) {
+            my $gru_id = $gru_dependency->gru_task->id;
+            if ($gru_task_ids{$gru_id}) {
+                push @{$gru_task_ids{$gru_id}}, $job_id;
+                next;
+            }
+            $gru_task_ids{$gru_id} = [$job_id];
+        }
+    }
+    return \%gru_task_ids;
+}
+
+subtest 'handle _URL in job settings' => sub {
+    $test_suites->find({name => 'kde'})->settings->create({key => 'HDD_1_URL', value => 'http://localhost/test.qcow2'});
+    $rsp = schedule_iso({%iso, TEST => 'kde'}, 200);
+    is $rsp->json->{count}, 1, 'one job was scheduled';
+    $gru = job_gru($rsp->json->{ids}->[0]);
+    check_download_asset('download asset when _URL in test suite settings',
+        ['http://localhost/test.qcow2', [locate_asset('hdd', 'test.qcow2', mustexist => 0)], 0]);
+};
+
+subtest 'create one download task when there is HDD_1_URL in isos post command' => sub {
+    $rsp = schedule_iso({%iso, HDD_1_URL => 'http://localhost/test.qcow2'}, 200);
+    is $rsp->json->{count}, $expected_job_count, 'ten job were scheduled';
+    my $gru_task_ids = get_gru_tasks($rsp->json->{ids});
+    is scalar(keys %$gru_task_ids), 1, 'only one download task was created';
+    my @value = values %$gru_task_ids;
+    is scalar(@{$value[0]}), $expected_job_count, 'ten job were blocked by the same download task';
+    check_download_asset('download asset was created',
+        ['http://localhost/test.qcow2', [locate_asset('hdd', 'test.qcow2', mustexist => 0)], 0]);
+};
+
+subtest 'create many download tasks when many test suites have different _URL' => sub {
+    $test_suites->find({name => 'textmode'})
+      ->settings->create({key => 'HDD_1_URL', value => 'http://localhost/test_textmode.qcow2'});
+    $test_suites->find({name => 'server'})
+      ->settings->create({key => 'HDD_1_URL', value => 'http://localhost/test_server.qcow2'});
+    $rsp = schedule_iso(\%iso, 200);
+    is $rsp->json->{count}, $expected_job_count, 'ten job was scheduled';
+    my $gru_task_ids = get_gru_tasks($rsp->json->{ids});
+    is scalar(keys %$gru_task_ids), 3, 'three download tasks were created';
+    my $expected_download_tasks = {
+        'http://localhost/test.qcow2'          => [locate_asset('hdd', 'test.qcow2',          mustexist => 0)],
+        'http://localhost/test_textmode.qcow2' => [locate_asset('hdd', 'test_textmode.qcow2', mustexist => 0)],
+        'http://localhost/test_server.qcow2'   => [locate_asset('hdd', 'test_server.qcow2',   mustexist => 0)],
+    };
+    my %created_download_tasks;
+    foreach my $gru_id (keys %$gru_task_ids) {
+        my $args = $gru_tasks->find($gru_id)->args;
+        $created_download_tasks{$args->[0]} = $args->[1];
+    }
+    is_deeply \%created_download_tasks, $expected_download_tasks, 'the download tasks were created correctly';
+};
+
+subtest 'create one download task when test suites have different destinations' => sub {
+    $test_suites->find({name => 'textmode'})->settings->create({key => 'HDD_1', value => 'test_textmode.qcow2'});
+    $test_suites->find({name => 'server'})->settings->create({key => 'HDD_1', value => 'test_server.qcow2'});
+    $test_suites->find({name => 'kde'})->settings->create({key => 'HDD_1', value => 'test_kde.qcow2'});
+    $rsp = schedule_iso({%iso, HDD_1_URL => 'http://localhost/test.qcow2'}, 200);
+    is $rsp->json->{count}, $expected_job_count, 'ten job was scheduled';
+    my @gru_task_ids = keys %{get_gru_tasks($rsp->json->{ids})};
+    is scalar(@gru_task_ids), 1, 'only one download task was created';
+    my $args = $gru_tasks->find($gru_task_ids[0])->args;
+    is $args->[0], 'http://localhost/test.qcow2', 'the url was correct';
+    my @destinations = sort @{$args->[1]};
+    is_deeply \@destinations,
+      [
+        locate_asset('hdd', 'test.qcow2',          mustexist => 0),
+        locate_asset('hdd', 'test_kde.qcow2',      mustexist => 0),
+        locate_asset('hdd', 'test_server.qcow2',   mustexist => 0),
+        locate_asset('hdd', 'test_textmode.qcow2', mustexist => 0)
+      ],
+      'one download task has 4 destinations';
+};
 
 done_testing();


### PR DESCRIPTION
Failed to create assets download lists when trigger jobs by using 'isos
post' without '_URL=' arguments, even though the test suites or others
already have a setting '_URL'. This is because the assets download lists
is created by using arguments.
Change this behavior to use job settings.

See: https://progress.opensuse.org/issues/62159