### PR TITLE
Re-do handling of placeholders and + after _URL variables parsed

### DIFF
--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -121,8 +121,32 @@ subtest 'handle_plus_in_settings' => sub {
         '+ARCH'  => 'x86_64',
         'DISTRI' => 'opensuse',
     };
+    OpenQA::JobSettings::handle_plus_in_settings($settings, 0);
+    is_deeply(
+        $settings,
+        {ISO => 'bar.iso', '+ISO' => 'bar.iso', ARCH => 'x86_64', '+ARCH' => 'x86_64', DISTRI => 'opensuse'},
+        'handle the plus correctly (explicitly not destructive)'
+    );
+
+    OpenQA::JobSettings::handle_plus_in_settings($settings, 1);
+    is_deeply(
+        $settings,
+        {ISO => 'bar.iso', ARCH => 'x86_64', DISTRI => 'opensuse'},
+        'handle the plus correctly (explicitly destructive)'
+    );
+
+    $settings = {
+        'ISO'    => 'foo.iso',
+        '+ISO'   => 'bar.iso',
+        '+ARCH'  => 'x86_64',
+        'DISTRI' => 'opensuse',
+    };
     OpenQA::JobSettings::handle_plus_in_settings($settings);
-    is_deeply($settings, {ISO => 'bar.iso', ARCH => 'x86_64', DISTRI => 'opensuse'}, 'handle the plus correctly');
+    is_deeply(
+        $settings,
+        {ISO => 'bar.iso', ARCH => 'x86_64', DISTRI => 'opensuse'},
+        'handle the plus correctly (destructive by default)'
+    );
 };
 
 done_testing;

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -298,4 +298,28 @@ subtest 'download task only blocks the related job when test suites have differe
     is scalar(@{$gru_dep_tasks->{$gru_task_ids[0]}}), 3, 'one download task was created and it blocked 3 jobs';
 };
 
+subtest 'placeholder expansions work with _URL-derived settings' => sub {
+    $test_suites->find({name => 'kde'})->settings->create({key => 'FOOBAR', value => '%ISO%'});
+    $rsp
+      = schedule_iso({%params, ISO_URL => 'http://localhost/openSUSE-13.1-DVD-i586-Build0091-Media.iso', TEST => 'kde'},
+        200);
+    is $rsp->json->{count}, 1, 'one job was scheduled';
+    my $expanderjob = get_job($rsp->json->{ids}->[0]);
+    is(
+        $expanderjob->{settings}->{FOOBAR},
+        'openSUSE-13.1-DVD-i586-Build0091-Media.iso',
+        '%ISO% in template is expanded by posted ISO_URL'
+    );
+};
+
+subtest 'plus-overrides work with _URL-derived settings' => sub {
+    $test_suites->find({name => 'kde'})->settings->create({key => '+ISO', value => 'templateoverride.iso'});
+    $rsp
+      = schedule_iso({%params, ISO_URL => 'http://localhost/openSUSE-13.1-DVD-i586-Build0091-Media.iso', TEST => 'kde'},
+        200);
+    is $rsp->json->{count}, 1, 'one job was scheduled';
+    my $overriddenjob = get_job($rsp->json->{ids}->[0]);
+    is($overriddenjob->{settings}->{ISO}, 'templateoverride.iso', '+ISO in template overrides posted ISO_URL');
+};
+
 done_testing();


### PR DESCRIPTION
b3bc8ebf caused some problems by moving the parsing of `_URL`
settings to after the call to `JobSettings::generate_settings`,
which is where handling of placeholders (%FOO%) and +-overrides
(+FOO), usually from the templates, is done. This broke the case
where e.g. a template sets `+ISO`, or uses `%ISO%` in a value,
and the job is posted with `ISO_URL` but no explicit `ISO` set.
In that case the derived `ISO` setting should be overridden or
used in the placeholder expansion, but this was broken.

This fixes the problems by handling placeholder expansion and
+-overrides *again* after the parsing of `_URL` settings. They
are pretty simple operations anyway so it shouldn't cause much
overhead. To facilitate this we have to set up destructive and
non-destructive modes for `handle_plus_in_settings` so it can be
run non-destructively at first and then destructively later.

Signed-off-by: Adam Williamson <awilliam@redhat.com>