### PR TITLE
Revert "Add postgresql service to requirements"

### DIFF
--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -3,7 +3,7 @@ Description=The openQA web UI
 Wants=apache2.service openqa-setup-db.service
 Before=apache2.service
 After=postgresql.service openqa-setup-db.service openqa-scheduler.service nss-lookup.target remote-fs.target
-Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service postgresql.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
+Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
 
 [Service]
 User=geekotest


### PR DESCRIPTION
Reverts os-autoinst/openQA#4971 as that would mean any openQA instance using a remote database would fail to start requiring a local postgresql.service running as well.