### PR TITLE
CI: Prevent commit message check on master when it is too late

### DIFF
--- a/.github/workflows/commit_message_checker.yml
+++ b/.github/workflows/commit_message_checker.yml
@@ -2,7 +2,11 @@
 # https://github.com/marketplace/actions/gs-commit-message-checker
 name: 'Commit Message Check'
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - '!master'  # we must not fix commit messages when they already reached master
 
 jobs:
   check-commit-message:


### PR DESCRIPTION
When updating "master" in my personal fork I realized that the git
commit message checker is called and fails due to a commit in master
which by now we can not fix anymore unless we would rewrite the history
in master which we should avoid.

This commit excludes the commit message check to run on pushes to
master.