### PR TITLE
apparmor: Allow /usr/bin/swtpm used by os-autoinst

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -81,6 +81,7 @@
   /usr/bin/lscpu rCx,
   /{usr/,}bin/mkdir rix,
   /usr/bin/nice rix,
+  /usr/bin/swtpm rix,
   /usr/bin/optipng rix,
   /{usr/,}bin/pwd rix,
   /usr/bin/python3.* ix,


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/103683