### PR TITLE
openqa-clone-job: Apply group settings to all cloned jobs

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -25,7 +25,7 @@ our @EXPORT = qw(
   post_jobs
 );
 
-use constant GLOBAL_SETTINGS => ('WORKER_CLASS');
+use constant GLOBAL_SETTINGS => (qw(WORKER_CLASS _GROUP _GROUP_ID));
 
 use constant JOB_SETTING_OVERRIDES => {
     _GROUP => '_GROUP_ID',


### PR DESCRIPTION
This change makes `_GROUP` and `_GROUP_ID` "global" settings so one can clone a set of jobs into another group or no group via, e.g. `openqa-clone-job $some_url _GROUP=0`. Otherwise one needed to take dependencies into account and possibly specify `--parental-inheritance` (which would then apply all settings to the parent which might not be wanted as well).

The downside is that leaving the parent jobs that are cloned as well in their job groups is not possible anymore. However, I don't think that this is a realy use case of our users anyways.