### PR TITLE
packaging: do not abuse %{_libexecdir} for systemd directories

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -528,7 +528,7 @@ fi
 %config %{_sysconfdir}/apparmor.d/usr.share.openqa.script.worker
 # init
 %dir %{_unitdir}
-%{_libexecdir}/systemd/system-generators
+%{_systemdgeneratordir}
 %{_unitdir}/openqa-worker.target
 %{_unitdir}/openqa-worker@.service
 %{_unitdir}/openqa-worker-cacheservice-minion.service


### PR DESCRIPTION
With %{_libexcdir} changing from /usr/lib to /usr/libexec, this would
no longer work in the not too far future.