### PR TITLE
Verify when maintenance update has already been released

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -13,6 +13,7 @@ use OpenQA::Client;
 use Mojo::File 'path';
 use Mojo::URL;
 use Mojo::JSON;    # booleans
+use OpenQA::Script::CloneJobSUSE;
 
 our @EXPORT = qw(
   clone_jobs
@@ -245,8 +246,9 @@ sub clone_job ($jobid, $url_handler, $options, $post_params = {}, $jobs = {}, $d
     return $post_params if defined $post_params->{$jobid};
 
     my $job = $jobs->{$jobid} = clone_job_get_job($jobid, $url_handler, $options);
-    my $settings = $post_params->{$jobid} = {%{$job->{settings}}};
 
+    my $settings = $post_params->{$jobid} = {%{$job->{settings}}};
+    OpenQA::Script::CloneJobSUSE::detect_maintenance_update($jobid, $url_handler, $settings);
     my $clone_children = $options->{'clone-children'};
     my $max_depth = $options->{'max-depth'} // 1;
     for my $job_type (qw(parents children)) {

--- a/lib/OpenQA/Script/CloneJobSUSE.pm
+++ b/lib/OpenQA/Script/CloneJobSUSE.pm
@@ -1,0 +1,41 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Script::CloneJobSUSE;
+use Mojo::Base -strict, -signatures;
+use Data::Dump 'pp';
+use Exporter 'import';
+
+our @EXPORT = qw(detect_maintenance_update);
+
+sub collect_incident_repos ($url_handler, $settings) {
+    my @urls;
+    for my $setting (keys %$settings) {
+        return verify_incident_repos($url_handler, $settings->{'INCIDENT_REPO'}) if ($setting =~ /INCIDENT_REPO/);
+        if ($setting =~ /SCC_ADDONS/) {
+            foreach my $SCC_ADDON (split(/,/, $settings->{'SCC_ADDONS'})) {
+                next unless $settings->{uc($SCC_ADDON) . '_TEST_REPOS'};
+                my $incident_urls = verify_incident_repos($url_handler, $settings->{uc($SCC_ADDON) . '_TEST_REPOS'});
+                push @urls, @$incident_urls;
+            }
+        }
+    }
+    return \@urls;
+}
+
+sub verify_incident_repos ($url_handler, $incident_repos) {
+    my @incident_urls;
+    my $ua = $url_handler->{ua};
+    foreach my $incident (split(/,/, $incident_repos)) {
+        push @incident_urls, $incident unless $ua->get($incident)->is_success;
+    }
+    return \@incident_urls;
+}
+
+sub detect_maintenance_update ($jobid, $url_handler, $settings) {
+    my $urls = collect_incident_repos($url_handler, $settings);
+    die "Current job $jobid will fail, because the repositories for the below updates are unavailable\n" . pp($urls)
+      if @$urls;
+}
+
+1;

--- a/t/35-script_clone_job_suse.t
+++ b/t/35-script_clone_job_suse.t
@@ -1,0 +1,54 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '6';
+use Mojo::Base -signatures;
+use Test::MockModule;
+use OpenQA::Script::CloneJobSUSE;
+use Mojo::URL;
+
+# define fake client
+{
+    package Test::FakeLWPUserAgentMirrorResult;
+    use Mojo::Base -base, -signatures;
+    has is_success => 1;
+}
+{
+    package Test::FakeLWPUserAgent;
+    use Mojo::Base -base, -signatures;
+    has is_validrepo => 1;
+    sub get ($self, $url) { Test::FakeLWPUserAgentMirrorResult->new(is_success => $self->is_validrepo) }
+}
+
+subtest 'maintenance update detect' => sub {
+    my $job_id = 1;
+    my %job = (
+        id => $job_id,
+        SCC_ADDONS => "we,sdk",
+        WE_TEST_REPOS => "http://foo/WE_suse/openqa,http://foo/WE_suse_2/openqa",
+        SDK_TEST_REPOS => "http://foo/SDK_suse/openqa,http://foo/SDK_suse_2/openqa",
+    );
+    my %incident_job = (
+        id => $job_id,
+        INCIDENT_REPO => "http://foo/incident_repo/openqa,http://foo/incident_repo_1/openqa",
+    );
+
+    my $fake_ua = Test::FakeLWPUserAgent->new;
+    my %url_handler = (remote_url => Mojo::URL->new('http://foo'), ua => $fake_ua);
+    my $clone_mock = Test::MockModule->new('OpenQA::Script::CloneJobSUSE');
+    $fake_ua->is_validrepo(1);
+    lives_ok { detect_maintenance_update($job_id, \%url_handler, \%job) } 'Maintenance updates are available';
+    lives_ok { detect_maintenance_update($job_id, \%url_handler, \%incident_job) } 'Maintenance updates are available';
+    $fake_ua->is_validrepo(0);
+    throws_ok { detect_maintenance_update($job_id, \%url_handler, \%job) } qr/Current job $job_id will fail/,
+      'Maintenance updates have been released';
+    throws_ok { detect_maintenance_update($job_id, \%url_handler, \%incident_job) } qr/Current job $job_id will fail/,
+      'Maintenance updates have been released';
+};
+
+done_testing();


### PR DESCRIPTION
Before cloning or restarting a job, verify the maintenance update has already been released.  

- Related ticket: https://progress.opensuse.org/issues/109707

