### PR TITLE
Pin gem ttfunk to version 1.7.0 due to Ruby version requirement

### DIFF
--- a/tools/generate-documentation
+++ b/tools/generate-documentation
@@ -202,7 +202,12 @@ install_asciidoctor() {
     # Note: pin to 4.0.7 because newer versions of publix_suffix need Ruby 2.6
     # Note: pin to 1.12.0 because newer versions of css_parser need Ruby 2.7
     # Note: pin to 1.6.2 because newer versions of asciidoctor-pdf need Ruby 2.7
-    [[ ${formats[pdf]} ]] && gem install public_suffix -v 4.0.7 && gem install css_parser -v 1.12.0 && gem install asciidoctor-pdf -v 1.6.2
+    [[ ${formats[pdf]} ]] && {
+        gem install public_suffix -v 4.0.7
+        gem install css_parser -v 1.12.0
+        gem install ttfunk -v 1.7.0
+        gem install asciidoctor-pdf -v 1.6.2
+    }
     cpanm -M https://cpan.metacpan.org --install Pod::AsciiDoctor
 }
 


### PR DESCRIPTION
Reference: https://progress.opensuse.org/issues/156769