### PR TITLE
Improve container documentation

### DIFF
--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -56,6 +56,8 @@ setup SELinux properly. If you are having problems with it, run this command:
 You can either build the images locally or use Fedora images from Docker Hub.
 
 For the `docker-compose` setup it is required to build the images locally.
+However, it is done automatically so this section can be skipped unless one
+wants to build the containers manually.
 
 === Download Fedora-based images from the Docker Hub
 
@@ -63,7 +65,7 @@ For the `docker-compose` setup it is required to build the images locally.
     docker pull fedoraqa/openqa_webui
     docker pull fedoraqa/openqa_worker
 
-=== Build openSUSE-based images locally (mandatory when using docker-compose)
+=== Build openSUSE-based images locally
 
     docker build -t openqa_data ./openqa_data
     docker build -t openqa_webui ./webui

--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -232,7 +232,8 @@ instance:
    - cert.key:/etc/ssl/certs/openqa.key
 ----
 
-3. Modify `nginx.cfg` to use this certificate. Uncomment the lines
+3. Modify `nginx.cfg` to use this certificate. Append ` ssl` to the listen command
+for port 443 and uncomment the lines:
 +
 [source]
 ----

--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -15,6 +15,31 @@ The second one uses `docker-compose` to deploy a complete web UI with HA for the
 API and the dashboard. This setup is under development and currently considered
 proof-of-concept. Do *not* expect that everything works yet.
 
+== Get container images
+
+You can either build the images locally or use Fedora images from Docker Hub.
+
+For the `docker-compose` setup it is required to build the images locally.
+However, it is done automatically so this section can be skipped unless one
+wants to build the containers manually.
+
+=== Download Fedora-based images from the Docker Hub
+
+    docker pull fedoraqa/openqa_data
+    docker pull fedoraqa/openqa_webui
+    docker pull fedoraqa/openqa_worker
+
+=== Build openSUSE-based images locally
+
+    docker build -t openqa_data ./openqa_data
+    docker build -t openqa_webui ./webui
+    docker build -t openqa_worker ./worker
+
+    # for docker-compose setup
+    docker build -f webui/Dockerfile-lb -t openqa_webui_lb ./webui
+
+== Setup with Fedora-based images
+
 == Data storage and directory structure
 
 Our intent was to create universal `webui` and `worker` containers and move
@@ -50,31 +75,6 @@ It could be necessary to either run all containers in privileged mode or to
 setup SELinux properly. If you are having problems with it, run this command:
 
     chcon -Rt svirt_sandbox_file_t data
-
-== Get container images
-
-You can either build the images locally or use Fedora images from Docker Hub.
-
-For the `docker-compose` setup it is required to build the images locally.
-However, it is done automatically so this section can be skipped unless one
-wants to build the containers manually.
-
-=== Download Fedora-based images from the Docker Hub
-
-    docker pull fedoraqa/openqa_data
-    docker pull fedoraqa/openqa_webui
-    docker pull fedoraqa/openqa_worker
-
-=== Build openSUSE-based images locally
-
-    docker build -t openqa_data ./openqa_data
-    docker build -t openqa_webui ./webui
-    docker build -t openqa_worker ./worker
-
-    # for docker-compose setup
-    docker build -f webui/Dockerfile-lb -t openqa_webui_lb ./webui
-
-== Setup with Fedora-based images
 
 === Update firewall rules
 

--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -9,52 +9,23 @@ This section describes two ways to deploy the containers for the openQA web UI
 and the workers.
 
 The first one describes how to deploy an openQA environment using Docker with
-the Fedora images or images built locally.
+Fedora images or images built locally.
 
 The second one uses `docker-compose` to deploy a complete web UI with HA for the
 API and the dashboard. This setup is under development and currently considered
 proof-of-concept. Do *not* expect that everything works yet.
 
-If a section or action is tagged as "Fedora", it should be applied only for a
-Fedora deployment. If the tag "docker-compose" is used it is supposed to be used
-for the `docker-compose` deployment.
-
-== Get container images
-
-You can either build the images locally or get the images from Docker Hub.
-Using the Docker Hub can be easier for a first try.
-
-=== Download images from the Docker Hub
-
-==== Fedora images (Fedora)
-
-    docker pull fedoraqa/openqa_data
-    docker pull fedoraqa/openqa_webui
-    docker pull fedoraqa/openqa_worker
-
-=== Build images locally (mandatory when using docker-compose)
-
-The Dockerfiles included in this project are for openSUSE:
-
-    # Fedora and docker-compose
-    docker build -t openqa_data ./openqa_data
-    docker build -t openqa_webui ./webui
-    docker build -t openqa_worker ./worker
-
-    # docker-compose only
-    docker build -f webui/Dockerfile-lb -t openqa_webui_lb ./webui
-
-== Running openQA
+== Data storage and directory structure
 
 Our intent was to create universal `webui` and `worker` containers and move
 all data storage and configurations to a third container, called `openqa_data`.
-`openqa_data` is so called
+`openqa_data` is a so called
 https://docs.docker.com/storage/volumes#creating-and-mounting-a-data-volume-container[Data Volume Container]
-and is used as database as well as results and configuration storage. During
+and is used for the database and to store results and configuration. During
 development and in production, you could update `webui` and `worker` images
 but as long as `openqa_data` is intact, you do not lose any data.
 
-To make development easier and to reduce final size of the `openqa_data`
+To make development easier and to reduce the final size of the `openqa_data`
 container, this guide describes how to override `tests` and `factory`
 directories with directories from your host system. This is not necessary but
 recommended. This guide is written with this setup in mind.
@@ -63,11 +34,47 @@ It is also possible to use `tests` and `factory` from within the `openqa_data`
 container (so you do not have any dependency on your host system) or to leave
 out the `openqa_data` container altogether (so you have only `webui` and
 `worker` containers and data is loaded and saved completely into your host
-system). If this is what you prefer, refer to [Keeping all data in the Data
-Volume Container] and [Keeping all data on the host system] sections
+system). If this is what you prefer, checkout the sections
+<<ContainerizedSetup.asciidoc#_keeping_all_data_in_the_data_volume_container,Keeping all data in the Data Volume Container>>
+and
+<<ContainerizedSetup.asciidoc#_keeping_all_data_on_the_host_system,Keeping all data on the host system>>
 respectively.
 
-=== Update firewall rules (Fedora)
+Otherwise, when you want to have the big files (isos and disk images, tests and
+needles) outside of the Volume container, you should create this file
+structure from within the directory you are going to execute the container:
+
+    mkdir -p data/factory/{iso,hdd} data/tests
+
+It could be necessary to either run all containers in privileged mode or to
+setup SELinux properly. If you are having problems with it, run this command:
+
+    chcon -Rt svirt_sandbox_file_t data
+
+== Get container images
+
+You can either build the images locally or use Fedora images from Docker Hub.
+
+For the `docker-compose` setup it is required to build the images locally.
+
+=== Download Fedora-based images from the Docker Hub
+
+    docker pull fedoraqa/openqa_data
+    docker pull fedoraqa/openqa_webui
+    docker pull fedoraqa/openqa_worker
+
+=== Build openSUSE-based images locally (mandatory when using docker-compose)
+
+    docker build -t openqa_data ./openqa_data
+    docker build -t openqa_webui ./webui
+    docker build -t openqa_worker ./worker
+
+    # for docker-compose setup
+    docker build -f webui/Dockerfile-lb -t openqa_webui_lb ./webui
+
+== Setup with Fedora-based images
+
+=== Update firewall rules
 
 There is a
 https://bugzilla.redhat.com/show_bug.cgi?id=1244124[bug in Fedora]
@@ -80,22 +87,8 @@ workaround, run:
 
 on the host machine.
 
-=== Create directory structure
+=== Run the data and web UI containers
 
-In case you want to have the big files (isos and disk images, tests and
-needles) outside of the Volume container, you should create this file
-structure from within the directory you are going to execute the container:
-
-    mkdir -p data/factory/{iso,hdd} data/tests
-
-It could be necessary to either run all containers in privileged mode, or to
-setup SELinux properly. If you are having problems with it, run this command:
-
-    chcon -Rt svirt_sandbox_file_t data
-
-=== Run the data and web UI containers (Fedora)
-
-    # Fedora
     docker run -d -h openqa_data --name openqa_data -v `pwd`/data/factory:/data/factory -v `pwd`/data/tests:/data/tests fedoraqa/openqa_data
     docker run -d -h openqa_webui --name openqa_webui --volumes-from openqa_data -p 80:80 -p 443:443 fedoraqa/openqa_webui
 
@@ -109,13 +102,82 @@ next two steps, you will set an OpenID provider (if necessary), create the API
 keys in the openQA's web interface, and store the configuration in the Data
 Container.
 
-=== Run the data and web UI containers in HA mode (docker-compose)
+==== Generate and connfigure API credentials
+
+Go to https://localhost/api_keys, generate key and secret. Then run the following
+command substituting `KEY` and `SECRET` with the generated values:
+
+    docker exec -it openqa_data /scripts/client-conf set -l KEY SECRET
+
+=== Run the worker container
+
+    docker run -d -h openqa_worker_1 --name openqa_worker_1 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
+
+Check whether the worker connected in the web UI's administration interface.
+
+To add more workers, increase the number that is used in hostname and
+container name, so to add worker 2 use:
+
+    docker run -d -h openqa_worker_2 --name openqa_worker_2 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
+
+=== Enable services
+
+Some systemd services are provided to start up the containers, so you do not
+have to keep doing it manually. To install and enable them:
+
+    sudo cp systemd/*.service /etc/systemd/system
+    sudo systemctl daemon-reload
+    sudo systemctl enable openqa-data.service
+    sudo systemctl enable openqa-webui.service
+    sudo systemctl enable openqa-worker@1.service
+
+Of course, if you set up two workers, also do `sudo systemctl enable
+openqa-worker@2.service`, and so on.
+
+=== Get tests, ISOs and create disks
+
+You have to put your tests under `data/tests` directory and ISOs under
+`data/factory/iso` directory. For testing Fedora, run:
+
+    git clone https://bitbucket.org/rajcze/openqa_fedora data/tests/fedora
+    wget https://dl.fedoraproject.org/pub/alt/stage/22_Beta_RC3/Server/x86_64/iso/Fedora-Server-netinst-x86_64-22_Beta.iso -O data/factory/iso/Fedora-Server-netinst-x86_64-22_Beta_RC3.iso
+
+And set permissions, so any user can read/write the data:
+
+    chmod -R 777 data
+
+This step is unfortunately necessary because Docker
+https://github.com/docker/docker/issues/7198[can not mount a volume with specific user ownership]
+in container, so ownership of mounted folders (uid and gid) is the same as on
+your host system (presumably 1000:1000 which maps into nonexistent user in all
+of the containers).
+
+If you wish to keep the tests (for example) separate from the shared
+directory, for any reason (we do, in our development scenario) refer to the
+[Developing tests with Container setup] section at the end of this document.
+
+Populate the openQA database:
+
+    docker exec openqa_webui /var/lib/openqa/tests/fedora/templates
+
+Create all necessary disk images:
+
+    cd data/factory/hdd && createhdds.sh VERSION
+
+where `VERSION` is the current stable Fedora version (its images will be
+created for upgrade tests) and createhdds.sh is in `openqa_fedora_tools`
+repository in `/tools` directory. Note that you have to have
+`libguestfs-tools` and `libguestfs-xfs` installed.
+
+== Setup with openSUSE-based images and docker-compose
+
+=== Run the data and web UI containers in HA mode
 
     # To create the containers
     # in the directory openQA/docker/webui execute:
     docker-compose up -d
 
-==== Change the number web UI replicas (optional)
+==== Change the number of web UI replicas (optional)
 
 To set the number of replicas set the environment variable
 `OPENQA_WEBUI_REPLICAS` to the desired number. If this is not set, then the
@@ -164,47 +226,25 @@ Enable the SSL access in three steps:
    ssl_certificate_key /etc/ssl/certs/openqa.key;
    ```
 
-==== Change the OpenID provider
+==== Generate and connfigure API credentials
 
-https://www.opensuse.org/openid/user/ is set as a default OpenID provider. To
-change it, run:
+Go to https://localhost/api_keys, generate key and secret. Then run the following
+command substituting `KEY` and `SECRET` with the generated values:
 
-    docker exec -it openqa_data /scripts/set_openid
-
-and enter the Provider's URL.
-
-==== Set API keys
-
-Go to https://localhost/api_keys, generate key and secret. Then run:
-
-    # Fedora
-    docker exec -it openqa_data /scripts/client-conf set -l KEY SECRET
-    # Where KEY is your openQA instance key
-    # and SECRET is your openQA instance secret
-
-    # docker-compose
     docker exec -it openqa_data /scripts/client-conf set -l -t webui_nginx_1 KEY SECRET
 
-=== Run the Worker container
+=== Run the worker container
 
-    # Fedora
-    docker run -d -h openqa_worker_1 --name openqa_worker_1 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
-
-    # docker-compose
     docker run -d -h openqa_worker_1 --name openqa_worker_1 --network webui_default --volumes-from openqa_data --privileged openqa_worker
 
-Check whether the worker connected in the WebUI's administration interface.
+Check whether the worker connected in the web UI's administration interface.
 
 To add more workers, increase the number that is used in hostname and
 container name, so to add worker 2 use:
 
-    # Fedora
-    docker run -d -h openqa_worker_2 --name openqa_worker_2 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
-
-    # docker-compose
     docker run -d -h openqa_worker_2 --name openqa_worker_2 --network webui_default --volumes-from openqa_data --privileged openqa_worker
 
-=== Run a pool of workers automatically (docker-compose)
+==== Run a pool of workers automatically
 
 To launch a pool of workers one could use the script `./launch_workers_pool.sh`.
 It will launch the desired number of workers in individual containers using
@@ -212,64 +252,11 @@ consecutive numbers for the `--instance` parameter.
 
     ./launch_workers_pool.sh <number-of-workers>
 
-=== Enable services
-
-Some systemd services are provided to start up the containers, so you do not
-have to keep doing it manually. To install and enable them:
-
-    sudo cp systemd/*.service /etc/systemd/system
-    sudo systemctl daemon-reload
-    sudo systemctl enable openqa-data.service
-    sudo systemctl enable openqa-webui.service
-    sudo systemctl enable openqa-worker@1.service
-
-Of course, if you set up two workers, also do `sudo systemctl enable
-openqa-worker@2.service`, and so on.
-
 === Get tests, ISOs and create disks
 
 You have to put your tests under `data/tests` directory and ISOs under
-`data/factory/iso` directory.
-
-==== openSUSE
-
-For testing openSUSE, follow
+`data/factory/iso` directory. For testing openSUSE, follow
 https://github.com/os-autoinst/openQA/blob/master/docs/GettingStarted.asciidoc#testing-opensuse-or-fedora[this guide].
-
-==== Fedora
-
-For testing Fedora, run:
-
-    git clone https://bitbucket.org/rajcze/openqa_fedora data/tests/fedora
-    wget https://dl.fedoraproject.org/pub/alt/stage/22_Beta_RC3/Server/x86_64/iso/Fedora-Server-netinst-x86_64-22_Beta.iso -O data/factory/iso/Fedora-Server-netinst-x86_64-22_Beta_RC3.iso
-
-And set permissions, so any user can read/write the data:
-
-    chmod -R 777 data
-
-This step is unfortunately necessary because Docker
-https://github.com/docker/docker/issues/7198[can not mount a volume with specific user ownership]
-in container, so ownership of mounted folders (uid and gid) is the same as on
-your host system (presumably 1000:1000 which maps into nonexistent user in all
-of the containers).
-
-If you wish to keep the tests (for example) separate from the shared
-directory, for any reason (we do, in our development scenario) refer to the
-[Developing tests with Container setup] section at the end of this document.
-
-Populate the openQA database:
-
-    docker exec openqa_webui /var/lib/openqa/tests/fedora/templates
-
-Create all necessary disk images:
-
-    cd data/factory/hdd && createhdds.sh VERSION
-
-where `VERSION` is the current stable Fedora version (its images will be
-created for upgrade tests) and createhdds.sh is in `openqa_fedora_tools`
-repository in `/tools` directory. Note that you have to have
-`libguestfs-tools` and `libguestfs-xfs` installed.
-
 
 == Running jobs
 
@@ -278,7 +265,16 @@ After performing the "setup" tasks above - do not forget about tests and ISOs
 
     docker exec openqa_webui /var/lib/openqa/script/client isos post ISO=Fedora-Server-netinst-x86_64-22_Beta_RC3.iso DISTRI=fedora VERSION=rawhide FLAVOR=generic_boot ARCH=x86_64 BUILD=22_Beta_RC3
 
-== Other specific cases
+== Further configuration options
+
+=== Change the OpenID provider
+
+https://www.opensuse.org/openid/user/ is set as a default OpenID provider. To
+change it, run:
+
+    docker exec -it openqa_data /scripts/set_openid
+
+and enter the provider's URL.
 
 === Adding workers on other hosts
 
@@ -289,7 +285,7 @@ Let's assume you are setting up a new 'worker host' and it can see the web UI
 host system with the hostname `openqa_webui`.
 
 You must somehow share the `data` directory from the web UI host to each host
-on which you want to run workers. For instance, to use sshfs, on the new
+on which you want to run workers. For instance, to use sshfs on the new
 worker host, run:
 
     sshfs -o context=unconfined_u:object_r:svirt_sandbox_file_t:s0 openqa_webui:/path/to/data /path/to/data
@@ -324,16 +320,13 @@ adjust these files if you use non-standard ports (see above).
 
 === Keeping all data in the Data Volume container
 
-If you decided to keep all the data in the Volume container (`openqa_data`),
-then do *not* follow the
-<<ContainerizedSetup.asciidoc#_create_directory_structure,Create directory structure section>>.
-Run the following commands instead:
+If you decided to keep all the data in the Volume container (`openqa_data`), run the following commands:
 
     docker exec openqa_data mkdir -p data/factory/{iso,hdd} data/tests
     docker exec openqa_data chmod -R 777 data/factory/{iso,hdd} data/tests
 
 In the
-<<ContainerizedSetup.asciidoc#_run_the_data_and_web_ui_containers_in_ha_mode_docker_compose,section about running the web UI and data container>>,
+<<ContainerizedSetup.asciidoc#_run_the_data_and_web_ui_containers,section about running the web UI and data container>>,
 use the `openqa_data`
 container like this instead:
 
@@ -349,15 +342,13 @@ The rest of the steps should be the same.
 === Keeping all data on the host system
 
 If you want to keep all the data in the host system and you prefer not to use
-a Volume Container then do *not* follow the
-<<ContainerizedSetup.asciidoc#_create_directory_structure,Create directory structure section>>.
-Run the following commands instead:
+a Volume Container, run the following commands:
 
     cp -a openqa_data/data.template data
     chcon -Rt svirt_sandbox_file_t data
 
 In the
-<<ContainerizedSetup.asciidoc#_run_the_data_and_web_ui_containers_in_ha_mode_docker_compose,section about running the web UI and data container>>,
+<<ContainerizedSetup.asciidoc#_run_the_data_and_web_ui_containers,section about running the web UI and data container>>,
 do *not* run the `openqa_data`
 container and run the `webui` container like this instead:
 
@@ -378,9 +369,9 @@ Then continue with tests and ISOs downloading as before.
 === Developing tests with container setup
 
 With this setup, the needles created from the web UI will almost certainly have
-different owner and group than your user account. As we have the tests in
-git, and still want to retain the original owner and permission, even as we
-update/create needles from openQA. To accomplish this, we are using BindFS.
+a different owner and group than your user account. As we have the tests in
+Git, we still want to retain the original owner and permissions, even when we
+update/create needles from openQA. To accomplish this, we can use BindFS.
 An example entry in `/etc/fstab`:
 
     bindfs#/home/jskladan/src/openQA/openqa_fedora    /home/jskladan/src/openQA/openqa_fedora_tools/docker/data/tests/fedora    fuse    create-for-user=jskladan,create-for-group=jskladan,create-with-perms=664:a+X,perms=777    0    0

--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -178,6 +178,10 @@ repository in `/tools` directory. Note that you have to have
     cd 'container/webui'
     docker-compose up -d
 
+To stop it again, run:
+
+    docker-compose down
+
 ==== Change the number of web UI replicas (optional)
 
 To set the number of replicas set the environment variable

--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -205,27 +205,36 @@ ports:
 Enable the SSL access in three steps:
 
 1. To expose the SSL port, uncomment this line in the `docker-compose.yaml` file
-   in the service nginx:
-   ```
+in the service nginx:
++
+[source,yaml]
+----
    - "443:443"
-   ```
-   You can change the exported port if 443 is already used in your computer, for
-   instance:
-   ```
+----
++
+You can change the exported port if 443 is already used in your computer, for
+instance:
++
+[source,yaml]
+----
    - "10443:443"
-   ```
+----
 
 2. Provide an SSL certificate:
-   ```
++
+[source,yaml]
+----
    - cert.crt:/etc/ssl/certs/openqa.crt
    - cert.key:/etc/ssl/certs/openqa.key
-   ```
+----
 
 3. Modify `nginx.cfg` to use this certificate. Uncomment the lines
-   ```
++
+[source]
+----
    ssl_certificate     /etc/ssl/certs/openqa.crt;
    ssl_certificate_key /etc/ssl/certs/openqa.key;
-   ```
+----
 
 ==== Generate and connfigure API credentials
 

--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -175,8 +175,7 @@ repository in `/tools` directory. Note that you have to have
 
 === Run the data and web UI containers in HA mode
 
-    # To create the containers
-    # in the directory openQA/docker/webui execute:
+    cd 'container/webui'
     docker-compose up -d
 
 ==== Change the number of web UI replicas (optional)


### PR DESCRIPTION
* Separate instructions for "Fedora" and "docker-compose" setups more from
  each other because the interleaving made it quite hard to follow
* Improve wording
* Fix references to "Keeping all data …" sections
* Merge section explaining the data storage with the directory structure
  setup because these seem to be very related
* See https://progress.opensuse.org/issues/76990