### PR TITLE
docker: Fix web UI container script in basic execution

### DIFF
--- a/docker/webui/run_openqa.sh
+++ b/docker/webui/run_openqa.sh
@@ -16,7 +16,7 @@ function websockets() {
 
 function gru() {
   wait_for_db_creation
-  su geekotest -c /usr/share/openqa/script/openqa-gru -m production run
+  su geekotest -c /usr/share/openqa/script/openqa-gru
 }
 
 function livehandler() {
@@ -31,12 +31,12 @@ function webui() {
 
 function all_together_apache() {
   # run services
-  start_daemon -u geekotest /usr/share/openqa/script/openqa-scheduler &
-  start_daemon -u geekotest /usr/share/openqa/script/openqa-websockets &
-  start_daemon -u geekotest /usr/share/openqa/script/openqa-livehandler &
-  start_daemon -u geekotest /usr/share/openqa/script/openqa gru -m production run &
+  su geekotest -c /usr/share/openqa/script/openqa-scheduler-daemon &
+  su geekotest -c /usr/share/openqa/script/openqa-websockets-daemon &
+  su geekotest -c /usr/share/openqa/script/openqa-gru &
+  su geekotest -c /usr/share/openqa/script/openqa-livehandler-daemon &
   apache2ctl start
-  start_daemon -u geekotest /usr/share/openqa/script/openqa prefork -m production --proxy
+  su geekotest -c /usr/share/openqa/script/openqa-webui-daemon
 }
 
 # run services


### PR DESCRIPTION
When web UI is executed in a container executes the script run_openqa.sh
if this is executed in the default mode with all components together
uses the function all_together_apache(). This function has some errors
that avoid the execution of the scheduler, websockets and livehandler
because some parameters for the command start_daemon are missing.

Additionally the same simplification applied here to the gru daemon
is also applied to the function gru() which is used by the load balance
execution mode.

progress.opensuse.org/issues/80534