### PR TITLE
Allow more shells in apparmor profile

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -126,7 +126,7 @@
   /usr/share/openqa/script/openqa-cli px,
   /usr/share/openqa/script/openqa-clone-job mrix,
   /usr/share/openqa/script/openqa-clone-job r,
-  /bin/bash mrix,
+  /{usr/,}bin/{b,d}ash rix,
   /usr/bin/cat rix,
   /usr/bin/curl rix,
   /usr/bin/date mrix,


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/99195

In Leap 15.2, /bin/sh points to /bin/bash, while in 15.3,
it points to /usr/bin/sh -> /usr/bin/bash

Using the opportunity to also allow dash.