### PR TITLE
Rework symlink CASEDIR and set values to relative path

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -85,6 +85,7 @@ our @EXPORT  = qw(
   change_sec_to_word
   find_video_files
   fix_top_level_help
+  looks_like_url_with_scheme
 );
 
 our @EXPORT_OK = qw(
@@ -898,5 +899,7 @@ sub find_video_files { path(shift)->list_tree->grep(VIDEO_FILE_NAME_REGEX) }
 
 # workaround https://github.com/mojolicious/mojo/issues/1629
 sub fix_top_level_help { @ARGV = () if ($ARGV[0] // '') =~ qr/^(-h|(--)?help)$/ }
+
+sub looks_like_url_with_scheme { return !!Mojo::URL->new(shift)->scheme }
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -139,7 +139,7 @@ sub productdir {
     my ($distri, $version, $rootfortests) = @_;
 
     my $dir = testcasedir($distri, $version, $rootfortests);
-    return $dir . "/products/$distri" if -e "$dir/products/$distri";
+    return "$dir/products/$distri" if $distri && -e "$dir/products/$distri";
     return $dir;
 }
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -20,7 +20,7 @@ use warnings;
 
 use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE WORKER_SR_DIED);
 use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle);
-use OpenQA::Utils qw(asset_type_from_setting base_host locate_asset);
+use OpenQA::Utils qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme);
 use POSIX qw(:sys_wait_h strftime uname _exit);
 use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();
@@ -346,14 +346,16 @@ sub engine_workit {
     $vars{CASEDIR}    //= $target_name;
     $vars{PRODUCTDIR} //= substr($productdir, rindex($casedir, $target_name));
 
-    if (my $error = _link_repo($casedir, $pooldir, $target_name)) { return $error }
+    if (!looks_like_url_with_scheme($vars{CASEDIR})) {
+        if (my $error = _link_repo($casedir, $pooldir, $target_name)) { return $error }
+    }
 
     # if NEEDLES_DIR is an absolute path, it means that users or openqa-clone-custom-git-refspec specify it,
     # if NEEDLES_DIR is an URL address, it means that users specify it and want to get the needles from URL.
-    # These two scenarios, we do not need to do the symlink.
+    # In these two scenarios, doing symlink is useless and the job may incomplete because fail to do symlink.
     if (   $vars{NEEDLES_DIR}
         && !File::Spec->file_name_is_absolute($vars{NEEDLES_DIR})
-        && $vars{NEEDLES_DIR} !~ /http(s)?\:\/\//)
+        && !looks_like_url_with_scheme($vars{NEEDLES_DIR}))
     {
         if (my $error = _link_repo("$productdir/needles", $pooldir, $vars{NEEDLES_DIR})) { return $error }
     }

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -226,6 +226,14 @@ subtest 'symlink testrepo' => sub {
     $casedir = testcasedir('opensuse', undef, undef);
     $result  = OpenQA::Worker::Engines::isotovideo::_link_repo($casedir, $pool_directory, 'opensuse');
     is $result, undef, 'create symlink successfully';
+
+    $settings->{DISTRI}   = 'mine';
+    $settings->{JOBTOKEN} = 'token99916';
+    delete $settings->{NEEDLES_DIR};
+    $settings->{CASEDIR} = 'https://github.com/foo/os-autoinst-distri-example.git#master';
+    $job                 = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
+    $result              = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
+    like $result->{child}->process_id, qr/\d+/, 'don\'t create symlink when CASEDIR is an url address';
 };
 
 done_testing();

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -26,7 +26,8 @@ use Test::MockModule;
 use Test::MockObject;
 use Test::Output 'combined_like';
 use OpenQA::Worker::Engines::isotovideo;
-use Mojo::File 'path';
+use Mojo::File qw(path tempdir);
+use OpenQA::Utils 'testcasedir';
 
 # define fake packages for testing asset caching
 {
@@ -40,7 +41,23 @@ use Mojo::File 'path';
     has minion_id => 13;
 }
 
-$ENV{OPENQA_CONFIG} = "$FindBin::Bin/data/24-worker-overall";
+# Fake worker, client
+{
+    package Test::FakeWorker;
+    use Mojo::Base -base;
+    has instance_number => 1;
+    has settings        => sub { OpenQA::Worker::Settings->new(1, {}) };
+    has pool_directory  => undef;
+}
+{
+    package Test::FakeClient;
+    use Mojo::Base -base;
+    has worker_id  => 1;
+    has webui_host => 'localhost';
+}
+
+$ENV{OPENQA_CONFIG}   = "$FindBin::Bin/data/24-worker-overall";
+$ENV{OPENQA_HOSTNAME} = "localhost";
 
 subtest 'isotovideo version' => sub {
     like(
@@ -175,6 +192,40 @@ subtest 'problems when caching assets' => sub {
     is($result->{error},    'Failed to download FOO to some/path', 'asset not found');
     is($result->{category}, WORKER_EC_ASSET_FAILURE, 'category set so problem is treated as asset failure');
 
+};
+
+subtest 'symlink testrepo' => sub {
+    my $worker         = Test::FakeWorker->new;
+    my $client         = Test::FakeClient->new;
+    my $settings       = {DISTRI => 'foo'};
+    my $job            = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
+    my $pool_directory = tempdir('poolXXXX');
+    my $casedir        = testcasedir('foo', undef, undef);
+    $worker->pool_directory($pool_directory);
+    my $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
+    like $result->{error}, qr/The source directory $casedir does not exist/,
+      'symlink failed because the source directory does not exist';
+
+    $settings->{DISTRI} = 'opensuse';
+    $casedir            = testcasedir('opensuse', undef, undef);
+    $job                = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
+    chmod(0444, $pool_directory);
+    $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
+    like $result->{error}, qr/Cannot create symlink from "$casedir" to "$pool_directory\/opensuse": Permission denied/,
+      'symlink failed because permission denied';
+    chmod(0755, $pool_directory);
+
+    delete $settings->{DISTRI};
+    $settings->{NEEDLES_DIR} = 'needles';
+    $casedir                 = testcasedir(undef, undef, undef);
+    $job                     = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
+    $result                  = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
+    like $result->{error}, qr/The source directory $casedir\/needles does not exist/,
+      'symlink needles directory failed because source directory does not exist';
+
+    $casedir = testcasedir('opensuse', undef, undef);
+    $result  = OpenQA::Worker::Engines::isotovideo::_link_repo($casedir, $pool_directory, 'opensuse');
+    is $result, undef, 'create symlink successfully';
 };
 
 done_testing();

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -37,6 +37,7 @@ use OpenQA::Test::Utils
   qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
   qw(stop_service setup_fullstack_temp_dir);
 use OpenQA::Test::TimeLimit '20';
+use OpenQA::Utils 'testcasedir';
 
 BEGIN {
     # set defaults
@@ -118,15 +119,21 @@ sub log_jobs {
     diag("All jobs:\n - " . join("\n - ", @job_info));
 }
 my %job_ids;
+my $distri       = 'opensuse';
+my $version      = 'Factory';
 my @job_settings = (
     BUILD   => '0048@0815',
-    DISTRI  => 'opensuse',
-    VERSION => 'Factory',
+    DISTRI  => $distri,
+    VERSION => $version,
     FLAVOR  => 'tape',
     ARCH    => 'x86_64',
     MACHINE => 'xxx',
 );
 $job_ids{$jobs->create({@job_settings, TEST => "dummy-$_"})->id} = 1 for 1 .. $job_count;
+
+# the casedir must exist before making symlink from casedir to the current working directory
+my $casedir = testcasedir($distri, $version, undef);
+path($casedir)->make_path unless -d $casedir;
 
 my $seconds_to_wait_per_worker = 5.0;
 my $seconds_to_wait_per_job    = 2.5;


### PR DESCRIPTION
The third commit is used to fix the issues mentioned in:
https://progress.opensuse.org/issues/67723#note-44

Here is also another about needles_dir. If users use `openqa-clone-custom-git-refspec` to trigger a new job whose CASEDIR is a basename, the needles_dir will be set as a relative path, the job will incomplete because fail to do NEEDLES_DIR symlink.

Verify run:
For PRODUCTDIR: http://10.67.19.103/tests/448#settings
For NEEDLES_DIR: http://10.67.19.103/tests/449#settings