### PR TITLE
Improve contrast of progress bar text

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -43,7 +43,7 @@ td div.progress {
         a { color: white; }
     }
     .progress-bar-skipped {
-        a { color: rgb(0, 0, 0); }
+        a { color: Black; }
     }
     .progress-bar-passed {
         background-color: $color-module-passed;

--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -43,7 +43,7 @@ td div.progress {
         a { color: white; }
     }
     .progress-bar-skipped {
-        a { color: Black; }
+        a { color: black; }
     }
     .progress-bar-passed {
         background-color: $color-module-passed;

--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -39,8 +39,11 @@ td div.progress {
     .progress-bar-passed, .progress-bar-softfailed, .progress-bar-unfinished {
         a { color: $color-result; }
     }
-    .progress-bar-failed, .progress-bar-skipped {
+    .progress-bar-failed{
         a { color: white; }
+    }
+    .progress-bar-skipped {
+        a { color: rgb(0, 0, 0); }
     }
     .progress-bar-passed {
         background-color: $color-module-passed;


### PR DESCRIPTION
This commit addresses the issue of poor contrast in the progress bar text, making it difficult to read for some users, especially those with visual impairments. By improving the contrast between the progress bar background and the text, we are ensuring better visibility and accessibility for all users. This update enhances the user experience by making the progress bar text more legible and easier to read, ensuring that all users can track progress accurately. 
![udsfgg](https://user-images.githubusercontent.com/93934416/232245974-7b3aad84-daec-4872-9aab-3b72edb31b22.jpg)
