### PR TITLE
scheduler tests: Take t_seen from the database

### DIFF
--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -295,8 +295,7 @@ subtest 'job listing' => sub {
 # assume the worker has just been seen
 my $last_seen = DateTime->now(time_zone => 'UTC');
 $last_seen->subtract(seconds => DB_TIMESTAMP_ACCURACY);
-$worker_db_obj->update({t_seen => $last_seen});
-$worker_db_obj->discard_changes;
+$last_seen = $worker_db_obj->update({t_seen => $last_seen})->t_seen;
 
 subtest 'job grab (WORKER_CLASS mismatch)' => sub {
     my $allocated = OpenQA::Scheduler::Model::Jobs->singleton->schedule();


### PR DESCRIPTION
If what is written to the db is what we want to compare, ad the value can be off by a second, maybe we should use whatever was written in the first place.