### PR TITLE
Do not build openQA-devel for archs where it would be unresolvable

### DIFF
--- a/dist/rpm/openQA-devel-test.spec
+++ b/dist/rpm/openQA-devel-test.spec
@@ -6,6 +6,10 @@ Summary:        Test package for %{short_name}
 License:        GPL-2.0-or-later
 BuildRequires:  %{short_name} == %{version}
 ExcludeArch:    i586
+%ifarch ppc ppc64 ppc64le s390x
+# missing chromedriver dependency
+ExclusiveArch:  do_not_build
+%endif
 
 %description
 .

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -154,6 +154,10 @@ Development package pulling in all build+test dependencies except chromedriver f
 Summary:        Development package pulling in all build+test dependencies
 Group:          Development/Tools/Other
 Requires:       %{devel_requires}
+%ifarch ppc ppc64 ppc64le s390x
+# missing chromedriver dependency
+ExclusiveArch:  do_not_build
+%endif
 
 %description devel
 Development package pulling in all build+test dependencies.


### PR DESCRIPTION
chromedriver does not exist under ppc ppc64 ppc64le s390x so only the
package opennQA-no-selenium-devel can be used there.