### PR TITLE
Retry on rsync error code 10

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -195,6 +195,7 @@ sub _link_asset {
 sub sync_tests {
     my ($job, $vars, $cache_dir, $webui_host, $rsync_source) = @_;
     my %rsync_retry_code = (
+        10 => 'Error in socket I/O',
         23 => 'Partial transfer due to error',
         24 => 'Partial transfer due to vanished source files',
     );


### PR DESCRIPTION
This is a small followup to #3476. [Socket I/O error](https://lxadm.com/Rsync_exit_codes) is very similar to the rsync exit codes already covered by the other PR and should also trigger a retry.

Progress: https://progress.opensuse.org/issues/69553