### PR TITLE
t: Disable coverage report for forked processes in scalability test

### DIFF
--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -73,8 +73,8 @@ my $workers = $schema->resultset('Workers');
 my $jobs    = $schema->resultset('Jobs');
 
 # create web UI and websocket server
-my $web_socket_server = create_websocket_server(undef, 0, 1, 1);
-my $webui             = create_webapi(undef, sub { });
+my $web_socket_server = create_websocket_server(undef, 0, 1, 1, 1);
+my $webui             = create_webapi(undef, 1);
 
 # prepare spawning workers
 my $sharedir        = setup_share_dir($ENV{OPENQA_BASEDIR});
@@ -99,6 +99,7 @@ note("Spawning $worker_count workers");
 sub spawn_worker {
     my ($instance) = @_;
 
+    local $ENV{PERL5OPT} = '';                                             # uncoverable statement
     note("Starting worker '$instance'");                                   # uncoverable statement
     $0 = 'openqa-worker';                                                  # uncoverable statement
     start ['perl', $worker_path, "--instance=$instance", @worker_args];    # uncoverable statement

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -263,8 +263,7 @@ sub stop_service {
     $h->finish;
 }
 
-sub create_webapi {
-    my ($port) = @_;
+sub create_webapi ($port = undef, $no_cover = undef) {
     $port //= service_port 'webui';
     note("Starting WebUI service. Port: $port");
 
@@ -275,7 +274,7 @@ sub create_webapi {
         my $daemon = Mojo::Server::Daemon->new(listen => ["http://127.0.0.1:$port"], silent => 1);
         $daemon->build_app('OpenQA::WebAPI');
         $daemon->run;
-        Devel::Cover::report() if Devel::Cover->can('report');
+        Devel::Cover::report() if !$no_cover && Devel::Cover->can('report');
     };
     # as this might download assets on first test, we need to wait a while
     my $wait = time + 50;
@@ -293,7 +292,7 @@ sub create_webapi {
 }
 
 sub create_websocket_server {
-    my ($port, $bogus, $nowait, $with_embedded_scheduler) = @_;
+    my ($port, $bogus, $nowait, $with_embedded_scheduler, $no_cover) = @_;
     $port //= service_port 'websocket';
 
     note("Starting WebSocket service. Port: $port");
@@ -337,7 +336,7 @@ sub create_websocket_server {
         }
 
         OpenQA::WebSockets::run;
-        Devel::Cover::report() if Devel::Cover->can('report');
+        Devel::Cover::report() if !$no_cover && Devel::Cover->can('report');
     };
     if (!defined $nowait) {
         # wait for websocket server


### PR DESCRIPTION
Preferred alternative to https://github.com/os-autoinst/openQA/pull/4070 (as it actually makes the test faster).

---

This speeds up the test significantly when coverage analysis is enabled
and fix https://progress.opensuse.org/issues/95851.

Before:
```
NAME                        TIME        CUMULATIVE      PERCENTAGE
 wait for workers to be idle 3.113       3.113           24.538%
 assign and run jobs         6.884       9.997           54.265%
 stop all workers            2.689       12.686          21.198%
```

After:
```
NAME                        TIME        CUMULATIVE      PERCENTAGE
 wait for workers to be idle 2.530       2.530           57.529%
 assign and run jobs         1.838       4.368           41.803%
 stop all workers            0.029       4.397           0.667%
```