### PR TITLE
Improve eval_param_grouping in OpenQA::WebAPI::Controller::API::V1::Job

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -264,13 +264,13 @@ returning "{jobA => {bar => 2}, jobB => {baz => 3}}".
 =cut
 
 sub _eval_param_grouping ($params) {
+    my @keys = keys %$params;
+    my @coloned_params = grep /:/, @keys;
     my %grouped_params;
-    for my $param_key (keys %$params) {
-        my $job_suffix_start = rindex($param_key, ':');
-        next unless $job_suffix_start >= 0;
-        my $job_suffix = substr $param_key, $job_suffix_start + 1;
-        my $setting_key = substr $param_key, 0, $job_suffix_start;
-        $grouped_params{$job_suffix}->{$setting_key} = delete $params->{$param_key};
+    for (@coloned_params) {
+        my $job_suffix_start = rindex $_, ':';
+        my ($job_suffix, $setting_key) = (substr($_, $job_suffix_start + 1), substr $_, 0, $job_suffix_start);
+        $grouped_params{$job_suffix}->{$setting_key} = delete $params->{$_};
     }
     return \%grouped_params;
 }


### PR DESCRIPTION
This commit tries to slightly improve the logic and also performance of the
function eval_param_grouping in OpenQA::WebAPI::Controller::API::V1::Job. This
is actually not critical or necessary at all. Originally I tried to replace the
for loop with an in-place creation of the "%grouped_params" hash using a
map-operator. I have not succeeded in that but I think my approach as at least
one step in that direction :)

Benchmarked with:

```
use strictures;
use Mojo::Base -strict, -signatures;
use Benchmark qw(:all);
use Test::More;
use Storable 'dclone';

sub _eval_param_grouping ($params) {
    my %grouped_params;
    for my $param_key (keys %$params) {
        my $job_suffix_start = rindex($param_key, ':');
        next unless $job_suffix_start >= 0;
        my $job_suffix = substr $param_key, $job_suffix_start + 1;
        my $setting_key = substr $param_key, 0, $job_suffix_start;
        $grouped_params{$job_suffix}->{$setting_key} = delete $params->{$param_key};
    }
    return \%grouped_params;
}

sub _eval_param_grouping_map($params) {
    my @keys = keys %$params;
    my @coloned_params = grep /:/, @keys;
    my %grouped_params;
    for (@coloned_params) {
        my $job_suffix_start = rindex $_, ':';
        my ($job_suffix, $setting_key) = (substr($_, $job_suffix_start + 1),substr $_, 0, $job_suffix_start);
        $grouped_params{$job_suffix}->{$setting_key} = delete $params->{$_};
    }
    return \%grouped_params;
}

my $params_orig = {foo => 1, 'bar:jobA' => 2, 'baz:jobB' => 3, 'blub:jobB' => 4};
my $params_ref = {jobA => {bar => 2}, jobB => {baz => 3, blub => 4}};

my $results = timethese($ENV{RUNS} // 1, {
        'martchus_for_loop' => sub {
            my $params = dclone $params_orig;
            is_deeply(_eval_param_grouping($params), $params_ref, 'returned hash - original implementation') or diag explain _eval_param_grouping($params);
            is_deeply($params, {foo => 1}, 'altered params - original implementation') or diag explain $params;
        },
        'okurz_map' => sub {
            my $params = dclone $params_orig;
            is_deeply(_eval_param_grouping_map($params), $params_ref, 'returned hash - map implementation') or diag explain _eval_param_grouping_map($params);
            #my %params = map { $_ => $params->{$_} } grep !/:/, keys %$params;
            #is_deeply(\%params, {foo => 1}, 'altered params - map implementation') or diag explain $params;
            is_deeply($params, {foo => 1}, 'altered params - map implementation') or diag explain $params;
        },
    });
cmpthese($results);

done_testing;
1;
```

resulting in a measurement speed improvement of 11% for a minimal
dataset:

```
 okurz_map:  3 wallclock secs ( 0.36 usr +  0.01 sys =  0.37 CPU) @ 2702.70/s (n=1000)
            (warning: too few iterations for a reliable count)
                    Rate martchus_for_loop         okurz_map
martchus_for_loop 2439/s                --              -10%
okurz_map         2703/s               11%                --
1..4000
```