### PR TITLE
Disable all kinds of CSS animations in tests to increase stability

### DIFF
--- a/assets/stylesheets/disable_animations.css
+++ b/assets/stylesheets/disable_animations.css
@@ -1,3 +1,11 @@
+/* ensure smooth scrolling (enabled by Bootstrap) is disabled during tests */
 :root {
     scroll-behavior: auto !important;
+}
+
+/* avoid all kinds of animations, e.g. the transition used in Bootstrap popovers */
+* {
+    animation: none !important;
+    transition: none !important;
+    transition-property: none !important;
 }


### PR DESCRIPTION
This also removes the fade animation from popovers which will hopefully avoid random test failures in tests opening/checking help popovers like `t/ui/15-admin-workers.t`.

Related ticket: https://progress.opensuse.org/issues/163127