### PR TITLE
Add darkmode

### DIFF
--- a/assets/stylesheets/ansi-colors.scss
+++ b/assets/stylesheets/ansi-colors.scss
@@ -16,3 +16,11 @@
 .ansi-blue-fg    { color: $blue; }
 .ansi-magenta-fg { color: $pink; }
 .ansi-cyan-fg    { color: $cyan; }
+
+@media (prefers-color-scheme: dark) {
+    .ansi-white-fg   { color: $default-font-color-darktheme; }
+    .ansi-black-fg   { color: $default-font-color-darktheme; }
+    .ansi-red-fg     { color: $red; }
+    .ansi-yellow-fg  { color: $yellow; }
+    .ansi-green-fg   { color: $green; }
+}

--- a/assets/stylesheets/ansi-colors.scss
+++ b/assets/stylesheets/ansi-colors.scss
@@ -17,7 +17,7 @@
 .ansi-magenta-fg { color: $pink; }
 .ansi-cyan-fg    { color: $cyan; }
 
-@media (prefers-color-scheme: dark) {
+.darkmode {
     .ansi-white-fg   { color: $default-font-color-darktheme; }
     .ansi-black-fg   { color: $default-font-color-darktheme; }
     .ansi-red-fg     { color: $red; }

--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -45,10 +45,6 @@
                 border-bottom: 1px solid #444;
             }
         }
-
-        @media (prefers-color-scheme: dark) {
-            color: rgb(152, 152, 152);
-        }
     }
 
     .openqa-label {
@@ -84,6 +80,12 @@
     }
 }
 
+.darkmode {
+    .comment-body .comment-anchor {
+        color: rgb(152, 152, 152);
+    }
+}
+
 .comment-row {
     align-items: center;
     margin-bottom: 1.25rem;
@@ -115,7 +117,9 @@
 
 .input-group-text {
     background-color: $default-bg-color;
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .input-group-text {
         background-color: $default-bg-color-darktheme;
     }
 }

--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -45,6 +45,10 @@
                 border-bottom: 1px solid #444;
             }
         }
+
+        @media (prefers-color-scheme: dark) {
+            color: rgb(152, 152, 152);
+        }
     }
 
     .openqa-label {
@@ -107,4 +111,11 @@
     display: grid;
     padding: 0.5rem;
     align-items: center;
+}
+
+.input-group-text {
+    background-color: $default-bg-color;
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+    }
 }

--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -6,8 +6,9 @@ div.progress {
     margin-bottom: 9px;
     height: 18px;
     background-color: $default-bg-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    div.progress {
         background-color: $default-bg-color-darktheme;
     }
 }

--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -5,6 +5,11 @@ div.progress {
     margin-top: 9px;
     margin-bottom: 9px;
     height: 18px;
+    background-color: $default-bg-color;
+
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+    }
 }
 #build-results .progress {
     min-width: 24.5em;

--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -7,12 +7,25 @@
 .btn .fa {
     padding-right: 3pt;
 }
-.form-control {
+.form-control, .form-control:focus {
     padding: 0.4rem;
     line-height: normal;
+
+    color: $default-font-color;
+    background-color: $default-bg-color;
+    border: 1px solid rgba(0,0,0,0.1);
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+        background-color: $default-bg-color-darktheme;
+        border: 1px solid rgba(255,255,255,0.1);
+    }
 }
 .form-control:invalid {
     background: #ffaaaa80;
+
+    @media (prefers-color-scheme: dark) {
+        background: #ff666680;
+    }
 }
 .form-group .control-label {
     font-weight: bold;
@@ -65,6 +78,18 @@ select.form-control {
 @include btn(light,$btn-light-bg);
 @include btn(dark,$btn-dark-bg);
 @include btn(link,#fff);
+@media (prefers-color-scheme: dark) {
+    @include btn(default,$btn-default-bg-darktheme);
+    @include btn(primary,$btn-primary-bg-darktheme);
+    @include btn(secondary,$btn-secondary-bg-darktheme);
+    @include btn(success,$btn-success-bg-darktheme);
+    @include btn(info,$btn-info-bg-darktheme);
+    @include btn(warning,$btn-warning-bg-darktheme);
+    @include btn(danger,$btn-danger-bg-darktheme);
+    @include btn(light,$btn-light-bg-darktheme);
+    @include btn(dark,$btn-dark-bg-darktheme);
+    @include btn(link,#000);
+}
 .btn {
     border: none;
     @include box-shadow(1px 1px 4px rgba(0,0,0,.4));
@@ -103,6 +128,12 @@ select.form-control {
         }
     }
 }
+@media (prefers-color-scheme: dark) {
+    .btn.btn-light {
+        background-color: #070605;
+        border-color: #070605;
+    }
+}
 
 // wells (used for comments)
 .well-lg {
@@ -113,11 +144,16 @@ select.form-control {
     min-height: 20px;
     padding: 19px;
     margin-bottom: 20px;
-    background-color: #fdfdfd;
+    background-color: $default-bg-color;
     border: 1px solid #e3e3e3;
     border-radius: 1px;
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+        border-color: #1c1c1c;
+    }
 }
 
 // round images (used for comments) and badges inside summary
@@ -128,4 +164,11 @@ select.form-control {
 .editor-yaml-guide {
     display: none;
     text-align: left !important;
+}
+
+.custom-select {
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+        background-color: $default-bg-color-darktheme;
+    }
 }

--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -14,7 +14,9 @@
     color: $default-font-color;
     background-color: $default-bg-color;
     border: 1px solid rgba(0,0,0,0.1);
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .form-control, .form-control:focus {
         color: $default-font-color-darktheme;
         background-color: $default-bg-color-darktheme;
         border: 1px solid rgba(255,255,255,0.1);
@@ -22,8 +24,9 @@
 }
 .form-control:invalid {
     background: #ffaaaa80;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .form-control:invalid {
         background: #ff666680;
     }
 }
@@ -78,7 +81,7 @@ select.form-control {
 @include btn(light,$btn-light-bg);
 @include btn(dark,$btn-dark-bg);
 @include btn(link,#fff);
-@media (prefers-color-scheme: dark) {
+.darkmode {
     @include btn(default,$btn-default-bg-darktheme);
     @include btn(primary,$btn-primary-bg-darktheme);
     @include btn(secondary,$btn-secondary-bg-darktheme);
@@ -128,7 +131,7 @@ select.form-control {
         }
     }
 }
-@media (prefers-color-scheme: dark) {
+.darkmode {
     .btn.btn-light {
         background-color: #070605;
         border-color: #070605;
@@ -149,8 +152,9 @@ select.form-control {
     border-radius: 1px;
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .well {
         background-color: $default-bg-color-darktheme;
         border-color: #1c1c1c;
     }
@@ -166,8 +170,8 @@ select.form-control {
     text-align: left !important;
 }
 
-.custom-select {
-    @media (prefers-color-scheme: dark) {
+.darkmode {
+    .custom-select {
         color: $default-font-color-darktheme;
         background-color: $default-bg-color-darktheme;
     }

--- a/assets/stylesheets/navigation.scss
+++ b/assets/stylesheets/navigation.scss
@@ -7,10 +7,6 @@
     padding-bottom: 0px;
     margin-bottom: 30px;
 
-    @media (prefers-color-scheme: dark) {
-        box-shadow: 0 1px 2px rgba(255, 255, 255, 0.3);
-    }
-
     &-brand {
         height: 64px;
         margin: 0px;
@@ -22,6 +18,11 @@
             padding: 8px;
             width: auto;
         }
+    }
+}
+.darkmode {
+    .navbar {
+        box-shadow: 0 1px 2px rgba(255, 255, 255, 0.3);
     }
 }
 .navbar-light .navbar-nav {
@@ -37,7 +38,11 @@
             text-decoration: none;
             background-color: $default-bg-color;
         }
-        @media (prefers-color-scheme: dark) {
+    }
+}
+.darkmode {
+    .navbar-light .navbar-nav {
+        @include media-breakpoint-up(lg) {
             a.nav-link {
                 color: $default-font-color-darktheme;
             }
@@ -59,8 +64,9 @@
     -webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     background-color: $default-bg-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .dropdown-menu, .candidates-selection .dropdown-menu {
         background-color: $default-bg-color-darktheme;
         color: $default-font-color-darktheme;
 

--- a/assets/stylesheets/navigation.scss
+++ b/assets/stylesheets/navigation.scss
@@ -7,6 +7,10 @@
     padding-bottom: 0px;
     margin-bottom: 30px;
 
+    @media (prefers-color-scheme: dark) {
+        box-shadow: 0 1px 2px rgba(255, 255, 255, 0.3);
+    }
+
     &-brand {
         height: 64px;
         margin: 0px;
@@ -20,30 +24,55 @@
         }
     }
 }
-.navbar-nav {
+.navbar-light .navbar-nav {
     @include media-breakpoint-up(lg) {
         .nav-link {
             // hack to let the navbar items take all vertical space like in Bootstrap 3
             padding-top: 22px;
             padding-bottom: 23px;
+            color: $default-font-color;
         }
         .nav-link:hover, .nav-link:focus {
-            color: #16181b;
+            color: $default-font-color;
             text-decoration: none;
-            background-color: #f8f9fa;
+            background-color: $default-bg-color;
+        }
+        @media (prefers-color-scheme: dark) {
+            a.nav-link {
+                color: $default-font-color-darktheme;
+            }
+            .nav-link:hover, .nav-link:focus {
+                color: $default-font-color-darktheme;
+                background-color: lighten($default-bg-color-darktheme, 25%);
+            }
         }
     }
 }
 .navbar-input {
     margin: 1em 0;
 }
-.dropdown-menu {
+.dropdown-menu, .candidates-selection .dropdown-menu {
     font-size: inherit;
     margin-top: 0;
     border: none;
     border-radius: 0;
     -webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    background-color: $default-bg-color;
+
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+        color: $default-font-color-darktheme;
+
+        a, h3, td, tr {
+            color: $default-font-color-darktheme;
+            background-color: $default-bg-color-darktheme;
+        }
+        a:hover, a:focus, h3:hover, h3:focus {
+            color: $default-font-color-darktheme;
+            background-color: lighten($default-bg-color-darktheme, 25%);
+        }
+    }
 }
 
 // adjust arrows for submenus

--- a/assets/stylesheets/openqa_theme.scss
+++ b/assets/stylesheets/openqa_theme.scss
@@ -57,3 +57,21 @@ $color-state-blocked:         #9167b7;
 $color-state-cancelled:       $color-module-none;
 $color-state-running:         #8BDFFF;
 $color-step-actions:          #666666;
+
+$default-font-color-darktheme:          #ccc;
+$default-bg-color-darktheme:            #000;
+$link-color-darktheme:                  #7fbbf7;
+$link-hover-color-darktheme:            darken($link-color, 15%) !default;
+$color-result-darktheme:                #c3c3c3;
+$table-border-color-darktheme:          darken($color-result-darktheme, 50%);
+
+$btn-default-color-darktheme:           #fff;
+$btn-default-bg-darktheme:              #010101;
+$btn-primary-bg-darktheme:              #007bff;
+$btn-secondary-bg-darktheme:            #6c757d;
+$btn-success-bg-darktheme:              #28a745;
+$btn-info-bg-darktheme:                 #17a2b8;
+$btn-warning-bg-darktheme:              #ffc107;
+$btn-danger-bg-darktheme:               #dc3545;
+$btn-light-bg-darktheme:                #070605;
+$btn-dark-bg-darktheme:                 #343a40;

--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -14,6 +14,11 @@ body {
     background-color: $default-bg-color;
     letter-spacing: .1px;
 
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+        background-color: $default-bg-color-darktheme;
+    }
+
     // always show a scrollbar not to flicker on tabs / long drop downs
     overflow-y: scroll;
 }
@@ -31,7 +36,11 @@ body {
     width: 100%;
     // set the fixed height of the footer here
     height: 30px;
-    background-color: #f5f5f5;
+    background-color: $default-bg-color;
+
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+    }
 }
 #footer-links {
     &.left {
@@ -59,6 +68,12 @@ p {
 }
 a {
     @include transition(all 0.2s);
+    
+    color: $link-color;
+
+    @media (prefers-color-scheme: dark) {
+        color: $link-color-darktheme;
+    }
 }
 .links {
     text-align: left;
@@ -76,11 +91,19 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     font-weight: 400;
     line-height: 1.1;
     color: #444;
+
+    @media (prefers-color-scheme: dark) {
+        color: #bbb;
+    }
 }
 
 // cards (former panels)
 .card {
     margin-bottom: 15px;
+    background-color: $default-bg-color;
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+    }
 }
 // colorful card headers (Bootstrap 4 only has colorful borders or fully colored cards)
 .card.border-danger {
@@ -88,6 +111,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #b94a48;
         background-color: #f2dede;
+
+        @media (prefers-color-scheme: dark) {
+            color: #cf4644;
+            background-color: #450202;
+        }
     }
 }
 .card.border-success {
@@ -95,6 +123,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #468847;
         background-color: #dff0d8;
+
+        @media (prefers-color-scheme: dark) {
+            color: #74f476;
+            background-color: #144500;
+        }
     }
 }
 .card.border-warning {
@@ -102,6 +135,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #c09853;
         background-color: #fcf8e3;
+
+        @media (prefers-color-scheme: dark) {
+            color: #fdca71;
+            background-color: #1d1800;
+        }
     }
 }
 .card.border-info {
@@ -109,6 +147,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #3a87ad;
         background-color: #d9edf7;
+
+        @media (prefers-color-scheme: dark) {
+            color: #64cafd;
+            background-color: #000000;
+        }
     }
 }
 
@@ -118,7 +161,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     padding-bottom: 30px;
     margin-bottom: 30px;
     color: inherit;
-    background-color: #f9f9f9;
+    background-color: $default-bg-color;
+
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+    }
 }
 .jumbotron p {
     margin-bottom: 15px;
@@ -140,11 +187,22 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     border: none;
     color: $default-font-color;
 
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+    }
+
     &:hover, &:focus, &.active {
         border: none;
         -webkit-box-shadow: inset 0 -2px 0 #446E9B;
         box-shadow: inset 0 -2px 0 #446E9B;
         color: #446E9B;
+
+        @media (prefers-color-scheme: dark) {
+            -webkit-box-shadow: inset 0 -2px 0 #6caef5;
+            box-shadow: inset 0 -2px 0 #6caef5;
+            color: #6caef5;
+            background-color: $default-bg-color-darktheme;
+        }
     }
 }
 
@@ -181,4 +239,63 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 // full screen mode
 #content_fullscreen {
     min-width: 100%;
+}
+
+.table {
+    color: $default-font-color;
+    background-color: $default-bg-color;
+
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+        background-color: $default-bg-color-darktheme;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    // All tests pagination
+    .page-link,.page-item.disabled .page-link {
+        background-color: $default-bg-color-darktheme;
+        color: $default-font-color-darktheme;
+        border:rgba(255, 255, 255, 0.3) solid 0.5px;
+    }
+
+    // All tests search field
+    .chosen-container .chosen-drop, .chosen-container .chosen-results li, .chosen-container ul.chosen-choices {
+        background-color: $default-bg-color-darktheme;
+        background-image: none;
+        color: $default-font-color-darktheme;
+    }
+
+     // All tests table rows
+    .table td {
+        border-top-color: rgba(255, 255, 255, 0.03);
+    }
+
+    .modal.show {
+        background-color: lighten($default-bg-color-darktheme, 25%);
+    }
+    .modal-content {
+        background-color: $default-bg-color-darktheme;
+    }
+    .modal-header, .modal-footer {
+        border-top: none;
+        border-bottom: none;
+    }
+
+    .container-fluid .btn {
+        color: $default-font-color-darktheme;
+    }
+    .container-fluid .btn-default:hover, .container-fluid .btn-default:active:hover {
+        background-color: #101010;
+        color: #cbc5bf;
+    }
+    .container-fluid .btn-default:active {
+        background-color: #101010;
+        background-image: radial-gradient(circle, lighten(#101010, 25%) 10%, #363636 11%);
+    }
+
+    input,textarea {
+        background-color: $default-bg-color-darktheme;
+        color: $default-font-color-darktheme;
+    }
 }

--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -14,13 +14,12 @@ body {
     background-color: $default-bg-color;
     letter-spacing: .1px;
 
-    @media (prefers-color-scheme: dark) {
-        color: $default-font-color-darktheme;
-        background-color: $default-bg-color-darktheme;
-    }
-
     // always show a scrollbar not to flicker on tabs / long drop downs
     overflow-y: scroll;
+}
+.darkmode {
+    color: $default-font-color-darktheme;
+    background-color: $default-bg-color-darktheme;
 }
 @include media-breakpoint-up(md) {
     #content {
@@ -37,8 +36,9 @@ body {
     // set the fixed height of the footer here
     height: 30px;
     background-color: $default-bg-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .footer {
         background-color: $default-bg-color-darktheme;
     }
 }
@@ -70,8 +70,9 @@ a {
     @include transition(all 0.2s);
     
     color: $link-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    a {
         color: $link-color-darktheme;
     }
 }
@@ -91,8 +92,9 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     font-weight: 400;
     line-height: 1.1;
     color: #444;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
         color: #bbb;
     }
 }
@@ -101,7 +103,9 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 .card {
     margin-bottom: 15px;
     background-color: $default-bg-color;
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .card {
         background-color: $default-bg-color-darktheme;
     }
 }
@@ -111,11 +115,12 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #b94a48;
         background-color: #f2dede;
-
-        @media (prefers-color-scheme: dark) {
-            color: #cf4644;
-            background-color: #450202;
-        }
+    }
+}
+.darkmode {
+    .card.border-danger .card-header {
+        color: #cf4644;
+        background-color: #450202;
     }
 }
 .card.border-success {
@@ -123,11 +128,12 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #468847;
         background-color: #dff0d8;
-
-        @media (prefers-color-scheme: dark) {
-            color: #74f476;
-            background-color: #144500;
-        }
+    }
+}
+.darkmode {
+    .card.border-success .card-header {
+        color: #74f476;
+        background-color: #144500;
     }
 }
 .card.border-warning {
@@ -135,11 +141,12 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #c09853;
         background-color: #fcf8e3;
-
-        @media (prefers-color-scheme: dark) {
-            color: #fdca71;
-            background-color: #1d1800;
-        }
+    }
+}
+.darkmode {
+    .card.border-warning .card-header {
+        color: #fdca71;
+        background-color: #1d1800;
     }
 }
 .card.border-info {
@@ -147,11 +154,12 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     .card-header {
         color: #3a87ad;
         background-color: #d9edf7;
-
-        @media (prefers-color-scheme: dark) {
-            color: #64cafd;
-            background-color: #000000;
-        }
+    }
+}
+.darkmode {
+    .card.border-info .card-header {
+        color: #64cafd;
+        background-color: #000000;
     }
 }
 
@@ -162,8 +170,9 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     margin-bottom: 30px;
     color: inherit;
     background-color: $default-bg-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .jumbotron {
         background-color: $default-bg-color-darktheme;
     }
 }
@@ -187,17 +196,18 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     border: none;
     color: $default-font-color;
 
-    @media (prefers-color-scheme: dark) {
-        color: $default-font-color-darktheme;
-    }
-
     &:hover, &:focus, &.active {
         border: none;
         -webkit-box-shadow: inset 0 -2px 0 #446E9B;
         box-shadow: inset 0 -2px 0 #446E9B;
         color: #446E9B;
+    }
+}
+.darkmode {
+    .nav-tabs .nav-link {
+        color: $default-font-color-darktheme;
 
-        @media (prefers-color-scheme: dark) {
+        &:hover, &:focus, &.active {
             -webkit-box-shadow: inset 0 -2px 0 #6caef5;
             box-shadow: inset 0 -2px 0 #6caef5;
             color: #6caef5;
@@ -244,14 +254,15 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 .table {
     color: $default-font-color;
     background-color: $default-bg-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .table {
         color: $default-font-color-darktheme;
         background-color: $default-bg-color-darktheme;
     }
 }
 
-@media (prefers-color-scheme: dark) {
+.darkmode {
     // All tests pagination
     .page-link,.page-item.disabled .page-link {
         background-color: $default-bg-color-darktheme;

--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -35,7 +35,7 @@
         float: right;
     }
 }
-@media (prefers-color-scheme: dark) {
+.darkmode {
     #summary .time-params {
         font-weight: bold;
     }
@@ -54,10 +54,6 @@
             color: #555;
             font-weight: 500;
             float: right;
-            
-            @media (prefers-color-scheme: dark) {
-                color: rgb(214, 214, 214);
-            }
         }
         .row span {
             text-align: right;
@@ -72,11 +68,6 @@
     }
     .card-body, .developer-mode-element {
         display: none;
-
-        @media (prefers-color-scheme: dark) {
-            color: $default-font-color-darktheme;
-            background-color: $default-bg-color-darktheme;
-        }
     }
 
     #filter-form {
@@ -86,6 +77,19 @@
         .form-group label {
             margin-right: 3px;
             font-weight: normal;
+        }
+    }
+}
+.darkmode {
+    #filter-panel, #developer-panel, #live-log-panel, #live-terminal-panel {
+        .card-header {
+            span {
+                color: rgb(214, 214, 214);
+            }
+        }
+        .card-body, .developer-mode-element {
+            color: $default-font-color-darktheme;
+            background-color: $default-bg-color-darktheme;
         }
     }
 }

--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -35,6 +35,11 @@
         float: right;
     }
 }
+@media (prefers-color-scheme: dark) {
+    #summary .time-params {
+        font-weight: bold;
+    }
+}
 
 /* dotted underline looks strange with default font size */
 .h4 {
@@ -49,6 +54,10 @@
             color: #555;
             font-weight: 500;
             float: right;
+            
+            @media (prefers-color-scheme: dark) {
+                color: rgb(214, 214, 214);
+            }
         }
         .row span {
             text-align: right;
@@ -63,6 +72,11 @@
     }
     .card-body, .developer-mode-element {
         display: none;
+
+        @media (prefers-color-scheme: dark) {
+            color: $default-font-color-darktheme;
+            background-color: $default-bg-color-darktheme;
+        }
     }
 
     #filter-form {

--- a/assets/stylesheets/parent_group_overview.scss
+++ b/assets/stylesheets/parent_group_overview.scss
@@ -1,8 +1,9 @@
 .parent_group_overview_grouping_active {
     font-weight: bold;
     color: $default-font-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .parent_group_overview_grouping_active {
         color: $default-font-color-darktheme;
     }
 }

--- a/assets/stylesheets/parent_group_overview.scss
+++ b/assets/stylesheets/parent_group_overview.scss
@@ -1,6 +1,10 @@
 .parent_group_overview_grouping_active {
     font-weight: bold;
     color: $default-font-color;
+
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+    }
 }
 
 .parent_group_overview_grouping_by_default {

--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -15,6 +15,10 @@
     border-color: #a9a9a9;
     box-shadow: inset 0 1px 3px rgba(169, 169, 169, 0.7);
 
+    @media (prefers-color-scheme: dark) {
+        background-color: #0a0a0a;
+    }
+
     // screenshot
     canvas {
         max-width: 100%;
@@ -44,6 +48,13 @@
 
 #preview_container_in > * {
     max-width: 100%;
+    color: $default-font-color;
+    background-color: $default-bg-color;
+
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+        background-color: $default-bg-color-darktheme;
+    }
 }
 
 .links > div {
@@ -118,6 +129,16 @@
         padding: 8pt;
         width: 100%;
         text-align: left;
+    }
+    @media (prefers-color-scheme: dark) {
+        #candidatesMenu, #candidatesMenu.dropdown-toggle {
+            box-shadow: 0 0 0 1px rgba(231,229,227,.15) inset;
+            background-color: $default-bg-color-darktheme;
+            color: $default-font-color-darktheme;
+        }
+        #screenshot_button {
+            border-color: #272625;
+        }
     }
 
     .dropdown-menu {

--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -15,10 +15,6 @@
     border-color: #a9a9a9;
     box-shadow: inset 0 1px 3px rgba(169, 169, 169, 0.7);
 
-    @media (prefers-color-scheme: dark) {
-        background-color: #0a0a0a;
-    }
-
     // screenshot
     canvas {
         max-width: 100%;
@@ -45,13 +41,19 @@
     }
 
 }
+.darkmode {
+    #preview_container_in {
+        background-color: #0a0a0a;
+    }
+}
 
 #preview_container_in > * {
     max-width: 100%;
     color: $default-font-color;
     background-color: $default-bg-color;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    #preview_container_in > * {
         color: $default-font-color-darktheme;
         background-color: $default-bg-color-darktheme;
     }
@@ -130,16 +132,6 @@
         width: 100%;
         text-align: left;
     }
-    @media (prefers-color-scheme: dark) {
-        #candidatesMenu, #candidatesMenu.dropdown-toggle {
-            box-shadow: 0 0 0 1px rgba(231,229,227,.15) inset;
-            background-color: $default-bg-color-darktheme;
-            color: $default-font-color-darktheme;
-        }
-        #screenshot_button {
-            border-color: #272625;
-        }
-    }
 
     .dropdown-menu {
         padding: 0pt;
@@ -206,6 +198,19 @@
                     }
                 }
             }
+        }
+    }
+}
+
+.darkmode {
+    .candidates-selection {
+        #candidatesMenu, #candidatesMenu.dropdown-toggle {
+            box-shadow: 0 0 0 1px rgba(231,229,227,.15) inset;
+            background-color: $default-bg-color-darktheme;
+            color: $default-font-color-darktheme;
+        }
+        #screenshot_button {
+            border-color: #272625;
         }
     }
 }

--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -43,7 +43,7 @@
         border-bottom: 1px solid $table-border-color;
     }
 }
-@media (prefers-color-scheme: dark) {
+.darkmode {
     .table thead:first-child tr:first-child th,
     .table tbody td:first-child, .table thead th:first-child,
     .table tbody td:last-child, .table thead:first-child tr:first-child th:last-child,
@@ -65,8 +65,8 @@
         @include transition(all 0.2s);
     }
 }
-.table-hover tbody tr:hover {
-    @media (prefers-color-scheme: dark) {
+.darkmode {
+    .table-hover tbody tr:hover {
         color: lighten($default-font-color-darktheme, 25%);
     }
 }
@@ -157,11 +157,12 @@ table.overview {
         span {
             word-wrap: break-word;
         }
-
-        @media (prefers-color-scheme: dark) {
-            background: #8c2b2b;
-            color: #fff;
-        }
+    }
+}
+.darkmode {
+    .failedmodule {
+        background: #8c2b2b;
+        color: #fff;
     }
 }
 
@@ -170,9 +171,10 @@ table.fixedheader {
         position: sticky;
         top: 0px;
         background: white; // prevent transparent during scrolling
-
-        @media (prefers-color-scheme: dark) {
-            background: $default-bg-color-darktheme;
-        }
+    }
+}
+.darkmode {
+    th {
+        background: $default-bg-color-darktheme;
     }
 }

--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -43,14 +43,31 @@
         border-bottom: 1px solid $table-border-color;
     }
 }
+@media (prefers-color-scheme: dark) {
+    .table thead:first-child tr:first-child th,
+    .table tbody td:first-child, .table thead th:first-child,
+    .table tbody td:last-child, .table thead:first-child tr:first-child th:last-child,
+    .table tbody tr:last-child td {
+        border-color: $table-border-color-darktheme;
+    }
+    .table thead:first-child tr:first-child th {
+        background-image: linear-gradient(to bottom, $table-border-color-darktheme, rgba(255,255,255,0.13)) !important;
+        box-shadow: none;
+    }
+}
 .table-striped tbody tr:nth-of-type(odd) {
-    background-color: rgba(0, 0, 0, 0.03);
+    background-color: rgba(255, 255, 255, 0.1);
 }
 .table-hover {
     > tbody > tr,
     > tbody > tr > th,
     > tbody > tr > td {
         @include transition(all 0.2s);
+    }
+}
+.table-hover tbody tr:hover {
+    @media (prefers-color-scheme: dark) {
+        color: lighten($default-font-color-darktheme, 25%);
     }
 }
 .dataTables_wrapper.container-fluid {
@@ -140,6 +157,11 @@ table.overview {
         span {
             word-wrap: break-word;
         }
+
+        @media (prefers-color-scheme: dark) {
+            background: #8c2b2b;
+            color: #fff;
+        }
     }
 }
 
@@ -148,5 +170,9 @@ table.fixedheader {
         position: sticky;
         top: 0px;
         background: white; // prevent transparent during scrolling
+
+        @media (prefers-color-scheme: dark) {
+            background: $default-bg-color-darktheme;
+        }
     }
 }

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -23,6 +23,17 @@
 .resultfailed { background-color: $color-result-failed; color: $color-result; }
 .resultmissing { background-color: $color-result-missing; color: $color-result; }
 
+@media (prefers-color-scheme: dark) {
+    .resultok { background-color: darken($color-ok, 75%); color: $color-result-darktheme; }
+    .resultpassed { background-color: darken($color-ok, 75%); color: $color-result-darktheme; }
+    .resultunknown { background-color: darken($color-result-missing, 75%); color: $color-result-darktheme; }
+    .resultrunning { background-color: darken($color-result-testing, 75%); color: $color-result-darktheme; }
+    .resultwarning { background-color: darken($color-warning, 75%); color: $color-result-darktheme; }
+    .resultsoftfailed { background-color: darken($color-softfailed, 75%); color: $color-result-darktheme; }
+    .resultfailed { background-color: darken($color-result-failed, 75%); color: $color-result-darktheme; }
+    .resultmissing { background-color: darken($color-result-missing, 75%); color: $color-result-darktheme; }
+}
+
 // Live view
 .container_16 .live-sidebar {
     width: 280px;
@@ -68,6 +79,12 @@ span.status .fa {
 .action.fa {
     color: $default-font-color !important;
     opacity: .7;
+
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme !important;
+    }
+
+    
 }
 div.flags {
     min-height: 1em;
@@ -182,6 +199,20 @@ span.thumbnail.current {
 .resborder_softfailed, .resborder_softfail {
     border-color: $color-softfailed;
 }
+@media (prefers-color-scheme: dark) {
+    .resborder_ok {
+        border-color: darken($color-resborder-ok, 15%);
+    }
+    .resborder_fail {
+        border-color: darken($color-resborder-fail, 15%);
+    }
+    .resborder_unk, .resborder_missing {
+        border-color: darken($color-resborder-unk, 15%);
+    }
+    .resborder_softfailed, .resborder_softfail {
+        border-color: darken($color-softfailed, 15%);
+    }
+}
 img.resborder_na {
     padding: 4px;
 }
@@ -197,6 +228,10 @@ span.resborder {
     background: #dfffff;
     font-size: small;
     padding: 1px;
+
+    @media (prefers-color-scheme: dark) {
+        background: #200000;
+    }
 
     &.icon_audio {
         background-size: contain;
@@ -236,12 +271,17 @@ span.resborder_na {
         border-bottom: none;
         border-right: none;
         padding-left: 0.4rem;
-        background-color: #e8f1f1;
+        background-color: $default-bg-color;
         max-height: 3.5rem;
         white-space: pre-wrap;
         overflow-wrap: break-word;
         font-size: 74%;
         line-height: 1.1;
+
+        @media (prefers-color-scheme: dark) {
+            background-color: $default-bg-color-darktheme;
+            color: lighten($link-color-darktheme, 25%);
+        }
     }
 }
 .external-result-container {
@@ -253,6 +293,10 @@ span.resborder_na {
 }
 pre.embedded-logfile {
     white-space: pre-wrap;
+
+    @media (prefers-color-scheme: dark) {
+        color: $default-font-color-darktheme;
+    }
 }
 
 h2.modcategory {
@@ -397,8 +441,39 @@ ul.modcategory {
     font-size: 75%;
     i {
         color: $link-color;
+
+        @media (prefers-color-scheme: dark) {
+            color: $link-color-darktheme;
+        }
     }
     i:hover {
         color: $link-hover-color;
+
+        @media (prefers-color-scheme: dark) {
+            color: $link-hover-color-darktheme;
+        }
+    }
+}
+
+.card#info_box {
+    background-color: $default-bg-color;    
+
+    .btn-link,.btn-link:hover {
+        color: $default-font-color;
+    }
+
+    @media (prefers-color-scheme: dark) {
+        background-color: $default-bg-color-darktheme;
+
+        .btn-link,.btn-link:hover {
+            color: $default-font-color-darktheme;
+            background-color: $default-bg-color-darktheme;
+        }
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    #settings td {
+        border-top-color: rgba(255, 255, 255, 0.03);
     }
 }

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -23,7 +23,7 @@
 .resultfailed { background-color: $color-result-failed; color: $color-result; }
 .resultmissing { background-color: $color-result-missing; color: $color-result; }
 
-@media (prefers-color-scheme: dark) {
+.darkmode {
     .resultok { background-color: darken($color-ok, 75%); color: $color-result-darktheme; }
     .resultpassed { background-color: darken($color-ok, 75%); color: $color-result-darktheme; }
     .resultunknown { background-color: darken($color-result-missing, 75%); color: $color-result-darktheme; }
@@ -79,12 +79,11 @@ span.status .fa {
 .action.fa {
     color: $default-font-color !important;
     opacity: .7;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    .action.fa {
         color: $default-font-color-darktheme !important;
     }
-
-    
 }
 div.flags {
     min-height: 1em;
@@ -199,7 +198,7 @@ span.thumbnail.current {
 .resborder_softfailed, .resborder_softfail {
     border-color: $color-softfailed;
 }
-@media (prefers-color-scheme: dark) {
+.darkmode {
     .resborder_ok {
         border-color: darken($color-resborder-ok, 15%);
     }
@@ -229,10 +228,6 @@ span.resborder {
     font-size: small;
     padding: 1px;
 
-    @media (prefers-color-scheme: dark) {
-        background: #200000;
-    }
-
     &.icon_audio {
         background-size: contain;
         background-repeat: no-repeat;
@@ -244,6 +239,11 @@ span.resborder {
     .step_actions {
         white-space: normal;
         float: right;
+    }
+}
+.darkmode {
+    span.resborder {
+        background: #200000;
     }
 }
 span.resborder_na {
@@ -277,8 +277,11 @@ span.resborder_na {
         overflow-wrap: break-word;
         font-size: 74%;
         line-height: 1.1;
-
-        @media (prefers-color-scheme: dark) {
+    }
+}
+.darkmode {
+    .text-result, .serial-result-preview {
+        .resborder {
             background-color: $default-bg-color-darktheme;
             color: lighten($link-color-darktheme, 25%);
         }
@@ -293,8 +296,9 @@ span.resborder_na {
 }
 pre.embedded-logfile {
     white-space: pre-wrap;
-
-    @media (prefers-color-scheme: dark) {
+}
+.darkmode {
+    pre.embedded-logfile {
         color: $default-font-color-darktheme;
     }
 }
@@ -441,15 +445,17 @@ ul.modcategory {
     font-size: 75%;
     i {
         color: $link-color;
-
-        @media (prefers-color-scheme: dark) {
-            color: $link-color-darktheme;
-        }
     }
     i:hover {
         color: $link-hover-color;
-
-        @media (prefers-color-scheme: dark) {
+    }
+}
+.darkmode {
+    .test-result-overview-link {
+        i {
+            color: $link-color-darktheme;
+        }
+        i:hover {
             color: $link-hover-color-darktheme;
         }
     }
@@ -461,8 +467,10 @@ ul.modcategory {
     .btn-link,.btn-link:hover {
         color: $default-font-color;
     }
+}
 
-    @media (prefers-color-scheme: dark) {
+.darkmode {
+    .card#info_box {
         background-color: $default-bg-color-darktheme;
 
         .btn-link,.btn-link:hover {
@@ -470,9 +478,7 @@ ul.modcategory {
             background-color: $default-bg-color-darktheme;
         }
     }
-}
 
-@media (prefers-color-scheme: dark) {
     #settings td {
         border-top-color: rgba(255, 255, 255, 0.03);
     }

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -550,6 +550,20 @@ the top of the group overview page. However, it only works as operator
 or admin.
 
 
+=== Dark mode
+
+The dark mode is natively supported by most modern browsers and
+is automatically turned on when dark user interface of either
+the operating system or browser is detected. To disable the dark
+mode please follow the instructions below:
+
+ * On Firefox, go to `about:preferences#general` and search for "Website appearance".
+ * On Chrome, go to `chrome://flags/` and search for "Dark mode".
+
+For more information, see
+https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme[developer.mozilla.org/CSS/@media/prefers-color-scheme]
+
+
 === Developer mode ===
 
 The developer mode allows to:

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -552,10 +552,9 @@ or admin.
 
 === Dark mode
 
-The dark mode is natively supported by most modern browsers and
-is automatically turned on when dark user interface of either
-the operating system or browser is detected. To disable the dark
-mode please follow the instructions below:
+A dark mode theme can be enabled via "Appearance" settings for all logged in users. It can either be forced with
+the "dark mode" setting, or left to browser detection. Switching automatically between light and dark mode is natively
+supported by most modern browsers and can also be controlled manually via flags:
 
  * On Firefox, go to `about:preferences#general` and search for "Website appearance".
  * On Chrome, go to `chrome://flags/` and search for "Dark mode".

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -114,6 +114,9 @@ sub startup ($self) {
     $apik_auth->post('/')->to('api_key#create');
     $apik_auth->delete('/:apikeyid')->name('api_key')->to('api_key#destroy');
 
+    $logged_in->get('/appearance')->to('appearance#index')->name('appearance');
+    $logged_in->post('/appearance')->to('appearance#save');
+
     $r->get('/search')->name('search')->to(template => 'search/search');
 
     $r->get('/tests')->name('tests')->to('test#list');

--- a/lib/OpenQA/WebAPI/Controller/Appearance.pm
+++ b/lib/OpenQA/WebAPI/Controller/Appearance.pm
@@ -1,0 +1,23 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Controller::Appearance;
+use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+sub index ($self) {
+    $self->render;
+}
+
+sub save ($self) {
+    my $validation = $self->validation;
+    $validation->required('theme')->in('light', 'dark', 'detect');
+    return $self->reply->exception('Invalid theme settings') unless $validation->is_valid;
+
+    my $theme = $validation->param('theme');
+    $self->session->{theme} = $theme;
+    $self->flash(info => 'Theme preferences updated');
+
+    $self->redirect_to('appearance');
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -139,6 +139,8 @@ sub register ($self, $app, $config) {
 
     $app->helper(current_job => sub { shift->stash('job') });
 
+    $app->helper(current_theme => sub ($c) { $c->session->{theme} || 'light' });
+
     $app->helper(is_operator_js => sub { Mojo::ByteStream->new(shift->helpers->is_operator ? 'true' : 'false') });
     $app->helper(is_admin_js => sub { Mojo::ByteStream->new(shift->helpers->is_admin ? 'true' : 'false') });
 

--- a/t/ui/04-appearance.t
+++ b/t/ui/04-appearance.t
@@ -1,0 +1,63 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use OpenQA::Test::TimeLimit '8';
+use OpenQA::Test::Case;
+
+my $test_case = OpenQA::Test::Case->new;
+$test_case->init_data(fixtures_glob => '03-users.pl');
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+subtest 'No login, no themes' => sub {
+    $t->get_ok('/appearance')->status_is(302);
+};
+
+subtest 'So lets grab the CSRF token and login as Percival' => sub {
+    $t->get_ok('/tests');
+    my $token = $t->tx->res->dom->at('meta[name=csrf-token]')->attr('content');
+    $test_case->login($t, 'percival');
+};
+
+subtest 'Default theme is light' => sub {
+    $t->get_ok('/appearance')->status_is(200)->element_exists('select option[selected][value="light"]');
+};
+
+subtest 'We can switch to dark theme' => sub {
+    $t->ua->max_redirects(5);
+    $t->get_ok('/appearance')->status_is(200)->element_exists('select option[selected][value="light"]')
+      ->element_exists_not('select option[selected][value="dark"]');
+    $t->post_ok('/appearance' => form => {theme => 'dark'})->status_is(200)
+      ->element_exists('select option[selected][value="dark"]')
+      ->element_exists_not('select option[selected][value="light"]');
+    $t->get_ok('/appearance')->status_is(200)->element_exists('select option[selected][value="dark"]')
+      ->element_exists_not('select option[selected][value="light"]');
+};
+
+subtest 'We can switch to theme detection' => sub {
+    $t->get_ok('/appearance')->status_is(200)->element_exists('select option[selected][value="dark"]')
+      ->element_exists_not('select option[selected][value="detect"]');
+    $t->post_ok('/appearance' => form => {theme => 'detect'})->status_is(200)
+      ->element_exists('select option[selected][value="detect"]')
+      ->element_exists_not('select option[selected][value="dark"]');
+    $t->get_ok('/appearance')->status_is(200)->element_exists('select option[selected][value="detect"]')
+      ->element_exists_not('select option[selected][value="dark"]');
+};
+
+subtest 'We can switch back to light theme' => sub {
+    $t->get_ok('/appearance')->status_is(200)->element_exists('select option[selected][value="detect"]')
+      ->element_exists_not('select option[selected][value="light"]');
+    $t->post_ok('/appearance' => form => {theme => 'light'})->status_is(200)
+      ->element_exists('select option[selected][value="light"]')
+      ->element_exists_not('select option[selected][value="detect"]');
+    $t->get_ok('/appearance')->status_is(200)->element_exists('select option[selected][value="light"]')
+      ->element_exists_not('select option[selected][value="detect"]');
+};
+
+done_testing();

--- a/t/ui/05-auth.t
+++ b/t/ui/05-auth.t
@@ -75,7 +75,7 @@ my $actions = OpenQA::Test::Case::trim_whitespace(
     $t->get_ok('/tests')->status_is(200)->tx->res->dom->at('#user-action')->all_text);
 like(
     $actions,
-    qr/Logged in as perci Operators Menu.*Manage API keys API help Changelog Logout/,
+    qr/Logged in as perci Operators Menu.*Manage API keys Appearance API help Changelog Logout/,
     'perci has operator links'
 );
 unlike($actions, qr/Administrators Menu/, 'perci has no admin links');

--- a/templates/webapi/appearance/index.html.ep
+++ b/templates/webapi/appearance/index.html.ep
@@ -1,0 +1,24 @@
+% layout 'bootstrap';
+% title 'Appearance';
+<div>
+    %= include 'layouts/info'
+    <div class="card">
+        <div class="card-header">Appearance</div>
+        <div class="card-body">
+            %= form_for appearance => (method => 'post') => begin
+                <div class="form-group">
+                    <label for="expiration">Theme</label>
+                    <select name="theme" class="form-select">
+                      % my $theme = current_theme;
+                      <option value="light"<%= $theme eq 'light' ? ' selected' : '' %>>Light mode</option>
+                      <option value="dark"<%= $theme eq 'dark' ? ' selected' : '' %>>Dark mode</option>
+                      <option value="detect"<%= $theme eq 'detect' ? ' selected' : '' %>>Detect from browser</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    %= submit_button 'Save', class => 'btn btn-primary'
+                </div>
+            % end
+        </div>
+    </div>
+</div>

--- a/templates/webapi/layouts/bootstrap.html.ep
+++ b/templates/webapi/layouts/bootstrap.html.ep
@@ -34,7 +34,11 @@
             % if (current_user) {
               newFeature(<%= current_user->feature_version %>);
             % }
-          } );
+
+            let theme = '<%= current_theme %>';
+            if (theme === 'detect') theme = window.matchMedia('(prefers-color-scheme: dark)').matches === true ? 'dark' : 'light';
+            if (theme === 'dark') document.body.classList.add('darkmode');
+          });
       % end
 
       <link id="favicon-16" rel="icon" href="<%= favicon_url '-16.png' %>" sizes="16x16" type="image/png">

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -79,6 +79,7 @@
                   % if (is_operator) {
                       %= link_to "Manage API keys" => url_for('api_keys') => class => 'dropdown-item'
                   % }
+                  %= link_to "Appearance" => url_for('appearance') => class => 'dropdown-item'
                   %= link_to "API help" => url_for('api_help') => class => 'dropdown-item'
                   %= link_to 'Changelog' => url_for('changelog') => class => 'dropdown-item'
                   %= link_to 'Logout' => url_for('logout') => 'data-method' => 'delete' => class => 'dropdown-item'


### PR DESCRIPTION
This PR adds theme settings to #4724. The CSS has been reorganised to work with a `.darkmode` class on the `<body>` element. And there is a new "Appearance" menu entry for all logged in users:

<img width="400" alt="menu" src="https://user-images.githubusercontent.com/30094/197516393-50fda7d3-bfe1-43d9-a735-77ee29115896.png">

The default theme is `light`, same as it used to be. And it can be switched manually to `dark` or browser detection (based on Chrome flag):

<img width="382" alt="appearance" src="https://user-images.githubusercontent.com/30094/197516659-c4a91ecc-3465-4026-b020-9f9d719fa58c.png">

Since this feature is only available for logged in users, we can store the theme setting in the session cookie, together with login information. That means we have no additional privacy considerations regarding cookies.

P.S.: I did not make any changes to the darkmode theme itself. There are still some rough edges, but since it is completely opt-in there should be no disruptions for our users.

Progress: https://progress.opensuse.org/issues/119032