### PR TITLE
Fix `restart_job` jobs failing with `already has clone`

### DIFF
--- a/lib/OpenQA/Task/Job/Restart.pm
+++ b/lib/OpenQA/Task/Job/Restart.pm
@@ -16,7 +16,7 @@ sub restart_delay { $ENV{OPENQA_JOB_RESTART_DELAY} // 5 }
 
 sub restart_openqa_job ($minion_job, $openqa_job) {
     my $cloned_job_or_error = $openqa_job->auto_duplicate;
-    my $is_ok = ref $cloned_job_or_error || $cloned_job_or_error =~ qr/(already.*cloned|direct parent)/i;
+    my $is_ok = ref $cloned_job_or_error || $cloned_job_or_error =~ qr/(already.*clone|direct parent)/i;
     $minion_job->note(
         ref $cloned_job_or_error
         ? (cluster_cloned => $cloned_job_or_error->{cluster_cloned})


### PR DESCRIPTION
Treat also the error "… already has clone …" as non-fatal in the context of automatic restarts. So far only the slightly different error message (when the immediately specified job has already been cloned) was accounted for.

Related ticket: https://progress.opensuse.org/issues/125276