### PR TITLE
fullstack: Unify unstable_worker loop and sleep

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -192,7 +192,7 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
 
     # start an unstable worker; it will register itself but ignore any job assignment (also not explicitely reject
     # assignments)
-    @workers = unstable_worker(@$worker_settings, 3, -1);
+    @workers = unstable_worker(@$worker_settings, 3, 'inf');
     wait_for_worker($schema, 5);
     for (1 .. 2) {
         $allocated = scheduler_step();
@@ -207,7 +207,7 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
     stop_workers;
     $jobs->find(99982)->update({state => OpenQA::Jobs::Constants::RUNNING});
 
-    @workers = unstable_worker(@$worker_settings, 3, -1);
+    @workers = unstable_worker(@$worker_settings, 3, 'inf');
     wait_for_worker($schema, 5);
 
     note 'waiting for job to be incompleted';


### PR DESCRIPTION
- Always use IOLOOP, also for indefinite wait
- Clarify the intention of the code
- Sleep unconditionally
- Report coverage at the end

See: https://progress.opensuse.org/issues/80274

Split off from #3655