### PR TITLE
Minor optimization: Turn SQL 'OR' into 'IN'

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -555,7 +555,7 @@ sub prepare_job_results {
     # prefetch test suite names from job settings
     my $job_settings
       = $schema->resultset('JobSettings')
-      ->search({job_id => [map { $_->id } @$jobs], key => [qw(JOB_DESCRIPTION TEST_SUITE_NAME)]});
+      ->search({job_id => {-in => [map { $_->id } @$jobs]}, key => {-in => [qw(JOB_DESCRIPTION TEST_SUITE_NAME)]}});
     my %settings_by_job_id;
     for my $js ($job_settings->all) {
         $settings_by_job_id{$js->job_id}->{$js->key} = $js->value;


### PR DESCRIPTION
for loading job settings in /tests/overview

Sometimes we are loading job settings for hundreds of job ids, and
then an `IN` can be significantly faster than an `OR`.

It turns out that I accidentally dropped the `-in` in this
commit: 819374a556d5bd122856bb0e3f1173416e093a0e
assuming that DBIx::Class would automatically turn it into an `IN` clause.

Test runs for an example Build with 273 jobs showed 55-61ms for `OR`,
and 16-21ms for `IN`.