### PR TITLE
Avoid sporadic failures in `t/ui/16-tests_job_next_previous.t`

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -314,11 +314,13 @@ sub wait_until_element_gone ($selector, @args) {
 sub wait_for_element (%args) {
     my $selector = $args{selector};
     my $expected_is_displayed = $args{is_displayed};
+    my $trigger_function = $args{trigger_function};
     my $method = $args{method} // $find_method;
 
     my $element;
     wait_until(
         sub {
+            $trigger_function->() if $trigger_function;
             my @elements = $_driver->find_elements($selector, $method);
             if (scalar @elements >= 1
                 && (!defined $expected_is_displayed || $elements[0]->is_displayed == $expected_is_displayed))

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -78,8 +78,10 @@ driver_missing unless my $driver = call_driver;
 disable_timeout;
 
 sub goto_next_previous_tab {
-    $driver->find_element('#nav-item-for-next_previous')->click();
-    wait_for_element(selector => '.dataTables_wrapper');
+    wait_for_element(
+        trigger_function => sub { $driver->find_element_by_link_text('Next & previous results')->click },
+        selector => '.dataTables_wrapper'
+    );
     wait_for_ajax(msg => 'Next & previous table ready');
 }
 


### PR DESCRIPTION
This test sometimes fails to go to the "Next & previous tab" leading to failures in subsequent test code. This is likely because the navigation handling of Bootstrap's JavaScript plugin hasn't been initialized when the test attempts to click on the tab. This change simply makes the test click again while waiting for the tab's contents to appear which should fix the problem.

Related ticket: https://progress.opensuse.org/issues/155068