### PR TITLE
Fail on unexpected Javascript console errors

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -135,7 +135,7 @@ $driver->find_element_by_link_text('core@coolone')->click();
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');
 my $job_page_url = $driver->get_current_url();
 like(status_text, qr/State: scheduled/, 'test 1 is scheduled');
-ok javascript_console_has_no_warnings_or_errors, 'no javascript warnings or errors after test 1 was scheduled';
+ok(javascript_console_has_no_warnings_or_errors(), 'no unexpected js warnings after test 1 was scheduled');
 
 sub assign_jobs ($worker_class = undef) {
     check_scheduled_job_and_wait_for_free_worker $worker_class // 'qemu_i386';
@@ -257,7 +257,7 @@ $job_name = 'tinycore-1-flavor-i386-Build1-core@noassets';
 $driver->title_is("openQA: $job_name test results", 'scheduled test page');
 like status_text, qr/State: scheduled/, 'test 4 is scheduled';
 
-ok javascript_console_has_no_warnings_or_errors, 'no javascript warnings or errors after test 4 was scheduled';
+ok(javascript_console_has_no_warnings_or_errors(), 'no unexpected js warnings after test 4 was scheduled');
 start_worker_and_assign_jobs;
 
 subtest 'incomplete job because of setup failure' => sub {

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -80,8 +80,8 @@ sub find_status_text { shift->find_element('#info_box .card-body')->get_text() }
 sub _fail_with_result_panel_contents {
     my ($result_panel_contents, $msg) = @_;    # uncoverable statement
     diag("full result panel contents:\n$result_panel_contents");    # uncoverable statement
-    javascript_console_has_no_warnings_or_errors;    # uncoverable statement
-    fail $msg;    # uncoverable statement
+    ok(javascript_console_has_no_warnings_or_errors, 'No unexpected js warnings');    # uncoverable statement
+    fail "Expected result not found";    # uncoverable statement
 }
 
 sub wait_for_result_panel {
@@ -104,7 +104,8 @@ sub wait_for_result_panel {
             diag("stopped waiting for '$result_panel', result turned out to be '$1'");    # uncoverable statement
             return _fail_with_result_panel_contents($status_text, $msg);    # uncoverable statement
         }
-        javascript_console_has_no_warnings_or_errors;
+        return _fail_with_result_panel_contents($status_text, $msg)
+          unless javascript_console_has_no_warnings_or_errors;    # uncoverable statement
         sleep $check_interval if $check_interval;
     }
     my $final_status_text = find_status_text($driver);    # uncoverable statement
@@ -134,9 +135,8 @@ sub _match_regex_returning_index {
 sub wait_for_developer_console_like {
     my ($driver, $message_regex, $diag_info) = @_;
 
-    # abort on javascript console errors
     my $js_erro_check_suffix = ', waiting for ' . $diag_info;
-    javascript_console_has_no_warnings_or_errors($js_erro_check_suffix);
+    ok(javascript_console_has_no_warnings_or_errors($js_erro_check_suffix), 'No unexpected js warnings');
 
     # get log
     my $position_of_last_match = $driver->execute_script('return window.lastWaitForDevelConsoleMsgMatch;') // 0;

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -71,7 +71,7 @@ sub switch_to_comments_tab {
 sub check_comment {
     my ($supposed_text, $edited) = @_;
 
-    javascript_console_has_no_warnings_or_errors;
+    ok(javascript_console_has_no_warnings_or_errors(), 'no unexpected js warnings');
 
     # check number of elements
     my @comment_headings = $driver->find_elements('h4.media-heading');
@@ -163,7 +163,7 @@ sub test_comment_editing {
         # check whether the counter in the comments tab has been decreased to zero
         switch_to_comments_tab(0) if ($in_test_results);
 
-        javascript_console_has_no_warnings_or_errors;
+        ok(javascript_console_has_no_warnings_or_errors(), 'no unexpected js warnings');
 
         # re-add a comment with the original message
         $driver->find_element_by_id('text')->send_keys($test_message);
@@ -486,7 +486,7 @@ subtest 'editing when logged in as regular user' => sub {
       for (@group_overview_urls);
 };
 
-javascript_console_has_no_warnings_or_errors;
+ok(javascript_console_has_no_warnings_or_errors(), 'no unexpected js warnings');
 
 kill_driver();
 

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -192,7 +192,7 @@ subtest 'graph rendering' => sub {
     $driver->get('/tests/99938');
     $driver->find_element_by_link_text('Dependencies')->click();
     wait_for_ajax();
-    javascript_console_has_no_warnings_or_errors();
+    ok(javascript_console_has_no_warnings_or_errors(), 'no unexpected js warnings');
 
     my $graph = $driver->find_element_by_id('dependencygraph');
     my $check_element_quandity = sub {


### PR DESCRIPTION
The function merely returns a truthy value. Let's fail always without relying on the caller. This means we will see errors in all cases, not just when something else happens to fail.

I'm also dropping a comment claiming the function aborts.

See: https://progress.opensuse.org/issues/98952