### PR TITLE
fullstack: Improve error/subtest handling

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -121,9 +121,9 @@ sub start_worker_and_schedule {
 sub autoinst_log { path($resultdir, '00000', sprintf("%08d", shift) . "-$job_name")->child('autoinst-log.txt') }
 
 start_worker_and_schedule;
-ok wait_for_job_running($driver), 'test 1 is running';
 
 subtest 'wait until developer console becomes available' => sub {
+    ok wait_for_job_running($driver), 'test 1 is running';
     # open developer console
     $driver->get('/tests/1/developer/ws-console');
     wait_for_developer_console_available($driver);

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -186,11 +186,11 @@ sub wait_for_developer_console_available {
     my ($driver) = @_;
 
     wait_for_or_bail_out {
-        note('waiting for worker to propagate URL for os-autoinst cmd srv');
         $driver->refresh;
         wait_for_ajax(msg => 'developer console available');
         my $console_form = $driver->find_element('#ws_console_form');
         my $text         = $console_form->get_text() // '';
+        note("worker response: $text");
         return $text =~ qr/The command server is not available./ ? 0 : 1;
     }
     'URL for os-autoinst cmd srv', {timeout => 120, interval => 2};


### PR DESCRIPTION
- The subtest fails cleaner if it has a check before the wait
- We can have a more useful message in the wait for the dev console

See: https://progress.opensuse.org/issues/80800

Split off from #3655