### PR TITLE
Simplify handling of potential not-implemented states of jobs

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -75,11 +75,9 @@ sub count_job {
         return;
     }
     my $state = $job->state;
-    if (grep { /$state/ } (OpenQA::Jobs::Constants::PENDING_STATES)) {
-        $jr->{unfinished}++;
-        return;
-    }
-    log_error("MISSING S:" . $job->state . " R:" . $job->result);
+    log_error("Encountered not-implemented state:" . $job->state . " result:" . $job->result)
+      unless grep { /$state/ } (OpenQA::Jobs::Constants::PENDING_STATES);
+    $jr->{unfinished}++;
     return;
 }
 


### PR DESCRIPTION
Helps with statement coverage in tests as well :) 

Encountered while looking at code statement coverage reports on codecov,
in particular
https://codecov.io/gh/os-autoinst/openQA/src/master/lib/OpenQA/BuildResults.pm

Related progress issue: https://progress.opensuse.org/issues/55364
