### PR TITLE
worker: Use WORKER_HOSTNAME instead of real hostname

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -76,7 +76,7 @@ sub new {
         app                          => $app,
         settings                     => $settings,
         clients_by_webui_host        => undef,
-        worker_hostname              => $hostname,
+        worker_hostname              => ($settings->global_settings->{WORKER_HOSTNAME} // $hostname),
         isotovideo_interface_version => $isotovideo_interface_version,
     );
     $self->{_cli_options}            = $cli_options;

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -723,15 +723,14 @@ sub _upload_results {
 sub _upload_results_step_0_prepare {
     my ($self, $callback) = @_;
 
-    my $worker_id       = $self->client->worker_id;
-    my $job_url         = $self->isotovideo_client->url;
-    my $global_settings = $self->worker->settings->global_settings;
-    my $pooldir         = $self->worker->pool_directory;
-    my $status_file     = "$pooldir/" . AUTOINST_STATUSFILE;
-    my %status          = (
+    my $worker_id   = $self->client->worker_id;
+    my $job_url     = $self->isotovideo_client->url;
+    my $pooldir     = $self->worker->pool_directory;
+    my $status_file = "$pooldir/" . AUTOINST_STATUSFILE;
+    my %status      = (
         worker_id             => $worker_id,
         cmd_srv_url           => $job_url,
-        worker_hostname       => $global_settings->{WORKER_HOSTNAME},
+        worker_hostname       => $self->worker->worker_hostname,
         test_execution_paused => 0,
     );
 

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -92,6 +92,7 @@ sub wait_until_uploading_logs_and_assets_concluded {
     has instance_number => 1;
     has settings        => sub { OpenQA::Worker::Settings->new(1, {}) };
     has pool_directory  => undef;
+    has worker_hostname => undef;
 }
 {
     package Test::FakeClient;

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -104,9 +104,13 @@ my @webui_hosts = sort keys %{$worker->clients_by_webui_host};
 is_deeply(\@webui_hosts, [qw(http://localhost:9527 https://remotehost)], 'client for each web UI host')
   or diag explain \@webui_hosts;
 
-
-combined_like { $worker->log_setup_info }
-qr/.*http:\/\/localhost:9527,https:\/\/remotehost.*qemu_i386,qemu_x86_64.*/s, 'setup info';
+combined_like { $worker->log_setup_info } qr/
+  worker\ hostname:.+myworker
+  .*
+  web\ UI\ hosts:.+http:\/\/localhost:9527,https:\/\/remotehost
+  .*
+  class:.+qemu_i386,qemu_x86_64
+  /sx, 'setup info';
 
 push(@{$worker->settings->parse_errors}, 'foo', 'bar');
 combined_like { $worker->log_setup_info }

--- a/t/data/24-worker-overall/workers.ini
+++ b/t/data/24-worker-overall/workers.ini
@@ -2,7 +2,7 @@
 
 [global]
 HOST = http://localhost:9527 https://remotehost
-WORKER_HOSTNAME = 127.0.0.1
+WORKER_HOSTNAME = myworker
 LOG_LEVEL = debug
 
 [1]


### PR DESCRIPTION
Otherwise the "setup info" output is potentially misleading.

i.e.

    worker hostname:      code

instead of

    worker hostname:      localhost

assuming my `workers.ini` contains the following line:

    WORKER_HOSTNAME = 127.0.0.1


I realize our example config says the setting is needed by the developer mode in some cases, but during debugging it made me think back and wonder, if my config was actually broken - and it probably is, but not in this regard.

1. Should the setting be used consistently?
2. If not, for whatever reason, it should probably be revealed in the "setup info" anyway