### PR TITLE
git subrepo clone (merge) --force git@github.com:os-autoinst/os-autoi…

### DIFF
--- a/external/os-autoinst-common/.github/workflows/commit_message_checker.yml
+++ b/external/os-autoinst-common/.github/workflows/commit_message_checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check Subject Begining
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^([A-Z]|[A-Za-z0-9_/.]+:)'
+          pattern: '^([A-Z]|\S+:)'
           flags: 'g'
           error: 'The subject does not start with a capital or tag.'
           excludeDescription: 'true'

--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = 3de570d96746ec44647c034ba6e107cbc06e4141
-	parent = 94bf360336469dd3f6c603860f7a629568adf6b6
+	commit = 7c2693575b15b902e0324c3fcd891b023d2aab5f
+	parent = 8d9fc9268271afe303fd65746c24f4ad3f29fa56
 	method = merge
 	cmdver = 0.4.3

--- a/external/os-autoinst-common/README.md
+++ b/external/os-autoinst-common/README.md
@@ -8,8 +8,6 @@ This repository is to be used as a
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/git-subrepo.svg)](https://repology.org/project/git-subrepo/versions)
 
-and in `devel:openQA`, e.g. https://download.opensuse.org/repositories/devel:/openQA:/Leap:/15.4/15.4/
-
 ## Usage
 
 ### Clone

--- a/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
+++ b/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
@@ -12,8 +12,8 @@ sub import {
     # disable timeout if requested by ENV variable or running within debugger
     return if ($ENV{OPENQA_TEST_TIMEOUT_DISABLE} or $INC{'perl5db.pl'});
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
-    $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI} // 2 if $ENV{CI};
-    $limit *= $SCALE_FACTOR;
+    $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI}    // 2 if $ENV{CI};
+    $limit        *= $SCALE_FACTOR;
     $SIG{ALRM} = sub { BAIL_OUT "test '$0' exceeds runtime limit of '$limit' seconds\n" };
     alarm $limit;
 }

--- a/external/os-autoinst-common/tools/update-deps
+++ b/external/os-autoinst-common/tools/update-deps
@@ -137,6 +137,7 @@ sub get_modules {
 }
 
 sub _requires_line {
+    # requires 'Archive::Extract', '> 0.7';
     my ($hash, $module) = @_;
     my $version = $hash->{$module};
     my $line = "requires '$module'";

--- a/external/os-autoinst-common/xt/01-make-update-deps.t
+++ b/external/os-autoinst-common/xt/01-make-update-deps.t
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings;
+use FindBin '$Bin';
+
+if (not -e "$Bin/../.git") {
+    pass("Skipping all tests, not in a git repository");
+    done_testing;
+    exit;
+}
+
+my $build_dir = $ENV{OS_AUTOINST_BUILD_DIRECTORY} || "$Bin/..";
+my $make_tool = $ENV{OS_AUTOINST_MAKE_TOOL} || 'make';
+my $make_cmd = "$make_tool update-deps";
+
+chdir $build_dir;
+my @out = qx{$make_cmd};
+my $rc = $?;
+die "Could not run $make_cmd: rc=$rc, out: @out" if $rc;
+
+my @status = grep { not m/^\?/ } qx{git -C "$Bin/.." status --porcelain};
+ok(!@status, "No changed files after '$make_cmd'") or diag @status;
+
+done_testing;
+


### PR DESCRIPTION
```
…nst-common.git external/os-autoinst-common

subrepo:
  subdir:   "external/os-autoinst-common"
  merged:   "92d3d4bd4"
upstream:
  origin:   "git@github.com:os-autoinst/os-autoinst-common.git"
  branch:   "master"
  commit:   "92d3d4bd4"
git-subrepo:
  version:  "0.4.3"
  origin:   "git@github.com:ingydotnet/git-subrepo"
  commit:   "2f68596"
```

I had to reclone the subrepo because there were changes made from here, but never pushed upstream.

If you want to reintroduce changes, do them in the external repo directory, or push the subrepo directly after the changes.