### PR TITLE
Make OAuth2 parameters customizable, get OAuth2 to work with salsa.debian.org (gitlab)

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -303,9 +303,10 @@ according to
 [[authentication]]
 === User authentication
 
-OpenQA supports three different authentication methods - OpenID (default),
-OAuth2 (currently limited to GitHub) and Fake (for development).
-See `auth` section in `/etc/openqa/openqa.ini`.
+OpenQA supports three different authentication methods: OpenID (default),
+OAuth2 and Fake (for development).
+
+Use the `auth` section in `/etc/openqa/openqa.ini` to configure the method:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -314,8 +315,15 @@ See `auth` section in `/etc/openqa/openqa.ini`.
 method = OpenID
 --------------------------------------------------------------------------------
 
-Independently of method used, the first user that logs in (if there is no admin yet)
-will automatically get administrator rights!
+Independently of method used, the first user that logs in (if there is no
+admin yet) will automatically get administrator rights!
+
+Note that only one authentication method and only one OpenID/OAuth2 provider
+can be configured at a time. When changing the method/provider no
+users/permissions are lost. However, a new and distinct user (with default
+permissions) will be created when logging in via a different method/provider
+because there is no automatic mapping of identities across different
+methods/providers.
 
 ==== OpenID
 
@@ -339,7 +347,15 @@ This method supports OpenID version up to 2.0.
 
 ==== OAuth2
 
-Login via OAuth 2.0 is currently limited to GitHub.
+An additional Mojolicious plugin is required to use this feature:
+
+[source,sh]
+-------------------------------------------------------------------------------
+# openSUSE
+zypper in 'perl(Mojolicious::Plugin::OAuth2)'
+-------------------------------------------------------------------------------
+
+Example for configuring OAuth2 with GitHub:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -353,17 +369,13 @@ key = mykey
 secret = mysecret
 --------------------------------------------------------------------------------
 
-In order to use GitHub for authorization, the instance needs to be
-https://github.com/settings/applications/new[registered on GitHub]. Afterwards
-the key and secret will be visible to the application owner(s).
+In order to use GitHub for authorization, an "OAuth App" needs to be
+https://github.com/settings/applications/new[registered on GitHub]. Use `…/login`
+as callback URL. Afterwards the key and secret will be visible to the application
+owner(s).
 
-Note: An additional Mojolicious plugin is required to use this feature:
-
-[source,sh]
--------------------------------------------------------------------------------
-# openSUSE
-zypper in 'perl(Mojolicious::Plugin::OAuth2)'
--------------------------------------------------------------------------------
+As shown in the comments of the default configuration file, it is also possible
+to use different providers.
 
 ==== Fake
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -87,23 +87,25 @@
 [auth]
 # method = Fake|OpenID|OAuth2
 
-# for GitHub/salsa.debian.org one can use:
+# for GitHub, salsa.debian.org and providers listed on https://metacpan.org/pod/Mojolicious::Plugin::OAuth2#Configuration
+# one can use:
 #[oauth2]
-#provider = github/debian_salsa
+#provider = github|debian_salsa
 #key = ...
 #secret = ...
 
-# alternatively, one can specify everything in this file with no magic provider name
+# alternatively, one can specify parameters manually without relying on magic a provider name:
 #[oauth2]
 #provider = custom
+#unique_name = debian_salsa
 #key = ...
 #secret = ...
-#authorize_url => https://salsa.debian.org/oauth/authorize?response_type=code
-#token_url     => https://salsa.debian.org/oauth/token
-#user_url      => https://salsa.debian.org/api/v4/user
-#token_scope   => read_user
-#token_label   => Bearer
-#nickname_from => username
+#authorize_url = https://salsa.debian.org/oauth/authorize?response_type=code
+#token_url = https://salsa.debian.org/oauth/token
+#user_url  = https://salsa.debian.org/api/v4/user
+#token_scope = read_user
+#token_label = Bearer
+#nickname_from = username
 
 [logging]
 #logging is to stderr (so systemd journal) by default

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -85,7 +85,26 @@
 
 ## Authentication method to use for user management
 [auth]
-# method = Fake|OpenID
+# method = Fake|OpenID|OAuth2
+
+#for salsa.debian.org one can use:
+#[oauth2]
+#provider = debian_salsa
+#key = ...
+#secret = ...
+
+# alternatively, one can specify everything in this file,
+# with no magic provider name like 'debian_salsa' or 'github'
+#[oauth2]
+#provider = custom
+#key = ...
+#secret = ...
+#authorize_url => https://salsa.debian.org/oauth/authorize?response_type=code
+#token_url     => https://salsa.debian.org/oauth/token
+#user_url      => https://salsa.debian.org/api/v4/user
+#token_scope   => read_user
+#token_label   => Bearer
+#nickname_from => username
 
 [logging]
 #logging is to stderr (so systemd journal) by default

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -87,14 +87,13 @@
 [auth]
 # method = Fake|OpenID|OAuth2
 
-#for salsa.debian.org one can use:
+# for GitHub/salsa.debian.org one can use:
 #[oauth2]
-#provider = debian_salsa
+#provider = github/debian_salsa
 #key = ...
 #secret = ...
 
-# alternatively, one can specify everything in this file,
-# with no magic provider name like 'debian_salsa' or 'github'
+# alternatively, one can specify everything in this file with no magic provider name
 #[oauth2]
 #provider = custom
 #key = ...

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -77,9 +77,15 @@ sub read_config {
             httpsonly => 1,
         },
         oauth2 => {
-            provider => '',
-            key      => '',
-            secret   => '',
+            provider      => '',
+            key           => '',
+            secret        => '',
+            authorize_url => '',
+            token_url     => '',
+            user_url      => '',
+            token_scope   => '',
+            token_label   => '',
+            nickname_from => '',
         },
         hypnotoad => {
             listen => ['http://localhost:9526/'],

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -86,6 +86,7 @@ sub read_config {
             token_scope   => '',
             token_label   => '',
             nickname_from => '',
+            unique_name   => '',
         },
         hypnotoad => {
             listen => ['http://localhost:9526/'],

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -54,6 +54,7 @@ sub auth_setup ($server) {
                 token_scope   => $config->{token_scope},
                 token_label   => $config->{token_label},
                 nickname_from => $config->{nickname_from},
+                unique_name   => $config->{unique_name},
             },
         },
     );
@@ -85,10 +86,12 @@ sub auth_login ($controller) {
                 # Note: Using 403 for consistency
                 return $controller->render(text => "$err->{code}: $err->{message}", status => 403);
             }
-            my $details = $res->json;
-            my $user    = $controller->schema->resultset('Users')->create_user(
+            my $details       = $res->json;
+            my $provider_name = $main_config->{provider};
+            $provider_name = $provider_config->{unique_name} || $provider_name if $provider_name eq 'custom';
+            my $user = $controller->schema->resultset('Users')->create_user(
                 $details->{id},
-                provider => "oauth2\@$main_config->{provider}",
+                provider => "oauth2\@$provider_name",
                 nickname => $details->{$provider_config->{nickname_from}},
                 fullname => $details->{name},
                 email    => $details->{email});

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -22,8 +22,8 @@ has config => undef;
 
 sub auth_setup {
     my ($self) = @_;
-    $self->config($self->app->config->{oauth2});
-    croak 'No OAuth2 provider selected' unless my $provider = $self->config->{provider};
+    $self->config(my $config = $self->app->config->{oauth2});
+    croak 'No OAuth2 provider selected' unless my $provider = $config->{provider};
     my $prov_args = {
         key    => $self->config->{key},
         secret => $self->config->{secret},
@@ -85,7 +85,7 @@ sub auth_login {
             }
             my $details = $res->json;
             my $user    = $self->schema->resultset('Users')->create_user(
-                $details->{id} . "@" . $self->config->{provider},
+                "$details->{id}\@$self->config->{provider}",
                 nickname => $details->{$self->config->{FIXME_oauth2_nickname_from}},
                 fullname => $details->{name},
                 email    => $details->{email});

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -66,39 +66,43 @@ sub auth_setup ($server) {
     $app->plugin(OAuth2 => {$provider => \%provider_args});
 }
 
+sub update_user ($controller, $main_config, $provider_config, $data) {
+    return undef unless $data;    # redirect to ID provider
+
+    # get or update user details
+    my $ua    = Mojo::UserAgent->new;
+    my $token = $data->{access_token};
+    my $tx    = $ua->get($provider_config->{user_url}, {Authorization => "$provider_config->{token_label} $token"});
+    if (my $err = $tx->error) {
+        my $msg = $err->{code} ? "$err->{code} response: $err->{message}" : "Connection error: $err->{message}";
+        return $controller->render(text => $msg, status => 403);    # return always 403 for consistency
+    }
+    my $details = $tx->res->json;
+    if (ref $details ne 'HASH' || !$details->{id} || !$details->{$provider_config->{nickname_from}}) {
+        return $controller->render(text => 'User data returned by OAuth2 provider is insufficient', status => 403);
+    }
+    my $provider_name = $main_config->{provider};
+    $provider_name = $provider_config->{unique_name} || $provider_name if $provider_name eq 'custom';
+    my $user = $controller->schema->resultset('Users')->create_user(
+        $details->{id},
+        provider => "oauth2\@$provider_name",
+        nickname => $details->{$provider_config->{nickname_from}},
+        fullname => $details->{name},
+        email    => $details->{email});
+
+    $controller->session->{user} = $user->username;
+    $controller->redirect_to('index');
+}
+
 sub auth_login ($controller) {
     croak 'Config was not parsed' unless my $main_config     = $controller->app->config->{oauth2};
     croak 'Setup was not called'  unless my $provider_config = $main_config->{provider_config};
 
     my $get_token_args = {redirect_uri => $controller->url_for('login')->userinfo(undef)->to_abs};
     $get_token_args->{scope} = $provider_config->{token_scope};
-    $controller->oauth2->get_token_p($main_config->{provider} => $get_token_args)->then(
-        sub {
-            return undef unless my $data = shift;    # redirect to ID provider
-
-            # Get or update user details
-            my $ua    = Mojo::UserAgent->new;
-            my $token = $data->{access_token};
-            my $res
-              = $ua->get($provider_config->{user_url}, {Authorization => "$provider_config->{token_label} $token"})
-              ->result;
-            if (my $err = $res->error) {
-                # Note: Using 403 for consistency
-                return $controller->render(text => "$err->{code}: $err->{message}", status => 403);
-            }
-            my $details       = $res->json;
-            my $provider_name = $main_config->{provider};
-            $provider_name = $provider_config->{unique_name} || $provider_name if $provider_name eq 'custom';
-            my $user = $controller->schema->resultset('Users')->create_user(
-                $details->{id},
-                provider => "oauth2\@$provider_name",
-                nickname => $details->{$provider_config->{nickname_from}},
-                fullname => $details->{name},
-                email    => $details->{email});
-
-            $controller->session->{user} = $user->username;
-            $controller->redirect_to('index');
-        })->catch(sub { $controller->render(text => shift, status => 403) });
+    $controller->oauth2->get_token_p($main_config->{provider} => $get_token_args)
+      ->then(sub { update_user($controller, $main_config, $provider_config, shift) })
+      ->catch(sub { $controller->render(text => shift, status => 403) });
     return (manual => 1);
 }
 

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,85 +14,88 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Auth::OAuth2;
-use Mojo::Base -base;
-
+use Mojo::Base -base, -signatures;
 use Carp 'croak';
 
-has config => undef;
-
-sub auth_setup {
-    my ($self) = @_;
-    $self->config(my $config = $self->app->config->{oauth2});
+sub auth_setup ($server) {
+    my $app    = $server->app;
+    my $config = $app->config->{oauth2};
     croak 'No OAuth2 provider selected' unless my $provider = $config->{provider};
-    my $prov_args = {
-        key    => $self->config->{key},
-        secret => $self->config->{secret},
-    };
-    # I'm afraid I don't quite get where I should tuck this away so that I get
-    # to use it in auth_login, so I'm doing this FIXME_oauth2_ nastiness for
-    # now. I had hoped to tack this onto $prov_args somehow, but I don't know
-    # how to then access that later.
-    if ($provider eq 'github') {
-        $self->config->{FIXME_oauth2_user_url} = 'https://api.github.com/user';
-        # Note: user:email is GitHub-specific, email may be empty
-        $self->config->{FIXME_oauth2_token_scope} = 'user:email';
-        $self->config->{FIXME_oauth2_token_label} = 'token';
-        $self->config->{FIXME_oauth2_nickname_from} = 'login';
-    }
-    elsif ('debian_salsa' eq $provider) {
-        $prov_args->{authorize_url} = 'https://salsa.debian.org/oauth/authorize?response_type=code';
-        $prov_args->{token_url} = 'https://salsa.debian.org/oauth/token';
-        $self->config->{FIXME_oauth2_user_url} = 'https://salsa.debian.org/api/v4/user';
-        $self->config->{FIXME_oauth2_token_scope} = 'read_user';
-        $self->config->{FIXME_oauth2_token_label} = 'Bearer';
-        $self->config->{FIXME_oauth2_nickname_from} = 'username';
-    }
-    elsif ('custom' eq $provider) {
-        $prov_args->{authorize_url} = $self->config->{authorize_url};
-        $prov_args->{token_url} = $self->config->{token_url};
-        $self->config->{FIXME_oauth2_user_url} = $self->config->{user_url};
-        $self->config->{FIXME_oauth2_token_scope} = $self->config->{token_scope};
-        $self->config->{FIXME_oauth2_token_label} = $self->config->{token_label};
-        $self->config->{FIXME_oauth2_nickname_from} = $self->config->{nickname_from};
-    }
-    else {
-        croak "Provider $provider not supported";
-    }
 
-    $self->app->plugin(
-        OAuth2 => {
-            $provider => $prov_args
-        });
+    my %parameters_by_provider = (
+        github => {
+            args   => [],
+            config => {
+                user_url      => 'https://api.github.com/user',
+                token_scope   => 'user:email',
+                token_label   => 'token',
+                nickname_from => 'login',
+            },
+        },
+        debian_salsa => {
+            args => [
+                authorize_url => 'https://salsa.debian.org/oauth/authorize?response_type=code',
+                token_url     => 'https://salsa.debian.org/oauth/token',
+            ],
+            config => {
+                user_url      => 'https://salsa.debian.org/api/v4/user',
+                token_scope   => 'read_user',
+                token_label   => 'Bearer',
+                nickname_from => 'username',
+            },
+        },
+        custom => {
+            args => [
+                authorize_url => $config->{authorize_url},
+                token_url     => $config->{token_url},
+            ],
+            config => {
+                user_url      => $config->{user_url},
+                token_scope   => $config->{token_scope},
+                token_label   => $config->{token_label},
+                nickname_from => $config->{nickname_from},
+            },
+        },
+    );
+    my $params = $parameters_by_provider{$provider};
+    croak "OAuth2 provider '$provider' not supported" unless $params;
+
+    my %provider_args = (key => $config->{key}, secret => $config->{secret}, @{$params->{args}});
+    $config->{provider_config} = $params->{config};
+    $app->plugin(OAuth2 => {$provider => \%provider_args});
 }
 
-sub auth_login {
-    my ($self) = @_;
-    croak 'Setup was not called' unless $self->config;
+sub auth_login ($controller) {
+    croak 'Config was not parsed' unless my $main_config     = $controller->app->config->{oauth2};
+    croak 'Setup was not called'  unless my $provider_config = $main_config->{provider_config};
 
-    my $get_token_args = {redirect_uri => $self->url_for('login')->userinfo(undef)->to_abs};
-    $get_token_args->{scope} = $self->config->{FIXME_oauth2_token_scope};
-    $self->oauth2->get_token_p($self->config->{provider} => $get_token_args)->then(
+    my $get_token_args = {redirect_uri => $controller->url_for('login')->userinfo(undef)->to_abs};
+    $get_token_args->{scope} = $provider_config->{token_scope};
+    $controller->oauth2->get_token_p($main_config->{provider} => $get_token_args)->then(
         sub {
-            return unless my $data = shift;  # redirect to ID provider
+            return undef unless my $data = shift;    # redirect to ID provider
 
             # Get or update user details
             my $ua    = Mojo::UserAgent->new;
             my $token = $data->{access_token};
-            my $res   = $ua->get($self->config->{FIXME_oauth2_user_url}, {Authorization => $self->config->{FIXME_oauth2_token_label} . " $token"})->result;
+            my $res
+              = $ua->get($provider_config->{user_url}, {Authorization => "$provider_config->{token_label} $token"})
+              ->result;
             if (my $err = $res->error) {
                 # Note: Using 403 for consistency
-                return $self->render(text => "$err->{code}: $err->{message}", status => 403);
+                return $controller->render(text => "$err->{code}: $err->{message}", status => 403);
             }
             my $details = $res->json;
-            my $user    = $self->schema->resultset('Users')->create_user(
-                "$details->{id}\@$self->config->{provider}",
-                nickname => $details->{$self->config->{FIXME_oauth2_nickname_from}},
+            my $user    = $controller->schema->resultset('Users')->create_user(
+                $details->{id},
+                provider => "oauth2\@$main_config->{provider}",
+                nickname => $details->{$provider_config->{nickname_from}},
                 fullname => $details->{name},
                 email    => $details->{email});
 
-            $self->session->{user} = $user->username;
-            $self->redirect_to('index');
-        })->catch(sub { $self->render(text => shift, status => 403) });
+            $controller->session->{user} = $user->username;
+            $controller->redirect_to('index');
+        })->catch(sub { $controller->render(text => shift, status => 403) });
     return (manual => 1);
 }
 

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,18 +51,10 @@ combined_like { test_auth_method_startup('OpenID')->status_is(403) } qr/Claiming
   'Plugin loaded, identity denied';
 
 subtest OAuth2 => sub {
-    lives_ok {
-        $t->app->plugin(
-            OAuth2 => {
-                mocked => {
-                    key => 'deadbeef',
-                }})
-    }
-    'auth mocked';
-
+    lives_ok { $t->app->plugin(OAuth2 => {mocked => {key => 'deadbeef'}}) } 'auth mocked';
     throws_ok { test_auth_method_startup 'OAuth2' } qr/No OAuth2 provider selected/, 'Error with no provider selected';
     throws_ok { test_auth_method_startup('OAuth2', ("[oauth2]\n", "provider = foo\n")) }
-    qr/Provider foo not supported/, 'Error with unsupported provider';
+    qr/OAuth2 provider 'foo' not supported/, 'Error with unsupported provider';
     combined_like { test_auth_method_startup('OAuth2', ("[oauth2]\n", "provider = github\n")) } qr/302 Found/,
       'Plugin loaded';
 };

--- a/t/config.t
+++ b/t/config.t
@@ -85,6 +85,7 @@ subtest 'Test configuration default modes' => sub {
             token_scope   => '',
             token_label   => '',
             nickname_from => '',
+            unique_name   => '',
         },
         hypnotoad => {
             listen => ['http://localhost:9526/'],

--- a/t/config.t
+++ b/t/config.t
@@ -76,9 +76,15 @@ subtest 'Test configuration default modes' => sub {
             httpsonly => 1,
         },
         oauth2 => {
-            provider => '',
-            key      => '',
-            secret   => '',
+            provider      => '',
+            key           => '',
+            secret        => '',
+            authorize_url => '',
+            token_url     => '',
+            user_url      => '',
+            token_scope   => '',
+            token_label   => '',
+            nickname_from => '',
         },
         hypnotoad => {
             listen => ['http://localhost:9526/'],


### PR DESCRIPTION
In the diff you'll see a load of config hash keys of the form FIXME_oauth2_*

I had rather hoped that I'd be able to put the data contained in them into the $prov_args hash, and thus attach them as extra fields to the provider's defaults, but I'm obviously not quite understanding all the perl5-isms (my perl is quite rusty ;-) )

If someone can have a look at this, and point out how to do this properly, that would be great.

BTW this is a patch arising from my current quest to a) get openqa.debian.net to be more useful, and more widely used, and b) to get an OpenQA package into the Debian package archive at some point soon.

Cheers, Phil.