### PR TITLE
t: Reduce back the test module specific timeout limits

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -267,6 +267,10 @@ rm \
     t/api/14-plugin_obs_rsync_async.t \
     t/ui/*.t
 
+# "CI" set with longer timeouts as needed for higher performance variations
+# within CI systems, e.g. OBS. See t/lib/OpenQA/Test/TimeLimit.pm
+export CI=1
+export OPENQA_TEST_TIMEOUT_SCALE_CI=10
 make test PROVE_ARGS='-r -v' CHECKSTYLE=0 TEST_PG_PATH=%{buildroot}/DB
 rm -rf %{buildroot}/DB
 %endif

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -17,7 +17,7 @@ use Test::Most;
 use Test::Warnings ':report_warnings';
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '400';
+use OpenQA::Test::TimeLimit '80';
 
 is(system('tools/tidy', '--check'), 0, "tidy");
 

--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -18,7 +18,7 @@ use warnings;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '800';
+use OpenQA::Test::TimeLimit '200';
 
 use Test::Strict;
 

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -22,7 +22,7 @@ use Test::Mojo;
 use Test::Output 'combined_like';
 use Test::Warnings;
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use Mojo::File qw(tempdir path);
 
 my $t;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -31,7 +31,7 @@ use Test::MockModule;
 use Test::Warnings ':report_warnings';
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '10';
 
 setup_mojo_app_with_default_worker_timeout;
 

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -27,7 +27,7 @@ use OpenQA::Test::Utils 'embed_server_for_testing';
 use Test::MockModule;
 use DBIx::Class::Timestamps 'now';
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 
 my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 06-job_dependencies.pl');
 

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -26,7 +26,7 @@ use OpenQA::WebAPI::Controller::API::V1::Worker;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Mojo::Util 'monkey_patch';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '10';
 
 setup_mojo_app_with_default_worker_timeout;
 

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -27,7 +27,7 @@ use Test::Warnings ':report_warnings';
 use OpenQA::WebSockets::Client;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::Jobs::Constants;
-use OpenQA::Test::TimeLimit '70';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::FakeWebSocketTransaction;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use Test::MockModule;

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -25,7 +25,7 @@ use OpenQA::Resource::Locks;
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
-use OpenQA::Test::TimeLimit '38';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::WebSockets::Client;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';

--- a/t/05-scheduler-serialize-directly-chained-dependencies.t
+++ b/t/05-scheduler-serialize-directly-chained-dependencies.t
@@ -21,7 +21,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Jobs::Constants;
 use OpenQA::Scheduler::Model::Jobs;
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '10';
 use Test::Warnings ':report_warnings';
 
 my %cluster_info = (

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/lib";
 
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -25,7 +25,7 @@ use OpenQA::Script::CloneJob;
 use OpenQA::Test::Client 'client';
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(create_webapi stop_service);
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '20';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -32,7 +32,7 @@ use Test::Warnings ':report_warnings';
 use Mojo::File qw(path tempdir);
 use Mojo::IOLoop::ReadWriteProcess;
 use OpenQA::Test::Utils 'redirect_output';
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;
 use OpenQA::Parser::Result::Output;

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -20,7 +20,7 @@ use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '40';
+use OpenQA::Test::TimeLimit '18';
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -20,7 +20,7 @@ use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 
 use File::Temp qw(tempfile);
 

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Jobs::Constants;
 use Test::Mojo;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -24,7 +24,7 @@ use OpenQA::Schema::Result::Jobs;
 use File::Copy;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job);
-use OpenQA::Test::TimeLimit '400';
+use OpenQA::Test::TimeLimit '160';
 use Test::MockModule;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -29,7 +29,7 @@ use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::WebSockets::Client;
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Schema::ResultSet::Assets;

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -23,7 +23,7 @@ use OpenQA::Git;
 use OpenQA::Utils;
 use OpenQA::Task::Needle::Save;
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use Mojo::File 'tempdir';
 use Test::MockModule;
 use Test::Mojo;

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Utils qw(:DEFAULT prjdir sharedir resultdir assetdir imagesdir base_host random_string random_hex);
 use OpenQA::Test::Utils 'redirect_output';
-use OpenQA::Test::TimeLimit '22';
+use OpenQA::Test::TimeLimit '10';
 use Scalar::Util 'reftype';
 use Mojo::File qw(path tempdir tempfile);
 

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -20,7 +20,7 @@ use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '42';
+use OpenQA::Test::TimeLimit '18';
 use OpenQA::JobGroupDefaults;
 use OpenQA::Schema::Result::JobGroupParents;
 use Date::Format qw(time2str);

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '10';
 use Mojo::JSON qw(decode_json);
 
 my $test_case;

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -28,7 +28,7 @@ use OpenQA::Jobs::Constants;
 use OpenQA::WebSockets;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(redirect_output);
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 
 my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 02-workers.pl 06-job_dependencies.pl');
 my $jobs   = $schema->resultset('Jobs');

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -23,7 +23,7 @@ use lib "$FindBin::Bin/lib";
 use Cwd 'abs_path';
 use OpenQA::Schema;
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '22';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Task::Needle::Scan;
 use File::Find;
 use Test::Output 'combined_like';

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '42';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Jobs::Constants;
 
 # init test case

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -23,7 +23,7 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Jobs::Constants;
 use OpenQA::Test::Client 'client';
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use Test::MockModule;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -17,7 +17,7 @@ use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
-use OpenQA::Test::TimeLimit '12';
+use OpenQA::Test::TimeLimit '10';
 use Test::Fatal;
 use Test::Warnings ':report_warnings';
 use OpenQA::Worker;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -33,7 +33,7 @@ use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME WORKER_COMMAND_CANCEL WORKER_COMMA
 use OpenQA::Worker::Job;
 use OpenQA::Worker::Settings;
 use OpenQA::Test::FakeWebSocketTransaction;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Worker::WebUIConnection;
 use OpenQA::Jobs::Constants;
 use OpenQA::Test::Utils 'shared_hash';

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -18,7 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
-use OpenQA::Test::TimeLimit '15';
+use OpenQA::Test::TimeLimit '10';
 use Test::Most;
 use Mojo::File 'tempdir';
 use Mojolicious;

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -29,7 +29,7 @@ use Test::MockModule;
 use OpenQA::App;
 use OpenQA::Test::Case;
 use OpenQA::Test::FakeWebSocketTransaction;
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Worker::WebUIConnection;
 use OpenQA::Worker::CommandHandler;
 use OpenQA::Worker::Job;

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/lib";
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job collect_coverage_of_gru_jobs);
-use OpenQA::Test::TimeLimit '32';
+use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -46,7 +46,7 @@ use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service wait_for_or_bail_out);
-use OpenQA::Test::TimeLimit '240';
+use OpenQA::Test::TimeLimit '40';
 use Mojo::Util qw(md5_sum);
 use OpenQA::CacheService;
 use OpenQA::CacheService::Request;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -51,7 +51,7 @@ use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server wait_for_or_bail_out);
-use OpenQA::Test::TimeLimit '80';
+use OpenQA::Test::TimeLimit '20';
 
 my $port = Mojo::IOLoop::Server->generate_port;
 my $host = "localhost:$port";

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -29,7 +29,7 @@ use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server wait_for_or_bail_out);
-use OpenQA::Test::TimeLimit '80';
+use OpenQA::Test::TimeLimit '20';
 use Mojo::File qw(tempdir);
 
 my $port = Mojo::IOLoop::Server->generate_port;

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use DateTime;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '12';
+use OpenQA::Test::TimeLimit '6';
 use OpenQA::WebAPI::Controller::Running;
 use OpenQA::Jobs::Constants;
 use Mojolicious;

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -20,7 +20,7 @@ use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '10';
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -21,7 +21,7 @@ use 5.018;
 use POSIX;
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Jobs::Constants;
 use OpenQA::WebSockets;
 use OpenQA::WebSockets::Model::Status;

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -30,7 +30,7 @@ use Sys::Hostname;
 use File::Spec::Functions 'catfile';
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::TimeLimit '4';
 
 my $reFile    = qr/\[.*?\] \[(.*?)\] (?:\[pid:\d+\]\s)?(.*?) message/;
 my $reStdOut  = qr/(?:.*?)\[(.*?)\] (?:\[pid:\d+\]\s)?(.*?) message/;

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -18,7 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA;
 use Test::Output 'combined_like';
 use OpenQA::Parser qw(parser p);

--- a/t/31-client.t
+++ b/t/31-client.t
@@ -16,7 +16,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "lib";
-use OpenQA::Test::TimeLimit '14';
+use OpenQA::Test::TimeLimit '6';
 
 use Test::Mojo;
 use Test::MockModule;

--- a/t/31-client_archive.t
+++ b/t/31-client_archive.t
@@ -17,7 +17,7 @@ use warnings;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "lib";
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 
 use Test::More;
 use Test::Mojo;

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -22,7 +22,7 @@ use OpenQA::Client;
 use OpenQA::File;
 use Digest::SHA 'sha1_base64';
 use Mojo::File qw(path tempfile tempdir);
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '10';
 
 sub file_path { OpenQA::File->new(file => path(@_)) }
 

--- a/t/32-openqa_client-script.t
+++ b/t/32-openqa_client-script.t
@@ -21,7 +21,7 @@ use Test::Exception;
 use Test::More;
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '32';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Utils qw(run_cmd test_cmd);
 
 

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -23,7 +23,7 @@ use Mojo::File qw(tempfile path);
 use OpenQA::Events;
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
-use OpenQA::Test::TimeLimit '240';
+use OpenQA::Test::TimeLimit '60';
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 my $chunk_size = 10000000;

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -46,7 +46,7 @@ use OpenQA::Test::Utils qw(
   start_worker stop_service
 );
 use OpenQA::Test::FullstackUtils;
-use OpenQA::Test::TimeLimit '180';
+use OpenQA::Test::TimeLimit '30';
 use OpenQA::SeleniumTest;
 
 plan skip_all => 'set DEVELOPER_FULLSTACK=1 (be careful)'                       unless $ENV{DEVELOPER_FULLSTACK};

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -33,7 +33,7 @@ use OpenQA::Client;
 use OpenQA::WebSockets::Client;
 use Mojo::IOLoop;
 use OpenQA::Utils qw(determine_web_ui_web_socket_url get_ws_status_only_url);
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '10';
 
 # mock OpenQA::Schema::Result::Jobs::cancel()
 my $jobs_mock_module = Test::MockModule->new('OpenQA::Schema::Result::Jobs');

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -17,7 +17,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::TimeLimit '6';
 use Test::Exception;
 use Test::Output 'combined_like';
 use OpenQA::Script::CloneJob;

--- a/t/36-job_group_defaults.t
+++ b/t/36-job_group_defaults.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '6';
 use OpenQA::Test::Case;
 use OpenQA::JobGroupDefaults;
 

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -23,7 +23,7 @@ use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use Test::Output qw(stdout_like stdout_from);
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use OpenQA::Task::Asset::Limit;
 use OpenQA::Utils qw(:DEFAULT assetdir);

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -23,7 +23,7 @@ use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Jobs::Constants;
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '6';
 
 # init test case
 my $test_case = OpenQA::Test::Case->new;

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Test::MockModule;
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '6';
 use OpenQA::Test::Case;
 use OpenQA::Utils;
 

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -19,7 +19,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::JobSettings;
-use OpenQA::Test::TimeLimit '6';
+use OpenQA::Test::TimeLimit '3';
 
 my $settings = {
     BUILD_SDK                => '%BUILD_HA%',

--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -18,7 +18,7 @@
 use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '40';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Utils qw(run_cmd test_cmd);
 
 

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -23,7 +23,7 @@ use OpenQA::Test::Database;
 use OpenQA::Test::Utils;
 use Test::Output;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '120';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Utils qw(run_cmd test_cmd stop_service);
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test::Warnings ':report_warnings';
 use Test::Output;
-use OpenQA::Test::TimeLimit '38';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Utils qw(run_cmd test_cmd);
 
 

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -22,7 +22,7 @@ use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Date::Format 'time2str';
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '22';
+use OpenQA::Test::TimeLimit '10';
 
 # init test case
 my $test_case = OpenQA::Test::Case->new(config_directory => "$FindBin::Bin/data/41-audit-log");

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -18,7 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '100';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Utils;
 use OpenQA::Test::Database;
 use OpenQA::Schema::Result::ScreenshotLinks;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -27,7 +27,7 @@ use Mojo::Util qw(encode);
 use OpenQA::CLI;
 use OpenQA::CLI::api;
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '32';
+use OpenQA::Test::TimeLimit '10';
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
 

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -25,7 +25,7 @@ use Mojo::File qw(tempdir tempfile);
 use OpenQA::CLI;
 use OpenQA::CLI::archive;
 use OpenQA::Test::Case;
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '10';
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
 

--- a/t/43-cli.t
+++ b/t/43-cli.t
@@ -20,7 +20,7 @@ use lib "$FindBin::Bin/lib";
 
 use Test::More;
 use OpenQA::CLI;
-use OpenQA::Test::TimeLimit '8';
+use OpenQA::Test::TimeLimit '4';
 
 my $cli = OpenQA::CLI->new;
 is_deeply $cli->namespaces, ['OpenQA::CLI'], 'right namespaces';

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -34,7 +34,7 @@ use OpenQA::Test::Utils
   qw(mock_service_ports setup_mojo_app_with_default_worker_timeout),
   qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
   qw(stop_service setup_fullstack_temp_dir);
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '20';
 
 BEGIN {
     # set default worker and job count

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -17,7 +17,7 @@
 use Test::Most;
 
 use FindBin '$Bin';
-use OpenQA::Test::TimeLimit '140';
+use OpenQA::Test::TimeLimit '20';
 my %allowed_types = (
     'text/x-perl'   => 1,
     'text/x-python' => 1,

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings qw(:all :report_warnings);
 use Mojo::URL;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use OpenQA::Client;

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings qw(:all :report_warnings);
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use Mojo::IOLoop;

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -21,7 +21,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings;
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use Mojo::IOLoop;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -21,7 +21,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '560';
+use OpenQA::Test::TimeLimit '100';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use OpenQA::Schema::Result::ScheduledProducts;

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -23,7 +23,7 @@ use Test::Mojo;
 use Test::Warnings qw(:all :report_warnings);
 use Mojo::URL;
 use Mojo::Util qw(encode hmac_sha1_sum);
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -23,7 +23,7 @@ use File::Temp;
 use Test::Mojo;
 use Test::Output;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '180';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::App;
 use OpenQA::Events;
 use OpenQA::File;

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use Mojo::IOLoop;

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use Mojo::IOLoop;

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use Mojo::IOLoop;

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -20,7 +20,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Test::MockModule;
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use OpenQA::WebAPI::Controller::API::V1::JobTemplate;

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use OpenQA::Client;

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '18';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client;
 use Mojo::IOLoop;

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -21,7 +21,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 require OpenQA::Schema::Result::Jobs;

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::WebSockets;

--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '120';
+use OpenQA::Test::TimeLimit '30';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use Mojo::File qw(tempdir path);

--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -19,7 +19,7 @@ use IPC::Run qw(start);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '16';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use Mojo::File qw(tempdir path);

--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -19,7 +19,7 @@ use Test::Mojo;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data(skip_fixtures => 1);

--- a/t/api/15-users.t
+++ b/t/api/15-users.t
@@ -19,7 +19,7 @@ use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Client;
 use OpenQA::Test::Case;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -20,7 +20,7 @@ use Test::Warnings ':report_warnings';
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OpenQA::Test::Database;
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '8';
 
 OpenQA::Test::Database->new->create(skip_fixtures => 1);
 Test::Mojo->new('OpenQA::WebAPI')->get_ok('/')->status_is(200)->content_like(qr/Welcome to openQA/i);

--- a/t/config.t
+++ b/t/config.t
@@ -22,7 +22,7 @@ use Test::Warnings ':report_warnings';
 use Test::Output 'combined_like';
 use Mojolicious;
 use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT MAX_TIMER);
-use OpenQA::Test::TimeLimit '8';
+use OpenQA::Test::TimeLimit '4';
 use OpenQA::Setup;
 use OpenQA::JobGroupDefaults;
 use OpenQA::Task::Job::Limit;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -25,7 +25,7 @@ use Test::Mojo;
 use DBIx::Class::DeploymentHandler;
 use SQL::Translator;
 use OpenQA::Schema;
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use Mojo::File 'path';
 use List::Util 'min';

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -53,7 +53,7 @@ use OpenQA::Test::Utils
   qw(create_websocket_server create_live_view_handler setup_share_dir),
   qw(cache_minion_worker cache_worker_service mock_service_ports setup_fullstack_temp_dir),
   qw(start_worker stop_service wait_for_or_bail_out);
-use OpenQA::Test::TimeLimit '350';
+use OpenQA::Test::TimeLimit '90';
 use OpenQA::Test::FullstackUtils;
 
 plan skip_all => 'set FULLSTACK=1 (be careful)'                                 unless $ENV{FULLSTACK};

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Date::Format 'time2str';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '80';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::Test::Database;
 

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 04-products.pl');

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 use Mojo::File 'path';
 

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Database;
 use OpenQA::SeleniumTest;

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Mojo::File 'path';
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -20,7 +20,7 @@ use lib "$FindBin::Bin/../lib";
 use Date::Format 'time2str';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '90';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 use OpenQA::Jobs::Constants;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Encode 'encode_utf8';
 use Test::Mojo;
 use Test::Warnings qw(:all :report_warnings);
-use OpenQA::Test::TimeLimit '120';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use Cwd 'abs_path';
 use Mojo::File;

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '18';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -22,7 +22,7 @@ use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '80';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::SeleniumTest;
 use OpenQA::Test::Case;
 use OpenQA::Utils 'assetdir';

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/../lib";
 use Date::Format;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '48';
+use OpenQA::Test::TimeLimit '16';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Log 'log_debug';
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Constants 'DEFAULT_WORKER_TIMEOUT';
-use OpenQA::Test::TimeLimit '54';
+use OpenQA::Test::TimeLimit '18';
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use Date::Format 'time2str';

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Log qw(log_debug);
-use OpenQA::Test::TimeLimit '120';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -21,7 +21,7 @@ use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use OpenQA::Test::TimeLimit '42';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::SeleniumTest;

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use Date::Format 'time2str';
 

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -22,7 +22,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use OpenQA::SeleniumTest;

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -24,7 +24,7 @@ use Test::Warnings qw(:all :report_warnings);
 use Mojo::JSON qw(decode_json encode_json);
 use Mojo::File qw(path);
 use Mojo::IOLoop;
-use OpenQA::Test::TimeLimit '80';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::Jobs::Constants;

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings qw(:all :report_warnings);
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 
 my $test_case = OpenQA::Test::Case->new;

--- a/t/ui/20-bugzilla-links.t
+++ b/t/ui/20-bugzilla-links.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Date::Format 'time2str';
 use Test::Warnings qw(:all :report_warnings);
-use OpenQA::Test::TimeLimit '70';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use Time::HiRes qw(sleep);
 use OpenQA::SeleniumTest;

--- a/t/ui/22-job_group_order.t
+++ b/t/ui/22-job_group_order.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Case;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -21,7 +21,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 
-use OpenQA::Test::TimeLimit '56';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use OpenQA::Client;
 

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -20,7 +20,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '42';
+use OpenQA::Test::TimeLimit '12';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -27,7 +27,7 @@ use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Test::MockModule;
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::WebSockets::Client;
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 use OpenQA::JobDependencies::Constants;

--- a/t/ui/27-plugin_obs_rsync.t
+++ b/t/ui/27-plugin_obs_rsync.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use Mojo::File qw(tempdir path);

--- a/t/ui/27-plugin_obs_rsync_gru.t
+++ b/t/ui/27-plugin_obs_rsync_gru.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '24';
+use OpenQA::Test::TimeLimit '8';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use Mojo::File qw(tempdir path);

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '12';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'wait_for_or_bail_out';

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::Warnings;
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '80';
+use OpenQA::Test::TimeLimit '16';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'wait_for_or_bail_out';

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -20,7 +20,7 @@ use FindBin;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use lib "$FindBin::Bin/../lib";
-use OpenQA::Test::TimeLimit '50';
+use OpenQA::Test::TimeLimit '18';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 use Mojo::File 'path';


### PR DESCRIPTION
After introducing global test timeout scaling factors the test module
specific timeout values should be lowered accordingly.