### PR TITLE
CI: Remove -q flag in docker-compose build in test_containers_compose 

### DIFF
--- a/tools/test_containers_compose
+++ b/tools/test_containers_compose
@@ -5,7 +5,7 @@ set -euo pipefail
 for i in webui worker; do
   (
     cd container/$i/ &&
-    sudo docker-compose build -q --parallel &&
+    sudo docker-compose build --parallel &&
     sudo docker-compose up -d &&
    (docker-compose ps --services --filter status=stopped | grep "^[[:space:]]*$") || (docker-compose logs; sudo docker-compose ps; exit 1)
   ) || exit 1;


### PR DESCRIPTION
The flag -q is silencing all the logs when the container images
are building. So when it fails we don't have enough information about
the failure.

This commit removes this flag.

https://progress.opensuse.org/issues/91097