### PR TITLE
t: Add full schema init+upgrade cycle test

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -32,7 +32,7 @@ use OpenQA::Utils qw(:DEFAULT prjdir);
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION = 90;
+our $VERSION = $ENV{OPENQA_SCHEMA_VERSION_OVERRIDE} // 90;
 
 __PACKAGE__->load_namespaces;
 

--- a/script/initdb
+++ b/script/initdb
@@ -32,6 +32,8 @@ my $prepare_init  = 0;
 my $init_database = 0;
 my $force         = 0;
 my $user;
+my $default_script_directory = "$FindBin::RealBin/../dbicdh";
+my $script_directory         = $default_script_directory;
 
 my $result = GetOptions(
     "help"          => \$help,
@@ -39,20 +41,23 @@ my $result = GetOptions(
     "init_database" => \$init_database,
     "force"         => \$force,
     "user=s"        => \$user,
+    "dir=s"         => \$script_directory,
 );
 
 sub usage {
     print "Usage: $0 [flags]\n\n";
-    print "  --prepare_init  : Create the deployment files used to initialize the database.\n";
-    print "                    Don't forget to increase the version before using this\n";
-    print "                    and note those files should be commited to the source repo.\n";
-    print "  --init_database : Use the generated deployment files created with --prepare_init\n";
-    print "                    to actually initialize a database (or upgrade an outdated one).\n";
-    print "                    Exit code 4 indicates database already exists and is updated and\n";
-    print "                    --force was not used.\n";
-    print "  --force         : Force overwriting existing data.\n";
-    print "  --user=login    : Change uid before connecting the DB.\n";
-    print "  --help          : This help message.\n";
+    print "  --prepare_init   : Create the deployment files used to initialize the database.\n";
+    print "                     Don't forget to increase the version before using this\n";
+    print "                     and note those files should be commited to the source repo.\n";
+    print "  --init_database  : Use the generated deployment files created with --prepare_init\n";
+    print "                     to actually initialize a database (or upgrade an outdated one).\n";
+    print "                     Exit code 4 indicates database already exists and is updated and\n";
+    print "                     --force was not used.\n";
+    print "  --force          : Force overwriting existing data.\n";
+    print "  --user=login     : Change uid before connecting the DB.\n";
+    print "  --dir=directory  : Create deployment and migration scripts in this directory.\n";
+    print "                     Default is '$default_script_directory'\n";
+    print "  --help           : This help message.\n";
     exit $_[0];
 }
 
@@ -68,9 +73,8 @@ if ($user) {
     setuid($uid) || die "can't suid to $user";
 }
 
-my $script_directory = "$FindBin::RealBin/../dbicdh";
-my @databases        = qw( PostgreSQL );
-my $schema           = OpenQA::Schema::connect_db(check => 0);
+my @databases = qw( PostgreSQL );
+my $schema    = OpenQA::Schema::connect_db(check => 0);
 
 if ($prepare_init) {
     my $dh = DBIx::Class::DeploymentHandler->new(

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -32,12 +32,15 @@ my $upgrade_database = 0;
 my $help             = 0;
 my $force            = 0;
 my $user;
+my $default_script_directory = "$FindBin::RealBin/../dbicdh";
+my $script_directory         = $default_script_directory;
 
 my $result = GetOptions(
     "help"             => \$help,
     "prepare_upgrades" => \$prepare_upgrades,
     "upgrade_database" => \$upgrade_database,
     "user=s"           => \$user,
+    "dir=s"            => \$script_directory,
     "force"            => \$force
 );
 
@@ -50,6 +53,8 @@ sub usage {
     print "                       to actually upgrade a database.\n";
     print "  --force            : Force overwriting existing data.\n";
     print "  --user=login       : Change uid before connecting the DB.\n";
+    print "  --dir=directory    : Create deployment and migration scripts in this directory.\n";
+    print "                       Default is '$default_script_directory'\n";
     print "  --help             : This help message.\n";
     exit $_[0];
 }
@@ -68,8 +73,7 @@ if ($user) {
 
 my $schema = OpenQA::Schema::connect_db(check => 0);
 
-my $script_directory = "$FindBin::RealBin/../dbicdh";
-my @databases        = qw( PostgreSQL );
+my @databases = qw( PostgreSQL );
 
 if ($prepare_upgrades) {
     my $dh = DH->new(


### PR DESCRIPTION
I found that our statement coverage analysis showed the
"sqlt_deploy_hook" methods that we have in OpenQA::Schema::Result were
never covered. As I learned from my helpful colleagues these methods are
never called from production code but only if users explicitly trigger
"initdb" or "upgradedb" for schema initialization scripts.

This commit adds a corresponding test to t/deploy.t which triggers the
exact same workflow users would follow for a schema version bump with
the mere difference that the test does not change our source files
directly but works with a schema version environment override and
writing the schema initialization and upgrade files into a temporary
directory. With this all "sqlt_deploy_hook" methods are called and
included in code coverage reports. A simple mutation test in these
methods also fails the test as expected.