### PR TITLE
Add force parameter forwarding in fetchneedles script

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -44,6 +44,7 @@ if [ -w / ]; then
         needles_giturl="$needles_giturl" \
         needles_branch="$needles_branch" \
         updateall="$updateall" \
+        force="$force" \
         "$0" "$@"
     exit 1
 fi


### PR DESCRIPTION
When running :
`sudo force=1  /usr/share/openqa/script/fetchneedles`

the script takes care to call itself with **sudo -u geekotest** forwarding one by one all the configurations variables.

Add **force** parameter forwarding  to script internal **exec sudo env**
