### PR TITLE
t: Mark statements as uncoverable in WebUIConnection.pm

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -182,9 +182,11 @@ sub _setup_websocket_connection {
                     $command_handler->handle_command(@_);
                 });
             $tx->on(
+                # uncoverable statement
                 finish => sub ($tx, $code, $reason = undef) {
-                    # uncoverable subroutine
                     # https://progress.opensuse.org/issues/55364
+                    # uncoverable subroutine
+                    # uncoverable statement
                     $reason //= 'no reason';
 
                     # Subprocesses reset the event loop (which triggers this event),


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/99597

The subroutine is called during t/full-stack.t, but not reliably,
and apparently not always in the process collecting the coverage.

So it is not actually uncoverable, but I couldn't find out the
conditions when this subroutine is called.