### PR TITLE
ci: Improve hadolint check

### DIFF
--- a/tools/static_check_containers
+++ b/tools/static_check_containers
@@ -9,7 +9,8 @@ else
     img=ghcr.io/hadolint/hadolint
 fi
 cre="${cre:-"docker"}"
-for i in container/*/Dockerfile*; do
-    echo "# Static check of $i"
-    $cre run --rm -i $img < "$i"
-done
+dockerfiles=(container/*/Dockerfile*)
+echo "# Static check of Dockerfiles"
+set -x
+$cre run --rm -v"$PWD":/repo -w /repo "$img" hadolint "${dockerfiles[@]}"
+echo "All files ok"


### PR DESCRIPTION
Issues:
* https://progress.opensuse.org/issues/96636
* https://github.com/hadolint/hadolint/issues/475

It seems repeated calls to docker can lead to rare unexpected exits with code
127.
While this commit does not fix the cause, it avoids calling docker repeatedly,
which also makes the test faster.

I tested that the check works by introducing an error in one of the files:
```
container/webui/Dockerfile-lb:2:1 unexpected 'F' expecting '#', '\', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, a pragma, at least one space, or end of input
```