### PR TITLE
Fix UI build bar alignment broken on index page

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -6,6 +6,9 @@ div.progress {
     margin-bottom: 9px;
     height: 18px;
 }
+#build-results .progress {
+    min-width: 24.5em;
+}
 @include media-breakpoint-down(lg) {
     div.progress {
         margin-top: 0px !important;


### PR DESCRIPTION
Problem: The right side of some build bars of is
misaligned when the screen is less wide than 880
pixels. This occurs because some bars have more
text than others and this text forces a minimum size.

Solution: a minimum size is set for all bars to
ensure the maximum possible text size.

https://progress.opensuse.org/issues/77929

![image](https://user-images.githubusercontent.com/11134265/99393142-3232b700-28dd-11eb-98c6-bce9e275eb59.png)
