### PR TITLE
Ensure curl, ping and ps are installed as deps for openQA-bootstrap

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -249,6 +249,9 @@ Use this package to setup a local instance with all services provided together.
 
 %package bootstrap
 Summary:        Automated openQA setup
+Requires:       curl
+Requires:       iputils
+Requires:       procps
 
 %description bootstrap
 This can automatically setup openQA - either directly on your system


### PR DESCRIPTION
The bootstrap script is using these tools and they might not be installed everywhere.