### PR TITLE
AMQP: allow and handle some TLS-related query parameters

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -113,6 +113,9 @@ sub read_config {
             url => 'amqp://guest:guest@localhost:5672/',
             exchange => 'pubsub',
             topic_prefix => 'suse',
+            cacertfile => '',
+            certfile => '',
+            keyfile => ''
         },
         obs_rsync => {
             home => '',

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -59,8 +59,15 @@ sub publish_amqp ($self, $topic, $event_data, $headers = {}, $remaining_attempts
     # create publisher and keep reference to avoid early destruction
     log_debug("Sending AMQP event: $topic");
     my $config = $self->{config}->{amqp};
-    my $url = Mojo::URL->new($config->{url})->query({exchange => $config->{exchange}});
-    my $publisher = Mojo::RabbitMQ::Client::Publisher->new(url => $url->to_unsafe_string);
+    my $url = Mojo::URL->new($config->{url});
+    $url->query({exchange => $config->{exchange}});
+    # append optional parameters
+    $url->query([cacertfile => $config->{cacertfile}]) if ($config->{cacertfile});
+    $url->query([certfile => $config->{certfile}]) if ($config->{certfile});
+    $url->query([keyfile => $config->{keyfile}]) if ($config->{keyfile});
+    $url = $url->to_unsafe_string;
+    my $publisher = Mojo::RabbitMQ::Client::Publisher->new(url => $url);
+    log_debug("AMQP URL: $url");
 
     $remaining_attempts //= $config->{publish_attempts};
     $retry_delay //= $config->{publish_retry_delay};

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -295,4 +295,17 @@ subtest 'promise handlers' => sub {
     is $last_promise, $previous_promise, 'no further promise has been made (running out of retries)';
 };
 
+$app->config->{amqp}{cacertfile} = '/some/cacert.pem';
+$app->config->{amqp}{certfile} = '/some/cert.pem';
+$app->config->{amqp}{keyfile} = '/some/key.pem';
+
+subtest 'extra TLS query params' => sub {
+    $amqp->publish_amqp('some.topic', 'some message');
+    # because of exactly how this URL is constructed, only the slashes
+    # in the extra params get escaped
+    my $expected
+      = 'amqp://guest:guest@localhost:5672/?exchange=pubsub&cacertfile=%2Fsome%2Fcacert.pem&certfile=%2Fsome%2Fcert.pem&keyfile=%2Fsome%2Fkey.pem';
+    is($last_publisher->url, $expected, 'url has all params');
+};
+
 done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -99,6 +99,9 @@ subtest 'Test configuration default modes' => sub {
             url => 'amqp://guest:guest@localhost:5672/',
             exchange => 'pubsub',
             topic_prefix => 'suse',
+            cacertfile => '',
+            certfile => '',
+            keyfile => ''
         },
         obs_rsync => {
             home => '',


### PR DESCRIPTION
We need to set these query parameters in Fedora infrastructure
in order for message publishing to work. Note they're kind of
odd: they aren't intended for the server to parse, they actually
get consumed on the client before the query is sent, by a rather
indirect route. Mojo::RabbitMQ::Client parses them twice -
first turning 'cacertfile' into 'ca' and 'certfile' into 'cert',
then turning 'certfile' into 'tls_cert' and 'ca' into 'tls_ca'
as options used in a call to `$self->_loop->client`. I didn't
trace it any further than that in detail, but I think these
eventually get used by `Mojo::IOLoop::TLS::negotiate` in
negotiating the TLS connection before the query is sent.

Per its documentation here:
https://metacpan.org/pod/Mojo::RabbitMQ::Client#SUPPORTED-QUERY-PARAMETERS
Mojo::RabbitMQ::Client is following upstream RabbitMQ conventions
in deciding what parameters to honor here, but unlike what's
documented for upstream clients, it does not appear to read the
same options from any configuration file, so it doesn't seem
like we can set these options any other way than jamming them
into the query parameters like this.

Signed-off-by: Adam Williamson <awilliam@redhat.com>