### PR TITLE
Makefile: remove superfluous statement seperators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,9 +184,9 @@ test-with-database:
 
 .PHONY: test-unit-and-integration
 test-unit-and-integration:
-	export GLOBIGNORE="$(GLOBIGNORE)";\
-	export DEVEL_COVER_DB_FORMAT=JSON;\
-	export PERL5OPT="$(COVEROPT)$(PERL5OPT) -It/lib -I$(PWD)/t/lib -MOpenQA::Test::PatchDeparse";\
+	export GLOBIGNORE="$(GLOBIGNORE)"
+	export DEVEL_COVER_DB_FORMAT=JSON
+	export PERL5OPT="$(COVEROPT)$(PERL5OPT) -It/lib -I$(PWD)/t/lib -MOpenQA::Test::PatchDeparse"
 	RETRY=${RETRY} timeout -s SIGINT -k 5 -v ${TIMEOUT_RETRIES} tools/retry prove ${PROVE_LIB_ARGS} ${PROVE_ARGS}
 
 # prepares running the tests within a container (eg. pulls os-autoinst) and then runs the tests considering


### PR DESCRIPTION
To reproduce:

    make coverage  TESTS=t/01-test-utilities.t

This didn't work for Oli and me on Leap 15.2

cover was failing with:

    Can't read /home/okurz/local/os-autoinst/openQA/cover_db/runs/1620219503.14849.03766/cover.14 with Sereal: Sereal: Error: Bad Sereal header: Not a valid Sereal document. at offset 1 of input at srl_decoder.c line 600 at /usr/lib/perl5/vendor_perl/5.26.1/x86_64-linux-thread-multi/Devel/Cover/DB/IO/Sereal.pm line 34, <$fh> chunk 1.

So apparently DEVEL_COVER_DB_FORMAT got lost somewhere.
Removing the `;\` fixed it.

Issue: https://progress.opensuse.org/issues/92179