### PR TITLE
Make host names used by internal clients configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ unstables := $(shell cat .circleci/unstable_tests.txt | tr '\n' :)
 # tests need these environment variables to be unset
 OPENQA_BASEDIR =
 OPENQA_CONFIG =
+OPENQA_SCHEDULER_HOST =
+OPENQA_WEB_SOCKETS_HOST =
 
 .PHONY: help
 help:

--- a/lib/OpenQA/Scheduler/Client.pm
+++ b/lib/OpenQA/Scheduler/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,13 +14,14 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::Scheduler::Client;
-use Mojo::Base -base;
+use Mojo::Base -base, -signatures;
 
 use OpenQA::Client;
 use OpenQA::Log 'log_warning';
 use OpenQA::Utils 'service_port';
 
-has client => sub { OpenQA::Client->new(api => 'localhost') };
+has host   => sub { $ENV{OPENQA_SCHEDULER_HOST} };
+has client => sub { OpenQA::Client->new(api => shift->host // 'localhost') };
 has port   => sub { service_port('scheduler') };
 
 my $IS_SCHEDULER_ITSELF;
@@ -44,10 +45,9 @@ sub wakeup {
 
 sub singleton { state $client ||= __PACKAGE__->new }
 
-sub _api {
-    my ($self, $method) = @_;
-    my $port = $self->port;
-    return "http://127.0.0.1:$port/api/$method";
+sub _api ($self, $method) {
+    my ($host, $port) = ($self->host // '127.0.0.1', $self->port);
+    return "http://$host:$port/api/$method";
 }
 
 1;

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,7 +43,9 @@ sub new {
             for my $i (qw(key secret)) {
                 my $attr = "api$i";
                 next if $self->$attr;
-                (my $val = $cfg->val($args{api}, $i)) =~ s/\s+$//;    # remove trailing whitespace
+                my $val = $cfg->val($args{api}, $i);
+                next unless $val;
+                $val =~ s/\s+$//;    # remove trailing whitespace
                 $self->$attr($val);
             }
             last;

--- a/lib/OpenQA/WebSockets/Client.pm
+++ b/lib/OpenQA/WebSockets/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,14 +14,15 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebSockets::Client;
-use Mojo::Base -base;
+use Mojo::Base -base, -signatures;
 
 use Mojo::Server::Daemon;
 use Carp 'croak';
 use OpenQA::Client;
 use OpenQA::Utils 'service_port';
 
-has client => sub { OpenQA::Client->new(api => 'localhost') };
+has host   => sub { $ENV{OPENQA_WEB_SOCKETS_HOST} };
+has client => sub { OpenQA::Client->new(api => shift->host // 'localhost') };
 has port   => sub { service_port('websocket') };
 
 my $IS_WS_SERVER_ITSELF;
@@ -59,10 +60,9 @@ sub send_msg {
 
 sub singleton { state $client ||= __PACKAGE__->new }
 
-sub _api {
-    my ($self, $method) = @_;
-    my $port = $self->port;
-    return "http://127.0.0.1:$port/api/$method";
+sub _api ($self, $method) {
+    my ($host, $port) = ($self->host // '127.0.0.1', $self->port);
+    return "http://$host:$port/api/$method";
 }
 
 1;


### PR DESCRIPTION
* This allows to run the web UI, websocket server and scheduler on
  different hosts (e.g. a load balanced environment) provided the newly
  introduced environment variables are set
* See https://progress.opensuse.org/issues/88187