### PR TITLE
 Do not enqueue more Minion jobs while waiting in 27-plugin_obs_rsync_status_details.t

### DIFF
--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -122,13 +122,14 @@ sub _wait_for_change ($selector, $break_cb, $refresh_cb = undef) {
     my $text;
     my $limit = int OpenQA::Test::TimeLimit::scale_timeout(10);
     for my $i (0 .. $limit) {
-        note 'Pending Minion jobs: ' . $minion->jobs({states => [qw(inactive active)]})->total;
 
         # sometimes gru is not fast enough, so let's refresh the page and see if that helped
         if ($i > 0) {
             sleep 1;
+            my $pending_minion_jobs = $minion->jobs({states => [qw(inactive active)]});
+            note 'Pending Minion jobs: ' . $pending_minion_jobs->total;
             note qq{Refreshing page, waiting for "$selector" to change};
-            $refresh_cb ? $refresh_cb->() : $driver->refresh;
+            $refresh_cb ? $refresh_cb->($pending_minion_jobs->total) : $driver->refresh;
         }
 
         wait_for_element(selector => $selector);
@@ -175,7 +176,12 @@ foreach my $proj (sort keys %params) {
     my $obsbuilds = _wait_for_change(
         "tr#folder_$ident .obsbuilds",
         sub { $_ eq $builds_text },
-        sub { $driver->find_element("tr#folder_$ident .obsbuildsupdate")->click() });
+        sub ($pending_minion_job_count) {
+            $driver->find_element("tr#folder_$ident .obsbuildsupdate")->click()
+              unless $pending_minion_job_count;
+            # note: Do not enqueue any further Minion jobs if there's still at least one
+            #       pending job.
+        });
     is($obsbuilds, $builds_text, "$proj obs builds");
 
     if ($dt ne 'no data') {


### PR DESCRIPTION
* Enqueuing even more `obs_rsync_update_builds_text` jobs only decreases
  the likeliness of processing all Minion jobs which need to run within the
  test in time
* See https://progress.opensuse.org/issues/89935