### PR TITLE
Allow scheduling and monitoring a product via `openqa-cli`

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -49,7 +49,6 @@ sub command ($self, @args) {
     my $url = $self->url_for($path);
     my $client = $self->client($url);
     my $tx = $client->build_tx($method, $url, $headers, @data);
-    my $ret;
     $retries //= $ENV{OPENQA_CLI_RETRIES} // 0;
     do {
         $tx = $client->start($tx);

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -14,8 +14,8 @@ has post_url => sub { shift->url_for('isos') };
 
 sub _create_jobs ($self, $client, $args, $param_file, $job_ids) {
     my $params = $self->parse_params($args, $param_file);
-    my $tx = $client->start($client->build_tx(POST => $self->post_url, {}, form => $params));
-    my $res = $self->handle_result($tx, {pretty => 0, quiet => 1, links => 0, verbose => 0});
+    my $tx = $client->build_tx(POST => $self->post_url, {}, form => $params);
+    my $res = $self->retry_tx($client, $tx, {pretty => 0, quiet => 1, links => 0, verbose => 0});
     return $res if $res != 0;
     my $json = $tx->res->json;
     push @$job_ids, $json->{id} if defined $json->{id} && ref $json->{id} eq '';
@@ -28,8 +28,8 @@ sub _create_jobs ($self, $client, $args, $param_file, $job_ids) {
 sub _monitor_jobs ($self, $client, $poll_interval, $job_ids, $job_results) {
     while (@$job_results < @$job_ids) {
         my $job_id = $job_ids->[@$job_results];
-        my $tx = $client->start($client->build_tx(GET => $self->url_for("experimental/jobs/$job_id/status"), {}));
-        my $res = $self->handle_result($tx, {pretty => 0, quiet => 1, links => 0, verbose => 0});
+        my $tx = $client->build_tx(GET => $self->url_for("experimental/jobs/$job_id/status"), {});
+        my $res = $self->retry_tx($client, $tx, {pretty => 0, quiet => 1, links => 0, verbose => 0});
         return $res if $res != 0;
         my $job = $tx->res->json;
         my $job_state = $job->{state} // NONE;

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -1,0 +1,97 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::CLI::schedule;
+use OpenQA::Jobs::Constants;
+use Mojo::Base 'OpenQA::Command', -signatures;
+use Mojo::Util qw(getopt);
+use Term::ANSIColor qw(colored);
+use open qw(:std :encoding(UTF-8));
+
+has description => 'Schedules a set of jobs (via "isos post" creating a schedule product)';
+has usage => sub { shift->extract_usage };
+has post_url => sub { shift->url_for('isos') };
+
+sub _create_jobs ($self, $client, $args, $param_file, $job_ids) {
+    my $params = $self->parse_params($args, $param_file);
+    my $tx = $client->start($client->build_tx(POST => $self->post_url, {}, form => $params));
+    my $res = $self->handle_result($tx, {pretty => 0, quiet => 1, links => 0, verbose => 0});
+    return $res if $res != 0;
+    my $json = $tx->res->json;
+    push @$job_ids, $json->{id} if defined $json->{id} && ref $json->{id} eq '';
+    push @$job_ids, @{$json->{ids}} if ref $json->{ids} eq 'ARRAY';
+    return 0 unless my $error = $json->{error};
+    print STDERR colored(['red'], $error, "\n");
+    return 1;
+}
+
+sub _monitor_jobs ($self, $client, $poll_interval, $job_ids, $job_results) {
+    while (@$job_results < @$job_ids) {
+        my $job_id = $job_ids->[@$job_results];
+        my $tx = $client->start($client->build_tx(GET => $self->url_for("experimental/jobs/$job_id/status"), {}));
+        my $res = $self->handle_result($tx, {pretty => 0, quiet => 1, links => 0, verbose => 0});
+        return $res if $res != 0;
+        my $job = $tx->res->json;
+        my $job_state = $job->{state} // NONE;
+        if (OpenQA::Jobs::Constants::meta_state($job_state) eq OpenQA::Jobs::Constants::FINAL) {
+            push @$job_results, $job->{result} // NONE;
+            next;
+        }
+        print "Job state of job ID $job_id: $job_state, waiting…\n";
+        sleep $poll_interval;
+    }
+}
+
+sub _compute_return_code ($self, $job_results) {
+    for my $job_result (@$job_results) {
+        return 2 unless OpenQA::Jobs::Constants::is_ok_result($job_result);
+    }
+    return 0;
+}
+
+sub command ($self, @args) {
+    die $self->usage
+      unless getopt \@args,
+      'param-file=s' => \my @param_file,
+      'm|monitor' => \my $monitor,
+      'i|poll-interval=i' => \my $poll_interval,
+      'r|set-return-code' => \my $set_return_code;
+    @args = $self->decode_args(@args);
+    my $client = $self->client($self->post_url);
+
+    my @job_ids;
+    my $create_res = $self->_create_jobs($client, \@args, \@param_file, \@job_ids);
+    return $create_res if $create_res != 0 || !($monitor || $set_return_code);
+
+    my @job_results;
+    my $monitor_res = $self->_monitor_jobs($client, $poll_interval // 10, \@job_ids, \@job_results);
+    return $monitor_res if $monitor_res != 0 || !$set_return_code;
+    return $self->_compute_return_code(\@job_results);
+}
+
+1;
+
+=encoding utf8
+
+=head1 SYNOPSIS
+
+  Usage: openqa-cli schedule [OPTIONS] DISTRI=… VERSION=… FLAVOR=… ARCH=… [ISO=… …]
+
+  Options:
+        --apibase <path>           API base, defaults to /api/v1
+        --apikey <key>             API key
+        --apisecret <secret>       API secret
+        --host <host>              Target host, defaults to http://localhost
+    -h, --help                     Show this summary of available options
+        --osd                      Set target host to http://openqa.suse.de
+        --o3                       Set target host to https://openqa.opensuse.org
+        --param-file <param=file>  Load content of params from files instead of
+                                   from command line arguments. Multiple params
+                                   may be specified by adding the option
+                                   multiple times
+    -m, --monitor                  Wait until all jobs are done/cancelled
+    -i, --poll-interval            Specifies the poll interval used with --monitor
+    -r, --set-return-code          Return non-zero exit code if at least one job
+                                   is not passed/softfailed (implies -m)
+
+=cut

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -37,7 +37,7 @@ sub _monitor_jobs ($self, $client, $poll_interval, $job_ids, $job_results) {
             push @$job_results, $job->{result} // NONE;
             next;
         }
-        print "Job state of job ID $job_id: $job_state, waiting…\n";
+        print "Job state of job ID $job_id: $job_state, waiting …\n";
         sleep $poll_interval;
     }
 }

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -4,9 +4,8 @@
 package OpenQA::CLI::schedule;
 use OpenQA::Jobs::Constants;
 use Mojo::Base 'OpenQA::Command', -signatures;
-use Mojo::Util qw(getopt);
+use Mojo::Util qw(encode getopt);
 use Term::ANSIColor qw(colored);
-use open qw(:std :encoding(UTF-8));
 
 has description => 'Schedules a set of jobs (via "isos post" creating a schedule product)';
 has usage => sub { shift->extract_usage };
@@ -37,7 +36,7 @@ sub _monitor_jobs ($self, $client, $poll_interval, $job_ids, $job_results) {
             push @$job_results, $job->{result} // NONE;
             next;
         }
-        print "Job state of job ID $job_id: $job_state, waiting …\n";
+        print encode('UTF-8', "Job state of job ID $job_id: $job_state, waiting …\n");
         sleep $poll_interval;
     }
 }

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -55,17 +55,17 @@ sub command ($self, @args) {
       'param-file=s' => \my @param_file,
       'm|monitor' => \my $monitor,
       'i|poll-interval=i' => \my $poll_interval,
-      'r|set-return-code' => \my $set_return_code;
+      ;
     @args = $self->decode_args(@args);
     my $client = $self->client($self->post_url);
 
     my @job_ids;
     my $create_res = $self->_create_jobs($client, \@args, \@param_file, \@job_ids);
-    return $create_res if $create_res != 0 || !($monitor || $set_return_code);
+    return $create_res if $create_res != 0 || !$monitor;
 
     my @job_results;
     my $monitor_res = $self->_monitor_jobs($client, $poll_interval // 10, \@job_ids, \@job_results);
-    return $monitor_res if $monitor_res != 0 || !$set_return_code;
+    return $monitor_res if $monitor_res != 0;
     return $self->_compute_return_code(\@job_results);
 }
 
@@ -89,9 +89,9 @@ sub command ($self, @args) {
                                    from command line arguments. Multiple params
                                    may be specified by adding the option
                                    multiple times
-    -m, --monitor                  Wait until all jobs are done/cancelled
+    -m, --monitor                  Wait until all jobs are done/cancelled and return
+                                   non-zero exit code if at least on job has not
+                                   passed/softfailed
     -i, --poll-interval            Specifies the poll interval used with --monitor
-    -r, --set-return-code          Return non-zero exit code if at least one job
-                                   is not passed/softfailed (implies -m)
 
 =cut

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -11,6 +11,7 @@ use Mojo::Util qw(decode getopt);
 use Mojo::URL;
 use Mojo::File qw(path);
 use Term::ANSIColor qw(colored);
+use open qw(:std :encoding(UTF-8));
 
 my $JSON = Cpanel::JSON::XS->new->utf8->canonical->allow_nonref->allow_unknown->allow_blessed->convert_blessed
   ->stringify_infnan->escape_slash->allow_dupkeys->pretty;
@@ -114,7 +115,7 @@ sub retry_tx ($self, $client, $tx, $handle_args, $retries = undef, $delay = unde
         $tx = $client->start($tx);
         my $res_code = $tx->res->code // 0;
         return $self->handle_result($tx, $handle_args) unless $res_code =~ /50[23]/ && $retries > 0;
-        print "Request failed, hit error $res_code, retrying up to $retries more times after waiting ...\n";
+        print "Request failed, hit error $res_code, retrying up to $retries more times after waiting …\n";
         sleep $delay;
     }
 }

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -7,11 +7,10 @@ use Mojo::Base 'Mojolicious::Command', -signatures;
 use Cpanel::JSON::XS ();
 use OpenQA::Client;
 use Mojo::IOLoop;
-use Mojo::Util qw(decode getopt);
+use Mojo::Util qw(encode decode getopt);
 use Mojo::URL;
 use Mojo::File qw(path);
 use Term::ANSIColor qw(colored);
-use open qw(:std :encoding(UTF-8));
 
 my $JSON = Cpanel::JSON::XS->new->utf8->canonical->allow_nonref->allow_unknown->allow_blessed->convert_blessed
   ->stringify_infnan->escape_slash->allow_dupkeys->pretty;
@@ -115,7 +114,8 @@ sub retry_tx ($self, $client, $tx, $handle_args, $retries = undef, $delay = unde
         $tx = $client->start($tx);
         my $res_code = $tx->res->code // 0;
         return $self->handle_result($tx, $handle_args) unless $res_code =~ /50[23]/ && $retries > 0;
-        print "Request failed, hit error $res_code, retrying up to $retries more times after waiting …\n";
+        print encode('UTF-8',
+            "Request failed, hit error $res_code, retrying up to $retries more times after waiting …\n");
         sleep $delay;
     }
 }

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -110,15 +110,13 @@ sub url_for ($self, $path) {
 sub retry_tx ($self, $client, $tx, $handle_args, $retries = undef, $delay = undef) {
     $delay //= $ENV{OPENQA_CLI_RETRY_SLEEP_TIME_S} // 3;
     $retries //= $ENV{OPENQA_CLI_RETRIES} // 0;
-    do {
+    for (;; --$retries) {
         $tx = $client->start($tx);
         my $res_code = $tx->res->code // 0;
         return $self->handle_result($tx, $handle_args) unless $res_code =~ /50[23]/ && $retries > 0;
         print "Request failed, hit error $res_code, retrying up to $retries more times after waiting ...\n";
         sleep $delay;
-        $retries--;
-    } while ($retries > 0);
-    return 1;
+    }
 }
 
 1;

--- a/t/43-cli-schedule.t
+++ b/t/43-cli-schedule.t
@@ -19,6 +19,7 @@ use Test::Output qw(combined_like);
 use Test::MockModule;
 
 my ($archive, $res) = OpenQA::CLI::schedule->new;
+$ENV{OPENQA_CLI_RETRIES} = 0;
 OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
 
 # change API to simulate job state/result changes

--- a/t/43-cli-schedule.t
+++ b/t/43-cli-schedule.t
@@ -1,0 +1,82 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings qw(:report_warnings warning);
+use Mojo::Base -strict, -signatures;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+
+use OpenQA::Test::TimeLimit '7';
+use OpenQA::CLI;
+use OpenQA::CLI::schedule;
+use OpenQA::Jobs::Constants;
+use OpenQA::Test::Case;
+use Mojo::Server::Daemon;
+use Mojo::File qw(tempdir tempfile);
+use Test::Output qw(combined_like);
+use Test::MockModule;
+
+my ($archive, $res) = OpenQA::CLI::schedule->new;
+OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
+
+# change API to simulate job state/result changes
+my $job_controller_mock = Test::MockModule->new('OpenQA::WebAPI::Controller::API::V1::Job');
+my @job_mock_results = (PASSED, SOFTFAILED, PASSED, USER_CANCELLED);    # results to assume for job 1, job 2, …
+$job_controller_mock->redefine(
+    get_status => sub ($self) {
+        # reply as usual
+        $job_controller_mock->original('get_status')->($self);
+        # fake that the job is done which will affect the next status query
+        my $job = $self->schema->resultset('Jobs')->find(int($self->stash('jobid')));
+        $job->done(result => (shift(@job_mock_results) // PASSED), reason => 'mocked') if $job && $job->result eq NONE;
+    });
+
+# start web server
+my $daemon = Mojo::Server::Daemon->new(listen => ['http://127.0.0.1']);
+my $app = $daemon->build_app('OpenQA::WebAPI');
+my $port = $daemon->start->ports->[0];
+my $host = "http://127.0.0.1:$port";
+$app->log->level($ENV{HARNESS_IS_VERBOSE} ? 'debug' : 'error');
+
+combined_like { OpenQA::CLI->new->run('help', 'schedule') } qr/Usage: openqa-cli schedule/, 'help';
+subtest 'unknown options' => sub {
+    like warning {
+        eval { $archive->run('--unknown') }
+    }, qr/Unknown option: unknown/, 'right output';
+    like $@, qr/Usage: openqa-cli schedule/, 'unknown option';
+};
+
+# define different sets of CLI args to be used in further tests
+my @options = ('--apikey', 'ARTHURKEY01', '--apisecret', 'EXCALIBUR', '--host', $host, '-r', '-i', 0);
+my @scenarios = ('--param-file', "SCENARIO_DEFINITIONS_YAML=$FindBin::Bin/data/09-schedule_from_file.yaml");
+my @settings1 = (qw(DISTRI=example VERSION=0 FLAVOR=DVD ARCH=x86_64 TEST=simple_boot));
+my @settings2 = (qw(DISTRI=opensuse VERSION=13.1 FLAVOR=DVD ARCH=i586 BUILD=0091 TEST=autoyast_btrfs));
+
+subtest 'running into error reply' => sub {
+    combined_like { $res = $archive->run(@options) } qr/Error: missing parameters: DISTRI VERSION FLAVOR ARCH/,
+      '"missing parameters" error';
+    is $archive->host, $host, 'host set';
+    is $res, 1, 'non-zero return-code if parameters missing';
+
+    combined_like { $res = $archive->run(@options, @settings1) } qr/no products found for/, '"no products found" error';
+    is $res, 1, 'non-zero return-code if no products could be found';
+};
+
+subtest 'scheduling and monitoring zero-sized set of jobs' => sub {
+    combined_like { $res = $archive->run(@options, @scenarios, @settings1) } qr/count.*0/, 'response logged';
+    is $res, 0, 'zero return-code';
+};
+
+subtest 'scheduling and monitoring set of two jobs' => sub {
+    combined_like { $res = $archive->run(@options, @scenarios, @settings2) } qr/count.*2.*passed.*softfailed/s,
+      'response logged if all jobs are ok';
+    is $res, 0, 'zero return-code if all jobs are ok';
+
+    combined_like { $res = $archive->run(@options, @scenarios, @settings2) } qr/count.*2.*passed.*user_cancelled/s,
+      'response logged if one job was cancelled';
+    is $res, 2, 'non-zero return-code if at least one job is not ok';
+};
+
+done_testing();

--- a/t/43-cli-schedule.t
+++ b/t/43-cli-schedule.t
@@ -50,7 +50,7 @@ subtest 'unknown options' => sub {
 };
 
 # define different sets of CLI args to be used in further tests
-my @options = ('--apikey', 'ARTHURKEY01', '--apisecret', 'EXCALIBUR', '--host', $host, '-r', '-i', 0);
+my @options = ('--apikey', 'ARTHURKEY01', '--apisecret', 'EXCALIBUR', '--host', $host, '-m', '-i', 0);
 my @scenarios = ('--param-file', "SCENARIO_DEFINITIONS_YAML=$FindBin::Bin/data/09-schedule_from_file.yaml");
 my @settings1 = (qw(DISTRI=example VERSION=0 FLAVOR=DVD ARCH=x86_64 TEST=simple_boot));
 my @settings2 = (qw(DISTRI=opensuse VERSION=13.1 FLAVOR=DVD ARCH=i586 BUILD=0091 TEST=autoyast_btrfs));


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/125720

---

Example invocation:
```
script/openqa-cli schedule --apikey … --apisecret … --host … DISTRI=example VERSION=0 FLAVOR=DVD ARCH=x86_64 TEST=simple_boot FOO=bar --param-file SCENARIO_DEFINITIONS_YAML=/hdd/openqa-devel/openqa/share/tests/example/scenaio-definitions.yaml -r
```

So one can use CLI-flags similar to `openqa-cli api`.

Still a draft because unit tests are missing and the error handling needs to be improved (it should retry like `openqa-cli api`).