### PR TITLE
Sensible timeouts for server waits in tests and fail hard

### DIFF
--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -43,7 +43,6 @@ use IO::Socket::INET;
 use Mojo::Server::Daemon;
 use Mojo::IOLoop::Server;
 use POSIX '_exit';
-use Time::HiRes qw(sleep);
 use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service wait_for_or_bail_out);
@@ -85,7 +84,7 @@ sub test_default_usage {
     my $asset_request = $cache_client->asset_request(id => $id, asset => $asset, type => 'hdd', host => $host);
 
     if (!$cache_client->enqueue($asset_request)) {
-        sleep .1 until $cache_client->status($asset_request)->is_processed;
+        wait_for_or_bail_out { $cache_client->status($asset_request)->is_processed } 'asset';
     }
     ok($cache_client->asset_exists('localhost', $asset), "Asset $asset downloaded");
     ok($asset_request->minion_id, "Minion job id recorded in the request object") or die diag explain $asset_request;
@@ -104,7 +103,7 @@ sub test_sync {
 
     ok !$cache_client->enqueue($rsync_request);
 
-    sleep .1 until $cache_client->status($rsync_request)->is_processed;
+    wait_for_or_bail_out { $cache_client->status($rsync_request)->is_processed } 'rsync';
 
     my $status = $cache_client->status($rsync_request);
     is $status->result, 'exit code 0', "exit code ok, run $run";
@@ -281,11 +280,11 @@ subtest 'Client can check if there are available workers' => sub {
     $cache_service->stop;
     ok !$cache_client->info->available, 'Cache server is not available';
     $cache_service->restart;
-    sleep .1 until $cache_client->info->available;
+    wait_for_or_bail_out { $cache_client->info->available } 'cache service';
     ok $cache_client->info->available, 'Cache server is available';
     ok !$cache_client->info->available_workers, 'No available workers at the moment';
     $worker_cache_service->start;
-    sleep .1 and note "waiting for minion worker to be available" until $cache_client->info->available_workers;
+    wait_for_or_bail_out { $cache_client->info->available_workers } 'minion_worker';
     ok $cache_client->info->available_workers, 'Workers are available now';
 };
 
@@ -312,7 +311,7 @@ subtest 'Race for same asset' => sub {
 
     my $concurrent_test = sub {
         if (!$cache_client->enqueue($asset_request)) {
-            sleep .1 until $cache_client->status($asset_request)->is_processed;
+            wait_for_or_bail_out { $cache_client->status($asset_request)->is_processed } 'asset';
             Devel::Cover::report() if Devel::Cover->can('report');
 
             return 1 if $cache_client->asset_exists('localhost', $asset);
@@ -342,7 +341,7 @@ subtest 'Default usage' => sub {
       or die diag "Asset already exists - abort test";
 
     if (!$cache_client->enqueue($asset_request)) {
-        sleep .1 until $cache_client->status($asset_request)->is_processed;
+        wait_for_or_bail_out { $cache_client->status($asset_request)->is_processed } 'asset';
         my $out = $cache_client->status($asset_request)->output;
         ok($out, 'Output should be present') or die diag $out;
         like $out, qr/Downloading "$asset" from/, "Asset download attempt logged";
@@ -364,7 +363,7 @@ subtest 'Small assets causes racing when releasing locks' => sub {
       or die diag "Asset already exists - abort test";
 
     if (!$cache_client->enqueue($asset_request)) {
-        sleep .1 until $cache_client->status($asset_request)->is_processed;
+        wait_for_or_bail_out { $cache_client->status($asset_request)->is_processed } 'asset';
         my $out = $cache_client->status($asset_request)->output;
         ok($out, 'Output should be present') or die diag $out;
         like $out, qr/Downloading "$asset" from/, "Asset download attempt logged";
@@ -402,7 +401,10 @@ subtest 'Multiple minion workers (parallel downloads, almost simulating real sce
       = map { $_ => $cache_client->asset_request(id => 922756, asset => $_, type => 'hdd', host => $host) } @assets;
     ok(!$cache_client->enqueue($requests{$_}), "Download enqueued for $_") for @assets;
 
-    sleep .1 until (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets;
+    wait_for_or_bail_out {
+        (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets
+    }
+    'assets';
 
     ok($cache_client->asset_exists('localhost', $_), "Asset $_ downloaded correctly") for @assets;
 
@@ -412,7 +414,10 @@ subtest 'Multiple minion workers (parallel downloads, almost simulating real sce
       = map { $_ => $cache_client->asset_request(id => 922756, asset => $_, type => 'hdd', host => $host) } @assets;
     ok(!$cache_client->enqueue($requests{$_}), "Download enqueued for $_") for @assets;
 
-    sleep .1 until (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets;
+    wait_for_or_bail_out {
+        (grep { $_ == 1 } map { $cache_client->status($requests{$_})->is_processed } @assets) == @assets
+    }
+    'assets';
 
     ok($cache_client->asset_exists('localhost', "sle-12-SP3-x86_64-0368-200_88888\@64bit.qcow2"),
         "Asset $_ downloaded correctly")

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -46,7 +46,7 @@ use POSIX '_exit';
 use Time::HiRes qw(sleep);
 use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
-use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service);
+use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service wait_for_or_bail_out);
 use Mojo::Util qw(md5_sum);
 use OpenQA::CacheService;
 use OpenQA::CacheService::Request;
@@ -77,12 +77,7 @@ sub start_server {
     $server_instance->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0)->restart;
     $cache_service->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0)->restart->restart;
     $worker_cache_service->restart;
-    my $cache_timeout = 60 * 10;
-    for (1 .. $cache_timeout) {
-        last if $cache_client->info->available;
-        note "Waiting for cache service to be reachable, try: $_";
-        sleep .1;
-    }
+    wait_for_or_bail_out { $cache_client->info->available } 'cache service';
 }
 
 sub test_default_usage {

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -50,7 +50,7 @@ use Mojo::Log;
 use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
-use OpenQA::Test::Utils qw(fake_asset_server);
+use OpenQA::Test::Utils qw(fake_asset_server wait_for_or_bail_out);
 
 my $port = Mojo::IOLoop::Server->generate_port;
 my $host = "localhost:$port";
@@ -76,8 +76,7 @@ my $server_instance = process sub {
 
 sub start_server {
     $server_instance->set_pipes(0)->start;
-    sleep 1 while !IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port);
-    return;
+    wait_for_or_bail_out { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port) } 'cache service';
 }
 
 sub stop_server {

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -28,7 +28,7 @@ use Mojo::Log;
 use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
-use OpenQA::Test::Utils qw(fake_asset_server);
+use OpenQA::Test::Utils qw(fake_asset_server wait_for_or_bail_out);
 use Mojo::File qw(tempdir);
 
 my $port = Mojo::IOLoop::Server->generate_port;
@@ -55,8 +55,7 @@ my $server_instance = process sub {
 
 sub start_server {
     $server_instance->set_pipes(0)->start;
-    sleep 1 while !IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port);
-    return;
+    wait_for_or_bail_out { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port) } 'worker';
 }
 
 sub stop_server {

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -20,6 +20,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
+use OpenQA::Test::Utils 'wait_for_or_bail_out';
 use Mojo::File qw(tempdir path);
 use File::Copy::Recursive 'dircopy';
 
@@ -149,8 +150,7 @@ my $server_instance = process sub {
 
 sub start_server {
     $server_instance->set_pipes(0)->start;
-    sleep 1 while !_port($fake_server_port);
-    return;
+    wait_for_or_bail_out { _port($fake_server_port) } 'API';
 }
 
 sub stop_server {

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -21,6 +21,7 @@ use Test::Warnings;
 use Test::Mojo;
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
+use OpenQA::Test::Utils 'wait_for_or_bail_out';
 use OpenQA::SeleniumTest;
 use Mojo::File qw(tempdir path);
 use File::Copy::Recursive 'dircopy';
@@ -85,8 +86,7 @@ my $server_instance = process sub {
 
 sub start_server {
     $server_instance->set_pipes(0)->start;
-    sleep 0.1 while !_port($port);
-    return;
+    wait_for_or_bail_out { _port($port) } 'worker';
 }
 
 sub stop_server {


### PR DESCRIPTION
- 600 seconds is too long to wait for the service
- The test should fail if the service never comes up
- Going one step further all tests should have a timeout
- Introduce a helper function for this

Fixes: https://progress.opensuse.org/issues/66664