### PR TITLE
Add X-Forwarded-Proto to nginx config

### DIFF
--- a/etc/nginx/vhosts.d/openqa-locations.inc
+++ b/etc/nginx/vhosts.d/openqa-locations.inc
@@ -55,4 +55,5 @@ location / {
     proxy_set_header X-Forwarded-Host $host:$server_port;
     proxy_set_header X-Forwarded-Server $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }


### PR DESCRIPTION
Mojolicious requires proper knowledge about the reverse proxy infrastructure for login redirects to work as described in https://docs.mojolicious.org/Mojolicious/Guides/Cookbook#Reverse-proxy. We were missing an additional header which I took from the example in https://docs.mojolicious.org/Mojolicious/Guides/Cookbook#Nginx.