### PR TITLE
Apply perlcritic rule for useless interpolation of literal string

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -61,7 +61,7 @@ sub count_job ($job, $jr, $labels) {
         return;
     }
     my $state = $job->state;
-    log_error("Encountered not-implemented state:" . $job->state . " result:" . $job->result)
+    log_error('Encountered not-implemented state:' . $job->state . ' result:' . $job->result)
       unless grep { /$state/ } (OpenQA::Jobs::Constants::PENDING_STATES);
     $jr->{unfinished}++;
     return;
@@ -206,7 +206,7 @@ sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_fi
 
         my %seen;
         my @jobs = map {
-            my $key = $_->TEST . "-" . $_->ARCH . "-" . $_->FLAVOR . "-" . ($_->MACHINE // '');
+            my $key = $_->TEST . '-' . $_->ARCH . '-' . $_->FLAVOR . '-' . ($_->MACHINE // '');
             $seen{$key}++ ? () : $_;
         } $jobs->all;
         my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs(\@jobs);

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -161,7 +161,7 @@ sub track_asset ($self, $asset) {
         my $db = $self->sqlite->db;
         my $tx = $db->begin('exclusive');
         my $sql = "INSERT INTO assets (filename, size, last_use) VALUES (?, 0, strftime('%s','now'))"
-          . "ON CONFLICT (filename) DO UPDATE SET pending=1";
+          . 'ON CONFLICT (filename) DO UPDATE SET pending=1';
         $db->query($sql, $asset);
         $tx->commit;
     };
@@ -169,7 +169,7 @@ sub track_asset ($self, $asset) {
 }
 
 sub metrics ($self) {
-    return {map { $_->{name} => $_->{value} } $self->sqlite->db->query("SELECT * FROM metrics")->hashes->each};
+    return {map { $_->{name} => $_->{value} } $self->sqlite->db->query('SELECT * FROM metrics')->hashes->each};
 }
 
 sub _exclusive_query ($self, $sql, @args) {

--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -36,7 +36,7 @@ sub _cache_tests ($job, $from = undef, $to = undef) {
     my $cmd = join ' ', @cmd;
     $ctx->info("Calling: $cmd");
     my $status;
-    my $full_output = "";
+    my $full_output = '';
     for my $retry (1 .. RSYNC_RETRIES) {
         my $output = `@cmd`;
         $status = $? >> 8;

--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -23,7 +23,7 @@ sub run ($self, $options) {
     my $code = $res->code;
     die "There's an error openQA client returned $code" unless $code eq 200;
 
-    my $job = $res->json->{job} || die("No job could be retrieved");
+    my $job = $res->json->{job} || die('No job could be retrieved');
 
     # We have a job now, make a directory in $pwd by default
     my $path = path($options->{archive})->make_path;
@@ -193,7 +193,7 @@ sub _progress_monitior ($ua, $tx) {
             $last_updated = time;
             if ($progress < $current) {
                 $progress = $current;
-                print("\rDownloading $filename: ", $size == $len ? 100 : $progress . "%");
+                print("\rDownloading $filename: ", $size == $len ? 100 : $progress . '%');
             }
         });
 }

--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -45,7 +45,7 @@ sub download ($self, $url, $target, $options = {}) {
         last;
     }
 
-    return $err ? $err : "No error message recorded";
+    return $err ? $err : 'No error message recorded';
 }
 
 sub _extract_asset ($self, $to_extract, $target) {
@@ -88,7 +88,7 @@ sub _get ($self, $url, $target, $options) {
     my $code = $res->code // 521;    # Used by cloudflare to indicate web server is down.
     if ($code eq 304) {
         $options->{on_unchanged}->() if $options->{on_unchanged};
-        return (520, "Unknown error") unless -e $target;    # Avoid race condition between check and removal
+        return (520, 'Unknown error') unless -e $target;    # Avoid race condition between check and removal
         return (undef, undef);
     }
 

--- a/lib/OpenQA/Files.pm
+++ b/lib/OpenQA/Files.pm
@@ -66,7 +66,7 @@ sub verify_chunks ($class, $chunk_path, $verify_file) {
         $chunk->decode_content;
         $sum = $chunk->total_cksum if !$sum;
         return Mojo::Exception->new(
-            "Chunk: " . $chunk->id() . " differs in total checksum, expected $sum given " . $chunk->total_cksum)
+            'Chunk: ' . $chunk->id() . ' differs in total checksum, expected $sum given ' . $chunk->total_cksum)
           if $sum ne $chunk->total_cksum;
         return Mojo::Exception->new("Can't verify written data from chunk")
           unless $chunk->verify_content($verify_file);

--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -31,7 +31,7 @@ sub generate_settings ($params) {
     }
 
     # Prevent the MACHINE from being overridden by input args when doing isos post
-    if (my $machine = $params->{'machine'}) {
+    if (my $machine = $params->{machine}) {
         $settings->{BACKEND} = $machine->backend;
         $settings->{MACHINE} = $machine->name;
     }

--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -188,7 +188,7 @@ sub setup_log ($app, $logfile = undef, $logdir = undef, $level = undef) {
         $logfile = catfile($logdir, $logfile) if $logfile && $logdir;
         # So each worker from each host get its own log (as the folder can be shared).
         # Hopefully the machine hostname is already sanitized. Otherwise we need to check
-        $logfile //= catfile($logdir, hostname() . (defined $app->instance ? "-${\$app->instance}" : '') . ".log");
+        $logfile //= catfile($logdir, hostname() . (defined $app->instance ? "-${\$app->instance}" : '') . '.log');
         $log = Mojo::Log->new(%settings, handle => path($logfile)->open('>>'));
         $log->format(\&log_format_callback);
     }

--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -49,7 +49,7 @@ sub _build_parser {
 
 sub load {
     my ($self, $file) = @_;
-    croak "You need to specify a file" if !$file;
+    croak 'You need to specify a file' if !$file;
     my $file_content = $self->_read_file($file);
     confess "Failed reading file $file" if !$file_content;
     $self->content($file_content) if $self->include_content;
@@ -80,25 +80,25 @@ sub gen_tree_el {
     if ($el->isa('OpenQA::Parser')) {
         $el_ref = $el;
     }
-    elsif ($el->can("gen_tree_el")) {
+    elsif ($el->can('gen_tree_el')) {
         return $el->gen_tree_el;
     }
-    elsif ($el->can("to_hash")) {
+    elsif ($el->can('to_hash')) {
         $el_ref = $el->to_hash;
     }
-    elsif ($el->can("to_array")) {
+    elsif ($el->can('to_array')) {
         $el_ref = $el->to_array;
     }
     elsif (reftype $el eq 'ARRAY') {
-        warn "Serialization is officially supported only if object can be turned into an array with ->to_array()";
+        warn 'Serialization is officially supported only if object can be turned into an array with ->to_array()';
         $el_ref = [@{$el}];
     }
     elsif (reftype $el eq 'HASH') {
-        warn "Serialization is officially supported only if object can be hashified with ->to_hash()";
+        warn 'Serialization is officially supported only if object can be hashified with ->to_hash()';
         $el_ref = {%{$el}};
     }
     else {
-        warn "Data type with format not supported for serialization";
+        warn 'Data type with format not supported for serialization';
         $el_ref = $el;
     }
 

--- a/lib/OpenQA/Parser/Format/Base.pm
+++ b/lib/OpenQA/Parser/Format/Base.pm
@@ -28,13 +28,13 @@ sub _write_all {
 
 sub write_output {
     my ($self, $dir) = @_;
-    croak "You need to specify a directory" unless $dir;
+    croak 'You need to specify a directory' unless $dir;
     $self->_write_all(generated_tests_output => $dir);
 }
 
 sub write_test_result {
     my ($self, $dir) = @_;
-    croak "You need to specify a directory" unless $dir;
+    croak 'You need to specify a directory' unless $dir;
     $self->_write_all(generated_tests_results => $dir);
 }
 

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -15,7 +15,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::OpenQA->new
 # Parser
 sub parse {
     my ($self, $json) = @_;
-    confess "No JSON given/loaded" unless $json;
+    confess 'No JSON given/loaded' unless $json;
     my $decoded_json = Mojo::JSON::from_json($json);
     my %unique_names;
 

--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -33,9 +33,9 @@ sub _add_result {
 
 sub parse {
     my ($self, $xml) = @_;
-    confess "No XML given/loaded" unless $xml;
+    confess 'No XML given/loaded' unless $xml;
     my $dom = Mojo::DOM->new($xml);
-    confess "Failed parsing XML" unless @{$dom->tree} > 2;
+    confess 'Failed parsing XML' unless @{$dom->tree} > 2;
 
     my @tests;
     for my $ts ($dom->find('testsuite')->each) {
@@ -103,7 +103,7 @@ sub parse {
             $text_fn .= '.txt';
             my $content = "# $tc->{name}\n";
             for my $out ($tc->children('system-out, system-err, failure, error, skipped')->each) {
-                $content .= "# " . $out->tag . ": \n\n";
+                $content .= '# ' . $out->tag . ": \n\n";
                 $content .= $out->text . "\n";
             }
             $details->{text} = $text_fn;

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -17,7 +17,7 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::LTP::Test->
 # Parser
 sub parse {
     my ($self, $json) = @_;
-    confess "No JSON given/loaded" unless $json;
+    confess 'No JSON given/loaded' unless $json;
     my $decoded_json = Mojo::JSON::from_json($json);
 
     # may be optional since format result_array:v2

--- a/lib/OpenQA/Parser/Format/TAP.pm
+++ b/lib/OpenQA/Parser/Format/TAP.pm
@@ -13,12 +13,12 @@ has [qw(test steps)];
 
 sub parse {
     my ($self, $TAP) = @_;
-    confess "No TAP given/loaded" unless $TAP;
+    confess 'No TAP given/loaded' unless $TAP;
     my $tap = TAP::Parser->new({tap => $TAP});
-    confess "Failed " . $tap->parse_errors if $tap->parse_errors;
+    confess 'Failed ' . $tap->parse_errors if $tap->parse_errors;
     my $test = {
         flags => {},
-        category => "TAP",
+        category => 'TAP',
         name => 'Extra test from TAP',
     };
     my $details;

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -13,7 +13,7 @@ sub addproperty { shift->{properties}->add(OpenQA::Parser::Result::XUnit::Proper
 
 sub parse {
     my ($self, $xml) = @_;
-    confess "No XML given/loaded" unless $xml;
+    confess 'No XML given/loaded' unless $xml;
     my $dom = Mojo::DOM->new->xml(1)->parse($xml);
 
     my @tests;
@@ -73,12 +73,12 @@ sub parse {
                 my $text_fn = "$ts_category-$ts_name-$num";
                 $text_fn =~ s/[\/.]/_/g;
                 $text_fn .= '.txt';
-                my $content = "# Test messages ";
+                my $content = '# Test messages ';
                 $content .= "# $tc->{name}\n" if $tc->{name};
 
                 for my $out ($tc->children('skipped, passed, error, failure')->each) {
                     $tc_result = 'fail' if ($out->tag =~ m/failure|error/);
-                    $content .= "# " . $out->tag . ": \n\n";
+                    $content .= '# ' . $out->tag . ": \n\n";
                     $content .= $out->{message} . "\n" if $out->{message};
                     $content .= $out->text . "\n";
                 }

--- a/lib/OpenQA/Scheduler.pm
+++ b/lib/OpenQA/Scheduler.pm
@@ -97,8 +97,8 @@ sub setup ($self) {
     # initial schedule
     Mojo::IOLoop->next_tick(
         sub {
-            log_debug("Scheduler default interval(ms): " . SCHEDULE_TICK_MS);
-            log_debug("Max job allocation: " . OpenQA::Scheduler::Model::Jobs::MAX_JOB_ALLOCATION());
+            log_debug('Scheduler default interval(ms): ' . SCHEDULE_TICK_MS);
+            log_debug('Max job allocation: ' . OpenQA::Scheduler::Model::Jobs::MAX_JOB_ALLOCATION());
             OpenQA::Scheduler::Model::Jobs->singleton->schedule;
             _reschedule();
         });

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -61,7 +61,7 @@ sub _allocate_jobs ($self, $free_workers) {
         my @rejected = sort { $rejected{$b} <=> $rejected{$a} || $a cmp $b } keys %rejected;
         splice @rejected, MAX_REPORT_MISSING_WORKER_CLASSES;
         my $stats = join ',', map { "$_:$rejected{$_}" } @rejected;
-        my $info = sprintf "Skipping %d jobs because of no free workers for requested worker classes (%s)",
+        my $info = sprintf 'Skipping %d jobs because of no free workers for requested worker classes (%s)',
           sum(values %rejected), $stats;
         log_debug($info);
     }
@@ -133,7 +133,7 @@ sub _allocate_jobs ($self, $free_workers) {
         my $busy = keys %$allocated_workers;
         if ($busy >= $max_allocate || $busy >= @$free_workers) {
             my $free_worker_count = @$free_workers;
-            log_debug("limit reached, scheduling no additional jobs"
+            log_debug('limit reached, scheduling no additional jobs'
                   . " (max_running_jobs=$limit, free workers=$free_worker_count, running=$running, allocated=$busy)");
             last;
         }
@@ -175,7 +175,7 @@ sub schedule ($self) {
         };
         next unless $worker;
         if ($worker->unfinished_jobs->count) {
-            log_debug "Worker already got jobs, skipping";
+            log_debug 'Worker already got jobs, skipping';
             next;
         }
 
@@ -268,7 +268,7 @@ sub schedule ($self) {
                     });
                 $res = $jobs[0]->ws_send($worker);
             }
-            die "Failed contacting websocket server over HTTP" unless ref($res) eq "HASH" && exists $res->{state};
+            die 'Failed contacting websocket server over HTTP' unless ref($res) eq 'HASH' && exists $res->{state};
         }
         catch {
             log_warning "Failed to send data to websocket server, reason: $_";
@@ -305,10 +305,10 @@ sub schedule ($self) {
         }
     }
 
-    my $elapsed_rounded = sprintf("%.5f", (time - $start_time));
+    my $elapsed_rounded = sprintf('%.5f', (time - $start_time));
     log_debug "Scheduler took ${elapsed_rounded}s to perform operations and allocated "
-      . scalar(@successfully_allocated) . " jobs";
-    log_debug "Allocated: " . pp($_) for @successfully_allocated;
+      . scalar(@successfully_allocated) . ' jobs';
+    log_debug 'Allocated: ' . pp($_) for @successfully_allocated;
     $self->emit('conclude');
 
     return (\@successfully_allocated);
@@ -439,7 +439,7 @@ sub _update_scheduled_jobs ($self) {
     }
     # fetch worker classes
     my $settings
-      = $schema->resultset("JobSettings")->search({key => 'WORKER_CLASS', job_id => {-in => \@missing_worker_class}});
+      = $schema->resultset('JobSettings')->search({key => 'WORKER_CLASS', job_id => {-in => \@missing_worker_class}});
     while (my $line = $settings->next) {
         push(@{$scheduled_jobs->{$line->job_id}->{worker_classes}}, $line->value);
     }

--- a/lib/OpenQA/Schema/Profiler.pm
+++ b/lib/OpenQA/Schema/Profiler.pm
@@ -13,7 +13,7 @@ sub query_end {
     my ($self, $sql, @params) = @_;
     $sql = "$sql: " . join(', ', @params) if @params;
     my $elapsed = tv_interval($self->{start}, [gettimeofday()]);
-    log_debug(sprintf("[DBIC] Took %.8f seconds: %s", $elapsed, $sql));
+    log_debug(sprintf('[DBIC] Took %.8f seconds: %s', $elapsed, $sql));
 }
 
 # We need to override print because DBIx::Class::Storage::Statistics::print()
@@ -25,7 +25,7 @@ sub print {
     my ($self, $msg) = @_;
     chomp $msg;
 
-    log_debug(sprintf("[DBIC] %s", $msg));
+    log_debug(sprintf('[DBIC] %s', $msg));
 }
 
 sub enable_sql_debugging {

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -51,38 +51,38 @@ __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(user => 'OpenQA::Schema::Result::Users', 'user_id');
 
 __PACKAGE__->belongs_to(
-    "group",
-    "OpenQA::Schema::Result::JobGroups",
-    {'foreign.id' => "self.group_id"},
+    'group',
+    'OpenQA::Schema::Result::JobGroups',
+    {'foreign.id' => 'self.group_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 
 __PACKAGE__->belongs_to(
-    "parent_group",
-    "OpenQA::Schema::Result::JobGroupParents",
-    {'foreign.id' => "self.parent_group_id"},
+    'parent_group',
+    'OpenQA::Schema::Result::JobGroupParents',
+    {'foreign.id' => 'self.parent_group_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 
 __PACKAGE__->belongs_to(
-    "job",
-    "OpenQA::Schema::Result::Jobs",
-    {'foreign.id' => "self.job_id"},
+    'job',
+    'OpenQA::Schema::Result::Jobs',
+    {'foreign.id' => 'self.job_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 
@@ -175,8 +175,8 @@ sub extended_hash ($self, $render_markdown = 1) {
         text => $self->text,
         renderedMarkdown => ($render_markdown) ? $self->rendered_markdown->to_string : undef,
         bugrefs => $self->bugrefs,
-        created => $self->t_created->strftime("%Y-%m-%d %H:%M:%S %z"),
-        updated => $self->t_updated->strftime("%Y-%m-%d %H:%M:%S %z"),
+        created => $self->t_created->strftime('%Y-%m-%d %H:%M:%S %z'),
+        updated => $self->t_updated->strftime('%Y-%m-%d %H:%M:%S %z'),
         userName => $self->user->name
     };
 }

--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -66,13 +66,13 @@ __PACKAGE__->add_columns(
 __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(
-    "job",
-    "OpenQA::Schema::Result::Jobs",
-    {'foreign.id' => "self.job_id"},
+    'job',
+    'OpenQA::Schema::Result::Jobs',
+    {'foreign.id' => 'self.job_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_update => 'CASCADE',
     },
 );
 __PACKAGE__->add_unique_constraint([qw(job_id name category script)]);

--- a/lib/OpenQA/Schema/Result/JobSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobSettings.pm
@@ -27,18 +27,18 @@ __PACKAGE__->add_columns(
 __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(
-    job => "OpenQA::Schema::Result::Jobs",
-    {'foreign.id' => "self.job_id"},
+    job => 'OpenQA::Schema::Result::Jobs',
+    {'foreign.id' => 'self.job_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 __PACKAGE__->has_many(
-    siblings => "OpenQA::Schema::Result::JobSettings",
-    {"foreign.job_id" => "self.job_id"});
+    siblings => 'OpenQA::Schema::Result::JobSettings',
+    {'foreign.job_id' => 'self.job_id'});
 
 sub sqlt_deploy_hook {
     my ($self, $sqlt_table) = @_;

--- a/lib/OpenQA/Schema/Result/JobTemplateSettings.pm
+++ b/lib/OpenQA/Schema/Result/JobTemplateSettings.pm
@@ -29,7 +29,7 @@ __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw(job_template_id key)]);
 __PACKAGE__->belongs_to(
     job_template => 'OpenQA::Schema::Result::JobTemplates',
-    {'foreign.id' => "self.job_template_id"},
+    {'foreign.id' => 'self.job_template_id'},
     {
         is_deferrable => 1,
         join_type => 'LEFT',

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -421,7 +421,7 @@ sub settings_hash ($self, $prefetched = undef) {
     for my $column (qw(DISTRI VERSION FLAVOR MACHINE ARCH BUILD TEST)) {
         if (my $value = $self->$column) { $settings->{$column} = $value }
     }
-    $settings->{NAME} = sprintf "%08d-%s", $self->id, $self->name;
+    $settings->{NAME} = sprintf '%08d-%s', $self->id, $self->name;
     if ($settings->{JOB_TEMPLATE_NAME}) {
         my $test = $settings->{TEST};
         my $job_template_name = $settings->{JOB_TEMPLATE_NAME};
@@ -525,7 +525,7 @@ sub can_be_duplicated ($self) {
 }
 
 sub _compute_asset_names_considering_parent_jobs ($parent_job_ids, $asset_name) {
-    [$asset_name, map { sprintf("%08d-%s", $_, $asset_name) } @$parent_job_ids]
+    [$asset_name, map { sprintf('%08d-%s', $_, $asset_name) } @$parent_job_ids]
 }
 
 sub _strip_parent_job_id ($parent_job_ids, $asset_name) {
@@ -1030,10 +1030,10 @@ sub save_screenshot ($self, $screen) {
 
     my $tmpdir = $self->worker->get_property('WORKER_TMPDIR');
     return unless -d $tmpdir;    # we can't help
-    my $current = readlink($tmpdir . "/last.png");
+    my $current = readlink($tmpdir . '/last.png');
     my $newfile = OpenQA::Utils::save_base64_png($tmpdir, $screen->{name}, $screen->{png});
-    unlink($tmpdir . "/last.png");
-    symlink("$newfile.png", $tmpdir . "/last.png");
+    unlink($tmpdir . '/last.png');
+    symlink("$newfile.png", $tmpdir . '/last.png');
     # remove old file
     unlink($tmpdir . "/$current") if $current;
 }
@@ -1110,7 +1110,7 @@ sub insert_test_modules ($self, $testmodules) {
 
 sub custom_module ($self, $module, $output) {
     my $parser = parser('Base');
-    $parser->include_results(1) if $parser->can("include_results");
+    $parser->include_results(1) if $parser->can('include_results');
 
     $parser->results->add($module);
     $parser->_add_output($output) if defined $output;
@@ -1199,14 +1199,14 @@ sub exclusively_used_screenshot_ids ($self) {
 }
 
 sub num_prefix_dir ($self, $archived = undef) {
-    my $numprefix = sprintf "%05d", $self->id / 1000;
+    my $numprefix = sprintf '%05d', $self->id / 1000;
     return catfile(resultdir($archived // $self->archived), $numprefix);
 }
 
 sub create_result_dir ($self) {
     my $dir = $self->result_dir;
     if (!$dir) {
-        $dir = sprintf "%08d-%s", $self->id, $self->name;
+        $dir = sprintf '%08d-%s', $self->id, $self->name;
         $dir = substr($dir, 0, 255);
         $self->update({result_dir => $dir});
         $dir = $self->result_dir;
@@ -1298,7 +1298,7 @@ sub parse_extra_tests ($self, $asset, $type, $script = undef) {
     eval {
         my $parser = parser($type);
 
-        $parser->include_results(1) if $parser->can("include_results");
+        $parser->include_results(1) if $parser->can('include_results');
         my $tmp_extra_test = tempfile;
 
         $asset->move_to($tmp_extra_test);
@@ -1316,7 +1316,7 @@ sub parse_extra_tests ($self, $asset, $type, $script = undef) {
     };
 
     if ($@) {
-        log_error("Failed parsing data $type for job " . $self->id . ": " . $@);
+        log_error("Failed parsing data $type for job " . $self->id . ': ' . $@);
         return;
     }
     return 1;
@@ -1340,7 +1340,7 @@ sub create_asset ($self, $asset, $scope, $local = undef) {
     $type = 'hdd' if $fname =~ /\.(?:qcow2|raw|vhd|vhdx)$/;
     $type //= 'other';
 
-    my $job_id = sprintf "%08d", $self->id;
+    my $job_id = sprintf '%08d', $self->id;
     $fname = "$job_id-$fname" if $scope ne 'public';
 
     my $assetdir = assetdir();
@@ -1447,10 +1447,10 @@ sub update_status ($self, $status) {
     my $state = $self->state;
     return {result => 0} unless $state eq RUNNING || $state eq UPLOADING || $state eq CANCELLED;
 
-    $self->append_log($status->{log}, "autoinst-log-live.txt");
-    $self->append_log($status->{serial_log}, "serial-terminal-live.txt");
-    $self->append_log($status->{serial_terminal}, "serial-terminal-live.txt");
-    $self->append_log($status->{serial_terminal_user}, "serial-terminal-live.txt");
+    $self->append_log($status->{log}, 'autoinst-log-live.txt');
+    $self->append_log($status->{serial_log}, 'serial-terminal-live.txt');
+    $self->append_log($status->{serial_terminal}, 'serial-terminal-live.txt');
+    $self->append_log($status->{serial_terminal_user}, 'serial-terminal-live.txt');
     # delete from the hash so it becomes dumpable for debugging
     my $screen = delete $status->{screen};
     $self->save_screenshot($screen) if $screen;
@@ -1549,7 +1549,7 @@ sub reevaluate_children_asset_settings ($self, $include_self = 0, $visited = {})
 sub _asset_find ($name, $type, $parents) {
     # add undef to parents so that we check regular assets too
     for my $parent (@$parents, undef) {
-        my $fname = $parent ? sprintf("%08d-%s", $parent, $name) : $name;
+        my $fname = $parent ? sprintf('%08d-%s', $parent, $name) : $name;
         return $fname if locate_asset($type, $fname, mustexist => 1);
     }
     return undef;
@@ -1628,7 +1628,7 @@ sub _previous_scenario_jobs ($self, $rows = undef) {
         order_by => ['me.id DESC'],
         rows => $rows
     );
-    return $schema->resultset("Jobs")->search({-and => $conds}, \%attrs)->all;
+    return $schema->resultset('Jobs')->search({-and => $conds}, \%attrs)->all;
 }
 
 sub _relevant_module_result_for_carry_over_evaluation ($module_result) {
@@ -1676,7 +1676,7 @@ sub _carry_over_candidate ($self) {
     my $lookup_depth = $config->{lookup_depth};
     my $state_changes_limit = $config->{state_changes_limit};
 
-    my $label = sprintf "_carry_over_candidate(%d)", $self->id;
+    my $label = sprintf '_carry_over_candidate(%d)', $self->id;
     log_debug(sprintf "$label: _failure_reason=%s", $current_failure_reason);
 
     # we only do carryover for jobs with some kind of (soft) failure
@@ -1840,12 +1840,12 @@ sub git_diff ($self, $dir, $refspec_range, $limit = undef) {
     my $res = run_cmd_with_log_return_error($cmd);
     if ($res->{return_code}) {
         warn "Problem with [@$cmd] rc=$res->{return_code}: $res->{stdout} . $res->{stderr}";
-        return "Cannot display diff because of a git problem";
+        return 'Cannot display diff because of a git problem';
     }
     chomp(my $count = $res->{stdout});
     if ($count =~ tr/0-9//c) {
         warn "Problem with [@$cmd]: returned non-numeric string '$count'";
-        return "Cannot display diff because of a git problem";
+        return 'Cannot display diff because of a git problem';
     }
     return "Too many commits ($count) to create a diff between $refspec_range (maximum: $limit)" if $count > $limit;
 
@@ -1853,7 +1853,7 @@ sub git_diff ($self, $dir, $refspec_range, $limit = undef) {
     $res = run_cmd_with_log_return_error($cmd, stdout => 'trace');
     if ($res->{return_code}) {
         warn "Problem with [@$cmd] rc=$res->{return_code}: $res->{stdout} . $res->{stderr}";
-        return "Cannot display diff because of a git problem";
+        return 'Cannot display diff because of a git problem';
     }
     return $res->{stdout} . $res->{stderr};
 }

--- a/lib/OpenQA/Schema/Result/MachineSettings.pm
+++ b/lib/OpenQA/Schema/Result/MachineSettings.pm
@@ -29,14 +29,14 @@ __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw(machine_id key)]);
 
 __PACKAGE__->belongs_to(
-    "machine",
-    "OpenQA::Schema::Result::Machines",
-    {'foreign.id' => "self.machine_id"},
+    'machine',
+    'OpenQA::Schema::Result::Machines',
+    {'foreign.id' => 'self.machine_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -165,7 +165,7 @@ sub name ($self) {
 }
 
 sub path ($self) {
-    return $self->directory->path . "/" . $self->filename;
+    return $self->directory->path . '/' . $self->filename;
 }
 
 sub remove ($self, $user) {
@@ -180,7 +180,7 @@ sub remove ($self, $user) {
         my $error = $git->commit(
             {
                 rm => [$fname, $screenshot],
-                message => sprintf("Remove %s/%s", $directory->name, $self->filename),
+                message => sprintf('Remove %s/%s', $directory->name, $self->filename),
             });
         return $error if $error;
     }

--- a/lib/OpenQA/Schema/Result/ProductSettings.pm
+++ b/lib/OpenQA/Schema/Result/ProductSettings.pm
@@ -29,14 +29,14 @@ __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw(product_id key)]);
 
 __PACKAGE__->belongs_to(
-    "product",
-    "OpenQA::Schema::Result::Products",
-    {'foreign.id' => "self.product_id"},
+    'product',
+    'OpenQA::Schema::Result::Products',
+    {'foreign.id' => 'self.product_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 

--- a/lib/OpenQA/Schema/Result/Products.pm
+++ b/lib/OpenQA/Schema/Result/Products.pm
@@ -52,9 +52,9 @@ sub name {
 # used in the job groups display
 sub mediagroup {
     my ($self) = @_;
-    my $mediagroup = $self->distri . "-";
+    my $mediagroup = $self->distri . '-';
     if ($self->version ne '*') {
-        $mediagroup .= $self->version . "-";
+        $mediagroup .= $self->version . '-';
     }
     $mediagroup . $self->flavor;
 }

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -674,7 +674,7 @@ sub _check_for_cycle {
     my ($child, $parent, $jobs) = @_;
     $jobs->{$parent} = $child;
     return unless $jobs->{$child};
-    die "CYCLE" if $jobs->{$child} == $parent;
+    die 'CYCLE' if $jobs->{$child} == $parent;
     # go deeper into the graph
     _check_for_cycle($jobs->{$child}, $parent, $jobs);
 }

--- a/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
+++ b/lib/OpenQA/Schema/Result/TestSuiteSettings.pm
@@ -29,14 +29,14 @@ __PACKAGE__->set_primary_key('id');
 __PACKAGE__->add_unique_constraint([qw(test_suite_id key)]);
 
 __PACKAGE__->belongs_to(
-    "test_suite",
-    "OpenQA::Schema::Result::TestSuites",
-    {'foreign.id' => "self.test_suite_id"},
+    'test_suite',
+    'OpenQA::Schema::Result::TestSuites',
+    {'foreign.id' => 'self.test_suite_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 

--- a/lib/OpenQA/Schema/Result/Users.pm
+++ b/lib/OpenQA/Schema/Result/Users.pm
@@ -77,7 +77,7 @@ sub gravatar {
     $size //= 40;
 
     if (my $email = $self->email) {
-        return "//www.gravatar.com/avatar/" . md5_hex(lc $email) . "?d=wavatar&s=$size";
+        return '//www.gravatar.com/avatar/' . md5_hex(lc $email) . "?d=wavatar&s=$size";
     }
     else {
         return "//www.gravatar.com/avatar?s=$size";

--- a/lib/OpenQA/Schema/Result/WorkerProperties.pm
+++ b/lib/OpenQA/Schema/Result/WorkerProperties.pm
@@ -27,14 +27,14 @@ __PACKAGE__->add_columns(
 __PACKAGE__->add_timestamps;
 __PACKAGE__->set_primary_key('id');
 __PACKAGE__->belongs_to(
-    "worker",
-    "OpenQA::Schema::Result::Workers",
-    {'foreign.id' => "self.worker_id"},
+    'worker',
+    'OpenQA::Schema::Result::Workers',
+    {'foreign.id' => 'self.worker_id'},
     {
         is_deferrable => 1,
-        join_type => "LEFT",
-        on_delete => "CASCADE",
-        on_update => "CASCADE",
+        join_type => 'LEFT',
+        on_delete => 'CASCADE',
+        on_update => 'CASCADE',
     },
 );
 

--- a/lib/OpenQA/Schema/Result/Workers.pm
+++ b/lib/OpenQA/Schema/Result/Workers.pm
@@ -66,7 +66,7 @@ __PACKAGE__->inflate_column(
 
 sub name {
     my ($self) = @_;
-    return $self->host . ":" . $self->instance;
+    return $self->host . ':' . $self->instance;
 }
 
 sub seen ($self, $options = {}) {
@@ -182,7 +182,7 @@ sub unprepare_for_work {
 
 sub info {
     my $self = shift;
-    my ($live) = ref $_[0] eq "HASH" ? @{$_[0]}{qw(live)} : @_;
+    my ($live) = ref $_[0] eq 'HASH' ? @{$_[0]}{qw(live)} : @_;
 
     my $settings = {
         id => $self->id,

--- a/lib/OpenQA/Schema/ResultSet/JobTemplates.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobTemplates.pm
@@ -49,7 +49,7 @@ sub create_or_update_job_template {
             group_id => $group_id,
             product_id => $product->id,
             machine_id => $machine->id,
-            name => $args->{job_template_name} // "",
+            name => $args->{job_template_name} // '',
             test_suite_id => $test_suite->id,
         },
         {

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -53,11 +53,11 @@ sub latest_build {
         my $value = $args{$key};
 
         if (grep { $key eq $_ } qw(distri version flavor machine arch build test)) {
-            push(@conds, {"me." . uc($key) => $value});
+            push(@conds, {'me.' . uc($key) => $value});
         }
         else {
 
-            my $subquery = $schema->resultset("JobSettings")->search(
+            my $subquery = $schema->resultset('JobSettings')->search(
                 {
                     key => uc($key),
                     value => $value
@@ -266,7 +266,7 @@ sub _prepare_complex_query_search_args ($self, $args) {
         push @conds, {'me.group_id' => $args->{groupid} || undef};
     }
     elsif ($args->{group}) {
-        my $subquery = $schema->resultset("JobGroups")->search({name => $args->{group}})->get_column('id')->as_query;
+        my $subquery = $schema->resultset('JobGroups')->search({name => $args->{group}})->get_column('id')->as_query;
         push @conds, {'me.group_id' => {-in => $subquery}};
     }
 
@@ -287,12 +287,12 @@ sub _prepare_complex_query_search_args ($self, $args) {
             $js_settings{$key} = $args->{lc $key} if defined $args->{lc $key};
         }
         if (keys %js_settings) {
-            my $subquery = $schema->resultset("JobSettings")->query_for_settings(\%js_settings);
+            my $subquery = $schema->resultset('JobSettings')->query_for_settings(\%js_settings);
             push(@conds, {'me.id' => {-in => $subquery->get_column('job_id')->as_query}});
         }
 
         for my $key (qw(distri version flavor arch test machine)) {
-            push(@conds, {"me." . uc($key) => $args->{$key}}) if $args->{$key};
+            push(@conds, {'me.' . uc($key) => $args->{$key}}) if $args->{$key};
         }
         if (my $build = $args->{build}) {
             push @conds, {'me.BUILD' => ref $build eq 'ARRAY' ? {-in => $build} : $build};
@@ -300,7 +300,7 @@ sub _prepare_complex_query_search_args ($self, $args) {
     }
 
     if (defined(my $c = $args->{comment_text})) {
-        push @conds, \["(select id from comments where job_id = me.id and text like ? limit 1) is not null", "%$c%"];
+        push @conds, \['(select id from comments where job_id = me.id and text like ? limit 1) is not null', "%$c%"];
     }
 
     push(@conds, @{$args->{additional_conds}}) if $args->{additional_conds};

--- a/lib/OpenQA/Schema/ResultSet/Needles.pm
+++ b/lib/OpenQA/Schema/ResultSet/Needles.pm
@@ -56,7 +56,7 @@ sub new_needles_since {
     if ($tags && @$tags) {
         my @tags_conds;
         for my $tag (@$tags) {
-            push(@tags_conds, \["? = ANY (tags)", $tag]);
+            push(@tags_conds, \['? = ANY (tags)', $tag]);
         }
         $new_needle_conds{-or} = \@tags_conds;
     }

--- a/lib/OpenQA/Script/Client.pm
+++ b/lib/OpenQA/Script/Client.pm
@@ -13,7 +13,7 @@ use Scalar::Util ();
 use OpenQA::Client;
 use OpenQA::YAML qw(dump_yaml load_yaml);
 # use UTF-8 on all streams to prevent problems when reading/writing unicode
-use open ":std", ":encoding(UTF-8)";
+use open ':std', ':encoding(UTF-8)';
 
 
 our @EXPORT = qw(
@@ -27,7 +27,7 @@ our $apibase = '/api/v1';
 
 sub handle_result ($options, $res) {
     my $rescode = $res->code // 0;
-    my $message = "{no message}";
+    my $message = '{no message}';
     $message = $res->{error}->{message} if ($rescode != 200 && $res->{error} && $res->{error}->{message});
 
     if ($rescode >= 200 && $rescode <= 299) {

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -76,7 +76,7 @@ sub clone_job_get_job ($jobid, $url_handler, $options) {
         die "failed to get job '$jobid': $err->{code} $err->{message}";
     }
     if ($tx->res->code != 200) {
-        warn sprintf("unexpected return code: %s %s", $tx->res->code, $tx->res->message);
+        warn sprintf('unexpected return code: %s %s', $tx->res->code, $tx->res->message);
         exit 1;
     }
     my $job = $tx->res->json->{job};
@@ -191,8 +191,8 @@ sub create_url_handler ($options) {
     $local_url->path('/api/v1/jobs');
     my $local = OpenQA::Client->new(
         api => $local_url->host,
-        apikey => $options->{'apikey'},
-        apisecret => $options->{'apisecret'});
+        apikey => $options->{apikey},
+        apisecret => $options->{apisecret});
     die "API key/secret for '$options->{host}' missing. Checkout '$0 --help' for the config file syntax/lookup.\n"
       unless $local->apikey && $local->apisecret;
 

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -65,7 +65,7 @@ sub read_config ($app) {
             do_push => 'no',
             do_cleanup => 'no',
         },
-        'scheduler' => {
+        scheduler => {
             max_job_scheduled_time => 7,
             max_running_jobs => -1,
         },
@@ -221,7 +221,7 @@ sub read_config ($app) {
     # Mojo's built in config plugins suck. JSON for example does not
     # support comments
     my $cfg;
-    my $cfgpath = $ENV{OPENQA_CONFIG} ? path($ENV{OPENQA_CONFIG}) : $app->home->child("etc", "openqa");
+    my $cfgpath = $ENV{OPENQA_CONFIG} ? path($ENV{OPENQA_CONFIG}) : $app->home->child('etc', 'openqa');
     my $cfgfile = $cfgpath->child('openqa.ini');
     my $config = $app->config;
 
@@ -230,7 +230,7 @@ sub read_config ($app) {
         $config->{ini_config} = $cfg;
     }
     else {
-        $app->log->warn("No configuration file supplied, will fallback to default configuration");
+        $app->log->warn('No configuration file supplied, will fallback to default configuration');
     }
 
     for my $section (sort keys %defaults) {
@@ -294,17 +294,17 @@ sub update_config ($config, @namespaces) {
     foreach my $plugin (loaded_plugins(@namespaces)) {
 
         # We take config only if the plugin has the method declared
-        next unless ($plugin->can("configuration_fields"));
+        next unless ($plugin->can('configuration_fields'));
 
         # If it is a Mojo::Base class, it requires to be instantiated
         # because the attributes are not populated until creation.
         my $fields
-          = UNIVERSAL::isa($plugin, "Mojo::Base")
+          = UNIVERSAL::isa($plugin, 'Mojo::Base')
           ? do { $plugin->new->configuration_fields() }
           : $plugin->configuration_fields();
 
         # We expect just hashrefs
-        next unless (ref($fields) eq "HASH");
+        next unless (ref($fields) eq 'HASH');
 
         # Walk the hash with the plugin returns that needs to be fetched
         # by our Ini file parser and fill config from it
@@ -382,7 +382,7 @@ sub load_plugins ($server, $monitoring_root_route = undef, %options) {
     }
 
     # Read configurations expected by plugins.
-    OpenQA::Setup::update_config($server->config, @{$server->plugins->namespaces}, "OpenQA::WebAPI::Auth");
+    OpenQA::Setup::update_config($server->config, @{$server->plugins->namespaces}, 'OpenQA::WebAPI::Auth');
 }
 
 sub set_secure_flag_on_cookies ($c) {

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -32,7 +32,7 @@ sub check ($self) {
                 if (my $secret = $api_key->secret) {
                     my $sum = hmac_sha1_sum($self->req->url->to_string . $timestamp, $secret);
                     $user = $api_key->user;
-                    log_trace(sprintf "API auth by user: %s, operator: %d", $user->username, $user->is_operator);
+                    log_trace(sprintf 'API auth by user: %s, operator: %d', $user->username, $user->is_operator);
                 }
             }
         }
@@ -71,7 +71,7 @@ sub auth ($self) {
     }
 
     if ($user) {
-        $log->trace(sprintf "API auth by user: %s, operator: %d", $user->username, $user->is_operator);
+        $log->trace(sprintf 'API auth by user: %s, operator: %d', $user->username, $user->is_operator);
         $self->stash(current_user => {user => $user});
         return 1;
     }

--- a/lib/OpenQA/Shared/Controller/Session.pm
+++ b/lib/OpenQA/Shared/Controller/Session.pm
@@ -17,7 +17,7 @@ sub ensure_operator {
     my ($self) = @_;
     $self->redirect_to($self->url_for('login')->query(return_page => $self->req->url)) and return undef
       unless $self->current_user;
-    $self->render(text => "Forbidden", status => 403) and return undef unless $self->is_operator;
+    $self->render(text => 'Forbidden', status => 403) and return undef unless $self->is_operator;
     return 1 if $self->req->method eq 'GET' || $self->valid_csrf;
     $self->render(text => 'Bad CSRF token!', status => 403);
     return undef;
@@ -27,7 +27,7 @@ sub ensure_admin {
     my ($self) = @_;
     $self->redirect_to($self->url_for('login')->query(return_page => $self->req->url)) and return undef
       unless $self->current_user;
-    $self->render(text => "Forbidden", status => 403) and return undef unless $self->is_admin;
+    $self->render(text => 'Forbidden', status => 403) and return undef unless $self->is_admin;
     return 1 if $self->req->method eq 'GET' || $self->valid_csrf;
     $self->render(text => 'Bad CSRF token!', status => 403);
     return undef;
@@ -87,7 +87,7 @@ sub response {
 
 sub test {
     my $self = shift;
-    $self->render(text => "You can see this because you are " . $self->current_user->username);
+    $self->render(text => 'You can see this because you are ' . $self->current_user->username);
 }
 
 1;

--- a/lib/OpenQA/Shared/Plugin/CSRF.pm
+++ b/lib/OpenQA/Shared/Plugin/CSRF.pm
@@ -8,7 +8,7 @@ sub register {
     my ($self, $app, $config) = @_;
 
     # replace form_for with our own that puts the csrf token in there
-    die "failed to find form_for" unless my $form_for = delete $app->renderer->helpers->{form_for};
+    die 'failed to find form_for' unless my $form_for = delete $app->renderer->helpers->{form_for};
     $app->helper(
         form_for => sub {
             my $self = shift;
@@ -28,7 +28,7 @@ sub register {
 
             my $validation = $c->validation;
             if ($validation->csrf_protect->has_error('csrf_token')) {
-                $c->app->log->debug("Bad CSRF token");
+                $c->app->log->debug('Bad CSRF token');
                 return 0;
             }
             return 1;

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -50,7 +50,7 @@ sub _current_user ($c) {
     my $current_user = $c->stash('current_user');
     unless ($current_user && ($current_user->{no_user} || defined $current_user->{user})) {
         my $id = $c->session->{user};
-        my $user = $id ? $c->schema->resultset("Users")->find({username => $id}) : undef;
+        my $user = $id ? $c->schema->resultset('Users')->find({username => $id}) : undef;
         $c->stash(current_user => $current_user = $user ? {user => $user} : {no_user => 1});
     }
 

--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -125,7 +125,7 @@ sub _save_needle {
         $success = 0;
     }
     if ($success) {
-        open(my $J, ">", "$baseneedle.json") or $success = 0;
+        open(my $J, '>', "$baseneedle.json") or $success = 0;
         if ($success) {
             print($J $needle_json);
             close($J);
@@ -141,7 +141,7 @@ sub _save_needle {
         my $error = $git->commit(
             {
                 add => ["$needlename.json", "$needlename.png"],
-                message => ($commit_message || sprintf("%s for %s", $needlename, $openqa_job->name)),
+                message => ($commit_message || sprintf('%s for %s', $needlename, $openqa_job->name)),
             });
         if ($error) {
             $app->log->error($error);

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -86,7 +86,7 @@ use constant FLAG_REGEX => qr/\bflag:(?<match>([\w:#]+))\b/;
 
 use constant ONE_SECOND_IN_MICROSECONDS => 1_000_000;
 
-our $VERSION = sprintf "%d.%03d", q$Revision: 1.12 $ =~ /(\d+)/g;
+our $VERSION = sprintf '%d.%03d', q$Revision: 1.12 $ =~ /(\d+)/g;
 our @EXPORT = qw(
   UNCONSTRAINED_BUGREF_REGEX
   BUGREF_REGEX
@@ -286,7 +286,7 @@ sub save_base64_png {
     # sanitize
     $newfile =~ s,\.png,,;
     $newfile =~ tr/a-zA-Z0-9-/_/cs;
-    open(my $fh, ">", $dir . "/$newfile.png") || die "can't open $dir/$newfile.png: $!";
+    open(my $fh, '>', $dir . "/$newfile.png") || die "can't open $dir/$newfile.png: $!";
     use MIME::Base64 'decode_base64';
     $fh->print(decode_base64($png));
     close($fh);
@@ -358,7 +358,7 @@ sub run_cmd_with_log_return_error ($cmd, %args) {
         return {
             status => 0,
             return_code => undef,
-            stderr => "an internal error occurred",
+            stderr => 'an internal error occurred',
             stdout => '',
         };
     };
@@ -456,7 +456,7 @@ sub bugurl {
     # versa for both an issue as well as pull request
     # for pagure.io it has to be "issue", not "issues"
     $bugref =~ BUGREF_REGEX;
-    my $issuetext = $+{marker} eq "pio" ? "issue" : "issues";
+    my $issuetext = $+{marker} eq 'pio' ? 'issue' : 'issues';
     return $BUGREFS{$+{marker}} . ($+{repo} ? "$+{repo}/$issuetext/" : '') . $+{id};
 }
 
@@ -619,11 +619,11 @@ sub human_readable_size {
     $size = abs($size);
     return "$p$size Byte" if $size < 3000;
     $size /= 1024.;
-    return $p . _round_a_bit($size) . " KiB" if $size < 1024;
+    return $p . _round_a_bit($size) . ' KiB' if $size < 1024;
     $size /= 1024.;
-    return $p . _round_a_bit($size) . " MiB" if $size < 1024;
+    return $p . _round_a_bit($size) . ' MiB' if $size < 1024;
     $size /= 1024.;
-    return $p . _round_a_bit($size) . " GiB";
+    return $p . _round_a_bit($size) . ' GiB';
 }
 
 sub read_test_modules {
@@ -739,7 +739,7 @@ sub detect_current_version {
             my $partial_hash = substr($master_head, 0, 8);
             if ($latest_ref && $partial_hash) {
                 my $tag = (split(/\//, $latest_ref))[-1];
-                $current_version = $tag ? "git-" . $tag . "-" . $partial_hash : undef;
+                $current_version = $tag ? 'git-' . $tag . '-' . $partial_hash : undef;
             }
         }
     }
@@ -758,7 +758,7 @@ sub loaded_modules {
 # Fallback to loaded_modules if no arguments are given.
 # Accepts namespaces as arguments. If supplied, it will filter by them
 sub loaded_plugins {
-    my $ns = join("|", map { quotemeta } @_);
+    my $ns = join('|', map { quotemeta } @_);
     return @_ ? grep { /^$ns/ } loaded_modules() : loaded_modules();
 }
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -51,8 +51,8 @@ sub startup ($self) {
     my $r = $self->routes->namespaces(['OpenQA::Shared::Controller', 'OpenQA::WebAPI::Controller', 'OpenQA::WebAPI']);
 
     # register basic routes
-    my $logged_in = $r->under('/')->to("session#ensure_user");
-    my $auth = $r->under('/')->to("session#ensure_operator");
+    my $logged_in = $r->under('/')->to('session#ensure_user');
+    my $auth = $r->under('/')->to('session#ensure_operator');
 
     # Routes used by plugins (UI and API)
     my $admin = $r->any('/admin');

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -24,7 +24,7 @@ sub auth_login ($self) {
     };
 
     my $user = $self->req->param('user') || 'Demo';
-    my $userinfo = $users{$user} || die "No such user";
+    my $userinfo = $users{$user} || die 'No such user';
     $userinfo->{username} = $user;
 
     $user = $self->schema->resultset('Users')->create_user(

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -70,7 +70,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
     }
     my $details = $tx->res->json;
     if (ref $details ne 'HASH' || !$details->{id} || !$details->{$provider_config->{nickname_from}}) {
-        log_debug("OAuth2 user provider returned: " . dumper($details));
+        log_debug('OAuth2 user provider returned: ' . dumper($details));
         return $controller->render(text => 'User data returned by OAuth2 provider is insufficient', status => 403);
     }
     my $provider_name = $main_config->{provider};

--- a/lib/OpenQA/WebAPI/Auth/OpenID.pm
+++ b/lib/OpenQA/WebAPI/Auth/OpenID.pm
@@ -38,9 +38,9 @@ sub auth_login ($self) {
         {
             mode => 'fetch_request',
             required => 'email,fullname,nickname,firstname,lastname',
-            'type.email' => "http://schema.openid.net/contact/email",
-            'type.fullname' => "http://axschema.org/namePerson",
-            'type.nickname' => "http://axschema.org/namePerson/friendly",
+            'type.email' => 'http://schema.openid.net/contact/email',
+            'type.fullname' => 'http://axschema.org/namePerson',
+            'type.nickname' => 'http://axschema.org/namePerson/friendly',
             'type.firstname' => 'http://axschema.org/namePerson/first',
             'type.lastname' => 'http://axschema.org/namePerson/last',
         },
@@ -71,7 +71,7 @@ sub auth_response ($self) {
     %params = map { $_ => URI::Escape::uri_unescape($params{$_}) } keys %params;
 
     my $csr = Net::OpenID::Consumer->new(
-        debug => sub { $self->app->log->debug("Net::OpenID::Consumer: " . join(' ', @_)); },
+        debug => sub { $self->app->log->debug('Net::OpenID::Consumer: ' . join(' ', @_)); },
         ua => LWP::UserAgent->new,
         required_root => $url,
         consumer_secret => $self->app->config->{_openid_secret},
@@ -87,7 +87,7 @@ sub auth_response ($self) {
 
     $csr->handle_server_response(
         not_openid => sub {
-            return $err_handler->("Failed to login", "OpenID provider returned invalid data. Please retry again");
+            return $err_handler->('Failed to login', 'OpenID provider returned invalid data. Please retry again');
         },
         setup_needed => sub {
             my $setup_url = shift;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -72,7 +72,7 @@ sub list ($self) {
     my $offset = $validation->param('offset') // 0;
 
     # We request one more than the limit to check if there are more results for pagination
-    my $rs = $schema->resultset("Assets")->search({}, {rows => $limit + 1, offset => $offset});
+    my $rs = $schema->resultset('Assets')->search({}, {rows => $limit + 1, offset => $offset});
     $rs->result_class('DBIx::Class::ResultClass::HashRefInflator');
     my @all = $rs->all;
 
@@ -111,7 +111,7 @@ sub get {
         $args{$arg} = $self->stash($arg) if defined $self->stash($arg);
     }
 
-    my $rs = $schema->resultset("Assets")->search(\%args);
+    my $rs = $schema->resultset('Assets')->search(\%args);
     $rs->result_class('DBIx::Class::ResultClass::HashRefInflator');
 
     if ($rs && $rs->single) {
@@ -141,7 +141,7 @@ sub delete {
         $args{$arg} = $self->stash($arg) if defined $self->stash($arg);
     }
 
-    my $asset = $self->schema->resultset("Assets")->search(\%args);
+    my $asset = $self->schema->resultset('Assets')->search(\%args);
     return $self->render(
         json =>
           {error => 'The asset might have already been removed and only the cached view has not been updated yet.'},

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Bug.pm
@@ -102,7 +102,7 @@ existing bug or not, and the date when the bug was last updated in the system.
 =cut
 
 sub show ($self) {
-    my $bug = $self->schema->resultset("Bugs")->find($self->param('id'));
+    my $bug = $self->schema->resultset('Bugs')->find($self->param('id'));
     return $self->reply->not_found unless $bug;
 
     my %json = map { $_ => $bug->get_column($_) }
@@ -130,10 +130,10 @@ sub create ($self) {
 
     my $schema = $self->schema;
     my $bugid = $validation->param('bugid');
-    my $bug = $schema->resultset("Bugs")->find({bugid => $bugid});
+    my $bug = $schema->resultset('Bugs')->find({bugid => $bugid});
     return $self->render(json => {error => 1}) if $bug;
 
-    $bug = $schema->resultset("Bugs")->create({bugid => $bugid, %{$self->get_bug_values}});
+    $bug = $schema->resultset('Bugs')->create({bugid => $bugid, %{$self->get_bug_values}});
     $self->emit_event('openqa_bug_create', {id => $bug->id, bugid => $bug->bugid, fromapi => 1});
     $self->render(json => {id => $bug->id});
 }
@@ -150,7 +150,7 @@ the id of the bug, or an error if the bug id is not found in the system.
 =cut
 
 sub update ($self) {
-    my $bug = $self->schema->resultset("Bugs")->find($self->param('id'));
+    my $bug = $self->schema->resultset('Bugs')->find($self->param('id'));
     return $self->reply->not_found unless $bug;
 
     my $validation = $self->validation;
@@ -173,7 +173,7 @@ Removes a bug from the system given its bug id. Return 1 on success or not found
 =cut
 
 sub destroy ($self) {
-    my $bug = $self->schema->resultset("Bugs")->find($self->param('id'));
+    my $bug = $self->schema->resultset('Bugs')->find($self->param('id'));
     return $self->reply->not_found unless $bug;
 
     $self->emit_event('openqa_bug_delete', {id => $bug->id, bugid => $bug->bugid});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -170,7 +170,7 @@ sub update ($self) {
     my $comment_id = $self->param('comment_id');
     my $comment = $comments->find($self->param('comment_id'));
     return $self->render(json => {error => "Comment $comment_id does not exist"}, status => 404) unless $comment;
-    return $self->render(json => {error => "Forbidden (must be author)"}, status => 403)
+    return $self->render(json => {error => 'Forbidden (must be author)'}, status => 403)
       unless ($comment->user_id == $self->current_user->id);
     my $txn_guard = $self->schema->txn_scope_guard;
     my $res = $comment->update({text => href_to_bugref($text)});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -61,7 +61,7 @@ sub validate_create_parameters ($self) {
     $validation->required($_) for (MANDATORY_PARAMETERS);
     return 1 unless $validation->has_error;
 
-    my $error = "Error: missing parameters:";
+    my $error = 'Error: missing parameters:';
     my $log = $self->log;
     for my $k (MANDATORY_PARAMETERS) {
         $log->debug(@{$validation->error($k)}) if $validation->has_error($k);
@@ -204,9 +204,9 @@ sub destroy {
     $self->emit_event('openqa_iso_delete', {iso => $iso});
 
     my $schema = $self->schema;
-    my $subquery = $schema->resultset("JobSettings")->query_for_settings({ISO => $iso});
+    my $subquery = $schema->resultset('JobSettings')->query_for_settings({ISO => $iso});
     my @jobs
-      = $schema->resultset("Jobs")->search({'me.id' => {-in => $subquery->get_column('job_id')->as_query}})->all;
+      = $schema->resultset('Jobs')->search({'me.id' => {-in => $subquery->get_column('job_id')->as_query}})->all;
 
     for my $job (@jobs) {
         $self->emit_event('openqa_job_delete', {id => $job->id});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -446,7 +446,7 @@ sub show ($self) {
     my $job_id = int($self->stash('jobid'));
     my $details = $self->stash('details') || 0;
     my $check_assets = !!$self->param('check_assets');
-    my $job = $self->schema->resultset("Jobs")->find($job_id, {prefetch => 'settings'});
+    my $job = $self->schema->resultset('Jobs')->find($job_id, {prefetch => 'settings'});
     return $self->reply->not_found unless $job;
     $job = $job->to_hash(assets => 1, check_assets => $check_assets, deps => 1, details => $details, parent_group => 1);
     $self->render(json => {job => $job});
@@ -732,7 +732,7 @@ sub upload_state ($self) {
     my $scope = $validation->param('scope') // 'private';
     my $job_id = $self->stash('jobid');
 
-    $file = sprintf("%08d-%s", $job_id, $file) if $scope ne 'public';
+    $file = sprintf('%08d-%s', $job_id, $file) if $scope ne 'public';
 
     if ($state eq 'fail') {
         $self->app->log->debug("FAIL chunk upload of $file");
@@ -741,7 +741,7 @@ sub upload_state ($self) {
                 $_->remove_tree if -d $_ && $_->basename eq $file . '.CHUNKS';
             });
     }
-    $self->render(text => "OK");
+    $self->render(text => 'OK');
 }
 
 =over 4

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -52,7 +52,7 @@ sub list {
     my @templates;
     eval {
         if (my $id = $self->param('job_template_id')) {
-            @templates = $schema->resultset("JobTemplates")->search({id => $id});
+            @templates = $schema->resultset('JobTemplates')->search({id => $id});
         }
         else {
             my %cond;
@@ -65,7 +65,7 @@ sub list {
                 if (my $value = $self->param($id)) { $cond{$id} = $value }
             }
             my %attrs = (prefetch => [qw(machine test_suite product)], rows => $limit);
-            @templates = $schema->resultset("JobTemplates")->search(\%cond, \%attrs);
+            @templates = $schema->resultset('JobTemplates')->search(\%cond, \%attrs);
         }
     };
 
@@ -123,7 +123,7 @@ sub _get_job_groups {
     my ($self, $id, $name) = @_;
 
     my %yaml;
-    my $groups = $self->schema->resultset("JobGroups")->search(
+    my $groups = $self->schema->resultset('JobGroups')->search(
         $id ? {id => $id} : ($name ? {name => $name} : undef),
         {select => [qw(id name parent_id default_priority template)]});
     while (my $group = $groups->next) {
@@ -356,7 +356,7 @@ sub create {
 
     my $schema = $self->schema;
     my $group_id = $self->param('group_id');
-    my $group = $schema->resultset("JobGroups")->find({id => $group_id});
+    my $group = $schema->resultset('JobGroups')->find({id => $group_id});
 
     if ($group && $group->template) {
         # An existing group with a YAML template must not be updated manually
@@ -374,7 +374,7 @@ sub create {
             machine_id => $validation->param('machine_id'),
             group_id => $group_id,
             test_suite_id => $validation->param('test_suite_id')};
-        eval { push @ids, $schema->resultset("JobTemplates")->create($values)->id };
+        eval { push @ids, $schema->resultset('JobTemplates')->create($values)->id };
         $error = $@;
     }
     elsif ($validation->param('prio_only')) {
@@ -384,7 +384,7 @@ sub create {
         return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
 
         eval {
-            my $job_templates = $schema->resultset("JobTemplates")->search(
+            my $job_templates = $schema->resultset('JobTemplates')->search(
                 {
                     group_id => $group_id,
                     test_suite_id => $validation->param('test_suite_id'),
@@ -410,7 +410,7 @@ sub create {
             machine => {name => $validation->param('machine_name')},
             prio => $prio,
             test_suite => {name => $validation->param('test_suite_name')}};
-        eval { push @ids, $schema->resultset("JobTemplates")->create($values)->id };
+        eval { push @ids, $schema->resultset('JobTemplates')->create($values)->id };
         $error = $@;
     }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -90,7 +90,7 @@ sub _search_perl_modules {
             next unless length $match;
             my ($filename, $linenr, $contents) = split(':', $match, 3);
             # Prefix each line with a 5 digit-padded number
-            $contents = sprintf("%5d ", $linenr) . $contents;
+            $contents = sprintf('%5d ', $linenr) . $contents;
             # Merge lines occurring in the same file
             if ($filename eq $last_filename) {
                 $results[-1]->{contents} .= "\n$contents";
@@ -173,9 +173,9 @@ sub query {
     my $lockname = 'webui_query_rate_limit';
     if (my $user = $self->current_user) { $lockname .= $user->username }
     return $self->render(json => {error => 'Rate limit exceeded'}, status => 400)
-      unless $self->app->minion->lock($lockname, 60, {limit => $self->app->config->{'rate_limits'}->{'search'}});
+      unless $self->app->minion->lock($lockname, 60, {limit => $self->app->config->{rate_limits}->{'search'}});
 
-    my $cap = $self->app->config->{'global'}->{'search_results_limit'};
+    my $cap = $self->app->config->{global}->{'search_results_limit'};
     my %results;
     my $keywords = $validation->param('q');
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -68,7 +68,7 @@ my %TABLES = (
         keys => [['id'], ['distri', 'version', 'arch', 'flavor'],],
         cols => ['id', 'distri', 'version', 'arch', 'flavor', 'description'],
         required => ['distri', 'version', 'arch', 'flavor'],
-        defaults => {description => "", name => ""},
+        defaults => {description => '', name => ''},
         ref_name => 'product'
     },
 );
@@ -170,7 +170,7 @@ OpenQA::WebAPI::Controller::API::V1::Table package documentation.
 
 sub create {
     my ($self) = @_;
-    my $table = $self->param("table");
+    my $table = $self->param('table');
     my %entry = %{$TABLES{$table}->{defaults}};
 
     my ($error_message, $settings, $keys) = $self->_prepare_settings($table, \%entry);
@@ -224,13 +224,13 @@ sub _verify_table_usage {
       ? 'Group'
       . (scalar(keys %groups) > 1 ? 's' : '') . ' '
       . join(', ', sort keys(%groups))
-      . " must be updated through the YAML template"
+      . ' must be updated through the YAML template'
       : undef;
 }
 
 sub update {
     my ($self) = @_;
-    my $table = $self->param("table");
+    my $table = $self->param('table');
 
     my $entry = {};
     my ($error_message, $settings, $keys) = $self->_prepare_settings($table, $entry);
@@ -303,7 +303,7 @@ with the number of deleted tables on success.
 sub destroy {
     my ($self) = @_;
 
-    my $table = $self->param("table");
+    my $table = $self->param('table');
     my $schema = $self->schema;
     my $machines = $schema->resultset('Machines');
     my $ret;
@@ -362,7 +362,7 @@ sub _prepare_settings {
     }
 
     if ($validation->has_error) {
-        return "Missing parameter: " . join(', ', @{$validation->failed});
+        return 'Missing parameter: ' . join(', ', @{$validation->failed});
     }
 
     $entry->{description} = $self->param('description');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -221,7 +221,7 @@ preventing it from taking jobs.
 
 sub show {
     my ($self) = @_;
-    my $worker = $self->schema->resultset("Workers")->find($self->param('workerid'));
+    my $worker = $self->schema->resultset('Workers')->find($self->param('workerid'));
     if ($worker) {
         $self->render(json => {worker => $worker->info(1)});
     }
@@ -245,13 +245,13 @@ sub delete {
     my ($self) = @_;
     my $message;
     my $worker_id = $self->param('worker_id');
-    my $worker = $self->schema->resultset("Workers")->find($worker_id);
+    my $worker = $self->schema->resultset('Workers')->find($worker_id);
 
     if (!$worker) {
-        return $self->render(json => {error => "Worker not found."}, status => 404);
+        return $self->render(json => {error => 'Worker not found.'}, status => 404);
     }
     if ($worker->status ne 'dead' || $worker->unfinished_jobs->count) {
-        $message = "Worker " . $worker->name . " status is not offline.";
+        $message = 'Worker ' . $worker->name . ' status is not offline.';
         return $self->render(json => {error => $message}, status => 400);
     }
 
@@ -259,7 +259,7 @@ sub delete {
     if ($@) {
         return $self->render(json => {error => $@}, status => 409);
     }
-    $message = "Delete worker " . $worker->name . " successfully.";
+    $message = 'Delete worker ' . $worker->name . ' successfully.';
     $self->emit_event('openqa_worker_delete', {id => $worker->id, name => $worker->name});
     $self->render(json => {message => $message});
 }

--- a/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/AuditLog.pm
@@ -80,7 +80,7 @@ sub _add_single_query {
         push(@{$query->{$actual_key}}, ($actual_key => {-like => '%' . $search . '%'}));
     }
     elsif ($key eq 'id') {
-        push(@{$query->{$key}}, ("CAST(me.id AS text)" => {-like => '%' . $search . '%'}));
+        push(@{$query->{$key}}, ('CAST(me.id AS text)' => {-like => '%' . $search . '%'}));
     }
     elsif ($key eq 'older' || $key eq 'newer') {
         if ($search eq 'today') {

--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -16,7 +16,7 @@ sub _queue_sub_stats ($query, $state, $result) {
     }
     my $archs = $query->search({}, {select => ['ARCH', {count => 'id'}], as => [qw(ARCH count)], group_by => 'ARCH'});
     while (my $c = $archs->next) {
-        $result->{openqa_jobs_by_arch}->{"arch=" . $c->get_column('ARCH')}->{$state} = $c->get_column('count');
+        $result->{openqa_jobs_by_arch}->{'arch=' . $c->get_column('ARCH')}->{$state} = $c->get_column('count');
     }
 }
 
@@ -26,7 +26,7 @@ sub _queue_output_measure ($url, $key, $tag, $states, $timestamp = undef) {
         $tag =~ s, ,\\ ,g;
         $line .= ",$tag";
     }
-    $line .= " ";
+    $line .= ' ';
     $line .= join(',', map { "$_=$states->{$_}i" } sort keys %$states);
     $line .= ' ' . $timestamp->epoch() * 1e9 if defined $timestamp;
     return $line . "\n";
@@ -55,7 +55,7 @@ sub jobs ($self) {
 
     while (my $c = $rs->next) {
         next unless $c->get_column('count');
-        $result->{openqa_jobs_by_worker}->{"worker=" . $c->get_column('host')}->{running} = $c->get_column('count');
+        $result->{openqa_jobs_by_worker}->{'worker=' . $c->get_column('host')}->{running} = $c->get_column('count');
     }
 
     # map group ids to names (and group by parent)
@@ -72,7 +72,7 @@ sub jobs ($self) {
         $result->{openqa_jobs_by_group}->{"group=$name"} = $merged;
     }
     if (my $group = $result->{by_group}->{0}) {
-        $result->{openqa_jobs_by_group}->{"group=No Group"} = $group;
+        $result->{openqa_jobs_by_group}->{'group=No Group'} = $group;
     }
 
     my $url = $self->app->config->{global}->{base_url} || $self->req->url->base->to_string;

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobGroup.pm
@@ -69,7 +69,7 @@ sub save_connect {
     my ($self) = @_;
 
     my $schema = $self->schema;
-    my $group = $schema->resultset("JobGroups")->find($self->param('groupid'));
+    my $group = $schema->resultset('JobGroups')->find($self->param('groupid'));
     if (!$group) {
         $self->flash(error => 'Specified group ID ' . $self->param('groupid') . 'doesn\'t exist.');
         return $self->redirect_to('admin_groups');
@@ -81,7 +81,7 @@ sub save_connect {
         machine_id => $self->param('machine'),
         group_id => $group->id,
         test_suite_id => $self->param('test')};
-    eval { $schema->resultset("JobTemplates")->create($values)->id };
+    eval { $schema->resultset('JobTemplates')->create($values)->id };
     if ($@) {
         $self->flash(error => $@);
         return $self->redirect_to('job_group_new_media', groupid => $group->id);

--- a/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/JobTemplate.pm
@@ -20,9 +20,9 @@ sub index {
         force_yaml_editor => $force_yaml_editor,
     );
 
-    my @machines = $schema->resultset("Machines")->search(undef, {order_by => 'name'});
+    my @machines = $schema->resultset('Machines')->search(undef, {order_by => 'name'});
     $self->stash(machines => \@machines);
-    my @tests = $schema->resultset("TestSuites")->search(undef, {order_by => 'name'});
+    my @tests = $schema->resultset('TestSuites')->search(undef, {order_by => 'name'});
     $self->stash(tests => \@tests);
 
     $self->render('admin/job_template/index');

--- a/lib/OpenQA/WebAPI/Controller/Admin/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/User.pm
@@ -6,7 +6,7 @@ use Mojo::Base 'Mojolicious::Controller';
 
 sub index {
     my ($self) = @_;
-    my @users = $self->schema->resultset("Users")->search(undef)->all;
+    my @users = $self->schema->resultset('Users')->search(undef)->all;
 
     $self->stash('users', \@users);
     $self->render('admin/user/index');

--- a/lib/OpenQA/WebAPI/Controller/ApiKey.pm
+++ b/lib/OpenQA/WebAPI/Controller/ApiKey.pm
@@ -19,7 +19,7 @@ sub create ($self) {
 
     my $error;
     if ($validation->has_error) {
-        $error = "Date must be in format " . DateTime::Format::Pg->format_datetime(DateTime->now());
+        $error = 'Date must be in format ' . DateTime::Format::Pg->format_datetime(DateTime->now());
     }
 
     if (!$error && $validation->is_valid('t_expiration')) {
@@ -27,7 +27,7 @@ sub create ($self) {
         $error = $@;
     }
     unless ($error) {
-        eval { $self->schema->resultset("ApiKeys")->create({user_id => $user->id, t_expiration => $expiration}) };
+        eval { $self->schema->resultset('ApiKeys')->create({user_id => $user->id, t_expiration => $expiration}) };
         $error = $@;
     }
     if ($error) {

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -83,7 +83,7 @@ sub needle_json_by_id ($self) {
 }
 
 sub _set_test ($self) {
-    $self->{job} = $self->schema->resultset("Jobs")->find({'me.id' => $self->param('testid')});
+    $self->{job} = $self->schema->resultset('Jobs')->find({'me.id' => $self->param('testid')});
     return unless $self->{job};
 
     $self->{testdirname} = $self->{job}->result_dir;
@@ -161,7 +161,7 @@ sub _serve_static ($self, $asset) {
             $headers->content_disposition("attachment; filename=$filename;") if $ext eq 'iso';
         }
         else {
-            $self->res->headers->content_type("application/octet-stream");
+            $self->res->headers->content_type('application/octet-stream');
         }
     }
 
@@ -173,7 +173,7 @@ sub _serve_static ($self, $asset) {
 sub test_thumbnail ($self) {
     return $self->reply->not_found unless $self->_set_test;
 
-    my $asset = $self->static->file(".thumbs/" . $self->param('filename'));
+    my $asset = $self->static->file('.thumbs/' . $self->param('filename'));
     return $self->_serve_static($asset);
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Running.pm
+++ b/lib/OpenQA/WebAPI/Controller/Running.pm
@@ -104,7 +104,7 @@ sub streamtext ($self, $file_name, $start_hook = undef, $close_hook = undef) {
             my $dummy = <$log>;
         }
         while (defined(my $l = <$log>)) {
-            $self->write("data: " . encode_json([$l]) . "\n\n");
+            $self->write('data: ' . encode_json([$l]) . "\n\n");
         }
         seek $log, 0, 1;
     }
@@ -140,7 +140,7 @@ sub streamtext ($self, $file_name, $start_hook = undef, $close_hook = undef) {
                 while (defined(my $l = <$log>)) {
                     $lines .= $l;
                 }
-                $self->write("data: " . encode_json([$lines]) . "\n\n");
+                $self->write('data: ' . encode_json([$lines]) . "\n\n");
                 seek $log, 0, 1;
             }
         });

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -78,7 +78,7 @@ sub needle_url ($self, $distri, $name, $version, $jsonfile) {
 sub view ($self) {
     # Redirect users with the old preview link
     if (!$self->req->is_xhr) {
-        my $anchor = "#step/" . $self->param('moduleid') . "/" . $self->param('stepid');
+        my $anchor = '#step/' . $self->param('moduleid') . '/' . $self->param('stepid');
         my $target_url = $self->url_for('test', testid => $self->param('testid'));
         return $self->redirect_to($target_url . $anchor);
     }
@@ -298,7 +298,7 @@ sub _basic_needle_info ($self, $name, $distri, $version, $file_name, $needles_di
 
     # Transform string-workaround-properties into HASH-workaround-properties
     $needle->{properties}
-      = [map { ref($_) eq "HASH" ? $_ : {name => $_, value => find_bug_number($name)} } @{$needle->{properties}}];
+      = [map { ref($_) eq 'HASH' ? $_ : {name => $_, value => find_bug_number($name)} } @{$needle->{properties}}];
 
     return ($needle, undef);
 }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -348,7 +348,7 @@ sub details ($self) {
     my %tplargs = (moduleid => '$MODULE$', stepid => '$STEP$');
     my $snips = {
         header => $self->render_to_string('test/details'),
-        bug_actions => $self->include_branding("external_reporting", %tplargs),
+        bug_actions => $self->include_branding('external_reporting', %tplargs),
         src_url => $self->url_for('src_step', testid => $job->id, moduleid => '$MODULE$', stepid => 1),
         module_url => $self->url_for('step', testid => $job->id, %tplargs),
         md5thumb_url => $self->url_for('thumb_image', md5_dirname => '$DIRNAME$', md5_basename => '$BASENAME$'),
@@ -480,7 +480,7 @@ sub infopanel {
 sub _get_current_job ($self, $with_assets = 0) {
     return $self->reply->not_found unless defined $self->param('testid');
 
-    my $job = $self->schema->resultset("Jobs")
+    my $job = $self->schema->resultset('Jobs')
       ->find($self->param('testid'), {$with_assets ? (prefetch => qw(jobs_assets)) : ()});
     return $job;
 }
@@ -854,7 +854,7 @@ sub _get_latest_job ($self) {
         next unless defined $self->param($key);
         $search_args{$key} = $self->param($key);
     }
-    return $self->schema->resultset("Jobs")->complex_query(%search_args)->first;
+    return $self->schema->resultset('Jobs')->complex_query(%search_args)->first;
 }
 
 sub latest ($self) {
@@ -870,7 +870,7 @@ sub module_fails {
     my ($self) = @_;
 
     return $self->reply->not_found unless defined $self->param('testid') and defined $self->param('moduleid');
-    my $module = $self->app->schema->resultset("JobModules")->search(
+    my $module = $self->app->schema->resultset('JobModules')->search(
         {
             job_id => $self->param('testid'),
             name => $self->param('moduleid'),

--- a/lib/OpenQA/WebAPI/Description.pm
+++ b/lib/OpenQA/WebAPI/Description.pm
@@ -10,7 +10,7 @@ use Mojo::File 'path';
 use Pod::POM;
 use Exporter 'import';
 
-our $VERSION = sprintf "%d.%03d", q$Revision: 0.01 $ =~ /(\d+)/g;
+our $VERSION = sprintf '%d.%03d', q$Revision: 0.01 $ =~ /(\d+)/g;
 our @EXPORT = qw(
   get_pod_from_controllers
   set_api_desc
@@ -52,11 +52,11 @@ sub get_pod_from_controllers ($app, @args) {
         next unless (-e -f $ctrlrpath->child($controllers{$ctrl})->to_string);
         $tree = $parser->parse_file($ctrlrpath->child($controllers{$ctrl})->to_string);
         unless ($tree) {
-            log_warning("get_pod_from_controllers: could not parse file: ["
+            log_warning('get_pod_from_controllers: could not parse file: ['
                   . $ctrlrpath->child($controllers{$ctrl})->to_string
-                  . "] for POD. Error: ["
+                  . '] for POD. Error: ['
                   . $tree->error()
-                  . "]");
+                  . ']');
             next;
         }
         _itemize($tree, $ctrl);
@@ -68,12 +68,12 @@ sub get_pod_from_controllers ($app, @args) {
 
 sub set_api_desc ($api_description, $api_route) {
     if (ref($api_description) ne 'HASH') {
-        log_warning("set_api_desc: expected HASH ref for api_descriptions. Got: " . ref($api_description));
+        log_warning('set_api_desc: expected HASH ref for api_descriptions. Got: ' . ref($api_description));
         return;
     }
 
     if (ref($api_route) ne 'Mojolicious::Routes::Route') {
-        log_warning("set_api_desc: expected Mojolicious::Routes::Route for api_routes. Got: " . ref($api_route));
+        log_warning('set_api_desc: expected Mojolicious::Routes::Route for api_routes. Got: ' . ref($api_route));
         return;
     }
 
@@ -89,7 +89,7 @@ sub set_api_desc ($api_description, $api_route) {
 
 sub _itemize ($node, $controller) {
     if (ref($node) !~ /^Pod::POM::Node/) {
-        log_warning("_itemize() expected Pod::POM::Node::* arg. Got " . ref($node));
+        log_warning('_itemize() expected Pod::POM::Node::* arg. Got ' . ref($node));
         return 0;    # Stop walking the tree
     }
     my $methodname = '';

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -18,7 +18,7 @@ sub register ($self, $app, $config) {
         format_time => sub {
             my ($c, $timedate, $format) = @_;
             return unless $timedate;
-            $format ||= "%Y-%m-%d %H:%M:%S %z";
+            $format ||= '%Y-%m-%d %H:%M:%S %z';
             return $timedate->strftime($format);
         });
 
@@ -27,13 +27,13 @@ sub register ($self, $app, $config) {
             my ($c, $timedate) = @_;
             return unless $timedate;
             if ($timedate->days() > 0) {
-                sprintf("%d days %02d:%02d hours", $timedate->days(), $timedate->hours(), $timedate->minutes());
+                sprintf('%d days %02d:%02d hours', $timedate->days(), $timedate->hours(), $timedate->minutes());
             }
             elsif ($timedate->hours() > 0) {
-                sprintf("%02d:%02d hours", $timedate->hours(), $timedate->minutes());
+                sprintf('%02d:%02d hours', $timedate->hours(), $timedate->minutes());
             }
             else {
-                sprintf("%02d:%02d minutes", $timedate->minutes(), $timedate->seconds());
+                sprintf('%02d:%02d minutes', $timedate->minutes(), $timedate->seconds());
             }
         });
 
@@ -48,7 +48,7 @@ sub register ($self, $app, $config) {
             my ($c, $text, $bug) = @_;
             my $css_class = ($text =~ /(poo|gh)#/) ? 'label_bug fa fa-bolt' : 'label_bug fa fa-bug';
             if ($bug && !$bug->open) {
-                $css_class .= " bug_closed";
+                $css_class .= ' bug_closed';
             }
             return $css_class;
         });
@@ -123,7 +123,7 @@ sub register ($self, $app, $config) {
                 $crumbs
                   .= $c->link_to($c->url_for('group_overview', groupid => $group_id) => (class => 'dropdown-item') =>
                       sub { return $job->group->name . ' (current)' });
-                $crumbs .= "</li>";
+                $crumbs .= '</li>';
                 $overview_text = 'Build ' . $job->BUILD;
             }
             else {
@@ -134,7 +134,7 @@ sub register ($self, $app, $config) {
             $crumbs .= "\n<li id='current-build-overview'>";
             $crumbs .= $c->link_to($overview_url => (class => 'dropdown-item') =>
                   sub { '<i class="fa fa-arrow-right"></i> ' . $overview_text });
-            $crumbs .= "</li>";
+            $crumbs .= '</li>';
             $crumbs .= "\n<li role='separator' class='dropdown-divider'></li>\n";
             return Mojo::ByteStream->new($crumbs);
         });
@@ -153,7 +153,7 @@ sub register ($self, $app, $config) {
         # allowing partial brands
         include_branding => sub {
             my ($c, $name, %args) = @_;
-            my $path = "branding/" . $c->app->config->{global}->{branding} . "/$name";
+            my $path = 'branding/' . $c->app->config->{global}->{branding} . "/$name";
             my $ret = $c->render_to_string($path, %args);
             if (defined($ret)) {
                 return $ret;

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -239,7 +239,7 @@ sub _get_batches {
     my $home = $c->obs_rsync->home;
     my $batches = Mojo::File->new($home, $project)->list({dir => 1})->grep(sub { -d $_ })->map('basename');
     return $batches->to_array() unless $only_first;
-    return "" if !$batches->size;
+    return '' if !$batches->size;
     return $batches->to_array()->[0];
 }
 
@@ -284,7 +284,7 @@ sub _read_test_id {
 
 sub _get_test_result {
     my ($c, $id) = @_;
-    return 'unknown' unless my $job = $c->schema->resultset("Jobs")->find($id);
+    return 'unknown' unless my $job = $c->schema->resultset('Jobs')->find($id);
     return $job->result;
 }
 
@@ -327,9 +327,9 @@ sub _get_run_last_info {
 
 sub _get_first_line {
     my ($file, $with_timestamp) = @_;
-    open(my $fh, '<', $file) or return "";
+    open(my $fh, '<', $file) or return '';
     my $res = readline $fh;
-    return "" unless $res;
+    return '' unless $res;
     chomp $res;
     if ($with_timestamp) {
         my @stats = stat($fh);
@@ -356,7 +356,7 @@ sub _get_dirty_status {
     my ($project, undef) = $helper->split_alias($alias);
     my $home = $helper->home;
     my ($status, $when) = _get_first_line(Mojo::File->new($home, $project, $dirty_status_filename), 1);
-    return "" unless $status;
+    return '' unless $status;
     return "$status on $when";
 }
 
@@ -371,7 +371,7 @@ sub _get_api_repo {
     my $home = $helper->home;
     my $ret = _get_first_line(Mojo::File->new($home, $project, $api_repo_filename));
     return $ret if $ret;
-    return "images";
+    return 'images';
 }
 
 # Which package on OBS should be checked for being published on obs
@@ -391,7 +391,7 @@ sub _get_api_dirty_status_url {
     my ($c, $project) = @_;
     my $helper = $c->obs_rsync;
     my $url_str = $helper->project_status_url;
-    return "" unless $url_str;
+    return '' unless $url_str;
     # need split eventual batch and repository in project name
     ($project, undef) = $helper->split_alias($project);
     my $package = $helper->get_api_package($project);
@@ -448,7 +448,7 @@ sub _get_obs_builds_text {
     $helper->for_every_batch($alias, $sub);
 
     my @builds = sort { $b cmp $a } keys %seen;
-    return "No data" unless @builds;
+    return 'No data' unless @builds;
     return join ', ', @builds;
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Folders.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Folders.pm
@@ -45,7 +45,7 @@ sub index {
         my ($fail_last_job_id, $fail_last_when) = $helper->get_fail_last_info($alias);
         my $dirty_status = $helper->get_dirty_status($obs_project // $folder);
         my $api_repo = $helper->get_api_repo($obs_project // $folder);
-        $dirty_status = "$dirty_status ($api_repo)" if $api_repo ne "images";
+        $dirty_status = "$dirty_status ($api_repo)" if $api_repo ne 'images';
         $folder_info_by_name{$folder} = {
             run_last => $run_last_info->{dt},
             run_last_builds => $run_last_info->{builds},
@@ -167,7 +167,7 @@ sub get_run_last {
     return undef if $helper->check_and_render_error($alias);
 
     my $run_last_info = $helper->get_run_last_info($alias);
-    my $run_last = "";
+    my $run_last = '';
     $run_last = $run_last_info->{dt} if (defined $run_last_info && defined $run_last_info->{dt});
 
     return $self->render(json => {message => $run_last}, status => 200);

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Gru.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Controller/Gru.pm
@@ -92,8 +92,8 @@ sub run {
 
     # uncoverable branch true
     if ($repo) {
-        $folder_repo = $project . "::" . $repo;    # uncoverable statement
-        $folder_repo = "" unless -d Mojo::File->new($home, $folder_repo);    # uncoverable statement
+        $folder_repo = $project . '::' . $repo;    # uncoverable statement
+        $folder_repo = '' unless -d Mojo::File->new($home, $folder_repo);    # uncoverable statement
         $project = $folder_repo if $folder_repo;    # uncoverable statement
     }
 

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
@@ -99,7 +99,7 @@ sub update_obs_builds_text {
         my $read_files = Mojo::File->new($helper->home, $project, $batch, 'read_files.sh');
         return $job->finish("Cannot find $read_files") unless -f $read_files;
 
-        my @cmd = ("bash", $read_files);
+        my @cmd = ('bash', $read_files);
         my ($stdin, $stdout, $error);
         my $exit_code = -1;
         eval { IPC::Run::run(\@cmd, \$stdin, \$stdout, \$error); $exit_code = $?; };

--- a/lib/OpenQA/WebAPI/Plugin/REST.pm
+++ b/lib/OpenQA/WebAPI/Plugin/REST.pm
@@ -13,7 +13,7 @@ sub register ($self, $app, $config) {
         action_link => sub ($c, $method, $content, @args) {
             my $url = $content;
             return '' unless $c->is_operator;
-            croak "url is not a url" unless blessed $url && $url->isa('Mojo::URL');
+            croak 'url is not a url' unless blessed $url && $url->isa('Mojo::URL');
             return $c->tag('a', href => $url, 'data-method' => $method, @args);
         });
 

--- a/lib/OpenQA/WebSockets.pm
+++ b/lib/OpenQA/WebSockets.pm
@@ -79,7 +79,7 @@ sub ws_send_job {
 
     unless (ref($job_info) eq 'HASH' && exists $job_info->{assigned_worker_id}) {
         # uncoverable statement untested exceptional error
-        $state->{error} = "No workerid assigned";
+        $state->{error} = 'No workerid assigned';
         return $result;    # uncoverable statement
     }
 

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -63,9 +63,9 @@ sub _message {
     # find relevant worker
     my $worker_status = OpenQA::WebSockets::Model::Status->singleton->worker_by_transaction->{$tx};
     unless ($worker_status) {
-        $app->log->warn("A message received from unknown worker connection");
+        $app->log->warn('A message received from unknown worker connection');
         log_debug(sprintf('A message received from unknown worker connection (terminating ws): %s', dumper($json)));
-        $self->finish("1008", "Connection terminated from WebSocket server - thought dead");
+        $self->finish('1008', 'Connection terminated from WebSocket server - thought dead');
         return undef;
     }
     my $worker_id = $worker_status->{id};
@@ -157,7 +157,7 @@ sub _message {
         my ($last_seen, $now) = ($worker_status->{last_seen}, time);
         if ($last_seen && ($last_seen + MIN_TIMER) > $now) {
             log_info("Received worker $worker_id status too close to the last update,"
-                  . " websocket server possibly overloaded or worker misconfigured")
+                  . ' websocket server possibly overloaded or worker misconfigured')
               if $current_worker_status ne 'working';
         }
         $worker_status->{last_seen} = $now;

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -158,7 +158,7 @@ sub capabilities ($self) {
         $caps->{cpu_arch} = $arch;
     }
     else {
-        open(my $LSCPU, "-|", "LC_ALL=C lscpu");
+        open(my $LSCPU, '-|', 'LC_ALL=C lscpu');
         for my $line (<$LSCPU>) {
             chomp $line;
             if ($line =~ m/Model name:\s+(.+)$/) {
@@ -178,7 +178,7 @@ sub capabilities ($self) {
     }
 
     # determine memory limit
-    open(my $MEMINFO, "<", "/proc/meminfo");
+    open(my $MEMINFO, '<', '/proc/meminfo');
     for my $line (<$MEMINFO>) {
         chomp $line;
         if ($line =~ m/MemTotal:\s+(\d+).+kB/) {

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -292,7 +292,7 @@ sub engine_workit ($job, $callback) {
     log_info(sprintf("Running on $hostname:%d ($sysname $release $version $machine)", $instance),
         channels => 'autoinst');
 
-    log_error("Failed enabling subreaper mode", channels => 'autoinst') unless session->subreaper;
+    log_error('Failed enabling subreaper mode', channels => 'autoinst') unless session->subreaper;
 
     # XXX: this should come from the worker table. Only included
     # here for convenience when looking at the pool of

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -402,8 +402,8 @@ sub _stop_step_4_upload ($self, $reason, $callback) {
     my $pooldir = $self->worker->pool_directory;
 
     # add notes
-    log_info("+++ worker notes +++", channels => 'autoinst');
-    log_info(sprintf("End time: %s", strftime("%F %T", gmtime)), channels => 'autoinst');
+    log_info('+++ worker notes +++', channels => 'autoinst');
+    log_info(sprintf('End time: %s', strftime('%F %T', gmtime)), channels => 'autoinst');
     log_info("Result: $reason", channels => 'autoinst');
 
     # upload logs and assets
@@ -1020,7 +1020,7 @@ sub _upload_asset {
         });
     $ua->upload->once(
         'upload_chunk.prepare' => sub ($upload, $pieces) {
-            log_info("$filename: " . $pieces->size() . " chunks", channels => \@channels_worker_only, default => 1);
+            log_info("$filename: " . $pieces->size() . ' chunks', channels => \@channels_worker_only, default => 1);
             log_info("$filename: chunks of $chunk_size bytes each", channels => \@channels_worker_only, default => 1);
         });
     my $t_start;

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -284,7 +284,7 @@ sub send ($self, $method, $path, %args) {
     my @args = ($method, $ua_url);
     push(@args, 'json', $json_data) if $json_data;
     my $tx = $ua->build_tx(@args);
-    if ($callback eq "no") {
+    if ($callback eq 'no') {
         $ua->start($tx);
         return undef;
     }


### PR DESCRIPTION
This is propably the biggest load of files which should adapt to the rule which force single quotes when string doesnt need interpolation.
Includes also some minor changes for *Hash key with quotes* but not all of them.

https://progress.opensuse.org/issues/138416