### PR TITLE
Overhaul info panel on job details page

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -1132,7 +1132,12 @@ function renderDependencyGraph(container, nodes, edges, cluster, currentNode) {
 }
 
 function rescheduleProductForJob(link) {
-  if (window.confirm('Do you really want to partially reschedule the product of this job?')) {
+  if (
+    window.confirm(
+      'Do you really want to partially reschedule the product of this job? This will' +
+        ' NOT be limited to the current job group! Click on the help icon for details.'
+    )
+  ) {
     rescheduleProduct(link.dataset.url);
   }
   return false; // avoid usual link handling

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -3,15 +3,6 @@
     background-color: $color-softfailed;
     color: $color-result;
 }
-#restart-result + .help_popover {
-    font-size: 80%;
-    position: relative;
-    top: 5px;
-    left: -3px;
-    margin-left: 0px;
-    padding-left: 0px;
-    opacity: 0.75;
-}
 
 // test result
 .resultok { background-color: $color-ok; color: $color-result; }
@@ -460,19 +451,35 @@ ul.modcategory {
             color: $link-hover-color-darktheme;
         }
     }
-}
-
-.darkmode {
     .card#info_box {
         background-color: $default-bg-color-darktheme;
-
-        .btn-link,.btn-link:hover {
+        .btn-secondary, .btn-secondary:hover {
             color: $default-font-color-darktheme;
-            background-color: $default-bg-color-darktheme;
+            background-color: lighten($default-bg-color-darktheme, 25%);
+        }
+        .btn-warning, .btn-warning:hover {
+            color: $default-bg-color-darktheme;
         }
     }
 
     #settings td {
         border-top-color: rgba(255, 255, 255, 0.03);
+    }
+}
+
+.info-panel-actions .help_popover {
+    margin: 0;
+}
+@include media-breakpoint-up(xl) {
+    .info-panel-actions {
+        border-left: 1px solid #ccc;
+        margin-left: 10px;
+    }
+}
+@include media-breakpoint-down(lg) {
+    .info-panel-actions {
+        border-top: 1px solid #ccc;
+        margin-top: 10px;
+        padding-top: 10px;
     }
 }

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -249,7 +249,7 @@ subtest 'scheduled product shown' => sub {
         qr/\/admin\/productlog\?id=$expected_scheduled_product_id/,
         'scheduled product href'
     );
-    my $reschedule_link = $driver->find_element('#scheduled-product-info div > a');
+    my $reschedule_link = $driver->find_element('#restart-scheduled-product');
     my $expected_params = qr/scheduled_product_clone_id=$expected_scheduled_product_id&TEST=kde/;
     like $reschedule_link->get_attribute('data-url'), $expected_params, 'reschedule link shown';
     $reschedule_link->click;

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -85,6 +85,8 @@ disable_timeout;
 
 $driver->title_is('openQA', 'on main page');
 $driver->find_element_by_link_text('Login')->click();
+$driver->find_element_by_id('dont-notify')->click;
+$driver->find_element_by_class_name('shepherd-cancel-icon')->click;
 
 subtest 'restart job from info panel in test results' => sub {
     subtest 'parent job shows options for advanced restart' => sub {

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -12,14 +12,15 @@
                     </span>
                 % }
             </div>
-            <div id="info-box-content" class="card-body"
+            <div id="info-box-content" class="card-body row"
                 % if ($additional_data) {
                     data-favicon-url-16="<%= favicon_url '-16.png' %>" data-favicon-url-svg="<%= favicon_url '.svg' %>"
                 % }
             >
+                <div class="col-xl">
                 <div>
                     % if ($job->state eq DONE) {
-                        <div class="position-absolute top-right pt-2-and-half pr-3">
+                        <div class="position-absolute top-right badge-pill badge-light">
                             %= $job->passed_module_count
                             <i class='fa module_passed fa-star' title='modules passed'></i>
                             % if ($job->softfailed_module_count) {
@@ -53,9 +54,9 @@
                     % if ($job->t_finished) {
                         <%= ', finished' =%>
                         <abbr class="timeago" title="<%= $job->t_finished->datetime() %>Z"><%= format_time($job->t_finished) %></abbr>
-                        (\
-                        <%= $job->t_started ?  format_time_duration($job->t_finished - $job->t_started) : 0 =%>\
-                        )
+                        % if (my $t_started = $job->t_started) {
+                            (<span>ran for </span><%= format_time_duration($job->t_finished - $t_started) =%>)
+                        % }
                     % }
                     % elsif ($job->t_started) {
                         <%= ', started' =%>
@@ -64,45 +65,6 @@
                     % else {
                         <%= ', created' =%>
                         <abbr class="timeago" title="<%= $job->t_created->datetime() %>Z"><%= format_time($job->t_created) %></abbr>
-                    % }
-                    % if (is_operator && $job->can_be_duplicated) {
-                      <div class = "btn-group btn-group-sm" id="restart-button-group">
-                        %= link_post url_for('apiv1_restart', jobid => $testid) => (class => 'btn btn-link restart-result', 'data-remote' => 'true', id => 'restart-result', 'data-jobid' => $testid) => begin
-                            <i class="fa fa-2 fa-undo" title="Restart job"></i>
-                        %= end
-                        % my $ok_results_explanation = join '/', OK_RESULTS;
-                        % if ($job->has_dependencies) {
-                        <button class="btn btn-link dropdown-toggle" type="button" id="restart-button-options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="caret" title="Additional options for restarting jobs with dependencies"></span></button>
-                          <div class="dropdown-menu" role="menu" aria-labelledby="restart-button-options" id="restart-menu">
-                            %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_parents => 1}) => (class => 'dropdown-item restart-result', 'data-remote' => 'true', id => 'restart-result-skip-parents', 'data-jobid' => $testid) => begin
-                            <span>Skip parents</span>
-                            %= end
-                            %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_children => 1}) => (class => 'dropdown-item restart-result', 'data-remote' => 'true', id => 'restart-result-skip-children', 'data-jobid' => $testid) => begin
-                            <span>Skip children</span>
-                            %= end
-                            %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_ok_result_children => 1}) => (class => 'dropdown-item restart-result', 'data-remote' => 'true', id => 'restart-result-skip-ok-children', 'data-jobid' => $testid) => begin
-                            <span>Skip restarting "OK" (<%= $ok_results_explanation %>) children</span>
-                            %= end
-                          </div>
-                        % }
-                      </div>
-                      <%= help_popover('Restart job' => "
-                          <p>Restarts the job and certain dependent jobs.</p>
-                          <p>Rules for restarting dependencies:</p>
-                          <ul>
-                              <li>If the job is part of a parallel cluster, all jobs within that cluster are restarted.</li>
-                              <li>Any kind of chained child jobs are restarted.</li>
-                              <li>Directly chained parent jobs are restarted.</li>
-                          </ul>
-                          All rules are applied recursively. Advanced restarting options allow changing the behavior, e.g. excluding parents and $ok_results_explanation children.",
-                          'https://open.qa/docs/#_handling_of_related_jobs_on_failure_cancellation_restart', 'documentation', 'bottom');
-                      %>
-                    % }
-                    % if (is_operator && (OpenQA::Jobs::Constants::meta_state($job->state) ne OpenQA::Jobs::Constants::FINAL)) {
-                        %= link_post url_for('apiv1_cancel', jobid => $job->id) => ('data-remote' => 'true', id => 'cancel_running') => begin
-                            <i class="fa fa-2 fa-times-circle-o" title="Cancel Job"></i>
-                        % end
                     % }
                     % if (my $reason = $job->reason) {
                         <br>Reason: <%= $reason %>
@@ -137,21 +99,6 @@
                     % if (my $scheduled_product = $job->scheduled_product) {
                         % my $sp_id = $scheduled_product->id;
                         %= link_to $scheduled_product->to_string, url_for('admin_product_log')->query(id => $sp_id)
-                        % if (is_operator) {
-                            <div class="btn-group btn-group-sm">
-                                <a href="#"
-                                   onclick="return rescheduleProductForJob(this);" \
-                                   class="btn btn-link"\
-                                   data-url="<%= url_for('apiv1_create_iso')->query(scheduled_product_clone_id => $sp_id, TEST => $job->TEST, _SKIP_CHAINED_DEPS => 1, _INCLUDE_CHILDREN => 1) %>">\
-                                     <i class="fa fa-2 fa-refresh" title="Reschedule product from here"></i>
-                                </a>
-                            </div>
-                            <%= help_popover('Partial product re-scheduling' => "
-                                <p>Schedules the product again using the current job as starting point. That means chained parents of
-                                the current job will not be scheduled again but all its children will be.</p>",
-                                undef, undef, 'bottom');
-                            %>
-                        % }
                     % } else {
                         job has not been created by posting an ISO
                         % if ($clone_of) {
@@ -182,5 +129,72 @@
                     <div id="scenario-description">
                             %= $scenario_description
                     </div>
+                % }
+                </div>
+                % if (is_operator) {
+                <div class="info-panel-actions col-xl-auto">
+                    <strong>Actions:</strong><br>
+                    % if ($job->can_be_duplicated) {
+                      <div class = "btn-group btn-group-sm dropleft">
+                        % my $has_dependencies = $job->has_dependencies;
+                        % my $ok_results_explanation = join '/', OK_RESULTS;
+                        % if ($has_dependencies) {
+                          <button class="btn btn-secondary dropdown-toggle" type="button" id="restart-button-options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <span class="caret" title="Additional options for restarting jobs with dependencies"></span>
+                          </button>
+                          <div class="dropdown-menu" role="menu" aria-labelledby="restart-button-options" id="restart-menu">
+                            %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_parents => 1}) => (class => 'dropdown-item restart-result', 'data-remote' => 'true', id => 'restart-result-skip-parents', 'data-jobid' => $testid) => begin
+                            <span>Skip parents</span>
+                            %= end
+                            %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_children => 1}) => (class => 'dropdown-item restart-result', 'data-remote' => 'true', id => 'restart-result-skip-children', 'data-jobid' => $testid) => begin
+                            <span>Skip children</span>
+                            %= end
+                            %= link_post url_for('apiv1_restart', jobid => $testid)->query({skip_ok_result_children => 1}) => (class => 'dropdown-item restart-result', 'data-remote' => 'true', id => 'restart-result-skip-ok-children', 'data-jobid' => $testid) => begin
+                            <span>Skip restarting "OK" (<%= $ok_results_explanation %>) children</span>
+                            %= end
+                          </div>
+                        % }
+                        % my $restart_text = $has_dependencies ? 'Restart this and dependent jobs' : 'Restart job';
+                        %= link_post url_for('apiv1_restart', jobid => $testid) => (class => 'btn btn-secondary restart-result', 'data-remote' => 'true', id => 'restart-result', 'data-jobid' => $testid) => begin
+                            <i class="fa fa-2 fa-undo"></i><%= $restart_text %>
+                        %= end
+                        <%= help_popover('Restart job' => "
+                            <p>Restarts the job and certain dependent jobs.</p>
+                            <p>Rules for restarting dependencies:</p>
+                            <ul>
+                                <li>If the job is part of a parallel cluster, all jobs within that cluster are restarted.</li>
+                                <li>Any kind of chained child jobs are restarted.</li>
+                                <li>Directly chained parent jobs are restarted.</li>
+                            </ul>
+                            All rules are applied recursively. Advanced restarting options allow changing the behavior, e.g. excluding parents and $ok_results_explanation children.",
+                            'https://open.qa/docs/#_handling_of_related_jobs_on_failure_cancellation_restart', 'documentation', 'bottom', class => 'help_popover fa fa-question-circle btn btn-secondary');
+                        %>
+                      </div>
+                    % }
+                    % if (OpenQA::Jobs::Constants::meta_state($job->state) ne OpenQA::Jobs::Constants::FINAL) {
+                      <div class = "btn-group btn-group-sm">
+                        %= link_post url_for('apiv1_cancel', jobid => $job->id) => (class => 'btn btn-warning', 'data-remote' => 'true', id => 'cancel_running') => begin
+                            <i class="fa fa-2 fa-times-circle-o"></i>Cancel job
+                        % end
+                      </div>
+                    % }
+                    % if (my $sp_id = $job->scheduled_product_id) {
+                      <div class="btn-group btn-group-sm">
+                        <a href="#"
+                          id="restart-scheduled-product" \
+                          onclick="return rescheduleProductForJob(this);" \
+                          class="btn btn-danger"\
+                           data-url="<%= url_for('apiv1_create_iso')->query(scheduled_product_clone_id => $sp_id, TEST => $job->TEST, _SKIP_CHAINED_DEPS => 1, _INCLUDE_CHILDREN => 1) %>">\
+                             <i class="fa fa-2 fa-refresh"></i>Reschedule product from here
+                        </a>
+                      <%= help_popover('Partial product re-scheduling' => "
+                          <p>Schedules the product again using the current job as starting point. That means chained parents of
+                          the current job will not be scheduled again but all its children will be. The re-scheduling is <strong>not</strong>
+                          limited to the current job group.</p>",
+                          undef, undef, 'bottom', class => 'help_popover fa fa-question-circle btn btn-danger');
+                      %>
+                      </div>
+                    % }
+                </div>
                 % }
             </div>


### PR DESCRIPTION
* Remove `… (0)` for jobs with undetermined runtime
* Use proper buttons to make it less likely for users to click on the wrong button
* Improve appearance of help popovers next to buttons
* State explicitly that re-scheduling is not limited to the current job group
* Move buttons to their own section at the right
* See https://progress.opensuse.org/issues/138593

---

The buttons are no actually proper bootstrap buttons. The help-popovers are also proper bootstrap buttons (part of the same button group). When focusing/hovering over the button it also becomes clear that the help-popover is actually a separate button.

![screenshot_%Y%M%D_%H%m%S](https://github.com/os-autoinst/openQA/assets/10248953/2869872f-c1ef-4e6b-98f6-05f32e39ead6)

Of course not always all actions are displayed and then the actions section at the right takes less space:
![screenshot_%Y%M%D_%H%m%S-1](https://github.com/os-autoinst/openQA/assets/10248953/25cc6941-b753-414e-9885-5082a57e4ea2)

The menu with additional options for dependencies is also still present (if relevant):
![screenshot_%Y%M%D_%H%m%S-2](https://github.com/os-autoinst/openQA/assets/10248953/58075c7b-b035-4e48-aed1-f5ac25595285)

On very small screen sizes actions are displayed below:
![screenshot_%Y%M%D_%H%m%S-3](https://github.com/os-autoinst/openQA/assets/10248953/973cd166-98c5-4999-9f21-b6688dd0b0b4)

It also looks acceptable when darkmode is enabled (but not the rest of the page so this is a bit pointless at the moment).

---

~~Addition a confirmation dialog before re-triggering the related scheduled product (as of this job) is still to be done.~~ A confirmation dialog was already present. I made the warning more clear (mentioning that it will not be limited to the current job group).