### PR TITLE
Speed up 12-needle-edit.t by running all Minion jobs in foreground

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -176,6 +176,8 @@ sub wait_for_ajax {
             return undef;                             # uncoverable statement
         }
 
+        $args{with_minion}->perform_jobs_in_foreground if $args{with_minion};
+
         $timeout -= $check_interval;
         sleep $check_interval;
         $slept = 1;


### PR DESCRIPTION
Not a huge win, but a win.

Before
```
t/ui/12-needle-edit.t .. ok    
All tests successful.
Files=1, Tests=19, 77 wallclock secs ( 0.10 usr  0.04 sys + 190.67 cusr 15.16 csys = 205.97 CPU)
Result: PASS
```

After:
```
t/ui/12-needle-edit.t .. ok    
All tests successful.
Files=1, Tests=19, 42 wallclock secs ( 0.12 usr  0.01 sys + 23.23 cusr  1.20 csys = 24.56 CPU)
Result: PASS
```

Progress: https://progress.opensuse.org/issues/96564