### PR TITLE
Update the format of the OBS workflow file

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,12 +9,14 @@ pr:
       project: devel:openQA:GitHub
       repositories:
       - name: openSUSE_Tumbleweed
-        target_project: openSUSE:Factory
-        target_repository: snapshot
+        paths:
+        - target_project: openSUSE:Factory
+          target_repository: snapshot
         architectures: [ x86_64 ]
       - name: openSUSE_Leap_15.3
-        target_project: devel:openQA:Leap:15.3
-        target_repository: openSUSE_Leap_15.3
+        paths:
+        - target_project: devel:openQA:Leap:15.3
+          target_repository: openSUSE_Leap_15.3
         architectures: [ x86_64 ]
   filters:
     event: pull_request


### PR DESCRIPTION
The changes in this PR are needed due to a breaking change in the
configure_repositories step.
https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.configure_repositories_architectures_for_a_project

See also https://github.com/os-autoinst/os-autoinst/pull/1944