### PR TITLE
Allow adding scheduling settings for informal purposes via `__`-prefix

### DIFF
--- a/assets/javascripts/audit_log.js
+++ b/assets/javascripts/audit_log.js
@@ -142,7 +142,11 @@ function showScheduledProductModalDialog(title, body) {
 function renderScheduledProductSettings(settings) {
   const table = $('<table/>').addClass('table table-striped');
   for (const [key, value] of Object.entries(settings || {})) {
-    table.append($('<tr/>').append($('<td/>').text(key)).append($('<td/>').text(value)));
+    table.append(
+      $('<tr/>')
+        .append($('<td/>').text(key))
+        .append($('<td/>').append(renderHttpUrlAsLink(value)))
+    );
   }
   return table;
 }

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -534,3 +534,15 @@ function renderComments(row) {
   }
   return html;
 }
+
+function renderHttpUrlAsLink(value) {
+  const text = document.createTextNode(value);
+  if (!value.match(/^https?:\/\//)) {
+    return text;
+  }
+  const link = document.createElement('a');
+  link.href = value;
+  link.target = 'blank';
+  link.appendChild(text);
+  return link;
+}

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1032,6 +1032,10 @@ _GROUP_ID:: Same as `_GROUP` but allows to specify the group directly by ID.
 _PRIORITY:: Sets the priority value for the new jobs (which otherwise defaults
 to the priority of the job template)
 
+__…:: All parameters starting with `__` will *not* be added as job settings.
+Those parameters can be used to store additional information about the scheduled
+product itself, e.g. the URL of a web page with more context.
+
 Example for `_DEPRIORITIZEBUILD` and `_DEPRIORITIZE_LIMIT`.
 
 [source,sh]

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -4,7 +4,7 @@
 package OpenQA::Schema::Result::ScheduledProducts;
 
 
-use Mojo::Base 'DBIx::Class::Core';
+use Mojo::Base 'DBIx::Class::Core', -signatures;
 
 use DBIx::Class::Timestamps 'now';
 use File::Basename;
@@ -180,6 +180,12 @@ sub schedule_iso {
 # make sure that the DISTRI is lowercase
 sub _distri_key { lc(shift->{DISTRI}) }
 
+sub _delete_prefixed_args_storing_info_about_product_itself ($args) {
+    for my $arg (keys %$args) {
+        delete $args->{$arg} if substr($arg, 0, 2) eq '__';
+    }
+}
+
 =over 4
 
 =item _schedule_iso()
@@ -219,6 +225,8 @@ sub _schedule_iso {
               . 'likely not intended to deprioritize the whole build when scheduling a single scenario.'
         };
     }
+
+    _delete_prefixed_args_storing_info_about_product_itself $args;
 
     my $result = $self->_generate_jobs($args, \@notes, $skip_chained_deps);
     return {error => $result->{error_message}, error_code => $result->{error_code} // 400}

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -108,9 +108,13 @@ subtest 'group filter and priority override' => sub {
     my $res = schedule_iso({%iso, PRECEDENCE => 'original', _GROUP => 'invalid group name'});
     is($res->json->{count}, 0, 'no jobs created if group invalid');
 
-    $res = schedule_iso({%iso, PRECEDENCE => 'original', _GROUP => 'opensuse test'});
+    $res = schedule_iso({%iso, PRECEDENCE => 'original', _GROUP => 'opensuse test', _FOO => 'bar', __FOO => 'bar'});
     is($res->json->{count}, 1, 'only one job created due to group filter');
-    is($jobs->find($res->json->{ids}->[0])->priority, 42, 'prio from job template used');
+    my $job = $jobs->find($res->json->{ids}->[0]);
+    is($job->priority, 42, 'prio from job template used');
+    my $job_settings = $job->settings_hash;
+    is($job_settings->{_FOO}, 'bar', 'setting with one leading underscore passed to job');
+    is($job_settings->{__FOO}, undef, 'setting with two leading underscores not passed to job');
 
     $res = schedule_iso(
         {
@@ -169,6 +173,8 @@ subtest 'scheduled products added' => sub {
         BUILD => '0091',
         PRECEDENCE => 'original',
         _GROUP => 'opensuse test',
+        _FOO => 'bar',
+        __FOO => 'bar',
     );
     is_deeply($stored_settings, \%expected_settings, 'settings stored correctly, 3') or diag explain $stored_settings;
 

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -14,6 +14,8 @@ use OpenQA::SeleniumTest;
 use Mojo::File 'path';
 
 my $schema = OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');
+my $scheduled_products = $schema->resultset('ScheduledProducts');
+my $product_id = $scheduled_products->create({settings => {__URL => 'https://foo', __NO_URL => 'foo'}});
 # setup openqa.ini with job_settings_ui
 $ENV{OPENQA_CONFIG} = "t/data/03-setting-links";
 my $t = Test::Mojo->new('OpenQA::WebAPI');
@@ -44,6 +46,14 @@ is(scalar @number_of_elem, 1, 'Only configured setting keys render as links');
 note 'Checking link Navigation to the source';
 $driver->find_element_by_link($foo_path)->click();
 is($driver->get_current_url(), "$url$uri_path_from_root_dir", 'Link is accessed with correct URI');
+
+subtest 'scheduled product settings' => sub {
+    $driver->get('/admin/productlog?id=' . $product_id->id);
+    my @links_in_table = $driver->find_elements('#scheduled-products > table a');
+    is scalar @links_in_table, 1, 'exactly one link is rendered' or return;
+    is $links_in_table[0]->get_text, 'https://foo', 'link text';
+    like $links_in_table[0]->get_attribute('href'), qr{^https://foo/?$}, 'link href';
+};
 
 kill_driver();
 done_testing();


### PR DESCRIPTION
Those settings will *not* be added scheduled openQA jobs and can be used to
store additional information about the scheduled product itsef, e.g. an URL
to SMELT.

As a bonus I've added a small change to render those setting values as link if
they are HTTP(S)-URLs.

See https://progress.opensuse.org/issues/109554