### PR TITLE
Downgrade single-instance-container to Leap

### DIFF
--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -2,7 +2,7 @@
 #!BuildTag: openqa-single-instance:latest opensuse/openqa-single-instance:latest opensuse/openqa-single-instance:%PKG_VERSION% opensuse/openqa-single-instance:%PKG_VERSION%.%RELEASE%
 
 # hadolint ignore=DL3006
-FROM opensuse/tumbleweed
+FROM opensuse/leap:15.5
 
 # labelprefix=org.opensuse.openqa-single-instance
 LABEL org.opencontainers.image.title="openQA single-instance container"
@@ -15,7 +15,9 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 
 # installing more of packages that are selected in openqa-bootstrap.  Combining here saves installation time
 # hadolint ignore=DL3037
-RUN zypper in -y openQA-single-instance openQA-bootstrap \
+RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/15.5 devel_openQA && \
+    zypper --gpg-auto-import-keys ref && \
+    zypper in -y openQA-single-instance openQA-bootstrap \
     qemu-arm qemu-ppc qemu-x86 qemu-tools sudo iputils os-autoinst-distri-opensuse-deps && \
     zypper clean -a
 EXPOSE 80 443 9526


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/87695

We talked about the above ticket, and that codespaces has a problem with tumbleweed containers.

Buildung a new container on every codespaces start was considered too slow, so it was suggested to downgrade the single-instance-container so that we can use it in codespace.

This is needed before #5648