### PR TITLE
Add support for SSH Authentication to ObsRsync Plugin

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -175,6 +175,7 @@ test_requires:
   '%main_requires':
   '%python_scripts_requires':
   '%worker_requires':
+  openssh-common:
   curl:
   jq:
   ShellCheck:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -64,7 +64,7 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq openssh-common os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else
@@ -199,6 +199,8 @@ Recommends:     qemu
 Recommends:     rsync
 # Optionally enabled with USE_PNGQUANT=1
 Recommends:     pngquant
+# for Build Service Authentication
+Recommends:     openssh-common
 %if 0%{?suse_version} >= 1330
 Requires(pre):  group(nogroup)
 %endif

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -296,3 +296,14 @@ concurrent = 0
 # lookup_depth = 10
 # Specify at how many state changes the search will be aborted (state = combination of failed/softfailed/skipped modules):
 # state_changes_limit = 3
+
+# Configuration for the OBS rsync plugin
+[obs_rsync]
+# project_status_url = %obs_instance%/build/%%PROJECT/_result;
+# concurrency = 2
+# queue_limit = 200
+# retry_interval = 60
+# retry_max_count = 2
+# home =
+# username = openqa-user
+# ssh_key_file = ~/.ssh/id_rsa

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -132,6 +132,8 @@ sub read_config ($app) {
             queue_limit => 200,
             concurrency => 2,
             project_status_url => '',
+            username => '',
+            ssh_key_file => ''
         },
         cleanup => {
             concurrent => 0,

--- a/t/config.t
+++ b/t/config.t
@@ -115,6 +115,8 @@ subtest 'Test configuration default modes' => sub {
             queue_limit => 200,
             concurrency => 2,
             project_status_url => '',
+            username => '',
+            ssh_key_file => '',
         },
         cleanup => {
             concurrent => 0,

--- a/tools/ci/ci-packages.txt
+++ b/tools/ci/ci-packages.txt
@@ -58,6 +58,7 @@ libXt6-1.1.5
 libXvnc1-1.12.0
 lsof-4.91
 luit-20150706
+openssh-common-8.4p1
 optipng-0.7.7
 pciutils-3.5.6
 perl-Algorithm-C3-0.11


### PR DESCRIPTION
ObsRsync Plugin now supports the new authentication mechanism of Build Service.

Heavily inspired by:
- https://github.com/openSUSE/obs-build/blob/master/PBuild/SigAuth.pm
- https://github.com/openSUSE/cavil/commit/583009d5476961557802c72250128cc2062c14b2
- https://www.suse.com/c/multi-factor-authentication-on-suses-build-service/

Addresses [poo#139073](https://progress.opensuse.org/issues/139073)

---

**Important:** The production `openqa.ini` config must be updated. `obs_rsync.project_status_url` must not include `/public/`.