### PR TITLE
Omit files in the test root from test search

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -88,6 +88,9 @@ sub query {
     my $keywords = $validation->param('q');
     my $distris  = path(OpenQA::Utils::testcasedir);
     for my $distri ($distris->list({dir => 1})->each) {
+        # Skip files residing in the test root
+        next unless -d $distri;
+
         # Perl module filenames
         for my $filename (
             $distri->list_tree()->head($cap)->map('to_rel', $distris)->grep(qr/.*\Q$keywords\E.*\.pm$/)->each)


### PR DESCRIPTION
This fixes the following error on osd:
    Grep failed: fatal:
    cannot change to '/var/lib/openqa/share/tests/old-tests-sle12-and_older.tar.xz': Not a directory

For whatever reason the test root contains old archived tests which trips up the search, which assumes folders containing test distributions.