### PR TITLE
Fix HTML for source view

### DIFF
--- a/templates/webapi/test/link_context.html.ep
+++ b/templates/webapi/test/link_context.html.ep
@@ -3,5 +3,5 @@
 % content_for 'src_code' => begin
   File path:
     <code><%= $contextpath %></code>
-    <div class="code" id="script" data-path="<%= $contextpath %>><%= $context %></div>
+    <div class="code" id="script" data-path="<%= $contextpath %>"><%= $context %></div>
 % end


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/159411

Typo introduced in d818a0eac4bd490cbea302181de2f8ba54a03704