### PR TITLE
Improve contrast of Progress bar text

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -39,8 +39,11 @@ td div.progress {
     .progress-bar-passed, .progress-bar-softfailed, .progress-bar-unfinished {
         a { color: $color-result; }
     }
-    .progress-bar-failed, .progress-bar-skipped {
+    .progress-bar-failed{
         a { color: white; }
+    }
+    .progress-bar-skipped {
+        a { color: black; }
     }
     .progress-bar-passed {
         background-color: $color-module-passed;


### PR DESCRIPTION
This commit addresses the issue of improvement on the contrast of progress bar text, the change in contrast ensured easy readability by the users especially those with visual impairment. The Contrast of the progress bar was changed from #CACACA to #000000 to ensure better visibility on the bar and accessibility for the users.