### PR TITLE
Ensure final status update for cancelled jobs

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1430,7 +1430,7 @@ sub update_status ($self, $status) {
     #       wins the race updating the job state.
     $self->discard_changes;
     my $state = $self->state;
-    return {result => 0} unless $state eq RUNNING || $state eq UPLOADING;
+    return {result => 0} unless $state eq RUNNING || $state eq UPLOADING || $state eq CANCELLED;
 
     $self->append_log($status->{log}, "autoinst-log-live.txt");
     $self->append_log($status->{serial_log}, "serial-terminal-live.txt");

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -890,6 +890,10 @@ subtest '"race" between status updates and stale job detection' => sub {
     is $job->update_status({})->{result}, 1, 'status updates still possible if uploading';
     $job->discard_changes;
     is $job->state, UPLOADING, 'job is still uploading';
+
+    $job->update({state => CANCELLED});
+    $update = $job->update_status({});
+    is $update->{job_result}, 'incomplete', 'cancelled jobs will still get a status update';
 };
 
 is $t->app->minion->jobs({states => ['failed']})->total, 0, 'No unexpected failed minion background jobs';


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/126665

Without this, cancelled jobs would not get their final status update and upload of details-*.json, so the uploaded screenshots could not be viewed.