### PR TITLE
Fix error when displaying help for minion sub command

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -341,7 +341,7 @@ sub setup_mojo_tmpdir () {
     }
 }
 
-sub load_plugins ($server, $monitoring_root_route, %options) {
+sub load_plugins ($server, $monitoring_root_route = undef, %options) {
     push @{$server->plugins->namespaces}, 'OpenQA::WebAPI::Plugin';
     $server->plugin($_) for qw(Helpers MIMETypes CSRF REST HashedParams Gru YAML);
     $server->plugin('AuditLog') if $server->config->{global}{audit_enabled};


### PR DESCRIPTION
This fixes the error
```
Too few arguments for subroutine 'OpenQA::Setup::load_plugins' at /usr/share/openqa/script/../lib/OpenQA/WebAPI.pm line 30.
```
when invoking e.g.
```
/usr/share/openqa/script/openqa minion job --help
```