### PR TITLE
Add git email address for dependency bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,8 @@ images:
 
   - &dependency_bot
     image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
+    environment:
+      COMMIT_AUTHOR_EMAIL: skynet@open.qa
 
 jobs:
   dependencies-pr:


### PR DESCRIPTION
The COMMIT_AUTHOR_EMAIL from &docker_config is not available
in &dependencybot

And for example `git-subrepo` seems to stumble over the empty email address.