### PR TITLE
Avoid long build numbers from taking too much space on dashboard

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -119,11 +119,10 @@ function renderDataSize(sizeInByte) {
 }
 
 function alignBuildLabels() {
-  var values = $.map($('.build-label'), function (el, index) {
-    return parseInt($(el).css('width'));
-  });
-  var max = Math.max.apply(null, values);
-  $('.build-label').css('min-width', max + 'px');
+  const max = Math.max(...Array.from(document.getElementsByClassName('build-label')).map(e => e.offsetWidth));
+  const style = document.createElement('style');
+  document.head.appendChild(style);
+  style.sheet.insertRule(`@media (min-width: 1000px) { .build-label { width: ${max}px; } }`);
 }
 
 // reloads the page - this wrapper exists to be able to disable the reload during tests

--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -79,6 +79,11 @@ td div.progress {
         margin-top: 2px;
     }
 }
+@include media-breakpoint-up(xl) {
+    .build-label {
+        max-width: 50%;
+    }
+}
 .col-lg-4.text-nowrap {
     display: flex;
     align-items: baseline;


### PR DESCRIPTION
Long build numbers might be assigned e.g. to incorporate Git commit hashes. So far they can take a huge amount of the available width so there is not much left for the progress bars next to them. This change limits the maximum width of the build numbers leaving room for the progress bars.

Related ticket: https://progress.opensuse.org/issues/130940