### PR TITLE
Add a limit for the maximum number of jobs to include in /tests/overview

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -197,6 +197,8 @@ concurrent = 0
 #results_min_free_disk_space_percentage = 0
 # Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800
+# Maximum number of jobs to include in tests overview page (to prevent performance issues)
+#tests_overview_max_jobs = 500
 
 [archiving]
 # Moves logs of jobs which are preserved during the cleanup because they are considered important

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -150,6 +150,7 @@ sub read_config ($app) {
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
             results_min_free_disk_space_percentage => undef,
             minion_job_max_age => ONE_WEEK,
+            tests_overview_max_jobs => 500,
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/t/config.t
+++ b/t/config.t
@@ -133,6 +133,7 @@ subtest 'Test configuration default modes' => sub {
             screenshot_cleanup_batch_size => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
             minion_job_max_age => ONE_WEEK,
+            tests_overview_max_jobs => 500,
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -8,6 +8,11 @@
   setupOverview();
 % end
 
+% if ($limit_exceeded) {
+  <div class="alert alert-warning" id="max-jobs-limit" role="alert">
+    <i class="fa fa-exclamation-circle"></i> Only <%= $limit_exceeded %> results included, please narrow down your search parameters.
+  </div>
+% }
 <div>
     <h2>Test result overview</h2>
     <div id="summary" class="card <%= ($aggregated->{failed} + $aggregated->{not_complete}) ? 'border-danger' : 'border-success' %>">


### PR DESCRIPTION
Before:
<img width="643" alt="before" src="https://user-images.githubusercontent.com/30094/170078173-b47448fb-d4ee-4039-82c8-bd3920e4ecbc.png">

After:
<img width="651" alt="after" src="https://user-images.githubusercontent.com/30094/170078275-48d4eec4-59fd-476b-99ee-44f09d0c3b63.png">

The default of 500 jobs is an arbitrary choice, based on the number of jobs i saw clicking around the latest builds in the O3 database. Around 300 was the maximum i saw there. Happy to change it though.

Progress: https://progress.opensuse.org/issues/110680