### PR TITLE
Mark t/ui/27-plugin_obs_rsync_status_details.t as unstable again

### DIFF
--- a/.circleci/unstable_tests.txt
+++ b/.circleci/unstable_tests.txt
@@ -2,3 +2,4 @@ t/25-cache-service.t
 t/ui/01-list.t
 t/ui/26-jobs_restart.t
 t/ui/13-admin.t
+t/ui/27-plugin_obs_rsync_status_details.t


### PR DESCRIPTION
This reverts commit 424154d7b829dd95e91f183ff9bd985529b6e244 due to more
recent failures.

Related progress issue: https://progress.opensuse.org/issues/89935