### PR TITLE
Fix worker container to allow job executions relying on KVM

### DIFF
--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -7,7 +7,7 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/op
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper --non-interactive in ca-certificates-mozilla curl gzip && \
-    zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 && \
+    zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 qemu-tools && \
     zypper --non-interactive in kmod && \
     (zypper --non-interactive in qemu-ovmf-x86_64 || true) && \
     (zypper --non-interactive in qemu-uefi-aarch64 || true)

--- a/container/worker/run_openqa_worker.sh
+++ b/container/worker/run_openqa_worker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2012
 set -e
 
 if [[ -z $OPENQA_WORKER_INSTANCE ]]; then
@@ -6,4 +7,12 @@ if [[ -z $OPENQA_WORKER_INSTANCE ]]; then
 fi
 
 /root/qemu/kvm-mknod.sh
+
+if [ -e "/dev/kvm" ] && getent group kvm > /dev/null; then
+  groupmod -g "$(ls -lhn /dev/kvm | cut -d ' ' -f 4)" kvm
+  usermod -a -G kvm _openqa-worker
+else
+  echo "Warning: /dev/kvm doesn't exist. If you want to use KVM, run the container with --device=/dev/kvm"
+fi
+
 su _openqa-worker -c "/usr/share/openqa/script/worker --verbose --instance \"$OPENQA_WORKER_INSTANCE\""


### PR DESCRIPTION
Problem: Container workers are unable to execute jobs because they
do not have permissions on the kvm device
Solution: Include the _openqa-worker user in the same group than /dev/kvm

Problem: qemu-tools is necessary when running a job. Otherwise it shows
the error: no kvm-img/qemu-img found

Notes: Using docker the container has to be runned using --device=/dev/kvm

https://progress.opensuse.org/issues/76978