### PR TITLE
t: Use fixtures explicitly in more tests to speedup runtime

### DIFF
--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -30,7 +30,7 @@ use OpenQA::WebSockets::Client;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 
-my $schema = OpenQA::Test::Database->new->create();
+my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 06-job_dependencies.pl');
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
 
 embed_server_for_testing(

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -33,7 +33,8 @@ use Test::Output 'stdout_like';
 # allow catching log messages via stdout_like
 delete $ENV{OPENQA_LOGFILE};
 
-my $schema     = OpenQA::Test::Database->new->create();
+my $fixtures   = '01-jobs.pl 03-users.pl 05-job_modules.pl 07-needles.pl';
+my $schema     = OpenQA::Test::Database->new->create(fixtures_glob => $fixtures);
 my $first_user = $schema->resultset('Users')->first;
 my $t          = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -60,26 +60,11 @@ subtest 'make git commit (error handling)' => sub {
     );
 
     my $empty_tmp_dir = tempdir();
+    my $git           = OpenQA::Git->new({app => $t->app, dir => $empty_tmp_dir, user => $first_user});
     my $res;
-    stdout_like {
-        $res = OpenQA::Git->new(
-            {
-                app  => $t->app,
-                dir  => $empty_tmp_dir,
-                user => $first_user,
-            }
-        )->commit(
-            {
-                cmd     => 'status',
-                message => 'test',
-            });
-    }
-    qr/.*\[warn\].*fatal: Not a git repository.*\n.*cmd returned [1-9][0-9]*/i;
-    like(
-        $res,
-        qr'^Unable to commit via Git: fatal: (N|n)ot a git repository \(or any of the parent directories\): \.git$',
-        'Git error message returned'
-    );
+    stdout_like { $res = $git->commit({cmd => 'status', message => 'test'}) }
+    qr/.*\[warn\].*fatal: Not a git repository/i, 'git message found';
+    like $res, qr'^Unable to commit via Git: fatal: (N|n)ot a git repository \(or any', 'Git error message returned';
 };
 
 # setup mocking

--- a/t/40-script_load_templates.t
+++ b/t/40-script_load_templates.t
@@ -55,7 +55,7 @@ test_once $args, qr/unknown error code - host $host unreachable?/, 'invalid host
 $ENV{MOJO_LOG_LEVEL} = 'fatal';
 my $mojoport = Mojo::IOLoop::Server->generate_port;
 $host = "localhost:$mojoport";
-my $schema = OpenQA::Test::Database->new->create;
+my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 my $webapi = OpenQA::Test::Utils::create_webapi($mojoport, sub { });
 END { stop_service $webapi; }
 # Note: See t/fixtures/03-users.pl for test user credentials

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -25,7 +25,7 @@ use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 use Mojo::File 'path';
 
-my $schema = OpenQA::Test::Case->new->init_data();
+my $schema = OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');
 # setup openqa.ini with job_settings_ui
 $ENV{OPENQA_CONFIG} = "t/data/03-setting-links";
 my $t   = Test::Mojo->new('OpenQA::WebAPI');


### PR DESCRIPTION
To lower runtimes in tests when using the default parameter we should be
explicit about which fixtures are needed as already done in other test
modules.

Related progress issue: https://progress.opensuse.org/issues/71500