### PR TITLE
docs: Align gre tunnel script with real use case

### DIFF
--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -414,6 +414,7 @@ on both hosts):
 #!/bin/sh
 action="$1"
 bridge="$2"
+ovs-vsctl set bridge $bridge stp_enable=true
 ovs-vsctl --may-exist add-port $bridge gre1 -- set interface gre1 type=gre options:remote_ip=<IP address of other host>
 ----
 


### PR DESCRIPTION
Before this patch documentation was missing STP enable. Which should prevent a loops in ovs switches for multi-machine tests when using >2 hosts - bridges are connected in mesh topology (each with each).