### PR TITLE
dist: Allow build on s390x after verification

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -161,10 +161,6 @@ Development package pulling in all build+test dependencies except chromedriver f
 %package devel
 Summary:        Development package pulling in all build+test dependencies
 Requires:       %{devel_requires}
-%ifarch s390x
-# missing chromedriver dependency
-ExclusiveArch:  do_not_build
-%endif
 
 %description devel
 Development package pulling in all build+test dependencies.


### PR DESCRIPTION
Similar as in https://progress.opensuse.org/issues/124670 and
corresponding commit 4b6067931 the "ExclusiveArch" setting in the spec
file seems to affect the complete source package and not just affects a
single sub-package preventing to build even the main package on s390x.

This commit removes the section completely accordingly. Any missing
dependencies preventing a sub-package to be used must be handled
differently, e.g. by disabling the build of certain sub-packages per
architecture in OBS.

A verification in
https://build.opensuse.org/package/show/home:okurz:branches:devel:openQA/openQA
shows promising results for building s390x packages in openSUSE Leap.

Related progress issue: https://progress.opensuse.org/issues/158898