### PR TITLE
Increase heartbeat timeout to 15 minutes

### DIFF
--- a/script/openqa-webui-daemon
+++ b/script/openqa-webui-daemon
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 # Our API commands are very expensive, so the default timeouts are too tight
-exec "$(dirname "$0")"/openqa prefork -m production --proxy -i 100 -H 400 -w 30 -c 1 -G 800 "$@"
+exec "$(dirname "$0")"/openqa prefork -m production --proxy -i 100 -H 900 -w 30 -c 1 -G 800 "$@"

--- a/script/openqa-workercache-daemon
+++ b/script/openqa-workercache-daemon
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-exec "$(dirname "$0")"/openqa-workercache prefork -m production -i 100 -H 400 -w 4 -G 80 "$@"
+exec "$(dirname "$0")"/openqa-workercache prefork -m production -i 100 -H 900 -w 4 -G 80 "$@"


### PR DESCRIPTION
We have some API endpoints that can run in a blocking manner for 10+ minutes, such as `/api/v1/jobs/:id/set_done`. Which exceeds the 400 second heartbeat timeout we currently use.

Fortunately this timeout only exists so a worker cannot be blocked indefinitely with something like an infinite loop. So increasing it a bit more should not cause any noticeable side effects.

Long term we should consider moving such slow code into Minion background jobs though.

Progress: https://progress.opensuse.org/issues/128345