### PR TITLE
Add ShellCheck directive for SC2153

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -21,6 +21,7 @@ if [ "$NAME" = "openSUSE Leap" ]; then
     # avoid using `obs://…` URL to workaround https://bugzilla.opensuse.org/show_bug.cgi?id=1187425
     repobase=https://download.opensuse.org/repositories/devel:/openQA
     # remove suffixes like " Beta" so e.g. "15.6 Beta" becomes just "15.6"
+    # shellcheck disable=SC2153
     version=${VERSION%% *}
     zypper -n addrepo -p 95 "$repobase/$version" 'devel:openQA'
     zypper -n addrepo -p 90 "$repobase:/Leap:/$version/$version" "devel:openQA:Leap:$version"


### PR DESCRIPTION
Details of the error https://www.shellcheck.net/wiki/SC2153. Hits on `${VERSION%% *}` variable since ShellCheck version 0.9.0.