### PR TITLE
Work around openQA-single-instance pulling old openQA on Leap 15.4

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -26,7 +26,7 @@ fi
 
 
 # install packages
-zypper -n install --no-recommends openQA-single-instance qemu-arm qemu-ppc qemu-x86 qemu-tools sudo iputils os-autoinst-distri-opensuse-deps
+zypper -n install --no-recommends openQA openQA-single-instance qemu-arm qemu-ppc qemu-x86 qemu-tools sudo iputils os-autoinst-distri-opensuse-deps
 
 if [ "$(uname -m)" = "aarch64" ]; then
     zypper -n install --no-recommends qemu-uefi-aarch64


### PR DESCRIPTION
Using the openQA-bootstrap script on Leap 15.4, without ssh keys in use, causes it to fail, because it pulls an older version of fetchneedles and openQA where poo#104794 has not been fixed.

However by explicitly adding openQA to the list of the packages to be installed, the problems seems to be fixed.

Related ticket: https://progress.opensuse.org/issues/115784