### PR TITLE
Simplify+signatures

### DIFF
--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -1,10 +1,9 @@
-# Copyright 2017-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Resource::Jobs;
 
-use strict;
-use warnings;
+use Mojo::Base -strict, -signatures;
 
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema;
@@ -26,8 +25,7 @@ Handle job restart by user (using API or WebUI). Job is only restarted when eith
 or done. Scheduled jobs can't be restarted.
 
 =cut
-sub job_restart {
-    my ($jobids, %args) = @_;
+sub job_restart ($jobids, %args) {
     my (@duplicates, @processed, @errors, @warnings);
     my %res = (duplicates => \@duplicates, errors => \@errors, warnings => \@warnings, enforceable => 0);
     unless (ref $jobids eq 'ARRAY' && @$jobids) {

--- a/lib/OpenQA/Resource/Locks.pm
+++ b/lib/OpenQA/Resource/Locks.pm
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Resource::Locks;
@@ -19,9 +19,7 @@ my %final_states = map { $_ => 1 } OpenQA::Jobs::Constants::NOT_OK_RESULTS();
 # So we have to specify, which child job is supposed to create the lock
 # and watch its state.
 #
-sub _get_lock {
-    my ($name, $jobid, $where) = @_;
-    return 0 unless defined $name && defined $jobid;
+sub _get_lock ($name, $jobid, $where) {
     my $schema = OpenQA::Schema->singleton;
     my $job = $schema->resultset('Jobs')->single({id => $jobid});
     return 0 unless $job;
@@ -43,12 +41,9 @@ sub _get_lock {
 }
 
 # returns -1 on unrecoverable error, 1 on have lock, 0 on try later (lock unavailable)
-sub lock {
-    my ($name, $jobid, $where) = @_;
-
+sub lock ($name, $jobid, $where) {
     my $locks = _get_lock($name, $jobid, $where);
     my $lock = $locks->single;
-
     if (!$lock and $where =~ /^\d+$/) {
         my $schema = OpenQA::Schema->singleton;
         # prevent deadlock - job that is supposed to create the lock already finished
@@ -69,8 +64,7 @@ sub lock {
     return 0;
 }
 
-sub unlock {
-    my ($name, $jobid, $where) = @_;
+sub unlock ($name, $jobid, $where) {
     my $locks = _get_lock($name, $jobid, $where // 'all');
     my $lock = $locks->single;
     return 0 unless $lock;
@@ -82,8 +76,7 @@ sub unlock {
     return 0;
 }
 
-sub create {
-    my ($name, $jobid) = @_;
+sub create ($name, $jobid) {
     my $lock = _get_lock($name, $jobid, 'all')->single;
     # nothing if lock already exist
     return 0 if $lock;
@@ -99,7 +92,7 @@ sub create {
 ## Barriers
 # barriers are created with number of expected jobs. Then wait call waits until the expected number of jobs is waiting
 
-sub barrier_create ($name, $jobid, $expected_jobs) {
+sub barrier_create ($name = undef, $jobid = undef, $expected_jobs = undef) {
     return 0 unless $name && $jobid && $expected_jobs;
     my $barriers = _get_lock($name, $jobid, 'all');
     return 0 if $barriers && $barriers->single;
@@ -110,7 +103,7 @@ sub barrier_create ($name, $jobid, $expected_jobs) {
     return $sth->rows > 0;
 }
 
-sub barrier_wait ($name, $jobid, $where, $check_dead_job) {
+sub barrier_wait ($name = undef, $jobid = undef, $where = undef, $check_dead_job = 0) {
     return -1 unless $name && $jobid;
     return -1 unless my $barriers = _get_lock($name, $jobid, $where);
     return -1 unless my $barrier = $barriers->single;
@@ -139,7 +132,7 @@ sub barrier_wait ($name, $jobid, $where, $check_dead_job) {
     return 0;
 }
 
-sub barrier_destroy ($name, $jobid, $where) {
+sub barrier_destroy ($name = undef, $jobid = undef, $where = undef) {
     return 0 unless $name && $jobid;
     return 0 unless my $barriers = _get_lock($name, $jobid, $where);
     return $barriers->delete > 0;

--- a/script/openqa-validate-yaml
+++ b/script/openqa-validate-yaml
@@ -43,18 +43,11 @@ EOM
 
 print($usage->text), exit if $opt->help;
 
-my @files = @ARGV;
+my @files = @ARGV or pass 'Nothing to do';
 
 my $default_schema = "$RealBin/../public/schema/JobTemplates-01.yaml";
 my $schema = $opt->schema_file // $default_schema;
-
-unless (@files) {
-    pass "Nothing to do";
-}
-
-if ($opt->validate_schema) {
-    diag 'Validating schema, too';
-}
+diag 'Validating schema, too' if $opt->validate_schema;
 for my $file (@files) {
     my $data;
     if ($file eq '-') {


### PR DESCRIPTION
* Simplify Resource::Locks with direct return of booleans
* Use signatures in Resource::Locks
* Use signatures in Resource::Jobs
* Slightly simplify script/openqa-validate-yaml