### PR TITLE
JobTemplates-01.yaml: Disallow empty test suites

### DIFF
--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -29,6 +29,7 @@ properties:
                 - type: string
                   description: Name of a test suite name
                 - type: object
+                  minProperties: 1
                   maxProperties: 1
                   description: A test suite with machine and/or priority value specified, or a custom job template name if testsuite was specified
                   additionalProperties: false

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -738,6 +738,13 @@ $t->json_is(
     'posting invalid YAML template - error content',
 );
 
+subtest 'Empty testsuite is invalid' => sub {
+    $form{template} = path("$FindBin::Bin/../data/08-testsuite-empty.yaml")->slurp;
+    $t->post_ok('/api/v1/job_templates_scheduling/' . $opensuse->id, form => \%form);
+    $t->status_is(400);
+    $t->json_is('/error_status' => 400, 'posting invalid YAML');
+};
+
 subtest 'Create and modify groups with YAML' => sub {
     my $job_group_id3 = $job_groups->create({name => 'foo'})->id;
     ok($job_group_id3, "Created group foo ($job_group_id3)");

--- a/t/data/08-testsuite-empty.yaml
+++ b/t/data/08-testsuite-empty.yaml
@@ -1,0 +1,9 @@
+scenarios:
+  i586:
+    opensuse-13.1-DVD-i586:
+      - {}
+products:
+  opensuse-13.1-DVD-i586:
+    distri: opensuse
+    flavor: DVD
+    version: '13.1'


### PR DESCRIPTION
The code already assumes we have exactly one test suite.

See: https://progress.opensuse.org/issues/157774