### PR TITLE
Add an API endpoint to find jobs with certain job settings

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -220,6 +220,8 @@ concurrent = 0
 #previous_jobs_default_limit = 400
 # Maximum number of previous jobs to include in jobs request (to prevent performance issues)
 #previous_jobs_max_limit = 4000
+# Maximum number of recent jobs to consider when returning jobs for a settings query (to prevent performance issues)
+#job_settings_max_recent_jobs = 20000
 
 [archiving]
 # Moves logs of jobs which are preserved during the cleanup because they are considered important

--- a/lib/OpenQA/Schema/ResultSet/JobSettings.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobSettings.pm
@@ -2,9 +2,41 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Schema::ResultSet::JobSettings;
+use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
 
+use OpenQA::App;
 
-use Mojo::Base 'DBIx::Class::ResultSet';
+sub jobs_for_setting ($self, $options) {
+    my $limit = OpenQA::App->singleton->config->{misc_limits}{job_settings_max_recent_jobs};
+
+    my $key_like = $options->{key};
+    $key_like =~ s/\*/\%/g;
+    my $list_value = $options->{list_value};
+    my $list_value_like = "%${list_value}%";
+
+    # Get the highest job id to limit the number of jobs that need to be considered (to improve performance)
+    my $dbh = $self->result_source->schema->storage->dbh;
+    my $sth = $dbh->prepare('SELECT max(job_id) FROM job_settings');
+    $sth->execute;
+
+    my $result = $sth->fetchrow_arrayref;
+    my $max_id = defined $result ? $result->[0] : 0;
+    my $min_id = $max_id > $limit ? $max_id - $limit : 0;
+
+    # Instead of limiting the number of jobs, this query could also use a trigram gin index to achieve even better
+    # performance (at the cost of disk space and setup complexity)
+    $sth = $dbh->prepare(
+        'SELECT job_id, value FROM job_settings WHERE key LIKE ? AND value LIKE ? AND job_id > ? ORDER BY job_id DESC');
+    $sth->execute($key_like, $list_value_like, $min_id);
+
+    # Match list values
+    my @jobs;
+    for my $row (@{$sth->fetchall_arrayref}) {
+        my ($job_id, $value) = @$row;
+        push @jobs, $job_id if $value =~ /(?:^|,)$list_value(?:$|,)/;
+    }
+    return \@jobs;
+}
 
 =head2 query_for_settings
 
@@ -16,11 +48,9 @@ use Mojo::Base 'DBIx::Class::ResultSet';
 
 Given a perl hash, will create a ResultSet of job_settings
 
-
 =cut
-sub query_for_settings {
-    my ($self, $args) = @_;
 
+sub query_for_settings ($self, $args) {
     my @conds;
     # Search into the following job_settings
     for my $setting (keys %$args) {

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -160,7 +160,8 @@ sub read_config ($app) {
             next_jobs_default_limit => 100,
             next_jobs_max_limit => 1000,
             previous_jobs_default_limit => 400,
-            previous_jobs_max_limit => 4000
+            previous_jobs_max_limit => 4000,
+            job_settings_max_recent_jobs => 20000
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -341,6 +341,9 @@ sub startup ($self) {
     $api_ro->post('/jobs/cancel')->name('apiv1_cancel_jobs')->to('job#cancel');
     $api_ro->post('/jobs/restart')->name('apiv1_restart_jobs')->to('job#restart');
 
+    # api/v1/job_settings/jobs
+    $api_public_r->get('/job_settings/jobs')->name('apiv1_get_jobs_for_job_settings')->to('job_settings#jobs');
+
     my $job_r = $api_ro->any('/jobs/<jobid:num>');
     push @api_routes, $job_r;
     $api_public_r->any('/jobs/<jobid:num>')->name('apiv1_job')->to('job#show');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobSettings.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobSettings.pm
@@ -1,0 +1,19 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Controller::API::V1::JobSettings;
+use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+sub jobs ($self) {
+    my $validation = $self->validation;
+    $validation->required('key')->like(qr/^[\w\*]+$/);
+    $validation->required('list_value')->like(qr/^\w+$/);
+    return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
+
+    my $key = $validation->param('key');
+    my $list_value = $validation->param('list_value');
+    my $jobs = $self->schema->resultset('JobSettings')->jobs_for_setting({key => $key, list_value => $list_value});
+    $self->render(json => {jobs => $jobs});
+}
+
+1;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -220,6 +220,47 @@ subtest 'job overview' => sub {
 
 };
 
+subtest 'jobs for job settings' => sub {
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26102})->status_is(200)
+      ->json_is({jobs => []});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '_TEST_ISSUES', list_value => 26103})->status_is(200)
+      ->json_is({jobs => []});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_', list_value => 26103})->status_is(200)
+      ->json_is({jobs => []});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '%test%', list_value => '%test%'})->status_is(400)
+      ->json_is({error_status => 400, error => 'Erroneous parameters (key invalid, list_value invalid)'});
+
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26103})->status_is(200)
+      ->json_is({jobs => [99926]});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26104})->status_is(200)
+      ->json_is({jobs => [99927]});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26105})->status_is(200)
+      ->json_is({jobs => [99928, 99927]});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26106})->status_is(200)
+      ->json_is({jobs => [99928, 99927]});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26110})->status_is(200)
+      ->json_is({jobs => [99981]});
+
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 261042})->status_is(200)
+      ->json_is({jobs => []});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 2610})->status_is(200)
+      ->json_is({jobs => []});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 2})->status_is(200)
+      ->json_is({jobs => []});
+
+    local $t->app->config->{misc_limits}{job_settings_max_recent_jobs} = 5;
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26110})->status_is(200)
+      ->json_is({jobs => [99981]});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26103})->status_is(200)
+      ->json_is({jobs => []});
+
+    local $t->app->config->{misc_limits}{job_settings_max_recent_jobs} = 1000000000;
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26110})->status_is(200)
+      ->json_is({jobs => [99981]});
+    $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26103})->status_is(200)
+      ->json_is({jobs => [99926]});
+};
+
 $schema->txn_begin;
 
 subtest 'restart jobs, error handling' => sub {

--- a/t/config.t
+++ b/t/config.t
@@ -142,7 +142,8 @@ subtest 'Test configuration default modes' => sub {
             next_jobs_default_limit => 100,
             next_jobs_max_limit => 1000,
             previous_jobs_default_limit => 400,
-            previous_jobs_max_limit => 4000
+            previous_jobs_max_limit => 4000,
+            job_settings_max_recent_jobs => 20000
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -62,7 +62,8 @@ use Time::Seconds;
             {key => 'DESKTOP', value => 'minimalx'},
             {key => 'ISO', value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'},
             {key => 'ISO_MAXSIZE', value => 737280000},
-            {key => 'ISO_1', value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'}
+            {key => 'ISO_1', value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'},
+            {key => 'BASE_TEST_ISSUES', value => '26103'}
         ],
         ARCH => 'x86_64',
         BUILD => '87.5011',
@@ -104,7 +105,7 @@ use Time::Seconds;
             {key => 'DESKTOP', value => 'kde'},
             {key => 'ISO_MAXSIZE', value => '4700372992'},
             {key => 'LIVETEST', value => '1'},
-        ]
+            {key => 'BASE_TEST_ISSUES', value => '26104,26105,26106'}]
     },
     Jobs => {
         id => 99928,
@@ -129,7 +130,7 @@ use Time::Seconds;
             {key => 'DESKTOP', value => 'kde'},
             {key => 'ISO_MAXSIZE', value => '4700372992'},
             {key => 'ISO', value => 'openSUSE-13.1-DVD-i586-Build0091-Media.iso'},
-        ]
+            {key => 'RT_TEST_ISSUES', value => '26105,26106'}]
     },
     Jobs => {
         id => 99937,
@@ -448,7 +449,7 @@ use Time::Seconds;
             {key => 'INSTALLONLY', value => '1'},
             {key => 'GNOME', value => '1'},
             {key => 'QEMUCPU', value => 'qemu32'},
-        ]
+            {key => 'RANDOM_NAME_TEST_ISSUES', value => '26110'}]
     },
     Jobs => {
         id => 99961,


### PR DESCRIPTION
This PR implements the solution we discussed, which limits the query to the 20000 most recent job ids in the `job_settings` table.

Progress: https://progress.opensuse.org/issues/117655