### PR TITLE
Add max_conns limit to nginx config

### DIFF
--- a/etc/nginx/vhosts.d/openqa.conf
+++ b/etc/nginx/vhosts.d/openqa.conf
@@ -1,3 +1,18 @@
+# The "max_conns" value should be identical to the maximum number of
+# connections the webui is configured to handle concurrently
+upstream webui {
+    zone upstream_webui 64k;
+    server [::1]:9526 max_conns=30;
+}
+
+upstream websocket {
+    server [::1]:9527;
+}
+
+upstream livehandler {
+    server [::1]:9528;
+}
+
 server {
     listen       80;
     server_name  openqa.example.com;
@@ -24,7 +39,7 @@ server {
     #}
 
     location /api/v1/ws/ {
-        proxy_pass http://[::1]:9527;
+        proxy_pass http://websocket;
         proxy_http_version 1.1;
         proxy_read_timeout 3600;
         proxy_send_timeout 3600;
@@ -34,7 +49,7 @@ server {
     }
 
     location /liveviewhandler/ {
-        proxy_pass http://[::1]:9528;
+        proxy_pass http://livehandler;
         proxy_http_version 1.1;
         proxy_read_timeout 3600;
         proxy_send_timeout 3600;
@@ -44,7 +59,7 @@ server {
     }
 
     location / {
-        proxy_pass "http://[::1]:9526";
+        proxy_pass "http://webui";
         tcp_nodelay        on;
         proxy_read_timeout 900;
         proxy_send_timeout 900;


### PR DESCRIPTION
Another lesson learned. Nginx will happily kill the webui by forwarding many more requests than it can handle, resulting in batches of 502 Bad Gateway errors. Setting `max_conns` to the exact number of connections the app server can handle fixes that problem. This is especially important when the app server runs in prefork mode with a connection limit of one per worker, as is the case for O3.

Progress: https://progress.opensuse.org/issues/129490