### PR TITLE
Make worker depend on network-online.target to avoid networking errors

### DIFF
--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -4,8 +4,8 @@
 # replace '1' with the instance number you want
 [Unit]
 Description=openQA Worker #%i
-Wants=network.target
-After=openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
+Wants=network-online.target
+After=openqa-slirpvde.service network-online.target nss-lookup.target remote-fs.target
 PartOf=openqa-worker.target
 
 [Service]


### PR DESCRIPTION
* This hopefully avoids the worker being stuck with the error
  "Address family for hostname not supported"
  (see https://progress.opensuse.org/issues/78390#note-38)
* According to the documentation "its primary purpose is network client
  software that cannot operate without network"; I suppose our worker falls
  into that category
  (from https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget)