### PR TITLE
Fix regression by moving tests/overview limit from SQL back to Perl

### DIFF
--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -409,6 +409,8 @@ subtest 'Maximum jobs limit' => sub {
     $t->get_ok('/tests/overview')->status_is(200)->element_exists('#max-jobs-limit')
       ->text_like('#max-jobs-limit', qr/Only 2 results included, please narrow down your search parameters/)
       ->element_count_is('table.overview td.name', 2);
+    $t->get_ok('/tests/overview?result=incomplete')->status_is(200)->element_exists_not('#max-jobs-limit')
+      ->element_count_is('table.overview td.name', 0);
 };
 
 done_testing();


### PR DESCRIPTION
Every time there are more than 500 jobs in the results we don't know if
the wrong ones have been left out. Because theoretically all 500 could
be sharing the same de-duplication key, taking up the space required by
other more releavant jobs.

The problem is that the de-duplication step needs to happen before jobs
get filtered out by conditions like the result. Unfortunately that
happens in Perl, after the main SQL has already been processed. I've
looked into doing the de-duplication in SQL too, but couldn't find a
solution that was good enough. So for now the best solution is to move
the limit from SQL back to Perl. Which fortunately seems to still be
fast enough for all the cases we care about.

What makes this issue so complicated is that the request and response
data goes through multiple transformations that have continuously grown
in complexity over the past 10 years:

* The `compose_job_overview_search_args` helper reads the HTTP GET
  parameters and transforms them into a simplified data structure
  vaguely representing a `DBIx::Class` query, parts of it are used to
  perform intermediate SQL queries (called in 2 places)

* The `complex_query` resultset method transforms various comma
  separated values into array references, and then uses
  `_prepare_complex_query_search_args` to transform about 20
  simplified parameters into something `DBIx::Class` can understand,
  before returning a resultset using these values as search parameters
  (called in 10 places)

* The `latest_jobs` method is called on the existing resultset, and adds
  more search parameters before retrieving the full list of matching
  jobs from PostgreSQL and doing a de-duplication of jobs based on
  various properties in memory (called in 6 places)

* And this is where things get complex :grin:, because now the
  `overview` action will call the `_prepare_job_results` method to
  prefetch various job related data such as comments (for labels) and
  then pull in HTTP GET parameters again and do the actual filtering of
  jobs for the `failed_modules`, `state`, `result`, `arch`, and `machine`
  conditions (all were previously relevant for de-duplication), and then
  transform the whole data structure into something that can be rendered
  in templates (the action can actually be called in 2 ways, because of
  a backcompat hack)

So, because i moved the limit condition from SQL to Perl, which makes
everything a little bit slower, i have also moved the final filtering
step before the part that prefetches comments. This should result in an
overall performance boost for all `tests/overview` requests.

Progress: https://progress.opensuse.org/issues/111833