### PR TITLE
WIP: Fix VLAN assignment on MM jobs created via "jobs post"

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1559,7 +1559,10 @@ sub _asset_find ($name, $type, $parents) {
 
 sub allocate_network ($self, $name) {
     my $vlan = $self->_find_network($name);
-    return $vlan if $vlan;
+    if ($vlan) {
+        $self->networks->find_or_create({name => $name, vlan => $vlan});
+        return $vlan;
+    }
     #allocate new
     my @used_rs = $self->result_source->schema->resultset('JobNetworks')->search(
         {},


### PR DESCRIPTION
Ticket: poo#109190

If a job was created using "jobs post" and `_PARALLEL_JOBS`, then
the method `Jobs::find_networks()` can retrieves the VLAN from
parent or child, but the current job do not have a entry in
`job_networks` db table.