### PR TITLE
cache service: Use DELETE journaling mode by default

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -76,7 +76,9 @@ sub startup {
     $sqlite->on(
         connection => sub {
             my ($sqlite, $dbh) = @_;
-            my $sqlite_mode = uc($ENV{OPENQA_CACHE_SERVICE_SQLITE_JOURNAL_MODE} || 'WAL');
+            # default to using DELETE journaling mode to avoid database corruption seen in production (see poo#67000)
+            # checkout https://www.sqlite.org/pragma.html#pragma_journal_mode for possible values
+            my $sqlite_mode = uc($ENV{OPENQA_CACHE_SERVICE_SQLITE_JOURNAL_MODE} || 'DELETE');
             $dbh->do("pragma journal_mode=$sqlite_mode");
             $dbh->do('pragma synchronous=NORMAL') if $sqlite_mode eq 'WAL';
             $dbh->sqlite_busy_timeout(360000);


### PR DESCRIPTION
* Tested on one of our production workers for almost 24 hours and the usual problems (see https://progress.opensuse.org/issues/67000) have not occurred yet.
* Match SQLite's default