### PR TITLE
templates: Clarify which filter options in /overview apply to the job

### DIFF
--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -86,13 +86,13 @@
         <div class="card-body">
             <form action="#" type="get" id="filter-form">
                 <div class="form-group" id="filter-results">
-                    <strong>Result</strong>
+                    <strong>Job result</strong>
                     % for my $result (OpenQA::Jobs::Constants::RESULTS) {
                         <label><input value="<%= $result %>" name="result" type="checkbox" id="filter-<%= $result %>"> <%= ucfirst $result =~ s/_/ /r %></label>
                     % }
                 </div>
                 <div class="form-group" id="filter-states">
-                    <strong>State</strong>
+                    <strong>Job state</strong>
                     % for my $state (OpenQA::Jobs::Constants::STATES) {
                         <label><input value="<%= $state %>" name="state" type="checkbox" id="filter-<%= $state %>"> <%= ucfirst $state =~ s/_/ /r %></label>
                     % }


### PR DESCRIPTION
We have filter options applying to the complete job as well as the
test modules. For modules we already prefix the strings with "Module".
So to be extra-explicit we can add "Job" as prefix for "Result" and
"State".

Related progress issue: https://progress.opensuse.org/issues/98460