### PR TITLE
Fix minion jobs stats retrieval DoS on login provider

### DIFF
--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -83,6 +83,11 @@ sub register {
     # Enable the Minion Admin interface under /minion
     my $auth = $app->routes->under('/minion')->to('session#ensure_admin');
     $app->plugin('Minion::Admin' => {route => $auth});
+    # allow the continuously polled stats to be available on an
+    # unauthenticated route to prevent recurring broken requests to the login
+    # provider if not logged in
+    my $route = $app->routes->find('minion_stats')->remove;
+    $app->routes->any('/minion')->add_child($route);
 
     my $gru = OpenQA::Shared::Plugin::Gru->new($app);
     $app->helper(gru => sub { $gru });

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -73,6 +73,7 @@ subtest OpenID => sub {
       ->header_is('Location', '/login?return_page=%2Fapi_keys', 'remember return_page for ensure_operator');
     $t->get_ok('/admin/users')->status_is(302)
       ->header_is('Location', '/login?return_page=%2Fadmin%2Fusers', 'remember return_page for ensure_admin');
+    $t->get_ok('/minion/stats')->status_is(200), 'minion stats is accessible unauthenticated (poo#110533)';
 };
 
 subtest OAuth2 => sub {


### PR DESCRIPTION
Allow the continuously polled stats to be available on an
unauthenticated route to prevent recurring broken requests to the login
provider if not logged in to prevent unnecessary and harmful recurring
traffic to the login provider service, e.g. id.opensuse.org, which
caused the login provider service to misbehave.

First to reproduce the issue what I did was to start a bare openQA
instance with config `httpsonly=0` in etc/openqa/openqa.ini of my openQA
working copy and keeping everything else in place. Then started
`sudo -u
geekotest env OPENQA_BASEDIR=$tmp script/openqa-webui-daemon`
with $tmp
being a directory owned by geekotest and an empty subdirectory db to
prevent an error about unable to create a lock file. Then I went to
http://127.0.0.1:9526/, logged in, then to
http://127.0.0.1:9526/minion/jobs in my browser, opened developer tools,
"Network" tab and saw a request every couple of seconds to "stats". I
opened http://127.0.0.1:9526/ in a second tab, logged out and could see
that the requests in the developer tools go to "www.opensuse.org/openid"
instead. With the change applied I could confirm that stats is continued
to be polled from the local server regardless of the authentication
state.

Related progress issue: https://progress.opensuse.org/issues/110533