### PR TITLE
munin: Include context in minion plugin title

### DIFF
--- a/contrib/munin/config/minion.config
+++ b/contrib/munin/config/minion.config
@@ -1,6 +1,7 @@
 # Put this into /etc/munin/plugin-conf.d/munin-node/openqa-minion
 [openqa_minion_*]
 #env.url https://openqa.opensuse.org/admin/influxdb/minion
+#env.webui https://openqa.opensuse.org
 #env.minion_jobs_failed_warning 400
 #env.minion_jobs_failed_critical 500
 #env.minion_jobs_hook_rc_failed_warning 5

--- a/contrib/munin/plugins/minion
+++ b/contrib/munin/plugins/minion
@@ -9,6 +9,7 @@ use v5.22;
 #
 #   [openqa_minion_*]
 #   env.url https://openqa.opensuse.org/admin/influxdb/minion
+#   env.webui https://openqa.opensuse.org
 #   # optional
 #   env.minion_jobs_failed_warning 400
 #   env.minion_jobs_failed_critical 500
@@ -25,17 +26,17 @@ use v5.22;
 my %config = (
     minion_jobs => {
         states => [qw/ active delayed failed inactive /],
-        title => "Minion Jobs",
+        title => "Minion Jobs - see " . ($ENV{webui} // "https://openqa.opensuse.org") . "/minion/jobs?state=failed",
         warning => { failed => $ENV{minion_jobs_failed_warning} // 400 },
         critical => { failed => $ENV{minion_jobs_failed_critical} // 500 },
     },
     minion_workers => {
         states => [qw/ active inactive registered /],
-        title => "Minion Workers",
+        title => "Minion Workers - see " . ($ENV{webui} // "https://openqa.opensuse.org") . "/minion/workers",
     },
     minion_jobs_hook_rc_failed => {
         states => [qw/ rc_failed_per_5min /],
-        title => "hook failed",
+        title => "hook failed - see openqa-gru service logs for details",
         warning => { rc_failed_per_5min => $ENV{minion_jobs_hook_rc_failed_warning} // 0.5 },
         critical => { rc_failed_per_5min => $ENV{minion_jobs_hook_rc_failed_critical} // 2 },
     },

--- a/t/46-munin.t
+++ b/t/46-munin.t
@@ -59,7 +59,7 @@ EOM
         main::main();
     };
     my $exp_minion_jobs_hook_rc_failed_config = <<'EOM';
-graph_title hook failed
+graph_title hook failed - see openqa-gru service logs for details
 graph_args --base 1000 -l 0
 graph_category minion
 graph_order rc_failed_per_5min


### PR DESCRIPTION
We can disambiguate what aspect of the minion setup the failure stems from.

See: https://progress.opensuse.org/issues/138545