### PR TITLE
doc: Improve references for a quick installation

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -35,7 +35,8 @@ refer to the section
 <<UsersGuide.asciidoc#_cloning_existing_jobs_openqa_clone_job,Cloning existing jobs - openqa-clone-job>>
 directly to trigger a new test based on already existing job. For a quick
 installation refer directly to
-<<Installing.asciidoc#_openqa_quick_bootstrap,openQA quick bootstrap>>.
+<<Installing.asciidoc#bootstrapping,Quick bootstrapping under openSUSE>> or
+<<Installing.asciidoc#container_setup,Container based setup>>.
 
 For the installation of openQA in general see the
 <<Installing.asciidoc#installing,Installation Guide>>, as a user of an

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -84,8 +84,8 @@ zypper in openQA-bootstrap
 systemd-run -tM openqa1 /bin/bash # start a shell in the container
 -------------------------------------------------------------------------------
 
-== Container based setup
 [id="container_setup"]
+== Container based setup
 
 Containers are provided for both the web UI and worker.
 


### PR DESCRIPTION
* Fix the broken reference to the bootstrapping section
* Mention the container-based setup section
* Related ticket: https://progress.opensuse.org/issues/129883