### PR TITLE
Allow configuring Cross-Origin Resource Sharing (CORS) for API requests

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -53,6 +53,7 @@ sub read_config ($app) {
             force_result_regex => '',
             parallel_children_collapsable_results => join(' ', OK_RESULTS),
             service_port_delta => $ENV{OPENQA_SERVICE_PORT_DELTA} // 2,
+            access_control_allow_origin_header => undef,
         },
         rate_limits => {
             search => 5,

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -55,8 +55,7 @@ subtest 'access limiting for non authenticated users' => sub {
     $t->get_ok('/api/v1/jobs')->status_is(200);
     is $t->tx->res->headers->access_control_allow_origin, '*', 'CORS header set for non authenticated routes';
     $t->get_ok('/api/v1/products')->status_is(200);
-    $t->delete_ok('/api/v1/assets/1')->status_is(403);
-    is($t->tx->res->code, 403, 'delete forbidden');
+    $t->delete_ok('/api/v1/assets/1')->status_is(403, 'delete forbidden');
     is_deeply(
         $t->tx->res->json,
         {


### PR DESCRIPTION
This is how adding the CORS header on Mojolicious-level would look like. That's probably better than implementing (multiple) reverse-proxy-specific solutions.

Related ticket: https://progress.opensuse.org/issues/159384