### PR TITLE
load_templates: Use ref instead of reftype to avoid Perl warning

### DIFF
--- a/script/load_templates
+++ b/script/load_templates
@@ -74,7 +74,6 @@ use Mojo::URL;
 use OpenQA::Client;
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
-use Scalar::Util qw(reftype);
 
 use Getopt::Long;
 
@@ -135,7 +134,7 @@ sub print_error {
         if (my $json = $res->json) {
             if (my $json_err = $json->{error}) {
                 die "$err->{message}: " . join("\n", @{$json_err})
-                  if reftype $json_err eq 'ARRAY';
+                  if ref $json_err eq 'ARRAY';
                 die "$err->{message}: $json_err";
             }
         }


### PR DESCRIPTION
See https://progress.opensuse.org/issues/80662