### PR TITLE
Increase timeouts of tests api/14 and ui/13

### DIFF
--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -6,7 +6,7 @@ use Test::Most;
 use IPC::Run qw(start);
 use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
-use OpenQA::Test::TimeLimit '16';
+use OpenQA::Test::TimeLimit '30';
 use OpenQA::Test::ObsRsync 'setup_obs_rsync_test';
 use Mojo::IOLoop;
 use Time::HiRes 'sleep';

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -10,7 +10,7 @@ use File::Path qw(remove_tree);
 use File::Spec::Functions 'catfile';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
-use OpenQA::Test::TimeLimit '20';
+use OpenQA::Test::TimeLimit '40';
 use OpenQA::SeleniumTest;
 use OpenQA::Test::Case;
 use OpenQA::Utils 'assetdir';


### PR DESCRIPTION
This PR would increase the timeout of tests:

- api/14-plugin_obs_rsync_async.t
- ui/13-admin.t

They failed on KVM machine with 14 cores host-passthrough and 16 GiB RAM otherwise.