### PR TITLE
Bump query limits to higher limits to fix users unable to get results

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -205,27 +205,27 @@ concurrent = 0
 # Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800
 # Default number of templates to include in job_templates api response (to prevent performance issues)
-#generic_default_limit = 500
+#generic_default_limit = 10000
 # Maximum number of templates to include in job_templates api response (to prevent performance issues)
-#generic_max_limit = 5000
+#generic_max_limit = 100000
 # Maximum number of jobs to include in tests overview page (to prevent performance issues)
-#tests_overview_max_jobs = 500
+#tests_overview_max_jobs = 2000
 # Default number of jobs to include in table of finished jobs on "All tests" page
 #all_tests_default_finished_jobs = 500
 # Maximum number of jobs to include in table of finished jobs on "All tests" page
-#all_tests_max_finished_jobs = 5000
+#all_tests_max_finished_jobs = 10000
 # Default number of templates to include in job_templates api response (to prevent performance issues)
-#list_templates_default_limit = 500
+#list_templates_default_limit = 5000
 # Maximum number of templates to include in job_templates api response (to prevent performance issues)
-#list_templates_max_limit = 5000
+#list_templates_max_limit = 20000
 # Default number of next jobs to include in jobs request (to prevent performance issues)
-#next_jobs_default_limit = 100
+#next_jobs_default_limit = 500
 # Maximum number of next jobs to include in jobs request (to prevent performance issues)
-#next_jobs_max_limit = 1000
+#next_jobs_max_limit = 10000
 # Default number of previous jobs to include in jobs request (to prevent performance issues)
-#previous_jobs_default_limit = 400
+#previous_jobs_default_limit = 500
 # Maximum number of previous jobs to include in jobs request (to prevent performance issues)
-#previous_jobs_max_limit = 4000
+#previous_jobs_max_limit = 10000
 # Maximum number of recent jobs to consider when returning jobs for a settings query (to prevent performance issues)
 #job_settings_max_recent_jobs = 20000
 # Default number of assets to include in asset listing request (to prevent performance issues)


### PR DESCRIPTION
Same as for assets there had been problems reported for other queries
and webUI views, e.g. test suites where the limit of 500 was just way
too strict. And without the users being able to select more entries to
show easily we should be more conservative regarding limits. Limits will
still have an effect although potentially systems can be loaded a bit
more with higher limits.

I am selecting reasonable higher values for default and max limits based
on my experiences how heavy the individual data sources are.

Related progress issue: https://progress.opensuse.org/issues/120315