### PR TITLE
Improved build_progressbar.html.ep

### DIFF
--- a/templates/webapi/main/build_progressbar.html.ep
+++ b/templates/webapi/main/build_progressbar.html.ep
@@ -1,9 +1,10 @@
-% my $class = stash '';
+# Assign a default value to $class if it's not defined
+my $class = $stash->{class} // '';
 
 <div class="progress build-dashboard <%= $class %>" title="<%= build_progress_bar_title($result) %>">
-    %= build_progress_bar_section(passed => $result->{passed}, $max_jobs, $params)
-    %= build_progress_bar_section(unfinished => $result->{unfinished}, $max_jobs, $params, 'progress-bar-striped')
-    %= build_progress_bar_section(softfailed => $result->{softfailed}, $max_jobs, $params)
-    %= build_progress_bar_section(failed => $result->{failed}, $max_jobs, $params)
-    %= build_progress_bar_section(skipped => $result->{skipped}, $max_jobs, $params)
+    <%= build_progress_bar_section('passed', $result->{passed}, $max_jobs, $params) %>
+    <%= build_progress_bar_section('unfinished', $result->{unfinished}, $max_jobs, $params, 'progress-bar-striped') %>
+    <%= build_progress_bar_section('softfailed', $result->{softfailed}, $max_jobs, $params) %>
+    <%= build_progress_bar_section('failed', $result->{failed}, $max_jobs, $params) %>
+    <%= build_progress_bar_section('skipped', $result->{skipped}, $max_jobs, $params) %>
 </div>

--- a/templates/webapi/main/build_progressbar.html.ep
+++ b/templates/webapi/main/build_progressbar.html.ep
@@ -1,5 +1,4 @@
-# Assign a default value to $class if it's not defined
-my $class = $stash->{class} // '';
+% my $class = stash '';
 
 <div class="progress build-dashboard <%= $class %>" title="<%= build_progress_bar_title($result) %>">
     <%= build_progress_bar_section('passed', $result->{passed}, $max_jobs, $params) %>


### PR DESCRIPTION
I think we should updated the variable assignment to use `$stash` instead of an empty string (`''`), assuming that `$stash` is an existing hash reference containing a `class` key
and I added quotes around the progress bar section names (`'passed'`, `'unfinished'`, etc.) to make the code more readable and less error-prone
and the last I removed the `%=`, as it is not needed for the `build_progress_bar_section()` function calls.
.
.
and yes if you asking about that what is the benefit of this improvized code so, in first point if we can't use variable assignment as a default value I think it makes the code more robust and also fail if the input data is incomplete and the progress bar section names are now enclosed in quotes, which makes the code more readable and less prone to errors and last the `%= build_progress_bar_section()` calls have been simplified by removing the unnecessary `%=`, which reduces clutter and improves the code's readability.