### PR TITLE
t: Bump timeout for ui/26-jobs_restart.t

### DIFF
--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -17,7 +17,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
-use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::TimeLimit '40';
 use Mojo::IOLoop;
 use OpenQA::Test::Utils 'collect_coverage_of_gru_jobs';
 use OpenQA::Test::ObsRsync 'setup_obs_rsync_test';

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -28,7 +28,7 @@ use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use Test::MockModule;
-use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::WebSockets::Client;
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -19,7 +19,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::TimeLimit '30';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 use OpenQA::JobDependencies::Constants;

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -17,7 +17,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
-use OpenQA::Test::TimeLimit '12';
+use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Utils qw(collect_coverage_of_gru_jobs wait_for_or_bail_out);
 use OpenQA::Test::ObsRsync 'setup_obs_rsync_test';
 


### PR DESCRIPTION
Since recently same like other test files also t/ui/26-jobs_restart.t runs into
timeouts both in CI as well as locally.

Before changes locally `count_fail_ratio prove -l t/ui/26-jobs_restart.t`
using
https://github.com/okurz/scripts/tree/master/count_fail_ratio

```
t/ui/26-jobs_restart.t .. 4/? Bailout called.  Further testing stopped:  findElement: Server returned error message Label not found for "last T2_SUBTEST_WRAPPER" at /usr/lib/perl5/vendor_perl/5.26.1/Test2/Hub/Subtest.pm line 67. at /home/okurz/local/os-autoinst/openQA/t/ui/../lib/OpenQA/SeleniumTest.pm:95
FAILED--Further testing stopped: findElement: Server returned error message Label not found for "last T2_SUBTEST_WRAPPER" at /usr/lib/perl5/vendor_perl/5.26.1/Test2/Hub/Subtest.pm line 67. at /home/okurz/local/os-autoinst/openQA/t/ui/../lib/OpenQA/SeleniumTest.pm:95
…
```

Bumping timeout from 10s to 20s:

```
…
t/ui/26-jobs_restart.t .. ok
All tests successful.
Files=1, Tests=10, 17 wallclock secs ( 0.12 usr  0.01 sys +  6.61 cusr  0.57 csys =  7.31 CPU)
Result: PASS
```

Crosscheck on an older commit state of openQA, 80f3d69ae from 2021-06-11
reproduces the timeout problems so our codebase did not recently introduce such
problems. Reproduced again on 627798bec from 2021-03-05 the last time when I
was working on the same test file myself:

```
```

so it's slower on CI and on other people's computers as well as mine (Leap
15.2, not quite up-to-date right now). So most likely hypothesis (not entirely
serious) is that the climate change caused this.

Related progress issue: https://progress.opensuse.org/issues/95024