### PR TITLE
Parse error messages from scheduling failures

### DIFF
--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -24,7 +24,7 @@ sub _create_jobs ($self, $client, $args, $param_file, $job_ids) {
         say $job_count == 1 ? '1 job has been created:' : "$job_count jobs have been created:";
         say ' - ' . $host_url->clone->path("tests/$_") for @$job_ids;
     }
-    return 0 unless my $error = $json->{error};
+    return 0 unless my $error = $json->{error} // join("\n", map { $_->{error_message} } @{$json->{failed}});
     print STDERR colored(['red'], $error, "\n");
     return 1;
 }


### PR DESCRIPTION
openqa-cli schedule will only fail if there is error key in the json
root. In our case, the error message is inside the failed job list. Make
openqa-cli fail on that as well.

Reference: https://progress.opensuse.org/issues/138203