### PR TITLE
Allow limit parameter for api/v1/jobs/overview

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -349,9 +349,10 @@ sub _compose_job_overview_search_args ($c) {
     $v->optional('group',          'not_empty');
     $v->optional('groupid',        'not_empty');
     $v->optional('id',             'not_empty');
+    $v->optional('limit',          'not_empty')->num(0, undef);
 
     # add simple query params to search args
-    for my $arg (qw(distri version flavor build test)) {
+    for my $arg (qw(distri version flavor build test limit)) {
         next unless $v->is_valid($arg);
         my $params      = $v->every_param($arg);
         my $param_count = scalar @$params;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -203,7 +203,7 @@ subtest 'job overview' => sub {
     );
 
     # overview for build 0048
-    $query->query(build => '0048',);
+    $query->query(build => '0048');
     $t->get_ok($query->path_query)->status_is(200);
     is_deeply(
         $t->tx->res->json,
@@ -223,6 +223,14 @@ subtest 'job overview' => sub {
         ],
         'latest build present'
     );
+
+    subtest 'limit parameter' => sub {
+        $query->query(build => '0048', limit => 1);
+        $t->get_ok($query->path_query)->status_is(200);
+        is(scalar(@{$t->tx->res->json}), 1, 'Expect only one job entry');
+        $t->json_is('/0/id' => 99939, 'Check correct order');
+    };
+
 };
 
 $schema->txn_begin;


### PR DESCRIPTION
This add a `LIMIT <num>` into the SQL query.
There is an additional job result limitation with
`OpenQA::Schema::Resultset::Jobs::latest_jobs()` but I think this change
is worth anyway.