### PR TITLE
CI: Fix execution of compound statements with "retry"

### DIFF
--- a/tools/retry
+++ b/tools/retry
@@ -7,21 +7,21 @@ STABILITY_TEST="${STABILITY_TEST:-0}"
 HOOK="${HOOK:-}"
 
 run_once() {
-    $*
+    "$@"
 }
 
 if [ "$RETRY" = "0" ]; then
-    run_once $*
+    run_once "$@"
 else
     n=1
     while :; do
         if [ "$STABILITY_TEST" = "0" ]; then
             [ $n -le "$RETRY" ] || exit 1
             [ $n -eq 0 ] || echo "Retry $n of $RETRY …"
-            run_once $* && break
+            run_once "$@" && break
         else
             [ $n -le "$RETRY" ] || exit 0
-            run_once $* || exit
+            run_once "$@" || exit
             echo "Rerun $n of $RETRY …"
         fi
         if [ -n "$HOOK" ]; then


### PR DESCRIPTION
In d7fb5d5 I introduced a compound 'zypper ref && zypper in' call to be
called by tools/retry. At that time I tested the combined zypper
statement itself but did not realize that tools/retry does not execute
the combined "sh" with the command line parameter string.

This commit fixes the problems we observed in circleCI runs on the
master branch trying to create a dependency update pull request.

This change is in line with
https://github.com/okurz/retry/blob/main/retry