### PR TITLE
Switch development base to Tumbleweed assuming problems are fixed

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -1,11 +1,9 @@
 #!BuildTag: openqa_dev
-FROM opensuse/leap:15.4
+FROM opensuse/tumbleweed
 
 # Define environment variable
 ENV NAME openQA test environment
 ENV LANG en_US.UTF-8
-
-RUN zypper ar -f -G 'http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.4/15.4' devel_openqa
 
 # hadolint ignore=DL3037
 RUN zypper in -y -C \

--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,7 +4,7 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.4
+FROM opensuse/tumbleweed
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use

--- a/container/devel:openQA:ci/dependency_bot/Dockerfile
+++ b/container/devel:openQA:ci/dependency_bot/Dockerfile
@@ -1,5 +1,5 @@
 #!BuildTag: dependency_bot
-FROM opensuse/leap:15.4
+FROM opensuse/tumbleweed
 ENV NAME Leap with container runtime environment and hub
 
 ENV LANG en_US.UTF-8

--- a/container/helm/charts/webui/values.yaml
+++ b/container/helm/charts/webui/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.4/openqa_webui
+  name: registry.opensuse.org/devel/openqa/containers-tw/openqa_webui
   pullPolicy: Always
   tag: "latest"
 

--- a/container/helm/charts/worker/values.yaml
+++ b/container/helm/charts/worker/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.4/openqa_worker
+  name: registry.opensuse.org/devel/openqa/containers-tw/openqa_worker
   pullPolicy: Always
   tag: "latest"
 

--- a/container/openqa_data/Dockerfile
+++ b/container/openqa_data/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.4
+FROM opensuse/tumbleweed
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -1,11 +1,10 @@
 #!BuildTag: openqa_webui
-FROM opensuse/leap:15.4
+FROM opensuse/tumbleweed
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.4 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.4/15.4 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     # openQA might need rubygem:sass to compile assets in this context due to
     # unknown reasons even though the package should use the precompiled

--- a/container/webui/Dockerfile-lb
+++ b/container/webui/Dockerfile-lb
@@ -1,10 +1,9 @@
 #!BuildTag: openqa_webui_lb
-FROM opensuse/leap:15.4
+FROM opensuse/tumbleweed
 LABEL maintainer Ivan Lausuch <ilausuch@suse.com>
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.4 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.4/15.4 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y openQA nginx && \
     zypper clean

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -1,11 +1,10 @@
 #!BuildTag: openqa_worker
-FROM opensuse/leap:15.4
+FROM opensuse/tumbleweed
 LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
 LABEL version="0.3"
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.4 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.4/15.4 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -yl ca-certificates-mozilla curl gzip rsync && \
     zypper in -yl openQA-worker os-autoinst-s390-deps && \

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -94,14 +94,14 @@ container engine:
 
 [source,sh]
 ----
-podman run --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest
+podman run --rm -it registry.opensuse.org/devel/openqa/containers-tw/openqa_webui:latest
 ----
 
 The worker container can be pulled and started with:
 
 [source,sh]
 ----
-podman run --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_worker:latest
+podman run --rm -it registry.opensuse.org/devel/openqa/containers-tw/openqa_worker:latest
 ----
 
 Some parameters are necessary to run them properly. See the

--- a/tools/ci/build_cache.sh
+++ b/tools/ci/build_cache.sh
@@ -5,8 +5,7 @@
 
 set -ex
 
-sudo zypper ar -f -p 90 https://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.4/15.4 openQA
-sudo zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/15.4 devel
+sudo zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel
 tools/retry sudo zypper --gpg-auto-import-keys ref
 sudo zypper -n install --download-only $(cat tools/ci/ci-packages.txt | sed -e 's/\r//' )
 sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')

--- a/tools/ci/build_dependencies.sh
+++ b/tools/ci/build_dependencies.sh
@@ -17,8 +17,7 @@ listdeps() {
 
 listdeps > $DEPS_BEFORE
 
-sudo zypper ar --priority 91 -f https://download.opensuse.org/repositories/devel:openQA/15.4 devel_openQA
-sudo zypper ar --priority 90 -f https://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.4/15.4 devel_openQA_Leap
+sudo zypper ar --priority 91 -f https://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel_openQA
 tools/retry sudo sh -c 'zypper --gpg-auto-import-keys ref && sudo zypper --no-refresh -n install openQA-devel perl-TAP-Harness-JUnit'
 
 listdeps > $DEPS_AFTER

--- a/tools/ci/build_local_container.sh
+++ b/tools/ci/build_local_container.sh
@@ -10,8 +10,7 @@ cre="${cre:-"podman"}"
 $cre build -t localtest -f- "$thisdir"<<EOF
 FROM registry.opensuse.org/devel/openqa/ci/containers/base:latest
 
-RUN sudo zypper ar -f -p 90 https://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.4/15.4 openQA
-RUN sudo zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/15.4 devel
+RUN sudo zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed devel
 RUN sudo zypper --gpg-auto-import-keys ref
 
 RUN sudo zypper -n install $(echo $(cat $thisdir/ci-packages.txt | sed -e 's/\r//' |sort))

--- a/tools/ci/ci-packages.txt
+++ b/tools/ci/ci-packages.txt
@@ -325,7 +325,6 @@ ShellCheck-0.8.0
 sqlite3-3.39.3
 tcl-8.6.12
 tk-8.6.12
-wallpaper-branding-openSUSE-15.4.20220322
 xauth-1.0.10
 xbitmaps-1.1.1
 xdg-menu-0.2


### PR DESCRIPTION
Similar as in https://github.com/os-autoinst/os-autoinst/pull/2122 for
os-autoinst we can switch to a Tumbleweed base for openQA. Let's see how
far we get :)

Related progress issue:
https://progress.opensuse.org/issues/111881

EDIT: This is an experimental alternative to
* https://github.com/os-autoinst/openQA/pull/4745