### PR TITLE
Fetch and display job status for test urls in comments

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -335,28 +335,36 @@ function renderSearchResults(query, url) {
   request.send();
 }
 
+function testStateHTML(job) {
+  var className = 'status fa fa-circle';
+  var title;
+  if (job.state === 'running' || job.state === 'scheduled') {
+    if (job.state === 'scheduled' && job.blocked_by_id) {
+      className += ' state_blocked';
+      title = 'blocked';
+    } else {
+      className += ' state_' + job.state;
+      title = job.state;
+    }
+  } else if (job.state === 'done') {
+    className += ' result_' + job.result;
+    title = 'Done: ' + job.result;
+  } else if (job.state === 'cancelled') {
+    className = 'status fa fa-times';
+    title = 'cancelled (' + job.result + ')';
+  }
+  return [className, title];
+}
+
 function renderTestState(item, job) {
   item.href = '/tests/' + job.id;
   while (item.firstChild) {
     item.firstChild.remove();
   }
   const icon = document.createElement('i');
-  icon.className = 'status fa fa-circle';
-  if (job.state === 'running' || job.state === 'scheduled') {
-    if (job.state === 'scheduled' && job.blocked_by_id) {
-      icon.className += ' state_blocked';
-      icon.title = 'blocked';
-    } else {
-      icon.className += ' state_' + job.state;
-      icon.title = job.state;
-    }
-  } else if (job.state === 'done') {
-    icon.className += ' result_' + job.result;
-    icon.title = 'Done: ' + job.result;
-  } else if (job.state === 'cancelled') {
-    icon.className = 'status fa fa-times';
-    icon.title = 'cancelled (' + job.result + ')';
-  }
+  const stateHTML = testStateHTML(job);
+  icon.className = stateHTML[0];
+  icon.title = stateHTML[1];
   item.appendChild(icon);
   item.appendChild(document.createTextNode(' ' + job.name + ' '));
   if (job.has_parents) {

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -729,6 +729,33 @@ function renderCommentsTab(response) {
   const tabPanelElement = this.panelElement;
   tabPanelElement.innerHTML = response;
   $(tabPanelElement).find('[data-toggle="popover"]').popover({html: true});
+  // Add job status icons to /t123 urls
+  const hostname = $(location).attr('host');
+  $(tabPanelElement)
+    .find('a')
+    .each(function (index, element) {
+      const href = $(element).attr('href');
+      if (href === undefined) {
+        return;
+      }
+      const re = new RegExp('^https?://' + hostname + '/t([0-9]+)$');
+      const found = href.match(re);
+      if (!found) {
+        return;
+      }
+      const id = found[1];
+      const url = '/api/v1/experimental/jobs/' + id + '/status';
+      $.ajax(url)
+        .done(function (response) {
+          const i = document.createElement('i');
+          const job = response;
+          const stateHTML = testStateHTML(job);
+          i.className = stateHTML[0];
+          i.title = stateHTML[1];
+          element.appendChild(i);
+        })
+        .fail(function (jqXHR, textStatus, errorThrown) {});
+    });
 }
 
 function renderInvestigationTab(response) {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -356,6 +356,7 @@ sub startup ($self) {
     my $job_r = $api_ro->any('/jobs/<jobid:num>');
     push @api_routes, $job_r;
     $api_public_r->any('/jobs/<jobid:num>')->name('apiv1_job')->to('job#show');
+    $api_public_r->get('/experimental/jobs/<jobid:num>/status')->name('apiv1_get_status')->to('job#get_status');
     $api_public_r->any('/jobs/<jobid:num>/details')->name('apiv1_job')->to('job#show', details => 1);
     $job_r->put('/')->name('apiv1_put_job')->to('job#update');
     $job_r->delete('/')->name('apiv1_delete_job')->to('job#destroy');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package OpenQA::WebAPI::Controller::API::V1::Job;
-use Mojo::Base 'Mojolicious::Controller';
+use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use OpenQA::Utils qw(:DEFAULT assetdir);
 use OpenQA::JobSettings;
@@ -460,6 +460,25 @@ sub update_status {
         return $self->render(json => {error => $ret->{error}}, status => $ret->{error_status});
     }
     $self->render(json => $ret);
+}
+
+=over 4
+
+=item get_status()
+
+Retrieve status of a job. Returns id, state, result, blocked_by_id.
+Preferrable over /job/<id> for performance and payload size, if you are only
+interested in the status.
+
+=back
+
+=cut
+
+sub get_status ($self) {
+    my $job_id = int $self->stash('jobid');
+    my @fields = qw(id state result blocked_by_id);
+    my $job    = $self->schema->resultset("Jobs")->find($job_id, {select => [@fields]});
+    $self->render(json => {map { $_ => $job->$_ } @fields});
 }
 
 =over 4

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -676,6 +676,12 @@ qr/Got status update for job 99963 with unexpected worker ID 999999 \(expected n
     $schema->txn_rollback;
 };
 
+subtest 'get job status' => sub {
+    $t->get_ok('/api/v1/experimental/jobs/80000/status')->status_is(200)->json_is('/id' => 80000, 'id present')
+      ->json_is('/state'         => 'done', 'status done')->json_is('/result' => 'passed', 'result passed')
+      ->json_is('/blocked_by_id' => undef,  'blocked_by_id undef');
+};
+
 subtest 'cancel job' => sub {
     $t->post_ok('/api/v1/jobs/99963/cancel')->status_is(200);
     is_deeply(

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -44,6 +44,7 @@ $schema->resultset('Bugs')->create(
 
 driver_missing unless my $driver = call_driver;
 disable_timeout;
+my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
 
 #
 # List with no parameters
@@ -299,6 +300,22 @@ subtest 'commenting in test results including labels' => sub {
     $driver->find_element_by_id('submitComment')->click();
     wait_for_ajax;
 
+    subtest 'add job status icons' => sub {
+        my $urls = <<"EOM";
+Can you see status circles after the URLs?
+
+- I'm green! $url/t80000
+- I'm red! $url/t99938
+EOM
+        $driver->find_element_by_id('text')->send_keys($urls);
+        $driver->find_element_by_id('submitComment')->click();
+        $driver->refresh;
+        wait_for_ajax;
+        my @i = $driver->find_elements('div.comment-body a i.status');
+        is $i[0]->get_attribute('class'), 'status fa fa-circle result_passed', "Icon for success is shown";
+        is $i[1]->get_attribute('class'), 'status fa fa-circle result_failed', "Icon for failure is shown";
+    };
+
     subtest 'check comment availability sign on test result overview' => sub {
         $driver->find_element_by_link_text('Job Groups')->click();
         like(
@@ -311,7 +328,7 @@ subtest 'commenting in test results including labels' => sub {
         $driver->title_is("openQA: Test summary", "back on test group overview");
         is(
             $driver->find_element('#res_DVD_x86_64_doc .fa-comment')->get_attribute('title'),
-            '2 comments available',
+            '3 comments available',
             "test results show available comment(s)"
         );
     };
@@ -450,7 +467,7 @@ subtest 'editing when logged in as regular user' => sub {
         $driver->find_element_by_id('text')->send_keys('test by nobody');
         $driver->find_element_by_id('submitComment')->click();
         wait_for_ajax(msg => 'comment for job 99938 added by regular user');
-        switch_to_comments_tab(5);
+        switch_to_comments_tab(6);
         only_edit_for_own_comments_expected;
     };
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/91773

TODO:

~~- [ ] Make it a feature switch (Don't know yet how to do that from client side)~~
- [x] Write a test

I added a new API route `/experimental/jobs/<id>/status` because it is much cheaper than `/jobs/<id>` which fetches also job_dependencies (2 selects) and assets (1 select per asset).
This is up for discussion, but it could be useful for other tools fetching the status of a job regularly.

Edit: I skip the feature switch as discussed in the daily. We don't expect a high performance impact, if any.