### PR TITLE
Makefile: Fix manual calls of codecov report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ COVER_REPORT_OPTS ?= -select_re '^(lib|script|t)/'
 
 .PHONY: coverage-report-codecov
 coverage-report-codecov:
+	export DEVEL_COVER_DB_FORMAT=JSON;\
 	cover $(COVER_REPORT_OPTS) -report codecovbash
 
 .PHONY: coverage-codecov


### PR DESCRIPTION
Same as when generating reports for generating codecov reports we should
specify the variables which help us with local calls in case of "Sereal"
packages being available locally to prevent errors.