### PR TITLE
Handle special releases in openqa-boostrap (like "Leap 15.6 Beta")

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -20,8 +20,10 @@ fi
 if [ "$NAME" = "openSUSE Leap" ]; then
     # avoid using `obs://…` URL to workaround https://bugzilla.opensuse.org/show_bug.cgi?id=1187425
     repobase=https://download.opensuse.org/repositories/devel:/openQA
-    zypper -n addrepo -p 95 "$repobase/${VERSION}" 'devel:openQA'
-    zypper -n addrepo -p 90 "$repobase:/Leap:/${VERSION}/${VERSION}" "devel:openQA:Leap:${VERSION}"
+    # remove suffixes like " Beta" so e.g. "15.6 Beta" becomes just "15.6"
+    version=${VERSION%% *}
+    zypper -n addrepo -p 95 "$repobase/$version" 'devel:openQA'
+    zypper -n addrepo -p 90 "$repobase:/Leap:/$version/$version" "devel:openQA:Leap:$version"
     zypper -n --gpg-auto-import-keys refresh
 fi
 


### PR DESCRIPTION
See https://progress.opensuse.org/issues/156907