### PR TITLE
Select 'Found by' when creating new bugs in bugzilla

### DIFF
--- a/templates/webapi/branding/openSUSE/external_reporting.html.ep
+++ b/templates/webapi/branding/openSUSE/external_reporting.html.ep
@@ -110,6 +110,7 @@ Always latest result in this scenario: [latest]($latest)
 %    $product_details{comment} = $description;
 %    $product_details{product} = "$distri $product";
 %    $product_details{bug_file_loc} = $step_url;
+%    $product_details{cf_foundby} = 'openQA';
 % }
 % if ($distri eq 'kubic') {
 %    $product_details{component} = 'Kubic';


### PR DESCRIPTION
Since there's now a value for openQA in the 'Found By' custom field, we can now tag bugs created from openQA directly,
and query that later, without having to rely on text, that could have been changed accidentally.

![image](https://user-images.githubusercontent.com/229240/92387403-c03c3580-f115-11ea-9704-c88dacfae5de.png)
