### PR TITLE
Add back to top button to layout

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -99,6 +99,7 @@
 << https://raw.githubusercontent.com/twbs/bootstrap/v4.1.1/scss/utilities/_visibility.scss
 << https://raw.githubusercontent.com/twbs/bootstrap/v4.1.1/scss/_print.scss
 < https://raw.githubusercontent.com/sorich87/bootstrap-tour/6a1028fb562f9aa68c451f0901f8cfeb43cad140/build/css/bootstrap-tour.css
+< stylesheets/back_to_top.css
 
 ! dagre-d3.js
 < https://d3js.org/d3.v4.js
@@ -136,6 +137,7 @@
 < javascripts/admin_groups.js
 < javascripts/admin_assets.js
 < javascripts/audit_log.js
+< javascripts/back_to_top.js
 < javascripts/tests.js
 < javascripts/job_templates.js
 < javascripts/overview.js

--- a/assets/javascripts/back_to_top.js
+++ b/assets/javascripts/back_to_top.js
@@ -1,0 +1,18 @@
+function backToTop() {
+    $(document).ready(function() {
+        $(window).scroll(function() {
+            // Increase the value to not show the button on shorter pages
+            if ($(this).scrollTop() > 50) {
+                $('#back-to-top').fadeIn();
+            } else {
+                $('#back-to-top').fadeOut();
+            }
+        });
+        $('#back-to-top').click(function() {
+            $('#back-to-top').tooltip('hide');
+            $('body, html').animate({ scrollTop: 0 }, 800);
+            return false;
+        });
+        $('#back-to-top').tooltip('show');
+    });
+}

--- a/assets/javascripts/back_to_top.js
+++ b/assets/javascripts/back_to_top.js
@@ -13,6 +13,5 @@ function backToTop() {
             $('body, html').animate({ scrollTop: 0 }, 800);
             return false;
         });
-        $('#back-to-top').tooltip('show');
     });
 }

--- a/assets/stylesheets/back_to_top.css
+++ b/assets/stylesheets/back_to_top.css
@@ -1,10 +1,13 @@
 .back-to-top {
     bottom: 20px;
+    border-radius: 50rem;
     cursor: pointer;
     display: none;
     position: fixed;
     right: 20px;
     z-index: 1000;
+    width: 2.2rem;
+    height: 2.2rem;
 }
 .back-to-top i {
     padding-left: 3pt !important;

--- a/assets/stylesheets/back_to_top.css
+++ b/assets/stylesheets/back_to_top.css
@@ -1,0 +1,11 @@
+.back-to-top {
+    bottom: 20px;
+    cursor: pointer;
+    display: none;
+    position: fixed;
+    right: 20px;
+    z-index: 1000;
+}
+.back-to-top i {
+    padding-left: 3pt !important;
+}

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -42,6 +42,16 @@ $driver->title_is("openQA", "on main page");
 my @build_headings = $driver->find_elements('.h4', 'css');
 is(scalar @build_headings, 4, '4 builds shown');
 
+subtest 'Back to top button' => sub {
+    my $back_to_top = $driver->find_element('#back-to-top');
+    ok $back_to_top, 'back to top button exists';
+    ok !$back_to_top->is_displayed, 'button is not visible';
+    $driver->execute_script('window.scrollTo(0, document.body.scrollHeight);');
+    ok $back_to_top->is_displayed, 'button is visible after scrolling down';
+    $back_to_top->click();
+    ok !$back_to_top->is_displayed, 'button is not visible anymore after using it';
+};
+
 # click on last build which should be Build0091
 $driver->find_child_element($build_headings[-1], 'a', 'css')->click();
 like(

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -47,6 +47,7 @@ subtest 'Back to top button' => sub {
     ok $back_to_top, 'back to top button exists';
     ok !$back_to_top->is_displayed, 'button is not visible';
     $driver->execute_script('window.scrollTo(0, document.body.scrollHeight);');
+    $back_to_top = $driver->find_element('#back-to-top');
     ok $back_to_top->is_displayed, 'button is visible after scrolling down';
     $back_to_top->click();
     ok !$back_to_top->is_displayed, 'button is not visible anymore after using it';

--- a/templates/webapi/layouts/bootstrap.html.ep
+++ b/templates/webapi/layouts/bootstrap.html.ep
@@ -29,6 +29,7 @@
           %= content_for 'head_javascript'
           $(function() {
             setupForAll();
+            backToTop();
             %= content_for 'ready_function'
             % if (current_user) {
               newFeature(<%= current_user->feature_version %>);
@@ -44,6 +45,10 @@
       %= include 'layouts/navbar'
       <div class="container-fluid" id="content">
           %= content
+          <a id="back-to-top" href="#" class="btn btn-primary btn-lg back-to-top" role="button"
+            title="Click to return to the top" data-toggle="tooltip" data-placement="left">
+            <i class="fas fa-angle-up"></i>
+          </a>
       </div>
 
       <footer class='footer'>

--- a/templates/webapi/layouts/bootstrap.html.ep
+++ b/templates/webapi/layouts/bootstrap.html.ep
@@ -45,8 +45,7 @@
       %= include 'layouts/navbar'
       <div class="container-fluid" id="content">
           %= content
-          <a id="back-to-top" href="#" class="btn btn-primary btn-lg back-to-top" role="button"
-            title="Click to return to the top" data-toggle="tooltip" data-placement="left">
+          <a id="back-to-top" href="#" class="btn btn-primary btn-lg back-to-top" role="button">
             <i class="fas fa-angle-up"></i>
           </a>
       </div>


### PR DESCRIPTION
![test](https://user-images.githubusercontent.com/30094/115868069-27f08800-a43c-11eb-97a9-ac802fb44587.png)

The button looks a little different than on the QAM Dashboard because openQA doesn't use Bootstrap defaults. But it's consistent with the look of other buttons.

Progress: https://progress.opensuse.org/issues/91601