### PR TITLE
Avoid wrong info message from shellcheck about possible misspelling

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -21,6 +21,7 @@ if [ "$NAME" = "openSUSE Leap" ]; then
     # avoid using `obs://…` URL to workaround https://bugzilla.opensuse.org/show_bug.cgi?id=1187425
     repobase=https://download.opensuse.org/repositories/devel:/openQA
     # remove suffixes like " Beta" so e.g. "15.6 Beta" becomes just "15.6"
+    # shellcheck disable=SC2153
     version=${VERSION%% *}
     zypper -n addrepo -p 95 "$repobase/$version" 'devel:openQA'
     zypper -n addrepo -p 90 "$repobase:/Leap:/$version/$version" "devel:openQA:Leap:$version"


### PR DESCRIPTION
This info message occurs since at least shellcheck 0.9.0 and leads to the tool exiting with a non-zero return code. The variable is not misspelled, it comes from sourcing `/etc/os-release`.