### PR TITLE
Display full footer on pages

### DIFF
--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -35,6 +35,8 @@ body {
     width: 100%;
     // set the fixed height of the footer here
     height: 30px;
+    display: flex;
+    align-content: end;
     background-color: #f5f5f5;
 }
 .darkmode {


### PR DESCRIPTION
Added align-content to the .footer element to make the element stick to the
end. align-content takes effect with flex position variable. The scroll bar
disappears but the stack still do not show pretty when the size of the
window is too small.
    
https://progress.opensuse.org/issues/157615