### PR TITLE
docker: Ask to not squash base image layers to fix circleCI download

### DIFF
--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -1,5 +1,9 @@
 #!BuildTag: base
 #!UseOBSRepositories
+# preserve layers to avoid failures in CircleCI while it downloads a big blob
+# in one go
+# see https://progress.opensuse.org/issues/67855
+#!NoSquash
 FROM opensuse/leap:15.2
 
 # these are autoinst dependencies


### PR DESCRIPTION
Reference:
https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.building.html#id-1.5.8.3.8

The combination of a heavy image in combination with downloading from
slow registry.opensuse.org to circleCI workers have a significant impact
causing frequent failures in the "cache" step of circleCI when the 542MB
blob of the base image is downloaded. As we can not configure circleCI
to retry the download or apply a longer timeout than 20 minutes this
means that manual interaction is necessary to retry.

This commit changes the base image to preserve individual layers within the
container image which makes downloading much more likely to succeed.

See test in https://github.com/os-autoinst/openQA/pull/3527

Related progress issue: https://progress.opensuse.org/issues/67855