### PR TITLE
format_time_duration: Also display days in test duration

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -34,7 +34,10 @@ sub register ($self, $app, $config) {
         format_time_duration => sub {
             my ($c, $timedate) = @_;
             return unless $timedate;
-            if ($timedate->hours() > 0) {
+            if ($timedate->days() > 0) {
+                sprintf("%d days %02d:%02d hours", $timedate->days(), $timedate->hours(), $timedate->minutes());
+            }
+            elsif ($timedate->hours() > 0) {
                 sprintf("%02d:%02d hours", $timedate->hours(), $timedate->minutes());
             }
             else {

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -17,6 +17,7 @@
 
 use Test::Most;
 
+use DateTime;
 use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
 use Test::Mojo;
@@ -671,6 +672,31 @@ subtest 'archived icon' => sub {
     $jobs->find(99947)->update({archived => 1});
     $t->get_ok('/tests/99947/infopanel_ajax')->status_is(200);
     is $t->tx->res->dom->find('#job-archived-badge')->size, 1, 'archived icon shown if job is archived';
+};
+
+subtest 'test duration' => sub {
+    my $start = DateTime->new(
+        year       => 2021,
+        month      => 9,
+        day        => 14,
+        hour       => 15,
+        minute     => 0,
+        second     => 0,
+        nanosecond => 0,
+        time_zone  => 'UTC',
+    );
+    my $end = DateTime->new(
+        year       => 2021,
+        month      => 9,
+        day        => 16,
+        hour       => 17,
+        minute     => 30,
+        second     => 0,
+        nanosecond => 0,
+        time_zone  => 'UTC',
+    );
+    my $duration = $t->app->format_time_duration($end - $start);
+    like $duration, qr/2 days 02:30 hours/, 'duration formatted';
 };
 
 kill_driver();


### PR DESCRIPTION
Some very long tests, such as https://openqa.opensuse.org/tests/1851295 (very slow because no KVM acceleration is used) can exceed 24 hours. 
Duration is currently shown as `25:23` minutes. With this patch, it will be shown properly as `1 day 00:25 hours`