### PR TITLE
Add script for package installation rollback on demand

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -530,6 +530,7 @@ fi
 %{_datadir}/openqa/script/openqa-enqueue-bug-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-result-cleanup
 %{_datadir}/openqa/script/openqa-gru
+%{_datadir}/openqa/script/openqa-rollback
 %{_datadir}/openqa/script/openqa-webui-daemon
 %{_datadir}/openqa/script/upgradedb
 %{_datadir}/openqa/script/modify_needle

--- a/script/openqa-rollback
+++ b/script/openqa-rollback
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    cat << EOF
+Usage: openqa-rollback
+Rollback openQA webUI instance and workers connected over salt
+
+Options:
+ -h, --help         display this help
+EOF
+    exit "$1"
+}
+
+opts=$(getopt -o hn --long help,dry-run -n 'parse-options' -- "$@") || usage 1
+eval set -- "$opts"
+while true; do
+  case "$1" in
+    -h | --help ) usage 0; shift ;;
+    -n | --dry-run ) dry_run="--dry-run"; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+webui_before="${webui_before:-"/tmp/openqa_webui_before"}"
+worker_before="${worker_before:-"/tmp/openqa_worker_before"}"
+dry_run="${dry_run:-""}"
+
+fail() {
+    echo "$*" >&2
+    exit 1
+}
+
+test -e "$webui_before" || fail "Could not find prerequisite file '$webui_before'"
+before_packages=$(paste -sd',' "$webui_before")
+before_package_paths=$(eval "ls /var/cache/zypp/packages/*/*/{$before_packages}*" | paste -sd' ')
+# shellcheck disable=SC2086
+sudo zypper -n --no-refresh in "$dry_run" --oldpackage $before_package_paths
+sudo salt -C 'G@roles:worker' cmd.run "set -x; test -e $worker_before && zypper -n --no-refresh in $dry_run --oldpackage \$(eval \"ls /var/cache/zypp/packages/*/*/{\$(paste -sd',' $worker_before)}* | paste -sd' ' \")"


### PR DESCRIPTION
We used the same approach within automatic deployment of the SUSE
internal instance openqa.suse.de within a gitlab CI YAML document
already. As debugging and improvement can become tricky in shell code
maintained in a YAML document calling a remote shell with eval code,
multiple levels of quoting, etc., I moved the functionality into a
dedicated shell script.

Tested manually with

```
cat script/openqa-rollback | ssh osd "cat - > /tmp/openqa-rollback && env webui_before=/tmp/before worker_before=/tmp/osd-deployment_rpm_q bash -ex /tmp/openqa-rollback --dry-run"
```

Related progress issue: https://progress.opensuse.org/issues/89993

```
diff --git a/script/openqa-rollback b/script/openqa-rollback
new file mode 100755
index 000000000..b39d30a60
--- /dev/null
+++ b/script/openqa-rollback
@@ -0,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    cat << EOF
+Usage: openqa-rollback
+Rollback openQA webUI instance and workers connected over salt
+
+Options:
+ -h, --help         display this help
+EOF
+    exit "$1"
+}
+
+opts=$(getopt -o hn --long help,dry-run -n 'parse-options' -- "$@") || usage 1
+eval set -- "$opts"
+while true; do
+  case "$1" in
+    -h | --help ) usage 0; shift ;;
+    -n | --dry-run ) dry_run="--dry-run"; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+webui_before="${webui_before:-"/tmp/openqa_webui_before"}"
+worker_before="${worker_before:-"/tmp/openqa_worker_before"}"
+dry_run="${dry_run:-""}"
+
+fail() {
+    echo "$*" >&2
+    exit 1
+}
+
+test -e "$webui_before" || fail "Could not find prerequisite file '$webui_before'"
+before_packages=$(paste -sd',' "$webui_before")
+before_package_paths=$(eval "ls /var/cache/zypp/packages/*/*/{$before_packages}*" | paste -sd' ')
+# shellcheck disable=SC2086
+sudo zypper -n --no-refresh in "$dry_run" --oldpackage $before_package_paths
+sudo salt -C 'G@roles:worker' cmd.run "set -x; test -e $worker_before && zypper -n --no-refresh in $dry_run --oldpackage \$(eval \"ls /var/cache/zypp/packages/*/*/{\$(paste -sd',' $worker_before)}* | paste -sd' ' \")"
```