### PR TITLE
Improve contrast between failed and incomplete color

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -39,10 +39,7 @@ td div.progress {
     .progress-bar-passed, .progress-bar-softfailed, .progress-bar-unfinished {
         a { color: $color-result; }
     }
-    .progress-bar-failed{
-        a { color: white; }
-    }
-    .progress-bar-skipped {
+    .progress-bar-failed, .progress-bar-skipped {
         a { color: black; }
     }
     .progress-bar-passed {

--- a/assets/stylesheets/openqa_theme.scss
+++ b/assets/stylesheets/openqa_theme.scss
@@ -34,7 +34,7 @@ $link-hover-color:            darken($link-color, 15%) !default;
 $color-softfailed:            #EEB560;
 $color-ok:                    #CDFFB9;
 $color-warning:               #ffff99;
-$color-failed:                #cc3333;
+$color-failed:                #FF4E46;
 $color-result-failed:         #FF9E9B;
 $color-incomplete:            #AF1E11;
 $color-result:                #3c3c3c;


### PR DESCRIPTION
Commit c3af6a39f2e72559c045666d1bafd749001de538 increased the contrast of progress bar segments showing the number of failures by making the color we generally use for failures darker. However, that decreased the difference between the color of failures and incompletes which makes them harder to distinguish. So this commit reverts this original change. To still have a good contrast in the progress bar segment the text color within the progress bar is set to black. This looks good in bright and dark mode (the mode actually makes no difference for the progress bars).