### PR TITLE
Output host of missing api credentials

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -178,7 +178,7 @@ sub create_url_handler ($options) {
         api => $local_url->host,
         apikey => $options->{'apikey'},
         apisecret => $options->{'apisecret'});
-    die "API key/secret missing. Checkout '$0 --help' for the config file syntax/lookup.\n"
+    die "API key/secret for '$options->{host}' missing. Checkout '$0 --help' for the config file syntax/lookup.\n"
       unless $local->apikey && $local->apisecret;
 
     my $remote_url = OpenQA::Client::url_from_host($options->{from});

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -269,7 +269,7 @@ subtest 'overall cloning with parallel and chained dependencies' => sub {
 
     my %options
       = (host => 'foo', from => 'bar', 'clone-children' => 1, 'skip-download' => 1, verbose => 1, args => ['FOO=bar']);
-    throws_ok { OpenQA::Script::CloneJob::clone_jobs(42, \%options) } qr|API key/secret missing|,
+    throws_ok { OpenQA::Script::CloneJob::clone_jobs(42, \%options) } qr|API key/secret for 'foo' missing|,
       'dies on missing API credentials';
 
     $options{apikey} = $options{apisecret} = 'bar';

--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -21,7 +21,7 @@ test_once '', qr/missing.*help for usage/, 'hint shown for mandatory parameter m
 test_once '--help', qr/Usage:/, 'help text shown', 0, 'help screen is success';
 test_once '--invalid-arg', qr/Usage:/, 'invalid args also yield help', 1, 'help screen on invalid not success';
 my $args = 'http://openqa.opensuse.org/t1';
-test_once $args, qr|API key/secret missing|, 'fails without API key/secret', 'non-zero', 'fail';
+test_once $args, qr|API key/secret for 'localhost' missing|, 'fails without API key/secret', 'non-zero', 'fail';
 test_once "--apikey foo --apisecret bar $args", qr/failed to get job '1'/, 'fails without network', 'non-zero', 'fail';
 
 done_testing();


### PR DESCRIPTION
If one messes up the commandline options, e.g.

    --within-instance --json-output http://...

then the error message about the missing credentials can be confusing.
Printing out the host (or in this case the misplaced option) will make it clear what's wrong.