### PR TITLE
Make --skip-deps and --skip-chained-deps work as described in the docs

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -202,8 +202,8 @@ sub openqa_baseurl ($local_url) {
 
 sub get_deps ($job, $options, $job_type) {
     my ($chained, $directly_chained, $parallel);
-    unless ($options->{'skip-deps'}) {
-        unless ($options->{'skip-chained-deps'}) {
+    unless ($job_type eq 'parents' && $options->{'skip-deps'}) {
+        unless ($job_type eq 'parents' && $options->{'skip-chained-deps'}) {
             $chained = $job->{$job_type}->{Chained};
             $directly_chained = $job->{$job_type}->{'Directly chained'};
         }


### PR DESCRIPTION
The documentation says that `--skip-deps` and `--skip-chained-deps` only affects parent jobs. But in the code both flags were applied unconditionally to all dependencies, no matter if `--clone-children` was present as well.

With this patch applied you can use `--skip-deps --clone-children` to clone a job with its children, but without parents.

The documentation was added 7 years ago, together with the dependency cloning feature, which at the time only allowed parents to be cloned. 4 years later another feature was introduced that allows for child jobs to be cloned as well. Here it appears the old documentation was missed, and has been incorrect since then.

Clone dependencies: https://github.com/os-autoinst/openQA/commit/39cbc4051d1eb0fcaeed7339af68475f7619ec30
Clone children: https://github.com/os-autoinst/openQA/commit/7cb28ed876052a3a65732caf93083a07ded473c4

Progress: https://progress.opensuse.org/issues/124493