### PR TITLE
Allow configuring concurrent cleanup

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -295,10 +295,10 @@ inherit properties from the category. The categories are meant to combine job gr
 with common builds so test results for the same build can be shown together on
 the index page.
 
-
+[id="basic_cleanup"]
 === Cleanup
 IMPORTANT: openQA automatically deletes data that it considers "old" based on
-different settings. For example job data is deleted from old jobs by the `gru` task.
+different settings. For example old jobs and assets are deleted at some point.
 
 The following cleanup settings can be done on job-group-level:
 
@@ -321,6 +321,9 @@ be completely removed from the database.
 
 *NOTE* Jobs which do not belong to a job group are currently not affected by
 the mentioned cleanup properties.
+
+*NOTE* For more details, checkout the
+<<Installing.asciidoc#advanced_cleanup,advanced cleanup>> section.
 
 *NOTE* Archiving of important jobs can be enabled. Checkout the related settings
 within the `[archiving]` section of the config file for details.

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -490,9 +490,27 @@ inconsistent test results.
 From this point on, you can refer to the <<GettingStarted.asciidoc#get-testing,Getting Started>> guide to
 fetch the tests cases and possibly take a look at <<WritingTests.asciidoc#writingtests,Test Developer Guide>>
 
-== Advanced configuration
 [id="advanced"]
+== Advanced configuration
 
+[id="advanced_cleanup"]
+=== Cleanup
+Cleanup jobs run within the Minion job queue provided by `openqa-gru.service`.
+The dashboard for Minion jobs is accessible via the administrator menu in the
+web UI. Only one cleanup job can run at the same time unless `concurrent` is set
+to `1` in the `[cleanup]` settings of `openqa.ini`.
+
+Many other cleanup-related settings can be found within `openqa.ini` as well,
+e.g. the `[…_limits]` sections contain various tweaks and allow to change
+certain defaults.
+
+Checkout further sections of the documentation for more details about:
+
+* <<UsersGuide.asciidoc#asset_cleanup,Asset cleanup>>
+* <<Installing.asciidoc#auditing,Audit log cleanup>>
+* <<GettingStarted.asciidoc#basic_cleanup,Basic cleanup settings>>
+* <<UsersGuide.asciidoc#build_tagging,Build tagging>> to keep jobs longer by
+marking them as important
 
 === Setting up git support
 
@@ -894,8 +912,8 @@ cloning.
 Note that jobs marked as incomplete by the stale job detection are not affected by this
 configuration and cloned in any case.
 
-== Auditing - tracking openQA changes
 [id="auditing"]
+== Auditing - tracking openQA changes
 
 Auditing plugin enables openQA administrators to maintain overview about what is happening with the system.
 Plugin records what event was triggered by whom, when and what the request looked like. Actions done by openQA

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -345,6 +345,7 @@ corresponding icons
 image::images/tests-overview-issue_icon.png[Different icons for product and test issues]
 
 
+[id="build_tagging"]
 === Build tagging ===
 
 ==== Tag builds with special comments on group overview ====
@@ -1062,7 +1063,8 @@ web-UI. That path has subdirectories for each of the asset types, and the file o
 be in the correct subdirectory, so e.g. the file for an asset `HDD_1` must be under
 `/var/lib/openqa/share/factory/hdd`. You may create a subdirectory called `fixed` for any asset
 type and place assets there (e.g. in `/var/lib/openqa/share/factory/hdd/fixed` for `hdd`-type
-assets): this exempts them from the automatic cleanup described under 'Asset cleanup' above.
+assets): this exempts them from the automatic cleanup described in the
+<<UsersGuide.asciidoc#asset_cleanup,Asset cleanup>> section.
 Non-fixed assets are always subject to the cleanup.
 
 `UEFI_PFLASH_VARS` is a special case: whether it is treated as an asset depends on the value. If
@@ -1120,10 +1122,10 @@ in the <<WritingTests.asciidoc,Writing Tests>> guide.
 When using this mechanism you will often also want to use the 'Variable expansion' mechanism
 described in the <<GettingStarted.asciidoc,Getting Started>> guide.
 
+[id="asset_cleanup"]
 === Asset cleanup ===
-
-For more information on assets, see <<UsersGuide.asciidoc#_asset_handling,Asset handling>>
-below.
+For more information on assets, start reading from the beginning of the
+<<UsersGuide.asciidoc#_asset_handling,Asset handling>> section.
 
 Assets like ISO files consume a huge amount of disk space. Therefore openQA
 removes assets automatically according to configurable limits.
@@ -1134,7 +1136,6 @@ be found in the <<UsersGuide.asciidoc#_asset_handling,Asset handling>> section u
 <<UsersGuide.asciidoc#_use_of_the_rest_api,Use of the REST API>>.
 
 ==== Cleanup strategy ====
-
 openQA frequently checks whether assets need to be removed according to
 the configured limits.
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -149,6 +149,13 @@ blocklist = job_grab job_done
 #exchange = pubsub
 #topic_prefix = suse
 
+# Cleanup related configuration (besides limits)
+[cleanup]
+# Specifies whether different cleanup tasks can run in parallel. This option
+# makes particularly sense if assets and results are stored on different storage
+# locations or if your common storage solution is performant enough.
+concurrent = 0
+
 # Default limits for cleanup (sizes are in GiB, durations in days, zero denotes infinity)
 [default_group_limits]
 #asset_size_limit = 100 # only used on job group level (parent groups have no default)

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -126,6 +126,9 @@ sub read_config {
             concurrency        => 2,
             project_status_url => '',
         },
+        cleanup => {
+            concurrent => 0,
+        },
         default_group_limits => {
             asset_size_limit                  => OpenQA::JobGroupDefaults::SIZE_LIMIT_GB,
             log_storage_duration              => OpenQA::JobGroupDefaults::KEEP_LOGS_IN_DAYS,

--- a/t/config.t
+++ b/t/config.t
@@ -113,6 +113,9 @@ subtest 'Test configuration default modes' => sub {
             concurrency        => 2,
             project_status_url => '',
         },
+        cleanup => {
+            concurrent => 0,
+        },
         default_group_limits => {
             asset_size_limit                  => OpenQA::JobGroupDefaults::SIZE_LIMIT_GB,
             log_storage_duration              => OpenQA::JobGroupDefaults::KEEP_LOGS_IN_DAYS,


### PR DESCRIPTION
* Default behavior remains unchanged (all cleanup tasks block each other)
* For simplicity this setting affects all cleanup tasks (and not just asset
  and result cleanup).
* See https://progress.opensuse.org/issues/98922