### PR TITLE
Allow changing job settings via restart API

### DIFF
--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -37,7 +37,8 @@ sub job_restart {
 
     # duplicate all jobs that are either running or done
     my $force = $args{force};
-    my %duplication_args = map { ($_ => $args{$_}) } qw(prio skip_parents skip_children skip_ok_result_children);
+    my @duplication_arg_keys = (qw(prio skip_parents skip_children skip_ok_result_children settings));
+    my %duplication_args = map { ($_ => $args{$_}) } @duplication_arg_keys;
     my $schema = OpenQA::Schema->singleton;
     my $jobs = $schema->resultset('Jobs')->search({id => $jobids, state => {'not in' => [PRISTINE_STATES]}});
     $duplication_args{no_directly_chained_parent} = 1 unless $force;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -43,6 +43,9 @@ use OpenQA::WebSockets::Client;
 use constant SCENARIO_KEYS => (qw(DISTRI VERSION FLAVOR ARCH TEST));
 use constant SCENARIO_WITH_MACHINE_KEYS => (SCENARIO_KEYS, 'MACHINE');
 
+# job settings which are defined directly as column of the jobs table
+use constant MAIN_SETTINGS => qw(DISTRI VERSION FLAVOR ARCH TEST MACHINE BUILD);
+
 __PACKAGE__->table('jobs');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime FilterColumn Timestamps));
 __PACKAGE__->add_columns(
@@ -629,8 +632,7 @@ sub _create_clone ($self, $cluster_job_info, $prio, $skip_ok_result_children, $s
 
     # Duplicate settings (with exceptions)
     my %spec_settings = %$settings;
-    my %main_settings
-      = map { $_ => (delete $spec_settings{$_}) // $self->$_ } qw(TEST VERSION ARCH FLAVOR MACHINE BUILD DISTRI);
+    my %main_settings = map { $_ => (delete $spec_settings{$_}) // $self->$_ } MAIN_SETTINGS;
     if (my $test_suffix = delete $spec_settings{'TEST+'}) { $main_settings{TEST} .= $test_suffix }
     my ($group_args, $group) = extract_group_args_from_settings(\%spec_settings);
     die "Specified _GROUP/_GROUP_ID settings are invalid\n" if keys %$group_args && !$group;

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -171,10 +171,8 @@ sub create_from_settings {
     }
 
     # move important keys from the settings directly to the job
-        my $value = delete $settings{$key};
-        next unless $value;
-        $new_job_args{$key} = $value;
     for my $key (OpenQA::Schema::Result::Jobs::MAIN_SETTINGS) {
+        if (my $value = delete $settings{$key}) { $new_job_args{$key} = $value }
     }
 
     # assign default for WORKER_CLASS

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -171,10 +171,10 @@ sub create_from_settings {
     }
 
     # move important keys from the settings directly to the job
-    for my $key (qw(DISTRI VERSION FLAVOR ARCH TEST MACHINE BUILD)) {
         my $value = delete $settings{$key};
         next unless $value;
         $new_job_args{$key} = $value;
+    for my $key (OpenQA::Schema::Result::Jobs::MAIN_SETTINGS) {
     }
 
     # assign default for WORKER_CLASS

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -10,6 +10,7 @@ use File::Basename 'basename';
 use IPC::Run;
 use OpenQA::App;
 use OpenQA::Log qw(log_debug log_warning);
+use OpenQA::Schema::Result::Jobs;
 use OpenQA::Schema::Result::JobDependencies;
 use OpenQA::Utils 'testcasedir';
 use Mojo::File 'path';
@@ -119,22 +120,11 @@ sub create_from_settings {
       keys %settings;
     die 'The ' . join(',', @invalid_keys) . ' cannot include / in value' if @invalid_keys;
 
-    # assign group ID
-    my $group;
-    my %group_args;
-    if ($settings{_GROUP_ID}) {
-        $group_args{id} = delete $settings{_GROUP_ID};
-    }
-    if ($settings{_GROUP}) {
-        my $group_name = delete $settings{_GROUP};
-        $group_args{name} = $group_name unless $group_args{id};
-    }
-    if (keys %group_args) {
-        $group = $schema->resultset('JobGroups')->find(\%group_args);
-        if ($group) {
-            $new_job_args{group_id} = $group->id;
-            $new_job_args{priority} = $group->default_priority;
-        }
+    # assign group ID and priority
+    my ($group_args, $group) = OpenQA::Schema::Result::Jobs::extract_group_args_from_settings(\%settings);
+    if ($group) {
+        $new_job_args{group_id} = $group->id;
+        $new_job_args{priority} = $group->default_priority;
     }
 
     # handle dependencies
@@ -207,8 +197,8 @@ sub create_from_settings {
     # associate currently available assets with job
     $job->register_assets_from_settings;
 
-    log_warning('Ignoring invalid group ' . encode_json(\%group_args) . ' when creating new job ' . $job->id)
-      if %group_args && !$group;
+    log_warning('Ignoring invalid group ' . encode_json($group_args) . ' when creating new job ' . $job->id)
+      if keys %$group_args && !$group;
     $job->calculate_blocked_by;
     $txn_guard->commit;
     return $job;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -718,6 +718,7 @@ sub _restart {
     $validation->optional('dup_type_auto')->num(0);    # recorded within the event; for informal purposes only
     $validation->optional('jobid')->num(0);
     $validation->optional('jobs');
+    $validation->optional('set')->like(qr/.+=.*/);
     $validation->optional($_)->num(0) for @flags;
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
 
@@ -734,10 +735,12 @@ sub _restart {
     }
 
     my $auto = defined $validation->param('dup_type_auto') ? int($validation->param('dup_type_auto')) : 0;
+    my %settings = map { split('=', $_, 2) } @{$validation->every_param('set')};
     my @params = map { $validation->param($_) ? ($_ => 1) : () } @flags;
     push @params, prio => int($validation->param('prio')) if defined $validation->param('prio');
     push @params, skip_aborting_jobs => 1 if $dup_route && !defined $validation->param('skip_aborting_jobs');
     push @params, force => 1 if $dup_route && !defined $validation->param('force');
+    push @params, settings => \%settings;
 
     my $res = OpenQA::Resource::Jobs::job_restart($jobs, @params);
     OpenQA::Scheduler::Client->singleton->wakeup;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -292,14 +292,29 @@ subtest 'restart jobs (forced)' => sub {
     is(scalar(@{$t->tx->res->json->{jobs}}), 15, 'job count stay the same');
 };
 
-subtest 'restart single job' => sub {
+subtest 'restart single job passing settings' => sub {
     is($jobs->find(99926)->clone_id, undef, 'job has not been cloned yet');
-    $t->post_ok('/api/v1/jobs/99926/restart')->status_is(200);
+    my $url = '/api/v1/jobs/99926/restart?';
+    my $params = 'set=_GROUP%3D0&set=TEST%2B%3D%3Ainvestigate&set=ARCH%3Di386&set=FOO%3Dbar&set=FLAVOR%3D';
+    $t->post_ok($url . 'set=_GROUP')->status_is(400, 'parameter without value does not pass validation');
+    $t->post_ok($url . $params)->status_is(200);
     $t->json_is('/warnings' => undef, 'no warnings generated');
     $t->json_is('/errors' => undef, 'no errors generated');
-    isnt($jobs->find(99926)->clone_id, undef, 'job has been cloned');
     my $event = OpenQA::Test::Case::find_most_recent_event($schema, 'job_restart');
-    is($event->{id}, 99926, 'restart produces event');
+    is $event->{id}, 99926, 'restart produces event';
+    my $clone = $jobs->find(99926)->clone;
+    isnt $clone, undef, 'job has been cloned' or return;
+    is $clone->group_id, undef, 'group has NOT been taken over due to _GROUP=0 parameter';
+    is $clone->TEST, 'minimalx:investigate', 'appending to TEST variable via TEST+=:investigate parameter';
+    is $clone->ARCH, 'i386', 'existing setting overridden via ARCH=i386 parameter';
+    is $clone->FLAVOR, '', 'existing setting cleared via FLAVOR= parameter';
+    is $clone->settings_hash->{FOO}, 'bar', 'new setting added via FOO=bar parameter';
+    $jobs->find(80000)->update({group_id => 1002});
+    $t->post_ok('/api/v1/jobs/restart?set=_GROUP_ID%3D0&prio=42&jobs=80000')->status_is(200);
+    $clone = $jobs->find(80000)->clone;
+    isnt $clone, undef, '2nd job has been cloned' or return;
+    is $clone->group_id, undef, 'group has NOT been taken over due to _GROUP_ID=0 parameter';
+    is $clone->priority, 42, 'prio set';
 };
 
 subtest 'duplicate route' => sub {
@@ -726,7 +741,7 @@ subtest 'json representation of group overview (actually not part of the API)' =
             key => 'Factory-0048',
         },
         'Build 0048 exported'
-    );
+    ) or diag explain $b48;
 };
 
 $t->get_ok('/dashboard_build_results.json?limit_builds=10')->status_is(200);


### PR DESCRIPTION
So `openqa-investigate` can use it to handle jobs with parallel
and directly chained dependencies, see
https://progress.opensuse.org/issues/95783.