### PR TITLE
WIP -- codecov.yml: Introduce specific coverage thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,9 +7,6 @@ comment:
 fixes:
   - "/home/circleci/openQA::"
 coverage:
-  range: 60..95
-  round: down
-  precision: 2
   status:
     changes: false
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,9 +10,15 @@ coverage:
   status:
     changes: false
     project:
-      default:
-        target: 97.2
-        threshold: 0.1
+      default: false
+      tests:
+        target: 98
+        paths: "t/"
+      app:
+        paths: "!t/"
+      absolute_path_test:
+        paths:
+          - /home/circleci/openQA/
     patch:
       default:
         branches: null


### PR DESCRIPTION
With path specific coverage targets we can introduce the hard
requirement for 100% coverage within the paths where it is feasible. It
makes sense to have 100% statement coverage within test code itself to
prevent relying on tests that are actually not running.

See https://docs.codecov.com/docs/commit-status#branches