### PR TITLE
doc: Use `async=1` flag in examples for posting a scheduled product (iso)

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1010,10 +1010,16 @@ Example for `_DEPRIORITIZEBUILD` and `_DEPRIORITIZE_LIMIT`.
 
 [source,sh]
 --------------------------------------------------------------------------------
-openqa-cli api -X POST isos ISO=my_iso.iso DISTRI=my_distri FLAVOR=sweet \
-         ARCH=my_arch VERSION=42 BUILD=1234 \
+openqa-cli api -X POST isos async=0 ISO=my_iso.iso DISTRI=my_distri \
+         FLAVOR=sweet ARCH=my_arch VERSION=42 BUILD=1234 \
          _DEPRIORITIZEBUILD=1 _DEPRIORITIZE_LIMIT=120 \
 --------------------------------------------------------------------------------
+
+*NOTE* By default scheduling products is done synchronously within the requests,
+corresponding to the parameter `async=0`. Use `async=1` to avoid possible
+timeouts by performing the task in background.
+This is recommended on big instances but means that the results (and
+possible errors) need to be polled via `openqa-cli api isos/$scheduled_product_id`.
 
 ==== Remarks ====
 

--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -99,9 +99,14 @@ sub command ($self, @args) {
     openqa-cli api -X POST jobs ISO=foo.iso DISTRI=my-distri \
       FLAVOR=my-flavor VERSION=42 BUILD=42 TEST=my-test
 
-    # Trigger jobs on ISO "foo.iso"
-    openqa-cli api --o3 -X POST isos ISO=foo.iso DISTRI=my-distri \
-      FLAVOR=my-flavor ARCH=my-arch VERSION=42 BUILD=1234
+    # Trigger jobs on ISO "foo.iso" creating a "scheduled product" (see
+    # https://open.qa/docs/#_spawning_multiple_jobs_based_on_templates_isos_post
+    # for details, e.g for considering to use the `async` flag)
+    openqa-cli api --o3 -X POST isos ISO=foo.iso \
+      DISTRI=my-distri FLAVOR=my-flavor ARCH=my-arch VERSION=42 BUILD=1234
+
+    # Track scheduled product
+    openqa-cli api --o3 isos/1234
 
     # Change group id for job
     openqa-cli api --json --data '{"group_id":1}' -X PUT jobs/639172


### PR DESCRIPTION
See https://progress.opensuse.org/issues/106762