### PR TITLE
Make global search more responsive

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -268,6 +268,8 @@ function htmlEscape(str) {
 }
 
 function renderSearchResults(query, url) {
+    var spinner = document.getElementById('progress-indication');
+    spinner.style.display = 'block';
     var request = new XMLHttpRequest();
     request.open('GET', '/api/v1/experimental/search?q=' + encodeURIComponent(query));
     request.setRequestHeader('Accept', 'application/json');
@@ -284,9 +286,12 @@ function renderSearchResults(query, url) {
             request.onerror();
             return;
         }
+        spinner.style.display = 'none';
         var heading = document.getElementById('results-heading');
         heading.appendChild(document.createTextNode(': ' + json.data.length + ' matches found'));
-        var results = document.getElementById('results');
+        var results = document.createElement('div');
+        results.id = 'results';
+        results.className = 'list-group';
         json.data.forEach(function(value, index) {
             var item = document.createElement('div');
             item.className = 'list-group-item';
@@ -305,8 +310,11 @@ function renderSearchResults(query, url) {
             }
             results.append(item);
         });
+        var oldResults = document.getElementById('results');
+        oldResults.parentElement.replaceChild(results, oldResults);
     };
     request.onerror = function() {
+        spinner.style.display = 'none';
         var msg = this.statusText;
         try {
             var json = JSON.parse(this.responseText);

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -50,6 +50,7 @@ sub read_config {
             changelog_file              => '/usr/share/openqa/public/Changelog',
             job_investigate_ignore      => '"(JOBTOKEN|NAME)"',
             job_investigate_git_timeout => 20,
+            search_results_limit        => 50000,
         },
         rate_limits => {
             search => 5,

--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -37,6 +37,12 @@ subtest 'Perl modules' => sub {
     );
 };
 
+subtest 'Limits' => sub {
+    $t->app->config->{global}->{search_results_limit} = 1;
+    $t->get_ok('/api/v1/experimental/search?q=test', 'Extensive search with limit');
+    is scalar @{$t->tx->res->json->{data}}, 1, 'capped at one match';
+};
+
 subtest 'Errors' => sub {
     $t->get_ok('/api/v1/experimental/search', 'Search succesful');
     $t->json_is('/error' => 'Erroneous parameters (q missing)', 'no search terms results in error');

--- a/t/config.t
+++ b/t/config.t
@@ -56,6 +56,7 @@ subtest 'Test configuration default modes' => sub {
             changelog_file              => '/usr/share/openqa/public/Changelog',
             job_investigate_ignore      => '"(JOBTOKEN|NAME)"',
             job_investigate_git_timeout => 20,
+            search_results_limit        => 50000,
         },
         rate_limits => {
             search => 5,

--- a/templates/webapi/search/search.html.ep
+++ b/templates/webapi/search/search.html.ep
@@ -10,6 +10,10 @@
     <p>The search currently finds Perl modules within the test distributions,
        either by <b>filename</b> or <b>source code</b>.</p>
     <div id="flash-messages"></div>
+    <p id="progress-indication" style="display: none">
+        <i class="fa fa-cog fa-spin fa-3x fa-fw"></i>
+        <span class="sr-only">Loading…</span>
+    </p>
     <div id="results" class="list-group">
     </div>
 </div>


### PR DESCRIPTION
- Show a spinner while results are being fetched
- Append results only after creating the elements
- Limit the total amount of matches (configurable)

Performance measured with `(performance.now() - t0).toFixed(1)` went from 3700 to 2900 with a big resultset on the same system.