### PR TITLE
Fix reporting URL for SLE Micro

### DIFF
--- a/templates/webapi/branding/openSUSE/external_reporting.html.ep
+++ b/templates/webapi/branding/openSUSE/external_reporting.html.ep
@@ -74,7 +74,7 @@
 %     }
 % }
 % elsif ($raw_distri eq 'sle-micro') {
-%     $product = 'Micro';
+%     $product = 'Micro ' . $job->VERSION;
 % }
 % elsif ($raw_distri eq 'opensuse' || $raw_distri eq 'microos') {
 %     $product = $job->VERSION eq 'Tumbleweed' ? 'Tumbleweed' : 'Distribution';


### PR DESCRIPTION
Available options are:
- `product=SUSE Linux Enterprise Micro 5.0`
- `product=SUSE Linux Enterprise Micro 5.1`
- `product=SUSE Linux Enterprise Micro 5.2`

![image](https://user-images.githubusercontent.com/11728254/149945491-65fe9490-b4d0-4b69-8f21-ff78261ff59d.png)
