### PR TITLE
Ensure workers are shown as offline after disconnecting gracefully immediately

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright (C) 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -29,6 +29,8 @@ sub _extend_info {
     if ($live && $error && ($error =~ qr/(graceful disconnect) at (.*)/)) {
         $info->{offline_note} = $1;
         $info->{t_seen}       = $2 . 'Z';
+        $info->{alive}        = undef;
+        $info->{status}       = 'dead';
     }
     elsif (my $last_seen = $w->t_seen) {
         $info->{t_seen} = $last_seen->datetime . 'Z';

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -73,7 +73,7 @@ subtest 'offline status' => sub {
         'worker just shown as offline'
     );
 
-    $workers->find($offline_worker_id)->update({error => 'graceful disconnect at foo'});
+    $workers->find($offline_worker_id)->update({error => 'graceful disconnect at foo', t_seen => $online_timestamp});
     $driver->get("/admin/workers/$offline_worker_id");
     like(
         $driver->find_element_by_class('status-info')->get_text,


### PR DESCRIPTION
The code so far relied on the fact that `t_seen` is unset on a graceful
disconnect. However, in practice that does not always work, likely due to
some race condition. So let's just not rely on that. Considering any worker
offline with the error 'gracefully disconnected at …' is simple and not a
problem because that error is unset when the worker connects again.