### PR TITLE
Ensure all scripts exit non-zero in case of invalid parameters

### DIFF
--- a/script/configure-web-proxy
+++ b/script/configure-web-proxy
@@ -8,14 +8,14 @@ Configure a local web proxy using apache for openQA.
 Options:
  -h, --help         display this help
 EOF
-    exit
+    exit "$1"
 }
 
-opts=$(getopt -o h --long help -n 'parse-options' -- "$@") || usage
+opts=$(getopt -o h --long help -n 'parse-options' -- "$@") || usage 1
 eval set -- "$opts"
 while true; do
   case "$1" in
-    -h | --help ) usage; shift ;;
+    -h | --help ) usage 0; shift ;;
     -- ) shift; break ;;
     * ) break ;;
   esac

--- a/script/create_admin
+++ b/script/create_admin
@@ -33,7 +33,19 @@ my $fullname = 'Administrator';
 my $key      = "";
 my $secret   = "";
 my $user     = $ARGV[0];
-my $help     = 1 unless $user && scalar @ARGV > 1;
+my $help;
+
+sub usage {
+    print "Usage: $0 [options] user \n\n";
+    print "  --email     : Email address.\n";
+    print "  --nickname  : Nickname.\n";
+    print "  --fullname  : Full name.\n";
+    print "  --key       : API key (will be randomly generated if not set).\n";
+    print "  --secret    : API secret (will be randomly generated if not set).\n";
+    print "  user        : User ID (e.g. OpenID URL).\n";
+    print "usage: $_[0]\n";
+    exit $_[0];
+}
 
 my $result = GetOptions(
     "email=s"    => \$email,
@@ -43,17 +55,8 @@ my $result = GetOptions(
     "secret=s"   => \$secret,
     "help"       => \$help,
 );
-
-if ($help) {
-    print "Usage: $0 [options] user \n\n";
-    print "  --email     : Email address.\n";
-    print "  --nickname  : Nickname.\n";
-    print "  --fullname  : Full name.\n";
-    print "  --key       : API key (will be randomly generated if not set).\n";
-    print "  --secret    : API secret (will be randomly generated if not set).\n";
-    print "  user        : User ID (e.g. OpenID URL).\n";
-    exit;
-}
+usage 0 if $help;
+usage 1 unless $result && $user && scalar @ARGV > 1;
 
 if (($key || $secret)
     && !($key =~ /^[[:xdigit:]]{16}$/ && $secret =~ /^[[:xdigit:]]{16}$/))

--- a/script/initdb
+++ b/script/initdb
@@ -41,11 +41,7 @@ my $result = GetOptions(
     "user=s"        => \$user,
 );
 
-if (!$prepare_init and !$init_database) {
-    $help = 1;
-}
-
-if ($help) {
+sub usage {
     print "Usage: $0 [flags]\n\n";
     print "  --prepare_init  : Create the deployment files used to initialize the database.\n";
     print "                    Don't forget to increase the version before using this\n";
@@ -57,8 +53,11 @@ if ($help) {
     print "  --force         : Force overwriting existing data.\n";
     print "  --user=login    : Change uid before connecting the DB.\n";
     print "  --help          : This help message.\n";
-    exit;
+    exit $_[0];
 }
+
+usage 0 if $help;
+usage 1 unless $result or $prepare_init or $init_database;
 
 if ($user) {
     my $uid = getpwnam($user) || die "No such login $user";

--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -20,7 +20,7 @@ Examples:
  openqa-clone-custom-git-refspec https://github.com/coolgw/os-autoinst-distri-opensuse/tree/nfs https://openqa.opensuse.org/tests/835060 DESKTOP=textmode
  openqa-clone-custom-git-refspec -n -c '--show-progress' https://github.com/coolgw/os-autoinst-distri-opensuse/tree/nfs https://openqa.opensuse.org/tests/835060 DESKTOP=textmode
 EOF
-    exit
+    exit "$1"
 }
 
 set -o pipefail
@@ -51,12 +51,12 @@ extract_urls_from_pr() {
     fi
 }
 
-opts=$(getopt -o vhnc: --long verbose,dry-run,help,clone-job-args: -n 'parse-options' -- "$@") || usage
+opts=$(getopt -o vhnc: --long verbose,dry-run,help,clone-job-args: -n 'parse-options' -- "$@") || usage 1
 eval set -- "$opts"
 while true; do
   case "$1" in
     -v | --verbose ) set -x; shift ;;
-    -h | --help ) usage; shift ;;
+    -h | --help ) usage 0; shift ;;
     -n | --dry-run ) dry_run=true; shift ;;
     -c | --clone-job-args ) clone_args="$2 $clone_args"; shift 2 ;;
     -- ) shift; break ;;

--- a/script/openqa-livehandler
+++ b/script/openqa-livehandler
@@ -27,4 +27,5 @@ use OpenQA::Utils qw(service_port set_listen_address);
 $ENV{MOJO_INACTIVITY_TIMEOUT} ||= 15 * 60;
 
 set_listen_address(service_port('livehandler'));
-OpenQA::LiveHandler::run;
+my $ret = OpenQA::LiveHandler::run;
+exit $ret unless $ENV{MOJO_HELP};

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -27,4 +27,5 @@ use OpenQA::Utils qw(service_port set_listen_address);
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 1024 * 1024 * 1024 * 20;
 
 set_listen_address(service_port('websocket'));
-OpenQA::WebSockets::run;
+my $ret = OpenQA::WebSockets::run;
+exit $ret unless $ENV{MOJO_HELP};

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -41,9 +41,7 @@ my $result = GetOptions(
     "force"            => \$force
 );
 
-$help = 1 unless $prepare_upgrades or $upgrade_database;
-
-if ($help) {
+sub usage {
     print "Usage: $0 [flags]\n\n";
     print "  --prepare_upgrades : Create the deployment files used to upgrade the database.\n";
     print "                       Don't forget to increase the version before using this\n";
@@ -53,8 +51,11 @@ if ($help) {
     print "  --force            : Force overwriting existing data.\n";
     print "  --user=login       : Change uid before connecting the DB.\n";
     print "  --help             : This help message.\n";
-    exit;
+    exit $_[0];
 }
+
+usage 0 if $help;
+usage 1 unless $result or $prepare_upgrades or $upgrade_database;
 
 if ($user) {
     my $uid = getpwnam($user) || die "No such login $user";

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -41,7 +41,7 @@ my $ret;
 test_once '', qr/Need.*parameter/, 'hint shown for mandatory parameter missing', 1,
   'openqa-clone-custom-git-refspec needs parameters';
 test_once '--help',        qr/Usage:/, 'help text shown',              0, 'help screen is regarded as success';
-test_once '--invalid-arg', qr/Usage:/, 'invalid args also yield help', 0, 'help screen still success';
+test_once '--invalid-arg', qr/Usage:/, 'invalid args also yield help', 1, 'help screen but no success recorded';
 my $args = 'https://github.com/user/repo/pull/9128 https://openqa.opensuse.org/tests/1234';
 isnt run_once($args), 0, 'without network we fail (without error)';
 # mock any external access with all arguments

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -38,6 +38,10 @@ for my $script (sort keys %types) {
     my $rc  = $?;
     is($rc, 0, "Calling '$script --help' returns exit code 0")
       or diag "Output: $out";
+    $out = qx{$Bin/../script/$script --invalid-option 2>&1};
+    $rc  = $?;
+    isnt($rc, 0, "Calling '$script --invalid-option' returns non-zero exit code")
+      or diag "Output: $out";
 }
 
 done_testing;


### PR DESCRIPTION
To prevent incorrect setup of services or scripts in automation we
should ensure that all scripts return a non-zero exit code signalling a
failure.

This commit adds corresponding handling of parameter parsing and
forwarding of the corresponding exit code in all scripts where not
already present. Also adding a corresponding test in t/44-scripts.t.
This increases the runtime especially due to the costly startup of
services but I consider it still beneficial to cover.

Related progress issue: https://progress.opensuse.org/issues/68167