### PR TITLE
Ensure consistent openQA version when installing openQA-local-db

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -222,7 +222,7 @@ Additional scripts for the use of openQA in the python programming language.
 %package local-db
 Summary:        Helper package to ease setup of postgresql DB
 Group:          Development/Tools/Other
-Requires:       %name
+Requires:       %{name} = %{version}
 Requires:       postgresql-server
 BuildRequires:  postgresql-server
 Supplements:    packageand(%name:postgresql-server)


### PR DESCRIPTION
As a step one, add version to openQA requirements for openQA-local-db as that package is to be picked and installed by the user.

Reference: https://progress.opensuse.org/issues/124316