### PR TITLE
t: Fix api/13-influxdb.t timezone issue

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -107,8 +107,8 @@ sub minion ($self) {
     # rc means hook script return code
     my $sth = $dbh->prepare(
         q{SELECT COUNT(*) AS rc_failed_count FROM minion_jobs
-		  WHERE finished >= ? AND finished < ? AND task = 'hook_script' AND
-		        state = 'finished' AND (notes->'hook_rc')::int != 0}
+                 WHERE finished >= ? AND finished < ? AND task = 'hook_script' AND
+                       state = 'finished' AND (notes->'hook_rc')::int != 0}
     );
     $sth->execute("$rc_fail_timespan_start+0", "$rc_fail_timespan_end+0");
 

--- a/t/api/13-influxdb.t
+++ b/t/api/13-influxdb.t
@@ -65,7 +65,7 @@ subtest 'openqa_minion_jobs_hook_rc_failed counter' => sub {
 q!INSERT INTO minion_jobs (id, args, created, delayed, finished, priority, result, retried, retries, started, state, task, worker, queue, attempts, parents, notes)
 		VALUES (7291599, '["/bin/true", 11201356, {"delay": 60, "retries": 1440, "skip_rc": 142, "timeout": "10m", "kill_timeout": "10s"}]', '2023-05-26 17:00:50.542916+02', '2023-05-26 17:00:50.542916+02', ?, 0, null, null, 0, '2023-05-26 17:00:50.565839+02', 'finished', 'hook_script', 1388, 'default', 1, '{}', '{"hook_rc": -1, "hook_cmd": "foobar", "hook_result": "Job is '':investigate:'' already, skipping investigation\n"}')!
     );
-    $sth->execute($rc_fail_finished);
+    $sth->execute("$rc_fail_finished+0");
     my $mock_dt = Test::MockModule->new('DateTime');
     $mock_dt->mock(now => sub { $static_now->clone });
     $t->get_ok('/admin/influxdb/minion')->status_is(200)


### PR DESCRIPTION
We also need to add the timezone offset in the test to tell postgres that the date is meant to be UTC.
Otherwise the test can fail depending on the local timezone.