### PR TITLE
worker cache: Prevent hiding errors due to repair attempts in corrupted database

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -59,15 +59,7 @@ sub repair_database {
         $db->query('create table if not exists cache_write_test (test text)');
         $db->query('drop table cache_write_test');
         undef $tx;
-        if (my $integrity_errors = $self->_check_database_integrity) {
-            $log->error('Re-indexing and vacuuming broken database');
-            # reindex to fix errors like "row 1 missing from index downloads_created"
-            # and "wrong # of entries in index downloads_created"
-            $db->query('reindex');
-            # vacuum to clear-up messages like "Page 2923 is never used" from integrity check
-            $db->query('vacuum');    # can not run vacuum in a transaction
-            die "Unable to fix errors reported by integrity check\n" if $self->_check_database_integrity;
-        }
+        die "database integrity check failed\n" if $self->_check_database_integrity;
 
         # test migration
         $sqlite->migrations->migrate;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -433,8 +433,7 @@ subtest 'cache directory is corrupted' => sub {
     $cache_log = '';
     $app->cache->sqlite->db->disconnect;
     $app->cache->init;
-    like $cache_log, qr/Database integrity check found errors.*foo.*bar/s, 'integrity check';
-    like $cache_log, qr/Re-indexing.*broken database.*Unable to fix errors reported by integrity check/s, 'reindexing';
+    like $cache_log, qr/Database integrity check found errors.*foo.*bar/s,               'integrity check';
     like $cache_log, qr/Purging cache directory because database has been corrupted:.+/, 'cache dir purged';
     undef $cache_mock;
 


### PR DESCRIPTION
If we encounter integrity errors in database files we should treat the
database as corrupted and not try any repair attempts which might make
the problem worse by hiding the underlying root causes.

Related progress issue: https://progress.opensuse.org/issues/67000