### PR TITLE
openqa-clone-job: Allow printing result as JSON

### DIFF
--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -180,10 +180,10 @@ sub usage ($r) {
 sub parse_options() {
     GetOptions(
         \%options, "from=s", "host=s", "dir=s",
-        "apikey:s", "apisecret:s", "verbose|v", "skip-deps",
-        "skip-chained-deps", "skip-download", "parental-inheritance", "help|h",
-        "show-progress", "within-instance|w=s", "clone-children", "max-depth:i",
-        "ignore-missing-assets",
+        "apikey:s", "apisecret:s", "verbose|v", "json-output|j",
+        "skip-deps", "skip-chained-deps", "skip-download", "parental-inheritance",
+        "help|h", "show-progress", "within-instance|w=s", "clone-children",
+        "max-depth:i", "ignore-missing-assets",
     ) or usage(1);
     usage(0) if $options{help};
     usage(1) if $options{help} || ($options{'within-instance'} && $options{from});


### PR DESCRIPTION
Printing the result of `openqa-clone-job` as JSON would likely be useful
for `openqa-investigate`'s dependency handling (see
https://progress.opensuse.org/issues/95783) but I suppose it is a good idea
in general to provide a machine-readable output format.