### PR TITLE
PART 2: Switch helm charts to current openSUSE Leap 15.4 as well - after #4745

### DIFF
--- a/container/helm/charts/webui/values.yaml
+++ b/container/helm/charts/webui/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.3/openqa_webui
+  name: registry.opensuse.org/devel/openqa/containers15.4/openqa_webui
   pullPolicy: Always
   tag: "latest"
 

--- a/container/helm/charts/worker/values.yaml
+++ b/container/helm/charts/worker/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.3/openqa_worker
+  name: registry.opensuse.org/devel/openqa/containers15.4/openqa_worker
   pullPolicy: Always
   tag: "latest"
 


### PR DESCRIPTION
Doing this separately after base images had a chance to be built on Leap
15.4.

After:
* #4745

Related progress issue: https://progress.opensuse.org/issues/111881