### PR TITLE
Add testcase "failure" (singular) to XUnit parser

### DIFF
--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -89,6 +89,7 @@ sub parse {
                 $content .= "# $tc->{name}\n" if $tc->{name};
 
                 for my $out ($tc->children('skipped, passed, error, failure')->each) {
+                    $tc_result = 'fail' if ($out->tag =~ m/failure|error/);
                     $content .= "# " . $out->tag . ": \n\n";
                     $content .= $out->{message} . "\n" if $out->{message};
                     $content .= $out->text . "\n";


### PR DESCRIPTION
XUnit files generated by some external tools (such as the [robot framework](https://robotframework.org/)), identify failed test cases with a children `failure` (in singular) and does not summarize the failures in a plural `failures` as expected by the current version of the XUnit openQA parser.

This can prevent external failed results from being properly rendered: http://1a102.qa.suse.de/tests/5546

As can be seen on one of the XUnit [files](http://1a102.qa.suse.de/tests/5546/file/robot_fw-limits.robot.xml) from that test, the plural `failures` is used in the test suite, while the singular `failure` is used in the test cases without summarization.

This PR marks the test case as `failed` when encountering test cases with children that have the tags `failure` (singular) or `error`.

Verification run: http://1a102.qa.suse.de/tests/5556
