### PR TITLE
t: Avoid tampering with git checkout

### DIFF
--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -24,7 +24,7 @@ use Test::Output qw(combined_like combined_unlike);
 use OpenQA::Test::Case;
 use File::Which 'which';
 use File::Path ();
-use Mojo::Util qw(dumper);
+use Mojo::Util qw(dumper scope_guard);
 use Date::Format 'time2str';
 use Fcntl ':mode';
 use Mojo::File qw(path tempdir);
@@ -33,15 +33,23 @@ use Mojo::Message::Response;
 use Storable qw(store retrieve);
 use Mojo::IOLoop;
 use Cwd qw(getcwd);
+use File::Copy::Recursive qw(dircopy);
 use utf8;
 use Time::Seconds;
 
 plan skip_all => 'set HEAVY=1 to execute (takes longer)' unless $ENV{HEAVY};
 
+# Avoid tampering with git checkout
+my $workdir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
+my $guard = scope_guard sub { chdir $FindBin::Bin };
+chdir $workdir;
+mkdir 't';
+dircopy "$FindBin::Bin/$_", "$workdir/t/$_" or BAIL_OUT($!) for qw(data testresults fixtures);
+
 # mock asset deletion
 # * prevent removing assets from database and file system
 # * keep track of calls to OpenQA::Schema::Result::Assets::delete and OpenQA::Schema::Result::Assets::remove_from_disk
-my $tempdir = tempdir;
+my $tempdir = tempdir("assets-XXXX", TMPDIR => 1);
 my $deleted = $tempdir->child('deleted');
 my $removed = $tempdir->child('removed');
 sub mock_deleted { -e $deleted ? retrieve($deleted) : [] }

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -249,8 +249,8 @@ is(
 $assets->update({size => 26 * $gib});
 run_gru_job($t->app, 'limit_assets');
 
-is(scalar @{mock_removed()}, 1, "one asset should have been 'removed' at size 26GiB");
-is(scalar @{mock_deleted()}, 1, "one asset should have been 'deleted' at size 26GiB");
+is(scalar @{mock_removed()}, 1, "asset is 'removed' at size 26GiB");
+is(scalar @{mock_deleted()}, 1, "asset is 'deleted' at size 26GiB");
 
 is_deeply(
     find_kept_assets_with_last_jobs,
@@ -283,8 +283,8 @@ reset_mocked_asset_deletions;
 $assets->update({size => 34 * $gib});
 run_gru_job($t->app, 'limit_assets');
 
-is(scalar @{mock_removed()}, 1, "two assets should have been 'removed' at size 34GiB");
-is(scalar @{mock_deleted()}, 1, "two assets should have been 'deleted' at size 34GiB");
+is(scalar @{mock_removed()}, 1, "asset is 'removed' at size 34GiB");
+is(scalar @{mock_deleted()}, 1, "asset is 'deleted' at size 34GiB");
 
 is_deeply(
     find_kept_assets_with_last_jobs,


### PR DESCRIPTION
I was running this test locally and it failed every second time, because it created some directory that wasn't cleaned up.

Now it copies everything it needs to a tempdir and leaves the source dir alone.

Related issue: https://progress.opensuse.org/issues/164883