### PR TITLE
branding: Again adapt bug reporting link for SUSE 15 SP4

### DIFF
--- a/templates/webapi/branding/openSUSE/external_reporting.html.ep
+++ b/templates/webapi/branding/openSUSE/external_reporting.html.ep
@@ -62,7 +62,10 @@
 %         if ($public_sle_product && ($version =~ qr/(\d+) SP(\d+)/)) {
 %             # only 15-SP3 has a specific "public" bug reporting section in
 %             # bugzilla, 15-SP4 again does not
-%             if ($1 == 15 && $2 == 3) {
+              # Apparently a new PUBLIC project was created *after* the
+              # initial internal only product so we should still go with
+              # PUBLIC as long as that exists. Hard to maintain.
+%             if ($1 == 15 && $2 >= 3) {
 %                 $distri      = "PUBLIC $distri" ;
 %                 $sle_product = $public_sle_product;
 %             }


### PR DESCRIPTION
Related to a request brought up by Vincent Moutoussamy.

In 2021-08 there was a product in bugzilla but it was not public so we
adjusted again the bug reporting template in openQA for
https://progress.opensuse.org/issues/96744 , see
https://github.com/os-autoinst/openQA/commit/339968ebc2fd6bedc290a077d19396172c9c4055#diff-2ccd52e84db0aec326ae41923febd47d8d1877952e3abb00dec955ee346342b6
. With going back and forth I am sure that we will not be able to ensure
this for automatic tooling as well as human reporters. So it would be
better find a way where we don't need to change URLs every couple of
months as we will most likely not succeed this way.