### PR TITLE
Add group filter options for /tests

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -245,7 +245,7 @@ function renderTestLists() {
       this[paramName] = paramValues[0];
     }
   };
-  jQuery.each(['limit', 'groupid', 'match'], function (index, paramName) {
+  jQuery.each(['limit', 'groupid', 'match', 'group_glob', 'not_group_glob'], (index, paramName) => {
     ajaxQueryParams.addFirstParam(paramName);
   });
   delete ajaxQueryParams.addFirstParam;

--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -99,7 +99,7 @@ use constant VIDEO_FILE_NAME_REGEX => qr/^.*\/video\.[^\/]*$/;
 use constant FRAGMENT_REGEX => qr'(#([-?/:@.~!$&\'()*+,;=\w]|%[0-9a-fA-F]{2})*)*';
 
 use constant JOBS_OVERVIEW_SEARCH_CRITERIA =>
-  (qw(distri version flavor build test modules modules_result module_re group groupid id group_glob not_group_glob));
+  (qw(distri version flavor build test modules modules_result module_re group groupid id));
 
 our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION DEFAULT_WORKER_TIMEOUT

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -10,23 +10,141 @@ use Test::Warnings ':report_warnings';
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 
-OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 04-products.pl');
+my $schema = OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 04-products.pl');
 
 use OpenQA::SeleniumTest;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 driver_missing unless my $driver = call_driver;
 
-ok $driver->get('/tests?groupid=0'), 'list jobs without group';
-wait_for_ajax(msg => 'wait for test list without group');
-my @rows = $driver->find_child_elements($driver->find_element('#scheduled tbody'), 'tr');
-is @rows, 1, 'one scheduled job without group';
+subtest 'groupid' => sub {
+    ok $driver->get('/tests?groupid=0'), 'list jobs without group';
+    wait_for_ajax(msg => 'wait for test list without group');
+    my @rows = $driver->find_child_elements($driver->find_element('#scheduled tbody'), 'tr');
+    is @rows, 1, 'one scheduled job without group';
 
-ok $driver->get('/tests?groupid=1001'), 'list jobs with group 1001';
-wait_for_ajax(msg => 'wait for test list with one group');
-@rows = $driver->find_child_elements($driver->find_element('#running tbody'), 'tr');
-is @rows, 1, 'one running job with this group';
-ok $driver->find_element('#running #job_99963'), '99963 listed';
+    ok $driver->get('/tests?groupid=1001'), 'list jobs with group 1001';
+    wait_for_ajax(msg => 'wait for test list with one group');
+    @rows = $driver->find_child_elements($driver->find_element('#running tbody'), 'tr');
+    is @rows, 1, 'one running job with this group';
+    ok $driver->find_element('#running #job_99963'), '99963 listed';
+};
+
+subtest 'group_glob and not_group_glob' => sub {
+    $schema->resultset('JobGroups')->create($_)
+      for (
+        {
+            id => 1003,
+            sort_order => 0,
+            name => 'opensuse development'
+        },
+        {
+            id => 1004,
+            sort_order => 0,
+            name => 'Tumbleweed'
+        },
+        {
+            id => 1005,
+            sort_order => 0,
+            name => 'SLE 15 SP5'
+        },
+        {
+            id => 1006,
+            sort_order => 0,
+            name => 'SLE 15 SP5 development'
+        });
+    my $template = {
+        state => 'done',
+        result => 'passed',
+        TEST => "textmode",
+        FLAVOR => 'DVD',
+        DISTRI => 'opensuse',
+        BUILD => '0091',
+        VERSION => '13.1',
+        MACHINE => '32bit',
+        ARCH => 'i586'
+    };
+    $_->delete for $schema->resultset('Jobs')->all;
+    $schema->resultset('Jobs')->create($_)
+      for (
+        {
+            %$template,
+            id => 99951,
+            group_id => 1003
+        },
+        {
+            %$template,
+            id => 99952,
+            group_id => 1004
+        },
+        {
+            %$template,
+            id => 99953,
+            group_id => 1005
+        },
+        {
+            %$template,
+            id => 99954,
+            group_id => 1006
+        });
+
+    subtest 'no group filter' => sub {
+        ok $driver->get('/tests'), 'list jobs';
+        wait_for_ajax(msg => 'wait for test list');
+        my @rows = $driver->find_child_elements($driver->find_element('#results tbody'), 'tr');
+        is @rows, 4, 'four jobs';
+        ok $driver->find_element('#results #job_99951'), '99951 listed';
+        ok $driver->find_element('#results #job_99952'), '99952 listed';
+        ok $driver->find_element('#results #job_99953'), '99953 listed';
+        ok $driver->find_element('#results #job_99954'), '99954 listed';
+    };
+
+    subtest 'filter with glob include' => sub {
+        ok $driver->get('/tests?group_glob=*SLE*'), 'list jobs';
+        wait_for_ajax(msg => 'wait for test list');
+        my @rows = $driver->find_child_elements($driver->find_element('#results tbody'), 'tr');
+        is @rows, 2, 'two jobs';
+        ok $driver->find_element('#results #job_99953'), '99953 listed';
+        ok $driver->find_element('#results #job_99954'), '99954 listed';
+    };
+
+    subtest 'filter with multiple glob includes' => sub {
+        ok $driver->get('/tests?group_glob=*SLE*,Tumbleweed'), 'list jobs';
+        wait_for_ajax(msg => 'wait for test list');
+        my @rows = $driver->find_child_elements($driver->find_element('#results tbody'), 'tr');
+        is @rows, 3, 'three jobs';
+        ok $driver->find_element('#results #job_99952'), '99952 listed';
+        ok $driver->find_element('#results #job_99953'), '99953 listed';
+        ok $driver->find_element('#results #job_99954'), '99954 listed';
+    };
+
+    subtest 'filter with exact exclude' => sub {
+        ok $driver->get('/tests?not_group_glob=Tumbleweed'), 'list jobs';
+        wait_for_ajax(msg => 'wait for test list');
+        my @rows = $driver->find_child_elements($driver->find_element('#results tbody'), 'tr');
+        is @rows, 3, 'three jobs';
+        ok $driver->find_element('#results #job_99951'), '99951 listed';
+        ok $driver->find_element('#results #job_99953'), '99953 listed';
+        ok $driver->find_element('#results #job_99954'), '99954 listed';
+    };
+
+    subtest 'filter with glob exclude' => sub {
+        ok $driver->get('/tests?not_group_glob=*SLE*'), 'list jobs';
+        wait_for_ajax(msg => 'wait for test list');
+        my @rows = $driver->find_child_elements($driver->find_element('#results tbody'), 'tr');
+        is @rows, 2, 'two jobs';
+        ok $driver->find_element('#results #job_99951'), '99951 listed';
+        ok $driver->find_element('#results #job_99952'), '99952 listed';
+    };
+
+    subtest 'filter with glob include and exclude' => sub {
+        ok $driver->get('/tests?group_glob=*opensuse*,*SLE*&not_group_glob=*development*'), 'list jobs';
+        wait_for_ajax(msg => 'wait for test list');
+        my @rows = $driver->find_child_elements($driver->find_element('#results tbody'), 'tr');
+        is @rows, 1, 'one job';
+        ok $driver->find_element('#results #job_99953'), '99953 listed';
+    };
+};
 
 kill_driver;
 done_testing;

--- a/templates/webapi/test/list.html.ep
+++ b/templates/webapi/test/list.html.ep
@@ -44,7 +44,8 @@
   <div>
   <h2 id="finished_jobs_heading" style="display: inline-block">Finished jobs</h2><%=
     help_popover 'Parameters for finished jobs' =>
-    '<p>It is possible to increase the number of finished jobs shown in the table via the <code>limit</code> query parameter.</p>',
+      '<p>It is possible to increase the number of finished jobs shown in the table via the <code>limit</code> query parameter.</p>'
+    . '<p>Additionally you can use the <code>group_glob</code> and <code>not_group_glob</code> query parameters to include and exclude job groups with comma separated lists of globs, like <code>*kernel*,*Tumbleweed*</code>.</p>',
     undef, undef, undef, style => 'vertical-align: text-top'; %>
   </div>
   <div id="flash-messages-finished-jobs"></div>


### PR DESCRIPTION
Based on #5388, and reusing most of the same logic, to bring job group filtering to `/tests` from `/tests/overview`. Similar to the `?match=...` option, this does not have a UI element yet and can only be used by manually entering the query parameter. Since the question of how to extend the filter form with text fields is still open, i consider it out of scope for this PR.

Progress: https://progress.opensuse.org/issues/134933