### PR TITLE
Only highlight the effective bugref(s) in the comments

### DIFF
--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -87,7 +87,7 @@
         text-align: right;
     }
 
-    &:last-child .openqa-bugref {
+    &:last-of-type .openqa-bugref {
         font-weight: bold;
     }
 }

--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -86,6 +86,10 @@
     .col-sm-1 {
         text-align: right;
     }
+
+    &:last-child .openqa-bugref {
+        font-weight: bold;
+    }
 }
 
 .pagination {

--- a/lib/OpenQA/Markdown.pm
+++ b/lib/OpenQA/Markdown.pm
@@ -5,17 +5,11 @@ use Mojo::Base -strict;
 
 use Exporter 'import';
 use Regexp::Common 'URI';
-use OpenQA::Utils qw(BUGREF_REGEX LABEL_REGEX bugurl);
+use OpenQA::Utils qw(BUGREF_REGEX LABEL_REGEX bugurl bugref_to_href);
 use OpenQA::Constants qw(FRAGMENT_REGEX);
 use CommonMark;
 
-our @EXPORT_OK = qw(bugref_to_markdown is_light_color markdown_to_html);
-
-sub bugref_to_markdown {
-    my $text = shift;
-    $text =~ s/${\BUGREF_REGEX}/"[$+{match}](" . bugurl($+{match}) . ')'/geio;
-    return $text;
-}
+our @EXPORT_OK = qw(is_light_color markdown_to_html);
 
 sub is_light_color {
     my $color = shift;
@@ -28,8 +22,6 @@ sub is_light_color {
 sub markdown_to_html {
     my $text = shift;
 
-    $text = bugref_to_markdown($text);
-
     # Turn all remaining URLs into links
     $text =~ s/(?<!['"(<>])($RE{URI}${\FRAGMENT_REGEX})/<$1>/gio;
 
@@ -37,6 +29,8 @@ sub markdown_to_html {
     $text =~ s!\b(t#([\w/]+))![$1](/tests/$2)!gi;
 
     my $html = CommonMark->markdown_to_html($text);
+
+    $html = bugref_to_href($html);
 
     # Make labels easy to highlight
     $html =~ s/${\LABEL_REGEX}/<span class="openqa-label">label:$+{match}<\/span>/g;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -447,7 +447,7 @@ sub bugurl {
 sub bugref_to_href {
     my ($text) = @_;
     my $regex = BUGREF_REGEX;
-    $text =~ s{$regex}{<a href="@{[bugurl($+{match})]}">$+{match}</a>}gi;
+    $text =~ s{$regex}{<a href="@{[bugurl($+{match})]}" class="openqa-bugref">$+{match}</a>}gi;
     return $text;
 }
 

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -8,7 +8,7 @@ use Test::Warnings ':report_warnings';
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';
-use OpenQA::Markdown qw(bugref_to_markdown is_light_color markdown_to_html);
+use OpenQA::Markdown qw(is_light_color markdown_to_html);
 
 subtest 'standard markdown' => sub {
     is markdown_to_html('Test'), "<p>Test</p>\n", 'HTML rendered';
@@ -124,28 +124,6 @@ subtest 'unsafe HTML filtered out' => sub {
       qq{<p><span style="color:#0000ff;background-color:white">}
       . qq{<!-- raw HTML omitted -->Test<!-- raw HTML omitted --></span></p>\n},
       'unsafe HTML filtered';
-};
-
-subtest 'bugrefs to markdown' => sub {
-    is bugref_to_markdown('bnc#9876'), '[bnc#9876](https://bugzilla.suse.com/show_bug.cgi?id=9876)', 'right markdown';
-    is bugref_to_markdown('bsc#9876'), '[bsc#9876](https://bugzilla.suse.com/show_bug.cgi?id=9876)', 'right markdown';
-    is bugref_to_markdown('boo#9876'), '[boo#9876](https://bugzilla.opensuse.org/show_bug.cgi?id=9876)',
-      'right markdown';
-    is bugref_to_markdown('bgo#9876'), '[bgo#9876](https://bugzilla.gnome.org/show_bug.cgi?id=9876)', 'right markdown';
-    is bugref_to_markdown('brc#9876'), '[brc#9876](https://bugzilla.redhat.com/show_bug.cgi?id=9876)', 'right markdown';
-    is bugref_to_markdown('bko#9876'), '[bko#9876](https://bugzilla.kernel.org/show_bug.cgi?id=9876)', 'right markdown';
-    is bugref_to_markdown('poo#9876'), '[poo#9876](https://progress.opensuse.org/issues/9876)', 'right markdown';
-    is bugref_to_markdown('gh#foo/bar#1234'), '[gh#foo/bar#1234](https://github.com/foo/bar/issues/1234)',
-      'right markdown';
-    is bugref_to_markdown('kde#9876'), '[kde#9876](https://bugs.kde.org/show_bug.cgi?id=9876)', 'right markdown';
-    is bugref_to_markdown('fdo#9876'), '[fdo#9876](https://bugs.freedesktop.org/show_bug.cgi?id=9876)',
-      'right markdown';
-    is bugref_to_markdown('jsc#9876'), '[jsc#9876](https://jira.suse.de/browse/9876)', 'right markdown';
-    is bugref_to_markdown("boo#9876\n\ntest boo#211\n"),
-      "[boo#9876](https://bugzilla.opensuse.org/show_bug.cgi?id=9876)\n\n"
-      . "test [boo#211](https://bugzilla.opensuse.org/show_bug.cgi?id=211)\n",
-      'right markdown';
-    is bugref_to_markdown('label:force_result:passed:bsc#1234'), 'label:force_result:passed:bsc#1234', 'right markdown';
 };
 
 subtest 'color detection' => sub {

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -114,18 +114,21 @@ is_deeply(find_bugrefs('bc#1234 #4321'), [], 'no bugrefs found');
 is bugurl('gh#os-autoinst/openQA#1234'), 'https://github.com/os-autoinst/openQA/issues/1234';
 is bugurl('poo#1234'), 'https://progress.opensuse.org/issues/1234';
 is href_to_bugref('https://progress.opensuse.org/issues/1234'), 'poo#1234';
-is bugref_to_href('boo#9876'), '<a href="https://bugzilla.opensuse.org/show_bug.cgi?id=9876">boo#9876</a>';
+is bugref_to_href('boo#9876'),
+  '<a href="https://bugzilla.opensuse.org/show_bug.cgi?id=9876" class="openqa-bugref">boo#9876</a>';
 is href_to_bugref('https://github.com/foo/bar/issues/1234'), 'gh#foo/bar#1234';
 is href_to_bugref('https://github.com/os-autoinst/os-autoinst/pull/960'), 'gh#os-autoinst/os-autoinst#960',
   'github pull are also transformed same as issues';
-is bugref_to_href('gh#foo/bar#1234'), '<a href="https://github.com/foo/bar/issues/1234">gh#foo/bar#1234</a>';
+is bugref_to_href('gh#foo/bar#1234'),
+  '<a href="https://github.com/foo/bar/issues/1234" class="openqa-bugref">gh#foo/bar#1234</a>';
 like bugref_to_href('bsc#2345 poo#3456 and more'),
-  qr{a href="https://bugzilla.suse.com/show_bug.cgi\?id=2345">bsc\#2345</a> <a href=.*3456.*> and more},
+qr{a href="https://bugzilla.suse.com/show_bug.cgi\?id=2345" class="openqa-bugref">bsc\#2345</a> <a href=.*3456.*> and more},
   'bugrefs in text get replaced';
 like bugref_to_href('boo#2345,poo#3456'),
-  qr{a href="https://bugzilla.opensuse.org/show_bug.cgi\?id=2345">boo\#2345</a>,<a href=.*3456.*},
+  qr{a href="https://bugzilla.opensuse.org/show_bug.cgi\?id=2345" class="openqa-bugref">boo\#2345</a>,<a href=.*3456.*},
   'interpunctation is not consumed by href';
-is bugref_to_href('jsc#SLE-3275'), '<a href="https://jira.suse.de/browse/SLE-3275">jsc#SLE-3275</a>';
+is bugref_to_href('jsc#SLE-3275'),
+  '<a href="https://jira.suse.de/browse/SLE-3275" class="openqa-bugref">jsc#SLE-3275</a>';
 is href_to_bugref('https://jira.suse.de/browse/FOOBAR-1234'), 'jsc#FOOBAR-1234', 'jira tickets url to bugref';
 is find_bug_number('yast_roleconf-ntp-servers-empty-bsc1114818-20181115.png'), 'bsc1114818',
   'find the bug number from the needle name';

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -358,6 +358,8 @@ EOM
         $driver->find_element_by_id('text')->send_keys('bsc#1234 poo#4321');
         $driver->find_element_by_id('submitComment')->click();
         wait_for_ajax(msg => 'comment added to job 99938 (2)');
+        my @takeover = $driver->find_elements('.openqa-bugref', 'css');
+        is(scalar @takeover, 1, '1 bugrefs highlighted for takeover');
         $driver->find_element_by_link_text('Job Groups')->click();
         $driver->find_element('#current-build-overview a')->click();
         is(

--- a/templates/webapi/comments/add_comment_form_groups.html.ep
+++ b/templates/webapi/comments/add_comment_form_groups.html.ep
@@ -27,7 +27,7 @@
         into <code>poo#11110</code>).
     </p>
     <p>
-        Issue references are automatically carried over to the next jobs in the same scenario when the corresponding job fails in
+        The comment with the latest issue reference(s) is automatically carried over to the next job in the same scenario when the corresponding job fails in
         the same module or the failed modules did not change.
     </p>
     <p>


### PR DESCRIPTION
The latest comment with one or more bugrefs is considered for takeover. Others are effectively ignored. This should be clearly visible in the web UI.