### PR TITLE
Fix scheduler getting max_running_jobs config

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -43,7 +43,7 @@ sub schedule ($self, $allocated_workers = {}, $allocated_jobs = {}) {
     my $worker_count = $schema->resultset('Workers')->count;
     my $free_worker_count = @$free_workers;
     my $running = $schema->resultset('Jobs')->count({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]});
-    my $limit = $self->{config}->{scheduler}->{max_running_jobs} // -1;
+    my $limit = OpenQA::App->singleton->config->{scheduler}->{max_running_jobs} // -1;
     if ($limit >= 0 && $running >= $limit) {
         log_debug("max_running_jobs ($limit) exceeded, scheduling no additional jobs");
         $self->emit('conclude');

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -312,10 +312,8 @@ subtest 'job grab (no jobs because max_running_jobs limit is exceeded)' => sub {
     $job2->update({state => DONE});
     $worker_db_obj->discard_changes;
     my $job4 = $jobs->create_from_settings(\%settings2);
-    my $s = OpenQA::Scheduler::Model::Jobs->singleton;
-    $s->{config}->{scheduler}->{max_running_jobs} = 0;
-
-    my $res = $s->schedule();
+    local OpenQA::App->singleton->config->{scheduler}->{max_running_jobs} = 0;
+    my $res = OpenQA::Scheduler::Model::Jobs->singleton->schedule();
     is $res, undef, 'schedule() returns nothing';
 
     my $scheduled = list_jobs(state => SCHEDULED);
@@ -330,9 +328,7 @@ subtest 'job grab (successful assignment)' => sub {
     $job2->update({state => SCHEDULED});
     my $rjobs_before = list_jobs(state => RUNNING);
     undef $ws_send_error;
-    my $s = OpenQA::Scheduler::Model::Jobs->singleton;
-    delete $s->{config}->{scheduler}->{max_running_jobs};
-    my $res = $s->schedule();
+    my $res = OpenQA::Scheduler::Model::Jobs->singleton->schedule();
     $worker_db_obj->discard_changes;
 
     my $grabbed = $sent->{$worker->{id}}->{job}->to_hash;


### PR DESCRIPTION
We have to access the config via an OpenQA::App singleton.
$self->{config} simply isn't set, but I was assuming that because
I looked at _update_scheduled_jobs which uses

    my $max_job_scheduled_time = $self->{config}->{scheduler}->{max_job_scheduled_time}

So I relied that this would just work. That's also why I had problems to
set the config in the test.

Issue: https://progress.opensuse.org/issues/129619