### PR TITLE
Fix bug where some pages briefly show up with light theme in darkmode

### DIFF
--- a/templates/webapi/layouts/bootstrap.html.ep
+++ b/templates/webapi/layouts/bootstrap.html.ep
@@ -34,10 +34,6 @@
             % if (current_user) {
               newFeature(<%= current_user->feature_version %>);
             % }
-
-            let theme = '<%= current_theme %>';
-            if (theme === 'detect') theme = window.matchMedia('(prefers-color-scheme: dark)').matches === true ? 'dark' : 'light';
-            if (theme === 'dark') document.body.classList.add('darkmode');
           });
       % end
 
@@ -75,4 +71,9 @@
             </div>
       </footer>
   </body>
+  <script>
+    let theme = '<%= current_theme %>';
+    if (theme === 'detect') theme = window.matchMedia('(prefers-color-scheme: dark)').matches === true ? 'dark' : 'light';
+    if (theme === 'dark') document.body.classList.add('darkmode');
+  </script>
 </html>


### PR DESCRIPTION
This problem can be observed when loading a very large and slow page like https://openqa.opensuse.org/admin/users. By changing the timing of when we execute the JavaScript code that applies the `.darkmode` class we can prevent this problem.

Progress: https://progress.opensuse.org/issues/119386