### PR TITLE
Display previews for `wait_serial`-results like before 009e9256

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -188,7 +188,7 @@ function renderModuleRow(module, snippets) {
       html += textresult.outerHTML;
       const txt = escape(html);
       const link = E('a', box, {
-        class: 'no_hover',
+        class: 'no_hover' + (title === 'wait_serial' ? ' serial-result-preview' : ''),
         'data-text': txt,
         title: title,
         href: href


### PR DESCRIPTION
* Display previews like before so they are well distinguishable from other
  text results (e.g. produced by `record_info`)
* Does *not* generally revert 009e9256 and in particular the floating
  container will still be used like for any other text result

---

Note that this makes results a little bit more inconsistent again. However,
the problem of not being able to spot normal text results easily within
lots of `wait_serial` results was mentioned by multiple users. I supposed
the main inconsistency which https://progress.opensuse.org/issues/93940 was
about was the expanded view and the missing arrow but not the preview.

---

Before: `wait_serial` and other text results look the same
![screenshot_20211028_165403](https://user-images.githubusercontent.com/10248953/139281698-5b8a89a0-2e7a-4a0e-b7f5-b4ed2b065568.png)

After: The preview is distinguishable but `wait_serial` results still use the floating container and the arrow points to the preview

![screenshot_20211028_165542](https://user-images.githubusercontent.com/10248953/139281983-52bc1ccc-39fb-4337-b9b0-b2f13b8d1329.png)

