### PR TITLE
Take test modules without result into account for carry-over

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1767,6 +1767,10 @@ sub _previous_scenario_jobs {
     return $schema->resultset("Jobs")->search({-and => $conds}, \%attrs)->all;
 }
 
+sub _relevant_module_result_for_carry_over_evaluation ($module_result) {
+    $module_result eq FAILED || $module_result eq SOFTFAILED || $module_result eq NONE;
+}
+
 # internal function to compare two failure reasons
 sub _failure_reason {
     my ($self) = @_;
@@ -1774,8 +1778,7 @@ sub _failure_reason {
     my %failed_modules;
     my $modules = $self->modules;
     while (my $m = $modules->next) {
-        my $module_result = $m->result;
-        next unless $module_result eq FAILED || $module_result eq SOFTFAILED;
+        next unless _relevant_module_result_for_carry_over_evaluation my $module_result = $m->result;
         # look for steps which reference a bug within the title to use it as failure reason (instead of the module name)
         # note: This allows the carry-over to happen if the same bug is found via different test modules.
         my $details     = ($m->results(skip_text_data => 1) // {})->{details};

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -155,10 +155,10 @@ subtest 'failed in different modules with same bugref in details' => sub {
     is join('', @{comments('/tests/99963')}), $comment_must, 'label is carried over without other failing modules';
 };
 
-subtest 'failure reason still computed without results' => sub {
+subtest 'failure reason still computed without results, modules without results taken into account' => sub {
     my $mock = Test::MockModule->new('OpenQA::Schema::Result::JobModules');
     $mock->redefine(results => undef);
-    is $curr_job->_failure_reason, 'aplay:failed,yast2_lan:failed', 'failure reason computed';
+    like $curr_job->_failure_reason, qr/amarok:none,aplay:failed,.*yast2_lan:failed,.*zypper_up:none/, 'failure reason';
 };
 
 done_testing;


### PR DESCRIPTION
This should be a small fix for https://progress.opensuse.org/issues/70915 (based on #3988).