### PR TITLE
Provide volume and default workdir for openqa_devel container

### DIFF
--- a/container/devel/Dockerfile
+++ b/container/devel/Dockerfile
@@ -22,3 +22,7 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # hadolint ignore=DL3037
 RUN zypper in -y os-autoinst-devel openQA-devel vim nodejs-default git mc perl-Devel-REPL perl-Term-ReadKey && \
     zypper clean -a
+
+ENV OPENQA_DIR /opt/openqa
+VOLUME $OPENQA_DIR
+WORKDIR $OPENQA_DIR


### PR DESCRIPTION
Create a working folder to mount/checkout openQA source code into.