### PR TITLE
Update all container references to current Leap 15.5

### DIFF
--- a/container/helm/charts/webui/values.yaml
+++ b/container/helm/charts/webui/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.4/openqa_webui
+  name: registry.opensuse.org/devel/openqa/containers15.5/openqa_webui
   pullPolicy: Always
   tag: "latest"
 

--- a/container/helm/charts/worker/values.yaml
+++ b/container/helm/charts/worker/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.4/openqa_worker
+  name: registry.opensuse.org/devel/openqa/containers15.5/openqa_worker
   pullPolicy: Always
   tag: "latest"
 

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -55,14 +55,14 @@ container engine:
 
 [source,sh]
 ----
-podman run -p 1080:80 -p 1443:443 --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest
+podman run -p 1080:80 -p 1443:443 --rm -it registry.opensuse.org/devel/openqa/containers15.5/openqa_webui:latest
 ----
 
 The worker container can be pulled and started with:
 
 [source,sh]
 ----
-podman run --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_worker:latest
+podman run --rm -it registry.opensuse.org/devel/openqa/containers15.5/openqa_worker:latest
 ----
 
 === Custom configuration for containers
@@ -81,7 +81,7 @@ podman run -p 1080:80 -p 1443:443 \
   -v ./container/webui/test-key.pem:/etc/apache2/ssl.key/server.key:z \
   -v ./container/webui/test-cert.pem:/etc/apache2/ssl.crt/ca.crt:z \
   -v ./container/webui/conf/openqa.ini:/data/conf/openqa.ini:z \
-  --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest
+  --rm -it registry.opensuse.org/devel/openqa/containers15.5/openqa_webui:latest
 ----
 
 
@@ -93,7 +93,7 @@ supply `workers.ini` and `client.conf`:
 podman run \
   -v ./container/worker/conf/workers.ini:/data/conf/workers.ini:z \
   -v ./container/worker/conf/client.conf:/data/conf/client.conf:z \
-  --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_worker:latest
+  --rm -it registry.opensuse.org/devel/openqa/containers15.5/openqa_worker:latest
 ----
 
 This examples assume the working directory is an openQA checkout. To avoid doing
@@ -113,7 +113,7 @@ commands mentioned there can also be invoked within a container, e.g.:
 [source,sh]
 ----
 podman run \
-   --rm -it registry.opensuse.org/devel/openqa/containers15.4/openqa_webui:latest \
+   --rm -it registry.opensuse.org/devel/openqa/containers15.5/openqa_webui:latest \
    openqa-cli --help
 ----
 


### PR DESCRIPTION
After we already switched bases for building and CI to a more recent
version long ago we now switch all remaining references before Leap 15.4
goes EOL.

Related progress issue: https://progress.opensuse.org/issues/130597