### PR TITLE
docker: Allow docker-compose build images

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -1,0 +1,12 @@
+---
+name: compose
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+jobs:
+  webui-docker-compose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Verify that containers can be composed
+        run: make test-containers-compose

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ test: test-with-database
 else
 test: test-checkstyle-standalone test-with-database
 endif
+ifeq ($(CONTAINER_TEST),1)
+test: test-containers-compose
+endif
 endif
 
 .PHONY: test-checkstyle
@@ -294,6 +297,10 @@ test-check-containers:
 .PHONY: tidy
 tidy: tidy-js
 	tools/tidy
+
+.PHONY: test-containers-compose
+test-containers-compose:
+	tools/test_containers_compose
 
 .PHONY: update-deps
 update-deps:

--- a/container/webui/docker-compose.yaml
+++ b/container/webui/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
   data:
     image: openqa_data
+    build: ../openqa_data/
     restart: always
     volumes:
       - ./workdir/data/factory:/data/factory
@@ -22,6 +23,7 @@ services:
 
   websockets:
     image: openqa_webui
+    build: .
     ports:
       - "9527:9527"  # worker connection
     volumes:
@@ -37,6 +39,7 @@ services:
 
   gru:
     image: openqa_webui
+    build: .
     volumes:
       - ./workdir/data/factory:/data/factory
       - ./workdir/data/tests:/data/tests
@@ -49,6 +52,7 @@ services:
 
   livehandler:
     image: openqa_webui
+    build: .
     ports:
       - "9528:9528"  # handle live view
     volumes:
@@ -64,6 +68,7 @@ services:
 
   webui:
     image: openqa_webui
+    build: .
     ports:
       - "9526"
     volumes:
@@ -91,6 +96,9 @@ services:
 
   nginx:
     image: openqa_webui_lb
+    build:
+      context: .
+      dockerfile: Dockerfile-lb
     restart: always
     ports:
       - "9526:9526"

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -290,6 +290,10 @@ rm \
 # within CI systems, e.g. OBS. See t/lib/OpenQA/Test/TimeLimit.pm
 export CI=1
 export OPENQA_TEST_TIMEOUT_SCALE_CI=10
+# Skip container tests that would need additional requirements, e.g.
+# docker-compose. Also, these tests are less relevant (or not relevant) for
+# packaging
+export CONTAINER_TEST=0
 make test PROVE_ARGS='-r -v' CHECKSTYLE=0 TEST_PG_PATH=%{buildroot}/DB
 rm -rf %{buildroot}/DB
 %endif

--- a/tools/test_containers_compose
+++ b/tools/test_containers_compose
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for i in webui; do
+  (
+    cd container/$i/ &&
+    sudo docker-compose build -q --parallel &&
+    sudo docker-compose up -d &&
+   (docker-compose ps --services --filter status=stopped | grep "^[[:space:]]*$") || (docker-compose logs; sudo docker-compose ps; exit 1)
+  ) || exit 1;
+done


### PR DESCRIPTION
Now docker-compose is able to build the images before try to start
the containers

https://progress.opensuse.org/issues/89719