### PR TITLE
Prevent failure when restarting Minion-related services

### DIFF
--- a/systemd/openqa-minion-restart.service
+++ b/systemd/openqa-minion-restart.service
@@ -4,3 +4,4 @@ Description=Restarts services which are using Minion
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/systemctl try-restart openqa-webui.service openqa-gru.service openqa-worker-cacheservice.service openqa-worker-cacheservice-minion.service
+SuccessExitStatus=5


### PR DESCRIPTION
Not all services we are trying to restart might be installed, e.g. in production setups workers are on separate hosts and therefore no cache service units are present. This change treats the restart still as success if not all units can be found.

Related ticket: https://progress.opensuse.org/issues/163013