### PR TITLE
Retry asset downloads automatically

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -73,6 +73,10 @@ sub startup ($self) {
     # setup asset pack
   # -> in case the following line is moved in another location, tools/generate-packed-assets needs to be adapted as well
     $self->plugin(AssetPack => {pipes => [qw(Sass Css JavaScript Fetch Combine)]});
+
+    # The feature was added in the 2.14 release, the version check can be removed once openQA depends on a newer version
+    $self->asset->store->retries(5) if $Mojolicious::Plugin::AssetPack::VERSION > 2.13;
+
     # -> read assets/assetpack.def
     $self->asset->process;
 


### PR DESCRIPTION
A retry feature has been added upstream to
Mojolicious::Plugin::AssetPack in the 2.14 release. See https://github.com/mojolicious/mojo-assetpack/pull/148 for more. The feature will have to remain optional until openQA can safely depend on 2.14, which is currently unavailable for Tumbleweed aarch64.

Progress: https://progress.opensuse.org/issues/122440