### PR TITLE
t: Consistently use Test::Most everwhere

### DIFF
--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -1,9 +1,7 @@
 # Copyright 2019-2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use strict;
-use warnings;
-
+use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '400';

--- a/t/01-style.t
+++ b/t/01-style.t
@@ -12,4 +12,5 @@ qq{git grep -I -l 'This program is free software.*if not, see <http://www.gnu.or
   ) != 0, 'No verbatim licenses in source files';
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!t/01-style.t'}) != 0,
   'SPDX-License-Identifier correctly terminated';
+is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 done_testing;

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -8,7 +8,6 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Mojo::Base -signatures;
 use OpenQA::Test::TimeLimit '10';
-use Test::Most;
 use Mojo::File 'tempdir';
 use Mojo::Util 'scope_guard';
 use Mojolicious;

--- a/t/31-client_archive.t
+++ b/t/31-client_archive.t
@@ -1,14 +1,10 @@
 # Copyright 2018-2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use strict;
-use warnings;
-
+use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';
-
-use Test::More;
 use Test::Mojo;
 use OpenQA::Client::Archive;
 use Mojo::File qw(tempdir path);

--- a/t/32-openqa_client-script.t
+++ b/t/32-openqa_client-script.t
@@ -2,10 +2,8 @@
 # Copyright 2019-2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use strict;
-use warnings;
+use Test::Most;
 use Test::Exception;
-use Test::More;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -18,14 +18,14 @@ use Mojo::Transaction;
 # define fake client
 {
     package Test::FakeLWPUserAgentMirrorResult;
-    use Mojo::Base -base;
+    use Mojo::Base -base, -signatures;
     has is_success => 1;
     has code => 304;
     has status_line => 'some status';
 }
 {
     package Test::FakeLWPUserAgent;
-    use Mojo::Base -base;
+    use Mojo::Base -base, -signatures;
     has mirrored => sub { {} };
     has missing => 0;
     sub mirror ($self, $from, $dest) {

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -1,12 +1,12 @@
 # Copyright 2020-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later.
 
+use Test::Most;
 use Mojo::Base -strict;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 
-use Test::More;
 use Capture::Tiny qw(capture capture_stdout);
 use Mojo::Server::Daemon;
 use Mojo::JSON qw(decode_json);

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -1,12 +1,12 @@
 # Copyright 2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+use Test::Most;
 use Mojo::Base -strict;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 
-use Test::More;
 use Capture::Tiny qw(capture_stdout);
 use Mojo::Server::Daemon;
 use Mojo::File qw(tempdir tempfile);

--- a/t/43-cli.t
+++ b/t/43-cli.t
@@ -1,12 +1,12 @@
 # Copyright 2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+use Test::Most;
 use Mojo::Base -strict;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 
-use Test::More;
 use OpenQA::CLI;
 use OpenQA::Test::TimeLimit '4';
 


### PR DESCRIPTION
Also adding a style check to ensure that.

Related progress issue: https://progress.opensuse.org/issues/103617