### PR TITLE
Bring back the old light theme

### DIFF
--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -115,9 +115,6 @@
     align-items: center;
 }
 
-.input-group-text {
-    background-color: $default-bg-color;
-}
 .darkmode {
     .input-group-text {
         background-color: $default-bg-color-darktheme;

--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -5,7 +5,6 @@ div.progress {
     margin-top: 9px;
     margin-bottom: 9px;
     height: 18px;
-    background-color: $default-bg-color;
 }
 .darkmode {
     div.progress {

--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -7,13 +7,9 @@
 .btn .fa {
     padding-right: 3pt;
 }
-.form-control, .form-control:focus {
+.form-control {
     padding: 0.4rem;
     line-height: normal;
-
-    color: $default-font-color;
-    background-color: $default-bg-color;
-    border: 1px solid rgba(0,0,0,0.1);
 }
 .darkmode {
     .form-control, .form-control:focus {
@@ -147,7 +143,7 @@ select.form-control {
     min-height: 20px;
     padding: 19px;
     margin-bottom: 20px;
-    background-color: $default-bg-color;
+    background-color: #fdfdfd;
     border: 1px solid #e3e3e3;
     border-radius: 1px;
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);

--- a/assets/stylesheets/navigation.scss
+++ b/assets/stylesheets/navigation.scss
@@ -25,16 +25,15 @@
         box-shadow: 0 1px 2px rgba(255, 255, 255, 0.3);
     }
 }
-.navbar-light .navbar-nav {
+.navbar-nav {
     @include media-breakpoint-up(lg) {
         .nav-link {
             // hack to let the navbar items take all vertical space like in Bootstrap 3
             padding-top: 22px;
             padding-bottom: 23px;
-            color: $default-font-color;
         }
         .nav-link:hover, .nav-link:focus {
-            color: $default-font-color;
+            color: #16181b;
             text-decoration: none;
             background-color: $default-bg-color;
         }
@@ -56,14 +55,13 @@
 .navbar-input {
     margin: 1em 0;
 }
-.dropdown-menu, .candidates-selection .dropdown-menu {
+.dropdown-menu {
     font-size: inherit;
     margin-top: 0;
     border: none;
     border-radius: 0;
     -webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-    background-color: $default-bg-color;
 }
 .darkmode {
     .dropdown-menu, .candidates-selection .dropdown-menu {

--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -35,7 +35,7 @@ body {
     width: 100%;
     // set the fixed height of the footer here
     height: 30px;
-    background-color: $default-bg-color;
+    background-color: #f5f5f5;
 }
 .darkmode {
     .footer {
@@ -68,8 +68,6 @@ p {
 }
 a {
     @include transition(all 0.2s);
-    
-    color: $link-color;
 }
 .darkmode {
     a {
@@ -102,7 +100,6 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 // cards (former panels)
 .card {
     margin-bottom: 15px;
-    background-color: $default-bg-color;
 }
 .darkmode {
     .card {
@@ -169,7 +166,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     padding-bottom: 30px;
     margin-bottom: 30px;
     color: inherit;
-    background-color: $default-bg-color;
+    background-color: #f9f9f9;
 }
 .darkmode {
     .jumbotron {
@@ -251,10 +248,6 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     min-width: 100%;
 }
 
-.table {
-    color: $default-font-color;
-    background-color: $default-bg-color;
-}
 .darkmode {
     .table {
         color: $default-font-color-darktheme;

--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -49,8 +49,6 @@
 
 #preview_container_in > * {
     max-width: 100%;
-    color: $default-font-color;
-    background-color: $default-bg-color;
 }
 .darkmode {
     #preview_container_in > * {

--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -56,7 +56,7 @@
     }
 }
 .table-striped tbody tr:nth-of-type(odd) {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(0, 0, 0, 0.03);
 }
 .table-hover {
     > tbody > tr,

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -271,7 +271,7 @@ span.resborder_na {
         border-bottom: none;
         border-right: none;
         padding-left: 0.4rem;
-        background-color: $default-bg-color;
+        background-color: #e8f1f1;
         max-height: 3.5rem;
         white-space: pre-wrap;
         overflow-wrap: break-word;
@@ -458,14 +458,6 @@ ul.modcategory {
         i:hover {
             color: $link-hover-color-darktheme;
         }
-    }
-}
-
-.card#info_box {
-    background-color: $default-bg-color;    
-
-    .btn-link,.btn-link:hover {
-        color: $default-font-color;
     }
 }
 


### PR DESCRIPTION
https://github.com/os-autoinst/openQA/commit/28fa7fdd591fac0a0c41a51b03d9281ebc005426 introduced some changes to the default theme. This patch reverts them all, so the default light theme should look the same again. It does make darkmode look worse, but there is no way around that if we want to fix lightmode quickly.

<img width="2551" alt="light" src="https://user-images.githubusercontent.com/30094/197735884-a958055e-1080-4c95-b4bd-fb36c77465c1.png">

