### PR TITLE
worker: Retry registration on timestamp mismatch

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -105,6 +105,7 @@ sub register ($self) {
         $error_message //= $tx->res->body || $error->{message};
         $error_message = "Failed to register at $webui_host - $error_class: $error_message";
         my $status = (defined $error_code && $error_code =~ /^4\d\d$/ ? 'disabled' : 'failed');
+        $status = 'failed' if $error_message =~ /timestamp mismatch/;
         $self->{_last_error} = $error_message;
         $self->_set_status($status => {error_message => $error_message});
         return undef;

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -538,6 +538,14 @@ subtest 'handle client status changes' => sub {
     like($output, qr/Test disabling - ignoring server/s, 'client disabled');
     unlike($output, qr/Stopping.*because registration/s, 'worker not stopped; there are still other clients');
 
+    # see if the expected number of retries is performed
+    $ENV{OPENQA_WORKER_CONNECT_INTERVAL} = 7;
+    combined_like {
+        $worker->_handle_client_status_changed($fake_client,
+            {status => 'failed', reason => 'test', error_message => '500 response: unavailable'})
+    }
+    qr/trying again in 7 seconds/s, 'worker will attempt to retry later';
+
     # assume all clients are disabled; worker should stop
     $fake_client_2->status('disabled');
 


### PR DESCRIPTION
Also respect OPENQA_WORKER_CONNECT_INTERVAL like in existing cases.

See: https://progress.opensuse.org/issues/105855