### PR TITLE
Properly handle duplicate sections on openqa/client.conf

### DIFF
--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -30,8 +30,9 @@ sub new {
             for my $i (qw(key secret)) {
                 my $attr = "api$i";
                 next if $self->$attr;
-                my $val = $cfg->val($args{api}, $i);
-                next unless $val;
+                # Fetch all the values in the file and keep the last one
+                my @values = $cfg->val($args{api}, $i);
+                next unless my $val = $values[-1];
                 $val =~ s/\s+$//;    # remove trailing whitespace
                 $self->$attr($val);
             }


### PR DESCRIPTION
When openqa/client.conf has two sections pointing to the same instance the workers won't be able to boot because the API Key returned by OpenQA::UserAgent will include a line break.

Now only the last value defined in openqa/client.conf will be used.

The issue raises when running `script/openqa-bootstrap` twice, a set of duplicate credentials will be created and trigger the error.

The error msg looks like:

```
# [...]
+ su _openqa-worker -c '/usr/share/openqa/script/worker --instance 1'
[info] worker 1:
 - config file:                      /etc/openqa/workers.ini
 - name used to register:            b17139cf73ec
 - worker address (WORKER_HOSTNAME): localhost
 - isotovideo version:               40
 - websocket API version:            1
 - web UI hosts:                     localhost
 - class:                            ?
 - no cleanup:                       no
 - pool directory:                   /var/lib/openqa/pool/1
[info] Project dir for host localhost is /var/lib/openqa/share
[info] Registering with openQA localhost
Mojo::Reactor::Poll: Timer failed: Invalid characters in X-API-Key header at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Headers.pm line 38.
        Mojo::Headers::add(Mojo::Headers=HASH(0x559529339240), "X-API-Key", "[key1]\x{a}[key2]") called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Headers.pm line 91
        Mojo::Headers::header(Mojo::Headers=HASH(0x559529339240), "X-API-Key", "[key1]\x{a}[key2]") called at /usr/share/openqa/script/../lib/OpenQA/UserAgent.pm line 74
        OpenQA::UserAgent::_add_auth_headers(OpenQA::Client=HASH(0x559529334118), OpenQA::Client=HASH(0x559529334118), Mojo::Transaction::HTTP=HASH(0x559529334d60)) called at /usr/share/openqa/script/../lib/OpenQA/UserAgent.pm line 50
        OpenQA::UserAgent::__ANON__(OpenQA::Client=HASH(0x559529334118), Mojo::Transaction::HTTP=HASH(0x559529334d60)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/EventEmitter.pm line 15
        Mojo::EventEmitter::emit(OpenQA::Client=HASH(0x559529334118), "start", Mojo::Transaction::HTTP=HASH(0x559529334d60)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/UserAgent.pm line 324
        Mojo::UserAgent::_start(OpenQA::Client=HASH(0x559529334118), Mojo::IOLoop=HASH(0x5595293394f8), Mojo::Transaction::HTTP=HASH(0x559529334d60), CODE(0x559529339540)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/UserAgent.pm line 66
        Mojo::UserAgent::start(OpenQA::Client=HASH(0x559529334118), Mojo::Transaction::HTTP=HASH(0x559529334d60), undef) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/UserAgent.pm line 38
        Mojo::UserAgent::post(OpenQA::Client=HASH(0x559529334118), Mojo::URL=HASH(0x5595262a3958), "json", HASH(0x559529334718)) called at /usr/share/openqa/script/../lib/OpenQA/Worker/WebUIConnection.pm line 92
        OpenQA::Worker::WebUIConnection::register(OpenQA::Worker::WebUIConnection=HASH(0x5595293203b8)) called at /usr/share/openqa/script/../lib/OpenQA/Worker.pm line 345
        OpenQA::Worker::__ANON__(Mojo::IOLoop=HASH(0x5595279753e8)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/IOLoop.pm line 72
        Mojo::IOLoop::__ANON__(Mojo::Reactor::Poll=HASH(0x559526447888)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 129
        Mojo::Reactor::Poll::_next(Mojo::Reactor::Poll=HASH(0x559526447888)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 141
        eval {...} called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 141
        Mojo::Reactor::Poll::_try(Mojo::Reactor::Poll=HASH(0x559526447888), "Timer", CODE(0x559527974668)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 83
        Mojo::Reactor::Poll::one_tick(Mojo::Reactor::Poll=HASH(0x559526447888)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 101
        Mojo::Reactor::Poll::start(Mojo::Reactor::Poll=HASH(0x559526447888)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/IOLoop.pm line 134
        Mojo::IOLoop::start(Mojo::IOLoop=HASH(0x5595279753e8)) called at /usr/share/openqa/script/../lib/OpenQA/Worker.pm line 364
        OpenQA::Worker::exec(OpenQA::Worker=HASH(0x55952931ad78)) called at /usr/share/openqa/script/worker line 125
 at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/IOLoop.pm line 22.
        Mojo::IOLoop::__ANON__(Mojo::Reactor::Poll=HASH(0x559526447888), "Timer failed: Invalid characters in X-API-Key header at /usr/"...) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/EventEmitter.pm line 15
        Mojo::EventEmitter::emit(Mojo::Reactor::Poll=HASH(0x559526447888), "error", "Timer failed: Invalid characters in X-API-Key header at /usr/"...) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 141
        Mojo::Reactor::Poll::_try(Mojo::Reactor::Poll=HASH(0x559526447888), "Timer", CODE(0x559527974668)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 83
        Mojo::Reactor::Poll::one_tick(Mojo::Reactor::Poll=HASH(0x559526447888)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/Reactor/Poll.pm line 101
        Mojo::Reactor::Poll::start(Mojo::Reactor::Poll=HASH(0x559526447888)) called at /usr/lib/perl5/vendor_perl/5.38.0/Mojo/IOLoop.pm line 134
        Mojo::IOLoop::start(Mojo::IOLoop=HASH(0x5595279753e8)) called at /usr/share/openqa/script/../lib/OpenQA/Worker.pm line 364
        OpenQA::Worker::exec(OpenQA::Worker=HASH(0x55952931ad78)) called at /usr/share/openqa/script/worker line 125
[error] Stopping because a critical error occurred.
[error] Another error occurred when trying to stop gracefully due to an error
[error] Trying to kill ourself forcefully now
+ '[' 0 -ne 0 ']'
# [...]
```