### PR TITLE
Remove codecov token again after problem fixed

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 codecov:
-  token: 058d4462-cb3c-455d-bb6d-3e6859f3de9e
   branch: master
 comment:
   behavior: default


### PR DESCRIPTION
According to https://community.codecov.com/t/commit-sha-does-not-match-circle-build/4266/11?u=martchus the problem has been fixed so the token added via
2af754957c56053241a07d05499808ecc236f811 can be removed again.

Related progress issue: https://progress.opensuse.org/issues/128129