### PR TITLE
Add distinct set of limits for assets

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -228,6 +228,10 @@ concurrent = 0
 #previous_jobs_max_limit = 4000
 # Maximum number of recent jobs to consider when returning jobs for a settings query (to prevent performance issues)
 #job_settings_max_recent_jobs = 20000
+# Default number of assets to include in asset listing request (to prevent performance issues)
+#assets_default_limit = 100000
+# Maximum number of next jobs to include asset listing request (to prevent performance issues)
+#assets_max_limit = 200000
 
 [archiving]
 # Moves logs of jobs which are preserved during the cleanup because they are considered important

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -164,7 +164,9 @@ sub read_config ($app) {
             next_jobs_max_limit => 1000,
             previous_jobs_default_limit => 400,
             previous_jobs_max_limit => 4000,
-            job_settings_max_recent_jobs => 20000
+            job_settings_max_recent_jobs => 20000,
+            assets_default_limit => 100000,
+            assets_max_limit => 200000,
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -63,7 +63,7 @@ sub list {
     my $self = shift;
     my $schema = $self->schema;
     my $limits = OpenQA::App->singleton->config->{misc_limits};
-    my $limit = min($limits->{generic_max_limit}, $self->param('limit') // $limits->{generic_default_limit});
+    my $limit = min($limits->{assets_max_limit}, $self->param('limit') // $limits->{assets_default_limit});
 
     my $rs = $schema->resultset("Assets")->search({}, {rows => $limit});
     $rs->result_class('DBIx::Class::ResultClass::HashRefInflator');

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -95,8 +95,8 @@ $t->json_is('/assets/6' => $listing->[0], "listing ok");
 #check user specified and server-side limit
 subtest 'server-side limit has precedence over user-specified limit' => sub {
     my $limits = OpenQA::App->singleton->config->{misc_limits};
-    $limits->{generic_max_limit} = 5;
-    $limits->{generic_default_limit} = 2;
+    $limits->{assets_max_limit} = 5;
+    $limits->{assets_default_limit} = 2;
 
     $t->get_ok('/api/v1/assets?limit=10', 'query with exceeding user-specified limit for assets')->status_is(200);
     my $assets = $t->tx->res->json->{assets};

--- a/t/config.t
+++ b/t/config.t
@@ -146,7 +146,9 @@ subtest 'Test configuration default modes' => sub {
             next_jobs_max_limit => 1000,
             previous_jobs_default_limit => 400,
             previous_jobs_max_limit => 4000,
-            job_settings_max_recent_jobs => 20000
+            job_settings_max_recent_jobs => 20000,
+            assets_default_limit => 100000,
+            assets_max_limit => 200000,
         },
         archiving => {
             archive_preserved_important_jobs => 0,


### PR DESCRIPTION
The generic default limit (that was taken from the "All tests" page for jobs) doesn't make any sense here so this change allows us to configure the limit for asset queries separately.

Related ticket: https://progress.opensuse.org/issues/120315