### PR TITLE
Add link to /test/overview from index page

### DIFF
--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -415,3 +415,16 @@ ul.modcategory {
         opacity: inherit;
     }
 }
+
+.test-result-overview-link {
+    position: relative;
+    top: -0.1em;
+    left: 0.2em;
+    font-size: 75%;
+    i {
+        color: $link-color;
+    }
+    i:hover {
+        color: $link-hover-color;
+    }
+}

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -107,7 +107,6 @@ is_deeply(
     ['opensuse test', 'Test parent', $test_overview_tooltip],
     'parent group shown and opensuse is no more on top-level'
 );
-$t->element_exists('#test_result_overview_link_1', 'parent group has link to tests/overview');
 my $tests_overview_dashboard = $t->tx->res->dom->find("#test_result_overview_link_1")->first;
 is(
     $tests_overview_dashboard->attr('href'),
@@ -210,8 +209,7 @@ for my $url (@urls) {
 # parent group overview
 $t->get_ok('/parent_group_overview/' . $test_parent->id)->status_is(200);
 check_test_parent('expanded');
-$t->element_exists('#test_result_overview_link');
-my $tests_overview = $t->tx->res->dom->find("#test_result_overview_link")->first;
+my $tests_overview = $t->tx->res->dom->find("#test_result_overview_link_1")->first;
 is(
     $tests_overview->attr("href"),
     "/tests/overview?groupid=1001&groupid=1002",

--- a/templates/webapi/main/dashboard_build_results.html.ep
+++ b/templates/webapi/main/dashboard_build_results.html.ep
@@ -6,6 +6,7 @@
     % if (@{$groupresults->{children}}) {
         <h2>
             %= link_to $group->{name} => url_for('parent_group_overview', groupid => $group->{id})
+            %= include 'main/test_result_overview_link', group_list => $groupresults->{children}, groupid => $group->{id}
         </h2>
         %= include 'main/group_builds', build_results => $build_results, group => $group, max_jobs => $max_jobs, children => $groupresults->{children}, default_expanded => $default_expanded
     % } else {

--- a/templates/webapi/main/parent_group_overview.html.ep
+++ b/templates/webapi/main/parent_group_overview.html.ep
@@ -19,6 +19,7 @@
 
 <h2 class="mb-4">
     Last Builds for <%= $group->{name} %>
+    %= include 'main/test_result_overview_link', group_list => $children, groupid => $group->{id}
 </h2>
 
 <p>

--- a/templates/webapi/main/test_result_overview_link.html.ep
+++ b/templates/webapi/main/test_result_overview_link.html.ep
@@ -1,0 +1,5 @@
+<a href="<%= url_for('tests_overview')->query(map { (groupid => $_->{id}) } @$group_list); %>"
+  title="Shows the latest test results for all job groups within this parent job group"
+  id="test_result_overview_link_<%= $groupid %>"
+  class="test-result-overview-link"
+><i class="fa fa-list"></i></a>


### PR DESCRIPTION
Provides link to /tests/overview of latest builds of all job groups
that are listed in the index page

https://progress.opensuse.org/issues/94732

Example in the index page

![image](https://user-images.githubusercontent.com/11134265/124165968-adc72a00-daa2-11eb-9086-b1512e845b7b.png)

Example in the parent group page

![image](https://user-images.githubusercontent.com/11134265/124170804-267cb500-daa8-11eb-84d4-21f08537c8ac.png)
