### PR TITLE
Remove uncovered conditions for internal search of job settings

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/JobSettings.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobSettings.pm
@@ -35,18 +35,12 @@ Given a perl hash, will create a ResultSet of job_settings
 sub query_for_settings {
     my ($self, $args) = @_;
 
-    my @joins;
     my @conds;
     # Search into the following job_settings
     for my $setting (keys %$args) {
         next unless $args->{$setting};
         # for dynamic self joins we need to be creative ;(
-        my $tname = 'me';
-        if (@conds) {
-            $tname = "siblings";
-            $tname .= '_' . (int(@joins) + 1) if @joins;
-            push(@joins, 'siblings');
-        }
+        my $tname         = 'me';
         my $setting_value = ($args->{$setting} =~ /^:\w+:/) ? {'like', "$&%"} : $args->{$setting};
         push(
             @conds,
@@ -55,7 +49,7 @@ sub query_for_settings {
                 "$tname.value" => $setting_value
             });
     }
-    return $self->search({-and => \@conds}, {join => \@joins});
+    return $self->search({-and => \@conds});
 }
 
 1;


### PR DESCRIPTION
Maybe we are just missing tests for this, maybe we do not need it at
all.

I have also tried to trigger the additional query condition over
/tests/overview, e.g.
https://openqa.opensuse.org/tests/overview?distri=opensuse&groupid=1&version=Tumbleweed&HDD_1=opensuse-Tumbleweed-x86_64-20210629-textmode@64bit.qcow2
but to no effect. Tests that do not have that HDD_1 setting still show
up so the filter is not effective.

See https://codecov.io/gh/os-autoinst/openQA/src/master/lib/OpenQA/Schema/ResultSet/JobSettings.pm