### PR TITLE
Fix worker's online/offline status

### DIFF
--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -86,7 +86,7 @@ sub name {
 
 sub seen {
     my ($self, $workercaps, $error) = @_;
-    $self->update({t_updated => now()});
+    $self->update({t_seen => now()});
     $self->update_caps($workercaps) if $workercaps;
 }
 
@@ -134,13 +134,13 @@ sub set_property {
 sub dead {
     my ($self) = @_;
 
+    return 1 unless my $t_seen = $self->t_seen;
     my $dt = DateTime->now(time_zone => 'UTC');
     # check for workers active in last WORKERS_CHECKER_THRESHOLD
     # last seen should be updated at least in MAX_TIMER t in worker
     # and should not be greater than WORKERS_CHECKER_THRESHOLD.
     $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD - DB_TIMESTAMP_ACCURACY);
-
-    $self->t_updated < $dt;
+    $t_seen < $dt;
 }
 
 sub websocket_api_version {
@@ -217,7 +217,7 @@ sub info {
     $settings->{websocket} = $live ? $alive : 0;
 
     # note: The keys "connected" and "websocket" are only provided for compatibility. The "live"
-    #       parameter makes no actual difference anymore. (`t_updated` is decrease when a worker
+    #       parameter makes no actual difference anymore. (`t_seen` is decreased when a worker
     #       disconnects from the ws server so relying on it is as live as it gets.)
 
     return $settings;

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -522,8 +522,8 @@ sub stale_ones {
     my $dtf  = $self->result_source->schema->storage->datetime_parser;
     my $dt   = DateTime->from_epoch(epoch => time() - $threshold, time_zone => 'UTC');
     my %cond = (
-        state              => [OpenQA::Jobs::Constants::EXECUTION_STATES],
-        'worker.t_updated' => {'<' => $dtf->format_datetime($dt)},
+        state           => [OpenQA::Jobs::Constants::EXECUTION_STATES],
+        'worker.t_seen' => {'<' => $dtf->format_datetime($dt)},
     );
     my %attrs = (join => 'worker', order_by => 'worker.id desc');
     return $self->search(\%cond, \%attrs);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,15 +98,15 @@ sub _register {
 
     # update or create database entry for worker
     if ($worker) {
-        $worker->update({t_updated => now()});
+        $worker->update({t_seen => now()});
     }
     else {
         $worker = $workers->create(
             {
                 host     => $host,
                 instance => $instance,
-                job_id   => undef
-            });
+                job_id   => undef,
+                t_seen   => now()});
     }
 
     # store worker's capabilities to database

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,8 +24,17 @@ sub _extend_info {
     my ($w, $live) = @_;
     $live //= 0;
     my $info = $w->info($live);
-    $info->{name}   = $w->name;
-    $info->{t_seen} = $w->t_seen;
+    $info->{name} = $w->name;
+    if ($live && ($info->{error} =~ qr/(graceful disconnect) at (.*)/)) {
+        $info->{offline_note} = $1;
+        $info->{t_seen}       = $2 . 'Z';
+    }
+    elsif (my $last_seen = $w->t_seen) {
+        $info->{t_seen} = $last_seen->datetime . 'Z';
+    }
+    else {
+        $info->{t_seen} = 'never';
+    }
     return $info;
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -24,8 +24,8 @@ sub _extend_info {
     my ($w, $live) = @_;
     $live //= 0;
     my $info = $w->info($live);
-    $info->{name}      = $w->name;
-    $info->{t_updated} = $w->t_updated;
+    $info->{name}   = $w->name;
+    $info->{t_seen} = $w->t_seen;
     return $info;
 }
 

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -100,9 +100,10 @@ sub _message {
 
     my $message_type = $json->{type};
     if ($message_type eq 'quit') {
-        my $dt = DateTime->now(time_zone => 'UTC');
+        my $dt     = DateTime->now(time_zone => 'UTC');
+        my $status = "graceful disconnect at $dt";
         $dt->subtract(seconds => WORKERS_CHECKER_THRESHOLD);
-        $worker_db->update({t_seen => $dt});
+        $worker_db->update({t_seen => $dt, error => $status});
         $worker_db->reschedule_assigned_jobs;
     }
     elsif ($message_type eq 'rejected') {

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -86,7 +86,7 @@ sub stop_workers { stop_service($_, 1) for @workers }
 
 sub dead_workers {
     my $schema = shift;
-    $_->update({t_updated => DateTime->from_epoch(epoch => time - WORKERS_CHECKER_THRESHOLD - DB_TIMESTAMP_ACCURACY)})
+    $_->update({t_seen => DateTime->from_epoch(epoch => time - WORKERS_CHECKER_THRESHOLD - DB_TIMESTAMP_ACCURACY)})
       for $schema->resultset("Workers")->all();
 }
 

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -57,7 +57,7 @@ subtest 'worker with job and not updated in last 120s is considered dead' => sub
     my $dtf = $schema->storage->datetime_parser;
     my $dt  = DateTime->from_epoch(epoch => time() - WORKERS_CHECKER_THRESHOLD - 1, time_zone => 'UTC');
 
-    $schema->resultset('Workers')->update_all({t_updated => $dtf->format_datetime($dt)});
+    $schema->resultset('Workers')->update_all({t_seen => $dtf->format_datetime($dt)});
     stderr_like { OpenQA::Scheduler::Model::Jobs->singleton->incomplete_and_duplicate_stale_jobs }
     qr/Dead job 99961 aborted and duplicated 99982\n.*Dead job 99963 aborted as incomplete/, 'dead jobs logged';
     _check_job_incomplete($_) for (99961, 99963);

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -168,6 +168,7 @@ subtest 'web socket message handling' => sub {
               . 'gracefully before starting to work on the job');
         $worker->discard_changes;
         ok($worker->dead, 'worker considered immediately dead when it goes offline gracefully');
+        like($worker->error, qr/graceful disconnect at .*/, 'graceful disconnect logged');
     };
 
     $schema->txn_rollback;

--- a/templates/webapi/admin/workers/show.html.ep
+++ b/templates/webapi/admin/workers/show.html.ep
@@ -19,12 +19,8 @@
         <div class="card-body status-info">
             <div><span>Host: </span><%= $worker->{host} %></div>
             <div><span>Instance: </span><%= $worker->{instance} %></div>
-            <div><span>Alive: </span><%= $worker->{alive} ? 'yes' : 'no' %></div>
-            <div><span>Websocket connection: </span><%= $worker->{websocket} ? 'Active' : 'Offline' %></div>
             <div><span>Seen: </span><abbr class="timeago" title="<%= $worker->{t_seen}->datetime() %>Z"><%= format_time($worker->{t_seen}) %></abbr></div>
-            <div><span>Status: </span>
-                %= include 'admin/workers/worker_status'
-            </div>
+            <div><span>Status: </span><%= include 'admin/workers/worker_status' %></div>
         </div>
     </div>
 

--- a/templates/webapi/admin/workers/show.html.ep
+++ b/templates/webapi/admin/workers/show.html.ep
@@ -21,7 +21,7 @@
             <div><span>Instance: </span><%= $worker->{instance} %></div>
             <div><span>Alive: </span><%= $worker->{alive} ? 'yes' : 'no' %></div>
             <div><span>Websocket connection: </span><%= $worker->{websocket} ? 'Active' : 'Offline' %></div>
-            <div><span>Seen: </span><abbr class="timeago" title="<%= $worker->{t_updated}->datetime() %>Z"><%= format_time($worker->{t_updated}) %></abbr></div>
+            <div><span>Seen: </span><abbr class="timeago" title="<%= $worker->{t_seen}->datetime() %>Z"><%= format_time($worker->{t_seen}) %></abbr></div>
             <div><span>Status: </span>
                 %= include 'admin/workers/worker_status'
             </div>

--- a/templates/webapi/admin/workers/show.html.ep
+++ b/templates/webapi/admin/workers/show.html.ep
@@ -19,7 +19,7 @@
         <div class="card-body status-info">
             <div><span>Host: </span><%= $worker->{host} %></div>
             <div><span>Instance: </span><%= $worker->{instance} %></div>
-            <div><span>Seen: </span><abbr class="timeago" title="<%= $worker->{t_seen}->datetime() %>Z"><%= format_time($worker->{t_seen}) %></abbr></div>
+            <div><span>Seen: </span><abbr class="timeago" title="<%= $worker->{t_seen} %>"><%= $worker->{t_seen} %></abbr></div>
             <div><span>Status: </span><%= include 'admin/workers/worker_status' %></div>
         </div>
     </div>

--- a/templates/webapi/admin/workers/worker_status.html.ep
+++ b/templates/webapi/admin/workers/worker_status.html.ep
@@ -20,4 +20,7 @@
     Online
 % } else {
     Offline
+    % if (my $note = $worker->{offline_note}) {
+        (<%= $note %>)
+    % }
 % }


### PR DESCRIPTION
See https://progress.opensuse.org/issues/69784 and particular commit messages.

---

To avoid a regression in the case of a graceful disconnect I added some extra handling for it, so as a bonus we get:

![screenshot_20200908_174215](https://user-images.githubusercontent.com/10248953/92503571-bdb70a00-f201-11ea-8a8b-6dc1a4e6917b.png)
