### PR TITLE
Override TERMINATE_AFTER_JOBS_DONE setting from environment variable

### DIFF
--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -51,8 +51,9 @@ sub new {
     }
 
     # read global settings from environment variables
-    $global_settings{LOG_DIR} = $ENV{OPENQA_WORKER_LOGDIR} if $ENV{OPENQA_WORKER_LOGDIR};
-    $global_settings{TERMINATE_AFTER_JOBS_DONE} //= $ENV{OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE};
+    for my $var (qw(LOG_DIR TERMINATE_AFTER_JOBS_DONE)) {
+        $global_settings{$var} = $ENV{"OPENQA_WORKER_$var"} if ($ENV{"OPENQA_WORKER_$var"} // '') ne '';
+    }
 
     # read global settings specified via CLI arguments
     $global_settings{LOG_LEVEL} = 'debug' if $cli_options->{verbose};

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -91,7 +91,6 @@ subtest 'instance-specific settings' => sub {
             LOG_DIR                   => 'log/dir',
             RETRY_DELAY               => 5,
             RETRY_DELAY_IF_WEBUI_BUSY => 60,
-            TERMINATE_AFTER_JOBS_DONE => undef,
         },
         'global settings (instance 1)'
     ) or diag explain $settings1->global_settings;
@@ -107,7 +106,6 @@ subtest 'instance-specific settings' => sub {
             FOO                       => 'bar',
             RETRY_DELAY               => 10,
             RETRY_DELAY_IF_WEBUI_BUSY => 120,
-            TERMINATE_AFTER_JOBS_DONE => undef,
         },
         'global settings (instance 2)'
     ) or diag explain $settings2->global_settings;


### PR DESCRIPTION
* and not vice verca; environment settings should have precedence unless
  they are empty.
* This is also consistent with how it is already documented.
* This change also prevents the following warning showing up in the
  fullstack test:
  ```
  [10:23:04] t/full-stack.t .. 16/? Use of uninitialized value $vars{"TERMINATE_AFTER_JOBS_DONE"} in concatenation (.) or string at /home/squamata/project/script/../lib/OpenQA/Worker/Engines/isotovideo.pm line 314.
  ```