### PR TITLE
Prevent github from caching badges too long

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -530,6 +530,7 @@ sub _badge ($self, $job) {
     }
 
     $self->stash({badge_text => $badge_text, badge_color => $badge_color, badge_width => $badge_width});
+    $self->res->headers->cache_control('max-age=0, no-cache');
     $self->render('test/badge', format => 'svg', status => $status);
 }
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -484,7 +484,7 @@ subtest 'scheduled job' => sub {
 
 subtest 'svg badge' => sub {
     $t->get_ok('/tests/99927/badge')->status_is(200)->content_type_is('image/svg+xml')
-      ->element_exists('svg', 'valid svg badge');
+      ->header_is('Cache-Control' => 'max-age=0, no-cache')->element_exists('svg', 'valid svg badge');
     $t->get_ok('/tests/9992711111/badge')->status_is(404)->content_type_is('image/svg+xml')->element_exists('svg')
       ->content_like(qr/404/, 'valid 404 svg badge');
     $t->get_ok('/tests/latest/badge?test=kde&machine=32bit')->status_is(200)->content_type_is('image/svg+xml')


### PR DESCRIPTION
See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls

```
$ curl -sI "https://circleci.com/gh/os-autoinst/openQA/tree/master.svg?style=svg" | grep cache-control
cache-control: max-age=0, no-cache
```