### PR TITLE
doc: Improve phrasing regarding worker instance number

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -469,7 +469,7 @@ systemctl start openqa-worker@1
 --------------------------------------------------------------------------------
 
 This will start worker number one. You can start as
-many workers as you dare, you just need to supply different 'instance number'
+many workers as you need, you just need to supply a different 'instance number'
 (the number after `@`).
 
 You can also run workers manually from command line.


### PR DESCRIPTION
The missing `a` is pointed out in the issue. I'm also changing *dare* to *need* because there's no reason to be cheeky here.

Fixes: #3691