### PR TITLE
Fix the multi-job-group overview link to show all results

### DIFF
--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -198,7 +198,7 @@ $t->element_exists('#test_result_overview_link');
 my $tests_overview = $t->tx->res->dom->find("#test_result_overview_link")->first;
 is(
     $tests_overview->attr("href"),
-    "/tests/overview?todo=1&groupid=1001&groupid=1002",
+    "/tests/overview?groupid=1001&groupid=1002",
     "The 'test result overview' anchor href points to /test/overview and includes all the groupids"
 );
 

--- a/templates/webapi/main/parent_group_overview.html.ep
+++ b/templates/webapi/main/parent_group_overview.html.ep
@@ -22,7 +22,7 @@
 </h2>
 
 <p>
-  <a href="<%= url_for('tests_overview')->query(todo => 1, map { (groupid => $_->{id}) } @$children); %>"
+  <a href="<%= url_for('tests_overview')->query(map { (groupid => $_->{id}) } @$children); %>"
     title="Shows the latest test results for all job groups within this parent job group"
     id="test_result_overview_link"
   >


### PR DESCRIPTION
0e0094d72 added a link to a test overview page for multiple job groups
within one parent group. The link by mistake includes the query
parameter "todo=1" which should not be the case to show all test results
as the link description explains.