### PR TITLE
Avoid incomplete jobs when Git cloning fails

### DIFF
--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -27,10 +27,11 @@ sub _git_clone_all ($job, $clones) {
 
     # Prevent multiple git clone tasks for the same path to run in parallel
     my @guards;
+    my $retry_delay = {delay => 30 + int(rand(10))};
     for my $path (sort keys %$clones) {
         $path = Mojo::File->new($path)->realpath if (-e $path);    # resolve symlinks
         my $guard = $app->minion->guard("git_clone_${path}_task", 2 * ONE_HOUR);
-        return $job->retry({delay => 30 + int(rand(10))}) unless $guard;
+        return $job->retry($retry_delay) unless $guard;
         push(@guards, $guard);
     }
 
@@ -41,7 +42,11 @@ sub _git_clone_all ($job, $clones) {
     for my $path (sort { length($a) <=> length($b) } keys %$clones) {
         my $url = $clones->{$path};
         die "Don't even think about putting '..' into '$path'." if $path =~ /\.\./;
-        _git_clone($job, $ctx, $path, $url);
+        eval { _git_clone($job, $ctx, $path, $url) };
+        next unless my $error = $@;
+        my $max_retries = $ENV{OPENQA_GIT_CLONE_RETRIES} // 10;
+        return $job->retry($retry_delay) if $job->retries < $max_retries;
+        return $job->fail($error);
     }
 }
 

--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -52,7 +52,7 @@ sub _git_clone_all ($job, $clones) {
 
 sub _get_current_branch ($path) {
     my $r = run_cmd_with_log_return_error(['git', '-C', $path, 'branch', '--show-current']);
-    die "Error detecting current branch for '$path'" unless $r->{status};
+    die "Error detecting current branch for '$path': $r->{stderr}" unless $r->{status};
     return trim($r->{stdout});
 }
 
@@ -62,30 +62,30 @@ sub _ssh_git_cmd($git_args) {
 
 sub _get_remote_default_branch ($url) {
     my $r = run_cmd_with_log_return_error(_ssh_git_cmd(['ls-remote', '--symref', $url, 'HEAD']));
-    die "Error detecting remote default branch name for '$url'"
+    die "Error detecting remote default branch name for '$url': $r->{stderr}"
       unless $r->{status} && $r->{stdout} =~ /refs\/heads\/(\S+)\s+HEAD/;
     return $1;
 }
 
 sub _git_clone_url_to_path ($url, $path) {
     my $r = run_cmd_with_log_return_error(_ssh_git_cmd(['clone', $url, $path]));
-    die "Failed to clone $url into '$path'" unless $r->{status};
+    die "Failed to clone $url into '$path': $r->{stderr}" unless $r->{status};
 }
 
 sub _git_get_origin_url ($path) {
     my $r = run_cmd_with_log_return_error(['git', '-C', $path, 'remote', 'get-url', 'origin']);
-    die "Failed to get origin url for '$path'" unless $r->{status};
+    die "Failed to get origin url for '$path': $r->{stderr}" unless $r->{status};
     return trim($r->{stdout});
 }
 
 sub _git_fetch ($path, $branch_arg) {
     my $r = run_cmd_with_log_return_error(_ssh_git_cmd(['-C', $path, 'fetch', 'origin', $branch_arg]));
-    die "_git_fetch: Failed with error '$r->{stderr}'" unless $r->{status};
+    die "Failed to fetch from '$branch_arg': $r->{stderr}" unless $r->{status};
 }
 
 sub _git_reset_hard ($path, $branch) {
     my $r = run_cmd_with_log_return_error(['git', '-C', $path, 'reset', '--hard', "origin/$branch"]);
-    die "_git_reset_hard: Failed with error '$r->{stderr}'" unless $r->{status};
+    die "Failed to reset to 'origin/$branch': $r->{stderr}" unless $r->{status};
 }
 
 sub _git_clone ($job, $ctx, $path, $url) {


### PR DESCRIPTION
* Retry Git processing instead of immediately failing the Minion job (and
  thus also setting the related openQA job to incomplete)
* Improve error messages in git_clone tasks (see separate commit message)
* See https://progress.opensuse.org/issues/163784