### PR TITLE
CloneJob: Set log level depending on verbose switch

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -49,6 +49,7 @@ sub is_global_setting {
 sub clone_job_apply_settings {
     my ($argv, $depth, $settings, $options) = @_;
 
+    $ENV{MOJO_LOG_LEVEL} = 'debug' if $options->{verbose};
     delete $settings->{NAME};         # usually autocreated
     $settings->{is_clone_job} = 1;    # used to figure out if this is a clone operation
 

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -16,6 +16,8 @@
 package OpenQA::UserAgent;
 use Mojo::Base 'Mojo::UserAgent';
 
+use OpenQA::Log 'log_info';
+
 use Mojo::Util 'hmac_sha1_sum';
 use Config::IniFiles;
 use Scalar::Util ();
@@ -38,6 +40,7 @@ sub new {
         for my $path (@cfgpaths) {
             my $file = $path . '/client.conf';
             next unless $file && -r $file;
+            log_info("Reading config from $file");
             my $cfg = Config::IniFiles->new(-file => $file) || last;
             last unless $cfg->SectionExists($args{api});
             for my $i (qw(key secret)) {


### PR DESCRIPTION
Also, add tests with and without verbose, to confirm the script is silent or reports settings and config filename.

See: https://progress.opensuse.org/issues/88053