### PR TITLE
Render serial results inline when collapsed

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -113,10 +113,10 @@ function renderModuleRow(module, snippets) {
             elem = E('span', [elem], {
                 title: title,
                 'data-href': href,
-                'class': (step.is_parser_text_result ? 'external-result text-result' : 'text-result'),
+                'class': 'text-result',
                 onclick: 'toggleTextPreview(this)'
             });
-            stepnodes.push(E('div', [elem], { 'class': 'links_a text-result-container' }));
+            stepnodes.push(E('div', [elem], { 'class': 'links_a ' + (step.is_parser_text_result ? 'external-result-container' : 'serial-result-container') }));
             continue;
         }
 

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -583,7 +583,7 @@ function renderTestModules(response) {
     // enable the external tab if there are text results
     // note: It would be more efficient to query "regular details" and external results in one go because both
     //       are just a different representation of the same data.
-    if (document.getElementsByClassName('external-result').length) {
+    if (document.getElementsByClassName('external-result-container').length) {
         showTabNavElement('external');
     }
 

--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -47,6 +47,7 @@
 
 .links > div {
     display: inline-block;
+    margin-top: 3px;
 }
 
 .links .fa-caret-up {

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -166,9 +166,6 @@ span.thumbnail {
 span.thumbnail.current {
     box-shadow: 0 0 3px 4px #666;
 }
-td .resborder {
-    margin-top: 3px;
-}
 .resborder {
     border: solid 3px;
     padding: 0px;
@@ -218,14 +215,9 @@ span.resborder_na {
     overflow: hidden;
     padding: 4px;
 }
-.text-result-container {
-    display: inline-block !important;
-    width: 100%;
-}
 .text-result {
     display: block;
     width: 100%;
-
     .resborder {
         min-width: -moz-available;
         min-width: -webkit-fill-available;
@@ -245,10 +237,38 @@ span.resborder_na {
         white-space: pre-wrap;
         overflow-wrap: break-word;
     }
-    &[title="wait_serial"] .resborder {
+}
+.external-result-container, .serial-result-container.current_preview {
+    display: inline-block !important;
+    width: 100%;
+}
+.serial-result-container {
+    margin-right: 3px;
+    cursor: pointer;
+    .resborder {
+        background-position: 1000px 1000px;
         background-repeat: no-repeat;
+        width: 60px;  // in accordance with the thumbnail width
+        height: 45px; // in accordance with the thumbnail height
+        font-size: 60%;
+        overflow: hidden;
+        .step_actions {
+            display: none;
+        }
+    }
+}
+.serial-result-container.current_preview {
+    margin-right: 0px;
+    cursor: initial;
+    .resborder {
+        width: initial;
+        height: initial;
         background-position: 0% 0%;
         padding-left: 40px;
+        font-size: 100%;
+        .step_actions {
+            display: initial;
+        }
     }
 }
 .current_preview .text-result .resborder {

--- a/templates/webapi/test/module_table.html.ep
+++ b/templates/webapi/test/module_table.html.ep
@@ -48,11 +48,11 @@
                         % my $resborder = $step->{resborder};
                         % my $is_external_result           = $step->{is_parser_text_result};
                         % my $is_external_or_serial_result = $is_external_result || $title eq 'wait_serial';
-                        <div class="links_a <%= $is_external_or_serial_result ? 'text-result-container' : '' %>">
+                        <div class="links_a <%= $is_external_or_serial_result ? 'external-result-container' : 'serial-result-container' %>">
                             % my $url   = url_for('step', moduleid => $module->{name}, stepid => $step->{num}, testid => $testid);
                             % my $href  = "#step/$module->{name}/$step->{num}";
                             % if ($is_external_or_serial_result) {
-                                <span title="<%= $title %>" data-href="<%= $href %>" onclick="toggleTextPreview(this)" class="text-result<%= $is_external_result ? 'external-result' : '' %>">
+                                <span title="<%= $title %>" data-href="<%= $href %>" onclick="toggleTextPreview(this)" class="text-result">
                                     <span class="resborder <%= $resborder %>"><span class="step_actions">
                                         %= bug_report_actions(moduleid => $module->{name}, stepid => $step->{num});
                                     </span><%= $step->{text_data} %></span>

--- a/templates/webapi/test/result.html.ep
+++ b/templates/webapi/test/result.html.ep
@@ -4,7 +4,7 @@
 % content_for 'head' => begin
 %= asset 'test_result.js'
 <style type="text/css">
-    .text-result[title="wait_serial"] .resborder {
+    .serial-result-container .resborder {
         background-image: url("<%= icon_url 'terminal.svg' %>");
     }
     .resborder.icon_audio {


### PR DESCRIPTION
UI-wise this is kind of a revert of #3340 because of https://progress.opensuse.org/issues/70648#note-3:

![screenshot_20200901_171835](https://user-images.githubusercontent.com/10248953/91870310-2db01800-ec77-11ea-828c-bd706346f77a.png)

However, there's still at least a tiny bit of a preview and no loading time to see the full text.

I know that there's still room for improvement, e.g. the tooltip could contain a preview and it would possibly be nicer not use use the same element for the "thumbnail" and for the expanded view. However, before doing that it would be nice to unify the code in `module_table.html.ep` with the code in `render.js` because currently these places always need to be adjusted simultaneously.

I hope this is sufficient so people annoyed by #3340 can live with it until I do further improvements. For people who wanted the new behavior: You can still browse very quickly though the serial results using the arrow keys. It is also conceivable to add a "non-inline" switch as a further improvement.