### PR TITLE
Cover much longer web UI unavailabilities in the cache service client

### DIFF
--- a/lib/OpenQA/CacheService/Client.pm
+++ b/lib/OpenQA/CacheService/Client.pm
@@ -25,10 +25,12 @@ use OpenQA::Utils qw(base_host service_port);
 use Mojo::URL;
 use Mojo::File 'path';
 
-has attempts   => 3;
+# Define sensible defaults to cover even a restarting openQA webUI host being
+# down for up to 5m
+has attempts   => $ENV{OPENQA_CACHE_ATTEMPTS}           // 60;
+has sleep_time => $ENV{OPENQA_CACHE_ATTEMPT_SLEEP_TIME} // 5;
 has host       => sub { 'http://127.0.0.1:' . service_port('cache_service') };
 has cache_dir  => sub { $ENV{OPENQA_CACHE_DIR} || OpenQA::Worker::Settings->new->global_settings->{CACHEDIRECTORY} };
-has sleep_time => 5;
 has ua         => sub { Mojo::UserAgent->new(inactivity_timeout => 300) };
 
 sub info {

--- a/t/25-cache-client.t
+++ b/t/25-cache-client.t
@@ -129,15 +129,15 @@ subtest 'Enqueue error' => sub {
 };
 
 subtest 'Enqueue error (with retry)' => sub {
-    is $client->sleep_time, 5, '5 second default';
-    is $client->attempts,   3, '3 attempts by default';
+    is $client->sleep_time, 5,  'correct number of seconds by default';
+    is $client->attempts,   60, 'correct attempts by default';
 
     my $cb = $client->ua->on(start => \&_refuse_connection);
     my $request
       = $client->asset_request(id => 9999, asset => 'asset_name.qcow2', type => 'hdd', host => 'openqa.opensuse.org');
     like $client->enqueue($request), qr/Cache service enqueue error: Connection refused/, 'error';
     $client->ua->unsubscribe(start => $cb);
-    is $sleep_count, 2, 'sleep called two times';
+    is $sleep_count, $client->attempts - 1, 'sleep called multiple times';
     ok !$request->minion_id, 'no Minion id';
 
     $sleep_count = 0;
@@ -192,7 +192,7 @@ subtest 'Info error (with retry)' => sub {
     my $cb   = $client->ua->on(start => \&_refuse_connection);
     my $info = $client->info;
     $client->ua->unsubscribe(start => $cb);
-    is $sleep_count, 2, 'sleep called two times';
+    is $sleep_count, $client->attempts - 1, 'sleep called multiple times';
     like $info->error, qr/Cache service info error: Connection refused/, 'right error';
 
     $sleep_count = 0;
@@ -365,7 +365,7 @@ subtest 'Status error (with retry)' => sub {
     ok $request->minion_id, 'has Minion id';
     my $cb     = $client->ua->on(start => \&_refuse_connection);
     my $status = $client->status($request);
-    is $sleep_count, 2, 'sleep called two times';
+    is $sleep_count, $client->attempts - 1, 'sleep called multiple times';
     $client->ua->unsubscribe(start => $cb);
     like $status->error, qr/Cache service status error: Connection refused/, 'right error';
 

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -20,7 +20,9 @@ my $tempdir;
 BEGIN {
     use Mojo::File qw(path tempdir);
 
-    $ENV{OPENQA_CACHE_SERVICE_QUIET} = $ENV{HARNESS_IS_VERBOSE} ? 0 : 1;
+    $ENV{OPENQA_CACHE_SERVICE_QUIET}      = $ENV{HARNESS_IS_VERBOSE} ? 0 : 1;
+    $ENV{OPENQA_CACHE_ATTEMPTS}           = 3;
+    $ENV{OPENQA_CACHE_ATTEMPT_SLEEP_TIME} = 0;
 
     $tempdir = tempdir;
     my $basedir = $tempdir->child('t', 'cache.d');


### PR DESCRIPTION
The commit 99746775b added retrying. There have been cases where 3*5s
have not been enough retries so this commits bumps up the values to also
cover longer unavailablities of the openQA webUI.

Related progress issue: https://progress.opensuse.org/issues/71185