### PR TITLE
Track download count to supress alert if no downloads ongoing

### DIFF
--- a/lib/OpenQA/CacheService/Command/run.pm
+++ b/lib/OpenQA/CacheService/Command/run.pm
@@ -12,11 +12,15 @@ has usage => sub ($self) { $self->extract_usage };
 sub run ($self, @args) {
     getopt \@args, ['pass_through'], 'reset-locks' => \my $reset_locks;
 
+    my $app = $self->app;
     if ($reset_locks) {
-        my $app = $self->app;
         $app->log->info('Resetting all leftover locks after restart');
         $app->minion->reset({locks => 1});
     }
+
+    # Reset download count after restart (might not be 0 after an unclean exit)
+    $app->cache->reset_download_count;
+
     $self->SUPER::run(@args);
 }
 

--- a/lib/OpenQA/CacheService/Controller/Influxdb.pm
+++ b/lib/OpenQA/CacheService/Controller/Influxdb.pm
@@ -23,7 +23,9 @@ sub minion ($self) {
     $text .= _output_measure($url, 'openqa_minion_workers', $workers);
 
     my $metrics = $app->cache->metrics;
+    my $count = $metrics->{download_count} // 0;
     my $bytes = $metrics->{download_rate};
+    $text .= "openqa_download_count,url=$url count=${count}i\n";
     $text .= "openqa_download_rate,url=$url bytes=${bytes}i\n" if defined $bytes;
 
     $self->render(text => $text);


### PR DESCRIPTION
* Return the download count in the same way as we currently the download rate (via the Minion's InfluxDB route)
* Increment the download count when starting one and decrement it when it finished (regardless of the result)
* Reset the download count to zero when starting `openqa-workercache run …` be start counting from scratch after an unclean exit. (still WIP)
* Related ticket: https://progress.opensuse.org/issues/127097