### PR TITLE
Revert "Add button to insert marker for unblocking incident to OSD branding"

### DIFF
--- a/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
+++ b/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
@@ -1,5 +1,0 @@
-% if (!$group_comment && !$job->is_ok) {
-    <a class="help_popover fa fa-unlink" title="Add marker so the specified maintenance incident will be approved despite this job"
-       role="button" data-template="@review:acceptable_for:incident_<incident_id>:<reason>" onclick="insertTemplate(this)"></a>
-    <br>
-% }

--- a/templates/webapi/comments/add_comment_form_groups.html.ep
+++ b/templates/webapi/comments/add_comment_form_groups.html.ep
@@ -54,7 +54,6 @@
                        data-template="label:force_result:new_result[:description_or_bugref]" onclick="insertTemplate(this)"></a>
                 % }
                 <br>
-                %= include_branding 'commenting_tools';
                 %= help_popover 'Help for comments' => $help_text, 'https://open.qa/docs/#_use_of_the_web_interface' => 'the documentation'
             </span>
         </div>


### PR DESCRIPTION
Reverts os-autoinst/openQA#4867 due to
https://progress.opensuse.org/issues/119467,
a problem on the group overview page where the comment edit field is also used