### PR TITLE
apparmor: Allow mkdir needed by git-call

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -82,6 +82,7 @@
   /usr/bin/podman rix,
   /usr/bin/lscpu rCx,
   /{usr/,}bin/mkdir rix,
+  /{usr/,}bin/mktemp mrix,
   /usr/bin/nice rix,
   /usr/bin/swtpm rix,
   /usr/bin/optipng rix,


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst/pull/2104