### PR TITLE
Use require for loading OpenQA::Test::Database

### DIFF
--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -10,7 +10,7 @@ use Test::MockModule;
 use Test::Mojo;
 use Test::Output 'combined_like';
 use Test::Warnings;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::WebAPI::Auth::OAuth2;
 use Mojo::File qw(tempdir path);

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -15,7 +15,7 @@ use OpenQA::Resource::Locks;
 use OpenQA::Resource::Jobs;
 use OpenQA::Constants qw(WEBSOCKET_API_VERSION DB_TIMESTAMP_ACCURACY);
 use OpenQA::Jobs::Constants;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils 'setup_mojo_app_with_default_worker_timeout';
 use OpenQA::Utils 'assetdir';
 use Test::Mojo;

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -12,7 +12,7 @@ use OpenQA::WebSockets::Client;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use Test::MockModule;
 use Test::Mojo;

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -8,7 +8,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils 'setup_mojo_app_with_default_worker_timeout';
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use Test::Mojo;

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -11,7 +11,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Constants qw(WEBSOCKET_API_VERSION WORKER_COMMAND_GRAB_JOBS);
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use Test::Output 'combined_like';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -28,7 +28,7 @@ use OpenQA::Scheduler::Client;
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Worker::WebUIConnection;
 use OpenQA::Utils;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(
   mock_service_ports setup_mojo_app_with_default_worker_timeout
   setup_fullstack_temp_dir create_user_for_workers

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -12,7 +12,7 @@ use OpenQA::JobDependencies::Constants;
 use OpenQA::Resource::Jobs qw(job_restart);
 use OpenQA::Resource::Locks;
 use OpenQA::Utils;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(assume_all_assets_exist embed_server_for_testing);
 use OpenQA::Test::TimeLimit '20';
 use OpenQA::WebSockets::Client;

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -7,7 +7,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Utils;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';

--- a/t/07-api_jobtokens.t
+++ b/t/07-api_jobtokens.t
@@ -7,7 +7,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Utils;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';

--- a/t/07-api_keys.t
+++ b/t/07-api_keys.t
@@ -8,7 +8,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 
 use OpenQA::Utils;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -11,7 +11,7 @@ use Mojo::File 'tempdir';
 use OpenQA::Jobs::Constants;
 use OpenQA::Script::CloneJob;
 use OpenQA::Test::Client 'client';
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(create_webapi stop_service);
 use OpenQA::Test::TimeLimit '20';
 use Test::Mojo;

--- a/t/13-joblocks.t
+++ b/t/13-joblocks.t
@@ -7,7 +7,7 @@ use Mojo::Base -strict, -signatures;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Utils;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '40';
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Jobs::Constants;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -14,7 +14,7 @@ use OpenQA::JobGroupDefaults;
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Task::Git::Clone;
 use File::Copy;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job perform_minion_jobs);
 use OpenQA::Test::TimeLimit '160';
 use Test::MockModule;

--- a/t/15-assets.t
+++ b/t/15-assets.t
@@ -14,7 +14,7 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Resource::Jobs 'job_restart';
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils 'embed_server_for_testing';
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::WebSockets::Client;

--- a/t/16-utils-vcs-provider.t
+++ b/t/16-utils-vcs-provider.t
@@ -6,7 +6,7 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '5';
 use OpenQA::VcsProvider;
 use Test::Mojo;

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -14,7 +14,7 @@ use OpenQA::App;
 use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT DB_TIMESTAMP_ACCURACY);
 use OpenQA::Jobs::Constants;
 use OpenQA::WebSockets;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(redirect_output);
 use OpenQA::Test::TimeLimit '10';
 

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -11,7 +11,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Cwd 'abs_path';
 use OpenQA::Schema;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::Task::Needle::Scan;
 use File::Find;

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -9,7 +9,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Jobs::Constants;
 use OpenQA::Test::Client 'client';
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '10';
 use Test::Output qw(combined_like combined_unlike);
 use Test::MockModule;

--- a/t/25-bugs.t
+++ b/t/25-bugs.t
@@ -7,7 +7,7 @@ use Test::Most;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Utils;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(run_gru_job);
 use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -19,7 +19,7 @@ use OpenQA::WebSockets;
 use OpenQA::WebSockets::Model::Status;
 use OpenQA::Constants 'WEBSOCKET_API_VERSION';
 use OpenQA::Test::Client 'client';
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::FakeWebSocketTransaction;
 use Test::Output;
 use Test::MockModule;

--- a/t/40-script_load_dump_templates.t
+++ b/t/40-script_load_dump_templates.t
@@ -7,7 +7,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use File::Temp qw(tempfile);
 use Mojo::File qw(path curfile);
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils;
 use Test::Output;
 use Test::Warnings ':report_warnings';

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -8,7 +8,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Log qw(log_error);
 use OpenQA::Test::TimeLimit '10';
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Task::Job::Limit;
 use OpenQA::Task::Utils qw(finish_job_if_disk_usage_below_percentage);
 use OpenQA::Test::Utils qw(perform_minion_jobs run_gru_job);

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -8,7 +8,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '20';
 use OpenQA::Utils qw(resultdir imagesdir);
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Schema::Result::ScreenshotLinks;
 use OpenQA::Task::Job::Limit;
 use OpenQA::Test::Utils qw(run_gru_job);

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Constants qw(WEBSOCKET_API_VERSION);
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::Utils qw(service_port);
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Jobs::Constants;
 use OpenQA::Log qw(setup_log);
 use OpenQA::Test::Utils

--- a/t/basic.t
+++ b/t/basic.t
@@ -7,7 +7,7 @@ use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '8';
 
 OpenQA::Test::Database->new->create;

--- a/t/lib/OpenQA/Test/Case.pm
+++ b/t/lib/OpenQA/Test/Case.pm
@@ -4,7 +4,7 @@
 package OpenQA::Test::Case;
 use Mojo::Base -base;
 
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Testresults;
 use OpenQA::Schema::Result::Users;
 use OpenQA::Schema;

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -15,7 +15,7 @@ use Test::Warnings ':report_warnings';
 use Time::Seconds;
 use OpenQA::Test::TimeLimit '40';
 use OpenQA::Test::Case;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(assume_all_assets_exist);
 use OpenQA::Jobs::Constants qw(NONE RUNNING);
 

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -9,7 +9,7 @@ use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use OpenQA::Test::TimeLimit '20';
 use OpenQA::Test::Case;
-use OpenQA::Test::Database;
+require OpenQA::Test::Database;
 use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;


### PR DESCRIPTION
It does a

    plan skip_all ...

in its main code, which is effectively an exit.
Since that happens in a BEGIN block currently during a 'use', it won't execute any INIT blocks any more in perl version >= 5.38. But the -c compile check is running in an INIT block.

Issue: https://progress.opensuse.org/issues/162866