### PR TITLE
Mark full-stack.t as stable and faster after recent stabilization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test-unstable:
 
 .PHONY: test-fullstack
 test-fullstack:
-	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=15 PROVE_ARGS="$$HARNESS t/full-stack.t" RETRY=3
+	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=9 PROVE_ARGS="$$HARNESS t/full-stack.t"
 
 .PHONY: test-scheduler
 test-scheduler:


### PR DESCRIPTION
After recent work done it seems that we can regard full-stack.t again as
more stable and also faster. Also, if there are test failures then we
can expect the test to timeout faster.

In
https://app.circleci.com/pipelines/github/os-autoinst/openQA?branch=master
I looked after recent past occurences of t/full-stack.t and found that
in 7/7 cases no retry was conducted and the runtime was always below 6m.

This commit therefore removes the retries on t/full-stack.t as well as
reduces the make-level timeout accordingly.

Related progress issue: https://progress.opensuse.org/issues/71554