### PR TITLE
Use a more feasible timeout for t/full-stack.t

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -56,7 +56,7 @@ use OpenQA::Test::Utils
   qw(create_websocket_server create_live_view_handler setup_share_dir),
   qw(cache_minion_worker cache_worker_service mock_service_ports setup_fullstack_temp_dir),
   qw(start_worker stop_service wait_for_or_bail_out);
-use OpenQA::Test::TimeLimit '90';
+use OpenQA::Test::TimeLimit '200';
 use OpenQA::Test::FullstackUtils;
 
 plan skip_all => 'set FULLSTACK=1 (be careful)'                                 unless $ENV{FULLSTACK};


### PR DESCRIPTION
I measured 2m 40s for this module so the internal timeout
should be at least 200s instead of 90.
When running in CI the default factor is 3 so the make level
timeout should be 12m to provide some selectivity over the
200s*3=10m internal timeout.

Ticket: https://progress.opensuse.org/issues/93677