### PR TITLE
Allow configure-web-proxy to use a custom port

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -374,8 +374,10 @@ For a local instance setup you can simply execute the script:
 /usr/share/openqa/script/configure-web-proxy
 ----
 
-This will automatically setup a local Apache http proxy. Read on for more
-detailed setup instructions with all the details.
+This will automatically setup a local Apache http proxy. The script
+also supports NGINX and a custom port to listen on. Try `--help` to
+learn about the available options. Read on for more detailed setup
+instructions with all the details.
 
 If you wish to run openQA behind an http proxy (Apache, NGINX, …) then see the
 *openqa.conf.template* config file in */etc/apache2/vhosts.d* (openSUSE) or

--- a/script/configure-web-proxy
+++ b/script/configure-web-proxy
@@ -9,19 +9,25 @@ Options:
  -h, --help         display this help
  -p, --proxy=PROXY  web proxy to configure (default: apache)
                     choose from: nginx, apache
+ -P, --port=PORT    port to configure
 EOF
     exit "$1"
 }
 
-opts=$(getopt -o hp: -l help -l proxy: -n "$0" -- "$@") || usage 1
+opts=$(getopt -o hp:P: -l help,proxy:,port: -n "$0" -- "$@") || usage 1
 eval set -- "$opts"
 web_proxy="apache"
+web_port=""
 while true; do
     case "$1" in
         -h | --help) usage 0 ;;
         -p | --proxy)
             web_proxy=${2#*=}
-            shift
+            shift 2
+            ;;
+        -P | --port)
+            web_port=${2#*=}
+            shift 2
             ;;
         --)
             shift
@@ -36,11 +42,18 @@ sed -i -e 's/^.*httpsonly.*$/httpsonly = 0/g' /etc/openqa/openqa.ini
 if [[ $web_proxy == "nginx" ]]; then
     echo "Setting up nginx"
     sed "s/openqa.example.com/$(hostname)/" /etc/nginx/vhosts.d/openqa.conf.template > /etc/nginx/vhosts.d/openqa.conf
+    # IPv6 uses [::]:80 syntax instead of just a port
+    if [[ -n "$web_port" ]]; then
+        sed -Ei "s@(.*listen.*)80@\1${web_port}@g" /etc/nginx/vhosts.d/openqa.conf /etc/nginx/nginx.conf
+    fi
     sed -i -e "s/\(^[^#]*server_name  localhost;\)/#\1/" /etc/nginx/nginx.conf
 elif [[ $web_proxy == "apache" || $web_proxy == "apache2" ]]; then
     echo "Setting up apache"
     for i in headers proxy proxy_http proxy_wstunnel rewrite; do a2enmod $i; done
     sed "s/#ServerName.*$/ServerName $(hostname)/" /etc/apache2/vhosts.d/openqa.conf.template > /etc/apache2/vhosts.d/openqa.conf
+    if [[ -n "$web_port" ]]; then
+        sed -i "s/^Listen.*$/Listen $web_port/" /etc/apache2/listen.conf
+    fi
 else
     echo "No supported proxy: $web_proxy"
     exit 1


### PR DESCRIPTION
Compared to the previous implementation the script code avoids `test` which has the side effect of changing the exit code of the entire script.

See: https://progress.opensuse.org/issues/162611