### PR TITLE
Remove copyright year to prevent outdated entries

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
 <!-- Site footer -->
 <div class="footer">
-  <p>&copy; SUSE LLC 2014-2024</p>
+  <p>&copy; SUSE LLC</p>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
 <!-- Site footer -->
 <div class="footer">
-  <p>&copy; SUSE LLC 2014-2021</p>
+  <p>&copy; SUSE LLC 2014-2024</p>
 </div>


### PR DESCRIPTION
As far as I understood the copyright year statement is not legally
required (anymore) hence it is better if we remove it completely to
prevent confusion and people thinking our page is outdated when it is
actually just timeless :)

Thanks to Vit Pelcak for pointing out the outdated date.