### PR TITLE
Add postgresql service to requirements

### DIFF
--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -3,7 +3,7 @@ Description=The openQA web UI
 Wants=apache2.service openqa-setup-db.service
 Before=apache2.service
 After=postgresql.service openqa-setup-db.service openqa-scheduler.service nss-lookup.target remote-fs.target
-Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
+Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service postgresql.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
 
 [Service]
 User=geekotest


### PR DESCRIPTION
If this unit gets activated, the units listed in Requires= will be activated as well. If one of the other units fails to activate, and an ordering dependency After= on the failing unit is set, this unit will not be started. Besides, with or without specifying After=, this unit will be stopped (or restarted) if one of the other units is explicitly stopped (or restarted).

Reference: https://progress.opensuse.org/issues/122578