### PR TITLE
Improve displaying serial results

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -107,16 +107,33 @@ function renderModuleRow(module, snippets) {
         }
 
         if (step.is_parser_text_result || title === 'wait_serial') {
-            let elem = E('span', [], { 'class': 'step_actions' });
-            elem.innerHTML = renderTemplate(snippets.bug_actions, { MODULE: module.name, STEP: step.num });
-            elem = E('span', [elem, step.text_data], { 'class': 'resborder ' + step.resborder });
-            elem = E('span', [elem], {
-                title: title,
+            const elements = [];
+            if (!step.is_parser_text_result) {
+                const previewLimit = 250;
+                let shortText = step.text_data.replace(/.*# Result:\n?/s, '');
+                if (shortText.length > previewLimit) {
+                    shortText = shortText.substr(0, previewLimit) + '…';
+                }
+                const stepFrame = E('span', [shortText], { 'class': 'resborder ' + step.resborder });
+                const serialPreview = E('span', [stepFrame], {
+                    title: shortText,
+                    'data-href': href,
+                    'class': 'serial-result-preview',
+                    onclick: 'toggleTextPreview(this)'
+                });
+                elements.push(serialPreview);
+            }
+            const stepActions = E('span', [], { 'class': 'step_actions' });
+            stepActions.innerHTML = renderTemplate(snippets.bug_actions, { MODULE: module.name, STEP: step.num });
+            const stepFrame = E('span', [stepActions, step.text_data], { 'class': 'resborder ' + step.resborder });
+            const textResult = E('span', [stepFrame], {
+                title: step.is_parser_text_result ? title : undefined,
                 'data-href': href,
                 'class': 'text-result',
                 onclick: 'toggleTextPreview(this)'
             });
-            stepnodes.push(E('div', [elem], { 'class': 'links_a ' + (step.is_parser_text_result ? 'external-result-container' : 'serial-result-container') }));
+            elements.push(textResult);
+            stepnodes.push(E('div', elements, { 'class': 'links_a ' + (step.is_parser_text_result ? 'external-result-container' : 'serial-result-container') }));
             continue;
         }
 

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -225,6 +225,10 @@ span.resborder_na {
         min-width: stretch;
         max-width: 100%;
         height: auto;
+    }
+}
+.text-result, .serial-result-preview {
+    .resborder {
         font-family: monospace;
         text-align: left;
         margin: 1px 0;
@@ -238,37 +242,35 @@ span.resborder_na {
         overflow-wrap: break-word;
     }
 }
-.external-result-container, .serial-result-container.current_preview {
-    display: inline-block !important;
+.external-result-container {
     width: 100%;
 }
 .serial-result-container {
-    margin-right: 3px;
-    cursor: pointer;
-    .resborder {
-        background-position: 1000px 1000px;
-        background-repeat: no-repeat;
+    margin-right: 4px;
+    .serial-result-preview .resborder {
+        cursor: pointer;
         width: 60px;  // in accordance with the thumbnail width
         height: 45px; // in accordance with the thumbnail height
         font-size: 60%;
         overflow: hidden;
-        .step_actions {
-            display: none;
+    }
+    .text-result {
+        display: none;
+        .resborder {
+            width: initial;
+            height: initial;
+            background-position: 0% 0%;
+            background-repeat: no-repeat;
+            padding-left: 40px;
+            font-size: 100%;
         }
     }
 }
 .serial-result-container.current_preview {
     margin-right: 0px;
-    cursor: initial;
-    .resborder {
-        width: initial;
-        height: initial;
-        background-position: 0% 0%;
-        padding-left: 40px;
-        font-size: 100%;
-        .step_actions {
-            display: initial;
-        }
+    display: inline;
+    .text-result {
+        display: initial;
     }
 }
 .current_preview .text-result .resborder {

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -153,10 +153,12 @@ $driver->go_back();
 is(current_tab, 'Details', 'back to details tab');
 
 subtest 'displaying wait_serial results' => sub {
-    my $wait_serial_element = $driver->find_element('[title="wait_serial"]');
+    my $wait_serial_element = $driver->find_element('.serial-result-container .serial-result-preview');
+    like($wait_serial_element->get_text(), qr/dBeHb-0-/, 'serial preview shown');
     $wait_serial_element->click();
-    like($wait_serial_element->get_text(), qr/wait_serial expected/, 'wait_serial output shown');
-    like($driver->get_current_url(),       qr/#step/,                'current url contains #step hash');
+    $wait_serial_element = $driver->find_element('.serial-result-container .text-result');
+    like($wait_serial_element->get_text(), qr/wait_serial expected.*dBeHb-0-/s, 'wait_serial output shown');
+    like($driver->get_current_url(),       qr/#step/,                           'current url contains #step hash');
     $wait_serial_element->click();
     unlike($driver->get_current_url(), qr/#step/, 'current url does not contain #step hash anymore');
 };
@@ -193,7 +195,8 @@ subtest 'bug reporting' => sub {
         check_report_links(bootloader => 1);
     };
     subtest 'wait_serial result' => sub {
-        check_report_links(sshfs => 2, $driver->find_element('[data-href="#step/sshfs/2"]'));
+        $driver->find_element('[data-href="#step/sshfs/2"].serial-result-preview')->click();
+        check_report_links(sshfs => 2, $driver->find_element('[data-href="#step/sshfs/2"].text-result'));
     };
 };
 

--- a/templates/webapi/test/result.html.ep
+++ b/templates/webapi/test/result.html.ep
@@ -4,7 +4,7 @@
 % content_for 'head' => begin
 %= asset 'test_result.js'
 <style type="text/css">
-    .serial-result-container .resborder {
+    .serial-result-container .text-result .resborder {
         background-image: url("<%= icon_url 'terminal.svg' %>");
     }
     .resborder.icon_audio {


### PR DESCRIPTION
* Show the serial text within the tooltip (instead of just "wait_serial")
* Keep preview visible in expanded state
* Strip additional info before the actual result in preview

---

![screenshot_20200907_180013](https://user-images.githubusercontent.com/10248953/92404484-fee0e880-f133-11ea-910d-e99645213e1b.png)

---

And yes, I haven't implemented all [suggestions from the ticket](https://progress.opensuse.org/issues/70648) but I guess this is a start.