### PR TITLE
Remove obsolete frontend code for sending commands to worker

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -176,22 +176,6 @@ function updateTestStatus(newStatus) {
     });
 }
 
-function sendCommand(command) {
-  var wid = testStatus.workerid;
-  if (wid == null) return false;
-  var url = $('#canholder').data('url').replace('WORKERID', wid);
-  $.ajax({
-    url: url,
-    type: 'POST',
-    data: {command: command},
-    success: function (resp) {
-      setTimeout(function () {
-        updateStatus();
-      }, 0);
-    }
-  });
-}
-
 function updateStatus() {
   // prevent status updates when window.enableStatusUpdates is set by test environment
   if (window.enableStatusUpdates !== undefined && !window.enableStatusUpdates) {

--- a/templates/webapi/test/live.html.ep
+++ b/templates/webapi/test/live.html.ep
@@ -193,7 +193,7 @@
     </div>
 </div>
 
-<div id="canholder" data-url="<%= url_for('apiv1_create_command', workerid => 'WORKERID')%>">
+<div id="canholder">
   <canvas id="livestream" width="1024" height="768" data-url='<%= url_for("streaming", testid => $testid) %>'>
   </canvas>
 </div>


### PR DESCRIPTION
Since the introduction of the developer mode the web UI does not send worker commands anymore. Note that the API could be removed in the backend as well but since it is strictly an API I would refrain from removing it to keep compatibility.