### PR TITLE
Make developer mode work in single-container setup

### DIFF
--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -17,7 +17,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # hadolint ignore=DL3037
 RUN zypper in -y openQA-single-instance openQA-bootstrap \
     qemu-arm qemu-ppc qemu-x86 qemu-tools sudo iputils os-autoinst-distri-opensuse-deps && \
-    zypper clean -a
+    zypper clean -a && \
+    sed -i -e 's/# service_port_delta =.*$/service_port_delta = 0/' /etc/openqa/openqa.ini
 EXPOSE 80 443 9526
 ENV skip_suse_specifics=1
 ENV skip_suse_tests=1


### PR DESCRIPTION
* Configure the service port delta to zero so the connection to the live view handler is still made via the reverse proxy despite the reverse proxy being exposed on a non-standard port
* Keep docker-compose-based setup as-is because it uses standard ports and also exposes the ports of the individual services
* See https://progress.opensuse.org/issues/153499

---

I tested this manually by building the image locally and then invoking the command from our documentation with my local image. It works (and with the current image the issue was reproducible).