### PR TITLE
Fix sort order of comments on job details page

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -373,7 +373,7 @@ sub show_filesrc {
 sub comments {
     my ($self) = @_;
 
-    $self->_stash_job({prefetch => 'comments'}) or return $self->reply->not_found;
+    $self->_stash_job({prefetch => 'comments', order_by => 'comments.id'}) or return $self->reply->not_found;
     $self->render('test/comments');
 }
 


### PR DESCRIPTION
Comments are accessed via `$job->comments` when rendering them so the
sorting is expected to be ascending by ID via
`__PACKAGE__->has_many(comments => 'OpenQA::Schema::Result::Comments',
'job_id', {order_by => 'id'});` in `Jobs.pm`. However, that's not effective
since we're prefetching the comments here. So it is necessary to specify
the order of the comments when querying the job (where comments are
prefetched).

---

I found this bug when testing #4717. So far I've only tested it manually.
I can extend tests if that's required.