### PR TITLE
Fix permission denied and sass application triggered by recent dependency upgrades

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -47,7 +47,7 @@
 %define python_scripts_requires %{nil}
 %endif
 # The following line is generated from dependencies.yaml
-%define assetpack_requires perl(CSS::Minifier::XS) >= 0.01 perl(JavaScript::Minifier::XS) >= 0.11 perl(Mojolicious::Plugin::AssetPack) >= 1.36
+%define assetpack_requires perl(CSS::Minifier::XS) >= 0.01 perl(JavaScript::Minifier::XS) >= 0.11 perl(Mojolicious::Plugin::AssetPack) >= 1.36 rubygem(sass)
 # The following line is generated from dependencies.yaml
 %define common_requires perl >= 5.20.0 perl(Carp::Always) >= 0.14.02 perl(Config::IniFiles) perl(Config::Tiny) perl(Cpanel::JSON::XS) >= 4.09 perl(Cwd) perl(Data::Dump) perl(Data::Dumper) perl(Digest::MD5) perl(Filesys::Df) perl(Getopt::Long) perl(Minion) >= 10.25 perl(Mojolicious) >= 9.30 perl(Regexp::Common) perl(Storable) perl(Time::Moment) perl(Try::Tiny)
 # runtime requirements for the main package that are not required by other sub-packages
@@ -58,7 +58,7 @@
 # The following line is generated from dependencies.yaml
 %define worker_requires bsdtar openQA-client optipng os-autoinst < 5 perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.7 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
-%define build_requires %assetpack_requires rubygem(sass)
+%define build_requires %assetpack_requires
 
 # All requirements needed by the tests executed during build-time.
 # Do not require on this in individual sub-packages except for the devel

--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -86,6 +86,9 @@
   /var/tmp/* rwk,
   owner /var/lib/openqa/share/tests/** rwl,
   owner /var/lib/openqa/archive/** rwl,
+  owner /.sass-cache/ w,
+  owner /var/lib/openqa/.gem/ w,
+  owner /var/lib/openqa/.sass-cache/ w,
 
 
   profile /usr/bin/ssh {
@@ -151,6 +154,9 @@
   /usr/bin/python3.6 ix,
   /usr/bin/rm rix,
   /usr/bin/rsync mrix,
+  /usr/bin/ruby mrix,
+  /usr/bin/ruby.* ix,
+  /usr/bin/sass.* mrix,
   /usr/bin/sed mrix,
   /usr/bin/tac mrix,
   /usr/bin/tail mrix,


### PR DESCRIPTION
Please check the individual commits.

I am not sure if the apparmor change is enough as the apparmor profile difference on o3 vs. the version in the git repo is rather big.

Related progress issue: https://progress.opensuse.org/issues/124739