### PR TITLE
Avoid perl warning in string concatenation

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -658,7 +658,7 @@ sub _create_clone {
     # not be created, somebody else was faster at cloning)
     my $orig_id       = $self->id;
     my $affected_rows = $rset->search({id => $orig_id, clone_id => undef})->update({clone_id => $new_job->id});
-    die "Job $orig_id has already been cloned as " . $self->clone_id . "\n" unless $affected_rows == 1;
+    die "Job $orig_id has already been cloned as " . $rset->find($orig_id)->clone_id . "\n" unless $affected_rows == 1;
 
     # Needed to load default values from DB
     $new_job->discard_changes;


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/95730

We try to search for a Job with `$self->id` and no `clone_id`, and update
it with the new `clone_id`.
If no rows are affected then it means that `$self` had already set a
`clone_id` in the database, but we didn't reload the values of self, that's why
it is undef and producing a warning.

Instead we search for the Job again now.
