### PR TITLE
Add an easy way to run a pool of workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ test-tidy-compile:
 .PHONY: test-shellcheck
 test-shellcheck:
 	@which shellcheck >/dev/null 2>&1 || (echo "Command 'shellcheck' not found, can not execute shell script checks" && false)
-	shellcheck -x $$(file --mime-type script/* t/* | sed -n 's/^\(.*\):.*text\/x-shellscript.*$$/\1/p')
+	shellcheck -x $$(file --mime-type script/* t/* docker/worker/*.sh | sed -n 's/^\(.*\):.*text\/x-shellscript.*$$/\1/p')
 
 .PHONY: test-yaml
 test-yaml:
@@ -278,4 +278,3 @@ tidy: tidy-js
 .PHONY: update-deps
 update-deps:
 	tools/update-deps --specfile openQA.spec
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -164,7 +164,7 @@ Go to https://localhost/api_keys, generate key and secret. Then run:
     docker run -d -h openqa_worker_1 --name openqa_worker_1 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
 
     # docker-compose
-    docker run -d -h openqa_worker_1 --name openqa_worker_1 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged openqa_worker
+    docker run -d -h openqa_worker_1 --name openqa_worker_1 --network webui_default --volumes-from openqa_data --privileged openqa_worker
 
 Check whether the worker connected in the WebUI's administration interface.
 
@@ -174,7 +174,15 @@ To add more workers, increase number that is used in hostname and container name
     docker run -d -h openqa_worker_2 --name openqa_worker_2 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
 
     # docker-compose
-    docker run -d -h openqa_worker_2 --name openqa_worker_2 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged openqa_worker
+    docker run -d -h openqa_worker_2 --name openqa_worker_2 --network webui_default --volumes-from openqa_data --privileged openqa_worker
+
+## Run a pool of workers automatically (docker-compose)
+
+To launch a pool of workers one could use the script `./launch_workers_pool.sh`.
+It will launch the desired number of workers in individual containers using
+consecutive numbers for the `--instance` parameter.
+
+    ./launch_workers_pool.sh <number-of-workers>
 
 ## Enable services
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -13,8 +13,10 @@ RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.2 openQA && \
 
 # set-up qemu
 RUN mkdir -p /root/qemu
-ADD kvm-mknod.sh /root/qemu/kvm-mknod.sh
+ADD kvm-mknod.sh /qemu/kvm-mknod.sh
+ADD run_openqa_worker.sh /run_openqa_worker.sh
 RUN chmod +x /root/qemu/*.sh && /root/qemu/kvm-mknod.sh && \
+    chmod a+x /run_openqa_worker.sh && \
     # set-up shared data and configuration
     rm -rf /etc/openqa/client.conf /etc/openqa/workers.ini && \
     mkdir -p /var/lib/openqa/share && \
@@ -28,5 +30,4 @@ RUN chmod +x /root/qemu/*.sh && /root/qemu/kvm-mknod.sh && \
     find /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool -type d -exec chmod ug+x {} \;
 
 USER _openqa-worker
-ENTRYPOINT ["/usr/share/openqa/script/worker", "--verbose", "--instance"]
-CMD ["1"]
+ENTRYPOINT ["/run_openqa_worker.sh"]

--- a/docker/worker/kvm-mknod.sh
+++ b/docker/worker/kvm-mknod.sh
@@ -3,12 +3,13 @@
 
 set -e
 
-([[ -f /proc/config.gz ]] && test $(gzip -c /proc/config.gz | grep CONFIG_KVM=y)) || lsmod | grep '\<kvm\>' > /dev/null || {
+kvm=$([[ -f /proc/config.gz ]] && test $(gzip -c /proc/config.gz | grep CONFIG_KVM=y))
+$kvm || lsmod | grep '\<kvm\>' > /dev/null || {
   echo >&2 "KVM module not loaded; software emulation will be used"
   exit 1
 }
 
-[[ -c /dev/kvm ]] || mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -f 1 -d' ') || {
+[[ -c /dev/kvm ]] || mknod /dev/kvm c 10 "$(grep '\<kvm\>' /proc/misc | cut -f 1 -d' ')" || {
   echo >&2 "Unable to make /dev/kvm node; software emulation will be used"
   echo >&2 "(This can happen if the container is run without -privileged)"
   exit 1

--- a/docker/worker/launch_workers_pool.sh
+++ b/docker/worker/launch_workers_pool.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+size=1
+
+usage() {
+    cat << EOF
+Usage: $0
+To launch a pool of workers with the desired number of workers in individual
+containers.
+Options:
+ -h, --help            display this help
+ -s, --size=NUM        number of workers (by default is 1)
+EOF
+    exit "$1"
+}
+
+opts=$(getopt -o hs: --long help,size: -n 'parse-options' -- "$@") || usage 1
+eval set -- "$opts"
+
+while true; do
+  case "$1" in
+    -h | --help ) usage 0; shift ;;
+    -s | --size ) size=$2; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+echo "Creating workers"
+
+for i in $(seq "$size"); do
+  docker run -d -h "openqa_worker_$i" --name "openqa_worker_$i" \
+  --volumes-from webui_data_1 \
+  --network webui_default \
+  -e OPENQA_WORKER_INSTANCE="$i" \
+  --privileged openqa_worker
+done

--- a/docker/worker/run_openqa_worker.sh
+++ b/docker/worker/run_openqa_worker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+/usr/share/openqa/script/worker --verbose --instance "$OPENQA_WORKER_INSTANCE"


### PR DESCRIPTION
Problem: To launch a pool of workers is a manual process
Solution: To prevent manual errors and work the script
launch_workers_pool.sh creates a pool of workers in one call.

Related with https://progress.opensuse.org/issues/43715