### PR TITLE
Allow all dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: all
-    open-pull-requests-limit: 0
     labels:
       - waiting
       - dependencies


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/157462

Allowing only security updates has the disadantage that there might be security update conflicts which require non security updates, and doing them manually is more work.

Let's try without any limit first.