### PR TITLE
Add Fedora SIGs gitlab group to bugrefs

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -52,6 +52,7 @@ BEGIN {
         jsc => 'https://jira.suse.de/browse/',
         pio => 'https://pagure.io/',
         ggo => 'https://gitlab.gnome.org/',
+        gfs => 'https://gitlab.com/fedora/sigs/',
     );
     %BUGURLS = (
         'https://bugzilla.novell.com/show_bug.cgi?id=' => 'bsc',
@@ -68,6 +69,7 @@ BEGIN {
         $BUGREFS{jsc} => 'jsc',
         $BUGREFS{pio} => 'pio',
         $BUGREFS{ggo} => 'ggo',
+        $BUGREFS{gfs} => 'gfs',
     );
 
     $MARKER_REFS = join('|', keys %BUGREFS);

--- a/t/16-markdown.t
+++ b/t/16-markdown.t
@@ -147,6 +147,9 @@ subtest 'bugrefs to markdown' => sub {
       'right markdown';
     is bugref_to_markdown('ggo#GNOME/foo#1234'),
       '[ggo#GNOME/foo#1234](https://gitlab.gnome.org/GNOME/foo/issues/1234)', 'right markdown';
+    is bugref_to_markdown('gfs#flatpak/fedora-flatpaks#26'),
+      '[gfs#flatpak/fedora-flatpaks#26](https://gitlab.com/fedora/sigs/flatpak/fedora-flatpaks/issues/26)',
+      'right markdown';
     is bugref_to_markdown("boo#9876\n\ntest boo#211\n"),
       "[boo#9876](https://bugzilla.opensuse.org/show_bug.cgi?id=9876)\n\n"
       . "test [boo#211](https://bugzilla.opensuse.org/show_bug.cgi?id=211)\n",

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -131,6 +131,9 @@ is href_to_bugref('https://pagure.io/foo/issue/1234'), 'pio#foo#1234', 'pagure.i
 is href_to_bugref('https://pagure.io/foo/bar/issue/1234'), 'pio#foo/bar#1234', 'pagure.io (with group) url to bugref';
 is href_to_bugref('https://gitlab.gnome.org/GNOME/foo/-/issues/1234'), 'ggo#GNOME/foo#1234',
   'GNOME gitlab url to bugref';
+is href_to_bugref('https://gitlab.com/fedora/sigs/flatpak/fedora-flatpaks/-/issues/26'),
+  'gfs#flatpak/fedora-flatpaks#26',
+  'Fedora SIGs gitlab url to bugref';
 is find_bug_number('yast_roleconf-ntp-servers-empty-bsc1114818-20181115.png'), 'bsc1114818',
   'find the bug number from the needle name';
 


### PR DESCRIPTION
There's a repo under here we need to reference for Fedora flatpak issues (the URL used in the tests is a real one we need to ref).