### PR TITLE
Render bugrefs as clickable links within labels

### DIFF
--- a/lib/OpenQA/Markdown.pm
+++ b/lib/OpenQA/Markdown.pm
@@ -1,7 +1,7 @@
 # Copyright 2019 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 package OpenQA::Markdown;
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use Exporter 'import';
 use Regexp::Common 'URI';
@@ -28,6 +28,7 @@ sub is_light_color {
 sub markdown_to_html {
     my $text = shift;
 
+sub markdown_to_html ($text) {
     $text = bugref_to_markdown($text);
 
     # Turn all remaining URLs into links
@@ -47,8 +48,7 @@ sub markdown_to_html {
     return $html;
 }
 
-sub _custom {
-    my ($full, $rules, $text) = @_;
+sub _custom ($full, $rules, $text) {
     if ($rules =~ /^color:(#[a-fA-F0-9]{6})$/) {
         my $color = $1;
         my $bg = is_light_color($color) ? 'black' : 'white';

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -34,7 +34,7 @@ use Mojo::Util 'xml_escape';
 
 my $FRAG_REGEX = FRAGMENT_REGEX;
 
-my (%BUGREFS, %BUGURLS, $MARKER_REFS, $MARKER_URLS);
+my (%BUGREFS, %BUGURLS, $MARKER_REFS, $MARKER_URLS, $BUGREF_REGEX);
 BEGIN {
     %BUGREFS = (
         bnc => 'https://bugzilla.suse.com/show_bug.cgi?id=',
@@ -71,18 +71,20 @@ BEGIN {
 
     $MARKER_REFS = join('|', keys %BUGREFS);
     $MARKER_URLS = join('|', keys %BUGURLS);
+
+    # <marker>[#<project/repo>]#<id>
+    $BUGREF_REGEX = qr{(?<match>(?<marker>$MARKER_REFS)\#?(?<repo>[a-zA-Z/-]+)?\#(?<id>([A-Z]+-)?\d+))};
 }
 
-# <marker>[#<project/repo>]#<id>
-use constant BUGREF_REGEX =>
-  qr{(?:^|(?<=\s|,))(?<match>(?<marker>$MARKER_REFS)\#?(?<repo>[a-zA-Z/-]+)?\#(?<id>([A-Z]+-)?\d+))(?![\w\"])};
-
+use constant UNCONSTRAINED_BUGREF_REGEX => $BUGREF_REGEX;
+use constant BUGREF_REGEX => qr{(?:^|(?<=\s|,))$BUGREF_REGEX(?![\w\"])};
 use constant LABEL_REGEX => qr/\blabel:(?<match>([\w:#]+))\b/;
 
 our $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
 our @EXPORT = qw(
-  LABEL_REGEX
+  UNCONSTRAINED_BUGREF_REGEX
   BUGREF_REGEX
+  LABEL_REGEX
   locate_needle
   needledir
   productdir

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -58,8 +58,9 @@ subtest 'bugrefs' => sub {
       qq{<p>related issue: <a href="https://bugzilla.suse.com/show_bug.cgi?id=1234">bsc#1234</a>, yada yada</p>\n},
       'bugref expanded';
     is markdown_to_html('label:force_result:passed:bsc#1234'),
-      qq{<p><span class="openqa-label">label:force_result:passed:bsc#1234</span></p>\n},
-      'bugref not expanded because part of larger string';
+      qq{<p><span class="openqa-label">label:force_result:passed:}
+      . qq{<a href="https://bugzilla.suse.com/show_bug.cgi?id=1234">bsc#1234</a></span></p>\n},
+      'bugref expaned within label';
 };
 
 subtest 'openQA additions' => sub {


### PR DESCRIPTION
So one does not need to add a bugref just for the sake of having a
clickable link. This is especially useful as having a label and a bugref
in one comment has caveats. In particular, a `force_result` will not be
evaluated if the comment is carried over and the carry over itself prevents
hook scripts from running.

With this, the change https://github.com/os-autoinst/scripts/pull/155 could
be reverted.

Related ticket/note: https://progress.opensuse.org/issues/124029#note-4

---

![grafik](https://user-images.githubusercontent.com/10248953/218502675-123e6a14-4623-4012-a83e-9f46997261a5.png)
