### PR TITLE
Improve logging for artefact uploads

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -247,9 +247,8 @@ sub _retry_delay ($self, $is_webui_busy) {
 }
 
 sub evaluate_error ($self, $tx, $remaining_tries) {
-    my $error = $tx->error;
     my ($msg, $retry_delay, $is_webui_busy);
-    return ($msg, $retry_delay) unless $error;
+    return ($msg, $retry_delay) unless my $error = $tx->error;
     $$remaining_tries -= 1;
     $msg = $tx->res->json->{error} if $tx->res && $tx->res->json;
     $msg = $error->{message} unless $msg;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1393,7 +1393,8 @@ subtest 'log file upload' => sub {
     my $upload_res;
     $mock_failure = 1;
     combined_like { $upload_res = $job->_upload_log_file({file => {filename => 'bar', some => 'param'}}) }
-    qr|Upload attempts remaining: 4/5 for bar.*All 5 upload attempts have failed for bar|s, 'errors logged';
+    qr|Uploading artefact bar.*500 resp.*attempts.*4/5.*1/5.*All 5 upload attempts have failed for bar.*500 resp|s,
+      'attempts and errors logged';
     is $upload_res, 0, 'upload failed';
 
     my $callback_invoked = 0;


### PR DESCRIPTION
It'll look like this:

```
[debug]   Uploading artefact bar
[warning] Error uploading bar: 500 response: Foo
[warning] Uploading artefact bar (attempts remaining: 4/5)
…
[warning] Uploading artefact bar (attempts remaining: 1/5)
[warning] All 5 upload attempts have failed for bar
[error]   Error uploading bar: 500 response: Foo
```

So the reason for failing attempts is logged and it is clear that a new
upload attempt starts. Previously the message

```
[warning] Upload attempts remaining: 4/5 for bar
```

was logged but not `Uploading artefact bar` anymore which made it look
like no further attempt was actually made.

Related to https://progress.opensuse.org/issues/94531 but not a fix.