### PR TITLE
Slice find_most_recent_event to only get one result

### DIFF
--- a/t/lib/OpenQA/Test/Case.pm
+++ b/t/lib/OpenQA/Test/Case.pm
@@ -79,13 +79,10 @@ sub trim_whitespace {
 sub find_most_recent_event {
     my ($schema, $event) = @_;
 
-    my $results
-      = $schema->resultset('AuditEvents')->search({event => $event}, {limit => 1, order_by => {-desc => 'id'}});
-    return undef unless $results;
-    if (my $result = $results->next) {
-        return decode_json($result->event_data);
-    }
-    return undef;
+    my $result
+      = $schema->resultset('AuditEvents')->find({event => $event}, {rows => 1, order_by => {-desc => 'id'}});
+    return undef unless $result;
+    return decode_json($result->event_data);
 }
 
 1;


### PR DESCRIPTION
The {limit =>} qualifier is a no-op. There is no difference in the result except it's faster when there's many events.