### PR TITLE
Retry the assets package generation if a CDN fails

### DIFF
--- a/tools/generate-packed-assets
+++ b/tools/generate-packed-assets
@@ -47,8 +47,15 @@ ASSETPACK_PLUGINS=$(grep 'AssetPack' lib/OpenQA/WebAPI.pm | awk -F '[()]' '{prin
 BUILD_CACHE="plugin AssetPack => { pipes => [qw(${ASSETPACK_PLUGINS})]} and app->asset->process()"
 BUILD_CACHE_OPTS='-Ilib/ -MMojolicious::Lite'
 
-# Allow command line options without quotes
-# shellcheck disable=SC2086
-env MOJO_MODE="test" perl $BUILD_CACHE_OPTS -e "$BUILD_CACHE" > /dev/null
-# shellcheck disable=SC2086
-env MOJO_MODE="development" perl $BUILD_CACHE_OPTS -e "$BUILD_CACHE" > /dev/null
+generate() {
+    # shellcheck disable=SC2039
+    for _ in {1..3}; do
+        # shellcheck disable=SC2086
+        env MOJO_MODE="$1" perl $BUILD_CACHE_OPTS -e "$BUILD_CACHE" > /dev/null && return 0
+        sleep 1
+    done
+}
+
+# Possibly requires a retry in case of CDN failures
+generate "test"
+generate "development"


### PR DESCRIPTION
We observed this kind of errors in the openqa test at install_from_git

[warn] [AssetPack] Unable to download https://cdn.datatables.net/1.10.16/css/dataTables.bootstrap4.css: Connect timeout

This PR introduces a retry on the tools/generate-packet-assets in
case the asset download fails

https://progress.opensuse.org/issues/95995