### PR TITLE
Improve documentation about containerized setup

### DIFF
--- a/docs/ContainerizedSetup.asciidoc
+++ b/docs/ContainerizedSetup.asciidoc
@@ -5,15 +5,15 @@
 :toclevels: 6
 :author: openQA developers
 
-This section describes two ways to deploy the containers for the openQA web UI
-and the workers.
+The installation guide already contains simple one-liners for starting
+the web UI and workers in the
+<<Installing.asciidoc#container_setup,Container based setup section>>.
 
-The first one describes how to deploy an openQA environment using containers
-with Fedora images or images built locally.
+This chapter describes how to deploy the containers for the openQA web UI
+and the workers using `docker-compose` or `podman-compose`.
 
-The second one uses `docker-compose` to deploy a complete web UI and a worker.
-This setup is under development and currently considered proof-of-concept.
-Do *not* expect that everything works yet.
+There is also an approach using Fedora-based images mentioned but it is not
+supported by upstream.
 
 == Get container images
 

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -124,9 +124,42 @@ podman run -p 1080:80 -p 1443:443 \
   --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest
 ----
 
+
+The same works for the workers container where you most likely want to to
+supply `workers.ini` and `client.conf`:
+
+[source,sh]
+----
+podman run \
+  -v ./container/worker/conf/workers.ini:/data/conf/workers.ini:z \
+  -v ./container/worker/conf/client.conf:/data/conf/client.conf:z \
+  --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_worker:latest
+----
+
+This examples assume the working directory is an openQA checkout. To avoid doing
+a checkout, you can also grab the config files from the
+https://github.com/os-autoinst/openQA/tree/master/container/webui/conf[webui/conf]
+and
+https://github.com/os-autoinst/openQA/tree/master/container/worker/conf[worker/conf]
+directory listings on GitHub.
+
+To learn more about how to run workers checkout the
+<<Installing.asciidoc#_run_openqa_workers,Run openQA workers section>>.
+
+For creating a first test job, checkout the
+<<UsersGuide.asciidoc#_triggering_tests,Triggering tests section>>. Note that the
+commands mentioned there can also be invoked within a container, e.g.:
+
+[source,sh]
+----
+podman run \
+   --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest \
+   openqa-cli --help
+----
+
 Checkout the
 <<ContainerizedSetup.asciidoc#containerizedsetup,containerized setup section>>
-for more details and how to configure and run these containers.
+for more details.
 
 Take a look at
 https://registry.opensuse.org/cgi-bin/cooverview?srch_term=project%3Ddevel%3AopenQA[openSUSE's registry]


### PR DESCRIPTION
* State that the approach using Fedora-based images is not
  supported
* Mention the one-liners that are already present in the
  "Getting started" chapter
* Don't consider the setup proof-of-concept anymore; it
  basically works and users are supposed to report issues with
  it
* Mention how to configure the worker
* Mention where the config files from the example commands come
  from
* Link the "Running openQA workers" and "Triggering tests"
  sections for how to continue once the containers are running
* Mention how to invoke other tools within a container

---

@AdamWill We've also noticed that the documentation about Fedora-based container images and how it is currently interleaved with the documentation about "our" containers is supposedly a bit confusing for newcomers. So I suggest we at least move these parts to the very end of the "Containerized setup" chapter in its own section. Are you ok with that? If it is ok with you we could also remove it entirely from the documentation as it is not regularly updated anymore anyways and might not even work anymore.