### PR TITLE
Revert "Switch to systemd-sysusers instead of getent + useradd"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,10 +110,6 @@ install-generic:
 
 	cp -Ra dbicdh "$(DESTDIR)"/usr/share/openqa/dbicdh
 
-	install -d -m 755 "$(DESTDIR)"/usr/lib/sysusers.d/
-	install    -m 644 usr/lib/sysusers.d/openQA-worker.conf "$(DESTDIR)"/usr/lib/sysusers.d/
-	install    -m 644 usr/lib/sysusers.d/geekotest.conf "$(DESTDIR)"/usr/lib/sysusers.d/
-
 # Additional services which have a strong dependency on SUSE/openSUSE and do not
 # make sense for other distributions
 .PHONY: install-opensuse

--- a/usr/lib/sysusers.d/geekotest.conf
+++ b/usr/lib/sysusers.d/geekotest.conf
@@ -1,3 +1,0 @@
-# Type Name       ID     GECOS           [HOME]    Shell
-   u   geekotest   -     "openQA user" /dev/null
-   m   geekotest  nogroup

--- a/usr/lib/sysusers.d/openQA-worker.conf
+++ b/usr/lib/sysusers.d/openQA-worker.conf
@@ -1,4 +1,0 @@
-# Type Name            ID     GECOS           [HOME]    Shell
-   u   _openqa-worker   -     "openQA worker" /dev/null
-   m   _openqa-worker  nogroup
-   m   _openqa-worker  kvm


### PR DESCRIPTION
This reverts commit 72a6d7f87b8773d3ffa8116e02f100966c0064eb.

The sysusers switch will not work until https://build.opensuse.org/request/show/901701 is in Factory.