### PR TITLE
Fix products being wrongly re-scheduled with the setting `AMP;ASYNC=1`

### DIFF
--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -136,6 +136,8 @@ subtest 'rescheduled ISO shown after refreshing page' => sub {
     ok($table, 'products tables found');
     @rows = $driver->find_child_elements($table, './tbody/tr[./td[text() = "whatever.iso"]]', 'xpath');
     is(scalar @rows, 2, 'rescheduled ISO shown');
+    like $rows[0]->get_text(), qr/2.*Demo.*added/,
+      'newly added product shown as first row; status is added as async flag was passed';
     like(
         $driver->find_element_by_id('product_log_table_info')->get_text(),
         qr/Showing 1 to 2 of 2 entries/,

--- a/templates/webapi/admin/audit_log/productlog.html.ep
+++ b/templates/webapi/admin/audit_log/productlog.html.ep
@@ -1,8 +1,8 @@
 % layout 'bootstrap';
 % title 'Scheduled products log';
 % content_for 'ready_function' => begin
-    loadProductLogTable('<%= url_for('admin_product_log_ajax') %>',
-                        '<%= url_for('apiv1_create_iso')->query(scheduled_product_clone_id => 'XXXXX', async => 1) %>',
+    loadProductLogTable('<%== url_for('admin_product_log_ajax') %>',
+                        '<%== url_for('apiv1_create_iso')->query(scheduled_product_clone_id => 'XXXXX', async => 1) %>',
                         <%= is_operator_js %>);
 % end
 


### PR DESCRIPTION
After f20a0bf597c495941edda7afaa649d657754b7c1 job settings specified as query parameters are handled also when the `scheduled_product_clone_id` parameter is present. This revealed the problem that we don't correctly pass the `async=1` parameter on the products log page. This change fixes the problem by removing the too excessive escaping.

This also fixes the problem that the async-flag was not actually passed. This is now tested in the UI test (which would fail without this change).

Related ticket: https://progress.opensuse.org/issues/162608