### PR TITLE
Avoid assigning a negative result_size to a job when cleaning up results

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1182,7 +1182,7 @@ sub delete_logs {
         find_video_files($result_dir),
     );
     my $deleted_size = _delete_returning_size_from_array(\@files);
-    $self->update({logs_present => 0, result_size => \"result_size - $deleted_size"});
+    $self->update({logs_present => 0, result_size => \"greatest(0, result_size - $deleted_size)"});
     return $deleted_size;
 }
 
@@ -1194,7 +1194,7 @@ sub delete_videos {
 
     my @files        = (find_video_files($result_dir), Mojo::Collection->new(path($result_dir, 'video_time.vtt')));
     my $deleted_size = _delete_returning_size_from_array(\@files);
-    $self->update({result_size => \"result_size - $deleted_size"});    # considering logs still present here
+    $self->update({result_size => \"greatest(0, result_size - $deleted_size)"});   # considering logs still present here
     return $deleted_size;
 }
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -757,6 +757,14 @@ subtest 'create result dir, delete results' => sub {
           or diag explain $job->video_file_paths->to_array;
         ok -e path($result_dir, $_), "$_ still present" for qw(autoinst-log.txt serial0.txt serial_terminal.txt);
     };
+    subtest 'result_size does not become negative' => sub {
+        $job_mock->redefine(_delete_returning_size_from_array => 5000);
+        $job->delete_logs;
+        $job->delete_videos;
+        $job->discard_changes;
+        is $job->result_size, 0, 'result_size just 0, not negative';
+        $job_mock->unmock('_delete_returning_size_from_array');
+    };
 
     # note: Deleting results is tested in 42-screenshots.t because the screenshots are the interesting part here.
 };


### PR DESCRIPTION
The accounting is not 100 % accurate so we might otherwise end up with jobs
having a negative result size.

I was made aware of this limitation by the following error showing up in a
cleanup task on OSD:
```
DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::Pg::st execute failed: ERROR:  integer out of range [for Statement "UPDATE jobs SET logs_present = ?, result_size = result_size - 9511751560, t_updated = ? WHERE id = ?" with ParamValues: 1=\'0\', 2=\'2021-03-12 23:23:27\', 3=\'5572530\'] at /usr/share/openqa/script/../lib/OpenQA/Schema/Result/Jobs.pm line 1185
```