### PR TITLE
CI: Add hadolint validation via GitHub workflow

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,11 @@
+---
+name: hadolint
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate container images
+        run: make test-containers-hadolint

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,11 @@ tidy-js: check-js-beautify
 tidy: tidy-js
 	tools/tidy
 
+.PHONY: test-containers-hadolint
+test-containers-hadolint:
+	docker run --rm -i hadolint/hadolint <container/webui/Dockerfile
+	docker run --rm -i hadolint/hadolint <container/worker/Dockerfile
+
 .PHONY: update-deps
 update-deps:
 	tools/update-deps --specfile dist/rpm/openQA.spec

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -3,11 +3,13 @@ FROM opensuse/leap:15.2
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
+# hadolint ignore=DL3037
 RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel_openQA && \
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    zypper --non-interactive in ca-certificates-mozilla curl && \
-    zypper --non-interactive in --force-resolution openQA-local-db apache2 hostname which w3m
+    zypper in -y ca-certificates-mozilla curl && \
+    zypper in -y --force-resolution openQA-local-db apache2 hostname which w3m && \
+    zypper clean
 
 # setup apache
 RUN gensslcert && \
@@ -18,9 +20,9 @@ RUN gensslcert && \
     a2enmod ssl && \
     a2enmod rewrite && \
     a2enflag SSL
-ADD openqa-ssl.conf /etc/apache2/vhosts.d/openqa-ssl.conf
-ADD openqa.conf /etc/apache2/vhosts.d/openqa.conf
-ADD run_openqa.sh /root/
+COPY openqa-ssl.conf /etc/apache2/vhosts.d/openqa-ssl.conf
+COPY openqa.conf /etc/apache2/vhosts.d/openqa.conf
+COPY run_openqa.sh /root/
 
 # set-up shared data and configuration
 RUN rm -rf /etc/openqa/openqa.ini /etc/openqa/client.conf \

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -3,18 +3,20 @@ FROM opensuse/leap:15.2
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
+# hadolint ignore=DL3037
 RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.2 devel_openQA && \
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.2/openSUSE_Leap_15.2 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    zypper --non-interactive in ca-certificates-mozilla curl gzip && \
-    zypper --non-interactive in openQA-worker qemu-arm qemu-ppc qemu-x86 qemu-tools && \
-    zypper --non-interactive in kmod && \
-    (zypper --non-interactive in qemu-ovmf-x86_64 || true) && \
-    (zypper --non-interactive in qemu-uefi-aarch64 || true)
+    zypper in -y ca-certificates-mozilla curl gzip && \
+    zypper in -y openQA-worker qemu-arm qemu-ppc qemu-x86 qemu-tools && \
+    zypper in -y kmod && \
+    (zypper in -y qemu-ovmf-x86_64 || true) && \
+    (zypper in -y qemu-uefi-aarch64 || true) && \
+    zypper clean
 
 RUN mkdir -p /root/qemu
-ADD kvm-mknod.sh /root/qemu/kvm-mknod.sh
-ADD run_openqa_worker.sh /run_openqa_worker.sh
+COPY kvm-mknod.sh /root/qemu/kvm-mknod.sh
+COPY run_openqa_worker.sh /run_openqa_worker.sh
 # ensure executability in case we loose file permissions, e.g. within open
 # build service when downloading files into the container build project
 RUN chmod +x /root/qemu/kvm-mknod.sh && \


### PR DESCRIPTION
Using [hadolint via GHA](https://github.com/marketplace/actions/hadolint-action), locally tested like so:

    podman run --rm -i hadolint/hadolint <container/worker/Dockerfile
    podman run --rm -i hadolint/hadolint <container/webui/Dockerfile

See: [poo#88451](https://progress.opensuse.org/issues/88451)