### PR TITLE
Avoid archiving jobs to fail with "Job terminated unexpectedly"

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -260,7 +260,7 @@ sub archivable_result_dir ($self) {
     return $result_dir && -d $result_dir ? $result_dir : undef;
 }
 
-sub archive ($self) {
+sub archive ($self, $signal_guard = undef) {
     return undef unless my $normal_result_dir = $self->archivable_result_dir;
 
     my $archived_result_dir = $self->add_result_dir_prefix($self->remove_result_dir_prefix($normal_result_dir), 1);
@@ -270,6 +270,7 @@ sub archive ($self) {
         die "Unable to copy '$normal_result_dir' to '$archived_result_dir': $error";
     }
 
+    $signal_guard->retry(0) if $signal_guard;
     $self->update({archived => 1});
     $self->discard_changes;
     File::Path::remove_tree($normal_result_dir);

--- a/lib/OpenQA/Task/Job/ArchiveResults.pm
+++ b/lib/OpenQA/Task/Job/ArchiveResults.pm
@@ -11,6 +11,7 @@ sub register ($self, $app, @args) {
 }
 
 sub _archive_results ($minion_job, @args) {
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($minion_job);
     my ($openqa_job_id) = @args;
     my $app = $minion_job->app;
     return $minion_job->fail('No job ID specified.') unless defined $openqa_job_id;
@@ -27,7 +28,7 @@ sub _archive_results ($minion_job, @args) {
 
     my $openqa_job = $app->schema->resultset('Jobs')->find($openqa_job_id);
     return $minion_job->finish("Job $openqa_job_id does not exist.") unless $openqa_job;
-    $minion_job->note(archived_path => $openqa_job->archive);
+    $minion_job->note(archived_path => $openqa_job->archive($ensure_task_retry_on_termination_signal_guard));
 }
 
 1;

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -811,9 +811,12 @@ subtest 'create result dir, delete results' => sub {
         ok -d $result_dir, 'normal result directory still exists';
         undef $copy_mock;
 
-        my $archive_dir = $job->archive;
+        my $signal_guard = OpenQA::Task::SignalGuard->new(undef);
+        my $archive_dir = $job->archive($signal_guard);
         ok -d $archive_dir, 'archive result directory created';
         ok !-d $result_dir, 'normal result directory removed';
+        ok !$signal_guard->retry, 'signal guard retry disabled in the end';
+        undef $signal_guard;
 
         $result_dir = path($job->result_dir);
         like $result_dir, qr|$base_dir/openqa/archive/testresults/\d{5}/\d{8}-to-be-archived|,


### PR DESCRIPTION
* Retry archiving jobs when receiving SIGTERM/SIGINT
* Try to conclude cleanup if almost done (should not take long anymore)
* See https://progress.opensuse.org/issues/104116