### PR TITLE
Prevent worker from getting stuck in final upload when no tests are scheduled

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -425,7 +425,9 @@ sub _prepare_job_execution {
     $job->on(
         uploading_results_concluded => sub ($event, $event_info) {
             my $upload_up_to = $event_info->{upload_up_to};
-            log_debug $upload_up_to ? "Upload concluded up to $upload_up_to" : 'Final result upload concluded';
+            my $module       = $job->current_test_module;
+            my $info         = $upload_up_to ? "up to $upload_up_to" : ($module ? "at $module" : 'no current module');
+            log_debug "Upload concluded ($info)";
         });
 
     if (!$args{only_skipping}) {

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -562,8 +562,10 @@ subtest 'handle job status changes' => sub {
     combined_like {
         $fake_job->emit(uploading_results_concluded => {upload_up_to => 'foo'});
         $fake_job->emit(uploading_results_concluded => {upload_up_to => ''});
+        $fake_job->{_current_test_module} = 'bar';
+        $fake_job->emit(uploading_results_concluded => {upload_up_to => ''});
     }
-    qr/Upload concluded up to foo.*Final result upload concluded/s, 'upload status logged';
+    qr/Upload concluded \(up to foo\).*\(no current module\).*\(at bar\)/s, 'upload status logged';
 
     subtest 'job accepted' => sub {
         is($fake_job->status, 'accepted', 'job has not been started so far');


### PR DESCRIPTION
* Add test so `_upload_results` has full test coverage
* Move common code for concluding the upload to its own function
* Improve logging of concluded upload further (see extra commit for details)

---

This fixes a problem I've found when investigating https://progress.opensuse.org/issues/90152 but does *not* fix the issue mentioned in that ticket.