### PR TITLE
Fix checkboxes on users table broken by ForkAwesome migration (35a5333) 

### DIFF
--- a/assets/stylesheets/admin-pages.scss
+++ b/assets/stylesheets/admin-pages.scss
@@ -347,7 +347,7 @@ table#users {
                         display: block;
                         color: #690;
                     }
-                    .fa.fa-circle {
+                    .fa.fa-circle-o {
                         display: none;
                     }
                 }

--- a/assets/stylesheets/admin-pages.scss
+++ b/assets/stylesheets/admin-pages.scss
@@ -345,7 +345,7 @@ table#users {
                 label {
                     .fa-circle {
                         display: block;
-                        color: #690;
+                        color: $btn-primary-bg;
                     }
                     .fa.fa-circle-o {
                         display: none;
@@ -357,7 +357,7 @@ table#users {
     label {
         // styling radiobuttons
         .fa-circle {
-            color: #C8D4AC;
+            color: $btn-default-bg;
         }
     }
 }

--- a/templates/webapi/admin/user/index.html.ep
+++ b/templates/webapi/admin/user/index.html.ep
@@ -46,7 +46,7 @@
                 <input type="radio" name="role" value="user" id="<%= $user->id %>_user" <%= $selects[0] %>/>
                 <label for="<%= $user->id %>_user">
                     <span class="fa-stack"> <!-- sexy checkboxes! -->
-                        <i class="fa fa-circle-o fa-stack-1x"></i>
+                        <i class="fa fa-circle fa-stack-1x"></i>
                         <i class="fa fa-circle-o fa-stack-1x"></i>
                     </span>
                     User
@@ -54,7 +54,7 @@
                 <input type="radio" name="role" value="operator" id="<%= $user->id %>_operator" <%= $selects[1] %>/>
                 <label for="<%= $user->id %>_operator">
                     <span class="fa-stack">
-                        <i class="fa fa-circle-o fa-stack-1x"></i>
+                        <i class="fa fa-circle fa-stack-1x"></i>
                         <i class="fa fa-circle-o fa-stack-1x"></i>
                     </span>
                     Operator
@@ -62,7 +62,7 @@
                 <input type="radio" name="role" value="admin" id="<%= $user->id %>_admin" <%= $selects[2] %>/>
                 <label for="<%= $user->id %>_admin">
                     <span class="fa-stack">
-                        <i class="fa fa-circle-o fa-stack-1x"></i>
+                        <i class="fa fa-circle fa-stack-1x"></i>
                         <i class="fa fa-circle-o fa-stack-1x"></i>
                     </span>
                     Administrator

--- a/templates/webapi/admin/user/index.html.ep
+++ b/templates/webapi/admin/user/index.html.ep
@@ -34,15 +34,9 @@
                         <td class="name"><%= $user->fullname %></td>
                         <td class="nick"><%= $user->nickname %></td>
                         <td class="role" data-order="<%= $user->is_admin %><%= $user->is_operator %>">
-                            %= form_for url_for('admin_user', userid => $user->id) => (method => 'POST') => begin
-                                % my @selects = ['', '', ''];
-                                % my $select = 0;
-                                % if ($user->is_admin) {
-                                    %   $select = 2;
-                                % } elsif ($user->is_operator) {
-                                %   $select = 1;
-                % }
-                % $selects[$select] = Mojo::ByteStream->new("checked='checked' class='default'");
+                %= form_for url_for('admin_user', userid => $user->id) => (method => 'POST') => begin
+                % my @selects = ('', '', '');
+                % $selects[$user->is_admin ? 2 : $user->is_operator ? 1 : 0] = Mojo::ByteStream->new("checked='checked' class='default'");
                 <input type="radio" name="role" value="user" id="<%= $user->id %>_user" <%= $selects[0] %>/>
                 <label for="<%= $user->id %>_user">
                     <span class="fa-stack"> <!-- sexy checkboxes! -->


### PR DESCRIPTION
Additionally, use consistent colors and avoid rendering `ARRAY(0x…)`.

Just checkout https://openqa.opensuse.org/admin/users to see the problem.

The fixed version looks like this:
![screenshot_20210908_132544](https://user-images.githubusercontent.com/10248953/132501206-16260a4d-51b5-4229-aba6-321f6ca0942c.png)
