### PR TITLE
Feature/ensure test warnings everywhere

### DIFF
--- a/t/01-style.t
+++ b/t/01-style.t
@@ -16,5 +16,6 @@ is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 is qx{git grep --all-match -e '^use Mojo::Base' -e 'use base'}, '', 'No redundant Mojo::Base+base';
 is qx{git grep -I --all-match -e '^use Mojo::Base' -e 'use \\(strict\\|warnings\\)' ':!docs'}, '',
   'Only combined Mojo::Base+strict+warnings';
+is qx{git grep -I -L '^use Test::Warnings' t/**.t ':!t/01-style.t'}, '', 'All tests use Test::Warnings';
 done_testing;
 

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings qw(:report_warnings warning);
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
@@ -178,54 +179,55 @@ subtest 'Parser base class object' => sub {
 
     $good_parser->results->add(Dummy->new);
 
-    combined_like { $good_parser->_build_tree }
-    qr/Serialization is officially supported only if object can be hashified with \-\>to_hash\(\)/,
+    like warning { $good_parser->_build_tree },
+      qr/Serialization is officially supported only if object can be hashified with \-\>to_hash\(\)/,
       'serialization support warns';
 
     $good_parser->results->remove(0);
 
     $good_parser->results->add(Dummy2->new);
-    combined_like { $good_parser->_build_tree }
-    qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
+    like warning { $good_parser->_build_tree },
+      qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
       'serialization support warns';
 
-    combined_like {
+    like warning {
         is_deeply $good_parser->_build_tree->{generated_tests_results}->[0]->{OpenQA::Parser::DATA_FIELD()},
           [qw(1 2 3)];
-    }
-    qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
+    },
+      qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
       'serialization support warns';
 
     $good_parser->results->add({test => 'bar'});
 
     $good_parser->results->add(Dummy3->new);
-    combined_like { $good_parser->_build_tree } qr/Data type with format not supported for serialization/,
+    like warning { $good_parser->_build_tree }->[0],
+      qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
       'serialization support warns';
     $good_parser->results->remove(2);
 
     is $good_parser->results->size, 2, '2 results';
-    combined_like {
+    like warning {
         is_deeply $good_parser->_build_tree->{generated_tests_results}->[1]->{OpenQA::Parser::DATA_FIELD()},
           {test => 'bar'}
-    }
-    qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
+    },
+      qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
       'serialization support warns';
 
     my $copy;
-    combined_like { $copy = parser("Base")->_load_tree($good_parser->_build_tree) }
-    qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
+    like warning { $copy = parser("Base")->_load_tree($good_parser->_build_tree) },
+      qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
       'serialization support warns';
-    combined_like {
+    like warning {
         is_deeply $copy->_build_tree->{generated_tests_results}->[0]->{OpenQA::Parser::DATA_FIELD()}, [qw(1 2 3)]
           or diag explain $copy->_build_tree->{generated_tests_results}
-    }
-    qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
+    },
+      qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
       'serialization support warns';
-    combined_like {
+    like warning {
         is_deeply $copy->_build_tree->{generated_tests_results}->[1]->{OpenQA::Parser::DATA_FIELD()}, {test => 'bar'}
           or die diag explain $good_parser->_build_tree
-    }
-    qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
+    },
+      qr/Serialization is officially supported only if object can be turned into an array with \-\>to_array\(\)/,
       'serialization support warns';
 
     $good_parser->results->remove(1);

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later.
 
 use Test::Most;
+use Test::Warnings qw(:all :report_warnings);
 use Mojo::Base -strict, -signatures;
 
 use FindBin;
@@ -114,14 +115,10 @@ subtest 'Client' => sub {
 
 subtest 'Unknown options' => sub {
     my $api = OpenQA::CLI::api->new;
-    my $buffer = '';
-    {
-        open my $handle, '>', \$buffer;
-        local *STDERR = $handle;
-        eval { $api->run('--unknown') };
-        like $@, qr/Usage: openqa-cli api/, 'unknown option';
-    }
-    like $buffer, qr/Unknown option: unknown/, 'right output';
+    like warning {
+        eval { $api->run('--unknown') }
+    }, qr/Unknown option/, 'warning about unknown option';
+    like $@, qr/Usage: openqa-cli api/, 'unknown option';
 };
 
 subtest 'Simple request with authentication' => sub {

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings qw(:report_warnings warning);
 use Mojo::Base -strict;
 
 use FindBin;
@@ -41,14 +42,10 @@ subtest 'Help' => sub {
 
 subtest 'Unknown options' => sub {
     my $archive = OpenQA::CLI::archive->new;
-    my $buffer = '';
-    {
-        open my $handle, '>', \$buffer;
-        local *STDERR = $handle;
-        eval { $archive->run('--unknown') };
-        like $@, qr/Usage: openqa-cli archive/, 'unknown option';
-    }
-    like $buffer, qr/Unknown option: unknown/, 'right output';
+    like warning {
+        eval { $archive->run('--unknown') }
+    }, qr/Unknown option: unknown/, 'right output';
+    like $@, qr/Usage: openqa-cli archive/, 'unknown option';
 };
 
 subtest 'Defaults' => sub {


### PR DESCRIPTION
As discussed in https://github.com/os-autoinst/openQA/pull/4391 we should use `Test::Warnings` everywhere but I have seen "unhandled warnings" reported though I can't see them directly when executing tests. Let's await CI results and I hope you can help me to fix all issues we see.