### PR TITLE
Only allow security PRs from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: all
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 0
     labels:
       - waiting
       - dependencies


### PR DESCRIPTION
Apparently it's not possible to tell the dependabot config to only do security update PRs. But there is a workaround by limiting the number of PRs to 0. The limit does not apply to security updates.

Issue: https://progress.opensuse.org/issues/155410