### PR TITLE
Avoid worker to wait until setup timeout on asset errors

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -90,7 +90,7 @@ sub _poll_cache_service ($job, $cache_client, $request, $delay, $callback) {
     my $status = $cache_client->status($request);
     return Mojo::IOLoop->singleton->timer(
         $delay => sub { _poll_cache_service($job, $cache_client, $request, $delay, $callback) })
-      unless $status->is_processed;
+      if !$status->is_processed && !$status->has_error;
     return $callback->({error => 'Job has been cancelled'}, undef) if $job->is_stopped_or_stopping;
     return $callback->({error => $status->error}, undef) if $status->has_error;
     return $callback->(undef, $status);


### PR DESCRIPTION
* Abort the job if the asset caching has already run into an error
* Tested locally by enabling the cache service, cloning a job from o3 and patching the worker so it would cache the asset from o3 and not the local web UI * After the caching task had exhausted all retries the Minion job was marked as failed (but not "processed") and then the openQA worker also marked the openQA job as incomplete with the reason `Reason: cache failure: Failed to download …` instead of letting it run into the setup timeout.
* See https://progress.opensuse.org/issues/132434