### PR TITLE
Allow hxnormalize in apparmor config

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -129,6 +129,7 @@
   /usr/bin/grep mrix,
   /usr/bin/head mrix,
   /usr/bin/hxselect mrix,
+  /usr/bin/hxnormalize mrix,
   /usr/bin/jq rix,
   /usr/bin/mv ix,
   /usr/bin/mktemp rix,


### PR DESCRIPTION
I just found this in the openqa-gru log on o3:
```
/opt/os-autoinst-scripts/openqa-label-known-issues: line 84: /usr/bin/hxnormalize: Permission denied
```