### PR TITLE
Avoid requiring `ShellCheck` and other style-related deps for RPM build

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -184,7 +184,7 @@ test_requires:
   openssh-common:
   curl:
   jq:
-  os-autoinst-devel:
+  os-autoinst:
   postgresql-server:
   python3-setuptools:
   python3-yamllint:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -66,7 +66,7 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires curl jq openssh-common os-autoinst-devel perl(App::cpanminus) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires curl jq openssh-common os-autoinst perl(App::cpanminus) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else


### PR DESCRIPTION
After 26586061eb2c8bc5e9929bec9352deef9ae344d5 the RPM build still depends on many development dependencies e.g. for style checks because we still depend on `os-autoinst-devel` which pulls those in.

Related ticket: https://progress.opensuse.org/issues/165683