### PR TITLE
Fix openqa-clone-custom-git-refspec on git-checkout job sources

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -123,11 +123,14 @@ Please try 'curl $json_url' or select another job, e.g. in the same scenario: $h
         old_productdir=$(echo "$json_data" | jq -r '.PRODUCTDIR') || throw_json_error "$json_url" "$json_data"
         local old_casedir
         old_casedir=$(echo "$json_data" | jq -r '.CASEDIR') || throw_json_error "$json_url" "$json_data"
+        # set a proper productdir pointing to the checked out repository for
+        # absolute+relative paths
         if [[ ${old_productdir:0:1} == "/" ]]; then
-            local productdir="${productdir:-"${repo_name##*/}${old_productdir##"$old_casedir"}"}"
+            local productdir="${productdir:-"${repo_name##*/}/${old_productdir##"$old_casedir"}"}"
         else
-            local productdir="${productdir:-"${repo_name##*/}${old_productdir#*"${old_casedir##*/}"}"}"
+            local productdir="${productdir:-"${repo_name##*/}/${old_productdir#*"${old_casedir##*/}"}"}"
         fi
+        productdir="${productdir/\/\//\/}"  # avoid consecutive slashes
         local old_needledir
         old_needledir=$(echo "$json_data" | jq -r '.NEEDLES_DIR | select (.!=null)') || throw_json_error "$json_url" "$json_data"
         local needles_dir="${needles_dir:-"$old_needledir"}"

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -107,16 +107,15 @@ $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "my/distri", "PRODUCTDIR": "distri/products/sle", "NEEDLES_DIR": "my/distri/products/sle/needles"}'; true};
 $dirs
   = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=my/distri/products/sle/needles';
-$expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
-$expected_re = qr/${expected}/;
+$expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ';
+$expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR is a relative directory";
 
 $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/openqa/cache/openqa1-opensuse/tests/opensuse", "PRODUCTDIR": "/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse"}'; true};
 $dirs
   = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse NEEDLES_DIR=/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse/needles';
-$expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
-$expected_re = qr/${expected}/;
+$expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR includes specific word";
 
 done_testing;

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -103,18 +103,19 @@ $expected_re = qr/${expected}/s;
 test_once $args, $expected_re, 'clone-job command with multiple URLs in PR and job URL';
 
 $ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my/branch"}, "body": "Lorem ipsum"}'; true};
+my $needles = 'my/distri/products/sle/needles';
 $ENV{curl_openqa}
-  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "my/distri", "PRODUCTDIR": "distri/products/sle", "NEEDLES_DIR": "my/distri/products/sle/needles"}'; true};
-$dirs
-  = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=my/distri/products/sle/needles';
+  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "my/distri", "PRODUCTDIR": "distri/products/sle", "NEEDLES_DIR": "$needles"}'; true};
+$dirs = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=$needles";
 $expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ';
 $expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR is a relative directory";
 
+my $casedir = '/openqa/cache/openqa1-opensuse/tests/opensuse';
 $ENV{curl_openqa}
-  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/openqa/cache/openqa1-opensuse/tests/opensuse", "PRODUCTDIR": "/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse"}'; true};
+  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "$casedir", "PRODUCTDIR": "$casedir/products/opensuse"}'; true};
 $dirs
-  = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse NEEDLES_DIR=/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse/needles';
+  = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse NEEDLES_DIR=$casedir/products/opensuse/needles";
 $expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR includes specific word";
 

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -104,17 +104,17 @@ test_once $args, $expected_re, 'clone-job command with multiple URLs in PR and j
 
 $ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my/branch"}, "body": "Lorem ipsum"}'; true};
 $ENV{curl_openqa}
-  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/var/lib/openqa/pool/25/os-autoinst-distri-opensuse", "PRODUCTDIR": "os-autoinst-distri-opensuse/products/sle", "NEEDLES_DIR": "/var/lib/openqa/pool/25/os-autoinst-distri-opensuse/products/sle/needles"}'; true};
+  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "my/distri", "PRODUCTDIR": "distri/products/sle", "NEEDLES_DIR": "my/distri/products/sle/needles"}'; true};
 $dirs
-  = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=/var/lib/openqa/pool/25/os-autoinst-distri-opensuse/products/sle/needles';
+  = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=my/distri/products/sle/needles';
 $expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
 $expected_re = qr/${expected}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR is a relative directory";
 
 $ENV{curl_openqa}
-  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/var/lib/openqa/cache/openqa1-opensuse/tests/opensuse", "PRODUCTDIR": "/var/lib/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse"}'; true};
+  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/openqa/cache/openqa1-opensuse/tests/opensuse", "PRODUCTDIR": "/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse"}'; true};
 $dirs
-  = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse NEEDLES_DIR=/var/lib/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse/needles';
+  = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse NEEDLES_DIR=/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse/needles';
 $expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ' . $dirs;
 $expected_re = qr/${expected}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR includes specific word";

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -111,6 +111,13 @@ $expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=us
 $expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR is a relative directory";
 
+$needles = "/$needles";
+$ENV{curl_openqa}
+  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/my/distri", "PRODUCTDIR": "products/sle", "NEEDLES_DIR": "$needles"}'; true};
+$dirs = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=$needles";
+$expected_re = qr/${expected}${dirs}/;
+test_once $args, $expected_re, 'Correct PRODUCTDIR for relative non-prefixed dir';
+
 my $casedir = '/openqa/cache/openqa1-opensuse/tests/opensuse';
 $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "$casedir", "PRODUCTDIR": "$casedir/products/opensuse"}'; true};


### PR DESCRIPTION
If openqa-clone-custom-git-refspec is called with openQA jobs that already
specify a git repository in CASEDIR the product dir is computed by the
openQA worker as a relative path without the git checkout directory as a
prefix. That so far has led to the problem that the product directory
string that is passed to openqa-clone-job
would be concatenated without separator leading to cases like
"my_distriproducts/foo" when instead "my_distri" and "products/foo"
should be joint with "/" as standard path separator. This commit fixes
this within openqa-clone-custom-git-refspec by always joining the path
components with "/" as path separator while ensuring that no slashes are
duplicated themselves.

Additionally tested by manually scheduling openQA jobs
openqa.opensuse.org with the generated product dir compontents.

Related progress issue: https://progress.opensuse.org/issues/130096