### PR TITLE
Fix needle tags display for check_screen and assert_screen

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -1100,7 +1100,7 @@ var messageToStatusVariable = [
     statusVar: 'currentApiFunction',
     action: function (value, data) {
       developerMode.currentApiFunctionArgs = '';
-      if ((value === 'assert_screen' || value === 'check_screen') && data.check_screen) {
+      if (value === 'assert_screen' || value === 'check_screen') {
         developerMode.currentApiFunctionArgs = data.check_screen.mustmatch;
       }
     }


### PR DESCRIPTION
`data.check_screen` returns `false` for `check_screen` and `assert_screen` so the needle tags aren't displayed. `data.check_screen.mustmatch` could be checked instead, but this check happens already in testapi.pm `_check_or_assert`