### PR TITLE
fetchneedles: Do a quiet git reset to avoid log spam

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -58,7 +58,7 @@ git_update() {
     git gc --auto --quiet
     git fetch -q origin
     # Clear any uncommitted changes that would prevent a rebase
-    [ "$force" = 1 ] && git reset --hard HEAD
+    [ "$force" = 1 ] && git reset -q --hard HEAD
     git rebase -q origin/"$branch" || fail 'Use force=1 to discard uncommitted changes before rebasing'
 }
 


### PR DESCRIPTION
Follow-up for #3658

See: https://progress.opensuse.org/issues/81180