### PR TITLE
docs: Explain that test runtime limits are automatically scaled

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -649,12 +649,15 @@ quite irritating.
 === Test runtime limits
 
 The test modules use `OpenQA::Test::TimeLimit` to introduce a test module
-specific timeout. Consider lowering the timeout value whenever a test module
-is optimized in runtime. If the timeout is hit the test module normally aborts
-with a corresponding message. Please be aware of the exception when the
-timeout triggers after the actual test part of a test module has finished but
-not all involved processes have finished or END blocks are processed. In this
-case the output can look like
+specific timeout. The timeout is automatically scaled up based on environment
+variables, e.g. `CI` for continuous integration environments, as well as when
+executing while test coverage data is collected as longer runtimes should be
+expected in these cases. Consider lowering the timeout value based on usual
+local execution times whenever a test module is optimized in runtime. If the
+timeout is hit the test module normally aborts with a corresponding message.
+Please be aware of the exception when the timeout triggers after the actual
+test part of a test module has finished but not all involved processes have
+finished or END blocks are processed. In this case the output can look like
 
 ```
 t/my_test.t .. All 1 subtests passed


### PR DESCRIPTION
Motivated by http://open.qa/docs/#_test_runtime_limits