### PR TITLE
Allow hxselect in apparmor profile

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -136,6 +136,7 @@
   /usr/bin/gawk mrix,
   /usr/bin/grep mrix,
   /usr/bin/head mrix,
+  /usr/bin/hxselect mrix,
   /usr/bin/jq rix,
   /usr/bin/mv ix,
   /usr/bin/mktemp rix,


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/99195