### PR TITLE
Check option existence in developer_mode test

### DIFF
--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -318,6 +318,7 @@ subtest 'expand developer panel' => sub {
     subtest 'behavior when changes have not been confirmed' => sub {
         my @options = $driver->find_elements('#developer-pause-at-module option');
 
+        ok $options[4], 'option #5 present' or return undef;
         $options[4]->click();
         assert_sent_commands(undef, 'changes not instantly submitted');
 
@@ -365,6 +366,7 @@ subtest 'start developer session' => sub {
 
     # select to pause at 'installation-bar'
     my @options = $driver->find_elements('#developer-pause-at-module option');
+    ok $options[4], 'option #5 present' or return undef;
     $options[4]->click();
 
     # start developer session by submitting the changes
@@ -445,9 +447,11 @@ subtest 'start developer session' => sub {
         fake_state(developerMode => {moduleToPauseAt => '"installation-foo"'});
         is($_->is_selected(), $_->get_value() eq 'foo' ? 1 : 0, 'foo selected') for (@options);
 
+        ok $options[3], 'option #4 present' or return undef;
         $options[3]->click();    # select installation-foo
         assert_sent_commands(undef, 'no command sent if nothing changes');
 
+        ok $options[4], 'option #5 present' or return undef;
         $options[4]->click();    # select installation-bar
         assert_sent_commands(
             [


### PR DESCRIPTION
Otherwise clicking non-existant items breaks the test plan.

Inspired by a failure on #3317:

    [13:53:34] t/ui/25-developer_mode.t ............... 11/? Bailout called.  Further testing stopped:  isElementSelected: stale element reference: element is not attached to the page document at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm:103
    FAILED--Further testing stopped: isElementSelected: stale element reference: element is not attached to the page document at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm:103

Which locally resulted in messages like this:

    Can't call method "click" on an undefined value at t/ui/25-developer_mode.t line 369.

For now this PR is not fixing any bugs, but making the test more robust.