### PR TITLE
Catch warnings from sub processes during tests

### DIFF
--- a/t/01-test-utilities.t
+++ b/t/01-test-utilities.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::Utils;
+use IPC::Run 'start';
+use Test::Output 'combined_like';
+use Test::MockModule;
+
+subtest 'warnings in sub processes are fatal test failures' => sub {
+    my $test_utils_mock        = Test::MockModule->new('OpenQA::Test::Utils');
+    my $test_would_have_failed = 0;
+    $test_utils_mock->redefine(
+        _fail_and_exit => sub {
+            like(shift, qr/sub process test-process terminated with exit code \d+/, 'message of test failure');
+            isnt(shift, 0, 'exit code of test failure is non-zero');
+            $test_would_have_failed = 1;
+        });
+    combined_like {
+        # start a sub process like the test helper do and simulate a Perl warning
+        OpenQA::Test::Utils::_setup_sigchld_handler 'test-process', start sub {
+            OpenQA::Test::Utils::_setup_sub_process 'test-process';
+            '' . undef;    # provoke Perl warning "Use of uninitialized value in concatenation …"
+        };
+        # wait at most 5 seconds (the sleep is supposed to be interrupted by SIGCHLD)
+        sleep 5;
+    }
+    qr/Stopping test-process process because a Perl warning occurred: Use of uninitialized value in concatenation/,
+      'warning logged';
+    ok($test_would_have_failed, 'test would have failed');
+};
+
+done_testing();

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -451,8 +451,8 @@ sub unstable_worker {
     note("Starting unstable worker. Instance: $instance for host $host");
     $ticks = 1 unless defined $ticks;
 
-    my $h = start sub {
-        $0 = 'openqa-worker-unstable';
+    my $h = _setup_sigchld_handler 'openqa-worker-unstable', start sub {
+        _setup_sub_process 'openqa-worker-unstable';
         my $worker = OpenQA::Worker->new(
             {
                 apikey    => $apikey,
@@ -506,8 +506,8 @@ sub c_worker {
     my ($apikey, $apisecret, $host, $instance, $bogus, %options) = @_;
     $bogus //= 1;
 
-    start sub {
-        $0 = 'openqa-worker-rejecting';
+    _setup_sigchld_handler 'openqa-worker', start sub {
+        _setup_sub_process 'openqa-worker';
         my $command_handler_mock = Test::MockModule->new('OpenQA::Worker::CommandHandler');
         if ($bogus) {
             $command_handler_mock->redefine(

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -231,6 +231,7 @@ sub _setup_sub_process {
         _exit 42;
     };
 }
+sub _fail_and_exit { fail shift; done_testing; exit shift }
 my %RELEVANT_CHILD_PIDS;
 my $SIGCHLD_HANDLER = sub {
     # produces a test failure in case any relevant sub process terminated with a non-zero exit code
@@ -239,10 +240,7 @@ my $SIGCHLD_HANDLER = sub {
     while ((my $pid = waitpid(-1, WNOHANG)) > 0) {
         my $exit_code = $?;
         next unless my $child_name = delete $RELEVANT_CHILD_PIDS{$pid};
-        if ($exit_code) {
-            fail "sub process $child_name terminated with exit code $exit_code";
-            _exit $exit_code;
-        }
+        _fail_and_exit "sub process $child_name terminated with exit code $exit_code", $exit_code if $exit_code;
     }
 };
 sub _setup_sigchld_handler {


### PR DESCRIPTION
See the message of the first commit for details and an example how it looks like in the error case. I'm not sure whether this is a clear win. The tests will be only aborted as a consequence of the child not being available. If the sub process is actually supposed to "passively do its thing" like the scheduler it might not immediately abort the test and the reason for the failure wouldn't be as easy to spot than in my example. Maybe it is better to explicitly handle `SIGCHLD` and call `BAIL_OUT` if it was an unexpected exit.