### PR TITLE
CI: Try to increase timeout for "cache" job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ jobs:
           command: tools/ci/prepare_dependency_pr.sh
 
   cache:
+    no_output_timeout: 50m
     docker:
       - <<: *base
     steps:


### PR DESCRIPTION
As seen in recent failures download from registry.opensuse.org seems to
either take longer than the usual timeouts or actually gets stuck for
too long. This commit should increase the timeout from 20m to 50m, just
short of the hard overall job timeout of 1h in our "free" plan of using
circleCI. With this we should be able to either fix the problems we
recently observed or it's more obvious if the download which should
normally only take a couple of minutes is instead getting stuck for
good.

Related progress issue: https://progress.opensuse.org/issues/152941