### PR TITLE
Improve error message (report filename instead of test name)

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -110,7 +110,7 @@ sub results {
     my $initial_file_size = -s $file_name;
     my $json_data         = eval { path($file_name)->slurp };
     if (my $error = $@) {
-        log_debug("Unable to read $name: $error");
+        log_debug("Unable to read $file_name: $error");
         return {};
     }
     my $json = eval { decode_json($json_data) } // {};


### PR DESCRIPTION
I guess in case the `details-$name.json` file cannot be read, it makes sense
to report the full filename and not just the test name.

Found this while looking through the code.