### PR TITLE
Deduplicate test distribution listings in search

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -87,7 +87,7 @@ sub query {
     my @results;
     my $keywords = $validation->param('q');
     my $distris  = path(OpenQA::Utils::testcasedir);
-    for my $distri ($distris->list({dir => 1})->each) {
+    for my $distri ($distris->list({dir => 1})->map('realpath')->uniq()->each) {
         # Skip files residing in the test root
         next unless -d $distri;
 


### PR DESCRIPTION
Due to the special symlink setup, sle and opensuse distributions currently lead to redundant results. This can be fixed by making sure we only look at unique resolved paths.

Note: As a side effect the total of results is reduced significantly which speeds up client-side rendering.

See: [poo#34486](https://progress.opensuse.org/issues/34486)