### PR TITLE
Avoid zypper errors when using singe-instance container

### DIFF
--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -16,7 +16,9 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # installing more of packages that are selected in openqa-bootstrap.  Combining here saves installation time
 # hadolint ignore=DL3037
 RUN zypper in -y openQA-single-instance openQA-bootstrap \
-    qemu-arm qemu-ppc qemu-x86 qemu-tools sudo iputils os-autoinst-distri-opensuse-deps && \
+    retry \
+    qemu-arm qemu-ppc qemu-x86 qemu-tools sudo iputils os-autoinst-distri-opensuse-deps \
+    qemu-hw-display-virtio-gpu qemu-hw-display-virtio-gpu-pci && \
     zypper clean -a
 EXPOSE 80 443 9526
 ENV skip_suse_specifics=1


### PR DESCRIPTION
* Make sure the single-instance container has all packages the boostrap script will install so it is less likely to run into errors
* See https://progress.opensuse.org/issues/165399