### PR TITLE
Introduce job setting _TRIGGER_JOB_DONE_HOOK to disable/enable hook

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -870,6 +870,14 @@ the `OPENQA_` prefix can be used in the format `job_done_hook_$result`. The
 corresponding environment value has precedence. The exit code of the
 externally called script is not evaluated and will have no effect.
 
+It is also possible to specify one general hook script via `job_done_hook` and
+enable that one for specific results via e.g. `job_done_hook_enable_failed = 1`.
+
+The job setting `_TRIGGER_JOB_DONE_HOOK=0` allows to disable the hook script
+execution for a particular job. It is also possible to specify
+`_TRIGGER_JOB_DONE_HOOK=1` to execute the general hook script configured via
+`job_done_hook` regardless of the result.
+
 The execution time of the script is by default limited to five minutes. If the
 script does not terminate after receiving `SIGTERM` for 30 seconds it is
 terminated forcefully via `SIGKILL`. One can change that by setting the

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -212,10 +212,23 @@ concurrent = 0
 #keys_to_render_as_links=YAML_SCHEDULE,AUTOYAST
 
 [hooks]
-# Specify custom hook scripts format `job_done_hook_$result` to be called when
-# a job is done. Any executable specified in the variable as absolute path or
-# executable name in `$PATH` is called with the job ID as first and only
-# parameter corresponding to the `$result`, for example
+# Specify a custom hook script to be executed when a job *with*
+# `_TRIGGER_JOB_DONE_HOOK=1` is done. The hook can also be enabled for jobs
+# *without* `_TRIGGER_JOB_DONE_HOOK=0` that are done with a certain result (see
+# further settings).
+#job_done_hook = my-openqa-hook
+
+# Specify that `job_done_hook` should be executed when a job is done with the a
+# certain result (unless the job setting `_TRIGGER_JOB_DONE_HOOK=0` is present).
+# Note that `failed` in the following example can be replaced with any job
+# result.
+#job_done_hook_enable_failed = 1
+
+# Specify a custom hook script in the format `job_done_hook_$result` to be
+# called when a job is done with the a certain result (unless the job setting
+# `_TRIGGER_JOB_DONE_HOOK=0` is present) . Any executable specified in the
+# variable as absolute path or executable name in `$PATH` is called with the job
+# ID as first and only parameter corresponding to the `$result`, for example:
 #job_done_hook_failed = my-openqa-hook-failed
 
 # Configuration for InfluxDB routes

--- a/lib/OpenQA/Task/Job/FinalizeResults.pm
+++ b/lib/OpenQA/Task/Job/FinalizeResults.pm
@@ -42,10 +42,14 @@ sub _finalize_results {
 }
 
 sub _run_hook_script ($minion_job, $openqa_job, $app, $guard) {
+    my $trigger_hook = $openqa_job->settings_hash->{_TRIGGER_JOB_DONE_HOOK};
+    return undef if defined $trigger_hook && !$trigger_hook;
     return undef unless my $result = $openqa_job->result;
     my $hooks = $app->config->{hooks};
     my $key = "job_done_hook_$result";
-    return undef unless my $hook = $ENV{'OPENQA_' . uc $key} // $hooks->{lc $key};
+    my $hook = $ENV{'OPENQA_' . uc $key} // $hooks->{lc $key};
+    $hook = $hooks->{job_done_hook} if !$hook && ($trigger_hook || $hooks->{"job_done_hook_enable_$result"});
+    return undef unless $hook;
     my $timeout = $ENV{OPENQA_JOB_DONE_HOOK_TIMEOUT} // '5m';
     my $kill_timeout = $ENV{OPENQA_JOB_DONE_HOOK_KILL_TIMEOUT} // '30s';
     $guard->abort(1);


### PR DESCRIPTION
This setting allows to disable/enable the hook script per job (or test
suite or wherever the setting is specified). It also comes with a generic
`job_done_hook` configuration setting which will be used in case
`_TRIGGER_JOB_DONE_HOOK=1` is specified and no result-specific job done
hook is configured anyways.

See
* https://progress.opensuse.org/issues/110518
* https://progress.opensuse.org/issues/110530