### PR TITLE
Optimize search: prefetch job columns

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -129,7 +129,10 @@ sub _search_job_modules {
         {-or => {name => $like}},
         {
             join     => 'job',
-            group_by => ['me.id', 'job.DISTRI', 'job.VERSION', 'job.FLAVOR', 'job.TEST', 'job.ARCH', 'job.MACHINE'],
+            group_by =>
+              ['me.id', 'job.DISTRI', 'job.VERSION', 'job.FLAVOR', 'job.TEST', 'job.ARCH', 'job.MACHINE', 'job.id'],
+            prefetch => [qw(job)],
+            select   => [qw(me.id me.script me.job_id job.DISTRI job.VERSION job.FLAVOR job.ARCH job.BUILD job.TEST)],
             order_by => {-desc => 'job_id'}})->slice(0, $limit);
     while (my $job_module = $job_modules->next) {
         my $contents = $job_module->script;


### PR DESCRIPTION
Currently for every job-module result a `SELECT FROM job` is executed,
when calling `$job_module->job->name`.

The prefetch will save the job data in the object and so the extra
SELECT is avoided.
Additionally this commit reduces the selected columns to what is actually
needed.

A search for 'vlc' `/api/v1/experimental/search?q=vlc` was reduced from 39s to 7s locally.

