### PR TITLE
Show dependency graph also for cloned/restarted jobs

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -1020,7 +1020,7 @@ function renderDependencyGraph(container, nodes, edges, cluster, currentNode) {
           tr.node().className = 'current';
         } else {
           var testNameLink = testNameTd.append('a');
-          testNameLink.attr('href', '/tests/' + node.id);
+          testNameLink.attr('href', '/tests/' + node.id + '#dependencies');
           testNameLink.text(node.label);
         }
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -889,7 +889,7 @@ sub _add_job ($dependency_data, $job, $as_child_of, $preferred_depth) {
     for my $child ($job->children->all) {
         # add chained deps only if we're still on the preferred depth to avoid dragging too many jobs into the tree
         next
-          if ($ancestors //= $job->ancestors) != $preferred_depth
+          if ($ancestors //= $job->ancestors) > $preferred_depth
           && $child->dependency != OpenQA::JobDependencies::Constants::PARALLEL;
         _add_job($dependency_data, $child->child, $job_id, $preferred_depth);
     }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -864,8 +864,7 @@ sub _add_job ($dependency_data, $job, $as_child_of, $preferred_depth) {
     if (DEPENDENCY_DEBUG_INFO) {
         ($descendants, $ancestors) = ($job->descendants, $job->ancestors);
         $name .= " (ancestors: $ancestors, descendants: $descendants, ";
-        $name .= "as child: " . ($as_child_of // 'undef');
-        $name .= ",  preferred depth: " . ($preferred_depth // 'undef') . ')';
+        $name .= "as child: $as_child_of, preferred depth: $preferred_depth)";
     }
     my %node = (
         id => $job_id,

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -7,6 +7,7 @@ BEGIN { $ENV{OPENQA_DEPENDENCY_DEBUG_INFO} = 1 }
 
 use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use Mojo::Base -signatures;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::TimeLimit '20';
@@ -14,6 +15,7 @@ use OpenQA::Test::Case;
 use OpenQA::Client;
 use OpenQA::SeleniumTest;
 use OpenQA::Schema::Result::JobDependencies;
+use OpenQA::Jobs::Constants;
 
 my $test_case = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database->generate_schema_name;
@@ -63,9 +65,12 @@ prepare_database;
 
 driver_missing unless my $driver = call_driver;
 
-sub get_tooltip {
-    my ($job_id) = @_;
-    return $driver->execute_script("return \$('#nodeTable$job_id').closest('.node').data('original-title');");
+sub get_tooltip ($job_id) {
+    $driver->execute_script("return \$('#nodeTable$job_id').closest('.node').data('original-title');");
+}
+
+sub node_name ($name, $a, $d, $as_child, $pd) {
+    "opensuse-$name (ancestors: $a, descendants: $d, as child: $as_child, preferred depth: $pd)";
 }
 
 subtest 'dependency json' => sub {
@@ -75,108 +80,71 @@ subtest 'dependency json' => sub {
     $t->ua(OpenQA::Client->new->ioloop(Mojo::IOLoop->singleton));
     $t->app($app);
 
-    $t->get_ok($baseurl . 'tests/99981/dependencies_ajax')->status_is(200)->json_is(
-        '' => {
-            cluster => {},
-            edges => [],
-            nodes => [
-                {
-                    blocked_by_id => undef,
-                    id => 99981,
-                    label => 'RAID0@32bit',
-                    result => 'skipped',
-                    state => 'cancelled',
-                    name => 'opensuse-13.1-GNOME-Live-i686-Build0091-RAID0@32bit (ancestors: 0, descendants: 0, as child: 0, preferred depth: 0)',
-                    chained => [],
-                    directly_chained => [],
-                    parallel => [],
-                }]
-        },
-        'single node for job without dependencies'
-    );
+    my (%cluster, @edges);
+    my @basic_node = (blocked_by_id => undef, chained => [], directly_chained => [], parallel => []);
+    my @nodes = (
+        {
+            @basic_node,
+            id => 99981,
+            label => 'RAID0@32bit',
+            result => SKIPPED,
+            state => CANCELLED,
+            name => node_name('13.1-GNOME-Live-i686-Build0091-RAID0@32bit', 0, 0, 0, 0),
+        });
+    my %expected = (cluster => \%cluster, edges => \@edges, nodes => \@nodes);
+    $t->get_ok($baseurl . 'tests/99981/dependencies_ajax')->status_is(200);
+    $t->json_is('' => \%expected, 'single node for job without dependencies');
     diag explain $t->tx->res->json unless $t->success;
 
-    $t->get_ok($baseurl . 'tests/99938/dependencies_ajax')->status_is(200)->json_is(
-        '' => {
-            cluster => {
-                cluster_99963 => [99963, 99961]
-            },
-            edges => [
-                {
-                    from => 99937,
-                    to => 99938,
-                },
-                {
-                    from => 99961,
-                    to => 99927,
-                },
-                {
-                    from => 99938,
-                    to => 99963,
-                }
-            ],
-            nodes => [
-                {
-                    blocked_by_id => undef,
-                    id => 99938,
-                    label => 'doc@64bit',
-                    result => 'failed',
-                    state => 'done',
-                    name => 'opensuse-Factory-DVD-x86_64-Build0048-doc@64bit (ancestors: 2, descendants: 0, as child: 0, preferred depth: 2)',
-                    chained => ['kde'],
-                    directly_chained => [],
-                    parallel => [],
-
-
-                },
-                {
-                    blocked_by_id => undef,
-                    id => 99937,
-                    label => 'kde@32bit',
-                    result => 'passed',
-                    state => 'done',
-                    name => 'opensuse-13.1-DVD-i586-Build0091-kde@32bit (ancestors: 0, descendants: 0, as child: 0, preferred depth: 2)',
-                    chained => [],
-                    directly_chained => [],
-                    parallel => [],
-                },
-                {
-                    blocked_by_id => undef,
-                    id => 99963,
-                    label => 'kde@64bit',
-                    result => 'none',
-                    state => 'running',
-                    name => 'opensuse-13.1-DVD-x86_64-Build0091-kde@64bit (ancestors: 1, descendants: 0, as child: 99938, preferred depth: 2)',
-                    chained => ['doc'],
-                    directly_chained => [],
-                    parallel => ['kde'],
-                },
-                {
-                    blocked_by_id => undef,
-                    id => 99961,
-                    label => 'kde@64bit',
-                    result => 'none',
-                    state => 'running',
-                    name => 'opensuse-13.1-NET-x86_64-Build0091-kde@64bit (ancestors: 0, descendants: 0, as child: 99938, preferred depth: 2)',
-                    chained => [],
-                    directly_chained => [],
-                    parallel => [],
-                },
-                {
-                    blocked_by_id => undef,
-                    id => 99927,
-                    label => 'RAID0@32bit',
-                    result => 'none',
-                    state => 'scheduled',
-                    name => 'opensuse-13.1-DVD-i586-Build0091-RAID0@32bit (ancestors: 0, descendants: 0, as child: 99961, preferred depth: 2)',
-                    chained => [],
-                    directly_chained => ['kde'],
-                    parallel => [],
-                }]
+    %cluster = (cluster_99963 => [99963, 99961]);
+    @edges = ({from => 99937, to => 99938}, {from => 99961, to => 99927}, {from => 99938, to => 99963});
+    @nodes = (
+        {
+            @basic_node,
+            id => 99938,
+            label => 'doc@64bit',
+            result => FAILED,
+            state => DONE,
+            name => node_name('Factory-DVD-x86_64-Build0048-doc@64bit', 2, 0, 0, 2),
+            chained => ['kde'],
         },
-        'nodes, edges and cluster computed'
-    );
-
+        {
+            @basic_node,
+            id => 99937,
+            label => 'kde@32bit',
+            result => PASSED,
+            state => DONE,
+            name => node_name('13.1-DVD-i586-Build0091-kde@32bit', 0, 0, 0, 2),
+        },
+        {
+            @basic_node,
+            id => 99963,
+            label => 'kde@64bit',
+            result => NONE,
+            state => RUNNING,
+            name => node_name('13.1-DVD-x86_64-Build0091-kde@64bit', 1, 0, 99938, 2),
+            chained => ['doc'],
+            parallel => ['kde'],
+        },
+        {
+            @basic_node,
+            id => 99961,
+            label => 'kde@64bit',
+            result => NONE,
+            state => RUNNING,
+            name => node_name('13.1-NET-x86_64-Build0091-kde@64bit', 0, 0, 99938, 2),
+        },
+        {
+            @basic_node,
+            id => 99927,
+            label => 'RAID0@32bit',
+            result => NONE,
+            state => SCHEDULED,
+            name => node_name('13.1-DVD-i586-Build0091-RAID0@32bit', 0, 0, 99961, 2),
+            directly_chained => ['kde'],
+        });
+    $t->get_ok($baseurl . 'tests/99938/dependencies_ajax')->status_is(200);
+    $t->json_is('' => \%expected, 'nodes, edges and cluster computed');
     diag explain $t->tx->res->json unless $t->success;
 };
 
@@ -224,9 +192,7 @@ subtest 'graph rendering' => sub {
         $driver->find_element_by_link_text('Dependencies')->click();
         wait_for_ajax();
         $graph = $driver->find_element_by_id('dependencygraph');
-        $check_element_quandity->(
-            '.cluster', 0, 'no cluster present (as only the latest job has dependency to cluster)'
-        );
+        $check_element_quandity->('.cluster', 0, 'no cluster present (as only the latest job depends on cluster)');
         $check_element_quandity->('.edgePath', 2, 'two edges present (direct parent and sibling)');
         $check_element_quandity->('.node', 3, 'three nodes present (direct parent and sibling)');
     };


### PR DESCRIPTION
* Do not blindly follow the clone chain to the latest job anymore
    * Display always the current job, even if it is not the latest clone
    * Avoid following the clone chain to the latest job for children if
      the child's clone is not a dependency of the parent job anymore
    * Avoid following the clone chain to the latest job for parents
* Do not display (directly) chained children of jobs when the clone depth
  does not match the one from the current job to avoid dragging too many
  jobs into the tree
* See https://progress.opensuse.org/issues/69976