### PR TITLE
Fix workaround for sporadic error in comments test

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -35,7 +35,7 @@ function renderCommentHeading(comment, commentId) {
   abbr_link.append(renderDate(comment.created));
   heading.append(comment.userName, ' wrote ', abbr_link);
   // add a margin of 1000ms to prevent erroneous update detected if off by 1
-  if (new Date(comment.updated).getTime() - 1000 >= new Date(comment.created)) {
+  if (new Date(comment.updated).getTime() - 1000 > new Date(comment.created).getTime()) {
     heading.append(' (last edited ', renderDate(comment.updated), ')');
   }
   return heading;


### PR DESCRIPTION
* Fix condition for "margin" introduced by
  d674bdf397dfc4a77cdef95091b2078a50e9d096
    * The resolution of the timestamps is one second. If `comment.updated`
      is really accidentally one second ahead we need `>` instead of `>=`
      to avoid adding the "last edited" notice.
* Convert both Date objects to a number of milliseconds instead of relying
  on an implicit conversion
* Note that the inaccuracy does not come from the JavaScript-side (unlike
  stated in d674bdf397dfc4a77cdef95091b2078a50e9d096). Before, the
  JavaScript code was merely comparing the timestamps as strings which
  should not introduce any rounding errors. The rounding errors must happen
  before (when generating the timestamps or even when adding the row to the
  database).
* See https://progress.opensuse.org/issues/111542