### PR TITLE
t: Simplify 25-cache.t with IPC::Run instead of Mojo::IOLoop::ReadWriteProcess

### DIFF
--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -72,8 +72,6 @@ $log->on(
         $cache_log .= "[$level] " . join "\n", @lines, '';
     });
 
-$SIG{INT} = sub { session->clean };
-
 END { session->clean }
 
 my $server_instance = process sub {


### PR DESCRIPTION
This is an optional follow-up to https://github.com/os-autoinst/openQA/pull/3590 with additionally replacing Mojo::IOLoop::ReadWriteProcess with IPC::Run which we might consider a better long-term choice.