### PR TITLE
Fix jumbotron and card background in darkmode

### DIFF
--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -104,6 +104,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 .darkmode {
     .card {
         background-color: $default-bg-color-darktheme;
+        border: $table-border-color-darktheme solid 0.5px;
     }
 }
 // colorful card headers (Bootstrap 4 only has colorful borders or fully colored cards)
@@ -170,7 +171,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 }
 .darkmode {
     .jumbotron {
-        background-color: $default-bg-color-darktheme;
+        background-color: #111111;
     }
 }
 .jumbotron p {


### PR DESCRIPTION
**Edit: Outdated screenshots, see last post!**

Before:
<img width="2553" alt="before" src="https://user-images.githubusercontent.com/30094/197748097-efe134ec-a0f3-4f1c-b75d-efe95cfc0c5a.png">

After:
<img width="2556" alt="after" src="https://user-images.githubusercontent.com/30094/197748128-e8b3f2ec-652b-4689-81f1-2b6a63139e48.png">

I'm starting small. This makes the jumbotron and bootstrap cards visible again.