### PR TITLE
Improve workaround for re-login in developer mode test

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -88,7 +88,8 @@ sub relogin_as ($user) {
     for (my $attempts = 0; $attempts < $max_login_attempts; ++$attempts) {
         if ($login_text ne 'Login') {
             $driver->get('/logout');
-            $driver->element_text_is('#user-action a', 'Login', 'logged-out before logging in as ' . $user);
+            $login_text = $driver->find_element('#user-action a')->get_text;
+            next if $login_text ne 'Login';    # uncoverable statement
         }
         $driver->get('/login?user=' . $user);    # uncoverable statement (must be bug in coverage tracking)
         $login_text = $driver->find_element('#user-action a')->get_text;


### PR DESCRIPTION
It looks like c6ffb423e116035ae5d470eadd6473ff31b0a49f was not enough. The test might also run into an unexpected login text when trying to logout (and not only after trying to login again). This problem shows up in the log like this:

```
    #   Failed test 'logged-out before logging in as Demo'
    #   at /usr/lib/perl5/vendor_perl/5.26.1/Test/Selenium/Remote/Driver.pm line 367.
    #          got: 'Logged in as Demo'
    #     expected: 'Login'
    # Looks like you failed 1 test of 9.
```

A simple retry like we already do for the login helps will likely help so that's what change is.

Related ticket/comment: https://progress.opensuse.org/issues/157540#note-3