### PR TITLE
Prevent bugrefs in comments from getting expanded if they are part of a larger string

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -405,7 +405,7 @@ my $MARKER_URLS = join('|', keys %bugurls);
 sub bugref_regex {
     my $repo_re = qr{[a-zA-Z/-]+};
     # <marker>[#<project/repo>]#<id>
-    return qr{(?<![\(\[\"\>])(?<match>(?<marker>$MARKER_REFS)\#?(?<repo>$repo_re)?\#(?<id>([A-Z]+-)?\d+))(?![\w\"])};
+    return qr{(?:^|(?<=\s|,))(?<match>(?<marker>$MARKER_REFS)\#?(?<repo>$repo_re)?\#(?<id>([A-Z]+-)?\d+))(?![\w\"])};
 }
 
 sub find_bugref {

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -50,6 +50,15 @@ subtest 'bugrefs' => sub {
     is markdown_to_html("boo\ntesting boo#123 123\n123"),
       qq{<p>boo\ntesting <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=123">boo#123</a> 123\n123</p>\n},
       'bugref expanded';
+    is markdown_to_html('related issues: boo#123,bsc#1234'),
+      qq{<p>related issues: <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=123">boo#123</a>,}
+      . qq{<a href="https://bugzilla.suse.com/show_bug.cgi?id=1234">bsc#1234</a></p>\n},
+      'bugref expanded';
+    is markdown_to_html('related issue: bsc#1234, yada yada'),
+      qq{<p>related issue: <a href="https://bugzilla.suse.com/show_bug.cgi?id=1234">bsc#1234</a>, yada yada</p>\n},
+      'bugref expanded';
+    is markdown_to_html('label:force_result:passed:bsc#1234'), "<p>label:force_result:passed:bsc#1234</p>\n",
+      'bugref not expanded because part of larger string';
 };
 
 subtest 'openQA additions' => sub {
@@ -135,6 +144,7 @@ subtest 'bugrefs to markdown' => sub {
       "[boo#9876](https://bugzilla.opensuse.org/show_bug.cgi?id=9876)\n\n"
       . "test [boo#211](https://bugzilla.opensuse.org/show_bug.cgi?id=211)\n",
       'right markdown';
+    is bugref_to_markdown('label:force_result:passed:bsc#1234'), 'label:force_result:passed:bsc#1234', 'right markdown';
 };
 
 subtest 'color detection' => sub {


### PR DESCRIPTION
Trying to simplify the comment rules openQA users have to follow for bugrefs.

Progress: https://progress.opensuse.org/issues/104199