### PR TITLE
apparmor: allow local additions to the worker profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ install-generic:
 	install -m 644 profiles/apparmor.d/usr.share.openqa.script.worker "$(DESTDIR)"/etc/apparmor.d
 	install -d -m 755 "$(DESTDIR)"/etc/apparmor.d/local
 	install -m 644 profiles/apparmor.d/local/usr.share.openqa.script.openqa "$(DESTDIR)"/etc/apparmor.d/local
+	install -m 644 profiles/apparmor.d/local/usr.share.openqa.script.worker "$(DESTDIR)"/etc/apparmor.d/local
 
 	cp -Ra dbicdh "$(DESTDIR)"/usr/share/openqa/dbicdh
 

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -606,6 +606,8 @@ fi
 # apparmor profile
 %dir %{_sysconfdir}/apparmor.d
 %config %{_sysconfdir}/apparmor.d/usr.share.openqa.script.worker
+%dir %{_sysconfdir}/apparmor.d/local
+%config %{_sysconfdir}/apparmor.d/local/usr.share.openqa.script.worker
 # init
 %dir %{_unitdir}
 %{_systemdgeneratordir}

--- a/profiles/apparmor.d/local/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/local/usr.share.openqa.script.worker
@@ -1,0 +1,2 @@
+# Site-specific additions and overrides for 'usr.share.openqa.script.worker'
+# For example to cover scripts for generalhw backend.

--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -203,4 +203,6 @@
     /var/lib/openqa/pool/1/x3trc.* w,
 
   }
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.share.openqa.script.worker>
 }


### PR DESCRIPTION
This is useful for example with generalhw backend, which uses
site-specific auxiliary scripts that may need extra profile entries
(or even subprofiles).

This is kind of related to https://github.com/os-autoinst/os-autoinst/pull/1741, but is useful independently too.