### PR TITLE
worker: Use proper callback instead of `delay` function during setup

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -156,9 +156,7 @@ sub _handle_asset_processed ($cache_client, $this_asset, $asset_uri, $status, $v
         log_error("Failed to download $asset_uri", channels => 'autoinst');
         # assume that if we have a full path, that's what we should use
         $vars->{$this_asset} = $asset_uri if -e $asset_uri;
-        # don't kill the job if the asset is not found
-        # TODO: This seems to leave the job stuck in some cases (observed in production on openqaworker3).
-        return undef;
+        return undef;    # don't abort the job if the asset is not found
     }
     if (!$asset) {
         my $error = "Failed to download $asset_uri to " . $cache_client->asset_path($webui_host, $asset_uri);

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -41,7 +41,9 @@ use Mojo::Collection 'c';
 use Mojo::File 'path';
 use Mojo::Util 'trim';
 
-use constant CGROUP_SLICE => $ENV{OPENQA_CGROUP_SLICE};
+use constant CGROUP_SLICE                     => $ENV{OPENQA_CGROUP_SLICE};
+use constant CACHE_SERVICE_POLL_DELAY         => $ENV{OPENQA_CACHE_SERVICE_POLL_DELAY}         // 5;
+use constant CACHE_SERVICE_TEST_SYNC_ATTEMPTS => $ENV{OPENQA_CACHE_SERVICE_TEST_SYNC_ATTEMPTS} // 3;
 
 my $isotovideo = '/usr/bin/isotovideo';
 my $workerpid;
@@ -92,76 +94,86 @@ sub detect_asset_keys ($vars) {
     return \%res;
 }
 
-sub _poll_cache_service ($job, $cache_client, $request, $status_ref, $delay = 5) {
-    until ($$status_ref->is_processed) {
-        $job->worker->delay($delay);
-        return {error => 'Status updates interrupted'} unless $job->post_setup_status;
-        return {error => 'Job has been cancelled'} if $job->is_stopped_or_stopping;
-        return {error => $$status_ref->error}      if $$status_ref->has_error;
-        $$status_ref = $cache_client->status($request);
-    }
-    return undef;
+sub _poll_cache_service ($job, $cache_client, $request, $delay, $callback) {
+    # perform status updates while waiting and handle interruptions
+    return $callback->({error => 'Status updates interrupted'}, undef) unless $job->post_setup_status;
+
+    my $status = $cache_client->status($request);
+    return Mojo::IOLoop->singleton->timer(
+        $delay => sub { _poll_cache_service($job, $cache_client, $request, $delay, $callback) })
+      unless $status->is_processed;
+    return $callback->({error => 'Job has been cancelled'}, undef) if $job->is_stopped_or_stopping;
+    return $callback->({error => $status->error},           undef) if $status->has_error;
+    return $callback->(undef, $status);
 }
 
-sub cache_assets ($job = undef, $vars = undef, $assetkeys = undef, $webui_host = undef, $pooldir = undef) {
-    my $cache_client = OpenQA::CacheService::Client->new;
-    for my $this_asset (sort keys %$assetkeys) {
-        my $asset;
-        my $asset_value = $vars->{$this_asset};
-        next unless $asset_value;
-        my $asset_uri = trim($asset_value);
-        # Skip UEFI_PFLASH_VARS asset if the job won't use UEFI.
-        next if (($this_asset eq 'UEFI_PFLASH_VARS') and !$vars->{UEFI});
-        # check cache availability
-        my $error = $cache_client->info->availability_error;
-        return {error => $error} if $error;
-        log_debug("Found $this_asset, caching $vars->{$this_asset}", channels => 'autoinst');
+sub cache_assets ($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir, $callback) {
+    return $callback->(undef) unless my $this_asset  = shift @$assets_to_cache;
+    return cache_assets(@_)   unless my $asset_value = $vars->{$this_asset};
 
-        my $asset_request = $cache_client->asset_request(
-            id    => $job->id,
-            asset => $asset_uri,
-            type  => $assetkeys->{$this_asset},
-            host  => $webui_host
-        );
-        if (my $err = $cache_client->enqueue($asset_request)) {
-            return {error => "Failed to send asset request for $asset_uri: $err"};
-        }
+    my $asset_uri = trim($asset_value);
+    # skip UEFI_PFLASH_VARS asset if the job won't use UEFI
+    return cache_assets(@_) if $this_asset eq 'UEFI_PFLASH_VARS' && !$vars->{UEFI};
+    # check cache availability
+    my $error = $cache_client->info->availability_error;
+    return $callback->({error => $error}) if $error;
+    log_debug("Found $this_asset, caching $vars->{$this_asset}", channels => 'autoinst');
 
-        my $minion_id = $asset_request->minion_id;
-        log_info("Downloading $asset_uri, request #$minion_id sent to Cache Service", channels => 'autoinst');
-        my $status = $cache_client->status($asset_request);
-        $error = _poll_cache_service($job, $cache_client, $asset_request, \$status);
-        return $error if $error;
-        my $msg = "Download of $asset_uri processed";
-        if (my $output = $status->output) { $msg .= ":\n$output" }
-        log_info($msg, channels => 'autoinst');
-
-        $asset = $cache_client->asset_path($webui_host, $asset_uri)
-          if $cache_client->asset_exists($webui_host, $asset_uri);
-
-        if ($this_asset eq 'UEFI_PFLASH_VARS' && !defined $asset) {
-            log_error("Failed to download $asset_uri", channels => 'autoinst');
-            # assume that if we have a full path, that's what we should use
-            $vars->{$this_asset} = $asset_uri if -e $asset_uri;
-            # don't kill the job if the asset is not found
-            # TODO: This seems to leave the job stuck in some cases (observed in production on openqaworker3).
-            next;
-        }
-        if (!$asset) {
-            $error = "Failed to download $asset_uri to " . $cache_client->asset_path($webui_host, $asset_uri);
-            return {error => $error, category => WORKER_EC_ASSET_FAILURE} if $msg =~ qr/4\d\d /;
-            # note: This check has no effect if the download was performed by
-            # an already enqueued Minion job or if the pruning happened within
-            # a completely different asset download.
-            $error .= '. Asset was pruned immediately after download (poo#71827), please retrigger'
-              if $msg =~ /Purging.*$asset_uri.*because we need space for new assets/;
-            log_error($error, channels => 'autoinst');
-            return {error => $error};
-        }
-        my $link_result = _link_asset($asset, $pooldir);
-        $vars->{$this_asset}
-          = $vars->{ABSOLUTE_TEST_CONFIG_PATHS} ? $link_result->{absolute_path} : $link_result->{basename};
+    my %params        = (id => $job->id, asset => $asset_uri, type => $assetkeys->{$this_asset}, host => $webui_host);
+    my $asset_request = $cache_client->asset_request(\%params);
+    if (my $err = $cache_client->enqueue($asset_request)) {
+        return $callback->({error => "Failed to send asset request for $asset_uri: $err"});
     }
+
+    my $minion_id = $asset_request->minion_id;
+    log_info("Downloading $asset_uri, request #$minion_id sent to Cache Service", channels => 'autoinst');
+    return _poll_cache_service(
+        $job,
+        $cache_client,
+        $asset_request,
+        CACHE_SERVICE_POLL_DELAY,
+        sub ($error, $status) {
+            $error
+              = _handle_asset_processed($cache_client, $assets_to_cache, $asset_uri, $status, $vars, $webui_host,
+                $pooldir)
+              unless $error;
+            return $callback->($error) if $error;
+            return cache_assets($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir,
+                $callback);
+        });
+}
+
+sub _handle_asset_processed ($cache_client, $this_asset, $asset_uri, $status, $vars, $webui_host, $pooldir) {
+    my $msg = "Download of $asset_uri processed";
+    if (my $output = $status->output) { $msg .= ":\n$output" }
+    log_info($msg, channels => 'autoinst');
+
+    my $asset
+      = $cache_client->asset_exists($webui_host, $asset_uri)
+      ? $cache_client->asset_path($webui_host, $asset_uri)
+      : undef;
+    if ($this_asset eq 'UEFI_PFLASH_VARS' && !defined $asset) {
+        log_error("Failed to download $asset_uri", channels => 'autoinst');
+        # assume that if we have a full path, that's what we should use
+        $vars->{$this_asset} = $asset_uri if -e $asset_uri;
+        # don't kill the job if the asset is not found
+        # TODO: This seems to leave the job stuck in some cases (observed in production on openqaworker3).
+        return undef;
+    }
+    if (!$asset) {
+        my $error = "Failed to download $asset_uri to " . $cache_client->asset_path($webui_host, $asset_uri);
+        return {error => $error, category => WORKER_EC_ASSET_FAILURE} if $msg =~ qr/4\d\d /;
+        # note: This check has no effect if the download was performed by
+        # an already enqueued Minion job or if the pruning happened within
+        # a completely different asset download.
+        $error .= '. Asset was pruned immediately after download (poo#71827), please retrigger'
+          if $msg =~ /Purging.*$asset_uri.*because we need space for new assets/;
+        log_error($error, channels => 'autoinst');
+        return {error => $error};
+    }
+    my $link_result = _link_asset($asset, $pooldir);
+    $vars->{$this_asset}
+      = $vars->{ABSOLUTE_TEST_CONFIG_PATHS} ? $link_result->{absolute_path} : $link_result->{basename};
     return undef;
 }
 
@@ -200,76 +212,76 @@ sub _link_repo {
 }
 
 # do test caching if TESTPOOLSERVER is set
-sub sync_tests ($job, $vars, $cache_dir, $webui_host, $rsync_source) {
+sub sync_tests ($cache_client, $job, $vars, $shared_cache, $rsync_source, $remaining_tries, $callback) {
     my %rsync_retry_code = (
         10 => 'Error in socket I/O',
         23 => 'Partial transfer due to error',
         24 => 'Partial transfer due to vanished source files',
     );
-    my $shared_cache  = catdir($cache_dir, base_host($webui_host));
-    my $cache_client  = OpenQA::CacheService::Client->new;
-    my $rsync_request = $cache_client->rsync_request(
-        from => $rsync_source,
-        to   => $shared_cache
-    );
+    my $rsync_request             = $cache_client->rsync_request(from => $rsync_source, to => $shared_cache);
     my $rsync_request_description = "from '$rsync_source' to '$shared_cache'";
     $job->worker->settings->global_settings->{PRJDIR} = $shared_cache;
 
     # enqueue rsync task; retry in some error cases
-    for (my $remaining_tries = 3; $remaining_tries > 0; --$remaining_tries) {
-        if (my $err = $cache_client->enqueue($rsync_request)) {
-            return {error => "Failed to send rsync $rsync_request_description: $err"};
-        }
-        my $minion_id = $rsync_request->minion_id;
-        log_info("Rsync $rsync_request_description, request #$minion_id sent to Cache Service", channels => 'autoinst');
-
-        my $status = $cache_client->status($rsync_request);
-        my $error  = _poll_cache_service($job, $cache_client, $rsync_request, \$status);
-        return $error if $error;
-
-        if (my $output = $status->output) {
-            log_info("Output of rsync:\n$output", channels => 'autoinst');
-        }
-
-        # treat "no sync necessary" as success as well
-        my $result    = $status->result // 'exit code 0';
-        my $exit_code = $result =~ /exit code (\d+)/ ? $1 : undef;
-
-        if ($result eq 'exit code 0') {
-            log_info('Finished to rsync tests', channels => 'autoinst');
-            last;
-        }
-        elsif ($remaining_tries > 1 && ($exit_code && $rsync_retry_code{$exit_code})) {
-            log_info("$rsync_retry_code{$exit_code} ($result), trying again", channels => 'autoinst');
-        }
-        else {
-            my $error_msg = "Failed to rsync tests: $result";
-            log_error($error_msg, channels => 'autoinst');
-            return {error => $error_msg};
-        }
+    if (my $err = $cache_client->enqueue($rsync_request)) {
+        return $callback->({error => "Failed to send rsync $rsync_request_description: $err"});
     }
-    return catdir($shared_cache, 'tests');
+    my $minion_id = $rsync_request->minion_id;
+    log_info("Rsync $rsync_request_description, request #$minion_id sent to Cache Service", channels => 'autoinst');
+
+    return _poll_cache_service(
+        $job,
+        $cache_client,
+        $rsync_request,
+        CACHE_SERVICE_POLL_DELAY,
+        sub ($error, $status) {
+            return $callback->($error) if $error;
+
+            if (my $output = $status->output) {
+                log_info("Output of rsync:\n$output", channels => 'autoinst');
+            }
+
+            # treat "no sync necessary" as success as well
+            my $result    = $status->result // 'exit code 0';
+            my $exit_code = $result =~ /exit code (\d+)/ ? $1 : undef;
+
+            if ($result eq 'exit code 0') {
+                log_info('Finished to rsync tests', channels => 'autoinst');
+                return $callback->(catdir($shared_cache, 'tests'));
+            }
+            elsif ($remaining_tries > 1 && ($exit_code && $rsync_retry_code{$exit_code})) {
+                log_info("$rsync_retry_code{$exit_code} ($result), trying again", channels => 'autoinst');
+                return sync_tests($cache_client, $job, $vars, $shared_cache, $rsync_source, $remaining_tries - 1,
+                    $callback);
+            }
+            else {
+                my $error_msg = "Failed to rsync tests: $result";
+                log_error($error_msg, channels => 'autoinst');
+                return $callback->({error => $error_msg});
+            }
+        });
 }
 
-sub do_asset_caching (
-    $job        = undef,
-    $vars       = undef,
-    $cache_dir  = undef,
-    $assetkeys  = undef,
-    $webui_host = undef,
-    $pooldir    = undef
-  )
-{
-    die 'Need parameters' unless $job;
-    my $error = cache_assets($job, $vars, $assetkeys, $webui_host, $pooldir);
-    return $error if $error;
-    if (my $rsync_source = $job->client->testpool_server) {
-        return sync_tests($job, $vars, $cache_dir, $webui_host, $rsync_source);
-    }
-    return undef;
+sub do_asset_caching ($job, $vars, $cache_dir, $assetkeys, $webui_host, $pooldir, $callback) {
+    my $cache_client = OpenQA::CacheService::Client->new;
+    cache_assets(
+        $cache_client,
+        $job, $vars,
+        [sort keys %$assetkeys],
+        $assetkeys,
+        $webui_host,
+        $pooldir,
+        sub ($error) {
+            return $callback->($error) if $error;
+            my $rsync_source = $job->client->testpool_server;
+            return $callback->(undef) unless $rsync_source;
+            my $attempts     = CACHE_SERVICE_TEST_SYNC_ATTEMPTS;
+            my $shared_cache = catdir($cache_dir, base_host($webui_host));
+            sync_tests($cache_client, $job, $vars, $shared_cache, $rsync_source, $attempts, $callback);
+        });
 }
 
-sub engine_workit ($job) {
+sub engine_workit ($job, $callback) {
     my $worker          = $job->worker;
     my $client          = $job->client;
     my $global_settings = $worker->settings->global_settings;
@@ -322,35 +334,51 @@ sub engine_workit ($job) {
     log_debug(join("\n", '', map { "    $_=$vars{$_}" } sort keys %vars));
 
     # cache/locate assets, set ASSETDIR
-    my $shared_cache;
     my $assetkeys = detect_asset_keys(\%vars);
     if (my $cache_dir = $global_settings->{CACHEDIRECTORY}) {
-        $shared_cache = do_asset_caching($job, \%vars, $cache_dir, $assetkeys, $webui_host, $pooldir);
-        if (ref $shared_cache eq 'HASH') {
-            $shared_cache->{category} //= WORKER_EC_CACHE_FAILURE;
-            return $shared_cache;
-        }
+        return do_asset_caching(
+            $job,
+            \%vars,
+            $cache_dir,
+            $assetkeys,
+            $webui_host,
+            $pooldir,
+            sub ($shared_cache) {
+                return _engine_workit_step_2($job, $job_settings, \%vars, $shared_cache, $callback)
+                  unless ref $shared_cache eq 'HASH';
+                $shared_cache->{category} //= WORKER_EC_CACHE_FAILURE;
+                return $callback->($shared_cache);
+            });
     }
     else {
         my $error = locate_local_assets(\%vars, $assetkeys, $pooldir);
-        return $error if $error;
+        return $callback->($error) if $error;
     }
-    $vars{ASSETDIR} //= OpenQA::Utils::assetdir;
+
+    return _engine_workit_step_2($job, $job_settings, \%vars, undef, $callback);
+}
+
+sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback) {
+    my $worker   = $job->worker;
+    my $pooldir  = $worker->pool_directory;
+    my $job_info = $job->info;
+
+    $vars->{ASSETDIR} //= OpenQA::Utils::assetdir;
 
     # ensure a CASEDIR and a PRODUCTDIR is assigned and create a symlink if required
-    my $absolute_paths        = $vars{ABSOLUTE_TEST_CONFIG_PATHS};
-    my @vars_for_default_dirs = ($vars{DISTRI}, $vars{VERSION}, $shared_cache);
+    my $absolute_paths        = $vars->{ABSOLUTE_TEST_CONFIG_PATHS};
+    my @vars_for_default_dirs = ($vars->{DISTRI}, $vars->{VERSION}, $shared_cache);
     my $default_casedir       = testcasedir(@vars_for_default_dirs);
     my $default_productdir    = productdir(@vars_for_default_dirs);
     my $target_name           = path($default_casedir)->basename;
-    my $has_custom_dir        = $vars{CASEDIR} || $vars{PRODUCTDIR};
-    my $casedir               = $vars{CASEDIR} //= $absolute_paths ? $default_casedir : $target_name;
+    my $has_custom_dir        = $vars->{CASEDIR} || $vars->{PRODUCTDIR};
+    my $casedir               = $vars->{CASEDIR} //= $absolute_paths ? $default_casedir : $target_name;
     if ($casedir eq $target_name) {
-        $vars{PRODUCTDIR} //= substr($default_productdir, rindex($default_casedir, $target_name));
-        if (my $error = _link_repo($default_casedir, $pooldir, $target_name)) { return $error }
+        $vars->{PRODUCTDIR} //= substr($default_productdir, rindex($default_casedir, $target_name));
+        if (my $error = _link_repo($default_casedir, $pooldir, $target_name)) { return $callback->($error) }
     }
     else {
-        $vars{PRODUCTDIR} //= $absolute_paths
+        $vars->{PRODUCTDIR} //= $absolute_paths
           && !$has_custom_dir ? $default_productdir : abs2rel($default_productdir, $default_casedir);
     }
 
@@ -365,21 +393,21 @@ sub engine_workit ($job) {
     # - If the specified NEEDLES_DIR is an absolute path or an URL we assume that it points to a custom location
     #   and keep it as-is.
     my $default_needles_dir     = needledir(@vars_for_default_dirs);
-    my $needles_dir             = $vars{NEEDLES_DIR};
+    my $needles_dir             = $vars->{NEEDLES_DIR};
     my $need_to_set_needles_dir = !$needles_dir && $has_custom_dir;
     if ($need_to_set_needles_dir && $absolute_paths) {
         # simply set the default needles dir when absolute paths are used
-        $vars{NEEDLES_DIR} = $default_needles_dir;
+        $vars->{NEEDLES_DIR} = $default_needles_dir;
     }
     elsif ($need_to_set_needles_dir
         || ($needles_dir && !file_name_is_absolute($needles_dir) && !looks_like_url_with_scheme($needles_dir)))
     {
         # create/assign a symlink for needles if NEEDLES_DIR has been specified by the user as a path relative to
         # the default CASEDIR/PRODUCTDIR
-        $vars{NEEDLES_DIR} = $needles_dir = basename($needles_dir || 'needles');
-        if (my $error = _link_repo($default_needles_dir, $pooldir, $needles_dir)) { return $error }
+        $vars->{NEEDLES_DIR} = $needles_dir = basename($needles_dir || 'needles');
+        if (my $error = _link_repo($default_needles_dir, $pooldir, $needles_dir)) { return $callback->($error) }
     }
-    _save_vars($pooldir, \%vars);
+    _save_vars($pooldir, $vars);
 
     # os-autoinst's commands server
     $job_info->{URL}
@@ -464,7 +492,7 @@ sub engine_workit ($job) {
     log_info('Starting isotovideo container');
     $container->start();
     $workerpid = $child->pid();
-    return {child => $child};
+    return $callback->({child => $child});
 }
 
 sub locate_local_assets ($vars, $assetkeys, $pooldir) {

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -271,7 +271,11 @@ sub start {
 
     # start isotovideo
     # FIXME: isotovideo.pm could be a class inheriting from Job.pm or simply be merged
-    my $engine      = OpenQA::Worker::Engines::isotovideo::engine_workit($self);
+    return OpenQA::Worker::Engines::isotovideo::engine_workit($self,
+        sub ($engine) { $self->_handle_engine_startup($engine, $max_job_time) });
+}
+
+sub _handle_engine_startup ($self, $engine, $max_job_time) {
     my $setup_error = $engine->{error};
     $setup_error = 'isotovideo can not be started'
       if !$setup_error && ($engine->{child}->errored || !$engine->{child}->is_running);
@@ -283,6 +287,7 @@ sub start {
         #          web UI.
         return undef if $self->is_stopped_or_stopping;
 
+        my $id = $self->id;
         log_error("Unable to setup job $id: $setup_error");
         $self->{_setup_error_category} = $engine->{category} // WORKER_SR_SETUP_FAILURE;
         return $self->stop(WORKER_SR_SETUP_FAILURE);

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -38,6 +38,8 @@ use OpenQA::Utils qw(testcasedir productdir needledir locate_asset);
     use Mojo::Base -base;
     has id     => 42;
     has worker => undef;
+    sub post_setup_status      { 1 }
+    sub is_stopped_or_stopping { 0 }
 }
 {
     package Test::FakeRequest;
@@ -67,6 +69,14 @@ sub get_job_json_data {
     my ($pool_dir) = @_;
     my $vars_json = path($pool_dir)->child("vars.json")->slurp;
     return decode_json $vars_json;
+}
+
+sub _run_engine ($job) {
+    my $result;
+    my $cb = sub ($res) { $result = $res; Mojo::IOLoop->stop };
+    OpenQA::Worker::Engines::isotovideo::engine_workit($job, $cb);
+    Mojo::IOLoop->start;
+    return $result;
 }
 
 subtest 'isotovideo version' => sub {
@@ -146,30 +156,43 @@ subtest 'asset settings' => sub {
 };
 
 subtest 'caching' => sub {
-    is(OpenQA::Worker::Engines::isotovideo::cache_assets, undef, 'cache_assets has nothing to do without assets');
+    my $error = 'not called';
+    my $cb    = sub ($err) { $error = $err };
+    OpenQA::Worker::Engines::isotovideo::cache_assets(undef, undef, undef, [], undef, undef, undef, $cb);
+    is $error, undef, 'cache_assets has nothing to do without assets';
+
     my %assets = (ISO => 'foo.iso');
-    my $got    = OpenQA::Worker::Engines::isotovideo::cache_assets(undef, undef, \%assets, undef, undef);
-    is($got->{error}, undef, 'cache_assets can not pick up supplied assets when not found') or diag explain $got;
+    $error = 'not called';
+    OpenQA::Worker::Engines::isotovideo::cache_assets(undef, undef, undef, [keys %assets], \%assets, undef, undef, $cb);
+    is $error, undef, 'cache_assets can not pick up supplied assets when not found';
 };
 
 subtest 'asset caching' => sub {
-    throws_ok { OpenQA::Worker::Engines::isotovideo::do_asset_caching() } qr/Need parameters/,
-      'do_asset_caching needs parameters';
     my $asset_mock = Test::MockModule->new('OpenQA::Worker::Engines::isotovideo');
-    $asset_mock->redefine(cache_assets => undef);
-    my $got;
-    my $job = Test::MockObject->new();
+    $asset_mock->redefine(
+        cache_assets =>
+          sub ($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir, $callback) {
+            $callback->(undef);
+        });
+    my $job = Test::MockObject->new;
     my $testpool_server;
-    $job->mock(client => sub { Test::MockObject->new()->set_bound(testpool_server => \$testpool_server) });
-    $got = OpenQA::Worker::Engines::isotovideo::do_asset_caching($job);
+    $job->mock(client => sub { Test::MockObject->new->set_bound(testpool_server => \$testpool_server) });
+    my $error = 'not called';
+    my $cb    = sub ($err) { $error = $err; Mojo::IOLoop->stop };
+    OpenQA::Worker::Engines::isotovideo::do_asset_caching($job, undef, undef, undef, undef, undef, $cb);
+    Mojo::IOLoop->start;
     ok $job->called('client'), 'client has been asked for parameters when accessing job for caching';
-    is $got, undef, 'Assets cached but not tests';
+    is $error, undef, 'Assets cached but not tests';
     $testpool_server = 'host1';
     my $prj_dir  = "FOO/$testpool_server";
     my $test_dir = "$prj_dir/tests";
-    $asset_mock->redefine(sync_tests => $test_dir);
-    $got = OpenQA::Worker::Engines::isotovideo::do_asset_caching($job);
-    is($got, $test_dir, 'Cache directory updated');
+    $asset_mock->redefine(
+        sync_tests => sub ($cache_client, $job, $vars, $shared_cache, $rsync_source, $remaining_tries, $callback) {
+            $callback->($test_dir);
+        });
+    OpenQA::Worker::Engines::isotovideo::do_asset_caching($job, undef, 'foo', undef, 'bar', undef, $cb);
+    Mojo::IOLoop->start;
+    is $error, $test_dir, 'Cache directory updated';
 };
 
 sub _mock_cache_service_client ($status_data) {
@@ -187,19 +210,23 @@ subtest 'problems when caching assets' => sub {
     $cache_client_mock->redefine(asset_path    => 'some/path');
     $cache_client_mock->redefine(asset_request => Test::FakeRequest->new);
 
-    my @args   = (Test::FakeJob->new, {ISO_1 => 'FOO'}, {ISO_1 => 'iso'}, 'webuihost');
-    my $result = OpenQA::Worker::Engines::isotovideo::cache_assets(@args);
-    is(
-        $result->{error},
-        'Failed to send asset request for FOO: some enqueue error',
-        'failed to enqueue request for asset download'
-    );
-    is($result->{category}, undef, 'no category set so problem is treated as cache service failure');
+    my $error  = 'not called';
+    my $cb     = sub ($err) { $error = $err; Mojo::IOLoop->stop };
+    my $job    = Test::FakeJob->new;
+    my @assets = ('ISO_1');
+    my @args   = ($job, {ISO_1 => 'FOO'}, \@assets, {ISO_1 => 'iso'}, 'webuihost', undef, $cb);
+    OpenQA::Worker::Engines::isotovideo::cache_assets(OpenQA::CacheService::Client->new, @args);
+    Mojo::IOLoop->start;
+    is $error->{error}, 'Failed to send asset request for FOO: some enqueue error',
+      'failed to enqueue request for asset download';
+    is $error->{category}, undef, 'no category set so problem is treated as cache service failure';
 
     $cache_client_mock->redefine(enqueue => 0);
-    $result = OpenQA::Worker::Engines::isotovideo::cache_assets(@args);
-    is($result->{error},    'Failed to download FOO to some/path', 'asset not found');
-    is($result->{category}, WORKER_EC_ASSET_FAILURE, 'category set so problem is treated as asset failure');
+    @assets = ('ISO_1');
+    OpenQA::Worker::Engines::isotovideo::cache_assets(OpenQA::CacheService::Client->new, @args);
+    Mojo::IOLoop->start;
+    is $error->{error}, 'Failed to download FOO to some/path', 'asset not found';
+    is $error->{category}, WORKER_EC_ASSET_FAILURE, 'category set so problem is treated as asset failure';
 };
 
 subtest 'syncing tests' => sub {
@@ -208,23 +235,26 @@ subtest 'syncing tests' => sub {
     $cache_client_mock->redefine(rsync_request => Test::FakeRequest->new(result => 'exit code 1'));
 
     my $worker = Test::FakeWorker->new;
-    my @args   = (Test::FakeJob->new(worker => $worker), {ISO_1 => 'iso'}, 'cache-dir', 'webuihost', 'rsync-source');
-    my $result = OpenQA::Worker::Engines::isotovideo::sync_tests(@args);
+    my $result = 'not called';
+    my $cb     = sub ($res) { $result = $res; Mojo::IOLoop->stop };
+    my @args = (Test::FakeJob->new(worker => $worker), {ISO_1 => 'iso'}, 'cache-dir/webuihost', 'rsync-source', 2, $cb);
+    OpenQA::Worker::Engines::isotovideo::sync_tests(OpenQA::CacheService::Client->new, @args);
     is $result->{error},
       "Failed to send rsync from 'rsync-source' to 'cache-dir/webuihost': some enqueue error",
       'failed to enqueue request for rsync';
-    is $result->{category}, undef, 'no category set so problem is treated as cache service failure';
+    is $result->{category}, undef, 'no category set so problem is treated as cache service failure (1)';
 
     $cache_client_mock->redefine(enqueue => 0);
-    $result = OpenQA::Worker::Engines::isotovideo::sync_tests(@args);
+    OpenQA::Worker::Engines::isotovideo::sync_tests(OpenQA::CacheService::Client->new, @args);
+    Mojo::IOLoop->start;
     is $result->{error}, 'Failed to rsync tests: exit code 1';
-    is $result->{category}, undef, 'no category set so problem is treated as cache service failure';
+    is $result->{category}, undef, 'no category set so problem is treated as cache service failure (2)';
 
-    $cache_client_mock->redefine(status => Test::MockObject->new->set_true('output')->set_always(result => undef));
-    my $mock = Test::MockModule->new('OpenQA::Worker::Engines::isotovideo');
-    $mock->redefine(_poll_cache_service => 0);
-    $result = OpenQA::Worker::Engines::isotovideo::sync_tests(@args);
-    is $result, 'cache-dir/webuihost/tests', 'returns synced test directory on success';
+    my $status_response = OpenQA::CacheService::Response::Status->new(data => {output => 'foo', status => 'processed'});
+    $cache_client_mock->redefine(status => $status_response);
+    OpenQA::Worker::Engines::isotovideo::sync_tests(OpenQA::CacheService::Client->new, @args);
+    Mojo::IOLoop->start;
+    is $result, 'cache-dir/webuihost/tests', 'returns synced test directory on success' or diag explain $result;
 };
 
 subtest 'symlink testrepo' => sub {
@@ -234,7 +264,7 @@ subtest 'symlink testrepo' => sub {
 
     subtest 'error case: CASEDIR missing' => sub {
         my $job     = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => {DISTRI => 'foo'}});
-        my $result  = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
+        my $result  = _run_engine($job);
         my $casedir = testcasedir('foo', undef, undef);
         like $result->{error}, qr/The source directory $casedir does not exist/,
           'symlink failed because the source directory does not exist';
@@ -243,7 +273,7 @@ subtest 'symlink testrepo' => sub {
     subtest 'error case: permission denied' => sub {
         chmod(0444, $pool_directory);
         my $job     = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => {DISTRI => 'opensuse'}});
-        my $result  = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
+        my $result  = _run_engine($job);
         my $casedir = testcasedir('opensuse', undef, undef);
         like $result->{error},
           qr/Cannot create symlink from "$casedir" to "$pool_directory\/opensuse": Permission denied/,
@@ -254,7 +284,7 @@ subtest 'symlink testrepo' => sub {
 
     subtest 'error case: NEEDLES_DIR missing' => sub {
         my $job     = OpenQA::Worker::Job->new($worker, $client, {id => 12, settings => {NEEDLES_DIR => 'needles'}});
-        my $result  = OpenQA::Worker::Engines::isotovideo::engine_workit($job);
+        my $result  = _run_engine($job);
         my $casedir = testcasedir(undef, undef, undef);
         like $result->{error}, qr/The source directory $casedir\/needles does not exist/,
           'symlink needles directory failed because source directory does not exist';
@@ -276,7 +306,7 @@ subtest 'symlink testrepo' => sub {
     subtest 'good case: custom CASEDIR and custom NEEDLES_DIR specified' => sub {
         my %job_settings = (id => 12, settings => {@custom_casedir_settings, NEEDLES_DIR => 'fedora/needles'});
         my ($job, $result) = OpenQA::Worker::Job->new($worker, $client, \%job_settings);
-        combined_like { $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
+        combined_like { $result = _run_engine($job) }
         qr {Symlinked from "t/data/openqa/share/tests/fedora/needles" to "$pool_directory/needles"},
           'symlink for needles dir created, points to default dir despite custom CASEDIR';
         my $vars_data = get_job_json_data($pool_directory);
@@ -290,7 +320,7 @@ subtest 'symlink testrepo' => sub {
     subtest 'good case: custom CASEDIR specified but no custom NEEDLES_DIR' => sub {
         my %job_settings = (id => 12, settings => {@custom_casedir_settings});
         my ($job, $result) = OpenQA::Worker::Job->new($worker, $client, \%job_settings);
-        combined_like { $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
+        combined_like { $result = _run_engine($job) }
         qr {Symlinked from "t/data/openqa/share/tests/fedora/needles" to "$pool_directory/needles"},
           'symlink for needles dir also created without NEEDLES_DIR, points to default dir despite custom CASEDIR';
         my $vars_data = get_job_json_data($pool_directory);
@@ -309,7 +339,7 @@ subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
     subtest 'don\'t do symlink when job settings include ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
         my %settings = (@settings, HDD_1 => 'foo.qcow2');
         my $job      = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => \%settings});
-        combined_unlike { OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
+        combined_unlike { _run_engine($job) }
         qr/Symlinked from/, 'don\'t do symlink when jobs have the ABSOLUTE_TEST_CONFIG_PATHS=1';
         my $vars_data = get_job_json_data($pool_directory);
         is $vars_data->{PRODUCTDIR}, productdir('fedora', undef, undef),  'default PRODUCTDIR assigned';
@@ -322,7 +352,7 @@ subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
     subtest 'absolute default NEEDLES_DIR with ABSOLUTE_TEST_CONFIG_PATHS=1 and custom CASEDIR' => sub {
         my %settings = (@settings, CASEDIR => 'git:foo/bar');
         my $job      = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => \%settings});
-        combined_unlike { OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
+        combined_unlike { _run_engine($job) }
         qr/Symlinked from/, 'don\'t do symlink when jobs have the ABSOLUTE_TEST_CONFIG_PATHS=1';
         my $vars_data           = get_job_json_data($pool_directory);
         my $expected_productdir = abs2rel(productdir('fedora', undef, undef), testcasedir('fedora', undef, undef));
@@ -341,7 +371,7 @@ subtest 'symlink asset' => sub {
     my $settings
       = {JOBTOKEN => 'token000', ISO => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso', HDD_1 => 'foo.qcow2'};
     my $job = OpenQA::Worker::Job->new($worker, $client, {id => 16, settings => $settings});
-    combined_like { my $result = OpenQA::Worker::Engines::isotovideo::engine_workit($job) }
+    combined_like { my $result = _run_engine($job) }
     qr/Linked asset/, 'linked asset';
     my $vars_data = get_job_json_data($pool_directory);
     ok(-e "$pool_directory/openSUSE-13.1-DVD-x86_64-Build0091-Media.iso", 'the iso is symlinked to pool directory');

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -120,25 +120,7 @@ qr/.*http:\/\/localhost:9527,https:\/\/remotehost.*qemu_i386,qemu_x86_64.*Errors
 subtest 'delay and exec' => sub {
     my $worker_mock = Test::MockModule->new('OpenQA::Worker');
     $worker_mock->redefine(init => 42);
-
-    my %executed_code_paths;
-    my %expected_code_paths = map { $_ => 1 } qw(before_delay after_delay another_event);
-    Mojo::IOLoop->next_tick(
-        sub {
-            $executed_code_paths{before_delay} = 1;
-            note 'before delay';
-            Mojo::IOLoop->timer(
-                0 => sub {
-                    $executed_code_paths{another_event} = 1;
-                    note 'another event';
-                });
-            $worker->delay(0);
-            $executed_code_paths{after_delay} = 1;
-            note 'after delay';
-        });
     is $worker->exec, 42, 'return code passed from init';
-    is_deeply \%executed_code_paths, \%expected_code_paths, 'all code paths executed'
-      or diag explain \%executed_code_paths;
 };
 
 subtest 'capabilities' => sub {


### PR DESCRIPTION
* Possibly fix crashes in web socket processing during setup
* Use proper callback instead of `delay` function when waiting for the
  cache service
* See https://progress.opensuse.org/issues/96710#note-15

---

The `delay` function can later be removed from the worker. This is not
included to avoid conflicts with #4123 (which we might want to merge
fast). Removing the delay function would [save use 44 lines of code](https://github.com/os-autoinst/openQA/commit/9b0a11ca499f48d6f760077a59ac260227e1cc82)
so in total the additional number of lines due to this change is < 30 and
it is less hacky.

Before merging this PR I need to do some more testing, possibly even
applying it on one production worker (e.g. openqaworker5).
