### PR TITLE
worker: Make uploading test order on final upload (when stopping job) work

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -745,15 +745,15 @@ sub _upload_results_step_0_prepare {
     );
 
     my $test_status  = -r $status_file ? decode_json(path($status_file)->slurp) : {};
-    my $running      = ($test_status->{status} || '') eq 'running';
-    my $finished     = ($test_status->{status} || '') eq 'finished';
+    my $test_state   = $test_status->{status}       || '';
     my $running_test = $test_status->{current_test} || '';
+    my $finished     = $test_state eq 'finished';
     $status{test_execution_paused} = $test_status->{test_execution_paused} // 0;
 
     # determine up to which module the results should be uploaded
     my $current_test_module = $self->current_test_module;
     my $upload_up_to;
-    if ($self->{_has_uploaded_logs_and_assets} || $running || $finished) {
+    if ($self->{_has_uploaded_logs_and_assets} || $test_state eq 'running' || $finished) {
         my @file_info = stat $self->_result_file_path('test_order.json');
         my $test_order;
         my $changed_schedule = (


### PR DESCRIPTION
Uploading the test order on the final upload (when stopping the job) was
broken because the function for loading the test module results cleared the
array holding the test order when the test has already been finished. So if
the test order hasn't been uploaded before because the test execution was
very short the test order couldn't be uploaded at all.

This change basically restores the array holding the test order before the
final upload. The worker will now post the entire test order and the all
information from result files again in the end to ensure everything is in
place. Images/files will known by the web UI will still be skipped and the
uploads during the test execution will still avoid uploading everything.

So I suppose this change will fix
https://progress.opensuse.org/issues/90152 where test modules are missing
and the test execution time might also be very short.

Note that this issue can also be reproduced by changing isotovideo *not* to
write `autoinst-status.json` because then the worker never knows that the
job is running and only relies on the final upload to post the test order.