### PR TITLE
Make CRITICAL_LOAD_AVG_THRESHOLD work with AppArmor

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -55,6 +55,7 @@
   /proc/[0-9]*/cgroup r,
   /proc/filesystems r,
   /proc/meminfo r,
+  /proc/loadavg r,
   /proc/sys/vm/overcommit_memory r,
   /proc/sys/fs/pipe-max-size r,
   /proc/sys/vm/nr_hugepages r,


### PR DESCRIPTION
The code otherwise runs into a permission error leading to the following warning:

```
Apr 23 14:46:30 aarch64-o3 worker[39373]: [warn] Unable to determine average load: Can't open file "/proc/loadavg": Permission denied at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/File.pm line 133.
```