### PR TITLE
docs: Point to new multi-machine setup script instead of manual steps

### DIFF
--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -56,6 +56,19 @@ required internet access, etc. on the host as described in the next section.
 
 === Multi-machine test setup
 
+The complete multi-machine test setup can be provided from the script
+`os-autoinst-setup-multi-machine` provided by "os-autoinst". The script can be
+also found online on
+https://github.com/os-autoinst/os-autoinst/blob/master/script/os-autoinst-setup-multi-machine
+
+[NOTE]
+====
+The rest of this chapter until the next chapter <<Verify the setup>> can be
+completely skipped if `os-autoinst-setup-multi-machine` was used. The
+following explanations are provided for reference and further explanation but
+are not guaranteed to provide a consistent working setup.
+====
+
 The section provides one of the ways for setting up the openQA environment to
 run tests that require network connection between several machines (e.g.
 client -- server tests).

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -93,6 +93,9 @@ This is basically a checklist to go through in case the developer mode is broken
 
 . Be sure to have everything up to date. That includes relevant packages on the
   machine hosting the web UI and on the worker.
+. Ensure the firewall configuration steps from
+  https://github.com/os-autoinst/os-autoinst/blob/master/script/os-autoinst-setup-multi-machine
+  have been applied to the worker machine
 . Check whether the web browser can reach the livehandler daemon. Go to a running test and open
   the live view. Then open the JavaScript console of the web browser. If it contains messages
   like `Received message via ws proxy: ...` the livehandler daemon can be reached. Otherwise,
@@ -123,15 +126,3 @@ This is basically a checklist to go through in case the developer mode is broken
   which component needs access to which other components and the ports used by default.
 
 //-
-
-=== Configure firewalld
-As mentioned, certain ports are required to be open on the worker host. If you are
-using firewalld and the ports are blocked, it is fairly simple to open them:
-
-```
-# add new service "isotovideo" with ports covering 50 worker slots as explained in debugging steps above
-firewall-cmd --permanent --new-service isotovideo
-for i in {1..50}; do firewall-cmd --permanent --service=isotovideo --add-port=$((i * 10 + 20003))/tcp ; done
-# allow the service in your zone (trusted in this example) right now
-firewall-cmd --permanent --zone=trusted --add-service=isotovideo
-```


### PR DESCRIPTION
With os-autoinst now having a setup script
os-autoinst-setup-multi-machine the documentation should clarify that
many steps do not need to be conducted manually anymore but are provided
by a setup script which is also linked as reference.

Related progress issue: https://progress.opensuse.org/issues/133025