### PR TITLE
Use codecov-bash to upload coverage reports

### DIFF
--- a/.circleci/ci-packages.txt
+++ b/.circleci/ci-packages.txt
@@ -122,6 +122,7 @@ perl-JavaScript-Minifier-XS-0.11
 perl-JSON-2.97001
 perl-JSON-Validator-3.08
 perl-JSON-XS-3.04
+perl-JSON-MaybeXS
 perl-libwww-perl-6.31
 perl-Lingua-EN-Inflect-1.903
 perl-List-MoreUtils-0.428

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ images:
       # that context in the prove calling context.
       PERL_TEST_HARNESS_DUMP_TAP: test-results
       HARNESS: --harness TAP::Harness::JUnit --timer
+      DEVEL_COVER_DB_FORMAT: JSON
       COVEROPT: -MDevel::Cover=-select_re,'^/lib',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement
       COMMIT_AUTHOR_EMAIL: skynet@open.qa
 
@@ -269,10 +270,16 @@ jobs:
       - run: *install_cached_packages
       - attach_workspace:
           at: .
-      - run: cover -write cover_db cover_db*
-      - run: cover -select_re '^(lib|script|t)/' -report html_minimal
+      - run:
+          name: Merge coverage databases
+          command: |
+            cover -write cover_db cover_db*
+            ls cover_db/*cov*
+      - run: make coverage-html
       - store_artifacts: *store_cover_db
-      - run: cover -select_re '^(lib|script|t)/' -report codecov
+      - run: sudo cpanm -nq 'Devel::Cover::Report::Codecovbash'
+      - run: make coverage-codecov
+      - run: bash <(curl -s https://codecov.io/bash)
 
   build-docs: &docs-template
     name: "Generating docs"

--- a/Makefile
+++ b/Makefile
@@ -204,12 +204,12 @@ coverage:
 COVER_REPORT_OPTS ?= -select_re '^(lib|script|t)/'
 
 .PHONY: coverage-codecov
-coverage-codecov: coverage
-	cover $(COVER_REPORT_OPTS) -report codecov
+coverage-codecov:
+	cover $(COVER_REPORT_OPTS) -report codecovbash
 
 .PHONY: coverage-html
-coverage-html: coverage
-	cover $(COVER_REPORT_OPTS) -report html_basic
+coverage-html:
+	cover $(COVER_REPORT_OPTS) -report html_minimal
 
 public/favicon.ico: assets/images/logo.svg
 	for w in 16 32 64 128; do \

--- a/cpanfile
+++ b/cpanfile
@@ -116,6 +116,7 @@ on 'test' => sub {
 on 'devel' => sub {
     requires 'Devel::Cover';
     requires 'Devel::Cover::Report::Codecov';
+    requires 'JSON::MaybeXS';
     requires 'Perl::Tidy', '== 20210111';
 
 };

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -72,6 +72,7 @@ devel_no_selenium_requires:
   xorg-x11-fonts:
   perl(Devel::Cover):
   perl(Devel::Cover::Report::Codecov):
+  perl(JSON::MaybeXS):
   perl(Perl::Tidy): '== 20210111'
 
 devel_requires:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -71,7 +71,7 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define devel_no_selenium_requires %build_requires %qemu %test_requires curl perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy) postgresql-devel rsync sudo tar xorg-x11-fonts
+%define devel_no_selenium_requires %build_requires %qemu %test_requires curl perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(JSON::MaybeXS) perl(Perl::Tidy) postgresql-devel rsync sudo tar xorg-x11-fonts
 # The following line is generated from dependencies.yaml
 %define devel_requires %devel_no_selenium_requires chromedriver
 


### PR DESCRIPTION
As per suggestion in [poo#88915](https://progress.opensuse.org/issues/88915) since it was't much work and I was still investigating the upload errors. And despite this being reproduced in other projects, *codecov-bash* seems to work fine.

- Add JSON::MaybeXS and use JSON for codecov db in CI
- Update and use makefile targets in CI
- Replace codecov (perl) with codecov-bash

**Note**: [Devel::Cover::Report::Codecovbash](https://metacpan.org/pod/Devel::Cover::Report::Codecovbash) is used in CI via CPAN