### PR TITLE
Prefer 'pngquant' over 'optipng' if it is installed

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -190,6 +190,8 @@ Requires(post): os-autoinst >= 4.6
 Recommends:     qemu
 # Needed for caching - not required if caching not used...
 Recommends:     rsync
+# Optionally enabled with USE_PNGQUANT=1
+Recommends:     pngquant
 %if 0%{?suse_version} >= 1330
 Requires(pre):  group(nogroup)
 %endif

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -57,6 +57,12 @@ SUT behavior as the execution of the first step after loading a snapshot might
 be delayed. This can lead to problems if the executed tests do not foresee an
 appropriate timeout margin.
 
+On some less powerful systems (like Raspberry Pi), reducing screenshots size
+with optipng may take significant amount of time. In this case, you can switch
+to `pngquant` which is significantly faster, but uses lossy compression. To do
+that, install `pngquant` package and set `USE_PNGQUANT=1` in worker or job
+settings.
+
 [[db-migration]]
 == DB migration from SQlite to postgreSQL
 As a first step to start using postgreSQL, please, configure postgreSQL database

--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -96,6 +96,7 @@
   /usr/bin/nice rix,
   /usr/bin/swtpm rix,
   /usr/bin/optipng rix,
+  /usr/bin/pngquant rix,
   /usr/bin/ping rix,
   /{usr/,}bin/pwd rix,
   /usr/bin/python3.* ix,

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1174,7 +1174,11 @@ subtest 'Dynamic schedule' => sub {
 };
 
 subtest 'optipng' => sub {
-    is OpenQA::Worker::Job::_optimize_image('foo'), undef, 'optipng call is "best-effort"';
+    is OpenQA::Worker::Job::_optimize_image('foo', {}), undef, 'optipng call is "best-effort"';
+};
+
+subtest 'pngquant' => sub {
+    is OpenQA::Worker::Job::_optimize_image('foo', {USE_PNGQUANT => 1}), undef, 'pngquant call is "best-effort"';
 };
 
 subtest '_read_module_result' => sub {


### PR DESCRIPTION
pngquant is significantly faster than optipng. On powerful server it
probably doesn't matter much, but on Raspberry Pi, optipng is unusably
slow (it takes over 15s to process one image). pngquant is significantly
faster - about 1s on the same image.