### PR TITLE
Have SeleniumTest::wait_until wait on jQuery once

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -327,6 +327,7 @@ sub wait_until {
     $timeout        //= 100;
     $check_interval //= .1;
 
+    my $first_iteration = 1;
     while (1) {
         if ($check_function->()) {
             pass($check_description);
@@ -336,8 +337,12 @@ sub wait_until {
             fail($check_description);
             return 0;
         }
+        if ($first_iteration) {
+            wait_for_ajax(msg => $check_description);
+            $first_iteration = 0;
+        }
         $timeout -= $check_interval;
-        wait_for_ajax(msg => $check_description) or sleep $check_interval;
+        sleep $check_interval;
     }
 }
 


### PR DESCRIPTION
- Waiting on jQuery once per loop leads to an inflated timeout.
- We only need to check once that jQuery is inactive if it was active.

Unlike #3315 there is no change to `wait_for_ajax` here. Instead, just use it once rather than inside the loop.