### PR TITLE
Make it less likely for jobs incompleting with `Cache … queue … full`

### DIFF
--- a/lib/OpenQA/CacheService/Response.pm
+++ b/lib/OpenQA/CacheService/Response.pm
@@ -5,7 +5,14 @@ package OpenQA::CacheService::Response;
 use Mojo::Base -base, -signatures;
 
 has [qw(data error)];
+
+# define soft-limit for inactive Minion jobs (enforced when determining idle worker slots availability)
 has max_inactive_jobs => $ENV{OPENQA_CACHE_MAX_INACTIVE_JOBS} // 5;
+
+# define hard-limit for inactive Minion jobs (enforced on setup of already started openQA job)
+has max_inactive_jobs_hard_limit => sub ($self) {
+    $ENV{OPENQA_CACHE_MAX_INACTIVE_JOBS_HARD_LIMIT} // ($self->max_inactive_jobs + 40);
+};
 
 sub has_error ($self) { !!$self->error }
 

--- a/lib/OpenQA/CacheService/Response/Info.pm
+++ b/lib/OpenQA/CacheService/Response/Info.pm
@@ -12,17 +12,19 @@ sub available_workers ($self) {
     return $data->{active_workers} != 0 || $data->{inactive_workers} != 0;
 }
 
-sub inactive_jobs_exceeded ($self) {
-    return undef if $self->max_inactive_jobs < 0;
+sub inactive_jobs_exceeded ($self, $options = {}) {
+    my $limit = $options->{hard_limit} ? $self->max_inactive_jobs_hard_limit : $self->max_inactive_jobs;
+    return undef if $limit < 0;
     return undef unless my $data = $self->data;
     return undef unless $data->{inactive_jobs};
-    return $data->{inactive_jobs} > $self->max_inactive_jobs;
+    return $data->{inactive_jobs} > $limit;
 }
 
-sub availability_error ($self) {
+sub availability_error ($self, $options = {}) {
     return $self->error if $self->has_error;
     return 'No workers active in the cache service' unless $self->available_workers;
-    return 'Cache service queue already full (' . $self->max_inactive_jobs . ')' if $self->inactive_jobs_exceeded;
+    return 'Cache service queue already full (' . $self->max_inactive_jobs . ')'
+      if $self->inactive_jobs_exceeded($options);
     return undef;
 }
 

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -104,8 +104,8 @@ sub cache_assets ($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $web
     my $asset_uri = trim($asset_value);
     return cache_assets($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir, $callback)
       if ($this_asset eq 'UEFI_PFLASH_VARS' && !$vars->{UEFI});
-    # check cache availability
-    my $error = $cache_client->info->availability_error;
+    # check cache availability but only fail if the hard limit is exceeded
+    my $error = $cache_client->info->availability_error({hard_limit => 1});
     return $callback->({error => $error}) if $error;
     log_debug("Found $this_asset, caching $vars->{$this_asset}", channels => 'autoinst');
 


### PR DESCRIPTION
* Introduce a hard-limit for inactive Minion jobs
* Make the hard-limit slightly higher than the normal limit
* Enforce only the hard-limit on openQA job setup; so when the normal Minion queue limit was reached after a job had already been picked-up it can still continue to create Minion jobs instead of ending up as incomplete
* See https://progress.opensuse.org/issues/128276

---

Still a draft because tests are missing.