### PR TITLE
Avoid workers from showing up shortly as broken after registration

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -96,7 +96,7 @@ sub _register {
 
     # update or create database entry for worker
     if ($worker) {
-        $worker->update({t_seen => now()});
+        $worker->update({t_seen => now(), error => undef});
     }
     else {
         $worker = $workers->create(


### PR DESCRIPTION
When working on https://progress.opensuse.org/issues/154927 I noticed that we don't reset the error state of a worker on registration. Normally this is not notable because we do when the worker sends a status update which happens only shortly after the registration. However, it makes still sense to clear the old error status on the registration to avoid workers from possibly being considered broken in the small window between the registration and the first status update. This makes only a difference when the worker did not disconnect gracefully.