### PR TITLE
Adapt AppArmor profile for switch to node modules

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -47,6 +47,7 @@
   /usr/share/openqa/assets/** r,
   /usr/share/openqa/dbicdh/** r,
   /usr/share/openqa/lib/** r,
+  /usr/share/openqa/node_modules/** r,
   /usr/share/openqa/public/** r,
   /usr/share/openqa/script/openqa r,
   /usr/share/openqa/templates/ r,


### PR DESCRIPTION
* Allow openQA to read packaged node modules
* See https://progress.opensuse.org/issues/153427