### PR TITLE
tests: Specify timezone for the test database

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -110,7 +110,7 @@ sub minion ($self) {
 		  WHERE finished >= ? AND finished < ? AND task = 'hook_script' AND
 		        state = 'finished' AND (notes->'hook_rc')::int != 0}
     );
-    $sth->execute("$rc_fail_timespan_start+0", "$rc_fail_timespan_end+0");
+    $sth->execute("$rc_fail_timespan_start", "$rc_fail_timespan_end");
 
     my $result = $sth->fetchrow_arrayref;
     my $jobs_hook_rc_failed_count = $result->[0];

--- a/t/test_postgresql
+++ b/t/test_postgresql
@@ -16,6 +16,7 @@ initdb --auth-local=peer -N "$DIR" -U "$(id -u -n)"
 (echo "listen_addresses=''"
 echo "unix_socket_directories='$DIR'"
 echo "fsync=off"
+echo "timezone='UTC'"
 echo "full_page_writes=off") >> "$DIR"/postgresql.conf
 
 LOGDIR="$DIR/log"


### PR DESCRIPTION
This way we can test that the worker timezone can deviate from the timezone of the database host.