### PR TITLE
Speed up 25-cache-service.t with a shorter worker timeout

### DIFF
--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -37,7 +37,7 @@ use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server cache_minion_worker cache_worker_service wait_for_or_bail_out);
-use OpenQA::Test::TimeLimit '110';
+use OpenQA::Test::TimeLimit '90';
 use Mojo::Util qw(md5_sum);
 use OpenQA::CacheService;
 use OpenQA::CacheService::Request;

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -93,7 +93,7 @@ sub cache_minion_worker {
             require OpenQA::CacheService;
             local $ENV{MOJO_MODE} = 'test';
             note('Starting cache minion worker');
-            OpenQA::CacheService::run(qw(run));
+            OpenQA::CacheService::run(qw(run --dequeue-timeout 1));
             note('Cache minion worker stopped');
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);


### PR DESCRIPTION
Turns out the test spends most of its time in a blocking SQL loop in `Minion::Backend::SQLite`.

Before:
```
All tests successful.
Files=1, Tests=23, 103 wallclock secs ( 0.07 usr  0.01 sys + 15.86 cusr  1.72 csys = 17.66 CPU)
Result: PASS
```

After:
```
All tests successful.
Files=1, Tests=23, 51 wallclock secs ( 0.05 usr  0.01 sys +  5.39 cusr  0.97 csys =  6.42 CPU)
Result: PASS
```

Progress: https://progress.opensuse.org/issues/102221