### PR TITLE
Avoid 500 response and error in logs when `filename` param not specified

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -166,8 +166,8 @@ sub startup ($self) {
     $test_r->get('/images/thumb/#filename')->name('test_thumbnail')->to('file#test_thumbnail');
     $test_r->get('/file/#filename')->name('test_file')->to('file#test_file');
     $test_r->get('/settings/:dir/*link_path')->name('filesrc')->to('test#show_filesrc');
-    $test_r->get('/video' => sub ($c) { $c->render('test/video') })->name('video');
-    $test_r->get('/logfile' => sub ($c) { $c->render('test/logfile') })->name('logfile');
+    $test_r->get('/video' => sub ($c) { $c->render_testfile('test/video') })->name('video');
+    $test_r->get('/logfile' => sub ($c) { $c->render_testfile('test/logfile') })->name('logfile');
     # adding assetid => qr/\d+/ doesn't work here. wtf?
     $test_r->get('/asset/#assetid')->name('test_asset_id')->to('file#test_asset');
     $test_r->get('/asset/#assettype/#assetname')->name('test_asset_name')->to('file#test_asset');

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -344,6 +344,11 @@ sub register ($self, $app, $config) {
             my ($c, $value) = @_;
             return exists $c->app->config->{settings_ui_links}->{$value};
         });
+
+    $app->helper(
+        render_testfile => sub ($c, $name) {
+            $c->param('filename') ? $c->render($name) : $c->reply->not_found;
+        });
 }
 
 # returns the search args for the job overview according to the parameter of the specified controller

--- a/templates/webapi/test/logfile.html.ep
+++ b/templates/webapi/test/logfile.html.ep
@@ -1,7 +1,5 @@
-% return unless my $filename = param 'filename'; # return 404 unless filename query parameter specified
-
 % layout 'bootstrap';
-% title $filename;
+% title my $filename = param 'filename';
 
 % content_for 'head' => begin
 %= asset $_ for qw(test_result.js anser.js ansi-colors.css)

--- a/templates/webapi/test/video.html.ep
+++ b/templates/webapi/test/video.html.ep
@@ -1,5 +1,3 @@
-% return unless my $filename = param 'filename'; # return 404 unless filename query parameter specified
-
 % layout 'bootstrap';
 % title 'Video';
 % content_for 'head' => begin
@@ -7,7 +5,7 @@
 % end
 
 <figure id="video_viewer">
-    <video id="video" src="<%= url_for('test_file', testid => $testid, filename => $filename)->fragment('t=' . (param('t') // 0)) %>" controls>
+    <video id="video" src="<%= url_for('test_file', testid => $testid, filename => param 'filename')->fragment('t=' . (param('t') // 0)) %>" controls>
         <track default="" kind="subtitles" srclang="en" label="Timestamps" src="<%= url_for('test_file', testid => $testid, filename => 'video_time.vtt') %>">
     </video>
 </figure>


### PR DESCRIPTION
* This is about the routes for serving the video/logfile pages.
* Prevent log message "Could not render a response …" and 500 response
* See https://progress.opensuse.org/issues/107719