### PR TITLE
Fix conflicting attr names in collapse class of the investigation tab

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -862,7 +862,7 @@ function renderInvestigationTab(response) {
               var statItem = document.createElement('div');
               var collapseSign = document.createElement('a');
               collapseSign.className = 'collapsed';
-              collapseSign.setAttribute('href', '#collapseEntry' + i);
+              collapseSign.setAttribute('href', '#collapse' + key + i);
               collapseSign.setAttribute('data-toggle', 'collapse');
               collapseSign.setAttribute('aria-expanded', 'false');
               collapseSign.setAttribute('aria-controls', 'collapseEntry');
@@ -870,7 +870,7 @@ function renderInvestigationTab(response) {
               collapseSign.setAttribute('onclick', 'toggleSign(this)');
               var spanElem = document.createElement('span');
               var logDetailsDiv = document.createElement('div');
-              logDetailsDiv.id = 'collapseEntry' + i;
+              logDetailsDiv.id = 'collapse' + key + i;
               logDetailsDiv.className = 'collapse';
               stats = gitstats[i].split('\n')[0];
               spanElem.innerHTML = stats;


### PR DESCRIPTION
The `href` values were mixed between the _needle_log_ and _test_log_ items.
Fix using and making unique names for each of them.

Signed-off-by: ybonatakis <ybonatakis@suse.com>