### PR TITLE
Add service_port_delta config for livehandler

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -145,13 +145,8 @@ function makeWsUrlAbsolute(url, servicePortDelta) {
     // don't put a port in the URL if there's no explicit port
     port = '';
   } else {
-    if (port !== 80 || port !== 443) {
-      // if not using default ports we assume we're not accessing the web UI via Apache/NGINX
-      // reverse proxy
-      // -> so if not specified otherwise, we're further assuming a connection to the livehandler
-      //    daemon which is supposed to run under the <web UI port> + 2
-      port += servicePortDelta ? servicePortDelta : 2;
-    }
+    if (port !== 80 || port !== 443)
+      port += servicePortDelta;
     port = ':' + port;
   }
 

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -445,6 +445,7 @@ var developerMode = {
   // state of the page elements and the web socket connection to web UI
   develWsUrl: undefined, // URL for developer session web socket connection
   statusOnlyWsUrl: undefined, // URL for status-only web socket connection
+  servicePortDelta: undefined, //delta from web UI port on which to direct connect to livehandler
   wsConnection: undefined, // current WebSocket object
   hasWsError: false, // whether an web socket error occurred (cleared when we finally receive a message from os-autoinst)
   useDeveloperWsRoute: undefined, // whether the developer web socket route is used
@@ -544,6 +545,7 @@ function setupDeveloperPanel() {
   // find URLs for web socket connections
   developerMode.develWsUrl = panel.data('developer-url');
   developerMode.statusOnlyWsUrl = panel.data('status-only-url');
+  developerMode.servicePortDelta = panel.data('service-port-delta');
 
   // setup toggle for body
   var panelHeader = panel.find('.card-header');
@@ -973,7 +975,7 @@ function setupWebsocketConnection() {
     developerMode.useDeveloperWsRoute = false;
     url = developerMode.statusOnlyWsUrl;
   }
-  url = makeWsUrlAbsolute(url);
+  url = makeWsUrlAbsolute(url, developerMode.servicePortDelta);
 
   // establish ws connection
   console.log('Establishing ws connection to ' + url);

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -91,6 +91,14 @@
 ## collapsing parallel children by default completely)
 #parallel_children_collapsable_results = passed softfailed
 
+## For the developer mode panel: if not accessing the web UI via Apache/NGINX reverse
+## proxy, then connect to the livehandler daemon at the <web UI port> + service_port_delta.
+## The livehandler daemon is supposed to run under the <web UI port> + 2.
+## If you want to keep using a reverse proxy while accessing the webUI through a custom port
+## (e.g. 8080) then just set the service_port_delta = 0.
+## Also set SERVICE_PORT_DELTA in workers.ini accordingly.
+# service_port_delta = 2
+
 #[scm git]
 # name of remote to get updates from before committing changes (e.g. origin, leave out-commented to disable remote update)
 #update_remote = origin

--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -73,6 +73,9 @@
 # their versions in plain text.
 #PACKAGES_CMD = rpm -qa
 
+# Config for livehandler port; see service_port_delta in openqa.ini.
+# SERVICE_PORT_DELTA = 2
+
 # The section ids are the instance of the workers.
 # The key/value pairs will appear in vars.json
 #[1]

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -52,6 +52,7 @@ sub read_config ($app) {
             auto_clone_limit => 20,
             force_result_regex => '',
             parallel_children_collapsable_results => join(' ', OK_RESULTS),
+            service_port_delta => 2,
         },
         rate_limits => {
             search => 5,

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -374,6 +374,7 @@ sub live ($self) {
             developer_session => $job->developer_session,
             is_devel_mode_accessible => $current_user && $current_user->is_operator,
             current_user_id => $current_user ? $current_user->id : 'undefined',
+            service_port_delta => $self->config->{global}->{service_port_delta},
         });
     $self->render('test/live');
 }

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -964,9 +964,11 @@ sub post_upload_progress_to_liveviewhandler {
     $self->{_progress_info} = \%new_progress_info;
 
     my $job_id = $self->id;
+    my $global_settings = OpenQA::Worker::Settings->new->global_settings;
+
     $self->client->send(
         post => "/liveviewhandler/api/v1/jobs/$job_id/upload_progress",
-        service_port_delta => 2,    # liveviewhandler is supposed to run on web UI port + 2
+        service_port_delta => $global_settings->{SERVICE_PORT_DELTA},
         json => \%new_progress_info,
         non_critical => 1,
         callback => sub {

--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -76,6 +76,9 @@ sub new ($class, $instance_number = undef, $cli_options = {}) {
     $global_settings{RETRY_DELAY} //= 5;
     $global_settings{RETRY_DELAY_IF_WEBUI_BUSY} //= ONE_MINUTE;
 
+    # liveviewhandler is supposed to run on web UI port + 2
+    $global_settings{SERVICE_PORT_DELTA} //= 2;
+
     my $self = $class->SUPER::new(
         global_settings => \%global_settings,
         webui_hosts => \@hosts,

--- a/templates/webapi/test/live.html.ep
+++ b/templates/webapi/test/live.html.ep
@@ -3,6 +3,7 @@
      id="developer-panel"
      data-developer-url="<%= $ws_developer_url %>"
      data-status-only-url="<%= $ws_status_only_url %>"
+     data-service-port-delta="<%= $service_port_delta %>"
      data-is-accessible="<%= ($is_devel_mode_accessible) ? ('true') : ('false') %>"
      data-own-user-id="<%= $current_user_id %>">
     <div class="card-header">


### PR DESCRIPTION
Instead of hard-coding the service port delta for the livehandler, make the service port delta configurable while still defaulting to the expected value of 2. This allows cloud and/or containerized setups to access the web UI through a non-standard port while continuing to access the livehandler through a reverse proxy just by setting the service port delta to 0.

Issue: https://progress.opensuse.org/issues/153499