### PR TITLE
cache service: Avoid throwing away database needlessly

### DIFF
--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -434,7 +434,7 @@ subtest 'cache directory is corrupted' => sub {
     $app->cache->sqlite->db->disconnect;
     $app->cache->init;
     like $cache_log, qr/Database integrity check found errors.*foo.*bar/s, 'integrity check';
-    like $cache_log, qr/Re-indexing broken database.*Unable to fix errors reported by integrity check/s, 'reindexing';
+    like $cache_log, qr/Re-indexing.*broken database.*Unable to fix errors reported by integrity check/s, 'reindexing';
     like $cache_log, qr/Purging cache directory because database has been corrupted:.+/, 'cache dir purged';
     undef $cache_mock;
 


### PR DESCRIPTION
* Run vacuum when repairing SQLite database
* Without this change the database repairing will throw away
  databases needlessly due to `Page 2923 is never used`
  reported by the integrity check
* See https://progress.opensuse.org/issues/67000