### PR TITLE
Make key-auth work for openQA instances under nested path

### DIFF
--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -7,6 +7,7 @@ use Mojo::Base 'Mojolicious::Controller', -signatures;
 use OpenQA::Schema;
 use OpenQA::Log qw(log_trace);
 use Mojo::Util qw(hmac_sha1_sum secure_compare);
+use Mojo::URL;
 
 sub check ($self) {
     if ($self->app->config->{no_localhost_auth}) {
@@ -180,7 +181,9 @@ sub _valid_hmac ($self, $hash, $request, $build_tx_timestamp, $timestamp, $api_k
     return 0 if _is_expired($api_key);
     return 0 unless $api_key->secret;
 
-    my $sum = hmac_sha1_sum($request . $timestamp, $api_key->secret);
+    my $base_url = $self->app->config->{global}->{base_url};
+    my $base_path = $base_url ? Mojo::URL->new($base_url)->path : '';
+    my $sum = hmac_sha1_sum($base_path . $request . $timestamp, $api_key->secret);
     return $sum eq $hash;
 }
 


### PR DESCRIPTION
By invoking `openqa-cli api --host http://myhost/foo/bar --apibase api/v1 …` one can do a request to an openQA instance that has been made available under the nested path `foo/bar` on the specified host using the Mojolicous plugin `RequestBase`.

The client will then compute the hmac for the full path, including the "base"- prefix (e.g. `foo/bar/api/v1/isos`). The web UI will however not take the "base-prefix into account (and compute the hmac just for e.g. `api/v1/isos`). With this change, the web UI will also take the "base"-prefix into account when a `base_url` has been specified (which is not the case for any of our production instances where nothing changes).