### PR TITLE
Improve out-of-the-box experience when invoking web UI container

### DIFF
--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -21,8 +21,7 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15
     a2enmod rewrite && \
     a2enflag SSL
 
-COPY openqa-ssl.conf /etc/apache2/vhosts.d/openqa-ssl.conf
-COPY openqa.conf /etc/apache2/vhosts.d/openqa.conf
+COPY openqa-ssl.conf openqa.conf /etc/apache2/vhosts.d/
 COPY run_openqa.sh /root/
 
 # set-up shared data and configuration

--- a/container/webui/run_openqa.sh
+++ b/container/webui/run_openqa.sh
@@ -35,7 +35,22 @@ function webui() {
 }
 
 function all_together_apache() {
-  # run services
+  # use certificate that comes with Mojolicious if none configured by the user (by making one available via `-v`)
+  local mojo_resources=$(perl -e 'use Mojolicious; print(Mojolicious->new->home->child("Mojo/IOLoop/resources"))')
+  cp --no-clobber "$mojo_resources"/server.crt /etc/apache2/ssl.crt/server.crt
+  cp --no-clobber "$mojo_resources"/server.key /etc/apache2/ssl.key/server.key
+  cp --no-clobber "$mojo_resources"/server.crt /etc/apache2/ssl.crt/ca.crt
+
+  # run the database within the container if no database is configured by the user (by making one available via `-v`)
+  if [[ ! -e /data/conf/database.ini ]]; then
+    mkdir -p /data/conf
+    echo -e "[production]\ndsn = DBI:Pg:dbname=openqa" > /data/conf/database.ini
+    chown -R postgres:postgres /var/lib/pgsql  # ensure right ownership in case `/var/lib/pgsql` is from host via `-v`
+    su postgres -c '/usr/share/postgresql/postgresql-script start'
+    su postgres -c '/usr/bin/openqa-setup-db'
+  fi
+
+  # run services and apache2
   su geekotest -c /usr/share/openqa/script/openqa-scheduler-daemon &
   su geekotest -c /usr/share/openqa/script/openqa-websockets-daemon &
   su geekotest -c /usr/share/openqa/script/openqa-gru &

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -1122,7 +1122,7 @@ drwx------ 20 postgres postgres 4096  8. Sep 2019  data.96
 +
 The next steps assume such a layout.
 
-3. Install same set of posgresql* packages as are installed for the old
+3. Install same set of postgresql* packages as are installed for the old
 version:
 +
 [source,sh]

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -94,8 +94,11 @@ container engine:
 
 [source,sh]
 ----
-podman run --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest
+podman run -p 1080:80 -p 1443:443 --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest
 ----
+
+Once the startup has finished, the web UI is accessible via http://localhost:1080
+or https://localhost:1443.
 
 The worker container can be pulled and started with:
 
@@ -104,7 +107,24 @@ The worker container can be pulled and started with:
 podman run --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_worker:latest
 ----
 
-Some parameters are necessary to run them properly. See the
+To supply a custom openQA config file, use the `-v` parameter. This also works
+for the database config file. Note that if a custom database config file is
+specified, no database is launched within the container.
+By default, the web UI container uses the self-signed certificate that comes
+with Mojolicious. To supply a different certificate, use the `-v` parameter.
+Example for running openQA with a custom config and certificate:
+
+[source,sh]
+----
+podman run -p 1080:80 -p 1443:443 \
+  -v ./container/webui/test-cert.pem:/etc/apache2/ssl.crt/server.crt:z \
+  -v ./container/webui/test-key.pem:/etc/apache2/ssl.key/server.key:z \
+  -v ./container/webui/test-cert.pem:/etc/apache2/ssl.crt/ca.crt:z \
+  -v ./container/webui/conf/openqa.ini:/data/conf/openqa.ini:z \
+  --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest
+----
+
+Checkout the
 <<ContainerizedSetup.asciidoc#containerizedsetup,containerized setup section>>
 for more details and how to configure and run these containers.
 


### PR DESCRIPTION
* Configure a default certificate in the container startup
  script (as a fallback)
* Start and configure the database inside the container unless
  the database has been configured by the user manually
* Improve documentation
* See https://progress.opensuse.org/issues/127091
* See https://progress.opensuse.org/issues/127139