### PR TITLE
cache service: Avoid purging assets which are currently being downloaded

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -153,6 +153,7 @@ worker_requires:
   os-autoinst: '< 5'
   openQA-client:
   optipng:
+  sqlite3: '>= 3.24.0'   # for INSERT INTO … ON CONFLICT … DO UPDATE SET … required by cache service
   perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.26'
   perl(Minion::Backend::SQLite): '>= 5.0.1'
   perl(Mojo::SQLite):

--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -190,3 +190,6 @@ CREATE INDEX IF NOT EXISTS downloads_created on downloads (created);
 
 -- 2 down
 DROP TABLE downloads;
+
+-- 3 up
+ALTER TABLE assets ADD COLUMN `pending` INTEGER DEFAULT 1;

--- a/openQA.spec
+++ b/openQA.spec
@@ -56,7 +56,7 @@
 # The following line is generated from dependencies.yaml
 %define client_requires curl git-core jq perl(Getopt::Long::Descriptive) perl(IO::Socket::SSL) >= 2.009 perl(IPC::Run) perl(JSON::Validator) perl(LWP::Protocol::https) perl(LWP::UserAgent) perl(Test::More) perl(YAML::PP) >= 0.020 perl(YAML::XS)
 # The following line is generated from dependencies.yaml
-%define worker_requires openQA-client optipng os-autoinst < 5 perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite)
+%define worker_requires openQA-client optipng os-autoinst < 5 perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
 %define build_requires %assetpack_requires rubygem(sass)
 


### PR DESCRIPTION
So far it is not guaranteed that an asset is preserved from purging while
being downloaded. Considering that we've seen cases where an asset is
immediately purged after its own download to make room for itself it also
makes sense to prevent an asset from being purged while being downloaded.

Note that an asset's last use is only updated after but not during its
download. So assets are "aging" while being downloaded and old assets are
preferred by the purging algorithm.

See https://progress.opensuse.org/issues/71827#note-14