### PR TITLE
Remove background color and redundant margin in needle editor

### DIFF
--- a/templates/webapi/step/edit.html.ep
+++ b/templates/webapi/step/edit.html.ep
@@ -268,7 +268,7 @@
                     % end
                 </div>
             </div>
-            <div style="margin: 0 10px; position: relative; width: 1024px; padding: 1px; border: 0px; background-color: black; margin: 10px auto">
+            <div style="margin: 10px auto; width: 1024px;">
                 <canvas tabindex="1" id="needleeditor_canvas" width="1024" height="768" style="border: 0px;">This text is displayed if your browser does not support HTML5 Canvas.</canvas>
                 % unless (is_operator) {
                     <div style="margin: 0; padding: 0; border: 0; width: 1024px; height: 768px; position: absolute; top: 0; left: 0;"></div>


### PR DESCRIPTION
Fixes: https://progress.opensuse.org/issues/105157

Before:

![image](https://user-images.githubusercontent.com/1204189/154754693-4767a039-1956-4c74-8727-50218104ca91.png)

After:

![image](https://user-images.githubusercontent.com/1204189/154754773-7aa627fc-9eb2-40fb-a492-0a4269b6bcc4.png)
