### PR TITLE
Add checkbox for "TODO" filter unifying code with "relevant" filter

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -1,5 +1,6 @@
 /* jshint esversion: 6 */
 
+const filters = ['todo', 'relevant'];
 var is_operator;
 var restart_url;
 
@@ -238,6 +239,12 @@ function renderTestLists() {
     ajaxQueryParams.addFirstParam(paramName);
   });
   delete ajaxQueryParams.addFirstParam;
+  filters.forEach(filter => {
+    const param = pageQueryParams[filter];
+    if (Array.isArray(param)) {
+      document.getElementById(filter + 'filter').checked = parseInt(param[0]);
+    }
+  });
 
   // initialize data tables for running, scheduled and finished jobs
   var runningTable = $('#running').DataTable({
@@ -326,9 +333,9 @@ function renderTestLists() {
     ajax: {
       url: '/tests/list_ajax',
       data: function () {
-        ajaxQueryParams.relevant = $('#relevantfilter').prop('checked');
-        var todo = parseQueryParams().todo || [];
-        ajaxQueryParams.todo = todo[0];
+        filters.forEach(filter => {
+          ajaxQueryParams[filter] = document.getElementById(filter + 'filter').checked ? 1 : 0;
+        });
         return ajaxQueryParams;
       },
       dataSrc: function (json) {
@@ -363,8 +370,8 @@ function renderTestLists() {
   });
 
   // register event listener to the two range filtering inputs to redraw on input
-  $('#relevantfilter').change(function () {
-    table.ajax.reload();
+  filters.forEach(filter => {
+    document.getElementById(filter + 'filter').onchange = () => table.ajax.reload();
   });
 
   // initialize filter for result (of finished jobs) as chosen

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -364,10 +364,7 @@ function renderTestLists() {
 
   // register event listener to the two range filtering inputs to redraw on input
   $('#relevantfilter').change(function () {
-    $('#relevantbox').css('color', 'cyan');
-    table.ajax.reload(function () {
-      $('#relevantbox').css('color', 'inherit');
-    });
+    table.ajax.reload();
   });
 
   // initialize filter for result (of finished jobs) as chosen

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -65,13 +65,9 @@ sub list_ajax ($self) {
     my @list;
     my $todo = $self->param('todo');
     for my $job (@jobs) {
+        next if $todo && !$job->overview_result($comment_data, {}, undef, [], $todo);
+
         my $job_id = $job->id;
-
-        if ($todo) {
-            $job->overview_result($comment_data, {}, undef, [], $todo)
-              or next;
-        }
-
         my $rendered_data = 0;
         if (my $cd = $comment_data->{$job_id}) {
             $rendered_data = $self->_render_comment_data_for_ajax($job_id, $cd);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -42,7 +42,8 @@ sub get_match_param {
 }
 
 sub list_ajax ($self) {
-    my $scope = ($self->param('relevant') ne 'false' ? 'relevant' : '');
+    my $scope = $self->param('relevant');
+    $scope = $scope && $scope ne 'false' && $scope ne '0' ? 'relevant' : '';
     my @jobs = $self->schema->resultset('Jobs')->complex_query(
         state => [OpenQA::Jobs::Constants::FINAL_STATES],
         scope => $scope,

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -196,6 +196,16 @@ sub register ($self, $app, $config) {
         });
 
     $app->helper(
+        help_popover_todo => sub ($c) {
+            $c->help_popover(
+                'Help for the <em>TODO</em>-filter',
+                '<p>Shows only jobs that need to be labeled for the black review badge to show up</p>',
+                'http://open.qa/docs/#_review_badges',
+                'documentation about review badges'
+            );
+        });
+
+    $app->helper(
         # emit_event helper, adds user, connection to events
         emit_event => sub {
             my ($self, $event, $data) = @_;

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -357,10 +357,13 @@ subtest 'filter-finished' => sub {
         '99945 again hidden'
     );
 
-    ok $driver->get('/tests?todo=1'), 'get todo-tests';
-    wait_for_ajax();
+    ok $driver->get('/tests?todo=1'), 'get TODO-tests';
+    wait_for_ajax(msg => 'tables loaded after reloading page with TODO-parameter');
     @jobs = map { $_->get_attribute('id') } @{$driver->find_elements('#results tbody tr', 'css')};
     is_deeply(\@jobs, [qw(job_99940 job_99938 job_99926 job_99962)], 'only todo tests are shown');
+    $driver->find_element_by_id('todofilter')->click;
+    wait_for_ajax(msg => 'table re-loaded after unchecking TODO-checkbox');
+    cmp_ok scalar $driver->find_elements('#results tbody tr', 'css'), '>', scalar @jobs, 'all jobs shown again';
 };
 
 $driver->get('/tests?match=staging_e');

--- a/templates/webapi/test/list.html.ep
+++ b/templates/webapi/test/list.html.ep
@@ -45,7 +45,7 @@
   <div id="flash-messages-finished-jobs"></div>
     <div class="row" style="margin-bottom: 10px;">
             <div class="col-sm-12 col-md-6">
-                %= check_box relevant => '1', 'checked' => 'checked' => (id => 'relevantfilter')
+                %= check_box relevant => '1', checked => 'checked', id => 'relevantfilter'
                 %= label_for 'relevantfilter' => 'Show only relevant jobs'
             </div>
             <div class="col-sm-12 col-md-6" style="text-align: right;">

--- a/templates/webapi/test/list.html.ep
+++ b/templates/webapi/test/list.html.ep
@@ -47,6 +47,9 @@
             <div class="col-sm-12 col-md-6">
                 %= check_box relevant => '1', checked => 'checked', id => 'relevantfilter'
                 %= label_for 'relevantfilter' => 'Show only relevant jobs'
+                %= check_box todo => '1', id => 'todofilter'
+                %= label_for 'todofilter' => 'TODO'
+                %= help_popover_todo
             </div>
             <div class="col-sm-12 col-md-6" style="text-align: right;">
                 Result:

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -144,10 +144,7 @@
                 <div class="form-group">
                     <strong>Misc</strong>
                     <label><input value="1" name="todo" type="checkbox" id="filter-todo"> TODO</label>
-                    <%= help_popover('Help for the <em>TODO</em>-filter' => '
-                        <p>Shows only jobs that need to be labeled for the black review badge to show up</p>',
-                        'http://open.qa/docs/#_review_badges' => 'documentation about review badges')
-                    %>
+                    %= help_popover_todo
                 </div>
                 <button type="submit" class="btn btn-default">Apply</button>
             </form>


### PR DESCRIPTION
* Deduce initial state of filters from query parameters
* Unify code for making AJAX query parameters and reloading the table
  contents
* Make code for help popover a helper to use it on multiple pages
* See https://progress.opensuse.org/issues/104995