### PR TITLE
Revert "script: Fallback to running openqa-bootstrap-container without pipe"

### DIFF
--- a/script/openqa-bootstrap-container
+++ b/script/openqa-bootstrap-container
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 [ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Setup a working openQA installation in a systemd-nspawn container" && exit
 
+# This script doesn't work on Leap 15.0 as it makes use of the -P option of systemd-run
+# which is not available there
+
 if [ "$(id -ru)" != "0" ]; then
     echo "$0 must be run as root"
     exit 1
@@ -11,14 +14,6 @@ set -x
 
 CONTAINER_NAME="openqa1"
 CONTAINER_PATH="/var/lib/machines/${CONTAINER_NAME}"
-
-systemd_run_params=(-q -M "$CONTAINER_NAME")
-if systemd-run --help | grep '\-P'; then
-    systemd_run_params+=(-P)
-else
-    echo "Your version of systemd-run does not support the '-P' parameter,
-piped output from the container will not be available here"
-fi
 
 ARCH="${ARCH:=$(arch)}"
 if [ "$ARCH" = "x86_64" ]; then
@@ -84,6 +79,6 @@ systemctl start systemd-nspawn-openqa@$CONTAINER_NAME
 # ensure that the container is really running
 # ignore expected errors about 'Failed to create bus connection: Protocol error' and restarting error
 while ! timeout -s9 2 systemd-run -qPM $CONTAINER_NAME /bin/bash -c whoami /dev/null 2>&1 ; do systemctl restart systemd-nspawn-openqa@$CONTAINER_NAME.service || true ; sleep 3 ; done
-systemd-run "${systemd_run_params[@]}" /bin/bash -c '/usr/share/openqa/script/openqa-bootstrap'
+systemd-run -qPM $CONTAINER_NAME /bin/bash -c '/usr/share/openqa/script/openqa-bootstrap'
 
 echo -e "$(tput setaf 2;tput bold)Your openQA container has been created. Run 'systemd-run -tM $CONTAINER_NAME /bin/bash' to get a shell in the container$(tput sgr0)"


### PR DESCRIPTION
Reverts os-autoinst/openQA#3709

This pr breaks the container installation on tumbleweed and it doesn't work on leap either.
Due to the missing `-M $CONTAINER_NAME` parameters for the `systemd-run` command, openQA is not installed in a container but directly onto the host. This is likely the reason why https://openqa.opensuse.org/tests/1786096 didn't catch it (as the container shares the host network namespace).