### PR TITLE
Fix show results for multiple groups in /test/overview

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -673,7 +673,7 @@ sub overview {
     my %stash = (
         # build, version, distri are not mandatory and therefore not
         # necessarily come from the search args so they can be undefined.
-        build   => $search_args->{build},
+        build   => ref $search_args->{build} eq 'ARRAY' ? join(',', @{$search_args->{build}}) : $search_args->{build},
         version => $search_args->{version},
         distri  => $search_args->{distri},
         groups  => $groups,
@@ -681,7 +681,6 @@ sub overview {
     );
     my @latest_jobs = $self->schema->resultset('Jobs')->complex_query(%$search_args)->latest_jobs($until);
     ($stash{archs}, $stash{results}, $stash{aggregated}) = $self->prepare_job_results(\@latest_jobs);
-
     # determine distri/version from job results if not explicitely specified via search args
     my @distris = keys %{$stash{results}};
     my $formatted_distri;

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -233,10 +233,39 @@ $t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=10
 $summary = get_summary;
 like(
     $summary,
-    qr/Summary of opensuse, opensuse test/i,
-    'multiple groups with no build specified yield latest build of first group'
+    qr/Summary of opensuse, opensuse test build 0091 /i,
+    'multiple groups with no build specified yield latest build of every group'
 );
 like($summary, qr/Passed: 2 Failed: 0 Scheduled: 1 Running: 2 None: 1/i);
+
+my $jobGroup = $t->app->schema->resultset('JobGroups')->create(
+    {
+        id         => 1003,
+        sort_order => 0,
+        name       => 'opensuse test 2'
+    });
+
+my $job = $t->app->schema->resultset('Jobs')->create(
+    {
+        id       => 99964,
+        BUILD    => '0092',
+        group_id => 1003,
+        TEST     => 'kde',
+        DISTRI   => 'opensuse',
+        VERSION  => '13.1'
+    });
+
+$t->get_ok('/tests/overview?distri=opensuse&version=13.1&groupid=1001&groupid=1003')->status_is(200);
+$summary = get_summary;
+like(
+    $summary,
+    qr/Summary of opensuse, opensuse test 2 build 0091,0092 /i,
+    'multiple groups with no build specified yield latest build of every group'
+);
+like($summary, qr/Passed: 3 Failed: 0 Scheduled: 2 Running: 1 None: 1/i);
+
+$jobGroup->delete();
+$job->delete();
 
 # overview page searches for all available data with less specified parameters
 $t->get_ok('/tests/overview' => form => {build => '0091', version => '13.1'})->status_is(200);


### PR DESCRIPTION
When the query has different groupid and every group
different builds the current operation only returns the jobs
for the last build of the first group.

This PR ensures to return all the jobs for all the last builds for
all the selected groups

https://progress.opensuse.org/issues/91650