### PR TITLE
Make t_created unambiguous in SQL

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -86,7 +86,7 @@ the return array.
 =cut
 
 sub latest_jobs ($self, $until = undef) {
-    my @jobs = $self->search($until ? {t_created => {'<=' => $until}} : undef, {order_by => ['me.id DESC']});
+    my @jobs = $self->search($until ? {'me.t_created' => {'<=' => $until}} : undef, {order_by => ['me.id DESC']});
 
     my @latest;
     my %seen;


### PR DESCRIPTION
Error message:

    DBIx::Class::Storage::DBI::_dbh_execute():
    DBI Exception: DBD::Pg::st execute failed: ERROR:  column reference "t_created" is ambiguous