### PR TITLE
Support use-case of "local" worker when detecting worker address

### DIFF
--- a/lib/OpenQA/Client/Handler.pm
+++ b/lib/OpenQA/Client/Handler.pm
@@ -5,6 +5,7 @@ package OpenQA::Client::Handler;
 use Mojo::Base 'Mojo::EventEmitter', -signatures;
 
 use OpenQA::Client;
+use OpenQA::Utils qw(is_host_local);
 
 has client => sub { OpenQA::Client->new };
 
@@ -25,11 +26,6 @@ sub _build_url ($self, $uri) {
 
 sub _build_post { $_[0]->client->build_tx(POST => shift()->_build_url(+shift()) => form => +shift()) }
 
-sub is_local {
-    my $self = shift;
-    my $host = $self->_build_url('/')->to_abs->host;
-    return $host eq 'localhost' || $host eq '127.0.0.1' || $host eq '[::1]';
-}
-
+sub is_local ($self) { is_host_local($self->_build_url('/')->to_abs->host) }
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -132,6 +132,7 @@ our @EXPORT = qw(
   check_df
   download_rate
   download_speed
+  is_host_local
 );
 
 our @EXPORT_OK = qw(
@@ -943,5 +944,7 @@ sub download_speed ($start, $end, $bytes) {
     my $human = human_readable_size($rate);
     return "$human/s";
 }
+
+sub is_host_local ($host) { $host eq 'localhost' || $host eq '127.0.0.1' || $host eq '[::1]' }
 
 1;

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -498,9 +498,11 @@ subtest 'checking and cleaning pool directory' => sub {
 
 subtest 'checking worker address' => sub {
     my $fqdn_lookup_mock = Test::MockModule->new('OpenQA::Worker::Settings');
-    undef $global_settings->{WORKER_HOSTNAME};
+    ok !$settings->is_local_worker, 'not considered local initially because we have https://remotehost configured';
+    $global_settings->{WORKER_HOSTNAME} = undef;
+    $settings->{_worker_address_auto_detected} = 0;
     $fqdn_lookup_mock->redefine(hostfqdn => undef);    # no hostname at all
-    $worker->settings->auto_detect_worker_address('some-fallback');
+    $settings->auto_detect_worker_address('some-fallback');
     is $global_settings->{WORKER_HOSTNAME}, 'some-fallback', 'fallback assigned without anything else';
     like $worker->check_availability, qr/Unable.*worker address/, 'the fallback is not considered good enough';
 
@@ -510,18 +512,15 @@ subtest 'checking worker address' => sub {
 
     $fqdn_lookup_mock->redefine(hostfqdn => 'foobar');    # only a "short" hostname available but not an FQDN
     $global_settings->{WORKER_HOSTNAME} = 'foo';    # but assume WORKER_HOSTNAME has been specified explicitly …
-    undef $worker->settings->{_worker_address_auto_detected};    # … by resetting auto-detected flag
+    undef $settings->{_worker_address_auto_detected};    # … by resetting auto-detected/required flags
     is $worker->check_availability, undef, 'no error if worker address explicitly specified (also if no FQDN)';
     is $global_settings->{WORKER_HOSTNAME}, 'foo', 'explicitly specified worker address not overridden';
 
     $global_settings->{WORKER_HOSTNAME} = undef;    # assume WORKER_HOSTNAME has not been explicitly specified
-    like $worker->check_availability, qr/Unable.*worker address/, 'a short hostname is not considered good enough';
-    is $global_settings->{WORKER_HOSTNAME}, 'foobar', 'short hostname is assigned';
+    $settings->{_local} = 1;    # and that it is a local worker
+    is $worker->check_availability, undef, 'a local worker does not require auto-detection to work';
+    is $global_settings->{WORKER_HOSTNAME}, 'localhost', '"localhost" assumed as WORKER_HOSTNAME for local worker';
 };
-
-# assign *some* WORKER_HOSTNAME so subsequent tests can run jobs (without requiring network)
-$worker->settings->{_worker_address_auto_detected} = undef;
-$global_settings->{WORKER_HOSTNAME} = '127.0.0.1';
 
 subtest 'handle client status changes' => sub {
     my $fake_client = OpenQA::Worker::WebUIConnection->new('some-host', {apikey => 'foo', apisecret => 'bar'});

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -52,6 +52,15 @@ is_deeply(
 
 delete $ENV{OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE};
 
+subtest 'check for local worker' => sub {
+    ok !$settings->is_local_worker, 'not considered local worker due to remotehost and despite localhost:9527';
+
+    $settings->{_local} = undef;
+    $settings->webui_hosts->[1] = 'https://[::1]';    # test whether an IPv6 address works
+    $settings->webui_hosts->[2] = 'localhost';    # test whether a "URL" without host/authority and only a path works
+    ok $settings->is_local_worker, 'considered local with localhost:9527 and remotehost being changed to ::1';
+};
+
 subtest 'apply settings to app' => sub {
     my ($setup_log_called, $setup_log_app);
     my $mock = Test::MockModule->new('OpenQA::Worker::Settings');


### PR DESCRIPTION
* Allow overriding WORKER_HOSTNAME as before (in which case the
  worker never considers itself broken, even if the override is
  no valid FQDN/IP)
* Assign "localhost" as fallback for local worker setups (where
  all HOSTs are local web UI instances) not requiring an FQDN
* Consider worker still broken for remote worker setups unless
  an FQDN could be detected or WORKER_HOSTNAME has been
  specified explicitly
* See https://progress.opensuse.org/issues/121567
  and https://progress.opensuse.org/issues/120261#note-42