### PR TITLE
Remove mostly useless logging for tag detection

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -683,20 +683,15 @@ sub read_test_modules {
 }
 
 # parse comments of the specified (parent) group and store all mentioned builds in $res (hashref)
-sub parse_tags_from_comments {
-    my ($group, $res) = @_;
-
-    my $comments = $group->comments;
-    return unless ($comments);
+sub parse_tags_from_comments ($group, $res) {
+    return unless my $comments = $group->comments;
 
     while (my $comment = $comments->next) {
         my @tag = $comment->tag;
-        my $build = $tag[0];
-        next unless $build;
+        next unless my $build = $tag[0];
 
         my $version = $tag[3];
         my $tag_id = $version ? "$version-$build" : $build;
-
         if ($tag[1] eq '-important') {
             delete $res->{$tag_id};
             next;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -697,10 +697,7 @@ sub parse_tags_from_comments {
         my $version = $tag[3];
         my $tag_id = $version ? "$version-$build" : $build;
 
-        log_debug('Tag found on build ' . $build . ' of type ' . $tag[1]);
-        log_debug('description: ' . $tag[2]) if $tag[2];
         if ($tag[1] eq '-important') {
-            log_debug('Deleting tag on build ' . $build);
             delete $res->{$tag_id};
             next;
         }


### PR DESCRIPTION
These log lines can take quite some room in our log files and they serve no purpose unless one really wanted develop this
particular feature. However, then it makes more sense to add debug-logging as needed. This feature can be developed
conveniently by running unit tests so I don't think we ever need this debug printing outside of a local development session.