### PR TITLE
Make openqa-cli set a non-zero exit code on failures

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -55,9 +55,7 @@ sub command {
     my $client = $self->client($url);
     my $tx     = $client->build_tx($method, $url, $headers, @data);
     $tx = $client->start($tx);
-    $self->handle_result($tx, {pretty => $pretty, quiet => $quiet, verbose => $verbose});
-
-    return 0;
+    return $self->handle_result($tx, {pretty => $pretty, quiet => $quiet, verbose => $verbose});
 }
 
 1;

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -71,6 +71,8 @@ sub handle_result {
 
     if    ($options->{pretty} && $is_json) { print $JSON->encode($res->json) }
     elsif (length(my $body = $res->body))  { say $body }
+
+    return $err ? 1 : 0;
 }
 
 sub parse_headers {

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -125,26 +125,32 @@ subtest 'Client' => sub {
 
 subtest 'Simple request with authentication' => sub {
     my ($stdout, $stderr, @result) = capture sub { $api->run(@host, 'test/op/hello') };
+    is_deeply \@result, [1], 'non-zero exit code';
     like $stderr, qr/403/, 'not authenticated';
     like $stdout, qr/403/, 'not authenticated';
 
     ($stdout, $stderr, @result) = capture sub { $api->run(@host, '-q', 'test/op/hello') };
+    is_deeply \@result, [1], 'non-zero exit code';
     is $stderr,   '',      'quiet';
     like $stdout, qr/403/, 'not authenticated';
 
     ($stdout, $stderr, @result) = capture sub { $api->run(@host, '--quiet', 'test/op/hello') };
+    is_deeply \@result, [1], 'non-zero exit code';
     is $stderr,   '',      'quiet';
     like $stdout, qr/403/, 'not authenticated';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@auth, 'test/op/hello') };
+    is_deeply \@result, [0], 'zero exit code';
     unlike $stdout, qr/200 OK.*Content-Type:/s, 'not verbose';
     like $stdout,   qr/Hello operator!/,        'operator response';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@auth, '--verbose', 'test/op/hello') };
+    is_deeply \@result, [0], 'zero exit code';
     like $stdout, qr/200 OK.*Content-Type:/s, 'verbose';
     like $stdout, qr/Hello operator!/,        'operator response';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@auth, '--v', 'test/op/hello') };
+    is_deeply \@result, [0], 'zero exit code';
     like $stdout, qr/200 OK.*Content-Type:/s, 'verbose';
     like $stdout, qr/Hello operator!/,        'operator response';
 };


### PR DESCRIPTION
This came up on Rocket Chat. Trivial change to make shell scripting with `openqa-cli api` a bit easier.