### PR TITLE
Remove unused CI dependency bot container

### DIFF
--- a/container/devel:openQA:ci/README.asciidoc
+++ b/container/devel:openQA:ci/README.asciidoc
@@ -12,9 +12,5 @@ The script .circeci/build_cache.sh is used inside circleci (both remote and
 local) to create testing environment by installing packages from 
  tools/ci/ci-packages.txt onto base image.
 
-dependency_bot provides an image with a container runtime environment, git and
-few other tools. It is used in tools/ci/config.yml to
-tools/ci/build_dependencies.sh
-
 These files normally don't need to be maintained, unless processes described
 above must be tweaked now and then.

--- a/container/devel:openQA:ci/dependency_bot/Dockerfile
+++ b/container/devel:openQA:ci/dependency_bot/Dockerfile
@@ -1,6 +1,0 @@
-#!BuildTag: dependency_bot
-FROM opensuse/leap:15.5
-ENV NAME Leap with container runtime environment and hub
-
-ENV LANG en_US.UTF-8
-RUN zypper -n install podman git hub curl make


### PR DESCRIPTION
According to the Readme, this container should be used only in CircleCI but that does not correspond to the reality from CircleCI config:

```
  - &dependency_bot
    image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
```

Reference: https://progress.opensuse.org/issues/159747