### PR TITLE
Give permission of check_qemu_oom

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -115,6 +115,7 @@
   /usr/lib/git/git rix,
   /usr/lib/git/git-remote-http rix,
   /usr/lib/os-autoinst/videoencoder rix,
+  /usr/lib/os-autoinst/check_qemu_oom arCx,
   /usr/libexec/git/git rix,
   /usr/libexec/git/git-remote-http rix,
   /usr/bin/ffmpeg rix,
@@ -165,7 +166,10 @@
 
   profile /usr/lib/os-autoinst/check_qemu_oom {
     #include <abstractions/base>
+    #include <abstractions/perl>
     /usr/bin/dmesg rix,
+    /dev/kmsg r,
+    /var/lib/openqa/pool/*/autoinst-log.txt w,
   }
 
   profile /usr/bin/lscpu {


### PR DESCRIPTION
After https://github.com/os-autoinst/os-autoinst/pull/1672 was merged,
there was a `Permission denied` when doing `check_qemu_oom`. So give
the permission of `check_qemu_oom` to worker.

Adding `/dev/kmsg r` is used to avoid the message in audit.log

```
apparmor="DENIED" operation="open" profile="/usr/share/openqa/script/
worker///usr/lib/os-autoinst/check_qemu_oom" name="/dev/kmsg" pid=8915
comm="dmesg" requested_mask="r" denied_mask="r" fsuid=457 ouid=0
```