### PR TITLE
Switch to docker compose subcommand

### DIFF
--- a/tools/test_containers_compose
+++ b/tools/test_containers_compose
@@ -19,19 +19,19 @@ wait_until() {
 
 setup_containers() {
     for retry in {2..0}; do
-        sudo docker-compose build && break
+        sudo docker compose --compatibility build && break
         echo "Remaining retries $retry"
     done
     exit_code=""
-    sudo MOJO_CLIENT_DEBUG=1 docker-compose up -d || exit_code=$?
+    sudo MOJO_CLIENT_DEBUG=1 docker compose --compatibility up -d || exit_code=$?
     if [[ -n $exit_code ]]; then
-        echo "docker-compose exited with non-zero code $exit_code, showing logs:"
-        docker-compose logs
+        echo "docker compose exited with non-zero code $exit_code, showing logs:"
+        docker compose --compatibility logs
         exit "$exit_code"
     fi
-    (docker-compose ps --services --filter status=stopped | grep "^[[:space:]]*$") || (
-        docker-compose logs
-        sudo docker-compose ps
+    (docker compose --compatibility ps --services --filter status=stopped | grep "^[[:space:]]*$") || (
+        docker compose --compatibility logs
+        sudo docker compose --compatibility ps
         exit 1
     )
 }
@@ -39,19 +39,19 @@ setup_containers() {
 test_webui() {
     (
         workspace=$(mktemp -d) \
-            && trap 'docker-compose down; sudo rm -r "$workspace"' EXIT \
+            && trap 'docker compose --compatibility down; sudo rm -r "$workspace"' EXIT \
             && cp -r container/webui "$workspace" \
             && cd "$workspace/webui" \
             && sed -i -e "s/method = OpenID/method = Fake/" conf/openqa.ini
         printf "[nginx]\nkey = 1234567890ABCDEF\nsecret = 1234567890ABCDEF\n" > conf/client.conf \
             && setup_containers \
-            && docker-compose exec -T webui openqa-cli api -X POST jobs ISO=foo.iso DISTRI=my-distri FLAVOR=my-flavor VERSION=42 BUILD=42 TEST=my-test \
+            && docker compose --compatibility exec -T webui openqa-cli api -X POST jobs ISO=foo.iso DISTRI=my-distri FLAVOR=my-flavor VERSION=42 BUILD=42 TEST=my-test \
                 --host http://nginx:9526 || (
             echo "Error executing a job"
             exit 1
         ) \
-            && (wait_until 'docker-compose logs webui | grep "GET /api/wakeup" >/dev/null' 10) || (
-            docker-compose logs webui
+            && (wait_until 'docker compose --compatibility logs webui | grep "GET /api/wakeup" >/dev/null' 10) || (
+            docker compose --compatibility logs webui
             exit 1
         )
     ) || exit 1
@@ -60,7 +60,7 @@ test_webui() {
 test_worker() {
     (
         workspace=$(mktemp -d) \
-            && trap 'docker-compose down; sudo rm -r "$workspace"' EXIT \
+            && trap 'docker compose --compatibility down; sudo rm -r "$workspace"' EXIT \
             && cp -r container/worker "$workspace" \
             && cd "$workspace/worker" \
             && setup_containers


### PR DESCRIPTION
The docker-compose tool isn't maintained anymore and should be replaced by the docker compose subcommand:
https://docs.docker.com/compose/migrate/

    docker-compose: command not found