### PR TITLE
Simplify generation of documentation

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -4,6 +4,6 @@ paths:
   "assets/stylesheets/**":
     - Consider providing screenshots in a PR comment to show the difference visually
   "docs/*.asciidoc":
-    - Consider generating documentation locally to verify it is rendered correctly using `tools/generate-htmldoc`
+    - Consider generating documentation locally to verify it is rendered correctly using `tools/generate-docs`
   "external/**":
     - Consider doing this change in the upstream repository directly, see external/os-autoinst-common/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ node_modules
 package-lock.json
 .tidyall.d/
 openqa-documentation.html
+docs/build/
+

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ package-lock.json
 .tidyall.d/
 openqa-documentation.html
 docs/build/
-
+docs/vendor/

--- a/Makefile
+++ b/Makefile
@@ -350,3 +350,11 @@ test-helm-install:
 .PHONY: update-deps
 update-deps:
 	tools/update-deps --specfile dist/rpm/openQA.spec
+
+.PHONY: generate-docs
+generate-docs:
+	tools/generate-docs
+
+.PHONY: serve-docs
+serve-docs: generate-docs
+	(cd docs/build/; python3 -m http.server)

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'asciidoctor'
+gem 'pygments.rb'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    asciidoctor (2.0.20)
+    pygments.rb (2.4.1)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  asciidoctor
+  pygments.rb
+
+BUNDLED WITH
+   2.4.10

--- a/tools/generate-docs
+++ b/tools/generate-docs
@@ -8,10 +8,16 @@ if [[ ! -e ./build/images ]]; then
     ln -s ../images build/images
 fi
 
-export BUNDLE_PATH=./vendor/
+asciidoctor_bin=$(command -v asciidoctor) || true
 
-# Make sure dependencies exist
-bundle install
+if [[ -z "$asciidoctor_bin" ]]; then
+    echo "asciidoc not found in PATH."
+    echo "Fallback to Rubygem's Asciidoc"
+    export BUNDLE_PATH=./vendor/
+    # Make sure dependencies exist
+    bundle install
+    asciidoctor_bin="bundle exec asciidoctor"
+fi
 
 # Run asciidoc
-bundle exec asciidoctor -o build/index.html ./index.asciidoc -d book
+$asciidoctor_bin -o build/index.html ./index.asciidoc -d book

--- a/tools/generate-docs
+++ b/tools/generate-docs
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# Navigate to the docs directory
+cd $(git rev-parse --show-toplevel)/docs
+
+# Make sure dependencies exist
+bundle install
+
+# Run asciidoc
+bundle exec asciidoctor -o openqa-documentation.html ./index.asciidoc -d book
+
+# Create a symlink to images (in case it doesn't exist).
+test -e build/images || ln -s ../images build/images

--- a/tools/generate-docs
+++ b/tools/generate-docs
@@ -1,13 +1,17 @@
 #!/bin/bash -e
 
 # Navigate to the docs directory
-cd $(git rev-parse --show-toplevel)/docs
+cd "$(dirname "${BASH_SOURCE[0]}")/../docs"
+mkdir -p ./build/
+
+if [[ ! -e ./build/images ]]; then
+    ln -s ../images build/images
+fi
+
+export BUNDLE_PATH=./vendor/
 
 # Make sure dependencies exist
 bundle install
 
 # Run asciidoc
-bundle exec asciidoctor -o openqa-documentation.html ./index.asciidoc -d book
-
-# Create a symlink to images (in case it doesn't exist).
-test -e build/images || ln -s ../images build/images
+bundle exec asciidoctor -o build/index.html ./index.asciidoc -d book

--- a/tools/generate-htmldoc
+++ b/tools/generate-htmldoc
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-
-cre=${cre:-"podman"}
-$cre run -it --rm -v"$PWD"/:/openqa --workdir /openqa --env GEM_HOME=/home/squamata/.gem registry.opensuse.org/devel/openqa/ci/containers/base:latest tools/generate-htmldoc-in-container

--- a/tools/generate-htmldoc-in-container
+++ b/tools/generate-htmldoc-in-container
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-gem install asciidoctor pygments.rb
-
-asciidoctor_bin=$(command -v asciidoctor) || true
-[[ -n "$asciidoctor_bin" ]] || \
-    for asciidoctor_bin in "${GEM_HOME}"/bin/asciidoctor.ruby*; do :; done
-set -x
-"$asciidoctor_bin" -o openqa-documentation.html docs/index.asciidoc -d book


### PR DESCRIPTION
- Introducing two `Makefile` targets:
  * `generate-docs`: Installs all dependencies and compiles the docs.
  * `serve-docs`: Spins a local webserver to inspect the compiled docs.

~~Once this is merged it may be possible to delete ruby dependencies from the OpenQA Docker image :thinking:~~

The documentation cron does not depend on this script, it runs isolated in its own way to run directly asciidoctor.

As a first step, for developers this would suffice to easily build docs. In a follow-up the documentation publisher script could be improved.