### PR TITLE
Prevent test timeouts with the introduction of "heavy" tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,10 +251,7 @@ jobs:
   unstable:
     <<: *test-template
 
-  developer:
-    <<: *test-fullstack-template
-
-  scheduler:
+  fullstack-unstable:
     <<: *test-fullstack-template
 
   codecov:
@@ -327,9 +324,7 @@ workflows:
       - fullstack: &requires_fullstack
           requires:
             - cache.fullstack
-      - developer:
-          <<: *requires_fullstack
-      - scheduler:
+      - fullstack-unstable:
           <<: *requires_fullstack
       - codecov:
           requires:
@@ -338,8 +333,7 @@ workflows:
             - ui
             - unstable
             - fullstack
-            - developer
-            - scheduler
+            - fullstack-unstable
       - build-docs:
           <<: *requires
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,9 @@ jobs:
   t:
     <<: *test-template
 
+  heavy:
+    <<: *test-template
+
   ui:
     <<: *test-template
 
@@ -311,6 +314,8 @@ workflows:
             - cache
       - t:
           <<: *requires
+      - heavy:
+          <<: *requires
       - api:
           <<: *requires
       - ui:
@@ -329,6 +334,7 @@ workflows:
       - codecov:
           requires:
             - t
+            - heavy
             - api
             - ui
             - unstable

--- a/Makefile
+++ b/Makefile
@@ -154,13 +154,9 @@ test-unstable:
 test-fullstack:
 	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=9 PROVE_ARGS="$$HARNESS t/full-stack.t"
 
-.PHONY: test-scheduler
-test-scheduler:
-	$(MAKE) test-with-database SCHEDULER_FULLSTACK=1 SCALABILITY_TEST=1 TIMEOUT_M=5 PROVE_ARGS="$$HARNESS t/05-scheduler-full.t t/43-scheduling-and-worker-scalability.t" RETRY=3
-
-.PHONY: test-developer
-test-developer:
-	$(MAKE) test-with-database DEVELOPER_FULLSTACK=1 TIMEOUT_M=10 PROVE_ARGS="$$HARNESS t/33-developer_mode.t" RETRY=3
+.PHONY: test-fullstack-unstable
+test-fullstack-unstable:
+	$(MAKE) test-with-database SCHEDULER_FULLSTACK=1 SCALABILITY_TEST=1 DEVELOPER_FULLSTACK=1 TIMEOUT_M=15 PROVE_ARGS="$$HARNESS t/05-scheduler-full.t t/33-developer_mode.t t/43-scheduling-and-worker-scalability.t" RETRY=3
 
 # we have apparently-redundant -I args in PERL5OPT here because Docker
 # only works with one and Fedora's build system only works with the other

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,11 @@ test-checkstyle: test-checkstyle-standalone test-tidy-compile
 
 .PHONY: test-t
 test-t:
-	$(MAKE) test-with-database TIMEOUT_M=35 PROVE_ARGS="$$HARNESS t/*.t" GLOBIGNORE="t/*tidy*:t/*compile*:$(unstables)"
+	$(MAKE) test-with-database TIMEOUT_M=25 PROVE_ARGS="$$HARNESS t/*.t" GLOBIGNORE="t/*tidy*:t/*compile*:$(unstables)"
+
+.PHONY: test-heavy
+test-heavy:
+	$(MAKE) test-with-database HEAVY=1 TIMEOUT_M=25 PROVE_ARGS="$$HARNESS $$(grep -l HEAVY=1 t/*.t | tr '\n' ' ')"
 
 .PHONY: test-ui
 test-ui:

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -600,8 +600,8 @@ environment variables defining our test matrix:
 |FULLSTACK=0| UITESTS=0
 |FULLSTACK=0| UITESTS=1
 |FULLSTACK=1|
-|SCHEDULER_FULLSTACK=1|
-|DEVELOPER_FULLSTACK=1|
+|SCHEDULER_FULLSTACK=1 DEVELOPER_FULLSTACK=1|
+|HEAVY=1|
 |GH_PUBLISH=true|
 |============================
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -42,6 +42,8 @@ use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;
 use OpenQA::Parser::Result::Output;
 
+plan skip_all => 'set HEAVY=1 to execute (takes longer)' unless $ENV{HEAVY};
+
 my $schema = OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl 06-job_dependencies.pl');
 my $t      = Test::Mojo->new('OpenQA::WebAPI');
 my $jobs   = $t->app->schema->resultset("Jobs");

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -43,6 +43,8 @@ use Mojo::IOLoop;
 use Cwd qw(getcwd);
 use utf8;
 
+plan skip_all => 'set HEAVY=1 to execute (takes longer)' unless $ENV{HEAVY};
+
 # mock asset deletion
 # * prevent removing assets from database and file system
 # * keep track of calls to OpenQA::Schema::Result::Assets::delete and OpenQA::Schema::Result::Assets::remove_from_disk
@@ -706,5 +708,5 @@ done_testing();
 # break subsequent tests; can happen if a subtest creates a task but
 # does not execute it, or we crash partway through a subtest...
 END {
-    $t->app->minion->reset;
+    $t && $t->app->minion->reset;
 }

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -25,6 +25,8 @@ use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use OpenQA::Test::TimeLimit '60';
 
+plan skip_all => 'set HEAVY=1 to execute (takes longer)' unless $ENV{HEAVY};
+
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 my $chunk_size = 10000000;
 

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -19,6 +19,9 @@ use Test::Most;
 use FindBin '$Bin';
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '60';
+
+plan skip_all => 'set HEAVY=1 to execute (takes longer)' unless $ENV{HEAVY};
+
 my %allowed_types = (
     'text/x-perl'        => 1,
     'text/x-python'      => 1,


### PR DESCRIPTION
Combine "scheduler"+"developer" test runs into one to save time
    
Both the scheduler-tests as well as developer-tests in relation to other
test runs do not take that long in comparison. Hence we can save time by
combining both test runs, save one circleCI job while saving the time
for duplicate test run setup.

Mark known slow tests as "heavy" so that it is easier to separate good
and fast tests from slow ones and to prevent premature Makefile-level
timeouts due to recent slowdown observed in CI environments.

Related progress issue: https://progress.opensuse.org/issues/88496