### PR TITLE
Fix includes of script/ in tidyall config

### DIFF
--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,3 +1,6 @@
 [PerlTidy]
-select = **/*.{pl,pm,t}
+; Notice that this does include also non-Perl files in script/ so it is
+; suggested to use tools/tidy to cover all appropriate files. "tidyall -a"
+; will try to cover too much and fail on the non-Perl files
+select = **/*.{pl,pm,t} script/*
 argv = --profile=$ROOT/.perltidyrc

--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = a6cbaa31f26302cf30431ec3bc810b8abf94a601
+	commit = d6bc4d5024296520344bbb80add1a345f275ac1a
 	parent = 94bf360336469dd3f6c603860f7a629568adf6b6
 	method = merge
 	cmdver = 0.4.3

--- a/external/os-autoinst-common/tools/update-deps
+++ b/external/os-autoinst-common/tools/update-deps
@@ -20,16 +20,16 @@ GetOptions(
 usage(0) if $help;
 usage(1) unless $specfile;
 
-my $scriptname   = path(__FILE__)->to_rel("$Bin/..");
-my $yamlfile     = "dependencies.yaml";
-my $file         = "$Bin/../$yamlfile";
-my $cpanfile     = "$Bin/../cpanfile";
+my $scriptname = path(__FILE__)->to_rel("$Bin/..");
+my $yamlfile = "dependencies.yaml";
+my $file = "$Bin/../$yamlfile";
+my $cpanfile = "$Bin/../cpanfile";
 
-my $data     = YAML::PP->new->load_file($file);
-my $spec     = path($specfile)->slurp;
+my $data = YAML::PP->new->load_file($file);
+my $spec = path($specfile)->slurp;
 
-my $spectargets   = $data->{targets}->{spec};
-my $cpantargets   = $data->{targets}->{cpanfile};
+my $spectargets = $data->{targets}->{spec};
+my $cpantargets = $data->{targets}->{cpanfile};
 my $dockertargets = $data->{targets}->{docker};
 my $cpantarget_mapping = $data->{targets}->{'cpanfile-targets'};
 
@@ -46,7 +46,7 @@ sub update_dockerfile {
     my @pkg;
     for my $target (@$dockertargets) {
         my $name = $target . '_requires';
-        my $deps     = $data->{$name};
+        my $deps = $data->{$name};
         for my $key (sort keys %$deps) {
             next if $key =~ m/^%/;
             my $line = '       ';
@@ -84,8 +84,8 @@ sub update_spec {
 
     for my $target (@$spectargets) {
         my $name = $target . '_requires';
-        my $deps     = $data->{$name};
-        my $prefix   = "%define $name";
+        my $deps = $data->{$name};
+        my $prefix = "%define $name";
         my $specline = $prefix;
         for my $key (sort keys %$deps) {
             my $version = $deps->{$key};
@@ -139,7 +139,7 @@ sub _requires_line {
     # requires 'Archive::Extract', '> 0.7';
     my ($hash, $module) = @_;
     my $version = $hash->{$module};
-    my $line    = "requires '$module'";
+    my $line = "requires '$module'";
     $line .= qq{, '$version'} if $version;
     $line .= ";\n";
     return $line;

--- a/tools/tidy
+++ b/tools/tidy
@@ -22,14 +22,17 @@ EOF
 set -eo pipefail
 
 args=""
-selection='--all'
-opts=$(getopt -o hco --long help,check,only-changed -n "$0" -- "$@") || usage
+mapfile -t files < <(file --mime-type -- script/* | (grep text/x-perl || true) | awk -F':' '{ print $1 }')
+files+=('**.p[ml]' '**.t')
+selection="$(git ls-files "${files[@]}")"
+opts=$(getopt -o hcol --long help,check,only-changed,list -n "$0" -- "$@") || usage
 eval set -- "$opts"
 while true; do
   case "$1" in
     -h | --help ) usage; shift ;;
     -c | --check ) args+=' --check-only'; shift ;;
     -o | --only-changed ) selection='--git'; shift ;;
+    -l | --list ) args+='--list'; shift ;;
     -- ) shift; break ;;
     * ) break ;;
   esac


### PR DESCRIPTION
Fix includes of script/ in tidyall config

Within the script/ dir we have Perl scripts and other scripts. Just
asking tidyall to include all in script/ would mean that tidyall tries
to apply a Perl style to shell scripts which will obviously fail. So I
am reincluding parts of the rule we had before in tools/tidy to
explicitly select Perl scripts and Perl modules and tests as file
parameters to tidyall. We still need to include the script directory in
.tidyallrc so that it's not excluded even if tidyall is called with an
explicit file list as arguments.

Related progress issue: https://progress.opensuse.org/issues/99678
