### PR TITLE
Avoid warning about clashing imported subroutine

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -19,12 +19,12 @@ BEGIN {
     $ENV{MOJO_INACTIVITY_TIMEOUT} = 10 * 60;
 }
 
+use Test::Warnings ':report_warnings';
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Mojo::Base -signatures;
-use List::Util qw(any);
+use List::Util ();
 use Test::Mojo;
-use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use Test::Exception;
 use autodie ':all';
@@ -103,7 +103,7 @@ sub check_scheduled_job_and_wait_for_free_worker ($worker_class) {
     my @scheduled_jobs = values %{OpenQA::Scheduler::Model::Jobs->singleton->determine_scheduled_jobs};
     my $relevant_jobs = 0;
     for my $job (@scheduled_jobs) {
-        ++$relevant_jobs if any { $_ eq $worker_class } @{$job->{worker_classes}};
+        ++$relevant_jobs if List::Util::any { $_ eq $worker_class } @{$job->{worker_classes}};
     }
     Test::More::ok $relevant_jobs, "$relevant_jobs job(s) with worker class $worker_class scheduled"
       or Test::More::diag explain 'scheduled jobs: ', \@scheduled_jobs;


### PR DESCRIPTION
Test::Most exports everything from several other modules, including Test::Deep, which exports 'any'.
This lead to:

    Prototype mismatch: sub main::any: none vs (&@)

I saw the warning in the reported issue
https://progress.opensuse.org/issues/164239