### PR TITLE
contrib: Remove conflicting product selection in autoyast

### DIFF
--- a/contrib/ay-openqa-worker.xml
+++ b/contrib/ay-openqa-worker.xml
@@ -5,9 +5,6 @@
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>
     <software>
-        <products config:type="list">
-            <product>openSUSE</product>
-        </products>
         <packages config:type="list">
           <package>openssh</package>
           <package>sudo</package>


### PR DESCRIPTION
Current versions of Leap would need an explicit Leap selection so the
profile would not be usable for both Tumbleweed and Leap but it seems we
can just rely on the default without an explicit product.