### PR TITLE
Partially revert "circleci: Strip down base image to prevent "cache" jobs failing" due to failures

### DIFF
--- a/docker/devel:openQA:ci/base/Dockerfile
+++ b/docker/devel:openQA:ci/base/Dockerfile
@@ -10,6 +10,15 @@ FROM opensuse/leap:15.2
 # and fix permissions for the unprivileged user we use
 RUN zypper -n in tar gzip sudo
 
+# these are autoinst dependencies
+RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\)
+
+# openQA dependencies
+RUN zypper install -y rubygem\(sass\) python3-base python3-requests python3-future git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
+
+# openQA chromedriver for Selenium tests
+RUN zypper install -y chromedriver
+
 ENV LANG en_US.UTF-8
 
 ENV NORMAL_USER squamata


### PR DESCRIPTION
Reverts #3536 as we had multiple problems, e.g. see #3572 for trying to fix the problems encountered in CI pipelines