### PR TITLE
Stop cache service after critical database error

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -44,7 +44,7 @@ sub startup {
             chomp $error;
             $log->error($error);
             $c->render(text => $error, status => 500);
-            if ($error =~ qr/database disk image is malformed/) {
+            if ($error =~ qr/(database disk image is malformed|no such (table|column))/) {
                 $c->app->{_app_return_code} = 1;    # ensure the return code is non-zero
                 $log->error('Stopping service after critical database error');
                 Mojo::IOLoop->singleton->stop_gracefully;

--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -68,8 +68,9 @@ sub startup {
                 location => $location,
                 defined $limit ? (limit => int($limit) * (1024**3)) : ());
         });
-    $self->helper(downloads => sub { state $dl = OpenQA::CacheService::Model::Downloads->new(sqlite => $sqlite) });
-    $self->cache->init;
+    my $cache = $self->cache;
+    $self->helper(downloads => sub { state $dl = OpenQA::CacheService::Model::Downloads->new(cache => $cache) });
+    $cache->init;
 
     $self->plugin(Minion => {SQLite => $sqlite});
     $self->plugin('Minion::Admin');

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -26,20 +26,53 @@ has downloader => sub { OpenQA::Downloader->new };
 has [qw(location log sqlite)];
 has limit => 50 * (1024**3);
 
+sub _perform_integrity_check {
+    return shift->sqlite->db->query('pragma integrity_check')->arrays->flatten->to_array;
+}
+
+sub _check_database_integrity {
+    my ($self)           = @_;
+    my $integrity_errors = $self->_perform_integrity_check;
+    my $log              = $self->log;
+    if (scalar @$integrity_errors == 1 && ($integrity_errors->[0] // '') eq 'ok') {
+        $log->debug('Database integrity check passed');
+        return undef;
+    }
+    $log->error('Database integrity check found errors:');
+    $log->error($_) for @$integrity_errors;
+    return $integrity_errors;
+}
+
 sub repair_database {
     my ($self, $db_file) = @_;
     $db_file //= $self->_locate_db_file;
     return undef unless -e $db_file;
 
+    # perform some tests; try to provoke an error
+    my $log = $self->log;
+    $log->debug("Testing sqlite database ($db_file)");
     eval {
+        # perform basic checks (table creation, integrity check)
         my $sqlite = $self->sqlite;
         my $db     = $sqlite->db;
-        $sqlite->migrations->migrate;
+        my $tx     = $db->begin('exclusive');
         $db->query('create table if not exists cache_write_test (test text)');
         $db->query('drop table cache_write_test');
+        if (my $integrity_errors = $self->_check_database_integrity) {
+            # try re-indexing and check again
+            $log->error('Re-indexing broken database');
+            $db->query('reindex');
+            die "Unable to fix errors reported by integrity check\n" if $self->_check_database_integrity;
+        }
+        undef $tx;
+
+        # test migration
+        $sqlite->migrations->migrate;
     };
+
+    # remove broken database
     if (my $err = $@) {
-        $self->log->info("Purging cache directory because database has been corrupted: $err");
+        $log->error("Purging cache directory because database has been corrupted: $err");
         $db_file->remove;
     }
 }

--- a/lib/OpenQA/CacheService/Model/Downloads.pm
+++ b/lib/OpenQA/CacheService/Model/Downloads.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,13 +21,13 @@ use Carp 'croak';
 # Two days
 use constant CLEANUP_AFTER => 172800;
 
-has 'sqlite';
+has 'cache';
 
 sub add {
     my ($self, $lock, $job_id) = @_;
 
     eval {
-        my $db = $self->sqlite->db;
+        my $db = $self->cache->sqlite->db;
         my $tx = $db->begin('exclusive');
 
         # Clean up entries that are older than 2 days
@@ -41,8 +41,8 @@ sub add {
 
 sub find {
     my ($self, $lock) = @_;
-    return undef
-      unless my $hash = $self->sqlite->db->select('downloads', ['job_id'], {lock => $lock}, {-desc => 'id'})->hash;
+    my $db = $self->cache->sqlite->db;
+    return undef unless my $hash = $db->select('downloads', ['job_id'], {lock => $lock}, {-desc => 'id'})->hash;
     return $hash->{job_id};
 }
 

--- a/script/openqa-workercache
+++ b/script/openqa-workercache
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,4 +24,4 @@ use OpenQA::CacheService;
 use OpenQA::Utils qw(service_port set_listen_address);
 
 set_listen_address(service_port('cache_service'));
-OpenQA::CacheService::run(@ARGV);
+exit OpenQA::CacheService::run(@ARGV);

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -269,13 +269,13 @@ subtest 'Job progress (guard against parallel downloads of the same file)' => su
     is $app->progress->downloading_job('foo'), 125, 'new job 125';
     undef $guard;
 
-    is $app->downloads->sqlite->db->select('downloads', '*', {lock => 'foo'})->hashes->size, 3, 'three entries';
-    $app->downloads->sqlite->db->update('downloads', {created => \'datetime(\'now\',\'-3 day\')'});
+    my $db = $app->downloads->cache->sqlite->db;
+    is $db->select('downloads', '*', {lock => 'foo'})->hashes->size, 3, 'three entries';
+    $db->update('downloads', {created => \'datetime(\'now\',\'-3 day\')'});
     $guard = $app->progress->guard('foo', 126);
     ok $app->progress->is_downloading('foo'), 'is downloading again for 126';
     is $app->progress->downloading_job('foo'), 126, 'new job 126';
-    is $app->downloads->sqlite->db->select('downloads', '*', {lock => 'foo'})->hashes->size, 1,
-      'old jobs have been removed';
+    is $db->select('downloads', '*', {lock => 'foo'})->hashes->size, 1, 'old jobs have been removed';
 };
 
 subtest 'Client can check if there are available workers' => sub {

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -446,7 +446,7 @@ subtest 'cache directory is corrupted' => sub {
     $cache_log = '';
     $t->post_ok('/enqueue')->status_is(500);
     like $cache_log, qr/database disk image is malformed.*Stopping service.*/s, 'service stopped after fatal db error';
-    is $t->app->{_app_return_code}, 1, 'non-zero return code';
+    is $t->app->exit_code, 1, 'non-zero return code';
 };
 
 stop_server;


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/67000#note-28
* Extend checks for broken database (see commit message for details)
* Stop service after a critical database error
* Example output:
```
<6>[15849] [i] Listening at "http://[::1]:9530"
<7>[15849] [d] [f36HfV4M] GET "/info"
<7>[15849] [d] [f36HfV4M] Routing to controller "OpenQA::CacheService::Controller::API" and action "info"
<3>[15849] [e] some non critical error at /usr/lib/perl5/vendor_perl/5.32.0/Minion/Backend/SQLite.pm line 366.
<7>[15849] [d] [f36HfV4M] 500 Internal Server Error (0.002338s, 427.716/s)
<7>[15849] [d] [J-Go_bwG] GET "/info"
<7>[15849] [d] [J-Go_bwG] Routing to controller "OpenQA::CacheService::Controller::API" and action "info"
<3>[15849] [e] DBD::SQLite::st execute failed: database disk image is malformed at /usr/lib/perl5/vendor_perl/5.32.0/Minion/Backend/SQLite.pm line 365.
<7>[15849] [d] [J-Go_bwG] 500 Internal Server Error (0.001104s, 905.797/s)
<3>[15849] [e] Stopping service after critical database error
```