### PR TITLE
t: Prevent duplicate test database initialization

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -47,7 +47,7 @@ use OpenQA::Test::Utils qw(
   stop_service unstable_worker
   unresponsive_worker broken_worker rejective_worker
 );
-use OpenQA::Test::TimeLimit '90';
+use OpenQA::Test::TimeLimit '150';
 
 # treat this test like the fullstack test
 plan skip_all => "set SCHEDULER_FULLSTACK=1 (be careful)" unless $ENV{SCHEDULER_FULLSTACK};

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -95,7 +95,7 @@ ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'));
 
 # start Selenium test driver and other daemons
 my $port   = service_port 'webui';
-my $driver = call_driver(sub { }, {mojoport => $port});
+my $driver = call_driver(undef, {mojoport => $port});
 $ws          = create_websocket_server(undef, 0, 0);
 $scheduler   = create_scheduler;
 $livehandler = create_live_view_handler;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -21,7 +21,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '420';
+use OpenQA::Test::TimeLimit '560';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::Schema::Result::ScheduledProducts;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -83,7 +83,7 @@ ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'), 'assets ar
 mock_service_ports;
 my $mojoport = service_port 'websocket';
 $ws = create_websocket_server($mojoport, 0, 0);
-my $driver = call_driver(sub { }, {mojoport => service_port 'webui'});
+my $driver = call_driver(undef, {mojoport => service_port 'webui'});
 $livehandler = create_live_view_handler;
 
 my $resultdir = path($ENV{OPENQA_BASEDIR}, 'openqa', 'testresults')->make_path;

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -35,8 +35,7 @@ our $drivermissing = 'Install Selenium::Remote::Driver and Selenium::Chrome to r
 
 sub _start_app {
     my ($schema_hook, $args) = @_;
-    $schema_hook = sub { OpenQA::Test::Database->new->create }
-      unless $schema_hook;
+    $schema_hook //= sub { };
     $mojoport    = $ENV{OPENQA_BASE_PORT} = $args->{mojoport} // $ENV{MOJO_PORT} // Mojo::IOLoop::Server->generate_port;
     $startingpid = $$;
     $webapi      = OpenQA::Test::Utils::create_webapi($mojoport, $schema_hook);

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -26,7 +26,7 @@ use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data(fixtures_glob => '03-users.pl');
-my $driver = call_driver();
+my $driver = call_driver;
 unless ($driver) {
     plan skip_all => $OpenQA::SeleniumTest::drivermissing;
     exit(0);

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -19,7 +19,6 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
-use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::TimeLimit '50';
 use OpenQA::Test::Case;
@@ -30,50 +29,43 @@ $test_case->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl');
 
 plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver();
 
-# First page without login
-$driver->title_is("openQA");
+$driver->title_is('openQA');
 
-# Test suites without login
-is $driver->get('/admin/test_suites'), 1, 'opened test suites';
-$driver->title_is('openQA: Test suites');
-wait_for_ajax;
-like($driver->find_element('#test-suites tbody tr:nth-child(2) td')->get_text(), qr/advanced_kde/, '2nd entry');
-like($driver->find_element('#test-suites tbody tr:nth-child(5) td')->get_text(), qr/kde/,          '5th entry');
-like(
-    $driver->find_element('#test-suites tbody tr:nth-child(5) td:nth-child(3)')->get_text(),
-    qr/Simple kde test, before advanced_kde/,
-    '5th entry has a description'
-);
-like($driver->find_element('#test-suites tbody tr:last-child td')->get_text(), qr/textmode/, 'last entry');
+subtest 'Test suites without login' => sub {
+    is $driver->get('/admin/test_suites'), 1, 'opened test suites';
+    $driver->title_is('openQA: Test suites');
+    wait_for_ajax(msg => 'Wait for test suites table');
+    like($driver->find_element('#test-suites tbody tr:nth-child(2) td')->get_text(), qr/advanced_kde/, '2nd entry');
+    like($driver->find_element('#test-suites tbody tr:nth-child(5) td')->get_text(), qr/kde/,          '5th entry');
+    my $description = $driver->find_element('#test-suites tbody tr:nth-child(5) td:nth-child(3)')->get_text();
+    like($description, qr/Simple kde test, before advanced_kde/, '5th entry has a description');
+    like($driver->find_element('#test-suites tbody tr:last-child td')->get_text(), qr/textmode/, 'last entry');
+};
 
-# Test suites can be searched
-$driver->get('/admin/test_suites?q=client2');
-wait_for_ajax;
-my $table = $driver->find_element_by_class('admintable');
-like($table->child('tbody tr:first-child td')->get_text(), qr/client2/, 'first entry');
+subtest 'Test suites can be searched' => sub {
+    $driver->get('/admin/test_suites?q=client2');
+    wait_for_ajax(msg => 'Wait for test suites table search result');
+    like($driver->find_element('#test-suites tbody tr:first-child td')->get_text(), qr/client2/, 'first entry');
+};
 
 subtest Products => sub {
     $driver->get('/admin/products');
-    wait_for_ajax;
-    my $table = $driver->find_element_by_class('admintable');
-    like($table->child('tbody tr:first-child td')->get_text(), qr/opensuse/, 'first entry');
+    wait_for_ajax(msg => 'Wait for products table');
+    like($driver->find_element('#products tbody tr:first-child td')->get_text(), qr/opensuse/, 'first product entry');
 
     $driver->get('/admin/products?q=sle');
-    wait_for_ajax;
-    $table = $driver->find_element_by_class('admintable');
-    like($table->child('tbody tr:first-child td')->get_text(), qr/sle/, 'first entry');
+    wait_for_ajax(msg => 'Wait for products table search result');
+    like($driver->find_element('#products tbody tr:first-child td')->get_text(), qr/sle/, 'product search entry');
 };
 
 subtest Machines => sub {
     $driver->get('/admin/machines');
-    wait_for_ajax;
-    my $table = $driver->find_element_by_class('admintable');
-    like($table->child('tbody tr:first-child td')->get_text(), qr/32bit/, 'first entry');
+    wait_for_ajax(msg => 'Wait for machines table');
+    like($driver->find_element('#machines tbody tr:first-child td')->get_text(), qr/32bit/, 'first machine entry');
 
     $driver->get('/admin/machines?q=laptop');
-    wait_for_ajax;
-    $table = $driver->find_element_by_class('admintable');
-    like($table->child('tbody tr:first-child td')->get_text(), qr/Laptop_64/, 'first entry');
+    wait_for_ajax(msg => 'Wait for machines table search result');
+    like($driver->find_element('#machines tbody tr:first-child td')->get_text(), qr/Laptop_64/, 'machine search entry');
 };
 
 kill_driver();

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -25,9 +25,9 @@ use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl');
+$test_case->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 04-products.pl');
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver();
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 $driver->title_is('openQA');
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -28,7 +28,7 @@ use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 
-my $driver = call_driver();
+my $driver = call_driver;
 unless ($driver) {
     plan skip_all => $OpenQA::SeleniumTest::drivermissing;
     exit(0);

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -29,7 +29,7 @@ use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
 
-my $driver = call_driver();
+my $driver = call_driver;
 if (!$driver) {
     plan skip_all => $OpenQA::SeleniumTest::drivermissing;
     exit(0);
@@ -53,7 +53,7 @@ subtest 'Perl modules' => sub {
     my $results = $driver->find_element_by_id('results');
     my @entries = $results->children('.list-group-item');
     is $header->get_text(), 'Search results: ' . scalar @entries . ' matches found', 'number of results in header';
-    is scalar @entries, 7, '7 elements' or return;
+    is scalar @entries, 2, '2 elements' or return;
 
     my $first = $entries[0];
     is $first->child('.occurrence')->get_text(), 'opensuse/tests/installation/installer_timezone.pm',

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -24,11 +24,11 @@ use OpenQA::Test::TimeLimit '50';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data(fixtures_glob => '01-jobs.pl');
+$test_case->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl');
 
 use OpenQA::SeleniumTest;
 
-my $driver = call_driver();
+my $driver = call_driver;
 unless ($driver) {
     plan skip_all => $OpenQA::SeleniumTest::drivermissing;
     exit(0);

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -28,8 +28,7 @@ use OpenQA::Client;
 use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
-
-my $driver = call_driver();
+my $driver = call_driver;
 if (!$driver) {
     plan skip_all => $OpenQA::SeleniumTest::drivermissing;
     exit(0);
@@ -69,19 +68,19 @@ my $search = $driver->find_element('#audit_log_table_filter input.form-control')
 ok($search, 'search box found');
 
 my @entries = $driver->find_child_elements($table, 'tbody/tr', 'xpath');
-is(scalar @entries, 3, 'three elements without filter');
+is(scalar @entries, 4, 'elements without filter');
 
 $search->send_keys('QA restart');
 wait_for_data_table;
 @entries = $driver->find_child_elements($table, 'tbody/tr', 'xpath');
-is(scalar @entries, 1, 'one element when filtered for event data');
+is(scalar @entries, 2, 'less elements when filtered for event data');
 like($entries[0]->get_text(), qr/openQA restarted/, 'correct element displayed');
 $search->clear;
 
 $search->send_keys('user:system');
 wait_for_data_table;
 @entries = $driver->find_child_elements($table, 'tbody/tr', 'xpath');
-is(scalar @entries, 1, 'one element when filtered by user');
+is(scalar @entries, 2, 'less elements when filtered by user');
 $search->clear;
 
 $search->send_keys('event:user_login');
@@ -93,7 +92,7 @@ $search->clear;
 $search->send_keys('newer:today');
 wait_for_data_table;
 @entries = $driver->find_child_elements($table, 'tbody/tr', 'xpath');
-is(scalar @entries, 3, 'three elements when filtered by today time');
+is(scalar @entries, 4, 'elements when filtered by today time');
 $search->clear;
 
 $search->send_keys('older:today');
@@ -106,7 +105,7 @@ $search->clear;
 $search->send_keys('user:system event:startup date:today');
 wait_for_data_table;
 @entries = $driver->find_child_elements($table, 'tbody/tr', 'xpath');
-is(scalar @entries, 1, 'one element when filtered by combination');
+is(scalar @entries, 2, 'elements when filtered by combination');
 
 
 kill_driver();

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -112,7 +112,7 @@ EOF
 note("Starting fake api server");
 start_server();
 
-my $driver = call_driver(sub { }, {with_gru => 1});
+my $driver = call_driver(undef, {with_gru => 1});
 
 plan skip_all => $OpenQA::SeleniumTest::drivermissing unless $driver;
 

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -39,7 +39,7 @@ my $foo_path                       = "foo/foo.txt";
 my $uri_path_from_root_dir         = "/tests/$job_id/settings/$foo_path";
 my $uri_path_from_default_data_dir = "/tests/$job_id/settings/bar/foo.txt";
 
-my $driver = call_driver();
+my $driver = call_driver;
 unless ($driver) {
     plan skip_all => $OpenQA::SeleniumTest::drivermissing;
     exit(0);

--- a/templates/webapi/admin/product/index.html.ep
+++ b/templates/webapi/admin/product/index.html.ep
@@ -12,7 +12,7 @@
 
     %= include 'layouts/info'
 
-    <table class="admintable table table-striped" id='test-suites'>
+    <table class="admintable table table-striped" id='products'>
         <thead>
             <tr>
                 <th class="col_value">Distri</th>


### PR DESCRIPTION
Our OpenQA::SeleniumTest::call_driver function when called without
arguments would implicitly create a test database. In all cases where
this was used the database was not used at all and just takes time to
initialize and is prone to confuse test writers with two parallel test
database instances.

This commit changes `call_driver` to not initialize its own database
anymore. If potentially necessary one could pass an externally created
database.

Related progress issue: https://progress.opensuse.org/issues/71500