### PR TITLE
Use perlcritic from os-autoinst-common

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,9 +1,1 @@
-theme = freenode
-severity = 4
-
-# TODO: Remove once Perl::Critic::Freenode 0.028 is widely available
-[Freenode::DiscouragedModules]
-severity = 3
-
-[Perl::Critic::Policy::HashKeyQuotes]
-severity = 5
+external/os-autoinst-common/.perlcriticrc


### PR DESCRIPTION
OpenQA is ready for adapt the perlcriticrc from os-autoinst-common.

https://progress.opensuse.org/issues/138416