### PR TITLE
Update version requirement of `rubygem(sass)` to 3.7.4 for Bootstrap 5

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -14,7 +14,7 @@ RUN zypper -n in tar gzip sudo
 RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
 
 # openQA dependencies
-RUN zypper install -y rubygem\(sass\) ruby-devel npm python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-tools tar xorg-x11-fonts sudo make
+RUN zypper install -y 'rubygem(sass)>=3.7.4' ruby-devel npm python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-tools tar xorg-x11-fonts sudo make
 
 # openQA chromedriver for Selenium tests
 RUN zypper install -y chromedriver

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -18,7 +18,7 @@ RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15
     # openQA might need rubygem:sass to compile assets in this context due to
     # unknown reasons even though the package should use the precompiled
     # assets from cache.tar
-    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m 'rubygem(sass)' && \
+    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m 'rubygem(sass)>=3.7.4' && \
     zypper clean && \
     gensslcert && \
     a2enmod headers && \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -25,7 +25,7 @@ assetpack_requires:
   perl(YAML::PP): '>= 0.026'
 
 build_requires:
-  rubygem(sass):
+  rubygem(sass): '>= 3.7.4'
   npm:
   '%assetpack_requires':
 

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -58,7 +58,7 @@
 # The following line is generated from dependencies.yaml
 %define worker_requires bsdtar openQA-client optipng os-autoinst < 5 perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.7 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
-%define build_requires %assetpack_requires npm rubygem(sass)
+%define build_requires %assetpack_requires npm rubygem(sass) >= 3.7.4
 
 # All requirements needed by the tests executed during build-time.
 # Do not require on this in individual sub-packages except for the devel


### PR DESCRIPTION
Version 3.5.3 provided by Leap cannot handle certain CSS syntax used by Bootstrap 5 leading to errors like:

```
Error: $color: "var(--bs-emphasis-color-rgb)" is not a color for `rgba'
```

Version 3.7.4 from Tumbleweed works. It also works when building the spec file from Tumbleweed against Leap 15.5 or Leap 15.6 so I am setting 3.7.4 as minimum version requirement. Testing out whether 3.6 would be recent enough as well is not worth it.

Related ticket: https://progress.opensuse.org/issues/159408