### PR TITLE
tour: Introduce the activity view

### DIFF
--- a/assets/javascripts/feature.js
+++ b/assets/javascripts/feature.js
@@ -1,4 +1,5 @@
 function newFeature(featureVersion) {
+    const latestFeature = 4;
     var currentFeature;
 
     //Create variable for each tour
@@ -8,7 +9,7 @@ function newFeature(featureVersion) {
         storage: window.localStorage,
         template: changeTemplate(),
         onShown: function() {
-            return dontShow(), currentFeature = 2, quitTour(currentFeature);
+            return dontShow(), currentFeature = latestFeature, quitTour(currentFeature);
         },
     });
 
@@ -25,6 +26,19 @@ function newFeature(featureVersion) {
         content: "Access the job group overview pages from here. Besides test results, a description and commenting area are provided.",
         placement: "bottom",
         backdrop: false,
+    }, {
+        element: "#user-action",
+        title: "User menu",
+        content: "Access your user menu from here.",
+        placement: "bottom",
+    }, {
+        element: "#activity_view",
+        title: "Activity View",
+        content: "Access the activity view from here. This view gives you an overview of your current jobs.",
+        placement: "right",
+        orphan: true,
+        onShown: function() { $('#user-action .dropdown-toggle').click(); },
+        onHidden: function() { $('#user-action .dropdown-toggle').click(); },
     }]);
 
     initTour(featureVersion);
@@ -51,7 +65,7 @@ function newFeature(featureVersion) {
     }
 
     function initTour(featureVersion) {
-        if ((2 > featureVersion) && (featureVersion != 0)) {
+        if (latestFeature > featureVersion && featureVersion > 0) {
             //Initialize the tour
             tour01.init(true);
             tour01._current = null;

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -48,7 +48,7 @@
                 </a>
                 <div class="dropdown-menu">
                   %= tag 'h3' => class => 'dropdown-header' => 'Operators Menu'
-                  %= link_to 'Activity View' => url_for('activity_view') => class => 'dropdown-item'
+                  %= link_to 'Activity View' => url_for('activity_view') => class => 'dropdown-item' => id => 'activity_view'
                   %= link_to 'Medium types' => url_for('admin_products') => class => 'dropdown-item'
                   %= link_to 'Machines' => url_for('admin_machines') => class => 'dropdown-item'
                   %= link_to 'Test suites' => url_for('admin_test_suites') => class => 'dropdown-item'


### PR DESCRIPTION
To make this work, a step for the user menu is also added.

See: https://progress.opensuse.org/issues/58304

Note: I could not find a way to get the popover to anchor to the Activity View menu item or make it appear selected respectively. I'm also not 100% sure if the feature levels work properly. The docs are not very helpful either. So this is my best effort.