### PR TITLE
Try running the full-stack test without retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ test-unstable:
 
 .PHONY: test-fullstack
 test-fullstack:
-	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=30 RETRY=15 PROVE_ARGS="$$HARNESS t/full-stack.t"
+	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=30 PROVE_ARGS="$$HARNESS t/full-stack.t"
 
 .PHONY: test-fullstack-unstable
 test-fullstack-unstable:


### PR DESCRIPTION
Manual testing has shown the test to be very stable now. So we can try running it without retry in CI. That should give us enough data points to conclude if the sporadic failures have really been resolved.

Progress: https://progress.opensuse.org/issues/120226