### PR TITLE
Add postgresql service to requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,12 @@ install-generic:
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf
 	install -m 644 systemd/tmpfiles-openqa-webui.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa-webui.conf
+	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-gru.service.requires
+	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-gru.service.requires/postgresql.service
+	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-scheduler.service.requires
+	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-scheduler.service.requires/postgresql.service
+	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-websockets.service.requires
+	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-websockets.service.requires/postgresql.service
 #
 # install openQA apparmor profile
 	install -d -m 755 "$(DESTDIR)"/etc/apparmor.d

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -537,8 +537,11 @@ fi
 %{_unitdir}/openqa-webui.service
 %{_unitdir}/openqa-livehandler.service
 %{_unitdir}/openqa-gru.service
+%dir %{_unitdir}/openqa-gru.service.requires
 %{_unitdir}/openqa-scheduler.service
+%dir %{_unitdir}/openqa-scheduler.service.requires
 %{_unitdir}/openqa-websockets.service
+%dir %{_unitdir}/openqa-websockets.service.requires
 %{_unitdir}/openqa-enqueue-audit-event-cleanup.service
 %{_unitdir}/openqa-enqueue-audit-event-cleanup.timer
 %{_unitdir}/openqa-enqueue-asset-cleanup.service
@@ -709,6 +712,9 @@ fi
 
 %files local-db
 %{_unitdir}/openqa-setup-db.service
+%{_unitdir}/openqa-gru.service.requires/postgresql.service
+%{_unitdir}/openqa-scheduler.service.requires/postgresql.service
+%{_unitdir}/openqa-websockets.service.requires/postgresql.service
 %{_datadir}/openqa/script/setup-db
 %{_bindir}/openqa-setup-db
 


### PR DESCRIPTION
Use openqa-webui.service.requires/ and add the requirement only if openQA-local-db is installed.

If this unit gets activated, the units listed in Requires= will be activated as well. If one of the other units fails to activate, and an ordering dependency After= on the failing unit is set, this unit will not be started. Besides, with or without specifying After=, this unit will be stopped (or restarted) if one of the other units is explicitly stopped (or restarted).

Reference: https://progress.opensuse.org/issues/122578