### PR TITLE
Allow settings to wrap into the next line

### DIFF
--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -65,7 +65,8 @@
 }
 table.settings-table tr {
     td span {
-        white-space: pre;
+        white-space: pre-wrap;
+        word-break: break-word;
     }
 }
 table.dataTable {


### PR DESCRIPTION
Settings become unreadable or even hidden when they flow outside of the containing element or window.

Fall back to wrapping the text if nothing else.

See: https://progress.opensuse.org/issues/134897