### PR TITLE
contrib: Update/extend autoyast profiles

### DIFF
--- a/contrib/ay-openqa-worker-leap.xml
+++ b/contrib/ay-openqa-worker-leap.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <networking>
+    <!-- For multiple network interfaces by default the last is configured, prefer the first -->
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <name>eth0</name>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <software>
+    <!-- It seems unfortunately we need to explicitly specify a product, would have preferred a more generic config -->
+    <products config:type="list">
+      <product>Leap</product>
+    </products>
+    <packages config:type="list">
+      <package>openssh</package>
+      <package>sudo</package>
+      <!-- could not find salt-minion in default Leap repos, disabling, handling in 2nd stage script -->
+      <!--<package>salt-minion</package>-->
+    </packages>
+  </software>
+  <partitioning config:type="list">
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <mount>/</mount>
+          <size>max</size>
+          <filesystem config:type="symbol">btrfs</filesystem>
+        </partition>
+        <partition>
+          <mount>swap</mount>
+          <size>auto</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+  <scripts>
+    <post-scripts config:type="list">
+      <script>
+        <filename>setup.sh</filename>
+        <interpreter>shell</interpreter>
+        <debug config:type="boolean">true</debug>
+        <!-- this likely will not work reliably and is assuming that all repositories could be properly setup -->
+        <source><![CDATA[
+            timeout 600 sh -c 'until ! pgrep -a zypper; do sleep 5; done'
+            zypper -n in salt-minion
+            echo 'roles: worker' > /etc/salt/grains
+            systemctl enable --now sshd
+        ]]></source>
+      </script>
+    </post-scripts>
+  </scripts>
+  <firewall>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+    <FW_CONFIGURATIONS_EXT>sshd</FW_CONFIGURATIONS_EXT>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+</profile>

--- a/contrib/ay-openqa-worker.xml
+++ b/contrib/ay-openqa-worker.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>

--- a/contrib/ay-openqa-worker.xml
+++ b/contrib/ay-openqa-worker.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-    <networking>
-        <keep_install_network config:type="boolean">true</keep_install_network>
-    </networking>
-    <software>
-        <packages config:type="list">
-          <package>openssh</package>
-          <package>sudo</package>
-          <package>salt-minion</package>
-        </packages>
-    </software>
-    <partitioning config:type="list">
-        <drive>
-            <initialize config:type="boolean">true</initialize>
-            <partitions config:type="list">
-                <partition>
-                    <mount>/</mount>
-                    <size>max</size>
-                    <filesystem config:type="symbol">btrfs</filesystem>
-                </partition>
-                <partition>
-                    <mount>swap</mount>
-                    <size>auto</size>
-                </partition>
-            </partitions>
-        </drive>
-    </partitioning>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <software>
+      <packages config:type="list">
+        <package>openssh</package>
+        <package>sudo</package>
+        <package>salt-minion</package>
+      </packages>
+  </software>
+  <partitioning config:type="list">
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <mount>/</mount>
+          <size>max</size>
+          <filesystem config:type="symbol">btrfs</filesystem>
+        </partition>
+        <partition>
+          <mount>swap</mount>
+          <size>auto</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
   <scripts>
     <post-scripts config:type="list">
       <script>

--- a/contrib/ay-openqa-worker.xml
+++ b/contrib/ay-openqa-worker.xml
@@ -47,7 +47,7 @@
         <interpreter>shell</interpreter>
         <debug config:type="boolean">true</debug>
         <source><![CDATA[
-            zypper in salt-minion
+            zypper -n in salt-minion
             echo 'roles: worker' > /etc/salt/grains
             systemctl enable --now sshd salt-minion
         ]]></source>

--- a/contrib/ay-openqa-worker.xml
+++ b/contrib/ay-openqa-worker.xml
@@ -7,6 +7,14 @@
     </mode>
   </general>
   <networking>
+    <!-- For multiple network interfaces by default the last is configured, prefer the first -->
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <name>eth0</name>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
   <software>


### PR DESCRIPTION
* contrib: Add openSUSE Leap specific profile
* contrib: Fix non-interactive 2nd stage autoyast script install
* contrib: Fix the network startup on machines with multiple interfaces
* contrib: Ensure a complete non-interactive autoyast run
* contrib: Use consistent 2-space indention in the autoyast profile