### PR TITLE
Use signatures in OpenQA::CLI::api and OpenQA::CLI::archive

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::CLI::api;
-use Mojo::Base 'OpenQA::Command';
+use Mojo::Base 'OpenQA::Command', -signatures;
 
 use Mojo::File 'path';
 use Mojo::JSON qw(decode_json);
@@ -15,8 +15,7 @@ has usage => sub {
     shift->extract_usage =~ s/\$search_criteria/$search_criteria/r;
 };
 
-sub command {
-    my ($self, @args) = @_;
+sub command ($self, @args) {
 
     my $data = $self->data_from_stdin;
 

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::CLI::archive;
-use Mojo::Base 'OpenQA::Command';
+use Mojo::Base 'OpenQA::Command', -signatures;
 
 use Mojo::Util qw(getopt);
 
 has description => 'Download assets and test results from a job';
 has usage => sub { shift->extract_usage };
 
-sub command {
-    my ($self, @args) = @_;
+sub command ($self, @args) {
 
     die $self->usage
       unless getopt \@args,


### PR DESCRIPTION
OpenQA/CLI/api.pm and OpenQA/CLI/archive.pm now use signatures.

https://progress.opensuse.org/issues/105127