### PR TITLE
search: Correctly use username for gru lock if logged in

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -183,7 +183,7 @@ sub query {
 
     # Allow n queries per minute, per user (if logged in)
     my $lockname = 'webui_query_rate_limit';
-    if (my $user = $self->current_user) { $lockname .= $user }
+    if (my $user = $self->current_user) { $lockname .= $user->username }
     return $self->render(json => {error => 'Rate limit exceeded'}, status => 400)
       unless $self->app->minion->lock($lockname, 60, {limit => $self->app->config->{'rate_limits'}->{'search'}});
 


### PR DESCRIPTION
$current_user is an object, $username is the user's name