### PR TITLE
Improve info about auto-restart behavior involving `auto_clone_regex`

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2143,13 +2143,15 @@ sub _compute_result_and_reason ($self, $new_val, $result, $reason, $restart) {
             my $ancestors = $self->incomplete_ancestors($limit + 1);
             # how many of those incomplete ancestors had a reason not matching auto_clone?
             my $unrelated = grep { $_->[2] !~ m/$auto_clone_regex/ } @$ancestors;
-            if (@$ancestors < $limit || $unrelated > 0) {
-                $append_reason = ' [Auto-restarting because reason matches /$auto_clone_regex/]';
+            my $restarts = @$ancestors;
+            if ($restarts < $limit || $unrelated > 0) {
+                $append_reason = ' [Auto-restarting because reason matches the configured "auto_clone_regex".]';
                 $$restart = 1;
             }
             else {
                 $append_reason
-                  = ' [Not restarting because job has been restarted already $auto_clone_limit times and failed with /$auto_clone_regex/]';
+                  = ' [Not restarting job despite failure reason matching the configured "auto_clone_regex". ';
+                $append_reason .= "It has already been restarted $restarts times (limit is $limit).]";
             }
         }
 

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -142,7 +142,7 @@ subtest 'auto_clone limits' => sub {
         $restart = 0;
         $last->_compute_result_and_reason(\%new, 'incomplete', $backend_reason, \$restart);
         is $restart, 0, "restart false";
-        like $new{reason}, qr{Not restarting because.*auto_clone_limit}, '$reason is modified';
+        like $new{reason}, qr{Not restarting.*"auto_clone_regex".*3 times.*limit is 3}, '$reason is modified';
     };
 
     subtest 'more than auto_clone_limit incompletes - but less matching auto_clone_regex' => sub {


### PR DESCRIPTION
* Avoid use of `$`-sign
* Include number of restarts and limit
* See https://progress.opensuse.org/issues/153475