### PR TITLE
Treat result uploads for non-existant modules as error

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1310,6 +1310,7 @@ sub update_module {
     }
 
     $mod->save_results($raw_result, $known_md5_sums, $known_file_names);
+    return 1;
 }
 
 # computes the progress info for the current job
@@ -1537,13 +1538,16 @@ sub update_status {
     $self->insert_test_modules($status->{test_order}) if $status->{test_order};
     my %known_image;
     my %known_files;
+    my @failed_modules;
     if (my $result = $status->{result}) {
         for my $name (sort keys %$result) {
-            $self->update_module($name, $result->{$name}, \%known_image, \%known_files);
+            push @failed_modules, $name
+              unless $self->update_module($name, $result->{$name}, \%known_image, \%known_files);
         }
     }
     $ret->{known_images} = [sort keys %known_image];
     $ret->{known_files}  = [sort keys %known_files];
+    $ret->{error}        = 'Failed modules: ' . join ', ', @failed_modules if @failed_modules;
 
     # update info used to compose the URL to os-autoinst command server
     if (my $assigned_worker = $self->assigned_worker) {


### PR DESCRIPTION
The worker reads the test order and updates it before each upload attempt
so the web UI should be aware of all test modules even if the test schedule
changes in the middle. So it should be safe to treat this situation as an
error.

This should improve the error feedback in cases like
https://progress.opensuse.org/issues/90152 where the logs tell us currently
that the result upload worked but in the end nothing is there. Of course
this just improves the symptom. The cause is likely that the test order
could not be uploaded in the first place.