### PR TITLE
apparmor: allow to read and lock fd files from /boot

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -19,6 +19,7 @@
 
   /{usr/,}bin/{b,d}ash rix,
   /{usr/,}bin/pkill rix,
+  /boot/*.fd rk,
   /dev/ r,
   /dev/bus/usb/ r,
   /dev/hugepages/** rwk,


### PR DESCRIPTION
* Failed run: https://openqa.opensuse.org/tests/2144276
* Succeeded run with this PR: https://openqa.opensuse.org/tests/2144282