### PR TITLE
Fix number of expected CI checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ pull_request_rules:
           # "unresolvable" is not reported in general:
           # https://trello.com/c/0N3jHq5M/2257-report-back-to-scm-when-build-results-arent-failed-and-succeeded
           # So we need to require the number of tests explicitly:
-          - "#check-success>=50"
+          - "#check-success>=45"
           - status-success=static-check-containers
           - status-success=webui-docker-compose
           - "#check-failure=0"


### PR DESCRIPTION
This was increased to 50 in 8ef5aca82c42a2c8b4246ea281056e7d2a04f199 but the correct number seems to be only 45.