### PR TITLE
style: Fix not-clickable links

### DIFF
--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -35,7 +35,6 @@ body {
     width: 100%;
     padding-bottom: 10px;
     background-color: #f5f5f5;
-    z-index: -1;
 }
 .darkmode {
     .footer {


### PR DESCRIPTION
The z-index recently added prevents links to be clickable. I suggest to
live with the unlikely bad impact of the content overlapped by the
footer and instead help to make links clickable again.

No visual difference except for the original problem of overlapping a
submit button on tiny window sizes.