### PR TITLE
Avoid errors in the logs when invalid group IDs are passed

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -84,6 +84,7 @@ sub list ($self) {
     $validation->optional('latest')->num(1);
     $validation->optional('limit')->num;
     $validation->optional('offset')->num;
+    $validation->optional('groupid')->num;
 
     my $limits = OpenQA::App->singleton->config->{misc_limits};
     my $limit = min($limits->{generic_max_limit}, $validation->param('limit') // $limits->{generic_default_limit});

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -212,8 +212,13 @@ subtest 'multiple ids' => sub {
     is(scalar(@{$t->tx->res->json->{jobs}}), 3);
     $t->get_ok('/api/v1/jobs?ids=99981&ids=99963&ids=99926');
     is(scalar(@{$t->tx->res->json->{jobs}}), 3);
+};
+
+subtest 'validation of IDs' => sub {
     $t->get_ok('/api/v1/jobs?ids=99981&ids=99963&ids=99926foo')->status_is(400);
     $t->json_is('/error', 'ids must be integers', 'validation error for IDs');
+    $t->get_ok('/api/v1/jobs?groupid=foo')->status_is(400);
+    $t->json_is('/error', 'Erroneous parameters (groupid invalid)', 'validation error for invalid group ID');
 };
 
 subtest 'job overview' => sub {
@@ -265,7 +270,6 @@ subtest 'job overview' => sub {
         is(scalar(@{$t->tx->res->json}), 1, 'Expect only one job entry');
         $t->json_is('/0/id' => 99939, 'Check correct order');
     };
-
 };
 
 subtest 'jobs for job settings' => sub {


### PR DESCRIPTION
* Validate group IDs passed to job list API route
* See https://progress.opensuse.org/issues/132545