### PR TITLE
Revert "client: Log what config file is being read"

### DIFF
--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -16,8 +16,6 @@
 package OpenQA::UserAgent;
 use Mojo::Base 'Mojo::UserAgent';
 
-use OpenQA::Log 'log_info';
-
 use Mojo::Util 'hmac_sha1_sum';
 use Config::IniFiles;
 use Scalar::Util ();
@@ -40,7 +38,6 @@ sub new {
         for my $path (@cfgpaths) {
             my $file = $path . '/client.conf';
             next unless $file && -r $file;
-            log_info("Reading config from $file");
             my $cfg = Config::IniFiles->new(-file => $file) || last;
             last unless $cfg->SectionExists($args{api});
             for my $i (qw(key secret)) {


### PR DESCRIPTION
This reverts commit b3ee9d2139dd77d6ad8ddebfb597fd81af7ad9f8. (https://github.com/os-autoinst/openQA/pull/3679)

Issue: https://progress.opensuse.org/issues/88053