### PR TITLE
Add timezone to SQL query

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -110,7 +110,7 @@ sub minion ($self) {
 		  WHERE finished >= ? AND finished < ? AND task = 'hook_script' AND
 		        state = 'finished' AND (notes->'hook_rc')::int != 0}
     );
-    $sth->execute($rc_fail_timespan_start, $rc_fail_timespan_end);
+    $sth->execute($rc_fail_timespan_start, "$rc_fail_timespan_end+0");
 
     my $result = $sth->fetchrow_arrayref;
     my $jobs_hook_rc_failed_count = $result->[0];


### PR DESCRIPTION
DBIx::Class would to the right thing, but we're using DBI directly, and the stringified DateTime object will by default not have the timezone offset appended.

Related issue: https://progress.opensuse.org/issues/133889