### PR TITLE
Fix displaying investigation fields like `diff_to_last_good`

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -786,6 +786,10 @@ function renderCommentsTab(response) {
 }
 
 function renderInvestigationTab(response) {
+  if (typeof response !== 'object') {
+    tabPanelElement.innerHTML = 'Investigation info returned by server is invalid.';
+    return;
+  }
   const tabPanelElement = this.panelElement;
   const testgiturl = response.testgiturl;
   const needlegiturl = response.needlegiturl;
@@ -793,10 +797,6 @@ function renderInvestigationTab(response) {
   delete response.needlegiturl;
   document.getElementById('investigation').setAttribute('data-testgiturl', testgiturl);
   document.getElementById('investigation').setAttribute('data-needlegiturl', needlegiturl);
-  if (typeof response !== 'object') {
-    tabPanelElement.innerHTML = 'Investigation info returned by server is invalid.';
-    return;
-  }
 
   var theadElement = document.createElement('thead');
   var headTrElement = document.createElement('tr');

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -847,57 +847,52 @@ function renderInvestigationTab(response) {
       var preElement = document.createElement('pre');
       var preElementMore = document.createElement('pre');
       var enable_more = false;
-      if (key === 'error') {
-        preElement.appendChild(document.createTextNode(value));
-      }
-      if (['test_log', 'test_diff_stat', 'needles_log', 'needles_diff_stat'].indexOf(key) >= 0) {
-        var repoUrl = getInvestigationDataAttr(key);
-        if (repoUrl) {
-          var gitstats = githashToLink(value, repoUrl);
-          // assume string 'No test changes..'
-          if (gitstats == null) {
-            preElement.appendChild(document.createTextNode(value));
-          } else {
-            for (let i = 0; i < gitstats.length; i++) {
-              var statItem = document.createElement('div');
-              var collapseSign = document.createElement('a');
-              collapseSign.className = 'collapsed';
-              collapseSign.setAttribute('href', '#collapse' + key + i);
-              collapseSign.setAttribute('data-toggle', 'collapse');
-              collapseSign.setAttribute('aria-expanded', 'false');
-              collapseSign.setAttribute('aria-controls', 'collapseEntry');
-              collapseSign.innerHTML = '+ ';
-              collapseSign.setAttribute('onclick', 'toggleSign(this)');
-              var spanElem = document.createElement('span');
-              var logDetailsDiv = document.createElement('div');
-              logDetailsDiv.id = 'collapse' + key + i;
-              logDetailsDiv.className = 'collapse';
-              stats = gitstats[i].split('\n')[0];
-              spanElem.innerHTML = stats;
-              logDetailsDiv.innerHTML = gitstats[i]
-                .split('\n')
-                .slice(1, gitstats[0].length - 1)
-                .join('\n');
-              statItem.append(collapseSign, spanElem, logDetailsDiv);
+      var repoUrl = getInvestigationDataAttr(key);
+      if (repoUrl) {
+        var gitstats = githashToLink(value, repoUrl);
+        // assume string 'No test changes..'
+        if (gitstats == null) {
+          preElement.appendChild(document.createTextNode(value));
+        } else {
+          for (let i = 0; i < gitstats.length; i++) {
+            var statItem = document.createElement('div');
+            var collapseSign = document.createElement('a');
+            collapseSign.className = 'collapsed';
+            collapseSign.setAttribute('href', '#collapse' + key + i);
+            collapseSign.setAttribute('data-toggle', 'collapse');
+            collapseSign.setAttribute('aria-expanded', 'false');
+            collapseSign.setAttribute('aria-controls', 'collapseEntry');
+            collapseSign.innerHTML = '+ ';
+            collapseSign.setAttribute('onclick', 'toggleSign(this)');
+            var spanElem = document.createElement('span');
+            var logDetailsDiv = document.createElement('div');
+            logDetailsDiv.id = 'collapse' + key + i;
+            logDetailsDiv.className = 'collapse';
+            stats = gitstats[i].split('\n')[0];
+            spanElem.innerHTML = stats;
+            logDetailsDiv.innerHTML = gitstats[i]
+              .split('\n')
+              .slice(1, gitstats[0].length - 1)
+              .join('\n');
+            statItem.append(collapseSign, spanElem, logDetailsDiv);
 
-              if (i < DISPLAY_LOG_LIMIT) {
-                preElement.appendChild(statItem);
-              } else {
-                enable_more = true;
-                preElementMore.appendChild(statItem);
-              }
+            if (i < DISPLAY_LOG_LIMIT) {
+              preElement.appendChild(statItem);
+            } else {
+              enable_more = true;
+              preElementMore.appendChild(statItem);
             }
           }
-        } else {
-          var textLines = typeof value === 'string' ? value.split('\n') : [value];
-          var textLinesRest;
-
-          if (textLines.length > DISPLAY_LINE_LIMIT) {
-            textLinesRest = textLines.slice(DISPLAY_LINE_LIMIT, textLines.length);
-            textLines = textLines.slice(0, DISPLAY_LINE_LIMIT);
-          }
-          preElement.appendChild(document.createTextNode(textLines.join('\n')));
         }
+      } else {
+        var textLines = typeof value === 'string' ? value.split('\n') : [value];
+        var textLinesRest;
+
+        if (textLines.length > DISPLAY_LINE_LIMIT) {
+          textLinesRest = textLines.slice(DISPLAY_LINE_LIMIT, textLines.length);
+          textLines = textLines.slice(0, DISPLAY_LINE_LIMIT);
+        }
+        preElement.appendChild(document.createTextNode(textLines.join('\n')));
       }
 
       valueElement.appendChild(preElement);

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -623,8 +623,8 @@ subtest 'additional investigation notes provided on new failed' => sub {
     wait_for_ajax(msg => 'details tab for job 99947 loaded to test investigation');
     $driver->find_element('#clones a')->click;
     $driver->find_element_by_link_text('Investigation')->click;
-    ok($driver->find_element('table#investigation_status_entry')->text_like(qr/No result dir/),
-        'investigation status content shown as table');
+    $driver->find_element('table#investigation_status_entry')
+      ->text_like(qr/No result dir/, 'investigation status content shown as table');
 };
 
 subtest 'alert box shown if not already on first bad' => sub {
@@ -636,12 +636,11 @@ subtest 'alert box shown if not already on first bad' => sub {
 
     $driver->find_element_by_xpath("//div[\@class='alert alert-info']/a[\@class='alert-link']")->click;
     wait_for_ajax(msg => 'details tab for job 99938 loaded to test investigation');
-    ok(
-        $driver->find_element('table#investigation_status_entry')
-          ->text_like(qr/error\nNo previous job in this scenario, cannot provide hints/),
-        'linked to investigation tab directly'
-    );
-    $driver->find_element_by_xpath("//div[\@class='tab-content']")->text_unlike(qr/Investigate the first bad test/);
+    $driver->find_element('table#investigation_status_entry')
+      ->text_like(qr/error\nNo previous job in this scenario, cannot provide hints/,
+        'linked to investigation tab directly');
+    $driver->find_element_by_xpath("//div[\@class='tab-content']")
+      ->text_unlike(qr/Investigate the first bad test/, 'no alert shown for first bad itself');
 };
 
 subtest 'archived icon' => sub {


### PR DESCRIPTION
* Remove extra case for displaying errors. This way our tests (which 
  render errors) will automatically cover rendering arbitrary fields.
* Remove check for displaying only certain fields; just use the same code
  path for all the fields as it already handles the case when there is no
  Git repository associated with the diff.
* Otherwise no code has changed. Everything within the previous
  `if ([…].indexOf(key) >= 0) { }`-block is just reindentated.

---

* Fix a few other details, see also further commit messages
* See https://progress.opensuse.org/issues/103032