### PR TITLE
Make searching for unfinished jobs faster (Option B)

### DIFF
--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -248,7 +248,7 @@ sub send_command {
 sub unfinished_jobs {
     my ($self) = @_;
 
-    return $self->previous_jobs->search({t_finished => undef});
+    return $self->previous_jobs->search({state => {-in => [OpenQA::Jobs::Constants::PENDING_STATES]}});
 }
 
 sub set_current_job {


### PR DESCRIPTION
This is option **B**. See #5301 for option A.

The `$worker->unfinished_jobs` in the websocket server is the last low hanging fruit shown by my profiling data. And it is an interesting one because it has the potential to be a huge improvement, or to be a bit underwhelming. It is entirely dependent on how many previous jobs the worker sending the status update has in the database.

Currently the SQL query generated by DBIx::Class ends up using an index for the `assigned_worker_id` field, but not for `t_finished`. A combined index for both fields has shown the best imporvements. But Tina brought up the idea of using the `state` instead of `t_finished`, which is almost as good.

For the benchmark i've used a real world example from OSD with 1420 previous jobs. Due to DBIx::Class overhead there is a performance floor around 1.6s, at that point no further optimizations at the PostgreSQL layer are possible. This patch does not reach the performance floor, but it has the advantage that no new index is required.

1000 status updates **before**:
<img width="1426" src="https://github.com/os-autoinst/openQA/assets/30094/d153545d-3fc2-478f-8914-5d7184d87e24">

1000 status updates **after**:
<img width="1546" src="https://github.com/os-autoinst/openQA/assets/30094/b73bdf73-1a80-4421-a705-df416bd46fea">

Progress: https://progress.opensuse.org/issues/135362