### PR TITLE
templates: Add group title names to title

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -140,12 +140,14 @@ sub _group_overview ($self, $resultset, $template) {
     my $group_hash = {
         id => $group->id,
         name => $group->name,
+        full_name => $group->name,
         is_parent => $is_parent_group,
         rendered_description => $group->rendered_description
     };
     if (!$is_parent_group && (my $parent = $group->parent)) {
         $group_hash->{parent_id} = $parent->id;
         $group_hash->{parent_name} = $parent->name;
+        $group_hash->{full_name} = $group->full_name;
     }
     $self->stash(
         group => $group_hash,

--- a/templates/webapi/main/group_overview.html.ep
+++ b/templates/webapi/main/group_overview.html.ep
@@ -1,5 +1,5 @@
 % layout 'bootstrap';
-% title '';
+% title $group->{full_name};
 
 %= include 'layouts/info'
 

--- a/templates/webapi/main/parent_group_overview.html.ep
+++ b/templates/webapi/main/parent_group_overview.html.ep
@@ -1,5 +1,5 @@
 % layout 'bootstrap';
-% title '';
+% title $group->{name};
 
 %= include 'layouts/info'
 


### PR DESCRIPTION
<title> tag should be always specific for various reasons (it's used as a default name when creating bookmark, it is a link description when link shared in a smartphone, used in os browser panel and tab name in a browser, maybe still SEO relevant, ...).

Therefore add group title names to the <title> (e.g. 'openSUSE Leap 15.6 Maintenance / openSUSE Leap 15.6 Backports') instead of generic 'openQA'.

To keep <title> reasonable long, don't include "Last Builds for ... group", but just a group name.

@Martchus @kalikiana @okurz FYI

Tested on my fork (restart web via: `systemctl restart openqa-webui`):
- http://quasar.suse.cz/group_overview/3
- http://quasar.suse.cz/group_overview/5
- http://quasar.suse.cz/parent_group_overview/2#grouped_by_build