### PR TITLE
Update CircleCI image to Leap 15.5

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,7 +4,7 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.4
+FROM opensuse/leap:15.5
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/130603