### PR TITLE
Prevent new comments from being considered edited

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -34,8 +34,7 @@ function renderCommentHeading(comment, commentId) {
   abbr_link.prop('class', 'comment-anchor');
   abbr_link.append(renderDate(comment.created));
   heading.append(comment.userName, ' wrote ', abbr_link);
-  // add a margin of 1000ms to prevent erroneous update detected if off by 1
-  if (new Date(comment.updated).getTime() - 1000 > new Date(comment.created).getTime()) {
+  if (comment.updated !== comment.created) {
     heading.append(' (last edited ', renderDate(comment.updated), ')');
   }
   return heading;

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -4,8 +4,26 @@
 package OpenQA::Schema::ResultSet::Comments;
 
 use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
+use DBIx::Class::Timestamps;
 use OpenQA::App;
 use OpenQA::Utils qw(find_bugrefs);
+
+=over 4
+
+=item create()
+
+Creates a comment ensuring t_created and t_updated are set consistently to avoid
+the new comment from being considered edited.
+
+=back
+
+=cut
+
+sub create ($self, $data, @additional_args) {
+    $data->{t_created} = $data->{t_updated} = DBIx::Class::Timestamps::now
+      unless exists $data->{t_created} || exists $data->{t_updated};
+    $self->SUPER::create($data, @additional_args);
+}
 
 =over 4
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -5,7 +5,6 @@ package OpenQA::WebAPI::Controller::API::V1::Comment;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use Date::Format;
-use DBIx::Class::Timestamps;
 use OpenQA::Utils qw(:DEFAULT href_to_bugref);
 use OpenQA::Jobs::Constants;
 
@@ -140,9 +139,6 @@ sub _insert_bugs_for_comment ($self, $comment) {
 Adds a new comment to the specified job/group. Returns a 200 code with a JSON containing the
 new comment id or 400 if no text is specified for the comment.
 
-Assigning t_created and t_updated manually so both are guaranteed to be
-identical and comments are not accidentally considered edited.
-
 =back
 
 =cut
@@ -155,14 +151,11 @@ sub create ($self) {
     $validation->required('text')->like(qr/^(?!\s*$).+/);
     my $text = $validation->param('text');
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
-    my $timestamp = DBIx::Class::Timestamps::now;
     my $txn_guard = $self->schema->txn_scope_guard;
     my $comment = $comments->create(
         {
             text => href_to_bugref($text),
-            user_id => $self->current_user->id,
-            t_created => $timestamp,
-            t_updated => $timestamp,
+            user_id => $self->current_user->id
         });
 
     eval { $self->_handle_special_comments($comment) };


### PR DESCRIPTION
The timestamps `t_created` and `t_updated` are used to check whether a
comment has been edited. They are computed in Perl code (via the package
`DBIx::Class::Timestamps` from our repository). Unfortunately it's `now`
function is invoked for each column individually, e.g. some debug printing
reveals:

```
called DBIx::Class::Timestamps::now: OpenQA::Schema::Result::Comments=HASH(0x55a31d4d9980)
called DBIx::Class::Timestamps::now: OpenQA::Schema::Result::Comments=HASH(0x55a31d4d9980)
called DBIx::Class::Timestamps::now: OpenQA::Schema::Result::AuditEvents=HASH(0x55a31d4d5080)
called DBIx::Class::Timestamps::now: OpenQA::Schema::Result::AuditEvents=HASH(0x55a31d4d5080)
```

That explains why the timestamps might be inconsistent leading to
https://progress.opensuse.org/issues/111542.

Having the debug printing still in-place, I could verify that with this
change the first two calls are replaced by a single call. So this change
should fix https://progress.opensuse.org/issues/111542 at the source and
the workaround in the JavaScript code can be removed.