### PR TITLE
Remove one UPDATE query from worker status updates

### DIFF
--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Schema::Result::Workers;
-
-
-use Mojo::Base 'DBIx::Class::Core';
+use Mojo::Base 'DBIx::Class::Core', -signatures;
 
 use DBIx::Class::Timestamps 'now';
 use Try::Tiny;
@@ -70,10 +68,10 @@ sub name {
     return $self->host . ":" . $self->instance;
 }
 
-sub seen {
-    my ($self, $workercaps, $error) = @_;
-    $self->update({t_seen => now()});
-    $self->update_caps($workercaps) if $workercaps;
+sub seen ($self, $options = {}) {
+    my $data = {t_seen => now()};
+    $data->{error} = $options->{error} if exists $options->{error};
+    $self->update($data);
 }
 
 # update worker's capabilities

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -156,8 +156,7 @@ sub _message {
                 sub {
                     return undef unless my $w = $schema->resultset("Workers")->find($worker_id);
                     log_debug("Updating seen of worker $worker_id from worker_status ($current_worker_status)");
-                    $w->seen;
-                    $w->update({error => $current_worker_error});
+                    $w->seen({error => $current_worker_error});
                 });
         }
         catch {


### PR DESCRIPTION
This combines the t_seen and error updates into one. Also removed some dead code in the seen method.

Progress: https://progress.opensuse.org/issues/135122