### PR TITLE
infopanel: render scenario_description as markdown

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -18,6 +18,7 @@ use OpenQA::Utils (
 use OpenQA::App;
 use OpenQA::Jobs::Constants;
 use OpenQA::JobDependencies::Constants;
+use OpenQA::Markdown 'markdown_to_html';
 use OpenQA::Setup;
 use OpenQA::ScreenshotDeletion;
 use File::Basename qw(basename dirname);
@@ -313,6 +314,11 @@ sub scenario_description ($self) {
     return $description if defined $description;
     my $scenario = $self->scenario or return undef;
     return $scenario->description;
+}
+
+sub rendered_scenario_description ($self) {
+    return undef unless my $desc = $self->scenario_description;
+    return Mojo::ByteStream->new(markdown_to_html($desc));
 }
 
 # return 0 if we have no worker

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -178,7 +178,7 @@
                         </span>
                     </div>
                 % }
-                % if (my $scenario_description = $job->scenario_description) {
+                % if (my $scenario_description = $job->rendered_scenario_description) {
                     <div id="scenario-description">
                             %= $scenario_description
                     </div>


### PR DESCRIPTION
I would like to have clickable links in the `JOB_DESCRIPTION`. With this, I could use the `JOB_DESCRIPTION` linking to a corresponding trigger source (e.g. a gitlab pipeline).