### PR TITLE
Allow configuring results to collapse as parallel children on overview

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -26,7 +26,7 @@ function toggleAllParallelChildren(expand, table) {
 }
 
 function hasOnlyOkChildren(table, parentID) {
-  const sel = '.parallel-child-of-' + parentID + ' .status:not(.result_passed):not(.result_softfailed)';
+  const sel = '.parallel-child-of-' + parentID + window.overviewParallelChildrenCollapsableResultsSel;
   return table.querySelector(sel) === null;
 }
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -84,6 +84,11 @@
 ## and no description is expected
 #force_result_regex =
 
+## Job results to collapse by default as parallel children on the test result
+## overview page (defaults to passed/softfailed, set to empty value to disable
+## collapsing parallel children by default completely)
+#parallel_children_collapsable_results = passed softfailed
+
 #[scm git]
 # name of remote to get updates from before committing changes (e.g. origin, leave out-commented to disable remote update)
 #update_remote = origin

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -648,6 +648,7 @@ sub _add_distri_and_version_to_summary {
 sub overview {
     my ($self) = @_;
     my ($search_args, $groups) = $self->compose_job_overview_search_args;
+    my $config = OpenQA::App->singleton->config;
     my $validation = $self->validation;
     $validation->optional('t')->datetime;
     my $until = $validation->param('t');
@@ -659,10 +660,11 @@ sub overview {
         distri => $search_args->{distri},
         groups => $groups,
         until => $until,
+        parallel_children_collapsable_results_sel => $config->{global}->{parallel_children_collapsable_results_sel},
     );
     my @jobs = $self->schema->resultset('Jobs')->complex_query(%$search_args)->latest_jobs($until);
 
-    my $limit = OpenQA::App->singleton->config->{misc_limits}->{tests_overview_max_jobs};
+    my $limit = $config->{misc_limits}->{tests_overview_max_jobs};
     (my $limit_exceeded, $stash{archs}, $stash{results}, $stash{aggregated})
       = $self->_prepare_job_results(\@jobs, $limit);
 

--- a/t/config.t
+++ b/t/config.t
@@ -50,6 +50,7 @@ subtest 'Test configuration default modes' => sub {
             search_results_limit => 50000,
             worker_timeout => DEFAULT_WORKER_TIMEOUT,
             force_result_regex => '',
+            parallel_children_collapsable_results_sel => ' .status:not(.result_passed):not(.result_softfailed)',
         },
         rate_limits => {
             search => 5,

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -5,6 +5,7 @@
 % use List::Util qw(sum);
 
 % content_for 'ready_function' => begin
+  window.overviewParallelChildrenCollapsableResultsSel = '<%= $parallel_children_collapsable_results_sel %>';
   setupOverview();
 % end
 


### PR DESCRIPTION
See https://progress.opensuse.org/issues/111470#note-5

@AdamWill 