### PR TITLE
Set using relative path as the default operation

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -344,7 +344,7 @@ sub engine_workit {
     my $target_name = path($casedir)->basename;
 
     $vars{ASSETDIR} //= OpenQA::Utils::assetdir();
-    $vars{CASEDIR}  //= $vars{ENABLE_RELATIVE_PATH} ? $target_name : $casedir;
+    $vars{CASEDIR}  //= $vars{ABSOLUTE_TEST_CONFIG_PATHS} ? $casedir : $target_name;
 
     if ($vars{CASEDIR} eq $target_name) {
         $vars{PRODUCTDIR} //= substr($productdir, rindex($casedir, $target_name));
@@ -356,7 +356,7 @@ sub engine_workit {
     # if NEEDLES_DIR is an URL address, it means that users specify it and want to get the needles from URL.
     # In these two scenarios, doing symlink is useless and the job may incomplete because fail to do symlink.
     if (   $vars{NEEDLES_DIR}
-        && $vars{ENABLE_RELATIVE_PATH}
+        && !$vars{ABSOLUTE_TEST_CONFIG_PATHS}
         && !File::Spec->file_name_is_absolute($vars{NEEDLES_DIR})
         && !looks_like_url_with_scheme($vars{NEEDLES_DIR}))
     {

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -204,7 +204,7 @@ subtest 'problems when caching assets' => sub {
 subtest 'symlink testrepo' => sub {
     my $worker         = Test::FakeWorker->new;
     my $client         = Test::FakeClient->new;
-    my $settings       = {DISTRI => 'foo', ENABLE_RELATIVE_PATH => 1};
+    my $settings       = {DISTRI => 'foo'};
     my $job            = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => $settings});
     my $pool_directory = tempdir('poolXXXX');
     my $casedir        = testcasedir('foo', undef, undef);
@@ -250,15 +250,15 @@ subtest 'symlink testrepo' => sub {
     is $vars_data->{NEEDLES_DIR}, 'needles', 'When NEEDLES_DIR is a relative path, set it to basename';
 };
 
-subtest 'don\'t do symlink when jobs without setting ENABLE_RELATIVE_PATH' => sub {
+subtest 'don\'t do symlink when job settings include ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
     my $worker         = Test::FakeWorker->new;
     my $client         = Test::FakeClient->new;
-    my $settings       = {DISTRI => 'fedora', JOBTOKEN => 'token000'};
+    my $settings       = {DISTRI => 'fedora', JOBTOKEN => 'token000', ABSOLUTE_TEST_CONFIG_PATHS => 1};
     my $job            = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => $settings});
     my $pool_directory = tempdir('poolXXXX');
     $worker->pool_directory($pool_directory);
     combined_unlike { my $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
-    qr/Symlinked from/, 'don\'t do symlink when jobs don\'t have the ENABLE_RELATIVE_PATH';
+    qr/Symlinked from/, 'don\'t do symlink when jobs have the ABSOLUTE_TEST_CONFIG_PATHS=1';
     my $vars_data  = get_job_json_data($pool_directory);
     my $productdir = productdir('fedora', undef, undef);
     my $casedir    = testcasedir('fedora', undef, undef);


### PR DESCRIPTION
Users can disable this feature by setting `ABSOLUTE_TEST_CONFIG_PATHS=1`.

See: https://progress.opensuse.org/issues/90293#note-11