### PR TITLE
Display line breaks in data tables

### DIFF
--- a/assets/javascripts/audit_log.js
+++ b/assets/javascripts/audit_log.js
@@ -149,7 +149,7 @@ function showScheduledProductModalDialog(title, body) {
 }
 
 function renderScheduledProductSettings(settings) {
-  const table = $('<table/>').addClass('table table-striped');
+  const table = $('<table/>').addClass('table table-striped settings-table');
   for (const [key, value] of Object.entries(settings || {})) {
     table.append(
       $('<tr/>')

--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -63,7 +63,11 @@
         text-align: center;
     }
 }
-
+table.settings-table tr {
+    td span {
+        white-space: pre;
+    }
+}
 table.dataTable {
     td.name {
         text-align: left;


### PR DESCRIPTION
Some values might contain line breaks, for example the relatively new setting SCENARIO_DEFINITIONS_YAML. Before everything was printed in one line. Line breaks got lost.

## Before:
![settings-old](https://github.com/os-autoinst/openQA/assets/688850/20f79022-ecfb-4ab5-85cd-f3e7bf35cf48)
## After:
![settings-newlines](https://github.com/os-autoinst/openQA/assets/688850/5c128078-4b65-4aa3-b324-c9f52c8fcba4)