### PR TITLE
apparmor: Allow /bin/mkdir as needed on 15.3

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -79,7 +79,7 @@
   /usr/bin/ipmitool rix,
   /usr/bin/isotovideo rix,
   /usr/bin/lscpu rCx,
-  /usr/bin/mkdir rix,
+  /{usr/,}bin/mkdir rix,
   /usr/bin/nice rix,
   /usr/bin/optipng rix,
   /{usr/,}bin/pwd rix,


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/103683