### PR TITLE
Fix failing CI check for container file (static check DL3059)

### DIFF
--- a/container/travis_test/Dockerfile
+++ b/container/travis_test/Dockerfile
@@ -147,16 +147,15 @@ CMD ["/sbin/init"]
 ENV OPENQA_DIR /opt/openqa
 ENV NORMAL_USER squamata
 
-RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-RUN mkdir -p /home/$NORMAL_USER
-RUN useradd -r -d /home/$NORMAL_USER -g users --uid=1000 $NORMAL_USER
-RUN chown $NORMAL_USER:users /home/$NORMAL_USER
+RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    mkdir -p /home/$NORMAL_USER && \
+    useradd -r -d /home/$NORMAL_USER -g users --uid=1000 $NORMAL_USER && \
+    chown $NORMAL_USER:users /home/$NORMAL_USER
 VOLUME [ "/opt/openqa" ]
 
 # explicitly set user/group IDs
-
-RUN mkdir -p /opt/testing_area
-RUN chown -R $NORMAL_USER:users /opt/testing_area
+RUN mkdir -p /opt/testing_area && \
+    chown -R $NORMAL_USER:users /opt/testing_area
 
 ENTRYPOINT ["/bin/bash"]
 WORKDIR $OPENQA_DIR

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -9,10 +9,8 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/op
     zypper --gpg-auto-import-keys ref && \
     zypper in -y ca-certificates-mozilla curl && \
     zypper in -y --force-resolution openQA-local-db apache2 hostname which w3m && \
-    zypper clean
-
-# setup apache
-RUN gensslcert && \
+    zypper clean && \
+    gensslcert && \
     a2enmod headers && \
     a2enmod proxy && \
     a2enmod proxy_http && \
@@ -20,6 +18,7 @@ RUN gensslcert && \
     a2enmod ssl && \
     a2enmod rewrite && \
     a2enflag SSL
+
 COPY openqa-ssl.conf /etc/apache2/vhosts.d/openqa-ssl.conf
 COPY openqa.conf /etc/apache2/vhosts.d/openqa.conf
 COPY run_openqa.sh /root/

--- a/container/webui/docker-compose.yaml
+++ b/container/webui/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:9529"]
       interval: 5s
       timeout: 2s
-      retries: 3
+      retries: 6
       start_period: 10s
 
   websockets:
@@ -40,7 +40,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:9527"]
       interval: 5s
       timeout: 2s
-      retries: 3
+      retries: 6
       start_period: 10s
 
   gru:
@@ -57,7 +57,7 @@ services:
       test: ["CMD", "grep", "started", "/var/log/gru.log"]
       interval: 5s
       timeout: 2s
-      retries: 3
+      retries: 6
       start_period: 10s
 
   livehandler:
@@ -76,7 +76,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:9528"]
       interval: 5s
       timeout: 2s
-      retries: 3
+      retries: 6
       start_period: 5s
 
   webui:
@@ -97,7 +97,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:9526/login"]
       interval: 5s
       timeout: 2s
-      retries: 3
+      retries: 6
       start_period: 5s
 
   webui_db_init:
@@ -114,7 +114,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:9526/login"]
       interval: 5s
       timeout: 2s
-      retries: 3
+      retries: 6
       start_period: 5s
 
   db:

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -12,9 +12,9 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/op
     zypper in -y kmod && \
     (zypper in -y qemu-ovmf-x86_64 ||:) && \
     (zypper in -y qemu-uefi-aarch64 ||:) && \
-    zypper clean
+    zypper clean && \
+    mkdir -p /root/qemu
 
-RUN mkdir -p /root/qemu
 COPY kvm-mknod.sh /root/qemu/kvm-mknod.sh
 COPY run_openqa_worker.sh /run_openqa_worker.sh
 # ensure executability in case we loose file permissions, e.g. within open


### PR DESCRIPTION
This check has recently been added to the linter, see
https://github.com/hadolint/hadolint/commit/4cb8f28ebecfd0343241369952fc9b3e7e4ea866 and https://progress.opensuse.org/issues/91377