### PR TITLE
Handle no job group filter matches gracefully

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -719,9 +719,8 @@ sub _prepare_job_results ($self, $all_jobs, $limit) {
 }
 
 sub _prepare_groupids ($self) {
-    if (my @groups = $self->groups_for_globs) {
-        return [map { $_->id } @groups];
-    }
+    return [0] unless my $groups = $self->groups_for_globs;
+    return [map { $_->id } @$groups] if @$groups;
 
     my $v = $self->validation;
     $v->optional('groupid')->num(0, undef);

--- a/t/ui/02-list-group.t
+++ b/t/ui/02-list-group.t
@@ -144,6 +144,13 @@ subtest 'group_glob and not_group_glob' => sub {
         is @rows, 1, 'one job';
         ok $driver->find_element('#results #job_99953'), '99953 listed';
     };
+
+    subtest 'filter with glob and no match' => sub {
+        ok $driver->get('/tests?group_glob=does_not_exist'), 'list jobs';
+        wait_for_ajax(msg => 'wait for test list');
+        my @rows = $driver->find_child_elements($driver->find_element('#results tbody'), 'tr');
+        like $rows[0]->get_text, qr/No data available in table/, 'no results';
+    };
 };
 
 kill_driver;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -533,6 +533,11 @@ subtest 'filtering by job group' => sub {
         my $text = $get_text->('/tests/overview?group_glob=*opensuse*,*SLE*&not_group_glob=*development*');
         like $text, qr/Summary of opensuse, opensuse test, SLE 15 SP5 build/, 'job group match';
     };
+
+    subtest 'filter with glob and no match' => sub {
+        my $text = $get_text->('/tests/overview?group_glob=does_not_exist');
+        like $text, qr/Overall Summary of multiple distri\/version/, 'no match';
+    };
 };
 
 subtest "job template names displayed on 'Test result overview' page" => sub {


### PR DESCRIPTION
This is a followup for #5388 and #5401. When there were no matches for job group globs, no query condition would be generated previously. Giving the false impression that all job groups were matching. So now we just generate an impossible query that cannot match anything with the group id `0`.

Progress: https://progress.opensuse.org/issues/134933