### PR TITLE
Add usleep_backoff function and use it for asset uploads

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -27,11 +27,11 @@
 #LOCAL_UPLOAD = 0
 
 # Maximum number of retries for asset uploads from the worker to the webui.
-# By default all asset uploads will be retried 5 times with 5 second delays
-# in between upload attempts. A larger number of attempts can be useful if
-# the webui gets restarted regularly for maintenance or needs to be rate
-# limited because of high workloads.
-#UPLOAD_RETRIES = 5
+# By default all asset uploads will be retried 10 times with slowly increasing
+# delays in between upload attempts, starting at around 5 seconds. A larger
+# number of attempts can be useful if the webui gets restarted regularly for
+# maintenance or needs to be rate limited because of high workloads.
+#UPLOAD_RETRIES = 10
 
 # Whether to terminate after all assigned jobs have been processed. When
 # combined with auto-restarting on service manager level (e.g. configuring

--- a/lib/OpenQA/Client/Upload.pm
+++ b/lib/OpenQA/Client/Upload.pm
@@ -45,7 +45,7 @@ sub asset ($self, $job_id, $opts) {
         sub { $self->_upload_asset_fail($uri => {filename => $file_name, scope => $opts->{asset}}) });
 
     # Each chunk of the file should get the full number of retry attempts
-    my $max_retries = $opts->{retries} // 5;
+    my $max_retries = $opts->{retries} // 10;
     my ($failed, $final_error);
     for my $part ($parts->each) {
         last if $failed;
@@ -76,7 +76,7 @@ sub asset ($self, $job_id, $opts) {
             }
 
             unless ($done) {
-                $self->emit('upload_chunk.fail', $tx, $part, $retries);
+                $self->emit('upload_chunk.fail', $tx, $part, $max_retries - $retries, $max_retries);
                 $final_error ||= $tx if $retries == 0;
             }
         } until ($retries == 0 || $done);

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1428,7 +1428,7 @@ subtest 'asset upload' => sub {
             $upload->emit('upload_chunk.finish', $chunk);
             $upload->emit('upload_local.response', $normal_tx, 0);
             $upload->emit('upload_chunk.response', $failure_tx, 4);
-            $upload->emit('upload_chunk.fail', undef, Test::MockObject->new->set_always(index => 3), 2);
+            $upload->emit('upload_chunk.fail', undef, Test::MockObject->new->set_always(index => 3), 2, 4);
             $upload->emit('upload_chunk.error') if $mock_failure;
             push @params, \@args;
         });
@@ -1444,7 +1444,7 @@ subtest 'asset upload' => sub {
       'upload logged';
     is $upload_res, 1, 'upload succeeded';
     is_deeply \@params,
-      [[14, {asset => undef, chunk_size => 1000000, file => 'foo', name => 'bar', local => 1, retries => 5}]],
+      [[14, {asset => undef, chunk_size => 1000000, file => 'foo', name => 'bar', local => 1, retries => 10}]],
       'expected params passed'
       or diag explain \@params;
 
@@ -1452,7 +1452,7 @@ subtest 'asset upload' => sub {
     my ($stdout, $stderr, @result) = capture sub { $job->_upload_asset(\%params) };
     like $stderr, qr/Failure during asset upload \(attempts remaining: 4\)/, 'failure is reported for asset';
     like $stderr, qr/Error uploading bar: 404 response: not found/, 'failure has details';
-    like $stderr, qr/Upload failed for chunk 3 \(attempts remaining: 2\)/, 'failure is reported for chunk';
+    like $stderr, qr/Upload failed for chunk 3 \(attempts: 2\/4\)/, 'failure is reported for chunk';
     like $stderr, qr/Upload failed, and all retry attempts have been exhausted/, 'all attempts exhausted message';
     is $result[0], 0, 'upload failed';
 };

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -221,7 +221,7 @@ subtest 'upload internal errors' => sub {
             99963 => {chunk_size => $chunk_size, file => $filename, name => 'hdd_image6.xml', asset => 'other'});
     };
     ok !$@, 'No function errors on internal errors' or die diag $@;
-    is $fail_chunk, 5, 'All chunks failed, no recovery on internal errors';
+    is $fail_chunk, 10, 'All chunks failed, no recovery on internal errors';
     like $e, qr/Subdly/, 'Internal error seen';
     ok !-d $chunkdir, 'Chunk directory should not exist anymore';
     ok !-e $rp, 'Asset does not exist after upload on internal errors';


### PR DESCRIPTION
This change introduces a slowly increasing backoff delay (5-30 seconds) into the asset upload retry logic to replace the hardcoded 5 second delay. Additonally a random 0-1 second padding will be used to decrease the chances of multiple workers retrying asset uploads at the exact same time. The algorithm was chosen fairly arbitrarily, i just wanted something that increases linearly and is easy to understand.

Since O3/OSD service restarts usually take around a minute, i've also increased the number of retries from 5 to 10. That should give all our workers more than enough time to recover from any expected webui downtime by default.

Progress: https://progress.opensuse.org/issues/132167