### PR TITLE
Fix dependencies not showing up in graph under certain conditions

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -944,7 +944,6 @@ sub _add_job ($dependency_data, $job, $as_child_of, $preferred_depth) {
     my $job_id = $job->id;
     my $visited = $dependency_data->{visited};
     return $job_id if $visited->{$job_id};
-    $visited->{$job_id} = 1;
 
     # show only the latest child jobs but still require the cloned job to be an actual child
     if ($as_child_of) {
@@ -970,6 +969,7 @@ sub _add_job ($dependency_data, $job, $as_child_of, $preferred_depth) {
         blocked_by_id => $job->blocked_by_id,
     );
     $node{$_} = [] for OpenQA::JobDependencies::Constants::names;
+    $visited->{$job_id} = 1;
     push(@{$dependency_data->{nodes}}, \%node);
 
     # add parents


### PR DESCRIPTION
When computing the dependencies to show in the dependency graph we prefer to show the latest child of a parent instead of the child we immediately found when traversing the list of children. This is implemented as an early return. In case of this early return we must *not* count the immediate child as visited. Otherwise we might miss it when traversing the dependency graph further (and it is the latest child from that perspective).

Related ticket: https://progress.opensuse.org/issues/136154

---

I have tested it manually ~~and it works but I'll keep it a draft because I need to extend unit tests~~.