### PR TITLE
Fix computation of missing assets if there are no relevant assets

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -588,6 +588,7 @@ sub missing_assets {
             name => {-in => _compute_asset_names_considering_parent_jobs($parent_job_ids, $_->{name})},
         }
     } @relevant_assets;
+    return [] unless @assets_query;
     my $assets          = $self->result_source->schema->resultset('Assets');
     my @existing_assets = $assets->search({-or => \@assets_query, size => \'is not null'});
     return [] if scalar @$parent_job_ids == 0 && scalar @assets_query == scalar @existing_assets;


### PR DESCRIPTION
Apparently DBIx produces invalid SQL if the array for the "or" condition
is empty so we need to handle this case specifically to prevent an SQL
exception.

Without the `return [] unless @assets_query;` the extended test fails in
the same way as in https://progress.opensuse.org/issues/99327 so this
change should this this issue.