### PR TITLE
Allow specifying `NEEDLES_DIR` to be relative to `CASEDIR`

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1619,6 +1619,26 @@ See
 https://github.com/os-autoinst/os-autoinst/blob/master/doc/backend_vars.asciidoc
 for details.
 
+[NOTE]
+====
+The openQA worker normally default-initializes `CASEDIR` and `NEEDLES_DIR` to
+point to default repositories provided by the openQA instance. This behavior
+interacts with specifying a custom `CASEDIR` or `NEEDLES_DIR` in the following
+way:
+
+* If `CASEDIR` or `NEEDLES_DIR` is customized the customized location is used
+  instead of the default repository.
+* If only one of `CASEDIR` or `NEEDLES_DIR` is customized the other variable
+  will still be initialized to point to the default repository.
+* A relative `NEEDLES_DIR` is treated to be relative to the default `CASEDIR`
+  (even if `CASEDIR` is customized). To have it treated to be relative to the
+  custom `CASEDIR`, prefix the relative path with `%CASEDIR%/`. So specifying
+  e.g. `CASEDIR=https://github.com/…` and `NEEDLES_DIR=%CASEDIR%/the-needles`
+  will lead to `%CASEDIR%` being substituted with the path of the Git checkout
+  created for the custom `CASEDIR`. That results in needles found in
+  https://github.com/…/tree/…/the-needles to be used.
+====
+
 A helper script `openqa-clone-custom-git-refspec` is available for
 convenience that supports some combinations.
 

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1605,13 +1605,13 @@ describes how downloadable assets can be specified. It is important to note
 that the specified asset is only downloaded once. New versions must be
 supplied as new, unambiguous download target file names.
 
-=== Triggering tests based on an any remote git refspec or open github pull request
+=== Triggering tests based on an any remote Git refspec or open GitHub pull request
 
 openQA also supports to trigger tests using test code from an open pull
-request on github or any branch or git refspec. That means that code changes
+request on GitHub or any branch or Git refspec. That means that code changes
 that are not yet available on a production instance of openQA can be tested
 safely to ensure the code changes work as expected before merging the code
-intro a production repository and branch. This works by setting the
+into a production repository and branch. This works by setting the
 `CASEDIR` parameter of os-autoinst to a valid Git repository path including
 an optional branch/refspec specifier. It is also possible to set `NEEDLES_DIR`
 to a valid Git repository path to use custom needles.

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -345,6 +345,19 @@ subtest 'symlink testrepo, logging behavior' => sub {
         is $result->{error}, undef, 'no error occurred (1)';
     };
 
+    subtest 'good case: custom CASEDIR and NEEDLES_DIR where NEEDLES_DIR starts with %CASEDIR%' => sub {
+        my %vars = (@custom_casedir_settings, NEEDLES_DIR => '%CASEDIR%/fedora/needles');
+        my %job_settings = (id => 12, settings => \%vars);
+        my ($job, $result) = OpenQA::Worker::Job->new($worker, $client, \%job_settings);
+        my $log = combined_from { $result = _run_engine($job) };
+        like $log,
+          qr{Job settings.*Symlinked from "os-autoinst-distri-example/fedora/needles" to "$pool_directory/needles"}s,
+          'symlink for needles dir created, %CASEDIR% replaced with checkout folder of custom CASEDIR';
+        my $vars_data = get_job_json_data($pool_directory);
+        is $vars_data->{NEEDLES_DIR}, 'needles', 'relative NEEDLES_DIR is set to its basename';
+        is $result->{error}, undef, 'no error occurred (2)';
+    };
+
     subtest 'good case: custom CASEDIR specified but no custom NEEDLES_DIR' => sub {
         my %job_settings = (id => 12, settings => {@custom_casedir_settings});
         my ($job, $result) = OpenQA::Worker::Job->new($worker, $client, \%job_settings);
@@ -353,7 +366,7 @@ subtest 'symlink testrepo, logging behavior' => sub {
           'symlink for needles dir also created without NEEDLES_DIR, points to default dir despite custom CASEDIR';
         my $vars_data = get_job_json_data($pool_directory);
         is $vars_data->{NEEDLES_DIR}, 'needles', 'relative NEEDLES_DIR is set to name of symlink';
-        is $result->{error}, undef, 'no error occurred (2)';
+        is $result->{error}, undef, 'no error occurred (3)';
 
     };
 


### PR DESCRIPTION
* Allows prepending `%CASEDIR%` to relative `NEEDLES_DIR` so `%CASEDIR%` is replaced with the path where the custom `CASEDIR` will be checked out
* Enables use-case of specifying a custom `CASEDIR` and a custom `NEEDLES_DIR` where the custom needles dir is a relative path within the custom `CASEDIR` (and *not* a separate repository or a relative path within the default needles directory).
* See https://progress.opensuse.org/issues/117133
* See https://github.com/os-autoinst/openQA/issues/4576