### PR TITLE
Add retry of openQA jobs based on test variables

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -847,6 +847,7 @@ The files referenced by the configured keys should be located either under the r
 of `CASEDIR` or the data folder within `CASEDIR`.
 
 === Enable custom hook scripts on "job done" based on result
+[id="custom_hook_scripts_job_done"]
 
 If a job is done, especially if no label could be found for carry-over, often
 more steps are needed for the review of the test result or providing the
@@ -927,6 +928,7 @@ General status and stdout output is visible in the GRU minion job dashboard on t
 `/minion/jobs?offset=0&task=finalize_job_results` of the openQA instance.
 
 === Automatic cloning of incomplete jobs
+[id="automatic_cloning_incomplete_jobs"]
 
 By default, when a worker reports an incomplete job due to a cache service related
 problem, the job is automatically cloned. It is possible to extend the regex to cover

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -299,6 +299,32 @@ WORKER_CLASS = desktop
 # WORKER_CLASS is not set
 --------------------------------------------------------------------------------
 
+=== Automatic retries of jobs
+
+You might encounter flaky openQA tests that fail sporadically. While the best
+way to address flaky test code is of course to fix the test code itself. For
+example if certain steps rely on external components over network retries
+within the test modules should be applied. However there can still be cases
+where you might want openQA to automatically retrigger jobs. This can be
+achieved by setting the test variable `RETRY` in the format
+`<retries>[:<description>]` to an integer value with the maximum number of
+retries with an optional, additional description string separated by a colon.
+For example triggering an openQA job with the variable `RETRY=2:bug#42` will
+retrigger an openQA test on failure up to 2 totalling to up to 3 jobs. Note
+that the retry jobs are scheduled immediately and will be executed as soon as
+possible depending on available worker slots. Many factors can change in
+retries impacting the reproducibility, e.g. the used worker host and instance,
+any network related content, etc. By default openQA tests do not retry. The
+optional, additional description string is used only for reference and has no
+functional impact.
+
+See <<Installing.asciidoc#automatic_cloning_incomplete_jobs,Automatic cloning of incomplete jobs>>
+for an additional solution intended for administrators handling known issues
+causing incomplete jobs.
+
+<<Installing.asciidoc#custom_hook_scripts_job_done,Custom hook scripts on "job done" based on result>>
+can be used to apply more elaborate issue detection and retriggering of tests.
+
 === Writing multi-machine tests
 [id="mm-tests"]
 

--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Downloader;
-use Mojo::Base -base;
+use Mojo::Base -base, -signatures;
 
 use Mojo::Loader 'load_class';
 use Mojo::UserAgent;
@@ -18,9 +18,7 @@ has sleep_time => 5;
 has ua => sub { Mojo::UserAgent->new(max_redirects => 5, max_response_size => 0) };
 has res => undef;
 
-sub download {
-    my ($self, $url, $target, $options) = (shift, shift, shift, shift // {});
-
+sub download ($self, $url, $target, $options = {}) {
     my $log = $self->log;
 
     local $ENV{MOJO_TMPDIR} = $self->tmpdir;
@@ -50,9 +48,7 @@ sub download {
     return $err ? $err : "No error message recorded";
 }
 
-sub _get {
-    my ($self, $url, $target, $options) = @_;
-
+sub _get ($self, $url, $target, $options) {
     my $ua = $self->ua;
     my $log = $self->log;
 

--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -4,7 +4,7 @@
 package OpenQA::Downloader;
 use Mojo::Base -base;
 
-use Archive::Extract;
+use Mojo::Loader 'load_class';
 use Mojo::UserAgent;
 use Mojo::File 'path';
 use Mojo::URL;
@@ -93,6 +93,8 @@ sub _get {
     if ($size == $headers->content_length) {
 
         if ($options->{extract}) {
+            my $e = load_class 'Archive::Extract';
+            die "Failed to load module 'Archive::Extract': $e" if ref $e;
             my $tempfile = path($ENV{MOJO_TMPDIR}, Mojo::URL->new($url)->path->parts->[-1])->to_string;
             $log->info(qq{Extracting "$tempfile" to "$target"});
             $asset->move_to($tempfile);

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -14,7 +14,6 @@ use OpenQA::Schema::Result::Jobs;
 use OpenQA::Log qw(log_info log_error);
 use OpenQA::Utils;
 use Date::Format;
-use Archive::Extract;
 use File::Basename;
 use File::Spec::Functions qw(catfile splitpath);
 use File::Path 'remove_tree';

--- a/t/10-jobs-referal.t
+++ b/t/10-jobs-referal.t
@@ -1,0 +1,82 @@
+#!/usr/bin/env perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Mojo::Base -signatures;
+use OpenQA::Events;
+use OpenQA::Jobs::Constants;
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::Case;
+
+my $schema = OpenQA::Test::Case->new->init_data(skip_schema => 1);
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+my %settings = (
+    DISTRI => 'Unicorn',
+    FLAVOR => 'pink',
+    VERSION => '42',
+    ARCH => 'x86_64',
+);
+
+sub _job_create (@args) { $schema->resultset('Jobs')->create_from_settings(@args) }
+
+sub job_is_linked ($job) {
+    $job->discard_changes;
+    $job->comments->find({text => {like => 'label:linked%'}}) ? 1 : 0;
+}
+
+subtest 'job is marked as linked if accessed from recognized referal' => sub {
+    my $test_referer = 'http://test.referer.info/foobar';
+    $t->app->config->{global}->{recognized_referers}
+      = ['test.referer.info', 'test.referer1.info', 'test.referer2.info', 'test.referer3.info'];
+    my %_settings = %settings;
+    my $openqa_events = OpenQA::Events->singleton;
+    my @comment_events;
+    my $cb = $openqa_events->on(openqa_comment_create => sub ($events, $data) { push @comment_events, $data });
+    $_settings{TEST} = 'refJobTest';
+    my $job = _job_create(\%_settings);
+    my $linked = job_is_linked($job);
+    is($linked, 0, 'new job is not linked');
+    $t->get_ok('/tests/' . $job->id => {Referer => $test_referer})->status_is(200);
+    $linked = job_is_linked($job);
+    is($linked, 1, 'job linked after accessed from known referer');
+    is(scalar @comment_events, 1, 'exactly one comment event emitted') or diag explain \@comment_events;
+    $openqa_events->unsubscribe($cb);
+
+    $_settings{TEST} = 'refJobTest-step';
+    $job = _job_create(\%_settings);
+
+    $job->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
+    my $module = $job->modules->find({name => 'a'});
+    $job->update;
+    $linked = job_is_linked($job);
+    is($linked, 0, 'new job is not linked');
+    $t->get_ok('/tests/' . $job->id . '/modules/' . $module->id . '/steps/1' => {Referer => $test_referer})
+      ->status_is(302);
+    $linked = job_is_linked($job);
+    is($linked, 1, 'job linked after accessed from known referer');
+};
+
+subtest 'job is not marked as linked if accessed from unrecognized referal' => sub {
+    $t->app->config->{global}->{recognized_referers}
+      = ['test.referer.info', 'test.referer1.info', 'test.referer2.info', 'test.referer3.info'];
+    my %_settings = %settings;
+    $_settings{TEST} = 'refJobTest2';
+    my $job = _job_create(\%_settings);
+    my $linked = job_is_linked($job);
+    is($linked, 0, 'new job is not linked');
+    $t->get_ok('/tests/' . $job->id => {Referer => 'http://unknown.referer.info'})->status_is(200);
+    $linked = job_is_linked($job);
+    is($linked, 0, 'job not linked after accessed from unknown referer');
+    $t->get_ok('/tests/' . $job->id => {Referer => 'http://test.referer.info/'})->status_is(200);
+    $linked = job_is_linked($job);
+    is($linked, 0, 'job not linked after accessed from referer with empty query_path');
+};
+
+done_testing;

--- a/t/10-jobs-results.t
+++ b/t/10-jobs-results.t
@@ -1,0 +1,185 @@
+#!/usr/bin/env perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+use Test::MockModule 'strict';
+use Mojo::File qw(path tempdir);
+use Mojo::JSON 'decode_json';
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use Mojo::Base -signatures;
+use autodie ':all';
+use OpenQA::Jobs::Constants;
+use OpenQA::Utils 'resultdir';
+use OpenQA::Test::Case;
+use OpenQA::Task::SignalGuard;
+use OpenQA::Test::TimeLimit '30';
+
+my $schema = OpenQA::Test::Case->new->init_data;
+my $jobs = $schema->resultset('Jobs');
+
+my %settings = (
+    DISTRI => 'Unicorn',
+    FLAVOR => 'pink',
+    VERSION => '42',
+    ARCH => 'x86_64',
+);
+
+sub _job_create {
+    my $job = $jobs->create_from_settings(@_);
+    # reload all values from database so we can check against default values
+    $job->discard_changes;
+    return $job;
+}
+
+subtest 'Create custom job module' => sub {
+    my %_settings = %settings;
+    $_settings{TEST} = 'TEST1';
+    my $job = _job_create(\%_settings);
+    my $result = OpenQA::Parser::Result::OpenQA->new(
+        details => [{text => "Test-CUSTOM.txt", title => 'CUSTOM'}],
+        name => 'random',
+        result => 'fail',
+        test => OpenQA::Parser::Result::Test->new(name => 'CUSTOM', category => 'w00t!'));
+    my $content = Encode::encode('UTF-8', 'Whatäver!');
+    my $output = OpenQA::Parser::Result::Output->new(file => 'Test-CUSTOM.txt', content => $content);
+
+    is($job->failed_module_count, 0, 'no failed modules before');
+    $job->custom_module($result => $output);
+    $job->update;
+    $job->discard_changes;
+    is($job->passed_module_count, 0, 'number of passed modules not incremented');
+    is($job->softfailed_module_count, 0, 'number of softfailed modules not incremented');
+    is($job->failed_module_count, 1, 'number of failed modules incremented');
+    is($job->skipped_module_count, 0, 'number of skipped modules not incremented');
+    is($job->result, OpenQA::Jobs::Constants::NONE, 'result is not yet set');
+    $job->done;
+    $job->discard_changes;
+    is($job->result, OpenQA::Jobs::Constants::FAILED, 'job result is failed');
+    is($job->result_size, length $content, 'size of custom module taken into account');
+
+    is(($job->failed_modules)->[0], 'CUSTOM', 'modules can have custom result');
+};
+
+subtest 'create result dir, delete results' => sub {
+    $ENV{OPENQA_BASEDIR} = my $base_dir = tempdir;
+    path(resultdir)->make_path;
+
+    # create job
+    my $initially_assumed_result_size = 1000;
+    my $job = $jobs->create({TEST => 'delete-logs', logs_present => 1, result_size => $initially_assumed_result_size});
+    $job->discard_changes;
+    my $result_dir = path($job->create_result_dir);
+    ok(-d $result_dir, 'result directory created');
+
+    # create fake results
+    my $ulogs_dir = path($result_dir, 'ulogs')->make_path;
+    my $file_content = Encode::encode('UTF-8', 'this text is 26 bytes long');
+    my @fake_results = qw(autoinst-log.txt video.ogv video.webm video_time.vtt serial0.txt serial_terminal.txt);
+    path($result_dir, $_)->spurt($file_content) for @fake_results;
+    my @ulogs = qw(bar.log foo.log);
+    path($ulogs_dir, $_)->spurt($file_content) for @ulogs;
+    is_deeply $job->test_uploadlog_list, \@ulogs, 'logs linked to job as uploaded';
+    is_deeply $job->video_file_paths->map('basename')->to_array, [qw(video.ogv video.webm)], 'all videos considered';
+
+    subtest 'delete logs' => sub {
+        $job->delete_logs;
+        $job->discard_changes;
+        is $job->logs_present, 0, 'logs not present anymore';
+        is $job->result_size, $initially_assumed_result_size - length($file_content) * (@fake_results + @ulogs),
+          'deleted size subtracted from result size';
+        is $result_dir->list_tree({hidden => 1})->size, 0, 'no more files left';
+        is_deeply $job->video_file_paths->to_array, [], 'no more videos found'
+          or diag explain $job->video_file_paths->to_array;
+    };
+    subtest 'delete only videos' => sub {
+        $job = $jobs->create({TEST => 'delete-logs', logs_present => 1, result_size => $initially_assumed_result_size});
+        $job->discard_changes;
+        ok -d ($result_dir = path($job->create_result_dir)), 'result directory created';
+        path($result_dir, $_)->spurt($file_content) for @fake_results;
+        symlink(path($result_dir, 'video.webm'), my $symlink = path($result_dir, 'video.mkv'))
+          or die "Unable to create symlink: $!";
+        my $symlink_size = $symlink->lstat->size;
+        $job->delete_videos;
+        $job->discard_changes;
+        is $job->logs_present, 1, 'logs still considered present';
+        is $job->result_size, $initially_assumed_result_size - length($file_content) * 3 - $symlink_size,
+          'deleted size subtracted from result size';
+        is_deeply $job->video_file_paths->to_array, [], 'no more videos found'
+          or diag explain $job->video_file_paths->to_array;
+        ok -e path($result_dir, $_), "$_ still present" for qw(autoinst-log.txt serial0.txt serial_terminal.txt);
+    };
+    subtest 'result_size does not become negative' => sub {
+        my $job_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs', no_auto => 1);
+        $job_mock->redefine(_delete_returning_size_from_array => 5000);
+        $job->delete_logs;
+        $job->delete_videos;
+        $job->discard_changes;
+        is $job->result_size, 0, 'result_size just 0, not negative';
+    };
+
+    # note: Deleting results is tested in 42-screenshots.t because the screenshots are the interesting part here.
+
+    subtest 'archiving job' => sub {
+        my $job = $jobs->create({TEST => 'to-be-archived'});
+        $job->discard_changes;
+        $job->create_result_dir;
+        is $job->archived, 0, 'job not archived by default';
+        is $job->archive, undef, 'early return if job has not been concluded yet';
+
+        my $result_dir = path($job->result_dir);
+        like $result_dir, qr|$base_dir/openqa/testresults/\d{5}/\d{8}-to-be-archived|,
+          'normal result directory returned by default';
+        $result_dir->child('subdir')->make_path->child('some-file')->spurt('test');
+        $job->update({state => DONE});
+        $job->discard_changes;
+
+        my $copy_mock = Test::MockModule->new('File::Copy::Recursive', no_auto => 1);
+        $copy_mock->redefine(dircopy => sub { $! = 4; return 0 });
+        throws_ok { $job->archive } qr/Unable to copy '.+' to '.+': .+/, 'error when copying archive handled';
+        ok -d $result_dir, 'normal result directory still exists';
+        undef $copy_mock;
+
+        my $signal_guard = OpenQA::Task::SignalGuard->new(undef);
+        my $archive_dir = $job->archive($signal_guard);
+        ok -d $archive_dir, 'archive result directory created';
+        ok !-d $result_dir, 'normal result directory removed';
+        ok !$signal_guard->retry, 'signal guard retry disabled in the end';
+        undef $signal_guard;
+
+        $result_dir = path($job->result_dir);
+        like $result_dir, qr|$base_dir/openqa/archive/testresults/\d{5}/\d{8}-to-be-archived|,
+          'archive result directory returned if archived';
+        is $result_dir->child('subdir')->make_path->child('some-file')->slurp, 'test', 'nested file moved';
+
+        is $job->archive, undef, 'early return if job has already been archived';
+    };
+};
+
+# continue testing with the usual base dir for test fixtures
+$ENV{OPENQA_BASEDIR} = 't/data';
+
+subtest 'modules are unique per job' => sub {
+    my %_settings = %settings;
+    $_settings{TEST} = 'X';
+    my $job = _job_create(\%_settings);
+    $job->insert_module({name => 'some_name', category => 'some_category', script => 'foo/bar.pm', flags => {}});
+    $job->insert_module({name => 'some_name', category => 'some_category', script => 'foo/bar.pm', flags => {}});
+    my @modules = $job->modules->all;
+    is $modules[0]->name, 'some_name', 'right name';
+    is $modules[0]->script, 'foo/bar.pm', 'right script';
+    is $modules[1], undef, 'no second result';
+};
+
+subtest 'saving results' => sub {
+    my %some_test_results = (results => [], spare => 'me the details');
+    my $arbitrary_job_module = $schema->resultset('JobModules')->first;
+    $arbitrary_job_module->save_results(\%some_test_results);
+    my $details_file = path($arbitrary_job_module->job->result_dir, 'details-' . $arbitrary_job_module->name . '.json');
+    is_deeply(decode_json($details_file->slurp), \%some_test_results, 'overall structure of test results preserved');
+};
+
+done_testing();

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -40,18 +40,6 @@ my $job_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs', no_auto => 
 my $fake_git_log = 'deadbeef Break test foo';
 $job_mock->redefine(git_log_diff => sub { $fake_git_log });
 
-is($jobs->latest_build, '0091', 'can find latest build from jobs');
-is($jobs->latest_build(version => 'Factory', distri => 'opensuse'), '0048@0815', 'latest build for non-integer build');
-is($jobs->latest_build(version => '13.1', distri => 'opensuse'), '0091', 'latest build for different version differs');
-
-my @latest = $jobs->latest_jobs;
-my @ids = map { $_->id } @latest;
-# These two jobs have later clones in the fixture set, so should not appear
-ok(grep(!/^(99962|99945)$/, @ids), 'jobs with later clones do not show up in latest jobs');
-# These are the later clones, they should appear
-ok(grep(/^99963$/, @ids), 'cloned jobs appear as latest job');
-ok(grep(/^99946$/, @ids), 'cloned jobs appear as latest job (2nd)');
-
 my %settings = (
     DISTRI => 'Unicorn',
     FLAVOR => 'pink',
@@ -68,6 +56,21 @@ sub _job_create {
     $job->discard_changes;
     return $job;
 }
+
+subtest 'latest jobs' => sub {
+    is $jobs->latest_build, '0091', 'can find latest build from jobs';
+    is $jobs->latest_build(version => 'Factory', distri => 'opensuse'), '0048@0815', 'latest for non-integer build';
+    is $jobs->latest_build(version => '13.1', distri => 'opensuse'), '0091', 'latest for different version differs';
+
+    my @latest = $jobs->latest_jobs;
+    my @ids = map { $_->id } @latest;
+    # These two jobs have later clones in the fixture set, so should not appear
+    ok(grep(!/^(99962|99945)$/, @ids), 'jobs with later clones do not show up in latest jobs');
+    # These are the later clones, they should appear
+    ok(grep(/^99963$/, @ids), 'cloned jobs appear as latest job');
+    ok(grep(/^99946$/, @ids), 'cloned jobs appear as latest job (2nd)');
+};
+
 
 subtest 'has_dependencies' => sub {
     ok($jobs->find(99961)->has_dependencies, 'positive case: job is parent');

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -26,9 +26,6 @@ use Mojo::File 'path';
 use Mojo::IOLoop::ReadWriteProcess;
 use OpenQA::Test::Utils qw(perform_minion_jobs redirect_output);
 use OpenQA::Test::TimeLimit '30';
-use OpenQA::Parser::Result::OpenQA;
-use OpenQA::Parser::Result::Test;
-use OpenQA::Parser::Result::Output;
 
 my $schema = OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 05-job_modules.pl 06-job_dependencies.pl');
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -18,16 +18,14 @@ use Encode;
 use File::Copy;
 use OpenQA::Events;
 use OpenQA::Jobs::Constants;
-use OpenQA::Utils 'resultdir';
 use OpenQA::Test::Case;
 use Test::MockModule 'strict';
 use Test::Mojo;
-use Mojo::JSON 'decode_json';
 use Test::Warnings ':report_warnings';
-use Mojo::File qw(path tempdir);
+use Mojo::File 'path';
 use Mojo::IOLoop::ReadWriteProcess;
 use OpenQA::Test::Utils qw(perform_minion_jobs redirect_output);
-use OpenQA::Test::TimeLimit '40';
+use OpenQA::Test::TimeLimit '30';
 use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;
 use OpenQA::Parser::Result::Output;
@@ -206,35 +204,6 @@ subtest 'inserting the same module twice keeps the job module statistics intact'
         is($job->failed_module_count, 0, 'number of failed modules still zero');
         is($job->skipped_module_count, 0, 'number of skipped modules still zero');
     };
-};
-
-subtest 'Create custom job module' => sub {
-    my %_settings = %settings;
-    $_settings{TEST} = 'TEST1';
-    my $job = _job_create(\%_settings);
-    my $result = OpenQA::Parser::Result::OpenQA->new(
-        details => [{text => "Test-CUSTOM.txt", title => 'CUSTOM'}],
-        name => 'random',
-        result => 'fail',
-        test => OpenQA::Parser::Result::Test->new(name => 'CUSTOM', category => 'w00t!'));
-    my $content = Encode::encode('UTF-8', 'Whatäver!');
-    my $output = OpenQA::Parser::Result::Output->new(file => 'Test-CUSTOM.txt', content => $content);
-
-    is($job->failed_module_count, 0, 'no failed modules before');
-    $job->custom_module($result => $output);
-    $job->update;
-    $job->discard_changes;
-    is($job->passed_module_count, 0, 'number of passed modules not incremented');
-    is($job->softfailed_module_count, 0, 'number of softfailed modules not incremented');
-    is($job->failed_module_count, 1, 'number of failed modules incremented');
-    is($job->skipped_module_count, 0, 'number of skipped modules not incremented');
-    is($job->result, OpenQA::Jobs::Constants::NONE, 'result is not yet set');
-    $job->done;
-    $job->discard_changes;
-    is($job->result, OpenQA::Jobs::Constants::FAILED, 'job result is failed');
-    is($job->result_size, length $content, 'size of custom module taken into account');
-
-    is(($job->failed_modules)->[0], 'CUSTOM', 'modules can have custom result');
 };
 
 subtest 'job with at least one failed module and one softfailed => overall is failed' => sub {
@@ -460,13 +429,13 @@ subtest 'carry over, including soft-fails' => sub {
         ok(my $inv = $job->investigate, 'job can provide investigation details');
         ok($inv, 'job provides failure investigation');
         is(ref(my $last_good = $inv->{last_good}), 'HASH', 'previous job identified as last good and it is a hash');
-        is($last_good->{text}, 99998, 'last_good hash has the text');
+        is($last_good->{text}, 99997, 'last_good hash has the text');
         is($last_good->{type}, 'link', 'last_good hash has the type');
-        is($last_good->{link}, '/tests/99998', 'last_good hash has the correct link');
+        is($last_good->{link}, '/tests/99997', 'last_good hash has the correct link');
         is(ref(my $first_bad = $inv->{first_bad}), 'HASH', 'previous job identified as first bad and it is a hash');
-        is($first_bad->{text}, 99999, 'first_bad hash has the text');
+        is($first_bad->{text}, 99998, 'first_bad hash has the text');
         is($first_bad->{type}, 'link', 'first_bad hash has the type');
-        is($first_bad->{link}, '/tests/99999', 'first_bad hash has the correct link');
+        is($first_bad->{link}, '/tests/99998', 'first_bad hash has the correct link');
         like($inv->{diff_to_last_good}, qr/^\+.*BUILD.*669/m, 'diff for job settings is shown');
         unlike($inv->{diff_to_last_good}, qr/JOBTOKEN/, 'special variables are not included');
         like($inv->{diff_packages_to_last_good}, qr/^\+python/m, 'diff packages for job is shown');
@@ -736,124 +705,6 @@ subtest 'delete job assigned as last use for asset' => sub {
     $some_asset = $assets->find($asset_id);
     ok($some_asset, 'asset still exists');
     is($some_asset->last_use_job_id, undef, 'last job unset');
-};
-
-subtest 'create result dir, delete results' => sub {
-    $ENV{OPENQA_BASEDIR} = my $base_dir = tempdir;
-    path(resultdir)->make_path;
-
-    # create job
-    my $initially_assumed_result_size = 1000;
-    my $job = $jobs->create({TEST => 'delete-logs', logs_present => 1, result_size => $initially_assumed_result_size});
-    $job->discard_changes;
-    my $result_dir = path($job->create_result_dir);
-    ok(-d $result_dir, 'result directory created');
-
-    # create fake results
-    my $ulogs_dir = path($result_dir, 'ulogs')->make_path;
-    my $file_content = Encode::encode('UTF-8', 'this text is 26 bytes long');
-    my @fake_results = qw(autoinst-log.txt video.ogv video.webm video_time.vtt serial0.txt serial_terminal.txt);
-    path($result_dir, $_)->spurt($file_content) for @fake_results;
-    my @ulogs = qw(bar.log foo.log);
-    path($ulogs_dir, $_)->spurt($file_content) for @ulogs;
-    is_deeply $job->test_uploadlog_list, \@ulogs, 'logs linked to job as uploaded';
-    is_deeply $job->video_file_paths->map('basename')->to_array, [qw(video.ogv video.webm)], 'all videos considered';
-
-    subtest 'delete logs' => sub {
-        $job->delete_logs;
-        $job->discard_changes;
-        is $job->logs_present, 0, 'logs not present anymore';
-        is $job->result_size, $initially_assumed_result_size - length($file_content) * (@fake_results + @ulogs),
-          'deleted size subtracted from result size';
-        is $result_dir->list_tree({hidden => 1})->size, 0, 'no more files left';
-        is_deeply $job->video_file_paths->to_array, [], 'no more videos found'
-          or diag explain $job->video_file_paths->to_array;
-    };
-    subtest 'delete only videos' => sub {
-        $job = $jobs->create({TEST => 'delete-logs', logs_present => 1, result_size => $initially_assumed_result_size});
-        $job->discard_changes;
-        ok -d ($result_dir = path($job->create_result_dir)), 'result directory created';
-        path($result_dir, $_)->spurt($file_content) for @fake_results;
-        symlink(path($result_dir, 'video.webm'), my $symlink = path($result_dir, 'video.mkv'))
-          or die "Unable to create symlink: $!";
-        my $symlink_size = $symlink->lstat->size;
-        $job->delete_videos;
-        $job->discard_changes;
-        is $job->logs_present, 1, 'logs still considered present';
-        is $job->result_size, $initially_assumed_result_size - length($file_content) * 3 - $symlink_size,
-          'deleted size subtracted from result size';
-        is_deeply $job->video_file_paths->to_array, [], 'no more videos found'
-          or diag explain $job->video_file_paths->to_array;
-        ok -e path($result_dir, $_), "$_ still present" for qw(autoinst-log.txt serial0.txt serial_terminal.txt);
-    };
-    subtest 'result_size does not become negative' => sub {
-        $job_mock->redefine(_delete_returning_size_from_array => 5000);
-        $job->delete_logs;
-        $job->delete_videos;
-        $job->discard_changes;
-        is $job->result_size, 0, 'result_size just 0, not negative';
-        $job_mock->unmock('_delete_returning_size_from_array');
-    };
-
-    # note: Deleting results is tested in 42-screenshots.t because the screenshots are the interesting part here.
-
-    subtest 'archiving job' => sub {
-        my $job = $jobs->create({TEST => 'to-be-archived'});
-        $job->discard_changes;
-        $job->create_result_dir;
-        is $job->archived, 0, 'job not archived by default';
-        is $job->archive, undef, 'early return if job has not been concluded yet';
-
-        my $result_dir = path($job->result_dir);
-        like $result_dir, qr|$base_dir/openqa/testresults/\d{5}/\d{8}-to-be-archived|,
-          'normal result directory returned by default';
-        $result_dir->child('subdir')->make_path->child('some-file')->spurt('test');
-        $job->update({state => DONE});
-        $job->discard_changes;
-
-        my $copy_mock = Test::MockModule->new('File::Copy::Recursive', no_auto => 1);
-        $copy_mock->redefine(dircopy => sub { $! = 4; return 0 });
-        throws_ok { $job->archive } qr/Unable to copy '.+' to '.+': .+/, 'error when copying archive handled';
-        ok -d $result_dir, 'normal result directory still exists';
-        undef $copy_mock;
-
-        my $signal_guard = OpenQA::Task::SignalGuard->new(undef);
-        my $archive_dir = $job->archive($signal_guard);
-        ok -d $archive_dir, 'archive result directory created';
-        ok !-d $result_dir, 'normal result directory removed';
-        ok !$signal_guard->retry, 'signal guard retry disabled in the end';
-        undef $signal_guard;
-
-        $result_dir = path($job->result_dir);
-        like $result_dir, qr|$base_dir/openqa/archive/testresults/\d{5}/\d{8}-to-be-archived|,
-          'archive result directory returned if archived';
-        is $result_dir->child('subdir')->make_path->child('some-file')->slurp, 'test', 'nested file moved';
-
-        is $job->archive, undef, 'early return if job has already been archived';
-    };
-};
-
-# continue testing with the usual base dir for test fixtures
-$ENV{OPENQA_BASEDIR} = 't/data';
-
-subtest 'modules are unique per job' => sub {
-    my %_settings = %settings;
-    $_settings{TEST} = 'X';
-    my $job = _job_create(\%_settings);
-    $job->insert_module({name => 'some_name', category => 'some_category', script => 'foo/bar.pm', flags => {}});
-    $job->insert_module({name => 'some_name', category => 'some_category', script => 'foo/bar.pm', flags => {}});
-    my @modules = $job->modules->all;
-    is $modules[0]->name, 'some_name', 'right name';
-    is $modules[0]->script, 'foo/bar.pm', 'right script';
-    is $modules[1], undef, 'no second result';
-};
-
-subtest 'saving results' => sub {
-    my %some_test_results = (results => [], spare => 'me the details');
-    my $arbitrary_job_module = $schema->resultset('JobModules')->first;
-    $arbitrary_job_module->save_results(\%some_test_results);
-    my $details_file = path($arbitrary_job_module->job->result_dir, 'details-' . $arbitrary_job_module->name . '.json');
-    is_deeply(decode_json($details_file->slurp), \%some_test_results, 'overall structure of test results preserved');
 };
 
 is $t->app->minion->jobs({states => ['failed']})->total, 0, 'No unexpected failed minion background jobs';

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -10,6 +10,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 
 use OpenQA::Downloader;
+use Archive::Extract;
 use IO::Socket::INET;
 use Mojo::Server::Daemon;
 use Mojo::IOLoop::Server;


### PR DESCRIPTION
Motivation: Similar as in
https://docs.microsoft.com/en-us/azure/devops/release-notes/2021/sprint-195-update#automatic-retries-for-a-task
and https://docs.gitlab.com/ee/ci/yaml/#retry and
https://github.com/marketplace/actions/retry-step

Acceptance criteria:
* **AC1:** openQA jobs are automatically retriggered with a maximum amount
  specified in test variables
* **AC2:** By default openQA tests apply no automatic retry

Acceptance tests:
* **AT1-1:** *Given* an unfinished openQA test with the special `RETRY`
  variable given with value `N` *When* the job fails *And* the current job is
  not already the N-th clone of an original job *Then* an automatic clone is
  created
* **AT1-2:** *Given* an unfinished openQA test with the special `RETRY`
  variable given with value `N` *When* the job fails *And* the current job is
  the N-th clone of an original job *Then* no automatic clone is created
* **AT2-1:** *Given* an unfinished openQA test with no special retry variable
  given *When* the job fails *Then* no automatic clone is created at this
  point (job done hooks or external events may still trigger clones as well
  as manual triggers)

Review hint: I suggest to review the commits individually. As desired I
can also split the pull request into multiple for easier review.

Related progress issue: https://progress.opensuse.org/issues/104007