### PR TITLE
Avoid horizontal scroll bars on dashboard pages

### DIFF
--- a/templates/webapi/main/group_builds.html.ep
+++ b/templates/webapi/main/group_builds.html.ep
@@ -5,7 +5,7 @@
     % my $group_id;
     % my @tests_overview_url_data = (distri  => [sort keys %{$build_res->{distris}}], version => $version, build => $build);
     % my %progress_bar_params = (url => url_for('tests_overview'), query_params => [@tests_overview_url_data, $children ? (map { (groupid => $_->{id}) } @{$children}) : (groupid => $group->{id})]);
-    <div class="d-md-flex flex-row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
+    <div class="d-xl-flex flex-row build-row <%= $children ? ($default_expanded ? 'children-expanded' : 'children-collapsed') : 'no-children' %>">
         <div class="px-2 build-label text-nowrap">
             <span class="h4">
                 % if ($children) {
@@ -28,7 +28,7 @@
                 % }
             </span>
         </div>
-        <div class="px-2 align-self-end flex-grow-1">
+        <div class="px-2 align-self-stretch flex-grow-1">
             % if ($max_jobs) {
                 %= include 'main/build_progressbar', max_jobs => $max_jobs, result => $build_res, params => \%progress_bar_params
             % }
@@ -40,14 +40,14 @@
                 % my $child_res = $build_res->{children}->{$child->{id}};
                 % my %child_progress_bar_params = (url => url_for('tests_overview'), query_params => [(distri  => [sort keys %{$child_res->{distris}}], version => $child_res->{version}, build => $build), groupid => $child->{id}]);
                 % if ($child_res->{total}) {
-                    <div class="d-md-flex flex-row build-row">
+                    <div class="d-xl-flex flex-row build-row">
                         <div class="px-2 build-label text-nowrap">
                             <span class="h4">
                                 %= link_to $child->{name} => url_for('tests_overview')->query(distri => [sort keys %{$child_res->{distris}}], version => $child_res->{version}, build => $build, groupid => $child->{id})
                                 %= include 'main/review_badge', group_build_id => $group_build_id, build_res => $child_res, id_prefix => 'child-'
                             </span>
                         </div>
-                        <div class="px-2 align-self-end flex-grow-1">
+                        <div class="px-2 align-self-stretch flex-grow-1">
                             %= include 'main/build_progressbar', max_jobs => $child_res->{total}, params => \%child_progress_bar_params, result => $child_res
                         </div>
                     </div>

--- a/templates/webapi/main/group_builds_functionality_view.html.ep
+++ b/templates/webapi/main/group_builds_functionality_view.html.ep
@@ -20,7 +20,7 @@
       % my $group_build_id = $group->{id} . '-' . $build_res->{escaped_id};
       % my %child_progress_bar_params = (url => url_for('tests_overview'), query_params => [(distri  => [sort keys %{$child_res->{distris}}], version => $child_res->{version}, build => $build_res->{build}), groupid => $child->{id}]);
 
-        <div class="d-md-flex flex-row build-row">
+        <div class="d-xl-flex flex-row build-row">
             <div class="px-2 build-label text-nowrap">
                 <span class="h4 m-0 d-inline">
                     % my $build = $build_res->{build};
@@ -40,7 +40,7 @@
                     %= $build_res->{oldest}
                 </abbr>
             </div>
-            <div class="px-2 align-self-end flex-grow-1">
+            <div class="px-2 align-self-stretch flex-grow-1">
                 %= include 'main/build_progressbar', max_jobs => $child_res->{total}, params => \%child_progress_bar_params, result => $child_res, class => "mt-0"
             </div>
         </div>


### PR DESCRIPTION
See https://github.com/os-autoinst/openQA/issues/4311

---

Before:
![screenshot_20220302_131145](https://user-images.githubusercontent.com/10248953/156359333-32b2b80b-bd1e-4c63-ac3c-a66a85cab717.png)

After:
![screenshot_20220302_131032](https://user-images.githubusercontent.com/10248953/156359188-c5f8a966-3903-445d-9247-252af174c262.png)
1

Of course the same applies to the (parent) group overview page as well.