### PR TITLE
Improve out-of-box experience with single-instance container

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -22,7 +22,7 @@ repository].
 
 Continue with the next section <<#container_setup,Container based setup>> to
 setup a simple, ready-to-use container based openQA instance which is useful
-for a single user setup. For a quick boostrapping under openSUSE go to
+for a single user setup. For a quick bootstrapping under openSUSE go to
 <<#bootstrapping,Quick bootstrapping>>. Else, continue with the more
 advanced section about <<#custom_installation,Custom installation>>. For a
 setup suitable to develop openQA itself, have a look at the

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -40,7 +40,8 @@ single command line using the `podman` container engine is the following:
 
 [source,sh]
 ----
-podman run -p 1080:80 -p 1443:443 --rm -it registry.opensuse.org/devel/openqa/containers/openqa-single-instance
+podman run --name openqa --device /dev/kvm -p 1080:80 -p 1443:443 --rm -it \
+  registry.opensuse.org/devel/openqa/containers/openqa-single-instance
 ----
 
 Once the startup has finished, the web UI is accessible via http://localhost:1080


### PR DESCRIPTION
* Give the container a name for easier reference in further explanations
* Add KVM support; this is very useful as many jobs in our instance seem
  to use `QEMUCPU=host` and would therefore otherwise fail because this
  setting requires KVM support
* Provide an example command for cloning a job and for making an API query;
  otherwise it isn't clear how to proceed with a containerized setup like
  that after exploring the web UI
* Explain how to provide test code in a containerized setup like this
* See https://progress.opensuse.org/issues/153499