### PR TITLE
cli: List supported search criteria for jobs/overview route

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -7,9 +7,13 @@ use Mojo::Base 'OpenQA::Command';
 use Mojo::File 'path';
 use Mojo::JSON qw(decode_json);
 use Mojo::Util qw(getopt);
+use OpenQA::Constants qw(JOBS_OVERVIEW_SEARCH_CRITERIA);
 
 has description => 'Issue an arbitrary request to the API';
-has usage => sub { shift->extract_usage };
+has usage => sub {
+    my $search_criteria = join(', ', JOBS_OVERVIEW_SEARCH_CRITERIA);
+    shift->extract_usage =~ s/\$search_criteria/$search_criteria/r;
+};
 
 sub command {
     my ($self, @args) = @_;
@@ -83,6 +87,7 @@ sub command {
     openqa-cli api --osd jobs groupid=135 distri=caasp version=3.0 latest=1
 
     # List the latest jobs matching the search criteria
+    # supported search criteria: $search_criteria
     openqa-cli api --osd jobs/overview groupid=135 distri=caasp version=3.0
 
     # Restart a job

--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -98,6 +98,9 @@ use constant VIDEO_FILE_NAME_REGEX => qr/^.*\/video\.[^\/]*$/;
 
 use constant FRAGMENT_REGEX => qr'(#([-?/:@.~!$&\'()*+,;=\w]|%[0-9a-fA-F]{2})*)*';
 
+use constant JOBS_OVERVIEW_SEARCH_CRITERIA =>
+  (qw(distri version flavor build test modules modules_result module_re group groupid id));
+
 our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION DEFAULT_WORKER_TIMEOUT
   WORKER_COMMAND_ABORT WORKER_COMMAND_QUIT WORKER_COMMAND_CANCEL WORKER_COMMAND_OBSOLETE WORKER_COMMAND_LIVELOG_STOP
@@ -112,6 +115,7 @@ our @EXPORT_OK = qw(
   DB_TIMESTAMP_ACCURACY
   VIDEO_FILE_NAME_START VIDEO_FILE_NAME_REGEX
   FRAGMENT_REGEX
+  JOBS_OVERVIEW_SEARCH_CRITERIA
 );
 
 1;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -5,6 +5,7 @@ package OpenQA::WebAPI::Plugin::Helpers;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use Mojo::ByteStream;
+use OpenQA::Constants qw(JOBS_OVERVIEW_SEARCH_CRITERIA);
 use OpenQA::Schema;
 use OpenQA::Utils qw(bugurl human_readable_size render_escaped_refs href_to_bugref);
 use OpenQA::Events;
@@ -340,17 +341,8 @@ sub _compose_job_overview_search_args ($c) {
     my %search_args;
 
     my $v = $c->validation;
-    $v->optional('distri', 'not_empty');
-    $v->optional('version', 'not_empty');
-    $v->optional('flavor', 'not_empty');
-    $v->optional('build', 'not_empty');
-    $v->optional('test', 'not_empty');
-    $v->optional('modules', 'comma_separated', 'not_empty');
-    $v->optional('modules_result', 'not_empty');
-    $v->optional('module_re', 'not_empty');
-    $v->optional('group', 'not_empty');
-    $v->optional('groupid', 'not_empty');
-    $v->optional('id', 'not_empty');
+    $v->optional($_, 'not_empty') for JOBS_OVERVIEW_SEARCH_CRITERIA;
+    $v->optional('modules', 'comma_separated');
     $v->optional('limit', 'not_empty')->num(0, undef);
 
     # add simple query params to search args

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -64,6 +64,7 @@ my $api = OpenQA::CLI::api->new;
 subtest 'Help' => sub {
     my ($stdout, $stderr, @result) = capture sub { $cli->run('help', 'api') };
     like $stdout, qr/Usage: openqa-cli api/, 'help';
+    like $stdout, qr/supported search criteria: distri, version.*id/, 'search criteria listed';
 };
 
 subtest 'Defaults' => sub {


### PR DESCRIPTION
Output in the openqa-cli help:

```
  # List the latest jobs matching the search criteria
  # supported search criteria: distri, version, flavor, build, test, modules, modules_result, module_re, group, groupid, id
  openqa-cli api --osd jobs/overview groupid=135 distri=caasp version=3.0
```

Related progress issue: https://progress.opensuse.org/issues/103864