### PR TITLE
Scale timeout in t/01-test-utilities.t to prevent failures observed on OBS

### DIFF
--- a/t/01-test-utilities.t
+++ b/t/01-test-utilities.t
@@ -24,34 +24,37 @@ use IPC::Run 'start';
 use Test::Output 'combined_like';
 use Test::MockModule;
 
+my $signal_timeout = OpenQA::Test::TimeLimit::scale_timeout 7;
+
 subtest 'warnings in sub processes are fatal test failures' => sub {
     my $test_utils_mock        = Test::MockModule->new('OpenQA::Test::Utils');
     my $test_would_have_failed = 0;
     $test_utils_mock->redefine(
         _fail_and_exit => sub {
-            like(shift, qr/sub process test-process terminated with exit code \d+/, 'message of test failure');
+            like(shift, qr/sub process test-process-1 terminated with exit code \d+/, 'message of test failure');
             isnt(shift, 0, 'exit code of test failure is non-zero');
             $test_would_have_failed = 1;
         });
     combined_like {
         # start a sub process like the test helper do and simulate a Perl warning
-        OpenQA::Test::Utils::_setup_sigchld_handler 'test-process', start sub {
-            OpenQA::Test::Utils::_setup_sub_process 'test-process';
+        OpenQA::Test::Utils::_setup_sigchld_handler 'test-process-1', start sub {
+            OpenQA::Test::Utils::_setup_sub_process 'test-process-1';
             '' . undef;    # provoke Perl warning "Use of uninitialized value in concatenation …"
         };
-        # wait at most 5 seconds (the sleep is supposed to be interrupted by SIGCHLD)
-        sleep 5;
+        note "waiting at most $signal_timeout seconds for SIGCHLD (sleep is supposed to be interrupted by SIGCHLD)";
+        sleep $signal_timeout;
     }
-    qr/Stopping test-process process because a Perl warning occurred: Use of uninitialized value in concatenation/,
+    qr/Stopping test-process-1 process because a Perl warning occurred: Use of uninitialized value in concatenation/,
       'warning logged';
     ok($test_would_have_failed, 'test would have failed');
 
     # stop the process via stop_service (previously tested handling of SIGCHLD/warnings does not interfere)
     $test_would_have_failed = 0;
-    my $ipc_run_harness = OpenQA::Test::Utils::_setup_sigchld_handler 'test-process', start sub {
-        OpenQA::Test::Utils::_setup_sub_process 'test-process';
-        # wait at most 5 seconds (supposed to be interrupted by SIGTERM)
-        sleep 5;
+    my $ipc_run_harness = OpenQA::Test::Utils::_setup_sigchld_handler 'test-process-2', start sub {
+        OpenQA::Test::Utils::_setup_sub_process 'test-process-2';
+        note "waiting at most $signal_timeout seconds for SIGTERM (sleep is supposed to be interrupted by SIGTERM)";
+        sleep $signal_timeout;
+        note 'timeout for receiving SIGTERM exceeded';
         exit -1;
     };
     stop_service($ipc_run_harness);

--- a/t/lib/OpenQA/Test/TimeLimit.pm
+++ b/t/lib/OpenQA/Test/TimeLimit.pm
@@ -16,13 +16,20 @@
 package OpenQA::Test::TimeLimit;
 use Test::Most;
 
+my $SCALE_FACTOR = 1;
+
 sub import {
     my ($package, $limit) = @_;
     die "$package: Need argument on import, e.g. use: use OpenQA::Test::TimeLimit '42';" unless $limit;
-    $limit *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
-    $limit *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI}    // 2 if $ENV{CI};
+    $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
+    $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI}    // 2 if $ENV{CI};
+    $limit        *= $SCALE_FACTOR;
     $SIG{ALRM} = sub { BAIL_OUT "test exceeds runtime limit of '$limit' seconds\n" };
     alarm $limit;
+}
+
+sub scale_timeout {
+    return $_[0] * $SCALE_FACTOR;
 }
 
 1;


### PR DESCRIPTION


We've seen the following test failure on OBS (see https://progress.opensuse.org/issues/73162):

```
[ 1108s]     #   Failed test 'manual termination via stop_service does not trigger _fail_and_exit'
[ 1108s]     #   at ./t/01-test-utilities.t line 58.
[ 1108s]     #          got: '1'
[ 1108s]     #     expected: '0'
[ 1108s]     # Looks like you failed 2 tests of 5.
```

The test is actually just running into a timeout. The exact failure can be
reproduced locally by adding a sleep at the right place to run there into
the timeout as well.

This PR adds an explicit log message if the test runs into the timeout and
applies the same scaling used for the overall timeout to the other timeouts
within the test.