### PR TITLE
Allow some special characters in tag labels

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -129,7 +129,7 @@ e.g. 'tag:0123:important:GM' returns a list of '0123', 'important' and 'GM'.
 =cut
 sub tag ($self) {
     $self->text
-      =~ /\btag:((?<version>[-.@\d\w]+)-)?(?<build>[-.@\d\w]+):(?<type>[-@\d\w]+)(:(?<description>[@\d\w]+))?\b/;
+      =~ /\btag:((?<version>[-.@\d\w]+)-)?(?<build>[-.@\d\w]+):(?<type>[-@\d\w]+)(:(?<description>[-.@\d\w]+))?\b/;
     return $+{build}, $+{type}, $+{description}, $+{version};
 }
 

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -343,6 +343,10 @@ subtest 'version tagging' => sub {
     $t->get_ok('/group_overview/1001')->status_is(200);
     $t->text_is('#tag-1001-1_2_2-5000 i', 'second', 'version 1.2-2 has version-specific tag');
     $t->text_is('#tag-1001-1_2_1-5000 i', 'first', 'version 1.2-1 has version-specific tag');
+
+    post_comment_1001('tag:1.2-1-5000:important:label-with.specialchars');
+    $t->get_ok('/group_overview/1001')->status_is(200);
+    $t->text_is('#tag-1001-1_2_1-5000 i', 'label-with.specialchars', 'version 1.2-1 has version-specific tag');
 };
 
 subtest 'content negotiation' => sub {


### PR DESCRIPTION
As of SP4 we have build names like `Alpha-202111-1`
which would be displayed as `Alpha` at the moment.

See https://openqa.suse.de/parent_group_overview/15 for example.