### PR TITLE
t: Bump timeout for 44-scripts

### DIFF
--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -17,6 +17,7 @@
 use Test::Most;
 
 use FindBin '$Bin';
+use lib "$FindBin::Bin/lib";
 use OpenQA::Test::TimeLimit '20';
 my %allowed_types = (
     'text/x-perl'   => 1,

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -18,7 +18,7 @@ use Test::Most;
 
 use FindBin '$Bin';
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '60';
 my %allowed_types = (
     'text/x-perl'   => 1,
     'text/x-python' => 1,


### PR DESCRIPTION
The recent reduction to 20s can lead to problems as observed on circleCI
as well as locally reproducible.

Related progress issue: https://progress.opensuse.org/issues/72127