### PR TITLE
Make text results rendering unified with other

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -114,25 +114,8 @@ function renderModuleRow(module, snippets) {
     const tplargs = {MODULE: encodeURIComponent(module.name), STEP: step.num};
     const alt = step.name || '';
 
-    if (step.is_parser_text_result || title === 'wait_serial') {
+    if (step.is_parser_text_result) {
       const elements = [];
-      if (!step.is_parser_text_result) {
-        const previewLimit = 250;
-        // jshint ignore:start
-        let shortText = step.text_data.replace(/.*# Result:\n?/s, '');
-        // jshint ignore:end
-        if (shortText.length > previewLimit) {
-          shortText = shortText.substr(0, previewLimit) + '…';
-        }
-        const stepFrame = E('span', [shortText], {class: 'resborder ' + step.resborder});
-        const serialPreview = E('span', [stepFrame], {
-          title: shortText,
-          'data-href': href,
-          class: 'serial-result-preview',
-          onclick: 'toggleTextPreview(this)'
-        });
-        elements.push(serialPreview);
-      }
       const stepActions = E('span', [], {class: 'step_actions'});
       stepActions.innerHTML = renderTemplate(snippets.bug_actions, {MODULE: module.name, STEP: step.num});
       const stepFrame = E('span', [stepActions, step.text_data], {class: 'resborder ' + step.resborder});
@@ -145,7 +128,7 @@ function renderModuleRow(module, snippets) {
       elements.push(textResult);
       stepnodes.push(
         E('div', elements, {
-          class: 'links_a ' + (step.is_parser_text_result ? 'external-result-container' : 'serial-result-container')
+          class: 'links_a external-result-container'
         })
       );
       continue;
@@ -181,20 +164,47 @@ function renderModuleRow(module, snippets) {
         })
       );
     } else if (step.text) {
-      box.push(E('span', [step.title ? step.title : 'Text'], {class: 'resborder ' + resborder}));
+      if (title === 'wait_serial') {
+        const previewLimit = 120;
+        // jshint ignore:start
+        let shortText = step.text_data.replace(/.*# Result:\n?/s, '');
+        // jshint ignore:end
+        if (shortText.length > previewLimit) {
+          shortText = shortText.substr(0, previewLimit) + '…';
+        }
+        box.push(E('span', [shortText], {class: 'resborder ' + resborder}));
+      } else {
+        box.push(E('span', [step.title ? step.title : 'Text'], {class: 'resborder ' + resborder}));
+      }
     } else {
       const content = step.title || E('i', [], {class: 'fa fa fa-question'});
       box.push(E('span', [content], {class: 'resborder ' + resborder}));
     }
-
-    const link = E('a', box, {
-      class: 'no_hover',
-      'data-url': url,
-      title: title,
-      href: href
-    });
-    link.onclick = showPreviewForLink;
-    stepnodes.push(E('div', [E('div', [], {class: 'fa fa-caret-up'}), link], {class: 'links_a'}));
+    if (step.text && title !== 'Soft Failed') {
+      const stepActions = E('span', [], {class: 'step_actions', style: 'float: right'});
+      stepActions.innerHTML = renderTemplate(snippets.bug_actions, {MODULE: module.name, STEP: step.num});
+      const textresult = E('pre', [step.text_data]);
+      var html = stepActions.outerHTML;
+      html += textresult.outerHTML;
+      const txt = escape(html);
+      const link = E('a', box, {
+        class: 'no_hover',
+        'data-text': txt,
+        title: title,
+        href: href
+      });
+      link.onclick = showPreviewForLink;
+      stepnodes.push(E('div', [E('div', [], {class: 'fa fa-caret-up'}), link], {class: 'links_a'}));
+    } else {
+      const link = E('a', box, {
+        class: 'no_hover',
+        'data-url': url,
+        title: title,
+        href: href
+      });
+      link.onclick = showPreviewForLink;
+      stepnodes.push(E('div', [E('div', [], {class: 'fa fa-caret-up'}), link], {class: 'links_a'}));
+    }
     stepnodes.push(' ');
   }
 

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -217,7 +217,17 @@ function setCurrentPreview(stepPreviewContainer, force) {
 
   // show preview for other/regular results
   var link = stepPreviewContainer.find('a');
-  if (!link || !link.data('url')) {
+  if (!link) {
+    return;
+  }
+  if (link.data('text')) {
+    stepPreviewContainer.addClass('current_preview');
+    setPageHashAccordingToCurrentTab(link.attr('href'), true);
+    const text = unescape(link.data('text'));
+    previewSuccess(stepPreviewContainer, text, force);
+    return;
+  }
+  if (!link.data('url')) {
     return;
   }
   stepPreviewContainer.addClass('current_preview');

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -245,34 +245,6 @@ span.resborder_na {
 .external-result-container {
     width: 100%;
 }
-.serial-result-container {
-    margin-right: 4px;
-    .serial-result-preview .resborder {
-        cursor: pointer;
-        width: 60px;  // in accordance with the thumbnail width
-        height: 45px; // in accordance with the thumbnail height
-        font-size: 60%;
-        overflow: hidden;
-    }
-    .text-result {
-        display: none;
-        .resborder {
-            width: initial;
-            height: initial;
-            background-position: 0% 0%;
-            background-repeat: no-repeat;
-            padding-left: 40px;
-            font-size: 100%;
-        }
-    }
-}
-.serial-result-container.current_preview {
-    margin-right: 0px;
-    display: inline;
-    .text-result {
-        display: initial;
-    }
-}
 .current_preview .text-result .resborder {
     max-height: none;
     box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.2);

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -126,18 +126,6 @@ subtest 'tab navigation via history' => sub {
     is(current_tab, 'Details', 'back to details tab');
 };
 
-subtest 'displaying wait_serial results' => sub {
-    wait_for_ajax(msg => 'details tab for job 99937 loaded');
-    my $wait_serial_element = $driver->find_element('.serial-result-container .serial-result-preview');
-    like($wait_serial_element->get_text(), qr/dBeHb-0-/, 'serial preview shown');
-    $wait_serial_element->click();
-    $wait_serial_element = $driver->find_element('.serial-result-container .text-result');
-    like($wait_serial_element->get_text(), qr/wait_serial expected.*dBeHb-0-/s, 'wait_serial output shown');
-    like($driver->get_current_url(), qr/#step/, 'current url contains #step hash');
-    $wait_serial_element->click();
-    unlike($driver->get_current_url(), qr/#step/, 'current url does not contain #step hash anymore');
-};
-
 subtest 'show job modules execution time' => sub {
     my $tds = $driver->find_elements('.component');
     my %modules_execution_time = (
@@ -243,10 +231,6 @@ subtest 'bug reporting' => sub {
         check_report_links(bootloader => 1);
         # close bootloader step preview so it will not hide other elements used by subsequent tests
         $driver->find_element('.links_a.current_preview')->click;
-    };
-    subtest 'wait_serial result' => sub {
-        $driver->find_element('[data-href="#step/sshfs/2"].serial-result-preview')->click();
-        check_report_links(sshfs => 2, $driver->find_element('[data-href="#step/sshfs/2"].text-result'));
     };
 };
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/93940

example: http://quasar.suse.cz/tests/7288

it changes all *text* results processing from ajax to use `data-` attribute with exception `Soft Failed` result with bug references , because this part is only implemented in template and perl code