### PR TITLE
Show logs when docker compose up fails in the test_containers_compose

### DIFF
--- a/tools/test_containers_compose
+++ b/tools/test_containers_compose
@@ -20,7 +20,13 @@ wait_until() {
 
 setup_containers() {
   for retry in {2..0}; do sudo docker-compose build && break; echo "Remaining retries $retry"; done
-  sudo MOJO_CLIENT_DEBUG=1 docker-compose up -d
+  exit_code=""
+  sudo MOJO_CLIENT_DEBUG=1 docker-compose up -d || exit_code=$?
+  if [[ -n $exit_code ]]; then
+    echo "docker-compose exited with non-zero code $exit_code, showing logs:"
+    docker-compose logs
+    exit "$exit_code"
+  fi
   (docker-compose ps --services --filter status=stopped | grep "^[[:space:]]*$") || (docker-compose logs; sudo docker-compose ps; exit 1)
 }
 


### PR DESCRIPTION
When docker-compose up fails we don't have information to investigate.
This PR show the logs when something wrong happens.

To test the failure case and see the logs. Introduce an "exit 1" as the first line in the script containers/webui/run_openqa.sh. The logs will be showed on the terminal as:

```
Creating webui_db_1 ... done
Creating webui_webui_db_init_1 ... done

ERROR: for webui  Container "XXXXXXXXXXXX" is unhealthy.
ERROR: Encountered errors while bringing up the project.
docker-compose exited with non-zero code 1, showing logs:
Attaching to webui_webui_db_init_1, webui_db_1
....
```

https://progress.opensuse.org/issues/95374