### PR TITLE
Fix firewall configuration in Autoyast profile

### DIFF
--- a/contrib/ay-openqa-worker-leap-3-nvme.xml
+++ b/contrib/ay-openqa-worker-leap-3-nvme.xml
@@ -139,7 +139,15 @@
   <firewall>
     <enable_firewall t="boolean">true</enable_firewall>
     <start_firewall t="boolean">true</start_firewall>
-    <FW_CONFIGURATIONS_EXT>sshd</FW_CONFIGURATIONS_EXT>
+    <default_zone>public</default_zone>
+    <zones config:type="list">
+      <zone>
+	<name>public</name>
+	<services config:type="list">
+          <service>ssh</service>
+	</services>
+      </zone>
+    </zones>
   </firewall>
   <services-manager>
     <services>

--- a/contrib/ay-openqa-worker.xml.erb
+++ b/contrib/ay-openqa-worker.xml.erb
@@ -98,7 +98,15 @@
   <firewall>
     <enable_firewall config:type="boolean">true</enable_firewall>
     <start_firewall config:type="boolean">true</start_firewall>
-    <FW_CONFIGURATIONS_EXT>sshd</FW_CONFIGURATIONS_EXT>
+    <default_zone>public</default_zone>
+    <zones config:type="list">
+      <zone>
+	<name>public</name>
+	<services config:type="list">
+          <service>ssh</service>
+	</services>
+      </zone>
+    </zones>
   </firewall>
   <services-manager t="map">
     <services>


### PR DESCRIPTION
Configure the firewall properties as SuSEfirewall2 has been replaced by firewalld and the validation produce a warning. FW_CONFIGURATIONS_EXT keeps working so far because is supported but it is deprecated.

* Avoid deprecation warning about using firewall property
  from SuSEfirewall2 times
* Use firewalld configuration instead

https://progress.opensuse.org/issues/156169