### PR TITLE
Add support for pagure.io and gitlab.gnome.org trackers

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -49,6 +49,8 @@ BEGIN {
         kde => 'https://bugs.kde.org/show_bug.cgi?id=',
         fdo => 'https://bugs.freedesktop.org/show_bug.cgi?id=',
         jsc => 'https://jira.suse.de/browse/',
+        pio => 'https://pagure.io/',
+        ggo => 'https://gitlab.gnome.org/',
     );
     %BUGURLS = (
         'https://bugzilla.novell.com/show_bug.cgi?id=' => 'bsc',
@@ -63,6 +65,8 @@ BEGIN {
         $BUGREFS{kde} => 'kde',
         $BUGREFS{fdo} => 'fdo',
         $BUGREFS{jsc} => 'jsc',
+        $BUGREFS{pio} => 'pio',
+        $BUGREFS{ggo} => 'ggo',
     );
 
     $MARKER_REFS = join('|', keys %BUGREFS);
@@ -440,8 +444,10 @@ sub bugurl {
     # calling https://github.com/os-autoinst/openQA/issues/966 will yield the
     # same page as https://github.com/os-autoinst/openQA/pull/966 and vice
     # versa for both an issue as well as pull request
+    # for pagure.io it has to be "issue", not "issues"
     $bugref =~ BUGREF_REGEX;
-    return $BUGREFS{$+{marker}} . ($+{repo} ? "$+{repo}/issues/" : '') . $+{id};
+    my $issuetext = $+{marker} eq "pio" ? "issue" : "issues";
+    return $BUGREFS{$+{marker}} . ($+{repo} ? "$+{repo}/$issuetext/" : '') . $+{id};
 }
 
 sub bugref_to_href {
@@ -456,7 +462,9 @@ sub href_to_bugref {
     my $regex = $MARKER_URLS =~ s/\?/\\\?/gr;
     # <repo> is optional, e.g. for github. For github issues and pull are
     # interchangeable, see comment in 'bugurl', too
-    $regex = qr{(?<!["\(\[])(?<url_root>$regex)((?<repo>.*)/(issues|pull)/)?(?<id>([A-Z]+-)?\d+)(?![\w])};
+    # gitlab URLs have an odd /-/ after the repo name, e.g.
+    # https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/5244
+    $regex = qr{(?<!["\(\[])(?<url_root>$regex)((?<repo>.*?)/(-/)?(issues?|pull)/)?(?<id>([A-Z]+-)?\d+)(?![\w])};
     $text =~ s{$regex}{@{[$BUGURLS{$+{url_root}} . ($+{repo} ? '#' . $+{repo} : '')]}#$+{id}}gi;
     return $text;
 }

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -141,6 +141,11 @@ subtest 'bugrefs to markdown' => sub {
     is bugref_to_markdown('fdo#9876'), '[fdo#9876](https://bugs.freedesktop.org/show_bug.cgi?id=9876)',
       'right markdown';
     is bugref_to_markdown('jsc#9876'), '[jsc#9876](https://jira.suse.de/browse/9876)', 'right markdown';
+    is bugref_to_markdown('pio#foo#1234'), '[pio#foo#1234](https://pagure.io/foo/issue/1234)', 'right markdown';
+    is bugref_to_markdown('pio#foo/bar#1234'), '[pio#foo/bar#1234](https://pagure.io/foo/bar/issue/1234)',
+      'right markdown';
+    is bugref_to_markdown('ggo#GNOME/foo#1234'),
+      '[ggo#GNOME/foo#1234](https://gitlab.gnome.org/GNOME/foo/issues/1234)', 'right markdown';
     is bugref_to_markdown("boo#9876\n\ntest boo#211\n"),
       "[boo#9876](https://bugzilla.opensuse.org/show_bug.cgi?id=9876)\n\n"
       . "test [boo#211](https://bugzilla.opensuse.org/show_bug.cgi?id=211)\n",

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -127,6 +127,10 @@ like bugref_to_href('boo#2345,poo#3456'),
   'interpunctation is not consumed by href';
 is bugref_to_href('jsc#SLE-3275'), '<a href="https://jira.suse.de/browse/SLE-3275">jsc#SLE-3275</a>';
 is href_to_bugref('https://jira.suse.de/browse/FOOBAR-1234'), 'jsc#FOOBAR-1234', 'jira tickets url to bugref';
+is href_to_bugref('https://pagure.io/foo/issue/1234'), 'pio#foo#1234', 'pagure.io (no group) url to bugref';
+is href_to_bugref('https://pagure.io/foo/bar/issue/1234'), 'pio#foo/bar#1234', 'pagure.io (with group) url to bugref';
+is href_to_bugref('https://gitlab.gnome.org/GNOME/foo/-/issues/1234'), 'ggo#GNOME/foo#1234',
+  'GNOME gitlab url to bugref';
 is find_bug_number('yast_roleconf-ntp-servers-empty-bsc1114818-20181115.png'), 'bsc1114818',
   'find the bug number from the needle name';
 


### PR DESCRIPTION
These have some little quirks: the weird useless /-/ that gitlab
puts in issue URLs, and how pagure uses /issue/ not /issues/ .

Signed-off-by: Adam Williamson <awilliam@redhat.com>