### PR TITLE
Prevent scheduler from assigning jobs while download tasks being created

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -267,9 +267,8 @@ sub create {
         $json->{id} = $job_id;
 
         # enqueue gru jobs
-        my $gru = $self->gru;
-        push @{$downloads->{$_}}, [$job_id] for (keys %$downloads);
-        $gru->enqueue_download_jobs($downloads);
+        push @{$downloads->{$_}}, [$job_id] for keys %$downloads;
+        $self->gru->enqueue_download_jobs($downloads);
         $job->calculate_blocked_by;
         OpenQA::Scheduler::Client->singleton->wakeup;
     }

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1277,10 +1277,8 @@ subtest 'handle FOO_URL' => sub {
     is($result->{ISO_1}, 'foo.iso',         'the ISO_1 was added in job setting');
     is($result->{HDD_1}, 'hdd@64bit.qcow2', 'the HDD_1 was overwritten by the value in testsuite settings');
 
-    my $gru_task_deps    = $schema->resultset('GruDependencies');
-    my @gru_dependencies = $gru_task_deps->search({job_id => $job_id});
     my %gru_task_values;
-    foreach my $gru_dep (@gru_dependencies) {
+    foreach my $gru_dep ($schema->resultset('GruDependencies')->search({job_id => $job_id})) {
         my $gru_task = $gru_dep->gru_task;
         is $gru_task->taskname, 'download_asset', 'the download asset was created';
         my @gru_args = @{$gru_task->args};


### PR DESCRIPTION
* Use a transaction when creating a job in 'jobs post' controller so
  queries by the scheduler don't see the new job until all download tasks
  have been created as well.
* See https://progress.opensuse.org/issues/72055