### PR TITLE
client: Log what config file is being read

### DIFF
--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -16,6 +16,8 @@
 package OpenQA::UserAgent;
 use Mojo::Base 'Mojo::UserAgent';
 
+use OpenQA::Log 'log_info';
+
 use Mojo::Util 'hmac_sha1_sum';
 use Config::IniFiles;
 use Scalar::Util ();
@@ -38,6 +40,7 @@ sub new {
         for my $path (@cfgpaths) {
             my $file = $path . '/client.conf';
             next unless $file && -r $file;
+            log_info("Reading config from $file");
             my $cfg = Config::IniFiles->new(-file => $file) || last;
             last unless $cfg->SectionExists($args{api});
             for my $i (qw(key secret)) {


### PR DESCRIPTION
When trying to debug why e.g. `/etc/openqa/client.conf` is not working it might be because `~/.config/openqa/client.conf` takes precedence. That could be seen more easily if we print the filename verbosely.

See: [poo#820670](https://progress.opensuse.org/issues/820670)