### PR TITLE
Avoid test failures due to localized error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 TIMEOUT_RETRIES ?= $$((${TIMEOUT_M} * ${SCALE_FACTOR} * (${RETRY} + 1) ))m
 CRE ?= podman
 # avoid localized error messages (that are matched against in certain cases)
-LANG = C.utf8
+LC_ALL = C.utf8
 LANGUAGE =
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ SCALE_FACTOR ?= 2
 endif
 TIMEOUT_RETRIES ?= $$((${TIMEOUT_M} * ${SCALE_FACTOR} * (${RETRY} + 1) ))m
 CRE ?= podman
+# avoid localized error messages (that are matched against in certain cases)
+LANG = C.utf8
+LANGUAGE =
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 container_env_file := "$(current_dir)/container.env"

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -226,7 +226,7 @@ it when running tests. Example:
 
 [source,sh]
 ----
-TEST_PG='DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg' OPENQA_BASEDIR= prove -v t/14-grutasks.t
+TEST_PG='DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg' OPENQA_BASEDIR= LANG=C.utf8 LANGUAGE= prove -v t/14-grutasks.t
 ----
 
 In the case of wanting to tweak the tests as above, to speed up the test
@@ -585,7 +585,9 @@ temporary PostgreSQL database used for testing. To do this step manually run
 `t/test_postgresql /dev/shm/tpg` to initialize a temporary PostgreSQL database
 and export the environment variable as instructed by that script.
 It is also possible to run a particular test, for example
-`prove t/api/01-workers.t`.
+`prove t/api/01-workers.t`. When using `prove` directly, make sure an English
+locale is set (e.g. `export LANG=C.utf8 LANGUAGE=` before initializing the database
+and running `prove`).
 
 To watch the execution of the UI tests, set the environment variable `NOT_HEADLESS`.
 

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -226,7 +226,7 @@ it when running tests. Example:
 
 [source,sh]
 ----
-TEST_PG='DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg' OPENQA_BASEDIR= LANG=C.utf8 LANGUAGE= prove -v t/14-grutasks.t
+TEST_PG='DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg' OPENQA_BASEDIR= LC_ALL=C.utf8 LANGUAGE= prove -v t/14-grutasks.t
 ----
 
 In the case of wanting to tweak the tests as above, to speed up the test
@@ -586,7 +586,7 @@ temporary PostgreSQL database used for testing. To do this step manually run
 and export the environment variable as instructed by that script.
 It is also possible to run a particular test, for example
 `prove t/api/01-workers.t`. When using `prove` directly, make sure an English
-locale is set (e.g. `export LANG=C.utf8 LANGUAGE=` before initializing the database
+locale is set (e.g. `export LC_ALL=C.utf8 LANGUAGE=` before initializing the database
 and running `prove`).
 
 To keep the test database running after executing tests with the `Makefile`, add

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -589,6 +589,10 @@ It is also possible to run a particular test, for example
 locale is set (e.g. `export LANG=C.utf8 LANGUAGE=` before initializing the database
 and running `prove`).
 
+To keep the test database running after executing tests with the `Makefile`, add
+`KEEP_DB=1` to the make arguments. To access the test database, use
+`psql --host=/dev/shm/tpg openqa_test`.
+
 To watch the execution of the UI tests, set the environment variable `NOT_HEADLESS`.
 
 === Run tests within a container


### PR DESCRIPTION
See particular commit messages

---

Maybe we should merge the different sections within our documentation where we explain how to run openQA's unit tests. For the sake of the PR I've just adjusted both places (as it is not a big change and relevant to both sections).