### PR TITLE
Add "early-abort" in asset/results cleanup jobs based on df-output

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -139,6 +139,9 @@ blocklist = job_grab job_done
 
 [misc_limits]
 #untracked_assets_storage_duration = 14
+# Skips the cleanup of results/assets if the used disk space on the given partition is below the specified percentage
+#result_cleanup_min_percentage = 0
+#asset_cleanup_min_percentage = 0
 # Specify the screenshot ID range to query at once from the database (reduce to avoid big queries, increase to lower query overhead)
 #screenshot_cleanup_batch_size = 200000
 # Specify the number of screenshot ID ranges (with a size as configured by screenshot_cleanup_batch_size) to process in a single Minion

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -139,9 +139,9 @@ blocklist = job_grab job_done
 
 [misc_limits]
 #untracked_assets_storage_duration = 14
-# Skips the cleanup of results/assets if the used disk space on the given partition is below the specified percentage
-#result_cleanup_min_percentage = 0
-#asset_cleanup_min_percentage = 0
+# Performs the cleanup of results/assets only if the free disk space on the relevant partition is below the specified percentage (and aborts early otherwise)
+#result_cleanup_max_free_percentage = 100
+#asset_cleanup_max_free_percentage = 100
 # Specify the screenshot ID range to query at once from the database (reduce to avoid big queries, increase to lower query overhead)
 #screenshot_cleanup_batch_size = 200000
 # Specify the number of screenshot ID ranges (with a size as configured by screenshot_cleanup_batch_size) to process in a single Minion

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -128,6 +128,8 @@ sub read_config {
         },
         misc_limits => {
             untracked_assets_storage_duration         => 14,
+            result_cleanup_min_percentage             => 0,
+            asset_cleanup_min_percentage              => 0,
             screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
             results_min_free_disk_space_percentage    => undef,

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -128,8 +128,8 @@ sub read_config {
         },
         misc_limits => {
             untracked_assets_storage_duration         => 14,
-            result_cleanup_min_percentage             => 0,
-            asset_cleanup_min_percentage              => 0,
+            result_cleanup_max_free_percentage        => 100,
+            asset_cleanup_min_percentage              => 100,
             screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
             results_min_free_disk_space_percentage    => undef,

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -129,7 +129,7 @@ sub read_config {
         misc_limits => {
             untracked_assets_storage_duration         => 14,
             result_cleanup_max_free_percentage        => 100,
-            asset_cleanup_min_percentage              => 100,
+            asset_cleanup_max_free_percentage         => 100,
             screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
             results_min_free_disk_space_percentage    => undef,

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -68,7 +68,7 @@ sub _limit {
     return undef
       if finish_job_if_disk_usage_below_percentage(
         job     => $job,
-        setting => 'asset_cleanup_min_percentage',
+        setting => 'asset_cleanup_max_free_percentage',
         dir     => assetdir,
       );
 

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -52,7 +52,7 @@ sub _limit {
     return undef
       if finish_job_if_disk_usage_below_percentage(
         job     => $job,
-        setting => 'result_cleanup_min_percentage',
+        setting => 'result_cleanup_max_free_percentage',
         dir     => resultdir,
       );
 

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -1,0 +1,65 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::Task::Utils;
+use Mojo::Base -signatures;
+
+use Exporter qw(import);
+use Filesys::Df qw(df);
+use Scalar::Util qw(looks_like_number);
+use OpenQA::Log qw(log_warning);
+
+our (@EXPORT, @EXPORT_OK);
+@EXPORT_OK = (qw(check_df finish_job_if_disk_usage_below_percentage));
+
+sub check_df ($dir) {
+    my $df              = Filesys::Df::df($dir, 1) // {};
+    my $available_bytes = $df->{bavail};
+    my $total_bytes     = $df->{blocks};
+    die "Unable to determine disk usage of '$dir'"
+      unless looks_like_number($available_bytes)
+      && looks_like_number($total_bytes)
+      && $total_bytes > 0
+      && $available_bytes >= 0
+      && $available_bytes <= $total_bytes;
+    return ($available_bytes, $total_bytes);
+}
+
+sub finish_job_if_disk_usage_below_percentage (%args) {
+    my $job        = $args{job};
+    my $percentage = $job->app->config->{misc_limits}->{$args{setting}};
+    return undef unless $percentage;
+
+    unless (looks_like_number($percentage) && $percentage > 0 && $percentage < 100) {
+        log_warning "Specified value for $args{setting} is not a percentage and will be ignored.";
+        return undef;
+    }
+
+    my $dir = $args{dir};
+    my ($available_bytes, $total_bytes) = eval { check_df($dir) };
+    if (my $error = $@) {
+        log_warning "$error Proceeding with cleanup.";
+        return undef;
+    }
+
+    my $used_percentage = 100 - $available_bytes / $total_bytes * 100;
+    return undef if $used_percentage < $percentage;
+    $job->finish("Skipping, disk usage of '$dir' is below configured percentage $percentage %"
+          . " (used percentage: $used_percentage %)");
+    return 1;
+}
+
+
+1;

--- a/t/config.t
+++ b/t/config.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -115,6 +115,8 @@ subtest 'Test configuration default modes' => sub {
         },
         misc_limits => {
             untracked_assets_storage_duration         => 14,
+            result_cleanup_min_percentage             => 0,
+            asset_cleanup_min_percentage              => 0,
             screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
         },

--- a/t/config.t
+++ b/t/config.t
@@ -115,8 +115,8 @@ subtest 'Test configuration default modes' => sub {
         },
         misc_limits => {
             untracked_assets_storage_duration         => 14,
-            result_cleanup_min_percentage             => 0,
-            asset_cleanup_min_percentage              => 0,
+            result_cleanup_max_free_percentage        => 100,
+            asset_cleanup_min_percentage              => 100,
             screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
         },

--- a/t/config.t
+++ b/t/config.t
@@ -116,7 +116,7 @@ subtest 'Test configuration default modes' => sub {
         misc_limits => {
             untracked_assets_storage_duration         => 14,
             result_cleanup_max_free_percentage        => 100,
-            asset_cleanup_min_percentage              => 100,
+            asset_cleanup_max_free_percentage         => 100,
             screenshot_cleanup_batch_size             => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
         },


### PR DESCRIPTION
* Make the minimum used disk space configurable having the new behavior not
  enabled by default
* See https://progress.opensuse.org/issues/88121#note-10