### PR TITLE
Fix race-condition reading job module details files

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -90,10 +90,9 @@ sub results {
     return {} unless my $dir = $self->job->result_dir;
     my $name = $self->name;
 
-    return {} unless -r (my $file = path($dir, "details-$name.json"));
-
-    my $json_data = $file->slurp;
-    die qq{Malformed JSON file "$file": $@} unless my $json = eval { decode_json($json_data) };
+    my $file = path($dir, "details-$name.json");
+    return {} unless my $json_data = eval { $file->slurp };
+    die qq{Malformed/unreadable JSON file "$file": $@} unless my $json = eval { decode_json($json_data) };
 
     # load detail file which restores all results provided by os-autoinst (with hash-root)
     # support also old format which only restores details information (with array-root)


### PR DESCRIPTION
A not readable test module result file is handled and gracefully
returned to the web UI and no error in log. The handling should be
atomic, not "check if readable and then read". Instead of trying to read
and then fail we should handle the read attempt as we handle the
exception in line 96 and return {} in case of error.

Related progress issue: https://progress.opensuse.org/issues/121444