### PR TITLE
Add IO::Uncompress::UnXz to dependencies

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -111,6 +111,8 @@ Recommends:     apparmor-utils
 Recommends:     logrotate
 # the plugin is needed if the auth method is set to "oauth2"
 Recommends:     perl(Mojolicious::Plugin::OAuth2)
+# required to decompress .tar.xz compressed disk images/isos
+Recommends:     perl(IO::Uncompress::UnXz)
 # server needs to run an rsync server if worker caching is used
 Recommends:     rsync
 BuildArch:      noarch


### PR DESCRIPTION
The UnXz module is required to decompress .xz files which are commonly created
by the kiwi appliance builder on OBS. If this package is not required, then its
availability on the webui is accidental and can cause hard to debug "download"
errors like reported in https://progress.opensuse.org/issues/94997