### PR TITLE
Stabilize scalability and fullstack test

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -31,6 +31,9 @@ use List::Util qw(all shuffle);
 # How many jobs to allocate in one tick. Defaults to 80 ( set it to 0 for as much as possible)
 use constant MAX_JOB_ALLOCATION => $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} // 80;
 
+# Whether the scheduler runs as part of a fullstack test
+use constant SCHEDULER_FULLSTACK_TEST => $ENV{FULLSTACK} // 0;
+
 has scheduled_jobs  => sub { {} };
 has shuffle_workers => 1;
 
@@ -53,10 +56,12 @@ sub schedule {
     log_debug("+=" . ("-" x 16) . "=+");
     log_debug("-> Scheduling new jobs.");
     log_debug("\t Free workers: " . scalar(@free_workers) . "/$all_workers");
+    log_debug(pp [map { $_->info } @free_workers]) if SCHEDULER_FULLSTACK_TEST;
 
     $self->_update_scheduled_jobs;
     my $scheduled_jobs = $self->scheduled_jobs;
     log_debug("\t Scheduled jobs: " . scalar(keys %$scheduled_jobs));
+    log_debug(pp [values %$scheduled_jobs]) if SCHEDULER_FULLSTACK_TEST;
 
     # update the matching workers to the current free
     for my $jobinfo (values %$scheduled_jobs) {

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@ use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Utils qw(service_port);
 use OpenQA::Test::Database;
 use OpenQA::Jobs::Constants;
+use OpenQA::Log qw(setup_log);
 use OpenQA::Test::Utils
   qw(mock_service_ports setup_mojo_app_with_default_worker_timeout),
   qw(create_user_for_workers create_webapi setup_share_dir create_websocket_server),
@@ -142,14 +143,19 @@ subtest 'wait for workers to be idle' => sub {
     my @non_idle_workers;
     for my $worker ($workers->all) {
         $worker_ids{$worker->id} = 1;
-        push(@non_idle_workers, $worker->id) if $worker->status ne 'idle';
+        push(@non_idle_workers, $worker->info) if $worker->status ne 'idle';
     }
     ok(!@non_idle_workers, 'all workers idling') or diag explain \@non_idle_workers;
 };
 
 subtest 'assign and run jobs' => sub {
-    my $allocated = OpenQA::Scheduler::Model::Jobs->singleton->schedule;
-    BAIL_OUT('Unable to assign jobs to (idling) workers') unless ref($allocated) eq 'ARRAY' && @$allocated > 0;
+    my $scheduler = OpenQA::Scheduler::Model::Jobs->singleton;
+    my $allocated = $scheduler->schedule;
+    unless (ref($allocated) eq 'ARRAY' && @$allocated > 0) {
+        diag explain 'Allocated: ', $allocated;
+        diag explain 'Scheduled: ', $scheduler->scheduled_jobs;
+        BAIL_OUT('Unable to assign jobs to (idling) workers');
+    }
 
     my $remaining_jobs = $job_count - $worker_count;
     note("Assigned jobs: " . dumper($allocated));

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@ use base 'Exporter';
 our @EXPORT = qw(get_connect_args client_output client_call prevent_reload
   reload_manually find_status_text wait_for_result_panel
   wait_for_job_running wait_for_developer_console_like
-  wait_for_developer_console_available schedule_one_job
+  wait_for_developer_console_available
   verify_one_job_displayed_as_scheduled
   schedule_one_job_over_api_and_verify);
 
@@ -197,10 +197,6 @@ sub wait_for_developer_console_available {
 
     # check initial connection
     wait_for_developer_console_like($driver, qr/Connection opened/, 'connection opened');
-}
-
-sub schedule_one_job {
-    wait_for_or_bail_out { OpenQA::Scheduler::Model::Jobs->singleton->schedule } 'job';
 }
 
 sub verify_one_job_displayed_as_scheduled {


### PR DESCRIPTION
by ensuring the worker property WEBSOCKET_API_VERSION (which is checked by
the scheduler) is passed before considering worker idle.

---

I thought I might be able to reproduce poo#80800 via the scalability test, see https://progress.opensuse.org/issues/80800#note-12. However, I didn't actually manage to do this. This PR fixes *another* issue I found along the way.