### PR TITLE
Add TimeLimit to more unit tests

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -47,6 +47,7 @@ use OpenQA::Test::Utils qw(
   stop_service unstable_worker
   unresponsive_worker broken_worker rejective_worker
 );
+use OpenQA::Test::TimeLimit '150';
 
 # treat this test like the fullstack test
 plan skip_all => "set SCHEDULER_FULLSTACK=1 (be careful)" unless $ENV{SCHEDULER_FULLSTACK};

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -46,6 +46,7 @@ use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service wait_for_or_bail_out);
+use OpenQA::Test::TimeLimit '240';
 use Mojo::Util qw(md5_sum);
 use OpenQA::CacheService;
 use OpenQA::CacheService::Request;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -51,6 +51,7 @@ use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server wait_for_or_bail_out);
+use OpenQA::Test::TimeLimit '100';
 
 my $port = Mojo::IOLoop::Server->generate_port;
 my $host = "localhost:$port";

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -34,6 +34,7 @@ use OpenQA::Test::Utils
   qw(mock_service_ports),
   qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
   qw(stop_service setup_fullstack_temp_dir);
+use OpenQA::Test::TimeLimit '60';
 
 BEGIN {
     # set default worker and job count

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -53,6 +53,7 @@ use OpenQA::Test::Utils
   qw(create_websocket_server create_live_view_handler setup_share_dir),
   qw(cache_minion_worker cache_worker_service mock_service_ports setup_fullstack_temp_dir),
   qw(start_worker stop_service);
+use OpenQA::Test::TimeLimit '350';
 use OpenQA::Test::FullstackUtils;
 
 plan skip_all => 'set FULLSTACK=1 (be careful)'                                 unless $ENV{FULLSTACK};


### PR DESCRIPTION
Specifying generous timeouts gives better, faster failures (as opposed to being stopped forcibly by CircleCI with no error message).

See: [poo#66664](https://progress.opensuse.org/issues/66664)