### PR TITLE
Remove obsolete checklist item about asset cache

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -1,6 +1,4 @@
 paths:
-  "assets/assetpack.def":
-    - Update the asset cache for openSUSE RPM package (see https://open.qa/docs/#update-asset-cache)
   "assets/stylesheets/**":
     - Consider providing screenshots in a PR comment to show the difference visually
   "docs/*.asciidoc":


### PR DESCRIPTION
This manual step is no longer required after using npm packages.