### PR TITLE
[WIP] Add 'INIT_PRODUCTDIR' to record the default needle_dir

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -323,9 +323,13 @@ sub engine_workit {
         return $error if $error;
     }
 
+    # record INIT_PRODUCTDIR in case when cloning a job which run on remote worker cannot find the needle_dir
+    # See: https://progress.opensuse.org/issues/67723
+    my $init_productdir = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
+    $vars{INIT_PRODUCTDIR} = $init_productdir;
     $vars{ASSETDIR}   //= OpenQA::Utils::assetdir();
     $vars{CASEDIR}    //= OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
-    $vars{PRODUCTDIR} //= OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
+    $vars{PRODUCTDIR} //= $init_productdir;
 
     _save_vars($pooldir, \%vars);
 


### PR DESCRIPTION
When we use `openqa-clone-custom-git-refspec` to trigger a job that is
run on a remote worker, the new job may fail because it cannot find the
needle dir. This is because not all workers' cache service is enabled and
the WebUI host is defined differently among these workers.

See more details in: https://progress.opensuse.org/issues/67723