### PR TITLE
feat: support configurable secrets hiding in UI and API

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -2016,10 +2016,13 @@ files).
 Authentication via OpenID is enabled by default. Do **not** change the
 authentication method to `Fake` unless access is otherwise restricted.
 
-Note that read-access to most data is possible even without being logged-in. So
-you need to be careful exposing an instance to the public even if authentication
-is enabled. To protect assets, the configuration setting
-`[auth] require_for_assets = 1` can be used. To prevent setting values from being logged, setting keys like *`SECRET`*`…` and `…_PASSWORD` can be used.
+Note that read-access to most data is possible even without being logged-in.
+So you need to be careful exposing an instance to the public even if
+authentication is enabled. To protect assets, the configuration setting
+`[auth] require_for_assets = 1` can be used. To prevent setting values from
+being logged or displayed in the UI, setting keys matching `^_SECRET_` or
+`_PASSWORD` are redacted by default. A custom regex for redacting additional
+variables can be specified via the `_HIDE_SECRETS_REGEX` job setting.
 
 ### Configuration settings with security implications
 

--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -29,6 +29,7 @@ our @EXPORT_OK = qw(
   log_format_callback
   get_channel_handle
   setup_log
+  redact_settings
   redact_settings_in_file
   format_settings
 );
@@ -210,8 +211,22 @@ sub setup_log ($app, $logfile = undef, $logdir = undef, $level = undef) {
     }
 }
 
+# same approach as in os-autoinst bmwqemu.pm
 sub redact_settings ($vars) {
-    return {map { m/(^_SECRET_|_PASSWORD)/ ? ($_ => '[redacted]') : ($_ => $vars->{$_}) } keys %$vars};
+    my $hide_re = qr/^_SECRET_|_PASSWORD/;
+    my $error;
+
+    if (my $custom = $vars->{_HIDE_SECRETS_REGEX}) {
+        try { $hide_re = qr/$hide_re|$custom/ }
+        catch ($e) {
+            ($error = $e) =~ s/ at .*//s;
+            $error =~ s/\s+$//;
+        }
+    }
+
+    my $redacted = {map { $_ =~ $hide_re ? ($_ => '[redacted]') : ($_ => $vars->{$_}) } keys %$vars};
+    $redacted->{_HIDE_SECRETS_REGEX} = "(invalid regex specified: $error)" if $error;
+    return $redacted;
 }
 
 sub redact_settings_in_file ($file) {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -7,7 +7,7 @@ use Mojo::Base 'DBIx::Class::Core', -signatures;
 use Fcntl;
 use DateTime;
 use OpenQA::Constants qw(WORKER_COMMAND_ABORT WORKER_COMMAND_CANCEL);
-use OpenQA::Log qw(log_trace log_debug log_info log_warning log_error);
+use OpenQA::Log qw(log_trace log_debug log_info log_warning log_error redact_settings);
 use OpenQA::Utils (
     qw(create_git_clone_list parse_assets_from_settings locate_asset),
     qw(resultdir assetdir read_test_modules find_bugref random_string effective_distri),
@@ -369,7 +369,7 @@ sub prepare_for_work ($self, $worker = undef, $worker_properties = {}) {
     $self->log_debug_job('Prepare for being processed by worker ' . $worker->id);
 
     my $job_hashref = {};
-    $job_hashref = $self->to_hash(assets => 1);
+    $job_hashref = $self->to_hash(assets => 1, unredacted => 1);
 
     # set JOBTOKEN for test access to API
     my $job_token = $worker_properties->{JOBTOKEN} // random_string();
@@ -433,6 +433,10 @@ sub settings_hash ($self, $prefetched = undef) {
     return $settings;
 }
 
+sub redacted_settings_hash ($self, $prefetched = undef) {
+    return redact_settings($self->settings_hash($prefetched));
+}
+
 sub add_result_dir_prefix ($self, $result_dir, $archived = undef) {
     return $result_dir ? catfile($self->num_prefix_dir($archived), $result_dir) : undef;
 }
@@ -483,7 +487,7 @@ sub to_hash ($job, %args) {
     if (my $reason = $job->reason) {
         $j->{reason} = $reason;
     }
-    $j->{settings} = $job->settings_hash($settings);
+    $j->{settings} = $args{unredacted} ? $job->settings_hash($settings) : $job->redacted_settings_hash($settings);
     # hashes are left for script compatibility with schema version 38
     $j->{test} = $job->TEST;
     if ($args{assets}) {

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -453,7 +453,13 @@ sub show ($self) {
     my $follow = $self->param('follow');
     return unless my $job = $self->find_job_or_render_not_found($job_id, $follow ? {prefetch => 'settings'} : {});
     $job = $job->latest_job if $follow;
-    $job = $job->to_hash(assets => 1, check_assets => $check_assets, deps => 1, details => $details, parent_group => 1);
+    $job = $job->to_hash(
+        assets => 1,
+        check_assets => $check_assets,
+        deps => 1,
+        details => $details,
+        parent_group => 1,
+    );
     $job->{followed_id} = $job_id if ($job_id != $job->{id});
     $self->render(json => {job => $job});
 }

--- a/t/28-logging.t
+++ b/t/28-logging.t
@@ -562,6 +562,12 @@ subtest 'Formatting settings' => sub {
     like $log, qr/FOO=bar.*THE_PASSWORD.*_SECRET_TOKEN/s, 'all keys and normal values present';
     unlike $log, qr/token/, 'secret token not present';
     unlike $log, qr/123/, 'password not present';
+    $log
+      = format_settings {FOO => 'bar', SNEAKY_TEXT => 'secret', _HIDE_SECRETS_REGEX => 'SNEAK', _SECRET_KEY => 'foo'};
+    like $log, qr/FOO=bar.*SNEAKY.*HIDE.*_SECRET_KEY/s, 'keys and normal values present with customized hiding';
+    unlike $log, qr/secret/, 'value of custom secret key not present';
+    $log = format_settings {_HIDE_SECRETS_REGEX => '['};
+    like $log, qr/invalid regex.*Unmatched \[/, 'invalid hide regex yields non-critical error information';
 };
 
 ok get_channel_handle, 'get_channel_handle returns valid handle from app';

--- a/templates/webapi/test/settings.html.ep
+++ b/templates/webapi/test/settings.html.ep
@@ -3,7 +3,7 @@
         <tr><th colspan="2">Settings</th></tr>
     </thead>
     <tbody>
-        % my $s = $job->settings_hash;
+        % my $s = $job->redacted_settings_hash;
         % for my $k (sort keys %$s) {
           % my $v = $s->{$k};
           <tr>


### PR DESCRIPTION
Motivation:
Some test settings might contain sensitive information that doesn't follow
the default redaction pattern (^_SECRET_ or _PASSWORD). Users should be able
to specify custom patterns for redaction to prevent leaking secrets in logs,
test settings files, and the web interface.

Design Choices:
- Added _HIDE_SECRETS_REGEX job setting to allow custom redaction patterns.
- Optimized regex compilation in OpenQA::Log::redact_settings.
- Added redacted_settings_hash to OpenQA::Schema::Result::Jobs for centralized
  redaction.
- Updated to_hash in Jobs result class to support optional redaction.
- Updated Web UI templates and API controllers to use redacted settings.

Benefits:
- Improved security by preventing accidental leakage of custom secrets.
- Greater flexibility for users to protect sensitive data.
- Consistent redaction across logs, worker files, web UI, and API.

Related progress issue: https://progress.opensuse.org/issues/162086