### PR TITLE
Fix openqa-bootstrap login

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -108,6 +108,7 @@ if command -v $setup; then
 else
     curl -s https://raw.githubusercontent.com/os-autoinst/openQA/master/script/configure-web-proxy | bash -ex -s -- "$proxy_args"
 fi
+sed -i -e 's/#*.*method.*=.*$/method = Fake/' /etc/openqa/openqa.ini
 
 if [[ -z $skip_suse_specifics ]] && ping -c1 download.suse.de. && (! rpm -q ca-certificates-suse); then
     # add internal CA if executed within suse network


### PR DESCRIPTION
The removal of the 'method = Fake' was an accident.

Issues:
* https://progress.opensuse.org/issues/164940
* https://progress.opensuse.org/issues/164919

edit: tested locally