### PR TITLE
Allow configuring the worker to terminate after all jobs have been processed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,10 @@ install-generic:
 	for i in systemd/*.{service,target,timer}; do \
 		install -m 644 $$i "$(DESTDIR)"/usr/lib/systemd/system ;\
 	done
-	sed -e 's_^\(ExecStart=/usr/share/openqa/script/worker\) \(--instance %i\)$$_\1 --no-cleanup \2_' \
-		systemd/openqa-worker@.service \
-		> "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
-	sed -i '/Wants/aConflicts=openqa-worker@.service' \
-		"$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
+	sed \
+		-e 's_^\(ExecStart=/usr/share/openqa/script/worker\) \(--instance %i\)$$_\1 --no-cleanup \2_' \
+		-e '/Wants/aConflicts=openqa-worker@.service' \
+		systemd/openqa-worker@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf
 	install -m 644 systemd/tmpfiles-openqa-webui.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa-webui.conf

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ install-generic:
 		-e 's_^\(ExecStart=/usr/share/openqa/script/worker\) \(--instance %i\)$$_\1 --no-cleanup \2_' \
 		-e '/Wants/aConflicts=openqa-worker@.service' \
 		systemd/openqa-worker@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
+	sed \
+		-e '/Type/aEnvironment=OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE=1' \
+		-e 's/Restart=on-failure/Restart=always/' \
+		-e '/Wants/aConflicts=openqa-worker@.service' \
+		systemd/openqa-worker@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-auto-restart@.service
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf
 	install -m 644 systemd/tmpfiles-openqa-webui.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa-webui.conf

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -565,6 +565,7 @@ fi
 %{_unitdir}/openqa-worker-cacheservice-minion.service
 %{_unitdir}/openqa-worker-cacheservice.service
 %{_unitdir}/openqa-worker-no-cleanup@.service
+%{_unitdir}/openqa-worker-auto-restart@.service
 %{_unitdir}/openqa-slirpvde.service
 %{_unitdir}/openqa-vde_switch.service
 %{_datadir}/openqa/script/openqa-slirpvde

--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -25,6 +25,13 @@
 # system.
 #LOCAL_UPLOAD = 0
 
+# Whether to terminate after all assigned jobs have been processed. When
+# combined with auto-restarting on service manager level (e.g. configuring
+# Restart=always in the systemd service) this helps applying updates and config
+# changes without interrupting jobs. This setting can be overridden by setting
+# the environment variable OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE.
+#TERMINATE_AFTER_JOBS_DONE = 0
+
 # Enable an investigation feature to compare the current list of installed
 # packages against the list of packages during the previous last good job.
 # Configuring this variable provides a command line to list the packages and

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -188,6 +188,7 @@ sub accept {
         sub {
             $self->_set_status(accepted => {});
         });
+    return 1;
 }
 
 sub _compute_max_job_time {
@@ -313,6 +314,7 @@ sub skip {
     $reason //= 'skipped';
     $self->_set_status(stopping => {reason => $reason});
     $self->_stop_step_5_finalize($reason, {result => OpenQA::Jobs::Constants::SKIPPED});
+    return 1;
 }
 
 sub stop {

--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -52,6 +52,7 @@ sub new {
 
     # read global settings from environment variables
     $global_settings{LOG_DIR} = $ENV{OPENQA_WORKER_LOGDIR} if $ENV{OPENQA_WORKER_LOGDIR};
+    $global_settings{TERMINATE_AFTER_JOBS_DONE} //= $ENV{OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE};
 
     # read global settings specified via CLI arguments
     $global_settings{LOG_LEVEL} = 'debug' if $cli_options->{verbose};

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -23,7 +23,8 @@ use OpenQA::Worker::Settings;
 use OpenQA::Worker::App;
 use Test::MockModule;
 
-$ENV{OPENQA_CONFIG} = "$FindBin::Bin/data/24-worker-settings";
+$ENV{OPENQA_CONFIG}                           = "$FindBin::Bin/data/24-worker-settings";
+$ENV{OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE} = 1;
 
 my $settings = OpenQA::Worker::Settings->new;
 
@@ -36,6 +37,7 @@ is_deeply(
         LOG_DIR                   => 'log/dir',
         RETRY_DELAY               => 5,
         RETRY_DELAY_IF_WEBUI_BUSY => 60,
+        TERMINATE_AFTER_JOBS_DONE => 1,
     },
     'global settings, spaces trimmed'
 ) or diag explain $settings->global_settings;
@@ -58,6 +60,8 @@ is_deeply(
     },
     'web UI host specific settings'
 ) or diag explain $settings->webui_host_specific_settings;
+
+delete $ENV{OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE};
 
 subtest 'apply settings to app' => sub {
     my ($setup_log_called, $setup_log_app);
@@ -87,6 +91,7 @@ subtest 'instance-specific settings' => sub {
             LOG_DIR                   => 'log/dir',
             RETRY_DELAY               => 5,
             RETRY_DELAY_IF_WEBUI_BUSY => 60,
+            TERMINATE_AFTER_JOBS_DONE => undef,
         },
         'global settings (instance 1)'
     ) or diag explain $settings1->global_settings;
@@ -102,6 +107,7 @@ subtest 'instance-specific settings' => sub {
             FOO                       => 'bar',
             RETRY_DELAY               => 10,
             RETRY_DELAY_IF_WEBUI_BUSY => 120,
+            TERMINATE_AFTER_JOBS_DONE => undef,
         },
         'global settings (instance 2)'
     ) or diag explain $settings2->global_settings;


### PR DESCRIPTION
See https://progress.opensuse.org/issues/80986

Besides the unit tests I've also conducted 2 full test runs (one with and one without the configuration) and both worked as expected.