### PR TITLE
Fix invisible buttons in some forms with darkmode

### DIFF
--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -299,8 +299,9 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
         background-image: radial-gradient(circle, lighten(#101010, 25%) 10%, #363636 11%);
     }
 
-    input,textarea {
+    input, textarea {
         background-color: $default-bg-color-darktheme;
         color: $default-font-color-darktheme;
+        border: $table-border-color-darktheme solid 0.5px;
     }
 }


### PR DESCRIPTION
Another simple one, `<button>` styling was fine, but `<input>` was not. Now they have a consistent border.

Before:
<img width="662" alt="before" src="https://user-images.githubusercontent.com/30094/197783190-de64dba7-82fc-4712-b7e6-c27cfd92c758.png">

After:
<img width="466" alt="after" src="https://user-images.githubusercontent.com/30094/197783216-3659a76d-ad61-4cb6-8fe5-aa02be9ce7ad.png">

Progress: https://progress.opensuse.org/issues/119365