### PR TITLE
Limit listing of job_templates to avoid timeouts

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -208,6 +208,10 @@ concurrent = 0
 #all_tests_default_finished_jobs = 500
 # Maximum number of jobs to include in table of finished jobs on "All tests" page
 #all_tests_max_finished_jobs = 5000
+# Default number of templates to include in job_templates api response (to prevent performance issues)
+#list_templates_default_limit = 500
+# Maximum number of templates to include in job_templates api response (to prevent performance issues)
+#list_templates_max_limit = 5000
 
 [archiving]
 # Moves logs of jobs which are preserved during the cleanup because they are considered important

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -155,6 +155,8 @@ sub read_config ($app) {
             tests_overview_max_jobs => 500,
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
+            list_templates_default_limit => 500,
+            list_templates_max_limit => 5000
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -4,7 +4,9 @@
 package OpenQA::WebAPI::Controller::API::V1::JobTemplate;
 use Mojo::Base 'Mojolicious::Controller';
 use Try::Tiny;
+use OpenQA::App;
 use OpenQA::YAML qw(load_yaml dump_yaml);
+use List::Util qw(min);
 
 =pod
 
@@ -44,6 +46,9 @@ sub list {
     my $self = shift;
 
     my $schema = $self->schema;
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    my $limit
+      = min($limits->{list_templates_max_limit}, $self->param('limit') // $limits->{list_templates_default_limit});
     my @templates;
     eval {
         if (my $id = $self->param('job_template_id')) {
@@ -68,13 +73,17 @@ sub list {
             );
 
             if ($has_query) {
-                my $attrs
-                  = {join => ['machine', 'test_suite', 'product'], prefetch => [qw(machine test_suite product)]};
+                my $attrs = {
+                    join => ['machine', 'test_suite', 'product'],
+                    prefetch => [qw(machine test_suite product)],
+                    rows => $limit
+                };
                 @templates = $schema->resultset("JobTemplates")->search(\%cond, $attrs);
             }
             else {
                 @templates
-                  = $schema->resultset("JobTemplates")->search({}, {prefetch => [qw(machine test_suite product)]});
+                  = $schema->resultset("JobTemplates")
+                  ->search({}, {prefetch => [qw(machine test_suite product)], rows => $limit});
             }
         }
     };

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -54,9 +54,7 @@ sub list {
         if (my $id = $self->param('job_template_id')) {
             @templates = $schema->resultset("JobTemplates")->search({id => $id});
         }
-
         else {
-
             my %cond;
             if (my $value = $self->param('machine_name')) { $cond{'machine.name'} = $value }
             if (my $value = $self->param('test_suite_name')) { $cond{'test_suite.name'} = $value }
@@ -66,25 +64,8 @@ sub list {
             for my $id (qw(machine_id test_suite_id product_id group_id)) {
                 if (my $value = $self->param($id)) { $cond{$id} = $value }
             }
-
-            my $has_query = grep { $cond{$_} } (
-                qw(machine_name machine_id test_suite.name test_suite_id group_id product.arch product.distri),
-                qw(product.flavor product.version product_id)
-            );
-
-            if ($has_query) {
-                my $attrs = {
-                    join => ['machine', 'test_suite', 'product'],
-                    prefetch => [qw(machine test_suite product)],
-                    rows => $limit
-                };
-                @templates = $schema->resultset("JobTemplates")->search(\%cond, $attrs);
-            }
-            else {
-                @templates
-                  = $schema->resultset("JobTemplates")
-                  ->search({}, {prefetch => [qw(machine test_suite product)], rows => $limit});
-            }
+            my %attrs = (prefetch => [qw(machine test_suite product)], rows => $limit);
+            @templates = $schema->resultset("JobTemplates")->search(\%cond, \%attrs);
         }
     };
 

--- a/t/config.t
+++ b/t/config.t
@@ -137,6 +137,8 @@ subtest 'Test configuration default modes' => sub {
             tests_overview_max_jobs => 500,
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
+            list_templates_default_limit => 500,
+            list_templates_max_limit => 5000
         },
         archiving => {
             archive_preserved_important_jobs => 0,


### PR DESCRIPTION
We already have a limit for the 'All tests' pages, this implementation follows the same approach.
Might need adjustments based on performance tests with production data.

see: https://progress.opensuse.org/issues/114421