### PR TITLE
apparmor: Allow 'sleep' as needed in os-autoinst scripts

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -22,6 +22,7 @@
   /usr/bin/dash ix,
   /usr/bin/perl ix,
   /usr/bin/pwd ix,
+  /usr/bin/sleep rix,
   /usr/bin/ssh rcx,
   /usr/bin/timeout rix,
   /usr/bin/unzip{,-plain} rix,


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/162752