### PR TITLE
Adapt tools/tidy to dotted version

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -51,12 +51,12 @@ if ! command -v perltidy > /dev/null 2>&1; then
     exit 1
 fi
 
-perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\).*['];$/\1/p" "$dir"/../cpanfile)
 # This might be used from another repo like os-autoinst-distri-opensuse
 if [ -z "${perltidy_version_expected}" ]; then
     # No cpanfile in the linked repo, use the one from os-autoinst instead
     dir="$(dirname "$(readlink -f "$0")")"
-    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\).*['];$/\1/p" "$dir"/../cpanfile)
 fi
 perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then


### PR DESCRIPTION
* Update code according to new Perl::Tidy
* Fix usage of spew with empty content
* Update tidy to 20230909
* Adapt to deprecation of spurt in upstream Mojolicious
* Dependency cron 2023-09-13
* git subrepo pull (merge) external/os-autoinst-common