### PR TITLE
Avoid logging worker status messages by default

### DIFF
--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -6,7 +6,7 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use DBIx::Class::Timestamps 'now';
 use OpenQA::Schema;
-use OpenQA::Log qw(log_debug log_error log_info log_warning);
+use OpenQA::Log qw(log_debug log_error log_info log_warning log_trace);
 use OpenQA::Constants qw(WEBSOCKET_API_VERSION);
 use OpenQA::WebSockets::Model::Status;
 use OpenQA::Jobs::Constants;
@@ -148,7 +148,7 @@ sub _message {
         my $job_token = $job_settings->{JOBTOKEN};
         my $pending_job_ids = $json->{pending_job_ids} // {};
 
-        log_debug "Received from worker $worker_id worker_status message: " . dumper($json)
+        log_trace "Received from worker $worker_id worker_status message: " . dumper($json)
           if LOG_WORKER_STATUS_MESSAGES;
 
         # log that we 'saw' the worker
@@ -169,7 +169,7 @@ sub _message {
         try {
             my $workers_population = $schema->resultset("Workers")->count();
             my $msg = {type => 'info', population => $workers_population};
-            $self->tx->send({json => $msg} => sub { log_debug("Sent population to worker: " . pp($msg)) });
+            $self->tx->send({json => $msg} => sub { log_trace("Sent population to worker: " . pp($msg)) });
         }
         catch {
             log_debug("Could not send the population number to worker $worker_id: $_");    # uncoverable statement
@@ -192,14 +192,14 @@ sub _message {
             }
 
             # log debugging info
-            log_debug("Found job $current_job_id in DB from worker_status update sent by worker $worker_id")
+            log_trace("Found job $current_job_id in DB from worker_status update sent by worker $worker_id")
               if defined $current_job_id;
-            log_debug("Received request has job id: $job_id")
+            log_trace("Received request has job id: $job_id")
               if defined $job_id;
             $registered_job_token = $worker->get_property('JOBTOKEN');
-            log_debug("Worker $worker_id for job $current_job_id has token $registered_job_token")
+            log_trace("Worker $worker_id for job $current_job_id has token $registered_job_token")
               if defined $current_job_id && defined $registered_job_token;
-            log_debug("Received request has token: $job_token")
+            log_trace("Received request has token: $job_token")
               if defined $job_token;
 
             # skip any further actions if worker just does the one job we expected it to do

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -11,6 +11,9 @@ use POSIX;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';
+
+BEGIN { $ENV{OPENQA_LOG_WORKER_STATUS_MESSAGES} = 1 }
+
 use OpenQA::Jobs::Constants;
 use OpenQA::WebSockets;
 use OpenQA::WebSockets::Model::Status;


### PR DESCRIPTION
Those messages make a great share of openQA's logging as they contain the
full list of job settings. The log message can be useful in certain
debugging scenarios so it can still be enabled via
`OPENQA_LOG_WORKER_STATUS_MESSAGES`. The current worker status (just the
status itself, e.g. 'broken') which is the most important information is
now included in the update log message so it is still there by default.

Related ticket: https://progress.opensuse.org/issues/104967