### PR TITLE
Avoid potentially slow ws server slowing down live handler as well

### DIFF
--- a/lib/OpenQA/WebSockets/Client.pm
+++ b/lib/OpenQA/WebSockets/Client.pm
@@ -35,9 +35,11 @@ sub send_jobs ($self, $job_info) {
     return $res->json->{result};
 }
 
-sub send_msg ($self, $worker_id, $msg, $job_id, $retry = undef) {
+sub send_msg ($self, $worker_id, $msg, $job_id, $retry = undef, $cb = undef) {
     my $data = {worker_id => $worker_id, msg => $msg, job_id => $job_id, retry => $retry};
-    my $res = $self->client->post($self->_api('send_msg'), json => $data)->result;
+    my $tx = $self->client->post($self->_api('send_msg'), json => $data, (defined $cb ? ($cb) : ()));
+    return undef if defined $cb;
+    my $res = $tx->result;
     croak "Expected 2xx status from WebSocket server but received @{[$res->code]}" unless $res->is_success;
     return $res->json->{result};
 }


### PR DESCRIPTION
After moving the code for dealing with the live view image streaming to the live handler we should avoid blocking calls in that code because the live handler is not using multiple processes.

Tested by running a test locally and observing that the `live_log` file in the pool directory is created/removed as expected. The unit test has also been extended to cover the error case as well.

Related ticket: https://progress.opensuse.org/issues/163757