### PR TITLE
Indent new lines for Logs

### DIFF
--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -173,12 +173,18 @@ sub add_log_channel {
 
 # The default format for logging
 sub log_format_callback {
-    my ($time, $level, @lines) = @_;
+    my ($time, $level, @items) = @_;
+
+    my $lines = join("\n", @items, '');
+
+    # ensure indentation for multi-line output
+    $lines =~ s/(?<!\A)^/  /gm;
+
     # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
     $time = gettimeofday;
     return
       sprintf(strftime("[%FT%T.%%04d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time)))
-      . join(' ', @lines) . "\n";
+      . $lines . "\n";
 }
 
 # Removes a channel from defaults.


### PR DESCRIPTION
Previosly the new lines appear without indentation. But for a
better reading and parsing the new lines that belongs to a
log entry are indented

(Pendent example)

progress.opensuse.org/issues/91527