### PR TITLE
openqa-bootstrap: Align Leap repo priorities with documentation

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -20,8 +20,8 @@ fi
 if [ "$NAME" = "openSUSE Leap" ]; then
     # avoid using `obs://…` URL to workaround https://bugzilla.opensuse.org/show_bug.cgi?id=1187425
     repobase=https://download.opensuse.org/repositories/devel:/openQA
-    zypper -n addrepo -p 90 "$repobase/${VERSION}" 'devel:openQA'
-    zypper -n addrepo -p 91 "$repobase:/Leap:/${VERSION}/${VERSION}" "devel:openQA:Leap:${VERSION}"
+    zypper -n addrepo -p 95 "$repobase/${VERSION}" 'devel:openQA'
+    zypper -n addrepo -p 90 "$repobase:/Leap:/${VERSION}/${VERSION}" "devel:openQA:Leap:${VERSION}"
     zypper -n  --gpg-auto-import-keys refresh
 fi
 


### PR DESCRIPTION
The Leap version specific sub-repo should be preferred over the main
devel:openQA repo so that version-specific package updates can be
supplied and are preferred. This change also aligns the priority values
with the one we have in documentation.