### PR TITLE
Avoid deadlock when updating asset size during job creation

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1517,7 +1517,7 @@ sub register_assets_from_settings ($self) {
         # in case ISO_1 and ISO_2 point to the same ISO
         # note: Not updating the asset size here as doing it in this big transaction
         #       would lead to deadlocks (see poo#120891).
-        my $asset = $assets->find_or_create($asset_info, {for => 'update'});
+        my $asset = $assets->find_or_create($asset_info);
         $self->jobs_assets->find_or_create({asset_id => $asset->id});
     }
 


### PR DESCRIPTION
* Remove `FOR UPDATE` when inserting assets on job creation to actually not acquire a write lock
* Follow-up of 79ba646617ebeb74a81ff2e61dd8f30ac3143feb which removed the update but not the locking
* See https://progress.opensuse.org/issues/120891