### PR TITLE
t: Disable OpenQA::Test::TimeLimit by ENV variable or when running within debugger

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -657,6 +657,10 @@ executing while test coverage data is collected as longer runtimes should be
 expected in these cases. Consider lowering the timeout value based on usual
 local execution times whenever a test module is optimized in runtime. If the
 timeout is hit the test module normally aborts with a corresponding message.
+
+To disable the timeout globably set the environment variable
+`OPENQA_TEST_TIMEOUT_DISABLE=1`.
+
 Please be aware of the exception when the timeout triggers after the actual
 test part of a test module has finished but not all involved processes have
 finished or END blocks are processed. In this case the output can look like

--- a/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
+++ b/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
@@ -21,7 +21,8 @@ my $SCALE_FACTOR = 1;
 sub import {
     my ($package, $limit) = @_;
     die "$package: Need argument on import, e.g. use: use OpenQA::Test::TimeLimit '42';" unless $limit;
-    return if $ENV{OPENQA_TEST_TIMEOUT_DISABLE};
+    # disable timeout if requested by ENV variable or running within debugger
+    return if $ENV{OPENQA_TEST_TIMEOUT_DISABLE} or defined $DB::single;
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI}    // 2 if $ENV{CI};
     $limit        *= $SCALE_FACTOR;


### PR DESCRIPTION
* t: Disable OpenQA::Test::TimeLimit when running within debugger
* t: Add option to disable test timeout with env variable