### PR TITLE
Fix remove link configuration for "Untracked" groups in /admin/assets

### DIFF
--- a/assets/javascripts/admin_assets.js
+++ b/assets/javascripts/admin_assets.js
@@ -220,7 +220,7 @@ function makeAssetsByGroup(assetStatus) {
         groupLi.append(label);
 
         // add configure button
-        if (window.isAdmin && groupId !== null && groupId !== undefined) {
+        if (window.isAdmin && groupId !== null && groupId !== undefined && groupInfo.group !== "Untracked") {
             var path = isParent ? ('/admin/edit_parent_group/' + groupId) : ('/admin/job_templates/' + groupId);
             groupLi.append('<a href="' + path + '"><i class="fa fa-wrench" title="Configure"></i></a>');
         }


### PR DESCRIPTION
Problem: Clicking on "Untracked" on /admin/assets yields "Not Found" page
Solution: Remove the clickable link at all

https://progress.opensuse.org/issues/88745