### PR TITLE
Remove max_conns setting again from Nginx config

### DIFF
--- a/etc/nginx/vhosts.d/openqa-upstreams.inc
+++ b/etc/nginx/vhosts.d/openqa-upstreams.inc
@@ -1,8 +1,6 @@
-# The "max_conns" value should be identical to the maximum number of
-# connections the webui is configured to handle concurrently
 upstream webui {
     zone upstream_webui 64k;
-    server [::1]:9526 max_conns=30;
+    server [::1]:9526;
 }
 
 upstream websocket {


### PR DESCRIPTION
Unfortunately `max_conns` does not make much sense for us without the `queue` setting, which is only available in the commercial version of Nginx currently. In the open source version any new incoming request would immediately receive a 502 response if all 30 upstream connections are in use.

However if we ever run into a problem where the openqa-webui service gets hopelessly overloaded because of too many incoming requests, `max_conns` would be a very good temporary measure to protect it. Because it is so easy to set up.

Progress: https://progress.opensuse.org/issues/132167