### PR TITLE
Don't try to use return value from run function as exit code

### DIFF
--- a/script/openqa-livehandler
+++ b/script/openqa-livehandler
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,5 +27,4 @@ use OpenQA::Utils qw(service_port set_listen_address);
 $ENV{MOJO_INACTIVITY_TIMEOUT} ||= 15 * 60;
 
 set_listen_address(service_port('livehandler'));
-my $ret = OpenQA::LiveHandler::run;
-exit $ret unless $ENV{MOJO_HELP};
+OpenQA::LiveHandler::run;

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,5 +27,4 @@ use OpenQA::Utils qw(service_port set_listen_address);
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 1024 * 1024 * 1024 * 20;
 
 set_listen_address(service_port('websocket'));
-my $ret = OpenQA::WebSockets::run;
-exit $ret unless $ENV{MOJO_HELP};
+OpenQA::WebSockets::run;

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -38,9 +38,9 @@ for my $script (sort keys %types) {
     my $rc  = $?;
     is($rc, 0, "Calling '$script --help' returns exit code 0")
       or diag "Output: $out";
-    $out = qx{$Bin/../script/$script --invalid-option 2>&1};
+    $out = qx{$Bin/../script/$script invalid-command --invalid-flag 2>&1};
     $rc  = $?;
-    isnt($rc, 0, "Calling '$script --invalid-option' returns non-zero exit code")
+    isnt($rc, 0, "Calling '$script invalid-command --invalid-flag' returns non-zero exit code")
       or diag "Output: $out";
 }
 


### PR DESCRIPTION
* The return value is always `undef` and therefore not meaningful to pass as
  exit code. Besides, passing `undef` here leads to Perl warnings, see
  https://progress.opensuse.org/issues/80576.
* Invalid arguments should be handled (and tested) within Mojolicious itself.
  It actually already handles invalid arguments within a command and invalid
  commands. For now I've adjusted the tests pass invalid flags all scripts
  consider invalid at this point.
* With Mojolicious 8.67 it will also work in the case the tests tried so far:
  https://github.com/mojolicious/mojo/commit/d0093749c73557bf0be66f76f541749667d04511
  I've already tested the Mojolicious commit together with this commit. The
  Mojolicious commit also contains a unit test so I wouldn't add another
  test in openQA itself as the scripts tests take long enough to execute
  anyways.