### PR TITLE
Update systemd dependencies in accordance to moving code to livehandler

### DIFF
--- a/systemd/openqa-livehandler.service
+++ b/systemd/openqa-livehandler.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Handler for live view in openQA's web UI
 After=postgresql.service nss-lookup.target remote-fs.target
-Requires=openqa-webui.service
+Requires=openqa-websockets.service
 
 [Service]
 User=geekotest


### PR DESCRIPTION
* Make `openqa-livehandler.service` depend on `openqa-websockets.service` as it now depends on it for starting/stopping the live view image of running jobs
* Remove dependency on `openqa-webui.service` as it creates a dependency cycle but the livehandler is not depending on the main web UI directly
    * The dependency was introduced in 8fe15fc7aed but without stating the reasoning.
* See https://progress.opensuse.org/issues/163757