### PR TITLE
docker: Fix web UI Dockerfile-lb to be buildable on OBS 

### DIFF
--- a/docker/webui/Dockerfile-lb
+++ b/docker/webui/Dockerfile-lb
@@ -1,8 +1,9 @@
+#!BuildTag: openqa_webui_lb
 FROM opensuse/leap:15.2
 LABEL maintainer Ivan Lausuch <ilausuch@suse.com>
 
-RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_15.2 openQA && \
-    zypper ar -f obs://devel:openQA:Leap:15.2/openSUSE_Leap_15.2 openQA-perl-modules && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in --force-resolution openQA nginx
 


### PR DESCRIPTION
Problem: OBS cannot deal with the current repositories format (obs://)
More info at openSUSE/open-build-service#10438
Solution: Change the repositories to be downloaded from
http://download.opensuse.org

Problem: OBS doesn't have a correct tag when build the images
Solution: Provide a tag

https://progress.opensuse.org/issues/43712#change-346618