### PR TITLE
worker: Fix clearing current error on status updates when idling

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -223,6 +223,7 @@ sub status {
     }
     else {
         $status{status} = 'free';
+        $self->current_error(undef);
     }
     my $pending_job_ids = $self->{_pending_job_ids};
     $status{pending_job_ids} = $pending_job_ids if keys %$pending_job_ids;


### PR DESCRIPTION
* Fix regression of d3d33b54affa617d9c54a2eac40804d9d1da2f51
* See https://progress.opensuse.org/issues/81228