### PR TITLE
spec: Enable tests on Leap as well to prevent breakage on known supported versions

### DIFF
--- a/openQA.spec
+++ b/openQA.spec
@@ -24,7 +24,8 @@
 %{_bindir}/systemd-tmpfiles --create %{?*} || : \
 %{nil}
 %endif
-%if 0%{?suse_version} >= 1550
+# Run tests on openSUSE Tumbleweed and supported openSUSE Leap versions
+%if 0%{?suse_version} >= 1550 || ( 0%{?is_opensuse} && 0%{?sle_version} >= 150100 )
 %ifarch x86_64
 %bcond_without tests
 %else


### PR DESCRIPTION
As we build against other repositories and architectures and our tests
are more stable we could benefit from testing on these as well using the
power of OBS. Enabling tests on openSUSE Leap helps us to prevent
deploying known broken package combinations which is not tested during
openQA development using circleCI, e.g. when a dependency has been
updated in openSUSE:Factory already, as happened in the past.

Related progress issue: https://progress.opensuse.org/issues/69160