### PR TITLE
Upgrade CI container image versions to Leap 15.3

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -1,11 +1,11 @@
 #!BuildTag: openqa_dev
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.3
 
 # Define environment variable
 ENV NAME openQA test environment
 ENV LANG en_US.UTF-8
 
-RUN zypper ar -f -G 'http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.2/openSUSE_Leap_15.2' devel_openqa
+RUN zypper ar -f -G 'http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.3/openSUSE_Leap_15.3' devel_openqa
 
 # hadolint ignore=DL3037
 RUN zypper in -y -C \

--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,7 +4,7 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.3
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use

--- a/container/devel:openQA:ci/dependency_bot/Dockerfile
+++ b/container/devel:openQA:ci/dependency_bot/Dockerfile
@@ -1,5 +1,5 @@
 #!BuildTag: dependency_bot
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.3
 ENV NAME Leap with docker and hub
 
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
* Base containers for CircleCI jobs on openSUSE Leap 15.3
* Keep other containers as-is
* See https://progress.opensuse.org/issues/99240