### PR TITLE
Fix dependency update script

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -115,7 +115,7 @@ on 'test' => sub {
 };
 
 on 'devel' => sub {
-    requires 'Perl::Tidy', '== 20230909';
+    requires 'Perl::Tidy', '== 20230909.0.0';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -77,7 +77,7 @@ devel_no_selenium_requires:
   sudo:
   tar:
   xorg-x11-fonts:
-  perl(Perl::Tidy): '== 20230909'
+  perl(Perl::Tidy): '== 20230909.0.0'
 
 devel_requires:
   '%devel_no_selenium_requires':

--- a/tools/ci/build_dependencies.sh
+++ b/tools/ci/build_dependencies.sh
@@ -26,7 +26,7 @@ listdeps > "$DEPS_AFTER"
 comm -13 "$DEPS_BEFORE" "$DEPS_AFTER" > "$CI_PACKAGES"
 
 # let's tidy if Tidy version changes
-newtidyver="$(git diff "$CI_PACKAGES" | grep perl-Perl-Tidy | grep '^+' | grep -o '[0-9]*' || :)"
+newtidyver="$(git diff "$CI_PACKAGES" | grep perl-Perl-Tidy | grep '^+' | grep -o '[0-9.]*' || :)"
 [ -z "$newtidyver" ] || {
     sed -i -e "s/\(Perl::Tidy):\s\+'==\s\)\([0-9]\+\)\(.*\)/\1$newtidyver\3/g" dependencies.yaml
     make update-deps

--- a/tools/ci/ci-packages.txt
+++ b/tools/ci/ci-packages.txt
@@ -114,7 +114,7 @@ perl-DateTime-Format-Strptime-1.74
 perl-DateTime-Locale-1.170000
 perl-DateTime-TimeZone-2.15
 perl-DBD-Pg-3.17.0
-perl-DBD-SQLite-1.72
+perl-DBD-SQLite-1.740.0
 perl-DBI-1.643
 perl-DBIx-Class-0.082843
 perl-DBIx-Class-DeploymentHandler-0.002233

--- a/tools/tidy
+++ b/tools/tidy
@@ -51,12 +51,12 @@ if ! command -v perltidy > /dev/null 2>&1; then
     exit 1
 fi
 
-perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\).*['];$/\1/p" "$dir"/../cpanfile)
 # This might be used from another repo like os-autoinst-distri-opensuse
 if [ -z "${perltidy_version_expected}" ]; then
     # No cpanfile in the linked repo, use the one from os-autoinst instead
     dir="$(dirname "$(readlink -f "$0")")"
-    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\).*['];$/\1/p" "$dir"/../cpanfile)
 fi
 perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then


### PR DESCRIPTION
Perl::Tidy version has two dots now, e.g. 20230909.0.0

The original grep for `[0-9]*` resulted in three lines, so that sed complained:

    sed: -e expression #1, char 55: unterminated `s' command

See https://app.circleci.com/pipelines/github/os-autoinst/openQA/12241/workflows/6a3918da-3db5-402a-9bc3-b616c7d5715d/jobs/114292