### PR TITLE
Fix showing preview of modules rendered while the test was running

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -181,15 +181,17 @@ function renderModuleRow(module, snippets) {
             box.push(E('span', [content], { 'class': 'resborder ' + resborder }));
         }
 
-        stepnodes.push(E('div', [
-            E('div', [], { 'class': 'fa fa-caret-up' }),
-            E('a', box, {
-                'class': 'no_hover',
-                title: title,
-                href: href,
-                'data-url': url
-            })
-        ], { 'class': 'links_a' }));
+        const link = E('a', box, {
+            'class': 'no_hover',
+            'data-url': url,
+            title: title,
+            href: href,
+        });
+        link.onclick = function() {
+            setCurrentPreview($(this).parent()); // show the preview when clicking on step links
+            return false;
+        };
+        stepnodes.push(E('div', [E('div', [], { 'class': 'fa fa-caret-up' }), link], { 'class': 'links_a' }));
         stepnodes.push(' ');
     }
 


### PR DESCRIPTION
* Fix regression introduced by https://github.com/os-autoinst/openQA/pull/3352
* Use same JavaScript code in any case (module rendered while running or in
  final state)
* Pass the step preview container directly and use better variable name (it
  is not an 'a' element)
* See https://progress.opensuse.org/issues/69490