### PR TITLE
Add repeat parameter to clone a job multiple times

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1113,6 +1113,25 @@ timeouts by performing the task in background.
 This is recommended on big instances but means that the results (and
 possible errors) need to be polled via `openqa-cli api isos/$scheduled_product_id`.
 
+
+===== Statistical investigation ===== 
+In case issues appear sporadically and are therefore hard to reproduce it can 
+help to trigger many more jobs on a production instance to gather more data 
+first, for example the failure ratio.
+
+Example of triggering 50 jobs in a development group so that the result of 
+passed/failed jobs is counted by openQA itself on the corresponding overview page:
+[source,sh]
+--------------------------------------------------------------------------------
+openqa-clone-job --skip-chained-deps --repeat=50 --within-instance \
+https://openqa.opensuse.org 123456  BUILD=poo32242_investigation \
+_GROUP="Test Development:openSUSE Tumbleweed" 
+--------------------------------------------------------------------------------
+
+To get an overview about the fail ratio and confidence interval of sporadically 
+failing applications you can also use a script like 
+https://github.com/okurz/scripts/blob/master/count_fail_ratio[this].
+
 [id="scenarios_yaml"]
 ===== Defining test scenarios in YAML =====
 Instead of relying on the tables for machines, mediums/products, test suites and

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -133,6 +133,17 @@ are cloned. Use C<0> to denote infinity.
 A shortcut for C<--skip-download --from HOST --host HOST> to clone a job within
 a local or remote instance.
 
+=item B<--repeat> N
+
+Do the same clone operation N times; this can be useful for Statistical 
+investigation. Example: 
+
+openqa-clone-job --skip-chained-deps --repeat=50 --within-instance \
+https://openqa.opensuse.org 123456 
+
+Will create 50 clones of the same job.
+
+
 =item B<--show-progress>
 
 Displays a progress bar when downloading assets.
@@ -175,6 +186,7 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 use OpenQA::Script::CloneJob;
 use OpenQA::Utils 'assetdir';
+use Scalar::Util qw(looks_like_number);
 
 my %options;
 my $jobid;
@@ -190,7 +202,7 @@ sub parse_options () {
         "apikey:s", "apisecret:s", "verbose|v", "json-output|j",
         "skip-deps", "skip-chained-deps", "skip-download", "parental-inheritance",
         "help|h", "show-progress", "within-instance|w=s", "clone-children",
-        "max-depth:i", "ignore-missing-assets", "export-command",
+        "max-depth:i", "repeat|r:i", "ignore-missing-assets", "export-command",
     ) or usage(1);
     usage(0) if $options{help};
     usage(1) if $options{help} || ($options{'within-instance'} && $options{from});
@@ -207,6 +219,8 @@ sub parse_options () {
     die "missing job reference, see --help for usage\n" unless $jobid;
     ($options{'from'}, $jobid) = split_jobid($jobid) unless $options{'from'};
     usage(1) unless ($jobid && $options{'from'});
+    my $repeat = $options{'repeat'} //= 1;
+    die "invalid repeat count, should be greater than or equal to 1\n" if !looks_like_number($repeat) || $repeat < 1;
     $options{'dir'} ||= assetdir();
     $options{'host'} ||= 'localhost';
     $options{'args'} = \@ARGV;


### PR DESCRIPTION
Reference ticket: https://progress.opensuse.org/issues/122953 

to better support statistical investigation, we want to provide an
immediate way to clone a job multiple times. Till now it has been done
with a for loop similar to

```
for i in {01..50}; do openqa-clone-job … TEST+=-$i; done
```

But we can avoid the API overhead of copying the same parameters and
assets again and again from the original job, simply by cloning it once and
posting the new job(s) N times. The TEST name is automatically numbered, so the
user is not forced to remember any shell syntax.

As the default is `--repeat=1`, the API remains compatible with any shell
script using the `openqa-clone-job` program.