### PR TITLE
Add trailing slashes and autoindex to asset config example

### DIFF
--- a/etc/nginx/vhosts.d/openqa-locations.inc
+++ b/etc/nginx/vhosts.d/openqa-locations.inc
@@ -12,7 +12,8 @@ if_modified_since before;
 
 ## Optional faster assets downloads for large deployments
 #location /assets {
-#    alias /var/lib/openqa/share/factory;
+#    alias /var/lib/openqa/share/factory/;
+#    autoindex          on;
 #    tcp_nopush         on;
 #    sendfile           on;
 #    sendfile_max_chunk 1m;
@@ -20,7 +21,7 @@ if_modified_since before;
 #
 ## Optional faster image downloads for large deployments
 #location /image {
-#    alias /var/lib/openqa/images;
+#    alias /var/lib/openqa/images/;
 #    tcp_nopush         on;
 #    sendfile           on;
 #    sendfile_max_chunk 1m;


### PR DESCRIPTION
Without the slash assets will be seen as redirects.

See: https://progress.opensuse.org/issues/160171