### PR TITLE
client: Fix warning "Wide character in print"

### DIFF
--- a/lib/OpenQA/Script/Client.pm
+++ b/lib/OpenQA/Script/Client.pm
@@ -24,6 +24,8 @@ use Mojo::URL;
 use Scalar::Util ();
 use OpenQA::Client;
 use OpenQA::YAML qw(dump_yaml load_yaml);
+# use UTF-8 on all streams to prevent problems when reading/writing unicode
+use open ":std", ":encoding(UTF-8)";
 
 
 our @EXPORT = qw(


### PR DESCRIPTION
Tested manually by putting a true unicode character into an openQA
job comment and reading that with

```
script/client --host openqa.suse.de --json-output jobs/$job/comments
```

Related progress issue: https://progress.opensuse.org/issues/76912