### PR TITLE
worker: Avoid running optipng/upload twice

### DIFF
--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1354,4 +1354,13 @@ subtest 'Cache setup error handling' => sub {
       'show the error message that is returned by do_asset_caching correctly';
 };
 
+subtest 'calculating md5sum of result file' => sub {
+    my $job = OpenQA::Worker::Job->new($worker, $client, {id => 12, URL => $engine_url});
+    my $png = $pool_directory->child('foo.png');
+    $png->spurt('not really a PNG');
+    is $job->_calculate_file_md5('foo.png'), '454b28784a187cd782891a721b7ae31b', 'md5sum computed';
+    $png->spurt('optimized');
+    is $job->_calculate_file_md5('foo.png'), '454b28784a187cd782891a721b7ae31b', 'previous md5sum returned';
+};
+
 done_testing();


### PR DESCRIPTION
Making the worker go though every test module again during the final
upload (https://github.com/os-autoinst/openQA/pull/3849) introduced the
problem of uploading images again during the final upload. This should have
been prevented by the usual skipping of known images. However, since we now
re-read the test module results the checksums were re-computed during the
final upload which breaks the matching. That's because the checksums
actually differ due to running optipng before the image upload. This change
restores the matching by simply caching and reusing the md5sum from before
the optimization.

Related issue: https://progress.opensuse.org/issues/90152