### PR TITLE
Fix asset cache error handling to avoid proceeding in case of failures

### DIFF
--- a/lib/OpenQA/CacheService/Client.pm
+++ b/lib/OpenQA/CacheService/Client.pm
@@ -12,6 +12,7 @@ use OpenQA::CacheService::Response::Status;
 use OpenQA::Utils qw(base_host service_port);
 use Socket qw(AF_INET IPPROTO_TCP SOCK_STREAM pack_sockaddr_in inet_aton);
 use Mojo::URL;
+use Mojo::UserAgent;
 use Mojo::File 'path';
 use Regexp::Common qw(net);
 

--- a/lib/OpenQA/CacheService/Controller/API.pm
+++ b/lib/OpenQA/CacheService/Controller/API.pm
@@ -18,8 +18,13 @@ sub status ($self) {
     # Our Minion job will finish early if another job is already downloading,
     # so we have to check if the lock has been released yet too
     my $status = {status => 'downloading'};
-    if ($info->{state} eq 'finished' && !$self->progress->is_downloading($info->{notes}{lock})) {
-        $status = {status => 'processed', result => $info->{result}, output => $info->{notes}{output}};
+    my $notes = $info->{notes};
+    if ($info->{state} eq 'finished' && !$self->progress->is_downloading($notes->{lock})) {
+        $status = {
+            status => 'processed',
+            result => $info->{result},
+            output => $notes->{output},
+            has_download_error => $notes->{has_download_error}};
 
         # Output from the job that actually did the download
         if (my $id = $info->{notes}{downloading_job}) {

--- a/lib/OpenQA/CacheService/Response/Status.pm
+++ b/lib/OpenQA/CacheService/Response/Status.pm
@@ -6,6 +6,7 @@ use Mojo::Base 'OpenQA::CacheService::Response', -signatures;
 
 sub is_downloading ($self) { ($self->data->{status} // '') eq 'downloading' }
 sub is_processed ($self) { ($self->data->{status} // '') eq 'processed' }
+sub is_success ($self) { !$self->has_error && !$self->data->{has_download_error} }
 sub output ($self) { $self->has_error ? $self->error : $self->data->{output} }
 sub result ($self) { $self->data->{result} }
 

--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -3,6 +3,7 @@
 
 package OpenQA::CacheService::Task::Asset;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
+use Mojo::JSON;
 
 sub register ($self, $app, $conf) { $app->minion->add_task(cache_asset => \&_cache_asset) }
 
@@ -33,8 +34,9 @@ sub _cache_asset ($job, $id, $type = undef, $asset_name = undef, $host = undef) 
             $output .= join("\n", map { "[$level] [#$job_id] $_" } @lines) . "\n";
         });
     my $cache = $app->cache->log($log)->refresh;
-    $cache->get_asset($host, {id => $id}, $type, $asset_name);
+    my $error = $cache->get_asset($host, {id => $id}, $type, $asset_name);
     $job->note(output => $output);
+    $job->note(has_download_error => $error ? Mojo::JSON->true : Mojo::JSON->false);
     $log->info('Finished download');
 }
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -138,7 +138,7 @@ sub _handle_asset_processed ($cache_client, $this_asset, $asset_uri, $status, $v
     log_info($msg, channels => 'autoinst');
 
     my $asset
-      = $cache_client->asset_exists($webui_host, $asset_uri)
+      = $status->is_success && $cache_client->asset_exists($webui_host, $asset_uri)
       ? $cache_client->asset_path($webui_host, $asset_uri)
       : undef;
     if ($this_asset eq 'UEFI_PFLASH_VARS' && !defined $asset) {

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -251,6 +251,12 @@ subtest '_handle_asset_processed' => sub {
     @args = (OpenQA::CacheService::Client->new, 'UEFI_PFLASH_VARS', $asset_uri, $status, $vars, undef, undef);
     is OpenQA::Worker::Engines::isotovideo::_handle_asset_processed(@args), undef, 'no error for UEFI_PFLASH_VARS';
     is $vars->{UEFI_PFLASH_VARS}, $asset_uri, 'specified asset URI set to vars';
+
+    $args[1] = 'HDD_1';    # assume a normal asset (to not run into the special case of UEFI_PFLASH_VARS)
+    $status->data->{has_download_error} = 1;    # assume download error
+    $error = OpenQA::Worker::Engines::isotovideo::_handle_asset_processed(@args);
+    is ref $error, 'HASH', 'error when download failed although asset is still existing'
+      and $error->{error}, 'Failed to download path2 to some/path2', 'expected error message returned';
 };
 
 subtest 'syncing tests' => sub {

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -147,6 +147,8 @@ sub test_download ($id, $asset) {
 
     # And then goes to PROCESSED state
     ok $status->is_processed, 'only other state is processed';
+    ok exists $status->data->{has_download_error}, 'whether a download error happened is added to status info';
+    ok !$status->data->{has_download_error}, 'no download error occurred';
 
     ok($cache_client->asset_exists('localhost', $asset), "Asset downloaded id $id, asset $asset");
     ok($asset_request->minion_id, "Minion job id recorded in the request object") or die diag explain $asset_request;

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -156,10 +156,11 @@ start_server;
 $cache->limit(1024);
 $cache->refresh;
 
-$cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-404@64bit.qcow2');
+my $res = $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-404@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-404\@64bit.qcow2" from/, 'Asset download attempt';
 like $cache_log, qr/failed: 404/, 'Asset download fails with: 404 Not Found';
 $cache_log = '';
+like $res, qr/Download of ".*qcow2" failed: 404 Not Found/, 'download error returned';
 
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-400@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-400\@64bit.qcow2" from/, 'Asset download attempt';
@@ -272,11 +273,12 @@ subtest 'cache purging after successful download' => sub {
     undef $cache_mock;
 };
 
-$cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_#:@64bit.qcow2');
+$res = $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_#:@64bit.qcow2');
 like $cache_log, qr/Download of ".*sle-12-SP3-x86_64-0368-200_#:.*" successful \([\d\.]+ \w+\/s\)/,
   'Asset with special characters was downloaded successfully';
 like $cache_log, qr/Size of .* is 20 Byte, with ETag "123456789"/, 'Etag and size are logged';
 $cache_log = '';
+is $res, undef, 'no error returned for successful download' or diag explain $res;
 
 $cache->get_asset("http://$host", {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200\@64bit.qcow2" from/, 'Asset download attempt';


### PR DESCRIPTION
So far the cache service doesn't treat download errors as such when the
asset is still present locally. However, that's not a good idea because the
local version might be outdated and problems on the server-side might only
surface later (on the next cache cleanup) which makes the investigation
more difficult (see https://progress.opensuse.org/issues/122776).

This change tracks whether the download has actually been succeeded instead
of only checking whether the cached asset exists locally.

Note assets that are locally cached are *not* re-downloaded unless the
asset has changed on the server. However, to check whether the asset has
changed on the server an HTTP request is done that might fail. With this
change this error case is now not ignored anymore.

---

~~Still a draft as tests maybe need to be adapted/extended.~~ However, I've already
tested it locally having the cache service enabled locally and by provoking
a download error for an already cached asset. Of course I've also tested the case
of not running into any download errors.