### PR TITLE
Streamline "duplicate" and "restart" routes

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright (C) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@ use OpenQA::Schema::Result::Jobs;
 use OpenQA::Events;
 use Mojo::RabbitMQ::Client::Publisher;
 
-my @job_events     = qw(job_create job_delete job_cancel job_duplicate job_restart job_update_result job_done);
+my @job_events     = qw(job_create job_delete job_cancel job_restart job_update_result job_done);
 my @comment_events = qw(comment_create comment_update comment_delete);
 
 sub new {

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -21,7 +21,7 @@ use Mojo::JSON 'to_json';
 use OpenQA::Events;
 
 my @table_events = qw(table_create table_update table_delete);
-my @job_events   = qw(job_create job_delete job_cancel job_duplicate job_restart jobs_restart job_update_result
+my @job_events   = qw(job_create job_delete job_cancel job_restart jobs_restart job_update_result
   job_done job_grab job_cancel_by_settings);
 my @jobgroup_events    = qw(jobgroup_create jobgroup_update jobgroup_delete jobgroup_connect);
 my @jobtemplate_events = qw(jobtemplate_create jobtemplate_delete);

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -100,14 +100,14 @@ for my $job ($job1, $job2) {
 is_deeply($job1, $job2, 'duplicated job equal');
 
 subtest 'restart job which has already been cloned' => sub {
-    my ($duplicated, $errors, $warnings) = OpenQA::Resource::Jobs::job_restart([99926]);
-    is_deeply($duplicated, [], 'no job ids returned') or diag explain $duplicated;
+    my $res = OpenQA::Resource::Jobs::job_restart([99926]);
+    is_deeply($res->{duplicates}, [], 'no job ids returned') or diag explain $res->{duplicates};
     is_deeply(
-        $errors,
+        $res->{errors},
         ['It is not possible to restart 99926. The job (or a dependent job) might have already a clone.'],
         'error returned'
-    ) or diag explain $errors;
-    is_deeply($warnings, [], 'no warnings') or diag explain $warnings;
+    ) or diag explain $res->{errors};
+    is_deeply($res->{warnings}, [], 'no warnings') or diag explain $res->{warnings};
 };
 
 $jobs = list_jobs();
@@ -163,7 +163,7 @@ subtest 'restart with (directly) chained child' => sub {
     my $job_before_restart = job_get(99937);
 
     # restart the job
-    my ($duplicated) = OpenQA::Resource::Jobs::job_restart([99937]);
+    my $duplicated = OpenQA::Resource::Jobs::job_restart([99937])->{duplicates};
     is(scalar @$duplicated, 1, 'one job id returned');
     my $job_after_restart = job_get(99937);
 
@@ -225,7 +225,7 @@ subtest 'restart with (directly) chained child' => sub {
     $job_before_restart = job_get(99937);
 
     # restart the job
-    ($duplicated) = OpenQA::Resource::Jobs::job_restart([99937]);
+    $duplicated = OpenQA::Resource::Jobs::job_restart([99937])->{duplicates};
     is(scalar @$duplicated, 1, 'one job id returned') or diag explain $duplicated;
     $job_after_restart = job_get(99937);
 

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -121,15 +121,12 @@ is($assets[0],     $theasset, 'the assigned asset is the same');
 
 # test asset is not assigned to scheduled jobs after duping
 my $jobA_id = $jobA->id;
-my ($duplicates, $errors, $warnings) = job_restart([$jobA_id]);
-is(@$duplicates, 1, 'one duplicate');
-is(@$errors,     0, 'no errors') or diag explain $errors;
-is(@$warnings,   0, 'no warnings') or diag explain $warnings;
+my $res     = job_restart([$jobA_id]);
+is(@{$res->{duplicates}}, 1, 'one duplicate');
+is(@{$res->{errors}},     0, 'no errors') or diag explain $res->{errors};
+is(@{$res->{warnings}},   0, 'no warnings') or diag explain $res->{warnings};
 
-my $cloneA = $schema->resultset('Jobs')->find(
-    {
-        id => $duplicates->[0]->{$jobA_id},
-    });
+my $cloneA = $schema->resultset('Jobs')->find($res->{duplicates}->[0]->{$jobA_id});
 @assets = $cloneA->jobs_assets;
 @assets = map { $_->asset_id } @assets;
 is($assets[0], $theasset, 'clone does have the same asset assigned');

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -172,20 +172,20 @@ subtest 'duplicate and cancel job' => sub {
     $t->post_ok("/api/v1/jobs/$job/duplicate")->status_is(200);
     my $newjob = $t->tx->res->json->{id};
     is_deeply(
-        $published{'suse.openqa.job.duplicate'},
+        $published{'suse.openqa.job.restart'},
         {
-            "ARCH"      => "x86_64",
-            "BUILD"     => "666",
-            "FLAVOR"    => "pink",
-            "ISO"       => "whatever.iso",
-            "MACHINE"   => "RainbowPC",
-            "TEST"      => "rainbow",
-            "auto"      => 0,
-            "bugref"    => undef,
-            "group_id"  => undef,
-            "id"        => $job,
-            "remaining" => 1,
-            "result"    => $newjob
+            id        => $job,
+            result    => {$job => $newjob},
+            auto      => 0,
+            ARCH      => 'x86_64',
+            BUILD     => '666',
+            FLAVOR    => 'pink',
+            ISO       => 'whatever.iso',
+            MACHINE   => 'RainbowPC',
+            TEST      => 'rainbow',
+            bugref    => undef,
+            group_id  => undef,
+            remaining => 1,
         },
         'job duplicate triggers amqp'
     );


### PR DESCRIPTION
* Drop the "job_duplicate" event; only emit "job_restart" events
* Keep the slightly different behavior of "restart" and "duplicate" in
  place for compatibility
* Point out the difference between the "duplicate" and "restart" route
* Point out that the "dup_type_auto" parameter has only informal purposes
* Support all the options in both routes
* Allow passing zero values to flag parameters in order to disable defaults
* Share the same implementation
* Improve returning results of "job_restart" (at some point returning an
  array becomes unhandy)
* Add explicit test for the "duplicate" route
* See https://progress.opensuse.org/issues/69997