### PR TITLE
Remove git fetch with destination refspec feature

### DIFF
--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -115,15 +115,9 @@ sub _git_clone ($job, $ctx, $path, $url) {
     }
 
     my $current_branch = _get_current_branch($path);
-    if ($requested_branch eq $current_branch) {
-        # updating default branch (including checkout)
-        _git_fetch($path, $requested_branch);
-        _git_reset_hard($path, $requested_branch);
-    }
-    else {
-        # updating local branch to latest remote branch version
-        _git_fetch($path, "$requested_branch:$requested_branch");
-    }
+    # updating default branch (including checkout)
+    _git_fetch($path, $requested_branch);
+    _git_reset_hard($path, $requested_branch) if ($requested_branch eq $current_branch);
 }
 
 1;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -671,7 +671,7 @@ subtest 'git clone' => sub {
     is $res->{result}, 'Job successfully executed', 'minion job result indicates success';
     like $mocked_git_calls[3], qr'git -C /etc/ fetch origin master', 'fetch origin master for /etc/';
     like $mocked_git_calls[4], qr'reset --hard origin/master', 'reset origin/master for /etc/';
-    like $mocked_git_calls[8], qr'git -C /root/ fetch origin foobranch:foobranch', 'fetch non-default branch';
+    like $mocked_git_calls[8], qr'git -C /root/ fetch origin foobranch', 'fetch non-default branch';
     like $mocked_git_calls[10], qr'git clone http://localhost/bar.git /this_directory_does_not_exist/',
       'clone to /this_directory_does_not_exist/';
 


### PR DESCRIPTION
As per git documentation the refspec can formed as <src>:<dst> but dst cannot
use arbitrary expressions (SHA) but an actual ref must be named. Its usage
in the `_git_clone` mistakely adds a SHA ref as destination creating a branch
with its name, which is not supported by git.
   
As far as now the feature is not used in OpenQA so it can be safely removed.

https://progress.opensuse.org/issues/164937