### PR TITLE
t: Fix querying stale reference in fullstack and developer mode test

### DIFF
--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -61,7 +61,13 @@ sub client_call ($args, $expected_out = undef, $desc = 'client_call') {
     like($out, $expected_out, $desc) or die;
 }
 
-sub find_status_text ($driver) { $driver->find_element('#info_box .card-body')->get_text() }
+sub find_status_text ($driver) {
+    # query text via JavaScript because when using `$driver->find_element('#info_box .card-body')->get_text`
+    # the element might be swapped out by the page's JavaScript under the hood after it has been returned by
+    # `find_element` and before the text is queried via `get_text` leading to the error `getElementText: stale
+    # element reference: element is not attached to the page document`
+    $driver->execute_script('return document.querySelector("#info_box .card-body").innerText');
+}
 
 # uncoverable statement
 sub _fail_with_result_panel_contents ($result_panel_contents, $msg) {

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -20,6 +20,7 @@ use OpenQA::Test::TimeLimit '30';
 use OpenQA::WebSockets::Client;
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
+use OpenQA::Test::FullstackUtils qw(find_status_text);
 
 sub prepare_database {
     my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
@@ -149,8 +150,7 @@ $driver->execute_script(
 );
 
 subtest 'devel UI hidden when running, but modules not initialized' => sub {
-    my $info_panel = $driver->find_element('#info_box .card-body');
-    my $info_text = $info_panel->get_text();
+    my $info_text = find_status_text $driver;
     like($info_text, qr/State\: running.*Assigned worker\: remotehost\:1/s, 'job is running');
     element_hidden('#developer-global-session-info');
     element_hidden('#developer-vnc-notice');


### PR DESCRIPTION
In these tests it is not possible to use
`$driver->find_element('#info_box .card-body')->get_text` because the
element might be swapped out by JavaScript under the hood after it has been
returned by `find_element` and before the text is queried via `get_text`.

This leads to errors like:

```
[16:04:54] t/full-stack.t .. 35/? getElementText: stale element reference: element is not attached to the page document at /home/squamata/project/t/lib/OpenQA/SeleniumTest.pm:80 at /home/squamata/project/t/lib/OpenQA/SeleniumTest.pm line 83.
…
    Selenium::Remote::WebElement::get_text(Test::Selenium::Remote::WebElement=HASH(0x55903e1b63d8)) called at /home/squamata/project/t/lib/OpenQA/Test/FullstackUtils.pm line 64
    OpenQA::Test::FullstackUtils::find_status_text(Test::Selenium::Chrome=HASH(0x55903dd0fc40)) called at /home/squamata/project/t/lib/OpenQA/Test/FullstackUtils.pm line 82
    OpenQA::Test::FullstackUtils::wait_for_result_panel(Test::Selenium::Chrome=HASH(0x55903dd0fc40), qr(Result: passed)u, "job 6") called at t/full-stack.t line 389
…
```
(see https://progress.opensuse.org/issues/98952#note-54 for details)

Querying the text via JavaScript should fix the race condition.

Note that this is only a problem if the test is not in a final state yet
and these seem to be the only instances of this situation in our test
suite.