### PR TITLE
Prevent developer mode test from failing on redirections

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -192,6 +192,10 @@ sub javascript_console_has_no_warnings_or_errors ($test_name_suffix = '') {
         # and ws_console.js will retry
         next if ($msg =~ qr/ws_console.*Error in connection establishment/);    # uncoverable statement
 
+        # ignore redirections in ws_console.js; this might be a race condition shortly after login and ws_console.js
+        # will retry
+        next if ($msg =~ qr/ws_console.*Unexpected response code.*302/);    # uncoverable statement
+
         # ignore errors when gravatar not found
         next if ($msg =~ qr/gravatar/);    # uncoverable statement
 


### PR DESCRIPTION
The console will retry and in the case we observed all subsequent testing indeed passed (so the whole test really only failed due to this JavaScript error being logged). If this error would be really problematic subsequent tests would also fail so we don't lose test sensitivity.

Related ticket: https://progress.opensuse.org/issues/157540