### PR TITLE
Extend regex to restart jobs in case of VNC errors automatically

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -77,7 +77,7 @@
 
 ## Causes jobs reported as incomplete by the worker to be cloned automatically when the
 ## reason matches; set to 0 to disable
-#auto_clone_regex = ^(cache failure: |terminated prematurely: |api failure: Failed to register .* 503|backend died: .*VNC.*Connection timed out|QEMU terminated: Failed to allocate KVM HPT of order 25.* Cannot allocate memory)
+#auto_clone_regex = ^(cache failure: |terminated prematurely: |api failure: Failed to register .* 503|backend died: .*VNC.*(timeout|timed out|refused)|QEMU terminated: Failed to allocate KVM HPT of order 25.* Cannot allocate memory)
 
 ## A regex pattern that a "force_result" label description in job comments
 ## must match to be accepted. If undefined and by default no rules are applied

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -47,7 +47,7 @@ sub read_config ($app) {
             worker_timeout => DEFAULT_WORKER_TIMEOUT,
             search_results_limit => 50000,
             auto_clone_regex =>
-'^(cache failure: |terminated prematurely: |api failure: Failed to register .* 503|backend died: .*VNC.*Connection timed out|QEMU terminated: Failed to allocate KVM HPT of order 25.* Cannot allocate memory)',
+'^(cache failure: |terminated prematurely: |api failure: Failed to register .* 503|backend died: .*VNC.*(timeout|timed out|refused)|QEMU terminated: Failed to allocate KVM HPT of order 25.* Cannot allocate memory)',
             force_result_regex => '',
         },
         rate_limits => {


### PR DESCRIPTION
We still see these errors from time to time (see
https://progress.opensuse.org/issues/99345#note-42) and currently there's
no better solution than restarting those jobs.