### PR TITLE
Log number of remaining retry attempts for asset uploads

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -710,7 +710,7 @@ sub create_artefact ($self) {
 =item upload_state()
 
 It is used by the worker to inform the webui of a failed download. This is the case when
-all upload retrials from the worker have been exhausted and webui can remove the file
+all upload retries from the worker have been exhausted and webui can remove the file
 that has been partially uploaded.
 
 =back

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -145,7 +145,7 @@ subtest 'upload other assets' => sub {
     $t->json_is('/name' => '00099963-hdd_image3.xml', 'name is expected for other asset');
 };
 
-subtest 'upload retrials' => sub {
+subtest 'upload retries' => sub {
     my $chunkdir = 't/data/openqa/share/factory/tmp/other/00099963-hdd_image4.xml.CHUNKS/';
     my $rp = "t/data/openqa/share/factory/other/00099963-hdd_image4.xml";
 


### PR DESCRIPTION
While retries for asset chunks do work correctly, the messages being logged for failures can be a little confusing. By adding the number of remaining retries in a way similar to other log messages, it gets a lot easier to spot what is really going on. And that the "errors" are actually fairly harmless given the context.

Once this has proven itself in production, we might want to redesign the event interface a bit and get rid of a few events. There is a bit of redundancy right now in the logging. But i can see how that might help find issues in the upload logic as it stands right now.

I've also cleaned up the upload code a little bit to bring it closer to our current standards, without making changes to the API (yet).

Progress: https://progress.opensuse.org/issues/132167