### PR TITLE
 Avoid worker assumed to be offline from interfering when it comes back after all

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -207,7 +207,9 @@ function showJobRestartResults(responseJSON, newJobUrl, retryFunction, targetEle
 }
 
 function forceJobRestartViaRestartLink(restartLink) {
-    restartLink.href += '?force=1';
+    if (!restartLink.href.endsWith('?force=1')) {
+        restartLink.href += '?force=1';
+    }
     restartLink.click();
 }
 

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -51,8 +51,9 @@ use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, DONE, CA
 # "meta" states
 use constant PENDING_STATES       => (SCHEDULED, ASSIGNED, SETUP,   RUNNING, UPLOADING);
 use constant EXECUTION_STATES     => (ASSIGNED,  SETUP,    RUNNING, UPLOADING);
-use constant PRE_EXECUTION_STATES => (SCHEDULED);        # Assigned belongs to pre execution, but makes no sense for now
-use constant FINAL_STATES         => (DONE, CANCELLED);
+use constant PRE_EXECUTION_STATES => (SCHEDULED);
+use constant PRISTINE_STATES      => (SCHEDULED, ASSIGNED);    # no worker reported any updates/results so far
+use constant FINAL_STATES         => (DONE,      CANCELLED);
 use constant {
     PRE_EXECUTION => 'pre_execution',
     EXECUTION     => 'execution',
@@ -120,6 +121,7 @@ our @EXPORT = qw(
   PASSED
   PENDING_STATES
   PRE_EXECUTION_STATES
+  PRISTINE_STATES
   RESULTS
   RUNNING
   SCHEDULED

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -51,11 +51,7 @@ sub job_restart {
     my $force            = $args{force};
     my %duplication_args = map { ($_ => $args{$_}) } qw(prio skip_parents skip_children skip_ok_result_children);
     my $schema           = OpenQA::Schema->singleton;
-    my $jobs             = $schema->resultset("Jobs")->search(
-        {
-            id    => $jobids,
-            state => [OpenQA::Jobs::Constants::EXECUTION_STATES, OpenQA::Jobs::Constants::FINAL_STATES],
-        });
+    my $jobs = $schema->resultset('Jobs')->search({id => $jobids, state => {'not in' => [PRISTINE_STATES]}});
     $duplication_args{no_directly_chained_parent} = 1 unless $force;
     while (my $job = $jobs->next) {
         my $job_id         = $job->id;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -539,7 +539,7 @@ Checks if a given job can be duplicated - not cloned yet and in correct state.
 =cut
 sub can_be_duplicated {
     my ($self) = @_;
-    return (!defined $self->clone_id) && ($self->state ne SCHEDULED);
+    return (!defined $self->clone_id) && !(grep { $self->state eq $_ } PRISTINE_STATES);
 }
 
 sub _compute_asset_names_considering_parent_jobs {
@@ -903,7 +903,8 @@ sub duplicate {
 
     # If the job already has a clone, none is created
     my ($orig_id, $clone_id) = ($self->id, $self->clone_id);
-    return "Job $orig_id is still scheduled"                   if $self->state eq SCHEDULED;
+    my $state = $self->state;
+    return "Job $orig_id is still $state"                      if grep { $state eq $_ } PRISTINE_STATES;
     return "Job $orig_id has already been cloned as $clone_id" if defined $clone_id;
 
     my $jobs = eval {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2026,17 +2026,9 @@ sub done {
 
 sub cancel {
     my ($self, $obsoleted) = @_;
-    $obsoleted //= 0;
-    my $result = $obsoleted ? OBSOLETED : USER_CANCELLED;
-    return if ($self->result ne NONE);
-    my $state = $self->state;
+    return undef if $self->result ne NONE;
     $self->release_networks;
-    $self->update(
-        {
-            state  => CANCELLED,
-            result => $result
-        });
-
+    $self->update({state => CANCELLED, result => ($obsoleted ? OBSOLETED : USER_CANCELLED)});
     my $count = 1;
     if (my $worker = $self->assigned_worker) {
         $worker->send_command(command => WORKER_COMMAND_CANCEL, job_id => $self->id);
@@ -2045,7 +2037,6 @@ sub cancel {
     for my $job (sort keys %$jobs) {
         $count += $self->_job_stop_cluster($job);
     }
-
     return $count;
 }
 

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -598,7 +598,9 @@ sub _set_job_done {
     $params->{reason} = $formatted_reason if defined $formatted_reason;
 
     my $job_id = $self->id;
-    return $self->client->send(
+    my $client = $self->client;
+    $params->{worker_id} = $client->worker_id;
+    return $client->send(
         post          => "jobs/$job_id/set_done",
         params        => $params,
         non_critical  => 1,

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -101,6 +101,11 @@ for my $job ($job1, $job2) {
 }
 is_deeply($job1, $job2, 'duplicated job equal');
 
+subtest 'restart job which is still scheduled' => sub {
+    my $res = OpenQA::Resource::Jobs::job_restart([99927]);
+    is_deeply($res->{duplicates}, [], 'scheduled job not considered') or diag explain $res->{duplicates};
+};
+
 subtest 'restart job which has already been cloned' => sub {
     my $res = OpenQA::Resource::Jobs::job_restart([99926]);
     is_deeply($res->{duplicates}, [], 'no job ids returned') or diag explain $res->{duplicates};

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -23,6 +23,7 @@ use File::Spec::Functions 'catfile';
 use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use Test::Mojo;
+use OpenQA::Jobs::Constants;
 use OpenQA::Resource::Jobs 'job_restart';
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
@@ -119,6 +120,9 @@ is($job->{id}, $jobA->id, 'jobA grabbed');
 @assets = map { $_->asset_id } @assets;
 is(scalar @assets, 1,         'job still has only one asset assigned after grabbing');
 is($assets[0],     $theasset, 'the assigned asset is the same');
+
+note 'assume worker picked up the job';
+$jobA->update({state => SETUP});
 
 # test asset is not assigned to scheduled jobs after duping
 my $jobA_id = $jobA->id;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -111,7 +111,7 @@ sub wait_until_uploading_logs_and_assets_concluded {
         my ($self, $method, $path, %args) = @_;
         my $params                = $args{params};
         my %relevant_message_data = (path => $path, json => $args{json});
-        for my $relevant_params (qw(result reason)) {
+        for my $relevant_params (qw(result reason worker_id)) {
             next unless $params->{$relevant_params};
             $relevant_message_data{$relevant_params} = $params->{$relevant_params};
         }
@@ -318,10 +318,11 @@ subtest 'Clean up pool directory' => sub {
         [
             usual_status_updates(job_id => 3),
             {
-                json   => undef,
-                path   => 'jobs/3/set_done',
-                result => 'incomplete',
-                reason => 'setup failure: this is not a real isotovideo',
+                json      => undef,
+                path      => 'jobs/3/set_done',
+                result    => 'incomplete',
+                reason    => 'setup failure: this is not a real isotovideo',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'
@@ -469,10 +470,11 @@ subtest 'Job aborted during setup' => sub {
         [
             usual_status_updates(job_id => 8, duplicate => 1),
             {
-                json   => undef,
-                path   => 'jobs/8/set_done',
-                result => 'incomplete',
-                reason => 'quit: worker has been stopped or restarted',
+                json      => undef,
+                path      => 'jobs/8/set_done',
+                result    => 'incomplete',
+                reason    => 'quit: worker has been stopped or restarted',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'
@@ -519,10 +521,11 @@ subtest 'Reason turned into "api-failure" if job duplication fails' => sub {
         [
             usual_status_updates(job_id => 9, duplicate => 1),
             {
-                json   => undef,
-                path   => 'jobs/9/set_done',
-                result => 'incomplete',
-                reason => 'api failure: fake API error on duplication after quit',
+                json      => undef,
+                path      => 'jobs/9/set_done',
+                result    => 'incomplete',
+                reason    => 'api failure: fake API error on duplication after quit',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'
@@ -606,8 +609,9 @@ subtest 'Successful job' => sub {
             },
             usual_status_updates(job_id => 4),
             {
-                json => undef,
-                path => 'jobs/4/set_done'
+                json      => undef,
+                path      => 'jobs/4/set_done',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'
@@ -685,9 +689,10 @@ subtest 'Skip job' => sub {
         $client->sent_messages,
         [
             {
-                json   => undef,
-                path   => 'jobs/4/set_done',
-                result => 'skipped',
+                json      => undef,
+                path      => 'jobs/4/set_done',
+                result    => 'skipped',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'
@@ -778,8 +783,9 @@ subtest 'Livelog' => sub {
             },
             usual_status_updates(job_id => 5),
             {
-                json => undef,
-                path => 'jobs/5/set_done'
+                json      => undef,
+                path      => 'jobs/5/set_done',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'
@@ -876,15 +882,17 @@ subtest 'handling API failures' => sub {
             },
             usual_status_updates(job_id => 6, no_overall_status => 1),
             {
-                json   => undef,
-                path   => 'jobs/6/set_done',
-                result => 'incomplete',
-                reason => 'api failure: fake API error',
+                json      => undef,
+                path      => 'jobs/6/set_done',
+                result    => 'incomplete',
+                reason    => 'api failure: fake API error',
+                worker_id => 1,
             },
             {
-                json   => undef,
-                path   => 'jobs/6/set_done',
-                reason => 'api failure: fake API error',
+                json      => undef,
+                path      => 'jobs/6/set_done',
+                reason    => 'api failure: fake API error',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'
@@ -969,14 +977,16 @@ subtest 'handle upload failure' => sub {
             },
             usual_status_updates(job_id => 7, no_overall_status => 1),
             {
-                json   => undef,
-                path   => 'jobs/7/set_done',
-                result => 'incomplete',
-                reason => 'api failure',
+                json      => undef,
+                path      => 'jobs/7/set_done',
+                result    => 'incomplete',
+                reason    => 'api failure',
+                worker_id => 1,
             },
             {
-                json => undef,
-                path => 'jobs/7/set_done'
+                json      => undef,
+                path      => 'jobs/7/set_done',
+                worker_id => 1,
             }
         ],
         'expected REST-API calls happened'

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -18,7 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
-use OpenQA::Test::TimeLimit '22';
+use OpenQA::Test::TimeLimit '15';
 use Test::Most;
 use Mojo::File 'tempdir';
 use Mojolicious;
@@ -75,6 +75,14 @@ $ENV{OPENQA_LOGFILE} = undef;
     }
     sub start { }
 }
+{
+    package Test::FakeCacheServiceClientInfo;
+    use Mojo::Base -base;
+    has availability_error => 'Cache service info error: Connection refused';
+}
+
+my $cache_service_client_mock = Test::MockModule->new('OpenQA::CacheService::Client');
+$cache_service_client_mock->redefine(info => sub { Test::FakeCacheServiceClientInfo->new });
 
 like(
     exception {

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -48,6 +48,7 @@ $ENV{OPENQA_LOGFILE} = undef;
     package Test::FakeClient;
     use Mojo::Base -base;
     has webui_host => 'fake';
+    has worker_id  => 42;
     has api_calls  => sub { [] };
     sub send {
         my ($self, $method, $path, %args) = @_;
@@ -332,7 +333,7 @@ subtest 'accept or skip next job' => sub {
         qr/Skipping job 27 from queue/, 'job 27 is skipped';
         is_deeply(
             $client->api_calls,
-            [post => 'jobs/27/set_done', {reason => 'skip for testing', result => 'skipped'}],
+            [post => 'jobs/27/set_done', {reason => 'skip for testing', result => 'skipped', worker_id => 42}],
             'API call for skipping done'
         ) or diag explain $client->api_calls;
     };

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -1,3 +1,4 @@
+% use OpenQA::Jobs::Constants;
             <div class="card-header">
                 Results for
                 % if (current_route 'latest') {
@@ -11,7 +12,7 @@
                 % }
             >
                 <div>
-                    % if ($job->state eq 'done') {
+                    % if ($job->state eq DONE) {
                         <div class="position-absolute top-right pt-2-and-half pr-3">
                             %= $job->passed_module_count
                             <i class='fa module_passed fa-star' title='modules passed'></i>
@@ -73,7 +74,7 @@
                             'https://open.qa/docs/#_handling_of_related_jobs_on_failure_cancellation_restart', 'documentation', 'bottom');
                         %>
                     % }
-                    % if (is_operator && ($job->state eq 'running' || $job->state eq 'scheduled')) {
+                    % if (is_operator && (OpenQA::Jobs::Constants::meta_state($job->state) ne OpenQA::Jobs::Constants::FINAL)) {
                         %= link_post url_for('apiv1_cancel', jobid => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin
                             <i class="far fa-2 fa-times-circle" title="Cancel Job"></i>
                         % end
@@ -116,7 +117,7 @@
                         % }
                     % }
                 </div>
-                % if ($job->state eq 'scheduled') {
+                % if ($job->state eq SCHEDULED) {
                     <div>
                         <a class="prio-down" data-method="post" href="javascript:void(0);" onclick="decreaseJobPrio(<%= $job->id %>, this);">
                             <i class="far fa-minus-square"></i>


### PR DESCRIPTION
The worker's status updates are already rejected by the web UI when the ID
specified by the worker does not match the ID of the actually assigned
worker. This change applies the same check to the API function to mark a
job as done.

So now, when a worker is assumed offline the job can be re-scheduled and
assigned to a different worker without running into problems when the
worker assumed to be offline comes back after all.

See https://progress.opensuse.org/issues/64520

---

I've also tested this locally with the full stack using a worker which needs 30 seconds to accept a job. In the 30 seconds I've re-scheduled the job and assigned it to a different worker. After the 30 seconds the first worker runs into API errors as expected but it no longer interferes with the job execution on the other worker. (The API errors are only visible in the worker log and no user is bothered with them.)