### PR TITLE
systemd: Remove undesired Wants=network.target (boo#1196359)

### DIFF
--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The openQA WebSockets server
-Wants=apache2.service network.target openqa-setup-db.service
+Wants=apache2.service openqa-setup-db.service
 Before=apache2.service openqa-webui.service
 After=openqa-scheduler.service postgresql.service openqa-setup-db.service network.target nss-lookup.target remote-fs.target
 

--- a/systemd/openqa-worker-cacheservice.service
+++ b/systemd/openqa-worker-cacheservice.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OpenQA Worker Cache Service
 After=network.target nss-lookup.target remote-fs.target
-Wants=network.target nss-lookup.target remote-fs.target
+Wants=nss-lookup.target remote-fs.target
 PartOf=openqa-worker.target
 
 [Service]

--- a/systemd/openqa-worker@.service
+++ b/systemd/openqa-worker@.service
@@ -4,7 +4,6 @@
 # replace '1' with the instance number you want
 [Unit]
 Description=openQA Worker #%i
-Wants=network.target
 After=openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
 PartOf=openqa-worker.target
 


### PR DESCRIPTION
One should never "Want" the network target as it is meant primarily for
ordering. Also see
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

Our systemd services already handle all cases properly at least on the
systemd level by restarting on failure which can happen here e.g. if the
network stack is not properly initialized yet on system start. This
shows up as errors in the service's journal but in the end is properly
handled with a ready and responsive service.

Related progress issue: https://progress.opensuse.org/issues/108091
Related https://bugzilla.suse.com/show_bug.cgi?id=1196359