### PR TITLE
Avoid race condition by waiting for the #text element

### DIFF
--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -471,6 +471,7 @@ subtest 'editing when logged in as regular user' => sub {
         $driver->get('/tests/99938#comments');
         wait_for_ajax(msg => 'comments tab for job 99938 loaded');
         no_edit_no_remove_on_other_comments_expected;
+        wait_for_element(selector => '#text', description => 'comment form is displayed');
         $driver->find_element_by_id('text')->send_keys('test by nobody');
         $driver->find_element_by_id('submitComment')->click();
         wait_for_ajax(msg => 'comment for job 99938 added by regular user');


### PR DESCRIPTION
It seems there's a race condition where the comment form element is not ready in some cases. I could replicate the issue in about 2 of 300 test runs. After adding the `wait_for_element` call i've had the test pass about 600 times without any issues. So this might be a good enough fix.

Progress: https://progress.opensuse.org/issues/121042