### PR TITLE
Fix log upload from openQA jobs in case of read-only cache directory

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -375,22 +375,9 @@ sub exec ($self) {
     return $return_code;
 }
 
-sub _prepare_cache_directory {
-    my ($webui_host, $cachedirectory) = @_;
-    die 'No cachedir' unless $cachedirectory;
-
+sub _prepare_cache_directory ($webui_host, $cachedirectory) {
     my $host_to_cache = Mojo::URL->new($webui_host)->host || $webui_host;
-    my $shared_cache = File::Spec->catdir($cachedirectory, $host_to_cache);
-    File::Path::make_path($shared_cache);
-    log_info("CACHE: caching is enabled, setting up $shared_cache");
-
-    # make sure the downloads are in the same file system - otherwise
-    # asset->move_to becomes a bit more expensive than it should
-    my $tmpdir = File::Spec->catdir($cachedirectory, 'tmp');
-    File::Path::make_path($tmpdir);
-    $ENV{MOJO_TMPDIR} = $tmpdir;
-
-    return $shared_cache;
+    return File::Spec->catdir($cachedirectory, $host_to_cache);
 }
 
 sub _assert_whether_job_acceptance_possible {


### PR DESCRIPTION
We observed a problem that the os-autoinst command server received log
upload attempts but failed with

```
Mojo::Reactor::Poll: I/O watcher failed: Error in tempfile() using template /var/lib/openqa/cache/tmp/mojo.tmp.XXXXXXXXXXXXXXXX: Could not create temp file /var/lib/openqa/cache/tmp/mojo.tmp.mbmTdPv6NyxTOBTy: Permission denied at /usr/lib/perl5/5.26.1/File/Temp.pm line 1102.
```

Setting the environment variable MOJO_TMPDIR from the worker will mean
that also the os-autoinst command server effectively started by
the openQA worker will inherit

The original change was done at a time when the openQA worker itself
downloaded assets before the introduction of the separate cache service
so we can simply remove the corresponding code without replacement.

Related progress issue: https://progress.opensuse.org/issues/119713