### PR TITLE
Add timestamp parameter to test overview to show only jobs older than that

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -2,6 +2,7 @@
 
 function setupOverview() {
     setupLazyLoadingFailedSteps();
+    $('.timeago').timeago();
     $('.cancel')
         .bind("ajax:success", function(event, xhr, status) {
             $(this).text(''); // hide the icon

--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -9,6 +9,14 @@
     color: #fff;
     background-color: #bbb;
 }
+#summary .time-params {
+    font-weight: lighter;
+}
+@include media-breakpoint-up(xl) {
+    #summary .time-params {
+        float: right;
+    }
+}
 
 /* dotted underline looks strange with default font size */
 .h4 {

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,9 +98,9 @@ the return array.
 
 =cut
 sub latest_jobs {
-    my ($self) = @_;
+    my ($self, $until) = @_;
 
-    my @jobs = $self->search(undef, {order_by => ['me.id DESC']});
+    my @jobs = $self->search($until ? {t_created => {'<=' => $until}} : undef, {order_by => ['me.id DESC']});
     my @latest;
     my %seen;
     foreach my $job (@jobs) {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -682,6 +682,9 @@ sub _add_distri_and_version_to_summary {
 sub overview {
     my ($self) = @_;
     my ($search_args, $groups) = $self->compose_job_overview_search_args;
+    my $validation = $self->validation;
+    $validation->optional('t')->datetime;
+    my $until = $validation->param('t');
     my %stash = (
         # build, version, distri are not mandatory and therefore not
         # necessarily come from the search args so they can be undefined.
@@ -689,10 +692,8 @@ sub overview {
         version => $search_args->{version},
         distri  => $search_args->{distri},
         groups  => $groups,
+        until   => $until,
     );
-    my $validation = $self->validation;
-    $validation->optional('t')->datetime;
-    my $until       = $validation->param('t');
     my @latest_jobs = $self->schema->resultset('Jobs')->complex_query(%$search_args)->latest_jobs($until);
     ($stash{archs}, $stash{results}, $stash{aggregated}) = $self->prepare_job_results(\@latest_jobs);
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -690,7 +690,10 @@ sub overview {
         distri  => $search_args->{distri},
         groups  => $groups,
     );
-    my @latest_jobs = $self->schema->resultset('Jobs')->complex_query(%$search_args)->latest_jobs;
+    my $validation = $self->validation;
+    $validation->optional('t')->datetime;
+    my $until       = $validation->param('t');
+    my @latest_jobs = $self->schema->resultset('Jobs')->complex_query(%$search_args)->latest_jobs($until);
     ($stash{archs}, $stash{results}, $stash{aggregated}) = $self->prepare_job_results(\@latest_jobs);
 
     # determine distri/version from job results if not explicitely specified via search args

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -21,6 +21,7 @@ use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::Case;
 use OpenQA::Test::TimeLimit '18';
+use Date::Format 'time2str';
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
@@ -139,6 +140,14 @@ $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => 'Facto
 $summary = get_summary;
 like($summary, qr/Summary of opensuse Factory build 87.5011/);
 like($summary, qr/Passed: 0 Incomplete: 1 Failed: 0/);
+
+subtest 'time parameter' => sub {
+    my @params = (distri => 'opensuse', version => 'Factory', build => '87.5011');
+    $t->get_ok('/tests/overview' => form => {@params, t => '2020-01-01T00:00:00'});
+    like(get_summary, qr/Passed: 0 Failed: 0/, 'jobs newer than time parameter filtered out');
+    $t->get_ok('/tests/overview' => form => {@params, t => time2str('%Y-%m-%d %H:%M:%S', time, 'UTC')});
+    like(get_summary, qr/Passed: 0 Incomplete: 1 Failed: 0/, 'jobs newer than time parameter shown');
+};
 
 # Advanced query parameters can be forwarded
 $form = {distri => 'opensuse', version => '13.1', result => 'passed'};

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -170,7 +170,7 @@ use warnings;
         t_finished => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),
         # Two hours ago
         t_started => time2str('%Y-%m-%d %H:%M:%S', time - 7200, 'UTC'),
-        # One hours ago
+        # One hour ago
         t_created  => time2str('%Y-%m-%d %H:%M:%S', time - 3600, 'UTC'),
         TEST       => "doc",
         ARCH       => 'x86_64',

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -131,6 +131,7 @@ sub prepare_database {
 prepare_database;
 
 plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+disable_timeout;
 
 $driver->title_is("openQA", "on main page");
 my $baseurl = $driver->get_current_url();

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -209,9 +209,9 @@ subtest 'filtering by test' => sub {
     my @rows = $driver->find_elements('#content tbody tr');
     is(scalar @rows, 1, 'exactly one row present');
     like($rows[0]->get_text(), qr/textmode/, 'test is textmode');
-    is(
+    like(
         OpenQA::Test::Case::trim_whitespace($driver->find_element('#summary .card-header')->get_text()),
-        'Overall Summary of opensuse 13.1 build 0092',
+        qr/Overall Summary of opensuse 13\.1 build 0092/,
         'summary states "opensuse 13.1" although no explicit search params',
     );
 };

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -96,7 +96,7 @@ $t->get_ok('/tests/99946')->status_is(200)->element_exists_not(
 my $job_header = $t->tx->res->dom->at('#next_previous #scenario .h5');
 like(
     OpenQA::Test::Case::trim_whitespace($job_header->all_text),
-    qr/Next & previous results for opensuse-13.1-DVD-i586-textmode/,
+    qr/Next & previous results for opensuse-13\.1-DVD-i586-textmode/,
     'header for job scenario'
 );
 
@@ -179,9 +179,9 @@ is(scalar @{$driver->find_elements('#job_next_previous_table #job_result_99901')
 
 #check build links to overview page
 $driver->find_element_by_link_text('0091')->click();
-is(
+like(
     $driver->find_element('#summary .card-header')->get_text(),
-    'Overall Summary of opensuse 13.1 build 0091',
+    qr/Overall Summary of opensuse 13\.1 build 0091/,
     'build links to overview page'
 );
 

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -86,6 +86,13 @@ sub prepare_database {
 prepare_database;
 
 plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+disable_timeout;
+
+sub goto_next_previous_tab {
+    $driver->find_element('#nav-item-for-next_previous')->click();
+    wait_for_element(selector => '.dataTables_wrapper');
+    wait_for_ajax(msg => 'Next & previous table ready');
+}
 
 # check job next and previous not loaded when open tests/x
 $t->get_ok('/tests/99946')->status_is(200)->element_exists_not(
@@ -105,9 +112,7 @@ $driver->title_is('openQA', 'on main page');
 $driver->find_element_by_link_text('All Tests')->click();
 wait_for_ajax(msg => 'wait for All Tests displayed before looking for 99946');
 wait_for_element(selector => '[href="/tests/99946"]')->click();
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 
 # check job next and previous for current job
 my ($entries) = $driver->get_text('#job_next_previous_table_info') =~ /of (\d+) entries$/;
@@ -135,9 +140,7 @@ is(scalar @{$driver->find_elements('#job_next_previous_table #job_result_99901')
 
 # select the most previous job in the table and check its job next and previous results
 $driver->find_element('[href="/tests/99901"]')->click();
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 
 ($entries) = $driver->get_text('#job_next_previous_table_info') =~ /of (\d+) entries$/;
 is($entries, 19, '19 entries found for 99901');
@@ -158,9 +161,7 @@ is(scalar @{$driver->find_elements('#job_next_previous_table #job_result_99947')
 
 # select the latest job in the table and check its job next and previous results
 $driver->find_element('[href="/tests/99947"]')->click();
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 
 ($entries) = $driver->get_text('#job_next_previous_table_info') =~ /of (\d+) entries$/;
 is($entries, 19, '19 entries found for 99947');
@@ -189,9 +190,7 @@ like(
 $driver->find_element_by_link_text('All Tests')->click();
 wait_for_ajax(msg => 'wait for All Tests displayed before looking for 99963');
 $driver->find_element('[href="/tests/99963"]')->click();
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 
 ($entries) = $driver->get_text('#job_next_previous_table_info') =~ /of (\d+) entries$/;
 is($entries, 2, '2 entries found for 99963');
@@ -207,9 +206,7 @@ is(scalar @{$driver->find_elements('#job_next_previous_table #job_result_99962')
 $driver->find_element_by_link_text('All Tests')->click();
 wait_for_ajax(msg => 'wait for All Tests displayed before looking for 99928');
 $driver->find_element('[href="/tests/99928"]')->click();
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 
 ($entries) = $driver->get_text('#job_next_previous_table_info') =~ /of (\d+) entries$/;
 is($entries, 1, '1 entries found for 99928');
@@ -223,9 +220,7 @@ is((shift @tds)->get_text(),       'Not yet: scheduled', '99928 is not yet finis
 
 # check job next and previous under tests/latest route
 $driver->get('/tests/latest');
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 ($entries) = $driver->get_text('#job_next_previous_table_info') =~ /of (\d+) entries$/;
 is($entries, 1, '1 entries found for 99981');
 my $job99981 = $driver->find_element('#job_next_previous_table #job_result_99981');
@@ -234,9 +229,7 @@ is((shift @tds)->get_text(), 'C&L', '99981 is current and the latest job');
 
 # check job next and previous with scenario latest url
 $driver->get('/tests/99945');
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 $driver->find_element_by_link_text('latest job for this scenario')->click();
 my $scenario_latest_url = $driver->get_current_url();
 like($scenario_latest_url, qr/latest?/,         'latest scenario URL includes latest');
@@ -246,9 +239,7 @@ like($scenario_latest_url, qr/test=textmode/,   'latest scenario URL includes te
 like($scenario_latest_url, qr/version=13.1/,    'latest scenario URL includes version');
 like($scenario_latest_url, qr/machine=32bit/,   'latest scenario URL includes machine');
 like($scenario_latest_url, qr/distri=opensuse/, 'latest scenario URL includes distri');
-$driver->find_element_by_link_text('Next & previous results')->click();
-wait_for_ajax();
-$driver->find_element_by_class('dataTables_wrapper');
+goto_next_previous_tab;
 ($entries) = $driver->get_text('#job_next_previous_table_info') =~ /of (\d+) entries$/;
 is($entries, 19, '19 entries found for 99947');
 $job99947 = $driver->find_element('#job_next_previous_table #job_result_99947');

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -1,3 +1,4 @@
+% use DateTime;
 % layout 'bootstrap';
 % title 'Test summary';
 % use OpenQA::Jobs::Constants;
@@ -20,6 +21,16 @@
             % if ($build) {
                 build <%= $build %>
             % }
+            <div class="time-params">
+                % if ($until) {
+                    from <abbr class="timeago" title="<%= $until %>Z"><%= $until %>Z</abbr>,
+                    <a href="<%= url_with->query({t => undef}) %>">show latest jobs</a>
+                % }
+                % else {
+                    showing latest jobs,
+                    <a href="<%= url_with->query({t => format_time(DateTime->now)}) %>">overview fixed to the current time</a>
+                %}
+            </div>
         </div>
         <div class="card-body">
             Passed: <span class="badge badge-success"><%= $aggregated->{passed} %></span>


### PR DESCRIPTION
The test overview page only shows the latest jobs by default. The new
parameter shows the overview page like it looked like at the specified
time.

See https://progress.opensuse.org/issues/70792

---

This is only the parameter itself so far. I still need to add the actual link somewhere or maybe add a datetime picker or time slider to the filter form.