### PR TITLE
Worker.pm: Print pool directory on error

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -792,7 +792,7 @@ sub _lock_pool_directory {
     make_path($pool_directory) unless -e $pool_directory;
 
     chdir $pool_directory || die "cannot change directory to $pool_directory: $!\n";
-    open(my $lockfd, '>>', '.locked') or die "cannot open lock file: $!\n";
+    open(my $lockfd, '>>', '.locked') or die "cannot open lock file in $pool_directory: $!\n";
     unless (fcntl($lockfd, F_SETLK, pack('ssqql', F_WRLCK, 0, 0, 0, $$))) {
         die "$pool_directory already locked\n";
     }


### PR DESCRIPTION
Printing directory name helps new users to investigate permissions.
Also this is the only related error message which does not print the directory name.

Signed-off-by: Petr Vorel <pvorel@suse.cz>