### PR TITLE
Save ipmi sol output as log file

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1819,7 +1819,7 @@ sub test_resultfile_list ($self) {
     for my $f (@filelist) {
         push(@$filelist_existing, $f) if -e "$testresdir/$f";
     }
-    for my $f (qw(serial_terminal.txt serial_terminal_user.txt)) {
+    for my $f (qw(serial_terminal.txt serial_terminal_user.txt ipmisol-log.txt)) {
         push(@$filelist_existing, $f) if -s "$testresdir/$f";
     }
 

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -260,7 +260,7 @@ sub start {
     # ensure log files are empty/removed
     if (my $pooldir = $worker->pool_directory) {
         open(my $fd, '>', "$pooldir/worker-log.txt") or log_error("Could not open worker log: $!");
-        foreach my $file (qw(serial0.txt autoinst-log.txt serial_terminal.txt)) {
+        foreach my $file (qw(serial0.txt autoinst-log.txt serial_terminal.txt ipmisol-log.txt)) {
             next unless -e "$pooldir/$file";
             unlink("$pooldir/$file") or log_error("Could not unlink '$file': $!");
         }
@@ -454,7 +454,7 @@ sub _stop_step_4_upload ($self, $reason, $callback) {
                 # NOTE: serial_terminal.txt is from svirt backend. But also
                 # virtio_console.log from qemu backend is renamed to
                 # serial_terminal.txt below.
-                qw(serial0 video_time.vtt serial_terminal.txt virtio_console.log virtio_console1.log virtio_console_user.log)
+                qw(serial0 video_time.vtt serial_terminal.txt ipmisol-log virtio_console.log virtio_console1.log virtio_console_user.log)
             );
             for my $other (@other) {
                 my $file = "$pooldir/$other";
@@ -463,6 +463,7 @@ sub _stop_step_4_upload ($self, $reason, $callback) {
 
                 # replace some file names
                 my $ofile = $file;
+                $ofile =~ s/ipmisol-log/ipmisol-log.txt/;
                 $ofile =~ s/serial0/serial0.txt/;
                 $ofile =~ s/virtio_console(.*)\.log/serial_terminal$1.txt/;
                 $ofile =~ s/\.log/.txt/;


### PR DESCRIPTION
* **IPMI** SOL console output records important information about system under test, including boot-up process, error messages, unexpected abnormal output and etc, detailed texts of which likely might not be recorded by screenshot or even video clip. 

* **By** saving full output of ipmi sol console to a log file, which will be uploaded at the end of test run, investigation and examination work can be executed much more easily and conveniently without losing any information.

* **Modify**  ```lib/OpenQA/Worker/Job.pm``` to include ```ipmisol-log.txt``` when job starts and ends.

* **Modify** ```lib/OpenQA/Schema/Result/Jobs.pm``` to include ```ipmisol-log.txt``` as result file.

* **This** pull request should be merged together with https://github.com/os-autoinst/os-autoinst/pull/2504.

* **Verification Runs:**
  * [**test run without IPMISOL_LOG** link1](http://10.67.18.153/tests/2842) [link2](http://10.100.228.134/tests/2842) [link3](http://10.100.204.18/tests/2842) [link4](http://10.149.193.170/tests/2842)
  * [**test run with IPMISOL_LOG=0** link1](http://10.67.18.153/tests/2845) [link2](http://10.100.228.134/tests/2845) [link3](http://10.100.204.18/tests/2845) [link4](http://10.149.193.170/tests/2845)
  * [**test run with IPMISOL_LOG=1 passed** link1](http://10.67.18.153/tests/2834) [link2](http://10.100.228.134/tests/2834) [link3](http://10.100.204.18/tests/2834) [link4](http://10.149.193.170/tests/2834)
  * [**test run with IPMISOL_LOG=1 cancelled** link1](http://10.67.18.153/tests/2835) [link2](http://10.100.228.134/tests/2835) [link3](http://10.100.204.18/tests/2835) [link4](http://10.149.193.170/tests/2835)
  * [**test run with IPMISOL_LOG=1 failed** link1](http://10.67.18.153/tests/2843) [link2](http://10.100.228.134/tests/2843) [link3](http://10.100.204.18/tests/2843) [link4](http://10.149.193.170/tests/2843)
  * [**test run with IPMISOL_LOG=1 timed-out** link1](http://10.67.18.153/tests/2844) [link2](http://10.100.228.134/tests/2844) [link3](http://10.100.204.18/tests/2844) [link4](http://10.149.193.170/tests/2844)
  * [**ipmisol-log records full installation and boot-up process** link1](http://10.67.18.153/tests/2834) [link2](http://10.100.228.134/tests/2834) [link3](http://10.100.204.18/tests/2834) [link4](http://10.149.193.170/tests/2834)
  * [**ipmisol-log records full call trace** link1](http://10.67.18.153/tests/2846) [link2](http://10.100.228.134/tests/2846) [link3](http://10.100.204.18/tests/2846) [link4](http://10.149.193.170/tests/2846)