### PR TITLE
Make serialization of test results portable

### DIFF
--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -186,7 +186,7 @@ sub _load_tree {
     return $self;
 }
 
-sub serialize { Storable::freeze(shift->_build_tree) }
+sub serialize { Storable::nfreeze(shift->_build_tree) }
 sub deserialize { shift->_load_tree(Storable::thaw(shift)) }
 
 sub to_json { encode_json shift->_build_tree }

--- a/lib/OpenQA/Parser/Result.pm
+++ b/lib/OpenQA/Parser/Result.pm
@@ -46,7 +46,7 @@ sub write {
 
 sub write_json { shift->write(@_) }
 
-sub serialize { Storable::freeze(shift->to_el) }
+sub serialize { Storable::nfreeze(shift->to_el) }
 sub deserialize { shift()->new(OpenQA::Parser::restore_el(Storable::thaw(shift))) }
 
 sub TO_JSON { shift->to_hash }

--- a/lib/OpenQA/Parser/Results.pm
+++ b/lib/OpenQA/Parser/Results.pm
@@ -40,7 +40,7 @@ sub to_el {
     return [map { maybe_convert_to_el($_) } @$self];
 }
 
-sub serialize { Storable::freeze(shift) }
+sub serialize { Storable::nfreeze(shift) }
 sub deserialize { shift->new(@{Storable::thaw(shift)}) }
 
 sub reset { @{$_[0]} = () }


### PR DESCRIPTION
Serialize the test results in network order to be compatible with the different type of endianness (big-endian and little-endian)

See: https://github.com/os-autoinst/os-autoinst/issues/2312