### PR TITLE
Add support for new hardware console log

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1190,7 +1190,7 @@ sub delete_logs {
     return undef unless $result_dir;
     my @files = (
         Mojo::Collection->new(
-            map { path($result_dir, $_) } qw(autoinst-log.txt serial0.txt serial_terminal.txt video_time.vtt)
+            map { path($result_dir, $_) } qw(autoinst-log.txt serial0.txt serial_terminal.txt video_time.vtt hardware-console-log.txt)
         ),
         path($result_dir, 'ulogs')->list_tree({hidden => 1}),
         find_video_files($result_dir),
@@ -1904,7 +1904,7 @@ sub test_resultfile_list {
     for my $f (@filelist) {
         push(@$filelist_existing, $f) if -e "$testresdir/$f";
     }
-    for my $f (qw(serial_terminal.txt)) {
+    for my $f (qw(serial_terminal.txt hardware-console-log.txt)) {
         push(@$filelist_existing, $f) if -s "$testresdir/$f";
     }
 

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -247,7 +247,7 @@ sub start {
     # ensure log files are empty/removed
     if (my $pooldir = $worker->pool_directory) {
         open(my $fd, '>', "$pooldir/worker-log.txt") or log_error("Could not open worker log: $!");
-        foreach my $file (qw(serial0.txt autoinst-log.txt serial_terminal.txt)) {
+        foreach my $file (qw(serial0.txt autoinst-log.txt serial_terminal.txt hardware-console-log.txt)) {
             next unless -e "$pooldir/$file";
             unlink("$pooldir/$file") or log_error("Could not unlink '$file': $!");
         }
@@ -430,7 +430,7 @@ sub _stop_step_4_upload ($self, $reason, $callback) {
             my @other = (
                 @{find_video_files($pooldir)->map('basename')->to_array},
                 COMMON_RESULT_FILES,
-                qw(serial0 video_time.vtt serial_terminal.txt virtio_console.log virtio_console1.log)
+                qw(serial0 video_time.vtt serial_terminal.txt virtio_console.log virtio_console1.log hardware-console-log.txt)
             );
             for my $other (@other) {
                 my $file = "$pooldir/$other";


### PR DESCRIPTION
Enhancement poo#103903: There is new log hardware-console-log.txt file
to capture console logs on IPMI and PowerVM backends.

Related os-autoinst PR: https://github.com/os-autoinst/os-autoinst/pull/1881