### PR TITLE
Update to Bootstrap v4.6.1 for real

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -24,6 +24,7 @@ td div.progress {
         // don' use flex box because it leads to undesired overflow behavior
         display: inline;
         overflow: hidden;
+        padding-top: 10px;
         a {
             display: block;
             width: 100%;

--- a/assets/stylesheets/openqa.scss
+++ b/assets/stylesheets/openqa.scss
@@ -7,7 +7,7 @@
 @import url($web-font-path);
 
 // include Bootstrap 4
-@import "../cache/raw.githubusercontent.com/twbs/bootstrap/v4.1.1/scss/bootstrap.scss";
+@import "../cache/raw.githubusercontent.com/twbs/bootstrap/v4.6.1/scss/bootstrap.scss";
 
 // include custom css for various aspects of the pages
 @import "overall.scss";


### PR DESCRIPTION
The previous PR (https://github.com/os-autoinst/openQA/pull/4323) missed one occurrence where we still referenced the old version.