### PR TITLE
Fetchneedles improvements

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -10,6 +10,7 @@
 : "${username:="openQA web UI"}"
 : "${product:="$dist"}"
 
+: "${git_lfs:="0"}"
 : "${needles_separate:="1"}"
 : "${needles_giturl:="git://github.com/os-autoinst/os-autoinst-needles-opensuse.git"}"
 : "${needles_branch:="master"}"
@@ -123,6 +124,9 @@ else
             git clone --depth 1 -b "$needles_branch" "$needles_giturl" .
             git config user.email "$email"
             git config user.name "$username"
+        fi
+        if [ "$git_lfs" = 1 ]; then
+            git lfs install --local
         fi
     else
         do_fetch "$target"

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -19,11 +19,11 @@
 : "${force:="0"}"
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ] ; then
-    echo "Get ${dist_name} tests and needles from:\n\t\t${giturl}"
+    printf "Get %s tests and needles from:\n\t\t%s\n" "${dist_name}" "${giturl}"
     if [ 1 = ${needles_separate} ] ; then
-        echo "\tand\t${needles_giturl}"
+        printf "\tand\t%s\n" "${needles_giturl}"
     fi
-    echo "\n(environment variables mentioned in '$0' can be set to change these values)"
+    printf "\n(environment variables mentioned in '%s' can be set to change these values)\n" "$0"
     exit
 fi
 

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -1,9 +1,8 @@
 #!/bin/sh -e
-[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Get openSUSE tests and needles from https://github.com/os-autoinst/os-autoinst-distri-opensuse" && exit
-
 : "${dbuser:="geekotest"}"
 : "${dbgroup:="www"}"
 
+: "${dist_name:=${dist:-"openSUSE"}}" # the display name, for the help message
 : "${dist:="opensuse"}"
 : "${giturl:="git://github.com/os-autoinst/os-autoinst-distri-opensuse.git"}"
 : "${branch:="master"}"
@@ -17,6 +16,15 @@
 
 : "${updateall:="0"}"
 : "${force:="0"}"
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ] ; then
+    echo "Get ${dist_name} tests and needles from:\n\t\t${giturl}"
+    if [ 1 = ${needles_separate} ] ; then
+        echo "\tand\t${needles_giturl}"
+    fi
+    echo "\n(environment variables mentioned in '$0' can be set to change these values)"
+    exit
+fi
 
 dir="/var/lib/openqa/share/tests"
 if [ -w / ]; then


### PR DESCRIPTION
This is mostly about making it easy to subsequently tune options used by downstream distros, but I think the changes should be of some benefit for OpenSUSE too.

I've not enabled the git-lfs change here (since you don't use it) but can assure you that it's been in use for openqa.debian.net (and workers) for months, and it works well.