### PR TITLE
Clone incompletes caused by cache service errors automatically

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -816,6 +816,17 @@ the openQA GRU service, the general status and any stdout output is visible in
 the GRU minion job dashboard on the route
 `/minion/jobs?offset=0&task=finalize_job_results` of the openQA instance.
 
+=== Automatic cloning of incomplete jobs
+
+By default, when a worker reports an incomplete job due to a cache service related
+problem, the job is automatically cloned. It is possible to extend the regex to cover
+other types of incompletes as well by adjusting `auto_clone_regex` in the `global`
+section of the config file. It is also possible to assign `0` to prevent the automatic
+cloning.
+
+Note that jobs marked as incomplete by the stale job detection are not affected by this
+configuration and cloned in any case.
+
 == Auditing - tracking openQA changes
 [id="auditing"]
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -71,6 +71,10 @@
 ## Gracefully restart the prefork workers if they reach a certain memory limit (in kB)
 #max_rss_limit = 180000
 
+## Causes jobs reported as incomplete by the worker to be cloned automatically when the
+## reason matches; set to 0 to disable
+#auto_clone_regex = ^cache failure:
+
 #[scm git]
 # name of remote to get updates from before commiting changes (e.g. origin, leave out-commented to disable remote update)
 #update_remote = origin

--- a/t/config.t
+++ b/t/config.t
@@ -28,7 +28,6 @@ use OpenQA::JobGroupDefaults;
 use OpenQA::Task::Job::Limit;
 use Mojo::File 'tempdir';
 
-
 sub read_config {
     my ($app, $msg) = @_;
     $msg //= 'reading config from default';
@@ -128,6 +127,7 @@ subtest 'Test configuration default modes' => sub {
     # Test configuration generation with "test" mode
     $test_config->{_openid_secret} = $config->{_openid_secret};
     $test_config->{logging}->{level} = "debug";
+    is ref delete $config->{global}->{auto_clone_regex}, 'Regexp', 'auto_clone_regex parsed as regex';
     is_deeply $config, $test_config, '"test" configuration';
 
     # Test configuration generation with "development" mode
@@ -135,6 +135,7 @@ subtest 'Test configuration default modes' => sub {
     $app->mode("development");
     $config = read_config($app, 'reading config from default with mode development');
     $test_config->{_openid_secret} = $config->{_openid_secret};
+    delete $config->{global}->{auto_clone_regex};
     is_deeply $config, $test_config, 'right "development" configuration';
 
     # Test configuration generation with an unknown mode (should fallback to default)
@@ -143,6 +144,7 @@ subtest 'Test configuration default modes' => sub {
     $config                        = read_config($app, 'reading config from default with mode foo_bar');
     $test_config->{_openid_secret} = $config->{_openid_secret};
     $test_config->{auth}->{method} = "OpenID";
+    delete $config->{global}->{auto_clone_regex};
     delete $test_config->{logging};
     is_deeply $config, $test_config, 'right default configuration';
 };


### PR DESCRIPTION
* It is possible to configure the regex being used
* It is possible to disable this kind of automatic cloning
* See https://progress.opensuse.org/issues/80202#note-15

---

* ~~Based on https://github.com/os-autoinst/openQA/pull/3618 which could be reviewed individually first~~ rebased on master after #3618 was merged
* See last commit for only the additional change
