### PR TITLE
Remove manual installation of npm when caching assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - restore_cache: *restore_npm_cache
       - run:
           name: "Install npm dependencies"
-          command: sudo zypper -n in npm && npm install
+          command: npm install
       - save_cache: *save_npm_cache
 
   checkstyle: &test-template


### PR DESCRIPTION
Just a draft because we need to merge #5473 first; only then the next paragraph is actually true.

---

This was only required for bootstrapping the switch to using npm. Now the container image we use for the CI has been rebuilt and contains the npm package.

Related ticket: https://progress.opensuse.org/issues/153427