### PR TITLE
t: Prevent aborting the complete test run when interactively debugging

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -78,7 +78,10 @@ sub start_driver {
                 # same problem exceeded console scrollback buffers easily
                 my ($driver, $exception, $args) = @_;    # uncoverable statement
                 my $err = (split /\n/, $exception)[0] =~ s/Error while executing command: //r;   # uncoverable statement
-                BAIL_OUT($err . ' at ' . __FILE__ . ':' . __LINE__);                             # uncoverable statement
+                $err .= ' at ' . __FILE__ . ':' . __LINE__;                                      # uncoverable statement
+
+                # prevent aborting the complete test when interactively debugging
+                $INC{'perl5db.pl'} ? fail $err : BAIL_OUT($err);                                 # uncoverable statement
             },
         );
 


### PR DESCRIPTION
A `BAIL_OUT` would stop the complete test execution in UI tests when an
UI element is not found. This is not necessarily helpful when
interactively debugging with the Perl debugger so instead we can simply
fail the test in this case.