### PR TITLE
Clean up git repository before rebase

### DIFF
--- a/container/openqa_data/data.template/conf/openqa.ini
+++ b/container/openqa_data/data.template/conf/openqa.ini
@@ -23,6 +23,8 @@ branding = plain
 #update_remote = origin
 # name of branch to rebase against before committing changes (e.g. origin/master, leave out-commented to disable rebase)
 #update_branch = origin/master
+# whether to do a hard reset of the local repository before rebasing
+#do_cleanup = no
 # whether committed changes should be pushed
 #do_push = no
 

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -578,6 +578,16 @@ update_remote = origin
 update_branch = origin/master
 --------------------------------------------------------------------------------
 
+If rebasing, it may be useful to perform a hard reset of the local repository
+to ensure that the rebase will not fail. To enable that, add the following to
+your openqa.ini (along with the previous snippet):
+
+[source,ini]
+--------------------------------------------------------------------------------
+[scm git]
+do_cleanup = yes
+--------------------------------------------------------------------------------
+
 === Referer settings to auto-mark important jobs
 
 Automatic cleanup of old results (see GRU jobs) can sometimes render important

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -94,6 +94,8 @@
 #update_remote = origin
 # name of branch to rebase against before committing changes (e.g. origin/master, leave out-commented to disable rebase)
 #update_branch = origin/master
+# whether to do a hard reset of the local repository before rebasing
+#do_cleanup = no
 # whether committed changes should be pushed
 #do_push = no
 

--- a/lib/OpenQA/Git.pm
+++ b/lib/OpenQA/Git.pm
@@ -54,6 +54,10 @@ sub set_to_latest_master ($self, $args = undef) {
     }
 
     if (my $update_branch = $self->config->{update_branch}) {
+        if ($self->config->{do_cleanup} eq 'yes') {
+            my $res = run_cmd_with_log_return_error([@git, 'reset', '--hard', 'HEAD']);
+            return _format_git_error($res, 'Unable to reset repository to HEAD') unless $res->{status};
+        }
         my $res = run_cmd_with_log_return_error([@git, 'rebase', $update_branch]);
         return _format_git_error($res, 'Unable to reset repository to origin/master') unless $res->{status};
     }

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -62,6 +62,7 @@ sub read_config ($app) {
             update_remote => '',
             update_branch => '',
             do_push => 'no',
+            do_cleanup => 'no',
         },
         'scheduler' => {
             max_job_scheduled_time => 7,

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -95,13 +95,17 @@ subtest 'git commands with mocked run_cmd_with_log_return_error' => sub {
     # configure update branch and remote
     $git->config->{update_remote} = 'origin';
     $git->config->{update_branch} = 'origin/master';
+    $git->config->{do_cleanup} = 'yes';
     is($git_config->{update_remote}, $git->config->{update_remote}, 'global git config reflects all changes');
 
     # test set_to_latest_master (non-error case)
     is($git->set_to_latest_master, undef, 'no error');
     is_deeply(
         \@executed_commands,
-        [[qw(git -C foo/bar remote update origin)], [qw(git -C foo/bar rebase origin/master)],],
+        [
+            [qw(git -C foo/bar remote update origin)], [qw(git -C foo/bar reset --hard HEAD)],
+            [qw(git -C foo/bar rebase origin/master)],
+        ],
         'git remote update and rebase executed',
     ) or diag explain \@executed_commands;
 
@@ -180,6 +184,7 @@ subtest 'saving needle via Git' => sub {
         \@executed_commands,
         [
             [qw(git -C), $empty_tmp_dir, qw(remote update origin)],
+            [qw(git -C), $empty_tmp_dir, qw(reset --hard HEAD)],
             [qw(git -C), $empty_tmp_dir, qw(rebase origin/master)],
             [qw(git -C), $empty_tmp_dir, qw(add), "foo.json", "foo.png"],
             [

--- a/t/config.t
+++ b/t/config.t
@@ -62,6 +62,7 @@ subtest 'Test configuration default modes' => sub {
             update_remote => '',
             update_branch => '',
             do_push => 'no',
+            do_cleanup => 'no',
         },
         'scheduler' => {
             max_job_scheduled_time => 7,


### PR DESCRIPTION
If there have been previous failures when adding new needles through the needle editor it is possible for the rebase to fail due to uncommitted changes. This commit will ensure that any uncommitted changes are cleaned up before attempting to rebase