### PR TITLE
Enable automatic cloning of Git repos in openqa-bootstrap setups

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -108,7 +108,7 @@ if command -v $setup; then
 else
     curl -s https://raw.githubusercontent.com/os-autoinst/openQA/master/script/configure-web-proxy | bash -ex -s -- "$proxy_args"
 fi
-sed -i -e 's/#*.*method.*=.*$/method = Fake/' /etc/openqa/openqa.ini
+sed -i -e 's/#*.*method.*=.*$/method = Fake/' -e 's/#git_auto_clone =.*$/git_auto_clone = yes' /etc/openqa/openqa.ini
 
 if [[ -z $skip_suse_specifics ]] && ping -c1 download.suse.de. && (! rpm -q ca-certificates-suse); then
     # add internal CA if executed within suse network


### PR DESCRIPTION
This enables automatic cloning of Git repositories by the web UI when tests using Git sources are scheduled. We should not yet remove the automatic cloning of openSUSE tests and needles in `openqa-boostrap` itself because we still want to support cloning tests from non-Git sources for now. Additionally, the download in advance might still be desirable.

I plan to add an according check in openQA-in-openQA tests as part of the related ticket (https://progress.opensuse.org/issues/161771).