### PR TITLE
Fix use of `isnt` in `t/lib/OpenQA/Test/Utils.pm`

### DIFF
--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -623,7 +623,7 @@ sub test_cmd {
     $exit_code_msg //= 'command exits successfully';
     my $ret;
     combined_like { $ret = run_cmd($cmd, $args) } $expected, $test_msg;
-    $exit_code eq 'non-zero' ? (isn't $ret, 0, $exit_code_msg) : (is $ret, $exit_code, $exit_code_msg);
+    $exit_code eq 'non-zero' ? (isnt $ret, 0, $exit_code_msg) : (is $ret, $exit_code, $exit_code_msg);
     return $ret;
 }
 


### PR DESCRIPTION
I broke this in 71bef7e because it is one of the false-positive changes
done by codespell.