### PR TITLE
tests: Improve failure when comparing expected image results fails

### DIFF
--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -151,7 +151,8 @@ subtest 'show job modules execution time' => sub {
 subtest 'displaying image result with candidates' => sub {
     $driver->find_element('[href="#step/bootloader/1"]')->click();
     wait_for_ajax;
-    is_deeply(find_candidate_needles, {'inst-bootmenu' => []}, 'correct tags displayed');
+    my $needles = find_candidate_needles;
+    is_deeply($needles, {'inst-bootmenu' => []}, 'correct tags displayed') or diag explain $needles;
 };
 
 subtest 'filtering' => sub {


### PR DESCRIPTION
A helpful failure might look something like this:

Using `diag explain` here so we're still checking the whole structure.

See: https://progress.opensuse.org/issues/132410