### PR TITLE
Fix request routing for Mojolicious 9.11

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -131,7 +131,8 @@ sub startup ($self) {
     $r->get('/search')->name('search')->to(template => 'search/search');
 
     $r->get('/tests')->name('tests')->to('test#list');
-    $r->get('/tests/overview')->name('tests_overview')->to('test#overview');
+    $r->get('/tests/overview' => [format => ['json', 'html']])->name('tests_overview')
+      ->to('test#overview', format => 'html');
     $r->get('/tests/latest')->name('latest')->to('test#latest');
 
     $r->get('/tests/export')->name('tests_export')->to('test#export');
@@ -195,7 +196,8 @@ sub startup ($self) {
 
     $r->get('/group_overview/<groupid:num>' => [format => ['json', 'html']])->name('group_overview')
       ->to('main#job_group_overview', format => 'html');
-    $r->get('/parent_group_overview/<groupid:num>')->name('parent_group_overview')->to('main#parent_group_overview');
+    $r->get('/parent_group_overview/<groupid:num>' => [format => ['json', 'html']])->name('parent_group_overview')
+      ->to('main#parent_group_overview', format => 'html');
 
     # Favicon
     $r->get('/favicon.ico'             => sub ($c) { $c->render_static('favicon.ico') });

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -139,8 +139,8 @@ sub check_test_parent {
     is_deeply(
         \@urls,
         [
-            '/tests/overview?distri=opensuse&version=13.1&build=0091&groupid=1001',
-            '/tests/overview?distri=opensuse&version=13.1&build=0091&groupid=1002'
+            '/tests/overview.html?distri=opensuse&version=13.1&build=0091&groupid=1001',
+            '/tests/overview.html?distri=opensuse&version=13.1&build=0091&groupid=1002'
         ],
         'link URLs'
     );
@@ -339,12 +339,12 @@ $t->get_ok('/dashboard_build_results?limit_builds=20&show_tags=0')->status_is(20
 is(scalar @urls, 12, 'now builds belong to different versions and are split');
 is(
     $urls[1]->attr('href'),
-    '/tests/overview?distri=suse&version=14.2&build=87.5011&groupid=1001',
+    '/tests/overview.html?distri=suse&version=14.2&build=87.5011&groupid=1001',
     'most recent version/build'
 );
 is(
     $urls[-1]->attr('href'),
-    '/tests/overview?distri=opensuse&version=13.1&build=0091&groupid=1002',
+    '/tests/overview.html?distri=opensuse&version=13.1&build=0091&groupid=1002',
     'oldest version/build still shown'
 );
 
@@ -365,7 +365,7 @@ subtest 'build which has jobs with different DISTRIs links to overview with all 
     my $first_url = $urls[1]->attr('href');
     is(
         $first_url,
-        '/tests/overview?distri=opensuse&distri=suse&version=14.2&build=87.5011&groupid=1001',
+        '/tests/overview.html?distri=opensuse&distri=suse&version=14.2&build=87.5011&groupid=1001',
         'both distris present in overview link'
     );
     $job_with_different_distri->delete;
@@ -453,7 +453,7 @@ subtest 'job parent groups with multiple version and builds' => sub {
     my $first_entire_build_url = $entire_build_url_list[0]->attr('href');
     is(
         $first_entire_build_url,
-        '/tests/overview?distri=suse&version=14.2&build=87.5011&groupid=1001&groupid=1002',
+        '/tests/overview.html?distri=suse&version=14.2&build=87.5011&groupid=1001&groupid=1002',
         'entire build url contains all the child group ids'
     );
 


### PR DESCRIPTION
Mojolicious 9.11 disables request "format detection" - where a route declared for `/foo` will be used for `/foo.iso` by default, with the 'format' included in the request stash - to improve security. There are several cases where we relied on this; these commits change those routes to explicitly declare the formats they accept. I hope this covers everything, it at least makes all the tests we run on Fedora package build work with Mojolicious 9.15.