### PR TITLE
Move 'dsn' functionality into only place where used

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -51,11 +51,6 @@ sub disconnect_db () {
     $SINGLETON = undef;
 }
 
-sub dsn {
-    my $self = shift;
-    return $self->storage->connect_info->[0]->{dsn};
-}
-
 sub deploy ($self, $force_overwrite = 0) {
     # lock config file to ensure only one thing will deploy/upgrade DB at once
     # we use a file in prjdir/db as the lock file as the install process and

--- a/t/15-shared-plugin-gru.t
+++ b/t/15-shared-plugin-gru.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+
+use Test::Warnings ':report_warnings';
+use Test::MockModule;
+use Test::MockObject;
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+use OpenQA::App;
+use OpenQA::Shared::Plugin::Gru;    # SUT
+
+ok my $gru = OpenQA::Shared::Plugin::Gru->new, 'can instantiate gru plugin';
+
+my $connect_info = {dsn => 'my_dsn', user => 'user', password => 'foo'};
+my $storage = Test::MockObject->new->set_always(connect_info => [$connect_info]);
+my $schema = Test::MockObject->new->set_always(storage => $storage)->set_true('search_path_for_tests');
+my %config = (misc_limits => {minion_job_max_age => 0});
+my $minion = Test::MockObject->new->set_true('on');
+my $log = Test::MockObject->new->set_true('level', 'info');
+my $under = Test::MockObject->new->set_true('to');
+my $routes = Test::MockObject->new->set_always(under => $under);
+my $app
+  = Test::MockObject->new->set_always(schema => $schema)->set_always(config => \%config)->set_always(minion => $minion)
+  ->set_always(log => $log)->set_always(routes => $routes)->set_true('plugin', 'helper');
+OpenQA::App->set_singleton($app);
+my $mock = Test::MockModule->new('OpenQA::Shared::Plugin::Gru');
+$mock->noop('_allow_unauthenticated_minion_stats');
+my $pg = Test::MockObject->new->set_true('dsn', 'username', 'password', 'search_path', 'find');
+my $pg_module = Test::MockModule->new('Mojo::Pg')->redefine(new => $pg);
+ok $gru->register($app, undef), 'can register gru plugin';
+$pg->called_ok('username', 'pg connection initialized with username');
+is(($pg->call_args(0))[1], $connect_info->{user}, 'pg connection username is correct');
+is(($pg->call_args(2))[1], $connect_info->{password}, 'pg connection password is correct');
+is(($app->call_args(4))[1], 'Minion', 'minion initialized');
+is(($app->call_args(4))[2]->{Pg}, $pg, 'pg connection initialized on minion');
+
+done_testing;


### PR DESCRIPTION
In b1da48eac I removed the "dsn" function and its usage as it looked
like that would not be necessary anymore at all and we did not have any
test coverage for that. This turned out to be a false assumption leading
to a production openQA instance to not start anymore with the error
message

```
openqa-webui-daemon: Can't connect to data source 'HASH(0x55d82c060598)' because I can't work out what driver to use (it doesn't seem to contain a 'dbi:driver:' prefix and the DBI_DRIVER env var is not set)>
```

so the change was quickly reverted.

This commit now moves the 'dsn' functionality to the only place where
it is needed, simplifies the call and adds complete test coverage for
the according method with a separate, new test module
"t/15-shared-plugin-gru.t".

Tests did not cover the 'dsn' function anyway.

Verified by calling

```
env OPENQA_BASEDIR=$PWD/t/data OPENQA_DATABASE=test script/openqa-gru
```

locally.