### PR TITLE
Prevent error when restarting jobs with `skip_parents=1`

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -661,9 +661,10 @@ sub _create_clones {
 
         # recreate dependencies if exists for cloned parents/children
         for my $p (@{$info->{parallel_parents}}) {
+            $p = $clones{$p}->id if defined $clones{$p};
             $res->parents->find_or_create(
                 {
-                    parent_job_id => $clones{$p}->id,
+                    parent_job_id => $p,
                     dependency => OpenQA::JobDependencies::Constants::PARALLEL,
                 });
         }

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -257,6 +257,7 @@ subtest 'prevent restarting parents' => sub {
         });
     # restart the two jobs 99963 and 99938; one has a parallel parent (99961) and one a directly chained parent (99937)
     $t->post_ok('/api/v1/jobs/restart?force=1&skip_parents=1', form => {jobs => [99963, 99938]})->status_is(200);
+    $t->json_is('/result' => [{99938 => 99983}, {99963 => 99984}], 'response') or diag explain $t->tx->res->json;
     # check whether jobs have been restarted but not their parents
     isnt($jobs->find(99963)->clone_id, undef, 'job with parallel parent has been cloned');
     isnt($jobs->find(99938)->clone_id, undef, 'job with directly chained parent has been cloned');


### PR DESCRIPTION
* Prevent erroneous dependency creation for parallel parent when the
  creation of the clone has been skipped leading to transaction rollback
* Prevent the warning `Duplication rolled back after error: Can't call
  method "id" on an undefined` being logged
* Note that the unit test passed before because they didn't check the API
  call response, only that certain clones are not present (which is also
  the case when the transaction has been rolled back)