### PR TITLE
Fix showing current result/state filters on overview page

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -217,7 +217,7 @@ function setupOverview() {
   const flags = {result: {}, state: {}};
   const modulesResults = [];
   const formatFilter = filter => {
-    filter.replace(/_/g, ' ');
+    return filter.replace(/_/g, ' ');
   };
   const filterLabels = parseFilterArguments((key, val) => {
     if (key === 'result' || key === 'state') {

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Mojo::Base -signatures;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
@@ -497,8 +498,8 @@ subtest 'filtering by job group' => sub {
             name => 'SLE 15 SP5 development'
         });
 
-    my $get_text = sub {
-        $driver->get(shift);
+    my $get_text = sub ($url) {
+        $driver->get($url);
         my @el = $driver->find_element('.card-header');
         return $el[0]->get_text;
     };

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -543,6 +543,15 @@ subtest 'filtering by job group' => sub {
     };
 };
 
+subtest 'filter by result and state' => sub {
+    $driver->get('/tests/overview?state=done&result=incomplete');
+    my $header = $driver->find_element('#filter-panel .card-header');
+    like $header->get_text, qr/Filter.*done.*incomplete/, 'filter parameters shown in header';
+    ok $driver->find_element_by_id('filter-incomplete')->is_selected, 'incomplete checkbox checked';
+    ok $driver->find_element_by_id('filter-done')->is_selected, 'done checkbox checked';
+    ok !$driver->find_element_by_id('filter-failed')->is_selected, 'other checkbox not checked';
+};
+
 subtest "job template names displayed on 'Test result overview' page" => sub {
     $driver->get('/group_overview/1002');
     is($driver->find_element('.progress-bar-failed')->get_text(), '1 failed', 'The number of failed jobs is right');


### PR DESCRIPTION
There's no ticket, just something I noticed when working on https://progress.opensuse.org/issues/154261.