### PR TITLE
ci: Add missing dependencies

### DIFF
--- a/.circleci/build_autoinst.sh
+++ b/.circleci/build_autoinst.sh
@@ -23,7 +23,8 @@ sha=${2}
 sudo zypper install -y -C \
     git-core cmake ninja gcc-c++ \
     pkg-config 'pkgconfig(opencv)' 'pkgconfig(fftw3)' 'pkgconfig(libpng)' \
-    'pkgconfig(sndfile)' 'pkgconfig(theoraenc)'
+    'pkgconfig(sndfile)' 'pkgconfig(theoraenc)' \
+    qemu qemu-kvm qemu-tools
 
 echo Building os-autoinst $destdir $sha
 git clone https://github.com/os-autoinst/os-autoinst.git "$destdir"

--- a/.circleci/build_autoinst.sh
+++ b/.circleci/build_autoinst.sh
@@ -25,6 +25,7 @@ sudo zypper install -y -C \
     pkg-config 'pkgconfig(opencv)' 'pkgconfig(fftw3)' 'pkgconfig(libpng)' \
     'pkgconfig(sndfile)' 'pkgconfig(theoraenc)' \
     qemu qemu-kvm qemu-tools
+sudo zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
 
 echo Building os-autoinst $destdir $sha
 git clone https://github.com/os-autoinst/os-autoinst.git "$destdir"

--- a/.circleci/build_autoinst.sh
+++ b/.circleci/build_autoinst.sh
@@ -20,6 +20,11 @@ set -ex
 destdir=${1:-../os-autoinst}
 sha=${2}
 
+sudo zypper install -y -C \
+    git-core cmake ninja gcc-c++ \
+    pkg-config 'pkgconfig(opencv)' 'pkgconfig(fftw3)' 'pkgconfig(libpng)' \
+    'pkgconfig(sndfile)' 'pkgconfig(theoraenc)'
+
 echo Building os-autoinst $destdir $sha
 git clone https://github.com/os-autoinst/os-autoinst.git "$destdir"
 ( cd "$destdir"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,20 @@ version: 2
 aliases:
   - &restore_cache
     keys:
-      - v1-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
+      - v2-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
 
   - &save_cache
-    key: v1-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
+    key: v2-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
     paths:
       - "/var/cache/zypp/packages"
       - "~/project/assets/cache"
 
   - &restore_fullstack_cache
     keys:
-      - v1-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
+      - v2-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
 
   - &save_fullstack_cache
-    key: v1-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
+    key: v2-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
     paths:
       - "/var/cache/autoinst"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ jobs:
       - run:
           command: |
             # pygments requires python2
-            sudo zypper -n install python-base
+            sudo zypper -n install python-base git-core
       - run:
           command: |
             export GEM_HOME=$(pwd)/.gem

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,20 @@ version: 2
 aliases:
   - &restore_cache
     keys:
-      - v2-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
+      - v1-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}-{{ checksum ".circleci/build_autoinst.sh" }}
 
   - &save_cache
-    key: v2-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}
+    key: v1-{{ checksum ".circleci/ci-packages.txt" }}-{{ checksum ".circleci/build_cache.sh" }}-{{ checksum ".circleci/build_autoinst.sh" }}
     paths:
       - "/var/cache/zypp/packages"
       - "~/project/assets/cache"
 
   - &restore_fullstack_cache
     keys:
-      - v2-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
+      - v1-full-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_cache.sh" }}-{{ checksum ".circleci/build_autoinst.sh" }}
 
   - &save_fullstack_cache
-    key: v2-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_autoinst.sh" }}
+    key: v1-full-{{ checksum ".circleci/autoinst.sha" }}-{{ checksum ".circleci/build_cache.sh" }}-{{ checksum ".circleci/build_autoinst.sh" }}
     paths:
       - "/var/cache/autoinst"
 


### PR DESCRIPTION
After https://github.com/os-autoinst/openQA/pull/3536
we are missing several dependencies for os-autoinst.
