### PR TITLE
WIP Allow excluding groupless jobs through filtering

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -85,6 +85,7 @@ sub list ($self) {
     $validation->optional('limit')->num;
     $validation->optional('offset')->num;
     $validation->optional('groupid')->num;
+    $validation->optional('not_groupid')->num; 
 
     my $limits = OpenQA::App->singleton->config->{misc_limits};
     my $limit = min($limits->{generic_max_limit}, $validation->param('limit') // $limits->{generic_default_limit});
@@ -124,6 +125,11 @@ sub list ($self) {
     my $latest = $validation->param('latest');
     my $schema = $self->schema;
     my $rs = $schema->resultset('Jobs')->complex_query(%args);
+
+    if (defined(my $not_groupid = $self->param('not_groupid'))) {
+        $rs = $rs->search({group_id => {-not_in => [$not_groupid]}});
+    }
+
     my @jobarray = defined $latest ? $rs->latest_jobs : $rs->all;
 
     # Pagination


### PR DESCRIPTION
Adds the ability to filter out (exclude) groupless jobs, as well as jobs of specific groups

Related ticket
[155398](https://progress.opensuse.org/issues/155398)