### PR TITLE
Remove retry from fullstack test as it seems stable again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ test-unstable:
 
 .PHONY: test-fullstack
 test-fullstack:
-	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=30 RETRY=15 PROVE_ARGS="$$HARNESS t/full-stack.t"
+	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=30 PROVE_ARGS="$$HARNESS t/full-stack.t"
 
 .PHONY: test-fullstack-unstable
 test-fullstack-unstable:


### PR DESCRIPTION
* Conducted 75 runs in the CI which all passed so it seems stable again
* See https://progress.opensuse.org/issues/98952