### PR TITLE
Avoid `database is locked` errors if SQLite writes are slow

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -74,9 +74,9 @@ sub startup {
             # default to using DELETE journaling mode to avoid database corruption seen in production (see poo#67000)
             # checkout https://www.sqlite.org/pragma.html#pragma_journal_mode for possible values
             my $sqlite_mode = uc($ENV{OPENQA_CACHE_SERVICE_SQLITE_JOURNAL_MODE} || 'DELETE');
+            $dbh->sqlite_busy_timeout(SQLITE_BUSY_TIMEOUT);
             $dbh->do("pragma journal_mode=$sqlite_mode");
             $dbh->do('pragma synchronous=NORMAL') if $sqlite_mode eq 'WAL';
-            $dbh->sqlite_busy_timeout(SQLITE_BUSY_TIMEOUT);
 
             # Log slow queries
             $dbh->sqlite_profile(


### PR DESCRIPTION
* Set SQLite busy timeout before invoking first query/pragma so the extended busy timeout we already apply counts for the first query/pargma as well. This should avoid the `database is locked` error we see on PowerPC workers when setting the journal mode.
* Tested locally by provoking a timeout via `$db->begin('exclusive')` and then never releasing the lock. Before this change `database is locked` is logged rather quickly on another connection attempt. With this change the error occurs only after 10 minutes. The database is still using the `DELETE` journaling mode.
* See https://progress.opensuse.org/issues/120744