### PR TITLE
Retry Minion jobs for cleaning job results on SIGTERM/SIGINT

### DIFF
--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -7,8 +7,8 @@ use Mojo::Base 'Mojolicious::Plugin';
 use OpenQA::Log 'log_debug';
 use OpenQA::ScreenshotDeletion;
 use OpenQA::Utils qw(:DEFAULT resultdir check_df);
-use OpenQA::Task::Utils (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage),
-    qw(enable_retry_on_signals conclude_on_signals));
+use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::SignalGuard;
 use Scalar::Util 'looks_like_number';
 use List::Util 'min';
 use Time::Seconds;
@@ -27,7 +27,7 @@ sub register {
 
 sub _limit {
     my ($job, $args) = @_;
-    enable_retry_on_signals $job;
+    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_results_and_logs tasks and limit_screenshots_task/archive_job_results to run in parallel
     my $app = $job->app;
@@ -67,7 +67,7 @@ sub _limit {
         }
     }
 
-    conclude_on_signals;
+    $signal_guard->retry(0);
 
     # prevent enqueuing new limit_screenshot if there are still inactive/delayed ones
     my $limit_screenshots_jobs
@@ -104,7 +104,7 @@ sub _limit {
 
 sub _limit_screenshots {
     my ($job, $args) = @_;
-    enable_retry_on_signals $job;
+    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_screenshots tasks to run in parallel
     my $app = $job->app;
@@ -158,7 +158,7 @@ sub _check_remaining_disk_usage {
 
 sub _ensure_results_below_threshold {
     my ($job, $args) = @_;
-    enable_retry_on_signals $job;
+    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_* tasks to run in parallel
     my $app = $job->app;

--- a/lib/OpenQA/Task/SignalGuard.pm
+++ b/lib/OpenQA/Task/SignalGuard.pm
@@ -1,0 +1,46 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Task::SignalGuard;
+use Mojo::Base -base, -signatures;
+use Scalar::Util qw(weaken);
+
+# whether the retry is enabled, set to a falsy value to keep the job running
+# despite receiving signals
+# note: It makes sense to disable the retry right before the job would terminate anyways, e.g.
+#       before spawning follow-up jobs. This is useful to prevent spawning an incomplete set of
+#       follow-up jobs.
+has retry => 1;
+
+# retries the specified Minion job when receiving SIGTERM/SIGINT as long as the returned object exists
+# note: Prevents the job to fail with "Job terminated unexpectedly".
+sub new ($class, $job, @attributes) {
+    my $self = $class->SUPER::new(@attributes);
+    $self->{_job} = $job;
+    $self->{_old_term_handler} = $SIG{TERM};
+    $self->{_old_int_handler} = $SIG{INT};
+
+    # assign closure to global signal handlers using a weak reference to $self so DESTROY will still run
+    my $self_weak = $self;
+    weaken $self_weak;
+    $SIG{TERM} = $SIG{INT} = sub ($signal) { _handle_signal($self_weak, $signal) };
+    return $self;
+}
+
+sub _handle_signal ($self_weak, $signal) {
+    # do nothing if the job is supposed to be concluded despite receiving a signal at this point
+    my $job = $self_weak->{_job};
+    return $job->note(signal_handler => "Received signal $signal, concluding") unless $self_weak->retry;
+
+    # schedule a retry before stopping the job's execution prematurely
+    $job->note(signal_handler => "Received signal $signal, scheduling retry and releasing locks");
+    $job->retry;
+    exit;
+}
+
+sub DESTROY ($self) {
+    $SIG{TERM} = $self->{_old_term_handler};
+    $SIG{INT} = $self->{_old_int_handler};
+}
+
+1;

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -11,10 +11,7 @@ use Scalar::Util qw(looks_like_number);
 use Time::Seconds;
 
 our (@EXPORT, @EXPORT_OK);
-@EXPORT_OK = (
-    qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage),
-    qw(enable_retry_on_signals conclude_on_signals)
-);
+@EXPORT_OK = (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage));
 
 # acquire lock to prevent multiple limit_* tasks to run in parallel unless
 # concurrency is configured to be allowed
@@ -50,29 +47,5 @@ sub finish_job_if_disk_usage_below_percentage (%args) {
           . " (free percentage: $free_percentage %)");
     return 1;
 }
-
-# define a signal handler for retrying the job after receiving a signal
-my $CONCLUDE_ON_SIGNALS = 0;
-sub _handle_signal ($job, $signal) {
-    # do nothing if the job is supposed to be concluded despite receiving a signal at this point
-    return $job->note(signal_handler => "Received signal $signal, concluding") if $CONCLUDE_ON_SIGNALS;
-
-    # schedule a retry before stopping the job's execution prematurely
-    $job->note(signal_handler => "Received signal $signal, scheduling retry and releasing locks");
-    $job->retry;
-    exit;
-}
-
-# enables retrying the specified Minion job when receiving SIGTERM/SIGINT
-# note: Prevents the job to fail with "Job terminated unexpectedly".
-sub enable_retry_on_signals ($job) {
-    $SIG{TERM} = $SIG{INT} = sub ($signal) { _handle_signal($job, $signal) };
-}
-
-# keeps the job running despite receiving signals
-# note: Supposed to be called right before the job would terminate anyways, e.g. before
-#       spawning follow-up jobs. This is useful to prevent spawning an incomplete set of
-#       follow-up jobs.
-sub conclude_on_signals () { $CONCLUDE_ON_SIGNALS = 1 }
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -148,9 +148,11 @@ sub productdir {
 sub testcasedir {
     my ($distri, $version, $rootfortests) = @_;
     my $prjdir = prjdir();
-    for my $dir (catdir($prjdir, 'share', 'tests'), catdir($prjdir, 'tests')) {
+    my $defaultroot = catdir($prjdir, 'share', 'tests');
+    for my $dir ($defaultroot, catdir($prjdir, 'tests')) {
         $rootfortests ||= $dir if -d $dir;
     }
+    $rootfortests ||= $defaultroot;
     $distri //= '';
     # TODO actually "distri" is misused here. It should rather be something
     # like the name of the repository with all tests

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -25,6 +25,7 @@ use OpenQA::Test::Utils 'redirect_output';
 use OpenQA::Test::TimeLimit '10';
 use Scalar::Util 'reftype';
 use Test::MockObject;
+use Test::Output qw(combined_like);
 use Mojo::File qw(path tempdir tempfile);
 
 subtest 'service ports' => sub {
@@ -364,7 +365,8 @@ subtest 'project directory functions' => sub {
         is resultdir, '/var/lib/openqa/testresults', 'resultdir';
         is assetdir, '/var/lib/openqa/share/factory', 'assetdir';
         is imagesdir, '/var/lib/openqa/images', 'imagesdir';
-        is gitrepodir, '', 'no gitrepodir when distri is not defined';
+        combined_like { is gitrepodir, '', 'no gitrepodir when distri is not defined' }
+        qr{/var/lib/openqa/share/tests is not a git directory}, 'warning about Git dir logged';
     };
     subtest 'custom OPENQA_BASEDIR' => sub {
         local $ENV{OPENQA_BASEDIR} = '/tmp/test';
@@ -375,7 +377,8 @@ subtest 'project directory functions' => sub {
         is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
         my $mocked_git = path(sharedir . '/tests/opensuse/.git');
         $mocked_git->remove_tree if -e $mocked_git;
-        is gitrepodir(distri => $distri), '', 'empty when .git is missing';
+        combined_like { is gitrepodir(distri => $distri), '', 'empty when .git is missing' }
+        qr{/tmp/test/openqa/share/tests/opensuse is not a git directory}, 'warning about Git dir logged';
         $mocked_git->make_path;
         $mocked_git->child('config')
           ->spurt(qq{[remote "origin"]\n        url = git\@github.com:fakerepo/os-autoinst-distri-opensuse.git});
@@ -392,7 +395,8 @@ subtest 'project directory functions' => sub {
         is resultdir, '/tmp/test/openqa/testresults', 'resultdir';
         is assetdir, '/tmp/share/factory', 'assetdir';
         is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
-        is gitrepodir, '', 'no gitrepodir when distri is not defined';
+        combined_like { is gitrepodir, '', 'no gitrepodir when distri is not defined' }
+        qr{/tmp/test/openqa/share/tests is not a git directory}, 'warning about Git dir logged';
         is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
     };
 };

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -355,54 +355,59 @@ subtest 'base_host' => sub {
 };
 
 subtest 'project directory functions' => sub {
-    local $ENV{OPENQA_BASEDIR};
-    local $ENV{OPENQA_SHAREDIR};
-    is prjdir(), '/var/lib/openqa', 'right directory';
-    is sharedir(), '/var/lib/openqa/share', 'right directory';
-    is resultdir(), '/var/lib/openqa/testresults', 'right directory';
-    is assetdir(), '/var/lib/openqa/share/factory', 'right directory';
-    is imagesdir(), '/var/lib/openqa/images', 'right directory';
-    is gitrepodir(), '', 'not url when distri is not defined';
-
-    local $ENV{OPENQA_BASEDIR} = '/tmp/test';
-    is prjdir(), '/tmp/test/openqa', 'right directory';
-    is sharedir(), '/tmp/test/openqa/share', 'right directory';
-    is resultdir(), '/tmp/test/openqa/testresults', 'right directory';
-    is assetdir(), '/tmp/test/openqa/share/factory', 'right directory';
-    is imagesdir(), '/tmp/test/openqa/images', 'right directory';
     my $distri = 'opensuse';
-    my $mocked_git = path(sharedir . '/tests/opensuse/.git');
-    $mocked_git->remove_tree if -e $mocked_git;
-    is gitrepodir(distri => $distri), '', 'empty when .git is missing';
-    $mocked_git->make_path;
-    $mocked_git->child('config')
-      ->spurt(qq{[remote "origin"]\n        url = git\@github.com:fakerepo/os-autoinst-distri-opensuse.git});
-    is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
-    $mocked_git->child('config')
-      ->spurt(qq{[remote "origin"]\n        url = https://github.com/fakerepo/os-autoinst-distri-opensuse.git});
-    is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
-
-    local $ENV{OPENQA_SHAREDIR} = '/tmp/share';
-    is prjdir(), '/tmp/test/openqa', 'right directory';
-    is sharedir(), '/tmp/share', 'right directory';
-    is resultdir(), '/tmp/test/openqa/testresults', 'right directory';
-    is assetdir(), '/tmp/share/factory', 'right directory';
-    is imagesdir(), '/tmp/test/openqa/images', 'right directory';
-    is gitrepodir(), '', 'not url when distri is not defined';
-    is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
+    subtest 'default OPENQA_BASEDIR/OPENQA_SHAREDIR' => sub {
+        local $ENV{OPENQA_BASEDIR};
+        local $ENV{OPENQA_SHAREDIR};
+        is prjdir, '/var/lib/openqa', 'prjdir';
+        is sharedir, '/var/lib/openqa/share', 'sharedir';
+        is resultdir, '/var/lib/openqa/testresults', 'resultdir';
+        is assetdir, '/var/lib/openqa/share/factory', 'assetdir';
+        is imagesdir, '/var/lib/openqa/images', 'imagesdir';
+        is gitrepodir, '', 'no gitrepodir when distri is not defined';
+    };
+    subtest 'custom OPENQA_BASEDIR' => sub {
+        local $ENV{OPENQA_BASEDIR} = '/tmp/test';
+        is prjdir, '/tmp/test/openqa', 'prjdir';
+        is sharedir, '/tmp/test/openqa/share', 'sharedir';
+        is resultdir, '/tmp/test/openqa/testresults', 'resultdir';
+        is assetdir, '/tmp/test/openqa/share/factory', 'assetdir';
+        is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
+        my $mocked_git = path(sharedir . '/tests/opensuse/.git');
+        $mocked_git->remove_tree if -e $mocked_git;
+        is gitrepodir(distri => $distri), '', 'empty when .git is missing';
+        $mocked_git->make_path;
+        $mocked_git->child('config')
+          ->spurt(qq{[remote "origin"]\n        url = git\@github.com:fakerepo/os-autoinst-distri-opensuse.git});
+        is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
+        $mocked_git->child('config')
+          ->spurt(qq{[remote "origin"]\n        url = https://github.com/fakerepo/os-autoinst-distri-opensuse.git});
+        is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
+    };
+    subtest 'custom OPENQA_BASEDIR and OPENQA_SHAREDIR' => sub {
+        local $ENV{OPENQA_BASEDIR} = '/tmp/test';
+        local $ENV{OPENQA_SHAREDIR} = '/tmp/share';
+        is prjdir, '/tmp/test/openqa', 'prjdir';
+        is sharedir, '/tmp/share', 'sharedir';
+        is resultdir, '/tmp/test/openqa/testresults', 'resultdir';
+        is assetdir, '/tmp/share/factory', 'assetdir';
+        is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
+        is gitrepodir, '', 'no gitrepodir when distri is not defined';
+        is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
+    };
 };
 
 subtest 'change_sec_to_word' => sub {
     is change_sec_to_word(), undef, 'do pass parameter';
     is change_sec_to_word(1.2), undef, 'treat float as invalid parameter';
     is change_sec_to_word('test'), undef, 'treat string as invalid parameter';
-    is change_sec_to_word(10), '10s', 'correctly converted';
-    is change_sec_to_word(70), '1m 10s', 'correctly converted';
-    is change_sec_to_word(900), '15m', 'correctly converted';
-    is change_sec_to_word(3900), '1h 5m', 'correctly converted';
-    is change_sec_to_word(7201), '2h 1s', 'correctly converted';
-    is change_sec_to_word(64890), '18h 1m 30s', 'correctly converted';
-    is change_sec_to_word(648906), '7d 12h 15m 6s', 'correctly converted';
+    is change_sec_to_word(10), '10s', 'correctly converted (seconds)';
+    is change_sec_to_word(70), '1m 10s', 'correctly converted (minutes + seconds)';
+    is change_sec_to_word(900), '15m', 'correctly converted (minutes)';
+    is change_sec_to_word(3900), '1h 5m', 'correctly converted (hours + minutes)';
+    is change_sec_to_word(7201), '2h 1s', 'correctly converted (hours + seconds)';
+    is change_sec_to_word(64890), '18h 1m 30s', 'correctly converted (hours + minutes + seconds)';
+    is change_sec_to_word(648906), '7d 12h 15m 6s', 'correctly converted (all units)';
 };
 
 my ($current_term_handler, $current_int_handler) = ($SIG{TERM}, $SIG{INT});

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -392,9 +392,3 @@ subtest 'change_sec_to_word' => sub {
 };
 
 done_testing;
-
-{
-    package foo;    # uncoverable statement
-    use Mojo::Base -base;
-    sub baz { @_ }    # uncoverable statement
-}


### PR DESCRIPTION
* Prevent `limit_results_and_logs` jobs and follow-up Minion jobs from
  running into "Job terminated unexpectedly" by retrying the jobs instead
* See https://progress.opensuse.org/issues/103416