### PR TITLE
Allow to partially re-schedule a product from a job

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -34,14 +34,6 @@ function renderCommentHeading(comment, commentId) {
   return heading;
 }
 
-function getXhrError(jqXHR, textStatus, errorThrown) {
-  try {
-    return JSON.parse(jqXHR.responseText).error || errorThrown || textStatus;
-  } catch {
-    return errorThrown || textStatus;
-  }
-}
-
 function showXhrError(context, jqXHR, textStatus, errorThrown) {
   window.alert(context + getXhrError(jqXHR, textStatus, errorThrown));
 }

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -550,3 +550,7 @@ function renderHttpUrlAsLink(value) {
   span.appendChild(document.createTextNode(value));
   return span;
 }
+
+function getXhrError(jqXHR, textStatus, errorThrown) {
+  return jqXHR.responseJSON?.error || jqXHR.responseText || errorThrown || textStatus;
+}

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -1123,4 +1123,11 @@ function renderDependencyGraph(container, nodes, edges, cluster, currentNode) {
   // note: centering is achieved by centering the svg element itself like any other html block element
 }
 
+function rescheduleProductForJob(link) {
+  if (window.confirm('Do you really want to partially reschedule the product of this job?')) {
+    rescheduleProduct(link.dataset.url);
+  }
+  return false; // avoid usual link handling
+}
+
 module = {};

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -129,7 +129,7 @@ sub create {
         }
         my $settings_to_clone = $previously_scheduled_product->settings // {};
         for my $required_param (MANDATORY_PARAMETERS) {
-            if (!$settings_to_clone->{$required_param}) {
+            if (!defined $settings_to_clone->{$required_param}) {
                 return $self->render(
                     text => "Scheduled product to clone settings from misses $required_param.",
                     status => 404

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -123,12 +123,8 @@ subtest 'trigger actions' => sub {
         'confirmation prompt shown'
     );
     $driver->accept_alert;
-    wait_for_ajax;
-    is(
-        $driver->find_element('#flash-messages span')->get_text(),
-        'Re-scheduling the product has been triggered. A new scheduled product should appear when refreshing the page.',
-        'flash with info message occurs'
-    );
+    wait_for_ajax msg => 'info message for rescheduling';
+    $driver->element_text_is('#flash-messages span', 'The product has been re-triggered as 2.', 'info message shown'),;
 };
 
 subtest 'rescheduled ISO shown after refreshing page' => sub {

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -252,6 +252,7 @@ subtest 'scheduled product shown' => sub {
     my $expected_params = qr/scheduled_product_clone_id=$expected_scheduled_product_id&TEST=kde/;
     like $reschedule_link->get_attribute('data-url'), $expected_params, 'reschedule link shown';
     $reschedule_link->click;
+    $driver->accept_alert;
     wait_for_ajax msg => 'message for rescheduling';
     element_visible '#flash-messages .alert > span', qr/Scheduled product to clone settings from misses DISTRI/, undef,
       'error shown';

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -240,7 +240,7 @@ subtest 'bug reporting' => sub {
 
 subtest 'scheduled product shown' => sub {
     # still on test 99937
-    my $scheduled_product_link = $driver->find_element('#scheduled-product-info a');
+    my $scheduled_product_link = $driver->find_element('#scheduled-product-info > a');
     my $expected_scheduled_product_id = $schema->resultset('Jobs')->find(99937)->scheduled_product_id;
     is($scheduled_product_link->get_text(), 'distri-dvd-1234', 'scheduled product name');
     like(
@@ -248,6 +248,13 @@ subtest 'scheduled product shown' => sub {
         qr/\/admin\/productlog\?id=$expected_scheduled_product_id/,
         'scheduled product href'
     );
+    my $reschedule_link = $driver->find_element('#scheduled-product-info div > a');
+    my $expected_params = qr/scheduled_product_clone_id=$expected_scheduled_product_id&TEST=kde/;
+    like $reschedule_link->get_attribute('data-url'), $expected_params, 'reschedule link shown';
+    $reschedule_link->click;
+    wait_for_ajax msg => 'message for rescheduling';
+    element_visible '#flash-messages .alert > span', qr/Scheduled product to clone settings from misses DISTRI/, undef,
+      'error shown';
     $driver->get('/tests/99963');
     like(
         $driver->find_element_by_id('scheduled-product-info')->get_text(),

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -139,7 +139,7 @@
                         % if (is_operator) {
                             <div class="btn-group btn-group-sm">
                                 <a href="#"
-                                   onclick="rescheduleProduct(this.dataset.url); return true;" \
+                                   onclick="return rescheduleProductForJob(this);" \
                                    class="btn btn-link"\
                                    data-url="<%= url_for('apiv1_create_iso')->query(scheduled_product_clone_id => $sp_id, TEST => $job->TEST, _SKIP_CHAINED_DEPS => 1, _INCLUDE_CHILDREN => 1) %>">\
                                      <i class="fa fa-2 fa-undo" title="Reschedule product from here"></i>

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -134,7 +134,23 @@
                 <div id="scheduled-product-info">
                     Scheduled product:\
                     % if (my $scheduled_product = $job->scheduled_product) {
-                        %= link_to $scheduled_product->to_string, url_for('admin_product_log')->query(id => $scheduled_product->id)
+                        % my $sp_id = $scheduled_product->id;
+                        %= link_to $scheduled_product->to_string, url_for('admin_product_log')->query(id => $sp_id)
+                        % if (is_operator) {
+                            <div class="btn-group btn-group-sm">
+                                <a href="#"
+                                   onclick="rescheduleProduct(this.dataset.url); return true;" \
+                                   class="btn btn-link"\
+                                   data-url="<%= url_for('apiv1_create_iso')->query(scheduled_product_clone_id => $sp_id, TEST => $job->TEST, _SKIP_CHAINED_DEPS => 1, _INCLUDE_CHILDREN => 1) %>">\
+                                     <i class="fa fa-2 fa-undo" title="Reschedule product from here"></i>
+                                </a>
+                            </div>
+                            <%= help_popover('Partial product re-scheduling' => "
+                                <p>Schedules the product again using the current job as starting point. That means chained parents of
+                                the current job will not be scheduled again but all its children will be.</p>",
+                                undef, undef, 'bottom');
+                            %>
+                        % }
                     % } else {
                         job has not been created by posting an ISO
                         % if ($clone_of) {

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -142,7 +142,7 @@
                                    onclick="return rescheduleProductForJob(this);" \
                                    class="btn btn-link"\
                                    data-url="<%= url_for('apiv1_create_iso')->query(scheduled_product_clone_id => $sp_id, TEST => $job->TEST, _SKIP_CHAINED_DEPS => 1, _INCLUDE_CHILDREN => 1) %>">\
-                                     <i class="fa fa-2 fa-undo" title="Reschedule product from here"></i>
+                                     <i class="fa fa-2 fa-refresh" title="Reschedule product from here"></i>
                                 </a>
                             </div>
                             <%= help_popover('Partial product re-scheduling' => "


### PR DESCRIPTION
* Fix re-triggering scheduled products with falsy required params
   (see commit message for details)

---

* Allow to re-trigger a scheduled product from the job details
  page of a job of this product
    * Re-schedule the job itself and all its chained children
      and parallel dependencies
    * Do *not* re-schedule chained parents
* Refactor JavaScript code for re-scheduling so it can be used
  on the job details page as well
* Improve error handling in JavaScript code for re-scheduling
* State successful re-triggering via "The product has been
  re-triggered as …" with a link (instead of "… should appear
  when refreshing page.").
* Related ticket: https://progress.opensuse.org/issues/124469