### PR TITLE
Render web UI URLs for jobs created via `openqa-cli schedule`

### DIFF
--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -19,6 +19,11 @@ sub _create_jobs ($self, $client, $args, $param_file, $job_ids) {
     my $json = $tx->res->json;
     push @$job_ids, $json->{id} if defined $json->{id} && ref $json->{id} eq '';
     push @$job_ids, @{$json->{ids}} if ref $json->{ids} eq 'ARRAY';
+    if (my $job_count = @$job_ids) {
+        my $host_url = Mojo::URL->new($self->host);
+        say $job_count == 1 ? '1 job has been created:' : "$job_count jobs have been created:";
+        say ' - ' . $host_url->clone->path("tests/$_") for @$job_ids;
+    }
     return 0 unless my $error = $json->{error};
     print STDERR colored(['red'], $error, "\n");
     return 1;

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -219,11 +219,10 @@ sub handle_tx ($tx, $url_handler, $options, $jobs) {
     if (!$tx->error && ref $json eq 'HASH' && ref $json->{ids} eq 'HASH') {
         my $cloned_jobs = $json->{ids};
         print Cpanel::JSON::XS->new->pretty->encode($cloned_jobs) and return $cloned_jobs if $options->{'json-output'};
-        my $base_url = openqa_baseurl($url_handler->{local_url});
-        for my $orig_job_id (keys %$cloned_jobs) {
-            my $orig_job = $jobs->{$orig_job_id};
-            my $cloned_job_id = $cloned_jobs->{$orig_job_id};
-            print "Created job #$cloned_job_id: $orig_job->{name} -> $base_url/t$cloned_job_id\n";
+        if (my $job_count = keys %$cloned_jobs) {
+            my $base_url = openqa_baseurl($url_handler->{local_url});
+            say $job_count == 1 ? '1 job has been created:' : "$job_count jobs have been created:";
+            say " - $jobs->{$_}->{name} -> $base_url/tests/$cloned_jobs->{$_}" for sort keys %$cloned_jobs;
         }
         return $cloned_jobs;
     }

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -231,7 +231,8 @@ subtest 'error handling' => sub {
     $tx->res->code(200)->body('{"foo": "bar"}');
     throws_ok { $test->() } qr/Failed to create job, server replied: \{ foo => "bar" \}/, 'unexpected JSON handled';
     ($tx = Mojo::Transaction->new)->res->code(200)->body('{"ids": {"42": 43}}');
-    combined_like { $test->() } qr|Created job #43: testjob -> https://base-url/t43|, 'expected response';
+    combined_like { $test->() } qr|1 job has been created:.* - testjob -> https://base-url/tests/43|s,
+      'expected response';
 };
 
 subtest 'export command' => sub {

--- a/t/43-cli-schedule.t
+++ b/t/43-cli-schedule.t
@@ -75,7 +75,8 @@ subtest 'scheduling and monitoring zero-sized set of jobs' => sub {
 
 subtest 'scheduling and monitoring set of two jobs' => sub {
     my $res;
-    combined_like { $res = $schedule->run(@options, @scenarios, @settings2) } qr/count.*2.*passed.*softfailed/s,
+    combined_like { $res = $schedule->run(@options, @scenarios, @settings2) }
+    qr|2 jobs have been created.*(http://127.0.0.1.*/tests/\d+.*){2}passed.*softfailed|s,
       'response logged if all jobs are ok';
     is $res, 0, 'zero return-code if all jobs are ok';
 


### PR DESCRIPTION
* This makes it more convenient to view the jobs manually in the web UI.
* Related ticket: https://progress.opensuse.org/issues/125723