### PR TITLE
t: Set time limit for 33-developer_mode.t

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -46,6 +46,7 @@ use OpenQA::Test::Utils qw(
   start_worker stop_service
 );
 use OpenQA::Test::FullstackUtils;
+use OpenQA::Test::TimeLimit '180';
 use OpenQA::SeleniumTest;
 
 plan skip_all => 'set DEVELOPER_FULLSTACK=1 (be careful)'                       unless $ENV{DEVELOPER_FULLSTACK};


### PR DESCRIPTION
In
https://app.circleci.com/pipelines/github/os-autoinst/openQA/4208/workflows/a42f68e0-60c7-46e0-88f3-2ace61b3c2b1/jobs/40235
we can see that the test 33-developer_mode.t took 115s so I selected a
conservative value of 180s.