### PR TITLE
[RFC] Create a hook placeholder

### DIFF
--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -35,6 +35,9 @@ openqa-cli - provides command-line access to the openQA API
     # Show details for OSD job (prettified JSON)
     openqa-cli api --osd --pretty jobs/4160811
 
+    # Trigger a product using a hook script
+    openqa-cli api --o3 --hook-script foo -X POST isos
+
     # Archive job from O3
     openqa-cli archive --o3 408 /tmp/job_408
 


### PR DESCRIPTION
`perl -I lib script/openqa-cli api --hook-scripts twdata --pretty --host http://127.0.0.1:9526 -X POST isos FOO=BARRR DISTRI=Awesome`

will get hook/twdata.json and will merge the variables with the ones from stdin. 
ofc location and dir name is under consideration. And also I thinkit is possible to extend it to run an actual script if the source is some program