### PR TITLE
Consistently skip RETRY on all aborted results

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -574,9 +574,7 @@ sub is_ok ($self) {
 
 sub is_ok_to_retry ($self) {
     return 1 unless my $result = $self->result;
-    return 0 if grep { $_ eq $result } OK_RESULTS;    # retry is not needed if job is ok
-    return 0 if $result eq USER_CANCELLED;    # retry is not needed if job is user-cancelled...
-    return 0 if $result eq OBSOLETED;    # ...or obsoleted
+    return 0 if any { $_ eq $result } (OK_RESULTS, ABORTED_RESULTS);    # retry is not needed if job is ok/aborted
     return 1;
 }
 


### PR DESCRIPTION
In efe1cdef6 next to "USER_CANCELLED" also "OBSOLETED" jobs were added
to the list where to skip a "RETRY" which was the safe choice. I think
we should treat all "aborted results" the same which means now
additionally including SKIPPED, PARALLEL_FAILED, PARALLEL_RESTARTED,
USER_RESTARTED.

As @baierjan explained in
https://github.com/os-autoinst/openQA/pull/5797/files#r1697036344
"restarting jobs which were already restarted (USER_RESTARTED,
PARALLEL_RESTARTED) probably does not make much sense, which leaves
PARALLEL_FAILED and SKIPPED. I guess PARALLEL_FAILED would be restarted
anyway if needed by the parallel job?" The later question can be
answered with yes so we should be good. And "SKIPPED" means "(directly)
chained dependencies failed before starting this job" so I also don't
see a need to try a RETRY on those.

Related progress issue: https://progress.opensuse.org/issues/164613