### PR TITLE
Fix live view dysfunctional with directly chained jobs

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -472,7 +472,11 @@ sub _assign_multiple_jobs_to_worker {
         assigned_worker_id => $worker_id,
     );
     my $first_job = $directly_chained_job_sequence->[0];
+    if (my $tmpdir = $worker->get_property('WORKER_TMPDIR')) {
+        File::Path::rmtree($tmpdir);
+    }
     my %worker_properties = (JOBTOKEN => random_string(), WORKER_TMPDIR => tempdir());
+    $worker->set_property(WORKER_TMPDIR => $worker_properties{WORKER_TMPDIR});
     $job_data{$_->id} = $_->prepare_for_work($worker, \%worker_properties) for @$jobs;
     return OpenQA::WebSockets::Client->singleton->send_jobs(\%job_info);
 }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -385,12 +385,13 @@ sub prepare_for_work ($self, $worker = undef, $worker_properties = {}) {
         $job_hashref->{settings}->{NICVLAN} = join(',', @vlans);
     }
 
-    # assign new tmpdir, clean previous one
-    if (my $tmpdir = $worker->get_property('WORKER_TMPDIR')) {
-        File::Path::rmtree($tmpdir);
+    unless ($worker_properties->{WORKER_TMPDIR}) {
+        # assign new tmpdir, clean previous one
+        if (my $tmpdir = $worker->get_property('WORKER_TMPDIR')) {
+            File::Path::rmtree($tmpdir);
+        }
+        $worker->set_property(WORKER_TMPDIR => tempdir());
     }
-    $worker->set_property(WORKER_TMPDIR => $worker_properties->{WORKER_TMPDIR} // tempdir());
-
     return $job_hashref;
 }
 


### PR DESCRIPTION
This's my Hackweek project :)
The issue ticket: https://progress.opensuse.org/issues/110824

The root cause:
The commit below introduced a regression.   live view and live log of directly chained jobs are not able to work due to this regression. https://github.com/os-autoinst/openQA/commit/591fba9fe7948f963300ff66074c6dd22092f4f1

In lib/OpenQA/Scheduler/Model/Jobs.pm, the line 476:
   ```$job_data{$_->id} = $_->prepare_for_work($worker, \%worker_properties) for @$jobs``` calls "prepare_for_work" multiples times .  Each call will delete the worker tmp directory created by previous call. In the end, no tmp directory exits so live view and live log can't be generated.

Below is the fix:

The fix will still clean up the tmp directory created by previous schedule, create new tmp directory and assign it to  hash %worker_properties{WORKER_TMPDIR}  in "_assign_multiple_jobs_to_worker" function before looping prepare_for_work. 
prepare_for_work will not delete the previous tmp directory and create new tmp directory if its parameter %worker_properties{WORKER_TMPDIR} has value.

Verification run:
direcltly-chained+two+jobs:  http://10.67.183.62/tests/overview?distri=sle&build=%3Adirecltly-chained+two+jobs&groupid=1&version=15-SP3
single job: http://10.67.183.62/tests/38