### PR TITLE
Avoid running out of database IDs

### DIFF
--- a/dbicdh/PostgreSQL/deploy/95/001-auto-__VERSION.sql
+++ b/dbicdh/PostgreSQL/deploy/95/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+--
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Mon Jun 13 10:16:51 2022
+--
+;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id serial NOT NULL,
+  version character varying(50) NOT NULL,
+  ddl text,
+  upgrade_sql text,
+  PRIMARY KEY (id),
+  CONSTRAINT dbix_class_deploymenthandler_versions_version UNIQUE (version)
+);
+
+;

--- a/dbicdh/PostgreSQL/deploy/95/001-auto.sql
+++ b/dbicdh/PostgreSQL/deploy/95/001-auto.sql
@@ -1,0 +1,794 @@
+--
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Mon Jun 13 10:16:51 2022
+--
+;
+--
+-- Table: bugs
+--
+CREATE TABLE bugs (
+  id bigserial NOT NULL,
+  bugid text NOT NULL,
+  title text,
+  priority text,
+  assigned boolean,
+  assignee text,
+  open boolean,
+  status text,
+  resolution text,
+  existing boolean DEFAULT '1' NOT NULL,
+  refreshed boolean DEFAULT '0' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT bugs_bugid UNIQUE (bugid)
+);
+
+;
+--
+-- Table: gru_tasks
+--
+CREATE TABLE gru_tasks (
+  id bigserial NOT NULL,
+  taskname text NOT NULL,
+  args text NOT NULL,
+  run_at timestamp NOT NULL,
+  priority integer NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX gru_tasks_run_at_reversed on gru_tasks (run_at DESC);
+
+;
+--
+-- Table: job_group_parents
+--
+CREATE TABLE job_group_parents (
+  id bigserial NOT NULL,
+  name text NOT NULL,
+  size_limit_gb integer,
+  exclusively_kept_asset_size bigint,
+  default_keep_logs_in_days integer,
+  default_keep_important_logs_in_days integer,
+  default_keep_results_in_days integer,
+  default_keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  build_version_sort boolean DEFAULT '1' NOT NULL,
+  carry_over_bugrefs boolean,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_group_parents_name UNIQUE (name)
+);
+
+;
+--
+-- Table: job_modules
+--
+CREATE TABLE job_modules (
+  id bigserial NOT NULL,
+  job_id bigint NOT NULL,
+  name text NOT NULL,
+  script text NOT NULL,
+  category text NOT NULL,
+  milestone integer DEFAULT 0 NOT NULL,
+  important integer DEFAULT 0 NOT NULL,
+  fatal integer DEFAULT 0 NOT NULL,
+  always_rollback integer DEFAULT 0 NOT NULL,
+  result character varying DEFAULT 'none' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_modules_job_id_name_category_script UNIQUE (job_id, name, category, script)
+);
+CREATE INDEX job_modules_idx_job_id on job_modules (job_id);
+CREATE INDEX idx_job_modules_result on job_modules (result);
+
+;
+--
+-- Table: job_settings
+--
+CREATE TABLE job_settings (
+  id bigserial NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  job_id bigint NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX job_settings_idx_job_id on job_settings (job_id);
+CREATE INDEX idx_value_settings on job_settings (key, value);
+CREATE INDEX idx_job_id_value_settings on job_settings (job_id, key, value);
+
+;
+--
+-- Table: job_template_settings
+--
+CREATE TABLE job_template_settings (
+  id bigserial NOT NULL,
+  job_template_id bigint NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_template_settings_job_template_id_key UNIQUE (job_template_id, key)
+);
+CREATE INDEX job_template_settings_idx_job_template_id on job_template_settings (job_template_id);
+
+;
+--
+-- Table: machine_settings
+--
+CREATE TABLE machine_settings (
+  id bigserial NOT NULL,
+  machine_id bigint NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT machine_settings_machine_id_key UNIQUE (machine_id, key)
+);
+CREATE INDEX machine_settings_idx_machine_id on machine_settings (machine_id);
+
+;
+--
+-- Table: machines
+--
+CREATE TABLE machines (
+  id bigserial NOT NULL,
+  name text NOT NULL,
+  backend text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT machines_name UNIQUE (name)
+);
+
+;
+--
+-- Table: needle_dirs
+--
+CREATE TABLE needle_dirs (
+  id bigserial NOT NULL,
+  path text NOT NULL,
+  name text NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT needle_dirs_path UNIQUE (path)
+);
+
+;
+--
+-- Table: product_settings
+--
+CREATE TABLE product_settings (
+  id bigserial NOT NULL,
+  product_id bigint NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT product_settings_product_id_key UNIQUE (product_id, key)
+);
+CREATE INDEX product_settings_idx_product_id on product_settings (product_id);
+
+;
+--
+-- Table: products
+--
+CREATE TABLE products (
+  id bigserial NOT NULL,
+  name text NOT NULL,
+  distri text NOT NULL,
+  version text DEFAULT '' NOT NULL,
+  arch text NOT NULL,
+  flavor text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT products_distri_version_arch_flavor UNIQUE (distri, version, arch, flavor)
+);
+
+;
+--
+-- Table: screenshots
+--
+CREATE TABLE screenshots (
+  id bigserial NOT NULL,
+  filename text NOT NULL,
+  t_created timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT screenshots_filename UNIQUE (filename)
+);
+
+;
+--
+-- Table: secrets
+--
+CREATE TABLE secrets (
+  id bigserial NOT NULL,
+  secret text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT secrets_secret UNIQUE (secret)
+);
+
+;
+--
+-- Table: test_suite_settings
+--
+CREATE TABLE test_suite_settings (
+  id bigserial NOT NULL,
+  test_suite_id bigint NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT test_suite_settings_test_suite_id_key UNIQUE (test_suite_id, key)
+);
+CREATE INDEX test_suite_settings_idx_test_suite_id on test_suite_settings (test_suite_id);
+
+;
+--
+-- Table: test_suites
+--
+CREATE TABLE test_suites (
+  id bigserial NOT NULL,
+  name text NOT NULL,
+  description text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT test_suites_name UNIQUE (name)
+);
+
+;
+--
+-- Table: users
+--
+CREATE TABLE users (
+  id bigserial NOT NULL,
+  username text NOT NULL,
+  provider text DEFAULT '' NOT NULL,
+  email text,
+  fullname text,
+  nickname text,
+  is_operator integer DEFAULT 0 NOT NULL,
+  is_admin integer DEFAULT 0 NOT NULL,
+  feature_version integer DEFAULT 1 NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT users_username_provider UNIQUE (username, provider)
+);
+
+;
+--
+-- Table: worker_properties
+--
+CREATE TABLE worker_properties (
+  id bigserial NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  worker_id bigint NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX worker_properties_idx_worker_id on worker_properties (worker_id);
+
+;
+--
+-- Table: api_keys
+--
+CREATE TABLE api_keys (
+  id bigserial NOT NULL,
+  key text NOT NULL,
+  secret text NOT NULL,
+  user_id bigint NOT NULL,
+  t_expiration timestamp,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT api_keys_key UNIQUE (key)
+);
+CREATE INDEX api_keys_idx_user_id on api_keys (user_id);
+
+;
+--
+-- Table: audit_events
+--
+CREATE TABLE audit_events (
+  id bigserial NOT NULL,
+  user_id bigint,
+  connection_id text,
+  event text NOT NULL,
+  event_data text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX audit_events_idx_user_id on audit_events (user_id);
+
+;
+--
+-- Table: comments
+--
+CREATE TABLE comments (
+  id bigserial NOT NULL,
+  job_id bigint,
+  group_id bigint,
+  parent_group_id bigint,
+  text text NOT NULL,
+  user_id bigint NOT NULL,
+  flags integer DEFAULT 0,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX comments_idx_group_id on comments (group_id);
+CREATE INDEX comments_idx_job_id on comments (job_id);
+CREATE INDEX comments_idx_parent_group_id on comments (parent_group_id);
+CREATE INDEX comments_idx_user_id on comments (user_id);
+
+;
+--
+-- Table: job_groups
+--
+CREATE TABLE job_groups (
+  id bigserial NOT NULL,
+  name text NOT NULL,
+  parent_id bigint,
+  size_limit_gb integer,
+  exclusively_kept_asset_size bigint,
+  keep_logs_in_days integer,
+  keep_important_logs_in_days integer,
+  keep_results_in_days integer,
+  keep_important_results_in_days integer,
+  default_priority integer,
+  sort_order integer,
+  description text,
+  template text,
+  build_version_sort boolean DEFAULT '1' NOT NULL,
+  carry_over_bugrefs boolean,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT job_groups_name_parent_id UNIQUE (name, parent_id)
+);
+CREATE INDEX job_groups_idx_parent_id on job_groups (parent_id);
+
+;
+--
+-- Table: workers
+--
+CREATE TABLE workers (
+  id bigserial NOT NULL,
+  host text NOT NULL,
+  instance integer NOT NULL,
+  job_id bigint,
+  t_seen timestamp,
+  upload_progress jsonb,
+  error text,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT workers_host_instance UNIQUE (host, instance),
+  CONSTRAINT workers_job_id UNIQUE (job_id)
+);
+CREATE INDEX workers_idx_job_id on workers (job_id);
+
+;
+--
+-- Table: needles
+--
+CREATE TABLE needles (
+  id bigserial NOT NULL,
+  dir_id bigint NOT NULL,
+  filename text NOT NULL,
+  last_seen_time timestamp,
+  last_seen_module_id bigint,
+  last_matched_time timestamp,
+  last_matched_module_id bigint,
+  last_updated timestamp,
+  file_present boolean DEFAULT '1' NOT NULL,
+  tags text[],
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT needles_dir_id_filename UNIQUE (dir_id, filename)
+);
+CREATE INDEX needles_idx_dir_id on needles (dir_id);
+CREATE INDEX needles_idx_last_matched_module_id on needles (last_matched_module_id);
+CREATE INDEX needles_idx_last_seen_module_id on needles (last_seen_module_id);
+
+;
+--
+-- Table: scheduled_products
+--
+CREATE TABLE scheduled_products (
+  id bigserial NOT NULL,
+  distri text DEFAULT '' NOT NULL,
+  version text DEFAULT '' NOT NULL,
+  flavor text DEFAULT '' NOT NULL,
+  arch text DEFAULT '' NOT NULL,
+  build text DEFAULT '' NOT NULL,
+  iso text DEFAULT '' NOT NULL,
+  status text DEFAULT 'added' NOT NULL,
+  settings jsonb NOT NULL,
+  results jsonb,
+  user_id bigint,
+  gru_task_id bigint,
+  minion_job_id bigint,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX scheduled_products_idx_gru_task_id on scheduled_products (gru_task_id);
+CREATE INDEX scheduled_products_idx_user_id on scheduled_products (user_id);
+
+;
+--
+-- Table: job_templates
+--
+CREATE TABLE job_templates (
+  id bigserial NOT NULL,
+  product_id bigint NOT NULL,
+  machine_id bigint NOT NULL,
+  test_suite_id bigint NOT NULL,
+  name text DEFAULT '' NOT NULL,
+  description text DEFAULT '' NOT NULL,
+  prio integer,
+  group_id bigint NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT scenario UNIQUE (product_id, machine_id, name, test_suite_id)
+);
+CREATE INDEX job_templates_idx_group_id on job_templates (group_id);
+CREATE INDEX job_templates_idx_machine_id on job_templates (machine_id);
+CREATE INDEX job_templates_idx_product_id on job_templates (product_id);
+CREATE INDEX job_templates_idx_test_suite_id on job_templates (test_suite_id);
+
+;
+--
+-- Table: jobs
+--
+CREATE TABLE jobs (
+  id bigserial NOT NULL,
+  result_dir text,
+  archived boolean DEFAULT '0' NOT NULL,
+  state character varying DEFAULT 'scheduled' NOT NULL,
+  priority integer DEFAULT 50 NOT NULL,
+  result character varying DEFAULT 'none' NOT NULL,
+  reason character varying,
+  clone_id bigint,
+  blocked_by_id bigint,
+  backend_info text,
+  TEST text NOT NULL,
+  DISTRI text DEFAULT '' NOT NULL,
+  VERSION text DEFAULT '' NOT NULL,
+  FLAVOR text DEFAULT '' NOT NULL,
+  ARCH text DEFAULT '' NOT NULL,
+  BUILD text DEFAULT '' NOT NULL,
+  MACHINE text,
+  group_id bigint,
+  assigned_worker_id bigint,
+  t_started timestamp,
+  t_finished timestamp,
+  logs_present boolean DEFAULT '1' NOT NULL,
+  passed_module_count integer DEFAULT 0 NOT NULL,
+  failed_module_count integer DEFAULT 0 NOT NULL,
+  softfailed_module_count integer DEFAULT 0 NOT NULL,
+  skipped_module_count integer DEFAULT 0 NOT NULL,
+  externally_skipped_module_count integer DEFAULT 0 NOT NULL,
+  scheduled_product_id bigint,
+  result_size bigint,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX jobs_idx_assigned_worker_id on jobs (assigned_worker_id);
+CREATE INDEX jobs_idx_blocked_by_id on jobs (blocked_by_id);
+CREATE INDEX jobs_idx_clone_id on jobs (clone_id);
+CREATE INDEX jobs_idx_group_id on jobs (group_id);
+CREATE INDEX jobs_idx_scheduled_product_id on jobs (scheduled_product_id);
+CREATE INDEX idx_jobs_state on jobs (state);
+CREATE INDEX idx_jobs_result on jobs (result);
+CREATE INDEX idx_jobs_build_group on jobs (BUILD, group_id);
+CREATE INDEX idx_jobs_scenario on jobs (VERSION, DISTRI, FLAVOR, TEST, MACHINE, ARCH);
+
+;
+--
+-- Table: assets
+--
+CREATE TABLE assets (
+  id bigserial NOT NULL,
+  type text NOT NULL,
+  name text NOT NULL,
+  size bigint,
+  checksum text,
+  last_use_job_id bigint,
+  fixed boolean DEFAULT '0' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT assets_type_name UNIQUE (type, name)
+);
+CREATE INDEX assets_idx_last_use_job_id on assets (last_use_job_id);
+
+;
+--
+-- Table: developer_sessions
+--
+CREATE TABLE developer_sessions (
+  job_id bigint NOT NULL,
+  user_id bigint NOT NULL,
+  ws_connection_count integer DEFAULT 0 NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  PRIMARY KEY (job_id)
+);
+CREATE INDEX developer_sessions_idx_user_id on developer_sessions (user_id);
+
+;
+--
+-- Table: gru_dependencies
+--
+CREATE TABLE gru_dependencies (
+  job_id bigint NOT NULL,
+  gru_task_id bigint NOT NULL,
+  PRIMARY KEY (job_id, gru_task_id)
+);
+CREATE INDEX gru_dependencies_idx_gru_task_id on gru_dependencies (gru_task_id);
+CREATE INDEX gru_dependencies_idx_job_id on gru_dependencies (job_id);
+
+;
+--
+-- Table: job_dependencies
+--
+CREATE TABLE job_dependencies (
+  child_job_id bigint NOT NULL,
+  parent_job_id bigint NOT NULL,
+  dependency integer NOT NULL,
+  PRIMARY KEY (child_job_id, parent_job_id, dependency)
+);
+CREATE INDEX job_dependencies_idx_child_job_id on job_dependencies (child_job_id);
+CREATE INDEX job_dependencies_idx_parent_job_id on job_dependencies (parent_job_id);
+CREATE INDEX idx_job_dependencies_dependency on job_dependencies (dependency);
+
+;
+--
+-- Table: job_locks
+--
+CREATE TABLE job_locks (
+  name text NOT NULL,
+  owner integer NOT NULL,
+  locked_by text,
+  count integer DEFAULT 1 NOT NULL,
+  PRIMARY KEY (name, owner)
+);
+CREATE INDEX job_locks_idx_owner on job_locks (owner);
+
+;
+--
+-- Table: job_networks
+--
+CREATE TABLE job_networks (
+  name text NOT NULL,
+  job_id bigint NOT NULL,
+  vlan integer NOT NULL,
+  PRIMARY KEY (name, job_id)
+);
+CREATE INDEX job_networks_idx_job_id on job_networks (job_id);
+
+;
+--
+-- Table: jobs_assets
+--
+CREATE TABLE jobs_assets (
+  job_id bigint NOT NULL,
+  asset_id bigint NOT NULL,
+  created_by boolean DEFAULT '0' NOT NULL,
+  t_created timestamp NOT NULL,
+  t_updated timestamp NOT NULL,
+  CONSTRAINT jobs_assets_job_id_asset_id UNIQUE (job_id, asset_id)
+);
+CREATE INDEX jobs_assets_idx_asset_id on jobs_assets (asset_id);
+CREATE INDEX jobs_assets_idx_job_id on jobs_assets (job_id);
+
+;
+--
+-- Table: screenshot_links
+--
+CREATE TABLE screenshot_links (
+  screenshot_id bigint NOT NULL,
+  job_id bigint NOT NULL
+);
+CREATE INDEX screenshot_links_idx_job_id on screenshot_links (job_id);
+CREATE INDEX screenshot_links_idx_screenshot_id on screenshot_links (screenshot_id);
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE job_modules ADD CONSTRAINT job_modules_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_settings ADD CONSTRAINT job_settings_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_template_settings ADD CONSTRAINT job_template_settings_fk_job_template_id FOREIGN KEY (job_template_id)
+  REFERENCES job_templates (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE machine_settings ADD CONSTRAINT machine_settings_fk_machine_id FOREIGN KEY (machine_id)
+  REFERENCES machines (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE product_settings ADD CONSTRAINT product_settings_fk_product_id FOREIGN KEY (product_id)
+  REFERENCES products (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE test_suite_settings ADD CONSTRAINT test_suite_settings_fk_test_suite_id FOREIGN KEY (test_suite_id)
+  REFERENCES test_suites (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE worker_properties ADD CONSTRAINT worker_properties_fk_worker_id FOREIGN KEY (worker_id)
+  REFERENCES workers (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE api_keys ADD CONSTRAINT api_keys_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_parent_group_id FOREIGN KEY (parent_group_id)
+  REFERENCES job_group_parents (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE comments ADD CONSTRAINT comments_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) DEFERRABLE;
+
+;
+ALTER TABLE job_groups ADD CONSTRAINT job_groups_fk_parent_id FOREIGN KEY (parent_id)
+  REFERENCES job_group_parents (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE workers ADD CONSTRAINT workers_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_dir_id FOREIGN KEY (dir_id)
+  REFERENCES needle_dirs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_last_matched_module_id FOREIGN KEY (last_matched_module_id)
+  REFERENCES job_modules (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE needles ADD CONSTRAINT needles_fk_last_seen_module_id FOREIGN KEY (last_seen_module_id)
+  REFERENCES job_modules (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE scheduled_products ADD CONSTRAINT scheduled_products_fk_gru_task_id FOREIGN KEY (gru_task_id)
+  REFERENCES gru_tasks (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE scheduled_products ADD CONSTRAINT scheduled_products_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_machine_id FOREIGN KEY (machine_id)
+  REFERENCES machines (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_product_id FOREIGN KEY (product_id)
+  REFERENCES products (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_templates ADD CONSTRAINT job_templates_fk_test_suite_id FOREIGN KEY (test_suite_id)
+  REFERENCES test_suites (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_assigned_worker_id FOREIGN KEY (assigned_worker_id)
+  REFERENCES workers (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_blocked_by_id FOREIGN KEY (blocked_by_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_clone_id FOREIGN KEY (clone_id)
+  REFERENCES jobs (id) ON DELETE SET NULL DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_group_id FOREIGN KEY (group_id)
+  REFERENCES job_groups (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs ADD CONSTRAINT jobs_fk_scheduled_product_id FOREIGN KEY (scheduled_product_id)
+  REFERENCES scheduled_products (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE assets ADD CONSTRAINT assets_fk_last_use_job_id FOREIGN KEY (last_use_job_id)
+  REFERENCES jobs (id) ON DELETE SET NULL ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE developer_sessions ADD CONSTRAINT developer_sessions_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE developer_sessions ADD CONSTRAINT developer_sessions_fk_user_id FOREIGN KEY (user_id)
+  REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_gru_task_id FOREIGN KEY (gru_task_id)
+  REFERENCES gru_tasks (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE gru_dependencies ADD CONSTRAINT gru_dependencies_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_dependencies ADD CONSTRAINT job_dependencies_fk_child_job_id FOREIGN KEY (child_job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_dependencies ADD CONSTRAINT job_dependencies_fk_parent_job_id FOREIGN KEY (parent_job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_locks ADD CONSTRAINT job_locks_fk_owner FOREIGN KEY (owner)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE job_networks ADD CONSTRAINT job_networks_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs_assets ADD CONSTRAINT jobs_assets_fk_asset_id FOREIGN KEY (asset_id)
+  REFERENCES assets (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE jobs_assets ADD CONSTRAINT jobs_assets_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE screenshot_links ADD CONSTRAINT screenshot_links_fk_job_id FOREIGN KEY (job_id)
+  REFERENCES jobs (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE screenshot_links ADD CONSTRAINT screenshot_links_fk_screenshot_id FOREIGN KEY (screenshot_id)
+  REFERENCES screenshots (id) ON UPDATE CASCADE DEFERRABLE;
+
+;

--- a/dbicdh/PostgreSQL/upgrade/94-95/000-warning.pl
+++ b/dbicdh/PostgreSQL/upgrade/94-95/000-warning.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use strict;
+use OpenQA::Log qw(log_warning);
+
+sub {
+    log_warning 'Job IDs will be converted to bigint. That may take multiple hours on big databases. '
+              . ' It is safe to stop the service (and start from scratch on the next startup).';
+}

--- a/dbicdh/PostgreSQL/upgrade/94-95/001-auto.sql
+++ b/dbicdh/PostgreSQL/upgrade/94-95/001-auto.sql
@@ -1,0 +1,237 @@
+-- Convert schema '/hdd/openqa-devel/repos/openQA/script/../dbicdh/_source/deploy/94/001-auto.yml' to '/hdd/openqa-devel/repos/openQA/script/../dbicdh/_source/deploy/95/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+ALTER TABLE api_keys ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE api_keys ALTER COLUMN user_id TYPE bigint;
+
+;
+ALTER TABLE assets ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE assets ALTER COLUMN last_use_job_id TYPE bigint;
+
+;
+ALTER TABLE audit_events ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE audit_events ALTER COLUMN user_id TYPE bigint;
+
+;
+ALTER TABLE bugs ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE comments ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE comments ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE comments ALTER COLUMN group_id TYPE bigint;
+
+;
+ALTER TABLE comments ALTER COLUMN parent_group_id TYPE bigint;
+
+;
+ALTER TABLE comments ALTER COLUMN user_id TYPE bigint;
+
+;
+ALTER TABLE developer_sessions ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE developer_sessions ALTER COLUMN user_id TYPE bigint;
+
+;
+ALTER TABLE gru_dependencies ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE gru_dependencies ALTER COLUMN gru_task_id TYPE bigint;
+
+;
+ALTER TABLE gru_tasks ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE job_dependencies ALTER COLUMN child_job_id TYPE bigint;
+
+;
+ALTER TABLE job_dependencies ALTER COLUMN parent_job_id TYPE bigint;
+
+;
+ALTER TABLE job_group_parents ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE job_groups ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE job_groups ALTER COLUMN parent_id TYPE bigint;
+
+;
+ALTER TABLE job_modules ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE job_networks ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE job_settings ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE job_settings ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE job_template_settings ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE job_template_settings ALTER COLUMN job_template_id TYPE bigint;
+
+;
+ALTER TABLE job_templates ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE job_templates ALTER COLUMN product_id TYPE bigint;
+
+;
+ALTER TABLE job_templates ALTER COLUMN machine_id TYPE bigint;
+
+;
+ALTER TABLE job_templates ALTER COLUMN test_suite_id TYPE bigint;
+
+;
+ALTER TABLE job_templates ALTER COLUMN group_id TYPE bigint;
+
+;
+ALTER TABLE jobs ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE jobs ALTER COLUMN clone_id TYPE bigint;
+
+;
+ALTER TABLE jobs ALTER COLUMN blocked_by_id TYPE bigint;
+
+;
+ALTER TABLE jobs ALTER COLUMN group_id TYPE bigint;
+
+;
+ALTER TABLE jobs ALTER COLUMN assigned_worker_id TYPE bigint;
+
+;
+ALTER TABLE jobs ALTER COLUMN scheduled_product_id TYPE bigint;
+
+;
+ALTER TABLE jobs_assets ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE jobs_assets ALTER COLUMN asset_id TYPE bigint;
+
+;
+ALTER TABLE machine_settings ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE machine_settings ALTER COLUMN machine_id TYPE bigint;
+
+;
+ALTER TABLE machines ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE needle_dirs ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE needles ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE needles ALTER COLUMN dir_id TYPE bigint;
+
+;
+ALTER TABLE product_settings ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE product_settings ALTER COLUMN product_id TYPE bigint;
+
+;
+ALTER TABLE products ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE scheduled_products ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE scheduled_products ALTER COLUMN user_id TYPE bigint;
+
+;
+ALTER TABLE scheduled_products ALTER COLUMN gru_task_id TYPE bigint;
+
+;
+ALTER TABLE scheduled_products ALTER COLUMN minion_job_id TYPE bigint;
+
+;
+ALTER TABLE screenshot_links ALTER COLUMN screenshot_id TYPE bigint;
+
+;
+ALTER TABLE screenshot_links ALTER COLUMN job_id TYPE bigint;
+
+;
+ALTER TABLE screenshots ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE secrets ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE test_suite_settings ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE test_suite_settings ALTER COLUMN test_suite_id TYPE bigint;
+
+;
+ALTER TABLE test_suites ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE users ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE worker_properties ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE worker_properties ALTER COLUMN worker_id TYPE bigint;
+
+;
+ALTER TABLE workers ALTER COLUMN id TYPE bigint;
+
+;
+ALTER TABLE workers ALTER COLUMN job_id TYPE bigint;
+
+;
+
+-- Ensure sequences are converted to bigint as well as it does not seem to be the case on all setups
+ALTER SEQUENCE IF EXISTS dbix_class_deploymenthandler_versions_id_seq AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS gru_tasks_id_seq                             AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS audit_events_id_seq                          AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS comments_id_seq                              AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS job_group_parents_id_seq                     AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS job_groups_id_seq                            AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS job_modules_id_seq                           AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS job_settings_id_seq                          AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS job_templates_id_seq                         AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS job_template_settings_id_seq                 AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS machine_settings_id_seq                      AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS jobs_id_seq                                  AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS machines_id_seq                              AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS needle_dirs_id_seq                           AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS product_settings_id_seq                      AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS needles_id_seq                               AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS products_id_seq                              AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS scheduled_products_id_seq                    AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS screenshots_id_seq                           AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS secrets_id_seq                               AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS test_suite_settings_id_seq                   AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS test_suites_id_seq                           AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS worker_properties_id_seq                     AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS users_id_seq                                 AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS workers_id_seq                               AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS bugs_id_seq                                  AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS api_keys_id_seq                              AS bigint NO MAXVALUE;
+ALTER SEQUENCE IF EXISTS assets_id_seq                                AS bigint NO MAXVALUE;
+
+COMMIT;
+

--- a/dbicdh/_source/deploy/95/001-auto-__VERSION.yml
+++ b/dbicdh/_source/deploy/95/001-auto-__VERSION.yml
@@ -1,0 +1,91 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args: {}
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 1.62

--- a/dbicdh/_source/deploy/95/001-auto.yml
+++ b/dbicdh/_source/deploy/95/001-auto.yml
@@ -1,0 +1,4535 @@
+---
+schema:
+  procedures: {}
+  tables:
+    api_keys:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - key
+          match_type: ''
+          name: api_keys_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: api_keys_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 2
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: secret
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_expiration:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_expiration
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: api_keys_idx_user_id
+          options: []
+          type: NORMAL
+      name: api_keys
+      options: []
+      order: 18
+    assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - type
+            - name
+          match_type: ''
+          name: assets_type_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_use_job_id
+          match_type: ''
+          name: assets_fk_last_use_job_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        checksum:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: checksum
+          order: 5
+          size:
+            - 0
+        fixed:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: fixed
+          order: 7
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        last_use_job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_use_job_id
+          order: 6
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        type:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: type
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - last_use_job_id
+          name: assets_idx_last_use_job_id
+          options: []
+          type: NORMAL
+      name: assets
+      options: []
+      order: 27
+    audit_events:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: audit_events_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        connection_id:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: connection_id
+          order: 3
+          size:
+            - 0
+        event:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: event
+          order: 4
+          size:
+            - 0
+        event_data:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: event_data
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        user_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: audit_events_idx_user_id
+          options: []
+          type: NORMAL
+      name: audit_events
+      options: []
+      order: 19
+    bugs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - bugid
+          match_type: ''
+          name: bugs_bugid
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        assigned:
+          data_type: boolean
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: assigned
+          order: 5
+          size:
+            - 0
+        assignee:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: assignee
+          order: 6
+          size:
+            - 0
+        bugid:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: bugid
+          order: 2
+          size:
+            - 0
+        existing:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: existing
+          order: 10
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        open:
+          data_type: boolean
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: open
+          order: 7
+          size:
+            - 0
+        priority:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 4
+          size:
+            - 0
+        refreshed:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: refreshed
+          order: 11
+          size:
+            - 0
+        resolution:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: resolution
+          order: 9
+          size:
+            - 0
+        status:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: status
+          order: 8
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 12
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 13
+          size:
+            - 0
+        title:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: title
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: bugs
+      options: []
+      order: 1
+    comments:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: comments_fk_group_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: comments_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_group_id
+          match_type: ''
+          name: comments_fk_parent_group_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_group_parents
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: comments_fk_user_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        flags:
+          data_type: integer
+          default_value: 0
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: flags
+          order: 7
+          size:
+            - 0
+        group_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        parent_group_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: parent_group_id
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        text:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: text
+          order: 5
+          size:
+            - 0
+        user_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 6
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: comments_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: comments_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_group_id
+          name: comments_idx_parent_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - user_id
+          name: comments_idx_user_id
+          options: []
+          type: NORMAL
+      name: comments
+      options: []
+      order: 20
+    developer_sessions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: developer_sessions_fk_job_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: developer_sessions_fk_user_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+        user_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 2
+          size:
+            - 0
+        ws_connection_count:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: ws_connection_count
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - user_id
+          name: developer_sessions_idx_user_id
+          options: []
+          type: NORMAL
+      name: developer_sessions
+      options: []
+      order: 28
+    gru_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - gru_task_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - gru_task_id
+          match_type: ''
+          name: gru_dependencies_fk_gru_task_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: gru_tasks
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: gru_dependencies_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        gru_task_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: gru_task_id
+          order: 2
+          size:
+            - 0
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - gru_task_id
+          name: gru_dependencies_idx_gru_task_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: gru_dependencies_idx_job_id
+          options: []
+          type: NORMAL
+      name: gru_dependencies
+      options: []
+      order: 29
+    gru_tasks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        args:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: args
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        run_at:
+          data_type: datetime
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: run_at
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 6
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 7
+          size:
+            - 0
+        taskname:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: taskname
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - run_at DESC
+          name: gru_tasks_run_at_reversed
+          options: []
+          type: NORMAL
+      name: gru_tasks
+      options: []
+      order: 2
+    job_dependencies:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+            - parent_job_id
+            - dependency
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - child_job_id
+          match_type: ''
+          name: job_dependencies_fk_child_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_job_id
+          match_type: ''
+          name: job_dependencies_fk_parent_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        child_job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: child_job_id
+          order: 1
+          size:
+            - 0
+        dependency:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: dependency
+          order: 3
+          size:
+            - 0
+        parent_job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: parent_job_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - child_job_id
+          name: job_dependencies_idx_child_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - parent_job_id
+          name: job_dependencies_idx_parent_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - dependency
+          name: idx_job_dependencies_dependency
+          options: []
+          type: NORMAL
+      name: job_dependencies
+      options: []
+      order: 30
+    job_group_parents:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: job_group_parents_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        build_version_sort:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: build_version_sort
+          order: 12
+          size:
+            - 0
+        carry_over_bugrefs:
+          data_type: boolean
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: carry_over_bugrefs
+          order: 13
+          size:
+            - 0
+        default_keep_important_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_important_logs_in_days
+          order: 6
+          size:
+            - 0
+        default_keep_important_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_important_results_in_days
+          order: 8
+          size:
+            - 0
+        default_keep_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_logs_in_days
+          order: 5
+          size:
+            - 0
+        default_keep_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_keep_results_in_days
+          order: 7
+          size:
+            - 0
+        default_priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_priority
+          order: 9
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 11
+          size:
+            - 0
+        exclusively_kept_asset_size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: exclusively_kept_asset_size
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        size_limit_gb:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size_limit_gb
+          order: 3
+          size:
+            - 0
+        sort_order:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: sort_order
+          order: 10
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 14
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 15
+          size:
+            - 0
+      indices: []
+      name: job_group_parents
+      options: []
+      order: 3
+    job_groups:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - parent_id
+          match_type: ''
+          name: job_groups_name_parent_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - parent_id
+          match_type: ''
+          name: job_groups_fk_parent_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_group_parents
+          type: FOREIGN KEY
+      fields:
+        build_version_sort:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: build_version_sort
+          order: 14
+          size:
+            - 0
+        carry_over_bugrefs:
+          data_type: boolean
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: carry_over_bugrefs
+          order: 15
+          size:
+            - 0
+        default_priority:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: default_priority
+          order: 10
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 12
+          size:
+            - 0
+        exclusively_kept_asset_size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: exclusively_kept_asset_size
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        keep_important_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_important_logs_in_days
+          order: 7
+          size:
+            - 0
+        keep_important_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_important_results_in_days
+          order: 9
+          size:
+            - 0
+        keep_logs_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_logs_in_days
+          order: 6
+          size:
+            - 0
+        keep_results_in_days:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: keep_results_in_days
+          order: 8
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        parent_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: parent_id
+          order: 3
+          size:
+            - 0
+        size_limit_gb:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: size_limit_gb
+          order: 4
+          size:
+            - 0
+        sort_order:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: sort_order
+          order: 11
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 16
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 17
+          size:
+            - 0
+        template:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: template
+          order: 13
+          size:
+            - 0
+      indices:
+        - fields:
+            - parent_id
+          name: job_groups_idx_parent_id
+          options: []
+          type: NORMAL
+      name: job_groups
+      options: []
+      order: 21
+    job_locks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - owner
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - owner
+          match_type: ''
+          name: job_locks_fk_owner
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        count:
+          data_type: integer
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: count
+          order: 4
+          size:
+            - 0
+        locked_by:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: locked_by
+          order: 3
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        owner:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: owner
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - owner
+          name: job_locks_idx_owner
+          options: []
+          type: NORMAL
+      name: job_locks
+      options: []
+      order: 31
+    job_modules:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - name
+            - category
+            - script
+          match_type: ''
+          name: job_modules_job_id_name_category_script
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_modules_fk_job_id
+          on_delete: ''
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        always_rollback:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: always_rollback
+          order: 9
+          size:
+            - 0
+        category:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: category
+          order: 5
+          size:
+            - 0
+        fatal:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: fatal
+          order: 8
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        important:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: important
+          order: 7
+          size:
+            - 0
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 2
+          size:
+            - 0
+        milestone:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: milestone
+          order: 6
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 3
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 10
+          size:
+            - 0
+        script:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: script
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 12
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_modules_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_job_modules_result
+          options: []
+          type: NORMAL
+      name: job_modules
+      options: []
+      order: 4
+    job_networks:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+            - job_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_networks_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: name
+          order: 1
+          size:
+            - 0
+        vlan:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: vlan
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_networks_idx_job_id
+          options: []
+          type: NORMAL
+      name: job_networks
+      options: []
+      order: 32
+    job_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: job_settings_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 4
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: job_settings_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - key
+            - value
+          name: idx_value_settings
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+            - key
+            - value
+          name: idx_job_id_value_settings
+          options: []
+          type: NORMAL
+      name: job_settings
+      options: []
+      order: 5
+    job_template_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_template_id
+            - key
+          match_type: ''
+          name: job_template_settings_job_template_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_template_id
+          match_type: ''
+          name: job_template_settings_fk_job_template_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_templates
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        job_template_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_template_id
+          order: 2
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_template_id
+          name: job_template_settings_idx_job_template_id
+          options: []
+          type: NORMAL
+      name: job_template_settings
+      options: []
+      order: 6
+    job_templates:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - machine_id
+            - name
+            - test_suite_id
+          match_type: ''
+          name: scenario
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: job_templates_fk_group_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: job_templates_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: job_templates_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: job_templates_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        description:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 6
+          size:
+            - 0
+        group_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 8
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        machine_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 3
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 5
+          size:
+            - 0
+        prio:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: prio
+          order: 7
+          size:
+            - 0
+        product_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 9
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 10
+          size:
+            - 0
+        test_suite_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - group_id
+          name: job_templates_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - machine_id
+          name: job_templates_idx_machine_id
+          options: []
+          type: NORMAL
+        - fields:
+            - product_id
+          name: job_templates_idx_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - test_suite_id
+          name: job_templates_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: job_templates
+      options: []
+      order: 25
+    jobs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - assigned_worker_id
+          match_type: ''
+          name: jobs_fk_assigned_worker_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - blocked_by_id
+          match_type: ''
+          name: jobs_fk_blocked_by_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - clone_id
+          match_type: ''
+          name: jobs_fk_clone_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - group_id
+          match_type: ''
+          name: jobs_fk_group_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_groups
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - scheduled_product_id
+          match_type: ''
+          name: jobs_fk_scheduled_product_id
+          on_delete: SET NULL
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: scheduled_products
+          type: FOREIGN KEY
+      fields:
+        ARCH:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: ARCH
+          order: 15
+          size:
+            - 0
+        BUILD:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: BUILD
+          order: 16
+          size:
+            - 0
+        DISTRI:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: DISTRI
+          order: 12
+          size:
+            - 0
+        FLAVOR:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: FLAVOR
+          order: 14
+          size:
+            - 0
+        MACHINE:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: MACHINE
+          order: 17
+          size:
+            - 0
+        TEST:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: TEST
+          order: 11
+          size:
+            - 0
+        VERSION:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: VERSION
+          order: 13
+          size:
+            - 0
+        archived:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: archived
+          order: 3
+          size:
+            - 0
+        assigned_worker_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: assigned_worker_id
+          order: 19
+          size:
+            - 0
+        backend_info:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: backend_info
+          order: 10
+          size:
+            - 0
+        blocked_by_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: blocked_by_id
+          order: 9
+          size:
+            - 0
+        clone_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: clone_id
+          order: 8
+          size:
+            - 0
+        externally_skipped_module_count:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: externally_skipped_module_count
+          order: 27
+          size:
+            - 0
+        failed_module_count:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: failed_module_count
+          order: 24
+          size:
+            - 0
+        group_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: group_id
+          order: 18
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        logs_present:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: logs_present
+          order: 22
+          size:
+            - 0
+        passed_module_count:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: passed_module_count
+          order: 23
+          size:
+            - 0
+        priority:
+          data_type: integer
+          default_value: 50
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: priority
+          order: 5
+          size:
+            - 0
+        reason:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: reason
+          order: 7
+          size:
+            - 0
+        result:
+          data_type: varchar
+          default_value: none
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: result
+          order: 6
+          size:
+            - 0
+        result_dir:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: result_dir
+          order: 2
+          size:
+            - 0
+        result_size:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: result_size
+          order: 29
+          size:
+            - 0
+        scheduled_product_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: scheduled_product_id
+          order: 28
+          size:
+            - 0
+        skipped_module_count:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: skipped_module_count
+          order: 26
+          size:
+            - 0
+        softfailed_module_count:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: softfailed_module_count
+          order: 25
+          size:
+            - 0
+        state:
+          data_type: varchar
+          default_value: scheduled
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: state
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 30
+          size:
+            - 0
+        t_finished:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_finished
+          order: 21
+          size:
+            - 0
+        t_started:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_started
+          order: 20
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 31
+          size:
+            - 0
+      indices:
+        - fields:
+            - assigned_worker_id
+          name: jobs_idx_assigned_worker_id
+          options: []
+          type: NORMAL
+        - fields:
+            - blocked_by_id
+          name: jobs_idx_blocked_by_id
+          options: []
+          type: NORMAL
+        - fields:
+            - clone_id
+          name: jobs_idx_clone_id
+          options: []
+          type: NORMAL
+        - fields:
+            - group_id
+          name: jobs_idx_group_id
+          options: []
+          type: NORMAL
+        - fields:
+            - scheduled_product_id
+          name: jobs_idx_scheduled_product_id
+          options: []
+          type: NORMAL
+        - fields:
+            - state
+          name: idx_jobs_state
+          options: []
+          type: NORMAL
+        - fields:
+            - result
+          name: idx_jobs_result
+          options: []
+          type: NORMAL
+        - fields:
+            - BUILD
+            - group_id
+          name: idx_jobs_build_group
+          options: []
+          type: NORMAL
+        - fields:
+            - VERSION
+            - DISTRI
+            - FLAVOR
+            - TEST
+            - MACHINE
+            - ARCH
+          name: idx_jobs_scenario
+          options: []
+          type: NORMAL
+      name: jobs
+      options: []
+      order: 26
+    jobs_assets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+            - asset_id
+          match_type: ''
+          name: jobs_assets_job_id_asset_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - asset_id
+          match_type: ''
+          name: jobs_assets_fk_asset_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: assets
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: jobs_assets_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        asset_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: asset_id
+          order: 2
+          size:
+            - 0
+        created_by:
+          data_type: boolean
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: created_by
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices:
+        - fields:
+            - asset_id
+          name: jobs_assets_idx_asset_id
+          options: []
+          type: NORMAL
+        - fields:
+            - job_id
+          name: jobs_assets_idx_job_id
+          options: []
+          type: NORMAL
+      name: jobs_assets
+      options: []
+      order: 33
+    machine_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+            - key
+          match_type: ''
+          name: machine_settings_machine_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - machine_id
+          match_type: ''
+          name: machine_settings_fk_machine_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: machines
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        machine_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: machine_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - machine_id
+          name: machine_settings_idx_machine_id
+          options: []
+          type: NORMAL
+      name: machine_settings
+      options: []
+      order: 7
+    machines:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: machines_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        backend:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: backend
+          order: 3
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 4
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+      indices: []
+      name: machines
+      options: []
+      order: 8
+    needle_dirs:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - path
+          match_type: ''
+          name: needle_dirs_path
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 3
+          size:
+            - 0
+        path:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: path
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: needle_dirs
+      options: []
+      order: 9
+    needles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+            - filename
+          match_type: ''
+          name: needles_dir_id_filename
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - dir_id
+          match_type: ''
+          name: needles_fk_dir_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: needle_dirs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_matched_module_id
+          match_type: ''
+          name: needles_fk_last_matched_module_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - last_seen_module_id
+          match_type: ''
+          name: needles_fk_last_seen_module_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: job_modules
+          type: FOREIGN KEY
+      fields:
+        dir_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: dir_id
+          order: 2
+          size:
+            - 0
+        file_present:
+          data_type: boolean
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: file_present
+          order: 9
+          size:
+            - 0
+        filename:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: filename
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        last_matched_module_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_matched_module_id
+          order: 7
+          size:
+            - 0
+        last_matched_time:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_matched_time
+          order: 6
+          size:
+            - 0
+        last_seen_module_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_seen_module_id
+          order: 5
+          size:
+            - 0
+        last_seen_time:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_seen_time
+          order: 4
+          size:
+            - 0
+        last_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: last_updated
+          order: 8
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 11
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 12
+          size:
+            - 0
+        tags:
+          data_type: 'text[]'
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: tags
+          order: 10
+          size:
+            - 0
+      indices:
+        - fields:
+            - dir_id
+          name: needles_idx_dir_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_matched_module_id
+          name: needles_idx_last_matched_module_id
+          options: []
+          type: NORMAL
+        - fields:
+            - last_seen_module_id
+          name: needles_idx_last_seen_module_id
+          options: []
+          type: NORMAL
+      name: needles
+      options: []
+      order: 23
+    product_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+            - key
+          match_type: ''
+          name: product_settings_product_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - product_id
+          match_type: ''
+          name: product_settings_fk_product_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: products
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        product_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: product_id
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - product_id
+          name: product_settings_idx_product_id
+          options: []
+          type: NORMAL
+      name: product_settings
+      options: []
+      order: 10
+    products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - distri
+            - version
+            - arch
+            - flavor
+          match_type: ''
+          name: products_distri_version_arch_flavor
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        arch:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: arch
+          order: 5
+          size:
+            - 0
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 7
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: distri
+          order: 3
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: flavor
+          order: 6
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: products
+      options: []
+      order: 11
+    scheduled_products:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - gru_task_id
+          match_type: ''
+          name: scheduled_products_fk_gru_task_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: gru_tasks
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - user_id
+          match_type: ''
+          name: scheduled_products_fk_user_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: users
+          type: FOREIGN KEY
+      fields:
+        arch:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: arch
+          order: 5
+          size:
+            - 0
+        build:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: build
+          order: 6
+          size:
+            - 0
+        distri:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: distri
+          order: 2
+          size:
+            - 0
+        flavor:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: flavor
+          order: 4
+          size:
+            - 0
+        gru_task_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: gru_task_id
+          order: 12
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        iso:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: iso
+          order: 7
+          size:
+            - 0
+        minion_job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: minion_job_id
+          order: 13
+          size:
+            - 0
+        results:
+          data_type: jsonb
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: results
+          order: 10
+          size:
+            - 0
+        settings:
+          data_type: jsonb
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: settings
+          order: 9
+          size:
+            - 0
+        status:
+          data_type: text
+          default_value: added
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: status
+          order: 8
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 14
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 15
+          size:
+            - 0
+        user_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: user_id
+          order: 11
+          size:
+            - 0
+        version:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: version
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - gru_task_id
+          name: scheduled_products_idx_gru_task_id
+          options: []
+          type: NORMAL
+        - fields:
+            - user_id
+          name: scheduled_products_idx_user_id
+          options: []
+          type: NORMAL
+      name: scheduled_products
+      options: []
+      order: 24
+    screenshot_links:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: screenshot_links_fk_job_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - screenshot_id
+          match_type: ''
+          name: screenshot_links_fk_screenshot_id
+          on_delete: ''
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: screenshots
+          type: FOREIGN KEY
+      fields:
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: job_id
+          order: 2
+          size:
+            - 0
+        screenshot_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: screenshot_id
+          order: 1
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: screenshot_links_idx_job_id
+          options: []
+          type: NORMAL
+        - fields:
+            - screenshot_id
+          name: screenshot_links_idx_screenshot_id
+          options: []
+          type: NORMAL
+      name: screenshot_links
+      options: []
+      order: 34
+    screenshots:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - filename
+          match_type: ''
+          name: screenshots_filename
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        filename:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: filename
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: screenshots
+      options: []
+      order: 12
+    secrets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - secret
+          match_type: ''
+          name: secrets_secret
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        secret:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: secret
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 3
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: secrets
+      options: []
+      order: 13
+    test_suite_settings:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+            - key
+          match_type: ''
+          name: test_suite_settings_test_suite_id_key
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - test_suite_id
+          match_type: ''
+          name: test_suite_settings_fk_test_suite_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: test_suites
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: key
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        test_suite_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: test_suite_id
+          order: 2
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - test_suite_id
+          name: test_suite_settings_idx_test_suite_id
+          options: []
+          type: NORMAL
+      name: test_suite_settings
+      options: []
+      order: 14
+    test_suites:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - name
+          match_type: ''
+          name: test_suites_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        description:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        name:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: name
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 4
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 5
+          size:
+            - 0
+      indices: []
+      name: test_suites
+      options: []
+      order: 15
+    users:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - username
+            - provider
+          match_type: ''
+          name: users_username_provider
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        email:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: email
+          order: 4
+          size:
+            - 0
+        feature_version:
+          data_type: integer
+          default_value: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: feature_version
+          order: 9
+          size:
+            - 0
+        fullname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: fullname
+          order: 5
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        is_admin:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_admin
+          order: 8
+          size:
+            - 0
+        is_operator:
+          data_type: integer
+          default_value: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: is_operator
+          order: 7
+          size:
+            - 0
+        nickname:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: nickname
+          order: 6
+          size:
+            - 0
+        provider:
+          data_type: text
+          default_value: ''
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: provider
+          order: 3
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 10
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 11
+          size:
+            - 0
+        username:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: username
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: users
+      options: []
+      order: 16
+    worker_properties:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - worker_id
+          match_type: ''
+          name: worker_properties_fk_worker_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - id
+          reference_table: workers
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        key:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: key
+          order: 2
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 6
+          size:
+            - 0
+        value:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: value
+          order: 3
+          size:
+            - 0
+        worker_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: worker_id
+          order: 4
+          size:
+            - 0
+      indices:
+        - fields:
+            - worker_id
+          name: worker_properties_idx_worker_id
+          options: []
+          type: NORMAL
+      name: worker_properties
+      options: []
+      order: 17
+    workers:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - host
+            - instance
+          match_type: ''
+          name: workers_host_instance
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: workers_job_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - job_id
+          match_type: ''
+          name: workers_fk_job_id
+          on_delete: SET NULL
+          on_update: ''
+          options: []
+          reference_fields:
+            - id
+          reference_table: jobs
+          type: FOREIGN KEY
+      fields:
+        error:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: error
+          order: 7
+          size:
+            - 0
+        host:
+          data_type: text
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: host
+          order: 2
+          size:
+            - 0
+        id:
+          data_type: bigint
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        instance:
+          data_type: integer
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: instance
+          order: 3
+          size:
+            - 0
+        job_id:
+          data_type: bigint
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 1
+          name: job_id
+          order: 4
+          size:
+            - 0
+        t_created:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_created
+          order: 8
+          size:
+            - 0
+        t_seen:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: t_seen
+          order: 5
+          size:
+            - 0
+        t_updated:
+          data_type: timestamp
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: t_updated
+          order: 9
+          size:
+            - 0
+        upload_progress:
+          data_type: jsonb
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upload_progress
+          order: 6
+          size:
+            - 0
+      indices:
+        - fields:
+            - job_id
+          name: workers_idx_job_id
+          options: []
+          type: NORMAL
+      name: workers
+      options: []
+      order: 22
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - ApiKeys
+      - Assets
+      - AuditEvents
+      - Bugs
+      - Comments
+      - DeveloperSessions
+      - GruDependencies
+      - GruTasks
+      - JobDependencies
+      - JobGroupParents
+      - JobGroups
+      - JobLocks
+      - JobModules
+      - JobNetworks
+      - JobNextPrevious
+      - JobSettings
+      - JobTemplateSettings
+      - JobTemplates
+      - Jobs
+      - JobsAssets
+      - MachineSettings
+      - Machines
+      - NeedleDirs
+      - Needles
+      - ProductSettings
+      - Products
+      - ScheduledProducts
+      - ScreenshotLinks
+      - Screenshots
+      - Secrets
+      - TestSuiteSettings
+      - TestSuites
+      - Users
+      - WorkerProperties
+      - Workers
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args: {}
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 1.62

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -20,7 +20,7 @@ use OpenQA::Utils qw(:DEFAULT prjdir);
 
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
-our $VERSION = $ENV{OPENQA_SCHEMA_VERSION_OVERRIDE} // 94;
+our $VERSION = $ENV{OPENQA_SCHEMA_VERSION_OVERRIDE} // 95;
 
 __PACKAGE__->load_namespaces;
 

--- a/lib/OpenQA/Schema/Result/ApiKeys.pm
+++ b/lib/OpenQA/Schema/Result/ApiKeys.pm
@@ -10,7 +10,7 @@ __PACKAGE__->table('api_keys');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     key => {
@@ -20,7 +20,7 @@ __PACKAGE__->add_columns(
         data_type => 'text',
     },
     user_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     t_expiration => {

--- a/lib/OpenQA/Schema/Result/Assets.pm
+++ b/lib/OpenQA/Schema/Result/Assets.pm
@@ -23,7 +23,7 @@ __PACKAGE__->table('assets');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     type => {
@@ -42,7 +42,7 @@ __PACKAGE__->add_columns(
         default_value => undef
     },
     last_use_job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 1,
         is_foreign_key => 1,
     },

--- a/lib/OpenQA/Schema/Result/AuditEvents.pm
+++ b/lib/OpenQA/Schema/Result/AuditEvents.pm
@@ -10,11 +10,11 @@ __PACKAGE__->table('audit_events');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     user_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 1
     },
     connection_id => {

--- a/lib/OpenQA/Schema/Result/Bugs.pm
+++ b/lib/OpenQA/Schema/Result/Bugs.pm
@@ -14,7 +14,7 @@ __PACKAGE__->table('bugs');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     bugid => {

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -13,21 +13,21 @@ __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->table('comments');
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1,
     },
     group_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1,
     },
     parent_group_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1,
     },
@@ -35,7 +35,7 @@ __PACKAGE__->add_columns(
         data_type => 'text'
     },
     user_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     flags => {

--- a/lib/OpenQA/Schema/Result/DeveloperSessions.pm
+++ b/lib/OpenQA/Schema/Result/DeveloperSessions.pm
@@ -15,12 +15,12 @@ __PACKAGE__->table('developer_sessions');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 0,
         is_foreign_key => 1,
     },
     user_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 0,
         is_foreign_key => 1,
     },

--- a/lib/OpenQA/Schema/Result/GruDependencies.pm
+++ b/lib/OpenQA/Schema/Result/GruDependencies.pm
@@ -14,11 +14,11 @@ use Mojo::Base 'DBIx::Class::Core';
 __PACKAGE__->table('gru_dependencies');
 __PACKAGE__->add_columns(
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     gru_task_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
 );

--- a/lib/OpenQA/Schema/Result/GruTasks.pm
+++ b/lib/OpenQA/Schema/Result/GruTasks.pm
@@ -14,7 +14,7 @@ __PACKAGE__->table('gru_tasks');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime FilterColumn Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     taskname => {

--- a/lib/OpenQA/Schema/Result/JobDependencies.pm
+++ b/lib/OpenQA/Schema/Result/JobDependencies.pm
@@ -11,11 +11,11 @@ use OpenQA::JobDependencies::Constants;
 __PACKAGE__->table('job_dependencies');
 __PACKAGE__->add_columns(
     child_job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     parent_job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     dependency => {data_type => 'integer'},

--- a/lib/OpenQA/Schema/Result/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/Result/JobGroupParents.pm
@@ -17,7 +17,7 @@ __PACKAGE__->load_components(qw(Timestamps));
 
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     name => {

--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -21,7 +21,7 @@ __PACKAGE__->load_components(qw(Timestamps));
 
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     name => {
@@ -29,7 +29,7 @@ __PACKAGE__->add_columns(
         is_nullable => 0,
     },
     parent_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1,
     },

--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -23,7 +23,7 @@ __PACKAGE__->add_columns(
         is_auto_increment => 1,
     },
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     name => {

--- a/lib/OpenQA/Schema/Result/JobNetworks.pm
+++ b/lib/OpenQA/Schema/Result/JobNetworks.pm
@@ -13,7 +13,7 @@ __PACKAGE__->add_columns(
         is_nullable => 0,
     },
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 0,
     },

--- a/lib/OpenQA/Schema/Result/JobSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobSettings.pm
@@ -10,7 +10,7 @@ __PACKAGE__->table('job_settings');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     key => {
@@ -20,7 +20,7 @@ __PACKAGE__->add_columns(
         data_type => 'text',
     },
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
 );

--- a/lib/OpenQA/Schema/Result/JobTemplateSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplateSettings.pm
@@ -10,11 +10,11 @@ __PACKAGE__->table('job_template_settings');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     job_template_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     key => {

--- a/lib/OpenQA/Schema/Result/JobTemplates.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplates.pm
@@ -10,17 +10,17 @@ __PACKAGE__->table('job_templates');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     product_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
     },
     machine_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
     },
     test_suite_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
     },
     name => {
         data_type => 'text',
@@ -35,7 +35,7 @@ __PACKAGE__->add_columns(
         is_nullable => 1,
     },
     group_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
 );

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -52,7 +52,7 @@ __PACKAGE__->table('jobs');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime FilterColumn Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     result_dir => {    # this is the directory below testresults
@@ -80,12 +80,12 @@ __PACKAGE__->add_columns(
         is_nullable => 1,
     },
     clone_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1
     },
     blocked_by_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1
     },
@@ -122,12 +122,12 @@ __PACKAGE__->add_columns(
         is_nullable => 1
     },
     group_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1
     },
     assigned_worker_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1
     },
@@ -164,7 +164,7 @@ __PACKAGE__->add_columns(
         default_value => 0,
     },
     scheduled_product_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1,
     },
@@ -1930,9 +1930,9 @@ sub ancestors ($self, $limit = -1) {
             union all
             select id as orig_id, orig_id.level + 1 as level from jobs join orig_id on orig_id.orig_id = jobs.clone_id where (? < 0 or level < ?))
         select level from orig_id order by level desc limit 1;');
-    $sth->bind_param(1, $self->id, SQL_INTEGER);
-    $sth->bind_param(2, $limit, SQL_INTEGER);
-    $sth->bind_param(3, $limit, SQL_INTEGER);
+    $sth->bind_param(1, $self->id, SQL_BIGINT);
+    $sth->bind_param(2, $limit, SQL_BIGINT);
+    $sth->bind_param(3, $limit, SQL_BIGINT);
     $sth->execute;
     $self->{_ancestors} = $sth->fetchrow_array;
 }
@@ -1946,9 +1946,9 @@ sub descendants ($self, $limit = -1) {
             union all
             select jobs.clone_id as clone_id, clone_id.level + 1 as level from jobs join clone_id on clone_id.clone_id = jobs.id where (? < 0 or level < ?))
         select level from clone_id order by level desc limit 1;');
-    $sth->bind_param(1, $self->id, SQL_INTEGER);
-    $sth->bind_param(2, $limit, SQL_INTEGER);
-    $sth->bind_param(3, $limit, SQL_INTEGER);
+    $sth->bind_param(1, $self->id, SQL_BIGINT);
+    $sth->bind_param(2, $limit, SQL_BIGINT);
+    $sth->bind_param(3, $limit, SQL_BIGINT);
     $sth->execute;
     $self->{_descendants} = $sth->fetchrow_array;
 }

--- a/lib/OpenQA/Schema/Result/JobsAssets.pm
+++ b/lib/OpenQA/Schema/Result/JobsAssets.pm
@@ -10,11 +10,11 @@ __PACKAGE__->table('jobs_assets');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     asset_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     created_by => {

--- a/lib/OpenQA/Schema/Result/MachineSettings.pm
+++ b/lib/OpenQA/Schema/Result/MachineSettings.pm
@@ -10,11 +10,11 @@ __PACKAGE__->table('machine_settings');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     machine_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     key => {

--- a/lib/OpenQA/Schema/Result/Machines.pm
+++ b/lib/OpenQA/Schema/Result/Machines.pm
@@ -10,7 +10,7 @@ __PACKAGE__->table('machines');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     name => {

--- a/lib/OpenQA/Schema/Result/NeedleDirs.pm
+++ b/lib/OpenQA/Schema/Result/NeedleDirs.pm
@@ -9,7 +9,7 @@ use Mojo::Base 'DBIx::Class::Core';
 __PACKAGE__->table('needle_dirs');
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     path => {

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -21,11 +21,11 @@ __PACKAGE__->table('needles');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     dir_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 0,
     },
     filename => {

--- a/lib/OpenQA/Schema/Result/ProductSettings.pm
+++ b/lib/OpenQA/Schema/Result/ProductSettings.pm
@@ -10,11 +10,11 @@ __PACKAGE__->table('product_settings');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     product_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     key => {

--- a/lib/OpenQA/Schema/Result/Products.pm
+++ b/lib/OpenQA/Schema/Result/Products.pm
@@ -10,7 +10,7 @@ __PACKAGE__->table('products');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     name => {

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -28,7 +28,7 @@ __PACKAGE__->table('scheduled_products');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     distri => {
@@ -67,17 +67,17 @@ __PACKAGE__->add_columns(
         is_nullable => 1,
     },
     user_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 1,
         is_foreign_key => 1,
     },
     gru_task_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 1,
         is_foreign_key => 1,
     },
     minion_job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 1,
     },
 );

--- a/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
+++ b/lib/OpenQA/Schema/Result/ScreenshotLinks.pm
@@ -10,11 +10,11 @@ __PACKAGE__->table('screenshot_links');
 
 __PACKAGE__->add_columns(
     screenshot_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 0,
     },
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_nullable => 0,
     });
 

--- a/lib/OpenQA/Schema/Result/Screenshots.pm
+++ b/lib/OpenQA/Schema/Result/Screenshots.pm
@@ -11,7 +11,7 @@ __PACKAGE__->load_components(qw(InflateColumn::DateTime));
 
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     filename => {

--- a/lib/OpenQA/Schema/Result/Secrets.pm
+++ b/lib/OpenQA/Schema/Result/Secrets.pm
@@ -12,7 +12,7 @@ __PACKAGE__->table('secrets');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     secret => {

--- a/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
+++ b/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
@@ -10,11 +10,11 @@ __PACKAGE__->table('test_suite_settings');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     test_suite_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
     key => {

--- a/lib/OpenQA/Schema/Result/TestSuites.pm
+++ b/lib/OpenQA/Schema/Result/TestSuites.pm
@@ -10,7 +10,7 @@ __PACKAGE__->table('test_suites');
 __PACKAGE__->load_components(qw(Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     name => {

--- a/lib/OpenQA/Schema/Result/Users.pm
+++ b/lib/OpenQA/Schema/Result/Users.pm
@@ -13,7 +13,7 @@ __PACKAGE__->table('users');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     username => {

--- a/lib/OpenQA/Schema/Result/WorkerProperties.pm
+++ b/lib/OpenQA/Schema/Result/WorkerProperties.pm
@@ -10,7 +10,7 @@ __PACKAGE__->table('worker_properties');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     key => {
@@ -20,7 +20,7 @@ __PACKAGE__->add_columns(
         data_type => 'text',
     },
     worker_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
     },
 );

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -20,7 +20,7 @@ __PACKAGE__->table('workers');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));
 __PACKAGE__->add_columns(
     id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_auto_increment => 1,
     },
     host => {
@@ -30,7 +30,7 @@ __PACKAGE__->add_columns(
         data_type => 'integer',
     },
     job_id => {
-        data_type => 'integer',
+        data_type => 'bigint',
         is_foreign_key => 1,
         is_nullable => 1
     },


### PR DESCRIPTION
* Convert all database ID-columns from integer to bigint
* Convert all related sequences as well (the sequences are already bigint
  on our production instances but that is not necessarily the case, e.g. on
  my local instance they were still integer)
* Adapt code that specifies the types explicitly
* See https://progress.opensuse.org/issues/112265