### PR TITLE
Fix cancelling any pending job from /tests/overview

### DIFF
--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -2,7 +2,7 @@
 % layout 'bootstrap';
 % title 'Test summary';
 % use OpenQA::Jobs::Constants;
-% use List::Util qw(sum);
+% use List::Util qw(any sum);
 
 % content_for 'ready_function' => begin
   window.overviewParallelChildrenCollapsableResultsSel = '<%= $parallel_children_collapsable_results_sel %>';

--- a/templates/webapi/test/tr_job_result.html.ep
+++ b/templates/webapi/test/tr_job_result.html.ep
@@ -8,7 +8,7 @@
                  <i class="action fa fa-undo" title="Restart the job"></i>
                  % end
              % }
-             % elsif ($state eq RUNNING || $state eq SCHEDULED) {
+             % elsif (any { $_ eq $state } PENDING_STATES) {
                  %= link_post url_for('apiv1_cancel', jobid => $jobid) => ('data-remote' => 'true', class => 'cancel', 'data-jobid' => $jobid) => begin
                      <i class="action fa fa-times-circle-o" title="Cancel the job"></i>
                  % end


### PR DESCRIPTION
As @perlpunk found out jobs in "uploading" state can be cancelled from
the tests details page but not the overview page. Also the alignment of
icons looks bad in that case as any row with a job in "uploading" shows
neither the "retrigger" nor the "cancel" action. This commit fixes this
problem for jobs in any "pending state" including not only "uploading"
but also "assigned" or "setup". The change changes the explicit check for
equality to a proper "any" check against the aggregate constant as we
should be using anyway.