### PR TITLE
Add test for render_specific_not_found

### DIFF
--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -75,8 +75,8 @@ sub _is_local_request ($c) {
 }
 
 sub _render_specific_not_found ($c, $title, $error_message) {
-    $c->stash(title => $title, error_message => $error_message);
-    return $c->render(template => 'main/specific_not_found', status => 404);
+    $c->res->headers->content_type('text/plain');
+    return $c->render(status => 404, text => "$title - $error_message");
 }
 
 1;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -611,28 +611,23 @@ subtest 'error handling when opening needle editor for running test' => sub {
 
     subtest 'no worker assigned' => sub {
         $t->get_ok('/tests/99946/edit')->status_is(404);
-        $t->text_is(title => 'openQA: Needle Editor', 'title still the same');
-        $t->text_like(
-            '#content p',
-qr/The test opensuse-13\.1-DVD-i586-Build0091-textmode\@32bit has no worker assigned so the page \"Needle Editor\" is not available\./,
+        $t->content_like(
+qr/Needle Editor.*The test opensuse-13\.1-DVD-i586-Build0091-textmode\@32bit has no worker assigned so the page \"Needle Editor\" is not available\./,
             'error message'
         );
 
         # test error handling for other 'Running.pm' routes as well
         $t->get_ok('/tests/99946/livelog')->status_is(404);
-        $t->text_is(title => 'openQA: Page not found', 'generic title present');
-        $t->text_like(
-            '#content p',
-qr/The test opensuse-13\.1-DVD-i586-Build0091-textmode\@32bit has no worker assigned so this route is not available\./,
+        $t->content_like(
+qr/Page not found.*The test opensuse-13\.1-DVD-i586-Build0091-textmode\@32bit has no worker assigned so this route is not available\./,
             'error message'
         );
     };
 
     subtest 'no running module' => sub {
         $t->get_ok('/tests/99963/edit')->status_is(404);
-        $t->text_like(
-            '#content p',
-qr/The test has no currently running module so opening the needle editor is not possible\. Likely results have not been uploaded yet so reloading the page might help\./,
+        $t->content_like(
+qr/Needle Editor.*The test has no currently running module so opening the needle editor is not possible\. Likely results have not been uploaded yet so reloading the page might help\./,
             'error message'
         );
     };


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/163931

It now returns a plain text, because we don't have all helpers and variables
for a fully fledged openQA page in the livehandler.
That's probably ok for such pages that you normally don't link to
directly.
