### PR TITLE
search: Search Python filenames and contents

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -79,17 +79,17 @@ sub _search_perl_modules {
         # Skip files residing in the test root
         next unless -d $distri;
 
-        # Perl module filenames
+        # Test module filenames
         for my $filename (
-            $distri->list_tree()->head($cap)->map('to_rel', $distris)->grep(qr/.*\Q$keywords\E.*\.pm$/)->each)
+            $distri->list_tree()->head($cap)->map('to_rel', $distris)->grep(qr/.*\Q$keywords\E.*\.p[my]$/)->each)
         {
             push(@results, {occurrence => $filename});
             $cap--;
         }
         last if $cap < 1;
 
-        # Contents of Perl modules
-        my @cmd = ('git', '-C', $distri, 'grep', '--line-number', '--no-index', '-F', $keywords, '--', '*.pm');
+        # Contents of test modules
+        my @cmd = ('git', '-C', $distri, 'grep', '--line-number', '--no-index', '-F', $keywords, '--', '*.p[my]');
         my $stdout;
         my $stderr;
         IPC::Run::run(\@cmd, \undef, \$stdout, \$stderr);

--- a/t/data/openqa/share/tests/opensuse/tests/openQA/search.py
+++ b/t/data/openqa/share/tests/opensuse/tests/openQA/search.py
@@ -1,0 +1,9 @@
+from testapi import *
+
+
+def run(self):
+    assert_screen('openqa-logged-in')
+    assert_and_click('openqa-search')
+    type_string('shutdown.pm')
+    send_key('ret')
+    assert_screen('openqa-search-results')

--- a/templates/webapi/search/search.html.ep
+++ b/templates/webapi/search/search.html.ep
@@ -9,7 +9,7 @@
     <h2 id="results-heading">Search results</h2>
     <p>The search currently finds <b>job templates</b> by name or description,
        <b>job modules</b> by filename,
-       or Perl modules within the test distributions,
+       or test modules within the test distributions,
        either by <b>filename</b> or <b>source code</b>.</p>
     <div id="flash-messages"></div>
     <p id="progress-indication" style="display: none">


### PR DESCRIPTION
The code actually hard-codes *.pm to avoid picking up other files but this should include *.py since test modules can be written in Python.

Related: [poo#91257](https://progress.opensuse.org/issues/91257)