### PR TITLE
Make use of query params in admin datatables

### DIFF
--- a/assets/javascripts/admintable.js
+++ b/assets/javascripts/admintable.js
@@ -446,6 +446,13 @@ function setupAdminTable(isAdmin) {
     dataTable.rowData = [];
     dataTable.emptyRow = emptyRow;
 
+    // take keywords from the URL
+    let params = new URLSearchParams(document.location.search.substring(1));
+    let keywords = params.get('q');
+    if (keywords) {
+        dataTable.search(keywords);
+    }
+
     // save the current editor values before redraw so they survive using filtering/sorting/pagination
     dataTable.on('preDraw', function() {
         var rowData = dataTable.rowData;

--- a/assets/javascripts/audit_log.js
+++ b/assets/javascripts/audit_log.js
@@ -104,7 +104,7 @@ function rescheduleProduct(link) {
         return;
     }
     const id = rowData.id;
-    if (id === undefined || !window.confirm('Do you really want to reschedule all jobs for the product ' + id + '?')) {
+    if (!id || !window.confirm('Do you really want to reschedule all jobs for the product ' + id + '?')) {
         return;
     }
     const url = scheduledProductsTable.rescheduleUrlTemplate.replace('XXXXX', id);
@@ -129,9 +129,10 @@ function showSettingsAndResults(rowData) {
 }
 
 function loadProductLogTable(dataTableUrl, rescheduleUrlTemplate, showActions) {
-    const id = (parseQueryParams().id || [])[0];
+    let params = new URLSearchParams(document.location.search.substring(1));
+    let id = params.get('id');
     let settingsAndResultsShown = false;
-    if (id !== undefined) {
+    if (id) {
         dataTableUrl += '?id=' + encodeURIComponent(id);
         $('#scheduled-products h2').text('Scheduled product ' + id);
     }
@@ -149,7 +150,7 @@ function loadProductLogTable(dataTableUrl, rescheduleUrlTemplate, showActions) {
             dataType: 'json',
             dataSrc: function(json) {
                 const data = json.data;
-                if (id !== undefined && !settingsAndResultsShown) {
+                if (id && !settingsAndResultsShown) {
                     showSettingsAndResults(data[0]);
                     settingsAndResultsShown = true;
                 }
@@ -162,7 +163,7 @@ function loadProductLogTable(dataTableUrl, rescheduleUrlTemplate, showActions) {
         ],
         columnDefs: [{
                 targets: 0,
-                visible: id === undefined,
+                visible: !id,
                 render: function(data, type, row) {
                     return type === 'display' ? '<a href="?id=' + encodeURIComponent(data) + '">' + data + '</a>' : data;
                 }
@@ -177,7 +178,7 @@ function loadProductLogTable(dataTableUrl, rescheduleUrlTemplate, showActions) {
                 orderable: false,
                 render: function(data, type, row) {
                     let html = '';
-                    if (id === undefined) {
+                    if (!id) {
                         html += '<a href="#" onclick="showScheduledProductSettings(this); return true;">\
                                  <i class="action fa fa-search-plus" title="Show settings"></i></a>\
                                  <a href="#" onclick="showScheduledProductResults(this); return true;">\
@@ -196,7 +197,7 @@ function loadProductLogTable(dataTableUrl, rescheduleUrlTemplate, showActions) {
     scheduledProductsTable.rescheduleUrlTemplate = rescheduleUrlTemplate;
 
     // remove unneccassary elements when showing only one particular product
-    if (id !== undefined) {
+    if (id) {
         const wrapper = document.getElementById('product_log_table_wrapper');
         wrapper.removeChild(wrapper.firstChild);
         wrapper.removeChild(wrapper.lastChild);

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -76,22 +76,13 @@ function toggleChildGroups(link) {
 
 function parseQueryParams() {
     var params = {};
-    $.each(window.location.search.substr(1).split('&'), function(index, param) {
-        var equationSignIndex = param.indexOf('=');
-        var key, value;
-        if (equationSignIndex < 0) {
-            key = decodeURIComponent(param);
-            value = undefined;
-        } else {
-            key = decodeURIComponent(param.substr(0, equationSignIndex));
-            value = decodeURIComponent(param.substr(equationSignIndex + 1));
-        }
+    for (const [key, value] of new URLSearchParams(document.location.search.substring(1))) {
         if (Array.isArray(params[key])) {
             params[key].push(value);
         } else {
             params[key] = [value];
         }
-    });
+    };
     return params;
 }
 

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -45,5 +45,35 @@ like(
 );
 like($driver->find_element('#test-suites tbody tr:last-child td')->get_text(), qr/textmode/, 'last entry');
 
+# Test suites can be searched
+$driver->get('/admin/test_suites?q=client2');
+wait_for_ajax;
+my $table = $driver->find_element_by_class('admintable');
+like($table->child('tbody tr:first-child td')->get_text(), qr/client2/, 'first entry');
+
+subtest Products => sub {
+    $driver->get('/admin/products');
+    wait_for_ajax;
+    my $table = $driver->find_element_by_class('admintable');
+    like($table->child('tbody tr:first-child td')->get_text(), qr/opensuse/, 'first entry');
+
+    $driver->get('/admin/products?q=sle');
+    wait_for_ajax;
+    $table = $driver->find_element_by_class('admintable');
+    like($table->child('tbody tr:first-child td')->get_text(), qr/sle/, 'first entry');
+};
+
+subtest Machines => sub {
+    $driver->get('/admin/machines');
+    wait_for_ajax;
+    my $table = $driver->find_element_by_class('admintable');
+    like($table->child('tbody tr:first-child td')->get_text(), qr/32bit/, 'first entry');
+
+    $driver->get('/admin/machines?q=laptop');
+    wait_for_ajax;
+    $table = $driver->find_element_by_class('admintable');
+    like($table->child('tbody tr:first-child td')->get_text(), qr/Laptop_64/, 'first entry');
+};
+
 kill_driver();
 done_testing();


### PR DESCRIPTION
When initializing the table, the initial keywords should be set so that individual items can be linked.

This PR also adds basic test coverage for products and machines tables which we don't currently have. And optimizations for existing search parsing, see the respective commits for details.

See: https://progress.opensuse.org/issues/49202