### PR TITLE
ci: Point out how to fix an empty cache

### DIFF
--- a/tools/ci/build_or_install_from_cache.sh
+++ b/tools/ci/build_or_install_from_cache.sh
@@ -3,6 +3,6 @@ set -ex
 if [ -z "$CIRCLE_WORKFLOW_ID" ]; then
     bash "$(dirname "$0")"/build_cache.sh
 else
-    packages=$(find /var/cache/zypp/packages/ | grep '.rpm$') || { echo "No RPM packages found, cache is empty, aborting" && exit 1; }
+    packages=$(find /var/cache/zypp/packages/ | grep '.rpm$') || { echo "No RPM packages found. The cache is empty. Please trigger a cache.fullstack job manually to ensure a cache is available for the latest version." && exit 1; }
     sudo rpm -i -f $packages
 fi


### PR DESCRIPTION
The cache is tied to the checksums and may not be generated in time when there is a temporary outage or fewer PRs have been prepared.

See: https://progress.opensuse.org/issues/123867