### PR TITLE
Allow mailx in apparmor

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -134,7 +134,7 @@
   /usr/bin/jq rix,
   /usr/bin/mv ix,
   /usr/bin/mktemp rix,
-  /usr/bin/mutt ix,
+  /usr/bin/mailx ix,
   /usr/bin/openqa-cli rix,
   /usr/bin/perl ix,
   /usr/bin/python3 ix,


### PR DESCRIPTION
See also https://github.com/os-autoinst/scripts/pull/150

Issue: https://progress.opensuse.org/issues/91605