### PR TITLE
Nicely wrap serial text boxes and don't display leading empty line

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -168,7 +168,7 @@ function renderModuleRow(module, snippets) {
       if (title === 'wait_serial') {
         const previewLimit = 120;
         // jshint ignore:start
-        let shortText = textData.replace(/.*# Result:\n?/s, '');
+        let shortText = textData.replace(/.*# Result:\n*/s, '');
         // jshint ignore:end
         if (shortText.length > previewLimit) {
           shortText = shortText.substr(0, previewLimit) + '…';

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -275,6 +275,7 @@ span.resborder_na {
         max-height: 3.5rem;
         white-space: pre-wrap;
         overflow-wrap: break-word;
+        word-break: break-all;
         font-size: 74%;
         line-height: 1.1;
     }


### PR DESCRIPTION
Before:
![2](https://github.com/os-autoinst/openQA/assets/725608/c3322711-8744-4368-980a-93d4b8c4bab0)

After:
![3](https://github.com/os-autoinst/openQA/assets/725608/cc06ccf0-45a3-4cab-90b6-1259487ca3ba)
