### PR TITLE
docker: Include the current web UI build alternatives

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -32,11 +32,18 @@ The Dockerfiles included in this project are for openSUSE:
 
     # Fedora and docker-compose
     docker build -t openqa_data ./openqa_data
-    docker build -t openqa_webui ./webui
     docker build -t openqa_worker ./worker
+
+    # Fedora
+    docker build -t openqa_webui ./webui
+
+    # Fedora providing SSL certificates
+    docker build -f webui/Dockerfile-ssl -t openqa_webui ./webui
+    # NOTE: you must provide in the same directory the servcer.crt, server.key and ca.crt
 
     # docker-compose only
     docker build -f webui/Dockerfile-lb -t openqa_webui_lb ./webui
+    docker build -f webui/Dockerfile-no-apache -t openqa_webui ./webui
 
 # Running openQA
 

--- a/docker/webui/Dockerfile-no-apache
+++ b/docker/webui/Dockerfile-no-apache
@@ -7,16 +7,8 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/op
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in ca-certificates-mozilla curl && \
-    zypper --non-interactive in --force-resolution openQA-local-db apache2 hostname which w3m
+    zypper --non-interactive in --force-resolution openQA-local-db hostname which w3m
 
-# setup apache
-RUN gensslcert && \
-    a2enmod headers && \
-    a2enmod proxy && \
-    a2enmod proxy_http && \
-    a2enmod proxy_wstunnel && \
-    a2enmod rewrite
-ADD openqa.conf /etc/apache2/vhosts.d/openqa.conf
 ADD run_openqa.sh /root/
 
 # set-up shared data and configuration

--- a/docker/webui/Dockerfile-ssl
+++ b/docker/webui/Dockerfile-ssl
@@ -15,7 +15,13 @@ RUN gensslcert && \
     a2enmod proxy && \
     a2enmod proxy_http && \
     a2enmod proxy_wstunnel && \
-    a2enmod rewrite
+    a2enmod ssl && \
+    a2enmod rewrite && \
+    a2enflag SSL
+ADD openqa-ssl.conf /etc/apache2/vhosts.d/openqa-ssl.conf
+ADD server.crt /etc/apache2/ssl.crt/server.crt
+ADD server.key /etc/apache2/ssl.crt/server.key
+ADD ca.crt /etc/apache2/ssl.crt/ca.crt
 ADD openqa.conf /etc/apache2/vhosts.d/openqa.conf
 ADD run_openqa.sh /root/
 


### PR DESCRIPTION
Currently the web UI can be compiled in three different ways,
to be used with all its services in the same container using
apache as a reverse proxy with or without SSL certificate,
or with its services separately to be used with nginx as a
reverse proxy for example in the docker-compose case.

This PR provides a docker file for each of the different models.

https://progress.opensuse.org/issues/80520