### PR TITLE
Protect second asset size update from possible deadlocks

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1515,10 +1515,11 @@ sub register_assets_from_settings ($self) {
         $updated{$k} = $name;
     }
 
-    for my $asset_info (values %assets) {
+    # ensure assets are updated in a consistent order across multiple processes to avoid ordering deadlocks
+    for my $asset_info (sort { $a->{name} cmp $b->{name} } values %assets) {
         # avoid plain create or we will get unique constraint problems
         # in case ISO_1 and ISO_2 point to the same ISO
-        my $asset = $assets->find_or_create($asset_info);
+        my $asset = $assets->find_or_create($asset_info, {for => 'update'});
         $asset->ensure_size;
         $self->jobs_assets->find_or_create({asset_id => $asset->id});
     }


### PR DESCRIPTION
We are dealing with an update order deadlock here. Imagine two processes are running an update query for three rows against the same table. Process 1 updates the rows in order A, B, C. Process 2 updates them in order C, B, A. Now process 1 holds the lock on A and is waiting for the lock on C, while process 2 holds the lock on C and is waiting for A. We have a deadlock that PostgreSQL cannot resolve on its own.

This is a similar case, the random order just happens to come from the Perl side in form of a `values %assets`. To fix that we ensure a consistent order based on the asset name. Additionally we also defensively use a `SELECT...FOR UPDATE` before the `UPDATE`.

Progress: https://progress.opensuse.org/issues/120891