### PR TITLE
activity view: Request events ordered by event ID

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -393,7 +393,8 @@ function renderJobStatus(item, id) {
         const name = document.createElement('a');
         header.appendChild(name);
         header.appendChild(title);
-        const timeago = document.createTextNode('');
+        const timeago = document.createElement('abbr');
+        timeago.className = 'timeago';
         header.appendChild(timeago);
         item.appendChild(header);
         const details = document.createElement('pre');
@@ -424,7 +425,11 @@ function renderActivityView(ajaxUrl, currentUser) {
     const spinner = document.getElementById('progress-indication');
     spinner.style.display = 'block';
     let request = new XMLHttpRequest();
-    request.open('GET', ajaxUrl + '?search[value]=user:' + encodeURIComponent(currentUser) + ' event:job_');
+    let query = new URLSearchParams();
+    query.append('search[value]', 'user:' + encodeURIComponent(currentUser) + ' event:job_');
+    query.append('order[0][column]', '0'); // t_created
+    query.append('order[0][dir]', 'desc');
+    request.open('GET', ajaxUrl + '?' + query.toString());
     request.setRequestHeader('Accept', 'application/json');
     request.onload = function() {
         // Make sure we have valid JSON here

--- a/t/ui/16-activity-view.t
+++ b/t/ui/16-activity-view.t
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Date::Format 'time2str';
 use Test::Most;
-
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Test::More;
@@ -50,32 +50,43 @@ subtest 'Current jobs' => sub {
     my $events = $schema->resultset('AuditEvents');
 
     # The events are interchangeable, but all of these should work
-    # Multiple events for the same job amount to one item
     my %fake_events = (
         80000 => 'job_done',             # passed
         99926 => 'job_restart',          # incomplete+reason
         99927 => 'job_update_result',    # scheduled,
-        99937 => 'job_done',             # passed,
-        99938 => 'job_create',           # failed
         99936 => 'job_create',           # softfailed
-        99936 => 'job_done',             # "
-        99936 => 'job_restart',          # "
+        99937 => 'job_done',             # passed,
     );
     my $user = $schema->resultset('Users')->find({is_admin => 1});
+    my $jobs = $schema->resultset('Jobs');
     $events->create(
         {
             user_id       => $user->id,
             connection_id => 'foo',
             event         => $fake_events{$_},
             event_data    => "{\"id\": $_}",
-        }) for keys %fake_events;
+            t_created     => time2str('%Y-%m-%d %H:%M:%S', time - $_ - 80000, 'UTC'),
+        }) for sort keys %fake_events;
+    # Multiple events for the same job amount to one item
+    $events->create(
+        {
+            user_id       => $user->id,
+            connection_id => 'foo',
+            event         => 'job_restart',
+            event_data    => "{\"id\": 99936}",
+        });
     $driver->refresh;
     wait_for_element(selector => '#results .list-group-item');
 
     like $driver->get_title(), qr/Activity View/, 'search shown' or return;
     my $results = $driver->find_element_by_id('results');
     my @entries = $results->children('.list-group-item');
-    is scalar @entries, 6, '6 jobs' or return diag explain @entries;
+    is scalar @entries, 5, '5 jobs' or return diag explain $results->get_text;
+
+    my $first = wait_for_element(selector => '#results .list-group-item:first-child .timeago:not(:empty)');
+    is $first->get_text, 'about 2 hours ago', 'first job';
+    my $last = wait_for_element(selector => '#results .list-group-item:last-child .timeago:not(:empty)');
+    is $last->get_text, '6 days ago', 'last job';
 };
 
 END { kill_driver() }


### PR DESCRIPTION
- Give timeago a proper class name
- Specify ordering in the audit log ajax call
- Tests check that the ordering is stable

See: https://progress.opensuse.org/issues/58304