### PR TITLE
Fix "duplicate key value violates unique constraint" on needle updates

### DIFF
--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -29,10 +29,13 @@ sub create {
     # create new database connection
     my $schema = OpenQA::Schema::connect_db(mode => 'test', deploy => 0);
 
+    # ensure the time zone is set consistently to UTC for this session
+    my $storage = $schema->storage;
+    my $dbh = $storage->dbh;
+    $dbh->do('SET TIME ZONE "utc"');
+
     # create a new schema or use an existing one
     unless (defined $options{skip_schema}) {
-        my $storage = $schema->storage;
-        my $dbh = $storage->dbh;
         my $schema_name = $options{schema_name} // generate_schema_name;
         log_info("using database schema \"$schema_name\"");
 


### PR DESCRIPTION
* Use raw SQL queries with "ON CONFLICT DO NOTHING" to avoid running into
  those errors
* Follow example from `OpenQA::Schema::ResultSet::Assets::register` where
  we already use raw queries like that followed by an DBIx call to get the
  newly inserted row
* Not using `{for => 'update'}` here to locking as we likely don't need it
  here as we don't mind the *exact* last module
* Avoid repeated function calls simplifying the code a little bit
* See https://progress.opensuse.org/issues/153616