### PR TITLE
apparmor: Allow access to subfolders under /tmp

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -58,7 +58,7 @@
   /sys/firmware/devicetree/base/ r,
   /sys/fs/cgroup/systemd/openqa.slice/** rw,
   /sys/kernel/mm/transparent_hugepage/enabled r,
-  /tmp/* rwk,
+  /tmp/** rwk,
   /usr/bin/Xvnc rCx,
   /{usr/,}bin/cat rix,
   /usr/bin/chattr rix,


### PR DESCRIPTION
`**` is required to allow subfolders (slashes):

https://man.archlinux.org/man/extra/apparmor/apparmor.d.5.en#Globbing

See: https://progress.opensuse.org/issues/103683