### PR TITLE
Show results for multiple groups in /test/overview

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,12 +98,13 @@ the return array.
 
 =cut
 sub latest_jobs {
-    my ($self, $until) = @_;
+    my ($self, $until, $hash_group_id) = @_;
 
     my @jobs = $self->search($until ? {t_created => {'<=' => $until}} : undef, {order_by => ['me.id DESC']});
     my @latest;
     my %seen;
     foreach my $job (@jobs) {
+        my $groupid = $job->group_id;
         my $test    = $job->TEST;
         my $distri  = $job->DISTRI;
         my $version = $job->VERSION;
@@ -112,6 +113,7 @@ sub latest_jobs {
         my $arch    = $job->ARCH;
         my $machine = $job->MACHINE // '';
         my $key     = "$distri-$version-$build-$test-$flavor-$arch-$machine";
+        $key = "$groupid-$key" if ($hash_group_id);
         next if $seen{$key}++;
         push(@latest, $job);
     }

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -271,6 +271,13 @@ subtest 'not complete results generally accounted as "Incomplete"' => sub {
     like(get_summary, qr/Passed: 0 Incomplete: 2 Failed: 0 Scheduled: 2 Running: 2 None: 1/i);
     $schema->txn_rollback;
 };
+
+#
+# Test multiple groupid
+#
+$t->get_ok('/tests/overview?groupid=1001&groupid=1002')->status_is(200);
+$t->element_exists('#res_DVD_x86_64_kde');        # Included groupid 1001
+$t->element_exists('#flavor_NET_arch_x86_64');    # Included groupid 1002
 
 #
 # Test filter form


### PR DESCRIPTION
The strategy is:
- Modify the query to include the jobs for all the groups_ids
- Modify last_jobs to include the group_id as part of the hash

https://progress.opensuse.org/issues/91650