### PR TITLE
Warn when modifying files under external directly

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -5,5 +5,5 @@ paths:
     - Consider providing screenshots in a PR comment to show the difference visually
   "docs/*.asciidoc":
     - Consider generating documentation locally to verify it is rendered correctly using `tools/generate-htmldoc`
-  "external":
+  "external/**":
     - Consider doing this change in the upstream repository directly, see external/os-autoinst-common/README.md


### PR DESCRIPTION
This is hopefully fixing it; apparently you can't just give it a directory name