### PR TITLE
systemd: Depend on time being in sync if possible

### DIFF
--- a/systemd/openqa-worker-plain@.service
+++ b/systemd/openqa-worker-plain@.service
@@ -4,7 +4,7 @@
 # replace '1' with the instance number you want
 [Unit]
 Description=openQA Worker #%i
-After=openqa-slirpvde.service network.target nss-lookup.target remote-fs.target
+After=openqa-slirpvde.service network.target nss-lookup.target remote-fs.target time-sync.target
 PartOf=openqa-worker.target
 
 [Service]


### PR DESCRIPTION
If the system has a unit implementing time-sync the worker service will
not come up until it can rely on the time. This prevents authentication
errors due to a timestamp mismatch.

See: https://progress.opensuse.org/issues/105855