### PR TITLE
Result/Jobs.pm: Update serial console name

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1815,7 +1815,8 @@ sub test_resultfile_list ($self) {
 
     my $virtio_console_num = $self->settings_hash->{VIRTIO_CONSOLE_NUM} // 1;
     for (my $i = 1; $i < $virtio_console_num; ++$i) {
-        push(@$filelist_existing, "virtio_console$i.log") if -s "$testresdir/virtio_console$i.log";
+        my $f = "serial_terminal$i.txt";
+        push(@$filelist_existing, $f) if -s "$testresdir/$f";
     }
 
     return $filelist_existing;


### PR DESCRIPTION
`virtio_consoleN.log` logs (e.g. `virtio_console1.log`) are uploaded as `serial_terminalN.txt` (e.g. `serial_terminal1.txt`). Due keeping old name they weren't visible in "Logs & Assets" section.

Fixes: b24718521 ("Worker/Job.pm: Rename all .log to *.txt")

Verification run (wicked):
* http://quasar.suse.cz/tests/2666#downloads (link to http://quasar.suse.cz/tests/2666/logfile?filename=serial_terminal_user.txt)