### PR TITLE
Allow python3 in apparmor

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -19,6 +19,7 @@
   /tmp/** rwk,
   /usr/bin/dash ix,
   /usr/bin/perl ix,
+  /usr/bin/python3 ix,
   /usr/bin/ssh rcx,
   /usr/bin/timeout rix,
   /usr/bin/unzip{,-plain} rix,


### PR DESCRIPTION
Likely related issue: https://progress.opensuse.org/issues/107014