### PR TITLE
worker: Avoid logging secret variables

### DIFF
--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -27,6 +27,7 @@ our @EXPORT_OK = qw(
   log_format_callback
   get_channel_handle
   setup_log
+  format_settings
 );
 
 my %CHANNELS;
@@ -202,6 +203,11 @@ sub setup_log ($app, $logfile = undef, $logdir = undef, $level = undef) {
     }
 
     OpenQA::App->set_singleton($app);
+}
+
+sub format_settings ($vars) {
+    my @s = map { $_ !~ qr/(^_SECRET_|_PASSWORD)/ ? ("    $_=$vars->{$_}") : ("    $_=[redacted]") } sort keys %$vars;
+    return join("\n", @s);
 }
 
 1;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -6,7 +6,7 @@ use Mojo::Base -base, -signatures;
 
 use Mojo::Base -signatures;
 use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE WORKER_SR_DIED);
-use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle);
+use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle format_settings);
 use OpenQA::Utils
   qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme testcasedir productdir needledir);
 use POSIX qw(:sys_wait_h strftime uname _exit);
@@ -265,11 +265,6 @@ sub do_asset_caching ($job, $vars, $cache_dir, $assetkeys, $webui_host, $pooldir
             my $shared_cache = catdir($cache_dir, base_host($webui_host));
             sync_tests($cache_client, $job, $vars, $shared_cache, $rsync_source, $attempts, $callback);
         });
-}
-
-sub format_settings ($vars) {
-    my @s = map { $_ !~ qr/(^_SECRET_|_PASSWORD)/ ? ("    $_=$vars->{$_}") : ("    $_=[redacted]") } sort keys %$vars;
-    return join("\n", @s);
 }
 
 sub engine_workit ($job, $callback) {

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -316,8 +316,8 @@ sub engine_workit ($job, $callback) {
     #       but for compatibility with current old os-autoinst we need to set PRJDIR for a consistent
     #       behavior.
 
-    log_debug('Job settings:');
-    log_debug(join("\n", '', map { "    $_=$vars{$_}" } sort keys %vars));
+    my @s = map { $_ !~ qr/(^_SECRET_|_PASSWORD)/ ? ("    $_=$vars{$_}") : ("    $_=[redacted]") } sort keys %vars;
+    log_debug "Job settings:\n" . join("\n", @s);
 
     # cache/locate assets, set ASSETDIR
     my $assetkeys = detect_asset_keys(\%vars);

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -267,6 +267,11 @@ sub do_asset_caching ($job, $vars, $cache_dir, $assetkeys, $webui_host, $pooldir
         });
 }
 
+sub format_settings ($vars) {
+    my @s = map { $_ !~ qr/(^_SECRET_|_PASSWORD)/ ? ("    $_=$vars->{$_}") : ("    $_=[redacted]") } sort keys %$vars;
+    return join("\n", @s);
+}
+
 sub engine_workit ($job, $callback) {
     my $worker = $job->worker;
     my $client = $job->client;
@@ -316,8 +321,7 @@ sub engine_workit ($job, $callback) {
     #       but for compatibility with current old os-autoinst we need to set PRJDIR for a consistent
     #       behavior.
 
-    my @s = map { $_ !~ qr/(^_SECRET_|_PASSWORD)/ ? ("    $_=$vars{$_}") : ("    $_=[redacted]") } sort keys %vars;
-    log_debug "Job settings:\n" . join("\n", @s);
+    log_debug "Job settings:\n" . format_settings(\%vars);
 
     # cache/locate assets, set ASSETDIR
     my $assetkeys = detect_asset_keys(\%vars);

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -410,14 +410,6 @@ subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
     };
 };
 
-subtest 'formatting settings' => sub {
-    my %vars = (FOO => 'bar', _SECRET_TOKEN => 'token', THE_PASSWORD => '123');
-    my $log = OpenQA::Worker::Engines::isotovideo::format_settings(\%vars);
-    like $log, qr/FOO=bar.*THE_PASSWORD.*_SECRET_TOKEN/s, 'all keys and normal values present';
-    unlike $log, qr/token/, 'secret token not present';
-    unlike $log, qr/123/, 'password not present';
-};
-
 subtest 'symlink asset' => sub {
     my $pool_directory = tempdir('poolXXXX');
     my $worker = OpenQA::Test::FakeWorker->new(pool_directory => $pool_directory);

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -410,6 +410,13 @@ subtest 'behavior with ABSOLUTE_TEST_CONFIG_PATHS=1' => sub {
     };
 };
 
+subtest 'formatting settings' => sub {
+    my %vars = (FOO => 'bar', _SECRET_TOKEN => 'token', THE_PASSWORD => '123');
+    my $log = OpenQA::Worker::Engines::isotovideo::format_settings(\%vars);
+    like $log, qr/FOO=bar.*THE_PASSWORD.*_SECRET_TOKEN/s, 'all keys and normal values present';
+    unlike $log, qr/token/, 'secret token not present';
+    unlike $log, qr/123/, 'password not present';
+};
 
 subtest 'symlink asset' => sub {
     my $pool_directory = tempdir('poolXXXX');

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -9,7 +9,7 @@ use Mojo::File qw(tempdir tempfile);
 use OpenQA::App;
 use OpenQA::Setup;
 use OpenQA::Log
-  qw(log_error log_warning log_fatal log_info log_debug log_trace add_log_channel remove_log_channel log_format_callback get_channel_handle setup_log);
+  qw(log_error log_warning log_fatal log_info log_debug log_trace add_log_channel remove_log_channel log_format_callback get_channel_handle setup_log format_settings);
 use OpenQA::Worker::App;
 use File::Path qw(make_path remove_tree);
 use Test::MockModule qw(strict);
@@ -571,6 +571,14 @@ subtest 'Formatting' => sub {
         like log_format_callback(undef, $level, ("test $level")), qr/\[.+\] \[$level\] test $level\n$/,
           "Formatting for $level works";
     }
+};
+
+subtest 'Formatting settings' => sub {
+    my %vars = (FOO => 'bar', _SECRET_TOKEN => 'token', THE_PASSWORD => '123');
+    my $log = format_settings \%vars;
+    like $log, qr/FOO=bar.*THE_PASSWORD.*_SECRET_TOKEN/s, 'all keys and normal values present';
+    unlike $log, qr/token/, 'secret token not present';
+    unlike $log, qr/123/, 'password not present';
 };
 
 ok get_channel_handle, 'get_channel_handle returns valid handle from app';


### PR DESCRIPTION
Using the same regex we also use in os-autoinst to filter secrets