### PR TITLE
Allow client to get YAML job templates from a file

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -35,6 +35,7 @@ sub command {
       'd|data=s'      => \$data,
       'f|form'        => \my $form,
       'j|json'        => \my $json,
+      'param-file=s'  => \my @param_file,
       'p|pretty'      => \my $pretty,
       'q|quiet'       => \my $quiet,
       'X|method=s'    => \(my $method = 'GET'),
@@ -45,7 +46,7 @@ sub command {
 
     $data = path($data_file)->slurp if $data_file;
     my @data   = ($data);
-    my $params = $form ? decode_json($data) : $self->parse_params(@args);
+    my $params = $form ? decode_json($data) : $self->parse_params(\@args, \@param_file);
     @data = (form => $params) if keys %$params;
 
     my $headers = $self->parse_headers(@headers);
@@ -105,26 +106,34 @@ sub command {
     openqa-cli api -X POST job_templates_scheduling/1 \
       schema=JobTemplates-01.yaml preview=0 template="$(cat foo.yaml)"
 
+    # Post job template (from file)
+    openqa-cli api -X POST job_templates_scheduling/1 \
+      schema=JobTemplates-01.yaml preview=0 --param-file template=foo.yaml
+
     # Post job template (from JSON file)
     openqa-cli api --data-file form.json -X POST job_templates_scheduling/1
 
   Options:
-        --apibase <path>        API base, defaults to /api/v1
-        --apikey <key>          API key
-        --apisecret <secret>    API secret
-    -a, --header <name:value>   One or more additional HTTP headers
-    -D, --data-file <path>      Load content to send with request from file
-    -d, --data <string>         Content to send with request, alternatively you
-                                can also pipe data to openqa-cli
-    -f, --form                  Turn JSON object into form parameters
-        --host <host>           Target host, defaults to http://localhost
-    -h, --help                  Show this summary of available options
-    -j, --json                  Request content is JSON
-        --osd                   Set target host to http://openqa.suse.de
-        --o3                    Set target host to https://openqa.opensuse.org
-    -p, --pretty                Pretty print JSON content
-    -q, --quiet                 Do not print error messages to STDERR
-    -X, --method <method>       HTTP method to use, defaults to GET
-    -v, --verbose               Print HTTP response headers
+        --apibase <path>          API base, defaults to /api/v1
+        --apikey <key>            API key
+        --apisecret <secret>      API secret
+    -a, --header <name:value>     One or more additional HTTP headers
+    -D, --data-file <path>        Load content to send with request from file
+    -d, --data <string>           Content to send with request, alternatively
+                                  you can also pipe data to openqa-cli
+    -f, --form                    Turn JSON object into form parameters
+        --host <host>             Target host, defaults to http://localhost
+    -h, --help                    Show this summary of available options
+    -j, --json                    Request content is JSON
+        --osd                     Set target host to http://openqa.suse.de
+        --o3                      Set target host to https://openqa.opensuse.org
+        --param-file <param=file> Load content of params from files instead of
+                                  from command line arguments. Multiple params
+                                  may be specified by adding the option
+                                  multiple times
+    -p, --pretty                  Pretty print JSON content
+    -q, --quiet                   Do not print error messages to STDERR
+    -X, --method <method>         HTTP method to use, defaults to GET
+    -v, --verbose                 Print HTTP response headers
 
 =cut


### PR DESCRIPTION
Currently, openQA client's help recommends the following to configure a job group from a YAML template:
```
  # Post job template
  openqa-cli api -X POST job_templates_scheduling/1 \
    schema=JobTemplates-01.yaml preview=0 template="$(cat foo.yaml)"
```
A potential issue with this, is that when the YAML file reaches a certain size, such a command can hit the `Argument list too long` error on a shell, for example:
```
openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret **** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    template="$(cat sle15_sp3_ha.yml)"
-bash: /usr/bin/openqa-cli: Argument list too long
```
Or:
```
cat sle15_sp3_ha.yml | openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret **** \
    -X POST job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    template="$(cat -)"
-bash: /usr/bin/openqa-cli: Argument list too long
```
With this PR, I'm suggesting adding a new option to `OpenQA::CLI::api` titled `--param-file`, which can be used to pass parameters whose value is read from files by the client before connection to the server, instead of given on the command line. An example of the previous calls would be:
```
openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret *** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    --param-file template=sle15_sp3_ha.yml
```
This way we avoid the `Argument list too long` error from the shell, and move the task of reading the file to the client.

--

Tests performed before and after applying changes to my local instance:

1. `Argument list too long` error with current version of `openqa-cli`, YAML file contents in command line:
```
# openqa-cli api --host http://mango.qa.suse.de --apikey *** --apisecret *** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    template="$(cat sle15_sp3_ha.yml)"
-bash: /usr/bin/openqa-cli: Argument list too long
```
2. `Expected object - got string` error with current version of `openqa-cli`, YAML file path in command line:
```
# openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret **** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    template=file:./sle15_sp3_ha.yml
400 Bad Request
{"error":[{"message":"Expected object - got string.","path":"\/"}],"error_status":400}
```
3. `Expected object - got string` error with `openqa-cli` **after changes were applied**, YAML file path in command line without new option:
```
# openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret **** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    template=file:./sle15_sp3_ha.yml 
400 Bad Request
{"error":[{"message":"Expected object - got string.","path":"\/"}],"error_status":400}
```
4. File not found error with `openqa-cli` **after changes were applied**, YAML file path in command line with new option but wrongly formatted:
```
# openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret **** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
   --param-file template=file:./sle15_sp3_ha.yml 
Can't open file "file:./sle15_sp3_ha.yml": No such file or directory at /usr/share/openqa/script/../lib/OpenQA/Command.pm line 95.
```
5. Template processing error (job already defined in another group) with `openqa-cli` **after changes were applied**, YAML file path in command line:
```
# openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret **** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    --param-file template=./sle15_sp3_ha.yml
400 Bad Request
{"error":["Job template name 'create_hdd_ha_textmode' with sle-15-SP3-Online-aarch64 and aarch64 is already used in job group 'HA'"],"error_status":400,"id":2,"job_group_id":2}
```
6. Success with `openqa-cli` **after changes were applied**, YAML file path in command line:
```
# openqa-cli api --host http://mango.qa.suse.de --apikey **** --apisecret **** -X POST \
    job_templates_scheduling/2 schema=JobTemplates-01.yaml preview=1 \
    --param-file template=./development.yml 
{"id":2,"ids":[495,496,497],"job_group_id":2,"preview":1}
```
--

As suggested in the comments, changes are only applied to `openqa-cli` and not to `openqa-client`.