### PR TITLE
doc: Clarify notes about setting `CASEDIR`/`NEEDLES_DIR`

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1984,10 +1984,12 @@ for details.
 
 [NOTE]
 ====
-The openQA worker normally default-initializes `CASEDIR` and `NEEDLES_DIR` to
-point to default repositories provided by the openQA instance. This behavior
-interacts with specifying a custom `CASEDIR` or `NEEDLES_DIR` in the following
-way:
+The openQA worker initializes `CASEDIR` and `NEEDLES_DIR` to point to
+repositories provided by the openQA instance (usually under
+`/var/lib/openqa/share/tests`).
+
+When the variables `CASEDIR` and `NEEDLES_DIR` are set, the behavior is as
+follows:
 
 * If `CASEDIR` or `NEEDLES_DIR` is customized the customized location is used
   instead of the default repository.
@@ -2020,9 +2022,10 @@ For example:
 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6649 https://openqa.opensuse.org/tests/839191
 ----
 
-Note that customizing `CASEDIR` does *not* mean needles will be loaded from
-there, even if the repository specified as `CASEDIR` contains needles. To load
-needles from that repository, it needs to be specified as `NEEDLES_DIR` as well.
+As noted above, customizing `CASEDIR` does *not* mean needles will be loaded
+from there, even if the repository specified as `CASEDIR` contains needles. To
+load needles from that repository, it needs to be specified as `NEEDLES_DIR` as
+described in the note above.
 
 Keep in mind that if `PRODUCTDIR` is overwritten as well, it might not relate to
 the state of the specified git refspec that is passed via the command line

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1972,16 +1972,14 @@ supplied as new, unambiguous download target file names.
 
 === Triggering tests based on an any remote Git refspec or open GitHub pull request
 
-openQA also supports to trigger tests using test code from an open pull
-request on GitHub or any branch or Git refspec. That means that code changes
-that are not yet available on a production instance of openQA can be tested
-safely to ensure the code changes work as expected before merging the code
-into a production repository and branch. This works by setting the
-`CASEDIR` parameter of os-autoinst to a valid Git repository path including
-an optional branch/refspec specifier. It is also possible to set `NEEDLES_DIR`
-to a valid Git repository path to use custom needles.
-See
-https://github.com/os-autoinst/os-autoinst/blob/master/doc/backend_vars.asciidoc
+openQA also supports to trigger tests using test code from a pull request or
+any branch or Git refspec. That means that code changes that are not yet
+available on a production instance of openQA can be tested safely to ensure the
+code changes work as expected before merging the code into a production
+repository and branch. This works by setting the `CASEDIR` parameter of
+os-autoinst to a valid Git repository path including an optional branch/refspec
+specifier. `NEEDLES_DIR` can be set in the same way to use custom needles. See
+https://github.com/os-autoinst/os-autoinst/blob/master/doc/backend_vars.asciidoc[the os-autoinst documentation]
 for details.
 
 [NOTE]


### PR DESCRIPTION
Make it especially more clear what the defaults are, see
https://progress.opensuse.org/issues/164577.