### PR TITLE
admin: Check textarea when checking for key input

### DIFF
--- a/assets/javascripts/admin_groups.js
+++ b/assets/javascripts/admin_groups.js
@@ -76,7 +76,7 @@ function checkJobGroupForm(formID) {
   if (empty) {
     $('button[type=submit]', formID).attr('disabled', 'disabled');
   }
-  $('.form-group input', formID).on('keyup change', function () {
+  $('.form-group input, .form-group textarea', formID).on('keyup change', function () {
     var trimmed = jQuery.trim($(this).val());
     if (!trimmed.length) {
       $(this).addClass('is-invalid');

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -409,7 +409,6 @@ subtest 'job property editor' => sub() {
         $ele = $driver->find_element_by_id('editor-keep-important-results-in-days');
         $ele->send_keys(Selenium::Remote::WDKeys->KEYS->{control}, 'a');
         $ele->send_keys('500');
-        $driver->find_element_by_id('editor-description')->send_keys('Test group');
         is($driver->find_element('#properties p.buttons button.btn-primary')->get_attribute('disabled'),
             undef, 'group properties save button is enabled');
         $driver->find_element_by_id('editor-carry-over-bugrefs')->click();
@@ -423,6 +422,11 @@ subtest 'job property editor' => sub() {
         is element_prop('editor-keep-important-results-in-days'), '500', 'keep important results in days edited';
         is element_prop('editor-default-priority'), '50', 'default priority should be the same';
         ok !element_prop('editor-carry-over-bugrefs', 'checked'), 'bug carry over disabled';
+
+        # change the description as well and check that it toggles the Save button
+        $driver->find_element_by_id('editor-description')->send_keys('Test group');
+        $driver->find_element('#properties p.buttons button.btn-primary')->click();
+        wait_for_ajax(msg => 'ensure there is no race condition, even though the page is reloaded');
         is element_prop('editor-description'), 'Test group', 'description added';
 
         # clear asset size limit again


### PR DESCRIPTION
Typing in any `input` affects the modified state. The description
however is a `textarea`.

See: https://progress.opensuse.org/issues/104037