### PR TITLE
Add route to schedule a product via a webhook

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1675,6 +1675,7 @@ It is possible to run openQA jobs as CI checks of a repository, e.g. a test
 distribution or an arbitrary repository containing software with openQA tests
 as part of the test suite.
 
+=== Create and monitor openQA jobs from within the CI runner
 The easiest approach is to create and monitor openQA jobs from within the CI
 runner. To make this easier, `openqa-cli` provides the `schedule` sub-command
 with the `--monitor` flag. This way you still need an openQA instance to run
@@ -1691,3 +1692,64 @@ https://github.com/os-autoinst/os-autoinst-distri-example/blob/master/scenario-d
 in a way that is independent from openQA's normal scheduling tables. This
 feature is explained in further detail in the corresponding
 <<UsersGuide.asciidoc#scenarios_yaml,users guide section>>.
+
+NOTE: This example shows that API credentials need to be present. When using
+GitHub actions the secrets configured in the main repository are not made
+available to PRs created from branches in fork repositories. So the credentials
+need to be configured for each repository context manually. The approach
+using webhooks mentioned in the next section does not have this limitation.
+
+=== Use webhooks and status reporting APIs of GitHub
+This approach is so far specific to GitHub and is a bit more effort to setup
+than the approach mentioned in the previous section. For this to work, GitHub
+needs to be able to inform openQA that a PR has been created or updated and
+openQA needs to be able to inform GitHub about the result of the jobs it ran.
+So authentication needs to be configured on both sides. On the upside, there
+is no additional CI runner required and the authentication also works when a
+PR is created from a fork repository branch which extra configuration.
+
+The test scenarios for your repository need to be defined in the file
+`scenario-definitions.yaml` at the root of your repository. Checkout the
+https://github.com/os-autoinst/os-autoinst-distri-example/blob/master/scenario-definitions.yaml[scenario definitions]
+from the example distribution for an example. You may append a parameter like
+`SCENARIO_DEFINITIONS_YAML=path/of/yaml` to the query parameters of the
+webhook to change the lookup path of this file.
+
+==== Setup a GitHub access token for openQA
+This setup is required for openQA to be able to report the status back to
+GitHub.
+
+1. Open https://github.com/settings/tokens/new and create a new token. It
+   needs at least the scope "repo".
+2. Open the openQA web UI's config file (usually `/etc/openqa/openqa.ini`)
+   and add the token created in the previous step:
++
+ [secrets]
+ github_token = $token
+
+3. Restart the web UI services.
+
+==== Setup webhook on GitHub
+This setup is required for GitHub to be able to inform openQA that a PR has
+been created or updated.
+
+1. Open https://github.com/$orga/$project/settings/hooks/new. You need to
+   substitute the placeholders `$orga`  and `$project` with the corresponding
+   value of the repository you want to add CI checks to.
+2. Add https://$user:$apikey:$apisecret@$openqa_host/api/v1/webhooks/product?DISTRI=example&VERSION=0&FLAVOR=DVD&ARCH=x86_64&TEST=simple_boot
+   as "Payload URL". You need to substitute the placeholders with valid API
+   credentials and hostname for your openQA instance. If you don't have
+   an API key/secret then you can create one on https://$openqa_host/api_keys.
+   Make sure the casing of the user name is correct. The scheduling
+   parameters need to be adjusted to produce the wanted set of jobs from
+   your scenario definitions YAML file.
+3. Select "application/json" as "Content type".
+4. Add `$user:$apikey:$apisecret` as secret replacing placeholders again.
+   You need to use the same credentials as in step 2.
+5. Keep SSL enabled. (Be sure your openQA instance is reachable via HTTPS.)
+6. Select "Let me select individual events." and then "Pull requests".
+7. Ensure "Active" is checked and confirm.
+8. GitHub should now have been delivering a "ping" event. Checkout whether
+   it could be delivered. If you have gotten a 200 response then everything
+   is setup correctly. Otherwise, checkout the response of the delivery to
+   investigate what is wrong.

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2015,6 +2015,9 @@ sub done ($self, %args) {
     # cancel other jobs in the cluster if a result has been set and it is not ok
     $self->cancel_other_jobs_in_cluster if defined $new_val{result} && !grep { $result eq $_ } OK_RESULTS;
 
+    # report back to GitHub if this job is part of a CI check which has concluded with this job
+    if (my $sp = $self->scheduled_product) { $sp->report_status_to_github }
+
     # enqueue the finalize job only after stopping the cluster so in case the job should be restarted the cluster
     # appears cancelled and thus its jobs in (pre-)execution are not set to PARALLEL_RESTARTED by `auto_duplicate`
     $self->enqueue_finalize_job_results([$carried_over], \%finalize_opts);

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -178,6 +178,7 @@ sub read_config ($app) {
         'assets/storage_duration' => {
             # intentionally left blank for overview
         },
+        secrets => {github_token => ''},
         # allow dynamic config keys based on job results
         hooks => {},
         influxdb => {

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -121,6 +121,7 @@ sub _token_auth ($self, $reason, $userinfo) {
             if (my $api_key = $self->schema->resultset('ApiKeys')->find({key => $key})) {
                 my $user = $api_key->user;
                 my $name = $user->name;
+                $self->stash(webhook_validation_secret => join(':', $name, $key, $secret));
                 if ($user && secure_compare($name, $username)) {
                     return ($user, undef) if secure_compare($api_key->secret, $secret);
                     $log->debug("$reject_msg, wrong secret");

--- a/lib/OpenQA/Task/Iso/Schedule.pm
+++ b/lib/OpenQA/Task/Iso/Schedule.pm
@@ -2,28 +2,46 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Task::Iso::Schedule;
-use Mojo::Base 'Mojolicious::Plugin';
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
-use OpenQA::Utils;
+use OpenQA::Utils 'format_tx_error';
 use Mojo::URL;
+use Mojo::UserAgent;
 
-sub register {
-    my ($self, $app) = @_;
+use constant SCENARIO_DEFS_YAML_MAX_REDIRECTS => $ENV{OPENQA_SCENARIO_DEFINITIONS_YAML_MAX_REDIRECTS} // 2;
+use constant SCENARIO_DEFS_YAML_MAX_SIZE => $ENV{OPENQA_SCENARIO_DEFINITIONS_YAML_MAX_SIZE} // (512 * 1024);
+use constant SCENARIO_DEFS_YAML_UA_ARGS =>
+  (max_redirects => SCENARIO_DEFS_YAML_MAX_REDIRECTS, max_response_size => SCENARIO_DEFS_YAML_MAX_SIZE);
+
+sub register ($self, $app, @) {
     $app->minion->add_task(schedule_iso => sub { _schedule_iso($app, @_) });
 }
 
-sub _schedule_iso {
-    my ($app, $minion_job, $args) = @_;
+sub _download_scenario_definitions ($minion_job, $scheduled_product, $scheduling_params) {
+    return 1 unless my $file = $scheduling_params->{SCENARIO_DEFINITIONS_YAML_FILE};
+    my $url = Mojo::URL->new($file);
+    my $scheme = $url->scheme;
+    return 1 unless $scheme eq 'http' || $scheme eq 'https';
+    return 1 unless $url->host eq 'raw.githubusercontent.com';    # restrict this for now to GitHub
+    my $ua = Mojo::UserAgent->new(SCENARIO_DEFS_YAML_UA_ARGS);
+    my $tx = $ua->get($url);
+    if (my $err = $tx->error) {
+        my $msg = format_tx_error($err);
+        my $res = {error => "Unable to download SCENARIO_DEFINITIONS_YAML_FILE from '$url': $msg"};
+        $scheduled_product->set_done($res);
+        $minion_job->finish($res);
+        return 0;
+    }
+    $scheduling_params->{SCENARIO_DEFINITIONS_YAML} = $tx->res->body;
+    return 1;
+}
 
+sub _schedule_iso ($app, $minion_job, $args, @) {
     my $scheduled_product_id = $args->{scheduled_product_id};
     my $scheduling_params = $args->{scheduling_params};
-
-    my $schema = $app->schema;
-    my $scheduled_product = $schema->resultset('ScheduledProducts')->find($scheduled_product_id);
-    if (!$scheduled_product) {
-        $minion_job->fail({error => "Scheduled product with ID $scheduled_product_id does not exist."});
-    }
-
+    return $minion_job->fail({error => "Scheduled product with ID $scheduled_product_id does not exist."})
+      unless my $scheduled_product = $app->schema->resultset('ScheduledProducts')->find($scheduled_product_id);
+    return undef unless _download_scenario_definitions($minion_job, $scheduled_product, $scheduling_params);
     $minion_job->finish($scheduled_product->schedule_iso($scheduling_params));
 }
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -135,6 +135,7 @@ our @EXPORT = qw(
   download_rate
   download_speed
   is_host_local
+  format_tx_error
 );
 
 our @EXPORT_OK = qw(
@@ -940,5 +941,9 @@ sub download_speed ($start, $end, $bytes) {
 }
 
 sub is_host_local ($host) { $host eq 'localhost' || $host eq '127.0.0.1' || $host eq '[::1]' }
+
+sub format_tx_error ($err) {
+    $err->{code} ? "$err->{code} response: $err->{message}" : "Connection error: $err->{message}";
+}
 
 1;

--- a/lib/OpenQA/VcsProvider.pm
+++ b/lib/OpenQA/VcsProvider.pm
@@ -1,0 +1,36 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::VcsProvider;
+
+use Mojo::Base -base, -signatures;
+use Mojo::JSON qw(encode_json);
+use Mojo::URL;
+
+has 'app';
+
+sub report_status_to_github ($self, $statuses_url, $params, $scheduled_product_id, $base_url, $callback = undef) {
+    $params->{context} //= 'openqa';
+    $params->{description} //= 'openQA test run';
+    $params->{target_url} //= "$base_url/admin/productlog?id=$scheduled_product_id"
+      if $scheduled_product_id && $base_url;
+
+    my $url = Mojo::URL->new($statuses_url);
+    my $app = $self->app;
+    my $ua = $app->ua;
+    my $tx = $ua->build_tx(POST => $url);
+    my $req = $tx->req;
+    my $headers = $req->headers;
+    my $github_token = $app->config->{secrets}->{github_token};
+    my $json = encode_json($params);
+    $req->body($json);
+    $headers->content_type('application/json');
+    $headers->content_length(length $json);
+    $headers->header(Accept => 'application/vnd.github+json');
+    $headers->header(Authorization => "Bearer $github_token");
+    $headers->header('X-GitHub-Api-Version' => '2022-11-28');
+    $ua->start($tx, $callback);
+    return $tx;
+}
+
+1;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -411,6 +411,9 @@ sub startup ($self) {
     $api_ra->delete('/isos/#name')->name('apiv1_destroy_iso')->to('iso#destroy');
     $api_ro->post('/isos/#name/cancel')->name('apiv1_cancel_iso')->to('iso#cancel');
 
+    # api/v1/webhooks
+    $api_ro->post('/webhooks/product')->name('apiv1_evaluate_webhook_product')->to('webhook#product');
+
     # api/v1/assets
     $api_ro->post('/assets')->name('apiv1_post_asset')->to('asset#register');
     $api_public_r->get('/assets')->name('apiv1_get_asset')->to('asset#list');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Webhook.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Webhook.pm
@@ -1,0 +1,154 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Controller::API::V1::Webhook;
+use Mojo::Base 'OpenQA::WebAPI::Controller::API::V1::Iso', -signatures;
+
+use Digest::SHA 'hmac_sha256_hex';
+use File::Basename;
+use OpenQA::Utils;
+use DBIx::Class::Timestamps 'now';
+use OpenQA::Schema::Result::JobDependencies;
+use OpenQA::Utils 'format_tx_error';
+use OpenQA::VcsProvider;
+use Mojo::Util 'secure_compare';
+
+my %SUPPORTED_PR_ACTIONS = (opened => 1, synchronize => 1);
+
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Webhook
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Webhook;
+
+=head1 DESCRIPTION
+
+Implements API methods to handle CI workflows based on the existing mechanism to
+schedule products.
+
+=head1 METHODS
+
+=over 4
+
+=item validate_signature()
+
+Validates the webhook's signature as documented on
+https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks.
+
+=back
+
+=cut
+
+sub validate_signature ($self) {
+    my $req = $self->tx->req;
+    return 0 unless my $sig = $req->headers->header('X-Hub-Signature-256');
+    return 0 unless my $secret = $self->stash('webhook_validation_secret');
+    my $hmac = hmac_sha256_hex($req->body, $secret);
+    return secure_compare $sig, "sha256=$hmac";
+}
+
+=over 4
+
+=item product()
+
+Evaluates payload from a GitHub webhook. This will schedule a new product (like
+OpenQA::WebAPI::Controller::API::V1::Iso::create does). It handles parameters
+from GitHub's webhook payload to decid what to do exactly. The scheduled product
+is always created asynchronously.
+
+This function does not handle the "closed" or "cancel" action yet. It would make
+sense to abort an existing scheduled product in this case.
+
+This function does not handle the "push" or "synchronize" actions yet. It would make
+sense to cancel and restart an existing scheduled product in this case.
+
+=back
+
+=cut
+
+sub product ($self) {
+
+    # catch the GitHub token not being configured early
+    my $app = $self->app;
+    my $config = $app->config;
+    return $self->render(
+        status => 404,
+        text => 'this route is not available because no GitHub token is configured on this openQA instance'
+    ) unless $config->{secrets}->{github_token};
+
+    # validate signature
+    return $self->render(status => 403, text => 'invalid signature') unless $self->validate_signature;
+
+    # handle event header
+    my $req = $self->req;
+    my $event = $req->headers->header('X-GitHub-Event') // '';
+    return $self->render(status => 200, text => 'pong') if $event eq 'ping';
+    return $self->render(status => 404, text => 'specified event cannot be handled') unless $event eq 'pull_request';
+
+    # validate parameters
+    return undef unless $self->validate_create_parameters;
+    my $json = $req->json;
+    return $self->render(status => 400, text => 'JSON object payload missing') unless ref $json eq 'HASH';
+    my $action = $json->{action} // '';
+    return $self->render(status => 404, text => 'specified action cannot be handled')
+      unless $SUPPORTED_PR_ACTIONS{$action};
+    my $pr = $json->{pull_request} // {};
+    my $head = $pr->{head} // {};
+    my $sha = $head->{sha};
+    my $repo = $head->{repo} // {};
+    my $repo_name = $repo->{full_name};
+    my $clone_url = $repo->{clone_url};
+    my $statuses_url = $pr->{statuses_url};
+    my $html_url = $pr->{html_url};
+    return $self->render(
+        status => 400,
+        text => '"pull_request" lacks "statuses_url", "head/sha" or "head/repo/full_name" or "head/repo/clone_url"'
+    ) unless $sha && $repo_name && $clone_url && $statuses_url;
+
+    # compute parameters
+    my $params = $req->params->to_hash;
+    my %up_params = map { uc $_ => $params->{$_} } keys %$params;
+    my %params = map { $_ => $up_params{$_} =~ s@%2F@/@gr } keys %up_params;
+    return undef unless $self->validate_download_parameters(\%params);
+
+    # set some useful defaults
+    $params{BUILD} //= "$repo_name#$sha";
+    $params{CASEDIR} //= "$clone_url#$sha";
+    $params{_GROUP_ID} //= '0';
+    $params{PRIO} //= '100';
+    $params{NEEDLES_DIR} //= '%%CASEDIR%%/needles';
+
+    # set the URL for the scenario definitions YAML file so the Minion job will download it from GitHub
+    my $relative_file_path = $params{SCENARIO_DEFINITIONS_YAML_FILE} // 'scenario-definitions.yaml';
+    $params{SCENARIO_DEFINITIONS_YAML_FILE} = "https://raw.githubusercontent.com/$repo_name/$sha/$relative_file_path";
+
+    # add "target URL" for the "Details" button of the CI status
+    my $base_url = $config->{global}->{base_url} // $req->url->base;
+    $params{CI_TARGET_URL} = $base_url if $base_url;
+
+    # set GitHub parameters so the Minion job will be able to report the status back to GitHub
+    $params{GITHUB_REPO} = $repo_name;
+    $params{GITHUB_SHA} = $sha;
+    $params{GITHUB_STATUSES_URL} = $statuses_url;
+    $params{GITHUB_PR_URL} = $html_url if $html_url;
+
+    # create scheduled product and enqueue minion job with parameter
+    my $scheduled_products = $self->schema->resultset('ScheduledProducts');
+    my $scheduled_product = $scheduled_products->create_with_event(\%params, $self->current_user);
+    my $vcs = OpenQA::VcsProvider->new(app => $app);
+    my $cb = sub ($ua, $tx, @) {
+        if (my $err = $tx->error) {
+            $scheduled_product->delete;
+            return $self->render(status => 500, text => format_tx_error($err));
+        }
+        return $self->render(json => $scheduled_product->enqueue_minion_job(\%params));
+    };
+    $scheduled_product->discard_changes;    # load value of columns that have a default value
+    my $tx = $vcs->report_status_to_github($statuses_url, {state => 'pending'}, $scheduled_product->id, $base_url, $cb);
+}
+
+1;

--- a/t/16-utils-vcs-provider.t
+++ b/t/16-utils-vcs-provider.t
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::Database;
+use OpenQA::Test::TimeLimit '5';
+use OpenQA::VcsProvider;
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+
+my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '03-users.pl');
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+subtest 'reporting status to GitHub' => sub {
+    # avoid making an actual query to GitHub; this test just checks whether an expected request would have been done
+    my $app = $t->app;
+    $app->config->{secrets}->{github_token} = 'some-token';
+
+    my $git = OpenQA::VcsProvider->new(app => $app);
+    my $url = 'http://127.0.0.1/repos/some/repo/statuses/some-sha';
+    my $tx = $git->report_status_to_github($url, {state => 'pending'}, '42', 'https://openqa.opensuse.org');
+    my $req = $tx->req;
+    is $req->method, 'POST', 'method';
+    is $req->url, $url, 'URL';
+    my %json = (
+        state => 'pending',
+        context => 'openqa',
+        description => 'openQA test run',
+        target_url => 'https://openqa.opensuse.org/admin/productlog?id=42'
+    );
+    is_deeply $req->json, \%json, 'payload';
+    is $req->headers->header('Authorization'), 'Bearer some-token', 'authorization header';
+    ok $tx->is_finished, 'transaction has finished (and thus was started in first place)';
+};
+
+done_testing();

--- a/t/api/16-webhooks.t
+++ b/t/api/16-webhooks.t
@@ -1,0 +1,167 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Mojo::Base -base, -signatures;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use Test::Mojo;
+use Test::Warnings;
+use Test::MockModule;
+use Digest::SHA qw(hmac_sha256_hex);
+use OpenQA::App;
+use OpenQA::Schema::Result::ScheduledProducts;
+use OpenQA::Test::TimeLimit '5';
+use OpenQA::Test::Case;
+use OpenQA::Test::Utils qw(perform_minion_jobs);
+use OpenQA::Jobs::Constants;
+use Mojo::File qw(path);
+use Mojo::JSON qw(encode_json decode_json);
+use Mojo::Transaction::HTTP;
+
+my $case = OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+my $app = OpenQA::App->singleton;
+my $minion = $app->minion;
+my $scheduled_products = $app->schema->resultset('ScheduledProducts');
+my $jobs = $app->schema->resultset('Jobs');
+my $ioloop = Mojo::IOLoop->singleton;
+my $url_base = '/api/v1/webhooks/product';
+my $url = "$url_base/?DISTRI=opensuse&VERSION=13.1&FLAVOR=DVD&ARCH=i586&BUILD=0091&TEST=autoyast_btrfs";
+my $test_payload = decode_json(path("$FindBin::Bin/../data/example-webhook-payload.json")->slurp);
+my $ua = $app->ua->ioloop($ioloop);
+my %headers = ('X-GitHub-Event' => 'pull_request');
+my $validation_mock = Test::MockModule->new('OpenQA::WebAPI::Controller::API::V1::Webhook');
+
+subtest 'signature validation' => sub {
+    my $payload = 'some text';
+    my $tx = Mojo::Transaction::HTTP->new;
+    my $c = OpenQA::WebAPI::Controller::API::V1::Webhook->new(tx => $tx);
+    ok !$c->validate_signature, 'failure without signature';
+    $c->tx->req->headers->header('X-Hub-Signature-256', 'sha256=' . hmac_sha256_hex($payload, 'foobar'));
+    ok !$c->validate_signature, 'failure without secret';
+    $c->stash(webhook_validation_secret => 'foobar');
+    ok !$c->validate_signature, 'failure without matching payload';
+    $c->tx->req->body($payload);
+    ok $c->validate_signature, 'success';
+};
+
+subtest 'error cases' => sub {
+    $t->ua(OpenQA::Client->new(apikey => 'LANCELOTKEY01', apisecret => 'MANYPEOPLEKNOW')->ioloop($ioloop))->app($app);
+    $t->post_ok($url_base)->status_is(403, 'posting webhook not allowed by any user');
+
+    $t->ua(OpenQA::Client->new(apikey => 'PERCIVALKEY01', apisecret => 'PERCIVALSECRET01')->ioloop($ioloop))->app($app);
+    $t->post_ok($url_base)->status_is(404, 'posting webhook not possible if GitHub token missing');
+    $t->content_like(qr/not available.+no.+token/, 'error message about missing token missing');
+
+    $app->config->{secrets}->{github_token} = 'the-token';
+    $t->post_ok($url_base)->status_is(403, 'posting webhook signature validation fails');
+    $t->content_is('invalid signature', 'error message about invalid signature');
+
+    $validation_mock->redefine(validate_signature => 1);
+    $t->post_ok($url_base);
+    $t->status_is(404, 'posting webhook not possible if GitHub event is missing/unsupported');
+    $t->content_like(qr/specified event cannot be handled/, 'error message about missing unsupported event');
+
+    $t->post_ok($url_base, {'X-GitHub-Event' => 'ping'})->status_is(200, 'ping -> pong');
+    $t->content_is('pong', 'got pong response for ping');
+
+    $t->post_ok($url_base, \%headers)->status_is(400, 'error if mandatory parameters missing');
+    $t->content_like(qr/missing parameters/, 'error message about missing mandatory parameters');
+
+    $t->post_ok($url, \%headers)->status_is(400, 'error if JSON payload missing');
+    $t->content_like(qr/payload missing/, 'error message about missing payload');
+
+    $t->post_ok($url, \%headers, json => {action => 'foo'})->status_is(404, 'error if action cannot be handled');
+    $t->content_like(qr/action cannot be handled/, 'error message about unsupported action');
+
+    $t->post_ok($url, \%headers, json => {action => 'opened'})->status_is(400, 'error if required fields are missing');
+    $t->content_like(qr/.+ lacks .+/, 'error message about missing required fields');
+};
+
+subtest 'failure when reporting status to GitHub' => sub {
+    $t->post_ok($url, \%headers, json => $test_payload)
+      ->status_is(500, 'error returned when GitHub status cannot be created');
+    is $minion->jobs->total, 0, 'no Minion job created';
+    is $scheduled_products->count, 0, 'no scheduled product created';
+};
+
+# mock reporting back to GitHub
+my $vcs_mock = Test::MockModule->new('OpenQA::VcsProvider');
+my $minion_job_id;
+my $status_reports = 0;
+my $expected_path = 'Martchus/openQA/04a3f669ea13a4aa7cbd4569f578a66f7403c43d/scenario-definitions.yaml';
+my $expected_url = "https://raw.githubusercontent.com/$expected_path";
+my $expected_ci_check_state = 'pending';
+$vcs_mock->redefine(
+    report_status_to_github =>
+      sub ($self, $statuses_url, $params, $scheduled_product_id, $base_url_from_req, $callback) {
+        my $tx = $ua->build_tx(POST => 'http://dummy');
+        is $statuses_url,
+          'https://127.0.0.1/repos/os-autoinst/openQA/statuses/04a3f669ea13a4aa7cbd4569f578a66f7403c43d',
+          'URL from webhook payload used for reporting back';
+        is $params->{state}, $expected_ci_check_state, "check reported to be $expected_ci_check_state";
+        ++$status_reports;
+        $callback ? $callback->($ua, $tx) : $tx;
+    });
+
+subtest 'scheduled product created via webhook' => sub {
+    $t->post_ok($url, \%headers, json => $test_payload)->status_is(200, 'scheduled product has been created');
+    $t->json_is('/scheduled_product_id', 2, 'scheduled product ID returned');
+    is $minion->jobs->total, 1, 'created one Minion job';
+    is $scheduled_products->count, 1, 'created one scheduled product';
+    is $status_reports, 1, 'exactly one status report to GitHub happened';
+} or BAIL_OUT 'unable to created scheduled product';
+
+subtest 'triggering the scheduled product will download scenario definitions YAML file from GitHub' => sub {
+    $expected_ci_check_state = 'failure';
+    perform_minion_jobs $minion;
+    my $expected_error = qr/Unable to download SCENARIO_DEFINITIONS_YAML_FILE from '$expected_url': .+/;
+    ok my $scheduled_product = $scheduled_products->find(2), 'scheduled product still there' or return;
+    is $scheduled_product->status, SCHEDULED, 'scheduled product considered scheduled';
+    like $scheduled_product->results->{error}, $expected_error, 'download error stored as result';
+    my $minion_job = $minion->jobs->next;
+    is $minion_job->{state}, 'finished', 'Minion job finished (not failed, we do not want alerts for these errors)';
+    like $minion_job->{result}->{error}, $expected_error, 'error assigned as Minion job result'
+      or diag explain $minion_job;
+    is $status_reports, 2, 'the status has been reported back to GitHub';
+    $minion_job_id = $minion_job->{id};
+    is $jobs->count, 0, 'no jobs have been created yet';
+};
+
+# mock download of SCENARIO_DEFINITIONS_YAML_FILE
+my $ua_mock = Test::MockModule->new('Mojo::UserAgent');
+my $yaml = path("$FindBin::Bin/../data/09-schedule_from_file.yaml")->slurp;
+$ua_mock->redefine(
+    get => sub ($self, $url) {
+        my $tx = $ua->build_tx(POST => 'http://dummy');
+        $tx->res->body($yaml);
+        is $url, $expected_url, 'expected URL used to download SCENARIO_DEFINITIONS_YAML_FILE';
+        return $tx;
+    });
+
+subtest 'triggering the scheduled product will report status back to GitHub' => sub {
+    # set back scheduled product and retry Minion job
+    $scheduled_products->find(2)->update({status => ADDED});
+    $minion->job($minion_job_id)->retry;
+    perform_minion_jobs $minion;
+
+    # check Minion job's result; we should have 2 jobs now (same scenarios/parameters as in `02-iso-yaml.t`)
+    my $minion_job = $minion->jobs->next;
+    my %expected_res = (failed_job_info => [], successful_job_ids => [1, 2]);
+    is $minion_job->{state}, 'finished', 'Minion job finished';
+    is_deeply $minion_job->{result}, \%expected_res, 'expected result' or diag explain $minion_job;
+
+    # set the jobs to done; this should lead to reporting back to GitHub
+    $expected_ci_check_state = 'success';
+    my @jobs = $jobs->search({}, {order_by => 'id'});
+    is @jobs, 2, 'two jobs have been cloned';
+    $jobs[0]->done(result => PASSED);
+    is $status_reports, 2, 'the status has not been reported back to GitHub as only one of two jobs is done';
+    $jobs[1]->done(result => SOFTFAILED);
+    is $status_reports, 3, 'the status has been reported back to GitHub as all jobs have concluded';
+};
+
+done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -164,6 +164,7 @@ subtest 'Test configuration default modes' => sub {
             lookup_depth => 10,
             state_changes_limit => 3,
         },
+        secrets => {github_token => ''},
     };
 
     # Test configuration generation with "test" mode

--- a/t/data/example-webhook-payload.json
+++ b/t/data/example-webhook-payload.json
@@ -1,0 +1,19 @@
+{
+  "action": "opened",
+  "pull_request": {
+    "url": "https://api.github.com/repos/os-autoinst/openQA/pulls/5111",
+    "html_url": "https://github.com/os-autoinst/openQA/pull/5111",
+    "state": "open",
+    "statuses_url": "https://127.0.0.1/repos/os-autoinst/openQA/statuses/04a3f669ea13a4aa7cbd4569f578a66f7403c43d",
+    "head": {
+      "label": "Martchus:allocate-network",
+      "ref": "allocate-network",
+      "sha": "04a3f669ea13a4aa7cbd4569f578a66f7403c43d",
+      "repo": {
+        "name": "openQA",
+        "full_name": "Martchus/openQA",
+        "clone_url": "https://github.com/Martchus/openQA.git"
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Sequence of the whole workflow
    1. The route `/api/v1/webhooks/product` is called by GitHub when
       a PR has been created.
        1. openQA creates a scheduled product as if
           `/api/v1/isos` was called and adds additional meta-
           data to be able to report the result back to GitHub.
           It also adds additional parameters like `_GROUP=0`.
        2. openQA reports a "pending" status back to GitHub so a
           CI check shows up in the PR.
    2. openQA downloads the YAML file with the scenario
       definitions from GitHub. It downloads the version from
       the PR.
    3. openQA creates jobs for the scheduled product as usual.
    4. Once a scheduled job has completed the status of the
       whole scheduled product is checked. Eventually success or
       failure is reported back to GitHub.
* Related ticket: https://progress.opensuse.org/issues/127949