### PR TITLE
Apply memory limit for openqa-worker services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ install-generic:
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system-generators
 	install -d -m 755 "$(DESTDIR)"/usr/lib/tmpfiles.d
-	for i in systemd/*.{service,target,timer,path}; do \
+	for i in systemd/*.{service,slice,target,timer,path}; do \
 		install -m 644 $$i "$(DESTDIR)"/usr/lib/systemd/system ;\
 	done
 	ln -s openqa-worker-plain@.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-worker@.service

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -693,6 +693,7 @@ fi
 %dir %{_unitdir}
 %{_systemdgeneratordir}
 %{_unitdir}/openqa-worker.target
+%{_unitdir}/openqa-worker.slice
 %{_unitdir}/openqa-worker@.service
 %{_unitdir}/openqa-worker-plain@.service
 %{_unitdir}/openqa-worker-cacheservice-minion.service

--- a/systemd/openqa-worker.slice
+++ b/systemd/openqa-worker.slice
@@ -1,0 +1,7 @@
+[Unit]
+Description=Slice for openqa-worker units
+
+[Slice]
+# Apply memory limit to this slice to ensure that memory cannot be exhausted
+# exclusively by openqa-worker services.
+MemoryMax=90%


### PR DESCRIPTION
All workers are already part of openqa-worker.slice, apply memory limit to that slice to ensure that memory cannot be exhausted exclusively by workers.

Reference: https://progress.opensuse.org/issues/133511