### PR TITLE
Enable faster local host uploads by default

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -17,12 +17,13 @@
 #  if the automatically deduced hostname is not sufficient)
 #WORKER_HOSTNAME = openqa-worker.example.host
 
-# Optimize asset uploads. When enabled the worker will try to copy assets on
-# the file system instead of uploading them to the webui via HTTP, for much
-# better performance (webui and worker need to be running on the same host).
-# For best performance it is also recommended to have /var/lib/openqa/pool
-# and /var/lib/openqa/share/factory on the same file system.
-#LOCAL_UPLOAD = 1
+# Optimize asset uploads. Enabled by default. When enabled the worker will
+# try to copy assets on the file system instead of uploading them to the
+# webui via HTTP, for much better performance (webui and worker need to be
+# running on the same host). For best performance it is also recommended to
+# have /var/lib/openqa/pool and /var/lib/openqa/share/factory on the same file
+# system.
+#LOCAL_UPLOAD = 0
 
 # The section ids are the instance of the workers.
 # The key/value pairs will appear in vars.json

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -1003,7 +1003,7 @@ sub _upload_asset {
     my $filename             = $upload_parameter->{file}->{filename};
     my $file                 = $upload_parameter->{file}->{file};
     my $chunk_size           = $self->worker->settings->global_settings->{UPLOAD_CHUNK_SIZE} // 1000000;
-    my $local_upload         = $self->worker->settings->global_settings->{LOCAL_UPLOAD};
+    my $local_upload         = $self->worker->settings->global_settings->{LOCAL_UPLOAD}      // 1;
     my $ua                   = $self->client->ua;
     my @channels_worker_only = ('worker');
     my @channels_both        = ('autoinst', 'worker');


### PR DESCRIPTION
I went with the most minimal solution i could think of and didn't rename the option. Anyone who has `LOCAL_UPLOAD = 1` configured already will have the feature still working as expected.

At first i wanted to just disable the feature in the full-stack test to keep coverage as it was before. But in the middle of the test we restart the worker with a new configuration anyway, so that seemed like a good opportunity to include both cases.

Progress: https://progress.opensuse.org/issues/69637