### PR TITLE
Makefile: Make replacements in unit files more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,13 @@ install-generic:
 	ln -s openqa-worker-plain@.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker@.service
 	sed \
 		-e 's_^\(ExecStart=/usr/share/openqa/script/worker\) \(--instance %i\)$$_\1 --no-cleanup \2_' \
-		-e '/After/aConflicts=openqa-worker-plain@.service' \
+		-e '/^$$/N;/\[Service\]/iConflicts=openqa-worker-plain@.service' \
 		systemd/openqa-worker-plain@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-no-cleanup@.service
 	sed \
-		-e '/Type/aEnvironment=OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE=1' \
+		-e '/\[Service\]/aEnvironment=OPENQA_WORKER_TERMINATE_AFTER_JOBS_DONE=1' \
 		-e '/ExecStart=/aExecReload=\/bin\/kill -HUP $$MAINPID' \
-		-e 's/Restart=on-failure/Restart=always/' \
-		-e '/After/aConflicts=openqa-worker-plain@.service' \
+		-e 's/Restart=.*/Restart=always/' \
+		-e '/^$$/N;/\[Service\]/iConflicts=openqa-worker-plain@.service' \
 		systemd/openqa-worker-plain@.service > "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker-auto-restart@.service
 	install -m 755 systemd/systemd-openqa-generator "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf


### PR DESCRIPTION
Improve the patterns and append/insert lines around the [Service] line, which should be present in a .service unit file in any case.

Reference: https://progress.opensuse.org/issues/133352