### PR TITLE
Remove redundant handling of test database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ test-fullstack-unstable:
 # only works with one and Fedora's build system only works with the other
 .PHONY: test-with-database
 test-with-database:
-	test -d $(TEST_PG_PATH) && (pg_ctl -D $(TEST_PG_PATH) -s status >&/dev/null || pg_ctl -D $(TEST_PG_PATH) -s start) || ./t/test_postgresql $(TEST_PG_PATH)
+	./t/test_postgresql $(TEST_PG_PATH)
 	$(MAKE) test-unit-and-integration TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)"
 	-[ $(KEEP_DB) = 1 ] || pg_ctl -D $(TEST_PG_PATH) stop
 

--- a/t/test_postgresql
+++ b/t/test_postgresql
@@ -1,16 +1,20 @@
 #!/bin/sh -e
 
+KEEP_DB="${KEEP_DB:-0}"
 DIR=$1
 if test -z "$DIR"; then
     DIR=$(mktemp -d)
 else
     DIR=$(readlink -f "$DIR")
-fi
-if test -e "$DIR"/postmaster.pid; then
-  pg_ctl -D "$DIR" stop
-fi
-if test -d "$DIR"; then
-  rm -r "$DIR"
+    if test "$KEEP_DB" = "0"; then
+        if test -d "$DIR"; then
+            test -e "$DIR"/postmaster.pid && pg_ctl -D "$DIR" stop
+            rm -r "$DIR"
+        fi
+    else
+        echo "Re-using existing database in $DIR because KEEP_DB is set to 1."
+        exit 0
+    fi
 fi
 initdb --auth-local=peer -N "$DIR" -U "$(id -u -n)"
 (echo "listen_addresses=''"


### PR DESCRIPTION
The makefile should take advantage of what the script does without duplicating the logic.