### PR TITLE
Add unit tests for limit implementations

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -212,6 +212,14 @@ concurrent = 0
 #list_templates_default_limit = 500
 # Maximum number of templates to include in job_templates api response (to prevent performance issues)
 #list_templates_max_limit = 5000
+# Default number of next jobs to include in jobs request (to prevent performance issues)
+#next_jobs_default_limit = 100
+# Maximum number of next jobs to include in jobs request (to prevent performance issues)
+#next_jobs_max_limit = 1000
+# Default number of previous jobs to include in jobs request (to prevent performance issues)
+#previous_jobs_default_limit = 400
+# Maximum number of previous jobs to include in jobs request (to prevent performance issues)
+#previous_jobs_max_limit = 4000
 
 [archiving]
 # Moves logs of jobs which are preserved during the cleanup because they are considered important

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -156,7 +156,11 @@ sub read_config ($app) {
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
             list_templates_default_limit => 500,
-            list_templates_max_limit => 5000
+            list_templates_max_limit => 5000,
+            next_jobs_default_limit => 100,
+            next_jobs_max_limit => 1000,
+            previous_jobs_default_limit => 400,
+            previous_jobs_max_limit => 4000
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -438,8 +438,11 @@ sub _show {
 sub job_next_previous_ajax ($self) {
     return $self->reply->not_found unless my $main_job = $self->_get_current_job;
     my $main_jobid = $main_job->id;
-    my $p_limit = $self->param('previous_limit') // 400;
-    my $n_limit = $self->param('next_limit') // 100;
+
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    my $p_limit = min($limits->{previous_jobs_max_limit},
+        $self->param('previous_limit') // $limits->{previous_jobs_default_limit});
+    my $n_limit = min($limits->{next_jobs_max_limit}, $self->param('next_limit') // $limits->{next_jobs_default_limit});
 
     my $schema = $self->schema;
     my $jobs_rs = $schema->resultset('Jobs')->next_previous_jobs_query(

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -20,8 +20,7 @@ use List::Util qw(min);
 
 use constant DEPENDENCY_DEBUG_INFO => $ENV{OPENQA_DEPENDENCY_DEBUG_INFO};
 
-sub referer_check {
-    my ($self) = @_;
+sub referer_check ($self) {
     return $self->reply->not_found if (!defined $self->param('testid'));
     my $referer = $self->req->headers->header('Referer') // '';
     if ($referer) {
@@ -210,9 +209,7 @@ sub list_scheduled_ajax {
     $self->render(json => {data => \@scheduled});
 }
 
-sub _stash_job {
-    my ($self, $args) = @_;
-
+sub _stash_job ($self, $args = undef) {
     return undef unless my $job_id = $self->param('testid');
     return undef unless my $job = $self->schema->resultset('Jobs')->find({id => $job_id}, $args);
     $self->stash(job => $job);
@@ -228,9 +225,7 @@ sub _stash_job_and_module_list {
     return $job;
 }
 
-sub details {
-    my ($self) = @_;
-
+sub details ($self) {
     return $self->reply->not_found unless my $job = $self->_stash_job;
 
     if ($job->should_show_autoinst_log) {
@@ -275,16 +270,12 @@ sub details {
     return $self->render(json => {snippets => $snips, modules => \@ret});
 }
 
-sub external {
-    my ($self) = @_;
-
+sub external ($self) {
     $self->_stash_job_and_module_list or return $self->reply->not_found;
     $self->render('test/external');
 }
 
-sub live {
-    my ($self) = @_;
-
+sub live ($self) {
     my $job = $self->_stash_job or return $self->reply->not_found;
     my $current_user = $self->current_user;
     my $worker = $job->worker;
@@ -301,9 +292,7 @@ sub live {
     $self->render('test/live');
 }
 
-sub downloads {
-    my ($self) = @_;
-
+sub downloads ($self) {
     my $job = $self->_stash_job({prefetch => [qw(settings jobs_assets)]}) or return $self->reply->not_found;
     $self->stash(
         $job->result_dir

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1461,6 +1461,24 @@ subtest 'show parent group name and id when getting job details' => sub {
     is $job->{parent_group_id}, $parent_group_id, 'parent group id was shown correctly';
 };
 
+subtest 'server-side limit has precedence over user-specified limit' => sub {
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    $limits->{generic_max_limit} = 5;
+    $limits->{generic_default_limit} = 2;
+
+    $t->get_ok('/api/v1/jobs?limit=10', 'query with exceeding user-specified limit for jobs')->status_is(200);
+    my $jobs = $t->tx->res->json->{jobs};
+    is ref $jobs, 'ARRAY', 'data returned (1)' and is scalar @$jobs, 5, 'maximum limit for jobs is effective';
+
+    $t->get_ok('/api/v1/jobs?limit=3', 'query with exceeding user-specified limit for jobs')->status_is(200);
+    $jobs = $t->tx->res->json->{jobs};
+    is ref $jobs, 'ARRAY', 'data returned (2)' and is scalar @$jobs, 3, 'user limit for jobs is effective';
+
+    $t->get_ok('/api/v1/jobs', 'query with (low) default limit for jobs')->status_is(200);
+    $jobs = $t->tx->res->json->{jobs};
+    is ref $jobs, 'ARRAY', 'data returned (3)' and is scalar @$jobs, 2, 'default limit for jobs is effective';
+};
+
 # delete the job with a registered job module
 $t->delete_ok('/api/v1/jobs/99937')->status_is(200);
 $t->get_ok('/api/v1/jobs/99937')->status_is(404);

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -92,7 +92,7 @@ $t->get_ok('/api/v1/machines', form => {name => "testmachineQ"})->status_is(200)
 is($t->tx->res->json->{Machines}->[0]->{settings}->[0]->{key}, "TEST");
 is($t->tx->res->json->{Machines}->[0]->{settings}->[0]->{value}, "'v'al1");
 
-$t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu"})->status_is(400);    #already exists
+$t->post_ok('/api/v1/machines', form => {name => "testmachine", backend => "qemu"})->status_is(400);    #already exist
 
 $t->get_ok("/api/v1/machines/$machine_id")->status_is(200);
 is_deeply(
@@ -209,5 +209,26 @@ $t->post_ok('/api/v1/machines',
 $t->put_ok("/api/v1/machines/$machine_id",
     form => {name => "testmachine", backend => "qemu", "settings[TEST2]" => "val1"})->status_is(403);
 $t->delete_ok("/api/v1/machines/$machine_id")->status_is(403);
+
+subtest 'server-side limit has precedence over user-specified limit' => sub {
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    $limits->{generic_max_limit} = 5;
+    $limits->{generic_default_limit} = 2;
+
+    $t->get_ok('/api/v1/machines?limit=10', 'query with exceeding user-specified limit for machines')->status_is(200);
+    my $machines = $t->tx->res->json->{Machines};
+    is ref $machines, 'ARRAY', 'data returned (1)'
+      and is scalar @$machines, 5, 'maximum limit for machines is effective';
+
+    $t->get_ok('/api/v1/machines?limit=3', 'query with exceeding user-specified limit for machines')->status_is(200);
+    $machines = $t->tx->res->json->{Machines};
+    is ref $machines, 'ARRAY', 'data returned (2)'
+      and is scalar @$machines, 3, 'user limit for machines is effective';
+
+    $t->get_ok('/api/v1/machines', 'query with (low) default limit for machines')->status_is(200);
+    $machines = $t->tx->res->json->{Machines};
+    is ref $machines, 'ARRAY', 'data returned (3)'
+      and is scalar @$machines, 2, 'default limit for machines is effective';
+};
 
 done_testing();

--- a/t/api/06-products.t
+++ b/t/api/06-products.t
@@ -165,4 +165,27 @@ $t->put_ok("/api/v1/products/$product_id",
   ->status_is(403);
 $t->delete_ok("/api/v1/products/$product_id")->status_is(403);
 
+
+subtest 'server-side limit has precedence over user-specified limit' => sub {
+    # TODO: add products
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    $limits->{generic_max_limit} = 5;
+    $limits->{generic_default_limit} = 2;
+
+    $t->get_ok('/api/v1/products?limit=10', 'query with exceeding user-specified limit for products')->status_is(200);
+    my $products = $t->tx->res->json->{Products};
+    is ref $products, 'ARRAY', 'data returned (1)'
+      and is scalar @$products, 5, 'maximum limit for products is effective';
+
+    $t->get_ok('/api/v1/products?limit=3', 'query with exceeding user-specified limit for products')->status_is(200);
+    $products = $t->tx->res->json->{Products};
+    is ref $products, 'ARRAY', 'data returned (2)'
+      and is scalar @$products, 3, 'user limit for products is effective';
+
+    $t->get_ok('/api/v1/products', 'query with (low) default limit for products')->status_is(200);
+    $products = $t->tx->res->json->{Products};
+    is ref $products, 'ARRAY', 'data returned (3)'
+      and is scalar @$products, 2, 'default limit for products is effective';
+};
+
 done_testing();

--- a/t/api/09-comments.t
+++ b/t/api/09-comments.t
@@ -155,6 +155,29 @@ subtest 'parent group comments' => sub {
     test_comments(parent_groups => 1);
 };
 
+subtest 'server-side limit has precedence over user-specified limit' => sub {
+  for my $i (1 .. 9) {
+    $t->post_ok("/api/v1/99981/comments" => form => {text => "comment number $i"});
+  }
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    $limits->{generic_max_limit} = 5;
+    $limits->{generic_default_limit} = 2;
+
+    $t->get_ok('/api/v1/jobs/99981/comments?limit=10', 'query with exceeding user-specified limit for comments')
+      ->status_is(200);
+    my $jobs = $t->tx->res->json;
+    is ref $jobs, 'ARRAY', 'data returned (1)' and is scalar @$jobs, 5, 'maximum limit for comments is effective';
+
+    $t->get_ok('/api/v1/jobs/99981/comments?limit=3', 'query with exceeding user-specified limit for comments')
+      ->status_is(200);
+    $jobs = $t->tx->res->json;
+    is ref $jobs, 'ARRAY', 'data returned (2)' and is scalar @$jobs, 3, 'user limit for comments is effective';
+
+    $t->get_ok('/api/v1/jobs/99981/comments', 'query with (low) default limit for comments')->status_is(200);
+    $jobs = $t->tx->res->json;
+    is ref $jobs, 'ARRAY', 'data returned (3)' and is scalar @$jobs, 2, 'default limit for comments is effective';
+};
+
 subtest 'admin can delete comments' => sub {
     client($t, apikey => 'ARTHURKEY01', apisecret => 'EXCALIBUR');
     my $new_comment_id = test_create_comment(jobs => 99981, $test_message);

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -66,4 +66,26 @@ subtest 'Created since' => sub {
     is(scalar(keys %{$t->tx->res->json->{bugs}}), 2, 'Only the latest bugs');
 };
 
+subtest 'server-side limit has precedence over user-specified limit' => sub {
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    $limits->{generic_max_limit} = 5;
+    $limits->{generic_default_limit} = 2;
+
+    for my $i (1 .. 9) {
+        $t->post_ok('/api/v1/jobs/99926/comments', form => {text => "test-bug $i"});
+    }
+
+    $t->get_ok('/api/v1/bugs?limit=10', 'query with exceeding user-specified limit for bugs')->status_is(200);
+    my $bugs = $t->tx->res->json->{bugs};
+    is ref $bugs, 'HASH', 'data returned (1)' and is scalar %$bugs, 5, 'maximum limit for bugs is effective';
+
+    $t->get_ok('/api/v1/bugs?limit=3', 'query with exceeding user-specified limit for bugs')->status_is(200);
+    $bugs = $t->tx->res->json->{bugs};
+    is ref $bugs, 'HASH', 'data returned (2)' and is scalar %$bugs, 3, 'user limit for bugs is effective';
+
+    $t->get_ok('/api/v1/bugs', 'query with (low) default limit for bugs')->status_is(200);
+    $bugs = $t->tx->res->json->{bugs};
+    is ref $bugs, 'HASH', 'data returned (3)' and is scalar %$bugs, 2, 'default limit for bugs is effective';
+};
+
 done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -138,7 +138,11 @@ subtest 'Test configuration default modes' => sub {
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
             list_templates_default_limit => 500,
-            list_templates_max_limit => 5000
+            list_templates_max_limit => 5000,
+            next_jobs_default_limit => 100,
+            next_jobs_max_limit => 1000,
+            previous_jobs_default_limit => 400,
+            previous_jobs_max_limit => 4000
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -276,5 +276,39 @@ subtest 'bug reference shown' => sub {
     );
 };
 
+subtest 'server-side limit has precedence over user-specified limit' => sub {
+    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    $limits->{next_jobs_max_limit} = 5;
+    $limits->{previous_jobs_max_limit} = 5;
+    $limits->{next_jobs_default_limit} = 2;
+    $limits->{previous_jobs_default_limit} = 2;
+
+    # expected amount is the defined limit plus current and latest job
+    $t->get_ok('/tests/99910/ajax?previous_limit=0&next_limit=6', 'query with exceeding user-specified limit for next')
+      ->status_is(200);
+    my $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (1)' and is scalar @$jobs, 7, 'maximum limit for next is effective';
+
+    $t->get_ok('/tests/99910/ajax?previous_limit=6&next_limit=0',
+        'query with exceeding user-specified limit for previous')->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (2)' and is scalar @$jobs, 7, 'maximum limit for previous is effective';
+
+    $t->get_ok('/tests/99910/ajax?previous_limit=3&next_limit=0', 'query with low user-specified limit for next')
+      ->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (3)' and is scalar @$jobs, 5, 'user-specified limit for next is effective';
+
+    $t->get_ok('/tests/99910/ajax?previous_limit=0&next_limit=3', 'query with low user-specified limit for previous')
+      ->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (4)'
+      and is scalar @$jobs, 5, 'user-specified limit for previous is effective';
+
+    $t->get_ok('/tests/99910/ajax', 'query with (low) default limit for next and previous')->status_is(200);
+    $jobs = $t->tx->res->json->{data};
+    is ref $jobs, 'ARRAY', 'data returned (5)' and is scalar @$jobs, 6, 'default limit for next is effective';
+};
+
 kill_driver();
 done_testing();

--- a/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
+++ b/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
@@ -1,5 +1,0 @@
-% if (!$group_comment && !$job->is_ok) {
-    <a class="help_popover fa fa-unlink" title="Add marker so the specified maintenance incident will be approved despite this job"
-       role="button" data-template="@review:acceptable_for:incident_<incident_id>:<reason>" onclick="insertTemplate(this)"></a>
-    <br>
-% }

--- a/templates/webapi/comments/add_comment_form_groups.html.ep
+++ b/templates/webapi/comments/add_comment_form_groups.html.ep
@@ -54,7 +54,6 @@
                        data-template="label:force_result:new_result[:description_or_bugref]" onclick="insertTemplate(this)"></a>
                 % }
                 <br>
-                %= include_branding 'commenting_tools';
                 %= help_popover 'Help for comments' => $help_text, 'https://open.qa/docs/#_use_of_the_web_interface' => 'the documentation'
             </span>
         </div>


### PR DESCRIPTION
These subtests are supposed to check the proper implementation of serverside and user specified limits for:

```
/api/v1/assets
/api/v1/bugs
/api/v1/jobs/<job_id:num>/comments
/api/v1/test_suites */machines  */products
/api/v1/workers
/api/v1/jobs
```

see: https://progress.opensuse.org/issues/114421