### PR TITLE
Enhance/speedup tests

### DIFF
--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -39,7 +39,7 @@ sub test_auth_method_startup {
     $t->get_ok('/login');
 }
 
-OpenQA::Test::Database->new->create(skip_fixtures => 1);
+OpenQA::Test::Database->new->create;
 
 combined_like { test_auth_method_startup('Fake')->status_is(302) } qr/302 Found/, 'Plugin loaded';
 

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -49,7 +49,7 @@ $mock_result->redefine(
         return {state => {msg_sent => 1}};
     });
 
-my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
+my $schema = OpenQA::Test::Database->new->create;
 my $jobs   = $schema->resultset('Jobs');
 my $t      = Test::Mojo->new('OpenQA::Scheduler');
 

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -30,7 +30,7 @@ use OpenQA::Test::TimeLimit '10';
 
 setup_mojo_app_with_default_worker_timeout;
 
-my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
+my $schema = OpenQA::Test::Database->new->create;
 my $sent   = {};
 
 OpenQA::Scheduler::Model::Jobs->singleton->shuffle_workers(0);

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ setup_mojo_app_with_default_worker_timeout;
 
 # setup directories and database
 my $tempdir         = setup_fullstack_temp_dir('scheduler');
-my $schema          = OpenQA::Test::Database->new->create;
+my $schema          = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 02-workers.pl');
 my $api_credentials = create_user_for_workers;
 my $api_key         = $api_credentials->key;
 my $api_secret      = $api_credentials->secret;

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -24,7 +24,7 @@ use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 
-OpenQA::Test::Database->new->create(skip_fixtures => 1);
+OpenQA::Test::Database->new->create;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 subtest 'new users are not ops and admins' => sub {

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -30,7 +30,7 @@ $ENV{MOJO_LOG_LEVEL}   = 'debug';
 $ENV{OPENQA_SQL_DEBUG} = 'true';
 $ENV{OPENQA_LOGFILE}   = $filename;
 
-OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
+OpenQA::Test::Case->new->init_data;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -52,7 +52,7 @@ $mock->redefine(
     });
 
 my $schema;
-ok($schema = OpenQA::Test::Database->new->create(skip_fixtures => 1), 'create database')
+ok($schema = OpenQA::Test::Database->new->create, 'create database')
   || BAIL_OUT('failed to create database');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -42,7 +42,7 @@ my %settings = (
     ARCH    => 'x86_64',
 );
 
-my $schema              = OpenQA::Test::Database->new->create(skip_fixtures => 1);
+my $schema              = OpenQA::Test::Database->new->create;
 my $needledir_archlinux = "t/data/openqa/share/tests/archlinux/needles";
 my $needledir_fedora    = "t/data/openqa/share/tests/fedora/needles";
 # create dummy job

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -25,7 +25,7 @@ use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 
-my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1);
+my $schema = OpenQA::Test::Database->new->create;
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
 my $bugs   = $schema->resultset('Bugs');
 my $app    = $t->app;

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -72,7 +72,7 @@ my $resultdir = path($ENV{OPENQA_BASEDIR}, 'openqa', 'testresults')->make_path;
 ok(-d $resultdir, "resultdir \"$resultdir\" exists");
 
 # setup database without fixtures and special admin users 'Demo' and 'otherdeveloper'
-my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1, schema_name => 'public', drop_schema => 1);
+my $schema = OpenQA::Test::Database->new->create(schema_name => 'public', drop_schema => 1);
 my $users  = $schema->resultset('Users');
 $users->create(
     {

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -24,9 +24,7 @@ use OpenQA::Test::TimeLimit '6';
 use OpenQA::Test::Case;
 use OpenQA::JobGroupDefaults;
 
-# init test case
-my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data(skip_fixtures => 1);
+OpenQA::Test::Case->new->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # get resultsets

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -25,9 +25,7 @@ use OpenQA::Test::TimeLimit '6';
 use OpenQA::Test::Case;
 use OpenQA::Utils;
 
-# init test case
-my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data(skip_fixtures => 1);
+OpenQA::Test::Case->new->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 my $schema             = $t->app->schema;

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -26,7 +26,7 @@ use OpenQA::Test::TimeLimit '10';
 
 # init test case
 my $test_case = OpenQA::Test::Case->new(config_directory => "$FindBin::Bin/data/41-audit-log");
-my $schema    = $test_case->init_data(skip_fixtures => 1);
+my $schema    = $test_case->init_data;
 my $t         = Test::Mojo->new('OpenQA::WebAPI');
 
 # get resultsets

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -67,7 +67,7 @@ mock_service_ports;
 
 # setup basedir, config dir and database
 my $tempdir = setup_fullstack_temp_dir('scalability');
-my $schema  = OpenQA::Test::Database->new->create(skip_fixtures => 1);
+my $schema  = OpenQA::Test::Database->new->create;
 my $workers = $schema->resultset('Workers');
 my $jobs    = $schema->resultset('Jobs');
 

--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common
 use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
-OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
+OpenQA::Test::Case->new->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 $t->app->config->{rate_limits}->{search} = 10;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '8';
 
-OpenQA::Test::Database->new->create(skip_fixtures => 1);
+OpenQA::Test::Database->new->create;
 Test::Mojo->new('OpenQA::WebAPI')->get_ok('/')->status_is(200)->content_like(qr/Welcome to openQA/i);
 
 done_testing;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -77,7 +77,7 @@ my $tempdir  = setup_fullstack_temp_dir('full-stack.d');
 my $sharedir = setup_share_dir($ENV{OPENQA_BASEDIR});
 
 # initialize database, start daemons
-my $schema = OpenQA::Test::Database->new->create(skip_fixtures => 1, schema_name => 'public', drop_schema => 1);
+my $schema = OpenQA::Test::Database->new->create(schema_name => 'public', drop_schema => 1);
 ok(Mojolicious::Commands->start_app('OpenQA::WebAPI', 'eval', '1+0'), 'assets are prefetched');
 mock_service_ports;
 my $mojoport = service_port 'websocket';

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -60,8 +60,7 @@ sub create {
     }
 
     $schema->deploy;
-    $self->insert_fixtures($schema, $options{fixtures_glob}) unless $options{skip_fixtures};
-
+    $self->insert_fixtures($schema, $options{fixtures_glob}) if $options{fixtures_glob};
     return $schema;
 }
 
@@ -136,14 +135,14 @@ Deploy schema & load fixtures
 
     # Creates an test database from DBIC OpenQA::Schema with or without fixtures
     my $schema = Test::Database->new->create;
-    my $schema = Test::Database->new->create(skip_fixtures => 1);
+    my $schema = Test::Database->new->create(fixtures_glob => '01-jobs.pl 02-foo.pl');
 
 =head1 METHODS
 
 =head2 create (%args)
 
 Create new database from DBIC schema.
-Use skip_fixtures to prevent loading fixtures.
+Use fixtures_glob to select fixtures to load from files.
 
 =head2 insert_fixtures
 

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -21,13 +21,14 @@ use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common
 use Date::Format 'time2str';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '40';
 use OpenQA::Test::Case;
 use OpenQA::Test::Database;
 
 my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
-my $schema      = $test_case->init_data(schema_name => $schema_name);
+my $fixtures    = '01-jobs.pl 03-users.pl 04-products.pl 05-job_modules.pl 06-job_dependencies.pl';
+my $schema      = $test_case->init_data(schema_name => $schema_name, fixtures_glob => $fixtures);
 
 use OpenQA::SeleniumTest;
 

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,8 +24,7 @@ use Mojo::File 'path';
 use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
-my $test_case = OpenQA::Test::Case->new;
-$test_case->init_data(fixures_glob => '01-jobs.t');
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl 07-needles.pl');
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -27,7 +27,7 @@ use OpenQA::Client;
 
 use OpenQA::SeleniumTest;
 
-OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
+OpenQA::Test::Case->new->init_data;
 
 plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -27,7 +27,7 @@ use OpenQA::Client;
 
 use OpenQA::SeleniumTest;
 
-OpenQA::Test::Case->new->init_data(skip_fixtures => 1);
+OpenQA::Test::Case->new->init_data;
 plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
 
 sub wait_for_data_table {

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,7 +27,8 @@ use Date::Format 'time2str';
 
 my $test_case   = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
-my $schema      = $test_case->init_data(schema_name => $schema_name);
+my $fixtures    = '01-jobs.pl 06-job_dependencies.pl';
+my $schema      = $test_case->init_data(schema_name => $schema_name, fixtures_glob => $fixtures);
 
 sub prepare_database {
     my $jobs = $schema->resultset('Jobs');

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -35,7 +35,8 @@ use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use Time::HiRes 'sleep';
 
-OpenQA::Test::Case->new->init_data();
+my $fixtures = '01-jobs.pl 03-users.pl';
+OpenQA::Test::Case->new->init_data(fixtures_glob => $fixtures);
 
 $SIG{INT} = sub {
     session->clean;

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
 use Test::Warnings;
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '60';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'wait_for_or_bail_out';
@@ -90,10 +90,9 @@ sub start_server {
     wait_for_or_bail_out { _port($port) } 'worker';
 }
 
-sub stop_server {
-    # now kill the worker
-    $server_instance->stop();
-}
+sub stop_server { $server_instance->stop }
+
+END { stop_server }
 
 my $url = "http://127.0.0.1:$port/public/build/%%PROJECT/_result";
 
@@ -228,6 +227,4 @@ foreach my $proj (sort keys %params) {
     }
 }
 
-stop_server();
-kill_driver();
 done_testing();


### PR DESCRIPTION
https://progress.opensuse.org/issues/72082

Comparing the execution times of complete pipelines on
https://app.circleci.com/pipelines/github/os-autoinst/openQA/5800/workflows/1c455a9b-553b-4b28-bf37-8ab31eb40f17
I can observe that (by rough estimation) with this change
execution finishes faster than the previous mean value :)