### PR TITLE
Add `priority` property to `job_templates` in YAML

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -812,6 +812,11 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, @load_yaml_args) {
             }
         }
 
+        # set priority of job if specified
+        if (my $priority = $job_template->{priority}) {
+            $settings->{PRIO} = $priority;
+        }
+
         # handle further settings
         $settings->{WORKER_CLASS} = join ',', sort @worker_class if @worker_class > 0;
         _merge_settings_uppercase($args, $settings, 'TEST');

--- a/public/schema/JobScenarios-01.yaml
+++ b/public/schema/JobScenarios-01.yaml
@@ -56,7 +56,7 @@ properties:
         properties:
           backend:
             type: string
-          priority:
+          priority: &priority-definition
             oneOf:
               - type: string
               - type: number
@@ -76,3 +76,4 @@ properties:
           machine:
             type: string
           settings: *settings-definition
+          priority: *priority-definition

--- a/t/api/02-iso-yaml.t
+++ b/t/api/02-iso-yaml.t
@@ -108,7 +108,8 @@ subtest 'schedule from yaml file: most simple case of two explicitly specified j
     $iso{DISTRI} = lc $iso{DISTRI};    # distri is expected to be converted to lower-case
     for my $i (1, 2) {
         my $job_id = $job_ids->[$i - 1];
-        my $job_settings = $jobs->find($job_id)->settings_hash;
+        my $job = $jobs->find($job_id);
+        my $job_settings = $job->settings_hash;
         my %expected = (
             %iso,
             TEST => "job$i",
@@ -117,6 +118,7 @@ subtest 'schedule from yaml file: most simple case of two explicitly specified j
             "FOO_$i" => "bar$i",
         );
         is_deeply $job_settings, \%expected, "job$i scheduled with expected settings" or diag explain $job_settings;
+        is $job->priority, $i, 'priority was set correctly';
     }
 };
 

--- a/t/data/09-schedule_from_file_minimal.yaml
+++ b/t/data/09-schedule_from_file_minimal.yaml
@@ -1,10 +1,13 @@
 job_templates:
   job1:
+    priority: 1
     settings:
       FOO_1: 'bar1'
   job2:
+    priority: 2
     settings:
       FOO_2: 'bar2'
   job3:
+    priority: 3
     settings:
       FOO_3: 'bar3'


### PR DESCRIPTION
This allows each job in a scenario definitions YAML file to be given its own priority value, which takes precedence over any other priority value specified in the file

Given this is possible when creating a job group in the WebUI it seems reasonable that is should exist here too.