### PR TITLE
Add `/usr/bin/tail` to apparmor profile to fix hook script on o3

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -134,6 +134,7 @@
   /usr/bin/rm rix,
   /usr/bin/rsync mrix,
   /usr/bin/sed mrix,
+  /usr/bin/tail mrix,
   /usr/bin/wget ix,
 
   owner /var/log/openqa_gru wk,


### PR DESCRIPTION
* It otherwise fails with a permission error:
  ```
  /opt/os-autoinst-scripts/_common: line 40: /usr/bin/tail: Permission denied
  ```
* See https://progress.opensuse.org/issues/97508