### PR TITLE
containers: Consistently use registry.opensuse.org

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -1,5 +1,5 @@
 #!BuildTag: openqa_dev
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.3
 
 # Define environment variable
 ENV NAME openQA test environment

--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,7 +4,7 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.3
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use

--- a/container/devel:openQA:ci/dependency_bot/Dockerfile
+++ b/container/devel:openQA:ci/dependency_bot/Dockerfile
@@ -1,5 +1,5 @@
 #!BuildTag: dependency_bot
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.3
 ENV NAME Leap with container runtime environment and hub
 
 ENV LANG en_US.UTF-8

--- a/container/openqa_data/Dockerfile
+++ b/container/openqa_data/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.3
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -1,5 +1,5 @@
 #!BuildTag: openqa_webui
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.3
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 

--- a/container/webui/Dockerfile-lb
+++ b/container/webui/Dockerfile-lb
@@ -1,5 +1,5 @@
 #!BuildTag: openqa_webui_lb
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.3
 LABEL maintainer Ivan Lausuch <ilausuch@suse.com>
 
 # hadolint ignore=DL3037

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -1,5 +1,5 @@
 #!BuildTag: openqa_worker
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.3
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 


### PR DESCRIPTION
We already use it in some but not in other cases. Being explicit avoids surprises and stops podman from asking to choose one.

See also https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/85