### PR TITLE
t: Fix sporadic test failure in ui/13-admin.t

### DIFF
--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -677,17 +677,24 @@ subtest 'Manage API keys' => sub {
     };
 
     subtest 'create key with expiration date' => sub {
-        $driver->find_element('#api-keys-form input[type=submit]')->click;
-        is(scalar @{$driver->find_child_elements($tbody = api_keys_tbody, 'tr')}, 1, 'exactly one key present');
-        like($tbody->get_text, qr/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/, 'new key has expiration date');
+        my $row = wait_for_element(
+            trigger_function => sub { $driver->find_element('#api-keys-form input[type=submit]')->click },
+            selector => '#api-keys-tbody > tr',
+            description => 'key row present'
+        ) or return;
+        like($row->get_text, qr/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/, 'new key has expiration date');
     };
 
     subtest 'create key without expiration date' => sub {
+        $tbody = api_keys_tbody;
         unlike($tbody->get_text, qr/never/, 'no key without expiration date present so far');
         $driver->find_element_by_id('expiration')->click;
-        $driver->find_element('#api-keys-form input[type=submit]')->click;
-        is(scalar @{$driver->find_child_elements($tbody = api_keys_tbody, 'tr')}, 2, 'two keys present now');
-        like($tbody->get_text, qr/never/, 'new key has expiration date');
+        my $row = wait_for_element(
+            trigger_function => sub { $driver->find_element('#api-keys-form input[type=submit]')->click },
+            selector => '#api-keys-tbody tr:nth-child(2)',
+            description => 'key row present (without expiration)'
+        ) or return;
+        like($row->get_text, qr/never/, 'new key has expiration date');
     };
 };
 


### PR DESCRIPTION
There was a sporadic failure originally observed in CI runs with very low
failure ratio looking like this

```
t/ui/13-admin.t .. 14/?
        #   Failed test 'exactly one key present'
        #   at t/ui/13-admin.t line 681.
        #          got: '0'
        #     expected: '1'
```

I reproduced the problem locally with

```
runs=200 OPENQA_TEST_TIMEOUT_DISABLE=1 count-fail-ratio make test KEEP_DB=1
TESTS=t/ui/13-admin.t
```

with results fails: 4. Fail ratio 2.00±1.94%, mean runtime: 39.0±3.0 s.

With `make coverage` the results were fails 7. Fail ratio 3.50±2.54%,
mean runtime: 80 s so slightly higher fail ratio with double runtime.

This commit uses "wait_for_element" combining the submit action with the lookup
of the resulting table rows to properly synchronize the action and waiting for
result. This fixes the problem. Verified with 400 runs with a computed failure
probability of less than .75%.

Previously I tried to just wait for "#api-keys-tbody > tr" in
"wait_for_element" but running into sporadic issues with similar failure rate
as in before. Apparently the key creation never yields a valid table
representation in this case without retriggering the action.

Related progress issue: https://progress.opensuse.org/issues/158422