### PR TITLE
Retry Minion jobs for cleanup on SIGTERM/SIGINT (e.g. service restarts)

### DIFF
--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -46,7 +46,7 @@ sub _update_exclusively_kept_asset_size {
 
 sub _limit {
     my ($app, $job) = @_;
-    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_assets tasks to run in parallel
     return $job->finish('Previous limit_assets job is still active')

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -7,6 +7,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 use OpenQA::Log qw(log_info log_debug);
 use OpenQA::Utils qw(:DEFAULT assetdir);
 use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::SignalGuard;
 
 use Mojo::URL;
 use Data::Dump 'pp';
@@ -45,6 +46,7 @@ sub _update_exclusively_kept_asset_size {
 
 sub _limit {
     my ($app, $job) = @_;
+    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_assets tasks to run in parallel
     return $job->finish('Previous limit_assets job is still active')

--- a/lib/OpenQA/Task/AuditEvents/Limit.pm
+++ b/lib/OpenQA/Task/AuditEvents/Limit.pm
@@ -4,6 +4,7 @@
 package OpenQA::Task::AuditEvents::Limit;
 use Mojo::Base 'Mojolicious::Plugin';
 use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry);
+use OpenQA::Task::SignalGuard;
 use Time::Seconds;
 
 sub register {
@@ -13,6 +14,7 @@ sub register {
 
 sub _limit {
     my ($app, $job) = @_;
+    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_audit_events tasks to run in parallel
     return $job->finish('Previous limit_audit_events job is still active')

--- a/lib/OpenQA/Task/AuditEvents/Limit.pm
+++ b/lib/OpenQA/Task/AuditEvents/Limit.pm
@@ -14,7 +14,7 @@ sub register {
 
 sub _limit {
     my ($app, $job) = @_;
-    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_audit_events tasks to run in parallel
     return $job->finish('Previous limit_audit_events job is still active')

--- a/lib/OpenQA/Task/Bug/Limit.pm
+++ b/lib/OpenQA/Task/Bug/Limit.pm
@@ -4,6 +4,7 @@
 package OpenQA::Task::Bug::Limit;
 use Mojo::Base 'Mojolicious::Plugin';
 use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry);
+use OpenQA::Task::SignalGuard;
 use Time::Seconds;
 
 sub register {
@@ -13,6 +14,7 @@ sub register {
 
 sub _limit {
     my $job = shift;
+    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
     my $app = $job->app;
 
     # prevent multiple limit_bugs tasks to run in parallel

--- a/lib/OpenQA/Task/Bug/Limit.pm
+++ b/lib/OpenQA/Task/Bug/Limit.pm
@@ -14,7 +14,7 @@ sub register {
 
 sub _limit {
     my $job = shift;
-    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
     my $app = $job->app;
 
     # prevent multiple limit_bugs tasks to run in parallel

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -27,7 +27,7 @@ sub register {
 
 sub _limit {
     my ($job, $args) = @_;
-    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_results_and_logs tasks and limit_screenshots_task/archive_job_results to run in parallel
     my $app = $job->app;
@@ -67,7 +67,7 @@ sub _limit {
         }
     }
 
-    $signal_guard->retry(0);
+    $ensure_task_retry_on_termination_signal_guard->retry(0);
 
     # prevent enqueuing new limit_screenshot if there are still inactive/delayed ones
     my $limit_screenshots_jobs
@@ -104,7 +104,7 @@ sub _limit {
 
 sub _limit_screenshots {
     my ($job, $args) = @_;
-    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_screenshots tasks to run in parallel
     my $app = $job->app;
@@ -158,7 +158,7 @@ sub _check_remaining_disk_usage {
 
 sub _ensure_results_below_threshold {
     my ($job, $args) = @_;
-    my $signal_guard = OpenQA::Task::SignalGuard->new($job);
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
 
     # prevent multiple limit_* tasks to run in parallel
     my $app = $job->app;


### PR DESCRIPTION
* Use the signal guard introduced by d90f00fd/8b96b710 for all the "limit"
  jobs to avoid them failing with "Job terminated unexpectedly"
* See https://progress.opensuse.org/issues/103416 and
  https://progress.opensuse.org/issues/99831

---

The code is covered by tests. Not sure whether it is necessary to add explicit checks for all these tasks. I did at least a full stack test for all tasks manually.