### PR TITLE
Cover wait_with_progress with basic tests

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -68,7 +68,6 @@ our @EXPORT  = qw(
   human_readable_size
   locate_asset
   detect_current_version
-  wait_with_progress
   parse_tags_from_comments
   path_to_class
   loaded_modules
@@ -652,20 +651,6 @@ sub read_test_modules {
         modules                 => \@modlist,
         has_parser_text_results => $has_parser_text_results,
     };
-}
-
-sub wait_with_progress {
-    my ($interval) = @_;
-    my $tics;
-    local $| = 1;
-
-    do {
-        $tics++;
-        sleep(1);
-        print '.';
-    } while ($interval > $tics);
-
-    print "\n";
 }
 
 # parse comments of the specified (parent) group and store all mentioned builds in $res (hashref)

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -662,7 +662,7 @@ sub wait_with_progress {
     do {
         $tics++;
         sleep(1);
-        print ".";
+        print '.';
     } while ($interval > $tics);
 
     print "\n";

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -1068,7 +1068,6 @@ sub _upload_log_file {
     my $regular_upload_failed = 0;
     my $retry_counter         = 5;
     my $retry_limit           = 5;
-    my $tics                  = 5;
     my $res;
     my $client = $self->client;
     my $url    = $client->url;
@@ -1080,12 +1079,8 @@ sub _upload_log_file {
         my $tx = $ua->build_tx(POST => $ua_url => form => $upload_parameter);
 
         if ($regular_upload_failed) {
-            log_warning(
-                sprintf(
-                    'Upload attempts remaining: %s/%s for %s, in %s seconds',
-                    $retry_counter--, $retry_limit, $filename, $tics
-                ));
-            OpenQA::Utils::wait_with_progress($tics);
+            log_warning(sprintf('Upload attempts remaining: %s/%s for %s', $retry_counter--, $retry_limit, $filename));
+            sleep 1;
         }
 
         $res = $ua->start($tx);

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -1080,7 +1080,7 @@ sub _upload_log_file {
 
         if ($regular_upload_failed) {
             log_warning(sprintf('Upload attempts remaining: %s/%s for %s', $retry_counter--, $retry_limit, $filename));
-            sleep 1;
+            sleep UPLOAD_DELAY;
         }
 
         $res = $ua->start($tx);

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -18,9 +18,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
-use Capture::Tiny qw(capture_stdout);
-use OpenQA::Utils
-  qw(:DEFAULT prjdir sharedir resultdir assetdir imagesdir base_host random_string random_hex wait_with_progress);
+use OpenQA::Utils qw(:DEFAULT prjdir sharedir resultdir assetdir imagesdir base_host random_string random_hex);
 use OpenQA::Test::Utils 'redirect_output';
 use OpenQA::Test::TimeLimit '10';
 use Scalar::Util 'reftype';
@@ -73,13 +71,6 @@ subtest 'random number generator' => sub {
     like($r, qr/^[0-9A-F]+$/a, "random_hex only consists of hex characters");
     is(length($r), length($r2), "same length");
     isnt($r, $r2, "random_hex produces different results");
-};
-
-subtest 'wait_with_progress' => sub {
-    my ($stdout, @result) = capture_stdout sub { wait_with_progress(1) };
-    is $stdout, ".\n", 'right output';
-    ($stdout, @result) = capture_stdout sub { wait_with_progress(2) };
-    is $stdout, "..\n", 'right output';
 };
 
 is bugurl('bsc#1234'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bug url is properly expanded';

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -18,7 +18,9 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
-use OpenQA::Utils qw(:DEFAULT prjdir sharedir resultdir assetdir imagesdir base_host random_string random_hex);
+use Capture::Tiny qw(capture_stdout);
+use OpenQA::Utils
+  qw(:DEFAULT prjdir sharedir resultdir assetdir imagesdir base_host random_string random_hex wait_with_progress);
 use OpenQA::Test::Utils 'redirect_output';
 use OpenQA::Test::TimeLimit '10';
 use Scalar::Util 'reftype';
@@ -71,6 +73,13 @@ subtest 'random number generator' => sub {
     like($r, qr/^[0-9A-F]+$/a, "random_hex only consists of hex characters");
     is(length($r), length($r2), "same length");
     isnt($r, $r2, "random_hex produces different results");
+};
+
+subtest 'wait_with_progress' => sub {
+    my ($stdout, @result) = capture_stdout sub { wait_with_progress(1) };
+    is $stdout, ".\n", 'right output';
+    ($stdout, @result) = capture_stdout sub { wait_with_progress(2) };
+    is $stdout, "..\n", 'right output';
 };
 
 is bugurl('bsc#1234'), 'https://bugzilla.suse.com/show_bug.cgi?id=1234', 'bug url is properly expanded';

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+use Test::Most;
+
 BEGIN {
     $ENV{OPENQA_UPLOAD_DELAY} = 0;
 }
-
-use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1369,8 +1369,6 @@ subtest 'asset upload' => sub {
 };
 
 subtest 'log file upload' => sub {
-    my $utils_mock = Test::MockModule->new('OpenQA::Utils');
-    $utils_mock->noop('wait_with_progress');
     my $ua_mock = Test::MockModule->new('Mojo::UserAgent');
     my ($req, $mock_failure);
     $ua_mock->redefine(


### PR DESCRIPTION
The `wait_with_progress` function in `OpenQA::Utils` is only used in one place. That place got test coverage [a few days ago](https://github.com/os-autoinst/openQA/commit/0858fdf42e4482808819c7b90bb202b9e37198f8), but `wait_with_progress` was mocked for the test. So it has no coverage itself currently.

Progress: https://progress.opensuse.org/issues/95170