### PR TITLE
Fix permission errors when running tidy after creating docker-compose setup

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -19,9 +19,8 @@ EOF
     exit
 }
 
-cleanup() {
-    find . -name '*.tdy' -delete
-}
+find-tdy() { find . \( -type d -path '*/container/webui/workdir/db' -prune -type f \) -or \( -name '*.tdy' \) ; }
+cleanup()  { find-tdy | xargs -r rm ; }
 
 set -eo pipefail
 
@@ -78,8 +77,7 @@ cleanup
 
 find-files | xargs perltidy --pro=.../.perltidyrc
 
-find . -name "*.tdy" | while read -r file
-do
+find-tdy | while read -r file; do
     if diff -u "${file%.tdy}" "$file"; then
         continue
     fi


### PR DESCRIPTION
Otherwise one gets the following error messages when running tidy because
the database directory for the docker-compose setup is not accessible:

```
find: ‘./container/webui/workdir/db’: Keine Berechtigung
```

Due to the strict error handling of the script this prevents tidy to work.
This change simply prevents `find` from traversing the directory.