### PR TITLE
Add `xz` to worker container

### DIFF
--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -7,7 +7,7 @@ LABEL version="0.3"
 RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.4 devel_openQA && \
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.4/15.4 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    zypper in -yl ca-certificates-mozilla curl gzip rsync && \
+    zypper in -yl ca-certificates-mozilla curl gzip rsync xz && \
     zypper in -yl openQA-worker os-autoinst-s390-deps && \
     zypper in -yl qemu-arm qemu-ppc qemu-x86 qemu-tools && \
     zypper in -yl qemu-hw-display-virtio-gpu qemu-hw-display-virtio-gpu-pci qemu-hw-display-virtio-vga && \


### PR DESCRIPTION
Hello,

I realize the worker container can't be all things to everyone... but it would be handy for GNOME's OpenQA setup if it contained `xz` so we can uncompress disk images on the worker. The increase in container image size is 319KB, which is not very noticeable in a 1.44GB container image :-)
