### PR TITLE
Avoid another race condition by waiting for the #text element

### DIFF
--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -489,6 +489,7 @@ subtest 'editing when logged in as regular user' => sub {
         only_edit_for_own_comments_expected;
 
         # pinned comments are not shown (pinning is only possible when commentator is operator)
+        wait_for_element(selector => '#text', description => 'comment form is displayed');
         $driver->find_element_by_id('text')->send_keys($description_test_message);
         $driver->find_element_by_id('submitComment')->click();
         wait_for_ajax(msg => 'comment with pinning for group added by regular user');


### PR DESCRIPTION
Similar to the previous race condition from #4978. Found by Marius this time, but i've been unable to replicate it locally. Applying the same `wait_for_element` to ensure that the comment field is visible should resolve this as well though. The test code is almost exactly the same.

Progress: https://progress.opensuse.org/issues/121042