### PR TITLE
selenium: No timeout for implicit waits by default

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -117,7 +117,7 @@ sub wait_for_session_info {
     my ($info_regex, $diag_info) = @_;
 
     # give the session info 10 seconds to appear
-    my $developer_session_info = $driver->find_element('#developer-session-info')->get_text();
+    my $developer_session_info = wait_for_element(selector => '#developer-session-info')->get_text();
     my $waited_s = 0;
     while (!$developer_session_info || !($developer_session_info =~ $info_regex)) {
         # handle case when there's no $developer_session_info at all
@@ -153,7 +153,7 @@ subtest 'pause at assert_screen timeout' => sub {
     );
 
     # send command to pause on assert_screen timeout
-    my $command_input = $driver->find_element('#msg');
+    my $command_input = wait_for_element(selector => '#msg');
     $command_input->send_keys('{"cmd":"set_pause_on_screen_mismatch","pause_on":"assert_screen"}');
     $command_input->send_keys(Selenium::Remote::WDKeys->KEYS->{'enter'});
     wait_for_developer_console_like(

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -100,7 +100,7 @@ sub start_driver {
         my $startup_timeout = $ENV{OPENQA_SELENIUM_TEST_STARTUP_TIMEOUT} // 10;
         $_driver = Test::Selenium::Chrome->new(%opts, startup_timeout => $startup_timeout);
         $_driver->{is_wd3} = 0;    # ensure the Selenium::Remote::Driver instance uses JSON Wire protocol
-        enable_timeout;
+
         # Scripts are considered stuck after this timeout
         $_driver->set_timeout(script => $ENV{OPENQA_SELENIUM_SCRIPT_TIMEOUT_MS} // 2000);
         $_driver->set_window_size(600, 800);

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -119,7 +119,6 @@ sub prepare_database {
 prepare_database;
 
 driver_missing unless my $driver = call_driver;
-disable_timeout;
 
 $driver->title_is("openQA", "on main page");
 my $baseurl = $driver->get_current_url();

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -46,8 +46,9 @@ plan skip_all => 'Install Selenium::Remote::WDKeys to run this test'
   unless can_load(modules => {'Selenium::Remote::WDKeys' => undef,});
 
 $driver->title_is("openQA");
-is($driver->find_element('#user-action a')->get_text(), 'Login', "no one logged in");
-$driver->find_element_by_link_text('Login')->click();
+my $login = wait_for_element(selector => '#user-action a');
+is($login->get_text(), 'Login', "no one logged in");
+$login->click();
 # we're back on the main page
 $driver->title_is("openQA", "back on main page");
 # but ...

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -27,6 +27,7 @@ plan skip_all => 'Install Selenium::Remote::WDKeys to run this test'
 # List with no parameters
 #
 $driver->title_is("openQA", "on main page");
+wait_for_element(selector => '.h4');
 my @build_headings = $driver->find_elements('.h4', 'css');
 is(scalar @build_headings, 4, '4 builds shown');
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -31,7 +31,6 @@ $schema->resultset('Bugs')->create(
     });
 
 driver_missing unless my $driver = call_driver;
-disable_timeout;
 my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
 
 #

--- a/t/ui/16-activity-view.t
+++ b/t/ui/16-activity-view.t
@@ -120,7 +120,7 @@ subtest 'Current jobs' => sub {
             event_data => "{\"id\": 99936}",
         });
     $driver->refresh;
-    wait_for_element(selector => '#results .list-group-item');
+    wait_for_element(selector => '#results .list-group-item a');
 
     like $driver->get_title(), qr/Activity View/, 'search shown' or return;
     my $results = $driver->find_element_by_id('results');

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -74,7 +74,6 @@ sub prepare_database {
 prepare_database;
 
 driver_missing unless my $driver = call_driver;
-disable_timeout;
 
 sub goto_next_previous_tab {
     $driver->find_element('#nav-item-for-next_previous')->click();

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -50,6 +50,7 @@ $driver->get($url . '/admin/productlog');
 like($driver->get_title(), qr/Scheduled products log/, 'on product log');
 my $table = $driver->find_element_by_id('product_log_table');
 ok($table, 'products tables present when not logged in');
+wait_for_element(selector => 'tbody tr td');
 my @rows = $driver->find_child_elements($table, './tbody/tr[./td[text() = "whatever.iso"]]', 'xpath');
 is(scalar @rows, 1, 'one row present');
 my @restart_buttons = $driver->find_elements('#product_log_table .fa-undo', 'css');
@@ -138,6 +139,7 @@ subtest 'rescheduled ISO shown after refreshing page' => sub {
     like($driver->get_title(), qr/Scheduled products log/, 'on product log');
     $table = $driver->find_element_by_id('product_log_table');
     ok($table, 'products tables found');
+    wait_for_element(selector => 'tbody tr td');
     @rows = $driver->find_child_elements($table, './tbody/tr[./td[text() = "whatever.iso"]]', 'xpath');
     is(scalar @rows, 2, 'rescheduled ISO shown');
     like(

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -74,9 +74,6 @@ sub find_candidate_needles {
     # ensure the candidates menu is visible
     my @candidates_menus = $driver->find_elements('#candidatesMenu');
     is(scalar @candidates_menus, 1, 'exactly one candidates menu present at a time');
-    # save implicit waiting time as long as we are only looking for elements
-    # that should be visible already
-    disable_timeout;
     $candidates_menus[0]->click();
 
     # read the tags/needles from the HTML structure
@@ -108,7 +105,6 @@ sub find_candidate_needles {
 
     # close the candidates menu again, return results
     $driver->find_element('#candidatesMenu')->click();
-    enable_timeout;
     return \%needles_by_tag;
 }
 
@@ -623,21 +619,17 @@ subtest 'additional investigation notes provided on new failed' => sub {
     wait_for_ajax(msg => 'details tab for job 99947 loaded to test investigation');
     $driver->find_element('#clones a')->click;
     $driver->find_element_by_link_text('Investigation')->click;
-    ok($driver->find_element('table#investigation_status_entry')->text_like(qr/No result dir/),
+    ok(wait_for_element(selector => 'table#investigation_status_entry')->text_like(qr/No result dir/),
         'investigation status content shown as table');
 };
 
 subtest 'alert box shown if not already on first bad' => sub {
     $driver->get('/tests/99940');
-    wait_for_ajax(msg => 'details tab for job 99940 loaded to test investigation');
-    $driver->find_element_by_link_text('Investigation')->click;
-    $driver->find_element("//div[\@class='alert alert-info']", 'xpath')
-      ->text_like(qr/Investigate the first bad test directly: 99938/);
-
+    wait_for_element(selector => '#nav-item-for-investigation')->click;
+    wait_for_element(selector => '.alert-info')->text_like(qr/Investigate the first bad test directly: 99938/);
     $driver->find_element_by_xpath("//div[\@class='alert alert-info']/a[\@class='alert-link']")->click;
-    wait_for_ajax(msg => 'details tab for job 99938 loaded to test investigation');
     ok(
-        $driver->find_element('table#investigation_status_entry')
+        wait_for_element(selector => 'table#investigation_status_entry')
           ->text_like(qr/error\nNo previous job in this scenario, cannot provide hints/),
         'linked to investigation tab directly'
     );

--- a/t/ui/24-feature-tour.t
+++ b/t/ui/24-feature-tour.t
@@ -19,7 +19,6 @@ my $t = Test::Mojo->new('OpenQA::WebAPI');
 my $users = $schema->resultset('Users');
 
 driver_missing unless my $driver = call_driver;
-disable_timeout;
 
 subtest 'tour does not appear for demo user' => sub {
     $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -36,13 +36,9 @@ $t->get_ok($uri_path_from_default_data_dir)->status_is(200)
   ->content_like(qr|test|i, 'setting file source found in default_data_dir');
 
 $driver->get("/tests/$job_id#settings");
-note 'Finding link associated with keys_to_render_as_links';
-$driver->find_element_by_link($foo_path);
-note 'Making sure that no other settings are rendered as links';
-my @number_of_elem = $driver->find_element_by_xpath('//*[@id="settings_box"]//a');
-is(scalar @number_of_elem, 1, 'Only configured setting keys render as links');
-note 'Checking link Navigation to the source';
-$driver->find_element_by_link($foo_path)->click();
+my $element = wait_for_element(selector => '.settings_box a:only-child');
+is($element->get_text(), $foo_path, 'Expected filename found as link text');
+$element->click();
 is($driver->get_current_url(), "$url$uri_path_from_root_dir", 'Link is accessed with correct URI');
 
 kill_driver();


### PR DESCRIPTION
- No timeout by default
- No disabling timeouts in individual tests

See: https://progress.opensuse.org/issues/98952