### PR TITLE
Only output JSON when using --json-output

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -245,7 +245,9 @@ sub clone_job ($jobid, $url_handler, $options, $post_params = {}, $jobs = {}, $d
         next unless $job->{$job_type};
 
         my ($chained, $directly_chained, $parallel) = get_deps($job, $job_type);
-        print STDERR "Cloning $job_type of $job->{name}\n" if @$chained || @$directly_chained || @$parallel;
+        print STDERR "Cloning $job_type of $job->{name}\n"
+          if not $options->{'json-output'} && (@$chained || @$directly_chained || @$parallel);
+
 
         for my $dependencies ($chained, $directly_chained, $parallel) {
             # constrain cloning parents according to specified options


### PR DESCRIPTION
If --json-output is used, users expect only JSON and no additional text, so the JSON can easily be parsed.
It was printed to stderr, so it can be treated separately, but still, such text output should only appear when for example in a verbose mode.

Issue: https://progress.opensuse.org/issues/128405