### PR TITLE
ci: Refresh circleci cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,20 @@ version: 2
 aliases:
   - &restore_cache
     keys:
-      - v1-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
+      - v2-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
 
   - &save_cache
-    key: v1-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
+    key: v2-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
     paths:
       - "/var/cache/zypp/packages"
       - "~/project/assets/cache"
 
   - &restore_fullstack_cache
     keys:
-      - v1-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
+      - v2-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
 
   - &save_fullstack_cache
-    key: v1-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
+    key: v2-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
     paths:
       - "/var/cache/autoinst"
 


### PR DESCRIPTION
After https://github.com/os-autoinst/openQA/pull/3536 it seems
we need to explicitly invalidate the cached packages,
otherwise we get:

    error: Failed dependencies:
     perl(:MODULE_COMPAT_5.26.1) is needed by perl-Test-Fatal-0.014-lp152.3.2.noarch
     perl(:MODULE_COMPAT_5.26.1) is needed by perl-Hash-Merge-0.200-lp152.3.2.noarch