### PR TITLE
Fix create_admin by not expecting ARGV after parsing it

### DIFF
--- a/script/create_admin
+++ b/script/create_admin
@@ -47,6 +47,9 @@ sub usage {
     exit $_[0];
 }
 
+# need to count this *before* calling GetOptions
+my $numargs = scalar @ARGV;
+
 my $result = GetOptions(
     "email=s"    => \$email,
     "nickname=s" => \$nickname,
@@ -55,8 +58,9 @@ my $result = GetOptions(
     "secret=s"   => \$secret,
     "help"       => \$help,
 );
+
 usage 0 if $help;
-usage 1 unless $result && $user && scalar @ARGV > 1;
+usage 1 unless $result && $user && $numargs > 1;
 
 if (($key || $secret)
     && !($key =~ /^[[:xdigit:]]{16}$/ && $secret =~ /^[[:xdigit:]]{16}$/))


### PR DESCRIPTION
a2d64957 inadvertently broke this script. It kept a check that
bails out unless ARGV is longer than 1, which was I think meant
to at least make sure the user passed more than one argument, but
moved option parsing to *before* that check. GetOptions consumes
the items it parses, so if you run the script as intended, then
after option parsing is done, only one thing is left in ARGV (the
user ID) and the check fails. You could force the script to run
by putting some extra argument after the user ID, but otherwise
it would always bail out.

This fixes it by moving the ARGV length check back to before we
parse the options. It seems like an odd check to me - why do we
want to check just that *at least one* of the allegedly-optional
arguments is passed? - but I figured for now minimal change is
best.

Signed-off-by: Adam Williamson <awilliam@redhat.com>