### PR TITLE
WIP: fix for progress bars broken by bootstrap4 update

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -24,6 +24,7 @@ td div.progress {
         // don' use flex box because it leads to undesired overflow behavior
         display: inline;
         overflow: hidden;
+        padding-top: 10px;
         a {
             display: block;
             width: 100%;


### PR DESCRIPTION
In Debian we try to use packaged versions of libraries etc. and also packages are not allowed to download things at build time (and it's generally frowned upon to do it at run-time) so I've got a patch that munges the assetpack.def to use local versions.

I'm therefore using the version of bootstrap4 that is found in debian's [libjs-bootstrap4](https://packages.debian.org/stable/libjs-bootstrap4) package, which is version 4.5.2 rather than the 4.1.1 that's specified in the `assetpack.def`.

The new version works, but the rendering of the text in the scroll bars is wrong, as one can see here:
![scrollbar-unpatched](https://user-images.githubusercontent.com/64984191/148239090-191a9b51-1e4a-4d86-bd0a-a6333fe00b02.png)

This patch fixes that, thus:
![image](https://user-images.githubusercontent.com/64984191/148238749-360eee32-7c2a-4be4-b147-96880e35db75.png)

although I'm not completely certain if that's the _right_ way to fix that, or whether it also works in 4.1.1 -- hence the WIP