### PR TITLE
Add various optimizations and bug fixes for O3 deployment

### DIFF
--- a/etc/nginx/vhosts.d/openqa.conf
+++ b/etc/nginx/vhosts.d/openqa.conf
@@ -1,12 +1,33 @@
 server {
     listen       80;
     server_name  openqa.example.com;
+
     root /usr/share/openqa/public;
+
     client_max_body_size 0;
+    client_body_buffer_size 64k;
+
+    ## Optional faster assets downloads for large deployments
+    #location /assets {
+    #    alias /var/lib/openqa/share/factory;
+    #    tcp_nopush         on;
+    #    sendfile           on;
+    #    sendfile_max_chunk 1m;
+    #}
+    #
+    ## Optional faster image downloads for large deployments
+    #location /image {
+    #    alias /var/lib/openqa/images;
+    #    tcp_nopush         on;
+    #    sendfile           on;
+    #    sendfile_max_chunk 1m;
+    #}
 
     location /api/v1/ws/ {
         proxy_pass http://[::1]:9527;
         proxy_http_version 1.1;
+        proxy_read_timeout 3600;
+        proxy_send_timeout 3600;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
@@ -15,15 +36,21 @@ server {
     location /liveviewhandler/ {
         proxy_pass http://[::1]:9528;
         proxy_http_version 1.1;
+        proxy_read_timeout 3600;
+        proxy_send_timeout 3600;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
     }
 
     location / {
+        proxy_pass "http://[::1]:9526";
+        tcp_nodelay        on;
+        proxy_read_timeout 900;
+        proxy_send_timeout 900;
+        proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host:$server_port;
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass "http://[::1]:9526";
     }
 }


### PR DESCRIPTION
While deploying Nginx in production on O3 we learned a couple of important lessons that led to these improvements:

* Buffer sizes better reflect the requests we are dealing with in production and reduce the need to write bodies to disk.
* Large file downloads without sendfile made the whole webui feel sluggish.
* Increased read and write timeouts are necessary for WebSockets, as well as certain HTTP endpoints that have not yet been optimized.
* The missing `Host` header resulted in OpenID authentication breaking because of localhost redirects.

Progress: https://progress.opensuse.org/issues/129490