### PR TITLE
Clarify caveats with custom job hooks after 6cf76ae8b

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -789,6 +789,33 @@ job_done_hook_incomplete = env host=openqa.example.com /opt/openqa-scripts/openq
 job_done_hook_failed = env host=openqa.example.com /opt/openqa-scripts/openqa-label-known-issues-hook
 ```
 
+The environment variable should be set in a systemd service override for the
+GRU service. A corresponding systemd override file
+`/etc/systemd/system/openqa-gru.service.d/override.conf` could look like this:
+
+```
+[Service]
+Environment="OPENQA_JOB_DONE_HOOK_INCOMPLETE=/opt/os-autoinst-scripts/openqa-label-known-issues-hook"
+```
+
+When using `apparmor` the called hook scripts must be covered by according
+`apparmor` rules, for example for the above in
+`/etc/apparmor.d/usr.share.openqa.script.openqa`:
+
+```
+  /opt/os-autoinst-scripts/** rix,
+  /usr/bin/cat rix,
+  /usr/bin/curl rix,
+  /usr/bin/jq rix,
+  /usr/bin/mktemp rix,
+  /usr/share/openqa/script/client rix,
+```
+
+Any stderr output of the hook scripts should be visible in the system logs of
+the openQA GRU service, the general status and any stdout output is visible in
+the GRU minion job dashboard on the route
+`/minion/jobs?offset=0&task=finalize_job_results` of the openQA instance.
+
 == Auditing - tracking openQA changes
 [id="auditing"]
 

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -137,7 +137,8 @@ sub read_config {
         'assets/storage_duration' => {
             # intentionally left blank for overview
         },
-    );
+        # allow dynamic config keys based on job results
+        hooks => {});
 
     # in development mode we use fake auth and log to stderr
     my %mode_defaults = (

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -32,7 +32,7 @@ use Test::Warnings ':report_warnings';
 use Mojo::File qw(path tempdir);
 use Mojo::IOLoop::ReadWriteProcess;
 use OpenQA::Test::Utils qw(collect_coverage_of_gru_jobs redirect_output);
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '40';
 use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;
 use OpenQA::Parser::Result::Output;


### PR DESCRIPTION
As it turned out reading job hook settings from configuration does not
work for a separate GRU service. Likely because this service never reads
the config file /etc/openqa/openqa.ini . Hence it is questionable if we
want to support reading from the generic config file considering that
the GRU service is standalone and can be run in a separate environment,
e.g. a separate host or container.

This commit removes the ineffective code for reading the config settings
and also clarifies some further caveats in the documentation, e.g.
apparmor rules as well as where the overall status can be found.

Related progress issue: https://progress.opensuse.org/issues/80736