### PR TITLE
Delete worker logs as well when cleaning up job logs

### DIFF
--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -88,7 +88,13 @@ use constant {
 use constant MODULE_RESULTS => (CANCELLED, FAILED, NONE, PASSED, RUNNING, SKIPPED, SOFTFAILED);
 
 # common result files to be expected in all jobs
-use constant COMMON_RESULT_FILES => ('vars.json', 'autoinst-log.txt', 'worker-log.txt', 'worker_packages.txt');
+use constant COMMON_RESULT_LOG_FILES => qw(autoinst-log.txt worker-log.txt worker_packages.txt);
+use constant COMMON_RESULT_FILES => COMMON_RESULT_LOG_FILES, qw(vars.json);
+
+# result files handled by the cleanup of logs
+use constant
+  RESULT_CLEANUP_LOG_FILES => COMMON_RESULT_LOG_FILES,
+  qw(serial0.txt serial_terminal.txt serial_terminal_user.txt video_time.vtt);
 
 # defaults for new jobs that are useful outside the schema
 use constant DEFAULT_JOB_PRIORITY => 50;
@@ -129,6 +135,7 @@ our @EXPORT = qw(
   COMMON_RESULT_FILES
   TIMEOUT_EXCEEDED
   DEFAULT_JOB_PRIORITY
+  RESULT_CLEANUP_LOG_FILES
 );
 
 # mapping from any specific job state/result to a meta state/result

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1123,10 +1123,7 @@ sub delete_logs ($self) {
     my $result_dir = $self->result_dir;
     return undef unless $result_dir;
     my @files = (
-        Mojo::Collection->new(
-            map { path($result_dir, $_) }
-              qw(autoinst-log.txt serial0.txt serial_terminal.txt serial_terminal_user.txt video_time.vtt)
-        ),
+        Mojo::Collection->new(map { path($result_dir, $_) } RESULT_CLEANUP_LOG_FILES),
         path($result_dir, 'ulogs')->list_tree({hidden => 1}),
         find_video_files($result_dir),
     );


### PR DESCRIPTION
With this change the files `worker-log.txt` and
`worker_packages.txt` will be deleted as well when cleaning up job logs. Those files usually don't take that much disk space which is likely why they haven't been considered for now. However, even just for the sake of consistency it makes sense to delete them - so when looking at job results it is immediately clear that logs have been cleaned up.

Related ticket/note: https://progress.opensuse.org/issues/129244#note-24