### PR TITLE
Install qemu-hw-display-virtio-gpu-pci in openqa-bootstrap

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -23,6 +23,11 @@ if [ "$(uname -m)" = "aarch64" ]; then
     zypper -n install --no-recommends qemu-uefi-aarch64
 fi
 
+# this was split into a separate package on newer dist versions - so install it if available
+if zypper -n search -x qemu-hw-display-virtio-gpu-pci ; then
+    zypper -n install --no-recommends qemu-hw-display-virtio-gpu-pci
+fi
+
 
 # setup database
 systemctl enable --now postgresql


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/81064

qemu-hw-display-virtio-gpu-pci is not required but only recommended.
So it needs to be explicitly installed.