### PR TITLE
Downgrade chromedriver from problematic version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,8 @@ aliases:
   - &make_test
     name: "Running unit tests"
     command: |
+      # downgrade chromedriver from problematic version to last good version, see https://progress.opensuse.org/issues/100850
+      rpm -q chromedriver | grep -v 94.0.4606.71 || sudo zypper -n in --oldpackage chromedriver-93.0.4577.82-bp153.2.28.1 chromium-93.0.4577.82-bp153.2.28.1
       export COVERAGE=1
       export COVERDB_SUFFIX="_${CIRCLE_JOB}"
       # circleCI can be particularly slow sometimes since some time around 2021-06


### PR DESCRIPTION
The version that landed on 11.10.21 in Leap 15.3 backports crashes for most
of our tests, e.g.:

```
Could not obtain new session: unknown error: Chrome failed to start: crashed.
  (chrome not reachable)
  (The process started from chrome location /usr/lib64/chromium/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
  (Driver info: chromedriver=94.0.4606.71 (1d32b169326531e600d836bd395efc1b53d0f6ef-refs/branch-heads/4606@{#1256}),platform=Linux 4.15.0-1110-aws x86_64) at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm line 98.
```

See https://progress.opensuse.org/issues/100850