### PR TITLE
apparmor: Allow run of ping which is required for ipmi backend jobs

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -96,6 +96,7 @@
   /usr/bin/nice rix,
   /usr/bin/swtpm rix,
   /usr/bin/optipng rix,
+  /usr/bin/ping rix,
   /{usr/,}bin/pwd rix,
   /usr/bin/python3.* ix,
   /usr/bin/qemu-img rix,


### PR DESCRIPTION
ping is called in backend/ipmi.pm but failed to run in workers due to `sh: /usr/bin/ping: Permission denied`. fg. https://openqa.opensuse.org/tests/2506550.

backend/ipmi.pm:
```
my $ping_cmd = "ping -c$ping_count '$bmwqemu::vars{IPMI_HOSTNAME}'";
eval { system($ping_cmd); };
```