### PR TITLE
t: Fix path in t/01-style.t

### DIFF
--- a/t/01-style.t
+++ b/t/01-style.t
@@ -8,8 +8,8 @@ ok system(qq{git grep -I -l 'Copyright \((C)\|(c)\|©\)' ':!COPYING' ':!external
   'No redundant copyright character';
 ok
   system(
-qq{git grep -I -l 'This program is free software.*if not, see <http://www.gnu.org/licenses/' ':!COPYING' ':!external/' ':!xt/01-style.t'}
+qq{git grep -I -l 'This program is free software.*if not, see <http://www.gnu.org/licenses/' ':!COPYING' ':!external/' ':!t/01-style.t'}
   ) != 0, 'No verbatim licenses in source files';
-ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!xt/01-style.t'}) != 0,
+ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!t/01-style.t'}) != 0,
   'SPDX-License-Identifier correctly terminated';
 done_testing;


### PR DESCRIPTION
```
t/01-style.t ..
ok 1 - No redundant copyright character
fatal: :!xt/01-style.t: no such path in the working tree.
Use 'git <command> -- <path>...' to specify paths that do not exist locally.
ok 2 - No verbatim licenses in source files
fatal: :!xt/01-style.t: no such path in the working tree.
Use 'git <command> -- <path>...' to specify paths that do not exist locally.
ok 3 - SPDX-License-Identifier correctly terminated
1..3
ok
All tests successful.
Files=1, Tests=3,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.05 cusr  0.04 csys =  0.10 CPU)
Result: PASS
```