### PR TITLE
Protect one asset size update from possible deadlocks

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -36,7 +36,9 @@ END_SQL
     $schema->txn_do(
         sub {
             $sth->execute($type, $name);    # ensure asset exists
-            return undef unless my $asset = $self->find({type => $type, name => $name}, {key => 'assets_type_name'});
+            return undef
+              unless my $asset
+              = $self->find({type => $type, name => $name}, {key => 'assets_type_name', for => 'update'});
             $asset->refresh_size if $options->{refresh_size};
             if (my $created_by = $options->{created_by}) {
                 my $scope = $options->{scope} // 'public';


### PR DESCRIPTION
This will probably not fix the actual deadlock issue, but using a `SELECT...FOR UPDATE` before the actual `UPDATE` query while inside a transaction is good defensive programming.

I supsect that the other `$asset->refresh_size` call in `OpenQA::Schema::Result::Jobs` is responsible for the deadlock. This change will prove it.

Progress: https://progress.opensuse.org/issues/120891