### PR TITLE
Pass TMPDIR=1 to OBS Rsync authentication

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -537,7 +537,7 @@ sub _for_every_batch {
 sub _bs_ssh_sign ($key, $realm, $value) {
     die "SSH key file not found at $key" unless -s $key;
     # This needs to be a bit portable for CI testing
-    my $tmp = Mojo::File::tempfile('obs-rsync-ssh-keyfile-XXXXX')->spew($value);
+    my $tmp = Mojo::File::tempfile('obs-rsync-ssh-keyfile-XXXXX', TMPDIR => 1)->spew($value);
     my @lines = split "\n", qx/ssh-keygen -Y sign -f "$key" -q -n "$realm" < $tmp/;
     shift @lines;
     pop @lines;


### PR DESCRIPTION
- Mojo::tempfile will create a temporary file in the current working directory. Passing TMPDIR=1 forces the function to use the global temp folder instead.

Addresses: [poo#139073](https://progress.opensuse.org/issues/139073)