### PR TITLE
Makefile: Add back retries for full-stack.t after sporadic failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test-unstable:
 
 .PHONY: test-fullstack
 test-fullstack:
-	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=9 PROVE_ARGS="$$HARNESS t/full-stack.t"
+	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=9 PROVE_ARGS="$$HARNESS t/full-stack.t" RETRY=3
 
 .PHONY: test-scheduler
 test-scheduler:


### PR DESCRIPTION
In ac0ccca26 we have removed the retries for the full stack test
assuming that it would be stable enough but
https://app.circleci.com/pipelines/github/os-autoinst/openQA/4698/workflows/3fc8c9cf-feb8-435d-b868-76fee3b20bb7/jobs/44844
showed that the test still can fail:

```
[09:55:15] t/full-stack.t .. 374/? # full result panel contents:
[09:55:15] t/full-stack.t .. 376/?

    #   Failed test 'worker did not propagate URL for os-autoinst cmd srv within 1 minute'
    #   at /home/squamata/project/t/lib/OpenQA/Test/FullstackUtils.pm line 195.

    #   Failed test 'developer console for test 1'
    #   at t/full-stack.t line 134.
    # Looks like you failed 2 tests of 3.
[09:55:15] t/full-stack.t .. 377/?
Bailout called.  Further testing stopped:  findElement: no such element: Unable to locate element: {"method":"css selector","selector":"#log"} at /home/squamata/project/t/lib/OpenQA/SeleniumTest.pm:101
FAILED--Further testing stopped: findElement: no such element: Unable to locate element: {"method":"css selector","selector":"#log"} at /home/squamata/project/t/lib/OpenQA/SeleniumTest.pm:101
```

Related progress issue: https://progress.opensuse.org/issues/76900