### PR TITLE
Add simple command to generate HTML documentation

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -4,4 +4,4 @@ paths:
   "assets/stylesheets/**":
     - Consider providing screenshots in a PR comment to show the difference visually
   "docs/*.asciidoc":
-    - Consider generating documentation locally to verify it is rendered correctly using `tools/generate-documentation`
+    - Consider generating documentation locally to verify it is rendered correctly using `tools/generate-htmldoc`

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ job.json
 node_modules
 package-lock.json
 .tidyall.d/
+openqa-documentation.html

--- a/tools/generate-htmldoc
+++ b/tools/generate-htmldoc
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+cre=${cre:-"podman"}
+$cre run -it --rm -v"$PWD"/:/openqa --workdir /openqa --env GEM_HOME=/home/squamata/.gem registry.opensuse.org/devel/openqa/ci/containers/base:latest tools/generate-htmldoc-in-container

--- a/tools/generate-htmldoc-in-container
+++ b/tools/generate-htmldoc-in-container
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+gem install asciidoctor pygments.rb
+
+asciidoctor_bin=$(command -v asciidoctor) || true
+[[ -n "$asciidoctor_bin" ]] || \
+    for asciidoctor_bin in "${GEM_HOME}"/bin/asciidoctor.ruby*; do :; done
+set -x
+"$asciidoctor_bin" -o openqa-documentation.html docs/index.asciidoc -d book


### PR DESCRIPTION
    tools/generate-htmldoc

will generate the HTML documentation in a container and
write it to openqa-documentation.html

The checklist suggestes to run this command to check if any asciidoc changes
are looking good, instead of the previous non functioning
tools/generate-documentation suggestion.

Issue: https://progress.opensuse.org/issues/110181