### PR TITLE
t: Remove unused debug code to ensure 100% statement coverage in 34-developer-mode-unit.t

### DIFF
--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -650,13 +650,6 @@ $t_livehandler->ua($ua);
 $t_livehandler->app($app);
 
 subtest 'websocket proxy (connection from client to live view handler not mocked)' => sub {
-    # dumps the state of the websocket connections established in the following subtests
-    # note: not actually used after all, but useful during development
-    sub dump_websocket_state {
-        print('finished: ' . Dumper($t_livehandler->{finished}) . "\n");
-        print('messages: ' . Dumper($t_livehandler->{messages}) . "\n");
-    }
-
     subtest 'job does not exist' => sub {
         $t_livehandler->websocket_ok(
             '/liveviewhandler/tests/54754/developer/ws-proxy',


### PR DESCRIPTION
The function "dump_websocket_state" has been introduced with fc67d9bbf
but is not actively used. We should not keep disabled code around which
leads to cluttered source code and in the end likely debugging is
conducted differently anyway or the "useful debug code" is overlooked.
Removing the dead code here also ensures 100% statement coverage of the
complete test module.

Related progress issue: https://progress.opensuse.org/issues/71857