### PR TITLE
Make parameters for carry-over configurable

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -221,3 +221,11 @@ concurrent = 0
 [scheduler]
 # Specify how many days a job can stay in 'SCHEDULED' state, defaults to 7 days
 # max_job_scheduled_time = 7
+
+# Configuration of the label/bugref carry-over
+[carry_over]
+# The carry over goes though the list of previous jobs to search for comments to carry over.
+# Specify at with depth this search will be aborted:
+# lookup_depth = 10
+# Specify at how many state changes the search will be aborted (state = combination of failed/softfailed/skipped modules):
+# state_changes_limit = 3

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -18,6 +18,7 @@ use OpenQA::Utils (
 use OpenQA::App;
 use OpenQA::Jobs::Constants;
 use OpenQA::JobDependencies::Constants;
+use OpenQA::Setup;
 use OpenQA::ScreenshotDeletion;
 use File::Basename qw(basename dirname);
 use File::Copy::Recursive qw();
@@ -1781,10 +1782,12 @@ sub _carry_over_candidate {
     my ($self) = @_;
 
     my $current_failure_reason = $self->_failure_reason;
+    my $app = OpenQA::App->singleton;
+    my $config = $app ? $app->config->{carry_over} : OpenQA::Setup::carry_over_defaults;
     my $prev_failure_reason = '';
     my $state_changes = 0;
-    my $lookup_depth = 10;
-    my $state_changes_limit = 3;
+    my $lookup_depth = $config->{lookup_depth};
+    my $state_changes_limit = $config->{state_changes_limit};
 
     # we only do carryover for jobs with some kind of (soft) failure
     return if $current_failure_reason eq 'GOOD';

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -19,6 +19,9 @@ use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT MAX_TIMER);
 use OpenQA::JobGroupDefaults;
 use OpenQA::Task::Job::Limit;
 
+my %CARRY_OVER_DEFAULTS = (lookup_depth => 10, state_changes_limit => 3);
+sub carry_over_defaults { \%CARRY_OVER_DEFAULTS }
+
 sub read_config {
     my $app = shift;
     my %defaults = (
@@ -160,7 +163,9 @@ sub read_config {
         hooks => {},
         influxdb => {
             ignored_failed_minion_jobs => '',
-        });
+        },
+        carry_over => \%CARRY_OVER_DEFAULTS
+    );
 
     # in development mode we use fake auth and log to stderr
     my %mode_defaults = (

--- a/t/config.t
+++ b/t/config.t
@@ -141,6 +141,10 @@ subtest 'Test configuration default modes' => sub {
         influxdb => {
             ignored_failed_minion_jobs => '',
         },
+        carry_over => {
+            lookup_depth => 10,
+            state_changes_limit => 3,
+        },
     };
 
     # Test configuration generation with "test" mode


### PR DESCRIPTION
We might want to tweak these settings. It is not clear whether the defaults
are the best for all use-cases.