### PR TITLE
Move asset-related setup into its own file to avoid extra build requires

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install-generic:
 		mkdir -p "$(DESTDIR)"/usr/share/openqa/$$i ;\
 		cp -a $$i/* "$(DESTDIR)"/usr/share/openqa/$$i ;\
 	done
-	for f in $(shell perl -Ilib -mOpenQA::Setup -e OpenQA::Setup::list_assets); do \
+	for f in $(shell perl -Ilib -mOpenQA::Assets -e OpenQA::Assets::list); do \
 		install -m 644 -D --target-directory="$(DESTDIR)/usr/share/openqa/$${f%/*}" "$$f";\
 	done
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,6 +20,7 @@ targets:
 assetpack_requires:
   perl(CSS::Minifier::XS): '>= 0.01'
   perl(JavaScript::Minifier::XS): '>= 0.11'
+  perl(Mojolicious):
   perl(Mojolicious::Plugin::AssetPack): '>= 1.36'
   perl(YAML::PP): '>= 0.026'
 

--- a/dist/rpm/openQA-test.spec
+++ b/dist/rpm/openQA-test.spec
@@ -25,8 +25,8 @@ touch %{_sourcedir}/%{short_name}
 /usr/share/openqa/script/initdb --help
 
 # verify whether assets can be loaded
-perl -I/usr/share/openqa/lib -mMojolicious -mMojo::Home -mOpenQA::Setup \
-    -e 'OpenQA::Setup::setup_asset_pack(Mojolicious->new(home => Mojo::Home->new("/usr/share/openqa")))'
+perl -I/usr/share/openqa/lib -mOpenQA::Assets \
+    -e 'OpenQA::Assets::setup(Mojolicious->new(home => Mojo::Home->new("/usr/share/openqa")))'
 
 getent passwd geekotest
 

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -47,7 +47,7 @@
 %define python_scripts_requires %{nil}
 %endif
 # The following line is generated from dependencies.yaml
-%define assetpack_requires perl(CSS::Minifier::XS) >= 0.01 perl(JavaScript::Minifier::XS) >= 0.11 perl(Mojolicious::Plugin::AssetPack) >= 1.36 perl(YAML::PP) >= 0.026
+%define assetpack_requires perl(CSS::Minifier::XS) >= 0.01 perl(JavaScript::Minifier::XS) >= 0.11 perl(Mojolicious) perl(Mojolicious::Plugin::AssetPack) >= 1.36 perl(YAML::PP) >= 0.026
 # The following line is generated from dependencies.yaml
 %define common_requires ntp-daemon perl >= 5.20.0 perl(Carp::Always) >= 0.14.02 perl(Config::IniFiles) perl(Config::Tiny) perl(Cpanel::JSON::XS) >= 4.09 perl(Cwd) perl(Data::Dump) perl(Data::Dumper) perl(Digest::MD5) perl(Filesys::Df) perl(Getopt::Long) perl(Minion) >= 10.25 perl(Mojolicious) >= 9.340.0 perl(Regexp::Common) perl(Storable) perl(Text::Glob) perl(Time::Moment) perl(Try::Tiny)
 # runtime requirements for the main package that are not required by other sub-packages

--- a/lib/OpenQA/Assets.pm
+++ b/lib/OpenQA/Assets.pm
@@ -1,0 +1,48 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Assets;
+use Mojo::Base -strict, -signatures;
+
+# This file contains helpers to setup handling of assets of the web UI. The list function is used at install-time.
+
+use Mojolicious;
+use Mojo::File qw(path);
+use Mojo::Home;
+use Mojolicious::Plugin::AssetPack;
+use YAML::PP qw(LoadFile);
+
+sub setup ($server) {
+    # setup asset pack, note that the config file is shared with tools/generate-packed-assets
+    $server->plugin(AssetPack => LoadFile($server->home->child('assets', 'assetpack.yml')));
+
+    # The feature was added in the 2.14 release, the version check can be removed once openQA depends on a newer version
+    $server->asset->store->retries(5) if $Mojolicious::Plugin::AssetPack::VERSION > 2.13;
+
+    # -> read assets/assetpack.def
+    eval { $server->asset->process };
+    if (my $assetpack_error = $@) {    # uncoverable statement
+        $assetpack_error    # uncoverable statement
+          .= 'If you invoked this service for development (from a Git checkout) you probably just need to'
+          . ' invoke "make node_modules" before running this service. If you invoked this service via a packaged binary/service'
+          . " then there is probably a problem with the packaging.\n"
+          if $assetpack_error =~ qr/could not find input asset.*node_modules/i;    # uncoverable statement
+        die $assetpack_error;    # uncoverable statement
+    }
+}
+
+sub _path ($url) { path('assets', ref $url eq 'Mojo::URL' ? $url->path : $url)->realpath->to_rel }
+
+sub list ($server = Mojolicious->new(home => Mojo::Home->new('.'))) {
+    setup $server unless $server->can('asset');
+    my %asset_urls;
+    my $assets_by_checksum = $server->asset->{by_checksum};
+    $asset_urls{_path($assets_by_checksum->{$_}->url)} = 1 for keys %$assets_by_checksum;
+    my $assets_by_topic = $server->asset->{by_topic};
+    for my $topic (keys %$assets_by_topic) {
+        $asset_urls{_path($_->url)} = 1 for @{$assets_by_topic->{$topic}};
+    }
+    say $_ for keys %asset_urls;
+}
+
+1;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -4,9 +4,7 @@
 package OpenQA::Setup;
 use Mojo::Base -strict, -signatures;
 
-use Mojolicious;
 use Mojo::File 'path';
-use Mojo::Home;
 use Mojo::Util 'trim';
 use Mojo::Loader 'load_class';
 use Config::IniFiles;
@@ -22,7 +20,6 @@ use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT MAX_TIMER);
 use OpenQA::JobGroupDefaults;
 use OpenQA::Jobs::Constants qw(OK_RESULTS);
 use OpenQA::Task::Job::Limit;
-use YAML::PP qw(LoadFile);
 
 my %CARRY_OVER_DEFAULTS = (lookup_depth => 10, state_changes_limit => 3);
 sub carry_over_defaults () { \%CARRY_OVER_DEFAULTS }
@@ -408,39 +405,6 @@ sub setup_validator_check_for_datetime ($server) {
             return 1 if $@;
             return;
         });
-}
-
-sub setup_asset_pack ($server) {
-    # setup asset pack, note that the config file is shared with tools/generate-packed-assets
-    $server->plugin(AssetPack => LoadFile($server->home->child('assets', 'assetpack.yml')));
-
-    # The feature was added in the 2.14 release, the version check can be removed once openQA depends on a newer version
-    $server->asset->store->retries(5) if $Mojolicious::Plugin::AssetPack::VERSION > 2.13;
-
-    # -> read assets/assetpack.def
-    eval { $server->asset->process };
-    if (my $assetpack_error = $@) {    # uncoverable statement
-        $assetpack_error    # uncoverable statement
-          .= 'If you invoked this service for development (from a Git checkout) you probably just need to'
-          . ' invoke "make node_modules" before running this service. If you invoked this service via a packaged binary/service'
-          . " then there is probably a problem with the packaging.\n"
-          if $assetpack_error =~ qr/could not find input asset.*node_modules/i;    # uncoverable statement
-        die $assetpack_error;    # uncoverable statement
-    }
-}
-
-sub _asset_path ($url) { path('assets', ref $url eq 'Mojo::URL' ? $url->path : $url)->realpath->to_rel }
-
-sub list_assets ($server = Mojolicious->new(home => Mojo::Home->new('.'))) {
-    setup_asset_pack $server unless $server->can('asset');
-    my %asset_urls;
-    my $assets_by_checksum = $server->asset->{by_checksum};
-    $asset_urls{_asset_path($assets_by_checksum->{$_}->url)} = 1 for keys %$assets_by_checksum;
-    my $assets_by_topic = $server->asset->{by_topic};
-    for my $topic (keys %$assets_by_topic) {
-        $asset_urls{_asset_path($_->url)} = 1 for @{$assets_by_topic->{$topic}};
-    }
-    say $_ for keys %asset_urls;
 }
 
 # add build_tx time to the header for HMAC time stamp check to avoid large timeouts on uploads

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -4,6 +4,7 @@
 package OpenQA::WebAPI;
 use Mojo::Base 'Mojolicious', -signatures;
 
+use OpenQA::Assets;
 use OpenQA::Schema;
 use OpenQA::WebAPI::Plugin::Helpers;
 use OpenQA::Log 'setup_log';
@@ -69,7 +70,7 @@ sub startup ($self) {
     OpenQA::Setup::load_plugins($self, $auth);
     OpenQA::Setup::set_secure_flag_on_cookies_of_https_connection($self);
     OpenQA::Setup::prepare_settings_ui_keys($self);
-    OpenQA::Setup::setup_asset_pack($self);
+    OpenQA::Assets::setup($self);
 
 
     # set cookie timeout to 48 hours (will be updated on each request)

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -19,6 +19,7 @@ BEGIN {
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '8';
+use OpenQA::Assets;
 use OpenQA::Log 'setup_log';
 use OpenQA::Setup;
 use OpenQA::Utils;
@@ -172,7 +173,7 @@ subtest 'Update configuration from Plugin requirements' => sub {
 
 subtest 'listing assets (for installation/Makefile)' => sub {
     my $app = Mojolicious->new(home => Mojo::Home->new("$FindBin::Bin/.."));
-    my $output = combined_from { OpenQA::Setup::list_assets($app) };
+    my $output = combined_from { OpenQA::Assets::list($app) };
     my @expected_extensions = qw(scss css js png svg ttf);
     like $output, qr{^(assets|node_modules)/.*\.$_$}m, "$_ file listed" for @expected_extensions;
 };


### PR DESCRIPTION
Otherwise we need many additional dependencies at build time. This is notable when those dependencies are not already pulled-in anyways for running tests and thus will fix builds on architectures where we have tests disabled.