### PR TITLE
Stop openQA worker processes gracefully to avoid 5xx responses

### DIFF
--- a/script/openqa-webui-daemon
+++ b/script/openqa-webui-daemon
@@ -22,8 +22,8 @@ function start_service {
     # wait until openQA is ready to accept requests by waiting for its PID file
     while [[ ! -e $pid_file ]] && [[ -e /proc/$pid ]]; do sleep 1; done
 
-    # terminate a previously started openQA instance
-    [[ $pid_last ]] && kill -s TERM "$pid_last"
+    # terminate the previously started openQA instance gracefully
+    [[ $pid_last ]] && kill -s SIGQUIT "$pid_last"
 
     # keep running until openQA terminates (with the "wait"-builtin so bash can handle SIGHUP)
     wait "$pid"


### PR DESCRIPTION
With this we no longer get `Stopping worker … immediately` which means that `SIGKILL` is sent to the worker process. We instead get `Stopping worker … gracefully` and only `SIGQUIT` is sent to the worker process so it can still conclude its current request.

Related ticket/note: https://progress.opensuse.org/issues/162533#note-24