### PR TITLE
Make text result thumb look same across browsers

### DIFF
--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -240,6 +240,8 @@ span.resborder_na {
         max-height: 3.5rem;
         white-space: pre-wrap;
         overflow-wrap: break-word;
+        font-size: 74%;
+        line-height: 1.1;
     }
 }
 .external-result-container {


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/101725

This looked fine but as of now I only tested this in the browser debugger as my instance is not working atm.