### PR TITLE
Do not fail Minion jobs when asset download fails due to a client error

### DIFF
--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ has attempts => 5;
 has [qw(log tmpdir)];
 has sleep_time => 5;
 has ua         => sub { Mojo::UserAgent->new(max_redirects => 5, max_response_size => 0) };
+has res        => undef;
 
 sub download {
     my ($self, $url, $target, $options) = (shift, shift, shift, shift // {});
@@ -76,6 +77,7 @@ sub _get {
     $tx->req->headers->header('If-None-Match' => $etag) if $etag && -e $target;
     $tx = $ua->start($tx);
     my $res = $tx->res;
+    $self->res($res);
 
     my $code = $res->code // 521;    # Used by cloudflare to indicate web server is down.
     if ($code eq 304) {

--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -100,12 +100,11 @@ sub _download {
             $ctx->debug(qq{Download of "$assetpath" successful});
         }
     };
-    if (my $err = $downloader->download($url, $assetpath, $options)) {
-        $ctx->error(my $msg = qq{Downloading "$url" failed with: $err});
-        return $job->fail($msg);
-    }
-
-    return _create_symlinks($job, $ctx, $assetpath, \@other_destinations);
+    return _create_symlinks($job, $ctx, $assetpath, \@other_destinations)
+      unless my $err = $downloader->download($url, $assetpath, $options);
+    my $res = $downloader->res;
+    $ctx->error(my $msg = qq{Downloading "$url" failed with: $err});
+    return $res && $res->is_client_error ? $job->finish($msg) : $job->fail($msg);
 }
 
 1;


### PR DESCRIPTION
Otherwise we'll get lots of failed Minion jobs which usually means
something is broken on our side. However, client errors are most likely
caused by users, e.g. by specifying an invalid asset URL which just
returns a 404 page. This change prevents unnecessary alerts in such cases.