### PR TITLE
Import log_error used when removing asset from disk fails

### DIFF
--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -23,7 +23,7 @@ use base 'DBIx::Class::Core';
 use OpenQA::App;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
-use OpenQA::Log 'log_info';
+use OpenQA::Log qw(log_info log_error);
 use OpenQA::Utils;
 use Date::Format;
 use Archive::Extract;


### PR DESCRIPTION
    "result" => "Undefined subroutine &OpenQA::Schema::Result::Assets::log_error called at /usr/share/openqa/script/../lib/OpenQA/Schema/Result/Assets.pm line 128.\n"