### PR TITLE
dist: Enable 'noarch' again trying to fix use of asset cache

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -120,7 +120,7 @@ Recommends:     rsync
 # uploaded to download.opensuse.org, and aarch for some reason has an older
 # version of that module. Then when we install on Tumbleweed, it doesn't
 # have that older version anymore
-#BuildArch:      noarch
+BuildArch:      noarch
 ExcludeArch:    i586
 %{?systemd_requires}
 %if %{with tests}


### PR DESCRIPTION
So far only generating to test out the actual package

Related progress issue: https://progress.opensuse.org/issues/124739