### PR TITLE
docs: Fix firewalld service setup commands

### DIFF
--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -130,10 +130,8 @@ using firewalld and the ports are blocked, it is fairly simple to open them:
 
 ```
 # add new service "isotovideo" with ports covering 50 worker slots as explained in debugging steps above
-firewall-cmd --new-service isotovideo
-for i in {1..50}; do firewall-cmd --service=isotovideo --add-port=$((i * 10 + 20003))/tcp ; done
+firewall-cmd --permanent --new-service isotovideo
+for i in {1..50}; do firewall-cmd --permanent --service=isotovideo --add-port=$((i * 10 + 20003))/tcp ; done
 # allow the service in your zone (trusted in this example) right now
-firewall-cmd --zone=trusted --add-service=isotovideo
-# ensure the settings to be effective after firewall or host restarts
-firewall-cmd --runtime-to-permanent
+firewall-cmd --permanent --zone=trusted --add-service=isotovideo
 ```

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -132,8 +132,8 @@ using firewalld and the ports are blocked, it is fairly simple to open them:
 # add new service "isotovideo" with ports covering 50 worker slots as explained in debugging steps above
 firewall-cmd --new-service isotovideo
 for i in {1..50}; do firewall-cmd --service=isotovideo --add-port=$((i * 10 + 20003))/tcp ; done
-# allow the service in your zone (public in this example) right now
-firewall-cmd --zone=public --add-service=isotovideo
+# allow the service in your zone (trusted in this example) right now
+firewall-cmd --zone=trusted --add-service=isotovideo
 # ensure the settings to be effective after firewall or host restarts
 firewall-cmd --runtime-to-permanent
 ```


### PR DESCRIPTION
Apparently the service setup commands for the service "isotovideo" need
the parameter "--permanent". Tried this out on a current openSUSE Leap
15.5 multiple times while setting up new openQA workers for
openqa.opensuse.org as part of https://progress.opensuse.org/issues/132134

Related progress issue: https://progress.opensuse.org/issues/133025