### PR TITLE
branding: Set "blocker" flag automatically in bugzilla bug reports

### DIFF
--- a/templates/webapi/branding/openSUSE/external_reporting.html.ep
+++ b/templates/webapi/branding/openSUSE/external_reporting.html.ep
@@ -111,6 +111,7 @@ Always latest result in this scenario: [latest]($latest)
 %    $product_details{product} = "$distri $product";
 %    $product_details{bug_file_loc} = $step_url;
 %    $product_details{cf_foundby} = 'openQA';
+%    $product_details{cf_blocker} = 'Yes';
 % }
 % if ($distri eq 'kubic') {
 %    $product_details{component} = 'Kubic';


### PR DESCRIPTION
This is recommended by the SUSE bug reporting policy for bugs reported
for automatic test cases. A reason is that an issue found in openQA
commonly is making the test fail hence implicitly the bug always
"blocks" further execution.