### PR TITLE
Fix select dropdown arrow floating over text

### DIFF
--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -172,3 +172,9 @@ select.form-control {
         background-color: $default-bg-color-darktheme;
     }
 }
+
+// fix drop-down arrow floating over text despite `with: auto;` from DataTable's upstream CSS
+div.dataTables_wrapper div.dataTables_length select {
+    background-position: right 0.2rem center;
+    padding: 0 1em 0 0.5em;
+}


### PR DESCRIPTION
Eg. by https://openqa.opensuse.org/tests/3937974#next_previous

Before:
![4](https://github.com/os-autoinst/openQA/assets/725608/00278c20-c2a2-4cfe-b5e3-b214c0c8060e)

After:
![5](https://github.com/os-autoinst/openQA/assets/725608/a9a344b4-45f7-4748-bc23-d31a9efcda71)
