### PR TITLE
Pass VNC argument for developer mode dynamically when test has started

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -506,10 +506,12 @@ var developerMode = {
     );
   },
 
-  // returns the specified property evaluating possibly assigned functions
-  prop: function (propertyName) {
-    var prop = this[propertyName];
-    return typeof prop === 'function' ? prop.apply(this) : prop;
+  // returns whether all specified properties/functions eveluate to true
+  allTrue: function (propertyNames) {
+    return propertyNames.split(',').every(propertyName => {
+      const prop = this[propertyName];
+      return typeof prop === 'function' ? prop.apply(this) : prop;
+    });
   }
 };
 
@@ -604,7 +606,7 @@ function updateDeveloperPanel() {
     var element = $(this);
     var visibleOn = element.data('visible-on');
     var hiddenOn = element.data('hidden-on');
-    var hide = (hiddenOn && developerMode.prop(hiddenOn)) || (visibleOn && !developerMode.prop(visibleOn));
+    var hide = (hiddenOn && developerMode.allTrue(hiddenOn)) || (visibleOn && !developerMode.allTrue(visibleOn));
     if (hide) {
       element.hide();
       element.tooltip('hide');
@@ -1180,6 +1182,17 @@ function processWsCommand(obj) {
           }
           break;
       }
+
+      // handle update of the VNC argument
+      const vncArg = data?.vnc_arg;
+      if (typeof vncArg === 'string' && vncArg !== developerMode.vncArg) {
+        developerMode.vncArg = vncArg;
+        somethingChanged = true;
+        Array.from(document.getElementsByClassName('vnc-arg')).forEach(e => {
+          e.textContent = vncArg;
+        });
+      }
+
       break;
   }
 

--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -47,29 +47,23 @@
 }
 
 #filter-panel, #developer-panel, #live-log-panel, #live-terminal-panel {
+    #developer-status span, .card-header-appendix span {
+        color: #555;
+        float: right;
+        font-weight: 500;
+    }
+    .card-header-appendix span {
+        text-align: right;
+        width: 100%;
+        display: inline-block;
+        font-weight: normal;
+    }
     .card-header {
         cursor: pointer;
-
-        span {
-            color: #555;
-            font-weight: 500;
-            float: right;
-        }
-        .row span {
-            text-align: right;
-            width: 100%;
-            display: inline-block;
-            float: none;
-        }
-    }
-    .card-header-appendix, .card-header-appendix span {
-        font-weight: normal;
-        float: none;
     }
     .card-body, .developer-mode-element {
         display: none;
     }
-
     #filter-form {
         strong {
             display: block;

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -287,7 +287,7 @@ sub reschedule_assigned_jobs {
 }
 
 sub vnc_argument ($self) {
-    my $hostname = $self->get_property('WORKER_HOSTNAME') // $self->host;
+    my $hostname = $self->get_property('WORKER_HOSTNAME') || $self->host;
     my $instance = $self->instance + 5990;
     return "$hostname:$instance";
 }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -371,7 +371,6 @@ sub live ($self) {
             developer_session => $job->developer_session,
             is_devel_mode_accessible => $current_user && $current_user->is_operator,
             current_user_id => $current_user ? $current_user->id : 'undefined',
-            worker_vnc => $worker_vnc,
         });
     $self->render('test/live');
 }

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -732,7 +732,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
             {
                 type => 'info',
                 what => 'connecting to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
-                data => undef,
+                data => {vnc_arg => 'remotehost.qa:5991'},
             });
         $t_livehandler->message_ok('another message received');
         $t_livehandler->json_message_is(
@@ -777,7 +777,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
             {
                 type => 'info',
                 what => 'connecting to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
-                data => undef,
+                data => {vnc_arg => 'remotehost.qa:5991'},
             });
         $t_livehandler->message_ok('another message received');
         $t_livehandler->json_message_is(
@@ -832,7 +832,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
             {
                 type => 'info',
                 what => 'connecting to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
-                data => undef,
+                data => {vnc_arg => 'remotehost.qa:5991'},
             });
         $t_livehandler->message_ok('another message received');
         $t_livehandler->json_message_is(
@@ -905,7 +905,7 @@ subtest 'websocket proxy (connection from client to live view handler not mocked
             {
                 type => 'info',
                 what => 'connecting to os-autoinst command server at ws://remotehost.qa:20013/token99961/ws',
-                data => undef,
+                data => {vnc_arg => 'remotehost.qa:5991'},
             });
         $t_livehandler->message_ok('another message received');
         $t_livehandler->json_message_is(

--- a/t/38-workers-table.t
+++ b/t/38-workers-table.t
@@ -124,6 +124,7 @@ subtest 'tmpdir handling when assigning multiple jobs to a worker' => sub {
 
 subtest 'VNC argument' => sub {
     my $worker = $workers->first;
+    $worker->set_property(WORKER_HOSTNAME => '');
     is $worker->vnc_argument, 'remotehost:5991', 'host:instance returned';
     $worker->set_property(WORKER_HOSTNAME => 'remotehost.foo.bar');
     is $worker->vnc_argument, 'remotehost.foo.bar:5991', 'WORKER_HOSTNAME used if set';

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -195,6 +195,10 @@ subtest 'state shown when connected' => sub {
     );
     element_hidden('#developer-panel .card-body');
 
+    # fake "connecting" message which contains VNC argument
+    my $connecting = '{\"type\":\"info\",\"what\":\"connecting\",\"data\":{\"vnc_arg\":\"remotehost:5991\"}}';
+    fake_message_from_ws_connection($connecting);
+
     # running, current module known
     fake_state(developerMode => {currentModule => '"installation-welcome"'});
     element_hidden('#developer-vnc-notice');

--- a/templates/webapi/test/live.html.ep
+++ b/templates/webapi/test/live.html.ep
@@ -44,11 +44,9 @@
         </div>
         <div class="row">
             <div class="col-sm-12" id="developer-flash-messages">
-                % if ($worker_vnc) {
-                    <div id="developer-vnc-notice" class="alert alert-secondary developer-mode-element" role="alert" data-visible-on="isPaused">
-                        You might be able to connect to the SUT at <%= $worker_vnc %> via VNC with shared mode enabled (eg. <code>vncviewer <%= $worker_vnc %> -Shared</code> for TigerVNC).
-                    </div>
-                % }
+                <div id="developer-vnc-notice" class="alert alert-secondary developer-mode-element" role="alert" data-visible-on="isPaused,vncArg">
+                    You might be able to connect to the SUT at <span class="vnc-arg">?</span> via VNC with shared mode enabled (eg. <code>vncviewer <span class="vnc-arg">?</span> -Shared</code> for TigerVNC).
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
* The `WORKER_HOSTNAME` variable is only available once the test is running
  and its value has been passed by the worker via a status update. To use
  it in the developer mode's VNC instructions we must pass the VNC argument
  dynamically once the web socket connection has been established.
  Otherwise one had to reload the page manually.
* See https://progress.opensuse.org/issues/151576