### PR TITLE
Prevent dangerous package removal by forcing resolution

### DIFF
--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/op
     # openQA might need rubygem:sass to compile assets in this context due to
     # unknown reasons even though the package should use the precompiled
     # assets from cache.tar
-    zypper in -y --force-resolution ca-certificates-mozilla curl openQA-local-db apache2 hostname which w3m 'rubygem(sass)' && \
+    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 hostname which w3m 'rubygem(sass)' && \
     zypper clean && \
     gensslcert && \
     a2enmod headers && \

--- a/container/webui/Dockerfile-lb
+++ b/container/webui/Dockerfile-lb
@@ -6,7 +6,7 @@ LABEL maintainer Ivan Lausuch <ilausuch@suse.com>
 RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Leap_15.3 devel_openQA && \
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.3/openSUSE_Leap_15.3 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    zypper in -y --force-resolution openQA nginx && \
+    zypper in -y openQA nginx && \
     zypper clean
 
 COPY nginx-entrypoint.sh /entrypoint.sh

--- a/script/openqa-auto-update
+++ b/script/openqa-auto-update
@@ -24,6 +24,6 @@ while true; do
 done
 
 "$(dirname "${BASH_SOURCE[0]}")"/openqa-check-devel-repo
-zypper -n dup --replacefiles --auto-agree-with-licenses --force-resolution --download-in-advance
+zypper -n dup --replacefiles --auto-agree-with-licenses --download-in-advance
 # shellcheck disable=SC2015
 needs-restarting --reboothint >/dev/null || (command -v rebootmgrctl >/dev/null && rebootmgrctl reboot ||:)


### PR DESCRIPTION
Whenever zypper repositories are unavailable or incompletely read it can
happen (and did happen) that packages are forcefully removed as zypper
was forced by us to find a resolution which is not what we want.

Related progress issue: https://progress.opensuse.org/issues/111755