### PR TITLE
t: Use consistent 'Mojo::Base' instead of strict+warnings

### DIFF
--- a/t/data/openqa/share/tests/opensuse/tests/openQA/kate.pm
+++ b/t/data/openqa/share/tests/opensuse/tests/openQA/kate.pm
@@ -13,8 +13,7 @@
 #   and closed
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 sub run {
     my @regexp = qw(test-kate-3 tes-module_re);


### PR DESCRIPTION
Same as suggested in our documentation we should use Mojo::Base
consistently in openQA test modules which we only have a single one of
within this repository.

Motivated by:
* https://github.com/os-autoinst/os-autoinst-distri-example/pull/28