### PR TITLE
Use correct filters in progress bar links

### DIFF
--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -89,7 +89,7 @@ subtest 'progress bar link' => sub {
     my $first_build_row = $driver->find_elements('.build-row')->[0];
     my $link = $driver->find_child_element($first_build_row, '.progress-bar-failed a');
     is($link->get_text, '1 failed', 'link text');
-    my $r = qr|.*/tests/overview\?result=failed&distri=opensuse&
+    my $r = qr|.*/tests/overview\?result=failed&result=incomplete&result=timeout_exceeded&distri=opensuse&
     version=Factory&build=87\.5011&groupid=1001&groupid=1002|x;
     like($link->get_attribute('href'), $r, 'link href');
 };


### PR DESCRIPTION
The dashboard's progress bar sections combine certain results. The link
should contain filter parameters for all those results - otherwise the
list of jobs shown in the linked overview page does not match the figure
from the progress bar.

See https://progress.opensuse.org/issues/107878