### PR TITLE
containers: Fix worker container entrypoint script

### DIFF
--- a/container/worker/conf/client.conf
+++ b/container/worker/conf/client.conf
@@ -1,0 +1,3 @@
+[openqa_webui]
+key = 1234567890ABCDEF
+secret = 1234567890ABCDEF

--- a/container/worker/conf/workers.ini
+++ b/container/worker/conf/workers.ini
@@ -1,0 +1,3 @@
+[global]
+BACKEND = qemu
+HOST = http://openqa_webui

--- a/container/worker/docker-compose.yaml
+++ b/container/worker/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  worker:
+    image: openqa_worker
+    build: .
+    privileged: true
+    devices:
+      - /dev/kvm
+    volumes:
+      - ./workdir/data/factory:/data/factory:rw
+      - ./workdir/data/tests:/data/tests:ro
+      - ./conf:/data/conf:ro
+    environment:
+      qemu_no_kvm: 1

--- a/container/worker/run_openqa_worker.sh
+++ b/container/worker/run_openqa_worker.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
-# shellcheck disable=SC2012
+# shellcheck disable=SC2012,SC2154
 set -e
 
 if [[ -z $OPENQA_WORKER_INSTANCE ]]; then
   OPENQA_WORKER_INSTANCE=1
 fi
 
-/root/qemu/kvm-mknod.sh
+if [[ -z $qemu_no_kvm ]] || [[ $qemu_no_kvm -eq 0 ]]; then
+  if [ -e "/dev/kvm" ] && getent group kvm > /dev/null; then
+    /root/qemu/kvm-mknod.sh
 
-if [ -e "/dev/kvm" ] && getent group kvm > /dev/null; then
-  groupmod -g "$(ls -lhn /dev/kvm | cut -d ' ' -f 4)" kvm
-  usermod -a -G kvm _openqa-worker
-else
-  echo "Warning: /dev/kvm doesn't exist. If you want to use KVM, run the container with --device=/dev/kvm"
+    group=$(ls -lhn /dev/kvm | cut -d ' ' -f 4)
+    groupmod -g "$group" --non-unique kvm
+    usermod -a -G kvm _openqa-worker
+  else
+    echo "Warning: /dev/kvm doesn't exist. If you want to use KVM, run the container with --device=/dev/kvm"
+  fi
 fi
+
+qemu-system-x86_64 -S &
+kill $!
 
 su _openqa-worker -c "/usr/share/openqa/script/worker --verbose --instance \"$OPENQA_WORKER_INSTANCE\""

--- a/tools/test_containers_compose
+++ b/tools/test_containers_compose
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-for i in webui; do
+for i in webui worker; do
   (
     cd container/$i/ &&
     sudo docker-compose build -q --parallel &&


### PR DESCRIPTION
Problem:
The current entrypoint.sh is generating this error
groupmod GID '0' already exists
    
Solution: Remove the group number in groupmod
    
Additionally
- Add qemu_no_kvm flag
- Provided a test for qemu
    
https://progress.opensuse.org/issues/88754