### PR TITLE
Show max running jobs on /tests page

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -264,7 +264,11 @@ function renderTestLists() {
       data: ajaxQueryParams,
       dataSrc: function (json) {
         // update heading when JSON is available
-        $('#running_jobs_heading').text(json.data.length + ' jobs are running');
+        let text = json.data.length + ' jobs are running';
+        if (json.max_running_jobs !== undefined && json.max_running_jobs >= 0) {
+          text += ' (limited by server config)';
+        }
+        $('#running_jobs_heading').text(text);
         return json.data;
       }
     },

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -282,8 +282,8 @@ concurrent = 0
 [scheduler]
 # Specify how many days a job can stay in 'SCHEDULED' state, defaults to 7 days
 # max_job_scheduled_time = 7
-# Specify how many jobs in total can run per webui instance. Defaults to no limit
-# max_running_jobs = 
+# Specify how many jobs in total can run per webui instance. Defaults to -1 (no limit)
+# max_running_jobs = -1
 
 # Configuration of the label/bugref carry-over
 [carry_over]

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -43,8 +43,8 @@ sub schedule ($self, $allocated_workers = {}, $allocated_jobs = {}) {
     my $worker_count = $schema->resultset('Workers')->count;
     my $free_worker_count = @$free_workers;
     my $running = $schema->resultset('Jobs')->count({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]});
-    my $limit = $self->{config}->{scheduler}->{max_running_jobs} // '';
-    if (length $limit and $running >= $limit) {
+    my $limit = $self->{config}->{scheduler}->{max_running_jobs} // -1;
+    if ($limit >= 0 && $running >= $limit) {
         log_debug("max_running_jobs ($limit) exceeded, scheduling no additional jobs");
         $self->emit('conclude');
         return;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -66,6 +66,7 @@ sub read_config ($app) {
         },
         'scheduler' => {
             max_job_scheduled_time => 7,
+            max_running_jobs => -1,
         },
         logging => {
             level => undef,

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -247,7 +247,10 @@ sub list_running_ajax {
                 progress => $job->progress_info,
             });
     }
-    $self->render(json => {data => \@running});
+    my %response = (data => \@running);
+    my $max_running = OpenQA::App->singleton->config->{scheduler}->{max_running_jobs} // -1;
+    $response{max_running_jobs} = $max_running if $max_running >= 0 && @running >= $max_running;
+    $self->render(json => \%response);
 }
 
 sub list_scheduled_ajax {

--- a/t/config.t
+++ b/t/config.t
@@ -66,6 +66,7 @@ subtest 'Test configuration default modes' => sub {
         },
         'scheduler' => {
             max_job_scheduled_time => 7,
+            max_running_jobs => -1,
         },
         openid => {
             provider => 'https://www.opensuse.org/openid/user/',


### PR DESCRIPTION
See individual commits

~~I think we could also show the actual limit value, e.g. `x jobs are running (limited by server config: 250)`
WDYT?~~