### PR TITLE
Add filter options for flavor and test

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -110,6 +110,9 @@ function setupOverview() {
         } else if (key === 'arch') {
             $('#filter-arch').prop('value', val);
             return val;
+        } else if (key === 'flavor') {
+            $('#filter-flavor').prop('value', val);
+            return val;
         } else if (key === 'machine') {
             $('#filter-machine').prop('value', val);
             return val;

--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -101,6 +101,9 @@ function setupOverview() {
         if (key === 'result') {
             results[val] = true;
             return formatFilter(val);
+        } else if (key === 'test') {
+            $('#filter-test').prop('value', val);
+            return val;
         } else if (key === 'state') {
             states[val] = true;
             return formatFilter(val);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -543,6 +543,7 @@ sub prepare_job_results {
     my $states         = $self->param_hash('state');
     my $results        = $self->param_hash('result');
     my $archs          = $self->param_hash('arch');
+    my $flavors        = $self->param_hash('flavor');
     my $machines       = $self->param_hash('machine');
 
     # prefetch the number of available labels for those jobs
@@ -570,6 +571,7 @@ sub prepare_job_results {
               (not $states         or $states->{$_->state})
           and (not $results        or $results->{$_->result})
           and (not $archs          or $archs->{$_->ARCH})
+          and (not $flavors        or $flavors->{$_->FLAVOR})
           and (not $machines       or $machines->{$_->MACHINE})
           and (not $failed_modules or $_->result eq OpenQA::Jobs::Constants::FAILED)
     } @$jobs;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -543,7 +543,6 @@ sub prepare_job_results {
     my $states         = $self->param_hash('state');
     my $results        = $self->param_hash('result');
     my $archs          = $self->param_hash('arch');
-    my $flavors        = $self->param_hash('flavor');
     my $machines       = $self->param_hash('machine');
 
     # prefetch the number of available labels for those jobs
@@ -571,7 +570,6 @@ sub prepare_job_results {
               (not $states         or $states->{$_->state})
           and (not $results        or $results->{$_->result})
           and (not $archs          or $archs->{$_->ARCH})
-          and (not $flavors        or $flavors->{$_->FLAVOR})
           and (not $machines       or $machines->{$_->MACHINE})
           and (not $failed_modules or $_->result eq OpenQA::Jobs::Constants::FAILED)
     } @$jobs;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -149,7 +149,8 @@ is(scalar @filtered_out, 0, 'result filter correctly applied');
 
 # Test whether all URL parameter are passed correctly
 my $url_with_escaped_parameters
-  = $baseurl . 'tests/overview?arch=&machine=&modules=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001';
+  = $baseurl
+  . 'tests/overview?arch=&flavor=&machine=&modules=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001';
 $driver->get($url_with_escaped_parameters);
 $driver->find_element('#filter-panel .card-header')->click();
 $driver->find_element('#filter-form button')->click();
@@ -200,6 +201,25 @@ subtest 'filtering by architecture' => sub {
         element_visible('#flavor_DVD_arch_i586', qr/i586/);
         element_not_present('#flavor_DVD_arch_x86_64');
         element_visible('#flavor_GNOME-Live_arch_i686', qr/i686/);
+        element_not_present('#flavor_NET_arch_x86_64');
+    };
+};
+
+subtest 'filtering by flavor' => sub {
+    $driver->get('/tests/overview?distri=opensuse&version=13.1&build=0091');
+
+    subtest 'by default, all flavors present' => sub {
+        check_build_0091_defaults;
+    };
+
+    subtest 'filter for specific flavors' => sub {
+        $driver->find_element('#filter-panel .card-header')->click();
+        $driver->find_element('#filter-flavor')->send_keys('DVD');
+        $driver->find_element('#filter-panel .btn-default')->click();
+
+        element_visible('#flavor_DVD_arch_i586',   qr/i586/);
+        element_visible('#flavor_DVD_arch_x86_64', qr/x86_64/);
+        element_not_present('#flavor_GNOME-Live_arch_i686');
         element_not_present('#flavor_NET_arch_x86_64');
     };
 };

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -97,7 +97,7 @@
                         <label><input value="<%= $state %>" name="state" type="checkbox" id="filter-<%= $state %>"> <%= ucfirst $state =~ s/_/ /r %></label>
                     % }
                 </div>
-                <div class="row" id="filter-modules">
+                <div class="row" id="filter-arch-flavor">
                     <div class="col-5">
                         <div class="form-group">
                             <strong>Architecture</strong>
@@ -111,9 +111,19 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-group">
-                    <strong>Machines</strong>
-                    <input type="text" class="form-control" name="machine" placeholder="any" id="filter-machine">
+                <div class="row" id="filter-machine-test">
+                    <div class="col-5">
+                        <div class="form-group">
+                            <strong>Machines</strong>
+                            <input type="text" class="form-control" name="machine" placeholder="any" id="filter-machine">
+                        </div>
+                    </div>
+                    <div class="col-5">
+                        <div class="form-group">
+                            <strong>Test</strong>
+                            <input type="text" class="form-control" name="test" placeholder="any" id="filter-test">
+                        </div>
+                    </div>
                 </div>
                 <div class="row" id="filter-modules">
                     <div class="col-8">

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -97,9 +97,19 @@
                         <label><input value="<%= $state %>" name="state" type="checkbox" id="filter-<%= $state %>"> <%= ucfirst $state =~ s/_/ /r %></label>
                     % }
                 </div>
-                <div class="form-group">
-                    <strong>Architecture</strong>
-                    <input type="text" class="form-control" name="arch" placeholder="any" id="filter-arch">
+                <div class="row" id="filter-modules">
+                    <div class="col-5">
+                        <div class="form-group">
+                            <strong>Architecture</strong>
+                            <input type="text" class="form-control" name="arch" placeholder="any" id="filter-arch">
+                        </div>
+                    </div>
+                    <div class="col-5">
+                        <div class="form-group">
+                            <strong>Flavor</strong>
+                            <input type="text" class="form-control" name="flavor" placeholder="any" id="filter-flavor">
+                        </div>
+                    </div>
                 </div>
                 <div class="form-group">
                     <strong>Machines</strong>


### PR DESCRIPTION
Just flavor and test for now, since i'm not sure how to best fit job groups into the form without making it look like a total mess.

<img width="1386" alt="form" src="https://user-images.githubusercontent.com/30094/124297220-24bff980-db5b-11eb-9254-6ad1ff2d7ba6.png">

This should also not be merged before #4003, since the form can create empty flavor values.

Progress: https://progress.opensuse.org/issues/91647