### PR TITLE
Render multiple URLs in scheduled products table correctly

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -536,13 +536,17 @@ function renderComments(row) {
 }
 
 function renderHttpUrlAsLink(value) {
-  const text = document.createTextNode(value);
-  if (!value.match(/^https?:\/\//)) {
-    return text;
+  const span = document.createElement('span');
+  for (let match; (match = value.match(/https?:\/\/[^\s,]*/)); ) {
+    const url = match[0];
+    const link = document.createElement('a');
+    link.href = url;
+    link.target = 'blank';
+    link.appendChild(document.createTextNode(url));
+    span.appendChild(document.createTextNode(value.substr(0, match.index)));
+    span.appendChild(link);
+    value = value.substr(match.index + url.length);
   }
-  const link = document.createElement('a');
-  link.href = value;
-  link.target = 'blank';
-  link.appendChild(text);
-  return link;
+  span.appendChild(document.createTextNode(value));
+  return span;
 }


### PR DESCRIPTION
Considering https://github.com/openSUSE/qem-bot/pull/16 and existing code
the same setting value might contain multiple URLs (separated by colons).

This change will render them as individual links.

See https://progress.opensuse.org/issues/109512