### PR TITLE
openqa-cli: Avoid reading unexpectedly from STDIN

### DIFF
--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -507,7 +507,7 @@ subtest 'PIPE input' => sub {
     my $file = tempfile;
     my $fh = $file->spew('Hello openQA!')->open('<');
     local *STDIN = $fh;
-    my ($stdout, @result) = capture_stdout sub { $api->run(@host, 'test/pub/http') };
+    my ($stdout, @result) = capture_stdout sub { $api->run(@host, '--data-file', '-', 'test/pub/http') };
     is decode_json($stdout)->{body}, 'Hello openQA!', 'request body';
 };
 


### PR DESCRIPTION
* Avoid skipping the rest of a script when that script is invoked via `sh < …` and internally invokes openqa-cli (which in this case must not consume all remaining lines in that script)
* Read only from STDIN if explicitly requested via `--data-file -` in consistency with curl (which also allows using `-` where a file can be specified to use STDIN)
* See https://progress.opensuse.org/issues/160820