### PR TITLE
Revert "No empty IOLoop timer for 5 second wait" to fix current test failures

### DIFF
--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -34,7 +34,6 @@ use OpenQA::WebSockets::Client;
 use Mojo::IOLoop;
 use OpenQA::Utils qw(determine_web_ui_web_socket_url get_ws_status_only_url);
 use OpenQA::Test::TimeLimit '10';
-use OpenQA::Test::Utils 'wait_for_or_bail_out';
 
 # mock OpenQA::Schema::Result::Jobs::cancel()
 my $jobs_mock_module = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
@@ -94,9 +93,18 @@ sub prepare_waiting_for_finished_handled {
         });
 }
 sub wait_for_finished_handled {
-    # wait until the finished event is handled
-    wait_for_or_bail_out { $finished_handled } 'finished event';
+    # wait until the finished event is handled (but at most 5 seconds)
+    if (!$finished_handled) {
+        my $timer = Mojo::IOLoop->timer(
+            5.0 => sub {
+
+            });
+        Mojo::IOLoop->one_tick;
+        Mojo::IOLoop->remove($timer);
+    }
+
     $finished_handled_mock->unmock_all();
+    fail('finished event not handled within 5 seconds') if (!$finished_handled);
 }
 
 # get CSRF token for auth


### PR DESCRIPTION
This reverts commit bbcead4e3fa7272ce28ba1d57b216b0a4bd32fd6 as
t/34-developer_mode-unit.t fails often in local runs, in circleCI as
well as our OBS checks.

Using https://github.com/okurz/scripts/blob/master/count_fail_ratio I ran

```
count_fail_ratio prove -l t/34-developer_mode-unit.t
```

and found

```
## count_fail_ratio: Run: 20. Fails: 8. Fail ratio 40%
```

with the failures being stopped by the timeout and increasing timeout does not help – as https://github.com/os-autoinst/openQA/pull/3510 already showed yesterday.

Reverting your PR shows

```
## count_fail_ratio: Run: 20. Fails: 0. Fail ratio 0%
```

Related progress issue: https://progress.opensuse.org/issues/71857