### PR TITLE
ci: Use PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS

### DIFF
--- a/tools/ci/run_unit_tests.sh
+++ b/tools/ci/run_unit_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 target="${1:?"Specify a makefile target"}"
+# Set to 1 to temporarily ignore warnings
+export PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS=0
 export COVERAGE=1
 export COVERDB_SUFFIX="_${target}"
 # Enable JUnit-compatible test results


### PR DESCRIPTION
Set to 0 so by default we get fatal warnings.

This makes it easy to quickly set the variable in the workflow settings when necessary.

Issue: https://progress.opensuse.org/issues/137105