### PR TITLE
container: Update CI base to Leap 15.4

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -1,11 +1,11 @@
 #!BuildTag: openqa_dev
-FROM opensuse/leap:15.3
+FROM opensuse/leap:15.4
 
 # Define environment variable
 ENV NAME openQA test environment
 ENV LANG en_US.UTF-8
 
-RUN zypper ar -f -G 'http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.3/openSUSE_Leap_15.3' devel_openqa
+RUN zypper ar -f -G 'http://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.4/openSUSE_Leap_15.4' devel_openqa
 
 # hadolint ignore=DL3037
 RUN zypper in -y -C \


### PR DESCRIPTION
First needed for
https://build.opensuse.org/package/show/devel:openQA/openqa_dev

Related progress issue: https://progress.opensuse.org/issues/111881