### PR TITLE
Limit git log in investigation tab

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -68,6 +68,10 @@
 ## Timeout for the git command in "job investigation"
 #job_investigate_git_timeout = 20
 
+## Limit for the git log --stat in "job investigation"
+#job_investigate_git_log_limit = 200
+
+
 ## Gracefully restart the prefork workers if they reach a certain memory limit (in kB)
 #max_rss_limit = 180000
 

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -41,6 +41,7 @@ sub read_config ($app) {
             recognized_referers => '',
             changelog_file => '/usr/share/openqa/public/Changelog',
             job_investigate_ignore => '"(JOBTOKEN|NAME)"',
+            job_investigate_git_log_limit => 200,
             job_investigate_git_timeout => 20,
             worker_timeout => DEFAULT_WORKER_TIMEOUT,
             search_results_limit => 50000,

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -902,7 +902,8 @@ sub dependencies ($self) {
 sub investigate {
     my ($self) = @_;
     return $self->reply->not_found unless my $job = $self->_get_current_job;
-    my $investigation = $job->investigate;
+    my $git_limit = OpenQA::App->singleton->config->{global}->{job_investigate_git_log_limit} // 200;
+    my $investigation = $job->investigate(git_limit => $git_limit);
     $self->render(json => $investigation);
 }
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -417,7 +417,12 @@ subtest 'carry over, including soft-fails' => sub {
 
     subtest 'additional investigation notes provided on new failed' => sub {
         my $job_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs', no_auto => 1);
-        $job_mock->redefine(git_log_diff => sub { $fake_git_log });
+        my $got_limit = 0;
+        $job_mock->redefine(
+            git_log_diff => sub ($self, $dir, $range, $limit) {
+                $got_limit = $limit;
+                return $fake_git_log;
+            });
         path('t/data/last_good.json')->copy_to(path(($job->_previous_scenario_jobs)[1]->result_dir(), 'vars.json'));
         path('t/data/first_bad.json')->copy_to(path($job->result_dir(), 'vars.json'));
         path('t/data/last_good_packages.txt')
@@ -453,13 +458,15 @@ subtest 'carry over, including soft-fails' => sub {
             like($inv->{test_log}, qr/^.*file changed/m, 'git log with test changes');
         };
         subtest 'investigation can display test_log with git stats when more than one commit' => sub {
+            $got_limit = 0;
             $fake_git_log
               = "\nqwertyuio0 test0\n mylogfile0 | 1 +\n 1 file changed, 1 insertion(+)\nqwertyuio1 test1\n mylogfile1 | 1 +\n 1 file changed, 1 insertion(+)\n";
-            ok($inv = $job->investigate, 'job investigation ok with test changes');
+            ok($inv = $job->investigate(git_limit => 23), 'job investigation ok with test changes');
             my $actual_lines = split(/\n/, $inv->{test_log});
             my $expected_lines = 7;
             is($actual_lines, $expected_lines, 'test_log have correct number of lines');
             like($inv->{test_log}, qr/^.*file changed/m, 'git log with test changes');
+            is $got_limit, 23, 'git_limit was correctly passed';
         };
     };
 

--- a/t/config.t
+++ b/t/config.t
@@ -45,6 +45,7 @@ subtest 'Test configuration default modes' => sub {
             changelog_file => '/usr/share/openqa/public/Changelog',
             job_investigate_ignore => '"(JOBTOKEN|NAME)"',
             job_investigate_git_timeout => 20,
+            job_investigate_git_log_limit => 200,
             search_results_limit => 50000,
             worker_timeout => DEFAULT_WORKER_TIMEOUT,
             force_result_regex => '',


### PR DESCRIPTION
A `git log --stat` can take a long time for several thousands of
commits, especially if there are many changes.

Issue: https://progress.opensuse.org/issues/110677

This commit limits the log to 200 commits.

Currently it is not configurable.

I have tested the `git log --stat` and `git diff --stat` commands, and the worst is the `git log --stat` on the needles repo, it took over 3 minutes in our case. `git diff --stat` is not that bad, so I left it alone.