### PR TITLE
Avoid live view getting stuck in a certain case

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -258,7 +258,7 @@ function addDataListener(elem, callback) {
         var newStartIndex = newLength - maxLiveLogLength;
 
         // discard one (probably) partial line (in accordance with OpenQA::WebAPI::Controller::Running::streamtext)
-        for (; catData[newStartIndex] !== '\n'; ++newStartIndex);
+        for (; newStartIndex < catData.length && catData[newStartIndex] !== '\n'; ++newStartIndex);
 
         firstElement.innerHTML = catData.substr(newStartIndex);
       }


### PR DESCRIPTION
If the to be appended part of the received log content does not contain a newline, the code for discarding the first probably partial line can get stuck in an endless loop. This change fixes the loop condition to avoid this.