### PR TITLE
containers: fix github test webui-docker-compose timeout

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   webui-docker-compose:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - name: Verify that containers can be composed


### PR DESCRIPTION
The test webui-docker-compose exceeds 30 minutes and is cancelled with the message
"The job running on runner Hosted Agent has exceeded the maximum execution time of 30 minutes."

Increased to 60 minutes

https://progress.opensuse.org/issues/90767