### PR TITLE
Fix scheduling directly chained dependencies when not all children restarted

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -759,6 +759,7 @@ sub cluster_jobs {
         # additional information for skip_ok_result_children
         is_parent_or_initial_job => ($args{added_as_child} ? 0 : 1),
         ok                       => $self->is_ok,
+        state                    => $self->state,
     };
 
     # fill dependency data; go up recursively if we have a directly chained or parallel parent

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -18,6 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
+use OpenQA::Jobs::Constants;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::WebSockets::Client;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
@@ -48,6 +49,7 @@ is_deeply(
         99961 => {
             is_parent_or_initial_job  => 1,
             ok                        => 0,
+            state                     => RUNNING,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -58,6 +60,7 @@ is_deeply(
         99963 => {
             is_parent_or_initial_job  => 1,
             ok                        => 0,
+            state                     => RUNNING,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -78,6 +81,7 @@ is_deeply(
         99982 => {
             is_parent_or_initial_job  => 1,
             ok                        => 0,
+            state                     => SCHEDULED,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],
@@ -88,6 +92,7 @@ is_deeply(
         99983 => {
             is_parent_or_initial_job  => 1,
             ok                        => 0,
+            state                     => SCHEDULED,
             chained_children          => [],
             chained_parents           => [],
             directly_chained_children => [],

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -164,6 +164,7 @@ $jobB->set_prio(2);
 $jobC->set_prio(4);
 $_->set_prio(1) for ($jobD, $jobE, $jobF);
 _schedule();
+$_->discard_changes for ($jobA, $jobB, $jobC, $jobD, $jobE, $jobF);
 
 subtest 'vlan setting' => sub {
     my @jobs_in_expected_order = (
@@ -192,6 +193,7 @@ my %exp_cluster_jobs = (
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 1,
         ok                        => 0,
+        state                     => RUNNING,
     },
     $jobB->id => {
         chained_children          => [],
@@ -202,6 +204,7 @@ my %exp_cluster_jobs = (
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 1,
         ok                        => 0,
+        state                     => RUNNING,
     },
     $jobC->id => {
         chained_children          => [],
@@ -212,6 +215,7 @@ my %exp_cluster_jobs = (
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
         ok                        => 0,
+        state                     => RUNNING,
     },
     $jobD->id => {
         chained_children          => [],
@@ -222,6 +226,7 @@ my %exp_cluster_jobs = (
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
         ok                        => 0,
+        state                     => RUNNING,
     },
     $jobE->id => {
         chained_children          => [],
@@ -232,6 +237,7 @@ my %exp_cluster_jobs = (
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
         ok                        => 0,
+        state                     => RUNNING,
     },
     $jobF->id => {
         chained_children          => [],
@@ -242,6 +248,7 @@ my %exp_cluster_jobs = (
         directly_chained_parents  => [],
         is_parent_or_initial_job  => 0,
         ok                        => 0,
+        state                     => RUNNING,
     },
 );
 sub exp_cluster_jobs_for {

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -18,6 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
+use OpenQA::Jobs::Constants;
 use OpenQA::JobDependencies::Constants;
 use OpenQA::Resource::Jobs;
 use OpenQA::Resource::Locks;
@@ -62,7 +63,6 @@ my $job = job_get_rs(99927)->auto_duplicate;
 is($job, 'Job 99927 is still scheduled', 'duplication rejected');
 
 $job1 = job_get(99926);
-is($job1->{state}, OpenQA::Jobs::Constants::DONE, 'trying to duplicate done job');
 is_deeply(
     job_get_rs(99926)->cluster_jobs,
     {
@@ -75,9 +75,10 @@ is_deeply(
             directly_chained_children => [],
             is_parent_or_initial_job  => 1,
             ok                        => 0,
+            state                     => DONE,
         },
     },
-    '99926 has no siblings'
+    '99926 has no siblings and is DONE'
 );
 $job = job_get_rs(99926)->auto_duplicate;
 ok(defined $job, "duplication works");
@@ -137,6 +138,7 @@ subtest 'restart with (directly) chained child' => sub {
             99937 => {
                 is_parent_or_initial_job  => 1,
                 ok                        => 0,
+                state                     => DONE,
                 chained_parents           => [99926],
                 chained_children          => [99938],
                 parallel_parents          => [],
@@ -147,6 +149,7 @@ subtest 'restart with (directly) chained child' => sub {
             99938 => {
                 is_parent_or_initial_job  => 0,
                 ok                        => 0,
+                state                     => DONE,
                 chained_parents           => [99937],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -188,6 +191,7 @@ subtest 'restart with (directly) chained child' => sub {
                 children_skipped          => 1,
                 is_parent_or_initial_job  => 1,
                 ok                        => 0,
+                state                     => DONE,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -198,6 +202,7 @@ subtest 'restart with (directly) chained child' => sub {
             99937 => {
                 is_parent_or_initial_job  => 1,
                 ok                        => 0,
+                state                     => DONE,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -208,6 +213,7 @@ subtest 'restart with (directly) chained child' => sub {
             99938 => {
                 is_parent_or_initial_job  => 0,
                 ok                        => 0,
+                state                     => DONE,
                 chained_parents           => [],
                 chained_children          => [],
                 parallel_parents          => [],
@@ -250,6 +256,7 @@ is_deeply(
         99963 => {
             is_parent_or_initial_job  => 1,
             ok                        => 0,
+            state                     => RUNNING,
             chained_parents           => [],
             chained_children          => [],
             parallel_parents          => [99961],
@@ -260,6 +267,7 @@ is_deeply(
         99961 => {
             is_parent_or_initial_job  => 1,
             ok                        => 0,
+            state                     => RUNNING,
             chained_parents           => [],
             chained_children          => [],
             parallel_parents          => [],


### PR DESCRIPTION
* PR https://github.com/os-autoinst/openQA/pull/3300 allows avoiding the
  restart of passed/softfailed children. However, so far the scheduler can
  not deal with the situation when not all directly chained children have
  been restarted and just skips the new directly chained job cluster.
* This change tries to fix that by simply ignoring direct (sub)chains which
  are not scheduled (which means they have not bene restarted).
* See https://progress.opensuse.org/issues/68956#note-33