### PR TITLE
Fix default cover db suffix/filename i.e. cover_db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ run-tests-within-container:
 	tools/run-tests-within-container
 
 ifeq ($(COVERAGE),1)
-COVERDB_SUFFIX ?= ''
+COVERDB_SUFFIX ?=
 COVEROPT ?= -MDevel::Cover=-select_re,'^/lib',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement,-db,cover_db$(COVERDB_SUFFIX),
 endif
 


### PR DESCRIPTION
COVERDB_SUFFIX should be '' which means the assignment trails off in
makefile syntax. This is only visible locally with something like this
since in CI the suffix is used for different jobs:

    make coverage TESTS=t/api/03-auth.t

This fixes a regression introduced in #3753