### PR TITLE
Fix force-restarting jobs when an advanced restarting option was chosen

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -213,10 +213,22 @@ function showJobRestartResults(responseJSON, newJobUrl, retryFunction, targetEle
   return true;
 }
 
-function forceJobRestartViaRestartLink(restartLink) {
-  if (!restartLink.href.endsWith('?force=1')) {
-    restartLink.href += '?force=1';
+function addParam(path, key, value) {
+  const paramsStart = path.indexOf('?');
+  let params;
+  if (paramsStart === -1) {
+    params = new URLSearchParams();
+    path = path + '?';
+  } else {
+    params = new URLSearchParams(path.substr(paramsStart + 1));
+    path = path.substr(0, paramsStart + 1);
   }
+  params.set(key, value);
+  return path + params.toString();
+}
+
+function forceJobRestartViaRestartLink(restartLink) {
+  restartLink.href = addParam(restartLink.href, 'force', '1');
   restartLink.click();
 }
 
@@ -242,7 +254,13 @@ function restartJob(ajaxUrl, jobId) {
       } catch {
         // Intentionally ignore all errors
       }
-      if (showJobRestartResults(responseJSON, newJobUrl, restartJob.bind(undefined, ajaxUrl + '?force=1', jobId))) {
+      if (
+        showJobRestartResults(
+          responseJSON,
+          newJobUrl,
+          restartJob.bind(undefined, addParam(ajaxUrl, 'force', '1'), jobId)
+        )
+      ) {
         return;
       }
       if (newJobUrl) {

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -488,7 +488,7 @@ function setupTestButtons() {
 function setupResultButtons() {
   $('.restart-result').click(function (event) {
     event.preventDefault();
-    restartJob($(this).attr('href'), $(this).data('jobid'));
+    restartJob(this.href, this.dataset.jobid);
     // prevent posting twice by clicking #restart-result
     return false;
   });

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -146,6 +146,11 @@ subtest 'restart job from info panel in test results' => sub {
             expected_job_id_regex(2),
             'warning with link to new job appears'
         );
+
+        my $test = "return addParam('/api/v1/jobs/123/restart?skip_ok_result_children=1', 'force', '1')";
+        my $path = $driver->execute_script($test);
+        is $path, '/api/v1/jobs/123/restart?skip_ok_result_children=1&force=1',
+          'advanced restarting parameter preserved when adding force parameter';
     };
     subtest 'successful restart' => sub {
         is($driver->get('/tests/99946'), 1, 'go to job 99946');


### PR DESCRIPTION
Appending the force-parameter doesn't work that easily when the URL already contains other parameters. So we need to take that case into account when adding the force-parameter.
    
I made this fix in the context of working on https://progress.opensuse.org/issues/150917.