### PR TITLE
Remove .jsbeautifyrc, since it is no longer needed

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,3 +1,0 @@
-{
-    "brace_style": "collapse,preserve-inline"
-}


### PR DESCRIPTION
I missed this in #4042 with the switch to ESLint.