### PR TITLE
Add simple "--help" test for all shell scripts in scripts/

### DIFF
--- a/script/openqa-enqueue-audit-event-cleanup
+++ b/script/openqa-enqueue-audit-event-cleanup
@@ -1,2 +1,3 @@
 #!/bin/sh -e
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Enqueue openQA audit event cleanup" && exit
 exec "$(dirname "$0")"/openqa minion -m production job -e limit_audit_events "$@"

--- a/script/openqa-enqueue-bug-cleanup
+++ b/script/openqa-enqueue-bug-cleanup
@@ -1,2 +1,3 @@
 #!/bin/sh -e
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Enqueue openQA bug database cleanup" && exit
 exec "$(dirname "$0")"/openqa minion -m production job -e limit_bugs "$@"

--- a/script/openqa-gru
+++ b/script/openqa-gru
@@ -1,2 +1,3 @@
 #!/bin/sh -e
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Start openQA GRU service" && exit
 exec "$(dirname "$0")"/openqa gru -m production run --reset-locks "$@"

--- a/script/openqa-slirpvde
+++ b/script/openqa-slirpvde
@@ -1,2 +1,3 @@
 #!/bin/sh -e
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Start openQA VDE Slirp interface service" && exit
 exec /usr/bin/slirpvde -D -s /run/openqa/vde.ctl "$@"

--- a/script/openqa-vde_switch
+++ b/script/openqa-vde_switch
@@ -1,2 +1,3 @@
 #!/bin/sh -e
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Start openQA VDE switch service" && exit
 exec /usr/bin/vde_switch -F -s /run/openqa/vde.ctl -M /run/openqa/vde.mgmt "$@"

--- a/script/openqa-worker-cacheservice-minion
+++ b/script/openqa-worker-cacheservice-minion
@@ -1,2 +1,3 @@
 #!/bin/sh -e
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Start openQA workercache minion service" && exit
 exec "$(dirname "$0")"/openqa-workercache run -m production --reset-locks "$@"

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -18,10 +18,11 @@ use Test::Most;
 
 use FindBin '$Bin';
 use lib "$FindBin::Bin/lib";
-use OpenQA::Test::TimeLimit '60';
+use OpenQA::Test::TimeLimit '70';
 my %allowed_types = (
-    'text/x-perl'   => 1,
-    'text/x-python' => 1,
+    'text/x-perl'        => 1,
+    'text/x-python'      => 1,
+    'text/x-shellscript' => 1,
 );
 
 # Could also use MIME::Types, would be new dependency


### PR DESCRIPTION
Test output:

```
$ prove -l -v t/44-scripts.t
t/44-scripts.t ..
ok 1 - Calling 'client --help' returns exit code 0
ok 2 - Calling 'configure-web-proxy --help' returns exit code 0
ok 3 - Calling 'create_admin --help' returns exit code 0
ok 4 - Calling 'dump_templates --help' returns exit code 0
ok 5 - Calling 'fetchneedles --help' returns exit code 0
ok 6 - Calling 'initdb --help' returns exit code 0
ok 7 - Calling 'load_templates --help' returns exit code 0
ok 8 - Calling 'modify_needle --help' returns exit code 0
ok 9 - Calling 'openqa --help' returns exit code 0
ok 10 - Calling 'openqa-bootstrap --help' returns exit code 0
ok 11 - Calling 'openqa-bootstrap-container --help' returns exit code 0
ok 12 - Calling 'openqa-cli --help' returns exit code 0
ok 13 - Calling 'openqa-clone-custom-git-refspec --help' returns exit code 0
ok 14 - Calling 'openqa-clone-job --help' returns exit code 0
ok 15 - Calling 'openqa-enqueue-asset-cleanup --help' returns exit code 0
ok 16 - Calling 'openqa-enqueue-audit-event-cleanup --help' returns exit code 0
ok 17 - Calling 'openqa-enqueue-bug-cleanup --help' returns exit code 0
ok 18 - Calling 'openqa-enqueue-result-cleanup --help' returns exit code 0
ok 19 - Calling 'openqa-gru --help' returns exit code 0
ok 20 - Calling 'openqa-label-all --help' returns exit code 0
ok 21 - Calling 'openqa-livehandler --help' returns exit code 0
ok 22 - Calling 'openqa-livehandler-daemon --help' returns exit code 0
ok 23 - Calling 'openqa-scheduler --help' returns exit code 0
ok 24 - Calling 'openqa-scheduler-daemon --help' returns exit code 0
ok 25 - Calling 'openqa-slirpvde --help' returns exit code 0
ok 26 - Calling 'openqa-validate-yaml --help' returns exit code 0
ok 27 - Calling 'openqa-vde_switch --help' returns exit code 0
ok 28 - Calling 'openqa-websockets --help' returns exit code 0
ok 29 - Calling 'openqa-websockets-daemon --help' returns exit code 0
ok 30 - Calling 'openqa-webui-daemon --help' returns exit code 0
ok 31 - Calling 'openqa-worker-cacheservice-minion --help' returns exit code 0
ok 32 - Calling 'openqa-workercache --help' returns exit code 0
ok 33 - Calling 'openqa-workercache-daemon --help' returns exit code 0
ok 34 - Calling 'setup-db --help' returns exit code 0
ok 35 - Calling 'upgradedb --help' returns exit code 0
ok 36 - Calling 'worker --help' returns exit code 0
1..36
ok
All tests successful.
Files=1, Tests=36, 14 wallclock secs ( 0.02 usr  0.00 sys + 12.48 cusr  0.92 csys = 13.42 CPU)
Result: PASS
```

Related progress issue: https://progress.opensuse.org/issues/68167