### PR TITLE
cache service: Do not perform re-indexing within a transaction

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -58,17 +58,16 @@ sub repair_database {
         my $tx     = $db->begin('exclusive');
         $db->query('create table if not exists cache_write_test (test text)');
         $db->query('drop table cache_write_test');
+        undef $tx;
         if (my $integrity_errors = $self->_check_database_integrity) {
             $log->error('Re-indexing and vacuuming broken database');
             # reindex to fix errors like "row 1 missing from index downloads_created"
             # and "wrong # of entries in index downloads_created"
             $db->query('reindex');
-            undef $tx;
             # vacuum to clear-up messages like "Page 2923 is never used" from integrity check
             $db->query('vacuum');    # can not run vacuum in a transaction
             die "Unable to fix errors reported by integrity check\n" if $self->_check_database_integrity;
         }
-        undef $tx;
 
         # test migration
         $sqlite->migrations->migrate;


### PR DESCRIPTION
* Otherwise the re-indexing seems not visible and we run into the die.
* I've tested this with a broken SQLite file from o3 worker openqaworker4
  and only with this change 'Unable to fix errors… Purging cache directory…'
  is prevented and instead 'Database integrity check passed' shown.
* Note that unlinking the SQLite file (log message 'Purging cache
  directory…') is actually problematic:
  https://www.sqlite.org/howtocorrupt.html#_unlinking_or_renaming_a_database_file_while_in_use
* See https://progress.opensuse.org/issues/67000