### PR TITLE
Reenable sysusers once again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ install-generic:
 
 	cp -Ra dbicdh "$(DESTDIR)"/usr/share/openqa/dbicdh
 
+	install -d -m 755 "$(DESTDIR)"/usr/lib/sysusers.d/
+	install    -m 644 usr/lib/sysusers.d/openQA-worker.conf "$(DESTDIR)"/usr/lib/sysusers.d/
+	install    -m 644 usr/lib/sysusers.d/geekotest.conf "$(DESTDIR)"/usr/lib/sysusers.d/
+
 # Additional services which have a strong dependency on SUSE/openSUSE and do not
 # make sense for other distributions
 .PHONY: install-opensuse

--- a/dist/rpm/openQA-test.spec
+++ b/dist/rpm/openQA-test.spec
@@ -6,6 +6,9 @@ Summary:        Test package for openQA
 License:        GPL-2.0-or-later
 BuildRequires:  %{short_name} == %{version}
 BuildRequires:  openQA-local-db
+%if 0%{?suse_version} > 1500
+BuildRequires:  user(geekotest)
+%endif
 ExcludeArch:    i586
 
 %description
@@ -20,6 +23,7 @@ touch %{_sourcedir}/%{short_name}
 # call one of the components but not openqa itself which would need a valid
 # configuration
 /usr/share/openqa/script/initdb --help
+getent passwd geekotest
 
 %install
 # disable debug packages in package test to prevent error about missing files

--- a/dist/rpm/openQA-worker-test.spec
+++ b/dist/rpm/openQA-worker-test.spec
@@ -5,6 +5,9 @@ Release:        0
 Summary:        Test package for %{short_name}
 License:        GPL-2.0-or-later
 BuildRequires:  %{short_name} == %{version}
+%if 0%{?suse_version} > 1500
+BuildRequires:  user(_openqa-worker)
+%endif
 ExcludeArch:    i586
 
 %description
@@ -17,6 +20,7 @@ touch %{_sourcedir}/%{short_name}
 
 %build
 /usr/share/openqa/script/worker --help
+getent passwd _openqa-worker
 
 %install
 # disable debug packages in package test to prevent error about missing files

--- a/usr/lib/sysusers.d/geekotest.conf
+++ b/usr/lib/sysusers.d/geekotest.conf
@@ -1,0 +1,3 @@
+# Type Name       ID     GECOS           [HOME]    Shell
+u   geekotest   -     "openQA user" /var/lib/openqa  /bin/bash
+m   geekotest  nogroup

--- a/usr/lib/sysusers.d/openQA-worker.conf
+++ b/usr/lib/sysusers.d/openQA-worker.conf
@@ -1,0 +1,4 @@
+# Type Name            ID     GECOS           [HOME]    Shell
+u   _openqa-worker   -     "openQA worker" /var/lib/empty  /bin/bash
+m   _openqa-worker  nogroup
+m   _openqa-worker  kvm


### PR DESCRIPTION
Next try at enabling systemd-sysusers, this time with the `_openqa-worker` and `geekotest` users having a login shell set.

This reverts commit c5ef15d99194f0f0600d2df5716643cc107c8231.