### PR TITLE
Add advanced restart dropdown menu

### DIFF
--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -88,6 +88,7 @@ $driver->find_element_by_link_text('Login')->click();
 subtest 'restart job from info panel in test results' => sub {
     subtest 'parent job shows options for advanced restart' => sub {
         $driver->get_ok('/tests/99900', 'go to job 99900');
+        is @{$driver->find_elements('//a[contains(@id, "restart")]', 'xpath')}, 4, 'multiple restart actions found';
         ok !$driver->find_element('#restart-result-skip-parents')->is_displayed, 'advanced restart entries present';
         $driver->find_element('#restart-button-options')->click;
         my $restart_parent = $driver->find_element('#restart-result-skip-parents');
@@ -108,6 +109,7 @@ subtest 'restart job from info panel in test results' => sub {
     };
     subtest 'assets missing; there is no parent' => sub {
         is($driver->get('/tests/99939'), 1, 'go to job 99939');
+        is @{$driver->find_elements('//a[contains(@id, "restart")]', 'xpath')}, 1, 'only one restart action found';
         $driver->find_element('#restart-result')->click();
         wait_for_ajax(msg => 'fail to start job with missing asset and no parent');
         like($driver->get_current_url, qr|tests/99939|, 'no auto refresh when there are errors/warnings');

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -69,6 +69,7 @@
                         %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result', 'data-jobid' => $testid) => begin
                             <i class="fa fa-2 fa-undo" title="Restart job"></i>
                         %= end
+                        % if ($job->has_dependencies) {
                         <button class="btn btn-link dropdown-toggle" type="button" id="restart-button-options" data-toggle="dropdown">
                         <span class="caret" title="Additional options for restarting jobs with dependencies"></span></button>
                           <ul class="dropdown-menu" role="menu" aria-labelledby="restart-button-options" id="restart-menu">
@@ -88,18 +89,19 @@
                               %= end
                             </li>
                           </ul>
-                        <%= help_popover('Restart job' => '
-                            <p>Restarts the job and certain dependent jobs.</p>
-                            <p>Rules for restarting dependencies:</p>
-                            <ul>
-                                <li>If the job is part of a parallel cluster, all jobs within that cluster are restarted.</li>
-                                <li>Any kind of chained child jobs are restarted.</li>
-                                <li>Directly chained parent jobs are restarted.</li>
-                            </ul>
-                            All rules are applied recursively. Direct use of the REST-API allows excluding parents and (passed/softfailed) children.',
-                            'https://open.qa/docs/#_handling_of_related_jobs_on_failure_cancellation_restart', 'documentation', 'bottom');
-                        %>
+                        % }
                       </div>
+                      <%= help_popover('Restart job' => '
+                          <p>Restarts the job and certain dependent jobs.</p>
+                          <p>Rules for restarting dependencies:</p>
+                          <ul>
+                              <li>If the job is part of a parallel cluster, all jobs within that cluster are restarted.</li>
+                              <li>Any kind of chained child jobs are restarted.</li>
+                              <li>Directly chained parent jobs are restarted.</li>
+                          </ul>
+                          All rules are applied recursively. Direct use of the REST-API allows excluding parents and (passed/softfailed) children.',
+                          'https://open.qa/docs/#_handling_of_related_jobs_on_failure_cancellation_restart', 'documentation', 'bottom');
+                      %>
                     % }
                     % if (is_operator && (OpenQA::Jobs::Constants::meta_state($job->state) ne OpenQA::Jobs::Constants::FINAL)) {
                         %= link_post url_for('apiv1_cancel', jobid => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -64,9 +64,30 @@
                         <abbr class="timeago" title="<%= $job->t_started->datetime() %>Z"><%= format_time($job->t_started) %></abbr>
                     % }
                     % if (is_operator && $job->can_be_duplicated) {
+                      <div class = "btn-group">
+                        <button class="btn btn-default" type="button" id="restart-button-default">
                         %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result', 'data-jobid' => $testid) => begin
                             <i class="fa fa-2 fa-undo" title="Restart job"></i>
                         %= end
+                        <button class="btn btn-default dropdown-toggle" type="button" id="restart-button-options" data-toggle="dropdown">
+                        <span class="caret" title="Additional options for restarting jobs with dependencies"></span></button>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="restart-button-options" id="restart-menu">
+                            <li role="presentation">
+                              %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_parents => 1}) => ('data-remote' => 'true', id => 'restart-result-skip-parents', 'data-jobid' => $testid, role => 'menuitem') => begin
+                              <span>Skip parents</span>
+                              %= end
+                            </li>
+                            <li role="presentation">
+                              %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_children => 1}) => ('data-remote' => 'true', id => 'restart-result-skip-children', 'data-jobid' => $testid, role => 'menuitem') => begin
+                              <span>Skip children</span>
+                              %= end
+                            </li>
+                            <li role="presentation">
+                              %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_ok_result_children => 1}) => ('data-remote' => 'true', id => 'restart-result-skip-ok-children', 'data-jobid' => $testid, role => 'menuitem') => begin
+                              <span>Skip restarting "OK" children</span>
+                              %= end
+                            </li>
+                          </ul>
                         <%= help_popover('Restart job' => '
                             <p>Restarts the job and certain dependent jobs.</p>
                             <p>Rules for restarting dependencies:</p>
@@ -78,6 +99,7 @@
                             All rules are applied recursively. Direct use of the REST-API allows excluding parents and (passed/softfailed) children.',
                             'https://open.qa/docs/#_handling_of_related_jobs_on_failure_cancellation_restart', 'documentation', 'bottom');
                         %>
+                      </div>
                     % }
                     % if (is_operator && (OpenQA::Jobs::Constants::meta_state($job->state) ne OpenQA::Jobs::Constants::FINAL)) {
                         %= link_post url_for('apiv1_cancel', jobid => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -64,12 +64,12 @@
                         <abbr class="timeago" title="<%= $job->t_started->datetime() %>Z"><%= format_time($job->t_started) %></abbr>
                     % }
                     % if (is_operator && $job->can_be_duplicated) {
-                      <div class = "btn-group">
-                        <button class="btn btn-default" type="button" id="restart-button-default">
+                      <div class = "btn-group btn-group-sm">
+                        <button class="btn btn-link" type="button" id="restart-button-default">
                         %= link_post url_for('apiv1_restart', jobid => $testid) => ('data-remote' => 'true', id => 'restart-result', 'data-jobid' => $testid) => begin
                             <i class="fa fa-2 fa-undo" title="Restart job"></i>
                         %= end
-                        <button class="btn btn-default dropdown-toggle" type="button" id="restart-button-options" data-toggle="dropdown">
+                        <button class="btn btn-link dropdown-toggle" type="button" id="restart-button-options" data-toggle="dropdown">
                         <span class="caret" title="Additional options for restarting jobs with dependencies"></span></button>
                           <ul class="dropdown-menu" role="menu" aria-labelledby="restart-button-options" id="restart-menu">
                             <li role="presentation">


### PR DESCRIPTION
Screenshot of the new button group:

![Screenshot_20211220_122717_openqa_restart_button_group](https://user-images.githubusercontent.com/1693432/146761268-d11e8388-bfde-4c39-9173-4f95f135a72b.png)

Advanced restart menu shown:

![Screenshot_20211220_130544_openqa_advanced_restart_shown](https://user-images.githubusercontent.com/1693432/146765052-36c2ef93-198f-4ce4-9bac-fcf28ea26618.png)

No restart menu shown where not applicable (on jobs without dependencies), preserving old design:

![Screenshot_20211220_130639_openqa_no_advanced_restart_on_jobs_without_dependencies_as_in_before](https://user-images.githubusercontent.com/1693432/146765128-3b622c88-e1c5-4590-a657-8496c1fe8508.png)

Related progress issue: https://progress.opensuse.org/issues/69979