### PR TITLE
t: Add Test::Warnings to most files where missing

### DIFF
--- a/t/01-compile-check-all.t
+++ b/t/01-compile-check-all.t
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+# We need :no_end_test here because otherwise it would output a no warnings
+# test for each of the modules, but with the same test number
+use Test::Warnings qw(:no_end_test :report_warnings);
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '400';

--- a/t/01-test-utilities.t
+++ b/t/01-test-utilities.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/02-pod.t
+++ b/t/02-pod.t
@@ -1,4 +1,5 @@
 use Test::Most;
+use Test::Warnings qw(:no_end_test :report_warnings);
 # no OpenQA::Test::TimeLimit for this trivial test
 
 eval 'use Test::Pod';

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 # define test helper to check for exit code
 our $exit_handler = sub { CORE::exit $_[0] };

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 BEGIN {
     $ENV{OPENQA_UPLOAD_DELAY} = 0;

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/25-cache-client.t
+++ b/t/25-cache-client.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 my $sleep_count = 0;
 my $tempdir;

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 use utf8;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 BEGIN {
     package OpenQA::FakePlugin::Fuzz;

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use 5.018;
 use POSIX;

--- a/t/31-api_descriptions.t
+++ b/t/31-api_descriptions.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 # no OpenQA::Test::TimeLimit for this trivial test
 
 use Mojo::Base 'Mojolicious', -signatures;

--- a/t/31-client_archive.t
+++ b/t/31-client_archive.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/32-openqa_client-script.t
+++ b/t/32-openqa_client-script.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 use Test::Exception;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -8,6 +8,7 @@
 #    execution)
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';

--- a/t/43-cli.t
+++ b/t/43-cli.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 use Mojo::Base -strict;
 
 use FindBin;

--- a/t/44-scripts-modify_needle.t
+++ b/t/44-scripts-modify_needle.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin '$Bin';
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::Warnings ':report_warnings';
 
 use FindBin '$Bin';
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";


### PR DESCRIPTION
First part of https://github.com/os-autoinst/openQA/pull/4393 . All tests that should pass without problems.

Related progress issue: https://progress.opensuse.org/issues/103617