### PR TITLE
Add possibility to call custom hook scripts on "job done" based on result

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -748,6 +748,47 @@ keys_to_render_as_links=FOO,AUTOYAST
 The files referenced by the configured keys should be located either under the root
 of `CASEDIR` or the data folder within `CASEDIR`.
 
+=== Enable custom hook scripts on "job done" based on result
+
+If a job is done, especially if no label could be found for carry-over, often
+more steps are needed for the review of the test result or providing the
+information to either external systems or users. As there can be very custom
+requirements openQA offers a point for optional configuration to let the
+instance administrators define specific actions.
+
+By setting custom hooks it is possible to call external scripts defined in
+either environment variables or config settings.
+
+If an environment variable corresponding to the job result is found following
+the name pattern `OPENQA_JOB_DONE_HOOK_$RESULT`, any executable specified in
+the variable as absolute path or executable name in `$PATH` is called with the
+job ID as first and only parameter. For example for a job with result
+"failed", the corresponding environment variable would be
+`OPENQA_JOB_DONE_HOOK_FAILED`. As alternative to an environment variable a
+corresponding config variable in the section `[hooks]` in lower-case without
+the `OPENQA_` prefix can be used in the format `job_done_hook_$result`. The
+corresponding environment value has precedence. The exit code of the
+externally called script is not evaluated and will have no effect.
+
+For example there is already an approach called "auto-review"
+https://github.com/os-autoinst/scripts/#auto-review---automatically-detect-known-issues-in-openqa-jobs-label-openqa-jobs-with-ticket-references-and-optionally-retrigger
+which offers helpful, external scripts. Config settings for
+openqa.opensuse.org enabling the auto-review scripts could look like:
+
+```
+[hooks]
+job_done_hook_incomplete = /opt/openqa-scripts/openqa-label-known-issues-hook
+job_done_hook_failed = /opt/openqa-scripts/openqa-label-known-issues-hook
+```
+
+or for a host openqa.example.com:
+
+```
+[hooks]
+job_done_hook_incomplete = env host=openqa.example.com /opt/openqa-scripts/openqa-label-known-issues-hook
+job_done_hook_failed = env host=openqa.example.com /opt/openqa-scripts/openqa-label-known-issues-hook
+```
+
 == Auditing - tracking openQA changes
 [id="auditing"]
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -148,3 +148,10 @@ blocklist = job_grab job_done
 # folder is used as default but it can be configured to cover needs of any test distribution. To change it, add the
 # `default_data_dir` variable with the name of the directory.
 #keys_to_render_as_links=YAML_SCHEDULE,AUTOYAST
+
+[hooks]
+# Specify custom hook scripts format `job_done_hook_$result` to be called when
+# a job is done. Any executable specified in the variable as absolute path or
+# executable name in `$PATH` is called with the job ID as first and only
+# parameter corresponding to the `$result`, for example
+#job_done_hook_failed = my-openqa-hook-failed

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1753,11 +1753,11 @@ sub carry_over_bugrefs {
     my ($self) = @_;
 
     if (my $group = $self->group) {
-        return unless $group->carry_over_bugrefs;
+        return undef unless $group->carry_over_bugrefs;
     }
 
     my $prev = $self->_carry_over_candidate;
-    return if !$prev;
+    return undef if !$prev;
 
     my $comments = $prev->comments->search({}, {order_by => {-desc => 'me.id'}});
 
@@ -1769,14 +1769,11 @@ sub carry_over_bugrefs {
             $text .= "\n\n(Automatic takeover from t#" . $prev->id . ")\n";
         }
         my %newone = (text => $text);
-        # TODO can we also use another user id to tell that
-        # this comment was created automatically and not by a
-        # human user?
         $newone{user_id} = $comment->user_id;
         $self->comments->create(\%newone);
-        last;
+        return 1;
     }
-    return;
+    return undef;
 }
 
 sub bugref {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1804,10 +1804,10 @@ sub store_column {
 }
 
 sub enqueue_finalize_job_results {
-    my ($self) = @_;
+    my ($self, $carried_over) = @_;
 
     my $gru = eval { OpenQA::App->singleton->gru };    # gru might not be present within tests
-    $gru->enqueue(finalize_job_results => [$self->id]) if $gru;
+    $gru->enqueue(finalize_job_results => [$self->id, $carried_over]) if $gru;
 }
 
 # used to stop jobs with some kind of dependency relationship to another
@@ -1996,7 +1996,9 @@ sub done {
         $new_val{reason} = $reason;
     }
     $self->update(\%new_val);
-    $self->enqueue_finalize_job_results;
+    # bugrefs are there to mark reasons of failure - the function checks itself though
+    my $carried_over = $self->carry_over_bugrefs;
+    $self->enqueue_finalize_job_results($carried_over);
 
     # stop other jobs in the cluster
     if (defined $new_val{result} && !grep { $result eq $_ } OK_RESULTS) {
@@ -2005,11 +2007,7 @@ sub done {
             $self->_job_stop_cluster($job);
         }
     }
-
-    # bugrefs are there to mark reasons of failure - the function checks itself though
-    $self->carry_over_bugrefs;
     $self->unblock;
-
     return $result;
 }
 


### PR DESCRIPTION
If a job is done, especially if no label could be found for carry-over,
often more steps are needed for the review of the test result or
providing the information to either external systems or users. As there
can be very custom requirements we should offer a point for
optional configuration to let the instance administrators define
specific actions.

There is already an approach called "auto-review"
https://github.com/os-autoinst/scripts/#auto-review---automatically-detect-known-issues-in-openqa-jobs-label-openqa-jobs-with-ticket-references-and-optionally-retrigger
which offers helpful, external scripts. With this commit it is possible
to call external scripts if defined and based on the selected either
environment variables or config settings. For example config settings
for openqa.opensuse.org enabling the auto-review scripts could look like:

```
[hooks]
job_done_hook_incomplete = /opt/openqa-scripts/openqa-label-known-issues-hook
job_done_hook_failed = /opt/openqa-scripts/openqa-label-known-issues-hook
```

or for openqa.suse.de:

```
[hooks]
job_done_hook_incomplete = env host=openqa.suse.de /opt/openqa-scripts/openqa-label-known-issues-hook
job_done_hook_failed = env host=openqa.suse.de /opt/openqa-scripts/openqa-label-known-issues-hook
```

Related progress issue: https://progress.opensuse.org/issues/77944

## TODO

* [X] Test manually with https://github.com/os-autoinst/scripts/pull/50
* [x] Extend documentation
* [x] Check coverage for newly added code