### PR TITLE
Fix PRODUCT issue when trigger a particular job

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -119,7 +119,7 @@ Please try 'curl $json_url' or select another job, e.g. in the same scenario: $h
         old_productdir=$(echo "$json_data" | jq -r '.PRODUCTDIR') || throw_json_error "$json_url" "$json_data"
         local old_casedir
         old_casedir=$(echo "$json_data" | jq -r '.CASEDIR') || throw_json_error "$json_url" "$json_data"
-        local productdir="${productdir:-"${repo_name##*/}${old_productdir##$old_casedir}"}"
+        local productdir="${productdir:-"${repo_name##*/}${old_productdir#*${old_casedir##*/}}"}"
         local old_needledir
         old_needledir=$(echo "$json_data" | jq -r '.NEEDLES_DIR | select (.!=null)') || throw_json_error "$json_url" "$json_data"
         local needles_dir="${needles_dir:-"$old_needledir"}"


### PR DESCRIPTION
In general, the PRODUCTDIR and CASEDIR in a job settings are:

```
CASRDIR    = /var/lib/openqa/cache/openqa.suse.de/tests/sle
PRODUCTDIR = /var/lib/openqa/cache/openqa.suse.de/tests/sle/products/sle
```
But in some particular jobs, such as
https://openqa.suse.de/tests/4427385 or the job which is triggered by
openqa-clone-custom-git-refspec, its PRODUCTDIR is different:

```
CASEDIR    = /var/lib/openqa/pool/25/os-autoinst-distri-opensuse
PRODUCTDIR = os-autoinst-distri-opensuse/products/sle
```
So we could not use the general way to produce the PRODUCTDIR in this
script. For the particular job, when using
openqa-clone-custom-git-refspec to trigger it, the PRODUCTDIR is
reproduced wrongly in current code, e.g.
`PRODUCTDIR="os-autoinst-distri-opensuseos-autoinst-distri-opensuse/products/sle"`