### PR TITLE
Improve documentation of cache service related variables in config

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -5,12 +5,23 @@
 [global]
 # space separated list of webuis to connect to (empty defaults to localhost)
 #HOST = http://openqa.example.host
-# per webui you can define if you want to get the assets and tests over NFS
-# (define a SHARE_DIRECTORY, default /var/lib/openqa/share) or http/rsync.
-# For the later you need to define a cache directory that is big enough.
-# Additionally you need to define the rsync URI to get
-# /var/lib/openqa/tests/ (TESTPOOLSERVER) in the webui section
+
+# Specify a cache directory for assets and tests to sync them automatically via
+# http/rsync; the specified path is just an example but what you would usually
+# use on a normal setup
+# Additionally you need to define the rsync URI to get /var/lib/openqa/tests/
+# via the TESTPOOLSERVER variable in the webui sections as shown below
+# If no CACHEDIRECTORY is specified these files are supposed to be mounted
+# at the SHARE_DIRECTORY (by default /var/lib/openqa/share) via e.g. NFS
 #CACHEDIRECTORY = /var/lib/openqa/cache
+
+# Limit size of CACHEDIRECTORY to the specified value in GiB (50 GiB by default)
+#CACHELIMIT = 50
+
+# Limit size of CACHEDIRECTORY to preserve the specified percentage of free disk
+# space on the filesystem it is located on (the default is NO limit; the 10 %
+# are just an example)
+#CACHE_MIN_FREE_PERCENTAGE = 10
 
 # host address (domain name or IP address) the web UI can reach the worker by
 # (required by the web UI's developer mode and backends using jump-hosts to


### PR DESCRIPTION
* Document `CACHELIMIT` and `CACHE_MIN_FREE_PERCENTAGE`
* Improve wording in documentation of `CACHEDIRECTORY`
* Make it clear what the default value is
* Related ticket: https://progress.opensuse.org/issues/152545