### PR TITLE
Improve error messages when cloning a job

### DIFF
--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -77,12 +77,12 @@ sub job_restart {
                 next;
             }
         }
-        if (my $dup = $job->auto_duplicate(\%duplication_args)) {
-            push @duplicates, $dup->{cluster_cloned};
+        my $cloned_job_or_error = $job->auto_duplicate(\%duplication_args);
+        if (ref $cloned_job_or_error) {
+            push @duplicates, $cloned_job_or_error->{cluster_cloned};
         }
         else {
-            push @errors,
-              "It is not possible to restart $job_id. The job (or a dependent job) might have already a clone.";
+            push @errors, ($cloned_job_or_error // "An internal error occurred when duplicating $job_id");
         }
         push @processed, $job_id;
     }

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -485,7 +485,7 @@ sub incomplete_and_duplicate_stale_jobs {
                         reason => "abandoned: associated $worker_info has not sent any status updates for too long",
                     );
                     my $res = $job->auto_duplicate;
-                    if ($res) {
+                    if (ref $res) {
                         log_warning(sprintf('Dead job %d aborted and duplicated %d', $job->id, $res->id));
                     }
                     else {
@@ -495,7 +495,7 @@ sub incomplete_and_duplicate_stale_jobs {
             });
     }
     catch {
-        log_info("Failed stale job detection : $_");
+        log_info("Failed stale job detection: $_");
     };
 }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -636,7 +636,7 @@ sub _create_clone {
     # not be created, somebody else was faster at cloning)
     my $orig_id       = $self->id;
     my $affected_rows = $rset->search({id => $orig_id, clone_id => undef})->update({clone_id => $new_job->id});
-    die "Job $orig_id has already been cloned as " . $self->clone_id unless $affected_rows == 1;
+    die "Job $orig_id has already been cloned as " . $self->clone_id . "\n" unless $affected_rows == 1;
 
     # Needed to load default values from DB
     $new_job->discard_changes;
@@ -848,7 +848,7 @@ sub _cluster_children {
 =item Arguments: optional hash reference containing the key 'prio'
 
 =item Return value: hash of duplicated jobs if duplication suceeded,
-                    undef otherwise
+                    an error message otherwise
 
 =back
 
@@ -881,23 +881,29 @@ for DIRECTLY_CHAINED dependencies:
 sub duplicate {
     my ($self, $args) = @_;
     $args ||= {};
-    my $schema = $self->result_source->schema;
 
     # If the job already has a clone, none is created
-    return unless $self->can_be_duplicated;
+    my ($orig_id, $clone_id) = ($self->id, $self->clone_id);
+    return "Job $orig_id is still scheduled"                   if $self->state eq SCHEDULED;
+    return "Job $orig_id has already been cloned as $clone_id" if defined $clone_id;
 
     my $jobs = $self->cluster_jobs(skip_parents => $args->{skip_parents}, skip_children => $args->{skip_children});
-    log_debug("Jobs to duplicate " . dump($jobs));
-    try {
-        $schema->txn_do(sub { $self->_create_clones($jobs, $args->{prio}, $args->{skip_ok_result_children}); });
-    }
-    catch {
-        my $error = shift;
-        log_debug("rollback duplicate: $error");
-        die "Rollback failed during failed job cloning!"
-          if ($error =~ /Rollback failed/);
-        $jobs = undef;
+    log_debug('Duplicating jobs: ' . dump($jobs));
+    eval {
+        $self->result_source->schema->txn_do(
+            sub { $self->_create_clones($jobs, $args->{prio}, $args->{skip_ok_result_children}) });
     };
+    if (my $error = $@) {
+        chomp $error;
+        $error =~ s/ at .* line \d*$// if $error =~ s/^\{UNKNOWN\}\: //;
+        if ($error =~ /Rollback failed/) {
+            log_error("Unable to roll back after duplication error: $error");
+            return "Rollback failed after failure to clone cluster of job $orig_id";
+        }
+        return $error if $error =~ /has already been cloned/;
+        log_warning("Duplication rolled back after error: $error");
+        return "An internal error occurred when cloning cluster of job $orig_id";
+    }
 
     return $jobs;
 }
@@ -906,42 +912,31 @@ sub duplicate {
 
 =over
 
-=item Arguments: HASHREF { dup_type_auto => SCALAR }
-
-=item Return value: ID of new job
+=item Return value: DBIx object of cloned job with information about the cloned cluster accessible
+                    as `$clone->{cluster_cloned}` or an error message.
 
 =back
 
-Handle individual job restart including associated job and asset dependencies. Note that
-the caller is responsible to notify the workers about the new job - the model is not doing that.
-
-I.e.
-    $job->auto_duplicate;
+Handle individual job restart including dependent jobs and asset dependencies. Note that
+the caller is responsible to notify the workers about the new job.
 
 =cut
 sub auto_duplicate {
     my ($self, $args) = @_;
     $args //= {};
-    # set this clone was triggered by manually if it's not auto-clone
-    $args->{dup_type_auto} //= 0;
 
-    my $job_id = $self->id;
     my $clones = $self->duplicate($args);
-    if (!$clones) {
-        log_debug("Duplication of job $job_id failed");
-        return undef;
-    }
+    return $clones unless ref $clones eq 'HASH';
 
     # abort jobs in the old cluster (exclude the original $args->{jobid})
+    my $job_id  = $self->id;
     my $rsource = $self->result_source;
-    my $jobs    = $rsource->schema->resultset("Jobs")->search(
+    my $jobs    = $rsource->schema->resultset('Jobs')->search(
         {
             id    => {'!=' => $job_id, '-in' => [keys %$clones]},
             state => [PRE_EXECUTION_STATES, EXECUTION_STATES],
         });
-
     $jobs->search({result => NONE})->update({result => PARALLEL_RESTARTED});
-
     while (my $j = $jobs->next) {
         next if $j->abort;
         next unless $j->state eq SCHEDULED || $j->state eq ASSIGNED;
@@ -950,18 +945,10 @@ sub auto_duplicate {
     }
 
     my $clone_id = $clones->{$job_id}->{clone};
+    my $dup      = $rsource->resultset->find($clone_id);
+    $dup->{cluster_cloned} = {map { $_ => $clones->{$_}->{clone} } keys %$clones};
     log_debug("Job $job_id duplicated as $clone_id");
-
-    # Attach all clones mapping to new job object
-    # TODO: better return a proper hash here
-    my $dup = $rsource->resultset->find($clone_id);
-    $dup->_cluster_cloned($clones);
     return $dup;
-}
-
-sub _cluster_cloned {
-    my ($self, $clones) = @_;
-    $self->{cluster_cloned} = {map { $_ => $clones->{$_}->{clone} } sort keys %$clones};
 }
 
 sub abort {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -539,11 +539,7 @@ Checks if a given job can be duplicated - not cloned yet and in correct state.
 =cut
 sub can_be_duplicated {
     my ($self) = @_;
-
-    my $state = $self->state;
-    return unless (grep { /$state/ } (EXECUTION_STATES, FINAL_STATES));
-    return if $self->clone;
-    return 1;
+    return (!defined $self->clone_id) && ($self->state ne SCHEDULED);
 }
 
 sub _compute_asset_names_considering_parent_jobs {

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -228,7 +228,7 @@ subtest 'Simulation of heavy unstable load' => sub {
     dead_workers($schema);
 
     # duplicate latest jobs ignoring failures
-    my @duplicated = map { $_->auto_duplicate // () } $schema->resultset('Jobs')->latest_jobs;
+    my @duplicated = map { my $dup = $_->auto_duplicate; ref $dup ? $dup : () } $schema->resultset('Jobs')->latest_jobs;
     my $nr         = $ENV{OPENQA_SCHEDULER_TEST_UNRESPONSIVE_COUNT} // 50;
     @workers = map { unresponsive_worker(@$worker_settings, $_) } (1 .. $nr);
     my $i = 2;

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -59,7 +59,7 @@ ok(@$current_jobs, "have jobs");
 my $job1 = job_get(99927);
 is($job1->{state}, OpenQA::Jobs::Constants::SCHEDULED, 'trying to duplicate scheduled job');
 my $job = job_get_rs(99927)->auto_duplicate;
-ok(!defined $job, "duplication rejected");
+is($job, 'Job 99927 is still scheduled', 'duplication rejected');
 
 $job1 = job_get(99926);
 is($job1->{state}, OpenQA::Jobs::Constants::DONE, 'trying to duplicate done job');
@@ -102,11 +102,8 @@ is_deeply($job1, $job2, 'duplicated job equal');
 subtest 'restart job which has already been cloned' => sub {
     my $res = OpenQA::Resource::Jobs::job_restart([99926]);
     is_deeply($res->{duplicates}, [], 'no job ids returned') or diag explain $res->{duplicates};
-    is_deeply(
-        $res->{errors},
-        ['It is not possible to restart 99926. The job (or a dependent job) might have already a clone.'],
-        'error returned'
-    ) or diag explain $res->{errors};
+    is_deeply($res->{errors}, ['Job 99926 has already been cloned as 99982'], 'error returned')
+      or diag explain $res->{errors};
     is_deeply($res->{warnings}, [], 'no warnings') or diag explain $res->{warnings};
 };
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -56,8 +56,8 @@ is($minimalx->state, "done",      "original test keeps its state");
 is($clone->state,    "scheduled", "the new job is scheduled");
 
 # Second attempt
-ok($minimalx->can_be_duplicated, "looks cloneable");
-is($minimalx->duplicate, undef, "cannot clone again");
+ok($minimalx->can_be_duplicated, 'looks cloneable');
+is($minimalx->duplicate, 'Job 99926 has already been cloned as 99982', 'cannot clone again');
 
 # Reload minimalx from the database
 $minimalx->discard_changes;
@@ -66,8 +66,8 @@ is($minimalx->clone->id, $clone->id,    "relationship works");
 is($clone->origin->id,   $minimalx->id, "reverse relationship works");
 
 # After reloading minimalx, it doesn't look cloneable anymore
-ok(!$minimalx->can_be_duplicated, "doesn't look cloneable after reloading");
-is($minimalx->duplicate, undef, "cannot clone after reloading");
+ok(!$minimalx->can_be_duplicated, 'does not look cloneable after reloading');
+is($minimalx->duplicate, 'Job 99926 has already been cloned as 99982', 'cannot clone after reloading');
 
 # But cloning the clone should be possible after job state change
 $clone->state(OpenQA::Jobs::Constants::CANCELLED);

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -228,9 +228,9 @@ subtest 'restart jobs, error handling' => sub {
         '/errors' => [
             "Job 99939 misses the following mandatory assets: iso/openSUSE-Factory-DVD-x86_64-Build0048-Media.iso\n"
               . 'Ensure to provide mandatory assets and/or force retriggering if necessary.',
-            'It is not possible to restart 99945. The job (or a dependent job) might have already a clone.'
+            'Job 99945 has already been cloned as 99946'
         ],
-        'error for missing asset of 99939, error for 99945 being already duplicated'
+        'error for missing asset of 99939, error for 99945 being already cloned'
     );
 };
 


### PR DESCRIPTION
* Return expected exceptions to the user as error messages
* Avoid returning random exceptions like database errors
* Improve logging
* See https://progress.opensuse.org/issues/69871