### PR TITLE
Prevent ambiguous PRJDIR ending up in vars.json

### DIFF
--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -86,8 +86,7 @@ sub update_needle_cache ($needle_cache) { $_->update for values %$needle_cache }
 # be aware that giving the optional needle_cache hash ref, makes you responsible
 # to call update_needle_cache after a loop
 sub update_needle ($filename, $module, $matched = undef, $needle_cache = undef) {
-    # assume that path of the JSON file is relative to the job's needle dir or (to support legacy versions
-    # of os-autoinst) relative to the "share dir" (the $bmwqemu::vars{PRJDIR} variable in legacy os-autoinst)
+    # assume that path of the JSON file is relative to the job's needle dir
     my $needle_dir;
     unless (-f $filename) {
         return undef unless $filename = locate_needle($filename, $needle_dir = $module->job->needle_dir);

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -212,7 +212,6 @@ sub sync_tests ($cache_client, $job, $vars, $shared_cache, $rsync_source, $remai
     );
     my $rsync_request = $cache_client->rsync_request(from => $rsync_source, to => $shared_cache);
     my $rsync_request_description = "from '$rsync_source' to '$shared_cache'";
-    $job->worker->settings->global_settings->{PRJDIR} = $shared_cache;
 
     # enqueue rsync task; retry in some error cases
     if (my $err = $cache_client->enqueue($rsync_request)) {
@@ -315,13 +314,8 @@ sub engine_workit ($job, $callback) {
         OPENQA_URL => $openqa_url,
         WORKER_INSTANCE => $instance,
         WORKER_ID => $workerid,
-        PRJDIR => OpenQA::Utils::sharedir(),
         %$job_settings
     );
-    # note: PRJDIR is used as base for relative needle paths by os-autoinst. This is supposed to change
-    #       but for compatibility with current old os-autoinst we need to set PRJDIR for a consistent
-    #       behavior.
-
     log_debug "Job settings:\n" . format_settings(\%vars);
 
     # cache/locate assets, set ASSETDIR


### PR DESCRIPTION
We observed that the variable PRJDIR ends up with inconsistent values in
vars.json files which is then rendered as a diff from the openQA
investigation tab even though likely the effective value used within
openQA never differed. The variable PRJDIR is actually never used itself
so to prevent confusion we can simply remove all according references.
The internal function "prjdir()" is untouched.

This change effectively prevents pre-2020 versions of os-autoinst, in
particular before commit 9eb2f564 removing the last use of PRJDIR, to
work which should not be our concern because for multiple reasons it
would be a bad idea if not outright impossible to have a current openQA
working with such old versions of os-autoinst.

Related progress issue: https://progress.opensuse.org/issues/152392