### PR TITLE
Use alarm scaling factors

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -638,6 +638,30 @@ standard output. This makes use of `Test::Output` simple but it should be
 taken care that the test output is not cluttered by log messages which can be
 quite irritating.
 
+=== Test runtime limits
+
+The test modules use `OpenQA::Test::TimeLimit` to introduce a test module
+specific timeout. Consider lowering the timeout value whenever a test module
+is optimized in runtime. If the timeout is hit the test module normally aborts
+with a corresponding message. Please be aware of the exception when the
+timeout triggers after the actual test part of a test module has finished but
+not all involved processes have finished or END blocks are processed. In this
+case the output can look like
+
+```
+t/my_test.t .. All 1 subtests passed
+
+Test Summary Report
+-------------------
+t/my_test.t (Wstat: 14 Tests: 1 Failed: 0)
+  Non-zero wait status: 14
+Files=1, Tests=1,  2 wallclock secs ( 0.03 usr  0.00 sys +  0.09 cusr  0.00 csys =  0.12 CPU)
+Result: FAIL
+```
+
+where "Wstat: 14" and "Non-zero wait status: 14" mean that the test process
+received the "ALRM" signal (signal number 14).
+
 [[circleci-workflow]]
 == CircleCI workflow
 

--- a/t/lib/OpenQA/Test/TimeLimit.pm
+++ b/t/lib/OpenQA/Test/TimeLimit.pm
@@ -19,6 +19,8 @@ use Test::Most;
 sub import {
     my ($package, $limit) = @_;
     die "$package: Need argument on import, e.g. use: use OpenQA::Test::TimeLimit '42';" unless $limit;
+    $limit *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
+    $limit *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI}    // 2 if $ENV{CI};
     $SIG{ALRM} = sub { BAIL_OUT "test exceeds runtime limit of '$limit' seconds\n" };
     alarm $limit;
 }
@@ -53,6 +55,12 @@ Example output for t/full-stack.t:
   Bailout called.  Further testing stopped:  get: Server returned error message test exceeds runtime limit of '6' seconds at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/SeleniumTest.pm:107
   Bail out!  get: Server returned error message test exceeds runtime limit of '6' seconds at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/SeleniumTest.pm:107
   FAILED--Further testing stopped: get: Server returned error message test exceeds runtime limit of '6' seconds at /home/okurz/local/os-autoinst/openQA/t/lib/OpenQA/SeleniumTest.pm:107
+
+The timeout is scaled up when C<Devel::Cover> is active as well as when
+running in a CI environment where the environment variable C<CI> is set. Both
+scaling factors can be overridden with environment variables
+C<OPENQA_TEST_TIMEOUT_SCALE_COVER> and C<OPENQA_TEST_TIMEOUT_SCALE_CI>
+respectively.
 
 =head2 Alternatives considered
 


### PR DESCRIPTION
* docs: Add section about "Test runtime limits"
* t: Add scaling parameters for OpenQA::Test::TimeLimit

Related progress issue: https://progress.opensuse.org/issues/71845