### PR TITLE
Reload dbus in post install script

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -495,10 +495,12 @@ else
 fi
 
 %service_add_post %{openqa_services}
+systemctl reload dbus || :
 
 %post worker
 %tmpfiles_create %{_tmpfilesdir}/openqa.conf
 %service_add_post %{openqa_worker_services}
+systemctl reload dbus || :
 
 %post auto-update
 %service_add_post openqa-auto-update.timer


### PR DESCRIPTION
This is needed so that newly created users are taken into account
for dbus permission handling.