### PR TITLE
Make it easier to distinguish OpenID-related errors

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -80,7 +80,7 @@ sub auth_response ($self) {
 
     my $err_handler = sub {
         my ($err, $txt) = @_;
-        $self->app->log->error("$err: $txt");
+        $self->app->log->error("OpenID: $err: $txt");
         $self->flash(error => "$err: $txt");
         return (error => 0);
     };

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -73,7 +73,7 @@ subtest OpenID => sub {
       ->header_is('Location', '/login?return_page=%2Fapi_keys', 'remember return_page for ensure_operator');
     $t->get_ok('/admin/users')->status_is(302)
       ->header_is('Location', '/login?return_page=%2Fadmin%2Fusers', 'remember return_page for ensure_admin');
-    $t->get_ok('/minion/stats')->status_is(200), 'minion stats is accessible unauthenticated (poo#110533)';
+    $t->get_ok('/minion/stats')->status_is(200, 'minion stats is accessible unauthenticated (poo#110533)');
 };
 
 subtest OAuth2 => sub {


### PR DESCRIPTION
* Add context when logging OpenID-related errors
* Allow to easily ignore OpenID-related errors in tools like logwarn
* Related ticket: https://progress.opensuse.org/issues/125459