### PR TITLE
Handle unknown options consistently with Mojolicious 8.63 in openqa-cli

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -28,7 +28,8 @@ sub command {
 
     my $data = $self->data_from_stdin;
 
-    getopt \@args,
+    die $self->usage
+      unless getopt \@args,
       'a|header=s'    => \my @headers,
       'D|data-file=s' => \my $data_file,
       'd|data=s'      => \$data,

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -24,7 +24,8 @@ has usage       => sub { shift->extract_usage };
 sub command {
     my ($self, @args) = @_;
 
-    getopt \@args,
+    die $self->usage
+      unless getopt \@args,
       'l|asset-size-limit=i' => \(my $limit),
       't|with-thumbnails'    => \my $thumbnails;
 

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -124,6 +124,18 @@ subtest 'Client' => sub {
     isa_ok $api->client(Mojo::URL->new('http://localhost')), 'OpenQA::Client', 'right class';
 };
 
+subtest 'Unknown options' => sub {
+    my $api    = OpenQA::CLI::api->new;
+    my $buffer = '';
+    {
+        open my $handle, '>', \$buffer;
+        local *STDERR = $handle;
+        eval { $api->run('--unknown') };
+        like $@, qr/Usage: openqa-cli api/, 'unknown option';
+    }
+    like $buffer, qr/Unknown option: unknown/, 'right output';
+};
+
 subtest 'Simple request with authentication' => sub {
     my ($stdout, $stderr, @result) = capture sub { $api->run(@host, 'test/op/hello') };
     is_deeply \@result, [1], 'non-zero exit code';

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -51,6 +51,18 @@ subtest 'Help' => sub {
     like $stdout, qr/Usage: openqa-cli archive/, 'help';
 };
 
+subtest 'Unknown options' => sub {
+    my $archive = OpenQA::CLI::archive->new;
+    my $buffer  = '';
+    {
+        open my $handle, '>', \$buffer;
+        local *STDERR = $handle;
+        eval { $archive->run('--unknown') };
+        like $@, qr/Usage: openqa-cli archive/, 'unknown option';
+    }
+    like $buffer, qr/Unknown option: unknown/, 'right output';
+};
+
 subtest 'Archive job' => sub {
     my $target = $dir->child('archive')->make_path;
     my ($stdout, $stderr, @result) = capture_stdout sub { $cli->run('archive', @host, 99937, $target->to_string) };


### PR DESCRIPTION
This was inspired by #3441 and makes `openqa-cli` behave [the same as all commands](https://github.com/mojolicious/mojo/commit/82efa95bbe28a69df57e16ffe3232e3ab8b3f766) we inherit from Mojolicious.