### PR TITLE
clone-custom-git-refspec: Call clone-job from same install

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -135,7 +135,9 @@ Please try 'curl $json_url' or select another job, e.g. in the same scenario: $h
     local casedir="${casedir:-"$repo#$branch"}"
     local GROUP="${GROUP:-0}"
     local dry_run="${dry_run:-""}"
-    local cmd="$dry_run openqa-clone-job $clone_args \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST=\"$test\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\""
+    local scriptdir
+    scriptdir=$(dirname "${BASH_SOURCE[0]}")
+    local cmd="$dry_run $scriptdir/openqa-clone-job $clone_args \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST=\"$test\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\""
     [[ ${#args[@]} -ne 0 ]] && cmd=$cmd"$(printf " '%s'" "${args[@]}")"
     if [[ -n "$MARKDOWN" ]]; then
         eval "$cmd" | sed 's/^Created job.*: \([^ ]*\) -> \(.*\)$/* [\1](\2)/'


### PR DESCRIPTION
I spent a little while being confused why a change wasn't working like I expected. Turns out clone-custom-refspec relies on the system path.

I would expect all commands calling into each other to be from the same install. Which is predictable. And avoids potential incompatibilities.