### PR TITLE
Bump max_redirects in OpenQA::Downloader to 5

### DIFF
--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -26,7 +26,7 @@ use Try::Tiny;
 has attempts => 5;
 has [qw(log tmpdir)];
 has sleep_time => 5;
-has ua         => sub { Mojo::UserAgent->new(max_redirects => 2, max_response_size => 0) };
+has ua         => sub { Mojo::UserAgent->new(max_redirects => 5, max_response_size => 0) };
 
 sub download {
     my ($self, $url, $target, $options) = (shift, shift, shift, shift // {});


### PR DESCRIPTION
The old limit could be hit easily:

https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2
http://ftp.uni-erlangen.de/pub/mirrors/opensuse/tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-15.1.0-kvm-and-xen-Snapshot20200824.qcow2
http://ftp.uni-erlangen.de/pub/opensuse/tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-15.1.0-kvm-and-xen-Snapshot20200824.qcow2
http://ftp.uni-erlangen.de/opensuse/tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-15.1.0-kvm-and-xen-Snapshot20200824.qcow2

Bump it to 5 to have some more room.