### PR TITLE
Makefile: set DEVEL_COVER_DB_FORMAT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ endif
 
 .PHONY: coverage
 coverage:
+	export DEVEL_COVER_DB_FORMAT=JSON;\
 	COVERAGE=1 cover ${COVER_OPTS} -test
 
 COVER_REPORT_OPTS ?= -select_re '^(lib|script|t)/'


### PR DESCRIPTION
To reproduce:

    make coverage  TESTS=t/01-test-utilities.t

This didn't work for Oli and me on Leap 15.2

cover was failing with:

    Can't read /home/okurz/local/os-autoinst/openQA/cover_db/runs/1620219503.14849.03766/cover.14 with Sereal: Sereal: Error: Bad Sereal header: Not a valid Sereal document. at offset 1 of input at srl_decoder.c line 600 at /usr/lib/perl5/vendor_perl/5.26.1/x86_64-linux-thread-multi/Devel/Cover/DB/IO/Sereal.pm line 34, <$fh> chunk 1.

So apparently DEVEL_COVER_DB_FORMAT got lost somewhere.

Issue: https://progress.opensuse.org/issues/92179