### PR TITLE
Provide container image to trigger/monitor jobs as CI

### DIFF
--- a/container/client/Dockerfile
+++ b/container/client/Dockerfile
@@ -1,0 +1,11 @@
+#!BuildTag: tumbleweed:client
+# This container is built on https://build.opensuse.org/package/show/devel:openQA/openQA_container_client.
+
+# hadolint ignore=DL3007
+FROM opensuse/tumbleweed:latest
+
+# hadolint ignore=DL3037
+RUN zypper ar -p 95 -f https://download.opensuse.org/repositories/devel:/openQA/openSUSE_Tumbleweed devel_openQA && \
+    zypper --gpg-auto-import-keys ref && \
+    zypper in -y openQA-client git && \
+    zypper clean


### PR DESCRIPTION
* Provide container with `openqa-cli` and Git pre-installed to utilize 6656bb7275c4e26c0b01afae071d310bb76242bd from CI runs
* Related ticket: https://progress.opensuse.org/issues/125723

---

When this PR has been merged, I'll change the OBS package to pull the Dockerfile from here.