### PR TITLE
Surface errors from failed test tries

### DIFF
--- a/tools/retry
+++ b/tools/retry
@@ -6,6 +6,16 @@ STABILITY_TEST="${STABILITY_TEST:-0}"
 
 run_once() {
     $*
+    RESULT=$?
+    # Surface failure messages from the TAP output if enabled
+    if [ -n "$PERL_TEST_HARNESS_DUMP_TAP" ]; then
+        # Get the filename from the last argument
+        # Ensure a positive result
+        a=($*)
+        OUTPUT_FILE=$PERL_TEST_HARNESS_DUMP_TAP/${a[@]: -1}
+        [ -f $OUTPUT_FILE ] && grep 'not ok' $OUTPUT_FILE || true
+    fi
+    return $RESULT
 }
 
 if [ "$RETRY" = "0" ]; then


### PR DESCRIPTION
The retry script can re-run a test that fails at the cost of losing the results (since we do not store them anywhere). We can get failures from TAP output (even if the testplan broken). This relies on the hardness dump which we use in CI. It can be enabled locally by setting the variable if desired.

See: [poo#66664](https://progress.opensuse.org/issues/66664)