### PR TITLE
Fix/improve reloading worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ install-generic:
 		systemd/openqa-worker@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
 	sed \
 		-e '/Type/aEnvironment=OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE=1' \
+		-e '/ExecStart=/aExecReload=\/bin\/kill -HUP $$MAINPID' \
 		-e 's/Restart=on-failure/Restart=always/' \
 		-e '/Wants/aConflicts=openqa-worker@.service' \
 		systemd/openqa-worker@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-auto-restart@.service

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -423,7 +423,7 @@ fi
 # notes: noop if no such units are running; daemon-reload already done by service_del_postun macro;
 #        "$1 -ge 1" checks for a package upgrade
 if [ -x /usr/bin/systemctl ] && [ $1 -ge 1 ]; then
-    /usr/bin/systemctl kill --signal SIGHUP --kill-who=main 'openqa-worker-auto-restart@*.service' || :
+    /usr/bin/systemctl reload 'openqa-worker-auto-restart@*.service' || :
 fi
 
 %postun auto-update

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -423,7 +423,7 @@ fi
 # notes: noop if no such units are running; daemon-reload already done by service_del_postun macro;
 #        "$1 -ge 1" checks for a package upgrade
 if [ -x /usr/bin/systemctl ] && [ $1 -ge 1 ]; then
-    /usr/bin/systemctl kill --signal SIGHUP 'openqa-worker-auto-restart@*.service' || :
+    /usr/bin/systemctl kill --signal SIGHUP --kill-who=main 'openqa-worker-auto-restart@*.service' || :
 fi
 
 %postun auto-update

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -604,7 +604,7 @@ ongoing testing. Example:
 
 [source,sh]
 --------------------------------------------------------------------------------
-systemctl kill --signal SIGHUP 'openqa-worker-auto-restart@*.service'
+systemctl kill --signal SIGHUP --kill-who=main 'openqa-worker-auto-restart@*.service'
 --------------------------------------------------------------------------------
 
 There is also the systemd unit `openqa-reload-worker-auto-restart@.path` which

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -604,7 +604,7 @@ ongoing testing. Example:
 
 [source,sh]
 --------------------------------------------------------------------------------
-systemctl kill --signal SIGHUP --kill-who=main 'openqa-worker-auto-restart@*.service'
+systemctl reload 'openqa-worker-auto-restart@*.service' # sends SIGHUP to worker
 --------------------------------------------------------------------------------
 
 There is also the systemd unit `openqa-reload-worker-auto-restart@.path` which

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -573,8 +573,10 @@ sub _inform_webuis_before_stopping {
 sub stop {
     my ($self, $reason) = @_;
 
+    # take record that the worker is supposed to terminate and whether it is supposed to finish off current jobs before
+    my $supposed_to_finish_off = $reason && $reason eq WORKER_SR_FINISH_OFF;
     $self->{_shall_terminate} = 1;
-    $self->{_finishing_off}   = !defined $self->{_finishing_off} && $reason && $reason eq WORKER_SR_FINISH_OFF;
+    $self->{_finishing_off}   = $supposed_to_finish_off if !defined $self->{_finishing_off} || !$supposed_to_finish_off;
 
     # stop immediately if there is currently no job
     my $current_job = $self->current_job;

--- a/systemd/openqa-reload-worker-auto-restart@.service
+++ b/systemd/openqa-reload-worker-auto-restart@.service
@@ -3,5 +3,5 @@ Description=Restarts openqa-worker-auto-restart@%i.service as soon as possible w
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl kill --signal SIGHUP --kill-who=main openqa-worker-auto-restart@%i.service
+ExecStart=/usr/bin/systemctl reload openqa-worker-auto-restart@%i.service
 Slice=openqa-worker.slice

--- a/systemd/openqa-reload-worker-auto-restart@.service
+++ b/systemd/openqa-reload-worker-auto-restart@.service
@@ -3,5 +3,5 @@ Description=Restarts openqa-worker-auto-restart@%i.service as soon as possible w
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl kill --signal SIGHUP openqa-worker-auto-restart@%i.service
+ExecStart=/usr/bin/systemctl kill --signal SIGHUP --kill-who=main openqa-worker-auto-restart@%i.service
 Slice=openqa-worker.slice

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -651,6 +651,12 @@ subtest 'handle job status changes' => sub {
             ok $worker->{_finishing_off}, 'worker is supposed to finish off the current jobs after SIGHUP';
             is $stop_called, WORKER_SR_FINISH_OFF, 'worker stopped with WORKER_SR_FINISH_OFF';
             is $fake_job->{_status}, 0, 'job NOT stopped';
+            subtest 'receiving a 2nd SIGHUP makes no further difference' => sub {
+                combined_like { $worker->handle_signal('HUP') } qr/Received signal HUP/, 'signal logged (3)';
+                ok $worker->{_finishing_off}, 'worker is supposed to finish off the current jobs after SIGHUP';
+                is $stop_called, WORKER_SR_FINISH_OFF, 'worker stopped with WORKER_SR_FINISH_OFF';
+                is $fake_job->{_status}, 0, 'job NOT stopped';
+            };
 
             # assume the job finished by itself and test how this is handled further
             combined_like {


### PR DESCRIPTION
* See particular commit messages for details
* See https://progress.opensuse.org/issues/80908#note-8 and https://progress.opensuse.org/issues/80910#note-25

---

I've tested this on openqaworker11 by hot patching its service files and `Worker.pm`. I've also tested the globbing with `systemctl reload` used within the spec file. I've also tested the changes to the Makefile. Everything worked as expected.