### PR TITLE
Use consistent "Copyright" header without problematic characters

### DIFF
--- a/.circleci/build_autoinst.sh
+++ b/.circleci/build_autoinst.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/.circleci/build_cache.sh
+++ b/.circleci/build_cache.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/.circleci/build_dependencies.sh
+++ b/.circleci/build_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/.circleci/build_local_container.sh
+++ b/.circleci/build_local_container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/.circleci/ci-packages.txt
+++ b/.circleci/ci-packages.txt
@@ -194,7 +194,7 @@ perl-Readonly-2.05
 perl-Regexp-Common-2017060201
 perl-Role-Tiny-2.000006
 perl-Scope-Guard-0.21
-perl-Selenium-Remote-Driver-1.41
+perl-Selenium-Remote-Driver-1.44
 perl-Socket6-0.28
 perl-Socket-MsgHdr-0.04
 perl-Sort-Versions-1.62

--- a/container/openqa_data/scripts/client-conf
+++ b/container/openqa_data/scripts/client-conf
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2015 Red Hat
+# Copyright 2015 Red Hat
 #
 # This script is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dbicdh/_common/upgrade/76-77/001-migrate-audit-events-to-scheduled-products.pl
+++ b/dbicdh/_common/upgrade/76-77/001-migrate-audit-events-to-scheduled-products.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dbicdh/_common/upgrade/82-83/001-migrate-machine-syntax-within-dependencies.pl
+++ b/dbicdh/_common/upgrade/82-83/001-migrate-machine-syntax-within-dependencies.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dbicdh/_common/upgrade/85-86/000-backup-asset-size-defaults-of-parents.pl
+++ b/dbicdh/_common/upgrade/85-86/000-backup-asset-size-defaults-of-parents.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dbicdh/_common/upgrade/92-93/001-migrate-jobs.pl
+++ b/dbicdh/_common/upgrade/92-93/001-migrate-jobs.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dbicdh/_common/upgrade/92-93/002-set-finished-and-fix-state.pl
+++ b/dbicdh/_common/upgrade/92-93/002-set-finished-and-fix-state.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dbicdh/_common/upgrade/92-93/003-initialized-worker-last-seen.pl
+++ b/dbicdh/_common/upgrade/92-93/003-initialized-worker-last-seen.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package openQA
 #
-# Copyright (c) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/lib/OpenQA.pm
+++ b/lib/OpenQA.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/App.pm
+++ b/lib/OpenQA/App.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Client.pm
+++ b/lib/OpenQA/CacheService/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Command/run.pm
+++ b/lib/OpenQA/CacheService/Command/run.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Controller/API.pm
+++ b/lib/OpenQA/CacheService/Controller/API.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Controller/Influxdb.pm
+++ b/lib/OpenQA/CacheService/Controller/Influxdb.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Model/Downloads.pm
+++ b/lib/OpenQA/CacheService/Model/Downloads.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Plugin/Helpers.pm
+++ b/lib/OpenQA/CacheService/Plugin/Helpers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Request.pm
+++ b/lib/OpenQA/CacheService/Request.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Request/Asset.pm
+++ b/lib/OpenQA/CacheService/Request/Asset.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Request/Sync.pm
+++ b/lib/OpenQA/CacheService/Request/Sync.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Response.pm
+++ b/lib/OpenQA/CacheService/Response.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Response/Info.pm
+++ b/lib/OpenQA/CacheService/Response/Info.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Response/Status.pm
+++ b/lib/OpenQA/CacheService/Response/Status.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Client.pm
+++ b/lib/OpenQA/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Client/Handler.pm
+++ b/lib/OpenQA/Client/Handler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Client/Upload.pm
+++ b/lib/OpenQA/Client/Upload.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Events.pm
+++ b/lib/OpenQA/Events.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/File.pm
+++ b/lib/OpenQA/File.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Files.pm
+++ b/lib/OpenQA/Files.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Git.pm
+++ b/lib/OpenQA/Git.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/JobDependencies/Constants.pm
+++ b/lib/OpenQA/JobDependencies/Constants.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/JobGroupDefaults.pm
+++ b/lib/OpenQA/JobGroupDefaults.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/LiveHandler/Controller/LiveViewHandler.pm
+++ b/lib/OpenQA/LiveHandler/Controller/LiveViewHandler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Markdown.pm
+++ b/lib/OpenQA/Markdown.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Format/Base.pm
+++ b/lib/OpenQA/Parser/Format/Base.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Format/TAP.pm
+++ b/lib/OpenQA/Parser/Format/TAP.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Result.pm
+++ b/lib/OpenQA/Parser/Result.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Result/Node.pm
+++ b/lib/OpenQA/Parser/Result/Node.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 SUSE LLC
+# Copyright 2017-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Result/OpenQA.pm
+++ b/lib/OpenQA/Parser/Result/OpenQA.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Result/OpenQA/Results.pm
+++ b/lib/OpenQA/Parser/Result/OpenQA/Results.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Result/Output.pm
+++ b/lib/OpenQA/Parser/Result/Output.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Result/Test.pm
+++ b/lib/OpenQA/Parser/Result/Test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright 2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Parser/Results.pm
+++ b/lib/OpenQA/Parser/Results.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Resource/Locks.pm
+++ b/lib/OpenQA/Resource/Locks.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Scheduler/Client.pm
+++ b/lib/OpenQA/Scheduler/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Scheduler/Controller/API.pm
+++ b/lib/OpenQA/Scheduler/Controller/API.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -1,4 +1,4 @@
-# Copyright © 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Profiler.pm
+++ b/lib/OpenQA/Schema/Profiler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/ApiKeys.pm
+++ b/lib/OpenQA/Schema/Result/ApiKeys.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/AuditEvents.pm
+++ b/lib/OpenQA/Schema/Result/AuditEvents.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Bugs.pm
+++ b/lib/OpenQA/Schema/Result/Bugs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright 2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/DeveloperSessions.pm
+++ b/lib/OpenQA/Schema/Result/DeveloperSessions.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/GruDependencies.pm
+++ b/lib/OpenQA/Schema/Result/GruDependencies.pm
@@ -1,5 +1,5 @@
-# Copyright (C) 2015 SUSE LLC
-# Copyright (C) 2015 Red Hat
+# Copyright 2015 SUSE LLC
+# Copyright 2015 Red Hat
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/GruTasks.pm
+++ b/lib/OpenQA/Schema/Result/GruTasks.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobDependencies.pm
+++ b/lib/OpenQA/Schema/Result/JobDependencies.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/Result/JobGroupParents.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobLocks.pm
+++ b/lib/OpenQA/Schema/Result/JobLocks.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobNetworks.pm
+++ b/lib/OpenQA/Schema/Result/JobNetworks.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobNextPrevious.pm
+++ b/lib/OpenQA/Schema/Result/JobNextPrevious.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobTemplateSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplateSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobTemplates.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplates.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright 2014-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/JobsAssets.pm
+++ b/lib/OpenQA/Schema/Result/JobsAssets.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/MachineSettings.pm
+++ b/lib/OpenQA/Schema/Result/MachineSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Machines.pm
+++ b/lib/OpenQA/Schema/Result/Machines.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/NeedleDirs.pm
+++ b/lib/OpenQA/Schema/Result/NeedleDirs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/ProductSettings.pm
+++ b/lib/OpenQA/Schema/Result/ProductSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Products.pm
+++ b/lib/OpenQA/Schema/Result/Products.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
+++ b/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 SUSE LLC
+# Copyright 2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Screenshots.pm
+++ b/lib/OpenQA/Schema/Result/Screenshots.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Secrets.pm
+++ b/lib/OpenQA/Schema/Result/Secrets.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
+++ b/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/TestSuites.pm
+++ b/lib/OpenQA/Schema/Result/TestSuites.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Users.pm
+++ b/lib/OpenQA/Schema/Result/Users.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/WorkerProperties.pm
+++ b/lib/OpenQA/Schema/Result/WorkerProperties.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #               2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify

--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/AuditEvents.pm
+++ b/lib/OpenQA/Schema/ResultSet/AuditEvents.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/Bugs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Bugs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 LLC
+# Copyright 2019 LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 LLC
+# Copyright 2020-2021 LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/DeveloperSessions.pm
+++ b/lib/OpenQA/Schema/ResultSet/DeveloperSessions.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobGroupParents.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/JobSettings.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobSettings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/JobTemplates.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobTemplates.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/Needles.pm
+++ b/lib/OpenQA/Schema/ResultSet/Needles.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 LLC
+# Copyright 2018-2020 LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/Screenshots.pm
+++ b/lib/OpenQA/Schema/ResultSet/Screenshots.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Schema/ResultSet/Users.pm
+++ b/lib/OpenQA/Schema/ResultSet/Users.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 LLC
+# Copyright 2019-2021 LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/ScreenshotDeletion.pm
+++ b/lib/OpenQA/ScreenshotDeletion.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Script/Client.pm
+++ b/lib/OpenQA/Script/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Shared/Controller/Session.pm
+++ b/lib/OpenQA/Shared/Controller/Session.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Shared/GruJob.pm
+++ b/lib/OpenQA/Shared/GruJob.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Shared/Plugin/CSRF.pm
+++ b/lib/OpenQA/Shared/Plugin/CSRF.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/AuditEvents/Limit.pm
+++ b/lib/OpenQA/Task/AuditEvents/Limit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Bug/Limit.pm
+++ b/lib/OpenQA/Task/Bug/Limit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Iso/Schedule.pm
+++ b/lib/OpenQA/Task/Iso/Schedule.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Job/ArchiveResults.pm
+++ b/lib/OpenQA/Task/Job/ArchiveResults.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Job/FinalizeResults.pm
+++ b/lib/OpenQA/Task/Job/FinalizeResults.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Needle/Delete.pm
+++ b/lib/OpenQA/Task/Needle/Delete.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Needle/Scan.pm
+++ b/lib/OpenQA/Task/Needle/Scan.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 SUSE LLC
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Command/gru.pm
+++ b/lib/OpenQA/WebAPI/Command/gru.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Command/gru/list.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/list.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Command/gru/run.pm
+++ b/lib/OpenQA/WebAPI/Command/gru/run.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 SUSE LLC
+# Copyright 2015-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Command.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 SUSE LLC
+# Copyright 2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright 2014-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Locks.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #           (C) 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify

--- a/lib/OpenQA/WebAPI/Controller/API/V1/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/User.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/ActivityView.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/ActivityView.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2018 SUSE LLC
+# Copyright 2014-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/Machine.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Machine.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/Product.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Product.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Table.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/TestSuite.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/TestSuite.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/User.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/ApiKey.pm
+++ b/lib/OpenQA/WebAPI/Controller/ApiKey.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Developer.pm
+++ b/lib/OpenQA/WebAPI/Controller/Developer.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2016 SUSE LLC
+# Copyright 2014-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Description.pm
+++ b/lib/OpenQA/WebAPI/Description.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2018 SUSE LLC
+# Copyright 2012-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AuditLog.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
+++ b/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
@@ -106,7 +106,7 @@ L<https://github.com/grishkovelli/Mojolicious-Plugin-HashedParams>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2013, Grishkovelli.
+Copyright 2013, Grishkovelli.
 
 This library is free software; you can redistribute it and/or modify it under the same terms as Perl itself.
 

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/MIMETypes.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MIMETypes.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/MemoryLimit.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MemoryLimit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Folders.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Folders.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Gru.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/REST.pm
+++ b/lib/OpenQA/WebAPI/Plugin/REST.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/Plugin/YAML.pm
+++ b/lib/OpenQA/WebAPI/Plugin/YAML.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebAPI/ServerSideDataTable.pm
+++ b/lib/OpenQA/WebAPI/ServerSideDataTable.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright 2014-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebSockets/Client.pm
+++ b/lib/OpenQA/WebSockets/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebSockets/Controller/API.pm
+++ b/lib/OpenQA/WebSockets/Controller/API.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebSockets/Model/Status.pm
+++ b/lib/OpenQA/WebSockets/Model/Status.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/WebSockets/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebSockets/Plugin/Helpers.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/App.pm
+++ b/lib/OpenQA/Worker/App.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/Isotovideo/Client.pm
+++ b/lib/OpenQA/Worker/Isotovideo/Client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/OpenQA/YAML.pm
+++ b/lib/OpenQA/YAML.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -1,7 +1,7 @@
 
 # ------------------------------------------------------------------
 #
-#    Copyright (C) 2014-2016 SUSE LLC
+#    Copyright 2014-2016 SUSE LLC
 #
 #    This program is free software; you can redistribute it and/or
 #    modify it under the terms of version 2 of the GNU General Public

--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -3,7 +3,7 @@
 
 # ------------------------------------------------------------------
 #
-#    Copyright (C) 2015 SUSE LLC
+#    Copyright 2015 SUSE LLC
 #
 #    This program is free software; you can redistribute it and/or
 #    modify it under the terms of version 2 of the GNU General Public

--- a/script/client
+++ b/script/client
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/create_admin
+++ b/script/create_admin
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015 Red Hat
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015 Red Hat
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/dump_templates
+++ b/script/dump_templates
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/initdb
+++ b/script/initdb
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/load_templates
+++ b/script/load_templates
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/modify_needle
+++ b/script/modify_needle
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright © 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/openqa
+++ b/script/openqa
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/openqa-cli
+++ b/script/openqa-cli
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2013-2021 SUSE LLC
+# Copyright 2013-2021 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/script/openqa-livehandler
+++ b/script/openqa-livehandler
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/openqa-scheduler
+++ b/script/openqa-scheduler
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/openqa-validate-yaml
+++ b/script/openqa-validate-yaml
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/openqa-workercache
+++ b/script/openqa-workercache
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/script/worker
+++ b/script/worker
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/01-style.t
+++ b/t/01-style.t
@@ -1,4 +1,5 @@
-# Copyright 2019-2020 SUSE LLC
+#!/usr/bin/perl
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,10 +15,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use Test::Most;
-# no OpenQA::Test::TimeLimit for this trivial test
 
-use Test::Warnings ':report_warnings';
-
-is(system('script/openqa-label-all --help'), 0);
-
-done_testing();
+ok system(qq{git grep -I -l 'Copyright \((C)\|(c)\|©\)' ':!COPYING' ':!external/'}) != 0,
+  'No redundant copyright character';
+done_testing;

--- a/t/01-test-utilities.t
+++ b/t/01-test-utilities.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-scheduler-serialize-directly-chained-dependencies.t
+++ b/t/05-scheduler-serialize-directly-chained-dependencies.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/11-commands.t
+++ b/t/11-commands.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/12-profiler.t
+++ b/t/12-profiler.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/16-utils-job-templates.t
+++ b/t/16-utils-job-templates.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/19-tests-export.t
+++ b/t/19-tests-export.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2016 Red Hat
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2016 Red Hat
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017-2021 SUSE Linux LLC
+# Copyright 2017-2021 SUSE Linux LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-cache-client.t
+++ b/t/25-cache-client.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (c) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (c) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/27-errorpages.t
+++ b/t/27-errorpages.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/31-api_descriptions.t
+++ b/t/31-api_descriptions.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/31-client.t
+++ b/t/31-client.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/31-client_archive.t
+++ b/t/31-client_archive.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/32-openqa_client-script.t
+++ b/t/32-openqa_client-script.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/36-job_group_settings.t
+++ b/t/36-job_group_settings.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/40-script_load_dump_templates.t
+++ b/t/40-script_load_dump_templates.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/43-cli.t
+++ b/t/43-cli.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/44-scripts-modify_needle.t
+++ b/t/44-scripts-modify_needle.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/45-make-update-deps.t
+++ b/t/45-make-update-deps.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
-# Copyright (C) 2016 Red Hat
+# Copyright 2014-2021 SUSE LLC
+# Copyright 2016 Red Hat
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
-# Copyright (C) 2016 Red Hat
+# Copyright 2014-2021 SUSE LLC
+# Copyright 2016 Red Hat
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/07-testsuites.t
+++ b/t/api/07-testsuites.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/12-admin-workers.t
+++ b/t/api/12-admin-workers.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/api/15-users.t
+++ b/t/api/15-users.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/config.t
+++ b/t/config.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/openqa/share/tests/opensuse/tests/openQA/kate.pm
+++ b/t/data/openqa/share/tests/opensuse/tests/openQA/kate.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/lib/OpenQA/Test/Case.pm
+++ b/t/lib/OpenQA/Test/Case.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/lib/OpenQA/Test/FakeWebSocketTransaction.pm
+++ b/t/lib/OpenQA/Test/FakeWebSocketTransaction.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/lib/OpenQA/Test/ObsRsync.pm
+++ b/t/lib/OpenQA/Test/ObsRsync.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/lib/OpenQA/Test/Testresults.pm
+++ b/t/lib/OpenQA/Test/Testresults.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/02-csrf.t
+++ b/t/ui/02-csrf.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/04-api_keys.t
+++ b/t/ui/04-api_keys.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/09-admin_creation.t
+++ b/t/ui/09-admin_creation.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/13-admin-no-login.t
+++ b/t/ui/13-admin-no-login.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/16-activity-view.t
+++ b/t/ui/16-activity-view.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2014-2021 SUSE LLC
+# Copyright 2014-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/20-bugzilla-links.t
+++ b/t/ui/20-bugzilla-links.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2014-2020 SUSE LLC
+# Copyright 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/22-job_group_order.t
+++ b/t/ui/22-job_group_order.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/27-plugin_obs_rsync.t
+++ b/t/ui/27-plugin_obs_rsync.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/27-plugin_obs_rsync_gru.t
+++ b/t/ui/27-plugin_obs_rsync_gru.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright © 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/generate-documentation
+++ b/tools/generate-documentation
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # shellcheck disable=SC2103
-# Copyright (C) 2016-2019 SUSE LLC
+# Copyright 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/generate-documentation-genapi
+++ b/tools/generate-documentation-genapi
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2016-2017 SUSE LLC
+# Copyright 2016-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/generate-packed-assets
+++ b/tools/generate-packed-assets
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-# Copyright (C) 2016-2019 SUSE LLC
-# Copyright (C) 2016 Red Hat
+# Copyright 2016-2019 SUSE LLC
+# Copyright 2016 Red Hat
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Same as done for os-autoinst in https://github.com/os-autoinst/os-autoinst/pull/1799

https://en.wikipedia.org/wiki/Copyright_symbol
explains that (c) can be used as a commonly accepted alternative to the
non-ASCII character previously used which can sometimes (still) cause
problems which we can avoid.

According to https://stackoverflow.com/a/221380 even the character
itself is seen as redundant as a repetition of the word "Copyright".
Also in the United States, the Berne Convention Implementation Act of
1988, effective March 1, 1989, removed the requirement for the copyright
symbol from U.S. copyright law so it is not necessary after all.

So we could have selected "(c)" or treat all files as unicode and
convert any ISO8859-1 copyright characters to the according unicode
character symbol or just get rid of the character at all.

This commit removes all variants of copyright characters in our source
files excluding binary files, full-text license files or external
references, i.e. os-autoinst-common.

I used the command

```
git grep -l 'Copyright' | xargs sed -i 's/Copyright \((C)\|(c)\|©\)/Copyright/g'
```

and manually reverted the changes in places where the change was
unintended as stated above.

This helps to not upset TidyAll and also seems to be a more consistent
standard among source files in multiple projects.

Related progress issue: https://progress.opensuse.org/issues/98616