### PR TITLE
Avoid race condition in Selenium test helper `element_hidden`

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -280,7 +280,8 @@ sub element_visible ($selector, $like = undef, $unlike = undef, $test_descriptio
 sub element_hidden ($selector, $test_description = undef) {
     my @elements = $_driver->find_elements($selector);
     is scalar @elements, 1, $selector . ' present exactly once';
-    ok !$elements[0]->is_displayed, $test_description // ($selector . ' hidden');
+    my $hidden = !$elements[0]->is_displayed || $elements[0]->get_css_attribute('display') eq 'none';
+    ok $hidden, $test_description // ($selector . ' hidden');
 }
 
 # asserts that an element is not part of the page


### PR DESCRIPTION
The ticket https://progress.opensuse.org/issues/111920 shows that there's
apparently a race condition.

The JavaScript code tested here seems unproblematic. Apparently Selenium's
displayedness check considers the viewport (see
https://w3c.github.io/webdriver/#element-displayedness). I suspect that
this can lead to the test failure we observed because Selenium only waits
until the JavaScript event-loop runs out of work but likely *not* until the
viewport has been updated.