### PR TITLE
docker: Add a test for openQA workers containers

### DIFF
--- a/.circleci/ci-packages.txt
+++ b/.circleci/ci-packages.txt
@@ -256,3 +256,4 @@ python3-setuptools-40.5.0
 python3-yamllint-1.22.1
 ShellCheck-0.7.1
 sqlite3-3.28.0
+docker

--- a/t/46-worker-container.t
+++ b/t/46-worker-container.t
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+use File::Copy;
+use File::Temp qw/ tempdir /;
+
+my $dir = tempdir( CLEANUP => 1 );
+copy("./t/data/workers.ini", "$dir/workers.ini") or die "Copy failed: $!";
+
+is(system('docker', 'build', '-t', 'openqa_worker', 'docker/worker'), 0, 'worker container image can be built');
+is(system("docker run -t -v $dir/workers.ini:/data/conf/workers.ini openqa_worker | grep 'worker connecting'"), 0, 'worker container starts');
+
+done_testing();


### PR DESCRIPTION
This PR add a test for the openQA workers containers

The current execution with an appropriate environment and configuration
is

```
[info] [pid:21] worker 1:
 - config file:           /etc/openqa/workers.ini
 - worker hostname:       f2fa029ca2ae
 - isotovideo version:    20
 - websocket API version: 1
 - web UI hosts:          http://localhost:9526
 - class:                 qemu_i386,qemu_x86_64
 - no cleanup:            no
 - pool directory:        /var/lib/openqa/pool/1
API key and secret are needed for the worker connecting
http://localhost:9526
```

The test probes that the container image can be build and can be used
deploying a worker. But because the is not a web UI is going to fail
in the execution. The test checks that show some part of this information

https://progress.opensuse.org/issues/80682