### PR TITLE
Fix openqa-single-instance build tag

### DIFF
--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -1,7 +1,18 @@
-#!BuildTag: openQA:single-instance
+# SPDX-License-Identifier: MIT
+#!BuildTag: openqa-single-instance:latest opensuse/openqa-single-instance:latest opensuse/openqa-single-instance:%PKG_VERSION% opensuse/openqa-single-instance:%PKG_VERSION%.%RELEASE%
 
-# hadolint ignore=DL3007
-FROM opensuse/tumbleweed:latest
+# hadolint ignore=DL3006
+FROM opensuse/tumbleweed
+
+# labelprefix=org.opensuse.openqa-single-instance
+LABEL org.opencontainers.image.title="openQA single-instance container"
+LABEL org.opencontainers.image.description="A complete openQA instance composed of all necessary components to execute openQA tests including an openQA worker"
+LABEL org.opencontainers.image.version="%PKG_VERSION%.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/opensuse/openqa-single-instance:%PKG_VERSION%.%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
+
 # installing more of packages that are selected in openqa-bootstrap.  Combining here saves installation time
 # hadolint ignore=DL3037
 RUN zypper in -y openQA-single-instance openQA-bootstrap \

--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -24,3 +24,4 @@ ENV skip_suse_tests=1
 
 COPY script/openqa-bootstrap /usr/share/openqa/script/
 ENTRYPOINT ["/usr/share/openqa/script/openqa-bootstrap"]
+HEALTHCHECK CMD curl -f http://localhost || exit 1


### PR DESCRIPTION
* container: Add healthcheck for single-instance
* container: Update single-instance according to best practices

This should address the problem observed in
https://build.opensuse.org/package/live_build_log/devel:openQA/openQA-single-instance-container/containers/x86_64

```
Error: tag openQA:single-instance: invalid reference format: repository name must be lowercase
```