### PR TITLE
Add regex and tests for fragment identifier recognition

### DIFF
--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -20,6 +20,7 @@ use warnings;
 
 use Time::Seconds;
 use Exporter 'import';
+use Regexp::Common 'URI';
 
 # Minimal worker version that allows them to connect;
 # To be modified manuallly when we want to break compatibility and force workers to update
@@ -107,6 +108,8 @@ use constant DB_TIMESTAMP_ACCURACY => 1;
 use constant VIDEO_FILE_NAME_START => 'video.';
 use constant VIDEO_FILE_NAME_REGEX => qr/^.*\/video\.[^\/]*$/;
 
+use constant FRAGMENT_REGEX => qr'(#([-?/:@.~!$&\'()*+,;=\w]|%[0-9a-fA-F]{2})*)*';
+
 our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION DEFAULT_WORKER_TIMEOUT
   WORKER_COMMAND_ABORT WORKER_COMMAND_QUIT WORKER_COMMAND_CANCEL WORKER_COMMAND_OBSOLETE WORKER_COMMAND_LIVELOG_STOP
@@ -120,6 +123,7 @@ our @EXPORT_OK = qw(
   DEFAULT_MAX_SETUP_TIME
   DB_TIMESTAMP_ACCURACY
   VIDEO_FILE_NAME_START VIDEO_FILE_NAME_REGEX
+  FRAGMENT_REGEX
 );
 
 1;

--- a/lib/OpenQA/Markdown.pm
+++ b/lib/OpenQA/Markdown.pm
@@ -18,11 +18,14 @@ use Mojo::Base -strict;
 use Exporter 'import';
 use Regexp::Common 'URI';
 use OpenQA::Utils qw(bugref_regex bugurl);
+use OpenQA::Constants qw(FRAGMENT_REGEX);
 use CommonMark;
 
 our @EXPORT_OK = qw(bugref_to_markdown is_light_color markdown_to_html);
 
 my $RE = bugref_regex;
+
+my $FRAG_REGEX = FRAGMENT_REGEX;
 
 sub bugref_to_markdown {
     my $text = shift;
@@ -44,7 +47,7 @@ sub markdown_to_html {
     $text = bugref_to_markdown($text);
 
     # Turn all remaining URLs into links
-    $text =~ s/(?<!['"(<>])($RE{URI})/<$1>/gio;
+    $text =~ s/(?<!['"(<>])($RE{URI}$FRAG_REGEX)/<$1>/gio;
 
     # Turn references to test modules and needling steps into links
     $text =~ s!\b(t#([\w/]+))![$1](/tests/$2)!gi;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -34,11 +34,13 @@ use Mojo::Log;
 use Scalar::Util qw(blessed reftype);
 use Exporter 'import';
 use OpenQA::App;
-use OpenQA::Constants qw(VIDEO_FILE_NAME_START VIDEO_FILE_NAME_REGEX);
+use OpenQA::Constants qw(VIDEO_FILE_NAME_START VIDEO_FILE_NAME_REGEX FRAGMENT_REGEX);
 use OpenQA::Log qw(log_info log_debug log_warning log_error);
 
 # avoid boilerplate "$VAR1 = " in dumper output
 $Data::Dumper::Terse = 1;
+
+my $FRAG_REGEX = FRAGMENT_REGEX;
 
 our $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
 our @EXPORT  = qw(
@@ -430,7 +432,7 @@ sub href_to_bugref {
 
 sub url_to_href {
     my ($text) = @_;
-    $text =~ s(($RE{URI}))(<a href="$1">$1</a>)gx;
+    $text =~ s!($RE{URI}$FRAG_REGEX)!<a href="$1">$1</a>!gx;
     return $text;
 }
 

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -66,6 +66,16 @@ subtest 'bugrefs' => sub {
 subtest 'openQA additions' => sub {
     is markdown_to_html('https://example.com'),
       qq{<p><a href="https://example.com">https://example.com</a></p>\n}, 'URL turned into a link';
+    is markdown_to_html('https://example.com/#fragment_-'),
+      qq{<p><a href="https://example.com/#fragment_-">https://example.com/#fragment_-</a></p>\n},
+      'URL with fragment turned into a link';
+    is markdown_to_html('https://example.com/#fragment/<script>test</script>'),
+qq{<p><a href="https://example.com/#fragment/">https://example.com/#fragment/</a><!-- raw HTML omitted -->test<!-- raw HTML omitted --></p>\n},
+      'URL with fragment + script turned into a link';
+    is markdown_to_html('https://example.com/#?(.-/\' some text'),
+      qq{<p><a href="https://example.com/#?(.-/&#x27;">https://example.com/#?(.-/'</a> some text</p>\n},
+      'URL w fragment + special characters turned into a link';
+
     is markdown_to_html('testing https://example.com 123'),
       qq{<p>testing <a href="https://example.com">https://example.com</a> 123</p>\n}, 'URL turned into a link';
     is markdown_to_html("t\ntesting https://example.com 123\n123"),


### PR DESCRIPTION
The regex used until now would not recognize fragment identifiers (part of the url that comes after '#'), which is now fixed. 

The accepted characters for fragments were derived from it's definition in https://datatracker.ietf.org/doc/html/rfc3986#section-3.5.