### PR TITLE
Add default and max limits to job_next_previous_ajax

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -212,6 +212,14 @@ concurrent = 0
 #list_templates_default_limit = 500
 # Maximum number of templates to include in job_templates api response (to prevent performance issues)
 #list_templates_max_limit = 5000
+# Default number of next jobs to include in jobs request (to prevent performance issues)
+#next_jobs_default_limit = 100
+# Maximum number of next jobs to include in jobs request (to prevent performance issues)
+#next_jobs_max_limit = 1000
+# Default number of previous jobs to include in jobs request (to prevent performance issues)
+#previous_jobs_default_limit = 400
+# Maximum number of previous jobs to include in jobs request (to prevent performance issues)
+#previous_jobs_max_limit = 4000
 
 [archiving]
 # Moves logs of jobs which are preserved during the cleanup because they are considered important

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -156,7 +156,11 @@ sub read_config ($app) {
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
             list_templates_default_limit => 500,
-            list_templates_max_limit => 5000
+            list_templates_max_limit => 5000,
+            next_jobs_default_limit => 100,
+            next_jobs_max_limit => 1000,
+            previous_jobs_default_limit => 400,
+            previous_jobs_max_limit => 4000
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -438,8 +438,11 @@ sub _show {
 sub job_next_previous_ajax ($self) {
     return $self->reply->not_found unless my $main_job = $self->_get_current_job;
     my $main_jobid = $main_job->id;
-    my $p_limit = $self->param('previous_limit') // 400;
-    my $n_limit = $self->param('next_limit') // 100;
+
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    my $p_limit = min($limits->{previous_jobs_max_limit},
+        $self->param('previous_limit') // $limits->{previous_jobs_default_limit});
+    my $n_limit = min($limits->{next_jobs_max_limit}, $self->param('next_limit') // $limits->{next_jobs_default_limit});
 
     my $schema = $self->schema;
     my $jobs_rs = $schema->resultset('Jobs')->next_previous_jobs_query(

--- a/t/config.t
+++ b/t/config.t
@@ -138,7 +138,11 @@ subtest 'Test configuration default modes' => sub {
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
             list_templates_default_limit => 500,
-            list_templates_max_limit => 5000
+            list_templates_max_limit => 5000,
+            next_jobs_default_limit => 100,
+            next_jobs_max_limit => 1000,
+            previous_jobs_default_limit => 400,
+            previous_jobs_max_limit => 4000
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -276,5 +276,39 @@ subtest 'bug reference shown' => sub {
     );
 };
 
+subtest 'server-side limit has precedence over user-specified limit' => sub {
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    $limits->{next_jobs_max_limit} = 5;
+    $limits->{previous_jobs_max_limit} = 5;
+    $limits->{next_jobs_default_limit} = 2;
+    $limits->{previous_jobs_default_limit} = 2;
+
+    # expected amount is the defined limit plus current and latest job
+    $t->get_ok('/tests/99910/ajax?previous_limit=0&next_limit=6', 'query with exceeding user-specified limit for next')
+      ->status_is(200);
+    my $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (1)' and is scalar @$jobs, 7, 'maximum limit for next is effective';
+
+    $t->get_ok('/tests/99910/ajax?previous_limit=6&next_limit=0',
+        'query with exceeding user-specified limit for previous')->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (2)' and is scalar @$jobs, 7, 'maximum limit for previous is effective';
+
+    $t->get_ok('/tests/99910/ajax?previous_limit=3&next_limit=0', 'query with low user-specified limit for next')
+      ->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (3)' and is scalar @$jobs, 5, 'user-specified limit for next is effective';
+
+    $t->get_ok('/tests/99910/ajax?previous_limit=0&next_limit=3', 'query with low user-specified limit for previous')
+      ->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (4)'
+      and is scalar @$jobs, 5, 'user-specified limit for previous is effective';
+
+    $t->get_ok('/tests/99910/ajax', 'query with (low) default limit for next and previous')->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (5)' and is scalar @$jobs, 6, 'default limit for next is effective';
+};
+
 kill_driver();
 done_testing();


### PR DESCRIPTION
This limit implementation follows the same approach as the default and maximum limits for the 'All tests' page as well as the limits for the API call listing JobTemplates

see: https://progress.opensuse.org/issues/114421