### PR TITLE
Run 10-jobs.t really fast

### DIFF
--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -50,8 +50,6 @@ my $t      = Test::Mojo->new('OpenQA::WebAPI');
 my $jobs   = $t->app->schema->resultset("Jobs");
 my $users  = $t->app->schema->resultset("Users");
 
-collect_coverage_of_gru_jobs($t->app);
-
 # for "investigation" tests
 my $job_mock     = Test::MockModule->new('OpenQA::Schema::Result::Jobs', no_auto => 1);
 my $fake_git_log = 'deadbeef Break test foo';

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -37,7 +37,7 @@ use Mojo::JSON 'decode_json';
 use Test::Warnings ':report_warnings';
 use Mojo::File qw(path tempdir);
 use Mojo::IOLoop::ReadWriteProcess;
-use OpenQA::Test::Utils qw(collect_coverage_of_gru_jobs redirect_output);
+use OpenQA::Test::Utils qw(collect_coverage_of_gru_jobs perform_minion_jobs_in_foreground redirect_output);
 use OpenQA::Test::TimeLimit '40';
 use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;
@@ -51,8 +51,6 @@ my $jobs   = $t->app->schema->resultset("Jobs");
 my $users  = $t->app->schema->resultset("Users");
 
 collect_coverage_of_gru_jobs($t->app);
-
-sub perform_minion_jobs { $t->app->minion->perform_jobs }
 
 # for "investigation" tests
 my $job_mock     = Test::MockModule->new('OpenQA::Schema::Result::Jobs', no_auto => 1);
@@ -501,19 +499,19 @@ subtest 'carry over, including soft-fails' => sub {
                 $openqa_job->update({reason => "timeout --kill-after=$kill_timeout $timeout $hook"}) if $hook;
             });
         $job->done;
-        perform_minion_jobs;
+        perform_minion_jobs_in_foreground($t->app->minion);
         $job->discard_changes;
         is($job->reason, undef, 'no hook is called by default');
         $ENV{OPENQA_JOB_DONE_HOOK_INCOMPLETE} = 'should not be called';
         $job->done;
-        perform_minion_jobs;
+        perform_minion_jobs_in_foreground($t->app->minion);
         $job->discard_changes;
         is($job->reason, undef, 'hook not called if result does not match');
         $ENV{OPENQA_JOB_DONE_HOOK_FAILED}       = 'true';
         $ENV{OPENQA_JOB_DONE_HOOK_TIMEOUT}      = '10m';
         $ENV{OPENQA_JOB_DONE_HOOK_KILL_TIMEOUT} = '5s';
         $job->done;
-        perform_minion_jobs;
+        perform_minion_jobs_in_foreground($t->app->minion);
         $job->discard_changes;
         is($job->reason, 'timeout --kill-after=5s 10m true', 'hook called if result matches');
         $job->update({reason => undef});
@@ -523,7 +521,7 @@ subtest 'carry over, including soft-fails' => sub {
         $t->app->config->{hooks}->{job_done_hook_failed} = 'echo hook called';
         $task_mock->unmock_all;
         $job->done;
-        perform_minion_jobs;
+        perform_minion_jobs_in_foreground($t->app->minion);
         my $res = $t->app->minion->jobs->next->{notes}{hook_result};
         like($res, qr/hook called/, 'real hook cmd from config called if result matches');
     };

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -53,7 +53,7 @@ our (@EXPORT, @EXPORT_OK);
     qw(unresponsive_worker broken_worker rejective_worker setup_share_dir setup_fullstack_temp_dir run_gru_job),
     qw(collect_coverage_of_gru_jobs stop_service start_worker unstable_worker fake_asset_server),
     qw(cache_minion_worker cache_worker_service shared_hash embed_server_for_testing),
-    qw(run_cmd test_cmd wait_for_or_bail_out)
+    qw(run_cmd test_cmd wait_for_or_bail_out perform_minion_jobs_in_foreground)
 );
 
 # The function OpenQA::Utils::service_port method hardcodes ports in a
@@ -204,6 +204,17 @@ sub redirect_output {
     open my $FD, '>', $buf;
     *STDOUT = $FD;
     *STDERR = $FD;
+}
+
+sub perform_minion_jobs_in_foreground {
+    my ($minion, $options) = (shift, shift // {});
+
+    my $worker = $minion->worker->register;
+    while (my $job = $worker->register->dequeue(0, $options)) {
+        my $err;
+        defined($err = $job->execute) ? $job->fail($err) : $job->finish;
+    }
+    $worker->unregister;
 }
 
 # define internal helper functions to keep track of Perl warnings produced by sub processes spawned by


### PR DESCRIPTION
I've added a `OpenQA::Test::Utils::perform_minion_jobs_in_foreground` function for now, but might also add this as an upstream feature to Minion, since there's enough reasonable use cases for it now.

Before:
```
[15:07:34] t/10-jobs.t ........... ok   160051 ms ( 0.06 usr  0.01 sys + 154.81 cusr  4.02 csys = 158.90 CPU)
```

After:
```
[15:39:48] t/10-jobs.t ........... ok    19263 ms ( 0.07 usr  0.01 sys + 18.16 cusr  0.66 csys = 18.90 CPU)
```

Progress: https://progress.opensuse.org/issues/93086