### PR TITLE
Tweak test timeouts for full-stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ aliases:
       export PERL5OPT="$COVEROPT,-db,cover_db_${CIRCLE_JOB}"
       echo PERL5OPT="$PERL5OPT"
       make test-$CIRCLE_JOB
-    no_output_timeout: 30m
+    no_output_timeout: 50m
 
   - &git_token_authentication
     name: "Prepare auth token"

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test-unstable:
 
 .PHONY: test-fullstack
 test-fullstack:
-	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=20 PROVE_ARGS="$$HARNESS t/full-stack.t" RETRY=3
+	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=15 PROVE_ARGS="$$HARNESS t/full-stack.t" RETRY=3
 
 .PHONY: test-scheduler
 test-scheduler:


### PR DESCRIPTION
Increase circleCI timeout to be bigger than the sum of the number of
retries times the timeout for a single test run while still keeping the
timeout for a single test run higher than the test module internal
timeout.

Related progress issue: https://progress.opensuse.org/issues/71554