### PR TITLE
Prevent failed testapi.pm download in doc generation

### DIFF
--- a/tools/generate-documentation
+++ b/tools/generate-documentation
@@ -124,7 +124,8 @@ update_docs() {
 
 update_api() {
         mkdir -p api/src
-        curl -o api/src/testapi.pm https://raw.githubusercontent.com/os-autoinst/os-autoinst/master/testapi.pm
+        response=$(curl -o api/src/testapi.pm -sS -w "%{http_code}\n" https://raw.githubusercontent.com/os-autoinst/os-autoinst/master/testapi.pm)
+        [[ $response != 200 ]] && echo "Download of testapi.pm failed" && exit 1
         cd api
         "${scriptroot}"/generate-documentation-genapi
 


### PR DESCRIPTION
In
https://github.com/os-autoinst/openQA/pull/4445
the documentation was generated with the test API content mostly
deleted.

The "last good" CI job in
https://app.circleci.com/pipelines/github/os-autoinst/openQA/8706/workflows/1ba62a05-5bba-4355-9074-b13874ca081b/jobs/82071?invite=true#step-108-292
says from curl "72124" bytes have been received. This is also the number
I get locally. The "first bad" says "54894" bytes have been downloaded
so this is not complete.

To be sure that the HTTP response code actually does not point to an
error we should only continue execution if we really received HTTP
status code "200", similar as we already do for example in
https://github.com/os-autoinst/scripts/blob/8aff4acbd225c4ce614fdc44a7903cffa7c05889/_common#L47

Tested locally with

```
FORMATS=html tools/generate-documentation
```

Related progress issue: https://progress.opensuse.org/issues/104827