### PR TITLE
Split monitoring of jobs via `openqa-cli` into a separate command

### DIFF
--- a/lib/OpenQA/CLI/monitor.pm
+++ b/lib/OpenQA/CLI/monitor.pm
@@ -13,7 +13,7 @@ has usage => sub { shift->extract_usage };
 sub _monitor_jobs ($self, $client, $poll_interval, $job_ids, $job_results) {
     while (@$job_results < @$job_ids) {
         my $job_id = $job_ids->[@$job_results];
-        my $tx = $client->build_tx(GET => $self->url_for("experimental/jobs/$job_id/status"), {});
+        my $tx = $client->build_tx(GET => $self->url_for("experimental/jobs/$job_id/status"));
         my $res = $self->retry_tx($client, $tx);
         return $res if $res != 0;
         my $job = $tx->res->json;

--- a/lib/OpenQA/CLI/monitor.pm
+++ b/lib/OpenQA/CLI/monitor.pm
@@ -1,0 +1,74 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::CLI::monitor;
+use Mojo::Base 'OpenQA::Command', -signatures;
+
+use OpenQA::Jobs::Constants;
+use Mojo::Util qw(encode getopt);
+
+has description => 'Monitors a set of jobs';
+has usage => sub { shift->extract_usage };
+
+sub _monitor_jobs ($self, $client, $poll_interval, $job_ids, $job_results) {
+    while (@$job_results < @$job_ids) {
+        my $job_id = $job_ids->[@$job_results];
+        my $tx = $client->build_tx(GET => $self->url_for("experimental/jobs/$job_id/status"), {});
+        my $res = $self->retry_tx($client, $tx);
+        return $res if $res != 0;
+        my $job = $tx->res->json;
+        my $job_state = $job->{state} // NONE;
+        if (OpenQA::Jobs::Constants::meta_state($job_state) eq OpenQA::Jobs::Constants::FINAL) {
+            push @$job_results, $job->{result} // NONE;
+            next;
+        }
+        print encode('UTF-8', "Job state of job ID $job_id: $job_state, waiting …\n");
+        sleep $poll_interval;
+    }
+}
+
+sub _compute_return_code ($self, $job_results) {
+    for my $job_result (@$job_results) {
+        return 2 unless OpenQA::Jobs::Constants::is_ok_result($job_result);
+    }
+    return 0;
+}
+
+sub _monitor_and_return ($self, $client, $poll_interval, $job_ids) {
+    my @job_results;
+    my $monitor_res = $self->_monitor_jobs($client, $poll_interval // 10, $job_ids, \@job_results);
+    return $monitor_res if $monitor_res != 0;
+    return $self->_compute_return_code(\@job_results);
+}
+
+sub command ($self, @args) {
+    die $self->usage unless getopt \@args, 'i|poll-interval=i' => \my $poll_interval;
+    @args = $self->decode_args(@args);
+    $self->_monitor_and_return($self->client($self->url_for('tests')), $poll_interval, \@args);
+}
+
+1;
+
+=encoding utf8
+
+=head1 SYNOPSIS
+
+  Usage: openqa-cli monitor [OPTIONS] [JOB_IDS]
+
+  Options:
+        --apibase <path>           API base, defaults to /api/v1
+        --apikey <key>             API key
+        --apisecret <secret>       API secret
+        --host <host>              Target host, defaults to http://localhost
+    -h, --help                     Show this summary of available options
+        --osd                      Set target host to http://openqa.suse.de
+        --o3                       Set target host to https://openqa.opensuse.org
+        --name <name>              Name of this client, used by openQA to
+                                   identify different clients via User-Agent
+                                   header, defaults to "openqa-cli"
+    -i, --poll-interval <seconds>  Specifies the poll interval
+    -p, --pretty                   Pretty print JSON content
+    -q, --quiet                    Do not print error messages to STDERR
+    -v, --verbose                  Print HTTP response headers
+
+=cut

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::CLI::schedule;
-use OpenQA::Jobs::Constants;
-use Mojo::Base 'OpenQA::Command', -signatures;
+use Mojo::Base 'OpenQA::CLI::monitor', -signatures;
 use Mojo::Util qw(encode getopt);
 use Term::ANSIColor qw(colored);
 
@@ -29,30 +28,6 @@ sub _create_jobs ($self, $client, $args, $param_file, $job_ids) {
     return 1;
 }
 
-sub _monitor_jobs ($self, $client, $poll_interval, $job_ids, $job_results) {
-    while (@$job_results < @$job_ids) {
-        my $job_id = $job_ids->[@$job_results];
-        my $tx = $client->build_tx(GET => $self->url_for("experimental/jobs/$job_id/status"), {});
-        my $res = $self->retry_tx($client, $tx);
-        return $res if $res != 0;
-        my $job = $tx->res->json;
-        my $job_state = $job->{state} // NONE;
-        if (OpenQA::Jobs::Constants::meta_state($job_state) eq OpenQA::Jobs::Constants::FINAL) {
-            push @$job_results, $job->{result} // NONE;
-            next;
-        }
-        print encode('UTF-8', "Job state of job ID $job_id: $job_state, waiting …\n");
-        sleep $poll_interval;
-    }
-}
-
-sub _compute_return_code ($self, $job_results) {
-    for my $job_result (@$job_results) {
-        return 2 unless OpenQA::Jobs::Constants::is_ok_result($job_result);
-    }
-    return 0;
-}
-
 sub command ($self, @args) {
     die $self->usage
       unless getopt \@args,
@@ -66,11 +41,7 @@ sub command ($self, @args) {
     my @job_ids;
     my $create_res = $self->_create_jobs($client, \@args, \@param_file, \@job_ids);
     return $create_res if $create_res != 0 || !$monitor;
-
-    my @job_results;
-    my $monitor_res = $self->_monitor_jobs($client, $poll_interval // 10, \@job_ids, \@job_results);
-    return $monitor_res if $monitor_res != 0;
-    return $self->_compute_return_code(\@job_results);
+    return $self->_monitor_and_return($client, $poll_interval, \@job_ids);
 }
 
 1;

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -70,7 +70,7 @@ sub command ($self, @args) {
         --name <name>              Name of this client, used by openQA to
                                    identify different clients via User-Agent
                                    header, defaults to "openqa-cli"
-    -i, --poll-interval            Specifies the poll interval used with --monitor
+    -i, --poll-interval <seconds>  Specifies the poll interval used with --monitor
     -p, --pretty                   Pretty print JSON content
     -q, --quiet                    Do not print error messages to STDERR
     -v, --verbose                  Print HTTP response headers


### PR DESCRIPTION
This allows to monitor a set of job which will be useful for further CI-related use cases like cloning existing jobs and monitoring them (see https://progress.opensuse.org/issues/130934).

Of course the existing `openqa-cli schedule` command will continue to support the `--monitor` parameter.