### PR TITLE
Docker: Fix worker dockerfile 

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -5,7 +5,7 @@ LABEL version="0.3"
 RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.2 openQA && \
     zypper ar -f obs://devel:openQA:Leap:15.2/openSUSE_Leap_15.2 openQA-perl-modules && \
     zypper --gpg-auto-import-keys ref && \
-    zypper --non-interactive in ca-certificates-mozilla curl && \
+    zypper --non-interactive in ca-certificates-mozilla curl gzip && \
     zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 && \
     zypper --non-interactive in kmod && \
     (zypper --non-interactive in qemu-ovmf-x86_64 || true) && \

--- a/docker/worker/kvm-mknod.sh
+++ b/docker/worker/kvm-mknod.sh
@@ -3,12 +3,12 @@
 
 set -e
 
-test $(gunzip -c /proc/config.gz | grep CONFIG_KVM=y) || lsmod | grep '\<kvm\>' > /dev/null || {
+([[ -f /proc/config.gz ]] && test $(gzip -c /proc/config.gz | grep CONFIG_KVM=y)) || lsmod | grep '\<kvm\>' > /dev/null || {
   echo >&2 "KVM module not loaded; software emulation will be used"
   exit 1
 }
 
-mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -f 1 -d' ') || {
+[[ -c /dev/kvm ]] || mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -f 1 -d' ') || {
   echo >&2 "Unable to make /dev/kvm node; software emulation will be used"
   echo >&2 "(This can happen if the container is run without -privileged)"
   exit 1


### PR DESCRIPTION
Docker image didn't build. This PR solves the problems:
Problem: gunzip is not in the repositories anymore. 
Solution: gzip replaces gunzip

Problem: when /proc/config.gz doesn't exists the execution of kvm-mknod.sh during the build fails. 
Solution: check that /proc/config.gz exists before to use this

Problem: kvm-mknod.sh tries to create /dev/kvm failing if exists
Solution: check /dev/kvm before

https://progress.opensuse.org/issues/43715