### PR TITLE
Remove a pointless git warning

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -214,7 +214,6 @@ sub gitrepodir {
     my %args = (distri => '', version => '', @_);
     my $path = $args{needles} ? needledir($args{distri}, $args{version}) : testcasedir($args{distri}, $args{version});
     my $filename = (-e path($path, '.git')) ? path($path, '.git', 'config') : '';
-    log_warning("$path is not a git directory") if $filename eq '';
     my $config = Config::Tiny->read($filename, 'utf8');
     return '' unless defined $config;
     if ($config->{'remote "origin"'}{url} =~ /^http(s?)/) {

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -26,7 +26,6 @@ use OpenQA::Test::Utils 'redirect_output';
 use OpenQA::Test::TimeLimit '10';
 use Scalar::Util 'reftype';
 use Test::MockObject;
-use Test::Output qw(combined_like);
 use Mojo::File qw(path tempdir tempfile);
 
 subtest 'service ports' => sub {
@@ -382,8 +381,7 @@ subtest 'project directory functions' => sub {
         is resultdir, '/var/lib/openqa/testresults', 'resultdir';
         is assetdir, '/var/lib/openqa/share/factory', 'assetdir';
         is imagesdir, '/var/lib/openqa/images', 'imagesdir';
-        combined_like { is gitrepodir, '', 'no gitrepodir when distri is not defined' }
-        qr{/var/lib/openqa/share/tests is not a git directory}, 'warning about Git dir logged';
+        is gitrepodir, '', 'no gitrepodir when distri is not defined';
     };
     subtest 'custom OPENQA_BASEDIR' => sub {
         local $ENV{OPENQA_BASEDIR} = '/tmp/test';
@@ -394,8 +392,7 @@ subtest 'project directory functions' => sub {
         is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
         my $mocked_git = path(sharedir . '/tests/opensuse/.git');
         $mocked_git->remove_tree if -e $mocked_git;
-        combined_like { is gitrepodir(distri => $distri), '', 'empty when .git is missing' }
-        qr{/tmp/test/openqa/share/tests/opensuse is not a git directory}, 'warning about Git dir logged';
+        is gitrepodir(distri => $distri), '', 'empty when .git is missing';
         $mocked_git->make_path;
         $mocked_git->child('config')
           ->spurt(qq{[remote "origin"]\n        url = git\@github.com:fakerepo/os-autoinst-distri-opensuse.git});
@@ -412,8 +409,7 @@ subtest 'project directory functions' => sub {
         is resultdir, '/tmp/test/openqa/testresults', 'resultdir';
         is assetdir, '/tmp/share/factory', 'assetdir';
         is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
-        combined_like { is gitrepodir, '', 'no gitrepodir when distri is not defined' }
-        qr{/tmp/test/openqa/share/tests is not a git directory}, 'warning about Git dir logged';
+        is gitrepodir, '', 'no gitrepodir when distri is not defined';
         is gitrepodir(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
     };
 };


### PR DESCRIPTION
```
[2022-04-25T09:17:28.805933Z] [warn] [pid:8752] /var/lib/openqa/share/tests/obs/needles is not a git directory
```

The warning does look very pointless in the openQA log. The `gitrepodir` function is written in a way that encourages probing for information, with a proper return value to indicate failure, and the investigate feature uses it that way already.

Progress: https://progress.opensuse.org/issues/110260