### PR TITLE
Introduce --skip-checks in openqa-clone-job

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -307,7 +307,8 @@ sub clone_job ($jobid, $url_handler, $options, $post_params = {}, $jobs = {}, $d
     $settings->{CLONED_FROM} = $url_handler->{remote_url}->clone->path("/tests/$jobid")->to_string;
     if (my $group_id = $job->{group_id}) { $settings->{_GROUP_ID} = $group_id }
     clone_job_apply_settings($options->{args}, $relation eq 'children' ? 0 : $depth, $settings, $options);
-    OpenQA::Script::CloneJobSUSE::detect_maintenance_update($jobid, $url_handler, $settings);
+    OpenQA::Script::CloneJobSUSE::detect_maintenance_update($jobid, $url_handler, $settings)
+      unless $options->{'skip-checks'};
     clone_job_download_assets($jobid, $job, $url_handler, $options) unless $options->{'skip-download'};
 }
 

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -153,7 +153,6 @@ https://openqa.opensuse.org 123456
 
 Will create 50 clones of the same job.
 
-
 =item B<--show-progress>
 
 Displays a progress bar when downloading assets.

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -104,6 +104,10 @@ from JOBREF if it is a URL).
 Specifies the directory to store test assets (defaults to
 $OPENQA_SHAREDIR/factory).
 
+=item B<--skip-checks>
+
+Skips additional checks like maintenance update availability.
+
 =item B<--skip-deps>
 
 Do NOT clone parent jobs (which is done by default).
@@ -209,6 +213,7 @@ sub parse_options () {
         "skip-deps", "skip-chained-deps", "skip-download", "parental-inheritance",
         "help|h", "show-progress", "within-instance|w=s", "clone-children",
         "max-depth:i", "repeat|r:i", "ignore-missing-assets", "export-command",
+        "skip-checks",
     ) or usage(1);
     usage(0) if $options{help};
     usage(1) if $options{help} || ($options{'within-instance'} && $options{from});


### PR DESCRIPTION
Introduces the `--skip-checks` parameter to avoid additional checks like maintenance update availability in `openqa-clone-job`.