### PR TITLE
Fix perl 5.36 warnings on use of @_ in functions with signature

### DIFF
--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -41,23 +41,23 @@ my %LOG_DEFAULTS = (LOG_TO_STANDARD_CHANNEL => 1, CHANNELS => []);
 #  log_debug("message");
 #  log_debug("message", channels=>'channel1')
 #  log_debug("message", channels=>'channel1', standard=>0)
-sub log_debug (@) { _log_msg('debug', @_); }
+sub log_debug (@args) { _log_msg('debug', @args); }
 
 # log_trace("message"[, param1=>val1, param2=>val2]);
-sub log_trace (@) { _log_msg('trace', @_); }
+sub log_trace (@args) { _log_msg('trace', @args); }
 
 # log_info("message"[, param1=>val1, param2=>val2]);
-sub log_info (@) { _log_msg('info', @_); }
+sub log_info (@args) { _log_msg('info', @args); }
 
 # log_warning("message"[, param1=>val1, param2=>val2]);
-sub log_warning (@) { _log_msg('warn', @_); }
+sub log_warning (@args) { _log_msg('warn', @args); }
 
 # log_error("message"[, param1=>val1, param2=>val2]);
-sub log_error (@) { _log_msg('error', @_); }
+sub log_error (@args) { _log_msg('error', @args); }
 # log_fatal("message"[, param1=>val1, param2=>val2]);
-sub log_fatal (@) {
-    _log_msg('fatal', @_);
-    croak $_[0];
+sub log_fatal (@args) {
+    _log_msg('fatal', @args);
+    croak $args[0];
 }
 
 sub _current_log_level () {

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -98,11 +98,12 @@ sub _poll_cache_service ($job, $cache_client, $request, $delay, $callback) {
 
 sub cache_assets ($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir, $callback) {
     return $callback->(undef) unless my $this_asset = shift @$assets_to_cache;
-    return cache_assets(@_) unless my $asset_value = $vars->{$this_asset};
+    return cache_assets($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir, $callback)
+      unless my $asset_value = $vars->{$this_asset};
 
     my $asset_uri = trim($asset_value);
-    # skip UEFI_PFLASH_VARS asset if the job won't use UEFI
-    return cache_assets(@_) if $this_asset eq 'UEFI_PFLASH_VARS' && !$vars->{UEFI};
+    return cache_assets($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir, $callback)
+      if ($this_asset eq 'UEFI_PFLASH_VARS' && !$vars->{UEFI});
     # check cache availability
     my $error = $cache_client->info->availability_error;
     return $callback->({error => $error}) if $error;

--- a/script/openqa-dump-templates
+++ b/script/openqa-dump-templates
@@ -115,7 +115,7 @@ my %options;
 sub usage ($r) {
     eval "use Pod::Usage; pod2usage($r);";
     die "cannot display help, install perl(Pod::Usage)\n" if $@;
-    exit $_[0];
+    exit $r;
 }
 
 GetOptions(

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -49,8 +49,7 @@ my $chunk_size = 10000000;
 
 my $io_loop_mock = mock_io_loop(subprocess => 1);
 
-sub calculate_file_md5($) {
-    my ($file) = @_;
+sub calculate_file_md5 ($file) {
     my $c = path($file)->slurp;
     my $md5 = Digest::MD5->new;
     $md5->add($c);


### PR DESCRIPTION
As with os-autoinst, building openQA with perl 5.36 results in
test failures due to several cases of subs with signatures using
`@_`, which they are not supposed to do. Fortunately the fixes
are fairly straightforward here.

Signed-off-by: Adam Williamson <awilliam@redhat.com>