### PR TITLE
Containers: Fix use of su by providing shell for geekotest

### DIFF
--- a/container/webui/run_openqa.sh
+++ b/container/webui/run_openqa.sh
@@ -39,6 +39,8 @@ function all_together_apache() {
   su geekotest -c /usr/share/openqa/script/openqa-webui-daemon
 }
 
+usermod --shell /bin/sh geekotest
+
 # run services
 case "$MODE" in
   scheduler ) scheduler;;


### PR DESCRIPTION
With this commit we ensure that the geekotest can execute commands,
and therefore we could use su to execute commands with this user.

During the investigation of the issue https://progress.opensuse.org/issues/95374
The execution of all the comands in run_openqa.sh script that were executed by
geekotest user (using su), exited with the error "This account is currently not available."

The reason for that is because that the user geekotest exists but doesn't have a default
shell assigned.

`webui_db_init_1 | geekotest:x:479:479:openQA user:/dev/null:/sbin/nologin`

https://progress.opensuse.org/issues/95374