### PR TITLE
Fix missing Conflicts in unit files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,13 @@ install-generic:
 	ln -s openqa-worker-plain@.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker@.service
 	sed \
 		-e 's_^\(ExecStart=/usr/share/openqa/script/worker\) \(--instance %i\)$$_\1 --no-cleanup \2_' \
-		-e '/Wants/aConflicts=openqa-worker-plain@.service' \
+		-e '/After/aConflicts=openqa-worker-plain@.service' \
 		systemd/openqa-worker-plain@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
 	sed \
 		-e '/Type/aEnvironment=OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE=1' \
 		-e '/ExecStart=/aExecReload=\/bin\/kill -HUP $$MAINPID' \
 		-e 's/Restart=on-failure/Restart=always/' \
-		-e '/Wants/aConflicts=openqa-worker-plain@.service' \
+		-e '/After/aConflicts=openqa-worker-plain@.service' \
 		systemd/openqa-worker-plain@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-auto-restart@.service
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf


### PR DESCRIPTION
There is no `Wants` in our unit files, so the `Conflicts` was never added. Change the expression to add it after `After`.

Reference: https://progress.opensuse.org/issues/133352