### PR TITLE
Re-try accepting directly chained jobs to avoid skipping whole chain

### DIFF
--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -26,7 +26,9 @@ use OpenQA::Utils qw(testcasedir productdir needledir locate_asset base_host);
 
 # define fake packages for testing asset caching
 {
-    package Test::FakeJob;    # uncoverable statement count:2
+    # uncoverable statement count:1
+    # uncoverable statement count:2
+    package Test::FakeJob;
     use Mojo::Base -base;
     has id => 42;
     has worker => undef;
@@ -34,14 +36,18 @@ use OpenQA::Utils qw(testcasedir productdir needledir locate_asset base_host);
     sub is_stopped_or_stopping { 0 }
 }
 {
-    package Test::FakeRequest;    # uncoverable statement count:2
+    # uncoverable statement count:1
+    # uncoverable statement count:2
+    package Test::FakeRequest;
     use Mojo::Base -base;
     has minion_id => 13;
 }
 
 # Fake client
 {
-    package Test::FakeClient;    # uncoverable statement count:2
+    # uncoverable statement count:1
+    # uncoverable statement count:2
+    package Test::FakeClient;
     use Mojo::Base -base;
     has worker_id => 1;
     has webui_host => 'localhost';

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -19,6 +19,7 @@ use Test::MockModule;
 use Test::MockObject;
 use Test::Output qw(combined_like combined_unlike);
 use OpenQA::Worker::Engines::isotovideo;
+use OpenQA::Test::FakeWorker;
 use Mojo::File qw(path tempdir);
 use Mojo::JSON 'decode_json';
 use OpenQA::Utils qw(testcasedir productdir needledir locate_asset base_host);
@@ -38,14 +39,7 @@ use OpenQA::Utils qw(testcasedir productdir needledir locate_asset base_host);
     has minion_id => 13;
 }
 
-# Fake worker, client
-{
-    package Test::FakeWorker;    # uncoverable statement count:2
-    use Mojo::Base -base;
-    has instance_number => 1;
-    has settings => sub { OpenQA::Worker::Settings->new(1, {}) };
-    has pool_directory => undef;
-}
+# Fake client
 {
     package Test::FakeClient;    # uncoverable statement count:2
     use Mojo::Base -base;
@@ -259,7 +253,7 @@ subtest 'syncing tests' => sub {
     my $cache_client_mock = _mock_cache_service_client \%fake_status;
     $cache_client_mock->redefine(rsync_request => Test::FakeRequest->new(result => 'exit code 10'));
 
-    my $worker = Test::FakeWorker->new;
+    my $worker = OpenQA::Test::FakeWorker->new;
     my $result = 'not called';
     my $cb = sub ($res) { $result = $res; Mojo::IOLoop->stop };
     my @args = (Test::FakeJob->new(worker => $worker), {ISO_1 => 'iso'}, 'cache-dir/webuihost', 'rsync-source', 2, $cb);
@@ -284,7 +278,7 @@ subtest 'syncing tests' => sub {
 
 subtest 'symlink testrepo' => sub {
     my $pool_directory = tempdir('poolXXXX');
-    my $worker = Test::FakeWorker->new(pool_directory => $pool_directory);
+    my $worker = OpenQA::Test::FakeWorker->new(pool_directory => $pool_directory);
     my $client = Test::FakeClient->new;
 
     subtest 'error case: CASEDIR missing' => sub {
@@ -375,7 +369,7 @@ subtest 'symlink testrepo' => sub {
 
 subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
     my $pool_directory = tempdir('poolXXXX');
-    my $worker = Test::FakeWorker->new(pool_directory => $pool_directory);
+    my $worker = OpenQA::Test::FakeWorker->new(pool_directory => $pool_directory);
     my $client = Test::FakeClient->new;
     my @settings = (DISTRI => 'fedora', JOBTOKEN => 'token000', ABSOLUTE_TEST_CONFIG_PATHS => 1);
 
@@ -409,7 +403,7 @@ subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
 
 subtest 'symlink asset' => sub {
     my $pool_directory = tempdir('poolXXXX');
-    my $worker = Test::FakeWorker->new(pool_directory => $pool_directory);
+    my $worker = OpenQA::Test::FakeWorker->new(pool_directory => $pool_directory);
     my $client = Test::FakeClient->new;
     my $settings
       = {JOBTOKEN => 'token000', ISO => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso', HDD_1 => 'foo.qcow2'};

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -85,7 +85,9 @@ sub wait_until_uploading_logs_and_assets_concluded {
 
 # Fake client and engine
 {
-    package Test::FakeClient;    # uncoverable statement count:2
+    # uncoverable statement count:1
+    # uncoverable statement count:2
+    package Test::FakeClient;
     use Mojo::Base -base;
     has worker_id => 1;
     has webui_host => 'not relevant here';
@@ -125,7 +127,9 @@ sub wait_until_uploading_logs_and_assets_concluded {
     sub evaluate_error { OpenQA::Worker::WebUIConnection::evaluate_error(@_) }
 }
 {
-    package Test::FakeEngine;    # uncoverable statement count:2
+    # uncoverable statement count:1
+    # uncoverable statement count:2
+    package Test::FakeEngine;
     use Mojo::Base -base;
     has pid => 1;
     has errored => 0;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -33,6 +33,7 @@ use OpenQA::Test::FakeWebSocketTransaction;
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::Worker::WebUIConnection;
 use OpenQA::Jobs::Constants;
+use OpenQA::Test::FakeWorker;
 use OpenQA::Test::Utils 'mock_io_loop';
 use OpenQA::UserAgent;
 
@@ -81,14 +82,7 @@ sub wait_until_uploading_logs_and_assets_concluded {
     wait_for_job($job, 'job concluded uploading logs an assets', 'uploading_logs_and_assets_concluded');
 }
 
-# Fake worker, client and engine
-{
-    package Test::FakeWorker;
-    use Mojo::Base -base;
-    has instance_number => 1;
-    has settings => sub { OpenQA::Worker::Settings->new(1, {}) };
-    has pool_directory => undef;
-}
+# Fake client and engine
 {
     package Test::FakeClient;    # uncoverable statement count:2
     use Mojo::Base -base;
@@ -139,7 +133,7 @@ sub wait_until_uploading_logs_and_assets_concluded {
 }
 
 my $isotovideo = Test::FakeEngine->new;
-my $worker = Test::FakeWorker->new;
+my $worker = OpenQA::Test::FakeWorker->new(settings => OpenQA::Worker::Settings->new(1, {}));
 my $pool_directory = tempdir('poolXXXX');
 my $testresults_dir = $pool_directory->child('testresults')->make_path;
 $testresults_dir->child('test_order.json')->spurt('[]');

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -18,6 +18,7 @@ use Test::MockModule;
 use OpenQA::App;
 use OpenQA::Test::Case;
 use OpenQA::Test::FakeWebSocketTransaction;
+use OpenQA::Test::FakeWorker;
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::Worker::WebUIConnection;
 use OpenQA::Worker::CommandHandler;
@@ -63,52 +64,7 @@ $client->on(
     });
 
 # assign a fake worker to the client
-{
-    package Test::FakeSettings;
-    use Mojo::Base -base;
-    has global_settings => sub { {RETRIES => 3, RETRY_DELAY => 10, RETRY_DELAY_IF_WEBUI_BUSY => 90} };
-    has webui_host_specific_settings => sub { {} };
-}
-{
-    package Test::FakeWorker;
-    use Mojo::Base -base;
-    has instance_number => 1;
-    has worker_hostname => 'test_host';
-    has current_webui_host => undef;
-    has capabilities => sub { {fake_capabilities => 1} };
-    has stop_current_job_called => 0;
-    has is_stopping => 0;
-    has current_error => undef;
-    has current_job => undef;
-    has has_pending_jobs => 0;
-    has pending_job_ids => sub { []; };
-    has current_job_ids => sub { []; };
-    has is_busy => 0;
-    has settings => sub { Test::FakeSettings->new; };
-    has enqueued_job_info => undef;
-    sub stop_current_job {
-        my ($self, $reason) = @_;
-        $self->stop_current_job_called($reason);
-    }
-    sub stop { shift->is_stopping(1); }
-    sub status { {fake_status => 1, reason => 'some error'} }
-    sub accept_job {
-        my ($self, $client, $job_info) = @_;
-        $self->current_job(OpenQA::Worker::Job->new($self, $client, $job_info));
-    }
-    sub enqueue_jobs_and_accept_first {
-        my ($self, $client, $job_info) = @_;
-        $self->enqueued_job_info($job_info);
-    }
-    sub find_current_or_pending_job {
-        my ($self, $job_id) = @_;
-        if (my $current_job = $self->current_job) {
-            return $current_job if $current_job->id eq $job_id;
-        }
-        return undef;
-    }
-}
-$client->worker(Test::FakeWorker->new);
+$client->worker(OpenQA::Test::FakeWorker->new);
 $client->working_directory('t/');
 
 is($client->status, 'new', 'client in status new');

--- a/t/lib/OpenQA/Test/FakeWorker.pm
+++ b/t/lib/OpenQA/Test/FakeWorker.pm
@@ -1,0 +1,41 @@
+package OpenQA::Test::FakeWorker;
+use Mojo::Base -base, -signatures;
+
+{
+    package Test::FakeSettings;
+    use Mojo::Base -base;
+    has global_settings => sub { {RETRIES => 3, RETRY_DELAY => 10, RETRY_DELAY_IF_WEBUI_BUSY => 90} };
+    has webui_host_specific_settings => sub { {} };
+}
+
+has pool_directory => undef;
+has instance_number => 1;
+has worker_hostname => 'test_host';
+has current_webui_host => undef;
+has capabilities => sub { {fake_capabilities => 1} };
+has stop_current_job_called => 0;
+has is_stopping => 0;
+has current_error => undef;
+has current_job => undef;
+has has_pending_jobs => 0;
+has pending_job_ids => sub { [] };
+has current_job_ids => sub { [] };
+has is_busy => 0;
+has settings => sub { Test::FakeSettings->new };
+has enqueued_job_info => undef;
+
+sub stop_current_job ($self, $reason) { $self->stop_current_job_called($reason) }
+sub stop ($self) { $self->is_stopping(1) }
+sub status ($self) { {fake_status => 1, reason => 'some error'} }
+sub accept_job ($self, $client, $job_info) {
+    $self->current_job(OpenQA::Worker::Job->new($self, $client, $job_info));
+}
+sub enqueue_jobs_and_accept_first ($self, $client, $job_info) {
+    $self->enqueued_job_info($job_info);
+}
+sub find_current_or_pending_job ($self, $job_id) {
+    return undef unless my $current_job = $self->current_job;
+    return $current_job if $current_job->id eq $job_id;
+}
+
+1;

--- a/t/lib/OpenQA/Test/FakeWorker.pm
+++ b/t/lib/OpenQA/Test/FakeWorker.pm
@@ -23,6 +23,7 @@ has current_job_ids => sub { [] };
 has is_busy => 0;
 has settings => sub { Test::FakeSettings->new };
 has enqueued_job_info => undef;
+has is_executing_single_job => 1;
 
 sub stop_current_job ($self, $reason) { $self->stop_current_job_called($reason) }
 sub stop ($self) { $self->is_stopping(1) }


### PR DESCRIPTION
The worker doesn't retry accepting a job so far. That makes actually sense
because at this point no work has been done anyways and the worker can just
wait for the scheduler to re-assign the job. However, for directly chained
jobs this is not true because the whole chain needed to be restarted in the
case of an error. So we should try a little bit harder - similarly to how
it is already done when the connection is lost during the job execution.

See https://progress.opensuse.org/issues/107746