### PR TITLE
Sync AMQP plugin config defaults with code

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -158,13 +158,17 @@ blocklist = job_grab job_done
 
 ## Configuration for AMQP plugin
 [amqp]
-#heartbeat_timeout = 60
 #reconnect_timeout = 5
 #publish_attempts = 10
+#publish_retry_delay = 1
+#publish_retry_delay_factor = 1.75
 # guest/guest is the default anonymous user/pass for RabbitMQ
 #url = amqp://guest:guest@localhost:5672/
 #exchange = pubsub
 #topic_prefix = suse
+#cacertfile =
+#certfile =
+#keyfile =
 
 # Cleanup related configuration (besides limits)
 [cleanup]


### PR DESCRIPTION
In particular there is no use of a heartbeat_timeout in code and there's a few missing keys.