### PR TITLE
Improve error handling when streaming images for live view

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -221,7 +221,7 @@ sub streaming {
         });
 
     # ask worker to create live stream
-    log_debug('Asking the worker to start providing livestream');
+    log_debug("Asking the worker $worker_id to start providing livestream for job $job_id");
 
     my $client = OpenQA::WebSockets::Client->singleton;
     $self->tx->once(
@@ -236,12 +236,12 @@ sub streaming {
             return undef unless defined $worker->job_id && $worker->job_id == $job_id;
 
             # ask worker to stop live stream
-            log_debug("Asking worker $worker_id to stop providing livestream");
+            log_debug("Asking worker $worker_id to stop providing livestream for job $job_id");
             try {
                 $client->send_msg($worker_id, WORKER_COMMAND_LIVELOG_STOP, $job_id);
             }
             catch {
-                log_error("Unable to ask worker to stop providing livestream: $_");
+                log_error("Unable to ask worker $worker_id to stop providing livestream for $job_id: $_");
             };
         },
     );
@@ -249,7 +249,7 @@ sub streaming {
         $client->send_msg($worker_id, WORKER_COMMAND_LIVELOG_START, $job_id);
     }
     catch {
-        my $error = "Unable to ask worker $worker_id to start providing livestream: $_";
+        my $error = "Unable to ask worker $worker_id to start providing livestream for $job_id: $_";
         $self->render(json => {error => $error}, status => 500);
         $close_connection->();
         log_error($error);

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -269,8 +269,7 @@ sub streaming {
     }
     catch {
         my $error = "Unable to ask worker $worker_id to start providing livestream for $job_id: $_";
-        $self->render(json => {error => $error}, status => 500);
-        $close_connection->();
+        $self->write("data: $error\n\n", $close_connection);
         log_error($error);
     };
 }

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright (C) 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,6 +26,9 @@ use OpenQA::WebSockets::Client;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use Try::Tiny;
+
+use constant IMAGE_STREAMING_INTERVAL => $ENV{OPENQA_IMAGE_STREAMING_INTERVAL} // 0.3;
+use constant TEXT_STREAMING_INTERVAL  => $ENV{OPENQA_TEXT_STREAMING_INTERVAL}  // 1.0;
 
 sub init {
     my ($self, $page_name) = @_;
@@ -134,7 +137,7 @@ sub streamtext {
         close $log;
     };
     $timer_id = Mojo::IOLoop->recurring(
-        1 => sub {
+        TEXT_STREAMING_INTERVAL() => sub {
             if (!$ino) {
                 # log file was not yet opened
                 return unless open($log, '<', $logfile);
@@ -210,7 +213,7 @@ sub streaming {
     my $backend_run_file = "$basepath/backend.run";
     my $lastfile         = '';
     $timer_id = Mojo::IOLoop->recurring(
-        0.3 => sub {
+        IMAGE_STREAMING_INTERVAL() => sub {
             my $newfile = readlink($last_png) || '';
             return if $lastfile eq $newfile;
 


### PR DESCRIPTION
* Handle exceptions when reading the image to close the connection in that
  case and return the error to the client
* Avoid spamming the log with the exception
* See https://progress.opensuse.org/issues/95290

---

So far I only tested this with a live test and producing errors manually (e.g. by setting a wrong image path after 5 updates).