### PR TITLE
Workaround candidates menu not opening sometimes in UI tests

### DIFF
--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -610,8 +610,16 @@ subtest 'test candidate list' => sub {
         \%expected_candidates, 'needles appear twice, each time under different tag');
 
     $driver->get('/tests/99946#step/installer_timezone/1');
-    wait_for_element(selector => '#candidatesMenu', is_displayed => 1)->click();
-    wait_for_element(selector => '#needlediff_selector .show-needle-info', is_displayed => 1)->click();
+    my $clicks = 0;
+    wait_for_element(
+        selector => '#needlediff_selector .show-needle-info',
+        is_displayed => 1,
+        trigger_function => sub () {
+            # open the candidates menu at the beginning and try again before every second check
+            return if $clicks != 0 && ($clicks % 2) == 1;
+            wait_for_element(selector => '#candidatesMenu', is_displayed => 1)->click;
+            ++$clicks;
+        })->click;
     like(
         $driver->find_element('.needle-info-table')->get_text(),
         qr/Last match.*T.*Last seen.*T.*/s,


### PR DESCRIPTION
See https://progress.opensuse.org/issues/164745

---

To check whether this actually works I added an additional commit to run the relevant test 200 times on CircleCI. So this is still a draft.