### PR TITLE
Update patch for B::Deparse

### DIFF
--- a/.circleci/ci-packages.txt
+++ b/.circleci/ci-packages.txt
@@ -139,7 +139,7 @@ perl-Module-Pluggable-5.2
 perl-Module-Runtime-0.016
 perl-Module-Runtime-Conflicts-0.003
 perl-Mojo-IOLoop-ReadWriteProcess-0.28
-perl-Mojolicious-8.71
+perl-Mojolicious-8.72
 perl-Mojolicious-Plugin-AssetPack-2.10
 perl-Mojolicious-Plugin-OAuth2-1.58
 perl-Mojo-Pg-4.23

--- a/t/lib/OpenQA/Test/PatchDeparse.pm
+++ b/t/lib/OpenQA/Test/PatchDeparse.pm
@@ -9,7 +9,12 @@ use Test::Most;
 
 # This might be fixed in newer versions of perl/B::Deparse
 # We only see a warning when running with Devel::Cover
-if ($B::Deparse::VERSION and $B::Deparse::VERSION eq '1.40') {
+if (
+    $B::Deparse::VERSION
+    and
+    ($B::Deparse::VERSION >= '1.40' and ($B::Deparse::VERSION <= '1.54'))
+  )
+{
 
 #<<<  do not let perltidy touch this
 # This is not our code, and formatting should stay the same for
@@ -39,7 +44,7 @@ no strict 'refs';
 		$i += $kids[$i]->sibling->name eq "unstack" ? 2 : 1);
 	    next;
 	}
-	my $expr2 = $self->deparse($kids[$i], (@kids != 1)/2);
+	my $expr2 = $self->deparse($kids[$i], (@kids != 1)/2) // ''; # prevent undef $expr2
 	$expr2 =~ s/^sub :(?!:)/+sub :/; # statement label otherwise
 	$expr .= $expr2;
 	$callback->($expr, $i);


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/40895

Now also $expr2 seems to be uninitialized.

    Use of uninitialized value $expr2 in concatenation (.) or string at /home/squamata/project/t/lib/OpenQA/Test/PatchDeparse.pm line 44.
    Use of uninitialized value $expr2 in substitution (s///) at /home/squamata/project/t/lib/OpenQA/Test/PatchDeparse.pm line 43.

Also update the version to 1.54 (perl 5.32.0) since the sub hasn't changed.