### PR TITLE
Prevent Perl warning in worker code introduced by 4c2e8c8a63

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -194,9 +194,10 @@ sub _setup_websocket_connection {
                     $command_handler->handle_command(@_);
                 });
             $tx->on(
-                finish => sub ($tx, $code, $reason = 'no reason') {
+                finish => sub ($tx, $code, $reason = undef) {
                     # uncoverable subroutine
                     # https://progress.opensuse.org/issues/55364
+                    $reason //= 'no reason';
 
                     # Subprocesses reset the event loop (which triggers this event),
                     # and since only the main worker process uses the WebSocket we


### PR DESCRIPTION
Default values of parameters are only used if the parameter has not been
specified but can not be used to ensure a parameter's value is not
undefined (as `undef` might be passed as parameter value explicitly).