### PR TITLE
docker: Fix kvm-mknod script in worker container

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -13,9 +13,9 @@ RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.2 openQA && \
 
 # set-up qemu
 RUN mkdir -p /root/qemu
-ADD kvm-mknod.sh /qemu/kvm-mknod.sh
+ADD kvm-mknod.sh /root/qemu/kvm-mknod.sh
 ADD run_openqa_worker.sh /run_openqa_worker.sh
-RUN chmod +x /root/qemu/*.sh && /root/qemu/kvm-mknod.sh && \
+RUN chmod +x /root/qemu/kvm-mknod.sh && /root/qemu/kvm-mknod.sh && \
     chmod a+x /run_openqa_worker.sh && \
     # set-up shared data and configuration
     rm -rf /etc/openqa/client.conf /etc/openqa/workers.ini && \

--- a/docker/worker/kvm-mknod.sh
+++ b/docker/worker/kvm-mknod.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # If possible, create the /dev/kvm device node.
-
 set -e
 
-kvm=$([[ -f /proc/config.gz ]] && test "$(gzip -c /proc/config.gz | grep CONFIG_KVM=y)")
+kvm=$({ [[ -f /proc/config.gz ]] && test "$(gzip -c /proc/config.gz | grep CONFIG_KVM=y)" ; } || true)
 $kvm || lsmod | grep '\<kvm\>' > /dev/null || {
   echo >&2 "KVM module not loaded; software emulation will be used"
   exit 1


### PR DESCRIPTION
Problems
    - kvm-mknod shouldn't fail if /proc/config.gz doesn't exist
    - kvm-mknod was copied to the wrong directory
