### PR TITLE
Separate 'Build' from real build display in groups and search results

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -38,7 +38,7 @@ function renderMediumName(data, type, row) {
     link += '&groupid=' + row.group;
   }
 
-  var name = "<a href='" + link + "'>" + 'Build' + row.build + '</a>';
+  var name = "<a href='" + link + "'>" + 'Build - ' + row.build + '</a>';
   name += ' of ';
   return name + row.distri + '-' + row.version + '-' + row.flavor + '.' + row.arch;
 }

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -121,7 +121,7 @@ subtest 'builds first tagged important, then unimportant disappear (poo#12028)' 
     $t->get_ok('/group_overview/1001?limit_builds=1')->status_is(200);
     my @tags = $t->tx->res->dom->find('a[href^=/tests/]')->map('text')->each;
     is(scalar @tags, 2, 'only one build');
-    is($tags[0], 'Build87.5011', 'only newest build present');
+    is($tags[0], 'Build - 87.5011', 'only newest build present');
 };
 
 subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -116,7 +116,7 @@ wait_for_ajax(msg => 'DataTables on "All tests" page');
 my $job99946 = $driver->find_element('#results #job_99946');
 my @tds = $driver->find_child_elements($job99946, 'td');
 is(scalar @tds, 4, '4 columns displayed');
-is((shift @tds)->get_text(), 'Build0091 of opensuse-13.1-DVD.i586', 'medium of 99946');
+is((shift @tds)->get_text(), 'Build - 0091 of opensuse-13.1-DVD.i586', 'medium of 99946');
 is((shift @tds)->get_text(), 'textmode@32bit', 'test of 99946');
 is((shift @tds)->get_text(), '28 1 1', 'result of 99946 (passed, softfailed, failed)');
 my $time = $driver->find_child_element(shift @tds, 'span');
@@ -259,7 +259,7 @@ subtest 'available comments shown' => sub {
     }
 };
 
-$driver->find_element_by_link_text('Build0091')->click();
+$driver->find_element_by_link_text('Build - 0091')->click();
 like(
     $driver->find_element_by_id('summary')->get_text(),
     qr/Overall Summary of opensuse build 0091/,

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -80,10 +80,10 @@ wait_for_ajax_and_animations;
 
 # test expanding/collapsing
 is(scalar @{$driver->find_elements('opensuse', 'link_text')}, 0, 'link to child group collapsed (in the first place)');
-$driver->find_element_by_link_text('Build0091')->click();
+$driver->find_element_by_link_text('Build - 0091')->click();
 my $element = $driver->find_element_by_link_text('opensuse');
 ok($element->is_displayed(), 'link to child group expanded');
-$driver->find_element_by_link_text('Build0091')->click();
+$driver->find_element_by_link_text('Build - 0091')->click();
 
 subtest 'progress bar link' => sub {
     my $first_build_row = $driver->find_elements('.build-row')->[0];
@@ -104,7 +104,7 @@ wait_for_ajax_and_animations;
 ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_displayed(), 'link to child group displayed');
 my @links = $driver->find_elements('.h4 a', 'css');
 is(scalar @links, 19, 'all links expanded in the first place');
-$driver->find_element_by_link_text('Build0091')->click();
+$driver->find_element_by_link_text('Build - 0091')->click();
 ok($driver->find_element('#group1_build13_1-0091 .h4 a')->is_hidden(), 'link to child group collapsed');
 
 # check same name group within different parent group

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -266,7 +266,7 @@ subtest 'commenting in test results including labels' => sub {
 
     # navigate to comments tab of test result page
     $driver->find_element_by_link_text('Job Groups')->click();
-    $driver->find_element_by_link_text('Build0048')->click();
+    $driver->find_element_by_link_text('Build - 0048')->click();
     $driver->find_element('.status')->click();
     is(
         $driver->get_title(),

--- a/t/ui/19-tests-links.t
+++ b/t/ui/19-tests-links.t
@@ -32,7 +32,7 @@ is_deeply(\@texts, ['2 softfailed'], 'Progress bars show soft fails');
 is($driver->find_element('#user-action a')->get_text(), 'Logged in as Demo', "logged in as demo");
 
 # follow a build to overview page
-$driver->find_element_by_link_text('Build0048')->click();
+$driver->find_element_by_link_text('Build - 0048')->click();
 $driver->title_is("openQA: Test summary", "on overview page");
 
 is($driver->find_element('.result_softfailed')->get_text(), '', 'We see one softfail');

--- a/templates/webapi/main/group_builds.html.ep
+++ b/templates/webapi/main/group_builds.html.ep
@@ -1,7 +1,7 @@
 % for my $build_res (@$build_results) {
     % my $version = $build_res->{version};
     % my $build = $build_res->{build};
-    % my $label = $build_res->{version_count} <= 1 ? "Build$build" : "$version-Build$build";
+    % my $label = $build_res->{version_count} <= 1 ? "Build - $build" : "$version-$build";
     % my $group_id;
     % my @tests_overview_url_data = (distri  => [sort keys %{$build_res->{distris}}], version => $version, build => $build);
     % my %progress_bar_params = (url => url_for('tests_overview'), query_params => [@tests_overview_url_data, $children ? (map { (groupid => $_->{id}) } @{$children}) : (groupid => $group->{id})]);


### PR DESCRIPTION
https://progress.opensuse.org/issues/129871
After:
<img width="509" alt="Group overview" src="https://github.com/os-autoinst/openQA/assets/931039/1bcb3116-4d5d-49e6-bded-e8e0facb9963">
<img width="1629" alt="Search results" src="https://github.com/os-autoinst/openQA/assets/931039/acf57218-79c1-4784-ae06-3bc3cf953203">


