### PR TITLE
Allow using force-result label with all final job states

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -185,8 +185,9 @@ sub _control_job_result ($self, $c) {
     die "force_result description '$description' does not match pattern '$force_result_re'\n"
       unless ($description // '') =~ /$force_result_re/;
     my $job = $self->job;
-    die "force_result only allowed on finished jobs\n" unless $job->state eq OpenQA::Jobs::Constants::DONE;
-    $job->update_result($new_result);
+    die "force_result only allowed on finished jobs\n"
+      unless OpenQA::Jobs::Constants::meta_state($job->state) eq OpenQA::Jobs::Constants::FINAL;
+    $job->update_result($new_result, OpenQA::Jobs::Constants::DONE);
     return undef;
 }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1049,9 +1049,11 @@ sub update_backend ($self, $backend_info) {
     $self->update({backend => $backend_info->{backend}});
 }
 
-sub update_result ($self, $result) {
-    my $res = $self->update({result => $result});
-    OpenQA::App->singleton->emit_event('openqa_job_update_result', {id => $self->id, result => $result}) if $res;
+sub update_result ($self, $result, $state = undef) {
+    my %values = (result => $result);
+    $values{state} = $state if defined $state;
+    my $res = $self->update(\%values);
+    OpenQA::App->singleton->emit_event('openqa_job_update_result', {id => $self->id, %values}) if $res;
     return $res;
 }
 


### PR DESCRIPTION
In particular, it makes sense to allow this not only for done jobs but also for jobs that are canceled (and have never been assigned to a worker).

See https://progress.opensuse.org/issues/127280