### PR TITLE
Pass job result from os-autoinst's state file to web UI

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -552,7 +552,20 @@ sub _stop_step_5_2_upload ($self, $reason, $callback) {
         });
 }
 
-sub _format_reason ($self, $result, $reason) {
+sub _read_state_file ($self) {
+    my $state_file = path($self->worker->pool_directory)->child(BASE_STATEFILE);
+    return {} unless -e $state_file;
+    my $state = eval {
+        my $state = decode_json($state_file->slurp);
+        die 'top-level element is not a hash' unless ref $state eq 'HASH';
+        return $state;
+    };
+    return $state unless my $error = $@;
+    log_warning "Found $state_file but failed to parse the JSON: $error";
+    return undef;
+}
+
+sub _format_reason ($self, $state, $result, $reason) {
     # format stop reasons from the worker itself
     return 'timeout: ' . ($self->{_engine} ? 'test execution exceeded MAX_JOB_TIME' : 'setup exceeded MAX_SETUP_TIME')
       if $reason eq WORKER_SR_TIMEOUT;
@@ -566,11 +579,7 @@ sub _format_reason ($self, $result, $reason) {
     return undef if $reason eq WORKER_COMMAND_CANCEL;
 
     # consider other reasons as os-autoinst specific; retrieve extended reason if available
-    my $state_file = path($self->worker->pool_directory)->child(BASE_STATEFILE);
-    try {
-        return unless -e $state_file;
-        my $state = decode_json($state_file->slurp);
-        die 'top-level element is not a hash' unless ref $state eq 'HASH';
+    if ($state) {
         if (my $component = $state->{component}) {
             # prepent the relevant component, e.g. turn "died" into "backend died" or "tests died"
             $reason = "$component $reason" unless $component =~ qr/$[\w\d]^/;
@@ -590,7 +599,7 @@ sub _format_reason ($self, $result, $reason) {
             $reason = "QEMU terminated$msg, see log output of details" if $msg;
         }
     }
-    catch {
+    else {
         my $msg = $self->_parse_log_file('No space left on device');
         # read autoinst-log.txt to check the reason, see poo#80334
         if ($reason eq WORKER_SR_DONE) {
@@ -599,8 +608,7 @@ sub _format_reason ($self, $result, $reason) {
         else {
             $reason = "terminated prematurely: Encountered corrupted state file$msg, see log output for details";
         }
-        log_warning("Found $state_file but failed to parse the JSON: $_");
-    };
+    }
 
     # return generic phrase if the reason would otherwise just be died
     return "$reason: terminated prematurely, see log output for details" if $reason eq WORKER_SR_DIED;
@@ -617,7 +625,8 @@ sub _format_reason ($self, $result, $reason) {
 sub _set_job_done ($self, $reason, $params, $callback) {
 
     # pass the reason if it is an additional specification of the result
-    my $formatted_reason = $self->_format_reason($params->{result}, $reason);
+    my $state = $self->_read_state_file;
+    my $formatted_reason = $self->_format_reason($state, $params->{result}, $reason);
     $params->{reason} = $formatted_reason if defined $formatted_reason;
 
     my $job_id = $self->id;

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -626,7 +626,8 @@ sub _set_job_done ($self, $reason, $params, $callback) {
 
     # pass the reason if it is an additional specification of the result
     my $state = $self->_read_state_file;
-    my $formatted_reason = $self->_format_reason($state, $params->{result}, $reason);
+    my $result = ($params->{result} //= $state->{result});
+    my $formatted_reason = $self->_format_reason($state, $result, $reason);
     $params->{reason} = $formatted_reason if defined $formatted_reason;
 
     my $job_id = $self->id;


### PR DESCRIPTION
For reviewing it makes likely most sense to view the particular
commits individually.

---

This allows os-autoinst to explicitly pass a job result to the
web UI in the same way it can already pass a reason.

The main motivation is https://progress.opensuse.org/issues/129068
but this can potentially be useful in other error situations as
well.