### PR TITLE
Remove worker population broadcasts

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -34,20 +34,20 @@
 #UPLOAD_RETRIES = 10
 
 # Minimum time in seconds between status updates from the worker to the
-# webui. By default this value is 20 seconds, and it should not be set lower,
-# as to not overwhelm the websocket server with too many messages if more
-# than a few workers are connected. Increasing this value can help scale
-# very large openQA setups with many workers. However, it should not
+# webui. By default this value is 60 seconds, and it should not be set much
+# lower, as to not overwhelm the websocket server with too many messages
+# if more than a few workers are connected. Increasing this value can help
+# scale very large openQA setups with many workers. However, it should not
 # exceed "STATUS_MAX_INTERVAL".
-#STATUS_MIN_INTERVAL = 20
+#STATUS_MIN_INTERVAL = 60
 
 # Maximum time in seconds between status updates from the worker to the
-# webui. By default this value is 100 seconds, and it should not be set lower,
+# webui. By default this value is 300 seconds, and it should not be set lower,
 # as to not overwhelm the websocket server with too many messages if more
 # than a few workers are connected. Increasing this value can help scale
 # very large openQA setups with many workers. However, you need to ensure
 # that it does not exceed the configured "worker_timeout" of the webui.
-#STATUS_MAX_INTERVAL = 100
+#STATUS_MAX_INTERVAL = 300
 
 # Whether to terminate after all assigned jobs have been processed. When
 # combined with auto-restarting on service manager level (e.g. configuring

--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -33,6 +33,22 @@
 # maintenance or needs to be rate limited because of high workloads.
 #UPLOAD_RETRIES = 10
 
+# Minimum time in seconds between status updates from the worker to the
+# webui. By default this value is 20 seconds, and it should not be set lower,
+# as to not overwhelm the websocket server with too many messages if more
+# than a few workers are connected. Increasing this value can help scale
+# very large openQA setups with many workers. However, it should not
+# exceed "STATUS_MAX_INTERVAL".
+#STATUS_MIN_INTERVAL = 20
+
+# Maximum time in seconds between status updates from the worker to the
+# webui. By default this value is 100 seconds, and it should not be set lower,
+# as to not overwhelm the websocket server with too many messages if more
+# than a few workers are connected. Increasing this value can help scale
+# very large openQA setups with many workers. However, you need to ensure
+# that it does not exceed the configured "worker_timeout" of the webui.
+#STATUS_MAX_INTERVAL = 100
+
 # Whether to terminate after all assigned jobs have been processed. When
 # combined with auto-restarting on service manager level (e.g. configuring
 # Restart=always in the systemd service) this helps applying updates and config

--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -74,10 +74,10 @@ use constant {
 
 # Time verification to use with the "worker_timeout" configuration.
 # It shouldn't be bigger than the "worker_timeout" configuration.
-use constant MAX_TIMER => 100;
+use constant MAX_TIMER => 300;
 
 # Time verification to use with the "worker_timeout" configuration.
-use constant MIN_TIMER => 20;
+use constant MIN_TIMER => 60;
 
 # The max. time a job is allowed to run by default before the worker stops it.
 use constant DEFAULT_MAX_JOB_TIME => 2 * ONE_HOUR;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -121,11 +121,6 @@ our @EXPORT = qw(
   loaded_plugins
   hashwalker
   read_test_modules
-  feature_scaling
-  logistic_map_steps
-  logistic_map
-  rand_range
-  in_range
   walker
   ensure_timestamp_appended
   set_listen_address
@@ -818,22 +813,6 @@ sub walker {
         }
     }
 }
-
-
-# Args:
-# First is i-th element, Second is maximum element number, Third and Fourth are the range limit (lower and upper)
-# $i, $imax, MIN, MAX
-sub feature_scaling { $_[2] + ((($_[0] - 1) * ($_[3] - $_[2])) / (($_[1] - 1) || 1)) }
-# $r, $xn
-sub logistic_map { $_[0] * $_[1] * (1 - $_[1]) }
-# $steps, $r, $xn
-sub logistic_map_steps {
-    $_[2] = 0.1 if $_[2] <= 0;    # do not let population die. - with this change we get more "chaos"
-    $_[2] = logistic_map($_[1], $_[2]) for (1 .. $_[0]);
-    $_[2];
-}
-sub rand_range { $_[0] + rand($_[1] - $_[0]) }
-sub in_range { $_[0] >= $_[1] && $_[0] <= $_[2] ? 1 : 0 }
 
 sub set_listen_address {
     my $port = shift;

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -40,7 +40,7 @@ use POSIX;
 use Try::Tiny;
 use Scalar::Util 'looks_like_number';
 use OpenQA::Constants
-  qw(WEBSOCKET_API_VERSION WORKER_COMMAND_QUIT WORKER_SR_BROKEN WORKER_SR_DONE WORKER_SR_DIED WORKER_SR_FINISH_OFF MAX_TIMER MIN_TIMER);
+  qw(WEBSOCKET_API_VERSION WORKER_COMMAND_QUIT WORKER_SR_BROKEN WORKER_SR_DONE WORKER_SR_DIED WORKER_SR_FINISH_OFF);
 use OpenQA::Client;
 use OpenQA::Log qw(log_error log_warning log_info log_debug add_log_channel remove_log_channel);
 use OpenQA::Utils qw(prjdir);

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -109,18 +109,9 @@ sub handle_command {
             return $worker->skip_job($job_id, $type);
         }
     }
-    log_warning("Ignoring WS message with unknown type $type from $webui_host:\n" . pp($json));
-}
 
-sub _handle_command_info {
-    my ($json, $client, $worker, $webui_host) = @_;
-
-    if (my $population = $json->{population}) {
-        $client->webui_host_population($population);
-    }
-
-    # enfore recalculation of interval for overall worker status update
-    $client->send_status_interval(undef);
+    # WS messages of type "info" can be sent for debugging
+    log_warning("Ignoring WS message with unknown type $type from $webui_host:\n" . pp($json)) if $type ne 'info';
 }
 
 sub _handle_command_livelog_start {

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -130,7 +130,7 @@ subtest 'Scheduler worker job allocation' => sub {
 subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes offline' => sub {
     # avoid wasting time waiting for status updates
     my $web_ui_connection_mock = Test::MockModule->new('OpenQA::Worker::WebUIConnection');
-    $web_ui_connection_mock->redefine(_calculate_status_update_interval => .1);
+    $web_ui_connection_mock->redefine(calculate_status_update_interval => .1);
 
     my $jobs = $schema->resultset('Jobs');
     my @latest = $jobs->latest_jobs;

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -181,7 +181,7 @@ subtest 'web socket message handling' => sub {
         combined_like {
             $t->send_ok({json => {type => 'worker_status', status => 'broken', reason => 'test'}});
             $t->message_ok('message received');
-            $t->json_message_is({type => 'info', population => $workers->count});
+            $t->json_message_is({type => 'info', seen => 1});
         }
         qr/Received.*worker_status message.*Updating seen of worker 1 from worker_status/s, 'update logged';
         is($workers->find($worker_id)->error, 'test', 'broken message set');
@@ -231,7 +231,6 @@ subtest 'web socket message handling' => sub {
         combined_like {
             $t->send_ok({json => {type => 'worker_status', status => 'idle'}});
             $t->message_ok('message received');
-            $t->json_message_is({type => 'info', population => $workers->count});
         }
         qr/Received.*worker_status message.*Updating seen of worker 1 from worker_status/s, 'update logged';
         is($workers->find($worker_id)->error, undef, 'broken status unset');


### PR DESCRIPTION
This patch gets rid of the expensive `SELECT COUNT(*) FROM workers` and replaces the complex status update interval calculation with something simpler.

1000 status updates **before**:
<img width="1760" src="https://github.com/os-autoinst/openQA/assets/30094/4e7739c0-8441-4d8f-8fd3-b82b983510e3">

1000 status updates **after**:
<img width="1713" src="https://github.com/os-autoinst/openQA/assets/30094/30adb70a-f1d5-4377-be09-ec7369de9bfc">

Progress: https://progress.opensuse.org/issues/135362
