### PR TITLE
Fix source view of local case dirs

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -347,19 +347,20 @@ sub src ($self) {
         my $casedir_url = Mojo::URL->new($casedir->value);
         # if CASEDIR points to a remote location let's assume it is a git repo
         # that we can reference like gitlab/github
-        last unless $casedir_url->scheme;
-        my $refspec = $casedir_url->fragment;
-        # try to read vars.json from resultdir and replace branch by actual git hash if possible
-        eval {
-            my $vars_json = Mojo::File->new($job->result_dir(), 'vars.json')->slurp;
-            my $vars = decode_json($vars_json);
-            $refspec = $vars->{TEST_GIT_HASH};
-        };
-        my $module_path = '/blob/' . $refspec . '/' . $module->script;
-        # github treats '.git' as optional extension which needs to be stripped
-        $casedir_url->path($casedir_url->path =~ s/\.git//r . $module_path);
-        $casedir_url->fragment('');
-        return $self->redirect_to($casedir_url);
+        if ($casedir_url->scheme) {
+            my $refspec = $casedir_url->fragment;
+            # try to read vars.json from resultdir and replace branch by actual git hash if possible
+            eval {
+                my $vars_json = Mojo::File->new($job->result_dir(), 'vars.json')->slurp;
+                my $vars = decode_json($vars_json);
+                $refspec = $vars->{TEST_GIT_HASH};
+            };
+            my $module_path = '/blob/' . $refspec . '/' . $module->script;
+            # github treats '.git' as optional extension which needs to be stripped
+            $casedir_url->path($casedir_url->path =~ s/\.git//r . $module_path);
+            $casedir_url->fragment('');
+            return $self->redirect_to($casedir_url);
+        }
     }
     my $testcasedir = testcasedir($job->DISTRI, $job->VERSION);
     my $scriptpath = "$testcasedir/" . $module->script;

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -31,6 +31,10 @@ subtest 'source view for jobs using VCS based tests' => sub {
     my $expected = qr@github.com/me/repo/blob/my/branch/tests.*/installer_timezone@;
     $t->get_ok($src_url)->status_is(302)->header_like('Location' => $expected);
 
+    $casedir = '/foo/bar';
+    $settings_rs->find({key => 'CASEDIR'})->update({value => $casedir});
+    $t->get_ok($src_url)->status_is(200)->content_like(qr{Maintainer: Allison Average});
+
     subtest 'github treats ".git" as optional extension which needs to be stripped' => sub {
         $casedir = 'https://github.com/me/repo.git#my/branch';
         $settings_rs->find({key => 'CASEDIR'})->update({value => $casedir});


### PR DESCRIPTION
When viewing a source of a test module when CASEDIR was set to a local file instead of an url, the code would be stuck and output these warnings:

    Exiting subroutine via last at /lib/OpenQA/WebAPI/Controller/Step.pm line 351.
    Exiting eval via last at /lib/OpenQA/WebAPI/Controller/Step.pm line 351.