### PR TITLE
Fix missing installation of further assets required by Ace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install-generic:
 		cp -a $$i/* "$(DESTDIR)"/usr/share/openqa/$$i ;\
 	done
 	for f in $(shell grep --perl-regexp '\.\.\/node_modules\/.*\.*+' assets/assetpack.def | sed -e 's|<* ../||') \
-		node_modules/fork-awesome/fonts/* node_modules/chosen-js/*.png; do \
+		node_modules/fork-awesome/fonts/* node_modules/chosen-js/*.png node_modules/ace-builds/css/main-*; do \
 		install -m 644 -D --target-directory="$(DESTDIR)/usr/share/openqa/$${f%/*}" "$$f";\
 	done
 


### PR DESCRIPTION
See https://progress.opensuse.org/issues/159411

---

Reproduced/tested locally by installing it using some `DESTDIR` and using the installed `node_modules` directory instead of the one populated by NPM. I'll come up with another change to test this, e.g. as part of our package builds. It would also be possible to avoid having to specify those files manually - although I'm not sure whether it is worth the effort.