### PR TITLE
Make sure munin config survives package update

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -769,6 +769,6 @@ fi
 %dir %{_sysconfdir}/munin
 %dir %{_sysconfdir}/munin/plugin-conf.d
 %{_prefix}/lib/munin/plugins/openqa_minion_
-%{_sysconfdir}/munin/plugin-conf.d/openqa-minion
+%config(noreplace) %{_sysconfdir}/munin/plugin-conf.d/openqa-minion
 
 %changelog


### PR DESCRIPTION
Local changes to this file have been overwritten by the latest package update. Using this macro should prevent that.