### PR TITLE
Fix signal guard for hook script since it is a separate Minion task

### DIFF
--- a/lib/OpenQA/Task/Job/FinalizeResults.pm
+++ b/lib/OpenQA/Task/Job/FinalizeResults.pm
@@ -4,6 +4,7 @@
 package OpenQA::Task::Job::FinalizeResults;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 use OpenQA::Jobs::Constants 'CANCELLED';
+use OpenQA::Task::SignalGuard;
 use Time::Seconds;
 
 sub register {
@@ -59,9 +60,7 @@ sub _run_hook_script ($minion_job, $openqa_job, $app, $guard) {
     my $delay = $settings->{_TRIGGER_JOB_DONE_DELAY} // $ENV{OPENQA_JOB_DONE_HOOK_DELAY} // ONE_MINUTE;
     my $retries = $settings->{_TRIGGER_JOB_DONE_RETRIES} // $ENV{OPENQA_JOB_DONE_HOOK_RETRIES} // 1440;
     my $skip_rc = $settings->{_TRIGGER_JOB_DONE_SKIP_RC} // $ENV{OPENQA_JOB_DONE_HOOK_SKIP_RC} // 142;
-
-    $guard->abort(1);
-
+    $guard->retry(0);
     my $id = $app->minion->enqueue(
         hook_script => [
             $hook,

--- a/lib/OpenQA/Task/Job/HookScript.pm
+++ b/lib/OpenQA/Task/Job/HookScript.pm
@@ -3,18 +3,21 @@
 
 package OpenQA::Task::Job::HookScript;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
+use OpenQA::Task::SignalGuard;
 
 sub register ($self, $app, $config) {
     $app->minion->add_task(hook_script => \&_hook_script);
 }
 
 sub _hook_script ($job, $hook, $openqa_job_id, $options) {
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
     my $timeout = $options->{timeout};
     my $kill_timeout = $options->{kill_timeout};
     my $delay = $options->{delay};
     my $retries = $options->{retries};
     my $skip_rc = $options->{skip_rc};
 
+    $ensure_task_retry_on_termination_signal_guard->abort(1);
     my ($rc, $out) = _run_hook($hook, $openqa_job_id, $timeout, $kill_timeout);
     $job->note(hook_cmd => $hook, hook_result => $out, hook_rc => $rc);
 


### PR DESCRIPTION
On OSD there are many failed `hook_script`-jobs with with result
`Job terminated unexpectedly (exit code: 0, signal: 15)`. Previously this
was prevented by using `OpenQA::Task::SignalGuard` but when the hook script
was moved to its own Minion job this hasn't been taken into account.

This change removes guard-handling from the finalize task which is now
useless there and introduces guard-handling in the hook script task.