### PR TITLE
OpenQA::Schema::ResultSet::Assets: Mark single exception log as uncoverable

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -352,7 +352,7 @@ END_SQL
             rename($new_cache_file_path, $cache_file_path) or die $!;
         }
         catch {
-            log_warning("Unable to create cache file $cache_file_path: $@");
+            log_warning("Unable to create cache file $cache_file_path: $@");    # uncoverable statement
         };
     }
 


### PR DESCRIPTION
This should bring statement coverage for the file to 100%