### PR TITLE
Simplify setup by removing path rewrite

### DIFF
--- a/container/webui/nginx.conf
+++ b/container/webui/nginx.conf
@@ -29,8 +29,6 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
-
-            rewrite /api/v1/ws/(.*) /ws/$1 break;
         }
 
         location /liveviewhandler/ {
@@ -39,8 +37,6 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
-
-            rewrite /liveviewhandler/(.*) /liveviewhandler/$1 break;
         }
 
         location /assets/ {

--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -58,13 +58,13 @@ ProxyPass /error !
 RewriteEngine On
 RewriteCond %{HTTP:Connection} Upgrade [NC]
 RewriteCond %{HTTP:Upgrade} websocket [NC]
-RewriteRule /api/v1/ws/(.*) ws://localhost:9527/ws/$1 [P,L]
+RewriteRule /api/v1/ws/(.*) ws://localhost:9527/api/v1/ws/$1 [P,L]
 RewriteCond %{HTTP:Connection} Upgrade [NC]
 RewriteCond %{HTTP:Upgrade} websocket [NC]
 RewriteRule /liveviewhandler/(.*) ws://localhost:9528/liveviewhandler/$1 [P,L]
 
 # pass websocket server where the worker connects to port 9527
-ProxyPass "/api/v1/ws/" "http://localhost:9527/ws/" keepalive=On
+ProxyPass "/api/v1/ws/" "http://localhost:9527/api/v1/ws/" keepalive=On
 
 # pass websocket server to handle live view to port 9528
 ProxyPass "/liveviewhandler/" "http://localhost:9528/liveviewhandler/" keepalive=On

--- a/etc/nginx/vhosts.d/openqa.conf
+++ b/etc/nginx/vhosts.d/openqa.conf
@@ -10,8 +10,6 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
-
-        rewrite /api/v1/ws/(.*) /ws/$1 break;
     }
 
     location /liveviewhandler/ {
@@ -20,8 +18,6 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
-
-        rewrite /liveviewhandler/(.*) /liveviewhandler/$1 break;
     }
 
     location / {


### PR DESCRIPTION
Make websockets server understand the `/api/v1/ws` route which is
currently rewritten by a reverse-proxy to `/ws`. This should remove the
need for having a reverse-proxy as all paths are now handled as are.

There is no need to change anything in the setup as the other route
(i.e. `/ws`) is also handled in the same way.

Prerequisites:
* #4660