### PR TITLE
Make the number of asset upload attempts configurable

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -26,6 +26,13 @@
 # system.
 #LOCAL_UPLOAD = 0
 
+# Maximum number of retries for asset uploads from the worker to the webui.
+# By default all asset uploads will be retried 5 times with 5 second delays
+# in between upload attempts. A larger number of attempts can be useful if
+# the webui gets restarted regularly for maintenance or needs to be rate
+# limited because of high workloads.
+#UPLOAD_RETRIES = 5
+
 # Whether to terminate after all assigned jobs have been processed. When
 # combined with auto-restarting on service manager level (e.g. configuring
 # Restart=always in the systemd service) this helps applying updates and config

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -1001,8 +1001,10 @@ sub _upload_asset {
     my $job_id = $self->id;
     my $filename = $upload_parameter->{file}->{filename};
     my $file = $upload_parameter->{file}->{file};
-    my $chunk_size = $self->worker->settings->global_settings->{UPLOAD_CHUNK_SIZE} // 1000000;
-    my $local_upload = $self->worker->settings->global_settings->{LOCAL_UPLOAD} // 1;
+    my $global_settings = $self->worker->settings->global_settings;
+    my $chunk_size = $global_settings->{UPLOAD_CHUNK_SIZE} // 1000000;
+    my $retries = $global_settings->{UPLOAD_RETRIES} // 5;
+    my $local_upload = $global_settings->{LOCAL_UPLOAD} // 1;
     my $ua = $self->client->ua;
     my @channels_worker_only = ('worker');
     my @channels_both = ('autoinst', 'worker');
@@ -1077,7 +1079,8 @@ sub _upload_asset {
                 name => $filename,
                 asset => $upload_parameter->{asset},
                 chunk_size => $chunk_size,
-                local => $local_upload
+                local => $local_upload,
+                retries => $retries
             });
     };
     log_error($@, channels => \@channels_both, default => 1) if $@;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1443,7 +1443,8 @@ subtest 'asset upload' => sub {
     combined_like { $upload_res = $job->_upload_asset(\%params) } qr/fake error.*404.*Upload failed for chunk 3/s,
       'upload logged';
     is $upload_res, 1, 'upload succeeded';
-    is_deeply \@params, [[14, {asset => undef, chunk_size => 1000000, file => 'foo', name => 'bar', local => 1}]],
+    is_deeply \@params,
+      [[14, {asset => undef, chunk_size => 1000000, file => 'foo', name => 'bar', local => 1, retries => 5}]],
       'expected params passed'
       or diag explain \@params;
 

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -192,11 +192,11 @@ subtest 'upload failures' => sub {
         });
 
     eval {
-        $t->ua->upload->asset(
-            99963 => {chunk_size => $chunk_size, file => $filename, name => 'hdd_image5.xml', asset => 'other'});
+        $t->ua->upload->asset(99963 =>
+              {chunk_size => $chunk_size, file => $filename, name => 'hdd_image5.xml', asset => 'other', retries => 7});
     };
     ok !$@, 'No function errors on upload failures' or die diag $@;
-    is $fail_chunk, 5, 'All chunks failed, no recovery on upload failures';
+    is $fail_chunk, 7, 'All attempts failed, no recovery on upload failures';
     is $errored, 1, 'Upload errors';
     ok !-d $chunkdir, 'Chunk directory should not exist anymore';
     ok !-e $rp, 'Asset does not exist after upload on upload failures';


### PR DESCRIPTION
I've only made the number of retries configurable via workers.ini for now. Because i believe it would make sense to replace the hardcoded 5 second delay in between attempts with a smarter backoff algorithm that slowly increases with each attempt.

Progress: https://progress.opensuse.org/issues/132167