### PR TITLE
Consider jobs with no modules incomplete

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1035,9 +1035,7 @@ sub calculate_result {
             $overall ||= PASSED;
         }
         elsif ($m->result eq SOFTFAILED) {
-            if (!defined $overall || $overall eq PASSED) {
-                $overall = SOFTFAILED;
-            }
+            $overall = SOFTFAILED if !defined $overall || $overall eq PASSED;
         }
         elsif ($m->result eq SKIPPED) {
             $overall ||= PASSED;
@@ -1046,8 +1044,7 @@ sub calculate_result {
             $overall = FAILED;
         }
     }
-
-    return $overall || FAILED;
+    return $overall || INCOMPLETE;
 }
 
 sub save_screenshot {
@@ -2066,6 +2063,9 @@ sub done {
         #       reasonable, human-readable length. This also avoids growing the database too big.
         $reason = substr($reason, 0, 300) . '…' if defined $reason && length $reason > 300;
         $new_val{reason} = $reason;
+    }
+    elsif ($reason_unknown && !defined $reason && $result eq INCOMPLETE) {
+        $new_val{reason} = 'no test modules scheduled/uploaded';
     }
     $self->update(\%new_val);
     # bugrefs are there to mark reasons of failure - the function checks itself though

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -399,17 +399,17 @@ subtest 'job with at least one softfailed => overall is softfailed' => sub {
     is($job->result, OpenQA::Jobs::Constants::SOFTFAILED, 'job result is softfailed');
 };
 
-subtest 'job with no modules => overall is failed' => sub {
+subtest 'job with no modules => overall is incomplete' => sub {
     my %_settings = %settings;
     $_settings{TEST} = 'J';
     my $job = _job_create(\%_settings);
     $job->update;
     $job->discard_changes;
 
-    is($job->result, OpenQA::Jobs::Constants::NONE, 'result is not yet set');
+    is $job->result, NONE, 'result is not yet set';
     $job->done;
     $job->discard_changes;
-    is($job->result, OpenQA::Jobs::Constants::FAILED, 'job result is failed');
+    is $job->result, INCOMPLETE, 'job result is incomplete';
 };
 
 subtest 'carry over, including soft-fails' => sub {

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright (C) 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -116,7 +116,7 @@ subtest 'mark job as done' => sub {
             "id"        => $job,
             "newbuild"  => undef,
             "remaining" => 0,
-            "result"    => "failed",
+            "result"    => INCOMPLETE,
             "reason"    => undef,
         },
         'job done triggers amqp'


### PR DESCRIPTION
* Consider jobs with no modules incomplete when the worker does not
  explicitly pass a result
* Use `no test modules scheduled/uploaded` as reason if there's no other
  reason
    * Compilation errors, needle initialization errors and other early
      errors (before the test module creation) still have a specific reason
* Tested manually by breaking controller code to simulate
  https://progress.opensuse.org/issues/90152