### PR TITLE
Fix websocket warning not to include the status "working"

### DIFF
--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -153,10 +153,12 @@ sub _message {
           if LOG_WORKER_STATUS_MESSAGES;
 
         # detect if the websocket server is running too close to its limit and falling behind with status updates
+        # (the status "working" is special because it will be sent immediately after a worker started a new job)
         my ($last_seen, $now) = ($worker_status->{last_seen}, time);
         if ($last_seen && ($last_seen + MIN_TIMER) > $now) {
             log_info("Received worker $worker_id status too close to the last update,"
-                  . " websocket server possibly overloaded or worker misconfigured");
+                  . " websocket server possibly overloaded or worker misconfigured")
+              if $current_worker_status ne 'working';
         }
         $worker_status->{last_seen} = $now;
 

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -195,6 +195,17 @@ subtest 'web socket message handling' => sub {
             $t->send_ok({json => {type => 'worker_status', status => 'idle'}})->message_ok('message received');
         }
         $expected_message, 'status update too frequent';
+
+        combined_unlike {
+            $t->finish_ok->websocket_ok('/ws/1', 're-establish ws connection')
+              ->send_ok({json => {type => 'worker_status', status => 'idle'}})->message_ok('message received');
+        }
+        $expected_message, 'status update not yet too frequent due to another reconnect';
+
+        combined_unlike {
+            $t->send_ok({json => {type => 'worker_status', status => 'working'}})->message_ok('message received');
+        }
+        $expected_message, 'status update not too frequent for status "working"';
     };
 
     subtest 'worker status: broken' => sub {


### PR DESCRIPTION
This is a small correction to #5303. The worker will send an immediate "working" status update
[here](https://github.com/os-autoinst/openQA/blob/98e54f9632959aed6a15e3d0afe0a9bdb6249bd4/lib/OpenQA/Worker/Job.pm#L307) whenever a new job has been started. So that case needs to be excluded. Since we do expect most problematic cases to involve "free" status updates, this shouldn't harm the effectiveness of the feature for detecting scalability issues.

Progress: https://progress.opensuse.org/issues/135362