### PR TITLE
Allow configuring a critical value for "load15" for openQA workers

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -73,6 +73,11 @@
 # their versions in plain text.
 #PACKAGES_CMD = rpm -qa
 
+# Specifies the threshold to consider the load on the machine critical. If the
+# average load (over the last 15 minutes) exceeds the specified value the worker
+# will not accept new jobs (until the load decreases again).
+#CRITICAL_LOAD_AVG_THRESHOLD = 10
+
 # The section ids are the instance of the workers.
 # The key/value pairs will appear in vars.json
 #[1]


### PR DESCRIPTION
When the configured value for "load15" is exceeded the worker won't accept new jobs anymore. This might be useful to avoid workers from being under too heavy load (which would otherwise lead to e.g. typing issues).

See https://progress.opensuse.org/issues/158125