### PR TITLE
Use same selectors in comments test as in real code

### DIFF
--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -63,13 +63,16 @@ my $user_name = 'Demo';
 
 # fills out the comment form and submits
 sub write_comment ($text, $desc) {
-    wait_for_element(selector => '#text', is_displayed => 1, description => 'comment form is displayed')
-      ->send_keys($text);
+    wait_for_element(
+        selector => '#commentForm textarea[name="text"]',
+        is_displayed => 1,
+        description => 'comment form is displayed'
+    )->send_keys($text);
     # wait until the text is there
     # notes:
     # - Considering poo#128153 just waiting for the return of `send_keys` is sometimes not good enough.
     # - Not using `get_text` as it apparently doesn't work for the `textarea` element.
-    wait_until sub { $driver->execute_script('return document.getElementById("text").value') }, 'comment text entered';
+    wait_until sub { $driver->execute_script('return document.forms.commentForm.text.value') }, 'comment text entered';
     $driver->find_element_by_id('submitComment')->click;
     wait_for_ajax msg => $desc;
 }


### PR DESCRIPTION
This way the code that enters the comment text uses the same selectors than the code under text that reads the comment text. Maybe this helps to fix https://progress.opensuse.org/issues/129946 or at least allows us to rule out certain theories¹ why the test sometimes fails.

---

¹ Somtimes
  * there might be multiple elements with the same ID on the page.
  * there might be multiple elements with the same name in the form.
  * the forms API behaves somehow differently than the normal DOM API.