### PR TITLE
apparmor: Add rules for default archive folder

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -82,6 +82,7 @@
   /var/log/openqa rwk,
   /var/tmp/* rwk,
   owner /var/lib/openqa/share/tests/** rwl,
+  owner /var/lib/openqa/archive/** rwl,
 
 
   profile /usr/bin/ssh {


### PR DESCRIPTION
As observed on openqa.opensuse.org after enabling archiving.

Related progress issue: https://progress.opensuse.org/issues/103953