### PR TITLE
Fix sporadic failure in t/ui/18-tests-details.t

### DIFF
--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -336,8 +336,8 @@ subtest 'running job' => sub {
         # pretend the text result has been uploaded
         $aplay_text_result->spurt('some text result');
         update_status sub {
-            $step_detail_element = $driver->find_element('#module_aplay .links');
-            $step_detail_element && $step_detail_element->get_text !~ qr/Unable to read/;
+            my $text = $driver->execute_script('return document.querySelector("#module_aplay .links")?.textContent');
+            ($text !~ qr/Unable to read/) && ($step_detail_element = $driver->find_element('#module_aplay .links'));
         }, 'step detail shows no longer "Unable to read"';
         ok $step_detail_element, 'step detail still present' or return;
         like $step_detail_element->get_text, qr/some text result/, 'text result finally shown';


### PR DESCRIPTION
Fixes
```
getElementText: stale element reference: element is not attached to the page document …
Selenium::Remote::WebElement::get_text(Test::Selenium::Remote::WebElement=HASH(0x563e27154330)) called at t/ui/18-tests-details.t line 340
```
which can occur when the element is swapped out by JavaScript at the wrong moment. That the JavaScript code swaps out the element is actually provoked by this test and supposed to happen.

This change simply does the check in JavaScript to avoid running into this condition.