### PR TITLE
Make openqa-cli retry also on connection errors

### DIFF
--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -124,7 +124,7 @@ sub retry_tx ($self, $client, $tx, $retries = undef, $delay = undef) {
     for (;; --$retries) {
         $tx = $client->start($tx);
         my $res_code = $tx->res->code // 0;
-        return $self->handle_result($tx) unless $res_code =~ /50[23]/ && $retries > 0;
+        return $self->handle_result($tx) unless $res_code =~ /^(50[23]|0)$/ && $retries > 0;
         print encode('UTF-8',
             "Request failed, hit error $res_code, retrying up to $retries more times after waiting …\n");
         sleep $delay;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -451,6 +451,11 @@ EOF
 
     ($stdout, $stderr, @result) = capture sub { $api->run('--retries', '1', @params) };
     like $stdout, qr/failed.*retrying/, 'requests are retried on error if requested';
+
+    @params = ('--host', 'http://localhost:123456', '--retries', 1, 'api', 'test');
+    ($stdout, $stderr, @result) = capture sub { $api->run(@params) };
+    like $stderr, qr/Connection refused/, 'aborts on connection refused';
+    like $stdout, qr/failed.*retrying/, 'requests are retried on error if requested';
 };
 
 subtest 'Pretty print JSON' => sub {


### PR DESCRIPTION
There may be temporary network problems or an overloaded webui. In those cases we also want to retry.

Issue: https://progress.opensuse.org/issues/138545