### PR TITLE
Improve error handling when automatically restarting a job

### DIFF
--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -33,6 +33,7 @@ sub startup ($self) {
     push @{$self->plugins->namespaces}, 'OpenQA::LiveHandler::Plugin', 'OpenQA::Shared::Plugin';
     $self->plugin('SharedHelpers');
     $self->plugin('CSRF');
+    $self->plugin('Gru');    # to invoke $job->cancel() when stopping developer session
 
     OpenQA::Setup::set_secure_flag_on_cookies_of_https_connection($self);
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1754,8 +1754,7 @@ sub store_column ($self, $columnname, $value) {
 }
 
 sub enqueue_finalize_job_results ($self, $carried_over = undef) {
-    my $gru = eval { OpenQA::App->singleton->gru };    # gru might not be present within tests
-    $gru->enqueue(finalize_job_results => [$self->id, $carried_over], {priority => -10}) if $gru;
+    OpenQA::App->singleton->gru->enqueue(finalize_job_results => [$self->id, $carried_over], {priority => -10});
 }
 
 # used to stop jobs with some kind of dependency relationship to another
@@ -1943,9 +1942,8 @@ sub handle_retry ($self) {
 }
 
 sub enqueue_restart ($self) {
-    return undef unless my $gru = eval { OpenQA::App->singleton->gru };    # gru might not be present within tests
     my $openqa_job_id = $self->id;
-    my $minion_job_id = $gru->enqueue(restart_job => [$openqa_job_id])->{minion_id};
+    my $minion_job_id = OpenQA::App->singleton->gru->enqueue(restart_job => [$openqa_job_id])->{minion_id};
     log_debug "Enqueued restarting openQA job $openqa_job_id via Minion job $minion_job_id";
 }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1753,8 +1753,9 @@ sub store_column ($self, $columnname, $value) {
     return $self->SUPER::store_column($columnname, $value);
 }
 
-sub enqueue_finalize_job_results ($self, @args) {
-    OpenQA::App->singleton->gru->enqueue(finalize_job_results => [$self->id, @args], {priority => -10});
+sub enqueue_finalize_job_results ($self, $args = [], $options = {}) {
+    $options->{priority} //= -10;
+    OpenQA::App->singleton->gru->enqueue(finalize_job_results => [$self->id, @$args], $options);
 }
 
 # used to stop jobs with some kind of dependency relationship to another
@@ -1945,6 +1946,7 @@ sub enqueue_restart ($self, $options = {}) {
     my $openqa_job_id = $self->id;
     my $minion_job_id = OpenQA::App->singleton->gru->enqueue(restart_job => [$openqa_job_id], $options)->{minion_id};
     log_debug "Enqueued restarting openQA job $openqa_job_id via Minion job $minion_job_id";
+    return $minion_job_id;
 }
 
 =head2 done
@@ -2008,9 +2010,11 @@ sub done ($self, %args) {
     }
     $self->update(\%new_val);
     $self->unblock;
+    my %finalize_opts = (lax => 1);
+    $finalize_opts{parents} = [$self->enqueue_restart] if $restart || ($self->is_ok_to_retry && $self->handle_retry);
     # bugrefs are there to mark reasons of failure - the function checks itself though
     my $carried_over = $self->carry_over_bugrefs;
-    $self->enqueue_finalize_job_results($carried_over, $restart || ($self->is_ok_to_retry && $self->handle_retry));
+    $self->enqueue_finalize_job_results([$carried_over], \%finalize_opts);
 
     # stop other jobs in the cluster
     if (defined $new_val{result} && !grep { $result eq $_ } OK_RESULTS) {

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -32,6 +32,7 @@ sub register_tasks ($self) {
         qw(OpenQA::Task::Job::ArchiveResults),
         qw(OpenQA::Task::Job::FinalizeResults),
         qw(OpenQA::Task::Job::HookScript),
+        qw(OpenQA::Task::Job::Restart),
         qw(OpenQA::Task::Iso::Schedule),
         qw(OpenQA::Task::Bug::Limit),
       );

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -127,12 +127,19 @@ sub enqueue ($self, $task, $args = [], $options = {}, $jobs = []) {
     my $gru_id = $gru->id;
     my @ttl = defined $ttl ? (expire => $ttl) : ();
     my @notes = defined $notes ? (%$notes) : ();
-    my $minion_id = $self->app->minion->enqueue(
-        $task => $args => {
-            @ttl,
-            priority => $priority,
-            delay => $delay,
-            notes => {gru_id => $gru_id, @notes}});
+    my $parents = $options->{parents};
+    my $lax = $options->{lax};
+    my %minion_options = (
+        @ttl,
+        priority => $priority,
+        delay => $delay,
+        notes => {gru_id => $gru_id, @notes},
+        defined $lax ? (lax => $lax) : (),
+        defined $parents ? (parents => $parents) : (),
+    );
+    use Data::Dumper;
+    print("$task options: " . Dumper(\%minion_options));
+    my $minion_id = $self->app->minion->enqueue($task => $args => \%minion_options);
 
     return {minion_id => $minion_id, gru_id => $gru_id};
 }

--- a/lib/OpenQA/Task/Job/FinalizeResults.pm
+++ b/lib/OpenQA/Task/Job/FinalizeResults.pm
@@ -5,14 +5,13 @@ package OpenQA::Task::Job::FinalizeResults;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 use OpenQA::Jobs::Constants 'CANCELLED';
 use OpenQA::Task::SignalGuard;
-use OpenQA::Task::Job::Restart;
 use Time::Seconds;
 
 sub register ($self, $app, @) {
     $app->minion->add_task(finalize_job_results => \&_finalize_results);
 }
 
-sub _finalize_results ($minion_job, $openqa_job_id = undef, $carried_over = undef, $restart = undef) {
+sub _finalize_results ($minion_job, $openqa_job_id = undef, $carried_over = undef) {
     my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($minion_job);
     my $app = $minion_job->app;
     return $minion_job->fail('No job ID specified.') unless defined $openqa_job_id;
@@ -21,9 +20,6 @@ sub _finalize_results ($minion_job, $openqa_job_id = undef, $carried_over = unde
 
     my $openqa_job = $app->schema->resultset('Jobs')->find($openqa_job_id);
     return $minion_job->finish("Job $openqa_job_id does not exist.") unless $openqa_job;
-
-    # restart the job if it should be restarted
-    my $restart_error = $restart ? _restart_job($minion_job, $openqa_job) : undef;
 
     # try to finalize each
     my %failed_to_finalize;
@@ -44,23 +40,6 @@ sub _finalize_results ($minion_job, $openqa_job_id = undef, $carried_over = unde
         _run_hook_script($minion_job, $openqa_job, $app, $ensure_task_retry_on_termination_signal_guard);
         $app->minion->enqueue($_ => []) for @{$app->config->{minion_task_triggers}->{on_job_done}};
     }
-
-    # fail Minion job if an error when restarting the job occurred
-    return $minion_job->fail($restart_error) if $restart_error;
-}
-
-sub _restart_job ($minion_job, $openqa_job) {
-    # duplicate job and finish normally if no error was returned or job can not be cloned
-    my ($is_ok, $cloned_job_or_error) = OpenQA::Task::Job::Restart::restart_openqa_job($minion_job, $openqa_job);
-    return undef if $is_ok;
-    # enqueue separate restart task for more attempts in the error case
-    return $cloned_job_or_error unless OpenQA::Task::Job::Restart::restart_attempts > 1;
-    my %options = (
-        delay => OpenQA::Task::Job::Restart::restart_delay,
-        notes => {failures => 1},
-    );
-    $openqa_job->enqueue_restart(\%options);
-    return undef;    # don't consider it an error yet
 }
 
 sub _run_hook_script ($minion_job, $openqa_job, $app, $guard) {

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -21,6 +21,8 @@ use Test::MockModule;
 use Test::Output qw(combined_like);
 use Test::Warnings ':report_warnings';
 use OpenQA::Schema::Result::Jobs;
+use OpenQA::App;
+use OpenQA::WebAPI;
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::Test::TimeLimit '10';
 
@@ -43,6 +45,7 @@ $mock_result->redefine(
 my $schema = OpenQA::Test::Database->new->create;
 my $jobs = $schema->resultset('Jobs');
 my $t = Test::Mojo->new('OpenQA::Scheduler');
+OpenQA::App->set_singleton(OpenQA::WebAPI->new);
 
 subtest 'Authentication' => sub {
     $t->get_ok('/test')->status_is(404)->content_like(qr/Not found/);

--- a/t/10-jobs-results.t
+++ b/t/10-jobs-results.t
@@ -12,14 +12,17 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Mojo::Base -signatures;
 use autodie ':all';
+use OpenQA::App;
 use OpenQA::Jobs::Constants;
 use OpenQA::Utils 'resultdir';
 use OpenQA::Test::Case;
 use OpenQA::Task::SignalGuard;
 use OpenQA::Test::TimeLimit '30';
+use OpenQA::WebAPI;
 
 my $schema = OpenQA::Test::Case->new->init_data;
 my $jobs = $schema->resultset('Jobs');
+OpenQA::App->set_singleton(OpenQA::WebAPI->new);
 
 my %settings = (
     DISTRI => 'Unicorn',

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -30,6 +30,10 @@ my $schema = $test_case->init_data(
 );
 my $jobs = $schema->resultset('Jobs');
 
+# avoid enqueuing Minion jobs
+my $jobs_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
+$jobs_mock->noop(qw(enqueue_finalize_job_results enqueue_restart));
+
 # prepare needles dir
 my $needle_dir_fixture = $schema->resultset('NeedleDirs')->find(1);
 my $needle_dir = prepare_clean_needles_dir;


### PR DESCRIPTION
The web UI automatically restarts a job when it is set to done under certain conditions. So far errors when restarting are ignored. This change moves the restarting into a Minion job. An error will now lead to failing Minion jobs with the error message assigned as result. This should allow us to investigate https://progress.opensuse.org/issues/125276. Minion jobs are also retried a few times before ending up failed which should make it a bit more robust as well.