### PR TITLE
Show error message from server when commenting fails

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -40,6 +40,14 @@ function renderCommentHeading(comment, commentId) {
   return heading;
 }
 
+function getXhrError(xhr, thrownError) {
+  try {
+    return JSON.parse(xhr.responseText).error || thrownError;
+  } catch {
+    return thrownError;
+  }
+}
+
 function deleteComment(deleteButton) {
   deleteButton = $(deleteButton);
   var author = deleteButton.data('author');
@@ -55,7 +63,7 @@ function deleteComment(deleteButton) {
         $('a[href="#comments"]').html('Comments (' + $('.comment-row').length + ')');
       },
       error: function (xhr, ajaxOptions, thrownError) {
-        window.alert("The comment couldn't be deleted: " + thrownError);
+        window.alert("The comment couldn't be deleted: " + getXhrError(xhr, thrownError));
       }
     });
   }
@@ -100,7 +108,7 @@ function updateComment(form) {
         textElement.val(text);
         markdownElement.html(markdown);
         showCommentEditor(form);
-        window.alert("The comment couldn't be updated: " + thrownError);
+        window.alert("The comment couldn't be updated: " + getXhrError(xhr, thrownError));
       }
     });
   } else {
@@ -152,7 +160,7 @@ function addComment(form, insertAtBottom) {
         });
       },
       error: function (xhr, ajaxOptions, thrownError) {
-        window.alert("The comment couldn't be added: " + thrownError);
+        window.alert("The comment couldn't be added: " + getXhrError(xhr, thrownError));
       }
     });
   } else {

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -229,6 +229,10 @@ sub javascript_console_has_no_warnings_or_errors {
             # FIXME: find the reason why Chromium says we are trying to send something over an already closed
             # WebSocket connection
         next if ($msg =~ qr/Data frame received after close/);    # uncoverable statement
+
+        # ignore when server replied with 400 response; this may be provoked when testing error cases and if it is
+        # not expected tests would fail anyways
+        next if ($msg =~ qr/server responded with a status of 400/);    # uncoverable statement
         push(@errors, $log_entry);
     }
 

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -285,6 +285,11 @@ subtest 'commenting in test results including labels' => sub {
         $driver->find_element('#commentForm .help_popover.fa-ticket')->click;
         my $textarea = $driver->find_element_by_id('text');
         like $textarea->get_value, qr/label:force_result:new_result/, 'label template added';
+        $driver->find_element_by_id('submitComment')->click;
+        eval { wait_for_ajax(msg => 'alert when trying to submit comment') };
+        like $@, qr/unexpected alert/, 'alert already shown shown when trying to wait for it' if $@;
+        like $driver->get_alert_text, qr/Invalid result 'new_result' for force_result/, 'error from server shown';
+        $driver->dismiss_alert;
         $textarea->clear;
     };
 


### PR DESCRIPTION
So we get e.g. "force_result only allowed on finished jobs" instead of just "BadRequest".

Related ticket: https://progress.opensuse.org/issues/127280