### PR TITLE
Fix build requirements in spec file when tests disabled after fc99325b

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -125,6 +125,8 @@ ExcludeArch:    %{ix86}
 %{?systemd_requires}
 %if %{with tests}
 BuildRequires:  %{test_requires}
+%else
+BuildRequires:  %{common_requires} %{main_requires}
 %endif
 Requires(pre):  group(nogroup)
 %if 0%{?suse_version} > 1500


### PR DESCRIPTION
The make target now needs to load `Setup.pm` so its dependencies need to be present at build time.