### PR TITLE
Allow loading scenario definitions for scheduling an ISO/product from templates from YAML file

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1146,29 +1146,11 @@ template like this:
 
 [source,sh]
 --------------------------------------------------------------------------------
-products:
-  example:
-    distri: 'example'
-    version: '1'
-    flavor: 'DVD'
-    arch: 'x86_64'
-    settings:
-      REPO: 'http://…'
-machines:
-  64bit:
-    backend: 'qemu'
-    settings:
-      QEMURAM: '3072'
-      WORKER_CLASS: 'qemu_x86_64'
 job_templates:
   create_hdd:
-    product: 'example'
-    machine: '64bit'
     settings:
       PUBLISH_HDD_1: 'example-%VERSION%-%ARCH%-%BUILD%@%MACHINE%.qcow2'
   boot_from_hdd:
-    product: 'example'
-    machine: '64bit'
     settings:
       HDD_1: 'example-%VERSION%-%ARCH%-%BUILD%@%MACHINE%.qcow2'
       START_AFTER_TEST: 'create_hdd'

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1048,12 +1048,16 @@ openqa-cli api -X POST jobs TEST=test KEY:WITH:COLONS:=example
 ```
 
 ==== Spawning multiple jobs based on templates - isos post ====
-
 The most common way of spawning jobs on production instances is using the
-`isos post` API route. Based on previously defined settings for media, job
-groups, machines and test suites jobs are triggered based on template
-matching. The <<GettingStarted.asciidoc#gettingstarted,Getting Started>> guide already
-mentioned examples. Additionally to the necessary template matching parameters
+`isos post` API route. Based on settings for media, job groups, machines and
+test suites jobs are triggered based on template matching. These settings
+need to be defined before on the corresponding pages of the web UI (accessible
+to operators from the user menu). The
+<<UsersGuide.asciidoc#job_templates,section on job templates>> already explains
+details about these tables. Alternatively, these settings can be
+supplied via a <<UsersGuide.asciidoc#scenarios_yaml,YAML document>>.
+
+Additionally to the necessary template matching parameters
 more parameters can be specified which are forwarded to all triggered jobs.
 There are also special parameters which only have an influence on the way the
 triggering itself is done. These parameters all start with a leading
@@ -1108,6 +1112,72 @@ corresponding to the parameter `async=0`. Use `async=1` to avoid possible
 timeouts by performing the task in background.
 This is recommended on big instances but means that the results (and
 possible errors) need to be polled via `openqa-cli api isos/$scheduled_product_id`.
+
+[id="scenarios_yaml"]
+===== Defining test scenarios in YAML =====
+Instead of relying on the tables for machines, mediums/products, test suites and
+job templates of the openQA instance, one can provide these definitions/settings
+also via a YAML document. This YAML document could be specific to a certain test
+distribution and stored in the same repository as those tests (making the versioning
+easier).
+
+WARNING: This feature is still experimental and may change in an incompatible way
+in future versions.
+
+This YAML document can be specified via the scheduling parameter
+`SCENARIO_DEFINITIONS_YAML`:
+
+[source,sh]
+--------------------------------------------------------------------------------
+openqa-cli api … -X POST isos --param-file SCENARIO_DEFINITIONS_YAML=/local/file.yaml …
+--------------------------------------------------------------------------------
+
+This command will upload the contents of the local file `/local/file.yaml` to a
+possibly remote openQA instance. The YAML document will only be used within the
+scope of this particular API request. No settings are stored/altered on the openQA
+instance.
+
+If the YAML document already exists on the openQA host, you can also use
+`SCENARIO_DEFINITIONS_YAML_FILE` which expects the file path of the YAML document
+on the openQA host.
+
+The YAML document itself should define at least one product, machine and job
+template like this:
+
+[source,sh]
+--------------------------------------------------------------------------------
+products:
+  example:
+    distri: 'example'
+    version: '1'
+    flavor: 'DVD'
+    arch: 'x86_64'
+    settings:
+      REPO: 'http://…'
+machines:
+  64bit:
+    backend: 'qemu'
+    settings:
+      QEMURAM: '3072'
+      WORKER_CLASS: 'qemu_x86_64'
+job_templates:
+  create_hdd:
+    product: 'example'
+    machine: '64bit'
+    settings:
+      PUBLISH_HDD_1: 'example-%VERSION%-%ARCH%-%BUILD%@%MACHINE%.qcow2'
+  boot_from_hdd:
+    product: 'example'
+    machine: '64bit'
+    settings:
+      HDD_1: 'example-%VERSION%-%ARCH%-%BUILD%@%MACHINE%.qcow2'
+      START_AFTER_TEST: 'create_hdd'
+      WORKER_CLASS: 'job-specific-class'
+
+--------------------------------------------------------------------------------
+
+These definitions are used like their openQA-instance-wide counterparts (so continue
+reading the next section for more details on job templates).
 
 ==== Remarks ====
 

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -90,6 +90,9 @@ use constant MODULE_RESULTS => (CANCELLED, FAILED, NONE, PASSED, RUNNING, SKIPPE
 # common result files to be expected in all jobs
 use constant COMMON_RESULT_FILES => ('vars.json', 'autoinst-log.txt', 'worker-log.txt', 'worker_packages.txt');
 
+# defaults for new jobs that are useful outside the schema
+use constant DEFAULT_JOB_PRIORITY => 50;
+
 our @EXPORT = qw(
   ASSIGNED
   CANCELLED
@@ -125,6 +128,7 @@ our @EXPORT = qw(
   MODULE_RESULTS
   COMMON_RESULT_FILES
   TIMEOUT_EXCEEDED
+  DEFAULT_JOB_PRIORITY
 );
 
 # mapping from any specific job state/result to a meta state/result

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -69,7 +69,7 @@ __PACKAGE__->add_columns(
     },
     priority => {
         data_type => 'integer',
-        default_value => 50,
+        default_value => DEFAULT_JOB_PRIORITY,
     },
     result => {
         data_type => 'varchar',

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -795,10 +795,10 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, @load_yaml_args) {
         push @job_templates, $settings;
     }
 
-    my %result;
-    $result{settings_result} = _handle_dependency(\@job_templates, \%wanted, $skip_chained_deps);
-    $result{error_message} = $error_msg;
-    return \%result;
+    return {
+        settings_result => _handle_dependency(\@job_templates, \%wanted, $skip_chained_deps),
+        error_message => $error_msg,
+    };
 }
 
 sub _count_wanted_jobs ($args, $settings, $wanted) {

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -231,7 +231,7 @@ sub _schedule_iso {
     _delete_prefixed_args_storing_info_about_product_itself $args;
 
     my $result;
-    if (my $yaml_file = delete $args->{SCHEDULE_FROM_YAML_FILE}) {
+    if (my $yaml_file = delete $args->{SCENARIO_DEFINITIONS_YAML_FILE}) {
         $result = get_schedule_file($yaml_file);
         $result = $self->_schedule_from_yaml_file($args, $skip_chained_deps, $result->{file})
           unless $result->{error_message};

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -14,6 +14,7 @@ use OpenQA::App;
 use OpenQA::Log qw(log_debug log_warning log_error);
 use OpenQA::Utils;
 use OpenQA::JobSettings;
+use OpenQA::Jobs::Constants;
 use OpenQA::JobDependencies::Constants;
 use OpenQA::Scheduler::Client;
 use Mojo::JSON qw(encode_json decode_json);
@@ -777,7 +778,7 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, @load_yaml_args) {
                     $settings->{$_} = $machine_settings->{$_};
                 }
                 $settings->{BACKEND} = $mach->{backend} if $mach->{backend};
-                $settings->{PRIO} = $mach->{priority} // 50;
+                $settings->{PRIO} = $mach->{priority} // DEFAULT_JOB_PRIORITY;
             }
         }
         $settings->{WORKER_CLASS} = join ',', sort @worker_class if @worker_class > 0;

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -231,8 +231,13 @@ sub _schedule_iso {
     _delete_prefixed_args_storing_info_about_product_itself $args;
 
     my $result;
-    if (my $yaml_file = delete $args->{SCENARIO_DEFINITIONS_YAML_FILE}) {
-        $result = $self->_schedule_from_yaml_file($args, $skip_chained_deps, $yaml_file);
+    my $yaml = delete $args->{SCENARIO_DEFINITIONS_YAML};
+    my $yaml_file = delete $args->{SCENARIO_DEFINITIONS_YAML_FILE};
+    if (defined $yaml) {
+        $result = $self->_schedule_from_yaml($args, $skip_chained_deps, string => $yaml);
+    }
+    elsif (defined $yaml_file) {
+        $result = $self->_schedule_from_yaml($args, $skip_chained_deps, file => $yaml_file);
     }
     else {
         $result = $self->_generate_jobs($args, \@notes, $skip_chained_deps);
@@ -722,8 +727,8 @@ sub _create_download_lists {
     }
 }
 
-sub _schedule_from_yaml_file ($self, $args, $skip_chained_deps, $file) {
-    my $data = eval { load_yaml(file => $file) };
+sub _schedule_from_yaml ($self, $args, $skip_chained_deps, @load_yaml_args) {
+    my $data = eval { load_yaml(@load_yaml_args) };
     if (my $error = $@) { return {error_message => "Unable to load YAML: $error"} }
     my $app = OpenQA::App->singleton;
     my $validation_errors = $app->validate_yaml($data, 'JobScenarios-01.yaml', $app->log->level eq 'debug');

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -232,9 +232,7 @@ sub _schedule_iso {
 
     my $result;
     if (my $yaml_file = delete $args->{SCENARIO_DEFINITIONS_YAML_FILE}) {
-        $result = get_schedule_file($yaml_file);
-        $result = $self->_schedule_from_yaml_file($args, $skip_chained_deps, $result->{file})
-          unless $result->{error_message};
+        $result = $self->_schedule_from_yaml_file($args, $skip_chained_deps, $yaml_file);
     }
     else {
         $result = $self->_generate_jobs($args, \@notes, $skip_chained_deps);

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -801,8 +801,7 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, @load_yaml_args) {
     return \%result;
 }
 
-sub _count_wanted_jobs {
-    my ($args, $settings, $wanted) = @_;
+sub _count_wanted_jobs ($args, $settings, $wanted) {
     my @tests = $args->{TEST} ? split(/\s*,\s*/, $args->{TEST}) : ();
     if (!$args->{MACHINE} || $args->{MACHINE} eq $settings->{MACHINE}) {
         if (!@tests) {
@@ -819,8 +818,7 @@ sub _count_wanted_jobs {
     }
 }
 
-sub _handle_dependency {
-    my ($jobs, $wanted, $skip_chained_deps) = @_;
+sub _handle_dependency ($jobs, $wanted, $skip_chained_deps) {
     $jobs = _sort_dep($jobs);
     # the array is sorted parents first - iterate it backward
     for (my $i = $#{$jobs}; $i >= 0; $i--) {

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -726,7 +726,10 @@ sub _create_download_lists {
 
 sub _schedule_from_yaml_file ($self, $args, $skip_chained_deps, $file) {
     my $data = eval { load_yaml(file => $file) };
-    if (my $error = $@) { return {error_message => $error} }
+    if (my $error = $@) { return {error_message => "Unable to load YAML: $error"} }
+    my $app = OpenQA::App->singleton;
+    my $validation_errors = $app->validate_yaml($data, 'JobScenarios-01.yaml', $app->log->level eq 'debug');
+    return {error_message => "YAML validation failed:\n" . join("\n", @$validation_errors)} if @$validation_errors;
 
     my $products = $data->{products};
     my $machines = $data->{machines};

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -135,6 +135,7 @@ our @EXPORT = qw(
   download_rate
   download_speed
   is_host_local
+  get_schedule_file
 );
 
 our @EXPORT_OK = qw(
@@ -948,5 +949,11 @@ sub download_speed ($start, $end, $bytes) {
 }
 
 sub is_host_local ($host) { $host eq 'localhost' || $host eq '127.0.0.1' || $host eq '[::1]' }
+
+sub get_schedule_file {
+    my $file = shift;
+    # TODO git clone the repo file and return the file path or error_message
+    return {error_message => undef, file => $file};
+}
 
 1;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -135,7 +135,6 @@ our @EXPORT = qw(
   download_rate
   download_speed
   is_host_local
-  get_schedule_file
 );
 
 our @EXPORT_OK = qw(
@@ -949,11 +948,5 @@ sub download_speed ($start, $end, $bytes) {
 }
 
 sub is_host_local ($host) { $host eq 'localhost' || $host eq '127.0.0.1' || $host eq '[::1]' }
-
-sub get_schedule_file {
-    my $file = shift;
-    # TODO git clone the repo file and return the file path or error_message
-    return {error_message => undef, file => $file};
-}
 
 1;

--- a/public/schema/JobScenarios-01.yaml
+++ b/public/schema/JobScenarios-01.yaml
@@ -4,8 +4,6 @@ description: Definitions for openQA job scenarios
 type: object
 additionalProperties: false
 required:
-- products
-- machines
 - job_templates
 patternProperties:
   '^\.[a-z0-9_]+$':
@@ -71,9 +69,6 @@ properties:
       '^[A-Za-z0-9._*-]+$':
         type: object
         description: The name of the job template
-        required:
-          - product
-          - machine
         additionalProperties: false
         properties:
           product:

--- a/public/schema/JobScenarios-01.yaml
+++ b/public/schema/JobScenarios-01.yaml
@@ -1,0 +1,83 @@
+$id: http://open.qa/api/schema/JobScenarios-01.yaml
+$schema: http://json-schema.org/draft-04/schema#
+description: Definitions for openQA job scenarios
+type: object
+additionalProperties: false
+required:
+- products
+- machines
+- job_templates
+patternProperties:
+  '^\.[a-z0-9_]+$':
+    type: object
+    description: Definitions that can be re-used
+
+properties:
+  products:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      '^[A-Za-z0-9._*-]+$':
+        type: object
+        description: The name of a product (medium)
+        required:
+          - distri
+          - flavor
+          - version
+          - arch
+        additionalProperties: false
+        properties:
+          distri:
+            type: string
+          flavor:
+            type: string
+          version:
+            oneOf:
+              - type: string
+              - type: number
+          arch:
+            type: string
+          settings: &settings-definition
+            type: object
+            description: Additional test variables to be set
+            additionalProperties: false
+            patternProperties:
+              '^[A-Z_+]+[A-Z0-9_]*$':
+                type: string
+
+  machines:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      '^[A-Za-z0-9._*-]+$':
+        type: object
+        description: The name of a machine
+        required:
+          - backend
+        additionalProperties: false
+        properties:
+          backend:
+            type: string
+          priority:
+            oneOf:
+              - type: string
+              - type: number
+          settings: *settings-definition
+
+  job_templates:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      '^[A-Za-z0-9._*-]+$':
+        type: object
+        description: The name of the job template
+        required:
+          - product
+          - machine
+        additionalProperties: false
+        properties:
+          product:
+            type: string
+          machine:
+            type: string
+          settings: *settings-definition

--- a/t/api/02-iso-yaml.t
+++ b/t/api/02-iso-yaml.t
@@ -12,22 +12,18 @@ use OpenQA::Test::TimeLimit '6';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use OpenQA::Test::Utils 'schedule_iso';
-use OpenQA::Schema::Result::ScheduledProducts;
 use Mojo::File 'path';
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
-
 my $schema = $t->app->schema;
 my $jobs = $schema->resultset('Jobs');
-
 my %iso = (ISO => 'foo.iso', DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091');
 
 subtest 'schedule from yaml file: error cases' => sub {
-    my $res
-      = schedule_iso($t,
-        {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => 'does-not-exist.yaml', TEST => 'autoyast_btrfs'},
-        400);
+    my $file = 'does-not-exist.yaml';
+    my %args = (%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs');
+    my $res = schedule_iso($t, \%args, 400);
     my $json = $res->json;
     like $json->{error},
       qr/Unable to load YAML:.*Could not open 'does-not-exist.yaml' for reading: No such file or directory/,
@@ -35,19 +31,18 @@ subtest 'schedule from yaml file: error cases' => sub {
       or diag explain $json;
     is $json->{count}, 0, 'no jobs are scheduled when loading YAML fails' or diag explain $json;
 
-    my $file = "$FindBin::Bin/../data/09-schedule_from_file_incomplete.yaml";
+    $file = "$FindBin::Bin/../data/09-schedule_from_file_incomplete.yaml";
     my @expected_errors
       = ('YAML validation failed:', 'machines: Expected object - got null', 'products: Expected object - got null');
     my $expected_errors = join '.*', @expected_errors;
-    $res
-      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 400);
+    %args = (%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs');
+    $res = schedule_iso($t, \%args, 400);
     $json = $res->json;
     like $json->{error}, qr|$expected_errors|s, 'error when YAML file is invalid' or diag explain $json;
     is $json->{count}, 0, 'no jobs are scheduled when validating YAML file fails' or diag explain $json;
 
-    $res
-      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'autoyast_btrfs'},
-        400);
+    %args = (%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'autoyast_btrfs');
+    $res = schedule_iso($t, \%args, 400);
     $json = $res->json;
     like $json->{error}, qr|$expected_errors|s, 'error when YAML is invalid' or diag explain $json;
     is $json->{count}, 0, 'no jobs are scheduled when validating YAML fails' or diag explain $json;
@@ -55,8 +50,8 @@ subtest 'schedule from yaml file: error cases' => sub {
 
 subtest 'schedule from yaml file: case with machines/products and job dependencies' => sub {
     my $file = "$FindBin::Bin/../data/09-schedule_from_file.yaml";
-    my $res
-      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 200);
+    my %args = (%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs');
+    my $res = schedule_iso($t, \%args, 200);
     my $json = $res->json;
     is $json->{count}, 2, 'two jobs were scheduled' or return diag explain $json;
     my $job_ids = $json->{ids};
@@ -104,9 +99,8 @@ subtest 'schedule from yaml file: case with machines/products and job dependenci
 
 subtest 'schedule from yaml file: most simple case of two explicitly specified jobs' => sub {
     my $file = "$FindBin::Bin/../data/09-schedule_from_file_minimal.yaml";
-    my $res
-      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'job1,job2'},
-        200);
+    my %args = (%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'job1,job2');
+    my $res = schedule_iso($t, \%args, 200);
     my $json = $res->json;
     is $json->{count}, 2, 'two jobs were scheduled without products/machines' or diag explain $json;
     my $job_ids = $json->{ids};
@@ -115,16 +109,14 @@ subtest 'schedule from yaml file: most simple case of two explicitly specified j
     for my $i (1, 2) {
         my $job_id = $job_ids->[$i - 1];
         my $job_settings = $jobs->find($job_id)->settings_hash;
-        is_deeply $job_settings,
-          {
+        my %expected = (
             %iso,
             TEST => "job$i",
             NAME => "0000000$job_id-opensuse-13.1-DVD-i586-Build0091-job$i",
             WORKER_CLASS => 'qemu_i586',
-            "FOO_$i" => "bar$i"
-          },
-          "job$i scheduled with expected settings"
-          or diag explain $job_settings;
+            "FOO_$i" => "bar$i",
+        );
+        is_deeply $job_settings, \%expected, "job$i scheduled with expected settings" or diag explain $job_settings;
     }
 };
 

--- a/t/api/02-iso-yaml.t
+++ b/t/api/02-iso-yaml.t
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use OpenQA::Test::TimeLimit '6';
+use OpenQA::Test::Case;
+use OpenQA::Test::Client 'client';
+use OpenQA::Test::Utils 'schedule_iso';
+use OpenQA::Schema::Result::ScheduledProducts;
+use Mojo::File 'path';
+
+OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
+my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
+
+my $schema = $t->app->schema;
+my $jobs = $schema->resultset('Jobs');
+
+my %iso = (ISO => 'foo.iso', DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091');
+
+subtest 'schedule from yaml file: error cases' => sub {
+    my $res
+      = schedule_iso($t,
+        {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => 'does-not-exist.yaml', TEST => 'autoyast_btrfs'},
+        400);
+    my $json = $res->json;
+    like $json->{error},
+      qr/Unable to load YAML:.*Could not open 'does-not-exist.yaml' for reading: No such file or directory/,
+      'error when YAML file does not exist'
+      or diag explain $json;
+    is $json->{count}, 0, 'no jobs are scheduled when loading YAML fails' or diag explain $json;
+
+    my $file = "$FindBin::Bin/../data/09-schedule_from_file_incomplete.yaml";
+    my @expected_errors
+      = ('YAML validation failed:', 'machines: Expected object - got null', 'products: Expected object - got null');
+    my $expected_errors = join '.*', @expected_errors;
+    $res
+      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 400);
+    $json = $res->json;
+    like $json->{error}, qr|$expected_errors|s, 'error when YAML file is invalid' or diag explain $json;
+    is $json->{count}, 0, 'no jobs are scheduled when validating YAML file fails' or diag explain $json;
+
+    $res
+      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'autoyast_btrfs'},
+        400);
+    $json = $res->json;
+    like $json->{error}, qr|$expected_errors|s, 'error when YAML is invalid' or diag explain $json;
+    is $json->{count}, 0, 'no jobs are scheduled when validating YAML fails' or diag explain $json;
+};
+
+subtest 'schedule from yaml file: case with machines/products and job dependencies' => sub {
+    my $file = "$FindBin::Bin/../data/09-schedule_from_file.yaml";
+    my $res
+      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 200);
+    my $json = $res->json;
+    is $json->{count}, 2, 'two jobs were scheduled' or return diag explain $json;
+    my $job_ids = $json->{ids};
+    is @$job_ids, 2, 'two job IDs returned' or return diag explain $json;
+    my $parent_job = $jobs->find($job_ids->[0]);
+    is $parent_job->TEST, 'create_hdd', 'parent job for creating HDD created';
+    my $parent_job_settings = $parent_job->settings_hash;
+    is $parent_job_settings->{PUBLISH_HDD_1},
+      'opensuse-13.1-i586-0091@aarch64-minimal_with_sdk0091_installed.qcow2',
+      'settings of parent job were handled correctly';
+    my $child_job = $jobs->find($job_ids->[1]);
+    is $child_job->TEST, 'autoyast_btrfs', 'correct child job was created';
+    my $child_job_settings = $child_job->settings_hash;
+    is $child_job_settings->{HDD_1},
+      'opensuse-13.1-i586-0091@aarch64-minimal_with_sdk0091_installed.qcow2',
+      'settings of child job were handled correctly';
+    ok !exists $parent_job_settings->{SCENARIO_DEFINITIONS_YAML_FILE},
+      'SCENARIO_DEFINITIONS_YAML_FILE does not end up as job setting (1)';
+    ok !exists $child_job_settings->{SCENARIO_DEFINITIONS_YAML_FILE},
+      'SCENARIO_DEFINITIONS_YAML_FILE does not end up as job setting (2)';
+    my @settings = ($parent_job_settings, $child_job_settings);
+    subtest 'settings from machine definition present' => sub {
+        for my $job_settings (@settings) {
+            is $job_settings->{QEMU}, 'aarch64', "QEMU ($job_settings->{TEST})";
+            is $job_settings->{QEMURAM}, 3072, "QEMURAM ($job_settings->{TEST})";
+            is $job_settings->{UEFI}, 1, "UEFI ($job_settings->{TEST})";
+        }
+    } or diag explain \@settings;
+    subtest 'settings from product definition present' => sub {
+        for my $job_settings (@settings) {
+            is $job_settings->{PRODUCT_SETTING}, 'foo', "PRODUCT_SETTING ($job_settings->{TEST})";
+            is $job_settings->{DISTRI}, 'opensuse', "DISTRI ($job_settings->{TEST})";
+            is $job_settings->{VERSION}, '13.1', "VERSION ($job_settings->{TEST})";
+            is $job_settings->{FLAVOR}, 'DVD', "FLAVOR ($job_settings->{TEST})";
+            is $job_settings->{ARCH}, 'i586', "ARCH ($job_settings->{TEST})";
+        }
+    } or diag explain \@settings;
+    subtest 'worker class merged from different places' => sub {
+        is $parent_job_settings->{WORKER_CLASS}, 'merged-with-machine-settings,qemu_aarch64', 'WORKER_CLASS (parent)';
+        is $child_job_settings->{WORKER_CLASS}, 'job-specific-class,merged-with-machine-settings,qemu_aarch64',
+          'WORKER_CLASS (child)';
+    };
+    is_deeply $child_job->dependencies->{parents}->{Chained}, [$parent_job->id], 'the dependency job was created';
+};
+
+subtest 'schedule from yaml file: most simple case of two explicitly specified jobs' => sub {
+    my $file = "$FindBin::Bin/../data/09-schedule_from_file_minimal.yaml";
+    my $res
+      = schedule_iso($t, {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'job1,job2'},
+        200);
+    my $json = $res->json;
+    is $json->{count}, 2, 'two jobs were scheduled without products/machines' or diag explain $json;
+    my $job_ids = $json->{ids};
+    is @$job_ids, 2, 'two job IDs returned' or return diag explain $json;
+    $iso{DISTRI} = lc $iso{DISTRI};    # distri is expected to be converted to lower-case
+    for my $i (1, 2) {
+        my $job_id = $job_ids->[$i - 1];
+        my $job_settings = $jobs->find($job_id)->settings_hash;
+        is_deeply $job_settings,
+          {
+            %iso,
+            TEST => "job$i",
+            NAME => "0000000$job_id-opensuse-13.1-DVD-i586-Build0091-job$i",
+            WORKER_CLASS => 'qemu_i586',
+            "FOO_$i" => "bar$i"
+          },
+          "job$i scheduled with expected settings"
+          or diag explain $job_settings;
+    }
+};
+
+done_testing();

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -974,8 +974,10 @@ subtest 'Expand specified variables when scheduling iso' => sub {
 };
 
 subtest 'schedule from yaml file' => sub {
-    my $res = schedule_iso(
-        {%iso, GROUP_ID => '0', SCHEDULE_FROM_YAML_FILE => 'does-not-exist.yaml', TEST => 'autoyast_btrfs'}, 400);
+    my $res
+      = schedule_iso(
+        {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => 'does-not-exist.yaml', TEST => 'autoyast_btrfs'},
+        400);
     my $json = $res->json;
     like $json->{error}, qr/Could not open 'does-not-exist.yaml' for reading: No such file or directory/,
       'error when YAML file does not exist'
@@ -989,13 +991,15 @@ subtest 'schedule from yaml file' => sub {
         'products: Expected object - got null',
     );
     my $expected_errors = join '.*', @expected_errors;
-    $res = schedule_iso({%iso, GROUP_ID => '0', SCHEDULE_FROM_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 400);
+    $res
+      = schedule_iso({%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 400);
     $json = $res->json;
     like $json->{error}, qr|$expected_errors|s, 'error when YAML file is invalid' or diag explain $json;
     is $json->{count}, 0, 'no jobs are scheduled when validating YAML fails' or diag explain $json;
 
     $file = "$FindBin::Bin/../data/09-schedule_from_file.yaml";
-    $res = schedule_iso({%iso, GROUP_ID => '0', SCHEDULE_FROM_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 200);
+    $res
+      = schedule_iso({%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 200);
     $json = $res->json;
     is $json->{count}, 2, 'two jobs were scheduled' or return diag explain $json;
     my $job_ids = $json->{ids};
@@ -1012,10 +1016,10 @@ subtest 'schedule from yaml file' => sub {
     is $child_job_settings->{HDD_1},
       'opensuse-13.1-i586-0091@aarch64-minimal_with_sdk0091_installed.qcow2',
       'settings of child job were handled correctly';
-    ok !exists $parent_job_settings->{SCHEDULE_FROM_YAML_FILE},
-      'SCHEDULE_FROM_YAML_FILE does not end up as job setting (1)';
-    ok !exists $child_job_settings->{SCHEDULE_FROM_YAML_FILE},
-      'SCHEDULE_FROM_YAML_FILE does not end up as job setting (2)';
+    ok !exists $parent_job_settings->{SCENARIO_DEFINITIONS_YAML_FILE},
+      'SCENARIO_DEFINITIONS_YAML_FILE does not end up as job setting (1)';
+    ok !exists $child_job_settings->{SCENARIO_DEFINITIONS_YAML_FILE},
+      'SCENARIO_DEFINITIONS_YAML_FILE does not end up as job setting (2)';
     my @settings = ($parent_job_settings, $child_job_settings);
     subtest 'settings from machine definition present' => sub {
         for my $job_settings (@settings) {

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -14,6 +14,7 @@ use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
 use OpenQA::Test::Utils qw(assume_all_assets_exist perform_minion_jobs);
 use OpenQA::Schema::Result::ScheduledProducts;
+use Mojo::File 'path';
 use Mojo::IOLoop;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
@@ -995,6 +996,13 @@ subtest 'schedule from yaml file' => sub {
       = schedule_iso({%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => $file, TEST => 'autoyast_btrfs'}, 400);
     $json = $res->json;
     like $json->{error}, qr|$expected_errors|s, 'error when YAML file is invalid' or diag explain $json;
+    is $json->{count}, 0, 'no jobs are scheduled when validating YAML file fails' or diag explain $json;
+
+    $res
+      = schedule_iso({%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'autoyast_btrfs'},
+        400);
+    $json = $res->json;
+    like $json->{error}, qr|$expected_errors|s, 'error when YAML is invalid' or diag explain $json;
     is $json->{count}, 0, 'no jobs are scheduled when validating YAML fails' or diag explain $json;
 
     $file = "$FindBin::Bin/../data/09-schedule_from_file.yaml";

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -980,13 +980,15 @@ subtest 'schedule from yaml file' => sub {
         {%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML_FILE => 'does-not-exist.yaml', TEST => 'autoyast_btrfs'},
         400);
     my $json = $res->json;
-    like $json->{error}, qr/Could not open 'does-not-exist.yaml' for reading: No such file or directory/,
+    like $json->{error},
+      qr/Unable to load YAML:.*Could not open 'does-not-exist.yaml' for reading: No such file or directory/,
       'error when YAML file does not exist'
       or diag explain $json;
     is $json->{count}, 0, 'no jobs are scheduled when loading YAML fails' or diag explain $json;
 
     my $file = "$FindBin::Bin/../data/09-schedule_from_file_incomplete.yaml";
     my @expected_errors = (
+        'YAML validation failed:',
         'job_templates/autoyast_bcache/machine: Missing property',
         'machines: Expected object - got null',
         'products: Expected object - got null',

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -28,9 +28,9 @@ assume_all_assets_exist;
 
 sub lj {
     return unless $ENV{HARNESS_IS_VERBOSE};
-    $t->get_ok('/api/v1/jobs')->status_is(200);
-    my $jobs = $t->tx->res->json->{jobs};
-    printf("%d %-10s %s (%s)\n", $_->{id}, $_->{state}, $_->{name}, $_->{priority}) for @$jobs;
+    $t->get_ok('/api/v1/jobs')->status_is(200);    # uncoverable statement
+    my $jobs = $t->tx->res->json->{jobs};    # uncoverable statement
+    printf("%d %-10s %s (%s)\n", $_->{id}, $_->{state}, $_->{name}, $_->{priority}) for @$jobs;  # uncoverable statement
 }
 
 sub find_job ($jobs, $newids, $name, $machine) {

--- a/t/data/09-schedule_from_file.yaml
+++ b/t/data/09-schedule_from_file.yaml
@@ -2,17 +2,17 @@ products:
   sle-online-aarch64-*:
     distri: "opensuse"
     flavor: "DVD"
-    arch  : "i586"
+    arch: "i586"
     version: '13.1'
     settings:
       foo: 1
   sle-offline-x86_64-*:
-     distri: "sle"
-     flavor: "offline"
-     arch: "x86_64"
-     version: '12-SP5'
-     settings:
-       foo : 2
+    distri: "sle"
+    flavor: "offline"
+    arch: "x86_64"
+    version: '12-SP5'
+    settings:
+      foo: 2
 machines:
   64bit:
     backend: "qemu"
@@ -25,7 +25,7 @@ machines:
       WORKER_CLASS: "qemu_x86_64"
   aarch64:
     backend: "qemu"
-    settings: 
+    settings:
       QEMU: "aarch64"
       QEMURAM: 3072
       UEFI: "1"
@@ -33,19 +33,20 @@ machines:
 job_templates:
   autoyast_bcache:
     product: "sle-offline-x86_64-*"
-    machine: "b4bit" 
+    machine: "b4bit"
     settings:
-      YAML_SCHEDULE: 'schedule/yast/autoyast_bcache.yaml'
       HDD_1: "SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
       BUILD_SDK: "%BUILD"
   autoyast_btrfs:
     product: "sle-online-aarch64-*"
     machine: "aarch64"
     settings:
-      YAML_SCHEDULE: 'schedule/yast/autoyast_btrfs.yaml'
       HDD_1: "opensuse-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
       BUILD_SDK: "%BUILD%"
       START_AFTER_TEST: "create_hdd"
   create_hdd:
     product: "sle-online-aarch64-*"
     machine: "aarch64"
+    settings:
+      PUBLISH_HDD_1: "opensuse-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
+      BUILD_SDK: "%BUILD%"

--- a/t/data/09-schedule_from_file.yaml
+++ b/t/data/09-schedule_from_file.yaml
@@ -4,15 +4,17 @@ products:
     flavor: "DVD"
     arch: "i586"
     version: '13.1'
+    some_odd_key: 'should not disturb everything'
     settings:
-      foo: 1
+      PRODUCT_SETTING: 'foo'
+      WORKER_CLASS: 'merged-with-machine-settings'
   sle-offline-x86_64-*:
     distri: "sle"
     flavor: "offline"
     arch: "x86_64"
     version: '12-SP5'
     settings:
-      foo: 2
+      PRODUCT_SETTING: 'bar'
 machines:
   64bit:
     backend: "qemu"
@@ -33,7 +35,7 @@ machines:
 job_templates:
   autoyast_bcache:
     product: "sle-offline-x86_64-*"
-    machine: "b4bit"
+    machine: "64bit"
     settings:
       HDD_1: "SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
       BUILD_SDK: "%BUILD"
@@ -44,6 +46,7 @@ job_templates:
       HDD_1: "opensuse-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
       BUILD_SDK: "%BUILD%"
       START_AFTER_TEST: "create_hdd"
+      WORKER_CLASS: "job-specific-class"
   create_hdd:
     product: "sle-online-aarch64-*"
     machine: "aarch64"

--- a/t/data/09-schedule_from_file.yaml
+++ b/t/data/09-schedule_from_file.yaml
@@ -1,0 +1,51 @@
+products:
+  sle-online-aarch64-*:
+    distri: "opensuse"
+    flavor: "DVD"
+    arch  : "i586"
+    version: '13.1'
+    settings:
+      foo: 1
+  sle-offline-x86_64-*:
+     distri: "sle"
+     flavor: "offline"
+     arch: "x86_64"
+     version: '12-SP5'
+     settings:
+       foo : 2
+machines:
+  64bit:
+    backend: "qemu"
+    priority: 20
+    settings:
+      ARCH_BASE_MACHINE: "64bit"
+      QEMUCPUS: "2"
+      QEMURAM: "2048"
+      QEMUVGA: "virtio"
+      WORKER_CLASS: "qemu_x86_64"
+  aarch64:
+    backend: "qemu"
+    settings: 
+      QEMU: "aarch64"
+      QEMURAM: 3072
+      UEFI: "1"
+      WORKER_CLASS: "qemu_aarch64"
+job_templates:
+  autoyast_bcache:
+    product: "sle-offline-x86_64-*"
+    machine: "b4bit" 
+    settings:
+      YAML_SCHEDULE: 'schedule/yast/autoyast_bcache.yaml'
+      HDD_1: "SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
+      BUILD_SDK: "%BUILD"
+  autoyast_btrfs:
+    product: "sle-online-aarch64-*"
+    machine: "aarch64"
+    settings:
+      YAML_SCHEDULE: 'schedule/yast/autoyast_btrfs.yaml'
+      HDD_1: "opensuse-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"
+      BUILD_SDK: "%BUILD%"
+      START_AFTER_TEST: "create_hdd"
+  create_hdd:
+    product: "sle-online-aarch64-*"
+    machine: "aarch64"

--- a/t/data/09-schedule_from_file.yaml
+++ b/t/data/09-schedule_from_file.yaml
@@ -4,7 +4,6 @@ products:
     flavor: "DVD"
     arch: "i586"
     version: '13.1'
-    some_odd_key: 'should not disturb everything'
     settings:
       PRODUCT_SETTING: 'foo'
       WORKER_CLASS: 'merged-with-machine-settings'
@@ -29,7 +28,7 @@ machines:
     backend: "qemu"
     settings:
       QEMU: "aarch64"
-      QEMURAM: 3072
+      QEMURAM: "3072"
       UEFI: "1"
       WORKER_CLASS: "qemu_aarch64"
 job_templates:

--- a/t/data/09-schedule_from_file_incomplete.yaml
+++ b/t/data/09-schedule_from_file_incomplete.yaml
@@ -1,0 +1,7 @@
+products:
+
+machines:
+
+job_templates:
+  autoyast_bcache:
+    product: "foo"

--- a/t/data/09-schedule_from_file_minimal.yaml
+++ b/t/data/09-schedule_from_file_minimal.yaml
@@ -1,0 +1,10 @@
+job_templates:
+  job1:
+    settings:
+      FOO_1: 'bar1'
+  job2:
+    settings:
+      FOO_2: 'bar2'
+  job3:
+    settings:
+      FOO_3: 'bar3'

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -22,6 +22,7 @@ use OpenQA::Scheduler::Client;
 use Mojo::Home;
 use Mojo::File qw(path tempfile tempdir);
 use Mojo::Util 'dumper';
+use Mojo::URL;
 use Cwd qw(abs_path getcwd);
 use IPC::Run qw(start);
 use Mojolicious;
@@ -54,7 +55,7 @@ our (@EXPORT, @EXPORT_OK);
     qw(stop_service start_worker unstable_worker fake_asset_server),
     qw(cache_minion_worker cache_worker_service shared_hash embed_server_for_testing),
     qw(run_cmd test_cmd wait_for wait_for_or_bail_out perform_minion_jobs),
-    qw(prepare_clean_needles_dir prepare_default_needle mock_io_loop assume_all_assets_exist)
+    qw(prepare_clean_needles_dir prepare_default_needle mock_io_loop assume_all_assets_exist schedule_iso)
 );
 
 # The function OpenQA::Utils::service_port method hardcodes ports in a
@@ -660,5 +661,9 @@ sub mock_io_loop (%args) {
 }
 
 sub assume_all_assets_exist { OpenQA::Schema->singleton->resultset('Assets')->search({})->update({size => 0}) }
+
+sub schedule_iso ($t, $args, $status = 200, $query_params = {}, $msg = undef) {
+    $t->post_ok(Mojo::URL->new('/api/v1/isos')->query($query_params), form => $args)->status_is($status, $msg)->tx->res;
+}
 
 1;


### PR DESCRIPTION
* Revive and rebase #3848 for https://progress.opensuse.org/issues/92311
* Improve tests

---

Open points for discussion:

1. Where should the YAML file come from? The approach from #3848 only allows for local file system paths. Supposedly we want to allow an HTTP-URL here as well (e.g. pointing to some place on GitHub/GitLab/…).
2. It is not to late to tweak the naming. I think `SCHEDULE_FROM_YAML_FILE` is a bad choice as it can be easily confused with `YAML_SCHEDULE`. What about `SCENARIO_DEFINITIONS_YAML_FILE`? After all, that's what this YAML file is going to contain. I don't think we should overuse the work "schedule" because it tends to become more meaningless the more we use it.
3. The YAML file clearly lacks a version field. To be able to extend it in the future, I suggest to add a `meta` section that will contain the `version` field (and possible other meta info).