### PR TITLE
Let `openqa-clone-custom-git-refspec` handle dependencies better

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1363,10 +1363,17 @@ script can be used. Within the openQA repository the script is located at
 `/usr/share/openqa/script/`.  This tool can be used to create a new job that
 adds, removes or changes settings.
 
+This example adds or overrides `FOO` to be `bar`, removes `BAZ` and appends
+`:PR-123` to `TEST`:
+
 [source,sh]
 --------------------------------------------------------------------------------
-openqa-clone-job --from localhost --host localhost 42 FOO=bar BAZ=
+openqa-clone-job --from localhost --host localhost 42 FOO=bar BAZ= TEST+=:PR-123
 --------------------------------------------------------------------------------
+
+NOTE: When cloning children via `--clone-children` as well, the children are also
+affected. Parent jobs (which are cloned as well by default) are _not_ affected
+unless the `--parental-inheritance` flag is used.
 
 If you do not want a cloned job to start up in the same job group as the job
 you cloned from, e.g. to not pollute build results, the job group can be

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -37,7 +37,7 @@ sub clone_job_apply_settings ($argv, $depth, $settings, $options) {
 
     for my $arg (@$argv) {
         # split arg into key and value
-        unless ($arg =~ /([A-Z0-9_]+)=(.*)/) {
+        unless ($arg =~ /([A-Z0-9_]+\+?)=(.*)/) {
             warn "arg '$arg' does not match";
             next;
         }
@@ -49,6 +49,12 @@ sub clone_job_apply_settings ($argv, $depth, $settings, $options) {
         if (!defined $value || $value eq '') {
             delete $settings->{$key};
             next;
+        }
+
+        # allow appending via `+=`
+        if (substr($key, -1) eq '+') {
+            $key = substr $key, 0, -1;
+            $value = ($settings->{$key} // '') . $value;
         }
 
         # assign value to key, delete overrides

--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-clone_args="${clone_args:-"--skip-chained-deps --within-instance"}"
+clone_args="${clone_args:-"--skip-chained-deps --parental-inheritance --within-instance"}"
 
 usage() {
     cat << EOF
@@ -130,14 +130,14 @@ Please try 'curl $json_url' or select another job, e.g. in the same scenario: $h
         needles_dir="${needles_dir:-"$old_productdir/needles"}"
     fi
     local repo_branch="${repo_branch:-"$repo_name#$branch"}"
-    local test="${test:-"$testsuite@$repo_branch"}"
+    local test_suffix="${test_suffix:-"@$repo_branch"}"
     local build="${build:-"$repo_name#$pr"}"
     local casedir="${casedir:-"$repo#$branch"}"
     local GROUP="${GROUP:-0}"
     local dry_run="${dry_run:-""}"
     local scriptdir
     scriptdir=$(dirname "${BASH_SOURCE[0]}")
-    local cmd="$dry_run $scriptdir/openqa-clone-job $clone_args \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST=\"$test\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\""
+    local cmd="$dry_run $scriptdir/openqa-clone-job $clone_args \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST+=\"$test_suffix\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\""
     [[ ${#args[@]} -ne 0 ]] && cmd=$cmd"$(printf " '%s'" "${args[@]}")"
     if [[ -n "$MARKDOWN" ]]; then
         eval "$cmd" | sed 's/^Created job.*: \([^ ]*\) -> \(.*\)$/* [\1](\2)/'

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -42,7 +42,7 @@ settings can be modified.
   openqa-clone-job --skip-download --from https://openqa.opensuse.org --host openqa.example.com 42
 
   # clones job 42 (and any existing parents) within the local openQA instance modifying some job settings
-  openqa-clone-job --within-instance 42 MAKETESTSNAPSHOTS=1 FOOBAR=
+  openqa-clone-job --within-instance 42 MAKETESTSNAPSHOTS=1 TEST+=:PR-123 FOOBAR=
 
   # clones job 42 including all of its direct children but excluding its chained parents
   openqa-clone-job --skip-chained-deps --clone-children https://openqa.opensuse.org/tests/42

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -36,28 +36,29 @@ isnt run_once($args), 0, 'without network we fail (without error)';
 $ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my/branch"}, "body": "Lorem ipsum"}'; true};
 $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/my/case/dir", "PRODUCTDIR": "/my/case/dir/product", "NEEDLES_DIR": "/my/case/dir/product/needles"}'; true};
-my $clone_job = 'openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org ';
+my $clone_job
+  = 'openqa-clone-job --skip-chained-deps --parental-inheritance --within-instance https://openqa.opensuse.org ';
 my $dirs
   = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles';
-my $expected = $clone_job . '1234 _GROUP=0 TEST=my_test@user/repo#my/branch BUILD=user/repo#9128 ' . $dirs;
+my $expected = $clone_job . '1234 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9128 ' . $dirs;
 my $expected_re = qr/${expected}/;
 test_once $args, $expected_re, 'clone-job command line is correct';
 test_once "-v $args", qr/\+ local dry_run/, 'clone-job with -v prints commands';
 test_once "-n -v $args", qr/\+ local dry_run/, 'clone-job with -n -v prints commands';
 my $args_branch = 'https://github.com/user/repo/tree/my/branch https://openqa.opensuse.org/tests/1234 FOO=bar';
 my $expected_branch_re
-  = qr{${clone_job}1234 _GROUP=0 TEST=my_test\@user/repo#my/branch BUILD=user/repo#my/branch ${dirs} FOO=bar};
+  = qr{${clone_job}1234 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#my/branch ${dirs} FOO=bar};
 test_once $args_branch, $expected_branch_re, 'alternative mode with branch reference also yields right variables';
 my $prefix = 'env repo_name=user/repo pr=9128 host=https://openqa.opensuse.org job=1234';
 combined_like { $ret = run_once('', $prefix) } $expected_re, 'environment variables can be used instead';
 is $ret, 0, 'exits successfully';
 $prefix .= ' testsuite=new_test needles_dir=/my/needles productdir=my/product';
 $dirs = 'PRODUCTDIR=my/product NEEDLES_DIR=/my/needles';
-my $expected_custom_re = qr{https://openqa.opensuse.org 1234 _GROUP=0 TEST=new_test\@user/repo#my/branch.*${dirs}};
+my $expected_custom_re = qr{https://openqa.opensuse.org 1234 _GROUP=0 .*${dirs}};
 combined_like { $ret = run_once('', $prefix) } $expected_custom_re, 'testsuite and dirs can be overridden';
 is $ret, 0, 'exits successfully';
 my $args_trailing = 'https://github.com/me/repo/pull/1/ https://openqa.opensuse.org/tests/1';
-test_once $args_trailing, qr{TEST=my_test\@user/repo#my/branch.*}, 'trailing slash ignored';
+test_once $args_trailing, qr{BUILD=user/repo#1.*}, 'trailing slash ignored';
 my $args_list = $args . ',https://openqa.opensuse.org/tests/1234';
 $expected_re = qr/${expected}.*opensuse.org 1234/s;
 test_once $args_list, $expected_re, 'accepts comma-separated list of jobs';
@@ -65,7 +66,7 @@ $args_list .= ' FOO=bar';
 $expected_re = qr/${expected} FOO=bar.*opensuse.org 1234.*FOO=bar/s;
 test_once $args_list, $expected_re, 'additional arguments are passed as test parameters for each job';
 my $args_clone = '--clone-job-args="--show-progress" ' . $args;
-$expected_re = qr/openqa-clone-job --show-progress --skip-chained-deps --within-instance https/;
+$expected_re = qr/openqa-clone-job --show-progress --skip-chained-deps --parental-inheritance --within-instance https/;
 test_once $args_clone, $expected_re, 'additional parameters can be passed to clone-job';
 
 my $args_escape
@@ -86,7 +87,7 @@ TODO: {
 my $test_url = 'https://openqa.opensuse.org/tests/1107158';
 $ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my_branch"}, "body": "\@openqa: Clone ${test_url}"}'; true};
 $args = 'https://github.com/user/repo/pull/9128';
-$expected = $clone_job . '1107158 _GROUP=0 TEST=my_test@user/repo#my_branch BUILD=user/repo#9128 ';
+$expected = $clone_job . '1107158 _GROUP=0 TEST\+=\@user/repo#my_branch BUILD=user/repo#9128 ';
 $expected_re = qr/${expected}/s;
 test_once $args, $expected_re, 'clone-job command with test from PR description';
 
@@ -97,7 +98,7 @@ $test_url = 'https://openqa.opensuse.org/tests/1169326';
 $ENV{curl_github}
   = qq{echo -e '{"head": {"label": "user:my_branch"}, "body": "https://progress.opensuse.org/issues/8888 (https://openqa.opensuse.org/tests/9999)"}'; true};
 $args = 'https://github.com/user/repo/pull/9539 https://openqa.opensuse.org/tests/1169326';
-$expected = $clone_job . '1169326 _GROUP=0 TEST=my_test@user/repo#my_branch BUILD=user/repo#9539 ';
+$expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my_branch BUILD=user/repo#9539 ';
 $expected_re = qr/${expected}/s;
 test_once $args, $expected_re, 'clone-job command with multiple URLs in PR and job URL';
 
@@ -106,7 +107,7 @@ $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/var/lib/openqa/pool/25/os-autoinst-distri-opensuse", "PRODUCTDIR": "os-autoinst-distri-opensuse/products/sle", "NEEDLES_DIR": "/var/lib/openqa/pool/25/os-autoinst-distri-opensuse/products/sle/needles"}'; true};
 $dirs
   = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=/var/lib/openqa/pool/25/os-autoinst-distri-opensuse/products/sle/needles';
-$expected = $clone_job . '1169326 _GROUP=0 TEST=my_test@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
+$expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
 $expected_re = qr/${expected}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR is a relative directory";
 
@@ -114,7 +115,7 @@ $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/var/lib/openqa/cache/openqa1-opensuse/tests/opensuse", "PRODUCTDIR": "/var/lib/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse"}'; true};
 $dirs
   = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse NEEDLES_DIR=/var/lib/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse/needles';
-$expected = $clone_job . '1169326 _GROUP=0 TEST=my_test@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
+$expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
 $expected_re = qr/${expected}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR includes specific word";
 


### PR DESCRIPTION
* Specify the `openqa-clone-job` parameter `--parental-inheritance` so the
  modified variables end up in all jobs which are possibly cloned
    * We specify `--skip-chained-deps` but for parallel dependencies
      parents are cloned as well so it makes a difference here.
* Do *not* override the `TEST` variable. Otherwise all cloned jobs will
  have the same `TEST` value which is very confusing, e.g. only one of the
  jobs will be shown within the test result overview. Instead, the branch
  name is only appended.
* Based on user feedback on https://github.com/os-autoinst/openQA/pull/4537
* Related to the https://progress.opensuse.org/issues/103971 epic
* Tested locally by modifying the script to clone to my local openQA
  instance