### PR TITLE
worker: Fix handling CASEDIR/PRODUCTDIR/NEEDLES_DIR in certain cases

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -21,12 +21,13 @@ use warnings;
 use Mojo::Base -signatures;
 use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE WORKER_SR_DIED);
 use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle);
-use OpenQA::Utils qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme testcasedir productdir);
+use OpenQA::Utils
+  qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme testcasedir productdir needledir);
 use POSIX qw(:sys_wait_h strftime uname _exit);
 use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();
 use Fcntl;
-use File::Spec::Functions 'catdir';
+use File::Spec::Functions qw(abs2rel catdir file_name_is_absolute);
 use File::Basename 'basename';
 use Errno;
 use Cwd 'abs_path';
@@ -332,6 +333,7 @@ sub engine_workit {
     log_debug('Job settings:');
     log_debug(join("\n", '', map { "    $_=$vars{$_}" } sort keys %vars));
 
+    # cache/locate assets, set ASSETDIR
     my $shared_cache;
     my $assetkeys = detect_asset_keys(\%vars);
     if (my $cache_dir = $global_settings->{CACHEDIRECTORY}) {
@@ -345,33 +347,48 @@ sub engine_workit {
         my $error = locate_local_assets(\%vars, $assetkeys, $pooldir);
         return $error if $error;
     }
-    my $casedir     = testcasedir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
-    my $productdir  = productdir($vars{DISTRI}, $vars{VERSION}, $shared_cache);
-    my $target_name = path($casedir)->basename;
+    $vars{ASSETDIR} //= OpenQA::Utils::assetdir;
 
-    $vars{ASSETDIR} //= OpenQA::Utils::assetdir();
-    $vars{CASEDIR}  //= $vars{ABSOLUTE_TEST_CONFIG_PATHS} ? $casedir : $target_name;
-
-    if ($vars{CASEDIR} eq $target_name) {
-        $vars{PRODUCTDIR} //= substr($productdir, rindex($casedir, $target_name));
-        if (my $error = _link_repo($casedir, $pooldir, $target_name)) { return $error }
+    # ensure a CASEDIR and a PRODUCTDIR is assigned and create a symlink if required
+    my $absolute_paths        = $vars{ABSOLUTE_TEST_CONFIG_PATHS};
+    my @vars_for_default_dirs = ($vars{DISTRI}, $vars{VERSION}, $shared_cache);
+    my $default_casedir       = testcasedir(@vars_for_default_dirs);
+    my $default_productdir    = productdir(@vars_for_default_dirs);
+    my $target_name           = path($default_casedir)->basename;
+    my $has_custom_dir        = $vars{CASEDIR} || $vars{PRODUCTDIR};
+    my $casedir               = $vars{CASEDIR} //= $absolute_paths ? $default_casedir : $target_name;
+    if ($casedir eq $target_name) {
+        $vars{PRODUCTDIR} //= substr($default_productdir, rindex($default_casedir, $target_name));
+        if (my $error = _link_repo($default_casedir, $pooldir, $target_name)) { return $error }
     }
-    $vars{PRODUCTDIR} //= $productdir;
+    else {
+        $vars{PRODUCTDIR} //= $absolute_paths ? $default_productdir : abs2rel($default_productdir, $default_casedir);
+    }
 
-    # if NEEDLES_DIR is an absolute path, it means that users or openqa-clone-custom-git-refspec specify it,
-    # if NEEDLES_DIR is an URL address, it means that users specify it and want to get the needles from URL.
-    # In these two scenarios, doing symlink is useless and the job may incomplete because fail to do symlink.
-    if (   $vars{NEEDLES_DIR}
-        && !$vars{ABSOLUTE_TEST_CONFIG_PATHS}
-        && !File::Spec->file_name_is_absolute($vars{NEEDLES_DIR})
-        && !looks_like_url_with_scheme($vars{NEEDLES_DIR}))
+    # ensure a NEEDLES_DIR is assigned and create a symlink if required
+    # explanation for the subsequent if-elsif conditions:
+    # - If a custom CASEDIR/PRODUCTDIR has been specified, we still assume that a *relative* NEEDLES_DIR is
+    #   relative to the default directory. In case the custom CASEDIR/PRODUCTDIR checkout would actually contain
+    #   needles as well (instead of relying on a separate repository) one must *not* specify a custom NEEDLES_DIR
+    #   and provide needles within the standard location (needles directory within custom PRODUCTDIR).
+    # - If a custom CASEDIR/PRODUCTDIR has been specified but no custom NEEDLES_DIR we assume that the default
+    #   needles directory is supposed to be used and make the assignment/symlink accordingly.
+    # - If the specified NEEDLES_DIR is an absolute path or an URL we assume that it points to a custom location
+    #   and keep it as-is.
+    my $default_needles_dir     = needledir(@vars_for_default_dirs);
+    my $needles_dir             = $vars{NEEDLES_DIR};
+    my $need_to_set_needles_dir = !$needles_dir && $has_custom_dir;
+    if ($need_to_set_needles_dir && $absolute_paths) {
+        # simply set the default needles dir when absolute paths are used
+        $vars{NEEDLES_DIR} = $default_needles_dir;
+    }
+    elsif ($need_to_set_needles_dir
+        || ($needles_dir && !file_name_is_absolute($needles_dir) && !looks_like_url_with_scheme($needles_dir)))
     {
-        # For example, when users use the old version of openqa-clone-custom-git-refspec
-        # to trigger a job whose CASEDIR is opensuse, PRODUCTDIR is opensuse/products/opensuse,
-        # the NEEDLES_DIR will be defined 'opensuse/products/opensuse/needles'.
-        # To be compatible with this scenario, we should change NEEDLES_DIR as a target_name, and do the symlink.
-        $vars{NEEDLES_DIR} = basename($vars{NEEDLES_DIR});
-        if (my $error = _link_repo("$productdir/needles", $pooldir, $vars{NEEDLES_DIR})) { return $error }
+        # create/assign a symlink for needles if NEEDLES_DIR has been specified by the user as a path relative to
+        # the default CASEDIR/PRODUCTDIR
+        $vars{NEEDLES_DIR} = $needles_dir = basename($needles_dir || 'needles');
+        if (my $error = _link_repo($default_needles_dir, $pooldir, $needles_dir)) { return $error }
     }
     _save_vars($pooldir, \%vars);
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -188,7 +188,7 @@ sub _link_asset {
     my $target         = $pooldir->child($asset_basename);
 
     # Prevent the syncing to abort e.g. for workers running with "--no-cleanup"
-    unlink $target if -e $target;
+    unlink $target;
 
     # Try to use hardlinks first and only fall back to symlinks when that fails,
     # to ensure that assets cannot be purged early from the pool even if the
@@ -207,7 +207,7 @@ sub _link_repo {
     my ($source_dir, $pooldir, $target_name) = @_;
     $pooldir = path($pooldir);
     my $target = $pooldir->child($target_name);
-    unlink $target if -e $target;
+    unlink $target;
     return {error => "The source directory $source_dir does not exist"} unless -e $source_dir;
     return {error => qq{Cannot create symlink from "$source_dir" to "$target": $!}}
       unless symlink($source_dir, $target);

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -362,7 +362,8 @@ sub engine_workit {
         if (my $error = _link_repo($default_casedir, $pooldir, $target_name)) { return $error }
     }
     else {
-        $vars{PRODUCTDIR} //= $absolute_paths ? $default_productdir : abs2rel($default_productdir, $default_casedir);
+        $vars{PRODUCTDIR} //= $absolute_paths
+          && !$has_custom_dir ? $default_productdir : abs2rel($default_productdir, $default_casedir);
     }
 
     # ensure a NEEDLES_DIR is assigned and create a symlink if required

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -30,7 +30,7 @@ use Test::Output qw(combined_like combined_unlike);
 use OpenQA::Worker::Engines::isotovideo;
 use Mojo::File qw(path tempdir);
 use Mojo::JSON 'decode_json';
-use OpenQA::Utils qw(testcasedir productdir locate_asset);
+use OpenQA::Utils qw(testcasedir productdir needledir locate_asset);
 
 # define fake packages for testing asset caching
 {
@@ -294,20 +294,37 @@ subtest 'symlink testrepo' => sub {
     };
 };
 
-subtest 'don\'t do symlink when job settings include ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
+subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
     my $pool_directory = tempdir('poolXXXX');
     my $worker         = Test::FakeWorker->new(pool_directory => $pool_directory);
     my $client         = Test::FakeClient->new;
-    my $settings = {DISTRI => 'fedora', JOBTOKEN => 'token000', ABSOLUTE_TEST_CONFIG_PATHS => 1, HDD_1 => 'foo.qcow2'};
-    my $job      = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => $settings});
-    combined_unlike { my $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
-    qr/Symlinked from/, 'don\'t do symlink when jobs have the ABSOLUTE_TEST_CONFIG_PATHS=1';
-    my $vars_data = get_job_json_data($pool_directory);
-    is $vars_data->{PRODUCTDIR}, productdir('fedora', undef, undef),  'default PRODUCTDIR assigned';
-    is $vars_data->{CASEDIR},    testcasedir('fedora', undef, undef), 'default CASEDIR assigned';
-    is $vars_data->{HDD_1},      locate_asset('hdd', 'foo.qcow2'),
-      'don\'t symlink asset when using ABSOLUTE_TEST_CONFIG_PATHS=>1';
+    my @settings       = (DISTRI => 'fedora', JOBTOKEN => 'token000', ABSOLUTE_TEST_CONFIG_PATHS => 1);
+
+    subtest 'don\'t do symlink when job settings include ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
+        my %settings = (@settings, HDD_1 => 'foo.qcow2');
+        my $job      = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => \%settings});
+        combined_unlike { OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
+        qr/Symlinked from/, 'don\'t do symlink when jobs have the ABSOLUTE_TEST_CONFIG_PATHS=1';
+        my $vars_data = get_job_json_data($pool_directory);
+        is $vars_data->{PRODUCTDIR},    productdir('fedora', undef, undef),  'default PRODUCTDIR assigned';
+        is $vars_data->{CASEDIR},       testcasedir('fedora', undef, undef), 'default CASEDIR assigned';
+        is $vars_data->{HDD_1},         locate_asset('hdd', 'foo.qcow2'),
+          is $vars_data->{NEEDLES_DIR}, undef, 'no NEEDLES_DIR assigned';
+        'don\'t symlink asset when using ABSOLUTE_TEST_CONFIG_PATHS=>1';
+    };
+
+    subtest 'absolute default NEEDLES_DIR with ABSOLUTE_TEST_CONFIG_PATHS=1 and custom CASEDIR' => sub {
+        my %settings = (@settings, CASEDIR => 'git:foo/bar');
+        my $job      = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => \%settings});
+        combined_unlike { OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
+        qr/Symlinked from/, 'don\'t do symlink when jobs have the ABSOLUTE_TEST_CONFIG_PATHS=1';
+        my $vars_data = get_job_json_data($pool_directory);
+        is $vars_data->{PRODUCTDIR},  productdir('fedora', undef, undef), 'default PRODUCTDIR assigned';
+        is $vars_data->{NEEDLES_DIR}, needledir('fedora', undef, undef),  'default NEEDLES_DIR assigned';
+        is $vars_data->{CASEDIR},     $settings{CASEDIR}, 'custom CASEDIR not touched';
+    };
 };
+
 
 subtest 'symlink asset' => sub {
     my $pool_directory = tempdir('poolXXXX');

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -318,10 +318,12 @@ subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
         my $job      = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => \%settings});
         combined_unlike { OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
         qr/Symlinked from/, 'don\'t do symlink when jobs have the ABSOLUTE_TEST_CONFIG_PATHS=1';
-        my $vars_data = get_job_json_data($pool_directory);
-        is $vars_data->{PRODUCTDIR},  productdir('fedora', undef, undef), 'default PRODUCTDIR assigned';
-        is $vars_data->{NEEDLES_DIR}, needledir('fedora', undef, undef),  'default NEEDLES_DIR assigned';
+        my $vars_data           = get_job_json_data($pool_directory);
+        my $expected_productdir = abs2rel(productdir('fedora', undef, undef), testcasedir('fedora', undef, undef));
+        is $vars_data->{NEEDLES_DIR}, needledir('fedora', undef, undef), 'default NEEDLES_DIR assigned';
         is $vars_data->{CASEDIR},     $settings{CASEDIR}, 'custom CASEDIR not touched';
+        is $vars_data->{PRODUCTDIR},  $expected_productdir,
+          'nevertheless relative PRODUCTDIR assigned to load main.pm from custom CASEDIR';
     };
 };
 


### PR DESCRIPTION
worker: Fix handling CASEDIR/PRODUCTDIR/NEEDLES_DIR in certain cases

This change ensures that the default-assignment for PRODUCTDIR is a
relative directory (unless the feature switch to use absolute paths is
turned on). That is required when a custom CASEDIR has been specified
because in this case it is expected that not only Perl modules but also
`main.pm` itself is loaded from that custom CASEDIR (unless PRODUCTDIR is
set explicitly to some other location). So this should fix
https://progress.opensuse.org/issues/93101.

When only changing the behavior for PRODUCTDIR the needles could not be
loaded anymore (unless NEEDLES_DIR is specified explicitly) because the
checkout of CASEDIR does not necessarily contain needles. To fix this, the
symlinking of the needles directory is done in that case. See the verbose
comments within the code for further explanations.

Note that the absolute PRODUCTDIR has been introduced by the commit
55420c174299d545d654d4c6266415a8e9ee8dd2 to fix two problems. The first
problem won't occur again because now the relative path for PRODUCTDIR is
computed correctly. The second problem is the needle problem mentioned in
the previous paragraph and thus handled as well.

Tested locally with
* no custom CASEDIR, NEEDLES_DIR and PRODUCTDIR
* custom CASEDIR, NEEDLES_DIR, PRODUCTDIR as produced by assigned by
  `openqa-clone-custom-git-refspec`
* only a custom CASEDIR as assigned by `openqa-investigate` (case mentioned
  in https://progress.opensuse.org/issues/93101)
* only a custom NEEDLES_DIR pointing a some Git repository

---

When extending the unit tests I also found a second issue, see the other commit
message.