### PR TITLE
Prevent execution of container test when `TESTS` has been specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,9 @@ else
 test: test-checkstyle-standalone test-with-database
 endif
 ifeq ($(CONTAINER_TEST),1)
+ifeq ($(TESTS),)
 test: test-containers-compose
+endif
 endif
 endif
 


### PR DESCRIPTION
The documentation states that the coverage of individual test files can be
checked via e.g. `make coverage TESTS=t/24-worker-engine.t`. This change
restores this possibility by avoiding the execution of the container test
when `TESTS` has been specified.