### PR TITLE
Fix overview table header in darkmode

### DIFF
--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -174,7 +174,7 @@ table.fixedheader {
     }
 }
 .darkmode {
-    th {
+    th, table.fixedheader th {
         background: $default-bg-color-darktheme;
     }
 }


### PR DESCRIPTION
This should be very easy to accept. 😁 

Before:
<img width="1623" alt="before" src="https://user-images.githubusercontent.com/30094/197767218-d61ed8e8-4165-426b-9021-6e4f4378711a.png">

After:
<img width="1631" alt="after" src="https://user-images.githubusercontent.com/30094/197767240-624959b9-1dda-4698-91c7-588b8a46ea26.png">

Progress: https://progress.opensuse.org/issues/119362