### PR TITLE
Add --links option to openqa-cli for pagination

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -26,6 +26,7 @@ sub command ($self, @args) {
       'd|data=s' => \$data,
       'f|form' => \my $form,
       'j|json' => \my $json,
+      'L|links' => \my $links,
       'param-file=s' => \my @param_file,
       'p|pretty' => \my $pretty,
       'q|quiet' => \my $quiet,
@@ -53,7 +54,7 @@ sub command ($self, @args) {
     do {
         $tx = $client->start($tx);
         my $res_code = $tx->res->code // 0;
-        return $self->handle_result($tx, {pretty => $pretty, quiet => $quiet, verbose => $verbose})
+        return $self->handle_result($tx, {pretty => $pretty, quiet => $quiet, links => $links, verbose => $verbose})
           unless $res_code =~ /50[23]/ && $retries > 0;
         print "Request failed, hit error $res_code, retrying up to $retries more times after waiting ...\n";
         sleep($ENV{OPENQA_CLI_RETRY_SLEEP_TIME_S} // 3);
@@ -148,6 +149,7 @@ sub command ($self, @args) {
                                   from command line arguments. Multiple params
                                   may be specified by adding the option
                                   multiple times
+    -L, --links                   Print pagination links to STDERR
     -p, --pretty                  Pretty print JSON content
     -q, --quiet                   Do not print error messages to STDERR
     -r, --retries <retries>       Retry up to the specified value on some

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -41,6 +41,13 @@ sub handle_result ($self, $tx, $options) {
     my $err = $res->error;
     my $is_connection_error = $err && !$err->{code};
 
+    if ($options->{links}) {
+        my $links = $res->headers->links;
+        for my $rel (sort keys %$links) {
+            print STDERR colored(['green'], "$rel: $links->{$rel}{link}", "\n");
+        }
+    }
+
     if ($options->{verbose} && !$is_connection_error) {
         my $version = $res->version;
         my $code = $res->code;

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -100,6 +100,9 @@ sub run ($self, @args) {
 }
 
 sub url_for ($self, $path) {
+    # Already absolute URL
+    return Mojo::URL->new($path) if $path =~ m!^(?:[^:/?#]+:|//|#)!;
+
     $path = "/$path" unless $path =~ m!^/!;
     return Mojo::URL->new($self->apibase . $path)->to_abs(Mojo::URL->new($self->host));
 }

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -466,6 +466,12 @@ subtest 'Pagination links' => sub {
     like $stderr, qr!next:.+/api/v1/test/op/hello\?offset=5!, 'links printed';
     is $stdout, "Hello operator!\n", 'request body';
 
+    $stderr =~ /(http.+offset=5)/;
+    my $next = $1;
+    ($stdout, $stderr, @result) = capture sub { $api->run(@host, '-L', $next) };
+    like $stderr, qr!next:.+/api/v1/test/op/hello\?offset=5!, 'links printed';
+    is $stdout, "Hello operator!\n", 'request body';
+
     ($stdout, $stderr, @result) = capture sub { $api->run(@host, '/test/op/hello') };
     is $stderr, '', 'no links printed';
     is $stdout, "Hello operator!\n", 'request body';


### PR DESCRIPTION
I've been thinking about how to use pagination from `openqa-cli`, and a flag that prints all the links to STDERR seems like a reasonable first step.
<img width="627" alt="pagination" src="https://user-images.githubusercontent.com/30094/205091729-b54fec14-1eb0-460e-a440-3e1f0a5abd8c.png">
It's a very unobtrusive change, since you have to opt-in with the `--links` flag. The green highlighting helps to separate it from the normal response body on STDOUT.