### PR TITLE
Add interactive log viewer

### DIFF
--- a/assets/javascripts/anser-import.js
+++ b/assets/javascripts/anser-import.js
@@ -3,3 +3,6 @@ const module = {};
 function ansiToHtml(data) {
   return Anser.linkify(Anser.ansiToHtml(Anser.escapeForHtml(data), {use_classes: true}));
 }
+function ansiToText(data) {
+  return Anser.ansiToText(data);
+}

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -483,6 +483,18 @@ subtest 'misc details: title, favicon, go back, go to source view, go to log vie
 
     wait_for_ajax msg => 'log contents';
     like $driver->find_element('.embedded-logfile .ansi-blue-fg')->get_text, qr/send(autotype|key)/, 'log is colorful';
+    like $driver->find_element('.embedded-logfile')->get_text, qr{/usr/bin/qemu-kvm}, 'qemu-kvm is shown in log viewer';
+
+    $driver->find_element('#filter-log-file')->send_keys('kate');
+    like $driver->find_element('#filter-info')->get_text, qr{Showing 3 / 1292 lines},
+      'Showing filter result info for substring';
+    unlike $driver->find_element('.embedded-logfile')->get_text, qr{/usr/bin/qemu-kvm},
+      'qemu-kvm is not shown when filtering for something else';
+    $driver->find_element('#filter-log-file')->clear;
+    like $driver->find_element('#filter-info')->get_text, qr{^$}, 'Filter result info cleared';
+    $driver->find_element('#filter-log-file')->send_keys('/kate-[12]/');
+    like $driver->find_element('#filter-info')->get_text, qr{Showing 2 / 1292 lines},
+      'Showing filter result info for regex';
 };
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');

--- a/templates/webapi/test/logfile.html.ep
+++ b/templates/webapi/test/logfile.html.ep
@@ -5,11 +5,13 @@
 %= asset $_ for qw(test_result.js anser.js ansi-colors.css)
 % end
 % content_for 'ready_function' => begin
-    loadEmbeddedLogFiles();
+    filterEmbeddedLogFiles();
 % end
 
 % my $url = url_for('test_file', testid => $testid, filename => $filename);
 <div class="corner-buttons" style="margin-top: -5px;">
+<span id="filter-info"></span>
+<input id="filter-log-file" placeholder="substring or /regex/i" type="search">
     <a class="btn btn-light" href=".#downloads">
         <i class="fa fa-chevron-left"></i> Back to job <%= $testid %>
     </a>


### PR DESCRIPTION
One can now filter the log files for substring and regexes.

Demo: https://github.com/user-attachments/assets/f6dec605-951a-4e14-8f93-18acd461a708

Issue: https://progress.opensuse.org/issues/162218

