### PR TITLE
Optimize /tests/overview by combining SQL

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2134,7 +2134,7 @@ sub cancel {
 }
 
 sub dependencies {
-    my ($self) = @_;
+    my ($self, $children_list, $parents_list) = @_;
 
     # make arrays for returning parents/children by the dependency type
     my @dependency_names = OpenQA::JobDependencies::Constants::display_names;
@@ -2149,14 +2149,16 @@ sub dependencies {
     my $is_final   = grep { $_ eq $state } FINAL_STATES;
     my $parents_ok = $result ne SKIPPED && $result ne PARALLEL_FAILED && $result ne PARALLEL_RESTARTED;
 
-    my $jp = $self->parents;
-    while (my $s = $jp->next) {
+    $parents_list ||= [$self->parents->all];
+    for my $s (@$parents_list) {
         push(@{$parents{$s->to_string}}, $s->parent_job_id);
         $has_parents = 1;
-        $parents_ok  = $s->parent->is_ok if $is_final && $parents_ok;
+        my $jobs = $self->result_source->schema->resultset('Jobs');
+        $parents_ok = $jobs->find($s->parent_job_id, {select => ['result']})->is_ok
+          if $is_final && $parents_ok;
     }
-    my $jc = $self->children;
-    while (my $s = $jc->next) {
+    $children_list ||= [$self->children->all];
+    for my $s (@$children_list) {
         push(@{$children{$s->to_string}}, $s->child_job_id);
     }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1533,7 +1533,7 @@ sub has_failed_modules {
 sub failed_modules {
     my ($self) = @_;
 
-    my $fails = $self->modules->search({result => 'failed'}, {order_by => 't_updated'});
+    my $fails = $self->modules->search({result => 'failed'}, {select => ['name'], order_by => 't_updated'});
     my @failedmodules;
 
     while (my $module = $fails->next) {
@@ -2258,8 +2258,7 @@ sub status_info {
 }
 
 sub _overview_result_done {
-    my ($self, $jobid, $job_labels, $aggregated, $failed_modules, $todo) = @_;
-    my $actually_failed_modules = $self->failed_modules;
+    my ($self, $jobid, $job_labels, $aggregated, $failed_modules, $actually_failed_modules, $todo) = @_;
     return undef
       unless !$failed_modules
       || OpenQA::Utils::any_array_item_contained_by_hash($actually_failed_modules, $failed_modules);
@@ -2290,11 +2289,12 @@ sub _overview_result_done {
 }
 
 sub overview_result {
-    my ($self, $job_labels, $aggregated, $failed_modules, $todo) = @_;
+    my ($self, $job_labels, $aggregated, $failed_modules, $actually_failed_modules, $todo) = @_;
 
     my $jobid = $self->id;
     if ($self->state eq OpenQA::Jobs::Constants::DONE) {
-        return $self->_overview_result_done($jobid, $job_labels, $aggregated, $failed_modules, $todo);
+        return $self->_overview_result_done($jobid, $job_labels, $aggregated, $failed_modules,
+            $actually_failed_modules, $todo);
     }
     return undef if $todo;
     my $result = {


### PR DESCRIPTION
When a build has hundreds of jobs, for example
`/tests/overview?distri=microos&distri=opensuse&version=Tumbleweed&build=20210607&groupid=1`, then for each job several SQL queries are executed:
```
SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.child_job_id = ? ): '1773830'
SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.parent_job_id = ? ): '1773830'
SELECT me.id, me.job_id, me.name, me.script, me.category, me.milestone, me.important, me.fatal, me.always_rollback, me.result, me.t_created, me.t_updated FROM job_modules me WHERE ( ( me.job_id = ? AND result = ? ) )  ORDER BY t_updated: '1
773829', 'failed'                                                                                                       
SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.child_job_id = ? ): '1773829'
SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.parent_job_id = ? ): '1773829'
SELECT me.id, me.job_id, me.name, me.script, me.category, me.milestone, me.important, me.fatal, me.always_rollback, me.result, me.t_created, me.t_updated FROM job_modules me WHERE ( ( me.job_id = ? AND result = ? ) )  ORDER BY t_updated: '1
773828', 'failed'                                                                                                                                                                                                                               SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.child_job_id = ? ): '1773828'                                                                                                                       
SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.parent_job_id = ? ): '1773828'                                                                                                                      SELECT me.id, me.job_id, me.name, me.script, me.category, me.milestone, me.important, me.fatal, me.always_rollback, me.result, me.t_created, me.t_updated FROM job_modules me WHERE ( ( me.job_id = ? AND result = ? ) )  ORDER BY t_updated: '1
773827', 'failed'                                                                                                                                                                                                                               SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.child_job_id = ? ): '1773827'                                                                                                                       
SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.parent_job_id = ? ): '1773827'                                                                                                                      SELECT me.id, me.job_id, me.name, me.script, me.category, me.milestone, me.important, me.fatal, me.always_rollback, me.result, me.t_created, me.t_updated FROM job_modules me WHERE ( ( me.job_id = ? AND result = ? ) )  ORDER BY t_updated: '1
773826', 'failed'                                                                                                                                                                                                                               SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.child_job_id = ? ): '1773826'                                                                                                                       
SELECT me.child_job_id, me.parent_job_id, me.dependency FROM job_dependencies me WHERE ( me.parent_job_id = ? ): '1773826'
SELECT me.id, me.job_id, me.name, me.script, me.category, me.milestone, me.important, me.fatal, me.always_rollback, me.result, me.t_created, me.t_updated FROM job_modules me WHERE ( ( me.job_id = ? AND result = ? ) )  ORDER BY t_updated: '1
773825', 'failed'      
...  etc.
```
So when there are 200 jobs, we get 600 SELECTs.
Additionally, the job_modules SELECTs retrieve all columns (including costly DateTime columns) instead of just the ones we need.

This PR:
* combines the job_modules SELECTs into one with `job_id IN (...)`
* Retrieves only necessary columns
* combines both the job_dependencies for children and parents into one SELECT with `parent_job_id IN (...) OR child_job_id IN (...)`


Issue: https://progress.opensuse.org/issues/93925

Local tests with the mentioned build showed that the total GET time goes down from 1.6s to 0.7s