### PR TITLE
Add clone parameter to restart API

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -205,7 +205,7 @@ sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_fi
 
         my %seen;
         my @jobs = map {
-            my $key = $_->TEST . "-" . $_->ARCH . "-" . $_->FLAVOR . "-" . $_->MACHINE;
+            my $key = $_->TEST . "-" . $_->ARCH . "-" . $_->FLAVOR . "-" . ($_->MACHINE // '');
             $seen{$key}++ ? () : $_;
         } $jobs->all;
         my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs(\@jobs);

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -37,7 +37,7 @@ sub job_restart {
 
     # duplicate all jobs that are either running or done
     my $force = $args{force};
-    my @duplication_arg_keys = (qw(prio skip_parents skip_children skip_ok_result_children settings));
+    my @duplication_arg_keys = (qw(clone prio skip_parents skip_children skip_ok_result_children settings));
     my %duplication_args = map { ($_ => $args{$_}) } @duplication_arg_keys;
     my $schema = OpenQA::Schema->singleton;
     my $jobs = $schema->resultset('Jobs')->search({id => $jobids, state => {'not in' => [PRISTINE_STATES]}});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -714,6 +714,7 @@ sub _restart {
     my $dup_route = $args{duplicate_route_compatibility};
     my @flags = qw(force skip_aborting_jobs skip_parents skip_children skip_ok_result_children);
     my $validation = $self->validation;
+    $validation->optional('clone')->num(0);
     $validation->optional('prio')->num;
     $validation->optional('dup_type_auto')->num(0);    # recorded within the event; for informal purposes only
     $validation->optional('jobid')->num(0);
@@ -737,6 +738,7 @@ sub _restart {
     my $auto = defined $validation->param('dup_type_auto') ? int($validation->param('dup_type_auto')) : 0;
     my %settings = map { split('=', $_, 2) } @{$validation->every_param('set')};
     my @params = map { $validation->param($_) ? ($_ => 1) : () } @flags;
+    push @params, clone => !defined $validation->param('clone') || $validation->param('clone');
     push @params, prio => int($validation->param('prio')) if defined $validation->param('prio');
     push @params, skip_aborting_jobs => 1 if $dup_route && !defined $validation->param('skip_aborting_jobs');
     push @params, force => 1 if $dup_route && !defined $validation->param('force');


### PR DESCRIPTION
This allows to restart jobs so the new jobs are not considered clones. It
will be used by the investigation script as investigation jobs should not
prevent one from restarting the original job as-is.

Related ticket: https://progress.opensuse.org/issues/95783