### PR TITLE
systemd: Prevent error reports in journal of openqa-auto-update service

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -19,7 +19,6 @@
 # can't use linebreaks here!
 %define openqa_services openqa-webui.service openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer openqa-enqueue-asset-cleanup.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.service openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.service openqa-enqueue-bug-cleanup.timer
 %define openqa_worker_services openqa-worker.target openqa-slirpvde.service openqa-vde_switch.service openqa-worker-cacheservice.service openqa-worker-cacheservice-minion.service
-%define openqa_auto_upgrade_services openqa-auto-update.service openqa-auto-update.timer
 %if %{undefined tmpfiles_create}
 %define tmpfiles_create() \
 %{_bindir}/systemd-tmpfiles --create %{?*} || : \
@@ -367,7 +366,7 @@ fi
 %service_add_pre %{openqa_worker_services}
 
 %pre auto-update
-%service_add_pre %{openqa_auto_upgrade_services}
+%service_add_pre openqa-auto-update.timer
 
 %post
 %tmpfiles_create %{_tmpfilesdir}/openqa-webui.conf
@@ -400,7 +399,7 @@ fi
 %service_add_post %{openqa_worker_services}
 
 %post auto-update
-%service_add_post %{openqa_auto_upgrade_services}
+%service_add_post openqa-auto-update.timer
 
 %preun
 %service_del_preun %{openqa_services}
@@ -409,7 +408,8 @@ fi
 %service_del_preun %{openqa_worker_services}
 
 %preun auto-update
-%service_del_preun %{openqa_auto_upgrade_services}
+# not changing the service which might have triggered this update itself
+%service_del_preun openqa-auto-update.timer
 
 %postun
 %service_del_postun %{openqa_services}
@@ -419,7 +419,7 @@ fi
 %service_del_postun %{openqa_worker_services}
 
 %postun auto-update
-%service_del_postun %{openqa_auto_upgrade_services}
+%service_del_postun openqa-auto-update.timer
 
 %post local-db
 %service_add_post openqa-setup-db.service


### PR DESCRIPTION
The service openqa-auto-update might trigger an update of the package
that includes the service openqa-auto-update itself which would trigger
a stop request for the service which can not be fulfilled as rpm does
not react on termination when trying to stop a systemd service causing a
deadlock until the service is killed which triggers errors despite
everything else seems to work just fine.

This commit changes the package pre/post scripts to only touch the timer
and not the service. I think it's fine because the script that is
started by the service has nothing to do with any other files from the
package. So I consider it safe because the script would already be fully
in memory during execution while the according service and package might
be replaced in an upgrade.

This is inspired by
https://src.fedoraproject.org/rpms/dnf/blob/master/f/dnf.spec
following the same approach.

Thanks to "defolos" for the hints and support while trying to dig into
this.

Related progress issue: https://progress.opensuse.org/issues/70978