### PR TITLE
Show "failed modules" with a coloring resembling an failed state

### DIFF
--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -129,11 +129,11 @@ table.overview {
     }
 
     .failedmodule {
-        background-color: #E9F7C9;
+        background-color: #F7E1E1;
         padding: 3px;
         margin-right: 1ex;
         border-radius: 3px;
-        border: 1px solid #D2DFB5;
+        border: 2px solid #D98A8A;
         @include media-breakpoint-down(sm) {
             display: none;
         }


### PR DESCRIPTION
Especially with the new openQA feature of "force_result" it is more
common to see openQA jobs where the result is passed or soft-failed
while there are still failed modules. Right now e.g. in /tests/overview
"failed modules" show up on a green background which could confuse
people thinking of these modules as not failed. We should reconsider
the coloring. This commit changes the styling so that the failed modules
in openQA are rendered with a slightly more alarming design using a
light red background and red border which I made a bit thicker.

**Before:**
![Screenshot_20220124_125343_before_failed_modules_green_border](https://user-images.githubusercontent.com/1693432/150795117-441fd558-1a32-418b-a561-4d3962a810bd.png)

**After:**
![Screenshot_20220124_125607_after_failed_modules_red_border](https://user-images.githubusercontent.com/1693432/150795121-54188b82-afdd-4026-8518-49dccd98acb5.png)

Related progress issue: https://progress.opensuse.org/issues/95479