### PR TITLE
Automatically update git for jobs without CASEDIR/NEEDLES_DIR

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -18,7 +18,7 @@
 
 # can't use linebreaks here!
 %define openqa_main_service openqa-webui.service
-%define openqa_extra_services openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer openqa-enqueue-asset-cleanup.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.service openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.service openqa-enqueue-bug-cleanup.timer
+%define openqa_extra_services openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer openqa-enqueue-asset-cleanup.service openqa-enqueue-git-auto-update.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.service openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.service openqa-enqueue-bug-cleanup.timer openqa-enqueue-git-auto-update.timer
 %define openqa_services %{openqa_main_service} %{openqa_extra_services}
 %define openqa_worker_services openqa-worker.target openqa-slirpvde.service openqa-vde_switch.service openqa-worker-cacheservice.service openqa-worker-cacheservice-minion.service
 %if %{undefined tmpfiles_create}
@@ -603,6 +603,8 @@ fi
 %{_unitdir}/openqa-enqueue-audit-event-cleanup.timer
 %{_unitdir}/openqa-enqueue-asset-cleanup.service
 %{_unitdir}/openqa-enqueue-asset-cleanup.timer
+%{_unitdir}/openqa-enqueue-git-auto-update.service
+%{_unitdir}/openqa-enqueue-git-auto-update.timer
 %{_unitdir}/openqa-enqueue-result-cleanup.service
 %{_unitdir}/openqa-enqueue-result-cleanup.timer
 %{_unitdir}/openqa-enqueue-bug-cleanup.service
@@ -636,6 +638,7 @@ fi
 %{_datadir}/openqa/script/openqa-enqueue-asset-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-audit-event-cleanup
 %{_datadir}/openqa/script/openqa-enqueue-bug-cleanup
+%{_datadir}/openqa/script/openqa-enqueue-git-auto-update
 %{_datadir}/openqa/script/openqa-enqueue-result-cleanup
 %{_datadir}/openqa/script/openqa-gru
 %{_datadir}/openqa/script/openqa-rollback

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -115,6 +115,8 @@
 #do_push = no
 ## whether to clone CASEDIR or NEEDLES_DIR on the web UI if that var points to a Git repo
 #git_auto_clone = yes
+## Experimental - Ensure a git update of all test code and needles
+#git_auto_update = no
 
 ## Authentication method to use for user management
 [auth]

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -68,6 +68,7 @@ sub read_config ($app) {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
+            git_auto_update => 'no',
         },
         scheduler => {
             max_job_scheduled_time => 7,

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -23,21 +23,20 @@ sub new ($class, $app = undef) {
 
 sub register_tasks ($self) {
     my $app = $self->app;
-    $app->plugin($_)
-      for (
-        qw(OpenQA::Task::AuditEvents::Limit),
-        qw(OpenQA::Task::Asset::Download),
-        qw(OpenQA::Task::Asset::Limit),
-        qw(OpenQA::Task::Git::Clone),
-        qw(OpenQA::Task::Needle::Scan OpenQA::Task::Needle::Save OpenQA::Task::Needle::Delete),
-        qw(OpenQA::Task::Job::Limit),
-        qw(OpenQA::Task::Job::ArchiveResults),
-        qw(OpenQA::Task::Job::FinalizeResults),
-        qw(OpenQA::Task::Job::HookScript),
-        qw(OpenQA::Task::Job::Restart),
-        qw(OpenQA::Task::Iso::Schedule),
-        qw(OpenQA::Task::Bug::Limit),
-      );
+    $app->plugin($_) for qw(
+      OpenQA::Task::AuditEvents::Limit
+      OpenQA::Task::Asset::Download
+      OpenQA::Task::Asset::Limit
+      OpenQA::Task::Git::Clone
+      OpenQA::Task::Needle::Scan OpenQA::Task::Needle::Save OpenQA::Task::Needle::Delete
+      OpenQA::Task::Job::Limit
+      OpenQA::Task::Job::ArchiveResults
+      OpenQA::Task::Job::FinalizeResults
+      OpenQA::Task::Job::HookScript
+      OpenQA::Task::Job::Restart
+      OpenQA::Task::Iso::Schedule
+      OpenQA::Task::Bug::Limit
+    );
 }
 
 # allow the continuously polled stats to be available on an

--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -5,7 +5,6 @@ package OpenQA::Task::Git::Clone;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 use Mojo::Util 'trim';
 
-use OpenQA::Utils qw(run_cmd_with_log_return_error);
 use Mojo::File;
 use Time::Seconds 'ONE_HOUR';
 

--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -54,18 +54,24 @@ sub _git_clone_all ($job, $clones) {
 
 sub _git_clone ($app, $job, $ctx, $path, $url) {
     my $git = OpenQA::Git->new(app => $app, dir => $path);
-    $ctx->debug(qq{Updating $path to $url});
-    $url = Mojo::URL->new($url);
-    my $requested_branch = $url->fragment;
-    $url->fragment(undef);
+    $ctx->debug(sprintf q{Updating '%s' to '%s'}, $path, ($url // 'n/a'));
+    my $requested_branch;
+    if ($url) {
+        $url = Mojo::URL->new($url);
+        $requested_branch = $url->fragment;
+        $url->fragment(undef);
 
-    # An initial clone fetches all refs, we are done
-    return $git->clone_url($url) unless -d $path;
+        # An initial clone fetches all refs, we are done
+        return $git->clone_url($url) unless -d $path;
 
-    my $origin_url = $git->get_origin_url;
-    if ($url ne $origin_url) {
-        $ctx->warn("Local checkout at $path has origin $origin_url but requesting to clone from $url");
-        return;
+        my $origin_url = $git->get_origin_url;
+        if ($url ne $origin_url) {
+            $ctx->warn("Local checkout at $path has origin $origin_url but requesting to clone from $url");
+            return;
+        }
+    }
+    else {
+        $url = $git->get_origin_url;
     }
 
     die "NOT updating dirty git checkout at $path" if !$git->is_workdir_clean();

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -603,6 +603,11 @@ sub create_downloads_list ($job_settings) {
 
 sub create_git_clone_list ($job_settings, $clones = {}) {
     my $distri = $job_settings->{DISTRI};
+    if (OpenQA::App->singleton->config->{'scm git'}->{git_auto_update} eq 'yes') {
+        # Potential existing git clones to update without having CASEDIR or NEEDLES_DIR
+        not $job_settings->{CASEDIR} and $clones->{testcasedir($distri)} = undef;
+        not $job_settings->{NEEDLES_DIR} and $clones->{needledir($distri)} = undef;
+    }
     my $case_url = Mojo::URL->new($job_settings->{CASEDIR} // '');
     my $needles_url = Mojo::URL->new($job_settings->{NEEDLES_DIR} // '');
     if ($case_url->scheme) {

--- a/script/openqa-enqueue-git-auto-update
+++ b/script/openqa-enqueue-git-auto-update
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+exec "$(dirname "$0")"/openqa eval -m production -V 'app->gru->enqueue_git_update_all()' "$@"

--- a/systemd/openqa-enqueue-git-auto-update.service
+++ b/systemd/openqa-enqueue-git-auto-update.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ensure a git update of all test code and needles regardless of test execution.
+After=postgresql.service openqa-setup-db.service
+Wants=openqa-setup-db.service
+
+[Service]
+Type=oneshot
+User=geekotest
+ExecStart=/usr/share/openqa/script/openqa-enqueue-git-update-all

--- a/systemd/openqa-enqueue-git-auto-update.timer
+++ b/systemd/openqa-enqueue-git-auto-update.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ensure a git update of all test code and needles regardless of test execution.
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -23,6 +23,8 @@ my $workdir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
 my $guard = scope_guard sub { chdir $FindBin::Bin };
 chdir $workdir;
 path('t/data/openqa/db')->make_path;
+my $git_clones = "$workdir/git-clones";
+mkdir $git_clones;
 
 my $schema = OpenQA::Test::Database->new->create();
 my $t = Test::Mojo->new('OpenQA::WebAPI');
@@ -32,7 +34,7 @@ my $mojo_port = Mojo::IOLoop::Server->generate_port;
 my $webapi = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
 
 # prevent writing to a log file to enable use of combined_like in the following tests
-$t->app->log(Mojo::Log->new(level => 'debug'));
+$t->app->log(Mojo::Log->new(level => 'warn'));
 
 subtest 'git clone' => sub {
     my $openqa_git = Test::MockModule->new('OpenQA::Git');
@@ -44,21 +46,33 @@ subtest 'git clone' => sub {
     };
     $openqa_git->redefine(
         run_cmd_with_log_return_error => sub ($cmd) {
-            push @mocked_git_calls, "@$cmd";
+            push @mocked_git_calls, "@$cmd" =~ s/\Q$git_clones//r;
             my $stdout = '';
             splice @$cmd, 0, 2 if $cmd->[0] eq 'env';
             my $path = '';
             (undef, $path) = splice @$cmd, 1, 2 if $cmd->[1] eq '-C';
             my $action = $cmd->[1];
-            $stdout = 'ref: refs/heads/master	HEAD' if $action eq 'ls-remote';
-            $stdout = $clone_dirs->{$path} =~ s/#.*//r if $cmd->[2] eq 'get-url';
-            $stdout = 'master' if $action eq 'branch';
-            $stdout = 'ref: something' if $action eq 'ls-remote' && "@$cmd" =~ m/nodefault/;
             my $return_code = 0;
-            $return_code = 1 if ($path eq '/opt/' and $action eq 'diff-index');    # /opt/ simulates dirty checkout
-            $return_code = 2
-              if ($path eq '/lib/' and $action eq 'diff-index')
-              ;    # /lib/ simulates error when checking checkout dirty status
+            if ($action eq 'remote') {
+                if ($clone_dirs->{$path}) {
+                    $stdout = $clone_dirs->{$path} =~ s/#.*//r;
+                }
+                elsif ($path =~ m/opensuse/) {
+                    $stdout = 'http://osado';
+                }
+            }
+            elsif ($action eq 'ls-remote') {
+                $stdout = 'ref: refs/heads/master	HEAD';
+                $stdout = 'ref: something' if "@$cmd" =~ m/nodefault/;
+            }
+            elsif ($action eq 'branch') {
+                $stdout = 'master';
+            }
+            elsif ($action eq 'diff-index') {
+                $return_code = 1 if $path eq '/opt/';    # /opt/ simulates dirty checkout
+                $return_code = 2
+                  if $path eq '/lib/';    # /lib/ simulates error when checking checkout dirty status
+            }
             return {
                 status => $return_code == 0,
                 return_code => $return_code,
@@ -70,23 +84,23 @@ subtest 'git clone' => sub {
     is $res->{result}, 'Job successfully executed', 'minion job result indicates success';
     #<<< no perltidy
     my $expected_calls = [
-    # /etc/
-    ['get-url' => 'git -C /etc/ remote get-url origin'],
-    ['check dirty' => 'git -C /etc/ diff-index HEAD --exit-code'],
-    ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://localhost/foo.git HEAD'],
-    ['current branch' => 'git -C /etc/ branch --show-current'],
-    ['fetch default' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /etc/ fetch origin master'],
-    ['reset' => 'git -C /etc/ reset --hard origin/master'],
+        # /etc/
+        ['get-url'        => 'git -C /etc/ remote get-url origin'],
+        ['check dirty'    => 'git -C /etc/ diff-index HEAD --exit-code'],
+        ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://localhost/foo.git HEAD'],
+        ['current branch' => 'git -C /etc/ branch --show-current'],
+        ['fetch default'  => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /etc/ fetch origin master'],
+        ['reset'          => 'git -C /etc/ reset --hard origin/master'],
 
-    # /root
-    ['get-url' => 'git -C /root/ remote get-url origin'],
-    ['check dirty' => 'git -C /root/ diff-index HEAD --exit-code'],
-    ['current branch' => 'git -C /root/ branch --show-current'],
-    ['fetch branch' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /root/ fetch origin foobranch'],
+        # /root
+        ['get-url'        => 'git -C /root/ remote get-url origin'],
+        ['check dirty'    => 'git -C /root/ diff-index HEAD --exit-code'],
+        ['current branch' => 'git -C /root/ branch --show-current'],
+        ['fetch branch'   => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /root/ fetch origin foobranch'],
 
-    # /this_directory_does_not_exist/
-    ['clone' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone http://localhost/bar.git /this_directory_does_not_exist/'],
-];
+        # /this_directory_does_not_exist/
+        ['clone' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone http://localhost/bar.git /this_directory_does_not_exist/'],
+    ];
     #>>> no perltidy
     for my $i (0 .. $#$expected_calls) {
         my $test = $expected_calls->[$i];
@@ -132,6 +146,41 @@ subtest 'git clone' => sub {
         my $res = run_gru_job($t->app, 'git_clone', $clone_dirs, {priority => 10});
         is $res->{state}, 'failed', 'minion job failed';
         like $res->{result}, qr/Internal Git error: Unexpected exit code 2/, 'error message';
+    };
+
+    subtest 'update clones without CASEDIR' => sub {
+        @mocked_git_calls = ();
+        #<<< no perltidy
+        my $expected_calls = [
+            # /opensuse
+            ['get-url'        => 'git -C /opensuse remote get-url origin'],
+            ['check dirty'    => 'git -C /opensuse diff-index HEAD --exit-code'],
+            ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://osado HEAD'],
+            ['current branch' => 'git -C /opensuse branch --show-current'],
+            ['fetch default ' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /opensuse fetch origin master'],
+            ['reset'          => 'git -C /opensuse reset --hard origin/master'],
+
+            # /opensuse/needles
+            ['get-url'        => 'git -C /opensuse/needles remote get-url origin'],
+            ['check dirty'    => 'git -C /opensuse/needles diff-index HEAD --exit-code'],
+            ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://osado HEAD'],
+            ['current branch' => 'git -C /opensuse/needles branch --show-current'],
+            ['fetch branch'   => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /opensuse/needles fetch origin master'],
+            ['reset'          => 'git -C /opensuse/needles reset --hard origin/master'],
+        ];
+        #>>> no perltidy
+        $ENV{OPENQA_GIT_CLONE_RETRIES} = 0;
+        $clone_dirs = {
+            "$git_clones/opensuse" => undef,
+            "$git_clones/opensuse/needles" => undef,
+        };
+        my $res = run_gru_job($t->app, 'git_clone', $clone_dirs, {priority => 10});
+        is $res->{state}, 'finished', 'minion job finished';
+        is $res->{result}, 'Job successfully executed', 'minion job result indicates success';
+        for my $i (0 .. $#$expected_calls) {
+            my $test = $expected_calls->[$i];
+            is $mocked_git_calls[$i], $test->[1], "$i: " . $test->[0];
+        }
     };
 
     subtest 'minion guard' => sub {

--- a/t/api/02-iso-download.t
+++ b/t/api/02-iso-download.t
@@ -28,6 +28,7 @@ my %iso = (ISO => $iso, DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD'
 my @tasks = $gru_tasks->search({taskname => 'download_asset'});
 is(scalar @tasks, 0, 'we have no gru download tasks to start with');
 $t->app->config->{global}->{download_domains} = 'localhost';
+$t->app->config->{'scm git'}->{git_auto_clone} = 'no';
 my $rsp;
 
 # we keep checking gru task count and args over and over in this next bit,

--- a/t/config.t
+++ b/t/config.t
@@ -66,6 +66,7 @@ subtest 'Test configuration default modes' => sub {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
+            git_auto_update => 'no',
         },
         'scheduler' => {
             max_job_scheduled_time => 7,

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -378,6 +378,10 @@ sub setup_fullstack_temp_dir {
     $datadir->child($_)->copy_to($configdir->child($_)) for qw(openqa.ini database.ini workers.ini);
     path($basedir, 'openqa', 'db')->make_path->child('db.lock')->spew('');
 
+    my $config = $configdir->child('openqa.ini')->slurp;
+    $config =~ s/^#\Q[scm git]/[scm git]/m;
+    $config =~ s/^#git_auto_clone = .*/git_auto_clone = no/m;
+    $configdir->child('openqa.ini')->spew($config);
     note("OPENQA_BASEDIR: $basedir\nOPENQA_CONFIG: $configdir");
     $ENV{OPENQA_BASEDIR} = $basedir;
     $ENV{OPENQA_CONFIG} = $configdir;


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/164898

This replaces the update part of `fetchneedles`. It doesn't replace the initial cloning yet.
git is updated when
* scheduling a product / job -> tests and needles of the relevant jobs are updated
* scheduled hourly via service (or cronjob) -> all repos under `OPENQA_BASEDIR` are updated


Note: `fetchneedles` has a `force` option. We set it to true in our cronjob currently.
This can be added later as a config option.