### PR TITLE
Improve performance of server-side asset upload handling

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -682,36 +682,17 @@ sub create_artefact ($self) {
         return $self->render(json => {error => 'Unable to parse extra test'}, status => 400);
     }
     elsif (my $scope = $self->param('asset')) {
-        $self->render_later;    # XXX: Not really needed, but in case of upstream changes
-
-        # See: https://mojolicious.org/perldoc/Mojolicious/Guides/FAQ#What-does-Connection-already-closed-mean
-        my $tx = $self->tx;    # NOTE: Keep tx around as long operations could make it disappear
-
-        return Mojo::IOLoop->subprocess(
-            sub {
-                die "Transaction empty\n" if $tx->is_empty;
-                OpenQA::Events->singleton->emit('chunk_upload.start' => $self);
-                my ($error, $fname, $type, $last)
-                  = $job->create_asset($validation->param('file'), $scope, $self->param('local'));
-                OpenQA::Events->singleton->emit('chunk_upload.end' => ($self, $error, $fname, $type, $last));
-                die $error if $error;
-                return $fname, $type, $last;
-            },
-            sub {
-                my ($subprocess, $error, @results) = @_;
-                if ($error) {
-                    # return 500 even if most probably it is an error on client side so the worker can keep
-                    # retrying if it was caused by network failures
-                    chomp $error;
-                    $self->app->log->debug($error);
-                    return $self->render(json => {error => "Failed receiving asset: $error"}, status => 500);
-                }
-
-                my ($fname, $type, $last) = @results;
-                my $assets = $schema->resultset('Assets');
-                $assets->register($type, $fname, {scope => $scope, created_by => $job, refresh_size => 1}) if $last;
-                return $self->render(json => {status => 'ok'});
-            });
+        my ($error, $fname, $type, $last)
+          = $job->create_asset($validation->param('file'), $scope, $self->param('local'));
+        if ($error) {
+            # return 500 even if most probably it is an error on client side so the worker can keep retrying if it was
+            # caused by network failures
+            $self->app->log->debug($error);
+            return $self->render(json => {error => "Failed receiving asset: $error"}, status => 500);
+        }
+        my $assets = $schema->resultset('Assets');
+        $assets->register($type, $fname, {scope => $scope, created_by => $job, refresh_size => 1}) if $last;
+        return $self->render(json => {status => 'ok'});
     }
     $job->create_artefact($validation->param('file'), $self->param('ulog'));
     $self->render(text => 'OK');

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -22,11 +22,6 @@ my $chunk_size = 10000000;
 # allow up to 200MB - videos mostly
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
 
-OpenQA::Events->singleton->on(
-    'chunk_upload.end' => sub {
-        Devel::Cover::report() if Devel::Cover->can('report');
-    });
-
 my @client_args = (apikey => 'PERCIVALKEY02', apisecret => 'PERCIVALSECRET02');
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'), @client_args);
 my $client = $t->ua;


### PR DESCRIPTION
* Do not use a sub process; this is not useful anymore because we start the web UI service via `… prefork … -c 1 …` to allow only one connection per process (so no other connections are impaired by blocking here)
* Remove event tracking that was only useful for a unit test to track coverage despite using a sub process
* Simplify the error handling and variable passing