### PR TITLE
openqa-bootstrap: Ensure to enforce expected error handling

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -1,7 +1,7 @@
-#!/bin/sh -e
+#!/bin/bash -e
 [ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Setup a working openQA installation, automating the steps mentioned in the 'custom installation' documentation section. Supports to immediately clone an existing job simply by supplying 'openqa-clone-job' parameters directly for a quickstart" && exit
 
-set -x
+set -xeuo pipefail
 
 dbname="${dbname:="openqa"}"
 dbuser="${dbuser:="geekotest"}"

--- a/script/openqa-bootstrap-container
+++ b/script/openqa-bootstrap-container
@@ -6,6 +6,7 @@ if [ "$(id -ru)" != "0" ]; then
     exit 1
 fi
 
+set -euo pipefail
 # Enable -x only here to show above error message cleanly
 set -x
 


### PR DESCRIPTION
Verified manually locally with

```
podman run --rm -it -v .:/opt/openqa registry.opensuse.org/opensuse/leap:15.3 sh -c 'zypper -n in curl && /opt/openqa/script/openqa-bootstrap'
```

aborting after some time as expected with

```
+ systemctl enable --now postgresql
Created symlink /etc/systemd/system/multi-user.target.wants/postgresql.service → /usr/lib/systemd/system/postgresql.service.
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
```

Related progress issue: https://progress.opensuse.org/issues/95185