### PR TITLE
Prevent label/flag/bugref overlapping

### DIFF
--- a/assets/stylesheets/comments.scss
+++ b/assets/stylesheets/comments.scss
@@ -55,6 +55,10 @@
         white-space: nowrap;
     }
 
+    *>.openqa-bugref, *>.openqa-label, *>.openqa-flag {
+        line-height: 2.05;
+    }
+
     .openqa-bugref {
         background-color: #eee;
         color: #666666;


### PR DESCRIPTION
Before:
![image](https://github.com/os-autoinst/openQA/assets/725608/b506eab5-fa47-475e-af09-a257f62326fe)

After:
![image](https://github.com/os-autoinst/openQA/assets/725608/9e3ebfaf-00ff-4cdc-a689-4fc784ff2e2f)
