### PR TITLE
Fix build by providing postgresql during build

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -224,6 +224,7 @@ Summary:        Helper package to ease setup of postgresql DB
 Group:          Development/Tools/Other
 Requires:       %name
 Requires:       postgresql-server
+BuildRequires:  postgresql-server
 Supplements:    packageand(%name:postgresql-server)
 
 %description local-db


### PR DESCRIPTION
This should fix the build problem mentioned in #4976 

```
[   59s] ERROR: link target doesn't exist (neither in build root nor in installed system):
[   59s]   /usr/lib/systemd/system/openqa-gru.service.requires/postgresql.service -> /usr/lib/systemd/system/postgresql.service
[   59s] Add the package providing the target to BuildRequires and Requires
```

Reference: https://progress.opensuse.org/issues/122578