### PR TITLE
ci: Bring back error context in log view as well as show unhandled test output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,13 @@ images:
     environment:
       JUNIT_PACKAGE: openQA
       JUNIT_NAME_MANGLE: perl
+      # Be aware that this option saves all verbose output caught by "prove"
+      # into test artifact files whereas the error output is still shows up
+      # where prove is executed to show initial context in case of failed
+      # tests or other problems. The "--merge" option of prove would loose
+      # that context in the prove calling context.
       PERL_TEST_HARNESS_DUMP_TAP: test-results
-      HARNESS: --harness TAP::Harness::JUnit --timer --merge
+      HARNESS: --harness TAP::Harness::JUnit --timer
       COVEROPT: -MDevel::Cover=-select_re,'^/lib',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement
       COMMIT_AUTHOR_EMAIL: skynet@open.qa
 


### PR DESCRIPTION
This reverts the change from f62ce8d8e where we added `--merge` to show
stderr along with stdout in the test artifact output which however makes
stderr output disappear from the log view where the initial information
about failed information is useful as well as where we want to see any
undhandled output.

This commit changes the behaviour back to what we had previously
comparable to what a local call to 
`PERL_TEST_HARNESS_DUMP_TAP=<dir> prove`
would also supply. Additionally we can benefit from colored test output
in the circleCI log view. One more issue tackled is that we try to cover
all error log output with Test::Output alike and now the output shows up 
again in the log view.

Previously the output in the circle CI log view looked like this:

```
[13:26:45] t/10-jobs.t ............................................... 1/?                                                                              [13:26:45] t/10-jobs.t ............................................... Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/12 subtests
```

instead of showing which specific tests failed.

Or in case of no test failing but uncovered test output

```
[14:37:26] t/14-grutasks.t ........................................... ok   274117 ms ( 0.22 usr  0.00 sys + 260.33 cusr  9.39 csys = 269.94 CPU)
```

instead of what should have shown up in this case

```
[21:33:58] t/14-grutasks.t .. 34/? [2020-09-26 21:34:04.39357] [15810] [error] Gru job error: No job ID specified.
[2020-09-26 21:34:04.44377] [15814] [error] Gru job error: Job 98765 does not exist.
[2020-09-26 21:34:04.51354] [15817] [error] Gru job error: Finalizing results of 1 modules failed
[21:33:58] t/14-grutasks.t .. ok     5976 ms ( 0.08 usr  0.01 sys +  3.34 cusr  0.90 csys =  4.33 CPU)
[21:34:04]
All tests successful.
Files=1, Tests=36,  6 wallclock secs ( 0.10 usr  0.01 sys +  3.34 cusr  0.90 csys =  4.35 CPU)
Result: PASS

Related progress issues:
* https://progress.opensuse.org/issues/71845 regarding incomplete test
  output in the circleCI log view in case of tests failing not with
  failed tests but exceptions and other problems
* https://progress.opensuse.org/issues/71464 regarding the missing
  output of failed tests in circleCI log view
* https://progress.opensuse.org/issues/71926 regarding unhandled test
  output not showing up in circleCI log view
