### PR TITLE
templates: Clarify which "Arch" we refer to on "Workers" page

### DIFF
--- a/templates/webapi/admin/workers/index.html.ep
+++ b/templates/webapi/admin/workers/index.html.ep
@@ -37,7 +37,7 @@
                     <th>Worker</th>
                     <th>Host</th>
                     <th>Class</th>
-                    <th>Arch</th>
+                    <th>Host Architecture</th>
                     <th>Status</th>
                     <th>Websocket Api version</th>
                     <th>os-autoinst version</th>


### PR DESCRIPTION
The table on the "Workers" admin page shows a column "Arch" which is the
detected architecture on the host running a worker instance. This "Arch"
can be misleading if a worker is used to connect to another, potential
remote architecture system under test. This commit changes the wording
to "Host Architecture" to unambiguously refer to the architecture on the
host machine, not what the backend of a specific openQA worker instance
might refer to.

Related progress issue: https://progress.opensuse.org/issues/107197