### PR TITLE
WIP: Add some manpages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,41 @@ help:
 	@sed -n 's/\(^[^.#[:space:]A-Z]*\):.*$$/\1/p' Makefile | uniq
 	@echo See docs/Contributing.asciidoc for more details
 
+OPENQA_VERSION ?= $(shell git log -1 --pretty=4.6.%ct.%h)
+
+man_names = openqa-cli openqa-client openqa-load-templates openqa-dump-templates openqa-clone-job openqa-label-all openqa-validate-yaml
+manpages = $(addprefix $(man_dir)/,$(addsuffix .1,$(man_names)))
+man_dir = build/man1
+
+$(man_dir):
+	mkdir -p $@
+
+define run-pod2man =
+pod2man --errors=stderr --section=1 \
+	--center "openQA Documentation" \
+	--release "openQA $(OPENQA_VERSION)" \
+	--name=$(notdir $(basename $@)) $< $@
+endef
+
+$(man_dir)/%.1: man/%.1.in
+	sed -e 's/%%VER%%/$(OPENQA_VERSION)/' <$< >$@
+
+$(man_dir)/openqa-%.1 $(man_dir)/%.1: script/%
+	$(run-pod2man)
+
+$(man_dir)/openqa-%-templates.1: script/%_templates
+	$(run-pod2man)
+
+$(man_dir)/openqa-cli.1: lib/OpenQA/CLI.pm
+	$(run-pod2man)
+
+.PHONY: build-manpages
+build-manpages: $(man_dir) $(manpages)
+
+.PHONY: clean
+clean:
+	-rm -r build
+
 .PHONY: install-generic
 install-generic:
 	./tools/generate-packed-assets

--- a/man/openqa-label-all.1.in
+++ b/man/openqa-label-all.1.in
@@ -1,0 +1,65 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH OPENQA\-LABEL\-ALL 1 "15 September 2021" "openQA %%VER%%" "openQA Documentation"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+openqa-label-all \- apply labels to openQA jobs based on various criteria
+.SH SYNOPSIS
+.B openqa-label-all
+.RI [OPTIONS]
+.SH DESCRIPTION
+.B openqa-label-all
+allows comments to be applied to a set jobs,
+which match the specified options,
+on the specified server.
+.SH OPTIONS
+.B openqa-label-all
+allows comments to be applied to the set of failing jobs
+that match the specified options.
+.TP
+.BI \-\-build =BUILD
+The build for which to look for a failing module
+.TP
+.BI \-\-module =MODULE
+The failing module to look for. (required)
+.TP
+.BI \-\-groupid =GROUP_ID
+Limits labeling to this group only.
+.TP
+.BI \-\-openqa-host =HOST
+The openQA host to act on, default: 'https://salsa.debian.net'
+.TP
+.BI \-\-result =RESULT
+The result of the jobs to look for, default: 'failed'
+.TP
+.BI \-\-label =LABEL
+The label to write as comment for each found job
+.TP
+.B \-\-dry-run
+Do not do any action on openQA
+.TP
+.B \-\-no-restart
+Do not restart the jobs after labelling
+.TP
+.BR \-v ", " \-\-verbose
+Increase verbosity level, specify multiple times to increase verbosity.
+.TP
+.BR \-h ", " \-\-help
+Prints help.
+
+.SH AUTHOR
+This manual page was written by Philip Hands <phil@hands.com>, for the Debian
+GNU/Linux system (but may be used by others).

--- a/script/openqa-validate-yaml
+++ b/script/openqa-validate-yaml
@@ -19,6 +19,52 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+=head1 NAME
+
+openqa-validate-yaml - check YAML files against a schema
+
+=head1 SYNOPSIS
+
+openqa-validate-yaml [I<OPTIONS>] [-] [I<file> ...]
+
+=head1 DESCRIPTION
+
+B<openqa-validate-yaml>
+should be given a list of one or more filenames.
+The files are expected to be YAML files.
+B<openqa-validate-yaml>
+tests each item in the list to see
+if the files are valid when checked against a Schema.
+
+'-' can be specified instead of a filename
+to read the test input from STDIN.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<--validate-schema>
+
+Validate the Schema file itself, in addition to any YAML files.
+
+=item B<--schema-file>=I<SCHEMA>
+
+Specify the schema file or URL to validate against (default .../public/schema/JobTemplates-01.yaml)'],
+
+=item B<--help, -h>
+
+Print a usage message, and exit.
+
+=back
+
+=head1 AUTHOR
+
+This manual page was written by Philip Hands <phil@hands.com>,
+for the Debian GNU/Linux system (but may be used by others).
+
+=cut
+
+
 use strict;
 use warnings;
 use 5.010;


### PR DESCRIPTION
This adds man page content for openqa-label-all(1) and openqa-label-yaml(1).

It also adds a `build-manpages:` target to the `Makefile` (as well as a `clean:` target that removes `build/`)

At present that causes the resulting manpages to be put in `build/man1`, which it creates.  One could also (or instead) have a `install-manpages` target that puts the (possibly compressed) man pages in `$(DESTDIR)/usr/share/man/man1` but for Debian we're fine with just picking the man pages up from the build directory, so I thought I'd leave it up to you.

You'll notice that I'm defining `$(OPENQA_VERSION)`, using git log to find the current commit, and then using that as the version number in the manuals.  I don't actually need that setting as we override it for Debian builds anyway, but I thought you'd want to have some sort of version number.

If any of the details of how that's being done doesn't fit in with the way you'd normally do things, just tell me and I'll try to fall into line.