### PR TITLE
Don't try and log without importing the log function

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -4,6 +4,7 @@
 package OpenQA::WebAPI::Controller::API::V1::Worker;
 use Mojo::Base 'Mojolicious::Controller';
 
+use OpenQA::Log 'log_warning';
 use OpenQA::Utils;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;


### PR DESCRIPTION
I saw some workers on one of our instance were stuck in a failed
registration loop caused by this:

worker[16088]: [info] Registering with openQA http://localhost
worker[16088]: [warn] Failed to register at http://localhost - 500 response: Failed: Undefined subroutine &OpenQA::WebAPI::Controller::API::V1::Worker::log_warning called at /usr/share/openqa/script/../lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm line 114.
worker[16088]:  - trying again in 10 seconds

The log statement was moved from another file in 4928543c86, but
the import wasn't also moved into the new file.

Signed-off-by: Adam Williamson <awilliam@redhat.com>