### PR TITLE
t: Bump timeout for ui/14-dashboard.t

### DIFF
--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Log 'log_debug';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '30';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 


### PR DESCRIPTION
With

```
count_fail_ratio prove -l t/ui/14-dashboard.t
```

in my local environment I get 20/20 passed with a runtime of 21-23s.