### PR TITLE
PART 3: Update helm charts to Leap 15.6 after base update - After #5627

### DIFF
--- a/container/helm/charts/webui/values.yaml
+++ b/container/helm/charts/webui/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.5/openqa_webui
+  name: registry.opensuse.org/devel/openqa/containers15.6/openqa_webui
   pullPolicy: Always
   tag: "latest"
 

--- a/container/helm/charts/worker/values.yaml
+++ b/container/helm/charts/worker/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 image:
-  name: registry.opensuse.org/devel/openqa/containers15.5/openqa_worker
+  name: registry.opensuse.org/devel/openqa/containers15.6/openqa_worker
   pullPolicy: Always
   tag: "latest"
 


### PR DESCRIPTION
After:
* #5627

Related progress issue: https://progress.opensuse.org/issues/157984