### PR TITLE
Makefile: Prevent "make help" outputting make variable definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ OPENQA_CONFIG =
 .PHONY: help
 help:
 	@echo Call one of the available targets:
-	@sed -n 's/\(^[^.#[:space:]A-Z].*\):.*$$/\1/p' Makefile | uniq
+	@sed -n 's/\(^[^.#[:space:]A-Z]*\):.*$$/\1/p' Makefile | uniq
 	@echo See docs/Contributing.asciidoc for more details
 
 .PHONY: install


### PR DESCRIPTION
Previously the output list of "make help" would include entries like:

```
mkfile_path
current_dir
docker_env_file
unstables := $(shell cat .circleci/unstable_tests.txt | tr '\n'
…
comma
space
```

This can be prevented simply by not allowing arbitrary characters
following valid make target identifiers as long as we only have sane
make targets following the common convention of lowercase alphabetic
characters only.