### PR TITLE
cache service: Emit download rate only if known

### DIFF
--- a/lib/OpenQA/CacheService/Controller/Influxdb.pm
+++ b/lib/OpenQA/CacheService/Controller/Influxdb.pm
@@ -20,8 +20,8 @@ sub minion ($self) {
     $text .= _output_measure($url, 'openqa_minion_workers', $workers);
 
     my $metrics = $app->cache->metrics;
-    my $bytes = $metrics->{download_rate} || 0;
-    $text .= "openqa_download_rate,url=$url bytes=${bytes}i\n";
+    my $bytes = $metrics->{download_rate};
+    $text .= "openqa_download_rate,url=$url bytes=${bytes}i\n" if defined $bytes;
 
     $self->render(text => $text);
 }


### PR DESCRIPTION
If no downloads have been done yet the download rate is unknown. We should
not return 0 in that case as it leads to false alerts.

See https://progress.opensuse.org/issues/110497