### PR TITLE
Also show "investigation" tabs for incomplete jobs

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -62,7 +62,7 @@ const tabConfiguration = {
   investigation: {
     descriptiveName: 'investigation info',
     conditionForShowingNavItem: function () {
-      return testStatus.state === 'done' && testStatus.result === 'failed';
+      return testStatus.state === 'done' && (testStatus.result === 'failed' || testStatus.result === 'incomplete');
     },
     renderContents: renderInvestigationTab
   },

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -140,3 +140,6 @@ my %META_RESULT_MAPPING = (
 );
 sub meta_state ($state) { $META_STATE_MAPPING{$state} // NONE }
 sub meta_result ($result) { $META_RESULT_MAPPING{$result} // NONE }
+sub is_ok_result ($result) {
+    !!grep { $result eq $_ } OK_RESULTS;
+}

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1957,7 +1957,7 @@ sub investigate {
     return {error => 'No result directory available for current job'} unless $self->result_dir();
     my $ignore = OpenQA::App->singleton->config->{global}->{job_investigate_ignore};
     for my $prev (@previous) {
-        if ($prev->result eq 'failed') {
+        if ($prev->should_show_investigation) {
             $inv{first_bad} = {type => 'link', link => '/tests/' . $prev->id, text => $prev->id};
             next;
         }
@@ -2223,7 +2223,8 @@ sub should_show_autoinst_log {
 sub should_show_investigation {
     my ($self) = @_;
 
-    return $self->state ne DONE || $self->result eq FAILED;
+    OpenQA::Jobs::Constants::meta_state($self->state) ne OpenQA::Jobs::Constants::FINAL
+      || !OpenQA::Jobs::Constants::is_ok_result($self->result);
 }
 
 sub status {

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -266,6 +266,9 @@ subtest 'reason and log details on incomplete jobs' => sub {
     my $log_element = $driver->find_element_by_xpath('//*[@id="details"]//pre[string-length(text()) > 0]');
     like($log_element->get_attribute('data-src'), qr/autoinst-log.txt/, 'log file embedded');
     like($log_element->get_text(), qr/Crashed\?/, 'log contents loaded');
+    $driver->find_element_by_link_text('Investigation')->click;
+    $driver->find_element('table#investigation_status_entry')
+      ->text_like(qr/cannot provide hints/, 'investigation status content shown as table');
 };
 
 sub update_status {


### PR DESCRIPTION
Also in case of incomplete jobs the problem can be caused by something
that the investigation tab could reveal, e.g. invalid test code that
causes the job to abort prematurely with incomplete.

Related progress issue: https://progress.opensuse.org/issues/94792