### PR TITLE
Enhance keyboard accessibility for filter and settings button

### DIFF
--- a/assets/javascripts/keyevent.js
+++ b/assets/javascripts/keyevent.js
@@ -1,27 +1,29 @@
 //Keyboard Accessibility
-let filterAndSettingsButton = document.querySelector("#filter-panel > div.card-header");
-let filterAndSettingsTitle = document.querySelector("#filter-panel > div.card-header > strong");
+// Wrap the code in a DOMContentLoaded event listener to ensure it runs after the DOM is fully loaded
+document.addEventListener('DOMContentLoaded', function() {
+  const filterAndSettingsButton = document.querySelector('#filter-panel > div.card-header');
 
-// Adding required roles and attributes
-filterAndSettingsButton.setAttribute("role", "button");
-filterAndSettingsButton.setAttribute("tabindex", "0");
-filterAndSettingsButton.setAttribute("aria-expanded", "false");
+  if (filterAndSettingsButton) {
+    // Adding required roles and attributes
+    filterAndSettingsButton.setAttribute('role', 'button');
+    filterAndSettingsButton.setAttribute('tabindex', '0');
+    filterAndSettingsButton.setAttribute('aria-expanded', 'false');
 
-// Adding keydown event on the control so that it can be expanded/collapsed using keyboard
-filterAndSettingsButton.addEventListener("keydown", function(event) {
-  if (event.key === "Enter") {
-    filterAndSettingsTitle.click();
+    // Adding keydown event on the control so that it can be expanded/collapsed using keyboard
+    filterAndSettingsButton.addEventListener('keydown', function(event) {
+      if (event.code === 'Enter') { // Use event.code for better cross-browser support
+        event.preventDefault(); // Prevent default form submission behavior
+        filterAndSettingsButton.click();
+      }
+    });
+
+    // Toggling between the value of aria-expanded attribute so that the expand/collapse state can be conveyed to screen reader users
+    filterAndSettingsButton.addEventListener('click', function() {
+      filterAndSettingsButton.setAttribute('aria-expanded', (filterAndSettingsButton.getAttribute('aria-expanded') === 'true') ? 'false' : 'true');
+    });
   }
 });
 
-// Toggling between the value of aria-expanded attribute so that the expand/collapse state can be conveyed to screen reader users
-filterAndSettingsButton.addEventListener("click", function() {
-  if (filterAndSettingsButton.getAttribute("aria-expanded") === "true") {
-    filterAndSettingsButton.setAttribute("aria-expanded", "false");
-  } else {
-    filterAndSettingsButton.setAttribute("aria-expanded", "true");
-  }
-});
 
 
 // http://stackoverflow.com/questions/5681146/chrome-10-keyevent-or-something-similar-to-firefoxs-keyevent

--- a/assets/javascripts/keyevent.js
+++ b/assets/javascripts/keyevent.js
@@ -1,5 +1,30 @@
-// http://stackoverflow.com/questions/5681146/chrome-10-keyevent-or-something-similar-to-firefoxs-keyevent
+//Keyboard Accessibility
+let filterAndSettingsButton = document.querySelector("#filter-panel > div.card-header");
+let filterAndSettingsTitle = document.querySelector("#filter-panel > div.card-header > strong");
 
+// Adding required roles and attributes
+filterAndSettingsButton.setAttribute("role", "button");
+filterAndSettingsButton.setAttribute("tabindex", "0");
+filterAndSettingsButton.setAttribute("aria-expanded", "false");
+
+// Adding keydown event on the control so that it can be expanded/collapsed using keyboard
+filterAndSettingsButton.addEventListener("keydown", function(event) {
+  if (event.key === "Enter") {
+    filterAndSettingsTitle.click();
+  }
+});
+
+// Toggling between the value of aria-expanded attribute so that the expand/collapse state can be conveyed to screen reader users
+filterAndSettingsButton.addEventListener("click", function() {
+  if (filterAndSettingsButton.getAttribute("aria-expanded") === "true") {
+    filterAndSettingsButton.setAttribute("aria-expanded", "false");
+  } else {
+    filterAndSettingsButton.setAttribute("aria-expanded", "true");
+  }
+});
+
+
+// http://stackoverflow.com/questions/5681146/chrome-10-keyevent-or-something-similar-to-firefoxs-keyevent
 // FIXME: key events may be different in other browsers:
 // http://www.javascripter.net/faq/keyeventconstantsfirefox.htm
 if (typeof KeyEvent === 'undefined') {

--- a/assets/javascripts/keyevent.js
+++ b/assets/javascripts/keyevent.js
@@ -11,7 +11,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Adding keydown event on the control so that it can be expanded/collapsed using keyboard
     filterAndSettingsButton.addEventListener('keydown', function(event) {
-      if (event.code === 'Enter') { // Use event.code for better cross-browser support
+      if (event.code === 'Enter') {
+        // Use event.code for better cross-browser support
         event.preventDefault(); // Prevent default form submission behavior
         filterAndSettingsButton.click();
       }
@@ -19,13 +20,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Toggling between the value of aria-expanded attribute so that the expand/collapse state can be conveyed to screen reader users
     filterAndSettingsButton.addEventListener('click', function() {
-      filterAndSettingsButton.setAttribute('aria-expanded', (filterAndSettingsButton.getAttribute('aria-expanded') === 'true') ? 'false' : 'true');
+      filterAndSettingsButton.setAttribute('aria-expanded', filterAndSettingsButton.getAttribute('aria-expanded') === 'true' ? 'false' : 'true');
     });
   }
+  
+  
+  
 });
-
-
-
 // http://stackoverflow.com/questions/5681146/chrome-10-keyevent-or-something-similar-to-firefoxs-keyevent
 // FIXME: key events may be different in other browsers:
 // http://www.javascripter.net/faq/keyeventconstantsfirefox.htm

--- a/assets/javascripts/keyevent.js
+++ b/assets/javascripts/keyevent.js
@@ -1,32 +1,33 @@
 //Keyboard Accessibility
 // Wrap the code in a DOMContentLoaded event listener to ensure it runs after the DOM is fully loaded
-document.addEventListener('DOMContentLoaded', function() {
-  const filterAndSettingsButton = document.querySelector('#filter-panel > div.card-header');
+document.addEventListener('DOMContentLoaded', function () {});
+const filterAndSettingsButton = document.querySelector('#filter-panel > div.card-header');
 
-  if (filterAndSettingsButton) {
-    // Adding required roles and attributes
-    filterAndSettingsButton.setAttribute('role', 'button');
-    filterAndSettingsButton.setAttribute('tabindex', '0');
-    filterAndSettingsButton.setAttribute('aria-expanded', 'false');
+if (filterAndSettingsButton) {
+  // Adding required roles and attributes
+  filterAndSettingsButton.setAttribute('role', 'button');
+  filterAndSettingsButton.setAttribute('tabindex', '0');
+  filterAndSettingsButton.setAttribute('aria-expanded', 'false');
 
-    // Adding keydown event on the control so that it can be expanded/collapsed using keyboard
-    filterAndSettingsButton.addEventListener('keydown', function(event) {
-      if (event.code === 'Enter') {
-        // Use event.code for better cross-browser support
-        event.preventDefault(); // Prevent default form submission behavior
-        filterAndSettingsButton.click();
-      }
-    });
-
-    // Toggling between the value of aria-expanded attribute so that the expand/collapse state can be conveyed to screen reader users
-    filterAndSettingsButton.addEventListener('click', function() {
-      filterAndSettingsButton.setAttribute('aria-expanded', filterAndSettingsButton.getAttribute('aria-expanded') === 'true' ? 'false' : 'true');
-    });
-  }
-  
-  
-  
-});
+  // Adding keydown event on the control so that it can be expanded/collapsed using keyboard
+  filterAndSettingsButton.addEventListener('keydown', function (event) {
+    if (event.code === 'Enter') {
+      // Use event.code for better cross-browser support
+      event.preventDefault(); // Prevent default  form submission behavior
+      filterAndSettingsButton.click();
+    }
+  });
+  // Toggling between the value of aria-expanded attribute so that the expand/collapse state can be conveyed to screen reader users
+  filterAndSettingsButton.addEventListener('click', function () {
+    filterAndSettingsButton.setAttribute(
+      'aria-expanded',
+      filterAndSettingsButton.getAttribute('aria-expanded') === 'true' ? 'false' : 'true'
+    );
+  });
+}
+// http://stackoverflow.com/questions/5681146/chrome-10-keyevent-or-something-similar-to-firefoxs-keyevent
+// FIXME: key events may be different in other browsers:
+// http://www.javascripter.net/faq/keyeventconstantsfirefox.htm
 // http://stackoverflow.com/questions/5681146/chrome-10-keyevent-or-something-similar-to-firefoxs-keyevent
 // FIXME: key events may be different in other browsers:
 // http://www.javascripter.net/faq/keyeventconstantsfirefox.htm


### PR DESCRIPTION
This commit adds improved keyboard accessibility for the filter and settings button in the #filter-panel element. The button now has the appropriate role, tabindex, and aria-expanded attributes to ensure it can be accessed and operated using the keyboard. Additionally, a keydown event listener has been implemented to allow expanding/collapsing the button using the "Enter" key. These changes enhance the accessibility of the button for keyboard users and screen reader users, making it easier for them to interact with the interface.

Changes Made:
- Added role, tabindex, and aria-expanded attributes to filter and settings button
- Implemented `keydown` event listener for "Enter" key to trigger button click