### PR TITLE
Log an info message when worker status updates are too frequent

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -34,7 +34,7 @@
 #UPLOAD_RETRIES = 10
 
 # Minimum time in seconds between status updates from the worker to the
-# webui. By default this value is 60 seconds, and it should not be set much
+# webui. By default this value is 60 seconds, and it should not be set
 # lower, as to not overwhelm the websocket server with too many messages
 # if more than a few workers are connected. Increasing this value can help
 # scale very large openQA setups with many workers. However, it should not


### PR DESCRIPTION
This will give us a hint at when the websocket server is falling behind with handling worker status updates. It should usually happen when multiple updates end up in the websocket buffer and are handled right after another.

In the future we could use this condition to ignore the extra status updates. Which would give the websocket server a much better chance to recover on its own, if this was only a temporary performance issue.

Progress: https://progress.opensuse.org/issues/135362