### PR TITLE
Fix kvm-mknod.sh shellcheck

### DIFF
--- a/docker/worker/kvm-mknod.sh
+++ b/docker/worker/kvm-mknod.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-kvm=$([[ -f /proc/config.gz ]] && test $(gzip -c /proc/config.gz | grep CONFIG_KVM=y))
+kvm=$([[ -f /proc/config.gz ]] && test "$(gzip -c /proc/config.gz | grep CONFIG_KVM=y)")
 $kvm || lsmod | grep '\<kvm\>' > /dev/null || {
   echo >&2 "KVM module not loaded; software emulation will be used"
   exit 1


### PR DESCRIPTION
There is a problem with the shellcheck in this file

... test $(gzip -c /proc/config.gz | grep CONFIG_KVM=y))
         ^-- SC2046: Quote this to prevent word splitting.