### PR TITLE
Display asset size

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -580,16 +580,16 @@ sub human_readable_size {
     }
     $size = $size / 1024.;
     if ($size < 1024) {
-        return $p . _round_a_bit($size) . "KiB";
+        return $p . _round_a_bit($size) . " KiB";
     }
 
     $size /= 1024.;
     if ($size < 1024) {
-        return $p . _round_a_bit($size) . "MiB";
+        return $p . _round_a_bit($size) . " MiB";
     }
 
     $size /= 1024.;
-    return $p . _round_a_bit($size) . "GiB";
+    return $p . _round_a_bit($size) . " GiB";
 }
 
 sub read_test_modules {

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -18,7 +18,7 @@ use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use Mojo::ByteStream;
 use OpenQA::Schema;
-use OpenQA::Utils qw(bugurl render_escaped_refs href_to_bugref);
+use OpenQA::Utils qw(bugurl human_readable_size render_escaped_refs href_to_bugref);
 use OpenQA::Events;
 
 sub register ($self, $app, $config) {
@@ -75,6 +75,12 @@ sub register ($self, $app, $config) {
         bug_report_actions => sub {
             my ($c, %args) = @_;
             return $c->include_branding('external_reporting', %args);
+        });
+
+    $app->helper(
+        human_readable_size => sub {
+            my ($c, $size) = @_;
+            return human_readable_size($size);
         });
 
     $app->helper(

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -417,13 +417,13 @@ subtest 'limit audit events' => sub {
 };
 
 subtest 'human readable size' => sub {
-    is(human_readable_size(0),           '0 Byte',  'zero');
-    is(human_readable_size(1),           '1 Byte',  'one');
-    is(human_readable_size(13443399680), '13GiB',   'two digits GB');
-    is(human_readable_size(8007188480),  '7.5GiB',  'smaller GB');
-    is(human_readable_size(-8007188480), '-7.5GiB', 'negative smaller GB');
-    is(human_readable_size(717946880),   '685MiB',  'large MB');
-    is(human_readable_size(245760),      '240KiB',  'less than a MB');
+    is(human_readable_size(0),           '0 Byte',   'zero');
+    is(human_readable_size(1),           '1 Byte',   'one');
+    is(human_readable_size(13443399680), '13 GiB',   'two digits GB');
+    is(human_readable_size(8007188480),  '7.5 GiB',  'smaller GB');
+    is(human_readable_size(-8007188480), '-7.5 GiB', 'negative smaller GB');
+    is(human_readable_size(717946880),   '685 MiB',  'large MB');
+    is(human_readable_size(245760),      '240 KiB',  'less than a MB');
 };
 
 subtest 'labeled jobs considered important' => sub {

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -92,8 +92,8 @@ my $app   = OpenQA::CacheService->new(log => $log);
 my $cache = $app->cache;
 is $cache->sqlite->migrations->latest, 3, 'version 3 is the latest version';
 is $cache->sqlite->migrations->active, 3, 'version 3 is the active version';
-like $cache_log, qr/Creating cache directory tree for "$cachedir"/,         'Cache directory tree created';
-like $cache_log, qr/Cache size of "$cachedir" is 0 Byte, with limit 50GiB/, 'Cache limit is default (50GB)';
+like $cache_log, qr/Creating cache directory tree for "$cachedir"/,          'Cache directory tree created';
+like $cache_log, qr/Cache size of "$cachedir" is 0 Byte, with limit 50 GiB/, 'Cache limit is default (50GB)';
 ok(-e $db_file, 'cache.sqlite is present');
 $cache_log = '';
 
@@ -120,7 +120,7 @@ $cache->downloader->sleep_time(0.01);
 $cache->init;
 $cache->limit(100);
 is $cache->sqlite->migrations->active, 3, 'version 3 is still the active version';
-like $cache_log, qr/Cache size of "$cachedir" is 168 Byte, with limit 50GiB/,
+like $cache_log, qr/Cache size of "$cachedir" is 168 Byte, with limit 50 GiB/,
   'Cache limit/size match the expected 100GB/168)';
 unlike $cache_log, qr/Purging ".*[13].qcow2"/,                                  'Registered assets 1 and 3 were kept';
 like $cache_log,   qr/Purging ".*2.qcow2" because the asset is not registered/, 'Unregistered asset 2 was removed';

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -455,7 +455,8 @@ subtest 'misc details: title, favicon, go back, go to source view, go to log vie
     # way lead to unstability (see poo#94060)
     $driver->get('/tests/99946/downloads_ajax');
     like $driver->find_element_by_id('asset-list')->get_text,
-      qr/openSUSE-13.1-DVD-i586-Build0091-Media.iso \(0 Byte\)[\n|\s]+openSUSE-13.1-x86_64.hda \(does not exist\)/, 'asset list';
+      qr/openSUSE-13.1-DVD-i586-Build0091-Media.iso \(0 Byte\)[\n|\s]+openSUSE-13.1-x86_64.hda \(does not exist\)/,
+      'asset list';
     $driver->find_element_by_link_text('autoinst-log.txt')->click;
     wait_for_ajax msg => 'log contents';
     like $driver->find_element('.embedded-logfile .ansi-blue-fg')->get_text, qr/send(autotype|key)/, 'log is colorful';

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -455,7 +455,7 @@ subtest 'misc details: title, favicon, go back, go to source view, go to log vie
     # way lead to unstability (see poo#94060)
     $driver->get('/tests/99946/downloads_ajax');
     like $driver->find_element_by_id('asset-list')->get_text,
-      qr/openSUSE-13.1-DVD-i586-Build0091-Media.iso[\n|\s]+openSUSE-13.1-x86_64.hda \(does not exist\)/, 'asset list';
+      qr/openSUSE-13.1-DVD-i586-Build0091-Media.iso \(0 Byte\)[\n|\s]+openSUSE-13.1-x86_64.hda \(does not exist\)/, 'asset list';
     $driver->find_element_by_link_text('autoinst-log.txt')->click;
     wait_for_ajax msg => 'log contents';
     like $driver->find_element('.embedded-logfile .ansi-blue-fg')->get_text, qr/send(autotype|key)/, 'log is colorful';

--- a/templates/webapi/test/downloads.html.ep
+++ b/templates/webapi/test/downloads.html.ep
@@ -17,6 +17,7 @@
                     %= link_to url_for('test_asset_name', testid => $testid, assettype => $asset->type, assetname => $asset->name) => (id => "asset_".$asset->id) => begin
                     %= $asset->name
                     % end
+                    (<%= human_readable_size($asset->size) %>)
                 % }
                 % else {
                     <%= $asset->name %> (does not exist)


### PR DESCRIPTION
Verification run: http://quasar.suse.cz/tests/7187#downloads
![example](https://user-images.githubusercontent.com/671766/134302809-50112493-057d-4059-8833-78d5eac20a12.png)

Obviously https://github.com/os-autoinst/openQA/pull/4212, i.e. printing "(does not exist)" still works :)
![example2](https://user-images.githubusercontent.com/671766/134302807-5b04f508-b0f7-4eda-9f60-9b7dced88730.png)
