### PR TITLE
Avoid errors about changing the working directory after asset extraction

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -19,6 +19,7 @@
   /tmp/** rwk,
   /usr/bin/dash ix,
   /usr/bin/perl ix,
+  /usr/bin/pwd ix,
   /usr/bin/ssh rcx,
   /usr/bin/timeout rix,
   /usr/bin/unzip{,-plain} rix,


### PR DESCRIPTION
* Set working directory explicitly before invoking archive extraction via `Archive::Extract`
    * Otherwise `cwd` returns an empty string in the case the working directory doesn't exist anymore which is then used by `Archive::Extract` which then runs into an error due to it.
    * Note that the error would not cause an actual problem as it is ignored anyways; however the log message due to it is not nice and avoided by this change.
* See https://progress.opensuse.org/issues/123649

---

Still a draft as I'll have to check whether it actually works on o3. (I've just noticed that my reproducer wouldn't reproduce the issue anymore anyways as the download is already 404.)