### PR TITLE
t: Use more concise one-line Selenium driver initialization; Completely remove unused schema_hook functionality

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -95,7 +95,7 @@ ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'));
 
 # start Selenium test driver and other daemons
 my $port   = service_port 'webui';
-my $driver = call_driver(undef, {mojoport => $port});
+my $driver = call_driver({mojoport => $port});
 $ws          = create_websocket_server(undef, 0, 0);
 $scheduler   = create_scheduler;
 $livehandler = create_live_view_handler;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -83,7 +83,7 @@ ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'), 'assets ar
 mock_service_ports;
 my $mojoport = service_port 'websocket';
 $ws = create_websocket_server($mojoport, 0, 0);
-my $driver = call_driver(undef, {mojoport => service_port 'webui'});
+my $driver = call_driver({mojoport => service_port 'webui'});
 $livehandler = create_live_view_handler;
 
 my $resultdir = path($ENV{OPENQA_BASEDIR}, 'openqa', 'testresults')->make_path;

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -34,11 +34,10 @@ our $startingpid   = 0;
 our $drivermissing = 'Install Selenium::Remote::Driver and Selenium::Chrome to run these tests';
 
 sub _start_app {
-    my ($schema_hook, $args) = @_;
-    $schema_hook //= sub { };
+    my ($args) = @_;
     $mojoport    = $ENV{OPENQA_BASE_PORT} = $args->{mojoport} // $ENV{MOJO_PORT} // Mojo::IOLoop::Server->generate_port;
     $startingpid = $$;
-    $webapi      = OpenQA::Test::Utils::create_webapi($mojoport, $schema_hook);
+    $webapi      = OpenQA::Test::Utils::create_webapi($mojoport);
     $gru         = _start_gru() if ($args->{with_gru});
     return $mojoport;
 }
@@ -167,11 +166,10 @@ sub check_driver_modules {
 }
 
 sub call_driver {
-    # return a omjs driver using specified schema hook if modules
-    # are available, otherwise return undef
+    # return a omjs driver if modules are available, otherwise return undef
     return undef unless check_driver_modules;
-    my ($schema_hook, $args) = @_;
-    my $mojoport = _start_app($schema_hook, $args);
+    my ($args) = @_;
+    my $mojoport = _start_app($args);
     return start_driver($mojoport);
 }
 

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -219,15 +219,12 @@ sub stop_service {
 }
 
 sub create_webapi {
-    my ($port, $schema_hook) = @_;
+    my ($port) = @_;
     $port //= service_port 'webui';
-    die 'No schema hook specified' unless $schema_hook;
     note("Starting WebUI service. Port: $port");
 
     my $h = start sub {
         $0 = 'openqa-webapi';
-        $schema_hook->();
-
         local $ENV{MOJO_MODE} = 'test';
         my $daemon = Mojo::Server::Daemon->new(listen => ["http://127.0.0.1:$port"], silent => 1);
         $daemon->build_app('OpenQA::WebAPI');

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -125,11 +125,7 @@ sub schema_hook {
               [{key => 'JOB_TEMPLATE_NAME', value => 'kde_variant'}, {key => 'TEST_SUITE_NAME', value => 'kde'}]});
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 $driver->title_is("openQA", "on main page");
 is($driver->get("/results"), 1, "/results gets");

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -53,10 +53,10 @@ my %job_param = (
 
 );
 
-# By defining a custom hook we can customize the database based on fixtures.
+# Customize the database based on fixtures.
 # We do not need job 99981 right now so delete it here just to have a helpful
 # example for customizing the test database
-sub schema_hook {
+sub prepare_database {
     my $jobs = $schema->resultset('Jobs');
     $jobs->find(99981)->delete;
 
@@ -125,7 +125,9 @@ sub schema_hook {
               [{key => 'JOB_TEMPLATE_NAME', value => 'kde_variant'}, {key => 'TEST_SUITE_NAME', value => 'kde'}]});
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+prepare_database();
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 $driver->title_is("openQA", "on main page");
 is($driver->get("/results"), 1, "/results gets");

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -26,12 +26,8 @@ OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 04-products.pl')
 
 use OpenQA::SeleniumTest;
 
-my $t      = Test::Mojo->new('OpenQA::WebAPI');
-my $driver = call_driver;
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 ok $driver->get('/tests?groupid=0'), 'list jobs without group';
 wait_for_ajax(msg => 'wait for test list without group');

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -26,11 +26,7 @@ use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data(fixtures_glob => '03-users.pl');
-my $driver = call_driver;
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -128,12 +128,7 @@ sub schema_hook {
     $jobs->create($job_hash);
 }
 
-my $driver = call_driver(\&schema_hook);
-
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 $driver->title_is("openQA", "on main page");
 my $baseurl = $driver->get_current_url();

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -33,7 +33,7 @@ my $schema      = $test_case->init_data(
 );
 my $jobs = $schema->resultset('Jobs');
 
-sub schema_hook {
+sub prepare_database {
     my $comments = $schema->resultset('Comments');
     my $bugs     = $schema->resultset('Bugs');
 
@@ -128,7 +128,9 @@ sub schema_hook {
     $jobs->create($job_hash);
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+prepare_database;
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 $driver->title_is("openQA", "on main page");
 my $baseurl = $driver->get_current_url();

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -85,8 +85,9 @@ sub create_running_job_for_needle_editor {
         });
 }
 
-my @driver_args = (\&create_running_job_for_needle_editor, {with_gru => 1});
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(@driver_args);
+create_running_job_for_needle_editor;
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver({with_gru => 1});
 
 my $elem;
 my $decode_textarea;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -85,11 +85,8 @@ sub create_running_job_for_needle_editor {
         });
 }
 
-my $driver = call_driver(\&create_running_job_for_needle_editor, {with_gru => 1});
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+my @driver_args = (\&create_running_job_for_needle_editor, {with_gru => 1});
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(@driver_args);
 
 my $elem;
 my $decode_textarea;

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -57,11 +57,7 @@ sub schema_hook {
         });
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -23,6 +23,7 @@ use File::Spec::Functions 'catfile';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::TimeLimit '80';
+use OpenQA::SeleniumTest;
 use OpenQA::Test::Case;
 use OpenQA::Utils 'assetdir';
 use Date::Format 'time2str';
@@ -38,26 +39,18 @@ my $schema      = $test_case->init_data(
     fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl 04-products.pl'
 );
 
-use OpenQA::SeleniumTest;
+my $job_groups = $schema->resultset('JobGroups');
+my $assets     = $schema->resultset('Assets');
+$assets->find(2)->update(
+    {
+        size            => 4096,
+        last_use_job_id => 99962,
+        t_created       => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),
+    });
 
-sub schema_hook {
-    my $job_groups = $schema->resultset('JobGroups');
-    my $assets     = $schema->resultset('Assets');
+$job_groups->find(1002)->update({exclusively_kept_asset_size => 4096});
 
-    $assets->find(2)->update(
-        {
-            size            => 4096,
-            last_use_job_id => 99962,
-            t_created       => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),
-        });
-
-    $job_groups->find(1002)->update(
-        {
-            exclusively_kept_asset_size => 4096,
-        });
-}
-
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -73,11 +73,7 @@ sub schema_hook {
             ]});
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -31,7 +31,7 @@ my $schema_name   = OpenQA::Test::Database->generate_schema_name;
 my $schema        = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '01-jobs.pl 02-workers.pl');
 my $parent_groups = $schema->resultset('JobGroupParents');
 
-sub schema_hook {
+sub prepare_database {
     my $job_groups = $schema->resultset('JobGroups');
     my $jobs       = $schema->resultset('Jobs');
     # add job groups from fixtures to new parent
@@ -73,7 +73,9 @@ sub schema_hook {
             ]});
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+prepare_database();
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -28,11 +28,7 @@ use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 
-my $driver = call_driver;
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -66,11 +66,7 @@ sub schema_hook {
     $workers->create({id => $offline_worker_id, host => 'offline_test', instance => 1, t_seen => $offline_timestamp});
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 $driver->title_is("openQA", "on main page");
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -44,12 +44,7 @@ sub schema_hook {
         });
 }
 
-my $driver = call_driver(\&schema_hook);
-
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 #
 # List with no parameters

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -32,19 +32,17 @@ my $schema
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-sub schema_hook {
-    # create a parent group
-    $schema->resultset('JobGroupParents')->create({id => 1, name => 'Test parent', sort_order => 0});
-    $schema->resultset('Bugs')->create(
-        {
-            bugid     => 'bsc#1234',
-            title     => 'some title with "quotes" and <html>elements</html>',
-            existing  => 1,
-            refreshed => 1,
-        });
-}
+# create a parent group
+$schema->resultset('JobGroupParents')->create({id => 1, name => 'Test parent', sort_order => 0});
+$schema->resultset('Bugs')->create(
+    {
+        bugid     => 'bsc#1234',
+        title     => 'some title with "quotes" and <html>elements</html>',
+        existing  => 1,
+        refreshed => 1,
+    });
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 #
 # List with no parameters

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -29,11 +29,7 @@ use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
 
-my $driver = call_driver;
-if (!$driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 # we need to talk to the phantom instance or else we're using wrong database

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -32,7 +32,7 @@ my $schema      = $test_case->init_data(
     fixtures_glob => '01-jobs.pl 05-job_modules.pl 06-job_dependencies.pl'
 );
 
-sub schema_hook {
+sub prepare_database {
     my $jobs         = $schema->resultset('Jobs');
     my $dependencies = $schema->resultset('JobDependencies');
 
@@ -69,7 +69,9 @@ sub schema_hook {
     # note: This cluster makes no sense but that is not the point of this test.
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+prepare_database;
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 sub get_tooltip {
     my ($job_id) = @_;

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -69,11 +69,7 @@ sub schema_hook {
     # note: This cluster makes no sense but that is not the point of this test.
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 sub get_tooltip {
     my ($job_id) = @_;

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -83,11 +83,7 @@ sub schema_hook {
         });
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 # check job next and previous not loaded when open tests/x
 $t->get_ok('/tests/99946')->status_is(200)->element_exists_not(

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -34,7 +34,7 @@ use OpenQA::SeleniumTest;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
-sub schema_hook {
+sub prepare_database {
     my $jobs = $schema->resultset('Jobs');
 
     # Populate more jobs to test page setting and include incompletes
@@ -83,7 +83,9 @@ sub schema_hook {
         });
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+prepare_database;
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 # check job next and previous not loaded when open tests/x
 $t->get_ok('/tests/99946')->status_is(200)->element_exists_not(

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -40,11 +40,7 @@ sub schema_hook {
     $test_suits->find(1017)->settings->find({key => 'START_AFTER_TEST'})->update({value => 'kda,textmode'});
 }
 
-my $driver = call_driver(\&schema_hook);
-if (!$driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 # setup test application with API access
 # note: Test::Mojo loses its app when setting a new ua (see https://github.com/kraih/mojo/issues/598).

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -34,13 +34,11 @@ my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema
   = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
-sub schema_hook {
-    # simulate typo in START_AFTER_TEST to check for error message in this case
-    my $test_suits = $schema->resultset('TestSuites');
-    $test_suits->find(1017)->settings->find({key => 'START_AFTER_TEST'})->update({value => 'kda,textmode'});
-}
+# simulate typo in START_AFTER_TEST to check for error message in this case
+my $test_suites = $schema->resultset('TestSuites');
+$test_suites->find(1017)->settings->find({key => 'START_AFTER_TEST'})->update({value => 'kda,textmode'});
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 # setup test application with API access
 # note: Test::Mojo loses its app when setting a new ua (see https://github.com/kraih/mojo/issues/598).

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -72,11 +72,7 @@ sub schema_hook {
     $needle_dir_fixture->update({path => $needle_dir->realpath});
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 my $baseurl = $driver->get_current_url;
 sub current_tab { $driver->find_element('.nav.nav-tabs .active')->get_text }
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -45,7 +45,7 @@ my $needle_dir         = path($needle_dir_fixture->path);
 $needle_dir->remove_tree({keep_root => 1});
 $needle_dir->child('inst-timezone-text.json')->spurt('{"area":[],"tags":["ENV-VIDEOMODE-text","inst-timezone"]}');
 
-sub schema_hook {
+sub prepare_database {
     my $jobs = $schema->resultset('Jobs');
 
     # set assigned_worker_id to test whether worker still displayed when job set to done
@@ -72,7 +72,9 @@ sub schema_hook {
     $needle_dir_fixture->update({path => $needle_dir->realpath});
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+prepare_database;
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 my $baseurl = $driver->get_current_url;
 sub current_tab { $driver->find_element('.nav.nav-tabs .active')->get_text }
 

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -28,11 +28,7 @@ $test_case->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl');
 
 use OpenQA::SeleniumTest;
 
-my $driver = call_driver;
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 $driver->title_is("openQA", "on main page");
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -51,11 +51,7 @@ sub schema_hook {
             file_present           => 1,
         });
 }
-my $driver = call_driver(\&schema_hook, {with_gru => 1});
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook, {with_gru => 1});
 
 my @needle_files = qw(inst-timezone-text.json inst-timezone-text.png never-matched.json never-matched.png);
 # create dummy files for needles

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -49,7 +49,7 @@ $schema->resultset('Needles')->create(
         file_present           => 1,
     });
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(undef, {with_gru => 1});
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver({with_gru => 1});
 
 my @needle_files = qw(inst-timezone-text.json inst-timezone-text.png never-matched.json never-matched.png);
 # create dummy files for needles

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -39,19 +39,17 @@ my $schema
 my $needle_dir = 't/data/openqa/share/tests/opensuse/needles/';
 chmod(0755, $needle_dir);
 
-sub schema_hook {
-    my $needles = $schema->resultset('Needles');
-    $needles->create(
-        {
-            dir_id                 => 1,
-            filename               => 'never-matched.json',
-            last_seen_module_id    => 10,
-            last_seen_time         => time2str('%Y-%m-%d %H:%M:%S', time - 100000),
-            last_matched_module_id => undef,
-            file_present           => 1,
-        });
-}
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook, {with_gru => 1});
+$schema->resultset('Needles')->create(
+    {
+        dir_id                 => 1,
+        filename               => 'never-matched.json',
+        last_seen_module_id    => 10,
+        last_seen_time         => time2str('%Y-%m-%d %H:%M:%S', time - 100000),
+        last_matched_module_id => undef,
+        file_present           => 1,
+    });
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(undef, {with_gru => 1});
 
 my @needle_files = qw(inst-timezone-text.json inst-timezone-text.png never-matched.json never-matched.png);
 # create dummy files for needles

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -28,11 +28,7 @@ use OpenQA::Client;
 use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
-my $driver = call_driver;
-if (!$driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 sub wait_for_data_table {
     wait_for_ajax;

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -28,12 +28,9 @@ my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema      = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '03-users.pl');
 my $t           = Test::Mojo->new('OpenQA::WebAPI');
+$schema->resultset('Users')->create({username => 'nobody', feature_version => 1});
 
-sub schema_hook {
-    $schema->resultset('Users')->create({username => 'nobody', feature_version => 1});
-}
-
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 $driver->title_is("openQA", "on main page");
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -33,12 +33,7 @@ sub schema_hook {
     $schema->resultset('Users')->create({username => 'nobody', feature_version => 1});
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
-
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 $driver->title_is("openQA", "on main page");
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -67,12 +67,8 @@ sub schema_hook {
       or note 'unable to register developer session for finished job';
 }
 
-my $t      = Test::Mojo->new('OpenQA::WebAPI');
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 # executes JavaScript code taking a note
 sub inject_java_script {

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -37,7 +37,7 @@ my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema      = $test_case->init_data(schema_name => $schema_name);
 my $tempdir     = tempdir;
 
-sub schema_hook {
+sub prepare_database {
     my $schema             = OpenQA::Test::Database->new->create;
     my $workers            = $schema->resultset('Workers');
     my $jobs               = $schema->resultset('Jobs');
@@ -67,8 +67,10 @@ sub schema_hook {
       or note 'unable to register developer session for finished job';
 }
 
+prepare_database;
+
 my $t = Test::Mojo->new('OpenQA::WebAPI');
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 # executes JavaScript code taking a note
 sub inject_java_script {

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -29,7 +29,7 @@ my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
 my $schema      = $test_case->init_data(schema_name => $schema_name);
 
-sub schema_hook {
+sub prepare_database {
     my $jobs = $schema->resultset('Jobs');
 
     # Populate more cluster jobs
@@ -78,6 +78,8 @@ sub schema_hook {
         });
 }
 
+prepare_database;
+
 my $last_job_id;
 sub update_last_job_id {
     $last_job_id = $schema->resultset('Jobs')->search(undef, {rows => 1, order_by => {-desc => 'id'}})->first->id;
@@ -88,7 +90,7 @@ sub expected_job_id_regex {
     return qr|tests/$expected_job_id|;
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 $driver->title_is('openQA', 'on main page');
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -88,11 +88,7 @@ sub expected_job_id_regex {
     return qr|tests/$expected_job_id|;
 }
 
-my $driver = call_driver(\&schema_hook);
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(\&schema_hook);
 
 $driver->title_is('openQA', 'on main page');
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -112,9 +112,7 @@ EOF
 note("Starting fake api server");
 start_server();
 
-my $driver = call_driver(undef, {with_gru => 1});
-
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless $driver;
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(undef, {with_gru => 1});
 
 $driver->find_element_by_class('navbar-brand')->click();
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -112,7 +112,7 @@ EOF
 note("Starting fake api server");
 start_server();
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver(undef, {with_gru => 1});
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver({with_gru => 1});
 
 $driver->find_element_by_class('navbar-brand')->click();
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -39,11 +39,7 @@ my $foo_path                       = "foo/foo.txt";
 my $uri_path_from_root_dir         = "/tests/$job_id/settings/$foo_path";
 my $uri_path_from_default_data_dir = "/tests/$job_id/settings/bar/foo.txt";
 
-my $driver = call_driver;
-unless ($driver) {
-    plan skip_all => $OpenQA::SeleniumTest::drivermissing;
-    exit(0);
-}
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
 
 $t->get_ok($uri_path_from_root_dir)->status_is(200)


### PR DESCRIPTION
* t: Replace all schema hooks by more simple schema updates
* t: Use more concise one-line Selenium driver initialization
* t: Completely remove unused schema_hook functionality