### PR TITLE
Fix regex to get AssetPack plugins

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -73,6 +73,10 @@ sub startup ($self) {
     # setup asset pack
   # -> in case the following line is moved in another location, tools/generate-packed-assets needs to be adapted as well
     $self->plugin(AssetPack => {pipes => [qw(Sass Css JavaScript Fetch Combine)]});
+
+    # The feature was added in the 2.14 release, the version check can be removed once openQA depends on a newer version
+    $self->asset->store->retries(5) if $Mojolicious::Plugin::AssetPack::VERSION > 2.13;
+
     # -> read assets/assetpack.def
     $self->asset->process;
 

--- a/tools/generate-packed-assets
+++ b/tools/generate-packed-assets
@@ -29,7 +29,7 @@
 # source tree.
 
 # Get Assetpack pipes from WebAPI.pm
-ASSETPACK_PLUGINS=$(grep 'AssetPack' lib/OpenQA/WebAPI.pm | awk -F '[()]' '{print $3}')
+ASSETPACK_PLUGINS=$(grep 'plugin.*AssetPack' lib/OpenQA/WebAPI.pm | head -1 | awk -F '[()]' '{print $3}')
 [ -z "$ASSETPACK_PLUGINS" ] && echo "Can't get AssetPack pipes" && exit 1
 
 BUILD_CACHE="plugin AssetPack => { pipes => [qw(${ASSETPACK_PLUGINS})]} and app->asset->process()"

--- a/tools/generate-packed-assets
+++ b/tools/generate-packed-assets
@@ -36,14 +36,17 @@ BUILD_CACHE="plugin AssetPack => { pipes => [qw(${ASSETPACK_PLUGINS})]} and app-
 BUILD_CACHE_OPTS='-Ilib/ -MMojolicious::Lite'
 
 generate() {
+    local rc=0
     # shellcheck disable=SC2039
     for _ in {1..3}; do
         # shellcheck disable=SC2086
         env MOJO_MODE="$1" perl $BUILD_CACHE_OPTS -e "$BUILD_CACHE" > /dev/null && return 0
+        rc=$?
         sleep 1
     done
+    return "$rc"
 }
 
 # Possibly requires a retry in case of CDN failures
-generate "test"
-generate "development"
+generate "test" || exit $?
+generate "development" || exit $?


### PR DESCRIPTION
Before it would return this:

    % grep 'AssetPack' lib/OpenQA/WebAPI.pm | awk -F '[()]' '{print $3}'
    Sass Css JavaScript Fetch Combine
     if $Mojolicious::Plugin::AssetPack::VERSION > 2.13;

Now the regex is more specific and also restricted to one line

Issue: https://progress.opensuse.org/issues/124739

Also reverts #5011 
