### PR TITLE
Avoid getting stuck syncing tests by adding timeout to `rsync` call

### DIFF
--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +17,9 @@ package OpenQA::CacheService::Task::Sync;
 use Mojo::Base 'Mojolicious::Plugin';
 
 use Mojo::URL;
+use Time::Seconds;
+
+use constant RSYNC_TIMEOUT => $ENV{OPENQA_RSYNC_TIMEOUT} // (30 * ONE_MINUTE);
 
 sub register {
     my ($self, $app) = @_;
@@ -45,7 +48,7 @@ sub _cache_tests {
     my $ctx = $app->log->context("[#$job_id]");
     $ctx->info(qq{Sync: "$from" to "$to"});
 
-    my @cmd = (qw(rsync -avHP), "$from/", qw(--delete), "$to/tests/");
+    my @cmd = (qw(rsync -avHP --timeout), RSYNC_TIMEOUT, "$from/", qw(--delete), "$to/tests/");
     my $cmd = join ' ', @cmd;
     $ctx->info("Calling: $cmd");
     my $output = `@cmd`;

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -117,7 +117,8 @@ sub test_sync {
     is $status->result, 'exit code 0', "exit code ok, run $run";
     ok $status->output, "output ok, run $run";
 
-    like $status->output, qr/100\%/, "output correct, run $run" or die diag $status->output;
+    like $status->output, qr/Calling: rsync .* --timeout 1800 .*100\%/s, "output correct, run $run"
+      or die diag $status->output;
 
     ok -e $expected, "expected file exists, run $run";
     is $expected->slurp, $data, "synced data identical, run $run";


### PR DESCRIPTION
See https://progress.opensuse.org/issues/95299