### PR TITLE
Treat as success when schedule_iso() cannot find product-arch combination

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -516,7 +516,7 @@ sub _generate_jobs {
     if (!@products) {
         my $error = 'no products found for ' . join('-', map { $args->{$_} } qw(DISTRI FLAVOR ARCH));
         push(@$notes, $error);
-        return {error_message => $error, error_code => 404};
+        return {error_message => $error, error_code => 200};
     }
 
     my %wanted;    # jobs specified by $args->{TEST} or $args->{MACHINE} or their parents

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -370,7 +370,7 @@ $t->get_ok("/api/v1/jobs/$newid")->status_is(200);
 is($t->tx->res->json->{job}->{state}, 'cancelled', "job $newid is cancelled");
 
 schedule_iso({iso => $iso, tests => "kde/usb"}, 400, {}, 'invalid parameters');
-schedule_iso({%iso, FLAVOR    => 'cherry'}, 404, {}, 'no product found');
+schedule_iso({%iso, FLAVOR    => 'cherry'}, 200, {}, 'no product found');
 schedule_iso({%iso, _GROUP_ID => 12345},    404, {}, 'no templates found');
 
 # handle list of tests


### PR DESCRIPTION
Route "isos post" was always used to "run tests if configured". After recent changes, client exits with error code when no tests are
configured for architecture. 
This makes a problem for scenario when one needs to run tests for all architectures which are configured in OpenQA