### PR TITLE
Add note about hook script in carry over comment

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1658,6 +1658,22 @@ sub _failure_reason ($self) {
     return keys %failed_modules ? (join(',', sort keys %failed_modules) || $self->result) : 'GOOD';
 }
 
+=head2 hook_script
+
+Returns the hook script for this job depending on its result and settings and the global configuration.
+
+=cut
+sub hook_script ($self) {
+    my $trigger_hook = $self->settings_hash->{_TRIGGER_JOB_DONE_HOOK};
+    return undef if defined $trigger_hook && !$trigger_hook;
+    return undef unless my $result = $self->result;
+    my $hooks = OpenQA::App->singleton->config->{hooks};
+    my $key = "job_done_hook_$result";
+    my $hook = $ENV{'OPENQA_' . uc $key} // $hooks->{lc $key};
+    $hook = $hooks->{job_done_hook} if !$hook && ($trigger_hook || $hooks->{"job_done_hook_enable_$result"});
+    return $hook;
+}
+
 sub _carry_over_candidate ($self) {
     my $current_failure_reason = $self->_failure_reason;
     my $app = OpenQA::App->singleton;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1731,7 +1731,10 @@ sub carry_over_bugrefs ($self) {
         next unless $comment->bugref;
         my $text = $comment->text;
         my $prev_id = $prev->id;
-        $text .= "\n\n(Automatic takeover from t#$prev_id)\n" unless $text =~ qr/Automatic takeover/;
+        $text .= "\n\n(Automatic takeover from t#$prev_id)" if $text !~ qr/Automatic takeover/;
+        $text .= "\n(The hook script will not be executed.)"
+          if $text !~ qr/The hook script will not be executed/ && defined $self->hook_script;
+        $text .= "\n" unless substr($text, -1, 1) eq "\n";
         my %newone = (text => $text, user_id => $comment->user_id);
         $self->comments->create_with_event(\%newone, {taken_over_from_job_id => $prev_id});
         return 1;

--- a/lib/OpenQA/Task/Job/FinalizeResults.pm
+++ b/lib/OpenQA/Task/Job/FinalizeResults.pm
@@ -43,20 +43,11 @@ sub _finalize_results ($minion_job, $openqa_job_id = undef, $carried_over = unde
 }
 
 sub _run_hook_script ($minion_job, $openqa_job, $app, $guard) {
-    my $settings = $openqa_job->settings_hash;
-    my $trigger_hook = $settings->{_TRIGGER_JOB_DONE_HOOK};
-
-    return undef if defined $trigger_hook && !$trigger_hook;
-    return undef unless my $result = $openqa_job->result;
-
-    my $hooks = $app->config->{hooks};
-    my $key = "job_done_hook_$result";
-    my $hook = $ENV{'OPENQA_' . uc $key} // $hooks->{lc $key};
-    $hook = $hooks->{job_done_hook} if !$hook && ($trigger_hook || $hooks->{"job_done_hook_enable_$result"});
-    return undef unless $hook;
+    return undef unless my $hook = $openqa_job->hook_script;
 
     my $timeout = $ENV{OPENQA_JOB_DONE_HOOK_TIMEOUT} // '5m';
     my $kill_timeout = $ENV{OPENQA_JOB_DONE_HOOK_KILL_TIMEOUT} // '30s';
+    my $settings = $openqa_job->settings_hash;
     my $delay = $settings->{_TRIGGER_JOB_DONE_DELAY} // $ENV{OPENQA_JOB_DONE_HOOK_DELAY} // ONE_MINUTE;
     my $retries = $settings->{_TRIGGER_JOB_DONE_RETRIES} // $ENV{OPENQA_JOB_DONE_HOOK_RETRIES} // 1440;
     my $skip_rc = $settings->{_TRIGGER_JOB_DONE_SKIP_RC} // $ENV{OPENQA_JOB_DONE_HOOK_SKIP_RC} // 142;


### PR DESCRIPTION
Add a note in the carry-over comment that no hook scripts are
executed (if hook scripts are configured).

Related ticket/note: https://progress.opensuse.org/issues/123724#note-12