### PR TITLE
Reduce retention of temporary files created by the web UI

### DIFF
--- a/systemd/tmpfiles-openqa-webui.conf
+++ b/systemd/tmpfiles-openqa-webui.conf
@@ -1,1 +1,1 @@
-d /var/lib/openqa/share/factory/tmp 1777 root root 30d
+d /var/lib/openqa/share/factory/tmp 1777 root root 6h


### PR DESCRIPTION
Considering 133 GiB of data has piled up on our production instance we
should decrease the retention time. Those files are only used for file
uploads so a value within the range of hours makes more sense.