### PR TITLE
Add devcontainer for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+    "name": "openQA Single Instance",
+    "image": "registry.opensuse.org/devel/openqa/containers15.5/openqa-single-instance",
+    "runArgs": [ "--privileged", "--device", "/dev/kvm", "--entrypoint", "bash" ],
+    "postCreateCommand": "chown root:kvm /dev/kvm",
+    "containerEnv": {
+      "VNCPORT_OFFSET": "100"
+    },
+    "postStartCommand": "/usr/share/openqa/script/openqa-bootstrap >/var/log/openqa-bootstrap.log 2>&1"
+
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    //"postCreateCommand": "pip3 install --user -r requirements.txt"
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -33,6 +33,12 @@ link:docs/UsersGuide.asciidoc[Users Guide].
 If you are interested in writing tests using openQA read the
 link:docs/WritingTests.asciidoc[Tests Developer Guide].
 
+Try out running tests without installing openQA in
+https://codespaces.new/os-autoinst/openQA?quickstart=1[our Codespace].
+See also: https://docs.github.com/en/codespaces[GitHub Codespaces documentation]
+
+For troubleshooting look into `/var/log/openqa-bootstrap.log`.
+
 == Contributing
 [id="getting_involved"]
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/87695

This PR also restructures openqa-bootstrap a bit.

To try it out, go to https://codespaces.new/os-autoinst/openQA/tree/codespace?quickstart=1 and create a new (or resume an existing) codespace. That can take a while.

## The current usage

openqa-bootstrap will automatically start in the background and write to `/var/log/openqa-bootstrap.log`.

Open a terminal:
```
tail -f /var/log/openqa-bootstrap.log
```

After the webserver has started at port 80, you should be able to open the url in the browser.
Now you can start another codespaces terminal and type
```
openqa-clone-job https://openqa.opensuse.org/tests/4191283
```
for example.

When your codespace is stopped after inactivity, you can resume it (that will only take a few seconds), but then you have to start the daemons (database, webui etc.) again with:
```
/usr/share/openqa/script/openqa-bootstrap start
```

