### PR TITLE
Remove workaround for broken Chromium on Leap 15.3

### DIFF
--- a/tools/ci/run_unit_tests.sh
+++ b/tools/ci/run_unit_tests.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 set -ex
-# downgrade chromedriver from problematic version to last good version, see https://progress.opensuse.org/issues/100850
-# and due to recurring problems ignore if zypper fails to refresh some repos
-# and try to continue
-rpm -q chromedriver | grep -v 94.0.4606.71 || (sudo tools/retry zypper -n refresh; sudo zypper --no-refresh -n in --oldpackage chromedriver-93.0.4577.82-bp153.2.28.1 chromium-93.0.4577.82-bp153.2.28.1)
 export COVERAGE=1
 export COVERDB_SUFFIX="_${CIRCLE_JOB}"
 # circleCI can be particularly slow sometimes since some time around 2021-06


### PR DESCRIPTION
* https://bugzilla.opensuse.org/show_bug.cgi?id=1191429 has been marked as
  fixed so the workaround should no longer be required
* See https://progress.opensuse.org/issues/100850