### PR TITLE
Enable eslint:recommended rules related to syntax and logic errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,44 @@
   "extends": ["prettier"],
   "plugins": ["prettier"],
   "rules": {
+    // Formatting
     "prettier/prettier": "error",
+
+    // Syntax and logic errors
+    "for-direction": "error",
+    "getter-return": "error",
+    "no-async-promise-executor": "error",
+    "no-constant-condition": "error",
+    "no-control-regex": "error",
+    "no-debugger": "error",
+    "no-dupe-args": "error",
+    "no-dupe-else-if": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-empty": "error",
+    "no-empty-character-class": "error",
+    "no-ex-assign": "error",
+    "no-extra-boolean-cast": "error",
+    "no-extra-semi": "error",
+    "no-func-assign": "error",
+    "no-import-assign": "error",
+    "no-inner-declarations": "error",
+    "no-invalid-regexp": "error",
+    "no-irregular-whitespace": "error",
+    "no-misleading-character-class": "error",
+    "no-obj-calls": "error",
+    "no-prototype-builtins": "error",
+    "no-regex-spaces": "error",
+    "no-setter-return": "error",
+    "no-sparse-arrays": "error",
+    "no-unexpected-multiline": "error",
+    "no-unreachable": "error",
+    "no-unsafe-finally": "error",
+    "no-unsafe-negation": "error",
+    "use-isnan": "error",
+    "valid-typeof": "error",
+
+    // Additional rules we find useful
     "prefer-const": "error"
   }
 }

--- a/assets/javascripts/audit_log.js
+++ b/assets/javascripts/audit_log.js
@@ -88,7 +88,9 @@ function loadAuditLogTable() {
               if (url) {
                 return '<a class="audit_event_details" href="' + url + '">' + htmlEscape(data) + '</a>';
               }
-            } catch (e) {}
+            } catch (e) {
+              // Intentionally ignore all errors
+            }
           }
           return data;
         }

--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -51,7 +51,7 @@ function templateRemoved(chosen, deselected) {
 
 function addFailed(data) {
   // display something without alert
-  if (data.hasOwnProperty('responseJSON')) {
+  if (Object.prototype.hasOwnProperty.call(data, 'responseJSON')) {
     alert(data.responseJSON.error);
   } else {
     alert('unknown error');
@@ -225,7 +225,7 @@ function buildMediumGroup(group, media) {
   $.each(media, function (index, temp) {
     var a = archs[temp.product.arch];
     if (!a) a = {};
-    if (!a.hasOwnProperty(temp.test_suite.name)) {
+    if (!Object.prototype.hasOwnProperty.call(a, temp.test_suite.name)) {
       a[temp.test_suite.name] = [];
       table.data('product-' + temp.product.arch, temp.product.id);
       a['_id'] = temp.product.id;
@@ -260,7 +260,10 @@ function buildMediumGroup(group, media) {
       select.attr('id', group + '-' + arch + '-' + test);
       select.attr('data-product-id', archs[arch]['_id']);
       select.addClass('chosen-select');
-      if (archs.hasOwnProperty(arch) && archs[arch].hasOwnProperty(test)) {
+      if (
+        Object.prototype.hasOwnProperty.call(archs, arch) &&
+        Object.prototype.hasOwnProperty.call(archs[arch], test)
+      ) {
         $.each(archs[arch][test], function (mi, temp) {
           var option = select.find("option[value='" + temp.machine.name + "']").prop('selected', true);
           // remember the id for DELETE
@@ -470,22 +473,24 @@ function submitTemplateEditor(button) {
     })
     .fail(function (data) {
       result.text('There was a problem applying the changes:');
-      if (!data.hasOwnProperty('responseJSON')) {
+      if (!Object.prototype.hasOwnProperty.call(data, 'responseJSON')) {
         $('<p/>')
           .text('Invalid server response: ' + data.statusText)
           .appendTo(result);
         return;
       }
       var data = data.responseJSON;
-      if (data.hasOwnProperty('error')) {
+      if (Object.prototype.hasOwnProperty.call(data, 'error')) {
         var errors = data.error;
         var list = $('<ul/>').appendTo(result);
         $.each(errors, function (i) {
-          var message = errors[i].hasOwnProperty('message') ? errors[i].message + ': ' + errors[i].path : errors[i];
+          var message = Object.prototype.hasOwnProperty.call(errors[i], 'message')
+            ? errors[i].message + ': ' + errors[i].path
+            : errors[i];
           $('<li/>').text(message).appendTo(list);
         });
       }
-      if (data.hasOwnProperty('changes')) {
+      if (Object.prototype.hasOwnProperty.call(data, 'changes')) {
         var preview = CodeMirror($('<pre/>').appendTo(result)[0], {
           mode: 'diff',
           lineNumbers: true,

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -241,7 +241,9 @@ function restartJob(ajaxUrl, jobId) {
       var newJobUrl;
       try {
         newJobUrl = responseJSON.test_url[0][jobId];
-      } catch {}
+      } catch {
+        // Intentionally ignore all errors
+      }
       if (showJobRestartResults(responseJSON, newJobUrl, restartJob.bind(undefined, ajaxUrl + '?force=1', jobId))) {
         return;
       }


### PR DESCRIPTION
A first followup to #4042. It enables all rules from the `eslint:recommended` set that are related to syntax and logic errors. We had quite a few violations of the [no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins) rule for example.

Progress: https://progress.opensuse.org/issues/91638