### PR TITLE
Makefile: Ensure "test" includes also helm tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ images:
       # Exclude container specific tests needing a container runtime
       # environment, using github actions instead
       CONTAINER_TEST: 0
+      HELM_TEST: 0
 
   - &base
     image: registry.opensuse.org/devel/openqa/ci/containers/base:latest

--- a/Makefile
+++ b/Makefile
@@ -142,10 +142,11 @@ ifeq ($(TRAVIS),true)
 test: run-tests-within-container
 else
 ifeq ($(CHECKSTYLE),0)
-test: test-with-database
+checkstyle_tests =
 else
-test: test-checkstyle-standalone test-with-database
+checkstyle_tests = test-checkstyle-standalone
 endif
+test: $(checkstyle_tests) test-with-database
 ifeq ($(CONTAINER_TEST),1)
 ifeq ($(TESTS),)
 test: test-containers-compose

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ KEEP_DB ?= 0
 # CONTAINER_TEST: Set to 0 to exclude container tests needing a container
 # runtime environment
 CONTAINER_TEST ?= 1
+# HELM_TEST: Set to 0 to exclude helm tests needing a kubernetes cluster
+HELM_TEST ?= 1
 # TESTS: Specify individual test files in a space separated lists. As the user
 # most likely wants only the mentioned tests to be executed and no other
 # checks this implicitly disables CHECKSTYLE
@@ -150,6 +152,11 @@ test: $(checkstyle_tests) test-with-database
 ifeq ($(CONTAINER_TEST),1)
 ifeq ($(TESTS),)
 test: test-containers-compose
+endif
+endif
+ifeq ($(HELM_TEST),1)
+ifeq ($(TESTS),)
+test: test-helm-chart
 endif
 endif
 endif

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -323,6 +323,7 @@ export OPENQA_TEST_TIMEOUT_SCALE_CI=10
 # docker-compose. Also, these tests are less relevant (or not relevant) for
 # packaging
 export CONTAINER_TEST=0
+export HELM_TEST=0
 make test PROVE_ARGS='-r -v' CHECKSTYLE=0 TEST_PG_PATH=%{buildroot}/DB
 rm -rf %{buildroot}/DB
 %endif


### PR DESCRIPTION
Running all tests as part of the "test" target is the safer approach to
ensure that no tests are overlooked. Many developers will unfortunately
not have all prerequisites to run all the tests necessary locally but
that was already the case in before. Indidvidual test parts can still be
selected explicitly as well as excluded based on variables. So this
commit adds the helm-chart test to the generic "test" target while
configuring it based on the HELM_TEST variable and same as the
CONTAINER_TEST excluding the helm-chart test when the TESTS variable is
specified to select individual test modules.