### PR TITLE
Don't do 'rpm -i' when there is no package in cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,8 @@ aliases:
         if [ -z "$CIRCLE_WORKFLOW_ID" ]; then
           bash .circleci/build_cache.sh
         else
-          sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
+          rpms=$(find /var/cache/zypp/packages/ | grep '.rpm$')
+          [ -z "$rpms" ] || sudo rpm -i -f "$rpms"
         fi
 
   - &test_junit


### PR DESCRIPTION
Relate: https://progress.opensuse.org/issues/98496