### PR TITLE
Avoid warning about use of uninitialized value

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -409,7 +409,7 @@ sub _parse_job_template_products ($yaml_products_for_arch, $yaml_defaults_for_ar
             my $description = '';
             if (ref $spec eq 'HASH') {
                 # We only have one key. Asserted by schema
-                $testsuite_name = (keys %$spec)[0];
+                next unless $testsuite_name = (keys %$spec)[0];
                 my $attr = $spec->{$testsuite_name};
                 if ($attr->{priority}) {
                     $prio = $attr->{priority};


### PR DESCRIPTION
The variable `$testsuite_name` might be `undef` if the spec is an empty hash leading to:

```
Use of uninitialized value $testsuite_name in hash element at /usr/share/openqa/script/../lib/OpenQA/Schema/Result/JobGroups.pm line 413.
```

We can just skip empty specs here avoiding the warning.