### PR TITLE
Fix AJAX/parsing error in needle tables

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -20,8 +20,7 @@ sub index {
 sub _translate_days ($days) { time2str('%Y-%m-%d %H:%M:%S', time - $days * ONE_DAY, 'UTC') }
 
 sub _translate_date_format ($datetime) {
-    my $datetime_obj = DateTime::Format::Pg->parse_datetime($datetime);
-    return DateTime::Format::Pg->format_datetime($datetime_obj);
+    DateTime::Format::Pg->format_datetime(DateTime::Format::Pg->parse_datetime($datetime));
 }
 
 sub _translate_cond ($cond) {

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -24,19 +24,15 @@ sub _translate_date_format ($datetime) {
 }
 
 sub _translate_cond ($cond) {
-    if ($cond =~ m/^min(\d+)$/) {
-        return {'>=' => _translate_days($1)};
+    my ($operator, @additional_conds) = rindex($cond, 'min', 0) == 0 ? ('>=') : ('<', {'=' => undef});
+    my $translated;
+    if ($cond =~ m/^(min|max)(\d+)$/) {
+        $translated = _translate_days($2);
     }
-    elsif ($cond =~ m/^max(\d+)$/) {
-        return [{'<' => _translate_days($1)}, {'=' => undef}];
+    elsif ($cond =~ m/^(min|max)(\d{4}\-\d{2}\-\d{2}\w\d{2}:\d{2}(:\d{2})?)$/) {
+        $translated = _translate_date_format($3 ? $2 : "$2:00");
     }
-    elsif ($cond =~ m/^min(\d{4}\-\d{2}\-\d{2}\w\d{2}:\d{2}:\d{2})$/) {
-        return {'>=' => _translate_date_format($1)};
-    }
-    elsif ($cond =~ m/^max(\d{4}\-\d{2}\-\d{2}\w\d{2}:\d{2}:\d{2})$/) {
-        return [{'<' => _translate_date_format($1)}, {'=' => undef}];
-    }
-    die "Unknown '$cond'";
+    $translated ? [{$operator => $translated}, @additional_conds] : die "Unknown '$cond'";
 }
 
 sub _prepare_data_table {

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::WebAPI::Controller::Admin::Needle;
-use Mojo::Base 'Mojolicious::Controller';
+use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use Cwd 'realpath';
 use OpenQA::Utils;
@@ -17,20 +17,14 @@ sub index {
     $self->render('admin/needle/index');
 }
 
-sub _translate_days($) {
-    my ($days) = @_;
-    return time2str('%Y-%m-%d %H:%M:%S', time - $days * ONE_DAY, 'UTC');
-}
+sub _translate_days ($days) { time2str('%Y-%m-%d %H:%M:%S', time - $days * ONE_DAY, 'UTC') }
 
-sub _translate_date_format($) {
-    my ($datetime) = @_;
+sub _translate_date_format ($datetime) {
     my $datetime_obj = DateTime::Format::Pg->parse_datetime($datetime);
     return DateTime::Format::Pg->format_datetime($datetime_obj);
 }
 
-sub _translate_cond($) {
-    my ($cond) = @_;
-
+sub _translate_cond ($cond) {
     if ($cond =~ m/^min(\d+)$/) {
         return {'>=' => _translate_days($1)};
     }

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -75,13 +75,16 @@ sub ajax {
     my $search_value = $self->param('search[value]');
     push(@filter_conds, {filename => {-like => '%' . $search_value . '%'}}) if $search_value;
     my $seen_query = $self->param('last_seen');
-    if ($seen_query && $seen_query ne 'none') {
-        push(@filter_conds, {last_seen_time => _translate_cond($seen_query)});
-    }
-    my $match_query = $self->param('last_match');
-    if ($match_query && $match_query ne 'none') {
-        push(@filter_conds, {last_matched_time => _translate_cond($match_query)});
-    }
+    eval {
+        if ($seen_query && $seen_query ne 'none') {
+            push(@filter_conds, {last_seen_time => _translate_cond($seen_query)});
+        }
+        my $match_query = $self->param('last_match');
+        if ($match_query && $match_query ne 'none') {
+            push(@filter_conds, {last_matched_time => _translate_cond($match_query)});
+        }
+    };
+    return $self->render(json => {error => ($@ =~ s/ at .*//sr)}, status => 400) if $@;
 
     OpenQA::WebAPI::ServerSideDataTable::render_response(
         controller => $self,

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -24,7 +24,7 @@ sub _translate_date_format ($datetime) {
 }
 
 sub _translate_cond ($cond) {
-    my ($operator, @additional_conds) = rindex($cond, 'min', 0) == 0 ? ('>=') : ('<', {'=' => undef});
+    my ($operator, @additional_conds) = ($cond =~ m/^min/) ? ('>=') : ('<', {'=' => undef});
     my $translated;
     if ($cond =~ m/^(min|max)(\d+)$/) {
         $translated = _translate_days($2);


### PR DESCRIPTION
The date/time picker of Firefox and Chromium passes a timestamp without
seconds when a timestamp on a whole minute is selected. So far this is not
accepted by the controller code leading to an alert box complaining about
an AJAX error. This change fixes the issue by allowing the format on the
controller side. Note that minutes and hours always seem to be present.

This issue has been found due to a test failure when the date/time picker
was randomly on a whole minute (see
https://github.com/os-autoinst/openQA/pull/4791#issuecomment-1234391043 and
further comments).