### PR TITLE
Revert mistaken worker write access to needles

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -150,8 +150,6 @@
   /var/lib/openqa/share/factory/tmp/ rw,
   /var/lib/openqa/share/factory/tmp/** rw,
   /var/lib/openqa/share/tests/** r,
-  /var/lib/openqa/share/tests/*/needles/** rw,
-  /var/lib/openqa/share/tests/*/profiles/*/needles/** rw,
   owner /sys/**/ rw,
 
 


### PR DESCRIPTION
Reverting a mistaken change, as requested here:  https://github.com/os-autoinst/openQA/pull/4199#discussion_r713637429