### PR TITLE
Get parent class as one row to avoid warnings

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -704,14 +704,7 @@ sub _create_dependencies_for_parents ($self, $job, $created_jobs, $deptype, $par
                 $worker_class = $job->settings->find({key => 'WORKER_CLASS'});
                 $worker_class = $worker_class ? $worker_class->value : '';
             }
-            my $parent_worker_class
-              = $schema->resultset('JobSettings')->find({job_id => $parent, key => 'WORKER_CLASS'});
-            $parent_worker_class = $parent_worker_class ? $parent_worker_class->value : '';
-            if ($worker_class ne $parent_worker_class) {
-                my $test_name = $job->TEST;
-                die
-"Worker class of $test_name ($worker_class) does not match the worker class of its directly chained parent ($parent_worker_class)";
-            }
+            my $parent_worker_class = $schema->resultset('JobSettings')->parent_worker_class($parent, $worker_class);
         }
         $job_dependencies->create(
             {

--- a/lib/OpenQA/Schema/ResultSet/JobSettings.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobSettings.pm
@@ -68,4 +68,14 @@ sub query_for_settings ($self, $args) {
     return $self->search({-and => \@conds});
 }
 
+sub parent_worker_class ($self, $parent_job_id, $worker_class) {
+    my $result = $self->search({parent_job_id => $job_id, key => 'WORKER_CLASS'})->next;
+    my $parent_worker_class = $result ? $result->value : '';
+    die
+      "Worker class $worker_class does not match the worker class of its directly chained parent ($parent_worker_class)"
+      unless $worker_class eq $parent_worker_class;
+    die "Ambiguous job settings for dependent jobs" if $result->next;
+    return $parent_worker_class;
+}
+
 1;


### PR DESCRIPTION
There should only ever be one match.

See: https://progress.opensuse.org/issues/154735