### PR TITLE
Improve full-stack.t - take 2

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -173,7 +173,7 @@ sub wait_for_ajax {
         sleep $check_interval;
         $slept = 1;
     }
-    pass("Wait for jQuery successful$msg");
+    note "Wait for jQuery successful$msg";
     return $slept;
 }
 

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -112,7 +112,7 @@ sub _match_regex_returning_index ($regex, $message, $start_index = 0) {
 
 # waits until the developer console content matches the specified regex
 # note: only considers the console output since the last successful call
-sub wait_for_developer_console_like ($driver, $message_regex, $diag_info) {
+sub wait_for_developer_console_like ($driver, $message_regex, $diag_info, $timeout_s = ONE_MINUTE * 2) {
     my $js_erro_check_suffix = ', waiting for ' . $diag_info;
     ok(javascript_console_has_no_warnings_or_errors($js_erro_check_suffix), 'No unexpected js warnings');
 
@@ -123,7 +123,7 @@ sub wait_for_developer_console_like ($driver, $message_regex, $diag_info) {
     my $previous_log = '';
     # poll less frequently when waiting for paused (might take a minute for the first test module to pass)
     my $check_interval = $diag_info eq 'paused' ? 5 : 1;
-    my $timeout = OpenQA::Test::TimeLimit::scale_timeout(ONE_MINUTE * 5) * $check_interval;
+    my $timeout = OpenQA::Test::TimeLimit::scale_timeout($timeout_s) * $check_interval;
 
     my $match_index;
     while (($match_index = _match_regex_returning_index($message_regex, $log, $position_of_last_match)) < 0) {

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -123,7 +123,7 @@ sub wait_for_developer_console_like ($driver, $message_regex, $diag_info, $timeo
     my $previous_log = '';
     # poll less frequently when waiting for paused (might take a minute for the first test module to pass)
     my $check_interval = $diag_info eq 'paused' ? 5 : 1;
-    my $timeout = OpenQA::Test::TimeLimit::scale_timeout($timeout_s) * $check_interval;
+    my $timeout = OpenQA::Test::TimeLimit::scale_timeout($timeout_s);
 
     my $match_index;
     while (($match_index = _match_regex_returning_index($message_regex, $log, $position_of_last_match)) < 0) {


### PR DESCRIPTION
* t: Prevent non-deterministic test step calculation using wait_for_ajax
* t: Fix timeout calculation in wait_for_developer_console_like
* t: Prevent trying to wait longer for dev console than overall timeout