### PR TITLE
CI: Add now needed 'ruby-devel' in base container

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -14,7 +14,7 @@ RUN zypper -n in tar gzip sudo
 RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
 
 # openQA dependencies
-RUN zypper install -y rubygem\(sass\) npm python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
+RUN zypper install -y rubygem\(sass\) ruby-devel npm python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-kvm qemu-tools tar xorg-x11-fonts sudo make
 
 # openQA chromedriver for Selenium tests
 RUN zypper install -y chromedriver


### PR DESCRIPTION
circleCI nightly documentation jobs fail with

```
mkmf.rb can't find header files for ruby at /usr/lib64/ruby/include/ruby.h
```

For reasons yet unknown it seems we now need to specify ruby-devel as
dependency to install explicitly.

I reproduced the error locally with

```
podman run --rm -it registry.opensuse.org/devel/openqa/ci/containers/base:latest
```

and then verified that after instally "ruby-devel" I could install the
other ruby gems successfully and finally call asciidoctor-pdf.

Related progress issue: https://progress.opensuse.org/issues/156769