### PR TITLE
Make jobs running without needing to set needles URL specifically

### DIFF
--- a/script/openqa-clone-custom-git-refspec
+++ b/script/openqa-clone-custom-git-refspec
@@ -137,7 +137,7 @@ clone_job() {
         local host=${job_url%%/t*}
         local job=${job_url##*/}
     fi
-    if [[ -z "$testsuite" ]] || [[ -z "$needles_dir" ]] || [[ -z "$productdir" ]]; then
+    if [[ -z "$testsuite" ]] || [[ -z "$productdir" ]]; then
         local json_url=${host}/tests/${job}/file/vars.json
         local json_data
         json_data=$(eval "${curl_openqa} -s ${json_url}")
@@ -157,10 +157,6 @@ Please try 'curl $json_url' or select another job, e.g. in the same scenario: $h
             local productdir="${productdir:-"${repo_name##*/}/${old_productdir#*"${old_casedir##*/}"}"}"
         fi
         productdir="${productdir/\/\//\/}" # avoid consecutive slashes
-        local old_needledir
-        old_needledir=$(echo "$json_data" | jq -r '.NEEDLES_DIR | select (.!=null)') || throw_json_error "$json_url" "$json_data"
-        local needles_dir="${needles_dir:-"$old_needledir"}"
-        needles_dir="${needles_dir:-"$old_productdir/needles"}"
     fi
     local repo_branch="${repo_branch:-"$repo_name#$branch"}"
     local test_suffix="${test_suffix:-"@$repo_branch"}"
@@ -170,7 +166,7 @@ Please try 'curl $json_url' or select another job, e.g. in the same scenario: $h
     local dry_run="${dry_run:-""}"
     local scriptdir
     scriptdir=$(dirname "${BASH_SOURCE[0]}")
-    local cmd="$dry_run $scriptdir/openqa-clone-job $clone_args \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST+=\"$test_suffix\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\" NEEDLES_DIR=\"$needles_dir\""
+    local cmd="$dry_run $scriptdir/openqa-clone-job $clone_args \"$host\" \"$job\" _GROUP=\"$GROUP\" TEST+=\"$test_suffix\" BUILD=\"$build\" CASEDIR=\"$casedir\" PRODUCTDIR=\"$productdir\""
     [[ ${#args[@]} -ne 0 ]] && cmd=$cmd"$(printf " '%s'" "${args[@]}")"
     if [[ -n "$MARKDOWN" ]]; then
         eval "$cmd" | sed 's/^Created job.*: \([^ ]*\) -> \(.*\)$/* [\1](\2)/'

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -35,11 +35,10 @@ isnt run_once($args), 0, 'without network we fail (without error)';
 # mock any external access with all arguments
 $ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my/branch"}, "body": "Lorem ipsum"}'; true};
 $ENV{curl_openqa}
-  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/my/case/dir", "PRODUCTDIR": "/my/case/dir/product", "NEEDLES_DIR": "/my/case/dir/product/needles"}'; true};
+  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/my/case/dir", "PRODUCTDIR": "/my/case/dir/product"}'; true};
 my $clone_job
   = 'openqa-clone-job --skip-chained-deps --parental-inheritance --within-instance https://openqa.opensuse.org ';
-my $dirs
-  = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/product NEEDLES_DIR=/my/case/dir/product/needles';
+my $dirs = 'CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/product';
 my $expected = $clone_job . '1234 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9128 ' . $dirs;
 my $expected_re = qr/${expected}/;
 test_once $args, $expected_re, 'clone-job command line is correct';
@@ -53,7 +52,7 @@ my $prefix = 'env repo_name=user/repo pr=9128 host=https://openqa.opensuse.org j
 combined_like { $ret = run_once('', $prefix) } $expected_re, 'environment variables can be used instead';
 is $ret, 0, 'exits successfully';
 $prefix .= ' testsuite=new_test needles_dir=/my/needles productdir=my/product';
-$dirs = 'PRODUCTDIR=my/product NEEDLES_DIR=/my/needles';
+$dirs = 'PRODUCTDIR=my/product';
 my $expected_custom_re = qr{https://openqa.opensuse.org 1234 _GROUP=0 .*${dirs}};
 combined_like { $ret = run_once('', $prefix) } $expected_custom_re, 'testsuite and dirs can be overridden';
 is $ret, 0, 'exits successfully';
@@ -103,26 +102,22 @@ $expected_re = qr/${expected}/s;
 test_once $args, $expected_re, 'clone-job command with multiple URLs in PR and job URL';
 
 $ENV{curl_github} = qq{echo -e '{"head": {"label": "user:my/branch"}, "body": "Lorem ipsum"}'; true};
-my $needles = 'my/distri/products/sle/needles';
 $ENV{curl_openqa}
-  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "my/distri", "PRODUCTDIR": "distri/products/sle", "NEEDLES_DIR": "$needles"}'; true};
-$dirs = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=$needles";
+  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "my/distri", "PRODUCTDIR": "distri/products/sle"}'; true};
+$dirs = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle";
 $expected = $clone_job . '1169326 _GROUP=0 TEST\+=\@user/repo#my/branch BUILD=user/repo#9539 ';
 $expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR is a relative directory";
 
-$needles = "/$needles";
-$ENV{curl_openqa}
-  = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/my/distri", "PRODUCTDIR": "products/sle", "NEEDLES_DIR": "$needles"}'; true};
-$dirs = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle NEEDLES_DIR=$needles";
+$ENV{curl_openqa} = qq{echo -e '{"TEST": "my_test", "CASEDIR": "/my/distri", "PRODUCTDIR": "products/sle"}'; true};
+$dirs = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/sle";
 $expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, 'Correct PRODUCTDIR for relative non-prefixed dir';
 
 my $casedir = '/openqa/cache/openqa1-opensuse/tests/opensuse';
 $ENV{curl_openqa}
   = qq{echo -e '{"TEST": "my_test", "CASEDIR": "$casedir", "PRODUCTDIR": "$casedir/products/opensuse"}'; true};
-$dirs
-  = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse NEEDLES_DIR=$casedir/products/opensuse/needles";
+$dirs = "CASEDIR=https://github.com/user/repo.git#my/branch PRODUCTDIR=repo/products/opensuse";
 $expected_re = qr/${expected}${dirs}/;
 test_once $args, $expected_re, "PRODUCTDIR is correct when the source job's PRODUCTDIR includes specific word";
 


### PR DESCRIPTION
As per https://progress.opensuse.org/issues/162632, openqa-clone-custom-git-refspec might fail in case NEEDLES_DIR is set and contains an absolute path which directs to the pool. Also in contrast of the poo's suggestion there is no change in removal of the vars.json logic.

```
❯ script/openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master https://openqa.opensuse.org/tests/4368385
1 job has been created:
 - microos-Tumbleweed-DVD-x86_64-Build20240730-fips-container-host@64bit -> https://openqa.opensuse.org/tests/4369552

❯ script/openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-openQA/tree/master https://openqa.opensuse.org/tests/4360621  
1 job has been created:
 - openqa-Tumbleweed-dev-x86_64-Build:TW.30160-openqa_from_bootstrap@64bit-2G -> https://openqa.opensuse.org/tests/4369553

```