### PR TITLE
Force cpanm to always use a trusted HTTPS mirror

### DIFF
--- a/container/openqa/entrypoint.sh
+++ b/container/openqa/entrypoint.sh
@@ -20,7 +20,7 @@ cd /opt/testing_area/openqa
 run_as_normal_user() {
     if [ "$INSTALL_FROM_CPAN" -eq 1 ]; then
        echo ">> Trying to get dependencies from CPAN"
-           cpanm --local-lib=~/perl5 local::lib && cpanm -n --installdeps .
+           cpanm -M https://cpan.metacpan.org --local-lib=~/perl5 local::lib && cpanm -M https://cpan.metacpan.org -n --installdeps .
     else
            cpanm -n --mirror http://no.where/ --installdeps .
     fi

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -279,7 +279,7 @@ sed -e 's,/bin/env python,/bin/python,' -i script/openqa-label-all
 #for double checking
 %if %{with tests}
 sed -i '/Perl::Tidy/d' cpanfile
-cpanm --installdeps --with-feature=test .
+cpanm -n --mirror http://no.where/ --installdeps --with-feature=test .
 %endif
 
 # we don't really need the tidy test

--- a/tools/generate-documentation
+++ b/tools/generate-documentation
@@ -195,7 +195,7 @@ install_asciidoctor() {
     # install dependencies
     gem install asciidoctor pygments.rb
     [[ ${formats[pdf]} ]] && gem install asciidoctor-pdf --pre
-    cpanm --install Pod::AsciiDoctor
+    cpanm -M https://cpan.metacpan.org --install Pod::AsciiDoctor
 }
 
 call_asciidoctor() {
@@ -217,7 +217,7 @@ call_asciidoctor() {
 }
 
 if [[ -n ${CI} ]]; then
-    cpanm --local-lib=~/perl5 local::lib && eval "$(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)"
+    cpanm -M https://cpan.metacpan.org --local-lib=~/perl5 local::lib && eval "$(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)"
     install_asciidoctor
 fi
 

--- a/tools/run-tests-within-container
+++ b/tools/run-tests-within-container
@@ -21,7 +21,7 @@ prepare_fullstack_test() {
 
     cd ../os-autoinst
     if [ "$INSTALL_FROM_CPAN" -eq 1 ]; then
-        cpanm --local-lib=~/perl5 local::lib && cpanm -n --installdeps .
+        cpanm -M https://cpan.metacpan.org --local-lib=~/perl5 local::lib && cpanm -M https://cpan.metacpan.org -n --installdeps .
     else
         cpanm -n --mirror http://no.where/ --installdeps .
     fi


### PR DESCRIPTION
This is the HTTPS mirror run by Fastly on their CDN.

Progress: https://progress.opensuse.org/issues/104164