### PR TITLE
ci: Prevent too early circleci timeout on no output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ aliases:
       export PERL5OPT="$COVEROPT,-db,cover_db_${CIRCLE_JOB}"
       echo PERL5OPT="$PERL5OPT"
       make test-$CIRCLE_JOB
+    no_output_timeout: 30m
 
   - &git_token_authentication
     name: "Prepare auth token"


### PR DESCRIPTION
We have some long running tests and especially with internal retrying
aborting after 10m prevents access to helpful details what actually went
wrong. This commit increases the timeout when circleci aborts a job from
10m without output to 30m to help in these cases. Still our goal should
be for each individual test to finish much faster of course.

Related progress issue: https://progress.opensuse.org/issues/66664