### PR TITLE
Prevent job_done_hooks not knowing that jobs will be retried anyway

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2017,6 +2017,8 @@ sub done ($self, %args) {
         $new_val{reason} = 'no test modules scheduled/uploaded';
     }
     $self->update(\%new_val);
+    $self->unblock;
+    $self->auto_duplicate if $restart || (!$self->is_ok && $self->handle_retry);
     # bugrefs are there to mark reasons of failure - the function checks itself though
     my $carried_over = $self->carry_over_bugrefs;
     $self->enqueue_finalize_job_results($carried_over);
@@ -2028,8 +2030,6 @@ sub done ($self, %args) {
             $self->_job_stop_cluster($job);
         }
     }
-    $self->unblock;
-    $self->auto_duplicate if $restart || (!$self->is_ok && $self->handle_retry);
 
     return $new_val{result} // $self->result;
 }


### PR DESCRIPTION
A common use case for job_done_hooks is to handle failed jobs. However
there can be that case that we already sufficiently handle any such
failures by retrying test cases using the openQA retry feature. So if
test maintainers signal the intent that the right approach to handle
failed jobs is to retry we should ensure that we trigger a retry and
hence put a comment on an openQA job to provide a consistent state
before we trigger any asynchronous job_done_hooks which can evaluate
such information, e.g. as
https://github.com/os-autoinst/scripts/blob/master/openqa-investigate
does to detect if an issue is "known" or "unknown" based on the presence
of a comment.

Related progress issue: https://progress.opensuse.org/issues/110911