### PR TITLE
Use the latest version of AceEditor instead of CodeMirror

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -102,15 +102,15 @@
 ! dependency_graph.css
 < stylesheets/dependency_graph.scss
 
-! codemirror.css
-< ../node_modules/codemirror/lib/codemirror.css
-< stylesheets/codemirror_customization.css
+! ace.css
+< ../node_modules/ace-builds/css/ace.css
+< stylesheets/ace.css
 
-! codemirror.js
-< ../node_modules/codemirror/lib/codemirror.js
-< ../node_modules/codemirror/mode/perl/perl.js
-< ../node_modules/codemirror/mode/yaml/yaml.js
-< ../node_modules/codemirror/mode/diff/diff.js
+! ace.js
+< ../node_modules/ace-builds/src-min/ace.js
+< ../node_modules/ace-builds/src-min/mode-perl.js
+< ../node_modules/ace-builds/src-min/mode-yaml.js
+< ../node_modules/ace-builds/src-min/mode-diff.js
 
 ! step_edit.js
 < javascripts/needleeditor.js

--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -356,31 +356,31 @@ function toggleTemplateEditor() {
   form.find('.buttons').hide();
   form.find('.progress-indication').show();
   $('#toggle-yaml-editor').toggleClass('btn-secondary');
-  if (editor == undefined) {
-    editor = CodeMirror.fromTextArea(document.getElementById('editor-template'), {
-      mode: 'yaml',
-      lineNumbers: true,
-      lineWrapping: true,
-      readOnly: 'nocursor',
-      viewportMargin: Infinity
+  if (editor === undefined) {
+    editor = ace.edit('editor-template', {
+      mode: 'ace/mode/yaml',
+      maxLines: Infinity,
+      tabSize: 2,
+      useSoftTabs: true
     });
-    editor.setOption('extraKeys', {
-      Tab: function (editor) {
-        // Convert tabs to spaces
-        editor.replaceSelection(Array(editor.getOption('indentUnit') + 1).join(' '));
+    editor.session.setUseWrapMode(true);
+    document.getElementById('toggle-yaml-guide').onclick = function () {
+      const editorElements = Array.from(document.getElementsByClassName('editor-container'));
+      const yamlGuideElements = Array.from(document.getElementsByClassName('editor-yaml-guide'));
+      if (yamlGuideElements[0].style.display === 'none') {
+        editorElements.forEach(e => {
+          e.classList.add('col-sm-7');
+          e.classList.remove('col-sm-12');
+        });
+        yamlGuideElements.forEach(e => (e.style.display = 'initial'));
+      } else {
+        editorElements.forEach(e => {
+          e.classList.remove('col-sm-7');
+          e.classList.add('col-sm-12');
+        });
+        yamlGuideElements.forEach(e => (e.style.display = 'none'));
       }
-    });
-
-    $('.CodeMirror').css('width', window.innerWidth * 0.9 + 'px');
-    $('.CodeMirror').css('height', window.innerHeight * 0.7 + 'px');
-    $(window).on('resize', function () {
-      $('.CodeMirror').css('height', window.innerHeight * 0.7 + 'px');
-    });
-    $('#toggle-yaml-guide').click(function () {
-      $('.editor-yaml-guide').toggle();
-      var guide_width = $('.editor-yaml-guide').is(':visible') ? $('.editor-yaml-guide').width() : 0;
-      $('.CodeMirror').css('width', window.innerWidth * 0.9 - guide_width + 'px');
-    });
+    };
   }
   $.ajax({
     url: form.data('put-url'),
@@ -389,7 +389,7 @@ function toggleTemplateEditor() {
 }
 
 function prepareTemplateEditor(data) {
-  editor.doc.setValue(data);
+  editor.setValue(data, -1);
   var form = $('#editor-form');
   form.find('.progress-indication').hide();
   form.find('.buttons').show();
@@ -408,17 +408,17 @@ function submitTemplateEditor(button) {
   result.text('Applying changes...');
 
   // Reset to the minimum viable YAML if empty
-  var template = editor.doc.getValue();
-  if (template === '') {
+  var template = editor.getValue();
+  if (!template) {
     template = 'products: {}\nscenarios: {}\n';
-    editor.doc.setValue(template);
+    editor.setValue(template, -1);
   }
 
   // Ensure final linebreak, as files without it often need additional
   // handling elsewhere
   else if (template.substr(-1) !== '\n') {
     template += '\n';
-    editor.doc.setValue(template);
+    editor.setValue(template, -1);
   }
 
   $.ajax({
@@ -438,12 +438,12 @@ function submitTemplateEditor(button) {
       switch (button) {
         case 'expand':
           result.text('Result of expanding the YAML:');
-          mode = 'yaml';
+          mode = 'ace/mode/yaml';
           value = data.result;
           break;
         case 'preview':
           result.text('Preview of the changes:');
-          mode = 'diff';
+          mode = 'ace/mode/diff';
           value = data.changes;
           break;
         case 'save':
@@ -451,22 +451,24 @@ function submitTemplateEditor(button) {
           $('#toggle-yaml-editor').hide();
           $('#media-add').hide();
           // Update the reference to the saved document
-          form.data('reference', editor.doc.getValue());
+          form.data('reference', editor.getValue());
 
           result.text('YAML saved!');
-          mode = 'diff';
+          mode = 'ace/mode/diff';
           value = data.changes;
           break;
       }
 
       if (value) {
-        var preview = CodeMirror($('<pre/>').appendTo(result)[0], {
+        const previewElement = document.createElement('pre');
+        previewElement.appendChild(document.createTextNode(value));
+        const preview = ace.edit(previewElement, {
           mode: mode,
-          lineNumbers: true,
-          lineWrapping: true,
           readOnly: true,
-          value: value
+          maxLines: Infinity
         });
+        editor.session.setUseWrapMode(true);
+        result.append(previewElement);
       } else {
         $('<strong/>').text(' No changes were made!').appendTo(result);
       }
@@ -491,13 +493,15 @@ function submitTemplateEditor(button) {
         });
       }
       if (Object.prototype.hasOwnProperty.call(data, 'changes')) {
-        var preview = CodeMirror($('<pre/>').appendTo(result)[0], {
+        const previewElement = document.createElement('pre');
+        previewElement.appendChild(document.createTextNode(value));
+        const preview = ace.edit(previewElement, {
           mode: 'diff',
-          lineNumbers: true,
-          lineWrapping: true,
           readOnly: true,
-          value: data.changes
+          maxLines: Infinity
         });
+        editor.session.setUseWrapMode(true);
+        result.append(previewElement);
       }
     })
     .always(function (data) {

--- a/assets/stylesheets/ace.css
+++ b/assets/stylesheets/ace.css
@@ -1,0 +1,7 @@
+.ace_editor {
+position: relative;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+}

--- a/assets/stylesheets/codemirror_customization.css
+++ b/assets/stylesheets/codemirror_customization.css
@@ -1,3 +1,0 @@
-.CodeMirror {
-    height: auto;
-}

--- a/assets/stylesheets/forms.scss
+++ b/assets/stylesheets/forms.scss
@@ -162,7 +162,6 @@ select.form-control {
 }
 
 .editor-yaml-guide {
-    display: none;
     text-align: left !important;
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_folder.html.ep
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_folder.html.ep
@@ -1,7 +1,7 @@
 % layout 'bootstrap';
 % content_for 'head' => begin
-  %= asset 'codemirror.js'
-  %= asset 'codemirror.css'
+  %= asset 'ace.js'
+  %= asset 'ace.css'
 % end
 
 % title 'OBS synchronization';

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_gru_index.html.ep
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_gru_index.html.ep
@@ -1,7 +1,7 @@
 % layout 'bootstrap';
 % content_for 'head' => begin
-  %= asset 'codemirror.js'
-  %= asset 'codemirror.css'
+  %= asset 'ace.js'
+  %= asset 'ace.css'
 % end
 
 % title 'OBS synchronization jobs';

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_index.html.ep
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_index.html.ep
@@ -1,7 +1,7 @@
 % layout 'bootstrap';
 % content_for 'head' => begin
-  %= asset 'codemirror.js'
-  %= asset 'codemirror.css'
+  %= asset 'ace.js'
+  %= asset 'ace.css'
 % end
 
 % my $title = 'OBS synchronization folders';

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_logfiles.html.ep
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_logfiles.html.ep
@@ -1,7 +1,7 @@
 % layout 'bootstrap';
 % content_for 'head' => begin
-  %= asset 'codemirror.js'
-  %= asset 'codemirror.css'
+  %= asset 'ace.js'
+  %= asset 'ace.css'
 % end
 
 % title 'OBS synchronization Log';

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_logs.html.ep
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/templates/ObsRsync_logs.html.ep
@@ -1,7 +1,7 @@
 % layout 'bootstrap';
 % content_for 'head' => begin
-  %= asset 'codemirror.js'
-  %= asset 'codemirror.css'
+  %= asset 'ace.js'
+  %= asset 'ace.css'
 % end
 
 % title 'OBS synchronization Logs';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "GPL-2.0",
       "dependencies": {
+        "ace-builds": "^1.33.1",
         "anser": "^2.1.1",
         "bootstrap": "^4.6.1",
         "chosen-js": "^1.8.7",
-        "codemirror": "^5.58.2",
         "d3": "^7.9.0",
         "dagre-d3": "^0.6.4",
         "datatables.net-bs4": "^2.0.5",
@@ -196,6 +196,11 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/ace-builds": {
+      "version": "1.33.1",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.33.1.tgz",
+      "integrity": "sha512-pj5mcXV1n3s86UI4SWUt8X0ltN8cTaYcvF76cSmvy5i2ZDtXX9KkjVcYTGkCV7ox6VUrzqHByeqH0xRsMjXi4g=="
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -326,11 +331,6 @@
       "version": "1.8.7",
       "resolved": "https://registry.npmjs.org/chosen-js/-/chosen-js-1.8.7.tgz",
       "integrity": "sha512-eVdrZJ2U5ISdObkgsi0od5vIJdLwq1P1Xa/Vj/mgxkMZf14DlgobfB6nrlFi3kW4kkvKLsKk4NDqZj1MU1DCpw=="
-    },
-    "node_modules/codemirror": {
-      "version": "5.58.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.2.tgz",
-      "integrity": "sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "prettier": "3.2.5"
   },
   "dependencies": {
+    "ace-builds": "^1.33.1",
     "anser": "^2.1.1",
     "bootstrap": "^4.6.1",
     "chosen-js": "^1.8.7",
-    "codemirror": "^5.58.2",
     "d3": "^7.9.0",
     "dagre-d3": "^0.6.4",
     "datatables.net-bs4": "^2.0.5",

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -453,7 +453,7 @@ subtest 'edit job templates' => sub() {
         ok($form->child('.progress-indication')->is_hidden(), 'spinner is hidden');
         is(scalar @{$driver->find_elements('Test new medium as part of this group', 'link_text')},
             0, 'link to add a new medium (via legacy editor) not shown');
-        my $yaml = $driver->execute_script('return editor.doc.getValue();');
+        my $yaml = $driver->execute_script('return editor.getValue();');
         like($yaml, qr/products:\s*{}.*scenarios:\s*{}/s, 'default YAML was fetched') or diag explain $yaml;
     };
 
@@ -466,7 +466,7 @@ subtest 'edit job templates' => sub() {
         wait_for_ajax;
         ok($form->is_displayed(), 'editor form is shown');
         ok($form->child('.progress-indication')->is_hidden(), 'spinner is hidden');
-        $yaml = $driver->execute_script('return editor.doc.getValue();');
+        $yaml = $driver->execute_script('return editor.getValue();');
         like($yaml, qr/scenarios:/, 'YAML was fetched') or diag explain $yaml;
     };
 
@@ -500,7 +500,7 @@ subtest 'edit job templates' => sub() {
     $yaml .= "        testsuite: advanced_kde\n";
     $yaml .= "        priority: 11\n";
     $yaml =~ s/\n/\\n/g;
-    $driver->execute_script("editor.doc.setValue(\"$yaml\");");
+    $driver->execute_script("editor.setValue(\"$yaml\");");
     $driver->find_element_by_id('preview-template')->click();
     wait_for_ajax;
     like($result->get_text(), qr/Preview of the changes/, 'preview shown') or diag explain $result->get_text();
@@ -532,17 +532,17 @@ subtest 'edit job templates' => sub() {
     $yaml .= "        testsuite: advanced_kde\n";
     $yaml .= "        priority: 99\n";
     $yaml =~ s/\n/\\n/g;
-    $driver->execute_script("editor.doc.setValue(\"$yaml\");");
+    $driver->execute_script("editor.setValue(\"$yaml\");");
     $driver->find_element_by_id('save-template')->click();
     wait_for_ajax;
     like($result->get_text(), qr/YAML saved!/, 'saving confirmed') or diag explain $result->get_text();
 
     # Empty the editor
-    $driver->execute_script("editor.doc.setValue('');");
+    $driver->execute_script("editor.setValue('');");
     $driver->find_element_by_id('save-template')->click();
     wait_for_ajax;
     like($result->get_text(), qr/YAML saved!/, 'saving confirmed') or diag explain $result->get_text();
-    $yaml = $driver->execute_script('return editor.doc.getValue();');
+    $yaml = $driver->execute_script('return editor.getValue();');
     is($yaml, "products: {}\nscenarios: {}\n", 'YAML was reset to default') or diag explain $yaml;
 
     my $first_tab = $driver->get_current_window_handle();
@@ -553,24 +553,24 @@ subtest 'edit job templates' => sub() {
     $result = $form->child('.result');
     $yaml .= " # additional comment";
     my $jsyaml = $yaml =~ s/\n/\\n/gr;
-    $driver->execute_script("editor.doc.setValue(\"$jsyaml\");");
+    $driver->execute_script("editor.setValue(\"$jsyaml\");");
     $driver->find_element_by_id('save-template')->click();
     wait_for_ajax;
     like($result->get_text(), qr/YAML saved!/, 'second tab saved') or diag explain $result->get_text();
-    my $saved_yaml = $driver->execute_script('return editor.doc.getValue();');
+    my $saved_yaml = $driver->execute_script('return editor.getValue();');
     is($saved_yaml, "$yaml\n", 'YAML got a final linebreak') or diag explain $yaml;
     # Try and save, after the database has already been modified
     $driver->switch_to_window($first_tab);
     $form = $driver->find_element_by_id('editor-form');
     $result = $form->child('.result');
     $jsyaml .= " # one more comment\\n";
-    $driver->execute_script("editor.doc.setValue(\"$jsyaml\");");
+    $driver->execute_script("editor.setValue(\"$jsyaml\");");
     $driver->find_element_by_id('save-template')->click();
     wait_for_ajax;
     like($result->get_text(), qr/Template was modified/, 'conflict reported') or diag explain $result->get_text();
 
     # Make the YAML invalid
-    $driver->execute_script('editor.doc.setValue("invalid: true");');
+    $driver->execute_script('editor.setValue("invalid: true");');
     $driver->find_element_by_id('preview-template')->click();
     wait_for_ajax;
     like($result->get_text(), qr/There was a problem applying the changes/, 'error shown');

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -467,7 +467,7 @@ subtest 'misc details: title, favicon, go back, go to source view, go to log vie
         qr{.*/tests/99946/modules/installer_timezone/steps/1/src$},
         'on src page for installer_timezone test'
     );
-    is($driver->find_element('.cm-comment')->get_text(), '#!/usr/bin/env perl', 'we have a perl comment');
+    is @{$driver->find_elements('.ace_comment')}[0]->get_text, '#!/usr/bin/env perl', 'shebang rendered as comment';
 
     # load "Logs & Assets" tab contents directly because accessing the tab within the whole page in a straight forward
     # way lead to unstability (see poo#94060)

--- a/templates/webapi/admin/job_template/index.html.ep
+++ b/templates/webapi/admin/job_template/index.html.ep
@@ -1,7 +1,7 @@
 % layout 'bootstrap';
 % content_for 'head' => begin
-  %= asset 'codemirror.js'
-  %= asset 'codemirror.css'
+  %= asset 'ace.js'
+  %= asset 'ace.css'
 % end
 
 % title 'Job templates for ' . $group->name;
@@ -103,7 +103,7 @@
         <form action="#" id="editor-form" class="form-horizontal" style="display: none;"
               data-put-url="<%= url_for('apiv1_job_templates_schedules' => (id => $group->id)) %>" data-reference="<%= $yaml_template %>">
             <div class="form-group row">
-                <label for="editor-template" class="col-sm-5 control-label editor-yaml-guide">
+                <label for="editor-template" class="col-sm-5 control-label editor-yaml-guide" style="display: none">
                     <div>
                         <div>Basic YAML structure for defining job templates:</div>
 <code>defaults:
@@ -181,19 +181,17 @@ scenarios:
                         </code>
                     </div>
                 </label>
-                <div class="col-sm-7">
-                    <textarea class="form-control" id="editor-template" name="template" spellcheck="false"></textarea>
-                </div>
+                <div class="editor-container col-sm-12" id="editor-template" name="template"></div>
             </div>
             <div class="form-group row">
-                <div class="col-sm-5 editor-yaml-guide">
+                <div class="col-sm-5 editor-yaml-guide" style="display: none">
                     <p class="buttons">
                         <a href="http://open.qa/docs/#_job_group_editor_gh2111" target="blank" class="btn">
                             <i class="fa fa-book"></i>YAML editor documentation
                         </a>
                     </p>
                 </div>
-                <div class="col-sm-7">
+                <div class="editor-container col-sm-12">
                     <p class="buttons">
                         <button id="toggle-yaml-guide" type="button" class="btn btn-help"><i class="fa fa-question-circle"></i>Show YAML guide</button>
                     % if (is_admin) {

--- a/templates/webapi/layouts/code_editor.html.ep
+++ b/templates/webapi/layouts/code_editor.html.ep
@@ -1,7 +1,7 @@
 % layout 'bootstrap';
 % content_for 'head' => begin
-  %= asset 'codemirror.js'
-  %= asset 'codemirror.css'
+  %= asset 'ace.js'
+  %= asset 'ace.css'
 % end
 %= content_for 'title'
 
@@ -10,9 +10,6 @@
 % end
 
 <div class="container">
-  <p>
-    %= content_for 'src_code'
-  </p>
-
+  %= content_for 'src_code'
   %= include 'layouts/js_editor'
 </div>

--- a/templates/webapi/layouts/js_editor.html.ep
+++ b/templates/webapi/layouts/js_editor.html.ep
@@ -1,7 +1,13 @@
 <script type="text/javascript">
-var editor = CodeMirror.fromTextArea(document.getElementById("script"), {
-    lineNumbers: true,
+let mode;
+let path = document.getElementById('script').dataset.path;
+if (path && path.endsWith('.pm') || path.endsWith('.pl')) {
+  mode = 'ace/mode/perl';
+}
+var editor = ace.edit("script", {
+    mode: mode,
+    maxLines: Infinity,
     readOnly: true,
-    lineWrapping: true
-  });
+});
+editor.session.setUseWrapMode(true);
 </script>

--- a/templates/webapi/step/src.html.ep
+++ b/templates/webapi/step/src.html.ep
@@ -1,4 +1,4 @@
-% layout 'codemirror';
+% layout 'code_editor';
 
 % content_for 'title' => begin
   % title $moduleid;
@@ -9,5 +9,5 @@
     %= link_to url_for('src_step', format => 'txt') => begin
     <code><%= $scriptpath %></code>
     % end
-    <textarea class="code" id="script"><%= $script %></textarea>
+    <div class="code" id="script" data-path="<%= $scriptpath %>"><%= $script %></div>
 % end

--- a/templates/webapi/test/link_context.html.ep
+++ b/templates/webapi/test/link_context.html.ep
@@ -1,7 +1,7 @@
-% layout 'codemirror';
+% layout 'code_editor';
 
 % content_for 'src_code' => begin
   File path:
     <code><%= $contextpath %></code>
-    <textarea class="code" id="script"><%= $context %></textarea>
+    <div class="code" id="script" data-path="<%= $contextpath %>><%= $context %></div>
 % end


### PR DESCRIPTION
The version of CodeMirror we are using is outdated. The latest version of AceEditor seems easier to use than the latest version of CodeMirror (as no bundling is required) and supports everything we need. So it makes sense to switch to AceEditor.

Related ticket: https://progress.opensuse.org/issues/159411