### PR TITLE
Remove obsolete websockets module property "worker_status"

### DIFF
--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -71,11 +71,13 @@ sub ws_send {
 
     my $tx = $worker->{tx};
     if (!$tx || $tx->is_finished) {
+        # uncoverable statement untested exceptional error
         log_debug("Unable to send command \"$msg\" to worker $workerid: worker not connected");
 
         # try again in 10 seconds because workers try to re-connect in 10 s intervals
+        # uncoverable statement
         Mojo::IOLoop->timer(10 => sub { ws_send($workerid, $msg, $jobid, ++$retry); }) if ($retry < 3);
-        return 0;
+        return 0;    # uncoverable statement
     }
     $tx->send({json => {type => $msg, jobid => $jobid}});
     return 1;
@@ -87,15 +89,17 @@ sub ws_send_job {
     my $state  = $result->{state};
 
     unless (ref($job_info) eq 'HASH' && exists $job_info->{assigned_worker_id}) {
+        # uncoverable statement untested exceptional error
         $state->{error} = "No workerid assigned";
-        return $result;
+        return $result;    # uncoverable statement
     }
 
     my $worker_id = $job_info->{assigned_worker_id};
     my $worker    = OpenQA::WebSockets::Model::Status->singleton->workers->{$worker_id};
     if (!$worker) {
+        # uncoverable statement untested exceptional error
         $state->{error} = "Unable to assign job to worker $worker_id: the worker has not established a ws connection";
-        return $result;
+        return $result;    # uncoverable statement
     }
 
     my $tx = $worker->{tx};

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -117,12 +117,6 @@ sub _setup {
 
     OpenQA::Setup::read_config($self);
     setup_log($self);
-
-    Mojo::IOLoop->recurring(
-        380 => sub {
-            log_debug('Resetting worker status table');
-            $self->status->worker_status({});
-        });
 }
 
 1;

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -84,23 +84,23 @@ sub ws_send {
 sub ws_send_job {
     my ($job_info, $message) = @_;
     my $result = {state => {msg_sent => 0}};
+    my $state  = $result->{state};
 
     unless (ref($job_info) eq 'HASH' && exists $job_info->{assigned_worker_id}) {
-        $result->{state}->{error} = "No workerid assigned";
+        $state->{error} = "No workerid assigned";
         return $result;
     }
 
     my $worker_id = $job_info->{assigned_worker_id};
     my $worker    = OpenQA::WebSockets::Model::Status->singleton->workers->{$worker_id};
     if (!$worker) {
-        $result->{state}->{error}
-          = "Unable to assign job to worker $worker_id: the worker has not established a ws connection";
+        $state->{error} = "Unable to assign job to worker $worker_id: the worker has not established a ws connection";
         return $result;
     }
 
     my $tx = $worker->{tx};
     if (!$tx || $tx->is_finished) {
-        $result->{state}->{error} = "Unable to assign job to worker $worker_id: the worker is not connected anymore";
+        $state->{error} = "Unable to assign job to worker $worker_id: the worker is not connected anymore";
         return $result;
     }
 
@@ -108,7 +108,7 @@ sub ws_send_job {
     $tx->send({json => $message});
     my $id_string = join(', ', @$job_ids) || '?';
     log_debug("Started to send message to $worker_id for job(s) $id_string");
-    $result->{state}->{msg_sent} = 1;
+    $state->{msg_sent} = 1;
     return $result;
 }
 

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -65,9 +65,8 @@ sub _finish {
 sub _message {
     my ($self, $json) = @_;
 
-    my $app           = $self->app;
-    my $schema        = $app->schema;
-    my $worker_status = $app->status->worker_status;
+    my $app    = $self->app;
+    my $schema = $app->schema;
 
     # find relevant worker
     my $worker = OpenQA::WebSockets::Model::Status->singleton->worker_by_transaction->{$self->tx};
@@ -159,7 +158,6 @@ sub _message {
         my $job_token             = $job_settings->{JOBTOKEN};
         my $pending_job_ids       = $json->{pending_job_ids} // {};
 
-        $worker_status->{$worker_id} = $json;
         log_debug(sprintf('Received from worker "%u" worker_status message "%s"', $worker_id, dumper($json)));
 
         # log that we 'saw' the worker

--- a/lib/OpenQA/WebSockets/Model/Status.pm
+++ b/lib/OpenQA/WebSockets/Model/Status.pm
@@ -20,7 +20,7 @@ use OpenQA::Schema;
 use OpenQA::Schema::Result::Workers ();
 use OpenQA::Jobs::Constants;
 
-has [qw(workers worker_by_transaction worker_status)] => sub { {} };
+has [qw(workers worker_by_transaction)] => sub { {} };
 
 sub singleton { state $status ||= __PACKAGE__->new }
 


### PR DESCRIPTION
As mentioned in
https://github.com/os-autoinst/openQA/pull/3588#discussion_r529614510
likely we can get rid of the "worker_status" property completely.

Related progress issue: https://progress.opensuse.org/issues/80298