### PR TITLE
Add ignore-missing-assets to clone-job

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -116,7 +116,11 @@ sub clone_job_download_assets ($jobid, $job, $remote, $remote_url, $ua, $options
 
             print "downloading\n$from\nto\n$dst\n";
             my $r = $ua->mirror($from, $dst);
-            die "$jobid failed: ", $r->status_line, "\n" unless $r->is_success || $r->code == 304;
+            unless ($r->is_success || $r->code == 304) {
+                print "$jobid failed: $file", $r->status_line, "\n";
+                die "Can't clone due to missing assets: ", $r->status_line, " \n"
+                  unless $options->{'ignore-missing-assets'};
+            }
 
             # ensure the asset cleanup preserves the asset the configured amount of days starting from the time
             # it has been cloned (otherwise old assets might be cleaned up directly again after cloning)

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -113,6 +113,10 @@ job again which is of course only possible if --host is the local machine.
 Do NOT download assets. You need to ensure all required assets are provided
 yourself.
 
+=item B<--ignore-missing-assets>
+
+Cloning a job will not fail if an asset is missing.
+
 =item B<--clone-children>
 
 Clone child jobs as well. This is useful if you want to clone a full
@@ -172,7 +176,7 @@ sub parse_options() {
         \%options,           "from=s",              "host=s",               "dir=s",
         "apikey:s",          "apisecret:s",         "verbose|v",            "skip-deps",
         "skip-chained-deps", "skip-download",       "parental-inheritance", "help|h",
-        "show-progress",     "within-instance|w=s", "clone-children",
+        "show-progress",     "within-instance|w=s", "clone-children",       "ignore-missing-assets",
     ) or usage(1);
     usage(0) if $options{help};
     usage(1) if $options{help} || ($options{'within-instance'} && $options{from});

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -100,7 +100,7 @@ subtest 'asset download' => sub {
     my $fake_ua       = Test::FakeLWPUserAgent->new;
     my $remote        = undef;                          # should not be used here (there are no parents)
     my $remote_url    = Mojo::URL->new('http://foo');
-    my %options       = (dir => $temp_assetdir);
+    my %options       = (dir => $temp_assetdir, 'ignore-missing-assets' => 1);
     my $job_id        = 1;
     my %job           = (
         assets => {

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -31,17 +31,22 @@ use Mojo::Transaction;
 {
     package Test::FakeLWPUserAgentMirrorResult;
     use Mojo::Base -base;
-    has is_success => 1;
-    has code       => 304;
+    has is_success  => 1;
+    has code        => 304;
+    has status_line => 'some status';
 }
 {
     package Test::FakeLWPUserAgent;
     use Mojo::Base -base;
     has mirrored => sub { [] };
-    sub mirror {
-        my $self = shift;
-        push(@{$self->mirrored}, @_);
-        return Test::FakeLWPUserAgentMirrorResult->new;
+    has missing  => 0;
+    sub mirror ($self, $from, $dest) {
+        my @res
+          = ($self->missing || $from !~ qr{http://foo/tests/1/asset/iso/(foo|bar)\.iso})
+          ? (is_success => 0, code => 404)
+          : ();
+        push @{$self->mirrored}, $from, $dest;
+        Test::FakeLWPUserAgentMirrorResult->new(@res);
     }
 }
 
@@ -100,7 +105,7 @@ subtest 'asset download' => sub {
     my $fake_ua       = Test::FakeLWPUserAgent->new;
     my $remote        = undef;                          # should not be used here (there are no parents)
     my $remote_url    = Mojo::URL->new('http://foo');
-    my %options       = (dir => $temp_assetdir, 'ignore-missing-assets' => 1);
+    my %options       = (dir => $temp_assetdir);
     my $job_id        = 1;
     my %job           = (
         assets => {
@@ -109,16 +114,23 @@ subtest 'asset download' => sub {
         },
     );
 
-    throws_ok {
-        clone_job_download_assets($job_id, \%job, $remote, $remote_url, $fake_ua, \%options)
-    }
+    throws_ok { clone_job_download_assets($job_id, \%job, $remote, $remote_url, $fake_ua, \%options) }
     qr/can't write $temp_assetdir/, 'error because folder does not exist';
 
     $temp_assetdir->child('iso')->make_path;
-
-    combined_like {
-        clone_job_download_assets($job_id, \%job, $remote, $remote_url, $fake_ua, \%options)
+    $fake_ua->missing(1);
+    throws_ok {
+        combined_like { clone_job_download_assets($job_id, \%job, $remote, $remote_url, $fake_ua, \%options) }
+        qr/downloading.*foo.*to.*failed.*some status/s, 'download error logged';
     }
+    qr/Can't clone due to missing assets: some status/, 'error if asset does not exist';
+
+    $options{'ignore-missing-assets'} = 1;
+    combined_like { clone_job_download_assets($job_id, \%job, $remote, $remote_url, $fake_ua, \%options) }
+    qr/downloading.*foo.*to.*failed.*some status.*downloading.*bar.*failed/s, 'download error logged but ignored';
+
+    $fake_ua->mirrored([])->missing(0);
+    combined_like { clone_job_download_assets($job_id, \%job, $remote, $remote_url, $fake_ua, \%options) }
     qr{downloading.*http://.*foo.iso.*to.*foo.iso.*downloading.*http://.*bar.iso.*to.*bar.iso}s, 'download logged';
     is_deeply(
         $fake_ua->mirrored,


### PR DESCRIPTION
Avoid problems when some assets are missing (i.e uefi-pvars), which
aren't really needed for specific cases

```
https://openqa.suse.de/tests/7126208/asset/hdd/SLES-15-SP4-x86_64-Build36.1@64bit-gnome-uefi-vars.qcow2 to 
/srv/data/openqa/development_basedir/openqa/share/factory//hdd/SLES-15-SP4-x86_64-Build36.1@64bit-gnome-uefi-vars.qcow2
7126208 failed: SLES-15-SP4-x86_64-Build36.1@64bit-gnome-uefi-vars.qcow2404 Not Found
```