### PR TITLE
[WIP] Grant access (rw) to geekotest user to /data subdirectories

### DIFF
--- a/container/webui/run_openqa.sh
+++ b/container/webui/run_openqa.sh
@@ -40,6 +40,7 @@ function all_together_apache() {
 }
 
 usermod --shell /bin/sh geekotest
+[ -d /data ] && chown -R geekotest /data    
 
 # run services
 case "$MODE" in


### PR DESCRIPTION
We found that eventually the test single_container_webui fails because the webui
cannot create the needed directories in /root/data/factory

The webui runs with the geekotest user. This commit ensure that the geekotest
has permissions to the working directory /data

https://progress.opensuse.org/issues/95179