### PR TITLE
Avoid having RPM build depend on packages only needed for style checks

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -98,8 +98,6 @@ requires 'warnings';
 
 on 'test' => sub {
     requires 'App::cpanminus';
-    requires 'Perl::Critic';
-    requires 'Perl::Critic::Freenode';
     requires 'Selenium::Remote::Driver', '>= 1.23';
     requires 'Selenium::Remote::WDKeys';
     requires 'Test::Exception';
@@ -116,6 +114,8 @@ on 'test' => sub {
 };
 
 on 'develop' => sub {
+    requires 'Perl::Critic';
+    requires 'Perl::Critic::Freenode';
     requires 'Perl::Tidy', '== 20240511.0.0';
 
 };

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,12 +8,13 @@
 #######################################################
 ---
 targets:
-  cpanfile: [ assetpack,        client, common, cover, devel, devel_no_selenium, main, test, worker ]
-  spec:     [ assetpack, build, client, common, cover, devel, devel_no_selenium, main, test, worker ]
+  cpanfile: [ assetpack,        client, common, cover, devel, devel_no_selenium, main, test, style_check, worker ]
+  spec:     [ assetpack, build, client, common, cover, devel, devel_no_selenium, main, test, style_check, worker ]
   cpanfile-targets:
     # target: cpanfile target type (default main)
     devel: develop
     devel_no_selenium: develop
+    style_check: develop
     cover: cover
     test: test
 
@@ -73,6 +74,7 @@ client_requires:
 devel_no_selenium_requires:
   '%build_requires':
   '%test_requires':
+  '%style_check_requires':
   '%qemu':
   '%cover_requires':
   curl:
@@ -182,15 +184,11 @@ test_requires:
   openssh-common:
   curl:
   jq:
-  ShellCheck:
-  shfmt:
   os-autoinst-devel:
   postgresql-server:
   python3-setuptools:
   python3-yamllint:
   perl(App::cpanminus):
-  perl(Perl::Critic):
-  perl(Perl::Critic::Freenode):
   perl(Selenium::Remote::Driver): '>= 1.23'
   perl(Selenium::Remote::WDKeys):
   perl(Test::Exception):
@@ -203,3 +201,9 @@ test_requires:
   perl(Test::Output):
   perl(Test::Pod):
   perl(Test::Warnings): '>= 0.029'
+
+style_check_requires:
+  perl(Perl::Critic):
+  perl(Perl::Critic::Freenode):
+  ShellCheck:
+  shfmt:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -66,16 +66,18 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires ShellCheck curl jq openssh-common os-autoinst-devel perl(App::cpanminus) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint shfmt
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires curl jq openssh-common os-autoinst-devel perl(App::cpanminus) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
+%define style_check_requires ShellCheck perl(Perl::Critic) perl(Perl::Critic::Freenode) shfmt
+# The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml
-%define devel_no_selenium_requires %build_requires %cover_requires %qemu %test_requires curl perl(Perl::Tidy) postgresql-devel rsync sudo tar xorg-x11-fonts
+%define devel_no_selenium_requires %build_requires %cover_requires %qemu %style_check_requires %test_requires curl perl(Perl::Tidy) postgresql-devel rsync sudo tar xorg-x11-fonts
 # The following line is generated from dependencies.yaml
 %define devel_requires %devel_no_selenium_requires chromedriver
 


### PR DESCRIPTION
The RPM builds do not execute style checks (also when `--with-tests` is used) so dependencies like ShellCheck should not be required for the build.

This avoids pulling in a lot of transitive dependencies into the build and thus also greatly reduces the number of packages we need submit to SLE to build openQA on/for SLE.

Related ticket: https://progress.opensuse.org/issues/165683