### PR TITLE
Require GruTask in database before running a minion job

### DIFF
--- a/lib/OpenQA/Shared/GruJob.pm
+++ b/lib/OpenQA/Shared/GruJob.pm
@@ -10,6 +10,12 @@ sub execute {
     my $self = shift;
 
     my $gru_id = $self->info->{notes}{gru_id};
+    if ($gru_id and not $self->info->{finished}) {
+        # We have a gru_id and this is the first run of the job
+        my $gru = $self->minion->app->schema->resultset('GruTasks')->find($gru_id);
+        # GruTask might not yet have landed in database due to open transaction
+        return $self->retry({delay => 2}) unless $gru;
+    }
     my $err = $self->SUPER::execute;
 
     # Non-Gru tasks


### PR DESCRIPTION
 It can happen that a GruTasks entry is added in a transaction and the minion
 job already enqueued and started before the transaction is committed.
    
  In that case we shouldn't start the minion job (the transaction could have
  been rollbacked even).
    
  The task needs to be deleted by the minion job in order to go on with
  processing a job, and it can't delete it if it doesn't see the entry in the
  database.
    
  But requiring the entry before the start of the job is even more correct IMHO.
    
  Issue: https://progress.opensuse.org/issues/165866




