### PR TITLE
doc: Improve documentation about job dependencies

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1140,8 +1140,8 @@ and uncompressed as.
 
 Assets may be shared between the web-UI and the workers by having them literally use a shared
 filesystem (this used to be the only option), or by having the workers download them from the
-server when needed and cache them locally. See 'Asset Caching' in the<<Installing.asciidoc,Installing>>
-guide for more on this.
+server when needed and cache them locally. Checkout the documentation about
+<<Installing.asciidoc#asset-caching,asset caching>> for more on this.
 
 `HDD_n` assets can be 'stored' or 'published' by a job, and `UEFI_PFLASH_VARS` assets can be
 'published'. These both mean that if the job completes successfully, the resulting state of those
@@ -1160,11 +1160,11 @@ same name" without conflicting. Of course, that would seem to make it hard for o
 the 'stored' image - but for "chained" jobs, the reverse operation is done transparently. This
 all means that a 'parent' job template can specify `STORE_HDD_1=somename.qcow2` and its 'child'
 job template(s) can specify `HDD_1=somename.qcow2`, and everything will work, without multiple
-runs of the same jobs overwriting the asset. For more on "chained" jobs, see  'Job dependencies'
-in the <<WritingTests.asciidoc,Writing Tests>> guide.
+runs of the same jobs overwriting the asset. For more on "chained" jobs, see the documentation
+of <<WritingTests.asciidoc#_job_dependencies,job dependencies>>.
 
-When using this mechanism you will often also want to use the 'Variable expansion' mechanism
-described in the <<GettingStarted.asciidoc,Getting Started>> guide.
+When using this mechanism you will often also want to use the
+<<UsersGuide.asciidoc#_variable_expansion,variable expansion>> mechanism.
 
 [id="asset_cleanup"]
 === Asset cleanup ===

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -346,7 +346,8 @@ In short, writing multi-machine tests adds a few more layers of complexity:
 3. actual technical realization (i.e. <<Networking.asciidoc#networking,custom networking>>)
 
 ==== Job dependencies
-There are three dependency *types*: `CHAINED`, `DIRECTLY_CHAINED` and `PARALLEL`
+There are different dependency *types*, most importantly _chained_ and
+_parallel_ dependencies.
 
 A dependency is always between two jobs where one of the jobs is the _parent_
 and one the _child_. The concept of parent and child jobs is *orthogonal* to
@@ -378,42 +379,43 @@ explained in the
 section. The variables mentioned in the subsequent sections do *not* apply.
 
 ====== Chained dependencies
-`CHAINED` and `DIRECTLY_CHAINED` dependencies declare that one test must only
+_Chained_ dependencies declare that one test must only
 run after another test has concluded. For instance, extra tests relying on a
 successfully finished installation should declare a chained dependency on the
 installation test.
 
-Tests that are waiting for their `CHAINED` parents to finish are shown as
-"blocked" in the web UI. Tests that are waiting for their `DIRECTLY_CHAINED`
+There are also _directly-chained_ dependencies. They are similar to _chained_
+dependencies but are strictly a distinct type. The difference between _chained_
+and _directly-chained_ dependencies is that directly-chained means the tests
+must run directly after another on the same worker slot. This can be useful to
+test efficiently on bare metal SUTs and other self-provisioning environments.
+
+Tests that are waiting for their _chained_ parents to finish are shown as
+"blocked" in the web UI. Tests that are waiting for their _directly-chained_
 parents to finish are shown as "assigned" in the web UI.
 
-The difference between `CHAINED` and `DIRECTLY_CHAINED` dependencies is that
-`DIRECTLY_CHAINED` means the tests must run directly after another on the same
-worker slot. This can be useful to test efficiently on bare metal SUTs and other
-self-provisioning environments.
-
-To declare a `CHAINED` dependency add the variable `START_AFTER_TEST` with the
+To declare a _chained_ dependency add the variable `START_AFTER_TEST` with the
 name(s) of test suite(s) after which the selected test suite is supposed to run.
 Use a comma-separated list for multiple test suite dependencies, e.g.
 `START_AFTER_TEST="kde,dhcp-server"`.
 
-To declare a `DIRECTLY_CHAINED` dependency add the variable
-`START_DIRECTLY_AFTER_TEST`. It works in the same way as for `CHAINED`
+To declare a _directly-chained_ dependency add the variable
+`START_DIRECTLY_AFTER_TEST`. It works in the same way as for _chained_
 dependencies. Mismatching worker classes between jobs to run in direct sequence
 on the same worker are considered an error.
 
-NOTE: The set of all jobs that have direct or indirect `DIRECTLY_CHAINED`
-dependencies between each other is sometimes called a _directly chained
+NOTE: The set of all jobs that have direct or indirect _directly-chained_
+dependencies between each other is sometimes called a _directly-chained
 cluster_. All jobs within the cluster will be assigned to a single worker-slot
 at the same time by the scheduler.
 
 ====== Parallel dependencies
-`PARALLEL` dependencies declare that tests must be scheduled to run at the same
+_Parallel_ dependencies declare that tests must be scheduled to run at the same
 time. An example are "multi-machine tests" which usually test some kind of
 server and multiple clients. In this example the client tests should declare a
 parallel dependency on the server tests.
 
-To declare a `PARALLEL` dependency, use the `PARALLEL_WITH` variable with the
+To declare a _parallel_ dependency, use the `PARALLEL_WITH` variable with the
 name(s) of test suite(s) that need other test suite(s) to run at the same time.
 In other words, `PARALLEL_WITH` declares "I need this test suite to be running
 during my run". Use a comma separated list for multiple test suite dependencies
@@ -422,7 +424,7 @@ during my run". Use a comma separated list for multiple test suite dependencies
 Keep in mind that the parent job _must be running until all children finish_.
 Otherwise the scheduler will cancel child jobs once parent is done.
 
-NOTE: The set of all jobs that have direct or indirect `PARALLEL` dependencies
+NOTE: The set of all jobs that have direct or indirect _parallel_ dependencies
 between each other is sometimes called a _parallel cluster_. The scheduler can
 only assign these jobs if there is a sufficient number of free worker-slots. To
 avoid a parallel cluster from starvation its priority is increased gradually and

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -346,34 +346,87 @@ In short, writing multi-machine tests adds a few more layers of complexity:
 3. actual technical realization (i.e. <<Networking.asciidoc#networking,custom networking>>)
 
 ==== Job dependencies
-There are different dependency *types* (see subsequent section). Additionally, dependencies can be machine-specific (see "Inter-machine dependencies" section).
+There are three dependency *types*: `CHAINED`, `DIRECTLY_CHAINED` and `PARALLEL`
 
-===== Dependency types
-There are 3 types of dependencies: `CHAINED`, `DIRECTLY_CHAINED` and `PARALLEL`
+A dependency is always between two jobs where one of the jobs is the _parent_
+and one the _child_. The concept of parent and child jobs is *orthogonal* to
+the concept of types.
+
+A job can have multiple dependencies. So in conclusion, a job can have multiple
+children and multiple parents at the same time and each child/parent-relation
+can be of an arbitrary type.
+
+Additionally, dependencies can be machine-specific (see
+<<WritingTests.asciidoc#_inter_machine_dependencies,Inter-machine dependencies>>
+section).
+
+===== Declaring dependencies
+Dependencies are declared by adding a job setting on the child job specifying
+its parents. There is one variable for each dependency type.
+
+When starting jobs
+<<UsersGuide.asciidoc#_spawning_multiple_jobs_based_on_templates_isos_post,based on templates>>
+the relevant settings are `START_AFTER_TEST`, `START_DIRECTLY_AFTER_TEST` and
+`PARALLEL_WITH`. Details are explained for the different dependency types
+specifically in the subsequent sections. Generally, if declaring a dependency
+does not work as expected, be sure to check the "scheduled product" for the jobs
+(which is linked on the info box of the details page of any created job).
+
+When starting a single set of new jobs, the dependencies must be declared as
+explained in the
+<<UsersGuide.asciidoc#_further_examples_for_advanced_dependency_handling,Further examples for advanced dependency handling>>
+section. The variables mentioned in the subsequent sections do *not* apply.
 
 ====== Chained dependencies
-`CHAINED` and `DIRECTLY_CHAINED` describe when one test case depends on another and both are run sequentially, i.e. KDE test suite is run after and only after Installation test suite is successfully finished and cancelled if fail.
+`CHAINED` and `DIRECTLY_CHAINED` dependencies declare that one test must only
+run after another test has concluded. For instance, extra tests relying on a
+successfully finished installation should declare a chained dependency on the
+installation test.
 
-The difference between `CHAINED` and `DIRECTLY_CHAINED` dependencies is that `DIRECTLY_CHAINED` means the tests must run directly after another on the same worker slot.
-This can be useful to test efficiently on bare metal SUTs and other self-provisioning environments.
+Tests that are waiting for their `CHAINED` parents to finish are shown as
+"blocked" in the web UI. Tests that are waiting for their `DIRECTLY_CHAINED`
+parents to finish are shown as "assigned" in the web UI.
 
-To define a `CHAINED` dependency add the variable `START_AFTER_TEST` with the name(s) of test suite(s) after which the selected test suite is supposed to run.
-Use comma separated list for multiple test suite dependency. E.g. `START_AFTER_TEST="kde,dhcp-server"`
+The difference between `CHAINED` and `DIRECTLY_CHAINED` dependencies is that
+`DIRECTLY_CHAINED` means the tests must run directly after another on the same
+worker slot. This can be useful to test efficiently on bare metal SUTs and other
+self-provisioning environments.
 
-To define a `DIRECTLY_CHAINED` dependency add the variable `START_DIRECTLY_AFTER_TEST`. It works in the same way as for `CHAINED` dependencies. Mismatching worker classes between jobs to run in direct sequence on the same worker are considered an error.
+To declare a `CHAINED` dependency add the variable `START_AFTER_TEST` with the
+name(s) of test suite(s) after which the selected test suite is supposed to run.
+Use a comma-separated list for multiple test suite dependencies, e.g.
+`START_AFTER_TEST="kde,dhcp-server"`.
+
+To declare a `DIRECTLY_CHAINED` dependency add the variable
+`START_DIRECTLY_AFTER_TEST`. It works in the same way as for `CHAINED`
+dependencies. Mismatching worker classes between jobs to run in direct sequence
+on the same worker are considered an error.
+
+NOTE: The set of all jobs that have direct or indirect `DIRECTLY_CHAINED`
+dependencies between each other is sometimes called a _directly chained
+cluster_. All jobs within the cluster will be assigned to a single worker-slot
+at the same time by the scheduler.
 
 ====== Parallel dependencies
-`PARALLEL` describes multi-machine tests. That are test suites scheduled to run at the same time and managed as a group. On top of that, `PARALLEL` also describes
-test suite dependencies, where some test suites (children) run parallel with other test suites (parents) only when parents are running.
+`PARALLEL` dependencies declare that tests must be scheduled to run at the same
+time. An example are "multi-machine tests" which usually test some kind of
+server and multiple clients. In this example the client tests should declare a
+parallel dependency on the server tests.
 
-To define a `PARALLEL` dependency, use the `PARALLEL_WITH` variable with the name(s) of test suite(s) which acts as a parent suite(s) to selected test suite.
-In other words, `PARALLEL_WITH` describes "I need this test suite to be running during my run". Use a comma separated list for multiple test suite dependency
+To declare a `PARALLEL` dependency, use the `PARALLEL_WITH` variable with the
+name(s) of test suite(s) that need other test suite(s) to run at the same time.
+In other words, `PARALLEL_WITH` declares "I need this test suite to be running
+during my run". Use a comma separated list for multiple test suite dependencies
 (e.g. `PARALLEL_WITH="web-server,dhcp-server"`).
-Keep in mind that the parent job _must be running until all children finish_. Otherwise the scheduler will cancel child jobs once parent is done.
 
-Job dependencies are only resolved when using the iso controller to
-create new jobs from job templates. Posting individual jobs manually
-won't work.
+Keep in mind that the parent job _must be running until all children finish_.
+Otherwise the scheduler will cancel child jobs once parent is done.
+
+NOTE: The set of all jobs that have direct or indirect `PARALLEL` dependencies
+between each other is sometimes called a _parallel cluster_. The scheduler can
+only assign these jobs if there is a sufficient number of free worker-slots. To
+avoid a parallel cluster from starvation its priority is increased gradually and
+eventually workers can be held back for the cluster.
 
 ===== Inter-machine dependencies
 Those dependencies make it possible to create job dependencies between tests which are supposed to run on different machines.


### PR DESCRIPTION
* Simplify the wording while trying to be more accurate at the same time
* Add reference to examples for creating a single set of jobs
* Make a clear distinction between the concept of dependency types and the
  concept of parents/children
* Wrap paragraphs consistently
* Explain the term "cluster" as it is also often used as there are certain
  consequences applying to a "cluster"
* Mention that errors can be checked in the "scheduled product"
* See https://progress.opensuse.org/issues/103962