### PR TITLE
Make sure openQA-single-instance package is present in the codespaces container

### DIFF
--- a/container/single-instance-codespaces/Dockerfile
+++ b/container/single-instance-codespaces/Dockerfile
@@ -14,6 +14,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # install Codespaces requirements
+# install openQA-single-instance which is supposed to be already installed but we need to specify it anyway for the replace_using_package_version buildtime service
 # hadolint ignore=DL3037
-RUN zypper in -y awk tar && \
+RUN zypper in -y awk tar \
+    openQA-single-instance && \
     zypper clean -a


### PR DESCRIPTION
OBS buildtime service replace_using_package_version needs the package in the zypper cache to be able to extract the version number to replace.