### PR TITLE
Deal with unknown git revision

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1834,6 +1834,7 @@ sub has_autoinst_log ($self) {
 }
 
 sub git_log_diff ($self, $dir, $refspec_range) {
+    return "Invalid range $refspec_range" if $refspec_range =~ m/UNKNOWN/;
     my $res = run_cmd_with_log_return_error(
         ['git', '-C', $dir, 'log', '--stat', '--pretty=oneline', '--abbrev-commit', '--no-merges', $refspec_range]);
     # regardless of success or not the output contains the information we need
@@ -1841,6 +1842,7 @@ sub git_log_diff ($self, $dir, $refspec_range) {
 }
 
 sub git_diff ($self, $dir, $refspec_range) {
+    return "Invalid range $refspec_range" if $refspec_range =~ m/UNKNOWN/;
     my $timeout = OpenQA::App->singleton->config->{global}->{job_investigate_git_timeout} // 20;
     my $res = run_cmd_with_log_return_error(['timeout', $timeout, 'git', '-C', $dir, 'diff', '--stat', $refspec_range]);
     return "\n" . $res->{stderr} if $res->{stderr};
@@ -1852,6 +1854,7 @@ Find pointers for investigation on failures, e.g. what changed vs. a "last
 good" job in the same scenario.
 
 =cut
+
 sub investigate ($self, %args) {
     my @previous = $self->_previous_scenario_jobs;
     return {error => 'No previous job in this scenario, cannot provide hints'} unless @previous;


### PR DESCRIPTION
TEST_GIT_HASH or NEEDLES_GIT_HASH might contain UNKNOWN.
To avoid error messages in the log, check and return early.

I moved the git_log_diff mocking to the subtests because it was global and
in my new test I actually did *not* want to mock that method.

Issue: https://progress.opensuse.org/issues/110389