### PR TITLE
Fix content negotiation with .txt file extension for module source

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -191,7 +191,7 @@ sub startup ($self) {
     my $step_auth = $test_auth->any('/modules/:moduleid/steps/<stepid:step>');
     $step_r->get('/view')->to(action => 'view');
     $step_r->get('/edit')->name('edit_step')->to(action => 'edit');
-    $step_r->get('/src')->name('src_step')->to(action => 'src');
+    $step_r->get('/src', [format => ['txt']])->name('src_step')->to(action => 'src', format => undef);
     $step_auth->post('/')->name('save_needle_ajax')->to('step#save_needle_ajax');
     $step_r->get('/')->name('step')->to(action => 'view');
 

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -40,7 +40,10 @@ subtest 'error pages shown for OpenQA::WebAPI::Controller::Step' => sub {
     $t->get_ok("/tests/$existing_job/modules/installer_timezone/steps/1")->status_is(302, 'redirection');
     $t->get_ok("/tests/$existing_job/modules/installer_timezone/steps/1", {'X-Requested-With' => 'XMLHttpRequest'})
       ->status_is(200);
-    $t->get_ok("/tests/$existing_job/modules/installer_timezone/steps/1/src")->status_is(200);
+    $t->get_ok("/tests/$existing_job/modules/installer_timezone/steps/1/src")->status_is(200)
+      ->content_type_is('text/html;charset=UTF-8');
+    $t->get_ok("/tests/$existing_job/modules/installer_timezone/steps/1/src.txt")->status_is(200)
+      ->content_type_is('text/plain;charset=UTF-8');
     $t->get_ok("/tests/$existing_job/modules/installer_timezone/steps/1/edit")->status_is(200);
 
     subtest 'get error 404 if job not found (instead of 500 and Perl warnings)' => sub {
@@ -49,6 +52,7 @@ subtest 'error pages shown for OpenQA::WebAPI::Controller::Step' => sub {
         $t->get_ok("/tests/$non_existing_job/modules/installer_timezone/steps/1",
             {'X-Requested-With' => 'XMLHttpRequest'})->status_is(404);
         $t->get_ok("/tests/$non_existing_job/modules/installer_timezone/steps/1/src")->status_is(404);
+        $t->get_ok("/tests/$non_existing_job/modules/installer_timezone/steps/1/src.txt")->status_is(404);
         $t->get_ok("/tests/$non_existing_job/modules/installer_timezone/steps/1/edit")->status_is(404);
     };
 };


### PR DESCRIPTION
A small regression caused by the same breaking change in Mojolicious that broke all the other routes before.

Progress: https://progress.opensuse.org/issues/93345