### PR TITLE
t: Add a hook to tools/retry to delete coverage data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ test-unit-and-integration:
 	export GLOBIGNORE="$(GLOBIGNORE)";\
 	export DEVEL_COVER_DB_FORMAT=JSON;\
 	export PERL5OPT="$(COVEROPT)$(PERL5OPT) -It/lib -I$(PWD)/t/lib -MOpenQA::Test::PatchDeparse";\
-	RETRY=${RETRY} timeout -s SIGINT -k 5 -v ${TIMEOUT_RETRIES} tools/retry prove ${PROVE_LIB_ARGS} ${PROVE_ARGS}
+	RETRY=${RETRY} HOOK=./tools/delete-coverdb-folder timeout -s SIGINT -k 5 -v ${TIMEOUT_RETRIES} tools/retry prove ${PROVE_LIB_ARGS} ${PROVE_ARGS}
 
 # prepares running the tests within a container (eg. pulls os-autoinst) and then runs the tests considering
 # the test matrix environment variables

--- a/tools/delete-coverdb-folder
+++ b/tools/delete-coverdb-folder
@@ -1,0 +1,13 @@
+#!/bin/bash
+# In case of a test failure and retry, we want to delete previously recorded
+# coverage because it might cover code paths not covered in case of
+# success, and this leads to flaky coverage reports.
+
+set -e
+
+dir="cover_db$COVERDB_SUFFIX"
+
+if [[ -d $dir ]]; then
+    echo "Deleting $dir/"
+    rm -fr "$dir"
+fi

--- a/tools/retry
+++ b/tools/retry
@@ -3,6 +3,8 @@
 
 RETRY="${RETRY:-3}"
 STABILITY_TEST="${STABILITY_TEST:-0}"
+# Pass a hook command which is executed if a retry occurs
+HOOK="${HOOK:-}"
 
 run_once() {
     $*
@@ -21,6 +23,10 @@ else
             [ $n -le "$RETRY" ] || exit 0
             run_once $* || exit
             echo "Rerun $n of $RETRY …"
+        fi
+        if [ -n "$HOOK" ]; then
+            echo "Calling retry hook $HOOK"
+            RETRY_ATTEMPT=$n "$HOOK"
         fi
         n=$((n+1))
     done


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/99594

Depends on #4295 to create individual cover_db directories per test in the `unstable` test