### PR TITLE
apparmor: Allow execution of smbd which is required for QEMU_ENABLE_SMBD

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -119,6 +119,7 @@
   /usr/libexec/git/git-remote-http rix,
   /usr/bin/ffmpeg rix,
   /usr/lib/utempter/utempter rix,
+  /usr/sbin/smbd rix,
   /usr/sbin/ipmiconsole rix,
   /usr/share/openqa/lib/** r,
   /usr/share/openqa/lib/DBIx/Class/Timestamps.pm r,


### PR DESCRIPTION
This is used by WSL tests which otherwise fail with log messages like

```
QEMU: qemu-system-x86_64: Slirp: fork_exec: Failed to execute child process /usr/sbin/smbd (Permission denied)
```

(example failure: https://openqa.opensuse.org/tests/1727032#step/prepare_wsl_feature/14)