### PR TITLE
Render the test_log value correctly when config has http url

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -176,7 +176,11 @@ sub gitrepodir {
     log_warning("$path is not a git directory") if $filename eq '';
     my $config = Config::Tiny->read($filename, 'utf8');
     return '' unless defined $config;
-    return $config->{'remote "origin"'}{url} if ($config->{'remote "origin"'}{url} =~ /^http(s?)/);
+    if ($config->{'remote "origin"'}{url} =~ /^http(s?)/) {
+        my $repo_url = $config->{'remote "origin"'}{url};
+        $repo_url =~ s{\.git$}{/commit/};
+        return $repo_url;
+    }
     my @url_tokenized = split(':', $config->{'remote "origin"'}{url});
     $url_tokenized[1] =~ s{\.git$}{/commit/};
     my @githost = split('@', $url_tokenized[0]);

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -348,6 +348,9 @@ subtest 'project directory functions' => sub {
     $mocked_git->child('config')
       ->spurt(qq{[remote "origin"]\n        url = git\@github.com:fakerepo/os-autoinst-distri-opensuse.git});
     is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
+    $mocked_git->child('config')
+      ->spurt(qq{[remote "origin"]\n        url = https://github.com/fakerepo/os-autoinst-distri-opensuse.git});
+    is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
 
     local $ENV{OPENQA_SHAREDIR} = '/tmp/share';
     is prjdir(), '/tmp/test/openqa', 'right directory';


### PR DESCRIPTION
The `gitrepodir` returns the url directly as it appears in the config file,
when the `renderInvestigationTab` expects the value of `data-testgiturl` retrieved from `investigation_ajax`
in the form of _http://github.com/<user>/<repo>/commit_

Apply the same substitution as in git before return

Signed-off-by: ybonatakis <ybonatakis@suse.com>