### PR TITLE
Use `--within-instance` in example for cloning MM jobs

### DIFF
--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -198,8 +198,9 @@ different jobs are executed on different workers. So you could call
 `openqa-clone-job` like this:
 ```
 openqa-clone-job \
-    --skip-download --skip-chained-deps \        # assuming assets are present
+    --skip-chained-deps \                        # assuming assets are present
     --max-depth 0 \                              # clone the entire parallel cluster
+    --within-instance                            # create new jobs on the same instance
     https://openqa.opensuse.org/tests/3886213 \  # arbitrary job in cluster to clone
     _GROUP=0 BUILD+=test-mm-setup \              # avoid interfering with production jobs
     WORKER_CLASS:wicked_basic_ref+=,worker_foo \ # ensure one job runs on `worker_foo`


### PR DESCRIPTION
In the context of verifying the setup it makes most sense to clone jobs on the production instance so `--within-instance` is useful as pointed out in the review.