### PR TITLE
Distinguish comment types on /tests

### DIFF
--- a/assets/javascripts/job_next_previous.js
+++ b/assets/javascripts/job_next_previous.js
@@ -108,22 +108,8 @@ function renderJobResults(data, type, row) {
     }
 
     // job bugs, comments and label
-    if (row.bugs != []) {
-        for (var bug of row.bugs) {
-            html += '<span id="bug-' + row.id + '">';
-            html += '<a href="' + bug.url + '">';
-            html += '<i class="test-label ' + bug.icon + '" title="' + bug.title + '"></i>';
-            html += '</a></span>';
-        }
-    }
-    if (row.label != null) {
-        html += '<span id="test-label-' + row.id + '">';
-        html += '<i class="test-label label_' + row.label + ' fa fa-bookmark" title="Label: ' + row.label + '"></i>';
-        html += '</span>';
-    } else if (row.comments != null) {
-        html += '<span id="comment-' + row.id + '">';
-        html += row.comment_icon;
-        html += '</span>';
+    if (row.comment_data) {
+        html += renderComments(row);
     }
     return html;
 }

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -486,3 +486,28 @@ function renderActivityView(ajaxUrl, currentUser) {
     };
     request.send();
 }
+
+function renderComments(row) {
+    const bugs = row.comment_data.bugs;
+    var html = '';
+    bugs.forEach(function(bug) {
+        const css_class = bug.css_class;
+        const title = bug.title;
+        const url = bug.url;
+        html += '<span id="bug-' + row.id + '"> ' + '<a href="' + htmlEscape(url) + '">';
+        html += '<i class="test-label ' + htmlEscape(css_class) + '" title="' + htmlEscape(title) + '"></i>';
+        html += '</a></span>';
+    });
+
+    if (row.comment_data.label) {
+        const label = row.comment_data.label;
+        html += '<span id="test-label-' + row.id + '">';
+        html += ' <i class="test-label label_' + htmlEscape(label) + ' fa fa-bookmark" title="Label: ' + htmlEscape(label) + '"></i>';
+        html += '</span>';
+    } else if (row.comment_data.comments) {
+        html += '<span id="comment-' + row.id + '"> ';
+        html += row.comment_data.comment_icon;
+        html += '</span>';
+    }
+    return html;
+}

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -90,9 +90,8 @@ function renderTestName(data, type, row) {
         }
         html += dependencyHtml;
     }
-    if (row.comment_count) {
-        html += ' <a href="/tests/' + row.id + '#comments"><i class="test-label label_comment fa fa-comment" title="' +
-            row.comment_count + (row.comment_count != 1 ? ' comments' : ' comment') + ' available"' + '></i></a>';
+    if (row.comment_data) {
+        html += renderComments(row);
     }
     if (row.clone) {
         html += ' <a href="/tests/' + row.clone + '">(restarted)</a>';

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Controller::Test;
-use Mojo::Base 'Mojolicious::Controller';
+use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
@@ -42,21 +42,6 @@ sub list {
     my ($self) = @_;
 }
 
-sub prefetch_comment_counts {
-    my ($self, $job_ids) = @_;
-
-    my $comments = $self->schema->resultset("Comments")->search(
-        {'me.job_id' => {in => $job_ids}},
-        {
-            select   => ['job_id', {count => 'job_id', -as => 'count'}],
-            group_by => [qw(job_id)]});
-    my $comment_count;
-    while (my $count = $comments->next) {
-        $comment_count->{$count->job_id} = $count->get_column('count');
-    }
-    return $comment_count;
-}
-
 sub get_match_param {
     my ($self) = @_;
 
@@ -68,9 +53,7 @@ sub get_match_param {
     return $match;
 }
 
-sub list_ajax {
-    my ($self) = @_;
-
+sub list_ajax ($self) {
     my $scope = ($self->param('relevant') ne 'false' ? 'relevant' : '');
     my @jobs  = $self->schema->resultset('Jobs')->complex_query(
         state    => [OpenQA::Jobs::Constants::FINAL_STATES],
@@ -90,33 +73,57 @@ sub list_ajax {
         prefetch => [qw(children parents)],
     )->all;
 
-    # need to use all as the order is too complex for a cursor
-    my $comment_count = $self->prefetch_comment_counts([map { $_->id } @jobs]);
+    my $comment_data = $self->schema->resultset('Comments')->comment_data_for_jobs(\@jobs, {bugdetails => 1});
     my @list;
     for my $job (@jobs) {
-        my $job_id = $job->id;
+        my $job_id        = $job->id;
+        my $rendered_data = 0;
+        if (my $cd = $comment_data->{$job_id}) {
+            $rendered_data = $self->_render_comment_data_for_ajax($job_id, $cd);
+        }
         push(
             @list,
             {
-                DT_RowId      => 'job_' . $job_id,
-                id            => $job_id,
-                result_stats  => $job->result_stats,
-                deps          => $job->dependencies,
-                clone         => $job->clone_id,
-                test          => $job->TEST . '@' . ($job->MACHINE // ''),
-                distri        => $job->DISTRI  // '',
-                version       => $job->VERSION // '',
-                flavor        => $job->FLAVOR  // '',
-                arch          => $job->ARCH    // '',
-                build         => $job->BUILD   // '',
-                testtime      => ($job->t_finished // '') . 'Z',
-                result        => $job->result,
-                group         => $job->group_id,
-                comment_count => $comment_count->{$job_id} // 0,
-                state         => $job->state,
+                DT_RowId     => 'job_' . $job_id,
+                id           => $job_id,
+                result_stats => $job->result_stats,
+                deps         => $job->dependencies,
+                clone        => $job->clone_id,
+                test         => $job->TEST . '@' . ($job->MACHINE // ''),
+                distri       => $job->DISTRI  // '',
+                version      => $job->VERSION // '',
+                flavor       => $job->FLAVOR  // '',
+                arch         => $job->ARCH    // '',
+                build        => $job->BUILD   // '',
+                testtime     => ($job->t_finished // '') . 'Z',
+                result       => $job->result,
+                group        => $job->group_id,
+                comment_data => $rendered_data,
+                state        => $job->state,
             });
     }
     $self->render(json => {data => \@list});
+}
+
+sub _render_comment_data_for_ajax ($self, $job_id, $comment_data) {
+    my %data;
+    $data{comments}     = $comment_data->{comments};
+    $data{reviewed}     = $comment_data->{reviewed};
+    $data{label}        = $comment_data->{label};
+    $data{comment_icon} = $self->comment_icon($job_id, $data{comments});
+    my $bugs = $comment_data->{bugs};
+    $data{bugs} = [
+        map {
+            my $bug = $comment_data->{bugdetails}->{$_};
+            +{
+                content   => $_,
+                title     => $self->bugtitle_for($_, $bug),
+                url       => $self->bugurl_for($_),
+                css_class => $self->bugicon_for($_, $bug),
+            };
+        } sort keys %$bugs
+    ];
+    return \%data;
 }
 
 sub list_running_ajax {
@@ -429,71 +436,51 @@ sub _show {
     $self->render('test/result');
 }
 
-sub job_next_previous_ajax {
-    my ($self) = @_;
-
-    my $job     = $self->get_current_job;
-    my $jobid   = $job->id;
-    my $p_limit = $self->param('previous_limit') // 400;
-    my $n_limit = $self->param('next_limit')     // 100;
+sub job_next_previous_ajax ($self) {
+    my $main_job   = $self->get_current_job;
+    my $main_jobid = $main_job->id;
+    my $p_limit    = $self->param('previous_limit') // 400;
+    my $n_limit    = $self->param('next_limit')     // 100;
 
     my $schema  = $self->schema;
     my $jobs_rs = $schema->resultset('Jobs')->next_previous_jobs_query(
-        $job, $jobid,
+        $main_job, $main_jobid,
         previous_limit => $p_limit,
         next_limit     => $n_limit,
     );
-    my (@jobs, @data);
-    my $latest = 1;
-    while (my $each = $jobs_rs->next) {
-        $latest = $each->id > $latest ? $each->id : $latest;
-        push @jobs, $each;
+    my @jobs         = $jobs_rs->all;
+    my $comment_data = $self->schema->resultset('Comments')->comment_data_for_jobs(\@jobs, {bugdetails => 1});
+    my $latest       = 1;
+    my @data;
+    for my $job (@jobs) {
+        my $job_id = $job->id;
+        $latest = $job_id > $latest ? $job_id : $latest;
+        my $rendered_data = 0;
+        if (my $cd = $comment_data->{$job_id}) {
+            $rendered_data = $self->_render_comment_data_for_ajax($job_id, $cd);
+        }
         push(
             @data,
             {
-                DT_RowId      => 'job_result_' . $each->id,
-                id            => $each->id,
-                name          => $each->name,
-                distri        => $each->DISTRI,
-                version       => $each->VERSION,
-                build         => $each->BUILD,
-                deps          => $each->dependencies,
-                result        => $each->result,
-                result_stats  => $each->result_stats,
-                state         => $each->state,
-                clone         => $each->clone_id,
-                failedmodules => $each->failed_modules(),
-                iscurrent     => $each->id == $jobid  ? 1                                   : undef,
-                islatest      => $each->id == $latest ? 1                                   : undef,
-                finished      => $each->t_finished    ? $each->t_finished->datetime() . 'Z' : undef,
-                duration      => $each->t_started
-                  && $each->t_finished ? $self->format_time_duration($each->t_finished - $each->t_started) : 0,
+                DT_RowId      => 'job_result_' . $job_id,
+                id            => $job_id,
+                name          => $job->name,
+                distri        => $job->DISTRI,
+                version       => $job->VERSION,
+                build         => $job->BUILD,
+                deps          => $job->dependencies,
+                result        => $job->result,
+                result_stats  => $job->result_stats,
+                state         => $job->state,
+                clone         => $job->clone_id,
+                failedmodules => $job->failed_modules(),
+                iscurrent     => $job_id == $main_jobid ? 1                                  : undef,
+                islatest      => $job_id == $latest     ? 1                                  : undef,
+                finished      => $job->t_finished       ? $job->t_finished->datetime() . 'Z' : undef,
+                duration      => $job->t_started
+                  && $job->t_finished ? $self->format_time_duration($job->t_finished - $job->t_started) : 0,
+                comment_data => $rendered_data,
             });
-    }
-    my $comment_data = $schema->resultset('Comments')->comment_data_for_jobs(\@jobs, {bugdetails => 1});
-    for my $data (@data) {
-        my $id           = $data->{id};
-        my $comment_info = $comment_data->{$id};
-        my $bugs         = $comment_info->{bugs};
-        my $bugdetails   = $comment_info->{bugdetails};
-
-        my @bugs;
-        for my $bug (sort { $b cmp $a } keys %$bugs) {
-            push @bugs,
-              {
-                bug   => $bug,
-                url   => $self->bugurl_for($bug),
-                icon  => $self->bugicon_for($bug, $bugdetails->{$bug}),
-                title => xml_escape($self->bugtitle_for($bug, $bugdetails->{$bug})),
-              };
-        }
-
-        $data->{bugs}  = \@bugs;
-        $data->{label} = $comment_info->{label};
-        if (my $comments = $comment_info->{comments}) {
-            $data->{comments}     = $comments;
-            $data->{comment_icon} = $self->comment_icon($id, $comments);
-        }
     }
     $self->render(json => {data => \@data});
 }


### PR DESCRIPTION
For finished tests (/tests/list_ajax):
Like in /tests/overview and next & previous, figure out the type of comment
(bug, closed/open, label) and display them including links.

Issue: https://progress.opensuse.org/issues/94937

Second try, ec7cae0b5614794724a9825b888c82958f1558d0 had to be reverted.

The problem was that some bugrefs don't have an entry in the Bugs table.
I removed `$bug->id` (not needed) and `$bug->closed` (this is handled already in the `bugicon_for` function).