### PR TITLE
Mark t/ui/12-needle-edit.t as unstable after recent CI failures

### DIFF
--- a/.circleci/unstable_tests.txt
+++ b/.circleci/unstable_tests.txt
@@ -1,4 +1,5 @@
 t/25-cache-service.t
 t/ui/01-list.t
 t/ui/26-jobs_restart.t
+t/ui/12-needle-edit.t
 t/ui/13-admin.t


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/95009