### PR TITLE
Set asset size on job creation

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -255,7 +255,8 @@ sub _schedule_iso {
     for my $asset (values %{parse_assets_from_settings($args)}) {
         my ($name, $type) = ($asset->{name}, $asset->{type});
         return {error => 'Asset type and name must not be empty.'} unless $name && $type;
-        return {error => "Failed to register asset $name."} unless $assets->register($type, $name, {missing_ok => 1});
+        return {error => "Failed to register asset $name."}
+          unless $assets->register($type, $name, {missing_ok => 1, refresh_size => 1});
     }
 
     # read arguments for deprioritization and obsoleten

--- a/t/data/openqa/share/factory/iso/dvdsize42.iso
+++ b/t/data/openqa/share/factory/iso/dvdsize42.iso
@@ -1,0 +1,1 @@
+this asset file is exactly 42 bytes long!


### PR DESCRIPTION
Assets without a size are treated like they don't exist. With POST isos, referenced assets don't directly get a size and are thus not shown as downloadable. Only the next limit_assets task run changes this by running refresh_assets. Improve this by setting the size for assets on job creation.

- [ ] Is this the right place? What about e.g. `ISO_1_URL`?
- [ ] Is it cheap enough to do `refresh_size` here or should this end up as `ensure_size` instead?