### PR TITLE
Fix key navigation on test details

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -644,16 +644,20 @@ function renderTestModules(response) {
     setCurrentPreviewFromStepLinkIfPossible($("[href='" + hash + "'], [data-href='" + hash + "']"));
   }
 
-  // setup keyboard navigation through test details
-  $(window).keydown(handleKeyDownOnTestDetails);
+  // setup event handlers for the window
+  if (!this.hasWindowEventHandlers) {
+    // setup keyboard navigation through test details
+    $(window).keydown(handleKeyDownOnTestDetails);
 
-  // ensure the size of the preview container is adjusted when the window size changes
-  $(window).resize(function () {
-    const currentPreview = $('.current_preview');
-    if (currentPreview.length) {
-      setCurrentPreview($('.current_preview'), true);
-    }
-  });
+    // ensure the size of the preview container is adjusted when the window size changes
+    $(window).resize(function () {
+      const currentPreview = $('.current_preview');
+      if (currentPreview.length) {
+        setCurrentPreview($('.current_preview'), true);
+      }
+    });
+    this.hasWindowEventHandlers = true;
+  }
 
   // setup result filter, define function to apply filter changes
   const detailsFilter = $('#details-filter');


### PR DESCRIPTION
When viewing a test live and test module details are added to the page dynamically, then the key navigation breaks. It skips steps instead of just selecting the next/previous step. This is because the event handler is registered multiple times. This change fixes the issue by making sure the event handler is only registered once.