### PR TITLE
Docker: Fix worker Dockerfile to be buildable on OBS

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,9 +1,10 @@
+#!BuildTag: openqa_worker
 FROM opensuse/leap:15.2
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
-RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.2 openQA && \
-    zypper ar -f obs://devel:openQA:Leap:15.2/openSUSE_Leap_15.2 openQA-perl-modules && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in ca-certificates-mozilla curl gzip && \
     zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 && \
@@ -11,11 +12,10 @@ RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.2 openQA && \
     (zypper --non-interactive in qemu-ovmf-x86_64 || true) && \
     (zypper --non-interactive in qemu-uefi-aarch64 || true)
 
-# set-up qemu
 RUN mkdir -p /root/qemu
 ADD kvm-mknod.sh /root/qemu/kvm-mknod.sh
 ADD run_openqa_worker.sh /run_openqa_worker.sh
-RUN chmod +x /root/qemu/kvm-mknod.sh && /root/qemu/kvm-mknod.sh && \
+RUN chmod +x /root/qemu/kvm-mknod.sh && \
     chmod a+x /run_openqa_worker.sh && \
     # set-up shared data and configuration
     rm -rf /etc/openqa/client.conf /etc/openqa/workers.ini && \
@@ -29,5 +29,4 @@ RUN chmod +x /root/qemu/kvm-mknod.sh && /root/qemu/kvm-mknod.sh && \
     chmod -R ug+rw /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool && \
     find /usr/share/openqa/script/worker /var/lib/openqa/cache /var/lib/openqa/pool -type d -exec chmod ug+x {} \;
 
-USER _openqa-worker
 ENTRYPOINT ["/run_openqa_worker.sh"]

--- a/docker/worker/run_openqa_worker.sh
+++ b/docker/worker/run_openqa_worker.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -e
 
-/usr/share/openqa/script/worker --verbose --instance "$OPENQA_WORKER_INSTANCE"
+if [[ -z $OPENQA_WORKER_INSTANCE ]]; then
+  OPENQA_WORKER_INSTANCE=1
+fi
+
+/root/qemu/kvm-mknod.sh
+su _openqa-worker -c "/usr/share/openqa/script/worker --verbose --instance \"$OPENQA_WORKER_INSTANCE\""


### PR DESCRIPTION
Problem: OBS cannot deal with the current repositories format (obs://)
More info at openSUSE/open-build-service#10438
Solution: Change the repositories to be downloaded from
http://download.opensuse.org

Problem: OBS doesn't have a correct tag when build the images
Solution: Provide a tag

Problem: kvm operations cannot be instantiated during the building 
because the workers may have kvm but the build machine don't
have to
Solution: Move script execution to the container execution time

Problem: OBS cannot build the image with the old way of choosing 
to install between the x86 or ARM package. 
Solution Since the objective is to create the image for x86, the ARM 
part is eliminated

https://progress.opensuse.org/issues/43715