### PR TITLE
Avoid worker from appearing stuck (e.g. not reacting to SIGTERM) on cache check

### DIFF
--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -195,6 +195,7 @@ subtest 'status' => sub {
 
     $worker->current_job(undef);
     $worker->settings->global_settings->{CACHEDIRECTORY} = 'foo';
+    $worker->configure_cache_client;
     my $worker_status;
     combined_like { $worker_status = $worker->status }
     qr/Worker cache not available: Cache service info error: Connection refused/, 'worker cache error logged';
@@ -209,6 +210,7 @@ subtest 'status' => sub {
     );
 
     delete $worker->settings->global_settings->{CACHEDIRECTORY};
+    $worker->configure_cache_client;
 };
 
 subtest 'accept or skip next job' => sub {


### PR DESCRIPTION
When the worker checks for the availability of the cache service the normal
behavior of the cache service client is applied (huge number of attempts,
high inactivity timeout). This is not nice for the availability check
because it leads to the worker getting stuck and not even reacting to
signals.

---

By the way, to reproduce this, just configure the worker to use the cache
service but don't start it. Then you can not stop the worker via `Ctrl+C`.