### PR TITLE
Remove log/ and log_test_postgresql from .gitignore which can confuse developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,4 @@ t/data/openqa/share/factory/iso/Core-7.2.iso
 t/log_chromedriver
 docker.env
 pool????/
-log/
-log_test_postgresql
 docker/webui/workdir


### PR DESCRIPTION
Mojo::Log writes to log/ if it exists instead of outputting content to
the calling terminal which can be confusing for local development. If
one has a log/ dir we can at least show it up as untracked by git :)