### PR TITLE
Fix skipping Selenium tests

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -352,9 +352,7 @@ sub get_mojoport () { $mojoport }
 # uncoverable subroutine
 # uncoverable statement
 sub driver_missing () {
-    diag 'Install Selenium::Remote::Driver and Selenium::Chrome to run these tests';    # uncoverable statement
-    done_testing;    # uncoverable statement
-    exit;    # uncoverable statement
+    plan skip_all => 'Install Selenium::Remote::Driver and Selenium::Chrome to run these tests'; # uncoverable statement
 }
 
 END {

--- a/t/ui/27-plugin_obs_rsync_status_details.t
+++ b/t/ui/27-plugin_obs_rsync_status_details.t
@@ -11,8 +11,9 @@ use OpenQA::Test::TimeLimit '60';
 use OpenQA::SeleniumTest;
 use OpenQA::Test::ObsRsync 'setup_obs_rsync_test';
 
+driver_missing unless check_driver_modules;
 my ($t, $tempdir) = setup_obs_rsync_test(fixtures_glob => '01-jobs.pl 03-users.pl');
-driver_missing unless my $driver = call_driver();
+my $driver = call_driver();
 $driver->find_element_by_class('navbar-brand')->click;
 $driver->find_element_by_link_text('Login')->click;
 


### PR DESCRIPTION
Not sure what changed, but on current Fedora Rawhide, just 'exit'ing like this now results in a 255 exit code and a failed test. Before:

 Install Selenium::Remote::Driver and Selenium::Chrome to run these tests
./t/ui/27-plugin_obs_rsync_status_details.t ................. ok
 Install Selenium::Remote::Driver and Selenium::Chrome to run these tests
./t/ui/28-keys_to_render_as_links.t ......................... ok All tests successful.

after:

 Install Selenium::Remote::Driver and Selenium::Chrome to run these tests
./t/ui/27-plugin_obs_rsync_status_details.t ................. ok
 Install Selenium::Remote::Driver and Selenium::Chrome to run these tests
./t/ui/28-keys_to_render_as_links.t ......................... skipped: (no reason given) ...
./t/ui/28-keys_to_render_as_links.t                       (Wstat: 65280 (exited 255) Tests: 0 Failed: 0)
  Non-zero exit status: 255

This uses `plan skip_all` to skip these tests correctly. We also have to reorder one test slightly so we skip before running any tests.