### PR TITLE
Emit worker_register event w/o caps or job ID's

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -202,8 +202,7 @@ sub create {
     };
     return unless defined $id;
 
-    my %event_data = (id => $id, host => $host, instance => $instance, caps => $caps);
-    $event_data{job_ids} = $job_ids if @$job_ids;
+    my %event_data = (id => $id, host => $host, instance => $instance);
     $self->emit_event('openqa_worker_register', \%event_data);
     $self->render(json => {id => $id});
 }

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -118,6 +118,15 @@ $registration_params{instance} = 42;
 $t->post_ok('/api/v1/workers', form => \%registration_params)->status_is(200, 'register new worker')
   ->json_is('/id' => 3, 'new worker id is 3');
 diag explain $t->tx->res->json unless $t->success;
+is_deeply(
+    OpenQA::Test::Case::find_most_recent_event($t->app->schema, 'worker_register'),
+    {
+        id       => $t->tx->res->json->{id},
+        host     => 'localhost',
+        instance => 42,
+    },
+    'worker event was logged correctly'
+);
 
 subtest 'incompleting previous job on worker registration' => sub {
     # assume the worker runs some job


### PR DESCRIPTION
- These values aren't required and jobs can be inspected by looking up the worker afterwards
- Also, add unit test coverage (the original motivation for this branch)

See: https://progress.opensuse.org/issues/49202