### PR TITLE
Remove obsolete entry from group_overview

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -124,25 +124,6 @@ h2 .fa {
     text-align: right;
 }
 
-// parent group overview
-* + #child_groups {
-    border-top: 1px solid #e3e3e3;
-    margin-top: 20px;
-    padding-top: 20px;
-}
-#child_groups {
-    h3 {
-        font-size: 150%;
-        margin-top: 0px;
-    }
-    ul {
-        margin: 0px;
-        padding: 0px;
-        list-style: none;
-        font-size: 120%;
-    }
-}
-
 // center comments pagination
 .comments-pagination {
     display: block;

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -174,8 +174,6 @@ sub _group_overview ($self, $resultset, $template) {
         comment_put_action => 'apiv1_put_' . $comment_context_route_suffix,
         comment_delete_action => 'apiv1_delete_' . $comment_context_route_suffix
     );
-    $self->stash(child_groups => [$group->children->all]) if $is_parent_group;
-
     $self->respond_to(
         json => sub ($self) {
             @comments = map($_->hash, @comments);


### PR DESCRIPTION
child_groups was removed in bd79969e32615c8bdacbf8cf1695b8cb60a2c27a but the CSS and the db query were left.

Related issue: https://progress.opensuse.org/issues/152939