### PR TITLE
Make default test runs less noisy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ aliases:
       export COVERDB_SUFFIX="_${CIRCLE_JOB}"
       # circleCI can be particularly slow sometimes since some time around 2021-06
       export OPENQA_TEST_TIMEOUT_SCALE_CI=3
+      export EXTRA_PROVE_ARGS="-v"
       make test-$CIRCLE_JOB
     no_output_timeout: 50m
 

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,13 @@ CONTAINER_TEST ?= 1
 # most likely wants only the mentioned tests to be executed and no other
 # checks this implicitly disables CHECKSTYLE
 TESTS ?=
+# EXTRA_PROVE_ARGS: Additional prove arguments to pass
+EXTRA_PROVE_ARGS ?= -v
 ifeq ($(TESTS),)
-PROVE_ARGS ?= --trap -r -v
+PROVE_ARGS ?= --trap -r ${EXTRA_PROVE_ARGS}
 else
 CHECKSTYLE ?= 0
-PROVE_ARGS ?= --trap -v $(TESTS)
+PROVE_ARGS ?= --trap ${EXTRA_PROVE_ARGS} $(TESTS)
 endif
 PROVE_LIB_ARGS ?= -l
 CONTAINER_IMG ?= openqa:latest

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ STABILITY_TEST ?= 0
 # KEEP_DB: Set to 1 to keep the test database process spawned for tests. This
 # can help with faster re-runs of tests but might yield inconsistent results
 KEEP_DB ?= 0
-# TESTS: Specify individual test files in a space separated lists. As the user
-# most likely wants only the mentioned tests to be executed and no other
-# checks this implicitly disables CHECKSTYLE
 # CONTAINER_TEST: Set to 0 to exclude container tests needing a container
 # runtime environment
 CONTAINER_TEST ?= 1
+# TESTS: Specify individual test files in a space separated lists. As the user
+# most likely wants only the mentioned tests to be executed and no other
+# checks this implicitly disables CHECKSTYLE
 TESTS ?=
 ifeq ($(TESTS),)
 PROVE_ARGS ?= --trap -r -v

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CONTAINER_TEST ?= 1
 # checks this implicitly disables CHECKSTYLE
 TESTS ?=
 # EXTRA_PROVE_ARGS: Additional prove arguments to pass
-EXTRA_PROVE_ARGS ?= -v
+EXTRA_PROVE_ARGS ?=
 ifeq ($(TESTS),)
 PROVE_ARGS ?= --trap -r ${EXTRA_PROVE_ARGS}
 else


### PR DESCRIPTION
Previously we called prove with the parameter "-v" from within the
Makefile which can make tests quite noisy. As prove already outputs
context to errors in case any happen I consider a better default to run
without "-v" but keep the verbose parameter for CI runs, hence this
commit is removing the "-v" from prove arguments by default but adding
them instead in .circleci/config.yml. With the new Makefile variable
"EXTRA_PROVE_ARGS" one can still select the verbose mode when calling
make without needing to replicate any other necessary prove arguments.