### PR TITLE
Filter settings by result and groupid

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobSettings.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobSettings.pm
@@ -8,11 +8,18 @@ sub jobs ($self) {
     my $validation = $self->validation;
     $validation->required('key')->like(qr/^[\w\*]+$/);
     $validation->required('list_value')->like(qr/^\w+$/);
+    $validation->optional('results')->like(qr/^\w+$/);
+    $validation->optional('list_groupids')->like(qr/^[\w\*]+$/);
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
 
     my $key = $validation->param('key');
     my $list_value = $validation->param('list_value');
-    my $jobs = $self->schema->resultset('JobSettings')->jobs_for_setting({key => $key, list_value => $list_value});
+    my $filter_result = $validation->param('results') // undef;
+    my $gids = $validation->param('list_groupids') // undef;
+    my $jobs = $self->schema->resultset('JobSettings')->jobs_for_setting({key => $key,
+									  list_value => $list_value,
+									  filter_results => $filter_result,
+									  gids => $gids});
     $self->render(json => {jobs => $jobs});
 }
 


### PR DESCRIPTION
This commit provides additional arguments to the job_settings API call in
order to get the ids of the jobs which, in additional the key and the its
value, it will match the job result per job_group. job_group is intended to be
a list for further grouping.
    
The proposal doesnt demostrate a complete solution.
    
Obviously the if statement is under further discussion.
An alternative approach could be a separate function, potential named
`blocked` but I am not sure for that particular name as it comes from
internal SUSE concept and it is not assisiated with openQA.

![image](https://github.com/os-autoinst/openQA/assets/330547/73f23464-d975-4c84-ba3b-46c7785e40d3)

https://progress.opensuse.org/issues/131279