### PR TITLE
Allow scheduling settings like `__…_URL`

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -507,10 +507,11 @@ sub check_download_passlist {
     # Passed the params hash ref for a job and the download_domains
     # passlist read from openqa.ini. Checks that all params ending
     # in _URL (i.e. requesting asset download) specify URLs that are
-    # passlisted. It's provided here so that we can run the check
-    # twice, once to return immediately and conveniently from the Iso
-    # controller, once again directly in the Gru asset download sub
-    # just in case someone somehow manages to bypass the API and
+    # passlisted (except those starting with __ as they are not
+    # actually download). It's provided here so that we can run the
+    # check twice, once to return immediately and conveniently from
+    # the Iso controller, once again directly in the Gru asset download
+    # sub just in case someone somehow manages to bypass the API and
     # create a gru task directly. On failure, returns an array of 4
     # items: the first is 1 if there was a passlist at all or 2 if
     # there was not, the second is the name of the param for which the
@@ -523,7 +524,7 @@ sub check_download_passlist {
         @okdomains = split(/ /, $passlist);
     }
     for my $param (keys %$params) {
-        next unless ($param =~ /_URL$/);
+        next unless ($param =~ /^(?!__).*_URL$/);
         my $url = $$params{$param};
         my @check = check_download_url($url, $passlist);
         next unless (@check);

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -108,7 +108,7 @@ subtest 'group filter and priority override' => sub {
     my $res = schedule_iso({%iso, PRECEDENCE => 'original', _GROUP => 'invalid group name'});
     is($res->json->{count}, 0, 'no jobs created if group invalid');
 
-    $res = schedule_iso({%iso, PRECEDENCE => 'original', _GROUP => 'opensuse test', _FOO => 'bar', __FOO => 'bar'});
+    $res = schedule_iso({%iso, PRECEDENCE => 'original', _GROUP => 'opensuse test', _FOO => 'bar', __FOO_URL => 'bar'});
     is($res->json->{count}, 1, 'only one job created due to group filter');
     my $job = $jobs->find($res->json->{ids}->[0]);
     is($job->priority, 42, 'prio from job template used');
@@ -174,7 +174,7 @@ subtest 'scheduled products added' => sub {
         PRECEDENCE => 'original',
         _GROUP => 'opensuse test',
         _FOO => 'bar',
-        __FOO => 'bar',
+        __FOO_URL => 'bar',
     );
     is_deeply($stored_settings, \%expected_settings, 'settings stored correctly, 3') or diag explain $stored_settings;
 


### PR DESCRIPTION
Those settings don't need to be checked against the passlist because they
are now actually downloaded as they only serve informational purposes.

(These settings are deleted before `_generate_jobs` so it is ensured they
are not passed to `create_downloads_list`.)

See https://progress.opensuse.org/issues/109512
and https://github.com/openSUSE/qem-bot/pull/13.