### PR TITLE
Adapt UI tests to chromedriver changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,6 @@ aliases:
   - &make_test
     name: "Running unit tests"
     command: |
-      # downgrade chromedriver from problematic version to last good version, see https://progress.opensuse.org/issues/93453
-      rpm -q chromedriver | grep -v 91.0.4472.77 || sudo zypper -n in --oldpackage chromedriver-90.0.4430.212-lp152.2.95.1 chromium-90.0.4430.212
       export COVERAGE=1
       export COVERDB_SUFFIX="_${CIRCLE_JOB}"
       make test-$CIRCLE_JOB

--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -161,6 +161,7 @@
 < javascripts/test_result.js
 < javascripts/needlediff.js
 < javascripts/running.js
+< javascripts/disable_status_updates.js [mode==test]
 
 ! job_next_previous.js
 < javascripts/job_next_previous.js

--- a/assets/javascripts/disable_status_updates.js
+++ b/assets/javascripts/disable_status_updates.js
@@ -1,0 +1,1 @@
+window.enableStatusUpdates = (parseQueryParams().status_updates || []).every(p => Number.parseInt(p) !== 0);

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -184,6 +184,11 @@ function sendCommand(command) {
 }
 
 function updateStatus() {
+    // prevent status updates when window.enableStatusUpdates is set by test environment
+    if (window.enableStatusUpdates !== undefined && !window.enableStatusUpdates) {
+        return;
+    }
+
     $.ajax(testStatus.status_url).done(function(status) {
         updateTestStatus(status);
         // continue polling for job state updates until the job state is done

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -2,6 +2,7 @@ package OpenQA::SeleniumTest;
 
 use Test::Most;
 
+use Mojo::Base -signatures;
 use base 'Exporter';
 
 require OpenQA::Test::Database;
@@ -12,7 +13,8 @@ our @EXPORT = qw($drivermissing check_driver_modules enable_timeout
   wait_for_ajax_and_animations
   open_new_tab mock_js_functions element_visible element_hidden
   element_not_present javascript_console_has_no_warnings_or_errors
-  wait_until wait_until_element_gone wait_for_element);
+  wait_until wait_until_element_gone wait_for_element
+  element_prop element_prop_by_selector map_elements);
 
 use Data::Dump 'pp';
 use IPC::Run qw(start);
@@ -307,6 +309,20 @@ sub element_not_present {
     is(scalar @elements, 0, $selector . ' not present');
 }
 
+# returns an element's property
+# note: Workaround for not relying on the functions Selenium::Remote::WebElement::get_value() and is_selected()
+#       because they ceased to work in some cases with chromedriver 91.0.4472.77. (Whether the functions work or
+#       not likely depends on how the property is populated.)
+sub element_prop ($element_id, $property = 'value') {
+    return $_driver->execute_script("return document.getElementById('$element_id').$property;");
+}
+sub element_prop_by_selector ($element_selector, $property = 'value') {
+    return $_driver->execute_script("return document.querySelector('$element_selector').$property;");
+}
+sub map_elements ($selector, $mapping) {
+    return $_driver->execute_script("return Array.from(document.querySelectorAll('$selector')).map(e => [$mapping]);");
+}
+
 sub wait_until {
     my ($check_function, $check_description, $timeout, $check_interval) = @_;
     $timeout        //= 100;
@@ -361,7 +377,7 @@ sub wait_for_element {
     return $element;
 }
 
-sub kill_driver() {
+sub kill_driver {
     return unless $startingpid && $$ == $startingpid;
     if ($_driver) {
         $_driver->quit();

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -359,9 +359,9 @@ $driver->get('/tests?match=staging_e');
 wait_for_ajax();
 
 @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('tbody tr', 'css')};
-is_deeply(\@jobs, ['', '', 'job_99926'], '1 job matching');
-# note: the first 2 empty IDs are the 'not found' row of the data tables for running and
-#       scheduled jobs
+ok !$jobs[0], 'no running job matching';
+ok !$jobs[1], 'no scheduled job matching';
+is $jobs[2], 'job_99926', 'exactly one finished job matching';
 
 $driver->get('/tests');
 wait_for_ajax();

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -328,7 +328,7 @@ subtest "filtering by machine" => sub {
 
         is($driver->find_element('#content tbody .name span')->get_text(), 'kde@uefi', 'Test suite name is shown');
         $driver->find_element('#filter-panel .card-header')->click();
-        is($driver->find_element('#filter-machine')->get_value(), 'uefi', 'machine text is correct.');
+        is(element_prop('filter-machine'), 'uefi', 'machine text is correct');
 
         $driver->find_element('#filter-machine')->clear();
         $driver->find_element('#filter-machine')->send_keys('64bit,uefi');

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -143,8 +143,8 @@ sub add_workaround_property() {
     $driver->find_element_by_id('property_workaround')->click();
     $driver->find_element_by_id('input_workaround_desc')->send_keys('bsc#123456 - this is a täst');
     wait_for_ajax;
-    is($driver->find_element_by_id('property_workaround')->is_selected(),    1, 'workaround property selected');
-    is($driver->find_element_by_id('input_workaround_desc')->is_displayed(), 1, 'workaround description displayed');
+    ok element_prop('property_workaround', 'checked'), 'workaround property selected';
+    ok $driver->find_element_by_id('input_workaround_desc')->is_displayed, 'workaround description displayed';
 }
 
 sub create_needle {
@@ -170,8 +170,7 @@ sub create_needle {
 sub change_needle_value {
     my ($xoffset, $yoffset) = @_;
 
-    my $elem                = $driver->find_element_by_id('needleeditor_textarea');
-    my $decode_new_textarea = decode_utf8_json($elem->get_value());
+    my $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     ok($decode_new_textarea->{area},       'json has area');
     ok($decode_new_textarea->{properties}, 'json has properties');
     ok($decode_new_textarea->{tags},       'json has tags');
@@ -179,19 +178,19 @@ sub change_needle_value {
     create_needle($xoffset, $yoffset);
 
     # check the value of textarea again
-    $decode_new_textarea = decode_utf8_json($elem->get_value());
+    $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     is($decode_new_textarea->{area}[0]->{xpos},        $xoffset, 'new xpos correct');
     is($decode_new_textarea->{area}[0]->{ypos},        $yoffset, 'new ypos correct');
     is($decode_new_textarea->{area}[0]->{click_point}, undef,    'initially no click_point');
 
     # test match type
-    $decode_new_textarea = decode_utf8_json($elem->get_value());
+    $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     is($decode_new_textarea->{area}[0]->{type}, "match", "type is match");
     $driver->double_click;    # the match type change to exclude
-    $decode_new_textarea = decode_utf8_json($elem->get_value());
+    $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     is($decode_new_textarea->{area}[0]->{type}, "exclude", "type is exclude");
     $driver->double_click;    # the match type change to ocr
-    $decode_new_textarea = decode_utf8_json($elem->get_value());
+    $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     is($decode_new_textarea->{area}[0]->{type}, "ocr", "type is ocr");
     $driver->double_click;    # the match type change back to match
 
@@ -202,19 +201,19 @@ sub change_needle_value {
     $driver->find_element_by_id('change-match')->click();
     wait_for_ajax;
     my $dialog = $driver->find_element_by_id('change-match-form');
-    is($driver->find_element_by_id('set_match')->is_displayed(),            1,    "found set button");
-    is($driver->find_element_by_xpath('//input[@id="match"]')->get_value(), "96", "default match level is 96");
-    $driver->find_element_by_xpath('//input[@id="match"]')->clear();
-    $driver->find_element_by_xpath('//input[@id="match"]')->send_keys("99");
-    is($driver->find_element_by_xpath('//input[@id="match"]')->get_value(), "99", "set match level to 99");
-    $driver->find_element_by_id('set_match')->click();
-    is($driver->find_element_by_id('change-match-form')->is_hidden(), 1, "match level form closed");
-    $decode_new_textarea = decode_utf8_json($elem->get_value());
-    is($decode_new_textarea->{area}[0]->{match}, 99, "match level is 99 now");
+    is $driver->find_element_by_id('set_match')->is_displayed(), 1, 'found set button';
+    is element_prop('match'), '96', 'default match level is 96';
+    $driver->find_element_by_xpath('//input[@id="match"]')->clear;
+    $driver->find_element_by_xpath('//input[@id="match"]')->send_keys('99');
+    is element_prop('match'), '99', 'set match level to 99';
+    $driver->find_element_by_id('set_match')->click;
+    is $driver->find_element_by_id('change-match-form')->is_hidden, 1, 'match level form closed';
+    $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
+    is $decode_new_textarea->{area}[0]->{match}, 99, 'match level is 99 now';
 
     # test adding click point
     $driver->find_element_by_id('toggle-click-coordinates')->click();
-    $decode_new_textarea = decode_utf8_json($elem->get_value());
+    $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     my $area = $decode_new_textarea->{area}[0];
     is_deeply(
         $area->{click_point},
@@ -227,7 +226,7 @@ sub change_needle_value {
 
     # test removing click point
     $driver->find_element_by_id('toggle-click-coordinates')->click();
-    $decode_new_textarea = decode_utf8_json($elem->get_value());
+    $decode_new_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     is($decode_new_textarea->{area}[0]->{click_point}, undef, 'click_point removed');
 }
 
@@ -238,9 +237,9 @@ sub overwrite_needle {
     $driver->execute_script('$(\'#modal-overwrite\').removeClass(\'fade\');');
 
     $driver->find_element_by_id('needleeditor_name')->clear();
-    is($driver->find_element_by_id('needleeditor_name')->get_value(), "", "needle name input clean up");
+    is element_prop('needleeditor_name'), '', 'needle name input clean up';
     $driver->find_element_by_id('needleeditor_name')->send_keys($needlename);
-    is($driver->find_element_by_id('needleeditor_name')->get_value(), "$needlename", "new needle name inputed");
+    is element_prop('needleeditor_name'), $needlename, 'new needle name inputed';
     $driver->find_element_by_id('save')->click();
     wait_for_ajax;
     my $diag;
@@ -282,6 +281,8 @@ sub check_flash_for_saving_logpackages {
     $driver->find_element('#flash-messages .close')->click();
 }
 
+
+
 # the actual test starts here
 
 subtest 'Open needle editor for installer_timezone' => sub {
@@ -303,25 +304,23 @@ subtest 'Needle editor layout' => sub {
     wait_for_ajax;
 
     # layout check
-    is($driver->find_element_by_id('tags_select')->get_value(),  'inst-timezone-text', "inst-timezone tags selected");
-    is($driver->find_element_by_id('image_select')->get_value(), 'screenshot', "Screenshot background selected");
-    is($driver->find_element_by_id('area_select')->get_value(),  'inst-timezone-text', "inst-timezone areas selected");
-    is($driver->find_element_by_id('take_matches')->is_selected(), 1, '"take matches" selected by default');
+    is element_prop('tags_select'),  'inst-timezone-text', 'inst-timezone tags selected';
+    is element_prop('image_select'), 'screenshot',         'screenshot background selected';
+    is element_prop('area_select'),  'inst-timezone-text', 'inst-timezone areas selected';
+    ok element_prop('take_matches', 'checked'), '"take matches" selected by default';
 
     # check needle suggested name
     my $today = strftime("%Y%m%d", gmtime(time));
-    is($driver->find_element_by_id('needleeditor_name')->get_value(),
-        "inst-timezone-text-$today", "has correct needle name");
+    is element_prop('needleeditor_name'), "inst-timezone-text-$today", "has correct needle name";
 
     # ENV-VIDEOMODE-text and inst-timezone tag are selected
     is($driver->find_element_by_xpath('//input[@value="inst-timezone"]')->is_selected(), 1, "tag selected");
 
     # workaround property isn't selected
-    is($driver->find_element_by_id('property_workaround')->is_selected(),    0, 'workaround property unselected');
-    is($driver->find_element_by_id('input_workaround_desc')->is_displayed(), 0, 'workaround description not displayed');
+    is element_prop('property_workaround', 'checked'), 0, 'workaround property unselected';
+    is $driver->find_element_by_id('input_workaround_desc')->is_displayed(), 0, 'workaround description not displayed';
 
-    $elem            = $driver->find_element_by_id('needleeditor_textarea');
-    $decode_textarea = decode_utf8_json($elem->get_value());
+    $decode_textarea = decode_utf8_json(element_prop('needleeditor_textarea'));
     # the value already defined in $default_json
     is(@{$decode_textarea->{area}},           2,         'exclude areas always present');
     is($decode_textarea->{area}[0]->{xpos},   0,         'xpos correct');
@@ -337,9 +336,9 @@ subtest 'Needle editor layout' => sub {
 
     # toggling 'take matches' has no effect
     $driver->find_element_by_xpath('//input[@value="inst-timezone"]')->click();
-    is(@{decode_utf8_json($elem->get_value())->{area}}, 2, 'exclude areas always present');
+    is @{decode_utf8_json(element_prop('needleeditor_textarea'))->{area}}, 2, 'exclude areas always present';
     $driver->find_element_by_xpath('//input[@value="inst-timezone"]')->click();
-    is(@{decode_utf8_json($elem->get_value())->{area}}, 2, 'no duplicated exclude areas present');
+    is @{decode_utf8_json(element_prop('needleeditor_textarea'))->{area}}, 2, 'no duplicated exclude areas present';
 };
 
 my $needlename = 'test-newneedle';
@@ -350,9 +349,9 @@ subtest 'Create new needle' => sub {
 
     # check needle name input
     $driver->find_element_by_id('needleeditor_name')->clear();
-    is($driver->find_element_by_id('needleeditor_name')->get_value(), "", "needle name input clean up");
+    is element_prop('needleeditor_name'), '', 'needle name input clean up';
     $driver->find_element_by_id('needleeditor_name')->send_keys($needlename);
-    is($driver->find_element_by_id('needleeditor_name')->get_value(), "$needlename", "new needle name inputed");
+    is element_prop('needleeditor_name'), $needlename, 'new needle name inputed';
 
     # select 'Copy areas from: None'
     $driver->execute_script('$("#area_select option").eq(0).prop("selected", true)');
@@ -492,19 +491,14 @@ subtest 'New needle instantly visible after reloading needle editor' => sub {
 
     # uncheck 'tag_inst-timezone' tag
     $driver->find_element_by_id('tag_inst-timezone')->click();
-    is($driver->find_element_by_id('tag_inst-timezone')->is_selected(), 0, 'tag_inst-timezone not checked anymore');
+    ok !element_prop('tag_inst-timezone', 'checked'), 'tag_inst-timezone not checked anymore';
 
     # check 'tag_inst-timezone' again by selecting new needle
     $based_on_option->[0]->click();
-    is($driver->find_element_by_id('tag_inst-timezone')->is_selected(),
-        1, 'tag_inst-timezone checked again via new needle');
-    is($driver->find_element_by_id('property_workaround')->is_selected(),    1, 'workaround property selected');
-    is($driver->find_element_by_id('input_workaround_desc')->is_displayed(), 1, 'workaround description displayed');
-    is(
-        $driver->find_element_by_id('input_workaround_desc')->get_value(),
-        'bsc#123456 - this is a täst',
-        'workaround description is shown'
-    );
+    ok element_prop('tag_inst-timezone',   'checked'), 'tag_inst-timezone checked again via new needle';
+    ok element_prop('property_workaround', 'checked'), 'workaround property selected';
+    is $driver->find_element_by_id('input_workaround_desc')->is_displayed, 1, 'workaround description displayed';
+    is element_prop('input_workaround_desc'), 'bsc#123456 - this is a täst', 'workaround description is shown';
     # check selecting/displaying image
     my $current_image_script = 'return nEditor.bgImage.src;';
     my $current_image        = $driver->execute_script($current_image_script);
@@ -557,8 +551,8 @@ foreach my $type (sort keys %tests) {
         $needle_json_file->spurt(qq({ "properties": [ $tests{$type} ] }));
         $driver->refresh;
         $driver->title_is('openQA: Needle Editor', 'needle editor shows up');
-        is($driver->find_element_by_id('property_workaround')->is_selected(),    1, 'workaround property selected');
-        is($driver->find_element_by_id('input_workaround_desc')->is_displayed(), 1, 'workaround description displayed');
+        ok element_prop('property_workaround', 'checked'), 'workaround property selected';
+        ok $driver->find_element_by_id('input_workaround_desc')->is_displayed, 'workaround description displayed';
     };
 }
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright (C) 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -249,7 +249,7 @@ qr(bsc#1234 boo#2345,poo#3456 t#4567 .*poo#6789 bsc#7890 bsc#1000629 bsc#1000630
     is((shift @urls)->get_text(), 'bsc#1043970',                             "url21");
 
     my @urls2 = $driver->find_elements('div.media-comment a', 'css');
-    is((shift @urls2)->get_attribute('href'), 'http://localhost:9562/',                             "url2-href");
+    like((shift @urls2)->get_attribute('href'), qr|^http://localhost:9562/?$|, "url2-href");
     is((shift @urls2)->get_attribute('href'), 'https://openqa.example.com/tests/181148',            "url3-href");
     is((shift @urls2)->get_attribute('href'), 'http://localhost/foo/bar',                           "url4-href");
     is((shift @urls2)->get_attribute('href'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234',     "url5-href");

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -20,6 +20,7 @@
 
 use Test::Most;
 
+use Mojo::Base -signatures;
 use Module::Load::Conditional qw(can_load);
 use Mojo::File qw(path tempdir);
 use FindBin;
@@ -130,6 +131,8 @@ sub click_header {
     $driver->find_element('#developer-status')->click();
 }
 
+sub options_state { map_elements('#developer-pause-at-module option', 'e.selected, e.value || ""') }
+
 # login an navigate to a running job with assigned worker
 $driver->get('/login');
 
@@ -210,26 +213,31 @@ subtest 'state shown when connected' => sub {
     fake_state(developerMode => {currentModule => '"installation-welcome"'});
     element_hidden('#developer-vnc-notice');
     element_visible('#developer-panel .card-header', qr/current module: installation-welcome/, qr/paused/,);
-    my @options   = $driver->find_elements('#developer-pause-at-module option');
-    my @optgroups = $driver->find_elements('#developer-pause-at-module optgroup');
-    is(
-        $_->get_css_attribute('display'),
-        (($_->get_value() // '') =~ qr/boot|welcome/) ? 'none' : 'block',
-        'only modules after the current module displayed'
-    ) for (@options, @optgroups);
+
+    my $options_state = map_elements('#developer-pause-at-module option, #developer-pause-at-module optgroup',
+        'e.style.display, e.value || ""');
+    subtest 'only modules after the current module displayed' => sub {
+        is $_->[0], ($_->[1] =~ qr/boot|welcome/) ? 'none' : '', "option $_->[1]" for @$options_state;
+    } or diag explain $options_state;
 
     # will pause at certain module
     fake_state(developerMode => {moduleToPauseAt => '"installation-foo"'});
     element_hidden('#developer-vnc-notice');
     element_visible('#developer-panel .card-header', qr/will pause at module: installation-foo/, qr/paused/,);
-    is(scalar @options,   5,                                '5 options in module to pause at selection present');
-    is($_->is_selected(), $_->get_value() eq 'foo' ? 1 : 0, 'only foo selected') for (@options);
+    $options_state = options_state;
+    subtest 'only foo selected' => sub {
+        is scalar @$options_state, 5, '5 options in module to pause at selection present';
+        is $_->[0], $_->[1] eq 'foo' ? 1 : 0, "option $_->[1]" for @$options_state;
+    } or diag explain $options_state;
 
     # has already completed the module to pause at
     fake_state(developerMode => {moduleToPauseAt => '"installation-boot"'});
     element_hidden('#developer-vnc-notice');
     element_visible('#developer-panel .card-header', qr/current module: installation-welcome/, qr/paused/,);
-    is($_->is_selected(), $_->get_value() eq 'boot' ? 1 : 0, 'only boot selected') for (@options);
+    $options_state = options_state;
+    subtest 'only boot selected' => sub {
+        is $_->[0], $_->[1] eq 'boot' ? 1 : 0, "option $_->[1]" for @$options_state;
+    } or diag explain $options_state;
 
     # currently paused
     fake_state(developerMode => {isPaused => '"some reason"'});
@@ -316,10 +324,11 @@ subtest 'expand developer panel' => sub {
         $options[4]->click();
         assert_sent_commands(undef, 'changes not instantly submitted');
 
-        subtest 'module to pause at not updated' => sub {
-            fake_state(developerMode => {moduleToPauseAt => '"installation-foo"'});
-            is($_->is_selected(), $_->get_value() eq 'bar' ? 1 : 0, 'still only bar selected') for (@options);
-        };
+        fake_state(developerMode => {moduleToPauseAt => '"installation-foo"'});
+        my $options_state = options_state;
+        subtest 'still only bar selected' => sub {
+            is $_->[0], $_->[1] eq 'bar' ? 1 : 0, "option $_->[1]" for @$options_state;
+        } or diag explain $options_state;
     };
 
     my $popover_icon = $driver->find_element('#developer-form .help_popover');
@@ -444,8 +453,10 @@ subtest 'start developer session' => sub {
 
     subtest 'select module to pause at' => sub {
         fake_state(developerMode => {moduleToPauseAt => '"installation-foo"'});
-        my @options = $driver->find_elements('#developer-pause-at-module option');
-        is $_->is_selected, $_->get_value eq 'foo' ? 1 : 0, 'foo selected (' . $_->get_value . ')' for @options;
+        my $options_state = options_state;
+        subtest 'only foo selected' => sub {
+            is $_->[0], $_->[1] eq 'foo' ? 1 : 0, "option $_->[1]" for @$options_state;
+        } or diag explain $options_state;
 
         ok $options[3], 'option #4 present' or return undef;
         $options[3]->click();    # select installation-foo
@@ -476,9 +487,10 @@ subtest 'start developer session' => sub {
     };
 
     subtest 'select whether to pause on assert_screen failure' => sub {
-        my @options = $driver->find_elements('#developer-pause-on-mismatch option');
-        is(scalar @options,            3, 'three options for pausing on screen mismatch');
-        is($options[0]->is_selected(), 1, 'pausing on screen mismatch disabled by default');
+        my @options       = $driver->find_elements('#developer-pause-on-mismatch option');
+        my $options_state = map_elements('#developer-pause-on-mismatch option', 'e.selected');
+        is scalar @options, 3, 'three options for pausing on screen mismatch';
+        is $options_state->[0]->[0], 1, 'pausing on screen mismatch disabled by default';
 
         # attempt to turn pausing on assert_screen on when current state unknown
         $options[1]->click();
@@ -486,7 +498,8 @@ subtest 'start developer session' => sub {
 
         # assume we know the pausing on screen match is disabled
         fake_state(developerMode => {pauseOnScreenMismatch => 'false'});
-        is($options[0]->is_selected(), 1, 'pausing on screen mismatch still disabled');
+        $options_state = map_elements('#developer-pause-on-mismatch option', 'e.selected');
+        is $options_state->[0]->[0], 1, 'pausing on screen mismatch still disabled';
 
         # turn pausing on assert_screen on
         $options[1]->click();
@@ -502,7 +515,8 @@ subtest 'start developer session' => sub {
 
         # fake the feedback from os-autoinst
         fake_state(developerMode => {pauseOnScreenMismatch => '"assert_screen"'});
-        is($options[1]->is_selected(), 1, 'still right option selected');
+        $options_state = map_elements('#developer-pause-on-mismatch option', 'e.selected');
+        is $options_state->[1]->[0], 1, 'still right option selected';
 
         # turn pausing on check_screen on
         $options[2]->click();
@@ -518,7 +532,8 @@ subtest 'start developer session' => sub {
 
         # fake the feedback from os-autoinst
         fake_state(developerMode => {pauseOnScreenMismatch => '"check_screen"'});
-        is($options[2]->is_selected(), 1, 'still right option selected');
+        $options_state = map_elements('#developer-pause-on-mismatch option', 'e.selected');
+        is $options_state->[2]->[0], 1, 'still right option selected (2)';
 
         # turn pausing on screen mismatch off
         $options[0]->click();
@@ -534,9 +549,9 @@ subtest 'start developer session' => sub {
     };
 
     subtest 'select whether to pause on next command' => sub {
-        my $checkbox = $driver->find_element_by_id('developer-pause-on-next-command');
-        is($checkbox->is_selected, 0, 'checkbox not checked yet');
+        ok !element_prop('developer-pause-on-next-command', 'checked'), 'checkbox not checked yet';
 
+        my $checkbox = $driver->find_element_by_id('developer-pause-on-next-command');
         $checkbox->click();
         assert_sent_commands(undef, 'nothing happens unless the current state is known');
 
@@ -555,14 +570,14 @@ subtest 'start developer session' => sub {
 
         # fake feedback from os-autoinst
         fake_state(developerMode => {pauseOnNextCommand => '1'});
-        is($checkbox->is_selected, 1, 'pause on next command is checked now');
+        ok element_prop('developer-pause-on-next-command', 'checked'), 'pause on next command is checked now';
 
         # test command processing
         $driver->execute_script(
 'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"pause_on_next_command\":0}}" });'
         );
-        is(js_variable('developerMode.pauseOnNextCommand'), 0, 'pauseOnNextCommand unset again');
-        is($checkbox->is_selected,                          0, 'pause on next command is disabled again');
+        is js_variable('developerMode.pauseOnNextCommand'), 0, 'pauseOnNextCommand unset again';
+        ok !element_prop('developer-pause-on-next-command', 'checked'), 'pause on next command is disabled again';
     };
 
     subtest 'quit session' => sub {
@@ -608,9 +623,9 @@ subtest 'process state changes from os-autoinst/worker' => sub {
         $driver->execute_script(
 'handleMessageFromWebsocketConnection(developerMode.wsConnection, { data: "{\"type\":\"info\",\"what\":\"cmdsrvmsg\",\"data\":{\"current_test_full_name\":\"some test\",\"paused\":true, \"set_pause_on_screen_mismatch\":\"assert_screen\"}}" });'
         );
-        element_visible('#developer-panel .card-header', qr/paused at module: some test/, qr/current module/,);
-        my @pause_on_mismatch_options = $driver->find_elements('#developer-pause-on-mismatch option');
-        is($pause_on_mismatch_options[1]->is_selected(), 1, 'selection for pausing on screen mismatch updated');
+        element_visible('#developer-panel .card-header', qr/paused at module: some test/, qr/current module/);
+        my $options_state = map_elements('#developer-pause-on-mismatch option', 'e.selected');
+        ok $options_state->[1]->[0], 'selection for pausing on screen mismatch updated' or diag explain $options_state;
     };
 
     subtest 'upload progress handled' => sub {

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -137,7 +137,7 @@ sub options_state { map_elements('#developer-pause-at-module option', 'e.selecte
 $driver->get('/login');
 
 # navigate to a finished test
-$driver->get('/tests/99926');
+$driver->get('/tests/99926?status_updates=0');
 like(
     $driver->find_element('#info_box .card-body')->get_text(),
     qr/Developer session was opened during testrun by artie/,
@@ -145,7 +145,7 @@ like(
 );
 
 # navigate to live view of running test
-$driver->get('/tests/99961#live');
+$driver->get('/tests/99961?status_updates=0#live');
 wait_for_ajax(msg => 'live tab of job 99961 loaded');
 
 # mock some JavaScript functions


### PR DESCRIPTION
Version 91.0.4472.77 of `chromedriver` changed its behavior so
`Selenium::Remote::WebElement` behaves different as well. This change
adapts our tests to the following changes (in a backwards compatible way):

* `Selenium::Remote::WebElement::get_attribute()` now returns `undef`
  instead of an empty string if the attribute is not present at all.
* `Selenium::Remote::WebElement::get_value()` and `is_selected()` sometimes
  no longer return a value. Likely it depends on how these form properties
  are populated. Possible an unwanted side-effect of the `get_attribute()`
  change.

See https://progress.opensuse.org/issues/93453#note-11