### PR TITLE
Fix race condition during asset registration

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -29,10 +29,10 @@ sub register ($self, $type, $name, $options = {}) {
         return undef;
     }
     my $schema = $self->result_source->schema;
-    my $sth = $schema->storage->dbh->prepare_cached(<<~'END_SQL');
+    my $sth = $schema->storage->dbh->prepare_cached(<<'END_SQL');
         INSERT INTO assets (type, name, t_created, t_updated)
                     VALUES (?,    ?,    now(),     now()    ) ON CONFLICT DO NOTHING
-        END_SQL
+END_SQL
     $schema->txn_do(
         sub {
             $sth->execute($type, $name);    # ensure asset exists


### PR DESCRIPTION
* Avoid using DBIx's `find_or_create` function which is not atomic¹ and
  therefore not race-free which can lead to errors like:
  ```
  duplicate key value violates unique constraint \"assets_type_name\"\nDETAIL:  Key (type, name)=(iso, foo.iso) already exists.
  ```
* Use `INSERT INTO … ON CONFLICT DO NOTHING` instead (which unfortunately
  requires the use of raw SQL)
* See https://progress.opensuse.org/issues/109292 although this is not a
  new issue; the oldest scheduled product I found in production was from 3
  years ago

---

¹ https://metacpan.org/dist/DBIx-Class/view/lib/DBIx/Class/ResultSet.pm#find_or_create