### PR TITLE
Distinguish different types of setup failures

### DIFF
--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -75,6 +75,12 @@ use constant WORKER_STOP_REASONS => (
 #       with special semantics/behavior, e.g. affecting the upload and result computation. Other reasons are
 #       always considered special errors leading to incomplete jobs.
 
+# Define error categories used alongside the reasons defined above for finer error handling where needed
+use constant {
+    WORKER_EC_CACHE_FAILURE => 'cache failure',   # the cache service made problems
+    WORKER_EC_ASSET_FAILURE => 'asset failure',   # a problem occurred when handling assets, e.g. an asset was not found
+};
+
 # Time verification to use with the "worker_timeout" configuration.
 # It shouldn't be bigger than the "worker_timeout" configuration.
 use constant MAX_TIMER => 100;
@@ -101,6 +107,7 @@ our @EXPORT_OK = qw(
   WORKER_COMMAND_ABORT WORKER_COMMAND_QUIT WORKER_COMMAND_CANCEL WORKER_COMMAND_OBSOLETE WORKER_COMMAND_LIVELOG_STOP
   WORKER_COMMAND_LIVELOG_START WORKER_COMMAND_DEVELOPER_SESSION_START WORKER_STOP_COMMANDS WORKER_LIVE_COMMANDS WORKER_COMMANDS
   WORKER_SR_SETUP_FAILURE WORKER_SR_API_FAILURE WORKER_SR_TIMEOUT WORKER_SR_BROKEN WORKER_SR_DONE WORKER_SR_DIED WORKER_STOP_REASONS
+  WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE
   WORKER_API_COMMANDS WORKER_COMMAND_GRAB_JOB WORKER_COMMAND_GRAB_JOBS WORKER_COMMANDS
   MAX_TIMER MIN_TIMER
   DEFAULT_MAX_JOB_TIME

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -49,6 +49,7 @@ use constant BASE_STATEFILE      => 'base_state.json';
 # define accessors for public read-only properties
 sub status                    { shift->{_status} }
 sub setup_error               { shift->{_setup_error} }
+sub setup_error_category      { shift->{_setup_error_category} }
 sub id                        { shift->{_id} }
 sub name                      { shift->{_name} }
 sub settings                  { shift->{_settings} }
@@ -258,6 +259,7 @@ sub start {
         return undef if $self->is_stopped_or_stopping;
 
         log_error("Unable to setup job $id: $setup_error");
+        $self->{_setup_error_category} = $engine->{category} // WORKER_SR_SETUP_FAILURE;
         return $self->stop(WORKER_SR_SETUP_FAILURE);
     }
 
@@ -537,7 +539,7 @@ sub _format_reason {
     my ($self, $result, $reason) = @_;
 
     # format stop reasons from the worker itself
-    return "setup failure: $self->{_setup_error}" if $reason eq WORKER_SR_SETUP_FAILURE;
+    return "$self->{_setup_error_category}: $self->{_setup_error}" if $reason eq WORKER_SR_SETUP_FAILURE;
     if ($reason eq WORKER_SR_API_FAILURE) {
         my $last_client_error = $self->client->last_error;
         return $last_client_error ? "api failure: $last_client_error" : 'api failure';


### PR DESCRIPTION
* Use `asset failure: …` if an asset could not be downloaded by the cache
  service due to an 4xx error
* Use `asset failure: …` if an asset can not be located locally if the
  cache service is disabled
* Use `cache failure: …` if the cache service returned an error
* Keep  using `setup failure: …` in other cases, e.g. isotovideo can not be
  started
* See https://progress.opensuse.org/issues/80202#note-15