### PR TITLE
Avoid warning in `untie_asset_from_job_and_unregister_if_unused`

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -348,7 +348,7 @@ sub untie_asset_from_job_and_unregister_if_unused ($self, $type, $name, $job) {
     $self->result_source->schema->txn_do(
         sub {
             my %query = (type => $type, name => $name, fixed => 0);
-            return 0 unless my $asset = $self->find(\%query, {join => 'jobs_assets'});
+            return 0 unless my $asset = $self->find(\%query);
             $job->jobs_assets->search({asset_id => $asset->id})->delete;
             return 0 if defined $asset->size || $asset->jobs->count;
             $asset->delete;


### PR DESCRIPTION
This avoids the warning
```
Sep 25 23:49:29 openqa openqa[20390]: DBIx::Class::Storage::DBI::select_single(): Query returned more than one row.  SQL that returns multiple rows is DEPRECATED for ->find and ->single at /usr/share/openqa/script/../lib/OpenQA/Schema/ResultSet/Assets.pm line 353
```
which I have observed in OSD logs.

According to my tests with `DBI_TRACE=1` the join does *not* help to avoid
an additional query for the number of jobs (of the asset) anyways.