### PR TITLE
tests: Use separate databases for unstable tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ test-api:
 # put unstable tests in tools/unstable_tests.txt and uncomment in circle CI config to handle unstables with retries
 .PHONY: test-unstable
 test-unstable:
-	for f in $$(cat tools/unstable_tests.txt); do $(MAKE) test-with-database TIMEOUT_M=10 PROVE_ARGS="$$HARNESS $$f" RETRY=5 || exit; done
+	for f in $$(cat tools/unstable_tests.txt); do $(MAKE) test-with-database COVERDB_SUFFIX=$$(echo $${COVERDB_SUFFIX}_$$f | tr '/' '_') TIMEOUT_M=10 PROVE_ARGS="$$HARNESS $$f" RETRY=5 || exit; done
 
 .PHONY: test-fullstack
 test-fullstack:


### PR DESCRIPTION
This prevents failing and passing re-runs from being merged and allows individual databases to be inspected or dropped.

See: https://progress.opensuse.org/issues/99594