### PR TITLE
FullStackUtils: More generous wait on developer console

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -130,8 +130,7 @@ ok wait_for_job_running($driver), 'test 1 is running';
 subtest 'wait until developer console becomes available' => sub {
     # open developer console
     $driver->get('/tests/1/developer/ws-console');
-    wait_for_ajax(msg => 'developer console available');
-    ok wait_for_developer_console_available($driver), 'developer console for test 1';
+    wait_for_developer_console_available($driver);
 };
 
 subtest 'pause at certain test' => sub {


### PR DESCRIPTION
- The current timeout claims to be one minute but it doesn't take the time actually slept into account.
- Maybe we should increase the timeout since it occasionally fails on CI.

See: https://progress.opensuse.org/issues/76900