### PR TITLE
Refresh asset size after the upload has been completed

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -43,6 +43,7 @@ sub register ($self, $type, $name, $options = {}) {
     $self->result_source->schema->txn_do(
         sub {
             my $asset = $self->find_or_create({type => $type, name => $name}, {key => 'assets_type_name'});
+            $asset->refresh_size if $options->{refresh_size};
             if (my $created_by = $options->{created_by}) {
                 my $scope = $options->{scope} // 'public';
                 $created_by->jobs_assets->create({asset_id => $asset->id, created_by => 1});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -617,7 +617,8 @@ sub create_artefact {
                 }
 
                 my ($fname, $type, $last) = @results;
-                $schema->resultset('Assets')->register($type, $fname, {scope => $scope, created_by => $job}) if $last;
+                my $assets = $schema->resultset('Assets');
+                $assets->register($type, $fname, {scope => $scope, created_by => $job, refresh_size => 1}) if $last;
                 return $self->render(json => {status => 'ok'});
             });
     }

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -394,10 +394,12 @@ subtest 'upload asset: successful chunk upload' => sub {
             ok(-d $chunkdir, 'Chunk directory exists') unless $_->is_last;
             $_->content(\undef);
         });
+    my $job = $jobs->find(99963);
     ok(!-d $chunkdir, 'Chunk directory should not exist anymore');
     ok(-e $rp,        'Asset exists after upload')
-      and is($jobs->find(99963)->result_size, $expected_result_size, 'asset size not taken into account');
+      and is($job->result_size, $expected_result_size, 'asset size not taken into account');
     $t->get_ok('/api/v1/assets/hdd/hdd_image.qcow2')->status_is(200)->json_is('/name' => 'hdd_image.qcow2');
+    isnt $_->asset->size, undef, $_->asset->name . ' has known size' for $job->jobs_assets->all;
 };
 
 subtest 'Test failure - if chunks are broken' => sub {


### PR DESCRIPTION
Otherwise it looks like the asset is known but does not exist and one gets
an error about the missing asset when trying to restart a job requiring it.

This is basically a follow-up of
https://github.com/os-autoinst/openQA/pull/4136 which introduced the
regression.

---

@mdoucha This fixes the problem you've mentioned in chat.