### PR TITLE
Add pagination for /api/v1/test_suites, /api/v1/machines, and /api/v1/products

### DIFF
--- a/t/api/01-workers.t
+++ b/t/api/01-workers.t
@@ -197,39 +197,51 @@ subtest 'server-side limit with pagination' => sub {
     };
 
     subtest 'navigation with limit' => sub {
-        $t->get_ok('/api/v1/workers?limit=3')->status_is(200)->json_has('/workers/0')->json_has('/workers/2')
-          ->json_hasnt('/workers/3');
-        my $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        my $links;
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/workers/0')->json_has('/workers/2')
-          ->json_hasnt('/workers/3');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'first page' => sub {
+            $t->get_ok('/api/v1/workers?limit=3')->status_is(200)->json_has('/workers/0')->json_has('/workers/2')
+              ->json_hasnt('/workers/3');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/workers/0')->json_hasnt('/workers/1');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok !$links->{next}, 'no next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'second page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/workers/0')->json_has('/workers/2')
+              ->json_hasnt('/workers/3');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{prev}{link})->status_is(200)->status_is(200)->json_has('/workers/0')
-          ->json_has('/workers/2')->json_hasnt('/workers/3');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'third page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/workers/0')->json_hasnt('/workers/1');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok !$links->{next}, 'no next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{first}{link})->status_is(200)->status_is(200)->json_has('/workers/0')
-          ->json_has('/workers/2')->json_hasnt('/workers/3');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'second page (prev link)' => sub {
+            $t->get_ok($links->{prev}{link})->status_is(200)->status_is(200)->json_has('/workers/0')
+              ->json_has('/workers/2')->json_hasnt('/workers/3');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok $links->{prev}, 'has previous page';
+        };
+
+        subtest 'first page (first link)' => sub {
+            $t->get_ok($links->{first}{link})->status_is(200)->status_is(200)->json_has('/workers/0')
+              ->json_has('/workers/2')->json_hasnt('/workers/3');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
     };
 };
 

--- a/t/api/02-assets.t
+++ b/t/api/02-assets.t
@@ -120,68 +120,90 @@ subtest 'server-side limit with pagination' => sub {
     };
 
     subtest 'navigation with high limit' => sub {
-        $t->get_ok('/api/v1/assets?limit=5')->status_is(200)->json_has('/assets/4')->json_hasnt('/assets/5');
-        my $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        my $links;
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/2')->json_hasnt('/assets/3');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok !$links->{next}, 'no next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'first page' => sub {
+            $t->get_ok('/api/v1/assets?limit=5')->status_is(200)->json_has('/assets/4')->json_hasnt('/assets/5');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
 
-        $t->get_ok($links->{prev}{link})->status_is(200)->json_has('/assets/4')->json_hasnt('/assets/5');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'second page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/2')->json_hasnt('/assets/3');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok !$links->{next}, 'no next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{first}{link})->status_is(200)->json_has('/assets/4')->json_hasnt('/assets/5');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'first page (prev link)' => sub {
+            $t->get_ok($links->{prev}{link})->status_is(200)->json_has('/assets/4')->json_hasnt('/assets/5');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
+
+        subtest 'first page (first link)' => sub {
+            $t->get_ok($links->{first}{link})->status_is(200)->json_has('/assets/4')->json_hasnt('/assets/5');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
     };
 
     subtest 'navigation with low limit' => sub {
-        $t->get_ok('/api/v1/assets?limit=2')->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
-          ->json_like('/assets/0/name', qr/openSUSE-13.1-DVD-i586-Build0091-Media\.iso/)
-          ->json_like('/assets/1/name', qr/openSUSE-13.1-DVD-x86_64-Build0091-Media\.iso/);
-        my $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        my $links;
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
-          ->json_like('/assets/0/name', qr/openSUSE-13.1-GNOME-Live-i686-Build0091-Media\.iso/)
-          ->json_like('/assets/1/name', qr/openSUSE-Factory-staging_e-x86_64-Build87.5011-Media\.iso/);
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'first page' => sub {
+            $t->get_ok('/api/v1/assets?limit=2')->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
+              ->json_like('/assets/0/name', qr/openSUSE-13.1-DVD-i586-Build0091-Media\.iso/)
+              ->json_like('/assets/1/name', qr/openSUSE-13.1-DVD-x86_64-Build0091-Media\.iso/);
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'second page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
+              ->json_like('/assets/0/name', qr/openSUSE-13.1-GNOME-Live-i686-Build0091-Media\.iso/)
+              ->json_like('/assets/1/name', qr/openSUSE-Factory-staging_e-x86_64-Build87.5011-Media\.iso/);
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
-          ->json_like('/assets/0/name', qr/test-dvd-1\.iso/)->json_like('/assets/1/name', qr/test-dvd-2\.iso/);
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok !$links->{next}, 'no next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'third page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{first}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
-          ->json_like('/assets/0/name', qr/openSUSE-13.1-DVD-i586-Build0091-Media\.iso/)
-          ->json_like('/assets/1/name', qr/openSUSE-13.1-DVD-x86_64-Build0091-Media\.iso/);
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'fourth page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
+              ->json_like('/assets/0/name', qr/test-dvd-1\.iso/)->json_like('/assets/1/name', qr/test-dvd-2\.iso/);
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok !$links->{next}, 'no next page';
+            ok $links->{prev}, 'has previous page';
+        };
+
+        subtest 'first page (first link)' => sub {
+            $t->get_ok($links->{first}{link})->status_is(200)->json_has('/assets/1')->json_hasnt('/assets/2')
+              ->json_like('/assets/0/name', qr/openSUSE-13.1-DVD-i586-Build0091-Media\.iso/)
+              ->json_like('/assets/1/name', qr/openSUSE-13.1-DVD-x86_64-Build0091-Media\.iso/);
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
     };
 };
 

--- a/t/api/05-machines.t
+++ b/t/api/05-machines.t
@@ -240,58 +240,77 @@ subtest 'server-side limit with pagination' => sub {
     };
 
     subtest 'navigation with high limit' => sub {
-        $t->get_ok('/api/v1/machines?limit=5')->status_is(200)->json_has('/Machines/4')->json_hasnt('/Machines/5');
-        my $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        my $links;
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/Machines/0')->json_hasnt('/Machines/1');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok !$links->{next}, 'no next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'first page' => sub {
+            $t->get_ok('/api/v1/machines?limit=5')->status_is(200)->json_has('/Machines/4')->json_hasnt('/Machines/5');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
 
-        $t->get_ok($links->{prev}{link})->status_is(200)->json_has('/Machines/4')->json_hasnt('/Machines/5');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'second page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/Machines/0')->json_hasnt('/Machines/1');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok !$links->{next}, 'no next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{first}{link})->status_is(200)->json_has('/Machines/4')->json_hasnt('/Machines/5');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'first page (prev link)' => sub {
+            $t->get_ok($links->{prev}{link})->status_is(200)->json_has('/Machines/4')->json_hasnt('/Machines/5');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
+
+        subtest 'first page (first link)' => sub {
+            $t->get_ok($links->{first}{link})->status_is(200)->json_has('/Machines/4')->json_hasnt('/Machines/5');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
     };
 
     subtest 'navigation with low limit' => sub {
-        $t->get_ok('/api/v1/machines?limit=2')->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2')
-          ->json_like('/Machines/0/name', qr/32bit/)->json_like('/Machines/1/name', qr/64bit/);
-        my $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        my $links;
+        subtest 'first page' => sub {
+            $t->get_ok('/api/v1/machines?limit=2')->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2')
+              ->json_like('/Machines/0/name', qr/32bit/)->json_like('/Machines/1/name', qr/64bit/);
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2')
-          ->json_like('/Machines/0/name', qr/Laptop_64/)->json_like('/Machines/1/name', qr/testmachineQ/);
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'second page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2')
+              ->json_like('/Machines/0/name', qr/Laptop_64/)->json_like('/Machines/1/name', qr/testmachineQ/);
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok !$links->{next}, 'no next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'third page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok !$links->{next}, 'no next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{first}{link})->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2')
-          ->json_like('/Machines/0/name', qr/32bit/)->json_like('/Machines/1/name', qr/64bit/);
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'first page (first link)' => sub {
+            $t->get_ok($links->{first}{link})->status_is(200)->json_has('/Machines/1')->json_hasnt('/Machines/2')
+              ->json_like('/Machines/0/name', qr/32bit/)->json_like('/Machines/1/name', qr/64bit/);
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
     };
 };
 

--- a/t/api/11-bugs.t
+++ b/t/api/11-bugs.t
@@ -97,44 +97,56 @@ subtest 'server-side limit with pagination' => sub {
     };
 
     subtest 'navigation with limit' => sub {
-        $t->get_ok('/api/v1/bugs?limit=5')->status_is(200)->json_has('/bugs/1')->json_has('/bugs/3')
-          ->json_has('/bugs/4')->json_has('/bugs/5')->json_has('/bugs/6')->json_hasnt('/bugs/10')
-          ->json_hasnt('/bugs/12');
-        my $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        my $links;
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/bugs/10')->json_has('/bugs/11')
-          ->json_has('/bugs/7')->json_has('/bugs/8')->json_has('/bugs/9')->json_hasnt('/bugs/1')
-          ->json_hasnt('/bugs/12');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'first page' => sub {
+            $t->get_ok('/api/v1/bugs?limit=5')->status_is(200)->json_has('/bugs/1')->json_has('/bugs/3')
+              ->json_has('/bugs/4')->json_has('/bugs/5')->json_has('/bugs/6')->json_hasnt('/bugs/10')
+              ->json_hasnt('/bugs/12');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
 
-        $t->get_ok($links->{next}{link})->status_is(200)->json_has('/bugs/12')->json_has('/bugs/13')
-          ->json_hasnt('/bugs/1')->json_hasnt('/bugs/10');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok !$links->{next}, 'no next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'second page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/bugs/10')->json_has('/bugs/11')
+              ->json_has('/bugs/7')->json_has('/bugs/8')->json_has('/bugs/9')->json_hasnt('/bugs/1')
+              ->json_hasnt('/bugs/12');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{prev}{link})->status_is(200)->json_has('/bugs/10')->json_has('/bugs/11')
-          ->json_has('/bugs/7')->json_has('/bugs/8')->json_has('/bugs/9')->json_hasnt('/bugs/1')
-          ->json_hasnt('/bugs/12');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok $links->{prev}, 'has previous page';
+        subtest 'third page' => sub {
+            $t->get_ok($links->{next}{link})->status_is(200)->json_has('/bugs/12')->json_has('/bugs/13')
+              ->json_hasnt('/bugs/1')->json_hasnt('/bugs/10');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok !$links->{next}, 'no next page';
+            ok $links->{prev}, 'has previous page';
+        };
 
-        $t->get_ok($links->{first}{link})->status_is(200)->json_has('/bugs/1')->json_has('/bugs/3')
-          ->json_has('/bugs/4')->json_has('/bugs/5')->json_has('/bugs/6')->json_hasnt('/bugs/10')
-          ->json_hasnt('/bugs/12');
-        $links = $t->tx->res->headers->links;
-        ok $links->{first}, 'has first page';
-        ok $links->{next}, 'has next page';
-        ok !$links->{prev}, 'no previous page';
+        subtest 'second page (prev link)' => sub {
+            $t->get_ok($links->{prev}{link})->status_is(200)->json_has('/bugs/10')->json_has('/bugs/11')
+              ->json_has('/bugs/7')->json_has('/bugs/8')->json_has('/bugs/9')->json_hasnt('/bugs/1')
+              ->json_hasnt('/bugs/12');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok $links->{prev}, 'has previous page';
+        };
+
+        subtest 'first page (first link)' => sub {
+            $t->get_ok($links->{first}{link})->status_is(200)->json_has('/bugs/1')->json_has('/bugs/3')
+              ->json_has('/bugs/4')->json_has('/bugs/5')->json_has('/bugs/6')->json_hasnt('/bugs/10')
+              ->json_hasnt('/bugs/12');
+            $links = $t->tx->res->headers->links;
+            ok $links->{first}, 'has first page';
+            ok $links->{next}, 'has next page';
+            ok !$links->{prev}, 'no previous page';
+        };
     };
 };
 


### PR DESCRIPTION
They all share the same controller and action.

Progress: https://progress.opensuse.org/issues/121105