### PR TITLE
openqa.ini: Move comment on template setting

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -196,7 +196,8 @@ concurrent = 0
 
 # Limits for cleanup of jobs in groups with no limits configured explicitly (sizes are in GiB, durations in days, zero denotes infinity)
 [default_group_limits]
-#asset_size_limit = 100 # only used on job group level (parent groups have no default)
+#asset_size_limit is only used on job group level (parent groups have no default)
+#asset_size_limit = 100
 #log_storage_duration = 30
 #important_log_storage_duration = 120
 #result_storage_duration = 365


### PR DESCRIPTION
The (by default disabled) setting for asset_size_limit contained a comment after its value. That causes a lot of lines in journalctl when the setting is activated by removing the hash at the beginning of the line:

```
Aug 15 07:00:59 openqa openqa-gru[1588700]: Argument "100 # only used on job group level (parent groups have n..." isn't numeric in multiplication (*) at /usr/share/openqa/script/../lib/OpenQA/Schema/ResultSet/Assets.pm line 237
```