### PR TITLE
Improve worker tests

### DIFF
--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -48,7 +48,7 @@ BEGIN {
 our (@EXPORT, @EXPORT_OK);
 @EXPORT_OK = (
     qw(mock_service_ports setup_mojo_app_with_default_worker_timeout),
-    qw(redirect_output standard_worker create_user_for_workers),
+    qw(redirect_output create_user_for_workers),
     qw(create_webapi create_websocket_server create_scheduler create_live_view_handler),
     qw(unresponsive_worker broken_worker rejective_worker setup_share_dir setup_fullstack_temp_dir run_gru_job),
     qw(collect_coverage_of_gru_jobs stop_service start_worker unstable_worker fake_asset_server),
@@ -482,12 +482,6 @@ sub unstable_worker {
     return $h;
 }
 
-sub standard_worker {
-    my ($apikey, $apisecret, $host, $instance) = @_;
-
-    note("Starting standard worker. Instance: $instance for host $host");
-    c_worker($apikey, $apisecret, $host, $instance, 0);
-}
 sub unresponsive_worker {
     my ($apikey, $apisecret, $host, $instance) = @_;
 

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -474,9 +474,9 @@ sub unstable_worker {
             Mojo::IOLoop->singleton->one_tick for (0 .. $ticks);
         }
         Devel::Cover::report() if Devel::Cover->can('report');
-        if ($sleep) {
-            1 while sleep $sleep;
-        }
+        if ($sleep) {    # uncoverable statement
+            1 while sleep $sleep;    # uncoverable statement
+        }    # uncoverable statement
     };
     sleep $sleep if $sleep;
     return $h;


### PR DESCRIPTION
See particular commit messages and https://github.com/os-autoinst/openQA/pull/3646#issuecomment-746967848

I wasn't able to fix the coverage for the `c_worker` function. Somehow the coverage collection via `Devel::Cover::report() if Devel::Cover->can('report');` doesn't work. (Increasing the time before we send `SIGKILL` didn't work.)