### PR TITLE
Avoid logging user-input related errors in YAML to server log

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -419,11 +419,12 @@ sub template_data_from_yaml {
                 foreach my $machine_name (@{$machine_names}) {
                     my $job_template_key
                       = $arch . $product_name . $machine_name . ($testsuite_name // '') . ($job_template_name // '');
-                    die "Job template name '"
-                      . ($job_template_name // $testsuite_name)
-                      . "' is defined more than once. "
-                      . "Use a unique name and specify 'testsuite' to re-use test suites in multiple scenarios.\n"
-                      if $job_template_names{$job_template_key};
+                    if ($job_template_names{$job_template_key}) {
+                        my $name = $job_template_name // $testsuite_name;
+                        my $error = "Job template name '$name' is defined more than once. "
+                          . "Use a unique name and specify 'testsuite' to re-use test suites in multiple scenarios.";
+                        return {error => $error};
+                    }
                     $job_template_names{$job_template_key} = {
                         prio => $prio,
                         machine_name => $machine_name,

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -434,7 +434,6 @@ sub create {
     $json->{id} = $ids[0] if scalar @ids == 1;
 
     if ($error) {
-        $self->app->log->error($error);
         $json->{error} = $error;
         $status = 400;
     }
@@ -499,10 +498,7 @@ sub destroy {
         $error = 'Not found';
     }
 
-    if ($error) {
-        $self->app->log->error($error);
-        $json->{error} = $error;
-    }
+    $json->{error} = $error if $error;
     $self->respond_to(
         json => {json => $json, status => $status},
         html => sub {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -400,10 +400,7 @@ sub create {
                     test_suite_id => $validation->param('test_suite_id'),
                 });
             push @ids, $_->id for $job_templates->all;
-            $job_templates->update(
-                {
-                    prio => $prio,
-                });
+            $job_templates->update({prio => $prio});
         };
         $error = $@;
     }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -252,7 +252,6 @@ sub update {
     catch {
         # The first line of the backtrace gives us the error message we want
         $error = (split /\n/, $_)[0];
-        log_debug("Table update error: $error");
     };
 
     if ($ret && $ret == 0) {

--- a/lib/OpenQA/WebAPI/Plugin/YAML.pm
+++ b/lib/OpenQA/WebAPI/Plugin/YAML.pm
@@ -33,7 +33,6 @@ sub register {
             my ($self, $yaml, $schema_filename, $validate_schema) = @_;
 
             my @errors;
-
             try {
                 my $schema_abspath = $self->app->home->child('public', 'schema', $schema_filename)->to_string;
                 my $errors = validate_data(
@@ -42,7 +41,6 @@ sub register {
                     validate_schema => $validate_schema,
                 );
                 push @errors, @$errors;
-
             }
             catch {
                 # The first line of the backtrace gives us the error message we want

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -18,6 +18,10 @@ use OpenQA::YAML qw(load_yaml dump_yaml);
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 
+my @logged_errors;
+my $log_mock = Test::MockModule->new('Mojo::Log');
+$log_mock->redefine(error => sub { push @logged_errors, $_[1] });
+
 my $accept_yaml = {Accept => 'text/yaml'};
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'), apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR');
 
@@ -1278,5 +1282,7 @@ $t->post_ok(
         prio => 30
     })->status_is(403);
 $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(403);
+
+is_deeply \@logged_errors, [], 'no errors logged' or diag explain \@logged_errors;
 
 done_testing();


### PR DESCRIPTION
* Distinguish between errors caused by user-input (1) and unhandled
  errors (2)
* Report only (1) to the user and log only (2) to the server log
* Treat constraint violations as user-input related as they are most likely
  caused by the input as well
* See https://progress.opensuse.org/issues/106880