### PR TITLE
RFC: never query isotovideo interface version

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -18,7 +18,8 @@ package OpenQA::Worker::Engines::isotovideo;
 use strict;
 use warnings;
 
-use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE WORKER_SR_DIED);
+use OpenQA::Constants
+  qw(WEBSOCKET_API_VERSION WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE WORKER_SR_DIED);
 use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle);
 use OpenQA::Utils qw(asset_type_from_setting base_host locate_asset);
 use POSIX qw(:sys_wait_h strftime uname _exit);
@@ -52,10 +53,8 @@ sub set_engine_exec {
         # save the absolute path as we chdir later
         $isotovideo = abs_path($path);
     }
-    if (-f $isotovideo && qx(perl $isotovideo --version) =~ /interface v(\d+)/) {
-        return $1;
-    }
-    return 0;
+    # Historically we would query the version from isotovideo, but we just return the expected version
+    return -f $isotovideo ? WEBSOCKET_API_VERSION : 0;
 }
 
 sub _kill($) {

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -18,7 +18,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';
-use OpenQA::Constants 'WORKER_EC_ASSET_FAILURE';
+use OpenQA::Constants qw(WEBSOCKET_API_VERSION WORKER_EC_ASSET_FAILURE);
 use Test::Fatal;
 use Test::Warnings ':report_warnings';
 use OpenQA::Worker;
@@ -58,7 +58,7 @@ subtest 'isotovideo version' => sub {
 
     my $isotovideo = path($FindBin::Bin)->child('fake-isotovideo.pl');
     my $worker2 = OpenQA::Worker->new({apikey => 'foo', apisecret => 'bar', instance => 1, isotovideo => $isotovideo});
-    is($worker2->isotovideo_interface_version, 15, 'isotovideo version set from os-autoinst');
+    is($worker2->isotovideo_interface_version, WEBSOCKET_API_VERSION, 'isotovideo version set from os-autoinst');
 };
 
 subtest 'asset settings' => sub {


### PR DESCRIPTION
- Querying the version has the same overhead as executing a job
- We don't use the version except to display it
- isotovideo already logs the version

I just prepared this PR since I had tested out briefly to see what the difference was. It's possible that I missed something. But I figure I might as well share it. I suspect I'll learn something from it either way.