### PR TITLE
Support parameters `arch` and `machine` in job overview API

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -227,6 +227,8 @@ sub overview ($self) {
     my $failed_modules = $self->param_hash('failed_modules');
     my $states = $self->param_hash('state');
     my $results = $self->param_hash('result');
+    my $archs = $self->param_hash('arch');
+    my $machines = $self->param_hash('machine');
 
     my @jobs = $self->schema->resultset('Jobs')->complex_query(%$search_args)->latest_jobs;
 
@@ -234,6 +236,8 @@ sub overview ($self) {
     for my $job (@jobs) {
         next if $states && !$states->{$job->state};
         next if $results && !$results->{$job->result};
+        next if $archs && !$archs->{$job->ARCH};
+        next if $machines && !$machines->{$job->MACHINE};
         if ($failed_modules) {
             next if $job->result ne OpenQA::Jobs::Constants::FAILED;
             next unless OpenQA::Utils::any_array_item_contained_by_hash($job->failed_modules, $failed_modules);


### PR DESCRIPTION
The job overview API already supports most filter parameters the overview
web page supports. This change adds support for the two remaining filter
parameters. (The `t` parameter is still not supported.)