### PR TITLE
Show FQDN in VNC command if available via `WORKER_HOSTNAME`

### DIFF
--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -286,4 +286,10 @@ sub reschedule_assigned_jobs {
     }
 }
 
+sub vnc_argument ($self) {
+    my $hostname = $self->get_property('WORKER_HOSTNAME') // $self->host;
+    my $instance = $self->instance + 5990;
+    return "$hostname:$instance";
+}
+
 1;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -363,7 +363,7 @@ sub live ($self) {
     my $job = $self->_stash_job or return $self->reply->not_found;
     my $current_user = $self->current_user;
     my $worker = $job->worker;
-    my $worker_vnc = ($worker ? $worker->host . ':' . (5990 + $worker->instance) : undef);
+    my $worker_vnc = $worker ? $worker->vnc_argument : undef;
     $self->stash(
         {
             ws_developer_url => determine_web_ui_web_socket_url($job->id),

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -121,4 +121,12 @@ subtest 'tmpdir handling when assigning multiple jobs to a worker' => sub {
     ok !-d $tmpdir, 'previous tmpdir removed';
     path($worker->get_property('WORKER_TMPDIR'))->remove_tree;
 };
+
+subtest 'VNC argument' => sub {
+    my $worker = $workers->first;
+    is $worker->vnc_argument, 'remotehost:5991', 'host:instance returned';
+    $worker->set_property(WORKER_HOSTNAME => 'remotehost.foo.bar');
+    is $worker->vnc_argument, 'remotehost.foo.bar:5991', 'WORKER_HOSTNAME used if set';
+};
+
 done_testing();


### PR DESCRIPTION
The `WORKER_HOSTNAME` variable usually contains the worker host's FQDN so it makes sense to show it (instead of just the `host` column) in the VNC instruction.

Related ticket: https://progress.opensuse.org/issues/151576