### PR TITLE
Avoid unhandled output in `t/25-downloader.t`

### DIFF
--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -35,6 +35,9 @@ use Mojo::File qw(tempdir);
 my $port = Mojo::IOLoop::Server->generate_port;
 my $host = "127.0.0.1:$port";
 
+# avoid cluttering log with warnings from the Archive::Extract module
+$Archive::Extract::WARN = 0;
+
 # Capture logs
 my $log = Mojo::Log->new;
 $log->unsubscribe('message');


### PR DESCRIPTION
See https://progress.opensuse.org/issues/73156

---

And unfortunately also this test takes a ridiculous time to run. Here its not because of all the forking but because the downloader which is tested here has so many sleeps and tries often multiple times. (Not sure how the test passed within 20 seconds at some point. I had to comment out the time limit to run it locally.)