### PR TITLE
Enable strict merge on Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,13 +5,28 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
       - "#review-requested=0"
-      - -label~=^acceptance-tests-needed|not-ready
+      - -label~=^acceptance-tests-needed|not-ready|no-automatic-rebase
       - base=master
       # wait explicitly for one of the final checks to show up to be on the
       # safe side even in case of checks not reporting back at all
       - "status-success=codecov/project"
       # wait for OBS package build as well which is triggered independantly
       # See https://progress.opensuse.org/issues/55346 for details
+      - "status-success=OBS Package Build"
+    actions:
+      merge:
+        method: merge
+        strict: smart+fasttrack
+        strict_method: rebase
+  - name: automatic merge (no automatic rebase)
+    conditions:
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - "#review-requested=0"
+      - -label~=^acceptance-tests-needed|not-ready
+      - "label=no-automatic-rebase"
+      - base=master
+      - "status-success=codecov/project"
       - "status-success=OBS Package Build"
     actions:
       merge:


### PR DESCRIPTION
- "strict merge" means that open PRs are checked again whenever the target branch has changed. Affected branches can be rebase automatically.
- Behavior for `merge-fast` will not change.
- The new label `no-automatic-rebase` can be used to retain the current behavior (i.e. your branch is not touched and only merged as-is if possible).

See https://docs.mergify.io/merge-action.html#strict-merge