### PR TITLE
openqa-clone-job: Prevent cloning jobs accidentally multiple times

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -239,6 +239,8 @@ sub clone_job ($jobid, $options, $clone_map = {}, $depth = 0, $parent_jobid = 0)
                 # don't clone parallel jobs yet if children job type
                 next if $dependencies == $parallel && $job_type eq 'children';
                 clone_job($_, $options, $clone_map, $depth + 1) for @$dependencies;
+                # abort here if the job has already been cloned as part of the preceding recursive clone_job call
+                return $clone_map->{$jobid} if defined $clone_map->{$jobid};
             }
 
             my @new_chained = map { $clone_map->{$_} } @$chained;

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -237,7 +237,7 @@ sub clone_job ($jobid, $options, $clone_map = {}, $depth = 0, $parent_jobid = 0)
             push @$child_list, @$parallel if (@$parallel && $job_type eq 'children');
             for my $dependencies ($chained, $directly_chained, $parallel) {
                 # don't clone parallel jobs yet if children job type
-                next if (@$dependencies && $dependencies == $parallel && $job_type eq 'children');
+                next if $dependencies == $parallel && $job_type eq 'children';
                 clone_job($_, $options, $clone_map, $depth + 1) for @$dependencies;
             }
 

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -274,6 +274,7 @@ subtest 'overall cloning with parallel and chained dependencies' => sub {
     is $post_args[1]->[3]->{_PARALLEL_JOBS}, '141', 'main job cloned to start parallel with parent job 141';
     is $post_args[2]->[3]->{TEST}, 'child', 'child job 43 cloned (as 143)';
     is $post_args[2]->[3]->{_START_AFTER_JOBS}, '142', 'child job cloned to start after main job 142';
+    is scalar @post_args, 3, 'exactly 3 jobs posted';
 };
 
 done_testing();


### PR DESCRIPTION
The `clone_job` function is called recursively and the recursive call might
already handle the job for which we make the recursive call. In this case
we can simply stop further processing the job to prevent cloning it twice.

This fixes https://progress.opensuse.org/issues/107311.

---

I'll still have to come up with a unit test. So far I only tested locally as
mentioned in https://progress.opensuse.org/issues/107311#note-9.