### PR TITLE
container: Fix missing shared directories and its permissions

### DIFF
--- a/container/webui/docker-compose.yaml
+++ b/container/webui/docker-compose.yaml
@@ -1,24 +1,20 @@
 version: '3.8'
-services:
-  data:
-    image: openqa_data
-    build: ../openqa_data/
-    restart: always
-    volumes:
-      - ./workdir/data/factory:/data/factory
-      - ./workdir/data/tests:/data/tests
 
+services:
   scheduler:
     image: openqa_webui
-    volumes:
-      - ./workdir/data/factory:/data/factory
-      - ./workdir/data/tests:/data/tests
-      - ./conf:/data/conf
+    volumes: &volumes
+      - ./workdir/data/factory/iso:/data/factory/iso:rw
+      - ./workdir/data/factory/hdd:/data/factory/hdd:rw
+      - ./workdir/data/factory/other:/data/factory/other:rw
+      - ./workdir/data/factory/tmp:/data/factory/tmp:rw
+      - ./workdir/data/testresults:/data/testresults:rw
+      - ./workdir/data/tests:/data/tests:ro
+      - ./conf:/data/conf:ro
     environment:
       MODE: "scheduler"
       MOJO_LISTEN: "http://0.0.0.0:9529"
     depends_on:
-      - data
       - db
 
   websockets:
@@ -26,28 +22,20 @@ services:
     build: .
     ports:
       - "9527:9527"  # worker connection
-    volumes:
-      - ./workdir/data/factory:/data/factory
-      - ./workdir/data/tests:/data/tests
-      - ./conf:/data/conf
+    volumes: *volumes
     environment:
       MODE: "websockets"
       MOJO_LISTEN: "http://0.0.0.0:9527"
     depends_on:
-      - data
       - db
 
   gru:
     image: openqa_webui
     build: .
-    volumes:
-      - ./workdir/data/factory:/data/factory
-      - ./workdir/data/tests:/data/tests
-      - ./conf:/data/conf
+    volumes: *volumes
     environment:
       MODE: "gru"
     depends_on:
-      - data
       - db
 
   livehandler:
@@ -55,15 +43,11 @@ services:
     build: .
     ports:
       - "9528:9528"  # handle live view
-    volumes:
-      - ./workdir/data/factory:/data/factory
-      - ./workdir/data/tests:/data/tests
-      - ./conf:/data/conf
+    volumes: *volumes
     environment:
       MODE: "livehandler"
       MOJO_LISTEN: "http://0.0.0.0:9528"
     depends_on:
-      - data
       - db
 
   webui:
@@ -71,18 +55,16 @@ services:
     build: .
     ports:
       - "9526"
-    volumes:
-      - ./workdir/data/factory:/data/factory
-      - ./workdir/data/tests:/data/tests
-      - ./conf:/data/conf
+    volumes: *volumes
     environment:
       MODE: "webui"
       MOJO_LISTEN: "http://0.0.0.0:9526"
     depends_on:
-      - data
       - db
     deploy:
       replicas: ${OPENQA_WEBUI_REPLICAS}
+    entrypoint: "sh -c 'chmod -R a+rwX /data/{factory,testresults}; /root/run_openqa.sh'"
+
 
   db:
     image: postgres


### PR DESCRIPTION
- Check and complete with the missing directories
The directories 'tmp' and 'others' were missing.
Added all the required directories as volumes.

- Check and fix the permissions over these directories for the gekotest user
Because this directories are shared between all the containers and also
with the host. This PR assign the write permissions for the directories that
the containers write.

https://progress.opensuse.org/issues/89755