### PR TITLE
t: Delete unused function in t/ui/13-admin.t

### DIFF
--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -456,16 +456,6 @@ subtest 'job property editor' => sub() {
     };
 };
 
-sub is_element_text {
-    my ($elements, $expected, $message) = @_;
-    my @texts = map {
-        my $text = $_->get_text();
-        $text =~ s/^\s+|\s+$//g;
-        $text;
-    } @$elements;
-    is_deeply(\@texts, $expected, $message) or diag explain \@texts;
-}
-
 subtest 'edit job templates' => sub() {
     subtest 'open YAML editor for new group with no templates' => sub {
         $driver->get('/admin/job_templates/1003');


### PR DESCRIPTION
As seen in
https://codecov.io/gh/os-autoinst/openQA/src/master/t/ui/13-admin.t the
function `is_element_text` was never called so we can delete it to reach
100% statement coverage.