### PR TITLE
Fix hadolint check

### DIFF
--- a/tools/static_check_containers
+++ b/tools/static_check_containers
@@ -12,5 +12,5 @@ cre="${cre:-"podman"}"
 dockerfiles=(container/*/Dockerfile*)
 echo "# Static check of Dockerfiles"
 set -x
-$cre run --rm -v"$PWD":/repo -w /repo "$img" hadolint "${dockerfiles[@]}"
+$cre run -e 'HOME=/' --rm -v"$PWD":/repo -w /repo "$img" hadolint "${dockerfiles[@]}"
 echo "All files ok"


### PR DESCRIPTION
Set the `HOME` variable explicitly as the current container image otherwise fails with:
```
hadolint: getXdgDirectory:getHomeDirectory:getUserEntryForID: does not exist (No such file or directory)
make: *** [Makefile:309: test-check-containers] Error 1
Error: Process completed with exit code 2.
```