### PR TITLE
Avoid action at a distance issues with global config changes

### DIFF
--- a/lib/OpenQA/Shared/GruJob.pm
+++ b/lib/OpenQA/Shared/GruJob.pm
@@ -4,7 +4,7 @@
 package OpenQA::Shared::GruJob;
 use Mojo::Base 'Minion::Job';
 
-use Data::Dumper 'Dumper';
+use Mojo::Util qw(dumper);
 
 sub execute {
     my $self = shift;
@@ -19,7 +19,7 @@ sub execute {
     my $state = $info->{state};
     if ($state eq 'failed' || defined $err) {
         $err //= $info->{result};
-        $err = Dumper($err) if ref $err;
+        $err = dumper($err) if ref $err;
         $self->app->log->error("Gru job error: $err");
         $self->fail($err);
         $self->_fail_gru($gru_id => $err);

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -29,9 +29,6 @@ use OpenQA::Log qw(log_info log_debug log_warning log_error);
 use Config::Tiny;
 use Time::HiRes qw(tv_interval);
 
-# avoid boilerplate "$VAR1 = " in dumper output
-$Data::Dumper::Terse = 1;
-
 my $FRAG_REGEX = FRAGMENT_REGEX;
 
 our $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -3,8 +3,9 @@
 
 package OpenQA::WebAPI::Auth::OAuth2;
 use Mojo::Base -base, -signatures;
+
 use Carp 'croak';
-use Data::Dumper;
+use Mojo::Util qw(dumper);
 use OpenQA::Log qw(log_debug);
 
 sub auth_setup ($server) {
@@ -69,7 +70,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
     }
     my $details = $tx->res->json;
     if (ref $details ne 'HASH' || !$details->{id} || !$details->{$provider_config->{nickname_from}}) {
-        log_debug("OAuth2 user provider returned: " . Dumper($details));
+        log_debug("OAuth2 user provider returned: " . dumper($details));
         return $controller->render(text => 'User data returned by OAuth2 provider is insufficient', status => 403);
     }
     my $provider_name = $main_config->{provider};

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -22,7 +22,7 @@ use Test::Output 'combined_like';
 use OpenQA::Test::Case;
 use File::Which 'which';
 use File::Path ();
-use Data::Dumper 'Dumper';
+use Mojo::Util qw(dumper);
 use Date::Format 'time2str';
 use Fcntl ':mode';
 use Mojo::File qw(path tempdir);
@@ -137,7 +137,7 @@ $t->app->minion->add_task(
 my $dbh = $schema->storage->dbh;
 my $initial_aessets = $dbh->selectall_arrayref('select * from assets order by id;');
 note('initially existing assets:');
-note(Dumper($initial_aessets));
+note(dumper($initial_aessets));
 
 sub find_kept_assets_with_last_jobs {
     my $last_used_jobs = $assets->search(


### PR DESCRIPTION
Having `use OpenQA::Utils` change the global behaviour of `Data::Dumper` is rather unintuitive. The Mojolicious helper function `Mojo::Util::dumper` should match our `Data::Dumper` requirements with `->Indent(1)->Sortkeys(1)->Terse(1)->Useqq(1)`.