### PR TITLE
CI: Add compose tests via GitHub workflow

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -1,0 +1,11 @@
+---
+name: compose
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+jobs:
+  webui-docker-compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Verify that containers can be composed
+        run: make test-containers-compose

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ endif
 endif
 
 .PHONY: test-checkstyle
-test-checkstyle: test-checkstyle-standalone test-tidy-compile
+test-checkstyle: test-checkstyle-standalone test-tidy-compile test-containers-compose
 
 .PHONY: test-t
 test-t:
@@ -279,6 +279,10 @@ tidy-js: check-js-beautify
 .PHONY: tidy
 tidy: tidy-js
 	tools/tidy
+
+.PHONY: test-containers-compose
+test-containers-compose:
+	for i in $(wildcard container/**/docker-compose.yaml); do sudo docker-compose up -d -f $$i; done
 
 .PHONY: update-deps
 update-deps:


### PR DESCRIPTION
Testing out a simple GHA to test the `docker-compose.yml` for the *webui* using [isbang/compose-action](https://github.com/marketplace/actions/docker-compose-action).

Related to #3755