### PR TITLE
Mark uncoverage statements in OpenQA::Worker::WebUIConnection

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -197,7 +197,7 @@ sub _setup_websocket_connection {
                 finish => sub {
                     # uncoverable subroutine
                     # https://progress.opensuse.org/issues/55364
-                    my (undef, $code, $reason) = @_;
+                    my ($tx, $code, $reason) = (shift, shift, shift // 'no reason');
 
                     # Subprocesses reset the event loop (which triggers this event),
                     # and since only the main worker process uses the WebSocket we
@@ -210,7 +210,6 @@ sub _setup_websocket_connection {
                     return log_debug("Websocket connection to $websocket_url finished from our side.")
                       unless $self->websocket_connection;
 
-                    $reason //= 'no reason';               # uncoverable statement
                     $self->websocket_connection(undef);    # uncoverable statement
                     $self->_set_status(                    # uncoverable statement
                         failed => {

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Worker::WebUIConnection;
-use Mojo::Base 'Mojo::EventEmitter';
+use Mojo::Base 'Mojo::EventEmitter', -signatures;
 
 use OpenQA::Log qw(log_error log_debug log_warning log_info);
 use OpenQA::Utils qw(feature_scaling rand_range logistic_map_steps);
@@ -194,10 +194,9 @@ sub _setup_websocket_connection {
                     $command_handler->handle_command(@_);
                 });
             $tx->on(
-                finish => sub {
+                finish => sub ($tx, $code, $reason = 'no reason') {
                     # uncoverable subroutine
                     # https://progress.opensuse.org/issues/55364
-                    my ($tx, $code, $reason) = (shift, shift, shift // 'no reason');
 
                     # Subprocesses reset the event loop (which triggers this event),
                     # and since only the main worker process uses the WebSocket we
@@ -210,8 +209,7 @@ sub _setup_websocket_connection {
                     return log_debug("Websocket connection to $websocket_url finished from our side.")
                       unless $self->websocket_connection;
 
-                    $self->websocket_connection(undef);    # uncoverable statement
-                    $self->_set_status(                    # uncoverable statement
+                    $self->websocket_connection(undef)->_set_status(    # uncoverable statement
                         failed => {
                             error_message =>
                               "Websocket connection to $websocket_url finished by remote side with code $code, $reason"

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -202,15 +202,17 @@ sub _setup_websocket_connection {
                     # Subprocesses reset the event loop (which triggers this event),
                     # and since only the main worker process uses the WebSocket we
                     # can safely ignore this (and do not want to reconnect)
+                    # uncoverable statement
                     return unless $websocket_pid == $$;
 
                     # ignore if the connection was disabled from our side
+                    # uncoverable statement
                     return log_debug("Websocket connection to $websocket_url finished from our side.")
                       unless $self->websocket_connection;
 
-                    $reason //= 'no reason';
-                    $self->websocket_connection(undef);
-                    $self->_set_status(
+                    $reason //= 'no reason';               # uncoverable statement
+                    $self->websocket_connection(undef);    # uncoverable statement
+                    $self->_set_status(                    # uncoverable statement
                         failed => {
                             error_message =>
                               "Websocket connection to $websocket_url finished by remote side with code $code, $reason"


### PR DESCRIPTION
Unreliable coverage observed in tests for
https://github.com/os-autoinst/openQA/pull/3713

Related progress issue: https://progress.opensuse.org/issues/55364