### PR TITLE
Improve contrast of progress bar showing number of failures

### DIFF
--- a/assets/stylesheets/openqa_theme.scss
+++ b/assets/stylesheets/openqa_theme.scss
@@ -34,7 +34,7 @@ $link-hover-color:            darken($link-color, 15%) !default;
 $color-softfailed:            #EEB560;
 $color-ok:                    #CDFFB9;
 $color-warning:               #ffff99;
-$color-failed:                #FF4E46;
+$color-failed:                #cc3333;
 $color-result-failed:         #FF9E9B;
 $color-incomplete:            #AF1E11;
 $color-result:                #3c3c3c;


### PR DESCRIPTION


This commit aims to enhance the contrast of the progress bar used to display the number of failures. The previous implementation had low contrast, making it difficult to discern the actual progress. The updated design uses a more prominent color scheme, improving visibility and making it easier to understand the number of failures at a glance. This change improves the overall user experience and ensures that the progress bar is more accessible to all users.

![232456699-4f5afdd7-306c-4399-856b-b8725b85bd3d](https://user-images.githubusercontent.com/93934416/232488971-1648c077-99ec-4044-8170-57028164c3ac.png)