### PR TITLE
Avoid alerts by not failing Minion jobs when downloads fail

### DIFF
--- a/lib/OpenQA/Schema/Result/GruTasks.pm
+++ b/lib/OpenQA/Schema/Result/GruTasks.pm
@@ -9,6 +9,7 @@ use Mojo::Base 'DBIx::Class::Core';
 use Mojo::JSON qw(decode_json encode_json);
 use OpenQA::Parser::Result::OpenQA;
 use OpenQA::Parser::Result::Test;
+use OpenQA::Jobs::Constants;
 
 __PACKAGE__->table('gru_tasks');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime FilterColumn Timestamps));
@@ -78,7 +79,7 @@ sub fail {
 
     while (my $d = $deps->next) {
         $d->job->custom_module($result => $output);
-        $d->job->done(result => OpenQA::Jobs::Constants::INCOMPLETE());
+        $d->job->done(result => INCOMPLETE, reason => "preparation failed: $reason");
         $d->delete();
     }
 

--- a/lib/OpenQA/Shared/GruJob.pm
+++ b/lib/OpenQA/Shared/GruJob.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Shared::GruJob;
-use Mojo::Base 'Minion::Job';
+use Mojo::Base 'Minion::Job', -signatures;
 
 use Mojo::Util qw(dumper);
 
@@ -49,6 +49,11 @@ sub _fail_gru {
     my ($self, $id, $reason) = @_;
     my $gru = $self->minion->app->schema->resultset('GruTasks')->find($id);
     $gru->fail($reason) if $gru;
+}
+
+sub user_fail ($self, $result) {
+    $self->note(user_error => $result);
+    $self->finish($result);
 }
 
 1;

--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -74,7 +74,7 @@ sub _download {
     if (my ($status, $host) = check_download_url($url, $app->config->{global}->{download_domains})) {
         my $empty_passlist_note = ($status == 2 ? ' (which is empty)' : '');
         $ctx->error(my $msg = qq{Host "$host" of URL "$url" is not on the passlist$empty_passlist_note});
-        return $job->fail($msg);
+        return $job->user_fail($msg);
     }
 
     if ($do_extract) { $ctx->debug(qq{Downloading and uncompressing "$url" to "$assetpath"}) }
@@ -92,7 +92,7 @@ sub _download {
       unless my $err = $downloader->download($url, $assetpath, $options);
     my $res = $downloader->res;
     $ctx->error(my $msg = qq{Downloading "$url" failed with: $err});
-    return $res && $res->is_client_error ? $job->finish($msg) : $job->fail($msg);
+    return $res && $res->is_success ? $job->finish($msg) : $job->user_fail($msg);
 }
 
 1;


### PR DESCRIPTION
* This affects only expected download errors (connection errors, error
  responses) but not any kind of unhandled exception or setup related
  errors.
* See https://progress.opensuse.org/issues/118969