### PR TITLE
Fix Mojolicious 9.11 compatibility

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -193,13 +193,15 @@ sub startup ($self) {
     # due to the split md5_dirname having a /
     $r->get('/image/:md5_1/:md5_2/.thumbs/#md5_basename')->to('file#thumb_image');
 
-    $r->get('/group_overview/<groupid:num>')->name('group_overview')->to('main#job_group_overview');
+    $r->get('/group_overview/<groupid:num>' => [format => ['json', 'html']])->name('group_overview')
+      ->to('main#job_group_overview', format => 'html');
     $r->get('/parent_group_overview/<groupid:num>')->name('parent_group_overview')->to('main#parent_group_overview');
 
     # Favicon
-    $r->get('/favicon.ico' => sub ($c) { $c->render_static('favicon.ico') });
-    $r->get('/index'       => sub ($c) { $c->render('main/index') });
-    $r->get('/dashboard_build_results')->name('dashboard_build_results')->to('main#dashboard_build_results');
+    $r->get('/favicon.ico'             => sub ($c) { $c->render_static('favicon.ico') });
+    $r->get('/index'                   => sub ($c) { $c->render('main/index') });
+    $r->get('/dashboard_build_results' => [format => ['json', 'html']])->name('dashboard_build_results')
+      ->to('main#dashboard_build_results', format => 'html');
     $r->get('/api_help' => sub ($c) { $c->render('admin/api_help') })->name('api_help');
 
     # Default route
@@ -238,7 +240,8 @@ sub startup ($self) {
     $pub_admin_r->get('/assets')->name('admin_assets')->to('asset#index');
     $pub_admin_r->get('/assets/status')->name('admin_asset_status_json')->to('asset#status_json');
 
-    $pub_admin_r->get('/workers')->name('admin_workers')->to('workers#index');
+    $pub_admin_r->get('/workers' => [format => ['json', 'html']])->name('admin_workers')
+      ->to('workers#index', format => 'html');
     $pub_admin_r->get('/workers/<worker_id:num>')->name('admin_worker_show')->to('workers#show');
     $pub_admin_r->get('/workers/<worker_id:num>/ajax')->name('admin_worker_previous_jobs_ajax')
       ->to('workers#previous_jobs_ajax');

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -55,7 +55,7 @@ $pub->any(
         $c->render(json => $data);
     });
 $pub->any(
-    '/test/pub/error' => sub {
+    '/test/pub/error' => [format => ['json']] => {format => 'html'} => sub {
         my $c      = shift;
         my $status = $c->param('status') // 500;
         $c->respond_to(

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -131,7 +131,7 @@ sub fake_asset_server {
             $c->render(text => 'This file was not compressed!', format => 'txt');
         });
     $r->get(
-        '/tests/:job/asset/:type/:filename' => sub {
+        '/tests/:job/asset/:type/*filename' => sub {
             my $c        = shift;
             my $id       = $c->stash('job');
             my $type     = $c->stash('type');

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -475,9 +475,9 @@ subtest 'route to latest' => sub {
     my $job_groups_links = $dom->find('.navbar .dropdown a + ul.dropdown-menu a');
     my ($job_group_text, $build_text) = $job_groups_links->map('text')->each;
     my ($job_group_href, $build_href) = $job_groups_links->map('attr', 'href')->each;
-    is($job_group_text, 'opensuse (current)',   'link to current job group overview');
-    is($build_text,     ' Build 0091',          'link to test overview');
-    is($job_group_href, '/group_overview/1001', 'href to current job group overview');
+    is($job_group_text, 'opensuse (current)',        'link to current job group overview');
+    is($build_text,     ' Build 0091',               'link to test overview');
+    is($job_group_href, '/group_overview/1001.html', 'href to current job group overview');
     like($build_href, qr/distri=opensuse/, 'href to test overview');
     like($build_href, qr/groupid=1001/,    'href to test overview');
     like($build_href, qr/version=13.1/,    'href to test overview');


### PR DESCRIPTION
Alternative to #3816. This should be the minimal fix to make openQA work with Mojolicious 9.01 and 9.11. [Here's](https://github.com/os-autoinst/openQA/compare/k/mojo_911) the same patch in a different branch running CI tests against 9.14.
```
 sudo perl - -M https://cpan.metacpan.org -n Mojolicious@9.14
 curl -L https://cpanmin.us
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  295k  100  295k    0     0  5097k      0 --:--:-- --:--:-- --:--:-- 5097k
--> Working on Mojolicious
Fetching https://cpan.metacpan.org/authors/id/S/SR/SRI/Mojolicious-9.14.tar.gz ... OK
Configuring Mojolicious-9.14 ... OK
Building Mojolicious-9.14 ... OK
Successfully installed Mojolicious-9.14 (upgraded from 9.01)
1 distribution installed
```