### PR TITLE
t: use JSON::PP when using Devel::Cover

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,10 @@ run-tests-within-container:
 
 ifeq ($(COVERAGE),1)
 COVERDB_SUFFIX ?=
-COVEROPT ?= -MDevel::Cover=-select_re,'^/lib',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement,-db,cover_db$(COVERDB_SUFFIX),
+# We use JSON::PP because there is a bug producing a (harmless) 'redefined'
+# warning when using Devel::Cover and Cpanel::JSON::XS
+# https://progress.opensuse.org/issues/90371
+COVEROPT ?= -mJSON::PP -MDevel::Cover=-select_re,'^/lib',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement,-db,cover_db$(COVERDB_SUFFIX),
 endif
 
 .PHONY: coverage


### PR DESCRIPTION
Devel::Cover uses Cpanel::JSON::XS which has a bug (defining JSON::PP::Boolean
namespace which the actual module will try to overwrite later).

    perl -wE 'use Cpanel::JSON::XS (); use JSON::PP ()'
    Subroutine JSON::PP::Boolean::(++ redefined at /usr/lib/perl5/5.26.1/overload.pm line 48.
    ...

Issue: https://progress.opensuse.org/issues/90371

See also https://github.com/rurban/Cpanel-JSON-XS/issues/65