### PR TITLE
Fix investigation git log

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -602,7 +602,6 @@ function setCurrentPreviewFromStepLinkIfPossible(stepLink) {
 
 function githashToLink(value, repo) {
   const logItems = value.split(/(?=^[0-9a-f])/gm);
-  logItems.shift();
   const commits = [];
   for (let i = 0; i < logItems.length; i++) {
     const item = logItems[i];


### PR DESCRIPTION
Don't remove the first item anymore.
Previously the string returned from git_log_diff contained a preceding linebreak. But that was removed in 6b31bdb8acd007de140fe4b7018817e7092174e3

Issue: https://progress.opensuse.org/issues/124476