### PR TITLE
tests: Increase the timeout for the test 34-developer_mode-unit

### DIFF
--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -33,7 +33,7 @@ use OpenQA::Client;
 use OpenQA::WebSockets::Client;
 use Mojo::IOLoop;
 use OpenQA::Utils qw(determine_web_ui_web_socket_url get_ws_status_only_url);
-use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Utils 'wait_for_or_bail_out';
 
 # mock OpenQA::Schema::Result::Jobs::cancel()


### PR DESCRIPTION
Problem: This test is eventually failing because of timeout.
For instance: https://app.circleci.com/pipelines/github/os-autoinst/openQA/4733/workflows/65889b6b-1b18-4067-85fa-d5e325db32a6/jobs/45180

Solution: Increase the timeout to the double.