### PR TITLE
Return size of symlink (and not its target) when deleting job results

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright (C) 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1157,10 +1157,9 @@ sub modules_with_job_prefetched {
 
 sub _delete_returning_size {
     my ($file_path) = @_;
-    my $size = -s $file_path;
-    return 0 unless defined $size;        # file does not exist
-    return 0 unless unlink $file_path;    # unable to delete file
-    return $size;
+    return 0 unless my @lstat = lstat $file_path;    # file does not exist
+    return 0 unless unlink $file_path;               # don't return size when unable to delete file
+    return $lstat[7];
 }
 
 sub _delete_returning_size_from_array {

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -740,10 +740,13 @@ subtest 'create result dir, delete results' => sub {
         $job->discard_changes;
         ok -d ($result_dir = path($job->create_result_dir)), 'result directory created';
         path($result_dir, $_)->spurt($file_content) for @fake_results;
+        symlink(path($result_dir, 'video.webm'), my $symlink = path($result_dir, 'video.mkv'))
+          or die "Unable to create symlink: $!";
+        my $symlink_size = $symlink->lstat->size;
         $job->delete_videos;
         $job->discard_changes;
         is $job->logs_present, 1, 'logs still considered present';
-        is $job->result_size, $initially_assumed_result_size - length($file_content) * 3,
+        is $job->result_size, $initially_assumed_result_size - length($file_content) * 3 - $symlink_size,
           'deleted size substracted from result size';
         is_deeply $job->video_file_paths->to_array, [], 'no more videos found'
           or diag explain $job->video_file_paths->to_array;


### PR DESCRIPTION
Otherwise we would take files which are symlinks into account twice. Note
that the screenshots are already taken into account when they are deleted
at their real location. So it makes no sense to consider their real size
when deleting their symlinks within the results directory of a job.

---

(part of https://progress.opensuse.org/issues/76984)