### PR TITLE
Revert "Remove unused 'dsn' function and its usage"

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -51,6 +51,11 @@ sub disconnect_db () {
     $SINGLETON = undef;
 }
 
+sub dsn {
+    my $self = shift;
+    return $self->storage->connect_info->[0]->{dsn};
+}
+
 sub deploy ($self, $force_overwrite = 0) {
     # lock config file to ensure only one thing will deploy/upgrade DB at once
     # we use a file in prjdir/db as the lock file as the install process and

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -45,8 +45,14 @@ sub register ($self, $app, $config) {
     my $schema = $app->schema;
 
     my $conn = Mojo::Pg->new;
-    my $connect_info = $schema->storage->connect_info->[0];
-    $self->dsn($connect_info);
+    if (ref $schema->storage->connect_info->[0] eq 'HASH') {
+        $self->dsn($schema->dsn);
+        $conn->username($schema->storage->connect_info->[0]->{user});
+        $conn->password($schema->storage->connect_info->[0]->{password});
+    }
+    else {
+        $self->dsn($schema->storage->connect_info->[0]);
+    }
     $conn->dsn($self->dsn());
 
     # set the search path in accordance with the test setup done in OpenQA::Test::Database


### PR DESCRIPTION
Reverts os-autoinst/openQA#4928 as it is actually used in production, e.g. o3