### PR TITLE
cache service: Avoid logging back-traces when scanning

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@
 requires 'Archive::Extract', '> 0.7';
 requires 'BSD::Resource';
 requires 'CSS::Minifier::XS', '>= 0.01';
+requires 'Capture::Tiny';
 requires 'Carp';
 requires 'Carp::Always';
 requires 'CommonMark';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -157,6 +157,7 @@ worker_requires:
   openQA-client:
   optipng:
   sqlite3: '>= 3.24.0'   # for INSERT INTO … ON CONFLICT … DO UPDATE SET … required by cache service
+  perl(Capture::Tiny):
   perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.26'
   perl(Minion::Backend::SQLite): '>= 5.0.1'
   perl(Mojo::SQLite):

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -56,7 +56,7 @@
 # The following line is generated from dependencies.yaml
 %define client_requires curl git-core jq perl(Getopt::Long::Descriptive) perl(IO::Socket::SSL) >= 2.009 perl(IPC::Run) perl(JSON::Validator) perl(LWP::Protocol::https) perl(LWP::UserAgent) perl(Test::More) perl(YAML::PP) >= 0.020 perl(YAML::XS)
 # The following line is generated from dependencies.yaml
-%define worker_requires openQA-client optipng os-autoinst < 5 perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
+%define worker_requires openQA-client optipng os-autoinst < 5 perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.1 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
 %define build_requires %assetpack_requires rubygem(sass)
 


### PR DESCRIPTION
Turns log messages like

```
Can't opendir(/var/lib/openqa/cache/bar): Permission denied
 at  … line …
Can't opendir(/var/lib/openqa/cache/lost+found): Permission denied
 at  … line …
```

into

```
Unable to fully sync cache directory:
Can't opendir(/var/lib/openqa/cache/bar): Permission denied
```

So the context `Unable to …` is added and `at … line …` omitted instead.
The message for `lost+found` is removed completely.

See https://progress.opensuse.org/issues/95299#note-6