### PR TITLE
CI: Automatically merge necessary dependency updates based on test results

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,11 +30,7 @@ pull_request_rules:
   - name: automatic merge on special label
     conditions:
       - and: *base_checks
-      - and:
-        # mergify config checks needs at least two rules in "and" so we repeat
-        # one from the base checks
-        - base=master
-        - "label=merge-fast"
+      - "label=merge-fast"
     actions: *merge
   - name: automatic merge for dependency bot updates
     conditions:


### PR DESCRIPTION
Whenever our development base has updated dependencies we explicitly
update the list of dependencies but old versions are not preserved in
the base OS layer so regardless of if we like the changes or not we need
to accept the changes anyway, in particular version updates. This commit
is extending the mergify configuration to automatically merge pull
requests by the "openqabot" user when all our common checks pass.