### PR TITLE
Allow escaping percentage signs in job settings to avoid substitution

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1633,10 +1633,12 @@ way:
 * A relative `NEEDLES_DIR` is treated to be relative to the default `CASEDIR`
   (even if `CASEDIR` is customized). To have it treated to be relative to the
   custom `CASEDIR`, prefix the relative path with `%CASEDIR%/`. So specifying
-  e.g. `CASEDIR=https://github.com/…` and `NEEDLES_DIR=%CASEDIR%/the-needles`
+  e.g. `CASEDIR=https://github.com/…` and `NEEDLES_DIR=%%CASEDIR%%/the-needles`
   will lead to `%CASEDIR%` being substituted with the path of the Git checkout
   created for the custom `CASEDIR`. That results in needles found in
-  https://github.com/…/tree/…/the-needles to be used.
+  https://github.com/…/tree/…/the-needles to be used. Note that double
+  `%`-signs are to avoid variable substitution. When using `curl`, you need to
+  escape the `%`-sign as `%25` *in addition*.
 ====
 
 A helper script `openqa-clone-custom-git-refspec` is available for

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -42,6 +42,11 @@ my $settings = {
     BUILD_HA => '%BUILD%',
     BUILD_SES => '%BUILD%',
     WORKAROUND_MODULES => 'base,desktop,serverapp,script,sdk',
+    CASEDIR => 'foo',
+    # %%CASEDIR%% will be preserved as %CASEDIR%, most simple case of escaping
+    # %%%%CASEDIR%%% will be preserved, number of surrounding % preserved except for outermost pair
+    # %CASEDIR% will still be substituted, despite other escaped occurrences in same value
+    NEEDLES_DIR => '%%CASEDIR%%/bar/%%%%CASEDIR%%%/%CASEDIR%',
 };
 
 subtest expand_placeholders => sub {
@@ -77,6 +82,8 @@ subtest expand_placeholders => sub {
         BUILD_HA => '1234',
         BUILD_SES => '1234',
         WORKAROUND_MODULES => 'base,desktop,serverapp,script,sdk',
+        CASEDIR => 'foo',
+        NEEDLES_DIR => '%CASEDIR%/bar/%%%CASEDIR%%/foo',
     };
     is($error, undef, "no error returned");
     is_deeply($settings, $match_settings, "Settings replaced");


### PR DESCRIPTION
Sometimes an expression surrounded by `%`-signs should be preserved and not be substituted, e.g. `NEEDLES_DIR=%CASEDIR%/foo` to express a `NEEDLES_DIR` relative to `CASEDIR`. This change enables the use of `NEEDLES_DIR=%%CASEDIR%%/foo` which will always be substituted to `NEEDLES_DIR=%CASEDIR%/foo` (so no real substitution happens, only the outermost pair of `%`-signs is removed).

The documentation for this specific use has also been extended (including how to pass `%`-signs via `curl`).

Of course this could be useful in other cases as well. Note that this particular use case is from day 4 of Oliver's hackweek (see https://hackweek.opensuse.org/22/projects/trigger-actual-openqa-tests-in-pull-requests).

Related ticket: https://progress.opensuse.org/issues/124502