### PR TITLE
[WIP] Load job templates from YAML file when scheduling isos

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,16 +20,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+use Mojo::Base -base, -signatures;
 use DBIx::Class::Timestamps 'now';
 use File::Basename;
 use Try::Tiny;
 use OpenQA::App;
-use OpenQA::Log qw(log_debug log_warning);
+use OpenQA::Log qw(log_debug log_warning log_error);
 use OpenQA::Utils;
 use OpenQA::JobSettings;
 use OpenQA::JobDependencies::Constants;
 use OpenQA::Scheduler::Client;
 use Mojo::JSON qw(encode_json decode_json);
+use OpenQA::YAML 'load_yaml';
 use Carp;
 
 use constant {
@@ -227,11 +229,18 @@ sub _schedule_iso {
     my $onlysame           = delete $args->{_ONLY_OBSOLETE_SAME_BUILD} // 0;
     my $skip_chained_deps  = delete $args->{_SKIP_CHAINED_DEPS}        // 0;
 
-    my $result = $self->_generate_jobs($args, \@notes, $skip_chained_deps);
+    my $result;
+    if ($args->{SCHEDULE_FROM_YAML_FILE}) {
+        $result = get_schedule_file($args->{SCHEDULE_FROM_YAML_FILE});
+        return $result if ($result->{error_message});
+        $result = $self->_schedule_from_yaml_file($args, $skip_chained_deps, $result->{file});
+    }
+    else {
+        $result = $self->_generate_jobs($args, \@notes, $skip_chained_deps);
+    }
     return {error => $result->{error_message}, error_code => $result->{error_code} // 400}
       if defined $result->{error_message};
     my $jobs = $result->{settings_result};
-
     # take some attributes from the first job to guess what old jobs to cancel
     # note: We should have distri object that decides which attributes are relevant here.
     if (($obsolete || $deprioritize) && $jobs && $jobs->[0] && $jobs->[0]->{BUILD}) {
@@ -516,9 +525,6 @@ sub _generate_jobs {
 
     my %wanted;    # jobs specified by $args->{TEST} or $args->{MACHINE} or their parents
 
-    # Allow a comma separated list of tests here; whitespaces allowed
-    my @tests = $args->{TEST} ? split(/\s*,\s*/, $args->{TEST}) : ();
-
     # allow filtering by group
     my $group_id   = delete $args->{_GROUP_ID};
     my $group_name = delete $args->{_GROUP};
@@ -564,46 +570,11 @@ sub _generate_jobs {
             $settings{PRIO}     = defined($priority) ? $priority : $job_template->prio;
             $settings{GROUP_ID} = $job_template->group_id;
 
-            if (!$args->{MACHINE} || $args->{MACHINE} eq $settings{MACHINE}) {
-                if (!@tests) {
-                    $wanted{_settings_key(\%settings)} = 1;
-                }
-                else {
-                    foreach my $test (@tests) {
-                        if ($test eq $settings{TEST}) {
-                            $wanted{_settings_key(\%settings)} = 1;
-                            last;
-                        }
-                    }
-                }
-            }
+            _count_wanted_jobs($args, \%settings, \%wanted);
             push @$ret, \%settings;
         }
     }
-
-    $ret = _sort_dep($ret);
-    # the array is sorted parents first - iterate it backward
-    for (my $i = $#{$ret}; $i >= 0; $i--) {
-        if ($wanted{_settings_key($ret->[$i])}) {
-            # add parents to wanted list
-            my @parents;
-            push @parents, _parse_dep_variable($ret->[$i]->{START_AFTER_TEST}, $ret->[$i]),
-              _parse_dep_variable($ret->[$i]->{START_DIRECTLY_AFTER_TEST}, $ret->[$i])
-              unless $skip_chained_deps;
-            push @parents, _parse_dep_variable($ret->[$i]->{PARALLEL_WITH}, $ret->[$i]);
-            for my $parent (@parents) {
-                my $parent_test_machine = join('@', @$parent);
-                my @parents_job_template
-                  = grep { join('@', $_->{TEST}, $_->{MACHINE}) eq $parent_test_machine } @$ret;
-                for my $parent_job_template (@parents_job_template) {
-                    $wanted{join('@', $parent_job_template->{TEST}, $parent_job_template->{MACHINE})} = 1;
-                }
-            }
-        }
-        else {
-            splice @$ret, $i, 1;    # not wanted - delete
-        }
-    }
+    $ret = _handle_dependency($ret, \%wanted, $skip_chained_deps);
     return {error_message => $error_message, settings_result => $ret};
 }
 
@@ -750,6 +721,130 @@ sub _create_download_lists {
         $download_info->{destination}->{$destination_path} = 1
           unless ($download_info->{destination}->{$destination_path});
     }
+}
+
+sub _schedule_from_yaml_file {
+    my ($slef, $args, $skip_chained_deps, $file) = @_;
+    my ($data, $result);
+    try {
+        $data = load_yaml(file => $file);
+    }
+    catch {
+        $result->{error_message} = $_;
+        return $result;
+    };
+    my $products      = $data->{products};
+    my $machines      = $data->{machines};
+    my $job_templates = $data->{job_templates};
+    my $error_msg;
+    my %wanted;
+    my @job_templates;
+    foreach my $key (keys %$job_templates) {
+        my $job_template = $job_templates->{$key};
+        next unless $job_template->{product};
+        next unless $products->{$job_template->{product}};
+
+        my $product = $products->{$job_template->{product}};
+        next
+          if ( $product->{distri} ne _distri_key($args)
+            || $product->{flavor} ne $args->{FLAVOR}
+            || $product->{version} ne $args->{VERSION}
+            || $product->{arch} ne $args->{ARCH});
+        my @worker_class;
+        my $settings = $job_template->{settings} // {};
+        $settings->{TEST} = $key;
+        push @worker_class, $settings->{WORKER_CLASS} if ($settings->{WORKER_CLASS});
+
+        my $product_settings = delete $product->{settings} // {};
+        foreach (keys %$product) {
+            $settings->{uc $_} = $product->{$_};
+        }
+        foreach my $s_key (keys %$product_settings) {
+            if ($s_key eq 'WORKER_CLASS') {
+                push @worker_class, $product_settings->{$s_key};
+                next;
+            }
+            $settings->{$s_key} = $product_settings->{$s_key};
+        }
+        if (my $machine = $job_template->{machine}) {
+            $settings->{MACHINE} = $machine;
+            if (my $mach = $machines->{$machine}) {
+                my $machine_settings = $mach->{settins} // {};
+                foreach (keys %$machine_settings) {
+                    if ($_ eq 'WORKER_CLASS') {
+                        push @worker_class, $machine_settings->{WORKER_CLASS};
+                        next;
+                    }
+                    $settings->{$_} = $machine_settings->{$_};
+                }
+                $settings->{BACKEND} = $mach->{backend} if $mach->{backend};
+                $settings->{PRIO}    = $mach->{priority} // 50;
+            }
+        }
+        $settings->{WORKER_CLASS} = join ',', sort @worker_class if @worker_class > 0;
+        foreach (keys %$args) {
+            $settings->{uc $_} = $args->{$_} if $_ ne 'TEST';
+        }
+        $settings->{DISTRI} = lc($settings->{DISTRI}) if $settings->{DISTRI};
+
+        OpenQA::JobSettings::parse_url_settings($settings);
+        OpenQA::JobSettings::handle_plus_in_settings($settings);
+        my $error = OpenQA::JobSettings::expand_placeholders($settings);
+        $error_msg .= $error if defined $error;
+
+        _count_wanted_jobs($args, $settings, \%wanted);
+
+        push @job_templates, $settings;
+    }
+    $result->{settings_result} = _handle_dependency(\@job_templates, \%wanted, $skip_chained_deps);
+    $result->{error_message}   = $error_msg;
+    return $result;
+}
+
+sub _count_wanted_jobs {
+    my ($args, $settings, $wanted) = @_;
+    my @tests = $args->{TEST} ? split(/\s*,\s*/, $args->{TEST}) : ();
+    if (!$args->{MACHINE} || $args->{MACHINE} eq $settings->{MACHINE}) {
+        if (!@tests) {
+            $wanted->{_settings_key($settings)} = 1;
+        }
+        else {
+            foreach my $test (@tests) {
+                if ($test eq $settings->{TEST}) {
+                    $wanted->{_settings_key($settings)} = 1;
+                    last;
+                }
+            }
+        }
+    }
+}
+
+sub _handle_dependency {
+    my ($jobs, $wanted, $skip_chained_deps) = @_;
+    $jobs = _sort_dep($jobs);
+    # the array is sorted parents first - iterate it backward
+    for (my $i = $#{$jobs}; $i >= 0; $i--) {
+        if ($wanted->{_settings_key($jobs->[$i])}) {
+            # add parents to wanted list
+            my @parents;
+            push @parents, _parse_dep_variable($jobs->[$i]->{START_AFTER_TEST}, $jobs->[$i]),
+              _parse_dep_variable($jobs->[$i]->{START_DIRECTLY_AFTER_TEST}, $jobs->[$i])
+              unless $skip_chained_deps;
+            push @parents, _parse_dep_variable($jobs->[$i]->{PARALLEL_WITH}, $jobs->[$i]);
+            for my $parent (@parents) {
+                my $parent_test_machine = join('@', @$parent);
+                my @parents_job_template
+                  = grep { join('@', $_->{TEST}, $_->{MACHINE}) eq $parent_test_machine } @$jobs;
+                for my $parent_job_template (@parents_job_template) {
+                    $wanted->{join('@', $parent_job_template->{TEST}, $parent_job_template->{MACHINE})} = 1;
+                }
+            }
+        }
+        else {
+            splice @$jobs, $i, 1;    # not wanted - delete
+        }
+    }
+    return $jobs;
 }
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -86,6 +86,7 @@ our @EXPORT  = qw(
   find_video_files
   fix_top_level_help
   looks_like_url_with_scheme
+  get_schedule_file
 );
 
 our @EXPORT_OK = qw(
@@ -901,5 +902,11 @@ sub find_video_files { path(shift)->list_tree->grep(VIDEO_FILE_NAME_REGEX) }
 sub fix_top_level_help { @ARGV = () if ($ARGV[0] // '') =~ qr/^(-h|(--)?help)$/ }
 
 sub looks_like_url_with_scheme { return !!Mojo::URL->new(shift)->scheme }
+
+sub get_schedule_file {
+    my $file = shift;
+    # TODO git clone the repo file and return the file path or error_message
+    return {error_message => undef, file => $file};
+}
 
 1;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -977,6 +977,25 @@ subtest 'Expand specified variables when scheduling iso' => sub {
     is($result->{YAML_SCHEDULE},   'foo@64bit-staging.yaml', 'the TEST was replaced correctly');
     is($result->{TEST_SUITE_NAME}, 'foo',                    'the TEST_SUITE_NAME was right');
     is($result->{JOB_DESCRIPTION}, undef,                    'There is no job description');
+    $schema->txn_rollback;
 };
+
+
+subtest 'schedule from yaml file' => sub {
+    $schema->txn_begin;
+    my $file = "$FindBin::Bin/../data/09-schedule_from_file.yaml";
+    my $res  = schedule_iso({%iso, GROUP_ID => '0', SCHEDULE_FROM_YAML_FILE => "$file", TEST => 'autoyast_btrfs'}, 200);
+    is($res->json->{count}, 2, 'two job was scheduled');
+    my $job_ids       = $res->json->{ids};
+    my $parent_job_id = $job_ids->[0];
+    my $child_job     = $jobs->find($job_ids->[1]);
+    is(
+        $child_job->settings_hash->{HDD_1},
+        'opensuse-13.1-i586-0091@aarch64-minimal_with_sdk0091_installed.qcow2',
+        'settings was handled correctly'
+    );
+    is_deeply($child_job->dependencies->{parents}->{Chained}, [$parent_job_id], 'the dependency job was created');
+};
+
 
 done_testing();

--- a/t/data/09-schedule_from_file.yaml
+++ b/t/data/09-schedule_from_file.yaml
@@ -1,0 +1,51 @@
+products:
+  sle-online-aarch64-*:
+    distri: "opensuse"
+    flavor: "DVD"
+    arch  : "i586"
+    version: '13.1'
+    settings:
+      foo: 1
+  sle-offline-x86_64-*:
+     distri: "sle"
+     flavor: "offline"
+     arch: "x86_64"
+     version: '12-SP5'
+     settings:
+       foo : 2
+machines:
+  64bit:
+    backend: "qemu"
+    priority: 20
+    settings: 
+      ARCH_BASE_MACHINE: "64bit"
+      QEMUCPUS: "2"
+      QEMURAM: "2048"
+      QEMUVGA: "virtio"
+      WORKER_CLASS: "qemu_x86_64"
+  aarch64:
+    backend: "qemu"
+    settings: 
+      QEMU: "aarch64"
+      QEMURAM: 3072
+      UEFI: "1"
+      WORKER_CLASS: "qemu_aarch64"
+job_templates:
+  autoyast_bcache:
+    product: "sle-offline-x86_64-*"
+    machine: "b4bit" 
+    settings:
+      YAML_SCHEDULE: 'schedule/yast/autoyast_bcache.yaml'
+      HDD_1: "SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
+      BUILD_SDK: "%BUILD"
+  autoyast_btrfs:
+    product: "sle-online-aarch64-*"
+    machine: "aarch64"
+    settings:
+      YAML_SCHEDULE: 'schedule/yast/autoyast_btrfs.yaml'
+      HDD_1: "opensuse-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
+      BUILD_SDK: "%BUILD%"
+      START_AFTER_TEST: "create_hdd"
+  create_hdd:
+    product: "sle-online-aarch64-*"
+    machine: "aarch64"


### PR DESCRIPTION
The purpose is reading all configurations from a git file (maybe a YAML
file in github) when doing `isos post`.
The format of the YAML file looks like the `09-schedule_from_file.yaml`.

Relate: https://progress.opensuse.org/issues/71758