### PR TITLE
Increase client_body_buffer_size to be larger than UPLOAD_CHUNK_SIZE

### DIFF
--- a/etc/nginx/vhosts.d/openqa.conf
+++ b/etc/nginx/vhosts.d/openqa.conf
@@ -20,7 +20,11 @@ server {
     root /usr/share/openqa/public;
 
     client_max_body_size 0;
-    client_body_buffer_size 64k;
+
+    # The "client_body_buffer_size" value should usually be larger
+    # than the UPLOAD_CHUNK_SIZE used by openQA workers, so there is
+    # no excessive buffering to disk
+    client_body_buffer_size 2m;
 
     ## Optional faster assets downloads for large deployments
     #location /assets {


### PR DESCRIPTION
The vast majority of requests handled by the webui are artefact uploads. These tend to be around 1mb in size because of the default UPLOAD_CHUNK_SIZE value. Buffering them all to disk is unnecessary and causes quite a bit of disk I/O overhead.

I've tested two solutions for this. The first was
`client_body_buffer_size 2m`, which had the desired effect and only left a very small number of uploads to be buffered to disk. The second was `proxy_request_buffering off` (disabling all upload buffering), which seemed to work as well at first, but then caused the webui app server to be overwhelmed at peak times (502 Bad Gateway responses).

Nginx appears to be doing a pretty good job protecting the webui from traffic spikes with buffering. We should probably leave it enabled for larger HTTP bodies.

Progress: https://progress.opensuse.org/issues/129490