### PR TITLE
Avoid race condition when reading step details

### DIFF
--- a/lib/OpenQA/Schema/Result/JobModules.pm
+++ b/lib/OpenQA/Schema/Result/JobModules.pm
@@ -110,7 +110,7 @@ sub results {
         my $text_file_name = $step->{text};
         if (!$skip_text_data && $text_file_name && !defined $step->{text_data}) {
             my $text_file = path($dir, $text_file_name);
-            my $text_data = -r $text_file ? decode('UTF-8', $text_file->slurp) : undef;
+            my $text_data = eval { decode('UTF-8', $text_file->slurp) };
             $step->{text_data} = $text_data // "Unable to read $text_file_name.";
         }
 
@@ -225,8 +225,8 @@ sub finalize_results {
     for my $step (@$details) {
         next unless my $text = $step->{text};
         my $txtfile = path($dir, $text);
-        next unless -e $txtfile;
-        $step->{text_data} = decode('UTF-8', $txtfile->slurp);
+        my $txtdata = eval { decode('UTF-8', $txtfile->slurp) };
+        $step->{text_data} = $txtdata if defined $txtdata;
     }
 
     # replace file contents on disk using a temp file to preserve old file if something goes wrong


### PR DESCRIPTION
The code currently checks whether the file is readable and shows an error to the user if not. This check is not atomic so we might still run into e.g. `Can't open file ".../libssh-18.txt": No such file or directory at OpenQA/Schema/Result/JobModules.pm line 113` leading to a server-side error and a 500 response. With this change we always show the error to the user.

This commit also changes another occurrence of the same lookup-pattern to be consistent (although it is probably not strictly required there).

Related ticket: https://progress.opensuse.org/issues/159447