### PR TITLE
Improve health-check for `devel:openQA` repository

### DIFF
--- a/container/worker/launch_workers_pool.sh
+++ b/container/worker/launch_workers_pool.sh
@@ -16,7 +16,7 @@ EOF
     exit "$1"
 }
 
-opts=$(getopt -o hs: --long help,size: -n 'parse-options' -- "$@") || usage 1
+opts=$(getopt -o hs: --long help,size: -n "$0" -- "$@") || usage 1
 eval set -- "$opts"
 
 while true; do

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -688,5 +688,6 @@ fi
 %dir %{_unitdir}
 %{_unitdir}/openqa-auto-update.*
 %{_datadir}/openqa/script/openqa-auto-update
+%{_datadir}/openqa/script/openqa-check-devel-repo
 
 %changelog

--- a/script/configure-web-proxy
+++ b/script/configure-web-proxy
@@ -11,7 +11,7 @@ EOF
     exit "$1"
 }
 
-opts=$(getopt -o h --long help -n 'parse-options' -- "$@") || usage 1
+opts=$(getopt -o h --long help -n "$0" -- "$@") || usage 1
 eval set -- "$opts"
 while true; do
   case "$1" in

--- a/script/openqa-auto-update
+++ b/script/openqa-auto-update
@@ -23,5 +23,7 @@ while true; do
   esac
 done
 
-# shellcheck disable=SC1091 disable=SC2015
-. /etc/os-release && result="$(curl -s "https://api.opensuse.org/public/build/devel:openQA/_result?repository=openSUSE_Leap_${VERSION}&arch=$(uname -i)")" && echo -e "$result" | grep -q "project.*state=.published." && echo "$result" | grep "status package" | (! grep -vE "(disabled|succeeded|excluded)") && zypper -n dup --replacefiles --auto-agree-with-licenses --force-resolution --download-in-advance && needs-restarting --reboothint >/dev/null || (command -v rebootmgrctl >/dev/null && rebootmgrctl reboot ||:)
+"$(dirname "${BASH_SOURCE[0]}")"/openqa-check-devel-repo
+zypper -n dup --replacefiles --auto-agree-with-licenses --force-resolution --download-in-advance
+# shellcheck disable=SC2015
+needs-restarting --reboothint >/dev/null || (command -v rebootmgrctl >/dev/null && rebootmgrctl reboot ||:)

--- a/script/openqa-auto-update
+++ b/script/openqa-auto-update
@@ -13,7 +13,7 @@ EOF
     exit "$1"
 }
 
-opts=$(getopt -o h --long help -n 'parse-options' -- "$@") || usage 1
+opts=$(getopt -o h --long help -n "$0" -- "$@") || usage 1
 eval set -- "$opts"
 while true; do
   case "$1" in

--- a/script/openqa-check-devel-repo
+++ b/script/openqa-check-devel-repo
@@ -2,6 +2,27 @@
 set -e
 set -o pipefail
 
+usage() {
+    cat << EOF
+Usage: openqa-check-devel-repo
+Checks whether devel:openQA packages are stable
+
+Options:
+ -h, --help         display this help
+EOF
+    exit "$1"
+}
+
+opts=$(getopt -o h --long help -n 'parse-options' -- "$@") || usage 1
+eval set -- "$opts"
+while true; do
+  case "$1" in
+    -h | --help ) usage 0; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
 trap 'log_error' ERR
 log_error() {
   echo "devel:openQA looks bad for Leap $VERSION ($ARCH):"

--- a/script/openqa-check-devel-repo
+++ b/script/openqa-check-devel-repo
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+trap 'log_error' ERR
+log_error() {
+  echo "devel:openQA looks bad for Leap $VERSION ($ARCH):"
+  echo "${result:-Unable to query OBS}"
+}
+
+[[ $VERSION ]] || . /etc/os-release
+[[ $ARCH ]] || ARCH=$(uname -i)
+result="$(curl -sS "${REPO_URL:-https://api.opensuse.org/public/build/devel:openQA}/_result?repository=openSUSE_Leap_${VERSION}&arch=${ARCH}")"
+
+echo -e "$result" | grep -q "project.*state=.published."
+echo "$result" | grep "status package" | (! grep -vE "(disabled|succeeded|excluded)")
+echo "devel:openQA looks good for Leap $VERSION ($ARCH)"

--- a/script/openqa-check-devel-repo
+++ b/script/openqa-check-devel-repo
@@ -13,7 +13,7 @@ EOF
     exit "$1"
 }
 
-opts=$(getopt -o h --long help -n 'parse-options' -- "$@") || usage 1
+opts=$(getopt -o h --long help -n "$0" -- "$@") || usage 1
 eval set -- "$opts"
 while true; do
   case "$1" in

--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -51,7 +51,7 @@ extract_urls_from_pr() {
     fi
 }
 
-opts=$(getopt -o vhnc: --long verbose,dry-run,help,clone-job-args: -n 'parse-options' -- "$@") || usage 1
+opts=$(getopt -o vhnc: --long verbose,dry-run,help,clone-job-args: -n "$0" -- "$@") || usage 1
 eval set -- "$opts"
 while true; do
   case "$1" in

--- a/script/openqa-rollback
+++ b/script/openqa-rollback
@@ -12,7 +12,7 @@ EOF
     exit "$1"
 }
 
-opts=$(getopt -o hn --long help,dry-run -n 'parse-options' -- "$@") || usage 1
+opts=$(getopt -o hn --long help,dry-run -n "$0" -- "$@") || usage 1
 eval set -- "$opts"
 while true; do
   case "$1" in

--- a/tools/js-tidy
+++ b/tools/js-tidy
@@ -14,7 +14,7 @@ EOF
 
 set -eo pipefail
 
-opts=$(getopt -o h --long help -n 'parse-options' -- "$@") || usage
+opts=$(getopt -o h --long help -n "$0" -- "$@") || usage
 eval set -- "$opts"
 while true; do
   case "$1" in

--- a/tools/tidy
+++ b/tools/tidy
@@ -26,7 +26,7 @@ set -eo pipefail
 
 check=
 only_changed=false
-opts=$(getopt -o hco --long help,check,only-changed -n 'parse-options' -- "$@") || usage
+opts=$(getopt -o hco --long help,check,only-changed -n "$0" -- "$@") || usage
 eval set -- "$opts"
 while true; do
   case "$1" in


### PR DESCRIPTION
* Move the code into a separate file and multiple lines
* Log error details in case something goes wrong by adding the curl flag
  `-S` and by printing the OBS response via `trap` to make it clear why
  subsequent actions are skipped
* For https://progress.opensuse.org/issues/103692