### PR TITLE
Add route for WebSockets to allow communication without a proxy

### DIFF
--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -39,6 +39,7 @@ sub startup {
     $api->post('/send_jobs')->to('API#send_jobs');
     $api->post('/send_msg')->to('API#send_msg');
     $ca->websocket('/ws/<workerid:num>')->to('Worker#ws');
+    $ca->websocket('/api/v1/ws/<workerid:num>')->to('Worker#ws');
 
     OpenQA::Setup::setup_plain_exception_handler($self);
 }


### PR DESCRIPTION
All routes in the workers are in the `/api/v1` namespace, we use reverse
proxy to strip the prefix for websocket connections. This route will
allow non-proxied traffic.