### PR TITLE
Mark t/ui/25-developer_mode.t as unstable due to recent failures

### DIFF
--- a/.circleci/unstable_tests.txt
+++ b/.circleci/unstable_tests.txt
@@ -2,4 +2,5 @@ t/25-cache-service.t
 t/ui/01-list.t
 t/ui/26-jobs_restart.t
 t/ui/13-admin.t
+t/ui/25-developer_mode.t
 t/ui/27-plugin_obs_rsync_status_details.t


### PR DESCRIPTION
See https://circleci.com/gh/os-autoinst/openQA/60185

Related progress issue: https://progress.opensuse.org/issues/80374