### PR TITLE
Add recording how to run openQA test in 5 minutes

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -47,6 +47,10 @@ podman run --name openqa --device /dev/kvm -p 1080:80 -p 1443:443 --rm -it \
 Once the startup has finished, the web UI is accessible via http://localhost:1080
 or https://localhost:1443.
 
+==== How to run a test with single-instance container in 5 minutes
+
+image::images/openqa-in-5-minutes.gif[Running openQA job within 5 minutes]
+
 === Separate web UI and worker containers
 As an alternative also separate containers are provided for both the web UI
 and worker.

--- a/docs/asciinema/.gitignore
+++ b/docs/asciinema/.gitignore
@@ -1,0 +1,1 @@
+openqa-in-5-minutes.gif

--- a/docs/asciinema/Dockerfile
+++ b/docs/asciinema/Dockerfile
@@ -1,10 +1,26 @@
+# syntax=docker/dockerfile:1.3
 FROM opensuse/tumbleweed:latest
 
-RUN zypper in -y asciinema bat cargo gcc make fira-code-fonts jq retry wget
+# Install recording prerequisites
+RUN zypper in -y asciinema cargo gcc make fira-code-fonts
 RUN cargo install autocast && \
     ln -s /root/.cargo/bin/autocast /usr/local/bin/
 RUN cargo install --git https://github.com/asciinema/agg && \
     ln -s /root/.cargo/bin/agg /usr/local/bin/
+
+# Install utilities used in the recording
+RUN zypper in -y bat jq retry wget
+
+# Use http://www.brow.sh to show the web in terminal
+RUN zypper in -y firefox
+RUN wget -O /usr/local/bin/browsh https://github.com/browsh-org/browsh/releases/download/v1.8.2/browsh_1.8.2_linux_amd64 && \
+    chmod +x /usr/local/bin/browsh
+RUN mkdir -p /root/.config/browsh
+COPY <<EOF /root/.config/browsh/config.toml
+browsh_supporter = "I have shown my support for Browsh"
+[firefox]
+path = "/usr/bin/firefox"
+EOF
 
 RUN mkdir -p /work
 VOLUME /work

--- a/docs/asciinema/Dockerfile
+++ b/docs/asciinema/Dockerfile
@@ -1,0 +1,11 @@
+FROM opensuse/tumbleweed:latest
+
+RUN zypper in -y asciinema bat cargo gcc make fira-code-fonts jq retry wget
+RUN cargo install autocast && \
+    ln -s /root/.cargo/bin/autocast /usr/local/bin/
+RUN cargo install --git https://github.com/asciinema/agg && \
+    ln -s /root/.cargo/bin/agg /usr/local/bin/
+
+RUN mkdir -p /work
+VOLUME /work
+WORKDIR /work

--- a/docs/asciinema/Makefile
+++ b/docs/asciinema/Makefile
@@ -1,0 +1,11 @@
+YAML_FILES=$(wildcard *.yaml)
+GIF_FILES=$(YAML_FILES:.yaml=.gif)
+THEME=monokai
+
+all: $(GIF_FILES)
+
+%.cast:%.yaml
+	autocast --overwrite $< $@
+
+%.gif: %.cast
+	agg --theme $(THEME) $< $@

--- a/docs/asciinema/Makefile
+++ b/docs/asciinema/Makefile
@@ -1,11 +1,24 @@
 YAML_FILES=$(wildcard *.yaml)
 GIF_FILES=$(YAML_FILES:.yaml=.gif)
 THEME=monokai
+BAT_THEME=Monokai Extended
 
-all: $(GIF_FILES)
+.PHONY: all
+all: build run
+
+.PHONY: cast
+cast: $(GIF_FILES)
 
 %.cast:%.yaml
 	autocast --overwrite $< $@
 
 %.gif: %.cast
 	agg --theme $(THEME) $< $@
+
+.PHONY: build
+build:
+	podman build . -t autocast
+
+.PHONY: run
+run:
+	podman run -e BAT_THEME="$(BAT_THEME)" --rm -ti -v .:/work --privileged --device /dev/kvm autocast make cast

--- a/docs/asciinema/openqa-in-5-minutes.yaml
+++ b/docs/asciinema/openqa-in-5-minutes.yaml
@@ -5,11 +5,21 @@ settings:
   title: How to run an openQA test in 5 minutes
   timeout: 300s
   type_speed: 50ms
-  environment:
-    - name: BAT_THEME
-      value: Solarized (light)
+  environment_capture:
+    - BAT_THEME
 instructions:
   - !Command
+    command: "# Install podman"
+  - !Command
+    command:
+      - zypper in -y podman
+  - !Command
+    # Workaround to hide some warnings due to having podman inside podman
+    command:
+      - alias podman='podman --log-level error'
+    hidden: true
+  - !Command
+    # Make sure the image will be downloaded, because that looks nice in the video
     command:
       - podman rmi
       - registry.opensuse.org/devel/openqa/containers/openqa-single-instance
@@ -23,6 +33,11 @@ instructions:
       - --env skip_suse_tests="" --env skip_suse_specifics=""
       - --device /dev/kvm -p 1080:80 -p 1443:443
       - registry.opensuse.org/devel/openqa/containers/openqa-single-instance
+  - !Command
+    # Workaround for healtchecks not working without systemd inside recording container
+    command: >-
+      ( nohup retry -r 20 -s 10 -- podman healthcheck run openqa &> /dev/null & )
+    hidden: true
   - !Command
     command: podman wait --condition healthy openqa
   - !Marker Clone job from openqa.opensuse.org
@@ -65,6 +80,9 @@ instructions:
     command: podman exec openqa openqa-cli api jobs/2 | jq -r .job.result
   - !Wait 3s
   - !Marker Clean up
+  - !Command
+    command: rm -f scenario-definitions.yaml
+    hidden: true
   - !Command
     command: "# Stop the container to remove all data"
   - !Command

--- a/docs/asciinema/openqa-in-5-minutes.yaml
+++ b/docs/asciinema/openqa-in-5-minutes.yaml
@@ -6,6 +6,7 @@ settings:
   timeout: 300s
   type_speed: 50ms
   environment_capture:
+    - HOME
     - BAT_THEME
 instructions:
   - !Command
@@ -78,7 +79,19 @@ instructions:
       - NEEDLES_DIR=%%CASEDIR%%/needles
   - !Command
     command: podman exec openqa openqa-cli api jobs/2 | jq -r .job.result
-  - !Wait 3s
+  - !Marker openQA web UI
+  - !Command
+    command: "# We can also use the local web UI"
+  - !Command
+    command: >-
+      alias xdg-open='browsh --time-limit 5 --startup-url'
+    hidden: true
+  - !Command
+    command: >-
+      xdg-open http://localhost:1080/t2
+  - !Command
+    command: pkill firefox
+    hidden: true
   - !Marker Clean up
   - !Command
     command: rm -f scenario-definitions.yaml

--- a/docs/asciinema/openqa-in-5-minutes.yaml
+++ b/docs/asciinema/openqa-in-5-minutes.yaml
@@ -1,0 +1,71 @@
+---
+settings:
+  width: 80
+  height: 24
+  title: How to run an openQA test in 5 minutes
+  timeout: 300s
+  type_speed: 50ms
+  environment:
+    - name: BAT_THEME
+      value: Solarized (light)
+instructions:
+  - !Command
+    command:
+      - podman rmi
+      - registry.opensuse.org/devel/openqa/containers/openqa-single-instance
+    hidden: true
+  - !Marker Pull openQA container
+  - !Command
+    command: "# Pull and run openQA single instance container"
+  - !Command
+    command:
+      - podman run --rm -ti --name openqa --detach
+      - --env skip_suse_tests="" --env skip_suse_specifics=""
+      - --device /dev/kvm -p 1080:80 -p 1443:443
+      - registry.opensuse.org/devel/openqa/containers/openqa-single-instance
+  - !Command
+    command: podman wait --condition healthy openqa
+  - !Marker Clone job from openqa.opensuse.org
+  - !Command
+    command: "# Clone any job from openqa.opensuse.org"
+  - !Command
+    command:
+      - podman exec openqa
+      - openqa-clone-job https://openqa.opensuse.org/tests/4109159
+  - !Command
+    command:
+      - podman exec -ti openqa
+      - openqa-cli monitor 1
+  - !Wait 3s
+  - !Marker Prepare scenario definition
+  - !Command
+    command: "# Create scenario definition"
+  - !Command
+    command:
+      - wget -qO scenario-definitions.yaml
+      - https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-example/main/scenario-definitions.yaml
+  - !Command
+    command: bat scenario-definitions.yaml
+  - !Command
+    command: >-
+      podman cp scenario-definitions.yaml openqa:scenario-definitions.yaml
+  - !Marker Schedule product
+  - !Command
+    command: "# Schedule the product"
+  - !Command
+    command:
+      - podman exec -ti openqa
+      - openqa-cli schedule --monitor
+      - --param-file SCENARIO_DEFINITIONS_YAML=scenario-definitions.yaml
+      - DISTRI=example VERSION=0 FLAVOR=DVD ARCH=x86_64
+      - TEST=simple_boot _GROUP_ID=0 BUILD=test
+      - CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-example.git
+      - NEEDLES_DIR=%%CASEDIR%%/needles
+  - !Command
+    command: podman exec openqa openqa-cli api jobs/2 | jq -r .job.result
+  - !Wait 3s
+  - !Marker Clean up
+  - !Command
+    command: "# Stop the container to remove all data"
+  - !Command
+    command: podman stop openqa

--- a/docs/images/.gitignore
+++ b/docs/images/.gitignore
@@ -1,0 +1,1 @@
+openqa-in-5-minutes.gif


### PR DESCRIPTION
Add scenario for asciinema recording and include it into documentation.

Add Dockerfile and a short Makefile to allow generating GIFs out of autocast yaml files with the asciicast + agg combo without installing anything. The cast will be done inside the container as well, so the recording is done isolated from the rest of the system.

Reference: https://progress.opensuse.org/issues/76978
