### PR TITLE
Add conditional check to skip maint. updates verification

### DIFF
--- a/lib/OpenQA/Script/CloneJobSUSE.pm
+++ b/lib/OpenQA/Script/CloneJobSUSE.pm
@@ -33,6 +33,7 @@ sub verify_incident_repos ($url_handler, $incident_repos) {
 }
 
 sub detect_maintenance_update ($jobid, $url_handler, $settings) {
+    return undef if $settings->{SKIP_MAINTENANCE_UPDATES};
     my $urls = collect_incident_repos($url_handler, $settings);
     die "Current job $jobid will fail, because the repositories for the below updates are unavailable\n" . pp($urls)
       if @$urls;

--- a/t/35-script_clone_job_suse.t
+++ b/t/35-script_clone_job_suse.t
@@ -37,7 +37,10 @@ subtest 'maintenance update detect' => sub {
         id => $job_id,
         INCIDENT_REPO => "http://foo/incident_repo/openqa,http://foo/incident_repo_1/openqa",
     );
-
+    my %skip_check = (
+        id => $job_id,
+        SKIP_MAINTENANCE_UPDATES => "1"
+    );
     my $fake_ua = Test::FakeLWPUserAgent->new;
     my %url_handler = (remote_url => Mojo::URL->new('http://foo'), ua => $fake_ua);
     my $clone_mock = Test::MockModule->new('OpenQA::Script::CloneJobSUSE');
@@ -49,6 +52,7 @@ subtest 'maintenance update detect' => sub {
       'Maintenance updates have been released';
     throws_ok { detect_maintenance_update($job_id, \%url_handler, \%incident_job) } qr/Current job $job_id will fail/,
       'Maintenance updates have been released';
+    lives_ok { detect_maintenance_update($job_id, \%url_handler, \%skip_check) } 'Skip updates check';
 };
 
 done_testing();


### PR DESCRIPTION
The function `detect_maintenance_update` sometimes prevents tests from being cloned. Now if the variable `SKIP_MAINTENANCE_UPDATES` is provided this check is skipped.

Test passed OK:
```
# make test TESTS=t/35-script_clone_job_suse.t
test -d /dev/shm/tpg && (pg_ctl -D /dev/shm/tpg -s status >&/dev/null || pg_ctl -D /dev/shm/tpg -s start) || ./t/test_postgresql /dev/shm/tpg
2023-04-19 09:12:15.789 CEST   [10380]LOG:  redirecting log output to logging collector process
2023-04-19 09:12:15.789 CEST   [10380]HINT:  Future log output will appear in directory "log".
make test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg"
make[1]: Entering directory '/home/pablo.herranz/GitHub/openQA'
export GLOBIGNORE="";\
export DEVEL_COVER_DB_FORMAT=JSON;\
export PERL5OPT=" -It/lib -I/home/pablo.herranz/GitHub/openQA/t/lib -I/home/pablo.herranz/GitHub/openQA/external/os-autoinst-common/lib -MOpenQA::Test::PatchDeparse";\
RETRY=0 HOOK=./tools/delete-coverdb-folder timeout -s SIGINT -k 5 -v $((60 * 1 * (0 + 1) ))m tools/retry prove -l --trap  t/35-script_clone_job_suse.t
t/35-script_clone_job_suse.t .. ok   
All tests successful.
Files=1, Tests=2,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.12 cusr  0.01 csys =  0.15 CPU)
Result: PASS
make[1]: Leaving directory '/home/pablo.herranz/GitHub/openQA'
[ 0 = 1 ] || pg_ctl -D /dev/shm/tpg stop
waiting for server to shut down.... done
server stopped
```