### PR TITLE
Document what the OBS rsync Minion job does

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
@@ -26,6 +26,13 @@ sub _retry_or_finish {
         {code => 2, message => "Exceeded retry count $retry_max_count. Consider job will be re-triggered later"});
 }
 
+# runs script/rsync.sh from the OBS rsync home directory for a specific project
+# note: The "project" is the first argument to script/rsync.sh and has a corresponding project on OBS and a corresponding
+#       subdirectory in the OBS rsync home directory. This subdirectory contains many generated scripts/commands which will be
+#       invoked by script/rsync.sh in a certain sequence. This Minion task merely does the top-level invocation and implements
+#       a retry but is otherwise not concerned with any details (such as invoking rsync or creating openQA jobs).
+#       Jobs of this task are enqueued by the "/obs_rsync/#project/runs" route (POST request) which can be triggered via the
+#       "Sync now" button on the web UI (e.g. on a page like "/admin/obs_rsync/openSUSE:Factory:Staging:C").
 sub run {
     my ($job, $args) = @_;
 


### PR DESCRIPTION
And also what details it is not concerned with: It is merely a runner for an external script.

This is relevant for deciding on what level we want to implement https://progress.opensuse.org/issues/161879.