### PR TITLE
Simplify error handling of downloader, avoid confusing error codes

### DIFF
--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -146,7 +146,7 @@ $cache_log = '';
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-textmode@64bit.qcow2');
 my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2" from "$from"/, 'Asset download attempt';
-like $cache_log, qr/failed: 521/, 'Asset download fails with: 521 Connection refused';
+like $cache_log, qr/failed: Connection refused/, 'Asset download fails with: Connection refused';
 $cache_log = '';
 
 $port = Mojo::IOLoop::Server->generate_port;
@@ -195,10 +195,10 @@ $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-589@64bi
 $cache->downloader->ua->inactivity_timeout($old_timeout);
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-589\@64bit.qcow2" from/, 'Asset download attempt';
 like $cache_log, qr/Size of .+ differs, expected 10 Byte but downloaded 6 Byte/, 'Incomplete download logged';
-like $cache_log, qr/Download error 598, waiting 0.01 seconds for next try \(4 remaining\)/, '4 tries remaining';
-like $cache_log, qr/Download error 598, waiting 0.01 seconds for next try \(3 remaining\)/, '3 tries remaining';
-like $cache_log, qr/Download error 598, waiting 0.01 seconds for next try \(2 remaining\)/, '2 tries remaining';
-like $cache_log, qr/Download error 598, waiting 0.01 seconds for next try \(1 remaining\)/, '1 tries remaining';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(4 remaining\)/, '4 tries remaining';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(3 remaining\)/, '3 tries remaining';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(2 remaining\)/, '2 tries remaining';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(1 remaining\)/, '1 tries remaining';
 like $cache_log, qr/Purging ".*qcow2" because of too many download errors/, 'Bailing out after too many retries';
 ok !-e $cachedir->child($host, 'sle-12-SP3-x86_64-0368-589@64bit.qcow2'), 'Asset does not exist in cache';
 $cache_log = '';
@@ -206,12 +206,11 @@ $cache_log = '';
 # Retry connection error (closed early)
 $cache->get_asset($host, {id => 922756}, 'hdd', 'sle-12-SP3-x86_64-0368-200_close@64bit.qcow2');
 like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-200_close\@64bit.qcow2" from/, 'Asset download attempt';
-like $cache_log, qr/Download of ".*200_close\@64bit.qcow2" failed: 521 Premature connection close/,
-  'Real error is logged';
-like $cache_log, qr/Download error 521, waiting 0.01 seconds for next try \(4 remaining\)/, '4 tries remaining';
-like $cache_log, qr/Download error 521, waiting 0.01 seconds for next try \(3 remaining\)/, '3 tries remaining';
-like $cache_log, qr/Download error 521, waiting 0.01 seconds for next try \(2 remaining\)/, '2 tries remaining';
-like $cache_log, qr/Download error 521, waiting 0.01 seconds for next try \(1 remaining\)/, '1 tries remaining';
+like $cache_log, qr/Download of ".*200_close\@64bit.qcow2" failed: Premature connection close/, 'Real error is logged';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(4 remaining\)/, '4 tries remaining';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(3 remaining\)/, '3 tries remaining';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(2 remaining\)/, '2 tries remaining';
+like $cache_log, qr/Download error, waiting 0.01 seconds for next try \(1 remaining\)/, '1 tries remaining';
 like $cache_log, qr/Purging ".*200_close\@64bit.qcow2" because of too many download errors/,
   'Bailing out after too many retries';
 like $cache_log, qr/Purging ".*200_close\@64bit.qcow2" failed because the asset did not exist/, 'Asset was missing';

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -69,15 +69,15 @@ $ua->connect_timeout(0.25)->inactivity_timeout(0.25);
 
 subtest 'Connection refused' => sub {
     my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
-    like $downloader->download($from, $to), qr/Download of "$to" failed: 521/, 'Failed';
+    like $downloader->download($from, $to), qr/Download of "$to" failed: Connection refused/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
 
     like $cache_log, qr/Downloading "test.qcow" from "$from"/, 'Download attempt';
-    like $cache_log, qr/Download of "$to" failed: 521/, 'Real error is logged';
-    like $cache_log, qr/Download error 521, waiting .* seconds for next try \(2 remaining\)/, '2 tries remaining';
-    like $cache_log, qr/Download error 521, waiting .* seconds for next try \(1 remaining\)/, '1 tries remaining';
-    unlike $cache_log, qr/Download error 521, waiting .* seconds for next try \(3 remaining\)/, 'only 3 attempts';
+    like $cache_log, qr/Download of "$to" failed: Connection refused/, 'Real error is logged';
+    like $cache_log, qr/Download error, waiting .* seconds for next try \(2 remaining\)/, '2 tries remaining';
+    like $cache_log, qr/Download error, waiting .* seconds for next try \(1 remaining\)/, '1 tries remaining';
+    unlike $cache_log, qr/Download error, waiting .* seconds for next try \(3 remaining\)/, 'only 3 attempts';
     $cache_log = '';
 };
 
@@ -112,14 +112,14 @@ subtest 'Success' => sub {
 
 subtest 'Connection closed early' => sub {
     my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_close@64bit.qcow2";
-    like $downloader->download($from, $to), qr/Download of "$to" failed: 521 Premature connection close/, 'Failed';
+    like $downloader->download($from, $to), qr/Download of "$to" failed: Premature connection close/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
 
     like $cache_log, qr/Downloading "test.qcow" from "$from"/, 'Download attempt';
-    like $cache_log, qr/Download of "$to" failed: 521 Premature connection close/, 'Real error is logged';
-    like $cache_log, qr/Download error 521, waiting .* seconds for next try \(2 remaining\)/, '2 tries remaining';
-    like $cache_log, qr/Download error 521, waiting .* seconds for next try \(1 remaining\)/, '1 tries remaining';
+    like $cache_log, qr/Download of "$to" failed: Premature connection close/, 'Real error is logged';
+    like $cache_log, qr/Download error, waiting .* seconds for next try \(2 remaining\)/, '2 tries remaining';
+    like $cache_log, qr/Download error, waiting .* seconds for next try \(1 remaining\)/, '1 tries remaining';
     $cache_log = '';
 };
 
@@ -144,8 +144,8 @@ subtest 'Size differs' => sub {
 
     like $cache_log, qr/Downloading "test.qcow" from "$from"/, 'Download attempt';
     like $cache_log, qr/Size of .+ differs, expected 10 Byte but downloaded 6 Byte/, 'Incomplete download logged';
-    like $cache_log, qr/Download error 598, waiting .* seconds for next try \(2 remaining\)/, '2 tries remaining';
-    like $cache_log, qr/Download error 598, waiting .* seconds for next try \(1 remaining\)/, '1 tries remaining';
+    like $cache_log, qr/Download error, waiting .* seconds for next try \(2 remaining\)/, '2 tries remaining';
+    like $cache_log, qr/Download error, waiting .* seconds for next try \(1 remaining\)/, '1 tries remaining';
     $cache_log = '';
 };
 


### PR DESCRIPTION
* Remove the made-up HTTP response codes introduced by aea93ad55199a661f84d9ef3aaced66b8ba0d433 (e.g. just log `Connect timeout` instead of `521 Connect timeout`)
* Simplify the code
* Keep retry behavior as-is, so if there's no response code at all or a real 5xx error code the downloader tries again
* Simplify code
* See https://progress.opensuse.org/issues/164222