### PR TITLE
Fix ever-passing codecov upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
       - run: make coverage-report-html
       - store_artifacts: *store_cover_db
       - run: make coverage-report-codecov
-      - run: curl -O https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov --nonZero
+      - run: curl -O https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov --nonZero -v
 
   build-docs: &docs-template
     name: "Generating docs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
       - run: make coverage-report-html
       - store_artifacts: *store_cover_db
       - run: make coverage-report-codecov
-      - run: curl -O https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov
+      - run: curl -O https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov --nonZero
 
   build-docs: &docs-template
     name: "Generating docs"


### PR DESCRIPTION
The codecov binary returns a zero return code by default, even in case of failures. The commit changes this to make errors more discoverable.

Related ticket: https://progress.opensuse.org/issues/128129