### PR TITLE
worker: Do not remove timer after delay and extend unit tests

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -390,9 +390,8 @@ sub delay ($self, $delay) {
     $loop->stop if $loop->is_running;
     $self->{_resume_loop} = 1;
 
-    my $timer = $loop->timer($delay, sub { $loop->stop });
+    $loop->timer($delay, sub { $loop->stop if $loop->is_running });
     $loop->start;
-    $loop->remove($timer);
 }
 
 sub stop_event_loop ($self) {


### PR DESCRIPTION
A few changes I came up with when investigating https://progress.opensuse.org/issues/96710. See particular commit messages for details.