### PR TITLE
Reduce two verbose log messages to trace level

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Screenshots.pm
+++ b/lib/OpenQA/Schema/ResultSet/Screenshots.pm
@@ -6,7 +6,7 @@ package OpenQA::Schema::ResultSet::Screenshots;
 
 use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
 
-use OpenQA::Log qw(log_debug);
+use OpenQA::Log qw(log_trace);
 
 sub create_screenshot ($self, $img) {
     my $dbh = $self->result_source->schema->storage->dbh;
@@ -22,7 +22,7 @@ sub create_screenshot ($self, $img) {
 sub populate_images_to_job ($self, $imgs, $job_id) {
     my %ids;
     for my $img (@$imgs) {
-        log_debug "creating $img";
+        log_trace "creating $img";
         my $res = $self->create_screenshot($img)->fetchrow_arrayref;
         $ids{$img} = $res ? $res->[0] : $self->find({filename => $img})->id;
     }

--- a/lib/OpenQA/Schema/ResultSet/Screenshots.pm
+++ b/lib/OpenQA/Schema/ResultSet/Screenshots.pm
@@ -4,12 +4,11 @@
 package OpenQA::Schema::ResultSet::Screenshots;
 
 
-use Mojo::Base 'DBIx::Class::ResultSet';
+use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
 
 use OpenQA::Log qw(log_debug);
 
-sub create_screenshot {
-    my ($self, $img) = @_;
+sub create_screenshot ($self, $img) {
     my $dbh = $self->result_source->schema->storage->dbh;
     my $columns = 'filename, t_created';
     my $values = '?, now()';
@@ -19,10 +18,8 @@ sub create_screenshot {
     return $sth;
 }
 
-sub populate_images_to_job {
-    my ($self, $imgs, $job_id) = @_;
-
-    # insert the symlinks into the DB
+# insert the symlinks into the DB
+sub populate_images_to_job ($self, $imgs, $job_id) {
     my %ids;
     for my $img (@$imgs) {
         log_debug "creating $img";

--- a/lib/OpenQA/WebAPI/Controller/API/V1.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1.pm
@@ -12,7 +12,7 @@ sub auth_jobtoken ($self) {
         {'properties.key' => 'JOBTOKEN', 'properties.value' => $token},
         {columns => ['id'], join => {worker => 'properties'}})->single;
     $self->stash('job_id', $job->id);
-    $self->app->log->debug(sprintf('Found associated job %u', $job->id));
+    $self->app->log->trace('Found associated job ' . $job->id);
     return 1;
 }
 

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -30,8 +30,7 @@ my $jobs = $schema->resultset('Jobs');
 $app->log(Mojo::Log->new(level => 'debug'));
 
 # add two screenshots to a job
-combined_like { $screenshots->populate_images_to_job([qw(foo bar)], 99926) }
-qr/creating foo.+creating bar/s, 'screenshots created';
+$screenshots->populate_images_to_job([qw(foo bar)], 99926);
 my @screenshot_links = $screenshot_links->search({job_id => 99926}, {order_by => 'screenshot_id'})->all;
 my @screenshot_ids = map { $_->screenshot_id } @screenshot_links;
 my @screenshots = $screenshots->search({id => {-in => \@screenshot_ids}})->search({}, {order_by => 'id'});
@@ -44,8 +43,7 @@ is_deeply([sort @$exclusive_screenshot_ids], \@screenshot_ids, 'screenshots are 
   or diag explain $exclusive_screenshot_ids;
 
 # add one of the screenshots to another job
-combined_like { $screenshots->populate_images_to_job([qw(foo)], 99927) }
-qr/creating foo/, 'screenshot created';
+$screenshots->populate_images_to_job([qw(foo)], 99927);
 @screenshot_links = $screenshot_links->search({job_id => 99927})->all;
 is(scalar @screenshot_links, 1, 'screenshot link for job 99927 created');
 is_deeply(
@@ -81,10 +79,8 @@ is_deeply(\@screenshot_data, [{filename => 'foo'}], 'foo still present (used in 
   or diag explain \@screenshot_data;
 
 subtest 'screenshots are unique' => sub {
-    combined_like { $screenshots->populate_images_to_job(['whatever'], 99927) }
-    qr/creating whatever/, 'screenshot created';
-    combined_like { $screenshots->populate_images_to_job(['whatever'], 99927) }
-    qr/creating whatever/, 'screenshot created (duplicate)';
+    $screenshots->populate_images_to_job(['whatever'], 99927);
+    $screenshots->populate_images_to_job(['whatever'], 99927);
     my @whatever = $screenshots->search({filename => 'whatever'})->all;
     is $whatever[0]->filename, 'whatever', 'right filename';
     is $whatever[1], undef, 'no second result';
@@ -184,8 +180,7 @@ subtest 'deleting screenshots of a single job' => sub {
     my $thumsdir = path($imagesdir, '.thumbs');
     my $job = $jobs->create({TEST => 'delete-results', logs_present => 1, result_size => 1000});
     $job->discard_changes;
-    combined_like { $screenshots->populate_images_to_job(\@fake_screenshots, $job->id) }
-    qr/creating.*a-screenshot.*another-screenshot.*foo/s, 'screenshots populated';
+    $screenshots->populate_images_to_job(\@fake_screenshots, $job->id);
     $thumsdir->make_path;
     for my $screenshot (@fake_screenshots) {
         path($imagesdir, $screenshot)->spurt('--');


### PR DESCRIPTION
On big openQA instances with debug log level enabled I can see multiple
log messages every second which is much more verbose than other type of
messages during normal operation.