### PR TITLE
Fix wrongly skipping directly chained jobs

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2015,7 +2015,7 @@ sub done ($self, %args) {
     $self->unblock;
     $self->auto_duplicate if $restart;
 
-    return $result;
+    return $new_val{result} // $self->result;
 }
 
 sub cancel ($self, $result, $reason = undef) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -861,8 +861,7 @@ sub done {
     # use $res as a result, it is recomputed result by scheduler
     $self->emit_event('openqa_job_done', {id => $job->id, result => $res, reason => $reason, newbuild => $newbuild});
 
-    # See comment in prio
-    $self->render(json => {result => \$res, reason => \$reason});
+    $self->render(json => {result => $res, reason => $reason});
 }
 
 sub _restart {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -99,9 +99,6 @@ sub new {
     $self->{_pool_directory_lock_fd} = undef;
     $self->{_shall_terminate} = 0;
     $self->{_finishing_off} = undef;
-    $self->{_pending_jobs} = [];
-    $self->{_pending_job_ids} = {};
-    $self->{_jobs_to_skip} = {};
 
     return $self;
 }
@@ -242,8 +239,9 @@ sub status {
         $status{status} = 'free';
         $self->current_error(undef);
     }
-    my $pending_job_ids = $self->{_pending_job_ids};
-    $status{pending_job_ids} = $pending_job_ids if keys %$pending_job_ids;
+    if (my $queue = $self->{_queue}) {
+        $status{pending_job_ids} = $queue->{pending_job_ids} if keys %{$queue->{pending_job_ids}};
+    }
     return \%status;
 }
 
@@ -432,88 +430,101 @@ sub _prepare_job_execution {
         $self->_clean_pool_directory unless $self->no_cleanup;
     }
 
-    delete $self->{_pending_job_ids}->{$job->id};
+    delete $self->{_queue}->{pending_job_ids}->{$job->id} if $self->{_queue};
     $self->current_job($job);
     $self->current_webui_host($job->client->webui_host);
 }
 
+sub _prepare_and_skip_job ($self, $job_to_skip, $skip_reason = undef) {
+    $self->_prepare_job_execution($job_to_skip, only_skipping => 1);
+    $job_to_skip->skip($skip_reason);
+}
+
 # makes a (sub) queue of pending OpenQA::Worker::Job objects from the specified $sub_sequence of job IDs
-sub _enqueue_job_sub_sequence {
-    my ($self, $client, $job_queue, $sub_sequence, $job_data, $job_ids) = @_;
+sub _enqueue_job_sub_sequence ($self, $client, $job_queue, $sub_sequence, $job_data) {
 
     for my $job_id_or_sub_sequence (@$sub_sequence) {
         if (ref($job_id_or_sub_sequence) eq 'ARRAY') {
-            push(@$job_queue,
-                $self->_enqueue_job_sub_sequence($client, [], $job_id_or_sub_sequence, $job_data, $job_ids));
+            push(@$job_queue, $self->_enqueue_job_sub_sequence($client, [], $job_id_or_sub_sequence, $job_data));
         }
         else {
             log_debug("Enqueuing job $job_id_or_sub_sequence");
-            $job_ids->{$job_id_or_sub_sequence} = 1;
+            $self->{_queue}->{pending_job_ids}->{$job_id_or_sub_sequence} = 1;
             push(@$job_queue, OpenQA::Worker::Job->new($self, $client, $job_data->{$job_id_or_sub_sequence}));
         }
     }
     return $job_queue;
 }
 
-# removes the first job of the specified sub queue; returns the removed job and the sub queue
-sub _get_next_job {
-    my ($job_queue) = @_;
-    return (undef, []) unless defined $job_queue && @$job_queue;
+# removes the first job of $job_queue updating $queue_info; returns the removed job
+# note: Have a look at subtest 'get next job in queue' in 24-worker-overall.t to see how this function is
+#       called and how it processes the specified $job_queue. Also see the subtests 'simple tree/chain …'
+#       in 05-scheduler-serialize-directly-chained-dependencies.t for simple examples showing what kind
+#       of array structure is passed as $job_queue for certain dependency trees.
+sub _grab_next_job ($job_queue, $queue_info, $depth = 0) {
+    # pop elements from parent chain when going up the chain
+    my $parent_chain = $queue_info->{parent_chain};
+    if (my $end_of_chain = $queue_info->{end_of_chain}) {
+        pop @$parent_chain while $end_of_chain--;
+        $queue_info->{end_of_chain} = 0;
+    }
 
+    # handle case of empty $job_queue
+    return $queue_info->{current_sub_queue} = undef unless defined $job_queue && @$job_queue;
+
+    # handle case when we've found the next job
     my $first_job_or_sub_sequence = $job_queue->[0];
-    return (shift @$job_queue, $job_queue) unless ref($first_job_or_sub_sequence) eq 'ARRAY';
+    if (ref $first_job_or_sub_sequence ne 'ARRAY') {
+        my $first_job = shift @$job_queue;
+        push @$parent_chain, $first_job if $depth == @$parent_chain;
+        $queue_info->{current_sub_queue} = $job_queue;
+        return $first_job;
+    }
 
-    my ($actually_first_job, $sub_sequence) = _get_next_job($first_job_or_sub_sequence);
-    shift @$job_queue unless @$first_job_or_sub_sequence;
-    return ($actually_first_job, $sub_sequence);
+    # handle case when we've hit another level of nesting
+    my $first_job = _grab_next_job($first_job_or_sub_sequence, $queue_info, $depth + 1);
+    unless (@$first_job_or_sub_sequence) {
+        shift @$job_queue;
+        ++$queue_info->{end_of_chain};
+    }
+    return $first_job;
 }
 
 # accepts or skips the next job in the queue of pending jobs
 # returns a truthy value if accepting/skipping the next job was started successfully
-sub _accept_or_skip_next_job_in_queue {
-    my ($self, $last_job_exit_status) = @_;
+sub _accept_or_skip_next_job_in_queue ($self) {
+    # grab the next job from the queue
+    my $queue_info = $self->{_queue};
+    return undef unless my $next_job = _grab_next_job($queue_info->{pending_jobs}, $queue_info);
 
-    # skip next job in the current sub queue if the last job was not successful
-    my $pending_jobs = $self->{_pending_jobs};
-    if (($last_job_exit_status //= '?') ne WORKER_SR_DONE) {
-        my $current_sub_queue = $self->{_current_sub_queue} // $pending_jobs;
-        if (scalar @$current_sub_queue > 0) {
-            my ($job_to_skip) = _get_next_job($pending_jobs);
-            my $job_id = $job_to_skip->id;
-            if ($last_job_exit_status eq WORKER_SR_BROKEN) {
-                my $current_error = $self->current_error;
-                log_info("Skipping job $job_id from queue because worker is broken ($current_error)");
-            }
-            else {
-                log_info("Skipping job $job_id from queue (parent failed with result $last_job_exit_status)");
-            }
-            $self->_prepare_job_execution($job_to_skip, only_skipping => 1);
-            return $job_to_skip->skip;
-
-            # note: When the job has been skipped it counts as stopped. As such _accept_or_skip_next_job_in_queue()
-            #       is called from _handle_job_status_changed() again to accept/skip the next job.
+    # skip the job if there's a general reason or if the directly chained parent failed
+    my $next_job_id = $next_job->id;
+    if ($self->{_shall_terminate} && !$self->{_finishing_off}) {
+        log_info("Skipping job $next_job_id from queue (worker is terminating)");
+        return $self->_prepare_and_skip_job($next_job, WORKER_COMMAND_QUIT);
+    }
+    if (my $skip_reason = $queue_info->{jobs_to_skip}->{$next_job_id}) {
+        log_info("Skipping job $next_job_id from queue (web UI sent command $skip_reason)");
+        return $self->_prepare_and_skip_job($next_job, $skip_reason);
+    }
+    if (my $current_error = $self->current_error) {
+        log_info("Skipping job $next_job_id from queue because worker is broken ($current_error)");
+        return $self->_prepare_and_skip_job($next_job);
+    }
+    my $parent_chain = $queue_info->{parent_chain};
+    my $last_parent = $parent_chain->[-1];
+    my $relevant_parent = $last_parent && $last_parent->id != $next_job_id ? $last_parent : $parent_chain->[-2];
+    if ($relevant_parent) {
+        if (my $parent_reason = $queue_info->{failed_jobs}->{$relevant_parent->id}) {
+            log_info("Skipping job $next_job_id from queue (parent failed with $parent_reason)");
+            return $self->_prepare_and_skip_job($next_job);
         }
     }
 
-    # accept or skip the next job
-    my $next_job;
-    ($next_job, $self->{_current_sub_queue}) = _get_next_job($pending_jobs);
-    return undef unless $next_job;
-
-    my $next_job_id = $next_job->id;
+    # accept the job otherwise
+    log_info("Accepting job $next_job_id from queue");
     $self->_prepare_job_execution($next_job);
-    if ($self->{_shall_terminate} && !$self->{_finishing_off}) {
-        log_info("Skipping job $next_job_id from queue (worker is terminating)");
-        return $next_job->skip(WORKER_COMMAND_QUIT);
-    }
-    if (my $skip_reason = $self->{_jobs_to_skip}->{$next_job_id}) {
-        log_info("Skipping job $next_job_id from queue (web UI sent command $skip_reason)");
-        return $next_job->skip($skip_reason);
-    }
-    else {
-        log_info("Accepting job $next_job_id from queue");
-        return $next_job->accept;
-    }
+    return $next_job->accept;
 }
 
 # accepts a single job from the job info received via the 'grab_job' command
@@ -521,9 +532,23 @@ sub accept_job {
     my ($self, $client, $job_info) = @_;
 
     $self->_assert_whether_job_acceptance_possible;
-    $self->{_single_job} = 1;
+    $self->{_queue} = undef;
     $self->_prepare_job_execution(OpenQA::Worker::Job->new($self, $client, $job_info));
     $self->current_job->accept;
+}
+
+# initializes a new job queue (empty by default)
+sub _init_queue ($self, $pending_jobs = []) {
+    $self->{_queue} = {
+        pending_jobs => $pending_jobs,
+        pending_job_ids => {},
+        jobs_to_skip => {},
+        failed_jobs => {},
+        parent_chain => [],
+        current_sub_queue => undef,
+        end_of_chain => 0,
+    };
+    return $pending_jobs;
 }
 
 # enqueues multiple jobs from the job info received via the 'grab_jobs' command and accepts the first one
@@ -535,13 +560,8 @@ sub enqueue_jobs_and_accept_first {
     #       if one job fails.
 
     $self->_assert_whether_job_acceptance_possible;
-    $self->{_single_job} = 0;
-    $self->{_current_sub_queue} = undef;
-    $self->{_jobs_to_skip} = {};
-    $self->{_pending_job_ids} = {};
-    $self->_enqueue_job_sub_sequence($client, $self->{_pending_jobs},
-        $job_info->{sequence}, $job_info->{data}, $self->{_pending_job_ids});
-    $self->_accept_or_skip_next_job_in_queue(WORKER_SR_DONE);
+    $self->_enqueue_job_sub_sequence($client, $self->_init_queue, $job_info->{sequence}, $job_info->{data});
+    $self->_accept_or_skip_next_job_in_queue;
 }
 
 sub _inform_webuis_before_stopping {
@@ -732,22 +752,15 @@ sub _handle_job_status_changed {
         log_debug("Stopping job $job_id from $webui_host: $job_name - reason: $reason");
     }
     elsif ($status eq 'stopped') {
-        if (my $error_message = $event_data->{error_message}) {
-            log_error($error_message);
-        }
         log_debug("Job $job_id from $webui_host finished - reason: $reason");
+        if (my $error_message = $event_data->{error_message}) { log_error($error_message) }
         $self->current_job(undef);
         $self->current_webui_host(undef);
+        $self->{_queue}->{failed_jobs}->{$job_id} = $reason if $self->{_queue} && $reason ne WORKER_SR_DONE;
 
         # handle case when the worker should not continue to run e.g. because the user stopped it or
         # a critical error occurred
-        if ($self->{_shall_terminate}) {
-            return $self->stop(WORKER_COMMAND_QUIT) unless $self->has_pending_jobs;
-
-            # ensure we actually skip the next jobs in the queue if user stops the worker with Ctrl+C right
-            # after the last job has concluded
-            $reason = 'worker terminates' if $reason eq WORKER_SR_DONE && !$self->{_finishing_off};
-        }
+        return $self->stop(WORKER_COMMAND_QUIT) if $self->{_shall_terminate} && !$self->has_pending_jobs;
 
         unless ($self->no_cleanup) {
             log_debug('Cleaning up for next job');
@@ -760,7 +773,8 @@ sub _handle_job_status_changed {
         # continue with the next job in the queue (this just returns if there are no further jobs)
         $self->current_error(my $availability_error = $self->check_availability);
         log_warning $availability_error if $availability_error;
-        if (!$self->_accept_or_skip_next_job_in_queue($availability_error ? WORKER_SR_BROKEN : $reason)) {
+
+        if (!$self->_accept_or_skip_next_job_in_queue) {
             # stop if we can not accept/skip the next job (e.g. because there's no further job) if that's configured
             $self->stop(WORKER_COMMAND_QUIT) if $self->settings->global_settings->{TERMINATE_AFTER_JOBS_DONE};
         }
@@ -820,19 +834,11 @@ sub _clean_pool_directory {
     }
 }
 
-sub is_executing_single_job ($self) { $self->{_single_job} }
+sub is_executing_single_job ($self) { !$self->{_queue} }
 
-sub has_pending_jobs {
-    my ($self) = @_;
+sub has_pending_jobs ($self) { $self->{_queue} && scalar @{$self->{_queue}->{pending_jobs}} > 0 }
 
-    return scalar @{$self->{_pending_jobs}} > 0;
-}
-
-sub pending_job_ids {
-    my ($self) = @_;
-
-    return [sort keys %{$self->{_pending_job_ids}}];
-}
+sub pending_job_ids ($self) { $self->{_queue} ? [sort keys %{$self->{_queue}->{pending_job_ids}}] : [] }
 
 sub _find_job_in_queue {
     my ($job_id, $queue) = @_;
@@ -854,7 +860,9 @@ sub find_current_or_pending_job {
     if (my $current_job = $self->current_job) {
         return $current_job if $current_job->id eq $job_id;
     }
-    return _find_job_in_queue($job_id, $self->{_pending_jobs});
+    if (my $queue = $self->{_queue}) {
+        return _find_job_in_queue($job_id, $queue->{pending_jobs});
+    }
 }
 
 sub current_job_ids {
@@ -868,18 +876,13 @@ sub current_job_ids {
     return \@current_job_ids;
 }
 
-sub is_busy {
-    my ($self) = @_;
-    return 1 if $self->current_job;
-    return 1 if $self->has_pending_jobs;
-    return 0;
-}
+sub is_busy ($self) { defined $self->current_job || $self->has_pending_jobs }
 
 # marks a job to be immediately skipped when picking it from the queue
 sub skip_job {
     my ($self, $job_id, $reason) = @_;
 
-    $self->{_jobs_to_skip}->{$job_id} = $reason;
+    if (my $queue = $self->{_queue}) { $queue->{jobs_to_skip}->{$job_id} = $reason }
 }
 
 sub handle_signal {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -756,7 +756,9 @@ sub _handle_job_status_changed {
         if (my $error_message = $event_data->{error_message}) { log_error($error_message) }
         $self->current_job(undef);
         $self->current_webui_host(undef);
-        $self->{_queue}->{failed_jobs}->{$job_id} = $reason if $self->{_queue} && $reason ne WORKER_SR_DONE;
+        if (my $queue = $self->{_queue}) {
+            $queue->{failed_jobs}->{$job_id} = $reason if $reason ne WORKER_SR_DONE || !$event_data->{ok};
+        }
 
         # handle case when the worker should not continue to run e.g. because the user stopped it or
         # a critical error occurred

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -470,14 +470,13 @@ sub _grab_next_job ($job_queue, $queue_info, $depth = 0) {
     }
 
     # handle case of empty $job_queue
-    return $queue_info->{current_sub_queue} = undef unless defined $job_queue && @$job_queue;
+    return undef unless defined $job_queue && @$job_queue;
 
     # handle case when we've found the next job
     my $first_job_or_sub_sequence = $job_queue->[0];
     if (ref $first_job_or_sub_sequence ne 'ARRAY') {
         my $first_job = shift @$job_queue;
         push @$parent_chain, $first_job if $depth == @$parent_chain;
-        $queue_info->{current_sub_queue} = $job_queue;
         return $first_job;
     }
 
@@ -545,7 +544,6 @@ sub _init_queue ($self, $pending_jobs = []) {
         jobs_to_skip => {},
         failed_jobs => {},
         parent_chain => [],
-        current_sub_queue => undef,
         end_of_chain => 0,
     };
     return $pending_jobs;

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -619,7 +619,13 @@ sub _set_job_done ($self, $reason, $params, $callback) {
 }
 
 sub _stop_step_5_finalize ($self, $reason, $params) {
-    $self->_set_job_done($reason, $params, sub { $self->_set_status(stopped => {reason => $reason}) });
+    $self->_set_job_done(
+        $reason, $params,
+        sub ($response = {}) {
+            my $result = $response->{result};
+            my $ok = defined $result && grep { $result eq $_ } OK_RESULTS;
+            $self->_set_status(stopped => {ok => $ok, reason => $reason});
+        });
 
     # note: The worker itself will react the the changed status and unassign this job object
     #       from its current_job property and will clean the pool directory.

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -313,8 +313,8 @@ subtest 'failed parallel parent causes parallel children to fails as PARALLEL_FA
     # reload changes from DB - parallel children should be cancelled by failed jobA
     $_->discard_changes for ($jobD, $jobE);
     # this should not change the result which is parallel_failed due to failed jobA
-    is($jobD->done(result => INCOMPLETE), INCOMPLETE, 'parallel child D set to incomplete');
-    is($jobE->done(result => INCOMPLETE), INCOMPLETE, 'parallel child E set to incomplete');
+    is($jobD->done(result => INCOMPLETE), PARALLEL_FAILED, 'parallel child D set to incomplete');
+    is($jobE->done(result => INCOMPLETE), PARALLEL_FAILED, 'parallel child E set to incomplete');
 
     my $job = _job_deps($jobA->id);
     is($job->{state}, DONE, 'job_set_done changed state');

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -152,8 +152,8 @@ is_deeply \@assets, [$jabasename, $theasset], 'both assets are assigned, jobasse
 # set jobA (normally this is done by worker after abort) and cloneA to done
 # needed for job grab to fulfill dependencies
 $jobA->discard_changes;
-is($jobA->done(result => 'passed'), 'passed', 'jobA job set to done');
-is($cloneA->done(result => 'passed'), 'passed', 'cloneA job set to done');
+is $jobA->done(result => PASSED), USER_RESTARTED, 'jobA job set to done (result already set and thus not changed)';
+is $cloneA->done(result => PASSED), PASSED, 'cloneA job set to done';
 
 # register asset and mark as created by cloneA
 path($japath)->spurt('foobar');

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -212,22 +212,22 @@ subtest 'accept or skip next job' => sub {
     subtest 'grab next job in queue' => sub {
         # define the job queue this test is going to process
         my @pending_jobs = (0, [1, [2, 3], [4, 5]], 6, 7, [8, 9, [10, 11]], 12);
-        # define expected results/states for each iteration step: [next job id, current sub queue, parent chain]
+        # define expected results/states for each iteration step: [next job id, parent chain]
         my @expected_iteration_steps = (
-            [0, [[1, [2, 3], [4, 5]], 6, 7, [8, 9, [10, 11]], 12], [0]],
-            [1, [[2, 3], [4, 5]], [0, 1]],
-            [2, [3], [0, 1, 2]],
-            [3, [], [0, 1, 2]],
-            [4, [5], [0, 1, 4]],
-            [5, [], [0, 1, 4]],
-            [6, [7, [8, 9, [10, 11]], 12], [0]],
-            [7, [[8, 9, [10, 11]], 12], [0]],
-            [8, [9, [10, 11]], [0, 8]],
-            [9, [[10, 11]], [0, 8]],
-            [10, [11], [0, 8, 10]],
-            [11, [], [0, 8, 10]],
-            [12, [], [0]],
-            [undef, undef, [0]],
+            [0, [0]],
+            [1, [0, 1]],
+            [2, [0, 1, 2]],
+            [3, [0, 1, 2]],
+            [4, [0, 1, 4]],
+            [5, [0, 1, 4]],
+            [6, [0]],
+            [7, [0]],
+            [8, [0, 8]],
+            [9, [0, 8]],
+            [10, [0, 8, 10]],
+            [11, [0, 8, 10]],
+            [12, [0]],
+            [undef, [0]],
         );
 
         # run `grab_next_job` on the job queue for the expected number of steps it'll take to process the queue
@@ -236,7 +236,7 @@ subtest 'accept or skip next job' => sub {
         for my $expected_step (@expected_iteration_steps) {
             note "step $step_index ($queue_info{end_of_chain}): " . Dumper(\@pending_jobs);
             my $next_job = OpenQA::Worker::_grab_next_job(\@pending_jobs, \%queue_info);
-            my @actual_step_results = ($next_job, $queue_info{current_sub_queue}, $queue_info{parent_chain});
+            my @actual_step_results = ($next_job, $queue_info{parent_chain});
             my $ok = is_deeply \@actual_step_results, $expected_step, "iteration step $step_index";
             $ok or diag explain $_ for @actual_step_results;
             $step_index += 1;

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -9,13 +9,14 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Mojo::Base -signatures;
 use OpenQA::Test::TimeLimit '10';
+use Data::Dumper;
 use Mojo::File 'tempdir';
 use Mojo::Util 'scope_guard';
 use Mojolicious;
 use Test::Fatal;
 use Test::Output qw(combined_like combined_from);
 use Test::MockModule;
-use OpenQA::Constants qw(WORKER_COMMAND_QUIT WORKER_SR_API_FAILURE WORKER_SR_DONE WORKER_SR_FINISH_OFF);
+use OpenQA::Constants qw(WORKER_COMMAND_QUIT WORKER_SR_API_FAILURE WORKER_SR_DIED WORKER_SR_DONE WORKER_SR_FINISH_OFF);
 use OpenQA::Worker;
 use OpenQA::Worker::Job;
 use OpenQA::Worker::WebUIConnection;
@@ -208,84 +209,131 @@ subtest 'status' => sub {
 };
 
 subtest 'accept or skip next job' => sub {
-    subtest 'get next job in queue' => sub {
+    subtest 'grab next job in queue' => sub {
+        # define the job queue this test is going to process
         my @pending_jobs = (0, [1, [2, 3], [4, 5]], 6, 7, [8, 9, [10, 11]], 12);
+        # define expected results/states for each iteration step: [next job id, current sub queue, parent chain]
         my @expected_iteration_steps = (
-            [0, [[1, [2, 3], [4, 5]], 6, 7, [8, 9, [10, 11]], 12]],
-            [1, [[2, 3], [4, 5]]],
-            [2, [3]],
-            [3, []],
-            [4, [5]],
-            [5, []],
-            [6, [7, [8, 9, [10, 11]], 12]],
-            [7, [[8, 9, [10, 11]], 12]],
-            [8, [9, [10, 11]]],
-            [9, [[10, 11]]],
-            [10, [11]],
-            [11, []],
-            [12, []],
-            [undef, []],
+            [0, [[1, [2, 3], [4, 5]], 6, 7, [8, 9, [10, 11]], 12], [0]],
+            [1, [[2, 3], [4, 5]], [0, 1]],
+            [2, [3], [0, 1, 2]],
+            [3, [], [0, 1, 2]],
+            [4, [5], [0, 1, 4]],
+            [5, [], [0, 1, 4]],
+            [6, [7, [8, 9, [10, 11]], 12], [0]],
+            [7, [[8, 9, [10, 11]], 12], [0]],
+            [8, [9, [10, 11]], [0, 8]],
+            [9, [[10, 11]], [0, 8]],
+            [10, [11], [0, 8, 10]],
+            [11, [], [0, 8, 10]],
+            [12, [], [0]],
+            [undef, undef, [0]],
         );
 
+        # run `grab_next_job` on the job queue for the expected number of steps it'll take to process the queue
         my $step_index = 0;
+        my %queue_info = (pending_jobs => \@pending_jobs, parent_chain => [], end_of_chain => 0);
         for my $expected_step (@expected_iteration_steps) {
-            my ($next_job, $current_sub_sequence) = OpenQA::Worker::_get_next_job(\@pending_jobs);
-            my $ok = is_deeply([$next_job, $current_sub_sequence], $expected_step, "iteration step $step_index");
-            $ok or diag explain $next_job and diag explain $current_sub_sequence;
+            note "step $step_index ($queue_info{end_of_chain}): " . Dumper(\@pending_jobs);
+            my $next_job = OpenQA::Worker::_grab_next_job(\@pending_jobs, \%queue_info);
+            my @actual_step_results = ($next_job, $queue_info{current_sub_queue}, $queue_info{parent_chain});
+            my $ok = is_deeply \@actual_step_results, $expected_step, "iteration step $step_index";
+            $ok or diag explain $_ for @actual_step_results;
             $step_index += 1;
         }
-
-        is(scalar @pending_jobs, 0, 'no pending jobs left');
+        is scalar @pending_jobs, 0, 'no pending jobs left';
     };
 
     subtest 'skip entire job queue (including sub queues) after failure' => sub {
         my $worker = OpenQA::Worker->new({instance => 1});
         my @jobs = map { Test::FakeJob->new(id => $_) } (0 .. 3);
-        $worker->{_pending_jobs} = [$jobs[0], [$jobs[1], $jobs[2]], $jobs[3]];
-        ok($worker->is_busy, 'worker considered busy without current job but pending ones');
+        $worker->_init_queue([$jobs[0], [$jobs[1], $jobs[2]], $jobs[3]]);
+        ok $worker->is_busy, 'worker considered busy without current job but pending ones';
 
         # assume the last job failed: all jobs in the queue are expected to be skipped
-        combined_like { is $worker->_accept_or_skip_next_job_in_queue(WORKER_SR_API_FAILURE), 1, 'jobs skipped' }
-        qr/Job 0.*finished.*skipped.*Job 1.*finished.*skipped.*Job 2.*finished.*skipped.*Job 3.*finished.*skipped/s,
+        combined_like { is $worker->_accept_or_skip_next_job_in_queue, 1, 'jobs accepted' }
+        qr/Accepting job 0 from queue/s, 'acceptance logged';
+        combined_like {
+            $worker->_handle_job_status_changed($jobs[0], {status => 'stopped', reason => WORKER_SR_API_FAILURE})
+        }
+        qr/Job 0 from fake finished - reason: api-failure.*Skipping job 1.*parent failed with api-failure/s,
           'skipping logged';
-        is($_->is_accepted, 0, 'job ' . $_->id . ' not accepted') for @jobs;
-        is($_->is_skipped, 1, 'job ' . $_->id . ' skipped') for @jobs;
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[0]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for ($jobs[0]);
+        is $_->is_accepted, 0, 'job ' . $_->id . ' not accepted' for ($jobs[1], $jobs[2], $jobs[3]);
+        is $_->is_skipped, 1, 'job ' . $_->id . ' skipped' for ($jobs[1], $jobs[2], $jobs[3]);
         subtest 'worker in clean state after skipping' => sub {
-            ok(!$worker->is_busy, 'worker not considered busy anymore');
-            is_deeply($worker->current_job_ids, [], 'no job IDs remaining');
-            is_deeply($worker->{_pending_jobs}, [], 'no pending jobs left');
-            is($worker->_accept_or_skip_next_job_in_queue(WORKER_SR_API_FAILURE), undef, 'no more jobs to skip/accept');
+            ok !$worker->is_busy, 'worker not considered busy anymore';
+            is_deeply $worker->current_job_ids, [], 'no job IDs remaining';
+            is_deeply $worker->{_queue}->{pending_jobs}, [], 'no pending jobs left';
+            is $worker->_accept_or_skip_next_job_in_queue, undef, 'no more jobs to skip/accept';
         };
     };
 
     subtest 'skip (only) a sub queue after a failure' => sub {
         my $worker = OpenQA::Worker->new({instance => 1});
         my @jobs = map { Test::FakeJob->new(id => $_) } (0 .. 3);
-        $worker->{_pending_jobs} = [$jobs[0], [$jobs[1], $jobs[2]], $jobs[3]];
+        $worker->_init_queue([$jobs[0], [$jobs[1], $jobs[2]], $jobs[3]]);
 
         # assume the last job has been completed: accept the next job in the queue
-        is($worker->_accept_or_skip_next_job_in_queue(WORKER_SR_DONE), 1, 'next job accepted');
-        is($_->is_accepted, 1, 'job ' . $_->id . ' accepted') for ($jobs[0]);
-        is($_->is_skipped, 0, 'job ' . $_->id . ' not skipped') for @jobs;
-        is_deeply($worker->{_pending_jobs}, [[$jobs[1], $jobs[2]], $jobs[3]], 'next jobs still pending');
+        combined_like { is $worker->_accept_or_skip_next_job_in_queue, 1, 'job 0 accepted' }
+        qr/Accepting job 0 from queue/s, 'acceptance of first job logged';
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[0]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for @jobs;
+        is_deeply $worker->{_queue}->{pending_jobs}, [[$jobs[1], $jobs[2]], $jobs[3]], 'next jobs still pending (0)';
 
         # assume the last job has been completed: accept the next job in the queue
-        is($worker->_accept_or_skip_next_job_in_queue(WORKER_SR_DONE), 1, 'next job accepted');
-        is($_->is_accepted, 1, 'job ' . $_->id . ' accepted') for ($jobs[1]);
-        is($_->is_skipped, 0, 'job ' . $_->id . ' not skipped') for @jobs;
-        is_deeply($worker->{_pending_jobs}, [[$jobs[2]], $jobs[3]], 'next jobs still pending');
+        combined_like { $worker->_handle_job_status_changed($jobs[0], {status => 'stopped', reason => WORKER_SR_DONE}) }
+        qr/Accepting job 1 from queue/s, 'acceptance of second job logged';
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[1]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for @jobs;
+        is_deeply $worker->{_queue}->{pending_jobs}, [[$jobs[2]], $jobs[3]], 'next jobs still pending (1)';
 
-        # assme the last job (job 0) failed: only the current sub queue (containing job 2) is skipped
-        combined_like {
-            is $worker->_accept_or_skip_next_job_in_queue(WORKER_SR_API_FAILURE), 1, 'jobs skipped/accepted'
-        }
-        qr/Job 2.*finished.*skipped/s, 'skipping logged';
-        is($_->is_accepted, 0, 'job ' . $_->id . ' not accepted') for ($jobs[2]);
-        is($_->is_skipped, 1, 'job ' . $_->id . ' skipped') for ($jobs[2]);
-        is($_->is_accepted, 1, 'job ' . $_->id . ' accepted') for ($jobs[3]);
-        is($_->is_skipped, 0, 'job ' . $_->id . ' not skipped') for ($jobs[3]);
+        # assme the last job failed: only the current sub queue (containing job 2) is skipped
+        combined_like { $worker->_handle_job_status_changed($jobs[1], {status => 'stopped', reason => WORKER_SR_DIED}) }
+        qr/Skipping job 2.*parent.*died.*Job 2.*finished.*skipped/s, 'skipping of third job logged';
+        is $_->is_accepted, 0, 'job ' . $_->id . ' not accepted' for ($jobs[2]);
+        is $_->is_skipped, 1, 'job ' . $_->id . ' skipped' for ($jobs[2]);
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[3]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for ($jobs[3]);
 
-        is_deeply($worker->{_pending_jobs}, [], 'no more pending jobs');
+        is_deeply $worker->{_queue}->{pending_jobs}, [], 'no more pending jobs';
+    };
+
+    subtest 'directly chained leafs not skipped after one fails' => sub {
+        my $worker = OpenQA::Worker->new({instance => 1});
+        my @jobs = map { Test::FakeJob->new(id => $_) } (0 .. 3);
+        $worker->_init_queue([$jobs[0], [$jobs[1], $jobs[2], $jobs[3]]]);
+
+        # assume the last job has been completed: accept the next job in the queue
+        combined_like { is $worker->_accept_or_skip_next_job_in_queue, 1, 'job 0 accepted' }
+        qr/Accepting job 0 from queue/s, 'acceptance of first job logged';
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[0]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for @jobs;
+        is_deeply $worker->{_queue}->{pending_jobs}, [[$jobs[1], $jobs[2], $jobs[3]]], 'next jobs still pending (0)';
+
+        # assume the last job has been completed: accept the next job in the queue
+        combined_like { $worker->_handle_job_status_changed($jobs[0], {status => 'stopped', reason => WORKER_SR_DONE}) }
+        qr/Accepting job 1 from queue/s, 'acceptance of second job logged';
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[1]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for @jobs;
+        is_deeply $worker->{_queue}->{pending_jobs}, [[$jobs[2], $jobs[3]]], 'next jobs still pending (1)';
+
+        # assme the last job failed: only the current sub queue (containing job 2) is skipped
+        combined_like { $worker->_handle_job_status_changed($jobs[1], {status => 'stopped', reason => WORKER_SR_DONE}) }
+        qr/Accepting job 2 from queue/s, 'acceptance of third job logged';
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[2]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' skipped' for ($jobs[2]);
+        is $_->is_accepted, 0, 'job ' . $_->id . ' not accepted' for ($jobs[3]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for ($jobs[3]);
+
+        # assme the last job failed: only the current sub queue (containing job 2) is skipped
+        combined_like { $worker->_handle_job_status_changed($jobs[2], {status => 'stopped', reason => WORKER_SR_DIED}) }
+        qr/Accepting job 3 from queue/s, 'acceptance of forth job logged';
+        is $_->is_accepted, 1, 'job ' . $_->id . ' accepted' for ($jobs[3]);
+        is $_->is_skipped, 0, 'job ' . $_->id . ' not skipped' for ($jobs[3]);
+
+        is_deeply $worker->{_queue}->{pending_jobs}, [], 'no more pending jobs';
     };
 
     subtest 'enqueue jobs and accept first' => sub {
@@ -327,8 +375,8 @@ subtest 'accept or skip next job' => sub {
         $worker->enqueue_jobs_and_accept_first($client, \%job_info);
         is_deeply($worker->current_job_ids, [26, 27], 'jobs accepted/enqueued');
         $worker->skip_job(27, 'skip for testing');
-        combined_like { $worker->_accept_or_skip_next_job_in_queue(WORKER_SR_DONE) }
-        qr/Skipping job 27 from queue/, 'job 27 is skipped';
+        combined_like { $worker->_accept_or_skip_next_job_in_queue } qr/Skipping job 27 from queue/,
+          'job 27 is skipped';
         is_deeply(
             $client->api_calls,
             [post => 'jobs/27/set_done', {reason => 'skip for testing', result => 'skipped', worker_id => 42}],
@@ -585,7 +633,7 @@ subtest 'handle job status changes' => sub {
             $worker->_handle_job_status_changed($fake_job,
                 {status => 'stopped', reason => 'test', error_message => 'some error message'});
         }
-        qr/some error message.*Job 42 from some-host finished - reason: test/s, 'status logged';
+        qr/Job 42 from some-host finished - reason: test.*some error message/s, 'status logged';
         is($cleanup_called, 0, 'pool directory not cleaned up');
         is($stop_called, 0, 'worker not stopped');
         is($worker->current_job, undef, 'current job unassigned');
@@ -600,13 +648,14 @@ subtest 'handle job status changes' => sub {
         $worker->current_job($fake_job);
         $worker->current_webui_host('some-host');
         $worker->settings->global_settings->{TERMINATE_AFTER_JOBS_DONE} = 1;
-        $worker->{_pending_jobs} = [$fake_job];    # assume there's another job in the queue
+        $worker->_init_queue([$fake_job]);    # assume there's another job in the queue
         combined_like {
             $worker->_handle_job_status_changed($fake_job, {status => 'stopped', reason => 'another test'});
         }
         qr/Job 42 from some-host finished - reason: another/, 'status logged';
         is($cleanup_called, 1, 'pool directory cleaned up after job finished');
         is($stop_called, 0, 'worker not stopped due to the other job added to queue');
+        ok !$worker->has_pending_jobs, 'no more jobs pending';
         combined_like {
             $worker->_handle_job_status_changed($fake_job, {status => 'stopped', reason => 'yet another test'});
         }
@@ -620,7 +669,7 @@ subtest 'handle job status changes' => sub {
             $stop_called = $inform_webuis_called = $worker->{_shall_terminate} = $fake_job->{_status} = 0;
             my $next_job = OpenQA::Worker::Job->new($worker, $fake_job->client, {id => 43});
             $worker->current_job($fake_job);
-            $worker->{_pending_jobs} = [$next_job];    # assume there's another job in the queue
+            $worker->_init_queue([$next_job]);    # assume there's another job in the queue
             combined_like { $worker->handle_signal('TERM') } qr/Received signal TERM/, 'signal logged';
             is $worker->{_shall_terminate}, 1, 'worker is supposed to terminate';
             ok !$worker->{_finishing_off}, 'worker is not supposed to finish off the current jobs';
@@ -651,7 +700,7 @@ subtest 'handle job status changes' => sub {
             $stop_called = $inform_webuis_called = $worker->{_shall_terminate} = 0;
             my $next_job = OpenQA::Worker::Job->new($worker, $fake_job->client, {id => 43});
             $worker->current_job($fake_job);
-            $worker->{_pending_jobs} = [$next_job];    # assume there's another job in the queue
+            $worker->_init_queue([$next_job]);    # assume there's another job in the queue
             combined_like { $worker->handle_signal('HUP') } qr/Received signal HUP/, 'signal logged';
             is $worker->{_shall_terminate}, 1, 'worker is supposed to terminate';
             ok !$worker->{_finishing_off},
@@ -696,9 +745,10 @@ subtest 'handle job status changes' => sub {
             $worker_mock->redefine(is_qemu_running => sub { return 17377; });
 
             # pretend we're still running the fake job and also that there's another pending job
+            my $pending_job = OpenQA::Worker::Job->new($worker, $fake_client, {id => 769, some => 'info'});
             $worker->current_job($fake_job);
-            $worker->{_pending_jobs} = $worker->{_current_sub_queue}
-              = [my $pending_job = OpenQA::Worker::Job->new($worker, $fake_client, {id => 769, some => 'info'})];
+            $worker->_init_queue([$pending_job]);
+            $worker->{_shall_terminate} = 0;
 
             is($worker->current_error, undef, 'no error assumed so far');
 


### PR DESCRIPTION
* Consider the result of the relevant directly chained parent job when
  deciding whether to skip the next job (instead of just considering the
  result of the last job that has been executed)
    * Rework queuing logic accordingly
    * In particular, keep track of the currently relevant parent when
      grabbing the next job from the queue
* See https://progress.opensuse.org/issues/108476

---

~~Still a draft because there's another problem to solve: The worker
doesn't really know whether a test has failed or not at this point (except
when the backend process exists with a non-zero exit code or some
other worker-related error happened). Hence the the logic for skipping
directly chained jobs is still flawed.~~

This is solved now by simply taking the web UI's response into account
when setting a job to done.

See the particular commit messages for detail.