### PR TITLE
Improve worker's exception handling and related test

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -293,8 +293,9 @@ sub init {
             $return_code = 1;
 
             # try to stop gracefully
+            my $fatal_error = 'Another error occurred when trying to stop gracefully due to an error';
             if (!$self->{_shall_terminate} || $self->{_finishing_off}) {
-                try {
+                eval {
                     # log error using print because logging utils might have caused the exception
                     # (no need to repeat $err, it is printed anyways)
                     log_error('Stopping because a critical error occurred.');
@@ -302,11 +303,13 @@ sub init {
                     # try to stop the job nicely
                     return $self->stop('exception');
                 };
+                $fatal_error = "$fatal_error: $@" if $@;
             }
 
             # kill if stopping gracefully does not work
-            log_error('Another error occurred when trying to stop gracefully due to an error. '
-                  . 'Trying to kill ourself forcefully now.');
+            chomp $fatal_error;
+            log_error($fatal_error);
+            log_error('Trying to kill ourself forcefully now');
             $self->kill;
         });
 


### PR DESCRIPTION
* Turn `try` into `eval` so the contained `return` actually returns from
  the enclosing `sub`
    * No longer log `Another error occurred…` when that's not actually the
      case
    * No longer stop the worker immediately after the first exception
* Log error message from the `eval` block
* Improve tests
    * Check whether the event loop is actually stopped in a controlled way
    * Check whether all error messages are logged
    * Check whether relevant functions are called exactly as many times as
      expected
* See https://progress.opensuse.org/issues/96710