### PR TITLE
ci: Optional check via #fullstack-stability comment

### DIFF
--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -1,0 +1,33 @@
+---
+name: Trigger CI via comment
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      retry:
+        description: 'RETRY'
+        default: 50
+      target:
+        description: 'Makefile target'
+        default: fullstack
+
+jobs:
+  fullstack-stability:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '#fullstack-stability'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Stability test (50 passes of fullstack must succeed)
+        run: make test-${{ github.event.inputs.target }}
+        if: steps.check.outputs.triggered == 'true'
+        env:
+          STABILITY_TEST: 1
+          RETRY: ${{ github.event.inputs.retry }}


### PR DESCRIPTION
- This is not expected to replace or even replicate our CircleCI setup,
  so no setup of coverage or caches is done here.
- This is only triggered if the special comment is used.
- Triggering arbitrary test targets is out of scope.

tl;dr; Add a comment instead of creating a PR like #4346.

See: https://progress.opensuse.org/issues/98952

I'm not sure a new workflow can be used in the same PR - I'll try anyway:

#fullstack-stability