### PR TITLE
Add service files to restart worker after config changes without interrupting running jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ install-generic:
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -d -m 755 "$(DESTDIR)"/usr/lib/tmpfiles.d
-	for i in systemd/*.{service,target,timer}; do \
+	for i in systemd/*.{service,target,timer,path}; do \
 		install -m 644 $$i "$(DESTDIR)"/usr/lib/systemd/system ;\
 	done
 	sed \

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -566,6 +566,8 @@ fi
 %{_unitdir}/openqa-worker-cacheservice.service
 %{_unitdir}/openqa-worker-no-cleanup@.service
 %{_unitdir}/openqa-worker-auto-restart@.service
+%{_unitdir}/openqa-reload-worker-auto-restart@.service
+%{_unitdir}/openqa-reload-worker-auto-restart@.path
 %{_unitdir}/openqa-slirpvde.service
 %{_unitdir}/openqa-vde_switch.service
 %{_datadir}/openqa/script/openqa-slirpvde

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -588,6 +588,9 @@ package provides further systemd units:
 ** Stops/restarts *all* worker units when stopped/restarted.
 ** Is restarted automatically when the `openQA-worker` package is updated
    (unless `DISABLE_RESTART_ON_UPDATE="yes"` is set in `/etc/sysconfig/services`).
+* `openqa-reload-worker-auto-restart@.path`: allows to restart the worker service
+  automatically on configuration changes without interrupting jobs (see next
+  section for details)
 
 ==== Stopping/restarting workers without interrupting currently running jobs
 It is possible to stop a worker as soon as it becomes idle and immediately if it
@@ -603,6 +606,11 @@ ongoing testing. Example:
 --------------------------------------------------------------------------------
 systemctl kill --signal SIGHUP 'openqa-worker-auto-restart@*.service'
 --------------------------------------------------------------------------------
+
+There is also the systemd unit `openqa-reload-worker-auto-restart@.path` which
+invokes the command above (for the specified slot) whenever the worker configuration
+under `/etc/openqa/workers.ini` changes. This unit is not enabled by default and
+only affects `openqa-worker-auto-restart@.service` but not other worker services.
 
 === Configuring remote workers
 

--- a/systemd/openqa-reload-worker-auto-restart@.path
+++ b/systemd/openqa-reload-worker-auto-restart@.path
@@ -1,0 +1,4 @@
+# see https://www.freedesktop.org/software/systemd/man/systemd.path.html#PathExists=
+
+[Path]
+PathChanged=/etc/openqa/workers.ini

--- a/systemd/openqa-reload-worker-auto-restart@.service
+++ b/systemd/openqa-reload-worker-auto-restart@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Restarts openqa-worker-auto-restart@%i.service as soon as possible without interrupting jobs
+
+[Service]
+Type=oneshot
+ExecStart=systemctl kill --signal SIGHUP openqa-worker-auto-restart@%i.service
+Slice=openqa-worker.slice


### PR DESCRIPTION
* As long as e.g. `openqa-soft-restart-worker@1.path` is running
  the worker started via the corresponding service unit
  `openqa-worker-auto-restart@1.service` is restarted as soon as it
  becomes idle (and immediately if it is already idling) when
  `/etc/openqa/workers.ini` is edited.
* See https://progress.opensuse.org/issues/80910
  and https://progress.opensuse.org/issues/80908#note-8

---

* ~~We could actually also watch for a packaged file so it would also apply
  to package updates.~~ Maybe that's better done on RPM level as suggested in https://progress.opensuse.org/issues/80908#note-8 (point 2.)?
* Then we could also get rid of `OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE=1`
  in the auto-restart service file.
