### PR TITLE
Fix enabling systemd unit `openqa-reload-worker-auto-restart@.path`

### DIFF
--- a/systemd/openqa-reload-worker-auto-restart@.path
+++ b/systemd/openqa-reload-worker-auto-restart@.path
@@ -2,3 +2,6 @@
 
 [Path]
 PathChanged=/etc/openqa/workers.ini
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add an `[Install]` section to the unit. Otherwise, trying to enable it only
results in the message "The unit files have no installation config. … This
means they are not meant to be enabled using systemctl.". However, this
unit is actually meant to be enabled as implied by `Installing.asciidoc`.