### PR TITLE
Add /job_groups/id/build_results API route

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -110,7 +110,7 @@ sub find_child_groups ($group, $subgroup_filter) {
     return filter_subgroups($group, $subgroup_filter);
 }
 
-sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_filter) {
+sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_filter, $show_tags) {
 
     # find relevant child groups taking filter into account
     my $child_groups = find_child_groups($group, $subgroup_filter);
@@ -233,8 +233,23 @@ sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_fi
         $max_jobs = $jr{total} if ($jr{total} > $max_jobs);
     }
     $result{max_jobs} = $max_jobs;
+    _map_tags_into_build($result{build_results}, $show_tags) if $show_tags;
     return \%result;
 }
 
-1;
+sub _map_tags_into_build ($results, $tags) {
+    for my $res (@$results) {
+        if (my $full_tag = $tags->{$res->{key}}) {
+            $res->{tag} = $full_tag;
+        }
+        elsif (my $build_only_tag = $tags->{$res->{build}}) {
+            # as fallback we are looking for build and not other criteria we can end
+            # up with multiple tags if the build appears more than once, e.g.
+            # for each version
+            $res->{tag} = $build_only_tag;
+        }
+    }
+}
 
+
+1;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -330,6 +330,8 @@ sub startup ($self) {
     $api_public_r->get('/job_groups')->name('apiv1_list_job_groups')->to('job_group#list');
     $api_public_r->get('/job_groups/<group_id:num>')->name('apiv1_get_job_group')->to('job_group#list');
     $api_public_r->get('/job_groups/<group_id:num>/jobs')->name('apiv1_get_job_group_jobs')->to('job_group#list_jobs');
+    $api_public_r->get('/job_groups/<group_id:num>/build_results')->name('apiv1_get_job_group_jobs')
+      ->to('job_group#build_results');
     $api_ra->post('/job_groups')->name('apiv1_post_job_group')->to('job_group#create');
     $api_ra->put('/job_groups/<group_id:num>')->name('apiv1_put_job_group')->to('job_group#update');
     $api_ra->delete('/job_groups/<group_id:num>')->name('apiv1_delete_job_group')->to('job_group#delete');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::WebAPI::Controller::API::V1::JobGroup;
-use Mojo::Base 'Mojolicious::Controller';
+use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use OpenQA::Schema::Result::JobGroups;
 
@@ -36,8 +36,7 @@ Reports true if the job group given to the method is a parent group.
 
 =cut
 
-sub is_parent {
-    my ($self) = @_;
+sub is_parent ($self) {
     return $self->req->url->path =~ qr/.*\/parent_groups/;
 }
 
@@ -51,8 +50,7 @@ Returns results for a set of groups.
 
 =cut
 
-sub resultset {
-    my ($self) = @_;
+sub resultset ($self) {
     return $self->schema->resultset($self->is_parent ? 'JobGroupParents' : 'JobGroups');
 }
 
@@ -66,9 +64,7 @@ Returns information from a job group given its ID.
 
 =cut
 
-sub find_group {
-    my ($self) = @_;
-
+sub find_group ($self) {
     my $group_id = $self->param('group_id');
     if (!defined $group_id) {
         $self->render(json => {error => 'No group ID specified'}, status => 400);
@@ -95,8 +91,7 @@ create or update a job group via DBIx.
 
 =cut
 
-sub load_properties {
-    my ($self) = @_;
+sub load_properties ($self) {
 
     if (my $cached_properties = $self->{cached_properties}) {
         return $cached_properties;
@@ -134,9 +129,7 @@ timestamps - is also returned as a list of indexed lists.
 
 =cut
 
-sub list {
-    my ($self) = @_;
-
+sub list ($self) {
     my $groups;
     my $group_id = $self->param('group_id');
     if ($group_id) {
@@ -170,9 +163,7 @@ Check existing job group on top level to prevent create/update duplicate.
 
 =cut
 
-sub check_top_level_group {
-    my ($self, $group_id) = @_;
-
+sub check_top_level_group ($self, $group_id = undef) {
     return 0 if $self->is_parent;
     my $properties = $self->load_properties;
     my $conditions = {name => $properties->{name}, parent_id => undef};
@@ -180,8 +171,7 @@ sub check_top_level_group {
     return $self->resultset->search($conditions);
 }
 
-sub _validate_common_properties {
-    my ($self) = @_;
+sub _validate_common_properties ($self) {
     my $validation = $self->validation;
     $validation->optional('parent_id')->like(qr/^(none|[0-9]+)\z/);
     $validation->optional('size_limit_gb')->like(qr/^(|[0-9]+)\z/);
@@ -215,9 +205,7 @@ Returns a 400 code on error or a 500 code if the group already exists.
 
 =cut
 
-sub create {
-    my ($self) = @_;
-
+sub create ($self) {
     my $validation = $self->validation;
     $validation->required('name')->like(qr/^(?!\s*$).+/);
     $validation->optional('default_keep_logs_in_days')->num(0);
@@ -257,9 +245,7 @@ Updates the properties of a job group.
 
 =cut
 
-sub update {
-    my ($self) = @_;
-
+sub update ($self) {
     my $group = $self->find_group;
     return unless $group;
 
@@ -299,9 +285,7 @@ List jobs belonging to a job group.
 
 =cut
 
-sub list_jobs {
-    my ($self) = @_;
-
+sub list_jobs ($self) {
     my $group = $self->find_group;
     return unless $group;
 
@@ -325,9 +309,7 @@ Deletes a job group. Verifies that it is not empty before attempting to remove.
 
 =cut
 
-sub delete {
-    my ($self) = @_;
-
+sub delete ($self) {
     my $group = $self->find_group();
     return unless $group;
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/152939
    
I moved `_map_tags_into_build` into the `compute_build_results()` function.
    
The command lime to get the last "published" build would look like this:
    
        openqa-cli api job_groups/1/build_results only_tagged=1 limit_builds=1 \
          | jq -r '[.build_results[] | select(.tag.description=="published") | select(.version=="Tumbleweed") | .build ][0]'
    
To only get the latest build:
    
        openqa-cli api job_groups/1/build_results  limit_builds=1| jq -r '[.build_results[] | .build ][0]'

Only normal groups are supported, not parent groups, to keep it simple. I can go though our logs to see if the group_overview.json is ever called for parent groups.

I am seeing a problem with the documentation display of the new function when getting a 404. The documentation for the new function is displayed for `+/job_groups/<group_id:num>/jobs GET` as well as ` +/job_groups/<group_id:num>/build_results`.
Maybe a bug in how Mojolicious renders the pod. I can't see anything wrong there.

Also I found a misdocumented route. I will open a seperate PR.

Still need to document this somewhere.