### PR TITLE
Don't log_debug git stdout in all cases

### DIFF
--- a/lib/OpenQA/Git.pm
+++ b/lib/OpenQA/Git.pm
@@ -30,9 +30,9 @@ sub _prepare_git_command ($self, $args = undef) {
     return ('git', '-C', $dir);
 }
 
-sub _format_git_error ($git_result, $error_message) {
-    if ($git_result->{stderr}) {
-        $error_message .= ': ' . $git_result->{stderr};
+sub _format_git_error ($result, $error_message) {
+    if ($result->{stderr} or $result->{stdout}) {
+        $error_message .= ': ' . $result->{stdout} . $result->{stderr};
     }
     return $error_message;
 }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1839,16 +1839,19 @@ sub git_log_diff ($self, $dir, $refspec_range, $limit = undef) {
         [
             'git', '-C', $dir, 'log', ($limit ? "-$limit" : ()),
             '--stat', '--pretty=oneline', '--abbrev-commit', '--no-merges', $refspec_range
-        ]);
+        ],
+        stdout => 'trace'
+    );
     # regardless of success or not the output contains the information we need
-    return "\n" . $res->{stderr} if $res->{stderr};
+    return $res->{stdout} . $res->{stderr};
 }
 
 sub git_diff ($self, $dir, $refspec_range) {
     return "Invalid range $refspec_range" if $refspec_range =~ m/UNKNOWN/;
     my $timeout = OpenQA::App->singleton->config->{global}->{job_investigate_git_timeout} // 20;
-    my $res = run_cmd_with_log_return_error(['timeout', $timeout, 'git', '-C', $dir, 'diff', '--stat', $refspec_range]);
-    return "\n" . $res->{stderr} if $res->{stderr};
+    my $res = run_cmd_with_log_return_error(['timeout', $timeout, 'git', '-C', $dir, 'diff', '--stat', $refspec_range],
+        stdout => 'trace');
+    return $res->{stdout} . $res->{stderr};
 }
 
 =head2 investigate

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -317,26 +317,30 @@ sub run_cmd_with_log {
 }
 
 sub run_cmd_with_log_return_error {
-    my ($cmd) = @_;
+    my ($cmd, %args) = @_;
+    my $stdout_level = $args{stdout} // 'debug';
+    my $stderr_level = $args{stderr} // 'debug';
 
     log_info('Running cmd: ' . join(' ', @$cmd));
     try {
-        my ($stdin, $stdout_err);
-        my $ipc_run_succeeded = IPC::Run::run($cmd, \$stdin, '>&', \$stdout_err);
+        my ($stdin, $stdout_err, $stdout, $stderr) = ('') x 4;
+        my $ipc_run_succeeded = IPC::Run::run($cmd, \$stdin, \$stdout, \$stderr);
         my $return_code = $?;
-        chomp $stdout_err;
+        chomp $stderr;
         if ($ipc_run_succeeded) {
-            log_debug($stdout_err);
+            OpenQA::Log->can("log_$stdout_level")->($stdout);
+            OpenQA::Log->can("log_$stderr_level")->($stderr);
             log_info("cmd returned $return_code");
         }
         else {
-            log_warning($stdout_err);
+            log_warning($stdout . $stderr);
             log_error("cmd returned $return_code");
         }
         return {
             status => $ipc_run_succeeded,
             return_code => $return_code,
-            stderr => $stdout_err,
+            stdout => $stdout,
+            stderr => $stderr,
         };
     }
     catch {
@@ -344,6 +348,7 @@ sub run_cmd_with_log_return_error {
             status => 0,
             return_code => undef,
             stderr => "an internal error occurred",
+            stdout => '',
         };
     };
 }

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -32,7 +32,7 @@ subtest 'run (arbitrary) command' => sub {
 
     my $res = run_cmd_with_log_return_error([qw(echo Hallo Welt)]);
     ok($res->{status}, 'status ok');
-    is($res->{stderr}, 'Hallo Welt', 'cmd output returned');
+    is($res->{stdout}, "Hallo Welt\n", 'cmd output returned');
 
     stdout_like { $res = run_cmd_with_log_return_error([qw(false)]) } qr/.*\[error\].*cmd returned [1-9][0-9]*/i;
     ok(!$res->{status}, 'status not ok (non-zero status returned)');
@@ -109,6 +109,7 @@ subtest 'git commands with mocked run_cmd_with_log_return_error' => sub {
     @executed_commands = ();
     $mock_return_value{status} = 0;
     $mock_return_value{stderr} = 'mocked error';
+    $mock_return_value{stdout} = '';
     is(
         $git->set_to_latest_master,
         'Unable to fetch from origin master: mocked error',


### PR DESCRIPTION
The output might be very long and usually not needed in
debug level.

Related issue: https://progress.opensuse.org/issues/110677