### PR TITLE
Sync tools/tidy with os-autoinst

### DIFF
--- a/tools/perlfiles
+++ b/tools/perlfiles
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mapfile -t files < <(file --mime-type -- script/* | (grep text/x-perl || true) | awk -F':' '{ print $1 }')
+files+=('**.p[ml]' '**.t')
+
+selection="$(git ls-files "${files[@]}")"
+echo "${selection[@]}"

--- a/tools/tidy
+++ b/tools/tidy
@@ -6,13 +6,17 @@
 usage() {
     cat << EOF
 Usage:
- tidy [--check] [--only-changed]
+ tidy [-c|--check] [-f|--force] [-o|--only-changed] [-l|--list] [path/to/file]
 
 Options:
  -h, -?, --help       display this help
  -c, --check          Only check for style check differences
+ -f, --force          Force check even if tidy version mismatches
  -o --only-changed    Only tidy files with uncommitted changes in git. This can
                       speed up execution a lot.
+-l --list             List files tidy would touch
+ path/to/file         When passing a file as argument, tidy will run perltidy
+                      wether it is added to the git tree or not
 
 perltidy rules can be found in .perltidyrc
 EOF
@@ -20,17 +24,18 @@ EOF
 }
 
 set -eo pipefail
+dir="$(dirname "$0")"
 
 args=""
-mapfile -t files < <(file --mime-type -- script/* | (grep text/x-perl || true) | awk -F':' '{ print $1 }')
-files+=('**.p[ml]' '**.t')
-selection="$(git ls-files "${files[@]}")"
-opts=$(getopt -o hcol --long help,check,only-changed,list -n "$0" -- "$@") || usage
+selection='--all'
+[[ -e "$dir/perlfiles" ]] && selection=$("$dir"/perlfiles)
+opts=$(getopt -o hcfol --long help,check,force,only-changed,list -n "$0" -- "$@") || usage
 eval set -- "$opts"
 while true; do
   case "$1" in
     -h | --help ) usage; shift ;;
     -c | --check ) args+=' --check-only'; shift ;;
+    -f | --force ) force=true; shift ;;
     -o | --only-changed ) selection='--git'; shift ;;
     -l | --list ) args+='--list'; shift ;;
     -- ) shift; break ;;
@@ -46,17 +51,26 @@ if ! command -v perltidy > /dev/null 2>&1; then
     exit 1
 fi
 
-# cpan file is in top directory
-dir="$(dirname "$(readlink -f "$0")")/.."
+perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+# This might be used from another repo like os-autoinst-distri-opensuse
+if [ -z "${perltidy_version_expected}" ]; then
+    # No cpanfile in the linked repo, use the one from os-autoinst instead
+    dir="$(dirname "$(readlink -f "$0")")"
+    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+fi
 perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
-perltidy_version_expected=$(sed -n "s/^.*Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/cpanfile)
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
-    echo "Wrong version of perltidy. Found '$perltidy_version_found', expected '$perltidy_version_expected'"
-    exit 1
+    echo -n "Wrong version of perltidy. Found '$perltidy_version_found', expected '$perltidy_version_expected'. "
+    if [[ "$force" = "true" ]]; then
+        echo "Found '--force', continuing"
+    else
+        echo "Consider '--force' but results might not be consistent."
+        exit 1
+    fi
 fi
 
 # go to caller directory
-cd "$(dirname "$0")/.."
+cd "$dir/.."
 
 # just to make sure we are at the right location
 test -e tools/tidy || exit 1


### PR DESCRIPTION
* Document --list
* Add --force option
* Add tools/perlfiles to allow special selection

Issue: https://progress.opensuse.org/issues/110142

For now I'm not adding this to os-autoinst-common because I have to solve the problem that os-autoinst-distri-opensuse uses `readlink -f $0` to get the `os-autoinst/cpanfile`.

See also https://github.com/os-autoinst/os-autoinst/pull/2034