### PR TITLE
Fix flaky coverage of lib/OpenQA/Scheduler.pm

### DIFF
--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -110,10 +110,7 @@ sub setup {
     $self->plugin('Gru');
 
     # check for stale jobs every 2 minutes
-    Mojo::IOLoop->recurring(
-        120 => sub {
-            OpenQA::Scheduler::Model::Jobs->singleton->incomplete_and_duplicate_stale_jobs;
-        });
+    Mojo::IOLoop->recurring(120 => \&_check_stale);
 
     # initial schedule
     Mojo::IOLoop->next_tick(
@@ -126,5 +123,8 @@ sub setup {
 }
 
 sub schema { OpenQA::Schema->singleton }
+
+# uncoverable statement
+sub _check_stale { OpenQA::Scheduler::Model::Jobs->singleton->incomplete_and_duplicate_stale_jobs }
 
 1;

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -357,9 +357,7 @@ sub create_websocket_server {
     return $h;
 }
 
-sub create_scheduler {
-    my ($port, $no_stale_job_detection) = @_;
-    $port //= service_port 'scheduler';
+sub create_scheduler ($port = service_port 'scheduler') {
     note("Starting Scheduler service. Port: $port");
     OpenQA::Scheduler::Client->singleton->port($port);
     _setup_sigchld_handler 'openqa-scheduler', start sub {
@@ -367,8 +365,6 @@ sub create_scheduler {
         local $ENV{MOJO_LISTEN}             = "http://127.0.0.1:$port";
         local $ENV{MOJO_INACTIVITY_TIMEOUT} = 9999;
         local @ARGV                         = ('daemon');
-        monkey_patch 'OpenQA::Scheduler::Model::Jobs', incomplete_and_duplicate_stale_jobs => sub { 1 }
-          if $no_stale_job_detection;
         OpenQA::Scheduler::run;
         Devel::Cover::report() if Devel::Cover->can('report');
     };


### PR DESCRIPTION
I've tried a few different things, like running the stale job detection code on scheduler startup, but that doesn't really gain us anything. So, in the end the simplest solution won, and i just marked the line as uncoverable. There is only one test (`33-developer_mode.t`) that starts a scheduler with the timer active anyway. And the stale detection code has reasonable coverage independently through `20-stale-job-detection.t`.

Progress: https://progress.opensuse.org/issues/96519.