### PR TITLE
Reduce log-level of non-critical issue

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -195,7 +195,7 @@ sub create_from_settings {
     # associate currently available assets with job
     $job->register_assets_from_settings;
 
-    log_warning('Ignoring invalid group ' . encode_json($group_args) . ' when creating new job ' . $job->id)
+    log_info('Ignoring invalid group ' . encode_json($group_args) . ' when creating new job ' . $job->id)
       if keys %$group_args && !$group;
     $job->calculate_blocked_by;
     $txn_guard->commit;


### PR DESCRIPTION
When users trigger jobs with an invalid job group we already ignore the
setting but so far we reported it as "warning". Well, I do not see what
we could do about this so let's just handle as "info".

Related progress issue: https://progress.opensuse.org/issues/105909