### PR TITLE
Make it easier to identify openqa-cli in logs

### DIFF
--- a/lib/OpenQA/CLI/api.pm
+++ b/lib/OpenQA/CLI/api.pm
@@ -135,6 +135,9 @@ sub command ($self, @args) {
                                   may be specified by adding the option
                                   multiple times
     -L, --links                   Print pagination links to STDERR
+        --name <name>             Name of this client, used by openQA to
+                                  identify different clients via User-Agent
+                                  header, defaults to "openqa-cli"
     -p, --pretty                  Pretty print JSON content
     -q, --quiet                   Do not print error messages to STDERR
     -r, --retries <retries>       Retry up to the specified value on some

--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -53,6 +53,9 @@ sub command ($self, @args) {
         --host <host>              Target host, defaults to http://localhost
     -h, --help                     Show this summary of available options
     -l, --asset-size-limit <num>   Asset size limit in bytes
+        --name <name>              Name of this client, used by openQA to
+                                   identify different clients via User-Agent
+                                   header, defaults to "openqa-cli"
         --osd                      Set target host to http://openqa.suse.de
         --o3                       Set target host to https://openqa.opensuse.org
     -t, --with-thumbnails          Download thumbnails as well

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -96,6 +96,9 @@ sub command ($self, @args) {
     -m, --monitor                  Wait until all jobs are done/cancelled and return
                                    non-zero exit code if at least on job has not
                                    passed/softfailed
+        --name <name>              Name of this client, used by openQA to
+                                   identify different clients via User-Agent
+                                   header, defaults to "openqa-cli"
     -i, --poll-interval            Specifies the poll interval used with --monitor
     -p, --pretty                   Pretty print JSON content
     -q, --quiet                    Do not print error messages to STDERR

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -22,8 +22,10 @@ has host => 'http://localhost';
 has options => undef;
 
 sub client ($self, $url) {
-    return OpenQA::Client->new(apikey => $self->apikey, apisecret => $self->apisecret, api => $url->host)
+    my $client = OpenQA::Client->new(apikey => $self->apikey, apisecret => $self->apisecret, api => $url->host)
       ->ioloop(Mojo::IOLoop->singleton);
+    $client->transactor->name('openqa-cli');
+    return $client;
 }
 
 sub data_from_stdin {

--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -18,13 +18,14 @@ my $PARAM_RE = qr/^([[:alnum:]_\[\]\.\:]+)=(.*)$/s;
 
 has apibase => '/api/v1';
 has [qw(apikey apisecret host)];
+has name => 'openqa-cli';
 has host => 'http://localhost';
 has options => undef;
 
 sub client ($self, $url) {
     my $client = OpenQA::Client->new(apikey => $self->apikey, apisecret => $self->apisecret, api => $url->host)
       ->ioloop(Mojo::IOLoop->singleton);
-    $client->transactor->name('openqa-cli');
+    $client->transactor->name($self->name);
     return $client;
 }
 
@@ -101,6 +102,7 @@ sub run ($self, @args) {
       'o3' => sub { $self->host('https://openqa.opensuse.org') },
       'osd' => sub { $self->host('http://openqa.suse.de') },
       'L|links' => \$options{links},
+      'name=s' => sub { $self->name($_[1]) },
       'p|pretty' => \$options{pretty},
       'q|quiet' => \$options{quiet},
       'v|verbose' => \$options{verbose};

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -197,6 +197,12 @@ subtest 'HTTP features' => sub {
     is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
 
     ($stdout, @result)
+      = capture_stdout sub { $api->run(@host, '--header', 'X-Test: works', '--name', 'openqa-whatever', $path) };
+    $data = decode_json $stdout;
+    is $data->{headers}{'User-Agent'}, 'openqa-whatever', 'User-Agent header';
+    is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
+
+    ($stdout, @result)
       = capture_stdout sub { $api->run(@host, '-a', 'X-Test: works', '-a', 'X-Test2: works too', $path) };
     $data = decode_json $stdout;
     is $data->{headers}{'X-Test'}, 'works', 'X-Test header';

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -187,14 +187,18 @@ subtest 'HTTP features' => sub {
     is decode_json($stdout)->{body}, 'Hello openQA!', 'request body';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@host, '-a', 'X-Test: works', $path) };
-    is decode_json($stdout)->{headers}{'X-Test'}, 'works', 'X-Test header';
+    my $data = decode_json $stdout;
+    is $data->{headers}{'User-Agent'}, 'openqa-cli', 'User-Agent header';
+    is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
 
     ($stdout, @result) = capture_stdout sub { $api->run(@host, '--header', 'X-Test: works', $path) };
-    is decode_json($stdout)->{headers}{'X-Test'}, 'works', 'X-Test header';
+    $data = decode_json $stdout;
+    is $data->{headers}{'User-Agent'}, 'openqa-cli', 'User-Agent header';
+    is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
 
     ($stdout, @result)
       = capture_stdout sub { $api->run(@host, '-a', 'X-Test: works', '-a', 'X-Test2: works too', $path) };
-    my $data = decode_json $stdout;
+    $data = decode_json $stdout;
     is $data->{headers}{'X-Test'}, 'works', 'X-Test header';
     is $data->{headers}{'X-Test2'}, 'works too', 'X-Test2 header';
 


### PR DESCRIPTION
As a result of our adventure today trying to track down the service unintentionally running a DoS attack against OSD. We should do this for all openQA clients to make them easy to identify in logs.