### PR TITLE
Mark WORKER_COMMAND_CANCEL condition as uncoverable

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -498,8 +498,8 @@ sub _stop_step_5_2_upload ($self, $reason, $callback) {
         return $self->_upload_results(sub { $callback->({result => INCOMPLETE, newbuild => 1}) });
     }
     if ($reason eq WORKER_COMMAND_CANCEL) {
-        log_debug("Considering job $job_id as cancelled/restarted by the user");
-        return $self->_upload_results(sub { $callback->({result => USER_CANCELLED}) });
+        log_debug("Considering job $job_id as cancelled/restarted by the user");    # uncoverable statement
+        return $self->_upload_results(sub { $callback->({result => USER_CANCELLED}) });    # uncoverable statement
     }
     if ($reason eq WORKER_SR_DONE) {
         log_debug("Considering job $job_id as regularly done");


### PR DESCRIPTION
The test covering this condition (`t/33-developer_mode.t`), specifically checks for two possible results, `user_cancelled` and `passed`. Making this an intentional race condition. So, for now, it seems like the best solution to mark the condition as uncoverable to prevent flaky code coverage data.

Progress: https://progress.opensuse.org/issues/124484