### PR TITLE
Avoid corrupted assets on concurrent uploads of same asset

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1358,13 +1358,14 @@ sub create_asset ($self, $asset, $scope, $local = undef) {
     $type = 'hdd' if $fname =~ /\.(?:qcow2|raw|vhd|vhdx)$/;
     $type //= 'other';
 
-    $fname = sprintf("%08d-%s", $self->id, $fname) if $scope ne 'public';
+    my $job_id = sprintf "%08d", $self->id;
+    $fname = "$job_id-$fname" if $scope ne 'public';
 
     my $assetdir = assetdir();
     my $fpath = path($assetdir, $type);
     my $temp_path = path($assetdir, 'tmp', $scope);
 
-    my $temp_chunk_folder = path($temp_path, join('.', $fname, 'CHUNKS'));
+    my $temp_chunk_folder = path($temp_path, $job_id, join('.', $fname, 'CHUNKS'));
     my $temp_final_file = path($temp_chunk_folder, $fname);
     my $final_file = path($fpath, $fname);
 

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -130,7 +130,7 @@ subtest 'upload private assets (local)' => sub {
 };
 
 subtest 'upload other assets' => sub {
-    my $chunkdir = 't/data/openqa/share/factory/tmp/other/00099963-hdd_image3.xml.CHUNKS/';
+    my $chunkdir = 't/data/openqa/share/factory/tmp/other/00099963/00099963-hdd_image3.xml.CHUNKS';
     my $rp = "t/data/openqa/share/factory/other/00099963-hdd_image3.xml";
 
     $t->ua->upload->once(

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -388,7 +388,7 @@ subtest 'upload asset: fails without chunks' => sub {
 };
 
 # prepare chunk upload
-my $chunkdir = path("$tempdir/openqa/share/factory/tmp/public/hdd_image.qcow2.CHUNKS");
+my $chunkdir = path("$tempdir/openqa/share/factory/tmp/public/00099963/hdd_image.qcow2.CHUNKS");
 $chunkdir->remove_tree;
 
 subtest 'upload asset: successful chunk upload' => sub {
@@ -469,8 +469,8 @@ subtest 'Failed upload, public assets' => sub {
 };
 
 subtest 'Failed upload, private assets' => sub {
-    $chunkdir = "$tempdir/openqa/share/factory/tmp/private/00099963-hdd_image.qcow2.CHUNKS/";
-    path($chunkdir)->remove_tree;
+    $chunkdir = "$tempdir/openqa/share/factory/tmp/private/00099963/00099963-hdd_image.qcow2.CHUNKS";
+    path($chunkdir)->dirname->remove_tree;
 
     my $pieces = OpenQA::File->new(file => Mojo::File->new($filename))->split($chunk_size);
     my $first_chunk = $pieces->first;


### PR DESCRIPTION
* Write temporary files to a job-specific location so multiple uploads
  don't interfere with each other
* The move in the end should be atomic as it is likely a move within the
  same file system (if not I suppose file corruption can still happen)
* See https://progress.opensuse.org/issues/109319