### PR TITLE
Make run_gru_job perform jobs without forking

### DIFF
--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -108,8 +108,6 @@ my $webapi    = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
 my $app = $t->app;
 $app->config->{default_group_limits}->{asset_size_limit} = 100;
 
-collect_coverage_of_gru_jobs($t->app);
-
 # Non-Gru task
 $t->app->minion->add_task(
     some_random_task => sub {

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -576,7 +576,8 @@ sub run_gru_job {
     my $id     = $app->gru->enqueue(@_)->{minion_id};
     my $worker = $app->minion->worker->register;
     my $job    = $worker->dequeue(0, {id => $id});
-    $job->perform;
+    my $err;
+    defined($err = $job->execute) ? $job->fail($err) : $job->finish;
     $worker->unregister;
     return $job->info;
 }


### PR DESCRIPTION
Small followup to #3934. Not as much of a win as the other change, but at least some improvement.

Before:
```
[15:10:15] t/14-grutasks.t ....... ok   261493 ms ( 0.21 usr  0.01 sys + 252.87 cusr  7.09 csys = 260.18 CPU)
```

After:
```
[13:00:57] t/14-grutasks.t ....... ok   128464 ms ( 0.21 usr  0.00 sys + 123.11 cusr  3.72 csys = 127.04 CPU)
```