### PR TITLE
Only apply the domain passlist-check for ASSETS as documented

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -499,12 +499,7 @@ sub check_download_url {
         my $quoted = qr/$okdomain/;
         $ok = 1 if ($host =~ /${quoted}$/);
     }
-    if ($ok) {
-        return ();
-    }
-    else {
-        return (1, $host);
-    }
+    return $ok ? () : (1, $host);
 }
 
 sub check_download_passlist {
@@ -524,11 +519,10 @@ sub check_download_passlist {
 
     my ($params, $passlist) = @_;
     my @okdomains;
-    if (defined $passlist) {
-        @okdomains = split(/ /, $passlist);
-    }
+    @okdomains = split(/ /, $passlist) if defined $passlist;
     for my $param (keys %$params) {
         next unless ($param =~ /^(?!__).*_URL$/);
+        next unless asset_type_from_setting((get_url_short($param))[0]);
         my $url = $$params{$param};
         my @check = check_download_url($url, $passlist);
         next unless (@check);

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -152,6 +152,10 @@ $rsp = schedule_iso({%params, HDD_1_DECOMPRESS_URL => 'http://adamshost/nonexist
 is($rsp->body, 'Asset download requested from non-passlisted host adamshost.');
 check_download_asset('asset _DECOMPRESS_URL not in passlist');
 
+$rsp = schedule_iso({%params, FOO_URL => 'http://example.org/my/url'});
+unlike $rsp->body, qr/Asset download requested/, 'No download triggered for arbitary URL';
+check_download_asset('arbitrary URL is ignored for download check');
+
 # schedule an existent ISO against a repo to verify the ISO is registered and the repo is not
 $rsp = schedule_iso({%iso, REPO_1 => 'http://open.qa/any-repo'}, 200);
 


### PR DESCRIPTION
This fixes an unexpected error when passing seemingly arbitrary test
variables into openQA that end with _URL. While we treat _URL variables
as special to render clickable links we should not deny scheduling
products when URLs correspond to domains not on the passlist which was
only ever intended for asset downloading.