### PR TITLE
Change auto-refresh selector

### DIFF
--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -42,7 +42,7 @@ function setupIndexPage() {
             return 'fullscreen';
         } else if (key === 'interval') {
             window.autoreload = val !== 0 ? val : undefined;
-            $('#filter-interval-' + val).prop('checked', true);
+            $('#filter-autorefresh-interval').prop('value', val);
             return 'auto refresh';
         } else if (key === 'default_expanded') {
             defaultExpanedCheckBox.prop('checked', val !== '0');

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -138,7 +138,8 @@ subtest 'filtering subgroups' => sub {
     $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{end}, '0');    # appended
     $driver->find_element('#filter-apply-button')->click();
     wait_for_ajax();
-    $url .= '?group=Test%20parent%20%2F%20.*%20test%24&default_expanded=1&limit_builds=30&time_limit_days=140';
+    $url .= '?group=Test%20parent%20%2F%20.*%20test%24';
+    $url .= '&default_expanded=1&limit_builds=30&time_limit_days=140&interval=';
     is($driver->get_current_url,                                  $url, 'URL parameters for filter are correct');
     is(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0,    "child group 'opensuse' filtered out");
     isnt(scalar @{$driver->find_elements('opensuse test', 'link_text')}, 0, "child group 'opensuse test' present'");

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -136,7 +136,7 @@ subtest 'filter form' => sub {
     $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{end}, '2');    # appended to default '14'
     $driver->find_element('#filter-apply-button')->click();
     wait_for_ajax;
-    $url .= '?group=SLE%2012%20SP2&limit_builds=38&time_limit_days=142';
+    $url .= '?group=SLE%2012%20SP2&limit_builds=38&time_limit_days=142&interval=';
     is($driver->get_current_url, $url, 'URL parameters for filter are correct');
 };
 

--- a/templates/webapi/main/index.html.ep
+++ b/templates/webapi/main/index.html.ep
@@ -81,22 +81,13 @@
                 %>
             </div>
 
-            <div class="form-group">
+            <div class="form-group form-inline">
                 <strong>
-                    Auto refresh
+                    Auto-refresh interval
                     <%= help_popover('Help for <i>Auto refresh</i>' => '<p>Allows to update the data of this page automatically</p>') %>
                 </strong>
+                <input type="number" class="form-control" name="interval" min="0" placeholder="no auto-refresh" id="filter-autorefresh-interval" onchange="event.target.value == 0 ? event.target.value='' : {} "> seconds
 
-                <input value="0" name="interval" type="radio" id="filter-interval-0">
-                <label for="filter-interval-0">No refresh</label>
-                <input value="30" name="interval" type="radio" id="filter-interval-30">
-                <label for="filter-interval-30">30 seconds</label>
-                <input value="60" name="interval" type="radio" id="filter-interval-60">
-                <label for="filter-interval-60">One minute</label>
-                <input value="120" name="interval" type="radio" id="filter-interval-120">
-                <label for="filter-interval-120">Two minutes</label>
-                <input value="180" name="interval" type="radio" id="filter-interval-180">
-                <label for="filter-interval-180">Three minutes</label>
             </div>
 
             <button type="submit" class="btn btn-default" id="filter-apply-button">Apply</button>


### PR DESCRIPTION
https://progress.opensuse.org/issues/17886

Actually the selector for the automatic refresh is several radio
buttons with hardcoded values.

In order to offer flexibility now is a numeric field

A enhancement of #3141