### PR TITLE
Fix error handling in web UI download jobs since 4cee25f

### DIFF
--- a/lib/OpenQA/Task/Asset/Download.pm
+++ b/lib/OpenQA/Task/Asset/Download.pm
@@ -92,7 +92,7 @@ sub _download {
       unless my $err = $downloader->download($url, $assetpath, $options);
     my $res = $downloader->res;
     $ctx->error(my $msg = qq{Downloading "$url" failed with: $err});
-    return $res && $res->is_success ? $job->finish($msg) : $job->user_fail($msg);
+    return !$err && $res && $res->is_success ? $job->finish($msg) : $job->user_fail($msg);
 }
 
 1;


### PR DESCRIPTION
* Commit 4cee25f5feb49e7ee393c1702d52ce10136c2ffd did not consider that `OpenQA::Downloader` might have a successful result but still returns an error which should be treated as such.
* See https://progress.opensuse.org/issues/119182