### PR TITLE
t: Remove obsolete test job database entry in all initializations

### DIFF
--- a/t/lib/OpenQA/Test/Case.pm
+++ b/t/lib/OpenQA/Test/Case.pm
@@ -35,17 +35,10 @@ sub new {
 sub init_data {
     my ($self, %options) = @_;
 
-    # This should result in the 't' directory, even if $0 is in a subdirectory
-    my ($tdirname) = $0 =~ qr/((.*\/t\/|^t\/)).+$/;
     my $schema = OpenQA::Test::Database->new->create(%options);
 
-    # ARGL, we can't fake the current time and the db manages
-    # t_started so we have to override it manually
-    my $r = $schema->resultset("Jobs")->search({id => 99937})->update(
-        {
-            t_created => time2str('%Y-%m-%d %H:%M:%S', time - 540000, 'UTC'),    # 150 hours ago;
-        });
-
+    # This should result in the 't' directory, even if $0 is in a subdirectory
+    my ($tdirname) = $0 =~ qr/((.*\/t\/|^t\/)).+$/;
     OpenQA::Test::Testresults->new->create(directory => $tdirname . 'testresults');
     return $schema;
 }


### PR DESCRIPTION
Since a very long time in our initialization of test database entries we 
updated the timestamp of one job, 99937. This was likely necessary for a
specific test and definitely not needed in all test modules that use the
same test database. Apparently the timestamp update is not even
necessary anymore in any current test module so this commit is removing
the according code completely.