### PR TITLE
Use constant `WORKER_COMMAND_ABORT`

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -962,7 +962,7 @@ sub abort ($self) {
 
     my ($job_id, $worker_id) = ($self->id, $worker->id);
     log_debug("Sending abort command to worker $worker_id for job $job_id");
-    $worker->send_command(command => 'abort', job_id => $job_id);
+    $worker->send_command(command => WORKER_COMMAND_ABORT, job_id => $job_id);
     return 1;
 }
 

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -407,7 +407,7 @@ sub _stop_step_4_upload ($self, $reason, $callback) {
 
     # upload logs and assets
     return Mojo::IOLoop->next_tick(sub { $self->_stop_step_5_1_upload($reason, $callback) })
-      if $reason eq WORKER_COMMAND_QUIT || $reason eq 'abort' || $reason eq WORKER_SR_API_FAILURE;
+      if $reason eq WORKER_COMMAND_QUIT || $reason eq WORKER_COMMAND_ABORT || $reason eq WORKER_SR_API_FAILURE;
     Mojo::IOLoop->subprocess(
         sub {
             # upload ulogs


### PR DESCRIPTION
Use the constant `WORKER_COMMAND_ABORT` so places where we deal with that worker command are easier to find.

Related ticket: https://progress.opensuse.org/issues/128267