### PR TITLE
Fix failing stylecheck for tools/test_containers_compose

### DIFF
--- a/tools/test_containers_compose
+++ b/tools/test_containers_compose
@@ -19,8 +19,8 @@ wait_until() {
 }
 
 setup_containers() {
-  for retry in {2..0}; do sudo docker-compose build && break; echo "Remaining retries $retry"; done &&
-  sudo MOJO_CLIENT_DEBUG=1 docker-compose up -d &&
+  for retry in {2..0}; do sudo docker-compose build && break; echo "Remaining retries $retry"; done
+  sudo MOJO_CLIENT_DEBUG=1 docker-compose up -d
   (docker-compose ps --services --filter status=stopped | grep "^[[:space:]]*$") || (docker-compose logs; sudo docker-compose ps; exit 1)
 }
 


### PR DESCRIPTION
Prevents

```
In tools/test_containers_compose line 23:
  sudo MOJO_CLIENT_DEBUG=1 docker-compose up -d &&
                                                ^-- SC2015: Note that A && B || C is not if-then-else. C may run when A is true.
```

It doesn't make much sense to use `&&` here anyways because the script uses
`-e`.