### PR TITLE
Sync testsuite name validation in YAML schema for template and scenario

### DIFF
--- a/public/schema/JobScenarios-01.yaml
+++ b/public/schema/JobScenarios-01.yaml
@@ -66,7 +66,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      '^[A-Za-z0-9._*-]+$':
+      '^[A-Za-z\s0-9_*.+-]+$':
         type: object
         description: The name of the job template
         additionalProperties: false


### PR DESCRIPTION
Both validation regexes should be the same.  So extend scenario as more restrictive pattern in templates will broke current instances