### PR TITLE
Ensure valid format for HTML element ids

### DIFF
--- a/templates/webapi/test/overview_result_table.html.ep
+++ b/templates/webapi/test/overview_result_table.html.ep
@@ -35,7 +35,7 @@
                         <td>-</td>
                         % next;
                     % }
-                    % my $resultid = join('_', $type, $arch, $config);
+                    % my $resultid = join('_', $type, $arch, $config) =~ tr/ /_/r;
                     %= include 'test/tr_job_result', resultid => $resultid, res => $res, state => $state, jobid => $jobid
                 % }
             </tr>


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/164973

Spaces, for example in FLAVOR, result in invalid ids for HTML elements.