### PR TITLE
Allow wildcard version in scenarios YAML

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -794,7 +794,7 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, @load_yaml_args) {
             next
               if ( $product->{distri} ne _distri_key($args)
                 || $product->{flavor} ne $args->{FLAVOR}
-                || $product->{version} ne $args->{VERSION}
+                || ($product->{version} ne '*' && $product->{version} ne $args->{VERSION})
                 || $product->{arch} ne $args->{ARCH});
             my $product_settings = $product->{settings} // {};
             _merge_settings_uppercase($product, $settings, 'settings');

--- a/t/data/09-schedule_from_file_wildcard.yaml
+++ b/t/data/09-schedule_from_file_wildcard.yaml
@@ -1,0 +1,15 @@
+products:
+  sle-online-aarch64-*:
+    distri: "opensuse"
+    flavor: "DVD"
+    arch: "i586"
+    version: '*'
+    settings:
+      PRODUCT_SETTING: 'foo'
+
+
+job_templates:
+  job1:
+    product: "sle-online-aarch64-*"
+    settings:
+      FOO: 'bar'


### PR DESCRIPTION
When using the `SCENARIO_DEFINITIONS_YAML[_FILE]` options, allow the use of a wildcard (`*`) for the version, as is allowed when defining job groups through the webUI