### PR TITLE
Simplify OpenQA::WebAPI::Auth::OpenID

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -108,7 +108,8 @@ sub auth_response ($c) {
     };
 
     $csr->handle_server_response(
-        not_openid => sub () { $err_handler->('Failed to login', 'OpenID provider returned invalid data. Please retry again') },
+        not_openid =>
+          sub () { $err_handler->('Failed to login', 'OpenID provider returned invalid data. Please retry again') },
         setup_needed => sub ($setup_url) {
             # Redirect the user to $setup_url
             $setup_url = URI::Escape::uri_unescape($setup_url);

--- a/t/03-auth-openid.t
+++ b/t/03-auth-openid.t
@@ -10,14 +10,23 @@ use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::WebAPI::Auth::OpenID;
 
+
 is OpenQA::WebAPI::Auth::OpenID::_first_last_name({'value.firstname' => 'Mordred'}), 'Mordred ',
   '_first_last_name concats also with empty fields';
-my $openid = OpenQA::WebAPI::Auth::OpenID->new();
 my (%openid_res, %openid_res2);
 my $vident = Test::MockObject->new->set_series('signed_extension_fields', \%openid_res, \%openid_res2);
 $vident->{identity} = 'mordred';
-my $mock = Test::MockModule->new('OpenQA::WebAPI::Auth::OpenID');
-$mock->noop('_create_user');
-$mock->mock('session', {});
-ok $openid->_handle_verified($vident), 'can call _handle_verified';
+my $users = Test::MockObject->new->set_always('create_user', 1);
+my $schema = Test::MockObject->new->set_always(resultset => $users);
+my %session;
+my $c
+  = Test::MockObject->new->set_always(schema => $schema)->set_always(session => \%session)->set_true('_create_user');
+ok OpenQA::WebAPI::Auth::OpenID::_handle_verified($c, $vident), 'can call _handle_verified';
+$c->set_always(
+    req => Test::MockObject->new->set_always(params => Test::MockObject->new->set_always(pairs => [1, 2]))
+      ->set_always(url => Test::MockObject->new->set_always(base => 'openqa')))
+  ->set_always(app => Test::MockObject->new->set_always(config => {})
+      ->set_always(log => Test::MockObject->new->set_true('error', 'debug')))->set_true('flash');
+is OpenQA::WebAPI::Auth::OpenID::auth_response($c), 0, 'can call auth_response';
+
 done_testing;

--- a/t/03-auth-openid.t
+++ b/t/03-auth-openid.t
@@ -1,0 +1,23 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+use Test::MockModule;
+use Test::MockObject;
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '10';
+use OpenQA::WebAPI::Auth::OpenID;
+
+is OpenQA::WebAPI::Auth::OpenID::_first_last_name({'value.firstname' => 'Mordred'}), 'Mordred ',
+  '_first_last_name concats also with empty fields';
+my $openid = OpenQA::WebAPI::Auth::OpenID->new();
+my (%openid_res, %openid_res2);
+my $vident = Test::MockObject->new->set_series('signed_extension_fields', \%openid_res, \%openid_res2);
+$vident->{identity} = 'mordred';
+my $mock = Test::MockModule->new('OpenQA::WebAPI::Auth::OpenID');
+$mock->noop('_create_user');
+$mock->mock('session', {});
+ok $openid->_handle_verified($vident), 'can call _handle_verified';
+done_testing;

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -59,7 +59,7 @@ subtest OpenID => sub {
         handle_server_response => sub ($self, %args) { },
         args => sub ($self, $query) { {return_page => encode_base64url('/tests/42')}->{$query} });
     $t->get_ok('/response')->status_is(302);
-    $t->header_is('Location', '/tests/42', 'redirect to original papge after login');
+    $t->header_is('Location', '/tests/42', 'redirect to original page after login');
 
     $t->get_ok('/api_keys')->status_is(302);
     $t->header_is('Location', '/login?return_page=%2Fapi_keys', 'remember return_page for ensure_operator');


### PR DESCRIPTION
* Use signatures in OpenQA::WebAPI::Auth::OpenID
* Simplify OpenQA::WebAPI::Auth::OpenID