### PR TITLE
Fix typo in t::16-utils-runcmd

### DIFF
--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -44,7 +44,7 @@ subtest 'make git commit (error handling)' => sub {
             OpenQA::Git->new({app => $t->app, dir => 'foo/bar'})->commit();
         },
         qr/no user specified/,
-        'OpenQA::Git thows an exception if parameter missing'
+        'OpenQA::Git throws an exception if parameter missing'
     );
 
     my $empty_tmp_dir = tempdir();


### PR DESCRIPTION
During my last pull request I noticed a small typo in t/16-utils-runcmd