### PR TITLE
Update SUSE links for openqa.suse.de branding

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -56,7 +56,7 @@
 ## Recognized referers contains list of hostnames separated by space. When
 # openQA detects (via 'Referer' header) that test job was accessed from
 # this domain, this job is labeled as linked and considered as important
-# recognized_referers = bugzilla.suse.com bugzilla.opensuse.org bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com
+# recognized_referers = bugzilla.suse.com bugzilla.opensuse.org progress.opensuse.org github.com
 
 ## A regex in a string of test settings to ignore for "job investigation"
 #job_investigate_ignore = "(JOBTOKEN|NAME)"

--- a/t/config.t
+++ b/t/config.t
@@ -179,7 +179,7 @@ subtest 'Test configuration override from file' => sub {
     my @data = (
         "[global]\n",
         "suse_mirror=http://blah/\n",
-"recognized_referers = bugzilla.suse.com bugzilla.opensuse.org bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com\n",
+        "recognized_referers = bugzilla.suse.com bugzilla.opensuse.org progress.opensuse.org github.com\n",
         "[audit]\n",
         "blacklist = job_grab job_done\n",
         "[assets/storage_duration]\n",
@@ -200,9 +200,7 @@ subtest 'Test configuration override from file' => sub {
 
     is_deeply(
         $app->config->{global}->{recognized_referers},
-        [
-            qw(bugzilla.suse.com bugzilla.opensuse.org bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com)
-        ],
+        [qw(bugzilla.suse.com bugzilla.opensuse.org progress.opensuse.org github.com)],
         'referers parsed correctly'
     );
 
@@ -220,7 +218,7 @@ subtest 'trim whitespace characters from both ends of openqa.ini value' => sub {
         [global]
         appname =  openQA  
         hide_asset_types = repo iso  
-        recognized_referers =   bugzilla.suse.com   bugzilla.novell.com   bugzilla.microfocus.com   progress.opensuse.org github.com
+        recognized_referers =   bugzilla.suse.com   progress.opensuse.org github.com
     ';
     $t_dir->child('openqa.ini')->spurt($data);
     OpenQA::Setup::read_config($app);
@@ -228,7 +226,7 @@ subtest 'trim whitespace characters from both ends of openqa.ini value' => sub {
     ok($app->config->{global}->{hide_asset_types} eq 'repo iso', 'hide_asset_types');
     is_deeply(
         $app->config->{global}->{recognized_referers},
-        [qw(bugzilla.suse.com bugzilla.novell.com bugzilla.microfocus.com progress.opensuse.org github.com)],
+        [qw(bugzilla.suse.com progress.opensuse.org github.com)],
         'recognized_referers'
     );
 };

--- a/templates/webapi/branding/openqa.suse.de/docbox.html.ep
+++ b/templates/webapi/branding/openqa.suse.de/docbox.html.ep
@@ -3,8 +3,5 @@
 <p><a href="http://open.qa">» More information regarding openQA</a></p>
 <p><a href="https://confluence.suse.com/display/openqa/openQA">» Description of internal setup and administration</a></p>
 <p><a href="https://chat.suse.de/channel/testing">» Chat</a></p>
-<p>»
-	<a href="https://build.suse.de/project/staging_projects/SUSE:SLE-15:GA">SLE 15</a> and
-	<a href="https://build.suse.de/project/staging_projects/SUSE:SLE-12-SP3:Update:Products:CASP30">CaaSP</a> staging dashboards
-</p>
-<p><a href="https://w3.suse.de/~okurz/openqa_suse_de_status.html">» Daily openQA review</a></p>
+<p><a href="https://build.suse.de/project/staging_projects/SUSE:SLE-15:GA">» SLE 15 staging dashboards</a></p>
+<p><a href="https://openqa.io.suse.de/openqa-review/">» Daily openQA review</a></p>

--- a/templates/webapi/branding/openqa.suse.de/docbox.html.ep
+++ b/templates/webapi/branding/openqa.suse.de/docbox.html.ep
@@ -1,7 +1,1 @@
 <h2>Welcome to <%= $appname %> at SUSE</h2>
-
-<p><a href="http://open.qa">» More information regarding openQA</a></p>
-<p><a href="https://confluence.suse.com/display/openqa/openQA">» Description of internal setup and administration</a></p>
-<p><a href="https://chat.suse.de/channel/testing">» Chat</a></p>
-<p><a href="https://build.suse.de/project/staging_projects/SUSE:SLE-15:GA">» SLE 15 staging dashboards</a></p>
-<p><a href="https://openqa.io.suse.de/openqa-review/">» Daily openQA review</a></p>

--- a/templates/webapi/branding/openqa.suse.de/docbox.html.ep
+++ b/templates/webapi/branding/openqa.suse.de/docbox.html.ep
@@ -2,7 +2,7 @@
 
 <p><a href="http://open.qa">» More information regarding openQA</a></p>
 <p><a href="https://confluence.suse.com/display/openqa/openQA">» Description of internal setup and administration</a></p>
-<p><a href="irc://irc.suse.de/testing">» IRC channel</a></p>
+<p><a href="https://chat.suse.de/channel/testing">» Chat</a></p>
 <p>»
 	<a href="https://build.suse.de/project/staging_projects/SUSE:SLE-15:GA">SLE 15</a> and
 	<a href="https://build.suse.de/project/staging_projects/SUSE:SLE-12-SP3:Update:Products:CASP30">CaaSP</a> staging dashboards


### PR DESCRIPTION
* branding: Use non-personal daily openQA review links
* branding: Remove outdated reference to caasp staging
* branding: Use new SUSE internal chat reference
* Delete outdated references to novell or microfocus after SUSE split out some time ago