### PR TITLE
Display the correct failing host on worker boot

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -157,6 +157,11 @@ sub _setup_websocket_connection ($self, $websocket_url = undef) {
 
                 my $error = $tx->error;
                 my $error_message = "Unable to upgrade to ws connection via $websocket_url";
+
+                if ($tx->res->error && $tx->res->error->{message}) {
+                    $error_message .= sprintf(", %s in %s", $tx->res->error->{message}, $tx->req->url);
+                }
+
                 $error_message .= ", code $error->{code}" if ($error && $error->{code});
                 $self->_set_status(failed => {error_message => $error_message});
                 return undef;


### PR DESCRIPTION
When a worker cannot establish a websocket connection the log line reports the URL of the REST API, and not the websocket endpoint where the connection failed.

Old output:
```
[info] Registering with openQA 127.0.0.1:9526
[info] Establishing ws connection via ws://127.0.0.1:9526/api/v1/ws/1
[warn] Unable to upgrade to ws connection via http://127.0.0.1:9526/api/v1/ws/1 - trying again in 10 seconds
```

New output:
```
[info] Registering with openQA 127.0.0.1:9526
[info] Establishing ws connection via ws://127.0.0.1:9526/api/v1/ws/1
[warn] Unable to upgrade to ws connection via http://127.0.0.1:9526/api/v1/ws/1, Connection refused in http://localhost:9527/ws/1 - trying again in 10 seconds
```

Notice the addition of the network error & the final request url where the failre happened.