### PR TITLE
Do not associate skipped child jobs with new parent when restarting jobs

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -643,6 +643,7 @@ sub _create_clone_with_parent ($res, $clones, $p, $dependency) {
 }
 
 sub _create_clone_with_child ($res, $clones, $c, $dependency) {
+    return undef unless exists $clones->{$c};
     $c = $clones->{$c}->id if defined $clones->{$c};
     $res->children->find_or_create({child_job_id => $c, dependency => $dependency});
 }

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -843,7 +843,7 @@ subtest 'clone chained child with siblings; then clone chained parent' =>
     #   |- C
     #   \- D
 
-    # B failed, auto clone it
+    # auto duplicate the incomplete job B
     my $jobBc = $jobB->auto_duplicate({dup_type_auto => 1});
     ok($jobBc, 'jobB duplicated');
 


### PR DESCRIPTION
See https://progress.opensuse.org/issues/150917