### PR TITLE
Revert "Symlink CASEDIR and set values to relative path"

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -139,7 +139,7 @@ sub productdir {
     my ($distri, $version, $rootfortests) = @_;
 
     my $dir = testcasedir($distri, $version, $rootfortests);
-    return $dir . "/products/$distri" if $distri && -e "$dir/products/$distri";
+    return $dir . "/products/$distri" if -e "$dir/products/$distri";
     return $dir;
 }
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -192,18 +192,6 @@ sub _link_asset {
     return $target->to_string;
 }
 
-sub _link_repo {
-    my ($source_dir, $pooldir, $target_name) = @_;
-    $pooldir = path($pooldir);
-    my $target = $pooldir->child($target_name);
-    unlink $target if -e $target;
-    return {error => "The source directory $source_dir does not exist"} unless -e $source_dir;
-    eval { symlink($source_dir, $target) or die qq{Cannot create symlink from "$source_dir" to "$target": $!} };
-    if (my $error = $@) { return {error => $error} }
-    log_debug(qq{Symlinked from "$source_dir" to "$target"});
-    return undef;
-}
-
 # do test caching if TESTPOOLSERVER is set
 sub sync_tests {
     my ($job, $vars, $cache_dir, $webui_host, $rsync_source) = @_;
@@ -338,25 +326,11 @@ sub engine_workit {
         my $error = locate_local_assets(\%vars, $assetkeys);
         return $error if $error;
     }
-    my $casedir     = OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
-    my $productdir  = OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
-    my $target_name = path($casedir)->basename;
 
     $vars{ASSETDIR}   //= OpenQA::Utils::assetdir();
-    $vars{CASEDIR}    //= $target_name;
-    $vars{PRODUCTDIR} //= substr($productdir, rindex($casedir, $target_name));
+    $vars{CASEDIR}    //= OpenQA::Utils::testcasedir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
+    $vars{PRODUCTDIR} //= OpenQA::Utils::productdir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
 
-    if (my $error = _link_repo($casedir, $pooldir, $target_name)) { return $error }
-
-    # if NEEDLES_DIR is an absolute path, it means that users or openqa-clone-custom-git-refspec specify it,
-    # if NEEDLES_DIR is an URL address, it means that users specify it and want to get the needles from URL.
-    # These two scenarios, we do not need to do the symlink.
-    if (   $vars{NEEDLES_DIR}
-        && !File::Spec->file_name_is_absolute($vars{NEEDLES_DIR})
-        && $vars{NEEDLES_DIR} !~ /http(s)?\:\/\//)
-    {
-        if (my $error = _link_repo("$productdir/needles", $pooldir, $vars{NEEDLES_DIR})) { return $error }
-    }
     _save_vars($pooldir, \%vars);
 
     # os-autoinst's commands server

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -26,8 +26,7 @@ use Test::MockModule;
 use Test::MockObject;
 use Test::Output 'combined_like';
 use OpenQA::Worker::Engines::isotovideo;
-use Mojo::File qw(path tempdir);
-use OpenQA::Utils 'testcasedir';
+use Mojo::File 'path';
 
 # define fake packages for testing asset caching
 {
@@ -41,23 +40,7 @@ use OpenQA::Utils 'testcasedir';
     has minion_id => 13;
 }
 
-# Fake worker, client
-{
-    package Test::FakeWorker;
-    use Mojo::Base -base;
-    has instance_number => 1;
-    has settings        => sub { OpenQA::Worker::Settings->new(1, {}) };
-    has pool_directory  => undef;
-}
-{
-    package Test::FakeClient;
-    use Mojo::Base -base;
-    has worker_id  => 1;
-    has webui_host => 'localhost';
-}
-
-$ENV{OPENQA_CONFIG}   = "$FindBin::Bin/data/24-worker-overall";
-$ENV{OPENQA_HOSTNAME} = "localhost";
+$ENV{OPENQA_CONFIG} = "$FindBin::Bin/data/24-worker-overall";
 
 subtest 'isotovideo version' => sub {
     like(
@@ -192,40 +175,6 @@ subtest 'problems when caching assets' => sub {
     is($result->{error},    'Failed to download FOO to some/path', 'asset not found');
     is($result->{category}, WORKER_EC_ASSET_FAILURE, 'category set so problem is treated as asset failure');
 
-};
-
-subtest 'symlink testrepo' => sub {
-    my $worker         = Test::FakeWorker->new;
-    my $client         = Test::FakeClient->new;
-    my $settings       = {DISTRI => 'foo'};
-    my $job            = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
-    my $pool_directory = tempdir('poolXXXX');
-    my $casedir        = testcasedir('foo', undef, undef);
-    $worker->pool_directory($pool_directory);
-    my $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
-    like $result->{error}, qr/The source directory $casedir does not exist/,
-      'symlink failed because the source directory does not exist';
-
-    $settings->{DISTRI} = 'opensuse';
-    $casedir            = testcasedir('opensuse', undef, undef);
-    $job                = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
-    chmod(0444, $pool_directory);
-    $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
-    like $result->{error}, qr/Cannot create symlink from "$casedir" to "$pool_directory\/opensuse": Permission denied/,
-      'symlink failed because permission denied';
-    chmod(0755, $pool_directory);
-
-    delete $settings->{DISTRI};
-    $settings->{NEEDLES_DIR} = 'needles';
-    $casedir                 = testcasedir(undef, undef, undef);
-    $job                     = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
-    $result                  = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
-    like $result->{error}, qr/The source directory $casedir\/needles does not exist/,
-      'symlink needles directory failed because source directory does not exist';
-
-    $casedir = testcasedir('opensuse', undef, undef);
-    $result  = OpenQA::Worker::Engines::isotovideo::_link_repo($casedir, $pool_directory, 'opensuse');
-    is $result, undef, 'create symlink successfully';
 };
 
 done_testing();

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -35,7 +35,6 @@ use OpenQA::Test::Utils
   qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
   qw(stop_service setup_fullstack_temp_dir);
 use OpenQA::Test::TimeLimit '20';
-use OpenQA::Utils 'testcasedir';
 
 BEGIN {
     # set defaults
@@ -117,21 +116,15 @@ sub log_jobs {
     diag("All jobs:\n - " . join("\n - ", @job_info));
 }
 my %job_ids;
-my $distri       = 'opensuse';
-my $version      = 'Factory';
 my @job_settings = (
     BUILD   => '0048@0815',
-    DISTRI  => $distri,
-    VERSION => $version,
+    DISTRI  => 'opensuse',
+    VERSION => 'Factory',
     FLAVOR  => 'tape',
     ARCH    => 'x86_64',
     MACHINE => 'xxx',
 );
 $job_ids{$jobs->create({@job_settings, TEST => "dummy-$_"})->id} = 1 for 1 .. $job_count;
-
-# the casedir must exist before making symlink from casedir to the current working directory
-my $casedir = testcasedir($distri, $version, undef);
-path($casedir)->make_path unless -d $casedir;
 
 my $seconds_to_wait_per_worker = 5.0;
 my $seconds_to_wait_per_job    = 2.5;


### PR DESCRIPTION
Reverts os-autoinst/openQA#3604 due to the report in
https://github.com/os-autoinst/openQA/pull/3604#issuecomment-765888161