### PR TITLE
Fix spec

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -9,7 +9,7 @@
 ---
 targets:
   cpanfile: [ assetpack,        client, common, cover, devel, devel_no_selenium, main, test, worker ]
-  spec:     [ assetpack, build, client, common,        devel, devel_no_selenium, main, test, worker ]
+  spec:     [ assetpack, build, client, common, cover, devel, devel_no_selenium, main, test, worker ]
   cpanfile-targets:
     # target: cpanfile target type (default main)
     devel: devel

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -71,6 +71,8 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
+%define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
+# The following line is generated from dependencies.yaml
 %define devel_no_selenium_requires %build_requires %cover_requires %qemu %test_requires curl perl(Perl::Tidy) postgresql-devel rsync sudo tar xorg-x11-fonts
 # The following line is generated from dependencies.yaml
 %define devel_requires %devel_no_selenium_requires chromedriver


### PR DESCRIPTION
The spec was broken by https://github.com/os-autoinst/openQA/pull/5117 because cover_requires was nowhere defined.

It has to be added to targets/spec.