### PR TITLE
nginx: Set if_modified_since before

### DIFF
--- a/etc/nginx/vhosts.d/openqa.conf
+++ b/etc/nginx/vhosts.d/openqa.conf
@@ -26,6 +26,9 @@ server {
     # no excessive buffering to disk
     client_body_buffer_size 2m;
 
+    # Default is exact which would need an exact match of Last-Modified
+    if_modified_since before;
+
     ## Optional faster assets downloads for large deployments
     #location /assets {
     #    alias /var/lib/openqa/share/factory;


### PR DESCRIPTION
We were experiencing repeated downloads of the same assets in openqa-clone-job, because the asset is set to the current timestamp after download, but by default nginx wants the exact timestamp match.