### PR TITLE
Compare SUT package versions in investigation, if available

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -473,6 +473,37 @@ sub run () {
 }
 --------------------------------------------------------------
 
+=== Logging package versions used for test
+
+There are two sets of packages that can be included in test logs:
+1. Packages installed on the worker itself - stored as `worker_packages.txt`.
+2. Packages installed on SUT - stored as `sut_packages.txt`.
+
+For both sets, if present, openQA will include the difference to the last good
+job in the "Investigation" tab of a failed job.
+
+To enable logging of worker package versions, set `PACKAGES_CMD` in
+`workers.ini`.  The command should print installed packages with their version
+to stdout. For RPM-based systems it can be for example `rpm -qa`.
+
+To enable logging of SUT package versions, make the test create the file
+`sut_packages.txt` in the current worker directory. If `upload_logs()` is used,
+the resulting file needs to be copied/moved.
+
+[caption="Example: "]
+.Logging SUT package versions
+[source,perl]
+--------------------------------------------------------------
+use Mojo::File qw(path);
+sub run {
+    ...
+    assert_script_run("rpm -qa > sut_packages.txt");
+    my $fname = upload_logs("sut_packages.txt");
+    path("ulogs/$fname")->move_to("sut_packages.txt");
+    ...
+}
+--------------------------------------------------------------
+
 === Assigning jobs to workers
 
 By default, any worker can get any job with the matching architecture.

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -88,7 +88,7 @@ use constant {
 use constant MODULE_RESULTS => (CANCELLED, FAILED, NONE, PASSED, RUNNING, SKIPPED, SOFTFAILED);
 
 # common result files to be expected in all jobs
-use constant COMMON_RESULT_LOG_FILES => qw(autoinst-log.txt worker-log.txt worker_packages.txt);
+use constant COMMON_RESULT_LOG_FILES => qw(autoinst-log.txt worker-log.txt worker_packages.txt sut_packages.txt);
 use constant COMMON_RESULT_FILES => COMMON_RESULT_LOG_FILES, qw(vars.json);
 
 # result files handled by the cleanup of logs


### PR DESCRIPTION
In addition to showing diff of worker_packages.txt, include also a diff
of sut_packages.txt. Creating the file is up to the test, but do add it
to list of files uploaded at the job end.

Document how to use this feature. And while at it, document also
`worker_packages.txt` and `PACKAGES_CMD` setting.