### PR TITLE
CI: Fix db & webui_init startup

### DIFF
--- a/container/webui/docker-compose.yaml
+++ b/container/webui/docker-compose.yaml
@@ -89,7 +89,7 @@ services:
       MODE: "webui"
       MOJO_LISTEN: "http://0.0.0.0:9526"
     depends_on:
-      webui_db_init:
+      db:
         condition: service_healthy
     deploy:
       replicas: ${OPENQA_WEBUI_REPLICAS}
@@ -109,9 +109,6 @@ services:
     environment:
       MODE: "webui"
       MOJO_LISTEN: "http://0.0.0.0:9526"
-    depends_on:
-      db:
-        condition: service_healthy
     entrypoint: "sh -c 'chmod -R a+rwX /data/{factory,testresults}; /root/run_openqa.sh'"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9526/login"]
@@ -130,7 +127,7 @@ services:
     volumes:
       - ./workdir/db:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "sh", "-c", "echo 'select * from api_keys;' | psql -U openqa openqa"]
+      test: ["CMD", "sh", "-c", "echo 'select * from api_keys;' | psql -U openqa -v 'ON_ERROR_STOP=1' openqa"]
       interval: 10s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
In #89731 we introduced a initial webui container in charge of initializing
the database. We have a test where the health check failed
https://github.com/os-autoinst/openQA/pull/3838/checks?check_run_id=2329551052

There are several detected problems:
- The db healthcheck command doesn't generate an errorcode when fails
echo 'select * from api_keys;' | psql -U openqa openqa
- There is a deathlock between db and webui: db healthcheck checks that
the table api_keys exists, but this table is created by webui_init, and
webui_init depends on the healthy start of the db to start

Solutions:

- Fix the DB healthcheck
- DB and webui_init are started at the same time
- webui pool starts when DB is healthy

https://progress.opensuse.org/issues/91046