### PR TITLE
Immediately search when clearing search field

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -685,6 +685,7 @@ window.onload = function () {
   const filter = filterLogLines.bind(null, searchBox);
   searchBox.addEventListener('keyup', delay(filter), 1000);
   searchBox.addEventListener('change', filter, false);
+  searchBox.addEventListener('search', filter, false);
 };
 
 function displaySearchInfo(text) {


### PR DESCRIPTION
The 'search' event is triggered when clicking on the little x in a search box.

Issue: https://progress.opensuse.org/issues/162218

~~That also makes the `change` handler superfluous.~~ Apparently it is still needed, test fails without it.
