### PR TITLE
Prevent keyboxd usage when gpg >= 2.4 is used

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -26,6 +26,8 @@ ENV USER squamata
 
 RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER
+# Create default directory to prevent keyboxd usage for GPG >= 2.4, see https://github.com/codecov/codecov-circleci-orb/issues/157 for details
+RUN sudo -u $NORMAL_USER mkdir -p /home/$NORMAL_USER/.gnupg
 
 RUN mkdir -p /opt/testing_area
 RUN chown -R $NORMAL_USER:users /opt/testing_area


### PR DESCRIPTION
As seen in https://github.com/os-autoinst/openQA/pull/5634, gpg in Leap 15.6 has a different default behavior. Creating the default folder should keep it the same as it was (i.e. prevent keyboxd usage).