### PR TITLE
Log user data received during OAuth2

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -16,6 +16,8 @@
 package OpenQA::WebAPI::Auth::OAuth2;
 use Mojo::Base -base, -signatures;
 use Carp 'croak';
+use Data::Dumper;
+use OpenQA::Log qw(log_debug);
 
 sub auth_setup ($server) {
     my $app    = $server->app;
@@ -79,6 +81,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
     }
     my $details = $tx->res->json;
     if (ref $details ne 'HASH' || !$details->{id} || !$details->{$provider_config->{nickname_from}}) {
+        log_debug("OAuth2 user provider returned: " . Dumper($details));
         return $controller->render(text => 'User data returned by OAuth2 provider is insufficient', status => 403);
     }
     my $provider_name = $main_config->{provider};


### PR DESCRIPTION
When the error "User data returned by OAuth2 provider is insufficient"
appears, it's important for admin to see what data the identity provider
actually returned.

This info will only be logged when log level is set to `debug`.