### PR TITLE
Make the job ID copying easier

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -57,6 +57,8 @@ function renderTestName(data, type, row) {
 
   var html = '';
   if (is_operator) {
+    html += '<a class="copy-jobid" href="#" data-jobid="' + row.id + '">';
+    html += '<i class="action fa fa-fw fa-copy" title="Copy job id"></i></a>';
     if (row.result !== 'none') {
       // allow to restart finished jobs
       if (!row.clone) {
@@ -554,3 +556,8 @@ function showJobDependency(deps) {
   }
   return result;
 }
+
+$(document).on('click', '.copy-jobid', function (event) {
+  event.preventDefault();
+  navigator.clipboard.writeText(this.dataset.jobid);
+});

--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -249,6 +249,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     min-width: 100%;
 }
 
+// Icon for copying job ID
+.copy-jobid {
+    margin-right: 5px;
+}
+
 .darkmode {
     .table {
         color: $default-font-color-darktheme;

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -4,6 +4,7 @@
                 % if (current_route 'latest') {
                     <%= link_to $job->id => url_for ('test', testid => $job->id) %>:
                 % }
+                <i><a class="copy-jobid" href="#" data-jobid="<%= $job->id %>">#<%= $job->id %></a></i>
                 %= $job->name
                 % if ($job->archived) {
                     <span id="job-archived-badge" class="badge badge-pill badge-secondary" title="Job has been archived">

--- a/templates/webapi/test/tr_job_result.html.ep
+++ b/templates/webapi/test/tr_job_result.html.ep
@@ -1,6 +1,8 @@
 <td id="res_<%= $resultid %>" name="jobid_td_<%= $jobid %>">
      % if ($res) {
          % if (is_operator) {
+         <a class="copy-jobid" href="#" data-jobid="<%= $jobid %>">
+         <i class="action fa fa-fw fa-copy" title="Copy job id"></i></a>
              % if ($state eq DONE || $state eq CANCELLED) {
                  %= link_post url_for('apiv1_restart', jobid => $jobid) => ('data-remote' => 'true', class => 'restart', 'data-jobid' => $jobid) => begin
                  <i class="action fa fa-undo" title="Restart the job"></i>


### PR DESCRIPTION
A lot of online systems allow user to either copy to clipboard or easily select the job/ticket/case ID.
My intention is to enable the same functionality for openQA, so when user wants to f.e. clone the job it will be faster.

There is [fa-copy](https://fontawesome.com/icons/copy?f=classic&s=solid) icon in All tests and in Job group overview and there is job ID printed in job overview and is clickable.

![image](https://github.com/os-autoinst/openQA/assets/1254493/3f561915-745c-4240-864b-71f658ba7c0d)
![image](https://github.com/os-autoinst/openQA/assets/1254493/2831f372-76ad-4676-9a82-5cd405479471)
![image](https://github.com/os-autoinst/openQA/assets/1254493/0695ae2f-4ec1-48bf-aa63-84bc648933a1)

