### PR TITLE
Move `python3-yamllint` from test to style-check dependencies

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -187,7 +187,6 @@ test_requires:
   os-autoinst:
   postgresql-server:
   python3-setuptools:
-  python3-yamllint:
   perl(App::cpanminus):
   perl(Selenium::Remote::Driver): '>= 1.23'
   perl(Selenium::Remote::WDKeys):
@@ -203,6 +202,7 @@ test_requires:
   perl(Test::Warnings): '>= 0.029'
 
 style_check_requires:
+  python3-yamllint:
   perl(Perl::Critic):
   perl(Perl::Critic::Freenode):
   ShellCheck:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -66,14 +66,14 @@
 # Do not require on this in individual sub-packages except for the devel
 # package.
 # The following line is generated from dependencies.yaml
-%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires curl jq openssh-common os-autoinst perl(App::cpanminus) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools python3-yamllint
+%define test_requires %common_requires %main_requires %python_scripts_requires %worker_requires curl jq openssh-common os-autoinst perl(App::cpanminus) perl(Selenium::Remote::Driver) >= 1.23 perl(Selenium::Remote::WDKeys) perl(Test::Exception) perl(Test::Fatal) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 postgresql-server python3-setuptools
 %ifarch x86_64
 %define qemu qemu qemu-kvm
 %else
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define style_check_requires ShellCheck perl(Perl::Critic) perl(Perl::Critic::Freenode) shfmt
+%define style_check_requires ShellCheck perl(Perl::Critic) perl(Perl::Critic::Freenode) python3-yamllint shfmt
 # The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml


### PR DESCRIPTION
This Python module is only required by the `test-yaml` target which in turn is only invoked by style checks. So it makes sense to treat this dependency like the other dependencies of style checks.

Related ticket: https://progress.opensuse.org/issues/165683