### PR TITLE
Fix retry/delay in FinalizeResults.pm leading to failing Minion jobs

### DIFF
--- a/lib/OpenQA/Task/Job/FinalizeResults.pm
+++ b/lib/OpenQA/Task/Job/FinalizeResults.pm
@@ -28,7 +28,7 @@ sub _finalize_results {
 
     my $app = $minion_job->app;
     return $minion_job->fail('No job ID specified.') unless defined $openqa_job_id;
-    return $minion_job->delay({delay => 30})
+    return $minion_job->retry({delay => 30})
       unless my $guard = $app->minion->guard("process_job_results_for_$openqa_job_id", ONE_DAY);
 
     # try to finalize each


### PR DESCRIPTION
This fixes
```
Can't locate object method "delay" via package "OpenQA::Shared::GruJob" at /usr/share/openqa/script/../lib/OpenQA/Task/Job/FinalizeResults.pm line 31.
```
introduced by b9ff4a43c5240e4c4207c8059ba7dd7e3852318e