### PR TITLE
WIP -- proof-of-concept -- docker: Ask to not squash base image layers to fix circleCI download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ images:
       COMMIT_AUTHOR_EMAIL: skynet@open.qa
 
   - &base
-    image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
+    image: registry.opensuse.org/home/okurz/openqa/containers/base:latest
     <<: *docker_config
 
   - &dependency_bot

--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -1,5 +1,8 @@
 #!BuildTag: base
 #!UseOBSRepositories
+# preserve layers to prevent circleCI failing to download single big blobs,
+# see https://progress.opensuse.org/issues/67855
+#!NoSquash
 FROM opensuse/leap:15.2
 
 # these are autoinst dependencies


### PR DESCRIPTION
Reference:
https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.building.html#id-1.5.8.3.8

Corresponding OBS project providing the updated base image:
https://build.opensuse.org/project/show/home:okurz:openQA

Related progress issue: https://progress.opensuse.org/issues/67855