### PR TITLE
Add support for query parameters to api command

### DIFF
--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -94,7 +94,7 @@ sub run ($self, @args) {
 
 sub url_for ($self, $path) {
     $path = "/$path" unless $path =~ m!^/!;
-    return Mojo::URL->new($self->host)->path($self->apibase . $path);
+    return Mojo::URL->new($self->apibase . $path)->to_abs(Mojo::URL->new($self->host));
 }
 
 1;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -223,6 +223,21 @@ subtest 'HTTP features' => sub {
     $data = decode_json $stdout;
     is $data->{method}, 'POST', 'POST request';
     is $data->{headers}{'Accept'}, 'application/json', 'Accept header';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http?async=1') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {async => '1'}, 'Query parameters';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X', 'POST', 'test/pub/http?async=1', 'foo=bar') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {async => '1', foo => 'bar'}, 'Query parameters';
+
+    ($stdout, @result) = capture_stdout sub { $api->run(@host, '-X', 'POST', '/test/pub/http?async=1&foo=bar') };
+    $data = decode_json $stdout;
+    is $data->{method}, 'POST', 'POST request';
+    is_deeply $data->{params}, {async => '1', foo => 'bar'}, 'Query parameters';
 };
 
 subtest 'Parameters' => sub {


### PR DESCRIPTION
Triggered by a Slack discussion. There's really no reason why the path doesn't allow query parameters currently.