### PR TITLE
Remove no critic annotation

### DIFF
--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -40,7 +40,7 @@ sub _build_parser {
         if (my $e = load_class $parser_name) {
             croak ref $e ? "Exception: $e" : 'Parser not found!';
         }
-        no strict 'refs';    ## no critic
+        no strict 'refs';
         eval { $p_instance = $parser_name->new(@args); };
         croak "Invalid parser supplied: $@" if $@;
     }
@@ -136,7 +136,7 @@ sub restore_el {
     my $data = $obj->{OpenQA::Parser::DATA_FIELD()};
 
     {
-        no strict 'refs';    ## no critic
+        no strict 'refs';
         return $type->can('new') ? $type->new(ref $data eq 'ARRAY' ? @{$data} : $data) : $data;
     };
 }
@@ -168,7 +168,7 @@ sub _load_tree {
     my @coll = sort keys %{$tree};
 
     {
-        no strict 'refs';    ## no critic
+        no strict 'refs';
         local $@;
         eval {
             foreach my $collection (@coll) {

--- a/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
+++ b/lib/OpenQA/WebAPI/Plugin/HashedParams.pm
@@ -3,8 +3,6 @@ use Mojo::Base 'Mojolicious::Plugin';
 
 our $VERSION = '0.04';
 
-## no critic
-
 sub register {
     my ($plugin, $app) = @_;
 


### PR DESCRIPTION
Those annotations do not need anymore and removed. perlcritic passes the test anyway so no policies need to get enabled.

https://progress.opensuse.org/issues/138416