### PR TITLE
circleci: Remove base image completely to prevent "cache" jobs failing

### DIFF
--- a/.circleci/build_cache.sh
+++ b/.circleci/build_cache.sh
@@ -17,9 +17,9 @@
 
 set -ex
 
-sudo zypper ar -f -p 90 https://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.2/openSUSE_Leap_15.2 openQA
-sudo zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel
-tools/retry sudo zypper --gpg-auto-import-keys ref
-sudo zypper -n install --download-only $(cat .circleci/ci-packages.txt | sed -e 's/\r//' )
-sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
+zypper ar -f -p 90 https://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.2/openSUSE_Leap_15.2 openQA
+zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel
+tools/retry zypper --gpg-auto-import-keys ref
+zypper -n install --download-only $(cat .circleci/ci-packages.txt | sed -e 's/\r//' )
+rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
 echo build_cache.sh done

--- a/.circleci/ci-packages.txt
+++ b/.circleci/ci-packages.txt
@@ -9,6 +9,7 @@ libjq1-1.6
 libonig4-6.7.0
 libssh2-1-1.8.0
 lsof-4.91
+make
 optipng-0.7.7
 perl-Algorithm-C3-0.10
 perl-Algorithm-Diff-1.1903
@@ -138,10 +139,10 @@ perl-Module-Pluggable-5.2
 perl-Module-Runtime-0.016
 perl-Module-Runtime-Conflicts-0.003
 perl-Mojo-IOLoop-ReadWriteProcess-0.28
-perl-Mojolicious-8.63
+perl-Mojolicious
 perl-Mojolicious-Plugin-AssetPack-2.09
 perl-Mojolicious-Plugin-OAuth2-1.58
-perl-Mojo-Pg-4.21
+perl-Mojo-Pg
 perl-Mojo-RabbitMQ-Client-0.3.1
 perl-Mojo-SQLite-3.004
 perl-Moo-2.003004
@@ -244,6 +245,7 @@ perl-XML-Simple-2.24
 perl-YAML-1.24
 perl-YAML-LibYAML-0.82
 perl-YAML-PP-0.026
+postgresql-server
 python3-appdirs-1.4.3
 python3-EditorConfig-0.12.2
 python3-jsbeautifier-1.6.14
@@ -253,4 +255,5 @@ python3-pyparsing-2.2.0
 python3-PyYAML-5.1.2
 python3-setuptools-40.5.0
 python3-yamllint-1.22.1
+ruby2.5-rubygem-sass
 ShellCheck-0.7.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,25 +20,11 @@ aliases:
     paths:
       - "/var/cache/autoinst"
 
-  - &chown_hack_for_cache
-    name: Chown package cache to user
-    command: |
-      [ -z "$CIRCLE_WORKFLOW_ID" ] || sudo chown -R squamata /var/cache/zypp/packages
-
-  - &chown_hack_for_cache_fullstack
-    name: Chown autoinst cache to user
-    command: |
-      # hack as we don't want run container as root
-      [ -z "$CIRCLE_WORKFLOW_ID" ] || {
-        sudo mkdir -p /var/cache/autoinst
-        sudo chown -R squamata /var/cache/autoinst
-      }
-
   - &check_cache
     name: Log cached packages
     command: |
       mkdir -p logs
-      find /var/cache/zypp/packages/ -iname *.rpm > ./logs/packages.txt
+      ! [ -d /var/cache/zypp/packages ] || find /var/cache/zypp/packages/ -iname *.rpm > ./logs/packages.txt
 
   - &store_logs
     path: logs
@@ -51,7 +37,7 @@ aliases:
         if [ -z "$CIRCLE_WORKFLOW_ID" ]; then
           bash .circleci/build_cache.sh
         else
-          sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
+          rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
         fi
 
   - &test_junit
@@ -77,9 +63,7 @@ aliases:
       if [ ! -z "$CIRCLE_WORKFLOW_ID" ]; then # only in workflow
         rm -rf ../os-autoinst
         sudo cp -r /var/cache/autoinst ../os-autoinst
-        sudo chown -R 1000 ../os-autoinst/t/data
       else # only in local run
-         [ -d ../os-autoinst ] || { sudo mkdir ../os-autoinst && sudo chown -R 1000 ../os-autoinst; }
          bash .circleci/build_autoinst.sh ../os-autoinst $(cat .circleci/autoinst.sha)
        fi
 
@@ -100,7 +84,6 @@ aliases:
 
 images:
   - &docker_config
-    user: squamata
     environment:
       JUNIT_PACKAGE: openQA
       JUNIT_NAME_MANGLE: perl
@@ -115,11 +98,11 @@ images:
       COMMIT_AUTHOR_EMAIL: skynet@open.qa
 
   - &base
-    image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
+    image: registry.opensuse.org/home/okurz/branches/devel/openqa/pr3529_use_tiny_base/containers/leap:tar
     <<: *docker_config
 
   - &dependency_bot
-    image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
+    image: registry.opensuse.org/opensuse/leap:15.2
 
 jobs:
   dependencies-pr:
@@ -165,7 +148,6 @@ jobs:
       - checkout
       - run: ls -la && pwd
       - run: cat .circleci/ci-packages.txt
-      - run: *chown_hack_for_cache
       - restore_cache: *restore_cache
       - run: *check_cache
       - store_artifacts: *store_logs
@@ -183,8 +165,6 @@ jobs:
       - <<: *base
     steps:
       - checkout
-      - run: *chown_hack_for_cache
-      - run: *chown_hack_for_cache_fullstack
       - restore_cache: *restore_cache
       - restore_cache: *restore_fullstack_cache
       - run: *check_cache
@@ -202,7 +182,6 @@ jobs:
       - <<: *base
     steps:
       - checkout
-      - run: *chown_hack_for_cache
       - restore_cache: *restore_cache
       - run: *check_cache
       - store_artifacts: *store_logs
@@ -221,8 +200,6 @@ jobs:
       - <<: *base
     steps:
       - checkout
-      - run: *chown_hack_for_cache
-      - run: *chown_hack_for_cache_fullstack
       - restore_cache: *restore_cache
       - restore_cache: *restore_fullstack_cache
       - run: *check_cache
@@ -260,7 +237,6 @@ jobs:
       - <<: *base
     steps:
       - checkout
-      - run: *chown_hack_for_cache
       - restore_cache: *restore_cache
       - run: *check_cache
       - store_artifacts: *store_logs
@@ -278,7 +254,6 @@ jobs:
       - <<: *base
     steps:
       - checkout
-      - run: *chown_hack_for_cache
       - restore_cache: *restore_cache
       - run: *check_cache
       - run: *install_cached_packages

--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -2,25 +2,7 @@
 #!UseOBSRepositories
 FROM opensuse/leap:15.2
 
-# these are autoinst dependencies
-RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\)
-
-# openQA dependencies
-RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
-
-# openQA chromedriver for Selenium tests
-RUN zypper install -y chromedriver
+# just circleCI dependencies to have cache
+RUN zypper install -y tar gzip
 
 ENV LANG en_US.UTF-8
-
-ENV NORMAL_USER squamata
-ENV USER squamata
-
-RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER
-
-RUN mkdir -p /opt/testing_area
-RUN chown -R $NORMAL_USER:users /opt/testing_area
-
-WORKDIR /opt/testing_area
-USER squamata

--- a/docker/devel:openQA:ci/dependency_bot/Dockerfile
+++ b/docker/devel:openQA:ci/dependency_bot/Dockerfile
@@ -1,8 +1,0 @@
-#!BuildTag: dependency_bot
-FROM opensuse/leap:15.2
-ENV NAME Leap with docker and hub
-
-ENV LANG en_US.UTF-8
-
-RUN zypper -n install docker
-RUN zypper -n install git hub curl make


### PR DESCRIPTION
The combination of a heavy image in combination with downloading from
slow registry.opensuse.org to circleCI workers have a significant impact
causing frequent failures in the "cache" step of circleCI when the 590MB
blob of the base image is downloaded. As we can not configure circleCI
to retry the download or apply a longer timeout than 20 minutes this
means that manual interaction is necessary to retry.

This commit completely removes the base image and changes the circleCI
configuration to use a vanilla openSUSE Leap container which is much
smaller. Then we rely on the package install within the "cache" step to
install all dependencies for which we can also apply timeouts and retry
values ourselves.

Related progress issue: https://progress.opensuse.org/issues/67855