### PR TITLE
Avoid messing with `PRODUCTDIR` if `CASEDIR`/`NEEDLES_DIR` are from Git

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -404,13 +404,15 @@ sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback)
     my $target_name = path($default_casedir)->basename;
     my $has_custom_dir = $vars->{CASEDIR} || $vars->{PRODUCTDIR};
     my $casedir = $vars->{CASEDIR} //= $absolute_paths ? $default_casedir : $target_name;
-    if ($casedir eq $target_name) {
-        $vars->{PRODUCTDIR} //= substr($default_productdir, rindex($default_casedir, $target_name));
-        if (my $error = _link_repo($default_casedir, $pooldir, $target_name)) { return $callback->($error) }
-    }
-    else {
-        $vars->{PRODUCTDIR} //= $absolute_paths
-          && !$has_custom_dir ? $default_productdir : abs2rel($default_productdir, $default_casedir);
+    unless (_is_job_only_relying_on_git($vars)) {
+        if ($casedir eq $target_name) {
+            $vars->{PRODUCTDIR} //= substr($default_productdir, rindex($default_casedir, $target_name));
+            if (my $error = _link_repo($default_casedir, $pooldir, $target_name)) { return $callback->($error) }
+        }
+        else {
+            $vars->{PRODUCTDIR} //= $absolute_paths
+              && !$has_custom_dir ? $default_productdir : abs2rel($default_productdir, $default_casedir);
+        }
     }
 
     # ensure a NEEDLES_DIR is assigned and create a symlink if required


### PR DESCRIPTION
The openQA worker tries to assign the correct `PRODUCTDIR` for a given `CASEDIR`. This is only done if the web UI provides a Git checkout for the specified `CASEDIR` (which is then either made available via NFS or synced via the worker cache). Unfortunately this leads to problems if that checkout is not representing the structure as it is actually in Git. For instance `os-autoinst-distri-openQA` has no `products/openqa` directory in Git but an admin added one within the web UIs checkout so the needle editor works for this test distribution. This leads to the worker assuming that this directory exists and setting `PRODUCTDIR` accordingly. This in turn leads to isotovideo not finding the directory as it is not actually in Git.

To avoid such problems in general it would make sense to simply not mess with any of the `CASEDIR`/`NEEDLES_DIR`/`PRODUCTDIR` variables in case the test is fully provided via Git. That is what this change does. It is a breaking change but I don't think anyone is currently relying on the existing behavior. It would probably already make sense to avoid messing with `PRODUCTDIR` if only `CASEDIR` comes from Git but I'm not sure whether this would break any existing use-cases.

Related ticket: https://progress.opensuse.org/issues/159168