### PR TITLE
Try to fix instability in comment update detection

### DIFF
--- a/templates/webapi/comments/comment_row.html.ep
+++ b/templates/webapi/comments/comment_row.html.ep
@@ -1,3 +1,5 @@
+% use OpenQA::Constants;
+
 % if (!$context->{pinned}) {
     <div class="row comment-row">
         <div class="col-sm-1">
@@ -26,7 +28,7 @@
                         % if($comment) {
                             <%= $user->name %> wrote
                             <a href="#comment-<%= $comment_id %>" class="comment-anchor"><abbr class="timeago" title="<%= $comment->t_created->datetime() %>Z"><%= format_time($comment->t_created) %></abbr></a>
-                            % if ($comment->t_created != $comment->t_updated) {
+                            % if ($comment->t_updated->subtract(seconds => OpenQA::Constants::DB_TIMESTAMP_ACCURACY) >= $comment->t_created) {
                                 (last edited <abbr class="timeago" title="<%= $comment->t_updated->datetime() %>Z"><%= format_time($comment->t_updated) %></abbr>)
                             % }
                         % }


### PR DESCRIPTION
The commit d674bdf397dfc4a77cdef95091b2078a50e9d096 tried to fix an
instability with an update of javascript code. A test failed in circleCI
again with:

```
[debug] [8YmjWcRI] POST "/api/v1/parent_groups/1/comments"
[debug] [8YmjWcRI] Routing to controller "OpenQA::Shared::Controller::Auth" and action "auth"
[debug] API auth by user: Demo, operator: 1
[debug] [8YmjWcRI] Routing to controller "OpenQA::WebAPI::Controller::API::V1::Comment" and action "create"
[debug] [8YmjWcRI] 200 OK (0.019251s, 51.945/s)
[debug] [j8Rvzc5Z] GET "/api/v1/parent_groups/1/comments/11"
[debug] [j8Rvzc5Z] Routing to controller "OpenQA::WebAPI::Controller::API::V1::Comment" and action "text"
[debug] [j8Rvzc5Z] 200 OK (0.017316s, 57.750/s)
        ok 1 - Wait for jQuery successful: comment added to group
        ok 2 - exactly one comment heading present
        ok 3 - exactly one comment body present
        not ok 4 - heading text

        #   Failed test 'heading text'
        #   at t/ui/15-comments.t line 99.
        #          got: 'Demo wrote less than a minute ago (last edited less than a minute ago)'
        #     expected: 'Demo wrote less than a minute ago'
        ok 5 - body text
        ok 6 - anchor matches expected format
        ok 7 - body found via anchor ref
        1..7
        # Looks like you failed 1 test of 7.
    not ok 2 - add

    #   Failed test 'add'
    #   at t/ui/15-comments.t line 130.
```

so this time I am trying to fix this by changing the perl template code
as well.

Related progress issue: https://progress.opensuse.org/issues/72319