### PR TITLE
Fix SQL error in `refresh_assets` caused by 5b14fe

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -95,7 +95,7 @@ sub refresh_assets {
     my ($self) = @_;
 
     while (my $asset = $self->next) {
-        my $is_fixed = $asset->is_fixed;
+        my $is_fixed = $asset->is_fixed ? 1 : 0;
         $asset->update({fixed => $is_fixed}) if $is_fixed != $asset->fixed;
 
         $asset->refresh_size;

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -69,6 +69,12 @@ my $job_without_assets
 my $missing_assets = $job_without_assets->missing_assets;
 is_deeply $missing_assets, [], 'no assets missing if job has no relevant assets' or diag explain $missing_assets;
 
+my $assets                   = $schema->resultset('Assets');
+my $not_actually_fixed_asset = $assets->create({type => 'iso', name => 'not actually fixed', fixed => 1});
+$assets->refresh_assets;
+$not_actually_fixed_asset->discard_changes;
+is $not_actually_fixed_asset->fixed, 0, 'asset known to be fixed not considered fixed anymore if not actually fixed';
+
 ## test asset is not assigned to scheduled jobs after job creation
 # create new job
 my %settings = (


### PR DESCRIPTION
Otherwise the asset cleanup fails due to an SQL error:

```
DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::Pg::st execute failed: ERROR:  invalid input syntax for type boolean: "" [for Statement "UPDATE assets SET fixed = ?, t_updated = ? WHERE id = ?" with ParamValues: 1='', 2='2021-09-28 15:01:21', 3='27487345'] at /usr/share/openqa/script/../lib/OpenQA/Schema/ResultSet/Assets.pm line 99
```

Apparently DBIx cannot cope with the boolean here so one
has to convert to int manually.

See https://progress.opensuse.org/issues/97979#note-26