### PR TITLE
Ensure only the Git cache directory from the local worker config is used

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -237,7 +237,7 @@ sub start {
     # delete settings we better not allow to be set on job-level (and instead should only be set within the
     # worker config)
     my $job_settings = $self->info->{settings} // {};
-    delete $job_settings->{GENERAL_HW_CMD_DIR};
+    delete $job_settings->{$_} for qw(GENERAL_HW_CMD_DIR GIT_CACHE_DIR);
     for my $key (keys %$job_settings) {
         delete $job_settings->{$key} if rindex($key, 'EXTERNAL_VIDEO_ENCODER', 0) == 0;
     }


### PR DESCRIPTION
* Prevent users from cluttering directories when accidentally specifying a wrong `GIT_CACHE_DIR`
* Avoid the Git cache directory configured on a production worker to be used when cloning a job to the local instance (where that directory might not even exists or another cache directory is wanted)
* See https://progress.opensuse.org/issues/154240

---

Note that I haven't extended tests because we already have a test for the changed line and we likely don't need to test the same behavior for all the relevant keys.