### PR TITLE
Fix sorting of jobs that have never run on 'All tests' page

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -53,10 +53,10 @@ sub list_ajax ($self) {
         match => $self->get_match_param,
         groupid => $self->param('groupid'),
         limit => ($self->param('limit') // 500),
-        order_by => [{-desc => 'me.t_finished'}, {-desc => 'me.id'}],
+        order_by => \'COALESCE(me.t_finished, me.t_updated) DESC, me.id DESC',
         columns => [
             qw(id MACHINE DISTRI VERSION FLAVOR ARCH BUILD TEST
-              state clone_id result group_id t_finished
+              state clone_id result group_id t_finished t_updated
               passed_module_count softfailed_module_count
               failed_module_count skipped_module_count
               externally_skipped_module_count
@@ -90,7 +90,7 @@ sub list_ajax ($self) {
                 flavor => $job->FLAVOR // '',
                 arch => $job->ARCH // '',
                 build => $job->BUILD // '',
-                testtime => ($job->t_finished // '') . 'Z',
+                testtime => ($job->t_finished // $job->t_updated // '') . 'Z',
                 result => $job->result,
                 group => $job->group_id,
                 comment_data => $rendered_data,


### PR DESCRIPTION
If jobs have no `t_finished` timestamp (as they've never run) they are
currently shown before any other jobs. In production that's not a problem
because we hardly cancel jobs before they had a chance to run. However, on
a local system where one experiments with openqa-clone-job that can easily
be the case. This change simply considers `t_updated` if `t_finished` is
not set. That should be good enough because `t_updated` is normally last
set when the job is canceled.

---

Note that this is just something I personally find annoying. I admit that with this
change it is a bit weird that the time of cancellation is shown within the "Finished"
column but I find it better than having the sorting out of place.