### PR TITLE
Improve git commands in git_clone job

### DIFF
--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -647,14 +647,23 @@ subtest 'handling dying GRU task' => sub {
 subtest 'git clone' => sub {
     my $openqa_utils = Test::MockModule->new('OpenQA::Task::Git::Clone');
     my @mocked_git_calls;
+    my $clone_dirs = {
+        '/etc/' => 'http://localhost/foo.git',
+        '/root/' => 'http://localhost/foo.git#foobranch',
+        '/this_directory_does_not_exist/' => 'http://localhost/bar.git',
+    };
     $openqa_utils->redefine(
         run_cmd_with_log_return_error => sub ($cmd) {
+            push @mocked_git_calls, "@$cmd";
             my $stdout = '';
-            $stdout = 'ref: refs/heads/master	HEAD' if $cmd->[3] eq 'ls-remote';
-            $stdout = 'http://localhost/foo.git' if $cmd->[4] eq 'get-url';
-            $stdout = 'master' if $cmd->[3] eq 'branch';
-            my $git_call = join(' ', @$cmd);
-            push @mocked_git_calls, $git_call;
+            splice @$cmd, 0, 2 if $cmd->[0] eq 'env';
+            my $path = '';
+            (undef, $path) = splice @$cmd, 1, 2 if $cmd->[1] eq '-C';
+            my $action = $cmd->[1];
+            $stdout = 'ref: refs/heads/master	HEAD' if $action eq 'ls-remote';
+            $stdout = $clone_dirs->{$path} =~ s/#.*//r if $cmd->[2] eq 'get-url';
+            $stdout = 'master' if $action eq 'branch';
+            $stdout = 'ref: something' if $action eq 'ls-remote' && "@$cmd" =~ m/nodefault/;
             return {
                 status => 1,
                 return_code => 0,
@@ -662,18 +671,38 @@ subtest 'git clone' => sub {
                 stdout => $stdout,
             };
         });
-    my $clone_dirs = {
-        '/etc/' => 'http://localhost/foo.git',
-        '/root/' => 'http://localhost/foo.git#foobranch',
-        '/this_directory_does_not_exist/' => 'http://localhost/bar.git',
-    };
     my $res = run_gru_job($t->app, 'git_clone', $clone_dirs, {priority => 10});
     is $res->{result}, 'Job successfully executed', 'minion job result indicates success';
-    like $mocked_git_calls[3], qr'git -C /etc/ fetch origin master', 'fetch origin master for /etc/';
-    like $mocked_git_calls[4], qr'reset --hard origin/master', 'reset origin/master for /etc/';
-    like $mocked_git_calls[8], qr'git -C /root/ fetch origin foobranch', 'fetch non-default branch';
-    like $mocked_git_calls[10], qr'git clone http://localhost/bar.git /this_directory_does_not_exist/',
-      'clone to /this_directory_does_not_exist/';
+    #<<< no perltidy
+    my $expected_calls = [
+        # /etc/
+        ['get-url' => 'git -C /etc/ remote get-url origin'],
+        ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://localhost/foo.git HEAD'],
+        ['current branch' => 'git -C /etc/ branch --show-current'],
+        ['fetch default' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /etc/ fetch origin master'],
+        ['reset' => 'git -C /etc/ reset --hard origin/master'],
+
+        # /root
+        ['get-url' => 'git -C /root/ remote get-url origin'],
+        ['current branch' => 'git -C /root/ branch --show-current'],
+        ['fetch branch' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /root/ fetch origin foobranch'],
+
+        # /this_directory_does_not_exist/
+        ['clone' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone http://localhost/bar.git /this_directory_does_not_exist/'],
+    ];
+    #>>> no perltidy
+    for my $i (0 .. $#$expected_calls) {
+        my $test = $expected_calls->[$i];
+        is $mocked_git_calls[$i], $test->[1], "$i: " . $test->[0];
+    }
+
+    subtest 'no default remote branch' => sub {
+        $ENV{OPENQA_GIT_CLONE_RETRIES} = 0;
+        $clone_dirs = {'/tmp/' => 'http://localhost/nodefault.git'};
+        my $res = run_gru_job($t->app, 'git_clone', $clone_dirs, {priority => 10});
+        is $res->{state}, 'failed', 'minion job failed';
+        like $res->{result}, qr/Error detecting remote default.*ref: something/, 'error message';
+    };
 
     subtest 'git clone retried on failure' => sub {
         $ENV{OPENQA_GIT_CLONE_RETRIES} = 1;
@@ -859,8 +888,6 @@ subtest 'finalize job results' => sub {
     };
 };
 
-$webapi->signal('TERM');
-$webapi->finish;
 
 done_testing();
 
@@ -868,5 +895,7 @@ done_testing();
 # break subsequent tests; can happen if a subtest creates a task but
 # does not execute it, or we crash partway through a subtest...
 END {
+    $webapi and $webapi->signal('TERM');
+    $webapi and $webapi->finish;
     $t && $t->app->minion->reset;
 }


### PR DESCRIPTION
I rearranged and got rid of some calls.

In case of the initial clone, we don't actually need to do a fetch afterwards, because an initial clone without any restrictions fetches all refs.
Also, we don't need to retrieve the default remote.

For an update we return early if the remote url doesn't match. And then only if there is no url fragment with a ref, we fetch the default remote.

Finally, I removed the second die in case we couldn't get a default remote. _get_remote_default_branch already dies, the outer die would have never been reached. This case is now also tested in a new subtest.

(And I improved the regex to avoid having to escape slashes: `\/ \/`)

The full list of commands is now tested, and better readable what commands are called for which use case.

Related Issue: https://progress.opensuse.org/issues/164886