### PR TITLE
ci: Update codecov uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ jobs:
       - run: make coverage-report-html
       - store_artifacts: *store_cover_db
       - run: make coverage-report-codecov
-      - run: bash <(curl -s https://codecov.io/bash)
+      - run: curl -O https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov
 
   build-docs: &docs-template
     name: "Generating docs"


### PR DESCRIPTION
The bash uploader was deprecated:
https://docs.codecov.com/docs/about-the-codecov-bash-uploader
https://docs.codecov.com/docs/codecov-uploader