### PR TITLE
doc: Avoid calling the worker instance number 'worker id'

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -457,8 +457,8 @@ systemctl start openqa-worker@1
 --------------------------------------------------------------------------------
 
 This will start worker number one. You can start as
-many workers as you dare, you just need to supply different 'worker id' (number
-after @).
+many workers as you dare, you just need to supply different 'instance number'
+(the number after `@`).
 
 You can also run workers manually from command line.
 


### PR DESCRIPTION
This number is called instance number in accordance with the workers help
and command line options. The instance number has nothing to do with the
worker IDs used by the web UI to track workers.