### PR TITLE
Install npm in the container we use on CircleCI

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -14,7 +14,7 @@ RUN zypper -n in tar gzip sudo
 RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
 
 # openQA dependencies
-RUN zypper install -y rubygem\(sass\) python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
+RUN zypper install -y rubygem\(sass\) npm python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
 
 # openQA chromedriver for Selenium tests
 RUN zypper install -y chromedriver


### PR DESCRIPTION
* This will allow us to remove the manual zypper call in the asset caching step.
* This was supposed to happen in c5ea52bdc464104d3d60c83d9346f7900e0870f0 but this commit only changed the development container and not the one actually used on CircleCI.
* See https://progress.opensuse.org/issues/153427