### PR TITLE
Avoid asset caching ending up with `Job terminated unexpectedly`

### DIFF
--- a/lib/OpenQA/CacheService/Task/Asset.pm
+++ b/lib/OpenQA/CacheService/Task/Asset.pm
@@ -3,11 +3,13 @@
 
 package OpenQA::CacheService::Task::Asset;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
+use OpenQA::Task::SignalGuard;
 use Mojo::JSON;
 
 sub register ($self, $app, $conf) { $app->minion->add_task(cache_asset => \&_cache_asset) }
 
 sub _cache_asset ($job, $id, $type = undef, $asset_name = undef, $host = undef) {
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
     my $app = $job->app;
     my $job_id = $job->id;
     my $lock = $job->info->{notes}{lock};


### PR DESCRIPTION
* Use the `SignalGuard` like in other places to retry the job on
  a service restart
* Tested by starting `script/openqa-workercache run` locally and
  enqueuing a `cache_asset` job manually:
  ```
  script/openqa-workercache minion job -e cache_asset -a [3421068, "iso", "openSUSE-Leap-15.4-DVD-x86_64.iso", "https://openqa.opensuse.org/"] -n {"lock":"foo"}
  ```
    * Without this change, the job ends up with `Job terminated
      unexpectedly` when sending SIGINT to
      `script/openqa-workercache run`
    * With this change, the job ends up inactive and is retried
      when invoking `script/openqa-workercache run` again
    * The restarted job finished successfully and the checksum
      of the downloaded file matches the one on o3
* See https://progress.opensuse.org/issues/132434