### PR TITLE
Let the worker retry uploading when updating module results failed

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1547,7 +1547,10 @@ sub update_status {
     }
     $ret->{known_images} = [sort keys %known_image];
     $ret->{known_files}  = [sort keys %known_files];
-    $ret->{error}        = 'Failed modules: ' . join ', ', @failed_modules if @failed_modules;
+    if (@failed_modules) {
+        $ret->{error}        = 'Failed modules: ' . join ', ', @failed_modules;
+        $ret->{error_status} = 490;    # let the worker do its usual retries (see poo#91902)
+    }
 
     # update info used to compose the URL to os-autoinst command server
     if (my $assigned_worker = $self->assigned_worker) {

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -311,7 +311,7 @@ sub send {
         $msg //= $err->{message};
         if (my $error_code = $err->{code}) {
             $msg = "$error_code response: $msg";
-            if (400 <= $error_code && $error_code < 500 && $error_code != 408 && $error_code != 425) {
+            if ($error_code < 500 && $error_code != 408 && $error_code != 425 && $error_code != 490) {
                 # don't retry on most 4xx errors (in this case we can't expect
                 # different results on further attempts)
                 $tries = 0;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -596,7 +596,7 @@ subtest 'update job status' => sub {
                         bar_module => {result => 'none'},                            # supposed to be ignored
                     },
                 }});
-        $t->post_ok(@post_args)->status_is(400, 'result upload returns error code if module does not exist');
+        $t->post_ok(@post_args)->status_is(490, 'result upload returns error code if module does not exist');
         is $t->tx->res->json->{error}, 'Failed modules: bar_module', 'error specifies problematic module';
 
         $job->modules->create({name => 'bar_module', category => 'selftests', script => 'bar_module.pm'});


### PR DESCRIPTION
* Avoid incompletes with the reason "Failed modules: …"
    * Weaken error handling introduced in
      a34d89c4a2a78d874c84596257ac28f27f20d892 so the worker would try the
      upload again
    * Affected tests actually have the failing test modules so it is likely
      that a retry would help
* See https://progress.opensuse.org/issues/91902