### PR TITLE
Handle placeholders after parsing _URL settings, don't set FOO from FOO_URL if FOO is defined but false

### DIFF
--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -121,7 +121,7 @@ sub parse_url_settings {
     for my $setting (keys %$settings) {
         my ($short, $do_extract) = get_url_short($setting);
         next unless ($short);
-        next if ($settings->{$short});
+        next if defined($settings->{$short});
         # As this comes in from an API call, URL will be URI-encoded
         # This obviously creates a vuln if untrusted users can POST
         $settings->{$setting} = url_unescape($settings->{$setting});

--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -132,12 +132,11 @@ sub parse_url_settings {
             # will have last extension removed
             $filename = fileparse($filename, qr/\.[^.]*/);
         }
-        $settings->{$short} = $filename;
-        if (!$settings->{$short}) {
+        if (!$filename) {
             log_debug("Unable to get filename from $url. Ignoring $setting");
-            delete $settings->{$short} unless $settings->{$short};
             next;
         }
+        $settings->{$short} = $filename;
     }
     return undef;
 }

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -158,6 +158,7 @@ check_job_setting($t, $rsp, 'KERNEL', 'callitvmlinuz',
 $rsp = schedule_iso({%params, NO_ASSET_URL => 'http://localhost/nonexistent.iso'});
 is($rsp->json->{count}, $expected_job_count, 'a regular ISO post creates the expected number of jobs');
 check_download_asset('non-asset _URL');
+check_job_setting($t, $rsp, 'NO_ASSET', undef, 'NO_ASSET is not parsed from NO_ASSET_URL');
 
 # Using asset _URL but without filename extractable from URL create warning in log file, jobs, but no gru job
 $rsp = schedule_iso({%iso, ISO_URL => 'http://localhost'});

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -298,4 +298,17 @@ subtest 'download task only blocks the related job when test suites have differe
     is scalar(@{$gru_dep_tasks->{$gru_task_ids[0]}}), 3, 'one download task was created and it blocked 3 jobs';
 };
 
+subtest 'placeholder expansions work with _URL-derived settings' => sub {
+    $test_suites->find({name => 'kde'})->settings->create({key => 'FOOBAR', value => '%ISO%'});
+    my $new_params = {%params, ISO_URL => 'http://localhost/openSUSE-13.1-DVD-i586-Build0091-Media.iso', TEST => 'kde'};
+    $rsp = schedule_iso($new_params, 200);
+    is $rsp->json->{count}, 1, 'one job was scheduled';
+    my $expanderjob = get_job($rsp->json->{ids}->[0]);
+    is(
+        $expanderjob->{settings}->{FOOBAR},
+        'openSUSE-13.1-DVD-i586-Build0091-Media.iso',
+        '%ISO% in template is expanded by posted ISO_URL'
+    );
+};
+
 done_testing();

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -311,4 +311,13 @@ subtest 'placeholder expansions work with _URL-derived settings' => sub {
     );
 };
 
+subtest 'test suite sets short asset setting to false value' => sub {
+    $test_suites->find({name => 'kde'})->settings->create({key => 'ISO', value => ''});
+    my $new_params = {%params, ISO_URL => 'http://localhost/openSUSE-13.1-DVD-i586-Build0091-Media.iso', TEST => 'kde'};
+    $rsp = schedule_iso($new_params, 200);
+    is $rsp->json->{count}, 1, 'one job was scheduled';
+    my $overriddenjob = get_job($rsp->json->{ids}->[0]);
+    is($overriddenjob->{settings}->{ISO}, '', 'false-evaluating ISO in template overrides posted ISO_URL');
+};
+
 done_testing();


### PR DESCRIPTION
This is an alternative to #3560 , using the approach suggested by @Amrysliu (thanks) - we split up the "generate FOO from FOO_URL" and "produce download list" parts of `create_downloads_list` so we can do the "generate FOO from FOO_URL" part before handling placeholders. This should fix the issue with placeholders referring to _URL-parsed settings that I identified in comments on #3309 .

We also "properly" fix the issue with a test suite or similar wanting to set a potentially-_URL-parsed setting to a false-y value that's discussed in https://github.com/os-autoinst/openQA/pull/3560#issuecomment-729103247 , by changing the test we use to decide whether to set the short form to check if it's already defined, rather than checking if it evaluates true.