### PR TITLE
Do not allow to deprioritize/obsolete build when specifying TEST

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -950,6 +950,12 @@ openqa-cli api -X POST isos ISO=my_iso.iso DISTRI=my_distri FLAVOR=sweet \
          _DEPRIORITIZEBUILD=1 _DEPRIORITIZE_LIMIT=120 \
 --------------------------------------------------------------------------------
 
+==== Remarks ====
+
+When scheduling a single test (variable `TEST` is specified) attempts to
+obsolete/deprioritize are prevented by default because this is likely not wanted.
+Use `_FORCE_OBSOLETE` or `_FORCE_DEPRIORITIZEBUILD` to nevertheless
+obsolete/deprioritize *all* jobs with matching `DISTRI`, `VERSION`, `FLAVOR` and `ARCH`.
 
 === Job template YAML ===
 

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -226,6 +226,13 @@ sub _schedule_iso {
     my $obsolete           = delete $args->{_OBSOLETE}                 // 0;
     my $onlysame           = delete $args->{_ONLY_OBSOLETE_SAME_BUILD} // 0;
     my $skip_chained_deps  = delete $args->{_SKIP_CHAINED_DEPS}        // 0;
+    my $force              = delete $args->{_FORCE_DEPRIORITIZEBUILD};
+    $force = delete $args->{_FORCE_OBSOLETE} || $force;
+    if (($deprioritize || $obsolete) && $args->{TEST} && !$force) {
+        return {error => 'One must not specify TEST and _DEPRIORITIZEBUILD=1/_OBSOLETE=1 at the same time as it is'
+              . 'likely not intended to deprioritize the whole build when scheduling a single scenario.'
+        };
+    }
 
     my $result = $self->_generate_jobs($args, \@notes, $skip_chained_deps);
     return {error => $result->{error_message}, error_code => $result->{error_code} // 400}

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 # Copyright (C) 2016 Red Hat
 #
 # This program is free software; you can redistribute it and/or modify
@@ -359,7 +359,7 @@ schedule_iso({%iso, FLAVOR    => 'cherry'}, 200, {}, 'no product found');
 schedule_iso({%iso, _GROUP_ID => 12345},    404, {}, 'no templates found');
 
 # handle list of tests
-$res = schedule_iso({%iso, TEST => 'server,kde,textmode', _OBSOLETE => 1}, 200);
+$res = schedule_iso({%iso, TEST => 'server,kde,textmode', _OBSOLETE => 1, _FORCE_OBSOLETE => 1}, 200);
 is($res->json->{count}, 5, '5 new jobs created (two twice for both machine types)');
 
 # delete the iso


### PR DESCRIPTION
When only scheduling a single scenario it is likely not intended to
deprioritize/obsolete which can be rather confusing. We've seen this
problem in production where a product has been scheduled with
`TEST=containers_sle_image_on_sle_host` and `_DEPRIORITIZEBUILD=1` which
deprioritized all previous jobs with the same DISTRI/VERSION/FLAVOR/ARCH.