### PR TITLE
Enable build for PowerPC after openQA packages are no longer noarch

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -165,7 +165,7 @@ Development package pulling in all build+test dependencies except chromedriver f
 Summary:        Development package pulling in all build+test dependencies
 Group:          Development/Tools/Other
 Requires:       %{devel_requires}
-%ifarch ppc ppc64 ppc64le s390x
+%ifarch s390x
 # missing chromedriver dependency
 ExclusiveArch:  do_not_build
 %endif


### PR DESCRIPTION
See https://progress.opensuse.org/issues/124670