### PR TITLE
templates: Fix wording for the "VNC display number"

### DIFF
--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -154,7 +154,7 @@
                 % if ($worker) {
                     <div id="assigned-worker">
                         Assigned worker:
-                        <span title="VNC port: <%= 90 + $worker->instance %>">
+                        <span title="VNC display number: <%= 90 + $worker->instance %>">
                             %= link_to $worker->name => url_for('admin_worker_show', worker_id => $worker->id)
                         </span>
                     </div>


### PR DESCRIPTION
"VNC port" makes it sound like a TCP port but a number like "90" or
"104" is not really that. The correct wording should be "VNC display
number".

This was wrong from the beginning, e.g. see 330c949b0 from 2014.