### PR TITLE
Only consider bugrefs/labels for black certificate icon

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -61,7 +61,7 @@ sub count_job {
         if (grep { $job->result eq $_ } OpenQA::Jobs::Constants::NOT_OK_RESULTS) {
             my $comment_data = $labels->{$job->id};
             $jr->{failed}++;
-            $jr->{labeled}++ if $comment_data && ($comment_data->{bugs} || $comment_data->{label});
+            $jr->{labeled}++ if $comment_data && $comment_data->{reviewed};
             return;
         }
         # note: Incompletes and timeouts are accounted to both categories - failed and skipped.

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2236,15 +2236,13 @@ sub _overview_result_done {
     my $result_stats = $self->result_stats;
     my $overall      = $self->result;
 
-    if ($todo) {
-        # skip all jobs NOT needed to be labeled for the black certificate icon to show up
-        return undef
-          if $self->result eq OpenQA::Jobs::Constants::PASSED
-          || $job_labels->{$jobid}{bugs}
-          || $job_labels->{$jobid}{label}
-          || ($self->result eq OpenQA::Jobs::Constants::SOFTFAILED
-            && ($job_labels->{$jobid}{label} || !$self->has_failed_modules));
-    }
+    # skip all jobs NOT needed to be labeled for the black certificate icon to show up
+    my $comment_data = $job_labels->{$jobid};
+    return undef
+      if $todo
+      && ( ($overall eq PASSED)
+        || ($overall eq SOFTFAILED && !$self->has_failed_modules)
+        || ($comment_data->{bugs} || $comment_data->{label}));
 
     $aggregated->{OpenQA::Jobs::Constants::meta_result($overall)}++;
     return {
@@ -2255,10 +2253,10 @@ sub _overview_result_done {
         jobid      => $jobid,
         state      => OpenQA::Jobs::Constants::DONE,
         failures   => $actually_failed_modules,
-        bugs       => $job_labels->{$jobid}{bugs},
-        bugdetails => $job_labels->{$jobid}{bugdetails},
-        label      => $job_labels->{$jobid}{label},
-        comments   => $job_labels->{$jobid}{comments},
+        bugs       => $comment_data->{bugs},
+        bugdetails => $comment_data->{bugdetails},
+        label      => $comment_data->{label},
+        comments   => $comment_data->{comments},
     };
 }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2240,9 +2240,7 @@ sub _overview_result_done {
     my $comment_data = $job_labels->{$jobid};
     return undef
       if $todo
-      && ( ($overall eq PASSED)
-        || ($overall eq SOFTFAILED && !$self->has_failed_modules)
-        || ($comment_data->{bugs} || $comment_data->{label}));
+      && ($comment_data->{reviewed} || $overall eq PASSED || ($overall eq SOFTFAILED && !$self->has_failed_modules));
 
     $aggregated->{OpenQA::Jobs::Constants::meta_result($overall)}++;
     return {

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -75,7 +75,7 @@ sub comment_data_for_jobs ($self, $jobs) {
         else {
             $res->{comments}++;
         }
-        # note: Previous occurences of bug or label are overwritten here.
+        # note: Previous labels are overwritten here so only the most recent label is returned.
     }
     return \%res;
 }

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 LLC
+# Copyright (C) 2020-2021 LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,11 +17,11 @@ package OpenQA::Schema::ResultSet::Comments;
 
 use strict;
 use warnings;
+use Mojo::Base -signatures;
+
+use OpenQA::Utils qw(find_bugrefs);
 
 use base 'DBIx::Class::ResultSet';
-
-use OpenQA::App;
-use OpenQA::Utils;
 
 =over 4
 
@@ -39,6 +39,43 @@ sub referenced_bugs {
     my $comments = $self->search({-not => {job_id => undef}});
     my %bugrefs  = map { $_ => 1 } map { @{find_bugrefs($_->text)} } $comments->all;
     return \%bugrefs;
+}
+
+=over 4
+
+=item comment_data_for_jobs($jobs)
+
+Return a hashref with bugrefs, labels and the number of regular comments per job ID.
+
+=back
+
+=cut
+
+sub comment_data_for_jobs ($self, $jobs) {
+    my @job_ids  = map { $_->id } ref $jobs eq 'ARRAY' ? @$jobs : $jobs->all;
+    my $comments = $self->search({job_id => {in => \@job_ids}}, {order_by => 'me.id'});
+    my $bugs     = $self->result_source->schema->resultset('Bugs');
+
+    my (%res, %bugdetails);
+    while (my $comment = $comments->next) {
+        my ($job_id, $bugrefs) = ($comment->job_id, $comment->bugrefs);
+        if (@$bugrefs) {
+            my $bugs_of_job = ($res{$job_id}{bugs} //= {});
+            for my $bug (@$bugrefs) {
+                $bugdetails{$bug} = $bugs->get_bug($bug) unless exists $bugdetails{$bug};
+                $bugs_of_job->{$bug} = 1;
+            }
+            $res{$job_id}{bugdetails} = \%bugdetails;
+        }
+        elsif (my $label = $comment->label) {
+            $res{$job_id}{label} = $label;
+        }
+        else {
+            $res{$job_id}{comments}++;
+        }
+        # note: Previous occurences of bug or label are overwritten here.
+    }
+    return \%res;
 }
 
 1;

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -58,20 +58,22 @@ sub comment_data_for_jobs ($self, $jobs) {
 
     my (%res, %bugdetails);
     while (my $comment = $comments->next) {
-        my ($job_id, $bugrefs) = ($comment->job_id, $comment->bugrefs);
+        my ($bugrefs, $res) = ($comment->bugrefs, $res{$comment->job_id} //= {});
         if (@$bugrefs) {
-            my $bugs_of_job = ($res{$job_id}{bugs} //= {});
+            my $bugs_of_job = ($res->{bugs} //= {});
             for my $bug (@$bugrefs) {
                 $bugdetails{$bug} = $bugs->get_bug($bug) unless exists $bugdetails{$bug};
                 $bugs_of_job->{$bug} = 1;
             }
-            $res{$job_id}{bugdetails} = \%bugdetails;
+            $res->{bugdetails} = \%bugdetails;
+            $res->{reviewed}   = 1;
         }
         elsif (my $label = $comment->label) {
-            $res{$job_id}{label} = $label;
+            $res->{label}    = $label;
+            $res->{reviewed} = 1;
         }
         else {
-            $res{$job_id}{comments}++;
+            $res->{comments}++;
         }
         # note: Previous occurences of bug or label are overwritten here.
     }

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright (C) 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -72,11 +72,13 @@ subtest 'Validation errors' => sub {
 };
 
 subtest 'Changelog' => sub {
+    my $global_cfg = $t->app->config->{global};
+    $global_cfg->{changelog_file} = 'does not exist';
     $t->get_ok('/changelog')->status_is(200)->content_like(qr/No changelog available/)
       ->content_unlike(qr/Custom changelog works/);
     my $changelog = tempfile;
     $changelog->spurt('Custom changelog works!');
-    local $t->app->config->{global}{changelog_file} = $changelog->to_string;
+    $global_cfg->{changelog_file} = $changelog->to_string;
     $t->get_ok('/changelog')->status_is(200)->content_like(qr/Custom changelog works/);
 };
 

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -324,6 +324,14 @@ my $failed_not_important_module_issueref
 # softfailed:                         reviewed
 check_badge(0, 'no badge as long as not all failed reviewed');
 
+# add arbitrary comment for job 99938
+my $failed_comment
+  = $opensuse_group->jobs->find({id => 99938})->comments->create({text => 'arbitrary comment', user_id => 99901});
+
+# failed:                             not reviewed (arbitrary comment does not count)
+# softfailed:                         reviewed
+check_badge(0, 'no badge as long as not all failed reviewed (arbitrary comment does not count)');
+
 # add review for job 99938 (so now the other failed jobs are reviewed but one is missing)
 my $failed_issueref
   = $opensuse_group->jobs->find({id => 99938})->comments->create({text => 'poo#4321', user_id => 99901});


### PR DESCRIPTION
* Do *not* count any kind of comment anymore when computing black
  certificate icon; only count bugrefs/labels in consistency with TODO
  parameter of test results overview page
* Use the same code for checking bugrefs/labels for certificate, test
  results overview page and 'Next & previous results' tab
* See https://progress.opensuse.org/issues/91658