### PR TITLE
Merge module search results from the same file

### DIFF
--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -31,7 +31,8 @@ subtest 'Perl modules' => sub {
     $t->json_is(
         '/data/1' => {
             occurrence => 'opensuse/tests/installation/installer_timezone.pm',
-            contents   => qq{    assert_screen "inst-timezone", 125 || die 'no timezone';}
+            contents   => qq{    3 # Summary: Verify timezone settings page\n}
+              . qq{   11     assert_screen "inst-timezone", 125 || die 'no timezone';}
         },
         'contents found'
     );

--- a/t/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm
+++ b/t/data/openqa/share/tests/opensuse/tests/installation/installer_timezone.pm
@@ -1,4 +1,8 @@
 #!/usr/bin/env perl
+
+# Summary: Verify timezone settings page
+# Maintainer: Allison Average <allison@example.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -61,7 +61,9 @@ subtest 'Perl modules' => sub {
     my $second = $entries[1];
     is $second->child('.occurrence')->get_text(), 'opensuse/tests/installation/installer_timezone.pm',
       'expected occurrence';
-    is $second->child('.contents')->get_text(), qq{    assert_screen "inst-timezone", 125 || die 'no timezone';},
+    is $second->child('.contents')->get_text(),
+      qq{    3 # Summary: Verify timezone settings page\n}
+      . qq{   11     assert_screen "inst-timezone", 125 || die 'no timezone';},
       'expected contents';
 };
 


### PR DESCRIPTION
- Enable line numbers on matches
- Merge subsequent matches with the same filename
- Specify split limit to avoid : in source getting parsed

![image](https://user-images.githubusercontent.com/1204189/90528360-cf614080-e172-11ea-936b-32a3ab47bb43.png)

Note: As a side effect the total of results is reduced significantly which speeds up client-side rendering.