### PR TITLE
Fix broken lookup of paths in coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ test-api:
 # put unstable tests in unstable_tests.txt and uncomment in circle CI to handle unstables with retries
 .PHONY: test-unstable
 test-unstable:
-	for f in $$(cat .circleci/unstable_tests.txt); do $(MAKE) test-with-database TIMEOUT_M=5 PROVE_ARGS="$$HARNESS $$f" RETRY=3 || exit; done
+	for f in $$(cat .circleci/unstable_tests.txt); do $(MAKE) test-with-database TIMEOUT_M=5 PROVE_ARGS="$$HARNESS $$f" RETRY=5 || exit; done
 
 .PHONY: test-fullstack
 test-fullstack:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,9 @@ codecov:
 comment:
   behavior: default
   require_changes: true
+# https://progress.opensuse.org/issues/88594
+fixes:
+  - "/home/circleci/openQA::"
 coverage:
   range: 60..95
   round: down

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
 use Test::Warnings;
 use Test::Mojo;
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '50';
 use OpenQA::Test::Database;
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils 'wait_for_or_bail_out';


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/88594