### PR TITLE
[WIP] docker: Base the webUI and worker Dockerfiles in Tumbleweed

### DIFF
--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -1,10 +1,9 @@
 #!BuildTag: openqa_webui
-FROM opensuse/leap:15.2
+FROM opensuse/tumbleweed
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in ca-certificates-mozilla curl && \
     zypper --non-interactive in --force-resolution openQA-local-db apache2 hostname which w3m

--- a/docker/webui/Dockerfile-lb
+++ b/docker/webui/Dockerfile-lb
@@ -1,9 +1,8 @@
 #!BuildTag: openqa_webui_lb
-FROM opensuse/leap:15.2
+FROM opensuse/tumbleweed
 LABEL maintainer Ivan Lausuch <ilausuch@suse.com>
 
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in --force-resolution openQA nginx
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,10 +1,9 @@
 #!BuildTag: openqa_worker
-FROM opensuse/leap:15.2
+FROM opensuse/tumbleweed
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in ca-certificates-mozilla curl gzip && \
     zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 && \


### PR DESCRIPTION
As developers we want that in order to preserve for our dev
environment the Dockerfiles should be build based on Tumbleweed,
not Leap 15.2

https://progress.opensuse.org/issues/80466