### PR TITLE
Revert "Reenable sysusers"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,6 @@ install-generic:
 
 	cp -Ra dbicdh "$(DESTDIR)"/usr/share/openqa/dbicdh
 
-	install -d -m 755 "$(DESTDIR)"/usr/lib/sysusers.d/
-	install    -m 644 usr/lib/sysusers.d/openQA-worker.conf "$(DESTDIR)"/usr/lib/sysusers.d/
-	install    -m 644 usr/lib/sysusers.d/geekotest.conf "$(DESTDIR)"/usr/lib/sysusers.d/
-
 # Additional services which have a strong dependency on SUSE/openSUSE and do not
 # make sense for other distributions
 .PHONY: install-opensuse

--- a/dist/rpm/openQA-test.spec
+++ b/dist/rpm/openQA-test.spec
@@ -6,10 +6,6 @@ Summary:        Test package for openQA
 License:        GPL-2.0-or-later
 BuildRequires:  %{short_name} == %{version}
 BuildRequires:  openQA-local-db
-%if 0%{?suse_version} > 1500
-BuildRequires:  user(geekotest)
-BuildRequires:  group(geekotest)
-%endif
 ExcludeArch:    i586
 
 %description
@@ -24,8 +20,6 @@ touch %{_sourcedir}/%{short_name}
 # call one of the components but not openqa itself which would need a valid
 # configuration
 /usr/share/openqa/script/initdb --help
-getent passwd geekotest
-getent group geekotest
 
 %install
 # disable debug packages in package test to prevent error about missing files

--- a/dist/rpm/openQA-worker-test.spec
+++ b/dist/rpm/openQA-worker-test.spec
@@ -5,10 +5,6 @@ Release:        0
 Summary:        Test package for %{short_name}
 License:        GPL-2.0-or-later
 BuildRequires:  %{short_name} == %{version}
-%if 0%{?suse_version} > 1500
-BuildRequires:  group(_openqa-worker)
-BuildRequires:  user(_openqa-worker)
-%endif
 ExcludeArch:    i586
 
 %description
@@ -21,8 +17,6 @@ touch %{_sourcedir}/%{short_name}
 
 %build
 /usr/share/openqa/script/worker --help
-getent passwd _openqa-worker
-getent group _openqa-worker
 
 %install
 # disable debug packages in package test to prevent error about missing files

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -122,8 +122,6 @@ BuildRequires:  %{test_requires}
 %if 0%{?suse_version} >= 1330
 Requires(pre):  group(nogroup)
 %endif
-BuildRequires:  sysuser-tools
-%sysusers_requires
 
 %description
 openQA is a testing framework that allows you to test GUI applications on one
@@ -266,8 +264,6 @@ sed -e 's,/bin/env python,/bin/python,' -i script/openqa-label-all
 
 %build
 %make_build
-%sysusers_generate_pre usr/lib/sysusers.d/%{name}-worker.conf %{name}-worker %{name}-worker.conf
-%sysusers_generate_pre usr/lib/sysusers.d/geekotest.conf %{name} geekotest.conf
 
 %check
 #for double checking
@@ -349,7 +345,11 @@ mkdir %{buildroot}%{_localstatedir}/lib/openqa/webui/cache
 #
 %fdupes %{buildroot}/%{_prefix}
 
-%pre -f %{name}.pre
+%pre
+if ! getent passwd geekotest > /dev/null; then
+    %{_sbindir}/useradd -r -g nogroup -c "openQA user" \
+        -d %{_localstatedir}/lib/openqa geekotest 2>/dev/null || :
+fi
 
 %service_add_pre %{openqa_services}
 
@@ -367,7 +367,13 @@ if [ "$1" = 1 ]; then
   fi
 fi
 
-%pre worker -f openQA-worker.pre
+%pre worker
+if ! getent passwd _openqa-worker > /dev/null; then
+  %{_sbindir}/useradd -r -g nogroup -c "openQA worker" \
+    -d %{_localstatedir}/lib/empty _openqa-worker 2>/dev/null || :
+  # might fail for non-kvm workers (qemu package owns the group)
+  %{_sbindir}/usermod _openqa-worker -a -G kvm || :
+fi
 
 %service_add_pre %{openqa_worker_services}
 
@@ -537,7 +543,6 @@ fi
 %dir %{_localstatedir}/lib/openqa/share/factory/repo
 %dir %{_localstatedir}/lib/openqa/share/factory/other
 %ghost %{_localstatedir}/log/openqa
-%{_sysusersdir}/geekotest.conf
 
 %files devel
 
@@ -602,7 +607,6 @@ fi
 %dir %{_localstatedir}/lib/openqa/cache
 # own one pool - to create the others is task of the admin
 %dir %{_localstatedir}/lib/openqa/pool/1
-%{_sysusersdir}/%{name}-worker.conf
 
 %files client
 %dir %{_datadir}/openqa

--- a/usr/lib/sysusers.d/geekotest.conf
+++ b/usr/lib/sysusers.d/geekotest.conf
@@ -1,3 +1,0 @@
-# Type Name       ID     GECOS           [HOME]    Shell
-u   geekotest   -     "openQA user" /dev/null
-m   geekotest  nogroup

--- a/usr/lib/sysusers.d/openQA-worker.conf
+++ b/usr/lib/sysusers.d/openQA-worker.conf
@@ -1,4 +1,0 @@
-# Type Name            ID     GECOS           [HOME]    Shell
-u   _openqa-worker   -     "openQA worker" /dev/null
-m   _openqa-worker  nogroup
-m   _openqa-worker  kvm


### PR DESCRIPTION
Reverts os-autoinst/openQA#3987

@dcermak https://build.opensuse.org/package/live_build_log/devel:openQA/openQA/SLE_15_SP3/aarch64 looks like caused by this. I will prepare this revert in case you don't have time to fix that soon