### PR TITLE
scheduler: Handle cycles in directly chained dependencies

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -124,7 +124,8 @@ sub schedule {
         for my $worker (keys %taken) {
             my $ji = $taken{$worker};
             $allocated_workers->{$worker} = $ji->{id};
-            $allocated_jobs->{$ji->{id}} = {job => $ji->{id}, worker => $worker};
+            $allocated_jobs->{$ji->{id}}
+              = {job => $ji->{id}, worker => $worker, priority_offset => \$j->{priority_offset}};
         }
         # we make sure we schedule clusters no matter what,
         # but we stop if we're over the limit
@@ -178,6 +179,8 @@ sub schedule {
             my $error = $_;
             chomp $error;
             log_info("Unable to serialize directly chained job sequence of $first_job_id: $error");
+            # deprioritize jobs with broken directly chained dependencies so they prevent other jobs from being assigned
+            ${$allocated->{priority_offset}} -= 1;
         };
         next unless $job_ids;
 

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -171,8 +171,15 @@ sub schedule {
         my $sort_function = sub {
             [sort { $sort_criteria{$a} cmp $sort_criteria{$b} } @{shift()}]
         };
-        my ($directly_chained_job_sequence, $job_ids)
-          = _serialize_directly_chained_job_sequence($first_job_id, $cluster_info, $sort_function);
+        my ($directly_chained_job_sequence, $job_ids) = try {
+            _serialize_directly_chained_job_sequence($first_job_id, $cluster_info, $sort_function);
+        }
+        catch {
+            my $error = $_;
+            chomp $error;
+            log_info("Unable to serialize directly chained job sequence of $first_job_id: $error");
+        };
+        next unless $job_ids;
 
         # find jobs
         my @jobs;
@@ -434,7 +441,7 @@ sub _serialize_directly_chained_job_sub_sequence {
     for my $current_job_id (@{$sort_function->($child_job_ids)}) {
         my $current_job_info = $cluster_info->{$current_job_id};
         next unless $current_job_info->{state} eq SCHEDULED;
-        die "detected cycle at $current_job_id" if $visited->{$current_job_id}++;
+        die "detected cycle at $current_job_id\n" if $visited->{$current_job_id}++;
         my $sub_sequence
           = _serialize_directly_chained_job_sub_sequence([$current_job_id], $visited,
             $current_job_info->{directly_chained_children},


### PR DESCRIPTION
Otherwise the unhandled exception prevents the scheduler from processing
*any* further scheduled jobs and jobs are stuck in the scheduled state.

See https://progress.opensuse.org/issues/32545#note-37 for a graph with
an example of such a problematic directly chained cluster.