### PR TITLE
Include virtio VGA support in the openqa_worker container

### DIFF
--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -10,6 +10,7 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15
     zypper in -yl ca-certificates-mozilla curl gzip rsync && \
     zypper in -yl openQA-worker os-autoinst-s390-deps && \
     zypper in -yl qemu-arm qemu-ppc qemu-x86 qemu-tools && \
+    zypper in -yl qemu-hw-display-virtio-gpu qemu-hw-display-virtio-gpu-pci qemu-hw-display-virtio-vga && \
     zypper in -yl kmod && \
     (zypper in -yl qemu-ovmf-x86_64 ||:) && \
     (zypper in -yl qemu-uefi-aarch64 ||:) && \


### PR DESCRIPTION
This was previously available and got removed somewhere in the 15.3 container lifecycle.

The effect on image size is negligible and it is useful to test images with kernels that only support the 'virtio' graphics driver without requiring a custom worker container.

Fixes https://github.com/os-autoinst/openQA/issues/4795