### PR TITLE
Revert "Enable strict merge on Mergify"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,28 +5,13 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
       - "#review-requested=0"
-      - -label~=^acceptance-tests-needed|not-ready|no-automatic-rebase
+      - -label~=^acceptance-tests-needed|not-ready
       - base=master
       # wait explicitly for one of the final checks to show up to be on the
       # safe side even in case of checks not reporting back at all
       - "status-success=codecov/project"
       # wait for OBS package build as well which is triggered independantly
       # See https://progress.opensuse.org/issues/55346 for details
-      - "status-success=OBS Package Build"
-    actions:
-      merge:
-        method: merge
-        strict: smart+fasttrack
-        strict_method: rebase
-  - name: automatic merge (no automatic rebase)
-    conditions:
-      - "#approved-reviews-by>=2"
-      - "#changes-requested-reviews-by=0"
-      - "#review-requested=0"
-      - -label~=^acceptance-tests-needed|not-ready
-      - "label=no-automatic-rebase"
-      - base=master
-      - "status-success=codecov/project"
       - "status-success=OBS Package Build"
     actions:
       merge:


### PR DESCRIPTION
Reverts os-autoinst/openQA#3452

The Mergify behavior doesn't seem to work as well as intended. It's come up a few times that it causes considerable delay and very often gets *stuck* because rebasing causes a failure or a failure prevents it from trying to rebase in the first place.

On the bright side we have [poo#76738](https://progress.opensuse.org/issues/76738) with a proposal for a better solution.