### PR TITLE
t: Bump timeout for deploy.t after recent slowdown

### DIFF
--- a/t/deploy.t
+++ b/t/deploy.t
@@ -26,7 +26,7 @@ use Mojo::File 'tempdir';
 use DBIx::Class::DeploymentHandler;
 use SQL::Translator;
 use OpenQA::Schema;
-use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
 use Mojo::File 'path';
 use List::Util 'min';


### PR DESCRIPTION
As observed in
https://app.circleci.com/pipelines/github/os-autoinst/openQA/6946/workflows/e5885c62-0f96-4fa2-bdd3-608f53a0caf0/jobs/65509

Just executing the test once locally already failed it for me.
Increasing the timeout to 20s I could verify stability with

```
make test RETRY=20 STABILITY_TEST=1 KEEP_DB=1 TESTS=t/deploy.t
```