### PR TITLE
Make max_running_jobs a hard limit

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -127,8 +127,9 @@ sub schedule ($self, $allocated_workers = {}, $allocated_jobs = {}) {
         }
         # we make sure we schedule clusters no matter what,
         # but we stop if we're over the limit
-        my $busy = scalar(keys %$allocated_workers);
-        last if $busy >= MAX_JOB_ALLOCATION || $busy >= $free_worker_count;
+        my $busy = keys %$allocated_workers;
+        last
+          if $busy >= MAX_JOB_ALLOCATION || $busy >= $free_worker_count || $limit >= 0 && ($running + $busy) >= $limit;
     }
 
     my @successfully_allocated;

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -118,7 +118,12 @@ sub _allocate_jobs ($self, $free_workers) {
         # we make sure we schedule clusters no matter what,
         # but we stop if we're over the limit
         my $busy = keys %$allocated_workers;
-        last if $busy >= $max_allocate || $busy >= @$free_workers;
+        if ($busy >= $max_allocate || $busy >= @$free_workers) {
+            my $free_worker_count = @$free_workers;
+            log_debug("limit reached, scheduling no additional jobs"
+                  . "(max_running_jobs=$limit, free workers=$free_worker_count, running=$running, allocated=$busy)");
+            last;
+        }
     }
     return ($allocated_workers, $allocated_jobs);
 }

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -14,7 +14,7 @@ use OpenQA::Utils 'random_string';
 use OpenQA::Constants qw(WEBSOCKET_API_VERSION);
 use OpenQA::Schema;
 use Time::HiRes 'time';
-use List::Util qw(all shuffle);
+use List::Util qw(all shuffle min);
 
 # How many jobs to allocate in one tick. Defaults to 80 ( set it to 0 for as much as possible)
 use constant MAX_JOB_ALLOCATION => $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} // 80;
@@ -36,33 +36,22 @@ sub determine_scheduled_jobs ($self) {
     return $self->scheduled_jobs;
 }
 
-sub schedule ($self, $allocated_workers = {}, $allocated_jobs = {}) {
-    my $start_time = time;
+sub _allocate_jobs ($self, $free_workers, $allocated_workers, $allocated_jobs) {
+    my $scheduled_jobs = $self->scheduled_jobs;
     my $schema = OpenQA::Schema->singleton;
-    my $free_workers = determine_free_workers($self->shuffle_workers);
-    my $worker_count = $schema->resultset('Workers')->count;
-    my $free_worker_count = @$free_workers;
     my $running = $schema->resultset('Jobs')->count({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]});
     my $limit = OpenQA::App->singleton->config->{scheduler}->{max_running_jobs};
     if ($limit >= 0 && $running >= $limit) {
         log_debug("max_running_jobs ($limit) exceeded, scheduling no additional jobs");
         $self->emit('conclude');
-        return;
+        return 0;
     }
-    unless ($free_worker_count) {
-        $self->emit('conclude');
-        return ();
-    }
-
-    my $scheduled_jobs = $self->determine_scheduled_jobs;
-    log_debug(
-        "Scheduling: Free workers: $free_worker_count/$worker_count; Scheduled jobs: " . scalar(keys %$scheduled_jobs));
+    my $max_allocate = $limit >= 0 ? min(MAX_JOB_ALLOCATION, $limit - $running) : MAX_JOB_ALLOCATION;
 
     # update the matching workers to the current free
     for my $jobinfo (values %$scheduled_jobs) {
         $jobinfo->{matching_workers} = _matching_workers($jobinfo, $free_workers);
     }
-
     # before we start looking at sorted jobs, we try to repair half scheduled clusters
     # note: This can happen e.g. with workers connected to multiple web UIs or when jobs are scheduled
     #       non-atomically via openqa-clone-job.
@@ -128,9 +117,28 @@ sub schedule ($self, $allocated_workers = {}, $allocated_jobs = {}) {
         # we make sure we schedule clusters no matter what,
         # but we stop if we're over the limit
         my $busy = keys %$allocated_workers;
-        last
-          if $busy >= MAX_JOB_ALLOCATION || $busy >= $free_worker_count || $limit >= 0 && ($running + $busy) >= $limit;
+        last if $busy >= $max_allocate || $busy >= @$free_workers;
     }
+    return scalar keys %$allocated_workers;
+}
+
+
+sub schedule ($self, $allocated_workers = {}, $allocated_jobs = {}) {
+    my $start_time = time;
+    my $schema = OpenQA::Schema->singleton;
+    my $free_workers = determine_free_workers($self->shuffle_workers);
+    my $worker_count = $schema->resultset('Workers')->count;
+    my $free_worker_count = @$free_workers;
+    unless ($free_worker_count) {
+        $self->emit('conclude');
+        return [];
+    }
+
+    my $scheduled_jobs = $self->determine_scheduled_jobs;
+    log_debug(
+        "Scheduling: Free workers: $free_worker_count/$worker_count; Scheduled jobs: " . scalar(keys %$scheduled_jobs));
+
+    return [] unless $self->_allocate_jobs($free_workers, $allocated_workers, $allocated_jobs);
 
     my @successfully_allocated;
 

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -101,7 +101,7 @@ $workercaps->{cpu_opmode} = '32-bit, 64-bit';
 $workercaps->{mem_max} = '4096';
 $workercaps->{websocket_api_version} = WEBSOCKET_API_VERSION;
 $workercaps->{isotovideo_interface_version} = WEBSOCKET_API_VERSION;
-sub register_worker { $c->_register($schema, 'host', '1', $workercaps) }
+sub register_worker ($host = 'host', $instance = 1) { $c->_register($schema, $host, $instance, $workercaps) }
 
 my ($id, $worker, $worker_db_obj);
 subtest 'worker registration' => sub {
@@ -307,11 +307,13 @@ subtest 'job grab (failed to send job to worker)' => sub {
     is_deeply($allocated, [], 'no workers/jobs allocated');
 };
 
-subtest 'job grab (no jobs because max_running_jobs limit is exceeded)' => sub {
+subtest 'job grab (no jobs because max_running_jobs is 0)' => sub {
     $job->update({state => DONE});
     $job2->update({state => DONE});
+    undef $ws_send_error;
     $worker_db_obj->discard_changes;
-    my $job4 = $jobs->create_from_settings(\%settings2);
+    my @jobs;
+    push @jobs, $jobs->create_from_settings(\%settings2) for 1 .. 10;
     local OpenQA::App->singleton->config->{scheduler}->{max_running_jobs} = 0;
     my $res = OpenQA::Scheduler::Model::Jobs->singleton->schedule();
     is @$res, 0, 'schedule() returns empty arrayref';
@@ -319,8 +321,31 @@ subtest 'job grab (no jobs because max_running_jobs limit is exceeded)' => sub {
     my $scheduled = list_jobs(state => SCHEDULED);
     my $assigned = list_jobs(state => ASSIGNED);
     is scalar @$assigned, 0, 'No jobs assigned';
-    is scalar @$scheduled, 1, '1 job still scheduled';
-    $jobs->find($job4->id)->delete;
+    is scalar @$scheduled, 10, '10 jobs still scheduled';
+    $jobs->find($_->id)->delete for @jobs;
+};
+
+subtest 'job grab (no jobs because max_running_jobs limit is exceeded)' => sub {
+    my @jobs;
+    my @workers;
+    for my $wid (2 .. 10) {
+        is(my $id = register_worker(host => $wid), $wid, 'new worker registered');
+        my $worker = $workers->find($id);
+        $worker->set_property(WORKER_CLASS => 'qemu_x86_64');
+        push @workers, $worker;
+    }
+    push @jobs, $jobs->create_from_settings(\%settings2) for 1 .. 10;
+
+    local OpenQA::App->singleton->config->{scheduler}->{max_running_jobs} = 5;
+    my $res = OpenQA::Scheduler::Model::Jobs->singleton->schedule();
+    is @$res, 5, 'schedule() returns 5 items';
+
+    my $scheduled = list_jobs(state => SCHEDULED);
+    my $assigned = list_jobs(state => ASSIGNED);
+    is scalar @$assigned, 5, '5 jobs assigned';
+    is scalar @$scheduled, 5, '5 jobs still scheduled';
+    $jobs->find($_->id)->delete for @jobs;
+    $_->delete for @workers;
 };
 
 subtest 'job grab (successful assignment)' => sub {

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -314,7 +314,7 @@ subtest 'job grab (no jobs because max_running_jobs limit is exceeded)' => sub {
     my $job4 = $jobs->create_from_settings(\%settings2);
     local OpenQA::App->singleton->config->{scheduler}->{max_running_jobs} = 0;
     my $res = OpenQA::Scheduler::Model::Jobs->singleton->schedule();
-    is $res, undef, 'schedule() returns nothing';
+    is @$res, 0, 'schedule() returns empty arrayref';
 
     my $scheduled = list_jobs(state => SCHEDULED);
     my $assigned = list_jobs(state => ASSIGNED);


### PR DESCRIPTION
Before the actual limit would have been max_running_jobs + MAX_JOB_ALLOCATION.

Note that any parallel cluster jobs might still get the number of running jobs
above that limit, but those are usually not more than a handful of jobs.

Issue: https://progress.opensuse.org/issues/129619

See individual commits