### PR TITLE
Avoid relying on project-level environment variables in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,7 +331,7 @@ workflows:
 
   # Nightly jobs are using the GitHub user "os-autoinst-bot" to create PRs (search for occurrences of `os-autoinst-bot`
   # within this repository). This user's access token is configured on https://github.com/settings/tokens as usual and set
-  # as variable `GITHUB_TOKEN` on https://app.circleci.com/settings/project/github/os-autoinst/openQA/environment-variables.
+  # as variable `GITHUB_TOKEN` on https://app.circleci.com/settings/organization/github/os-autoinst/contexts/200658e0-47ad-4806-bca3-eefa618e6611.
   nightly:
     triggers:
       - schedule:
@@ -347,6 +347,8 @@ workflows:
       - cache-npm
       - cache-fullstack:
           <<: *requires
-      - dependencies-pr
+      - dependencies-pr:
+          context: GitHub
       - build-docs-nightly:
+          context: GitHub
           <<: *requires_fullstack


### PR DESCRIPTION
We need to make some variables available on forks but some should better not be available on forks. The security settings of CircleCI contexts on organization-level allow that so it makes sense to avoid relying on project-level variables.

Related ticket: https://progress.opensuse.org/issues/163187