### PR TITLE
Remove unused 'skip_deployment_check'; Prevent confusion on 'deployment_check' with rename

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -76,6 +76,7 @@ sub dsn {
 }
 
 sub deploy {
+    my ($self, $force_overwrite) = @_;
 
     # lock config file to ensure only one thing will deploy/upgrade DB at once
     # we use a file in prjdir/db as the lock file as the install process and
@@ -86,7 +87,6 @@ sub deploy {
     # LOCK_EX works most reliably if the file is open with write intent
     open($dblock, '>>', $dblockfile) or die "Can't open database lock file ${dblockfile}!";
     flock($dblock, LOCK_EX)          or die "Can't lock database lock file ${dblockfile}!";
-    my ($schema, $force_overwrite) = @_;
     $force_overwrite //= 0;
     my $dir = $FindBin::Bin;
     while (abs_path($dir) ne '/') {
@@ -98,7 +98,7 @@ sub deploy {
 
     my $dh = DBIx::Class::DeploymentHandler->new(
         {
-            schema              => $schema,
+            schema              => $self,
             script_directory    => $dir,
             databases           => ['PostgreSQL'],
             sql_translator_args => {add_drop_table => 0},

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -57,7 +57,7 @@ sub connect_db {
             die 'Could not find database section \'' . $mode . '\' in ' . $database_file unless $ini{$mode};
             $SINGLETON = __PACKAGE__->connect($ini{$mode});
         }
-        deployment_check $SINGLETON if $check;
+        deploy $SINGLETON if $check;
     }
 
     return $SINGLETON;
@@ -75,7 +75,7 @@ sub dsn {
     return $self->storage->connect_info->[0]->{dsn};
 }
 
-sub deployment_check {
+sub deploy {
 
     # lock config file to ensure only one thing will deploy/upgrade DB at once
     # we use a file in prjdir/db as the lock file as the install process and

--- a/script/initdb
+++ b/script/initdb
@@ -101,7 +101,7 @@ if ($prepare_init) {
 }
 if ($init_database) {
     # Create the schema
-    my $ret = OpenQA::Schema::deploy($schema, $force);
+    my $ret = $schema->deploy($force);
     if ($ret == 0) {
         print "Database already exists and schema is up to date.\n";
         exit 4;

--- a/script/initdb
+++ b/script/initdb
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014 SUSE LLC
-# Copyright (C) 2016 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -102,7 +101,7 @@ if ($prepare_init) {
 }
 if ($init_database) {
     # Create the schema
-    my $ret = OpenQA::Schema::deployment_check($schema, $force);
+    my $ret = OpenQA::Schema::deploy($schema, $force);
     if ($ret == 0) {
         print "Database already exists and schema is up to date.\n";
         exit 4;
@@ -116,7 +115,7 @@ if ($init_database) {
         exit 0;
     }
     else {
-        print "Unexpected result from deployment_check!\n";
+        print "Unexpected result from deployment!\n";
         exit 1;
     }
 }

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014 SUSE LLC
-# Copyright (C) 2016 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,9 +41,7 @@ my $result = GetOptions(
     "force"            => \$force
 );
 
-if (!$prepare_upgrades and !$upgrade_database) {
-    $help = 1;
-}
+$help = 1 unless $prepare_upgrades or $upgrade_database;
 
 if ($help) {
     print "Usage: $0 [flags]\n\n";
@@ -104,7 +101,4 @@ if ($prepare_upgrades) {
     $dh->prepare_upgrade({from_version => $prev_version, to_version => $version});
 }
 
-if ($upgrade_database) {
-    OpenQA::Schema::deployment_check($schema, $force);
-}
-
+OpenQA::Schema::deploy($schema, $force) if $upgrade_database;

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -101,4 +101,4 @@ if ($prepare_upgrades) {
     $dh->prepare_upgrade({from_version => $prev_version, to_version => $version});
 }
 
-OpenQA::Schema::deploy($schema, $force) if $upgrade_database;
+$schema->deploy($force) if $upgrade_database;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -63,7 +63,7 @@ try {
 };
 ok(!$deployed_version, 'DB not deployed by plain schema connection with check => 0');
 
-my $ret = OpenQA::Schema::deploy($schema);
+my $ret = $schema->deploy;
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
 is($ret,                                   2,                   'Expected return value (2) for a deployment');
@@ -86,7 +86,7 @@ $schema->create_system_user;
 
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $oldest_still_supported_schema_version, 'Schema at correct, old, version');
-$ret = OpenQA::Schema::deploy($schema);
+$ret = $schema->deploy;
 
 # insert default fixtures so this test is at least a little bit closer to migrations in production
 OpenQA::Test::Database->new->insert_fixtures($schema);
@@ -96,7 +96,7 @@ is($dh->version_storage->database_version, $dh->schema_version, 'Schema at corre
 is($ret,                                   1,                   'Expected return value (1) for an upgrade');
 
 # check another deployment call doesn't do a thing
-$ret = OpenQA::Schema::deploy($schema);
+$ret = $schema->deploy;
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
 is($ret,                                   0,                   'Expected return value (0) for no action needed');

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -63,7 +63,7 @@ try {
 };
 ok(!$deployed_version, 'DB not deployed by plain schema connection with check => 0');
 
-my $ret = OpenQA::Schema::deployment_check($schema);
+my $ret = OpenQA::Schema::deploy($schema);
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
 is($ret,                                   2,                   'Expected return value (2) for a deployment');
@@ -72,7 +72,7 @@ OpenQA::Schema::disconnect_db;
 $schema = OpenQA::Schema::connect_db(mode => 'test', check => 0);
 ensure_schema_is_created_and_empty $schema;
 
-# redeploy DB to the oldest still supported version and check if deployment_check upgrades the DB
+# redeploy DB to the oldest still supported version and check if deployment upgrades the DB
 $dh = DBIx::Class::DeploymentHandler->new(
     {
         schema              => $schema,
@@ -86,7 +86,7 @@ $schema->create_system_user;
 
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $oldest_still_supported_schema_version, 'Schema at correct, old, version');
-$ret = OpenQA::Schema::deployment_check($schema);
+$ret = OpenQA::Schema::deploy($schema);
 
 # insert default fixtures so this test is at least a little bit closer to migrations in production
 OpenQA::Test::Database->new->insert_fixtures($schema);
@@ -95,8 +95,8 @@ ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
 is($ret,                                   1,                   'Expected return value (1) for an upgrade');
 
-# check another deployment_check call doesn't do a thing
-$ret = OpenQA::Schema::deployment_check($schema);
+# check another deployment call doesn't do a thing
+$ret = OpenQA::Schema::deploy($schema);
 ok($dh->version_storage->database_version, 'DB deployed');
 is($dh->version_storage->database_version, $dh->schema_version, 'Schema at correct version');
 is($ret,                                   0,                   'Expected return value (0) for no action needed');

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -59,7 +59,7 @@ sub create {
         $storage->on_connect_do("SET search_path TO \"$schema_name\"");
     }
 
-    OpenQA::Schema::deploy($schema);
+    $schema->deploy;
     $self->insert_fixtures($schema, $options{fixtures_glob}) unless $options{skip_fixtures};
 
     return $schema;

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -59,7 +59,7 @@ sub create {
         $storage->on_connect_do("SET search_path TO \"$schema_name\"");
     }
 
-    OpenQA::Schema::deployment_check($schema);
+    OpenQA::Schema::deploy($schema);
     $self->insert_fixtures($schema, $options{fixtures_glob}) unless $options{skip_fixtures};
 
     return $schema;

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -59,7 +59,7 @@ sub create {
         $storage->on_connect_do("SET search_path TO \"$schema_name\"");
     }
 
-    OpenQA::Schema::deployment_check($schema)                unless $options{skip_deployment_check};
+    OpenQA::Schema::deployment_check($schema);
     $self->insert_fixtures($schema, $options{fixtures_glob}) unless $options{skip_fixtures};
 
     return $schema;


### PR DESCRIPTION
* Improve name of method 'deployment_check' to prevent confusion
* t: Remove unused and useless 'skip_deployment_check'

Related progress issue: https://progress.opensuse.org/issues/71500