### PR TITLE
Fix unstable `t/ui/23-audit-log.t` by implementing wait condition

### DIFF
--- a/tools/unstable_tests.txt
+++ b/tools/unstable_tests.txt
@@ -3,4 +3,3 @@ t/43-scheduling-and-worker-scalability.t
 t/ui/01-list.t
 t/ui/26-jobs_restart.t
 t/ui/13-admin.t
-t/ui/23-audit-log.t


### PR DESCRIPTION
* Wait until the expected number of rows show up in the DataTable (with a
  timeout) instead of using `sleep 1` to prevent failures when the one
  second is not enough
* See https://progress.opensuse.org/issues/113138