### PR TITLE
Refactor git functionality into OpenQA::Git

### DIFF
--- a/lib/OpenQA/Git.pm
+++ b/lib/OpenQA/Git.pm
@@ -4,6 +4,7 @@
 package OpenQA::Git;
 
 use Mojo::Base -base, -signatures;
+use Mojo::Util 'trim';
 use Cwd 'abs_path';
 use OpenQA::Utils qw(run_cmd_with_log_return_error);
 
@@ -21,45 +22,67 @@ sub config ($self, $args = undef) {
     return $app->config->{'scm git'};
 }
 
-sub _prepare_git_command ($self, $args = undef) {
-    my $dir = $args->{dir} // $self->dir;
-    if ($dir !~ /^\//) {
-        my $absolute_path = abs_path($dir);
-        $dir = $absolute_path if ($absolute_path);
-    }
-    return ('git', '-C', $dir);
-}
-
-sub _format_git_error ($result, $error_message) {
-    if ($result->{stderr} or $result->{stdout}) {
-        $error_message .= ': ' . $result->{stdout} . $result->{stderr};
-    }
-    return $error_message;
-}
-
 sub _validate_attributes ($self) {
     for my $mandatory_property (qw(app dir user)) {
         die "no $mandatory_property specified" unless $self->$mandatory_property();
     }
 }
 
+sub _run_cmd ($self, $args, $options = {}) {
+    my $include_git_path = $options->{include_git_path} // 1;
+    my $ssh_batchmode = $options->{ssh_batchmode} // 0;
+    my @cmd;
+
+    if ($ssh_batchmode) {
+        push @cmd, 'env', 'GIT_SSH_COMMAND="ssh -oBatchMode=yes"';
+    }
+
+    push @cmd, $self->_prepare_git_command($include_git_path), @$args;
+
+    my $result = run_cmd_with_log_return_error(\@cmd);
+    if (!$result->{status}) {
+        $self->app->log->error("Git command failed: @cmd - Error: $result->{stderr}");
+    }
+    return $result;
+}
+
+sub _prepare_git_command ($self, $include_git_path) {
+    if ($include_git_path) {
+        my $dir = $self->dir;
+        die 'no valid directory was found during git preparation' unless $dir;
+        if ($dir !~ /^\//) {
+            my $absolute_path = abs_path($dir);
+            $dir = $absolute_path if ($absolute_path);
+        }
+        return ('git', '-C', $dir);
+    }
+    else {
+        return 'git';
+    }
+}
+
+sub _format_git_error ($self, $result, $error_message) {
+    my $dir = $self->dir;
+    if ($result->{stderr} or $result->{stdout}) {
+        $error_message .= " ($dir): " . $result->{stdout} . $result->{stderr};
+    }
+    return $error_message;
+}
+
 sub set_to_latest_master ($self, $args = undef) {
     $self->_validate_attributes;
-
-    my @git = $self->_prepare_git_command($args);
-
     if (my $update_remote = $self->config->{update_remote}) {
-        my $res = run_cmd_with_log_return_error([@git, 'remote', 'update', $update_remote]);
-        return _format_git_error($res, 'Unable to fetch from origin master') unless $res->{status};
+        my $res = $self->_run_cmd(['remote', 'update', $update_remote]);
+        return $self->_format_git_error($res, 'Unable to fetch from origin master') unless $res->{status};
     }
 
     if (my $update_branch = $self->config->{update_branch}) {
         if ($self->config->{do_cleanup} eq 'yes') {
-            my $res = run_cmd_with_log_return_error([@git, 'reset', '--hard', 'HEAD']);
-            return _format_git_error($res, 'Unable to reset repository to HEAD') unless $res->{status};
+            my $res = $self->_run_cmd(['reset', '--hard', 'HEAD']);
+            return $self->_format_git_error($res, 'Unable to reset repository to HEAD') unless $res->{status};
         }
-        my $res = run_cmd_with_log_return_error([@git, 'rebase', $update_branch]);
-        return _format_git_error($res, 'Unable to reset repository to origin/master') unless $res->{status};
+        my $res = $self->_run_cmd(['rebase', $update_branch]);
+        return $self->_format_git_error($res, 'Unable to reset repository to origin/master') unless $res->{status};
     }
 
     return undef;
@@ -68,30 +91,63 @@ sub set_to_latest_master ($self, $args = undef) {
 sub commit ($self, $args = undef) {
     $self->_validate_attributes;
 
-    my @git = $self->_prepare_git_command($args);
     my @files;
 
     # stage changes
     for my $cmd (qw(add rm)) {
         next unless $args->{$cmd};
         push(@files, @{$args->{$cmd}});
-        my $res = run_cmd_with_log_return_error([@git, $cmd, @{$args->{$cmd}}]);
-        return _format_git_error($res, "Unable to $cmd via Git") unless $res->{status};
+        my $res = $self->_run_cmd([$cmd, @{$args->{$cmd}}]);
+        return $self->_format_git_error($res, "Unable to $cmd via Git") unless $res->{status};
     }
 
     # commit changes
     my $message = $args->{message};
     my $author = sprintf('--author=%s <%s>', $self->user->fullname, $self->user->email);
-    my $res = run_cmd_with_log_return_error([@git, 'commit', '-q', '-m', $message, $author, @files]);
-    return _format_git_error($res, 'Unable to commit via Git') unless $res->{status};
+    my $res = $self->_run_cmd(['commit', '-q', '-m', $message, $author, @files]);
+    return $self->_format_git_error($res, 'Unable to commit via Git') unless $res->{status};
 
     # push changes
     if (($self->config->{do_push} || '') eq 'yes') {
-        $res = run_cmd_with_log_return_error([@git, 'push']);
-        return _format_git_error($res, 'Unable to push Git commit') unless $res->{status};
+        $res = $self->_run_cmd(['push']);
+        return $self->_format_git_error($res, 'Unable to push Git commit') unless $res->{status};
     }
 
     return undef;
+}
+
+sub get_current_branch ($self) {
+    my $r = $self->_run_cmd(['branch', '--show-current']);
+    die $self->_format_git_error($r, 'Error detecting current branch') unless $r->{status};
+    return trim($r->{stdout});
+}
+
+sub get_remote_default_branch ($self, $url) {
+    my $r = $self->_run_cmd(['ls-remote', '--symref', $url, 'HEAD'], {include_git_path => 0, ssh_batchmode => 1});
+    die "Error detecting remote default branch name for '$url': $r->{stdout} $r->{stderr}"
+      unless $r->{status} && $r->{stdout} =~ m{refs/heads/(\S+)\s+HEAD};
+    return $1;
+}
+
+sub clone_url ($self, $url) {
+    my $r = $self->_run_cmd(['clone', $url, $self->dir], {include_git_path => 0, ssh_batchmode => 1});
+    die $self->_format_git_error($r, "Failed to clone $url") unless $r->{status};
+}
+
+sub get_origin_url ($self) {
+    my $r = $self->_run_cmd(['remote', 'get-url', 'origin']);
+    die $self->_format_git_error($r, 'Failed to get origin url') unless $r->{status};
+    return trim($r->{stdout});
+}
+
+sub fetch ($self, $branch_arg) {
+    my $r = $self->_run_cmd(['fetch', 'origin', $branch_arg], {ssh_batchmode => 1});
+    die $self->_format_git_error($r, "Failed to fetch from '$branch_arg'") unless $r->{status};
+}
+
+sub reset_hard ($self, $branch) {
+    my $r = $self->_run_cmd(['reset', '--hard', "origin/$branch"]);
+    die $self->_format_git_error($r, "Failed to reset to 'origin/$branch'") unless $r->{status};
 }
 
 1;

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -53,7 +53,8 @@ subtest 'make git commit (error handling)' => sub {
     my $res;
     stdout_like { $res = $git->commit({cmd => 'status', message => 'test'}) }
     qr/.*\[warn\].*fatal: Not a git repository/i, 'git message found';
-    like $res, qr'^Unable to commit via Git: fatal: (N|n)ot a git repository \(or any', 'Git error message returned';
+    like $res, qr"^Unable to commit via Git \($empty_tmp_dir\): fatal: (N|n)ot a git repository \(or any",
+      'Git error message returned';
 };
 
 # setup mocking
@@ -117,7 +118,7 @@ subtest 'git commands with mocked run_cmd_with_log_return_error' => sub {
     $mock_return_value{stdout} = '';
     is(
         $git->set_to_latest_master,
-        'Unable to fetch from origin master: mocked error',
+        'Unable to fetch from origin master (foo/bar): mocked error',
         'an error occurred on remote update'
     );
     is_deeply(\@executed_commands, [[qw(git -C foo/bar remote update origin)],], 'git reset not attempted',)


### PR DESCRIPTION
Refactor git related functions from OpenQA::Task::Git::Clone into the OpenQA::Git module for easier re-usability.
Related Ticket: [164886](https://progress.opensuse.org/issues/164886)

- Turn git functions into git module methods
- Avoid array recreation with _run_cmd helper method and optional use_ssh and use_path parameters
- Improve and adjust and test cases
- Fix merge conflicts after rebase to master branch