### PR TITLE
Remove surplus `+` signs in documentation for importing production data

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -310,11 +310,11 @@ The script `openqa-setup-db` can be used to conduct step 4 and 5.
 ==== Importing production data
 Assuming you have already followed steps 1. to 4. above:
 
-1. Create a separate database: `createdb -O your_username openqa-o3+` where
+1. Create a separate database: `createdb -O your_username openqa-o3` where
    `openqa-o3+` is the name you want to use for the database
 2. The next steps must be run as the user you start your local openQA
    instance with, i.e. the `your_username` user.
-3. Import dump: `pg_restore -c -d openqa-o3+ path/to/dump`
+3. Import dump: `pg_restore -c -d openqa-o3 path/to/dump`
    Note that errors of the form `ERROR:  role "geekotest" does not exist` are
    due to the users in the production setup and can safely be ignored.
    Everything will be owned by `your_username`.


### PR DESCRIPTION
These `+` signs must have been wrongly added when changing the quotation style.