### PR TITLE
Improve appearance of tables

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -2,7 +2,6 @@
 # download the fonts
 < https://cdn.datatables.net/1.10.16/css/dataTables.bootstrap4.css
 < https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css
-< stylesheets/openqa.scss
 < https://raw.githubusercontent.com/bootstrapthemesco/bootstrap-4-multi-dropdown-navbar/beta2.0/css/bootstrap-4-navbar.css
 < https://cdnjs.cloudflare.com/ajax/libs/chosen/1.7.0/chosen.css
 << https://raw.githubusercontent.com/twbs/bootstrap/v4.6.1/scss/bootstrap.scss
@@ -94,6 +93,7 @@
 << https://raw.githubusercontent.com/twbs/bootstrap/v4.6.1/scss/utilities/_visibility.scss
 << https://raw.githubusercontent.com/twbs/bootstrap/v4.6.1/scss/vendor/_rfs.scss
 << https://raw.githubusercontent.com/twbs/bootstrap/v4.6.1/scss/_print.scss
+< stylesheets/openqa.scss
 < stylesheets/back_to_top.css
 
 ! dagre-d3.js

--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -2,52 +2,22 @@
 .table {
     border-collapse: separate;
     border-spacing: 0px;
+    border-radius: 0.2rem;
+    border: 1px solid $table-border-color;
+}
+.table th, .table td {
+    vertical-align: middle;
+}
+.table td {
+    border-top: 1px solid $table-border-color;
 }
 .table thead:first-child tr:first-child th {
     background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.0) 0%, rgba(0, 0, 0, 0.13)) !important;
     box-shadow: inset 0 1px 0 0 #fff;
-    border-bottom: 1px solid $table-border-color;
-    border-right: 0 solid $table-border-color;
-    border-top: 1px solid $table-border-color;
-}
-.table tbody td:first-child, .table thead th:first-child {
-    border-left: 1px solid $table-border-color;
-}
-.table tbody td:last-child, .table thead:first-child tr:first-child th:last-child {
-    border-right: 1px solid $table-border-color;
-}
-.table thead:first-child tr:first-child {
-    th:last-child {
-        border-radius: 0 0.2rem 0 0;
-    }
-    th:first-child
-    {
-        border-radius: 0.2rem 0 0 0;
-    }
-    th:only-child
-    {
-        border-radius: 0.2rem 0.2rem 0 0;
-    }
-}
-.table tbody tr:last-child {
-    td:first-child {
-        border-radius: 0 0 0 0.2rem;
-    }
-    td:only-child {
-        border-radius: 0 0 0.2rem 0.2rem;
-    }
-    td:last-child {
-        border-radius: 0 0 0.2rem 0;
-    }
-    td {
-        border-bottom: 1px solid $table-border-color;
-    }
+    border: none;
 }
 .darkmode {
-    .table thead:first-child tr:first-child th,
-    .table tbody td:first-child, .table thead th:first-child,
-    .table tbody td:last-child, .table thead:first-child tr:first-child th:last-child,
-    .table tbody tr:last-child td {
+    .table, .table td {
         border-color: $table-border-color-darktheme;
     }
     .table thead:first-child tr:first-child th {


### PR DESCRIPTION
Initially I only noticed that if the last <tr/> in a .table had "display: none" the bottom border would be missing entirely. The only way to address that was to redo the way the table border is laid out. This turned out to be shorter than the original code and fixes other issues like missing borders in dark mode.

Additionally, vertically center table contents explicitly. This requires including openqa.scss after bootstrap so that our declarations are preferred.

Before:

![Screenshot_20230207_113147](https://user-images.githubusercontent.com/1622084/217220656-aec75a4b-921d-497e-aa2e-6ff65809cf81.png)
![Screenshot_20230207_113310](https://user-images.githubusercontent.com/1622084/217220917-2b371294-1c93-4219-b835-2734176e9c51.png)

After:

![Screenshot_20230207_113034](https://user-images.githubusercontent.com/1622084/217220330-3e4d4b3a-1530-4626-8236-323a64191725.png)
![Screenshot_20230207_112935](https://user-images.githubusercontent.com/1622084/217220140-9983a611-fe85-432f-95b4-9a8e487748a4.png)
