### PR TITLE
plugins: Rate limit all routes

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -399,6 +399,23 @@ secret = 1234567890ABCDEF
 If you switch authentication method from Fake to any other, review your API keys!
 You may be vulnerable for up to a day until Fake API key expires.
 
+[[rate_limits]]
+=== Rate limits
+
+OpenQA allows routes to be rate limited. Any limit is applied by the number of requests per minute
+and per user. If there's no authenticated user the limit is considered global.
+
+Use the `rate_limits` section in `/etc/openqa/openqa.ini` to configure limits for individual routes:
+
+[source,ini]
+--------------------------------------------------------------------------------
+[rate_limits]
+tests_overview     => 50,
+apiv1_search_query => 5,
+--------------------------------------------------------------------------------
+
+The examples above are also the current defaults for these routes.
+
 == Run the web UI
 
 To start openQA and enable it to run on each boot call

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -57,7 +57,8 @@ sub read_config {
             auto_clone_regex            => '^(cache failure|terminated prematurely): ',
         },
         rate_limits => {
-            search => 5,
+            tests_overview     => 50,
+            apiv1_search_query => 5,
         },
         auth => {
             method => 'OpenID',
@@ -327,7 +328,7 @@ sub load_plugins {
 
     push @{$server->plugins->namespaces}, 'OpenQA::WebAPI::Plugin';
 
-    foreach my $plugin (qw(Helpers MIMETypes CSRF REST HashedParams Gru YAML)) {
+    foreach my $plugin (qw(Helpers MIMETypes CSRF RateLimits REST HashedParams Gru YAML)) {
         $server->plugin($plugin);
     }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -181,12 +181,6 @@ sub query {
     $validation->required('q');
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
 
-    # Allow n queries per minute, per user (if logged in)
-    my $lockname = 'webui_query_rate_limit';
-    if (my $user = $self->current_user) { $lockname .= $user->username }
-    return $self->render(json => {error => 'Rate limit exceeded'}, status => 400)
-      unless $self->app->minion->lock($lockname, 60, {limit => $self->app->config->{'rate_limits'}->{'search'}});
-
     my $cap = $self->app->config->{'global'}->{'search_results_limit'};
     my @results;
     my $keywords = $validation->param('q');

--- a/lib/OpenQA/WebAPI/Plugin/RateLimits.pm
+++ b/lib/OpenQA/WebAPI/Plugin/RateLimits.pm
@@ -1,0 +1,42 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package OpenQA::WebAPI::Plugin::RateLimits;
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
+
+
+use Time::Seconds;
+
+sub register ($self, $app, $conf) {
+    $app->hook(
+        around_action => sub ($next, $c, $action, $last) {
+            return $next->() unless $last;
+            # Allow n queries per minute, per user (if logged in)
+            my $route = $c->current_route;
+            # Only handle named routes with an explicit limit
+            if ($route && (my $limit = $c->app->config->{rate_limits}{$route})) {
+                my $lockname = "webui_${route}_rate_limit";
+                if (my $user = $c->current_user) { $lockname .= $user->username }
+                my $error = "Rate limit exceeded";
+                return $c->respond_to(
+                    json => {json     => {error => $error}, status => 429},
+                    html => {template => 'layouts/rate_limit_error', limit => $limit, status => 429},
+                ) unless $c->app->minion->lock($lockname, ONE_MINUTE, {limit => $limit});
+            }
+            return $next->();
+        });
+}
+
+1;

--- a/t/config.t
+++ b/t/config.t
@@ -61,7 +61,8 @@ subtest 'Test configuration default modes' => sub {
             worker_timeout              => DEFAULT_WORKER_TIMEOUT,
         },
         rate_limits => {
-            search => 5,
+            tests_overview     => 50,
+            ap1v1_search_query => 5,
         },
         auth => {
             method => 'Fake',

--- a/templates/webapi/layouts/rate_limit_error.html.ep
+++ b/templates/webapi/layouts/rate_limit_error.html.ep
@@ -1,0 +1,8 @@
+% layout 'bootstrap';
+
+<h2>Rate limit exceeded</h2>
+<div id="summary" class="card">
+  The rate limit of <%= $limit %> requests per minute was exceeded for this API route. If you're logged in
+  the limit counts against your account, otherwise it's counted globally for everyone. Please reach out
+  to the maintainers of this openQA instance if you feel it's too low.
+</div>


### PR DESCRIPTION
This is a plugin that adds configurable rate limits to all routes.

- This is an alternative to #3990 which doesn't require manual configuration in all routes but rather works for all routes by default  ~~The configuration key `any` is used when nothing more specific was specified~~
- `search` is replaced by `apiv1_search_query` since now the route name is used for the key, and since this is experimental I assume we don't need compatibility code or migration - the default for this route is unchanged.
- Existing search tests are adapted accordingly.
- New tests for the overview route also check the rate limit