### PR TITLE
Handle dead job status outside of transactions

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -337,10 +337,10 @@ sub reschedule_state ($self, $state = OpenQA::Jobs::Constants::SCHEDULED) {
             result => NONE
         });
 
-    log_debug('Job ' . $self->id . " reset to state $state");
-
     # free the worker
     if (my $worker = $self->worker) { $worker->update({job_id => undef}) }
+
+    return 'Job ' . $self->id . " reset to state $state";
 }
 
 sub log_debug_job ($self, $msg) { log_debug('[Job#' . $self->id . '] ' . $msg) }


### PR DESCRIPTION
As per https://metacpan.org/pod/DBIx::Class::Storage#txn_do results assuming a transaction was executed should only be logged after the entire coderef was executed.

See: https://progress.opensuse.org/issues/121768