### PR TITLE
Add button to insert marker for unblocking incident to OSD branding

### DIFF
--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -547,4 +547,17 @@ subtest 'extra plugin links' => sub {
       ->element_exists('a[href*="/tests/latest"]');
 };
 
+subtest 'SUSE branding' => sub {
+    $t->app->config->{global}->{branding} = 'openqa.suse.de';
+    $t->get_ok('/')->status_is(200, 'main page');
+    $t->text_like('.jumbotron h2', qr/Welcome to.*at SUSE/, 'text from docbox rendered');
+    $t->attr_like('#sponsorbox a', 'href', qr/suse.com/, 'link to SUSE website');
+    $t->get_ok('/group_overview/1002')->status_is(200, 'group dashboard');
+    $t->get_ok('/parent_group_overview/' . $test_parent->id)->status_is(200, 'parent group dashboard');
+    $t->get_ok('/tests/99962/comments_ajax')->status_is(200, 'job comments');
+    my $btn_sel = '#commentForm .comment-toolbar a.fa-unlink';
+    $t->attr_like($btn_sel, 'title', qr/Add marker.*approved/, 'button title for adding review marker');
+    $t->attr_like($btn_sel, 'data-template', qr/\@review:acceptable_for/, 'button template for adding review marker');
+};
+
 done_testing;

--- a/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
+++ b/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
@@ -1,0 +1,6 @@
+% my $current_job = stash 'job';
+% if ($current_job && !$current_job->is_ok) {
+    <a class="help_popover fa fa-unlink" title="Add marker so the specified maintenance incident will be approved despite this job"
+       role="button" data-template="@review:acceptable_for:incident_<incident_id>:<reason>" onclick="insertTemplate(this)"></a>
+    <br>
+% }

--- a/templates/webapi/comments/add_comment_form_groups.html.ep
+++ b/templates/webapi/comments/add_comment_form_groups.html.ep
@@ -54,6 +54,7 @@
                        data-template="label:force_result:new_result[:description_or_bugref]" onclick="insertTemplate(this)"></a>
                 % }
                 <br>
+                %= include_branding 'commenting_tools';
                 %= help_popover 'Help for comments' => $help_text, 'https://open.qa/docs/#_use_of_the_web_interface' => 'the documentation'
             </span>
         </div>


### PR DESCRIPTION
* Fixed version of c6c4b2292a4ac1b5f7e7b0495b33273131214ccd with tests
* Related ticket: https://progress.opensuse.org/issues/107923