### PR TITLE
Fix highlighting of parent/child jobs after Bootstrap 5 migration

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -111,10 +111,10 @@ h2 .fa {
 }
 
 // highlighting on running table under 'All tests'
-.highlight_parent {
+.highlight_parent td {
     background-color: $color-highlight-parent !important;
 }
-.highlight_child {
+.highlight_child td {
     background-color: $color-highlight-child !important;
 }
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/162488