### PR TITLE
style: Fix custom footer overflow

### DIFF
--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -35,6 +35,7 @@ body {
     width: 100%;
     padding-bottom: 10px;
     background-color: #f5f5f5;
+    z-index: -1;
 }
 .darkmode {
     .footer {

--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -33,8 +33,7 @@ body {
     position: absolute;
     bottom: 0;
     width: 100%;
-    // set the fixed height of the footer here
-    height: 30px;
+    padding-bottom: 10px;
     background-color: #f5f5f5;
 }
 .darkmode {


### PR DESCRIPTION
On an openQA page using a custom links_footer_left and/or
links_footer_right, e.g.
https://openqa.suse.de/tests/overview?distri=sle&build=20240318-1&result=incomplete
the version string in the footer is cropped despite enough white space
being available. The full version string is readable by scrolling down
but the scroll bar should not be necessary. So no cropping and no scroll
bar should appear if there is enough blank space in both the case of
with or without a custom footer_link content used or not.

This problem was originally introduced with 58747a5ef setting a fixed
height which offsets the version string from the bottom to make it more
readable but does not account for the optional custom_footer inclusion.

This commit fixes this by using a bottom padding instead of prescribing
the overall height of the complete footer box.

Before:
![Screenshot_20240325_221909_before_fixed_height](https://github.com/os-autoinst/openQA/assets/1693432/53b4bb91-c8b4-4562-8a2f-04f55b7a08f8)

After:
![Screenshot_20240325_221758_after_padding-bottom-10px](https://github.com/os-autoinst/openQA/assets/1693432/532eb6f6-e5e2-4165-8f35-5e674cdbdb09)

Related progress issue: https://progress.opensuse.org/issues/157576