### PR TITLE
codecov.yml: Introduce specific coverage thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,8 +11,11 @@ coverage:
     changes: false
     project:
       default:
-        target: 98.0
-        threshold: 0.1
+        target: 98
+      tests:
+        target: 99.48
+        paths:
+          - t/
     patch:
       default:
         target: 100.0

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,9 +7,6 @@ comment:
 fixes:
   - "/home/circleci/openQA::"
 coverage:
-  range: 60..95
-  round: down
-  precision: 2
   status:
     changes: false
     project:


### PR DESCRIPTION
With path specific coverage targets we can introduce the hard
requirement for 100% coverage within the paths where it is feasible. It
makes sense to have 100% statement coverage within test code itself to
prevent relying on tests that are actually not running.

Previously tried in
* https://github.com/os-autoinst/openQA/pull/3938

In os-autoinst we already added according changes in
* https://github.com/os-autoinst/os-autoinst/pull/2016

See https://docs.codecov.com/docs/commit-status#branches