### PR TITLE
Ensure all hidden form fields in test overview filter

### DIFF
--- a/assets/javascripts/filter_form.js
+++ b/assets/javascripts/filter_form.js
@@ -31,6 +31,7 @@ function setupFilterForm(options) {
 function parseFilterArguments(paramHandler) {
   var varPairs = window.location.search.substring(1).split('&');
   var filterLabels = [];
+  var hiddenInputs = [];
   for (var j = 0; j < varPairs.length; ++j) {
     var pair = varPairs[j].split('=');
     if (pair.length > 1) {
@@ -47,9 +48,12 @@ function parseFilterArguments(paramHandler) {
         input.attr('value', val);
         input.attr('name', key);
         input.attr('hidden', true);
-        $('#filter-form').append(input);
+        hiddenInputs.push(input);
       }
     }
+  }
+  for (var i = 0; i < hiddenInputs.length; i++) {
+    $('#filter-form').append(hiddenInputs[i]);
   }
   if (filterLabels.length > 0) {
     $('#filter-panel .card-header')

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -332,6 +332,9 @@ subtest 'filtering by distri' => sub {
             'foo/opensuse/bar 13.1',
             'filter also visible in summary'
         );
+        my $form_inputs = $driver->find_elements('#filter-form input');
+        my @distris = grep { $_->get_attribute('name') eq 'distri' && $_->get_attribute('hidden') } @$form_inputs;
+        is scalar(@distris), 3, 'Got expected number of distri form fields';
     };
 
     subtest 'everything filtered out' => sub {


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/154537

The code was skipping elements that already existed in the form, and this resulted in elements with multiple values to only keep one value. Now the elements to be added are collected and only added to the form after the loop.

Bug was introduced in 2f6b7e0fd