### PR TITLE
CI: Add more explicit error message in cache load script

### DIFF
--- a/.circleci/build_or_install_from_cache.sh
+++ b/.circleci/build_or_install_from_cache.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+if [ -z "$CIRCLE_WORKFLOW_ID" ]; then
+    bash "$(dirname "$0")"/build_cache.sh
+else
+    packages=$(find /var/cache/zypp/packages/ | grep '.rpm$') || { echo "No RPM packages found, cache is empty, aborting" && exit 1; }
+    sudo rpm -i -f $packages
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,7 @@ aliases:
 
   - &install_cached_packages
     name: Install cached packages
-    command: |
-        set -x
-        if [ -z "$CIRCLE_WORKFLOW_ID" ]; then
-          bash .circleci/build_cache.sh
-        else
-          sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
-        fi
+    command: .circleci/build_or_install_from_cache.sh
 
   - &test_junit
     name: "Enabling JUnit output for Perl tests"


### PR DESCRIPTION
Tested locally with

```
podman run --rm -it -v .circleci/:/opt:ro registry.opensuse.org/opensuse/tumbleweed
```

running both `CIRCLE_WORKFLOW_ID=1 /opt/build_or_install_from_cache.sh`
and `/opt/build_or_install_from_cache.sh`.

Related progress issue: https://progress.opensuse.org/issues/98496