### PR TITLE
CI: Retry if docker-compose build fails in webui-docker-compose test

### DIFF
--- a/tools/test_containers_compose
+++ b/tools/test_containers_compose
@@ -5,8 +5,8 @@ set -euo pipefail
 for i in webui worker; do
   (
     cd container/$i/ &&
-    sudo docker-compose build --parallel &&
+     for retry in {2..0}; do sudo docker-compose build && break; echo "Remaining retries $retry"; done &&
     sudo docker-compose up -d &&
-   (docker-compose ps --services --filter status=stopped | grep "^[[:space:]]*$") || (docker-compose logs; sudo docker-compose ps; exit 1)
+    (docker-compose ps --services --filter status=stopped | grep "^[[:space:]]*$") || (docker-compose logs; sudo docker-compose ps; exit 1)
   ) || exit 1;
 done


### PR DESCRIPTION
Eventually docker-compose build fails because of the zypper
respositories. This commit sets 3 retries before consider the test
failed

https://progress.opensuse.org/issues/90614