### PR TITLE
Improve commenting UI

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -160,3 +160,9 @@ function addComment(form, insertAtBottom) {
     window.alert("The comment text mustn't be empty.");
   }
 }
+
+function insertTemplate(button) {
+  const textarea = document.getElementById('text');
+  const template = button.dataset.template;
+  textarea.value += textarea.value ? '\n' + template : template;
+}

--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -74,10 +74,18 @@
         text-align: center;
         padding-left: .25em;
     }
+
+    .well {
+        margin: 0px;
+    }
 }
 
-.comment-editor {
-    margin-bottom: 20px;
+.comment-row {
+    align-items: center;
+    margin-bottom: 1.25rem;
+    .col-sm-1 {
+        text-align: right;
+    }
 }
 
 .pagination {

--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -94,3 +94,9 @@
         font-weight: bold;
     }
 }
+
+.comment-toolbar {
+    display: grid;
+    padding: 0.5rem;
+    align-items: center;
+}

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -275,10 +275,17 @@ subtest 'commenting in test results including labels' => sub {
     subtest 'help popover' => sub {
         wait_for_ajax(msg => 'comments tab loaded');
         disable_bootstrap_animations;
-        my $help_icon = $driver->find_element('#commentForm .help_popover');
+        my $help_icon = $driver->find_element('#commentForm .help_popover.fa-question-circle');
         $help_icon->click;
         like($driver->find_element('.popover')->get_text, qr/Help for comments/, 'popover shown on click');
         $help_icon->click;
+    };
+
+    subtest 'add label' => sub {
+        $driver->find_element('#commentForm .help_popover.fa-ticket')->click;
+        my $textarea = $driver->find_element_by_id('text');
+        like $textarea->get_value, qr/label:force_result:new_result/, 'label template added';
+        $textarea->clear;
     };
 
     # do the same tests for comments as in the group overview

--- a/templates/webapi/comments/add_comment_form_groups.html.ep
+++ b/templates/webapi/comments/add_comment_form_groups.html.ep
@@ -36,7 +36,7 @@
     </p>';
 %>
 <div class="row form-group">
-    <label for="text" class="col-sm-1 control-label">Comment
+    <label for="text" class="col-sm-1 control-label">
         <img class="img-circle" src="<%= current_user->gravatar(60) %>" alt="Own avatar" title="<%= current_user->name %>">
     </label>
     <div class="col-sm-11 input-group">

--- a/templates/webapi/comments/add_comment_form_groups.html.ep
+++ b/templates/webapi/comments/add_comment_form_groups.html.ep
@@ -1,55 +1,69 @@
+<% my $help_text = '
+    <p>
+        The comment field supports Markdown, automatic detection of URLs and special tags to record issue references, \'labels\'
+        as well as \'build tagging\'.
+    </p>
+    <ul>
+        <li>
+            For bugreferences write <code><i>bugtracker_shortname</i>#<i>bug_nr</i></code> in a comment, e.g. <code>bsc#1234</code>.
+        </li>
+        <li>
+            For generic labels use <code>label:<i>keyword</i></code> where <i>keyword</i> can be any valid character up to the next whitespace, e.g. "false_positive".
+        </li>
+    </ul>
+    <p>
+        The keywords are not defined within openQA itself. A valid list of keywords should be decided upon within each project or
+        environment of one openQA instance.
+    </p>
+    <p>
+        One special label format is available which allows to forcefully overwrite the result of a job using a comment. The expected format is <code>label:force_result:<i>new_result[:description]</i></code>, for example <code>label:force_result:failed</code> or <code>label:force_result:softfailed:bsc#1234</code>. For this command to be effective the according user needs to have at least operator permissions.
+    </p>
+    <p>
+        Also GitHub pull requests and issues can be linked using the generic format <i>marker</i>[#<i>project/repo</i>]#<i>id</i>,
+        e.g. gh#os-autoinst/openQA#1234. You can also write (or copy-paste) full links to bugs and issues.
+    </p>
+    <p>
+        The links are automatically changed to the shortlinks (e.g. <code>https://progress.opensuse.org/issues/11110</code> turns
+        into <code>poo#11110</code>).
+    </p>
+    <p>
+        Issue references are automatically carried over to the next jobs in the same scenario when the corresponding job fails in
+        the same module or the failed modules did not change.
+    </p>
+    <p>
+        Comments on job group pages can be "pinned" to the top by including the special keyword <code>pinned-description</code>
+        anywhere in the text.
+    </p>';
+%>
 <div class="row form-group">
     <label for="text" class="col-sm-1 control-label">Comment
         <img class="img-circle" src="<%= current_user->gravatar(60) %>" alt="Own avatar" title="<%= current_user->name %>">
     </label>
-    <div class="col-sm-11">
+    <div class="col-sm-11 input-group">
         <textarea class="form-control" name="text" id="text" placeholder="Write your comments here (Markdown and special tags supported)…" rows="5"></textarea>
+        <div class="input-group-append">
+            <span class="input-group-text comment-toolbar">
+                <a class="help_popover fa fa-tag" title="Add generic label" role="button"
+                   data-template="label:keyword" onclick="insertTemplate(this)"></a>
+                <br>
+                % if ($group_comment) {
+                    <a class="help_popover fa fa-map-pin" title="Pin comment" role="button"
+                       data-template="pinned-description" onclick="insertTemplate(this)"></a>
+                % } else {
+                    <a class="help_popover fa fa-ticket" title="Add force result label" role="button"
+                       data-template="label:force_result:new_result[:description_or_bugref]" onclick="insertTemplate(this)"></a>
+                % }
+                <br>
+                %= help_popover 'Help for comments' => $help_text, 'https://open.qa/docs/#_use_of_the_web_interface' => 'the documentation'
+            </span>
+        </div>
     </div>
 </div>
 <div class="row form-group">
     <div class="col-sm-1"></div>
     <div class="col-sm-11">
         <button class="btn btn-success btn-circle" type="submit" id="submitComment">
-            <i class="fa fa-comment"></i>
-            Submit comment</button>
-            <% my $content = '
-                <p>
-                    The comment field supports Markdown, automatic detection of URLs and special tags to record issue references, \'labels\'
-                    as well as \'build tagging\'.
-                </p>
-                <ul>
-                    <li>
-                        For bugreferences write <code><i>bugtracker_shortname</i>#<i>bug_nr</i></code> in a comment, e.g. <code>bsc#1234</code>.
-                    </li>
-                    <li>
-                        For generic labels use <code>label:<i>keyword</i></code> where <i>keyword</i> can be any valid character up to the next whitespace, e.g. "false_positive".
-                    </li>
-                </ul>
-                <p>
-                    The keywords are not defined within openQA itself. A valid list of keywords should be decided upon within each project or
-                    environment of one openQA instance.
-                </p>
-                <p>
-                    One special label format is available which allows to forcefully overwrite the result of a job using a comment. The expected format is <code>label:force_result:<i>new_result[:description]</i></code>, for example <code>label:force_result:failed</code> or <code>label:force_result:softfailed:bsc#1234</code>. For this command to be effective the according user needs to have at least operator permissions.
-                </p>
-                <p>
-                    Also GitHub pull requests and issues can be linked using the generic format <i>marker</i>[#<i>project/repo</i>]#<i>id</i>,
-                    e.g. gh#os-autoinst/openQA#1234. You can also write (or copy-paste) full links to bugs and issues.
-                </p>
-                <p>
-                    The links are automatically changed to the shortlinks (e.g. <code>https://progress.opensuse.org/issues/11110</code> turns
-                    into <code>poo#11110</code>).
-                </p>
-                <p>
-                    Issue references are automatically carried over to the next jobs in the same scenario when the corresponding job fails in
-                    the same module or the failed modules did not change.
-                </p>
-                <p>
-                    Comments on job group pages can be "pinned" to the top by including the special keyword <code>pinned-description</code>
-                    anywhere in the text.
-                </p>';
-            %>
-            %= help_popover 'Help for comments' => $content, 'https://open.qa/docs/#_use_of_the_web_interface' => 'the documentation'
+            <i class="fa fa-comment"></i> Submit comment
+        </button>
     </div>
-
 </div>

--- a/templates/webapi/main/comment_area.html.ep
+++ b/templates/webapi/main/comment_area.html.ep
@@ -10,6 +10,6 @@
         %= include 'comments/comment_row', comment_id => '@comment_id@', comment => 0, user => current_user, context => {type => $comment_context, id => $group->{id}}, put_action => $comment_put_action, delete_action => $comment_delete_action
     </script>
     %= form_for url_for($comment_post_action, $comment_context . '_id' => $group->{id}) => (method => "post", class => "form-horizontal", id => "commentForm", onsubmit => "addComment(this, false); return false;") => begin
-        %= include 'comments/add_comment_form_groups'
+        %= include 'comments/add_comment_form_groups', group_comment => 1
     % end
 % }

--- a/templates/webapi/test/comments.html.ep
+++ b/templates/webapi/test/comments.html.ep
@@ -7,6 +7,6 @@
         %= include 'comments/comment_row', comment_id => '@comment_id@', comment => 0, user => current_user, context => {type => 'job', id => $job->id}, put_action => 'apiv1_put_comment', delete_action => 'apiv1_delete_comment'
     </script>
     %= form_for url_for('apiv1_post_comment', job_id => $job->id) => (method => "post", class => "form-horizontal", id => "commentForm", onsubmit => "addComment(this, true); return false;") => begin
-        %= include 'comments/add_comment_form_groups'
+        %= include 'comments/add_comment_form_groups', group_comment => 0
     % end
 % }


### PR DESCRIPTION
* [Add button to insert (force result) label into comment text](https://github.com/os-autoinst/openQA/commit/8be09a3e064f27913f3524fbf2ac06d55e999cbb):
   * On job page, showing tooltip: ![screenshot_20220519_170804](https://user-images.githubusercontent.com/10248953/169329430-83f51bf9-2427-423a-8a76-c73a0ba91f13.png)
   * On group page: ![screenshot_20220519_170934](https://user-images.githubusercontent.com/10248953/169329978-2e7cb42c-4a7f-46cb-a51d-79f0247f5c2a.png)
* [Fix alignment of avatar icons beside comments](https://github.com/os-autoinst/openQA/commit/2406d2a2e77f57338e2fec3ad5d4b4745dbb581b)
    * Before:  
      ![screenshot_20220519_163458](https://user-images.githubusercontent.com/10248953/169327960-0f6b3662-e3ee-4d23-8e0c-8da7d322ca1a.png)
    * After:  
      ![screenshot_20220519_170145](https://user-images.githubusercontent.com/10248953/169328109-fa4a544d-1a15-4973-9dc3-7b547495df17.png)

 