### PR TITLE
Ensure openQA-single-instance pulls in same version of openQA

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -232,7 +232,8 @@ next to the webui.
 Summary:        Convenience package for a single-instance setup
 Group:          Development/Tools/Other
 Requires:       %{name}-local-db
-Requires:       %{name}-worker
+Requires:       %{name} = %{version}
+Requires:       %{name}-worker = %{version}
 Requires:       apache2
 
 %description single-instance


### PR DESCRIPTION
So far openQA-single-instance pulls in openQA itself only indirectly via openQA-local-db package that doesn't require a specific openQA version. However, for openQA-single-instance it makes sense to require a specific version of openQA and the worker to avoid pulling in older versions from other repositories (which is likely not expected/wanted by users).

See https://github.com/os-autoinst/openQA/pull/4901 and https://progress.opensuse.org/issues/115784 for additional context.