### PR TITLE
Give permission of dmesg to worker

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -163,6 +163,11 @@
 
   }
 
+  profile /usr/lib/os-autoinst/check_qemu_oom {
+    #include <abstractions/base>
+    /usr/bin/dmesg rix,
+  }
+
   profile /usr/bin/lscpu {
     #include <abstractions/base>
 


### PR DESCRIPTION
We would like to read the dmesg and find out if the qemu is killed
because of out of memory. So we give the permisson to worker.

Relate: https://progress.opensuse.org/issues/90974