### PR TITLE
[WIP] Docker: Fix worker Dockerfile to be build by OBS

### DIFF
--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -1,13 +1,11 @@
-FROM opensuse/leap:15.2
+#!BuildTag: openqa_webui
+FROM opensuse/leap:15.1
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
-RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.2 openQA && \
-    zypper ar -f obs://devel:openQA:Leap:15.2/openSUSE_Leap_15.2 openQA-perl-modules && \
-    zypper --gpg-auto-import-keys ref && \
+RUN zypper ar -f -G http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.1/openSUSE_Leap_15.1 openQA && \
     zypper --non-interactive in ca-certificates-mozilla curl && \
     zypper --non-interactive in --force-resolution openQA-local-db apache2 hostname which w3m
-
 
 # setup apache
 RUN gensslcert && \

--- a/docker/worker/Dockerfile_arm
+++ b/docker/worker/Dockerfile_arm
@@ -1,0 +1,31 @@
+#!BuildTag: openqa_worker_arm
+FROM opensuse/leap:15.1
+LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
+LABEL version="0.3"
+
+RUN zypper ar -f -G http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.1/openSUSE_Leap_15.1 openQA && \
+    zypper --non-interactive in ca-certificates-mozilla curl gzip && \
+    zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 && \
+    zypper --non-interactive in kmod && \
+    zypper --non-interactive in qemu-uefi-aarch64
+
+# set-up qemu
+RUN mkdir -p /root/qemu
+ADD kvm-mknod.sh /root/qemu/kvm-mknod.sh
+ADD run_openqa_worker.sh /run_openqa_worker.sh
+
+RUN chmod +x /root/qemu/*.sh && chmod a+x /run_openqa_worker.sh && \
+    # set-up shared data and configuration && \
+    rm -rf /etc/openqa/client.conf /etc/openqa/workers.ini && \
+    mkdir -p /var/lib/openqa/share && \
+    ln -s /data/conf/client.conf /etc/openqa/client.conf && \
+    ln -s /data/conf/workers.ini /etc/openqa/workers.ini && \
+    ln -s /data/factory /var/lib/openqa/share/factory && \
+    ln -s /data/tests /var/lib/openqa/share/tests && \
+    # set proper ownership and file modes
+    chown -R _openqa-worker /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool && \
+    chmod -R ug+rw /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool && \
+    find /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool -type d -exec chmod ug+x {} \;
+
+USER _openqa-worker
+ENTRYPOINT ["/run_openqa_worker.sh"]

--- a/docker/worker/Dockerfile_x86
+++ b/docker/worker/Dockerfile_x86
@@ -1,0 +1,32 @@
+#!BuildTag: openqa_worker_x86
+FROM opensuse/leap:15.1
+LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
+LABEL version="0.3"
+
+RUN zypper ar -f -G http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.1/openSUSE_Leap_15.1 openQA
+RUN zypper --non-interactive in ca-certificates-mozilla curl gzip && \
+    zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 && \
+    zypper --non-interactive in kmod && \
+    zypper --non-interactive in qemu-ovmf-x86_64
+
+# set-up qemu
+RUN mkdir -p /root/qemu
+ADD kvm-mknod.sh /root/qemu/kvm-mknod.sh
+ADD run_openqa_worker.sh /run_openqa_worker.sh
+RUN chmod +x /root/qemu/*.sh
+#RUN /root/qemu/kvm-mknod.sh
+RUN chmod a+x /run_openqa_worker.sh
+    # set-up shared data and configuration
+RUN rm -rf /etc/openqa/client.conf /etc/openqa/workers.ini
+RUN mkdir -p /var/lib/openqa/share
+RUN ln -s /data/conf/client.conf /etc/openqa/client.conf
+RUN ln -s /data/conf/workers.ini /etc/openqa/workers.ini
+RUN ln -s /data/factory /var/lib/openqa/share/factory
+RUN ln -s /data/tests /var/lib/openqa/share/tests
+    # set proper ownership and file modes
+RUN chown -R _openqa-worker /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool
+RUN chmod -R ug+rw /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool
+RUN find /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool -type d -exec chmod ug+x {} \;
+
+#USER _openqa-worker
+ENTRYPOINT ["/run_openqa_worker.sh"]

--- a/docker/worker/extendUserInfo.js
+++ b/docker/worker/extendUserInfo.js
@@ -1,0 +1,39 @@
+/*
+Works with __extendedInfo: true
+*/
+//const notify = require("../../libs/Notify.js")('api','user.hooks.extendUserInfo')
+const generalHookResultProcessing = require("../../libs/generalHookResultProcessing")
+const merge = require('merge-anything').merge
+
+module.exports = function () {
+  return async context => {
+    return await generalHookResultProcessing(context, async (item) => {
+      if (context.params && context.params.query && context.params.query["__extendedInfo"]){
+        context.params.__extendedInfo = context.params.query["__extendedInfo"]
+        delete context.params.query["__extendedInfo"]
+      }
+
+      if (!context.params.__extendedInfo)
+        return context
+
+      if (context.type == "before"){
+        var relation = "Client.ActivePlans.ServicePlan"
+        if (context.params.__relations)
+          context.params.__relations += "," + relation
+        else
+          context.params.__relations = relation
+      }
+      else{
+        item.permissions =  []
+
+        if (item.Client.ActivePlans !== undefined){
+          item.Client.ActivePlans.forEach((activePlan) => {
+            item.permissions = merge(item.permissions, activePlan.ServicePlan.permissions)
+          })
+        }
+      }
+
+      return context
+    })
+  };
+};

--- a/docker/worker/kvm-mknod.sh
+++ b/docker/worker/kvm-mknod.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # If possible, create the /dev/kvm device node.
+kvm=$([[ -f /proc/config.gz ]] && test "$(gzip -c /proc/config.gz | grep CONFIG_KVM=y)")
 
 set -e
 
-kvm=$([[ -f /proc/config.gz ]] && test "$(gzip -c /proc/config.gz | grep CONFIG_KVM=y)")
 $kvm || lsmod | grep '\<kvm\>' > /dev/null || {
   echo >&2 "KVM module not loaded; software emulation will be used"
   exit 1

--- a/docker/worker/run_openqa_worker.sh
+++ b/docker/worker/run_openqa_worker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 
-/usr/share/openqa/script/worker --verbose --instance "$OPENQA_WORKER_INSTANCE"
+/root/qemu/kvm-mknod.sh
+su _openqa-worker -c /usr/share/openqa/script/worker --verbose --instance "$OPENQA_WORKER_INSTANCE"


### PR DESCRIPTION
Problem: OBS cannot deal with the current repositories (OBS)
Solution: Change the repositories to be downloaded from
http://download.opensuse.org

Problem: The default OS Leap version for containers in OBS is 15.1
Solution: Fix the Dockerfile to use Leap 15.1 instead

Problem: OBS doesn't have a correct tag when build the images
Solution: Provide a tag

https://progress.opensuse.org/issues/43715