### PR TITLE
Fix off-by-one error when limiting jobs API route using `latest=1`

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -120,10 +120,8 @@ sub list ($self) {
     my @jobarray = defined $latest ? $rs->latest_jobs : $rs->all;
 
     # Pagination
-    unless (defined $latest) {
-        pop @jobarray if my $has_more = @jobarray > $limit;
-        $self->pagination_links_header($limit, $offset, $has_more);
-    }
+    pop @jobarray if my $has_more = @jobarray > $limit;
+    $self->pagination_links_header($limit, $offset, $has_more) unless defined $latest;
     my %jobs = map { $_->id => $_ } @jobarray;
 
     # we can't prefetch too much at once as the resulting JOIN will kill our performance horribly

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1548,13 +1548,17 @@ subtest 'server-side limit has precedence over user-specified limit' => sub {
     my $jobs = $t->tx->res->json->{jobs};
     is ref $jobs, 'ARRAY', 'data returned (1)' and is scalar @$jobs, 5, 'maximum limit for jobs is effective';
 
-    $t->get_ok('/api/v1/jobs?limit=3', 'query with exceeding user-specified limit for jobs')->status_is(200);
+    $t->get_ok('/api/v1/jobs?limit=3', 'query with user-specified limit for jobs')->status_is(200);
     $jobs = $t->tx->res->json->{jobs};
     is ref $jobs, 'ARRAY', 'data returned (2)' and is scalar @$jobs, 3, 'user limit for jobs is effective';
 
+    $t->get_ok('/api/v1/jobs?latest=1&limit=2', 'query with user-specified limit for latest jobs')->status_is(200);
+    $jobs = $t->tx->res->json->{jobs};
+    is ref $jobs, 'ARRAY', 'data returned (3)' and is scalar @$jobs, 2, 'user limit for jobs is effective (latest)';
+
     $t->get_ok('/api/v1/jobs', 'query with (low) default limit for jobs')->status_is(200);
     $jobs = $t->tx->res->json->{jobs};
-    is ref $jobs, 'ARRAY', 'data returned (3)' and is scalar @$jobs, 2, 'default limit for jobs is effective';
+    is ref $jobs, 'ARRAY', 'data returned (4)' and is scalar @$jobs, 2, 'default limit for jobs is effective';
 };
 
 # delete the job with a registered job module


### PR DESCRIPTION
See https://progress.opensuse.org/issues/124230