### PR TITLE
Move render_specific_not_found to SharedHelpers

### DIFF
--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -20,6 +20,7 @@ sub register ($self, $app, @) {
     $app->helper(is_operator => \&_is_operator);
     $app->helper(is_admin => \&_is_admin);
     $app->helper(is_local_request => \&_is_local_request);
+    $app->helper(render_specific_not_found => \&_render_specific_not_found);
 }
 
 # returns the isotovideo command server web socket URL and the VNC argument for the given job or undef if not available
@@ -71,6 +72,11 @@ sub _is_local_request ($c) {
     # IPv4 and IPv6 should be treated the same
     my $address = $c->tx->remote_address;
     return $address eq '127.0.0.1' || $address eq '::1';
+}
+
+sub _render_specific_not_found ($c, $title, $error_message) {
+    $c->stash(title => $title, error_message => $error_message);
+    return $c->render(template => 'main/specific_not_found', status => 404);
 }
 
 1;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -287,20 +287,6 @@ sub register ($self, $app, $config) {
         });
 
     $app->helper(
-        render_specific_not_found => sub {
-            my ($c, $title, $error_message) = @_;
-
-            $c->stash(
-                title => $title,
-                error_message => $error_message,
-            );
-            return $c->render(
-                template => 'main/specific_not_found',
-                status => 404,
-            );
-        });
-
-    $app->helper(
         populate_hash_with_needle_timestamps_and_urls => sub {
             my ($c, $needle, $hash) = @_;
 


### PR DESCRIPTION
Issues:
* https://progress.opensuse.org/issues/163931
* https://progress.opensuse.org/issues/163592
* https://progress.opensuse.org/issues/163757

Prevents:

    Can't locate object method "render_specific_not_found" via package "OpenQA::Shared::Controller::Running"

I'm not sure how to test this. The t/26-controllerrunning.t is mocking that function.