### PR TITLE
Add a personal activity view based on audit events

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -347,6 +347,12 @@ function renderTestState(item, job) {
         item.appendChild(icon);
     }
     item.appendChild(document.createTextNode(' ' + job.name + ' '));
+    if (job.has_parents) {
+        const icon = document.createElement('i');
+        icon.className = job.parents_ok ? 'fa fa-link' : 'fa fa-unlink';
+        icon.title = job.parents_ok ? 'dependency passed' : 'dependency failed';
+        item.appendChild(icon);
+    }
 }
 
 function updateTestState(job, name, timeago, reason) {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -429,22 +429,6 @@ sub settings_hash {
     return $settings;
 }
 
-sub deps_hash {
-    my ($self) = @_;
-    return $self->{_deps_hash} if defined $self->{_deps_hash};
-    my @dependency_names = OpenQA::JobDependencies::Constants::display_names;
-    my %parents          = map { $_ => [] } @dependency_names;
-    my %children         = map { $_ => [] } @dependency_names;
-    $self->{_deps_hash} = {parents => \%parents, children => \%children};
-    for my $dep ($self->parents) {
-        push @{$parents{$dep->to_string}}, $dep->parent_job_id;
-    }
-    for my $dep ($self->children) {
-        push @{$children{$dep->to_string}}, $dep->child_job_id;
-    }
-    return $self->{_deps_hash};
-}
-
 sub add_result_dir_prefix {
     my ($self, $rd) = @_;
     return $rd ? catfile($self->num_prefix_dir, $rd) : undef;
@@ -513,7 +497,7 @@ sub to_hash {
         }
     }
     if ($args{deps}) {
-        $j = {%$j, %{$job->deps_hash}};
+        $j = {%$j, %{$job->dependencies}};
     }
     if ($args{details}) {
         my $test_modules = read_test_modules($job);

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -227,6 +227,7 @@ sub startup {
     my $pub_admin_r = $admin->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
 
     # operators accessible tables
+    $admin_r->get('/activity_view')->name('activity_view')->to('activity_view#user');
     $pub_admin_r->get('/products')->name('admin_products')->to('product#index');
     $pub_admin_r->get('/machines')->name('admin_machines')->to('machine#index');
     $pub_admin_r->get('/test_suites')->name('admin_test_suites')->to('test_suite#index');

--- a/lib/OpenQA/WebAPI/Controller/Admin/ActivityView.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/ActivityView.pm
@@ -1,0 +1,25 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Controller::Admin::ActivityView;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub user {
+    my ($self) = @_;
+
+    $self->render('admin/activity_view/user');
+}
+
+1;

--- a/t/ui/16-activity-view.t
+++ b/t/ui/16-activity-view.t
@@ -1,0 +1,82 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use Test::More;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::Case;
+use OpenQA::Client;
+
+use OpenQA::SeleniumTest;
+
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');
+
+plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+# we need to talk to the phantom instance or else we're using the wrong database
+my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+
+subtest 'Access activity view via the menu' => sub {
+    $driver->find_element_by_link_text('Login')->click();
+    $driver->title_is('openQA', 'on main page');
+    is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', 'logged in as demo');
+    $driver->find_element('#user-action a')->click();
+    $driver->find_element_by_link_text('Activity View')->click();
+    $driver->title_is('openQA: Personal Activity View', 'on activity view');
+};
+
+subtest 'Current jobs' => sub {
+    my $schema = $t->app->schema;
+    my $events = $schema->resultset('AuditEvents');
+
+    # The events are interchangeable, but all of these should work
+    # Multiple events for the same job amount to one item
+    my %fake_events = (
+        80000 => 'job_done',             # passed
+        99926 => 'job_restart',          # incomplete+reason
+        99927 => 'job_update_result',    # scheduled,
+        99937 => 'job_done',             # passed,
+        99938 => 'job_create',           # failed
+        99936 => 'job_create',           # softfailed
+        99936 => 'job_done',             # "
+        99936 => 'job_restart',          # "
+    );
+    my $user = $schema->resultset('Users')->find({is_admin => 1});
+    $events->create(
+        {
+            user_id       => $user->id,
+            connection_id => 'foo',
+            event         => $fake_events{$_},
+            event_data    => "{\"id\": $_}",
+        }) for keys %fake_events;
+    $driver->refresh;
+    wait_for_element(selector => '#results .list-group-item');
+
+    like $driver->get_title(), qr/Activity View/, 'search shown' or return;
+    my $results = $driver->find_element_by_id('results');
+    my @entries = $results->children('.list-group-item');
+    is scalar @entries, 6, '6 jobs' or return diag explain @entries;
+};
+
+END { kill_driver() }
+done_testing();

--- a/templates/webapi/admin/activity_view/user.html.ep
+++ b/templates/webapi/admin/activity_view/user.html.ep
@@ -1,0 +1,19 @@
+% layout 'bootstrap';
+% title 'Personal Activity View';
+
+% content_for ready_function => begin
+  % my $user = $self->current_user;
+  renderActivityView("<%= url_for('audit_ajax') %>", "<%= $user ? $user->nickname : '' %>");
+% end
+
+<div>
+    <h2 id="results-heading">Current activities</h2>
+    <p>The activity view includes <b>your current jobs</b>.</p>
+    <div id="flash-messages"></div>
+    <p id="progress-indication" style="display: none">
+        <i class="fa fa-cog fa-spin fa-3x fa-fw"></i>
+        <span class="sr-only">Loading…</span>
+    </p>
+    <div id="results" class="list-group">
+    </div>
+</div>

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -48,6 +48,7 @@
                 </a>
                 <div class="dropdown-menu">
                   %= tag 'h3' => class => 'dropdown-header' => 'Operators Menu'
+                  %= link_to 'Activity View' => url_for('activity_view') => class => 'dropdown-item'
                   %= link_to 'Medium types' => url_for('admin_products') => class => 'dropdown-item'
                   %= link_to 'Machines' => url_for('admin_machines') => class => 'dropdown-item'
                   %= link_to 'Test suites' => url_for('admin_test_suites') => class => 'dropdown-item'


### PR DESCRIPTION
- A new item *Activity View* is available from the menu
- The view is based off of the search view, although it's backed by the audit log and public jobs API
  - The `parents_ok` state is added to the public jobs API
- Running jobs are updated dynamically without requiring a refresh (5s like test result pages)

![image](https://user-images.githubusercontent.com/1204189/95486305-21fcf300-0993-11eb-8b27-d6bfe8d87fc1.png)

Fixes: [poo#58304](https://progress.opensuse.org/issues/58304)