### PR TITLE
Use full path in openqa-reload-….service to support

### DIFF
--- a/systemd/openqa-reload-worker-auto-restart@.service
+++ b/systemd/openqa-reload-worker-auto-restart@.service
@@ -3,5 +3,5 @@ Description=Restarts openqa-worker-auto-restart@%i.service as soon as possible w
 
 [Service]
 Type=oneshot
-ExecStart=systemctl kill --signal SIGHUP openqa-worker-auto-restart@%i.service
+ExecStart=/usr/bin/systemctl kill --signal SIGHUP openqa-worker-auto-restart@%i.service
 Slice=openqa-worker.slice


### PR DESCRIPTION
to avoid
```
openqaworker-arm-1 systemd[1]: /usr/lib/systemd/system/openqa-reload-worker-auto-restart@.service:6: Executable path is not absolute: systemctl kill --signal SIGHUP openqa-worker-auto-restart@%i.service
```
when using it on production workers with older systemd version.

Related ticket: https://progress.opensuse.org/issues/80908#note-8