### PR TITLE
docker: Use devel package for base image instead of hardcoded base deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ images:
       COMMIT_AUTHOR_EMAIL: skynet@open.qa
 
   - &base
-    image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
+    image: registry.opensuse.org/home/okurz/branches/devel/openqa/pr3528_use_devel_package_in_base_image/containers/base:latest
     <<: *docker_config
 
   - &dependency_bot

--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -1,5 +1,8 @@
 #!BuildTag: base
 #!UseOBSRepositories
+# preserve layers to prevent circleCI failing to download single big blobs,
+# see https://progress.opensuse.org/issues/67855
+#!NoSquash
 FROM opensuse/leap:15.2
 
 # these are autoinst dependencies

--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -5,14 +5,7 @@
 #!NoSquash
 FROM opensuse/leap:15.2
 
-# these are autoinst dependencies
-RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\)
-
-# openQA dependencies
-RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
-
-# openQA chromedriver for Selenium tests
-RUN zypper install -y chromedriver
+RUN zypper -n in openQA-devel
 
 ENV LANG en_US.UTF-8
 


### PR DESCRIPTION
Corresponding OBS test project https://build.opensuse.org/package/show/home:okurz:branches:devel:openQA:pr3528_use_devel_package_in_base_image/base

Related progress issue: https://progress.opensuse.org/issues/67855