### PR TITLE
Decouple SeleniumTest::wait_until from jQuery

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -187,7 +187,12 @@ sub wait_for_ajax {
     my $slept          = 0;
     my $msg            = $args{msg} ? (': ' . $args{msg}) : '';
 
-    while (!$_driver->execute_script('return window.jQuery && jQuery.active === 0')) {
+    if (!$_driver->execute_script('window.jQuery')) {
+        note("There is no jQuery here$msg");
+        return undef;
+    }
+
+    while (!$_driver->execute_script('jQuery.active === 0')) {
         if ($timeout <= 0) {
             fail("Wait for jQuery timed out$msg");
             return undef;


### PR DESCRIPTION
This leads to an inflated timeout when used without *jQuery* because the property will not become available, for example `wait_for_element` which calls it in each iteration.

Conceptually I think we should wait on a specific element or the jQuery status in general, rather than mixing both.

Note: I noticed this while working on #3313 because a test failure simply timed out in CI and the timeout never expired.