### PR TITLE
Add 2 spaces to indent the logs of the download assets

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -80,6 +80,8 @@ sub _save_vars {
     close($fd);
 }
 
+sub indent_log_raw_output ($text) { $text =~ s/(?<!\A)^/ /gmr }
+
 sub detect_asset_keys {
     my ($vars) = @_;
 
@@ -140,7 +142,7 @@ sub cache_assets {
             $status = $cache_client->status($asset_request);
         }
         my $msg = "Download of $asset_uri processed";
-        if (my $output = $status->output) { $msg .= ":\n$output" }
+        if (my $output = $status->output) { $msg .= ":\n" . indent_log_raw_output($output) }
         log_info($msg, channels => 'autoinst');
 
         $asset = $cache_client->asset_path($webui_host, $asset_uri)


### PR DESCRIPTION
This commit helps users distinguish between log lines and the output
of asset download operations. This adds two spaces before every output
line

https://progress.opensuse.org/issues/91527