### PR TITLE
Add link to /test/overview from a parent job group

### DIFF
--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -194,6 +194,13 @@ for my $url (@urls) {
 # parent group overview
 $t->get_ok('/parent_group_overview/' . $test_parent->id)->status_is(200);
 check_test_parent('expanded');
+$t->element_exists('#test_result_overview_link');
+my $tests_overview = $t->tx->res->dom->find("#test_result_overview_link")->first;
+is(
+    $tests_overview->attr("href"),
+    "/tests/overview?todo=1&groupid=1001&groupid=1002",
+    "The 'test result overview' anchor href points to /test/overview and includes all the groupids"
+);
 
 # add tags (99901 is user ID of arthur)
 my $tag_for_0092_comment = $opensuse_group->comments->create({text => 'tag:0092:important:some_tag', user_id => 99901});

--- a/templates/webapi/main/parent_group_overview.html.ep
+++ b/templates/webapi/main/parent_group_overview.html.ep
@@ -21,6 +21,15 @@
     Last Builds for <%= $group->{name} %>
 </h2>
 
+<p>
+  <a href="<%= url_for('tests_overview')->query(todo => 1, map { (groupid => $_->{id}) } @$children); %>"
+    title="Shows the latest test results for all job groups within this parent job group"
+    id="test_result_overview_link"
+  >
+    Test result overview
+  </a>
+</p>
+
 %= include 'main/pinned_comments'
 
 <div class="well well-lg" id="group_description">


### PR DESCRIPTION
Provides link to /tests/overview of latest builds of all job groups
within a parent job group

https://progress.opensuse.org/issues/94732