### PR TITLE
t: Increase timeout in 27-plugin_obs_rsync_status_details.t

### DIFF
--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -127,8 +127,8 @@ my %params = (
 sub _wait_helper {
     my ($element, $test_break, $refresh) = @_;
     my $ret;
-    for (0 .. 1) {
-        for (0 .. 50) {
+    for (0 .. 3) {
+        for (0 .. 30) {
             $ret = $driver->find_element($element)->get_text();
             return $ret if $test_break->($ret);    # uncoverable statement
             sleep .1;                              # uncoverable statement


### PR DESCRIPTION
Sometimes gru is very slow in CI, so the test reports a failure.
This change aims to wait longer for gru to catch up.