### PR TITLE
Fix fullstack test by ensuring whole os-autoinst checkout has right owner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ aliases:
       if [ ! -z "$CIRCLE_WORKFLOW_ID" ]; then # only in workflow
         rm -rf ../os-autoinst
         sudo cp -r /var/cache/autoinst ../os-autoinst
-        sudo chown -R 1000 ../os-autoinst/t/data
+        sudo chown -R 1000 ../os-autoinst
       else # only in local run
          tools/ci/build_autoinst.sh
        fi


### PR DESCRIPTION
This should prevent
```
[09:07:33] t/full-stack.t .. 9/? fatal: unsafe repository ('/home/squamata/os-autoinst' is owned by someone else)
```