### PR TITLE
Increase the waiting time for job results in scheduler-full test

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -213,7 +213,7 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
     note 'waiting for job to be incompleted';
     for (0 .. 100) {
         last if $jobs->find(99982)->state eq OpenQA::Jobs::Constants::DONE;
-        sleep .2;
+        sleep .3;
     }
 
     my $job = $jobs->find(99982);


### PR DESCRIPTION
We observed that t/05-scheduler-full.t fails more often than
it used too (it is in "unstable" already)

In one of the cases we wait for a job to be incompleted. We use
a active wait with a timeout, but seems that in environments with
a high load this timeout is not enough.

This PR increase the timeout from 20 seg. to 30 seg.

https://progress.opensuse.org/issues/95848