### PR TITLE
Document how to use Perl signatures

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -79,14 +79,23 @@ requests for consideration or create an issue with a code change proposal.
 === Code style suggestions
 [id="code_style_suggestions"]
 
-* In Perl files sort the use statements in this order from top to bottom:
-** "strict", "warnings" or other modules that provide static checks
-** All external modules and from "lib" folder
-** `use FindBin; use lib "$FindBin::Bin/lib";` or similar to resolve internal
-   modules
-** internal test modules which provide early checks before other modules
-** other internal test modules
+* In Perl files:
 
+** Sort the use statements in this order from top to bottom:
+*** `strict`, `warnings` or other modules that provide static checks
+*** All external modules and from "lib" folder
+*** `use FindBin; use lib "$FindBin::Bin/lib";` or similar to resolve internal modules
+*** Internal test modules which provide early checks before other modules
+*** Other internal test modules
+
+** When using https://perldoc.perl.org/perlsub#Signatures[signatures] try to follow these rules:
+*** Activate the feature with modules we already use if possible, e.g. `use Mojo::Base 'Something', -signatures;`
+*** Use positional parameters whenever possible, e.g. `sub foo ($first, $second) {`
+*** Use default values when appropriate, e.g. `sub foo ($first, $second = 'some value') {`
+*** Use slurpy parameters when appropriate (hash and array), e.g. `sub foo ($first, @more) {`
+*** Use nameless parameters when appropriate (very uncommon), e.g. `sub foo ($first, $, $third) {`
+*** Do *not* get too creative with computational default values, e.g. `sub foo ($first, $second = rand($first)) {`
+*** Do *not* combine sub attributes with signatures (requires Perl 5.28+), e.g. `sub foo :lvalue ($first) {`
 
 == Getting involved into development
 [id="getting_involved"]


### PR DESCRIPTION
This PR extends the code style section with a few rules for how to get the most value out of [signatures](https://perldoc.perl.org/perlsub#Signatures). So far it only discourages the most risky features (sub attribute order and complex computational default values). But i'm happy to bikeshed about what might be best for openQA specifically. How we activate signatures consistently, or if we want to use nameless parameters at all for examples would be candidates.

~~While looking at the use statement section, i noticed that the order was incorrect (`use lib` statements should have been higher up), and fixed that too.~~ Changed that back after noticing that the order in most of our tests is random and nobody follows the code style section anyway. 🤦 So that topic is for a future PR.