### PR TITLE
Lower the log level of livestream related problem considering low impact

### DIFF
--- a/lib/OpenQA/Shared/Controller/Running.pm
+++ b/lib/OpenQA/Shared/Controller/Running.pm
@@ -168,7 +168,7 @@ sub _send_livestream_command_to_worker ($client, $command, $verb, $worker_id, $j
         return $cb ? $cb->(undef) : 1 unless my $err = $tx->error;
         my $msg = $err->{code} ? "$err->{code} response: $err->{message}" : $err->{message};
         $msg = "Unable to ask worker $worker_id to $verb providing livestream for $job_id: $msg";
-        log_error $msg;
+        log_debug $msg;
         $cb->($msg) if $cb;
     };
     $client->send_msg($worker_id, $command, $job_id, undef, $txn_cb);


### PR DESCRIPTION
This error condition has no impact on the job execution. It just means that the web socket server is not ready yet as we saw in https://progress.opensuse.org/issues/164709#note-4. The request is already retried on the client-side so the live view will be able to resume once the web socket server is ready and the worker connected back. I tested this locally by entering the "Live" tab while the web socket server is not running. When starting it the live view updates itself after a few seconds (without having to switch tabs or reloading the page).