### PR TITLE
Allow python3.6 in apparmor

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -138,6 +138,7 @@
   /usr/bin/openqa-cli rix,
   /usr/bin/perl ix,
   /usr/bin/python3 ix,
+  /usr/bin/python3.6 ix,
   /usr/bin/rm rix,
   /usr/bin/rsync mrix,
   /usr/bin/sed mrix,


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/91605

Tested locally on o3