### PR TITLE
Makefile: Fix evaluation of failing unstable tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test-api:
 # put unstable tests in unstable_tests.txt and uncomment in circle CI to handle unstables with retries
 .PHONY: test-unstable
 test-unstable:
-	for f in $$(cat .circleci/unstable_tests.txt); do $(MAKE) test-with-database TIMEOUT_M=5 PROVE_ARGS="$$HARNESS $$f" RETRY=3 || break; done
+	for f in $$(cat .circleci/unstable_tests.txt); do $(MAKE) test-with-database TIMEOUT_M=5 PROVE_ARGS="$$HARNESS $$f" RETRY=3 || exit; done
 
 .PHONY: test-fullstack
 test-fullstack:


### PR DESCRIPTION
We observed the problem that probably since
https://github.com/os-autoinst/openQA/pull/3242
t/25-cache-service.t which is part of "unstable_tests.txt" always fails
in all retries. The other unstable tests were never executed but the
final exit code was reported as 0 so also circleCI reported the test as
successful. The root cause is the "break" in the for-loop not forwarding
the exit code of the underlying failing test. Using a call to "exit"
without argument in the shell code will exit the rule in make with the
according exit code of the underlying test correctly.

Related progress issue: https://progress.opensuse.org/issues/71449