### PR TITLE
Avoid hard dependency on Apache in systemd file

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -506,11 +506,13 @@ To start openQA and enable it to run on each boot call
 systemctl enable --now postgresql
 systemctl enable --now openqa-webui
 systemctl enable --now openqa-scheduler
-# openSUSE
+# to use Apache as reverse proxy under openSUSE
+systemctl enable apache2
 systemctl restart apache2
-# Fedora
+# to use Apache as reverse proxy under Fedora
 # for now this is necessary to allow Apache to connect to openQA
 setsebool -P httpd_can_network_connect 1
+systemctl enable httpd
 systemctl restart httpd
 --------------------------------------------------------------------------------
 

--- a/systemd/openqa-livehandler.service
+++ b/systemd/openqa-livehandler.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Handler for live view in openQA's web UI
-Wants=apache2.service
-Before=apache2.service
 After=postgresql.service nss-lookup.target remote-fs.target
 Requires=openqa-webui.service
 

--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=The openQA WebSockets server
-Wants=apache2.service openqa-setup-db.service
-Before=apache2.service openqa-webui.service
+Wants=openqa-setup-db.service
+Before=openqa-webui.service
 After=openqa-scheduler.service postgresql.service openqa-setup-db.service network.target nss-lookup.target remote-fs.target
 
 [Service]

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=The openQA web UI
-Wants=apache2.service openqa-setup-db.service
-Before=apache2.service
+Wants=openqa-setup-db.service
 After=postgresql.service openqa-setup-db.service openqa-scheduler.service nss-lookup.target remote-fs.target
 Requires=openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer
 


### PR DESCRIPTION
* Allow using a different HTTP server without having to mask the unit of Apache
* Update documentation to explicitly enable Apache; the bootstrap script already does this anyways
* Keep the spec file as-is because it only lists `apache2` as as recommended dependency
* This is a breaking change for users of Apache that don't have its unit explicitly enabled; I guess it is acceptable as this is easy to notice and fix and not the case when the bootstrap script or our salt states were used to setup
* Related ticket: https://progress.opensuse.org/issues/130477