### PR TITLE
Install rsync to worker container image

### DIFF
--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -7,7 +7,7 @@ LABEL version="0.3"
 RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.3 devel_openQA && \
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.3/openSUSE_Leap_15.3 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    zypper in -yl ca-certificates-mozilla curl gzip && \
+    zypper in -yl ca-certificates-mozilla curl gzip rsync && \
     zypper in -yl openQA-worker os-autoinst-s390-deps && \
     zypper in -yl qemu-arm qemu-ppc qemu-x86 qemu-tools && \
     zypper in -yl kmod && \


### PR DESCRIPTION
To be able to use cache service, one need to have rsync client in the
worker image. As it is only a recommended package, we need to install it
explicitly.

Related issue: https://progress.opensuse.org/issues/110524