### PR TITLE
ci: Execute fullstack tests via GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,7 @@ aliases:
         sudo cp -r /var/cache/autoinst ../os-autoinst
         sudo chown -R 1000 ../os-autoinst/t/data
       else # only in local run
-         [ -d ../os-autoinst ] || { sudo mkdir ../os-autoinst && sudo chown -R 1000 ../os-autoinst; }
-         bash tools/ci/build_autoinst.sh ../os-autoinst
+         tools/ci/build_autoinst.sh
        fi
 
   - &make_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,6 @@ aliases:
     name: Install cached packages
     command: tools/ci/build_or_install_from_cache.sh
 
-  - &test_junit
-    name: "Enabling JUnit output for Perl tests"
-    command: |
-      mkdir -p test-results/junit
-      echo 'export JUNIT_OUTPUT_FILE=test-results/junit/${CIRCLE_JOB}.xml' >> $BASH_ENV
-
   - &store_test_results
     path: test-results/junit
 
@@ -79,7 +73,7 @@ aliases:
 
   - &make_test
     name: "Running unit tests"
-    command: tools/ci/run_unit_tests.sh
+    command: tools/ci/run_unit_tests.sh $CIRCLE_JOB
     no_output_timeout: 50m
 
   - &git_token_authentication
@@ -93,15 +87,6 @@ images:
   - &docker_config
     user: squamata
     environment:
-      JUNIT_PACKAGE: openQA
-      JUNIT_NAME_MANGLE: perl
-      # Be aware that this option saves all verbose output caught by "prove"
-      # into test artifact files whereas the error output is still shows up
-      # where prove is executed to show initial context in case of failed
-      # tests or other problems. The "--merge" option of prove would loose
-      # that context in the prove calling context.
-      PERL_TEST_HARNESS_DUMP_TAP: test-results
-      HARNESS: --harness TAP::Harness::JUnit --timer
       COMMIT_AUTHOR_EMAIL: skynet@open.qa
       # Exclude container specific tests needing a container runtime
       # environment, using github actions instead
@@ -182,7 +167,6 @@ jobs:
       - run: *check_cache
       - store_artifacts: *store_logs
       - run: *install_cached_packages
-      - run: *test_junit
       - run: *make_test
       - persist_to_workspace:
           root: .
@@ -204,7 +188,6 @@ jobs:
       - store_artifacts: *store_logs
       - run: *install_cached_packages
       - run: *build_autoinst
-      - run: *test_junit
       - run: *make_test
       - persist_to_workspace:
           root: .

--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: bash -x tools/ci/build_cache.sh
-      - name: Fix permissions of working folder
-        run: sudo chown -R squamata ..
       - name: Build os-autoinst
         run: bash -x tools/ci/build_autoinst.sh
       - name: Make project folder user-writable

--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -1,0 +1,43 @@
+---
+name: Perl tests
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      stability_test:
+        description: 'Set to 1 to fail if any of the RETRY fails'
+        default: 0
+      target:
+        description: 'Makefile target'
+        default: fullstack
+
+jobs:
+  fullstack:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: bash -x tools/ci/build_cache.sh
+      - name: Fix permissions of working folder
+        run: sudo chown -R squamata ..
+      - name: Build os-autoinst
+        run: bash -x tools/ci/build_autoinst.sh
+      - name: Make project folder user-writable
+        run: sudo chown -R $USER $PWD
+      - name: Running unit tests
+        run: tools/ci/run_unit_tests.sh ${{ github.event.inputs.target }}
+        env:
+          STABILITY_TEST: ${{ github.event.inputs.stability_test }}
+      - name: Merge coverage databases
+        run: cover -write cover_db cover_db*
+      - name: Generate coverage report
+        run: make coverage-report-html
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Upload artifacts
+          path: |
+            test-results
+            cover_db
+        if: always()

--- a/tools/ci/build_autoinst.sh
+++ b/tools/ci/build_autoinst.sh
@@ -8,6 +8,10 @@ set -ex
 destdir=${1:-../os-autoinst}
 sha=${2:-$(cat tools/ci/autoinst.sha)}
 
+[[ -d $destdir ]] || {
+  sudo mkdir "$destdir"
+  sudo chown -R $USER "$destdir"
+}
 echo Building os-autoinst $destdir $sha
 git clone https://github.com/os-autoinst/os-autoinst.git "$destdir"
 ( cd "$destdir"

--- a/tools/ci/run_unit_tests.sh
+++ b/tools/ci/run_unit_tests.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 set -ex
+target="${1:?"Specify a makefile target"}"
 export COVERAGE=1
-export COVERDB_SUFFIX="_${CIRCLE_JOB}"
+export COVERDB_SUFFIX="_${target}"
+# Enable JUnit-compatible test results
+export JUNIT_PACKAGE=openQA
+export JUNIT_NAME_MANGLE=perl
+export JUNIT_OUTPUT_FILE=test-results/junit/$target.xml
+# Be aware that this option saves all verbose output caught by "prove"
+# into test artifact files whereas the error output is still shows up
+# where prove is executed to show initial context in case of failed
+# tests or other problems. The "--merge" option of prove would loose
+# that context in the prove calling context.
+export PERL_TEST_HARNESS_DUMP_TAP=test-results
+export HARNESS='--harness TAP::Harness::JUnit --timer'
+mkdir -p test-results/junit
+sudo chown -R $USER test-results
 # circleCI can be particularly slow sometimes since some time around 2021-06
 export OPENQA_TEST_TIMEOUT_SCALE_CI=3
 export EXTRA_PROVE_ARGS="-v"
-make test-$CIRCLE_JOB
+make test-$target


### PR DESCRIPTION
- This is not expected to replace or replicate our CircleCI setup,
  so no setup of coverage or caches is done here.
- Triggering arbitrary test targets is out of scope.

Fixes: https://progress.opensuse.org/issues/102581