### PR TITLE
Emit jobgroup_create with an ID

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -255,7 +255,7 @@ sub create {
         return $self->render(json => {error => $@}, status => 400);
     }
 
-    $self->emit_event(openqa_jobgroup_create => $properties);
+    $self->emit_event(openqa_jobgroup_create => {id => $id});
     $self->render(json => {id => $id});
 }
 
@@ -297,7 +297,7 @@ sub update {
         return $self->render(json => {error => $@}, status => 400);
     }
 
-    $self->emit_event(openqa_jobgroup_update => $properties);
+    $self->emit_event(openqa_jobgroup_update => {id => $id});
     $self->render(json => {id => $id});
 }
 


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/49202

Note: Currently `$properties` typically carries the name of the group. As per conversations I'm simply replacing it with the ID.