### PR TITLE
Enhance Python test docs

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -178,8 +178,8 @@ def run(self):
     # import further Perl-based libraries (besides `testapi`)
     perl.require("x11utils") 
 
-    # Example on how to use imported libraries and named arguments.
-    # In Perl would have been: x11_start_program("flatpak run com.obsproject.Studio", "target_match" => "obsproject-wizard")
+    # use imported Perl-based libraries; call Perl function that would be called via "named arguments" in Perl
+    # note: In Perl the call would have been: x11_start_program('flatpak run com.obsproject.Studio', target_match => 'obsproject-wizard')
     perl.x11utils.x11_start_program("flatpak run com.obsproject.Studio", "target_match", "obsproject-wizard") 
 
 def switch_to_root_console():

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -175,6 +175,12 @@ def run(self):
     send_key('ret')
     assert_screen('openqa-search-results')
 
+    # This is how to import libraries other than 'testapi'
+    perl.require("x11utils") 
+
+    # Example on how to use imported libraries and named arguments.
+    # In Perl would have been: x11_start_program("flatpak run com.obsproject.Studio", "target_match" => "obsproject-wizard")
+    perl.x11utils.x11_start_program("flatpak run com.obsproject.Studio", "target_match", "obsproject-wizard") 
 
 def switch_to_root_console():
     send_key('ctrl-alt-f3')

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -175,7 +175,7 @@ def run(self):
     send_key('ret')
     assert_screen('openqa-search-results')
 
-    # This is how to import libraries other than 'testapi'
+    # import further Perl-based libraries (besides `testapi`)
     perl.require("x11utils") 
 
     # Example on how to use imported libraries and named arguments.


### PR DESCRIPTION
Add more info on how to write python tests for openQA, based on https://progress.opensuse.org/issues/109891 and https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17325/files findings.

2 main points:
- be able to use other libraries than testapi
- be able to call perl functions that expect named arguments

I am of course open to change it in any way you feel like, the important thing is to have it described somewhere!

