### PR TITLE
worker cache: Try to prevent any process accessing still malformed database file handles

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -157,6 +157,7 @@ worker_requires:
   perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.26'
   perl(Minion::Backend::SQLite): '>= 5.0.1'
   perl(Mojo::SQLite):
+  psmisc:
 
 test_requires:
   '%common_requires':

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -57,7 +57,7 @@
 # The following line is generated from dependencies.yaml
 %define client_requires curl git-core jq perl(Getopt::Long::Descriptive) perl(IO::Socket::SSL) >= 2.009 perl(IPC::Run) perl(JSON::Validator) perl(LWP::Protocol::https) perl(LWP::UserAgent) perl(Test::More) perl(YAML::PP) >= 0.020 perl(YAML::XS)
 # The following line is generated from dependencies.yaml
-%define worker_requires openQA-client optipng os-autoinst < 5 perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) sqlite3 >= 3.24.0
+%define worker_requires openQA-client optipng os-autoinst < 5 perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
 %define build_requires %assetpack_requires rubygem(sass)
 

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -81,7 +81,7 @@ sub repair_database {
     # remove broken database
     if (my $err = $@) {
         $log->error("Purging cache directory because database has been corrupted: $err");
-        $db_file->remove;
+        $_->remove for ($db_file, $db_file->sibling('cache.sqlite-shm'), $db_file->sibling('cache.sqlite-wal'));
         $log->error('Killing all processes accessing the corrupted database file handles (including ourselves)');
         $self->_kill_db_accessing_processes;
     }

--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -76,6 +76,7 @@
   /usr/bin/env rix,
   /usr/bin/find rix,
   /usr/bin/flock rix,
+  /usr/bin/fuser rix,
   /usr/bin/git rix,
   /usr/bin/gzip rix,
   /usr/bin/head rix,


### PR DESCRIPTION
Other processes might still have an open database connection. According to
sqlite.org/howtocorrupt.html#_unlinking_or_renaming_a_database_file_while_in_use
this can lead to database corruption.

This commit triggers killing all processes that access the relevant
files that we removed. This kills, not terminates, to prevent any other
processes even flushing or anything. Also we effectively kill the own
process which is a good thing here

The scope that started the cache services must then handle any restarts.
With our systemd services we already do that automatically. For this
note that openqa-worker-cacheservice-minion depends on
openqa-worker-cacheservice so if openqa-worker-cacheservice restarts
this also triggers a restart of openqa-worker-cacheservice-minion but
not the other way around.

Related progress issue: https://progress.opensuse.org/issues/67000