### PR TITLE
Run cache.fullstack job also in nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,5 +306,11 @@ workflows:
               only:
                 - master
     jobs:
+      # We also need the package cache for build-docs
+      # https://progress.opensuse.org/issues/123867
+      - cache
+      - cache.fullstack:
+          <<: *requires
       - dependencies-pr
-      - build-docs-nightly
+      - build-docs-nightly:
+          <<: *requires_fullstack


### PR DESCRIPTION
To prevent empty cache errors that we get from time to time.

Issue: https://progress.opensuse.org/issues/123867

I ran the job on my fork, looked good