### PR TITLE
Enable signatures in …::Result::Jobs and fix issues

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -18,9 +18,9 @@ package OpenQA::Schema::Result::Jobs;
 use strict;
 use warnings;
 
+use Mojo::Base -strict, -signatures;
 use base 'DBIx::Class::Core';
 
-use Encode qw(decode);
 use Try::Tiny;
 use Mojo::JSON 'encode_json';
 use Fcntl;
@@ -1714,8 +1714,7 @@ sub release_networks {
     $self->networks->delete;
 }
 
-sub needle_dir() {
-    my ($self) = @_;
+sub needle_dir ($self) {
     unless ($self->{_needle_dir}) {
         my $distri  = $self->DISTRI;
         my $version = $self->VERSION;
@@ -2061,7 +2060,7 @@ sub done {
         # limit length of the reason
         # note: The reason can be anything the worker picked up as useful information so better cut it at a
         #       reasonable, human-readable length. This also avoids growing the database too big.
-        $reason = substr($reason, 0, 300) . decode('UTF-8', '…') if defined $reason && length $reason > 300;
+        $reason = substr($reason, 0, 300) . '…' if defined $reason && length $reason > 300;
         $new_val{reason} = $reason;
     }
     $self->update(\%new_val);


### PR DESCRIPTION
* Fix declaration of needle_dir
* Fix string literal '…' as this apparently also pulls in changed UTF-8 handling

---

When enabling signatures in `…::Result::Jobs` in https://github.com/os-autoinst/openQA/pull/3858 I've noticed that this is not completely straight forward as these two issues need to be fixed. So I've created a separate PR to have these fixes independently of https://github.com/os-autoinst/openQA/pull/3858.