### PR TITLE
Simplify base inheritance statement with Mojo::Base everywhere

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -3,12 +3,7 @@
 
 package OpenQA::Schema::Result::JobGroups;
 
-use strict;
-use warnings;
-
-use base 'DBIx::Class::Core';
-
-use Mojo::Base -signatures;
+use Mojo::Base 'DBIx::Class::Core', -signatures;
 use OpenQA::App;
 use OpenQA::Markdown 'markdown_to_html';
 use OpenQA::JobGroupDefaults;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -3,12 +3,7 @@
 
 package OpenQA::Schema::Result::Jobs;
 
-use strict;
-use warnings;
-
-use Mojo::Base -strict, -signatures;
-use base 'DBIx::Class::Core';
-
+use Mojo::Base 'DBIx::Class::Core', -signatures;
 use Try::Tiny;
 use Mojo::JSON 'encode_json';
 use Fcntl;

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -3,14 +3,9 @@
 
 package OpenQA::Schema::ResultSet::Comments;
 
-use strict;
-use warnings;
-use Mojo::Base -signatures;
-
+use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
 use OpenQA::App;
 use OpenQA::Utils qw(find_bugrefs);
-
-use base 'DBIx::Class::ResultSet';
 
 =over 4
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -3,10 +3,7 @@
 
 package OpenQA::Schema::ResultSet::Jobs;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'DBIx::Class::ResultSet';
-
+use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
 use DBIx::Class::Timestamps 'now';
 use Date::Format 'time2str';
 use File::Basename 'basename';

--- a/lib/OpenQA/Schema/ResultSet/Users.pm
+++ b/lib/OpenQA/Schema/ResultSet/Users.pm
@@ -3,8 +3,7 @@
 
 package OpenQA::Schema::ResultSet::Users;
 
-use Mojo::Base -strict, -signatures;
-use base 'DBIx::Class::ResultSet';
+use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
 
 sub create_user ($self, $id, %attrs) {
     return unless $id;

--- a/t/01-style.t
+++ b/t/01-style.t
@@ -13,4 +13,5 @@ qq{git grep -I -l 'This program is free software.*if not, see <http://www.gnu.or
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!t/01-style.t'}) != 0,
   'SPDX-License-Identifier correctly terminated';
 is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
+is qx{git grep --all-match -e '^use Mojo::Base' -e 'use base'}, '', 'No redundant Mojo::Base+base';
 done_testing;

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -1,9 +1,7 @@
 package OpenQA::SeleniumTest;
 
 use Test::Most;
-
-use Mojo::Base -signatures;
-use base 'Exporter';
+use Mojo::Base 'Exporter', -signatures;
 
 require OpenQA::Test::Database;
 


### PR DESCRIPTION
Wherever we use "Mojo::Base" as well as "base" we can simply combine the
both including some redundant "strict" and "warnings" statements which
are also implicitly included with Mojo::Base.