### PR TITLE
Fix nightly dependency checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
                 curl -s https://api.github.com/repos/os-autoinst/os-autoinst/commits | grep sha | head -n 1 | grep -o -E '[0-9a-f]{40}' > .circleci/autoinst.sha
                 git add .circleci/ci-packages.txt .circleci/autoinst.sha
                 # these might have changed by tidy in .circleci/build_dependencies.sh
-                git add cpanfile tools/* script/* lib/* t/*
+                git add cpanfile dbicdh dependencies.yaml tools/* script/* lib/* t/*
                 git commit -m "Dependency cron $depid"
                 git push -q -f https://token@github.com/openqabot/openQA.git dependency_$depid
                 hub pull-request -m "Dependency cron $depid" --base "$CIRCLE_PROJECT_USERNAME":"$CIRCLE_BRANCH" --head "openqabot:dependency_$depid"


### PR DESCRIPTION
Add dbicdh and dependencies.yaml to the files that might have been changed by perltidy

Last PR was failing because of that: https://github.com/os-autoinst/openQA/pull/3342