### PR TITLE
cache service: Do not unlink the (broken) database

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -73,11 +73,10 @@ sub repair_database {
         $sqlite->migrations->migrate;
     };
 
-    # remove broken database
-    if (my $err = $@) {
-        $log->error("Purging cache directory because database has been corrupted: $err");
-        $db_file->remove;
-    }
+    # croak on broken database
+    # note: We better not simply remove the db file here, see
+    #       https://www.sqlite.org/howtocorrupt.html#_unlinking_or_renaming_a_database_file_while_in_use
+    if (my $err = $@) { croak qq{Database "$db_file" is broken: $err} }
 }
 
 sub init {


### PR DESCRIPTION
Other processes might still have an open database connection. According to
https://www.sqlite.org/howtocorrupt.html#_unlinking_or_renaming_a_database_file_while_in_use
this can lead to database corruption.

And no, this will not solve our initial problem of corrupted databases
because this code is only executed if the database is already corrupted.
However, we should avoid making things even worse.