### PR TITLE
Fix performance issue with `/tests/overview?...&flavor=`

### DIFF
--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -217,6 +217,15 @@ subtest 'filtering by test' => sub {
     );
 };
 
+subtest 'empty flavor value does not result in all jobs being loaded (regression test)' => sub {
+    $driver->get('/tests/overview?test=textmode&flavor=');
+    like(
+        OpenQA::Test::Case::trim_whitespace($driver->find_element('#summary .card-header')->get_text()),
+        qr/Overall Summary of opensuse 13\.1 build 0092/,
+        'summary states "opensuse 13.1" although no explicit search params',
+    );
+};
+
 subtest 'filtering by distri' => sub {
     subtest 'no distri filter yields everything' => sub {
         $driver->get('/tests/overview?version=13.1&build=0091');


### PR DESCRIPTION
As discussed earlier in the weekly meeting, just the most minimal validation (not even actual validation, just filtering of parameters). It prevents `/tests/overview?...&flavor=` from affecting the database query and loading 70k+ jobs on O3, instead of just jobs from the latest build. Right now this is unlikely to happen, but we want to extend the filter form with new options, including `flavor`.

Progress: https://progress.opensuse.org/issues/94901