### PR TITLE
Fix Mojolicious 9.0 compatibility

### DIFF
--- a/.circleci/ci-packages.txt
+++ b/.circleci/ci-packages.txt
@@ -140,7 +140,7 @@ perl-Module-Pluggable-5.2
 perl-Module-Runtime-0.016
 perl-Module-Runtime-Conflicts-0.003
 perl-Mojo-IOLoop-ReadWriteProcess-0.28
-perl-Mojolicious-8.73
+perl-Mojolicious-9.01
 perl-Mojolicious-Plugin-AssetPack-2.10
 perl-Mojolicious-Plugin-OAuth2-1.58
 perl-Mojo-Pg-4.24

--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -181,7 +181,7 @@ sub log_format_callback {
     $time = gettimeofday;
     return
       sprintf(strftime("[%FT%T.%%04d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time)))
-      . join("\n", @lines, '');
+      . join(' ', @lines) . "\n";
 }
 
 # Removes a channel from defaults.
@@ -243,8 +243,8 @@ sub setup_log {
         $log = $log_module->new(%settings, handle => \*STDOUT);
         $log->format(
             sub {
-                my ($time, $level, @lines) = @_;
-                return "[$level] " . join "\n", @lines, '';
+                my ($time, $level, @parts) = @_;
+                return "[$level] " . join(' ', @parts) . "\n";
             });
     }
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -128,7 +128,7 @@ sub startup ($self) {
     $apik_auth->post('/')->to('api_key#create');
     $apik_auth->delete('/:apikeyid')->name('api_key')->to('api_key#destroy');
 
-    $r->get('/search')->name('search')->to('search#search');
+    $r->get('/search')->name('search')->to(template => 'search/search');
 
     $r->get('/tests')->name('tests')->to('test#list');
     $r->get('/tests/overview')->name('tests_overview')->to('test#overview');
@@ -358,7 +358,7 @@ sub startup ($self) {
     # api/v1/mm
     my $mm_api = $api_r_job->any('/mm');
     push @api_routes, $mm_api;
-    $mm_api->get('/children/:status' => [status => [qw(running scheduled done)]])->name('apiv1_mm_running_children')
+    $mm_api->get('/children/:state' => [state => [qw(running scheduled done)]])->name('apiv1_mm_running_children')
       ->to('mm#get_children_status');
     $mm_api->get('/children')->name('apiv1_mm_children')->to('mm#get_children');
     $mm_api->get('/parents')->name('apiv1_mm_parents')->to('mm#get_parents');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
@@ -52,20 +52,20 @@ JSON block with the list.
 # IMHO it should be replaced with get_children and removed
 sub get_children_status {
     my ($self) = @_;
-    my $status = $self->stash('status');
-    if ($status eq 'running') {
-        $status = OpenQA::Jobs::Constants::RUNNING;
+    my $state = $self->stash('state');
+    if ($state eq 'running') {
+        $state = OpenQA::Jobs::Constants::RUNNING;
     }
-    elsif ($status eq 'scheduled') {
-        $status = OpenQA::Jobs::Constants::SCHEDULED;
+    elsif ($state eq 'scheduled') {
+        $state = OpenQA::Jobs::Constants::SCHEDULED;
     }
     else {
-        $status = OpenQA::Jobs::Constants::DONE;
+        $state = OpenQA::Jobs::Constants::DONE;
     }
     my $jobid = $self->stash('job_id');
 
     my @res = $self->schema->resultset('Jobs')
-      ->search({'parents.parent_job_id' => $jobid, state => $status}, {columns => ['id'], join => 'parents'});
+      ->search({'parents.parent_job_id' => $jobid, state => $state}, {columns => ['id'], join => 'parents'});
     my @res_ids = map { $_->id } @res;
     return $self->render(json => {jobs => \@res_ids}, status => 200);
 }

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -26,6 +26,7 @@ use OpenQA::Jobs::Constants;
 use Mojolicious;
 use Mojo::File 'path';
 use Mojo::IOLoop;
+use Mojo::Promise;
 
 my $log_messages = '';
 
@@ -41,17 +42,16 @@ subtest streamtext => sub {
                     $buffer .= $chunk;            # uncoverable statement
                 });
         });
-    my $port   = Mojo::IOLoop->acceptor($id)->port;
-    my $delay  = Mojo::IOLoop->delay;
-    my $end    = $delay->begin;
-    my $handle = undef;
+    my $port    = Mojo::IOLoop->acceptor($id)->port;
+    my $promise = Mojo::Promise->new;
+    my $handle  = undef;
     Mojo::IOLoop->client(
         {port => $port} => sub {
             my ($loop, $err, $stream) = @_;
             $handle = $stream->steal_handle;
-            $end->();
+            $promise->resolve;
         });
-    $delay->wait;
+    $promise->wait;
 
     my $stream = Mojo::IOLoop::Stream->new($handle);
     $id = Mojo::IOLoop->stream($stream);

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -134,13 +134,14 @@ sub _wait_helper {
             sleep .1;                              # uncoverable statement
         }
         # sometimes gru is not fast enough, so let's refresh the page and see if that helped
-        if($refresh) {                             # uncoverable statement
+        if ($refresh) {                            # uncoverable statement
             $refresh->();                          # uncoverable statement
-        } else {
+        }
+        else {
             $driver->refresh();                    # uncoverable statement
         }
     }
-    return $driver->find_element($element)->get_text();  # uncoverable statement
+    return $driver->find_element($element)->get_text();    # uncoverable statement
 }
 
 foreach my $proj (sort keys %params) {
@@ -176,12 +177,14 @@ foreach my $proj (sort keys %params) {
     $builds_text = ($builds_text ? $builds_text : 'No data');
     # now request fetching builds from obs
     $driver->find_element("tr#folder_$ident .obsbuildsupdate")->click();
-    my $obsbuilds = _wait_helper("tr#folder_$ident .obsbuilds", sub { 
+    my $obsbuilds = _wait_helper(
+        "tr#folder_$ident .obsbuilds",
+        sub {
             shift eq $builds_text;
-        }, sub {
+        },
+        sub {
             $driver->find_element("tr#folder_$ident .obsbuildsupdate")->click();
-        }
-    );
+        });
     is($obsbuilds, $builds_text, "$proj obs builds");
 
     if ($dt ne 'no data') {


### PR DESCRIPTION
1. Reserved stash values.
```
Route pattern "/children/:status" contains a reserved stash value at lib/OpenQA/WebAPI.pm line 361.
```
It is forbidden to use reserved stash values as placeholders in routes.

2. New log formatting

Individual log messages are now joined with a whitespace character instead of a newline. Additionally `Mojo::Log::Colored` is incompatible with Mojolicious 9.0 (reported upstream).

3. Missing controllers are now an exception
```
[error] [1Whlu6Jt] Controller "OpenQA::WebAPI::Search" does not exist at extlib/lib/perl5/Mojolicious.pm line 124.
```
One of the routes used `->to('search#search')` as a hack to render the template `search/search.html.ep`.

4. `Mojo::IOLoop::Delay` no longer exists
```
Can't locate object method "delay" via package "Mojo::IOLoop" at t/26-controllerrunning.t line 45.
```
The module is no longer part of Mojolicious, since `Mojo::Promise` exists as a much better alternative.

Progress: https://progress.opensuse.org/issues/88609