### PR TITLE
Fix 'This: command not found' errors

### DIFF
--- a/container/webui/run_openqa.sh
+++ b/container/webui/run_openqa.sh
@@ -3,7 +3,7 @@ set -e
 
 function wait_for_db_creation() {
   echo "Waiting for DB creation"
-  while ! $(su geekotest -c 'PGPASSWORD=openqa psql -h db -U openqa --list | grep -qe openqa'); do sleep .1; done
+  while ! su geekotest -c 'PGPASSWORD=openqa psql -h db -U openqa --list | grep -qe openqa'; do sleep .1; done
 }
 
 function scheduler() {


### PR DESCRIPTION
The output of the command should not get executed as another command.

This should fix problems like https://openqa.opensuse.org/tests/1832939#step/multiple_container_webui/3


```
# su geekotest -c 'PGPASSWORD=openqa psql -h db -U openqa --list | grep -qe openqa'
This account is currently not available.
```