### PR TITLE
Allow to configure Selenium chromedriver startup timeout for slow environments

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -707,6 +707,11 @@ coverage analysis enabled the scaling factor of
 `OPENQA_TEST_TIMEOUT_SCALE_COVER` is applied to account for the runtime
 overhead.
 
+In case of Selenium based UI tests timing out trying to find a local
+chromedriver instance the variable `OPENQA_SELENIUM_TEST_STARTUP_TIMEOUT` can
+be set to a higher value. See
+https://metacpan.org/pod/Selenium::Chrome#startup_timeout for details.
+
 [[circleci-workflow]]
 == CircleCI workflow
 

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -696,6 +696,17 @@ Result: FAIL
 where "Wstat: 14" and "Non-zero wait status: 14" mean that the test process
 received the "ALRM" signal (signal number 14).
 
+In case of problems with timeouts look into `OpenQA::Test::TimeLimit` to find
+environment variables that can tweaked to disable or change timeout values or
+timeout scale factors. If you want to disable the timeout for indefinite
+manual debugging, set the environment variable
+`OPENQA_TEST_TIMEOUT_DISABLE=1`. The option `OPENQA_TEST_TIMEOUT_SCALE_CI` is
+only effective if the environment variable `CI` is set, which e.g. it is in
+circleCI and OBS but not in local development environments. When running with
+coverage analysis enabled the scaling factor of
+`OPENQA_TEST_TIMEOUT_SCALE_COVER` is applied to account for the runtime
+overhead.
+
 [[circleci-workflow]]
 == CircleCI workflow
 

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -106,7 +106,8 @@ sub start_driver {
             push(@{$opts{extra_capabilities}{$_}{args}}, qw(--headless --disable-gpu --no-sandbox))
               for @chrome_option_keys;
         }
-        $_driver           = Test::Selenium::Chrome->new(%opts);
+        my $startup_timeout = $ENV{OPENQA_SELENIUM_TEST_STARTUP_TIMEOUT} // 10;
+        $_driver           = Test::Selenium::Chrome->new(%opts, startup_timeout => $startup_timeout);
         $_driver->{is_wd3} = 0;    # ensure the Selenium::Remote::Driver instance uses JSON Wire protocol
         enable_timeout;
         # Scripts are considered stuck after this timeout


### PR DESCRIPTION
Motivated by a problem in a slow, container based development
environment of a user.

Tested locally by running

```
env OPENQA_TEST_TIMEOUT_DISABLE=1 OPENQA_SELENIUM_TEST_STARTUP_TIMEOUT=12 perl -d -Ilib t/ui/18-tests-details.t
```

and comparing the value of `startup_timeout` with the value of a run
with default values.

For crosschecking I used

```
env OPENQA_TEST_TIMEOUT_DISABLE=1 OPENQA_SELENIUM_TEST_STARTUP_TIMEOUT=1 perl -Ilib t/ui/18-tests-details.t
```

which as expected fails as the timeout of 1s is too low for a complete
chromedriver startup.