### PR TITLE
Relabel the shared volumes for hadolint

### DIFF
--- a/tools/static_check_containers
+++ b/tools/static_check_containers
@@ -12,5 +12,5 @@ cre="${cre:-"podman"}"
 dockerfiles=(container/*/Dockerfile*)
 echo "# Static check of Dockerfiles"
 set -x
-$cre run -e 'HOME=/' --rm -v"$PWD":/repo -w /repo "$img" hadolint "${dockerfiles[@]}"
+$cre run -e 'HOME=/' --rm -v"$PWD":/repo:Z -w /repo "$img" hadolint "${dockerfiles[@]}"
 echo "All files ok"


### PR DESCRIPTION
This is required to run hadolint on systems with SELinux enabled