### PR TITLE
Use simpler SQL for has_modules

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2265,7 +2265,7 @@ sub is_child_of ($self, $job_id) {
 sub has_modules {
     my ($self) = @_;
 
-    return defined $self->modules->search(undef, {rows => 1})->first;
+    return $self->modules->count();
 }
 
 sub should_show_autoinst_log {


### PR DESCRIPTION
We only want to know if there are modules or not, so a COUNT
is sufficient (and will also not confuse postgres' query planner ;-)

Issue: https://progress.opensuse.org/issues/107701