### PR TITLE
Validate `groupid` parameter properly to avoid SQL errors in logs

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -361,6 +361,7 @@ sub _compose_job_overview_search_args ($c) {
 
     my $v = $c->validation;
     $v->optional($_, 'not_empty') for JOBS_OVERVIEW_SEARCH_CRITERIA;
+    $v->optional('groupid')->num(0, undef);
     $v->optional('modules', 'comma_separated');
     $v->optional('limit', 'not_empty')->num(0, undef);
 
@@ -402,6 +403,9 @@ sub _compose_job_overview_search_args ($c) {
         my @search_terms = (@group_id_search, @group_name_search);
         @groups = $schema->resultset('JobGroups')->search(\@search_terms)->all;
     }
+    # add flash message if optional "groupid" parameter is invalid
+    $c->stash(flash_error => 'Specified "groupid" is invalid and therefore ignored.')
+      if $c->param('groupid') && !$v->is_valid('groupid');
 
     # determine build number
     if (!$search_args{build}) {

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -108,6 +108,11 @@ like(
     qr/Summary of opensuse build 0091/i,
     'specifying job group but with no build yields latest build in this group'
 );
+sub flash_msg { $t->tx->res->dom->at('#flash-messages')->all_text }
+unlike flash_msg, qr/Specified "groupid" is invalid/i, 'no msg about invalid groupid';
+
+$t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', groupid => 'a'})->status_is(200);
+like flash_msg, qr/Specified "groupid" is invalid/i, 'msg about invalid groupid';
 
 #
 # Default overview for Factory

--- a/templates/webapi/layouts/info.html.ep
+++ b/templates/webapi/layouts/info.html.ep
@@ -7,7 +7,7 @@
             </button>
         </div>
     % }
-    % if (my $msg = flash('error')) {
+    % if (my $msg = flash('error') || stash('flash_error')) {
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
             <span><%= $msg %></span>
             <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -150,7 +150,7 @@
             </form>
         </div>
     </div>
-    <div id="flash-messages"></div>
+    %= include 'layouts/info'
     % for my $distri (sort keys %$results) {
         % my $type_prefix_distri = $only_distri ? '' : "Distri: $distri / ";
         % my $version_results = $results->{$distri};


### PR DESCRIPTION
In contrast to the other test overview search parameters it must be an
integer. Otherwise we end up with an SQL error (see
https://progress.opensuse.org/issues/107926).

If the `groupid` is invalid a flash message will be shown about it on the
page. Note that this kind of user feedback is not useful for the other
parameters because we only use the validation to filter out empty values
here. So I'm only covering `groupid` here.