### PR TITLE
Search job templates by test module name

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -118,6 +118,31 @@ sub _search_perl_modules {
     return \@results;
 }
 
+sub _search_job_modules {
+    my ($self, $keywords, $limit) = @_;
+
+    my @results;
+    my $last_job = -1;
+    my $like     = {like => "%${keywords}%"};
+    # Get job modules for distinct jobs (by the columns comprising the computed name)
+    my $job_modules = $self->schema->resultset('JobModules')->search(
+        {-or => {name => $like}},
+        {
+            join     => 'job',
+            group_by => ['me.id', 'job.DISTRI', 'job.VERSION', 'job.FLAVOR', 'job.TEST', 'job.ARCH', 'job.MACHINE'],
+            order_by => {-desc => 'job_id'}})->slice(0, $limit);
+    while (my $job_module = $job_modules->next) {
+        my $contents = $job_module->script;
+        if ($job_module->job_id == $last_job) {
+            $results[-1]->{contents} .= "\n$contents";
+            next;
+        }
+        $last_job = $job_module->job_id;
+        push(@results, {occurrence => $job_module->job->name, contents => $contents});
+    }
+    return \@results;
+}
+
 sub _search_job_templates {
     my ($self, $keywords, $limit) = @_;
 
@@ -158,6 +183,9 @@ sub query {
     my $perl_module_results = $self->_search_perl_modules($keywords, $cap);
     $cap -= scalar @{$perl_module_results};
     push @results, @{$perl_module_results};
+    my $job_module_results = $self->_search_job_modules($keywords, $cap);
+    $cap -= scalar @{$job_module_results};
+    push @results, @{$job_module_results};
     push @results, @{$self->_search_job_templates($keywords, $cap)};
 
     $self->render(json => {data => \@results});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -183,9 +183,13 @@ sub query {
     my $perl_module_results = $self->_search_perl_modules($keywords, $cap);
     $cap -= scalar @{$perl_module_results};
     push @results, @{$perl_module_results};
+    return $self->render(json => {data => \@results}) unless $cap > 0;
+
     my $job_module_results = $self->_search_job_modules($keywords, $cap);
     $cap -= scalar @{$job_module_results};
     push @results, @{$job_module_results};
+    return $self->render(json => {data => \@results}) unless $cap > 0;
+
     push @results, @{$self->_search_job_templates($keywords, $cap)};
 
     $self->render(json => {data => \@results});

--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -103,8 +103,8 @@ subtest 'Job templates' => sub {
 
 subtest 'Limits' => sub {
     $t->app->config->{global}->{search_results_limit} = 1;
-    $t->get_ok('/api/v1/experimental/search?q=test', 'Extensive search with limit');
-    is scalar @{$t->tx->res->json->{data}}, 1, 'capped at one match';
+    $t->get_ok('/api/v1/experimental/search?q=test', 'Extensive search with limit')->status_is(200);
+    $t->json_is('/data/1' => undef, 'capped at one match');
 };
 
 subtest 'Errors' => sub {

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -48,11 +48,11 @@ subtest 'Perl modules' => sub {
     wait_for_element(selector => '#results .list-group-item');
 
     like $driver->get_title(), qr/Search/, 'search shown' or return;
-    my $header = $driver->find_element_by_id('results-heading');
-    is $header->get_text(), 'Search results: 2 matches found', 'number of results in header';
+    my $header  = $driver->find_element_by_id('results-heading');
     my $results = $driver->find_element_by_id('results');
     my @entries = $results->children('.list-group-item');
-    is scalar @entries, 2, 'two elements' or return;
+    is $header->get_text(), 'Search results: ' . scalar @entries . ' matches found', 'number of results in header';
+    is scalar @entries, 7, '7 elements' or return;
 
     my $first = $entries[0];
     is $first->child('.occurrence')->get_text(), 'opensuse/tests/installation/installer_timezone.pm',

--- a/templates/webapi/search/search.html.ep
+++ b/templates/webapi/search/search.html.ep
@@ -8,6 +8,7 @@
 <div>
     <h2 id="results-heading">Search results</h2>
     <p>The search currently finds <b>job templates</b> by name or description,
+       <b>job modules</b> by filename,
        or Perl modules within the test distributions,
        either by <b>filename</b> or <b>source code</b>.</p>
     <div id="flash-messages"></div>


### PR DESCRIPTION
- Search job modules by `name` only (to avoid unrelated hits from the same category)
- Return early if the limit is hit
  - Unlike SQL with DBIX a limit of 0 is an error and with  the additional result type this can lead to an exception. Put another way, this PR fails without the fix, but the test won't fail without it.

See: [poo#33486](https://progress.opensuse.org/issues/34486)