### PR TITLE
Refine check for error message about immediately pruned assets

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -160,7 +160,7 @@ sub cache_assets {
             # an already enqueued Minion job or if the pruning happened within
             # a completely different asset download.
             $error .= '. Asset was pruned immediately after download (poo#71827), please retrigger'
-              if $msg =~ /Purging.*$asset_uri/;
+              if $msg =~ /Purging.*$asset_uri.*because we need space for new assets/;
             log_error($error, channels => 'autoinst');
             return {error => $error};
         }


### PR DESCRIPTION
* The check has been introduced with
  https://github.com/os-autoinst/openQA/pull/3418 in order to match
  messages like
  ```
  Purging "…" because we need space for new assets, reclaiming …
  ```
* See https://progress.opensuse.org/issues/71827#note-11
* The regex it too generic and therefore matches in unrelated cases, e.g.:
  ```
  Purging "…" because of too many download errors
  ```
* See https://progress.opensuse.org/issues/81022#note-5 as well