### PR TITLE
Allow to override isotovideo executable with command line

### DIFF
--- a/.circleci/unstable_tests.txt
+++ b/.circleci/unstable_tests.txt
@@ -1,3 +1,4 @@
 t/25-cache-service.t
 t/ui/01-list.t
 t/ui/26-jobs_restart.t
+t/ui/13-admin.t

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -371,7 +371,7 @@ sub engine_workit {
 
     # os-autoinst's commands server
     $job_info->{URL}
-      = "http://localhost:" . ($job_info->{settings}->{QEMUPORT} + 1) . "/" . $job_info->{settings}->{JOBTOKEN};
+      = "http://localhost:" . ($job_settings->{QEMUPORT} + 1) . "/" . $job_settings->{JOBTOKEN};
 
     # create cgroup within /sys/fs/cgroup/systemd
     log_info('Preparing cgroup to start isotovideo');

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -426,7 +426,9 @@ sub engine_workit {
             # PERL5OPT may have Devel::Cover options, we don't need and want
             # them in the spawned process as it does not belong to openQA code
             local $ENV{PERL5OPT} = "";
-            exec "perl", "$isotovideo", '-d';
+            # Allow to override isotovideo executable with an arbitrary
+            # command line based on a config option
+            exec $job_settings->{ISOTOVIDEO} ? $job_settings->{ISOTOVIDEO} : ('perl', $isotovideo, '-d');
             die "exec failed: $!\n";
         });
     $child->on(


### PR DESCRIPTION
os-autoinst includes multiple backends which can require changes to 
support different technologies or specific testing needs. Also, the
worker environment needs to provide requirements to run tests which
include more package than originally required for os-autoinst or newer
versions.

This commit introduces the possibility to customize the actual worker
engine that is started with keeping the default of starting "perl
$isotovideo -d". For example a different location for isotovideo can be 
specified or a container providing different versions of packages or 
even a completely different worker engine that is interface-compatible.

Working on https://github.com/os-autoinst/os-autoinst/pull/1558 this
idea came back to mind. I had already thought about doing something
similar couple of times, also based on requests by other users to be
able to test os-autoinst changes more easily. With this change it
should be possible to execute an arbitrary command within the worker
based on a job setting. For example the use case I envision is to
build a container image from a still open pull request of os-autoinst
and execute tests on a production instance without harmful impact of
the general environment, e.g.
`podman run --rm -it registry.opensuse.org/devel/openqa/...`.

This could also be helpful for customized backend environments needed
to access other, more exotic hardware and such.

https://progress.opensuse.org/issues/90362
