### PR TITLE
Add /usr/bin/tac to apparmor profile to fix hook script on o3

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -134,6 +134,7 @@
   /usr/bin/rm rix,
   /usr/bin/rsync mrix,
   /usr/bin/sed mrix,
+  /usr/bin/tac mrix,
   /usr/bin/tail mrix,
   /usr/bin/wget ix,
 


### PR DESCRIPTION
* See https://progress.opensuse.org/issues/97508

From the gru logs:
```
/opt/os-autoinst-scripts/_common: line 43: /usr/bin/tac: Permission denied
/opt/os-autoinst-scripts/_common: line 43: echo: write error: Broken pipe
```