### PR TITLE
Fix skip_all in 27-plugin_obs_rsync_status_details.t

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -63,7 +63,7 @@ sub turn_down_stack {
     stop_service($_) for ($worker, $ws, $livehandler, $scheduler);
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless check_driver_modules;
+driver_missing unless check_driver_modules;
 
 # setup directories
 my $tempdir   = setup_fullstack_temp_dir('full-stack.d');

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -70,7 +70,7 @@ sub turn_down_stack {
 }
 sub stop_worker { stop_service $worker }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless check_driver_modules;
+driver_missing unless check_driver_modules;
 
 # setup directories
 my $tempdir  = setup_fullstack_temp_dir('full-stack.d');

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -7,7 +7,7 @@ use base 'Exporter';
 
 require OpenQA::Test::Database;
 
-our @EXPORT = qw($drivermissing check_driver_modules enable_timeout
+our @EXPORT = qw(driver_missing check_driver_modules enable_timeout
   disable_timeout start_driver
   call_driver kill_driver wait_for_ajax disable_bootstrap_animations
   wait_for_ajax_and_animations
@@ -32,8 +32,7 @@ our $_driver;
 our $webapi;
 our $gru;
 our $mojoport;
-our $startingpid   = 0;
-our $drivermissing = 'Install Selenium::Remote::Driver and Selenium::Chrome to run these tests';
+our $startingpid = 0;
 
 sub _start_app {
     my ($args) = @_;
@@ -397,6 +396,12 @@ sub kill_driver {
 
 sub get_mojoport {
     return $mojoport;
+}
+
+sub driver_missing {
+    diag 'Install Selenium::Remote::Driver and Selenium::Chrome to run these tests';
+    done_testing;
+    exit;
 }
 
 END {

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -139,7 +139,7 @@ sub prepare_database {
 
 prepare_database();
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 $driver->title_is("openQA", "on main page");
 is($driver->get("/results"), 1, "/results gets");

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -27,7 +27,7 @@ OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 04-products.pl')
 use OpenQA::SeleniumTest;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 ok $driver->get('/tests?groupid=0'), 'list jobs without group';
 wait_for_ajax(msg => 'wait for test list without group');

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -26,7 +26,7 @@ use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data(fixtures_glob => '03-users.pl');
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -130,7 +130,7 @@ sub prepare_database {
 
 prepare_database;
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 disable_timeout;
 
 $driver->title_is("openQA", "on main page");

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -98,7 +98,7 @@ shared_hash {};
 my $git_mock = Test::MockModule->new('OpenQA::Git');
 $git_mock->redefine(commit => sub ($self, $args) { shared_hash $args; return undef });
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver({with_gru => 1});
+driver_missing unless my $driver = call_driver({with_gru => 1});
 
 # prepare clean needles directory, create default 'inst-timezone' needle
 my $dir              = prepare_clean_needles_dir;

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -27,7 +27,7 @@ use OpenQA::SeleniumTest;
 my $test_case = OpenQA::Test::Case->new;
 $test_case->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 04-products.pl');
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 $driver->title_is('openQA');
 

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -50,7 +50,7 @@ $assets->find(2)->update(
 
 $job_groups->find(1002)->update({exclusively_kept_asset_size => 4096});
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -75,7 +75,7 @@ sub prepare_database {
 
 prepare_database();
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -28,7 +28,7 @@ use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 # DO NOT MOVE THIS INTO A 'use' FUNCTION CALL! It will cause the tests
 # to crash if the module is unavailable

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -61,7 +61,7 @@ my $offline_timestamp = time2str('%Y-%m-%d %H:%M:%S', time - DEFAULT_WORKER_TIME
 $workers->create({id => $online_worker_id,  host => 'online_test',  instance => 1, t_seen => $online_timestamp});
 $workers->create({id => $offline_worker_id, host => 'offline_test', instance => 1, t_seen => $offline_timestamp});
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 $driver->title_is("openQA", "on main page");
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -42,7 +42,7 @@ $schema->resultset('Bugs')->create(
         refreshed => 1,
     });
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 disable_timeout;
 
 #

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -29,7 +29,7 @@ use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data;
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 # we need to talk to the phantom instance or else we're using wrong database

--- a/t/ui/16-activity-view.t
+++ b/t/ui/16-activity-view.t
@@ -33,7 +33,7 @@ use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 # we need to talk to the phantom instance or else we're using the wrong database

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -71,7 +71,7 @@ sub prepare_database {
 
 prepare_database;
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 sub get_tooltip {
     my ($job_id) = @_;

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -85,7 +85,7 @@ sub prepare_database {
 
 prepare_database;
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 disable_timeout;
 
 sub goto_next_previous_tab {

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -36,7 +36,7 @@ my $schema      = $test_case->init_data(schema_name => $schema_name, fixtures_gl
 $schema->resultset('TestSuites')->find(1017)->settings->find({key => 'START_AFTER_TEST'})
   ->update({value => 'kda,textmode'});
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 my $t = client;
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -73,7 +73,7 @@ sub prepare_database {
 
 prepare_database;
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 my $baseurl = $driver->get_current_url;
 sub current_tab { $driver->find_element('.nav.nav-tabs .active')->get_text }
 

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -28,7 +28,7 @@ $test_case->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl');
 
 use OpenQA::SeleniumTest;
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 $driver->title_is("openQA", "on main page");
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -49,7 +49,7 @@ $schema->resultset('Needles')->create(
         file_present           => 1,
     });
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver({with_gru => 1});
+driver_missing unless my $driver = call_driver({with_gru => 1});
 
 my @needle_files = qw(inst-timezone-text.json inst-timezone-text.png never-matched.json never-matched.png);
 # create dummy files for needles

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -28,7 +28,7 @@ use OpenQA::Client;
 use OpenQA::SeleniumTest;
 
 OpenQA::Test::Case->new->init_data;
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 sub wait_for_data_table {
     wait_for_ajax;

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -30,7 +30,7 @@ my $schema      = $test_case->init_data(schema_name => $schema_name, fixtures_gl
 my $t           = Test::Mojo->new('OpenQA::WebAPI');
 my $users       = $schema->resultset('Users');
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 disable_timeout;
 
 subtest 'tour does not appear for demo user' => sub {

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -66,7 +66,7 @@ sub prepare_database {
 prepare_database;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 # executes JavaScript code taking a note
 sub inject_java_script {

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -91,7 +91,7 @@ sub expected_job_id_regex {
     return qr|tests/$expected_job_id|;
 }
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 
 $driver->title_is('openQA', 'on main page');
 $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -24,7 +24,7 @@ use OpenQA::SeleniumTest;
 use OpenQA::Test::ObsRsync 'setup_obs_rsync_test';
 
 my ($t, $tempdir) = setup_obs_rsync_test(fixtures_glob => '01-jobs.pl 03-users.pl');
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver({with_gru => 0});
+driver_missing unless my $driver = call_driver({with_gru => 0});
 $driver->find_element_by_class('navbar-brand')->click;
 $driver->find_element_by_link_text('Login')->click;
 

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -39,7 +39,7 @@ my $foo_path                       = "foo/foo.txt";
 my $uri_path_from_root_dir         = "/tests/$job_id/settings/$foo_path";
 my $uri_path_from_default_data_dir = "/tests/$job_id/settings/bar/foo.txt";
 
-plan skip_all => $OpenQA::SeleniumTest::drivermissing unless my $driver = call_driver;
+driver_missing unless my $driver = call_driver;
 my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
 
 $t->get_ok($uri_path_from_root_dir)->status_is(200)


### PR DESCRIPTION
Where it is is too late; if you actually hit the condition, you
get this error:

Parse errors: Plan (1..0) must be at the beginning or end of the TAP output
              Bad plan.  You planned 0 tests but ran 3.

This fixes that by moving it up a line.

Signed-off-by: Adam Williamson <awilliam@redhat.com>