### PR TITLE
Stop setting NOVIDEO=1 for longer jobs

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -210,10 +210,6 @@ The download of assets, synchronization of tests and other setup tasks do *not*
 count into `MAX_JOB_TIME`. However, the setup time is limited by default to one
 hour. This can be changed by setting `MAX_SETUP_TIME`.
 
-To save disk space, increasing `MAX_JOB_TIME` beyond the default will
-automatically disable the video by adding `NOVIDEO=1` to the test settings.
-This can be prevented by adding `NOVIDEO=0` explicitly.
-
 The variable `TIMEOUT_SCALE` allows to scale `MAX_JOB_TIME` and timeouts
 within the backend, for example the <<_api,test API>>. This is supposed to
 be set within the worker settings on slow worker hosts. It has no influence on

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -196,8 +196,6 @@ sub _compute_timeouts ($job_settings) {
     my $timeout_scale = $job_settings->{TIMEOUT_SCALE};
     $max_job_time = DEFAULT_MAX_JOB_TIME unless looks_like_number $max_job_time;
     $max_setup_time = DEFAULT_MAX_SETUP_TIME unless looks_like_number $max_setup_time;
-    # disable video for long-running scenarios by default
-    $job_settings->{NOVIDEO} = 1 if !exists $job_settings->{NOVIDEO} && $max_job_time > DEFAULT_MAX_JOB_TIME;
     $max_job_time *= $timeout_scale if looks_like_number $timeout_scale;
     return ($max_job_time, $max_setup_time);
 }

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1236,18 +1236,6 @@ subtest 'computing max job time and max setup time' => sub {
     is $max_job_time, DEFAULT_MAX_JOB_TIME * 2, 'max job time scaled';
     is $max_setup_time, DEFAULT_MAX_SETUP_TIME, 'max setup time not scaled';
     is_deeply [sort keys %settings], [qw(MAX_JOB_TIME TIMEOUT_SCALE)], 'no extra settings added so far';
-
-    $settings{TIMEOUT_SCALE} = undef;
-    $settings{MAX_JOB_TIME} = DEFAULT_MAX_JOB_TIME + 1;
-    ($max_job_time, $max_setup_time) = OpenQA::Worker::Job::_compute_timeouts(\%settings);
-    is $max_job_time, DEFAULT_MAX_JOB_TIME + 1, 'long scenario, NOVIDEO not specified';
-    is $settings{NOVIDEO}, 1, 'NOVIDEO set to 1 for long scenarios';
-
-    $settings{NOVIDEO} = 0;
-    ($max_job_time, $max_setup_time) = OpenQA::Worker::Job::_compute_timeouts(\%settings);
-    is $max_job_time, DEFAULT_MAX_JOB_TIME + 1, 'long scenario, NOVIDEO specified';
-    is $settings{NOVIDEO}, 0, 'NOVIDEO not overridden if set to 0 explicitely';
-    is_deeply [sort keys %settings], [qw(MAX_JOB_TIME NOVIDEO TIMEOUT_SCALE)], 'only expected settings added';
 };
 
 subtest 'handling timeout' => sub {


### PR DESCRIPTION
Videos are not that big even if the job is running longer than whatever the
"default" is resp. the maximum time is. They are very valuable for debugging
failed tests and even more useful in the case of those longer running tests,
like upgrade scenarios.