### PR TITLE
Ease setup for Git-based workflows

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -366,9 +366,8 @@ to play deeper, you can configure the whole openQA manually from scratch, but
 this document should help you to get started faster.
 
 === Getting tests
-Set `git_auto_clone = yes` in `openqa.ini`. Then you can point `CASEDIR` and
-`NEEDLES_DIR` to Git repositories. openQA will checkout those repositories
-automatically and no manual setup is needed.
+You can point `CASEDIR` and `NEEDLES_DIR` to Git repositories. openQA will
+checkout those repositories automatically and no manual setup is needed.
 
 Otherwise you will need to clone tests and needles manually. First you need to
 get actual tests. You can get openSUSE tests and needles (the expected results)

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -114,7 +114,7 @@
 # whether committed changes should be pushed
 #do_push = no
 # whether to clone CASEDIR or NEEDLES_DIR on the web UI if that var points to a Git repo
-#git_auto_clone = no
+#git_auto_clone = yes
 
 ## Authentication method to use for user management
 [auth]

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -67,7 +67,7 @@ sub read_config ($app) {
             update_branch => '',
             do_push => 'no',
             do_cleanup => 'no',
-            git_auto_clone => 'no',
+            git_auto_clone => 'yes',
         },
         scheduler => {
             max_job_scheduled_time => 7,

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -108,7 +108,6 @@ if command -v $setup; then
 else
     curl -s https://raw.githubusercontent.com/os-autoinst/openQA/master/script/configure-web-proxy | bash -ex -s -- "$proxy_args"
 fi
-sed -i -e 's/#*.*method.*=.*$/method = Fake/' -e 's/#\[scm git\]/[scm git]/' -e 's/#git_auto_clone =.*$/git_auto_clone = yes/' /etc/openqa/openqa.ini
 
 if [[ -z $skip_suse_specifics ]] && ping -c1 download.suse.de. && (! rpm -q ca-certificates-suse); then
     # add internal CA if executed within suse network

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1564,7 +1564,6 @@ subtest 'handle git CASEDIR' => sub {
             ],
         });
     my $params = {TEST => 'handle_foo_casedir',};
-    OpenQA::App->singleton->config->{'scm git'}->{git_auto_clone} = 'yes';
     $t->post_ok('/api/v1/jobs', form => $params)->status_is(200);
 
     my $job_id = $t->tx->res->json->{id};

--- a/t/api/16-webhooks.t
+++ b/t/api/16-webhooks.t
@@ -34,6 +34,7 @@ my $test_payload = decode_json(path("$FindBin::Bin/../data/example-webhook-paylo
 my $ua = $app->ua->ioloop($ioloop);
 my %headers = ('X-GitHub-Event' => 'pull_request');
 my $validation_mock = Test::MockModule->new('OpenQA::WebAPI::Controller::API::V1::Webhook');
+$app->config->{'scm git'}->{git_auto_clone} = 'no';
 
 subtest 'signature validation' => sub {
     my $payload = 'some text';

--- a/t/config.t
+++ b/t/config.t
@@ -65,7 +65,7 @@ subtest 'Test configuration default modes' => sub {
             update_branch => '',
             do_push => 'no',
             do_cleanup => 'no',
-            git_auto_clone => 'no',
+            git_auto_clone => 'yes',
         },
         'scheduler' => {
             max_job_scheduled_time => 7,


### PR DESCRIPTION
Enable the `git_auto_clone` feature by default as it seems to work well enough in openQA-in-openQA tests.

Related tickets: https://progress.opensuse.org/issues/162077