### PR TITLE
spec: Use PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -361,6 +361,8 @@ export OPENQA_TEST_TIMEOUT_SCALE_CI=10
 # packaging
 export CONTAINER_TEST=0
 export HELM_TEST=0
+# We don't want fatal warnings during package building
+export PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS=1
 make test PROVE_ARGS='-r -v' CHECKSTYLE=0 TEST_PG_PATH=%{buildroot}/DB
 rm -rf %{buildroot}/DB
 %endif


### PR DESCRIPTION
This way warnings won't make our builds and PRs fail.

Issue: https://progress.opensuse.org/issues/137105