### PR TITLE
Fix linkify to only link to proper URLs

### DIFF
--- a/assets/javascripts/anser-import.js
+++ b/assets/javascripts/anser-import.js
@@ -1,7 +1,15 @@
 const module = {};
 
+// https://github.com/IonicaBizau/anser/pull/75
+// https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
+function linkify(txt) {
+  const re = /(https?:\/\/(?:[A-Za-z0-9#;/?:@=+$',_.!~*()[\]-]|&amp;|%[A-Fa-f0-9]{2})+)/gm;
+  return txt.replace(re, function (str) {
+    return '<a href="' + str + '">' + str + '</a>';
+  });
+}
 function ansiToHtml(data) {
-  return Anser.linkify(Anser.ansiToHtml(Anser.escapeForHtml(data), {use_classes: true}));
+  return linkify(Anser.ansiToHtml(Anser.escapeForHtml(data), {use_classes: true}));
 }
 function ansiToText(data) {
   return Anser.ansiToText(data);

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -513,6 +513,18 @@ subtest 'misc details: title, favicon, go back, go to source view, go to log vie
     is $url->fragment, 'line-68', 'URL fragment points to clicked line';
 };
 
+subtest ansiToHtml => sub {
+    my @links = (
+        'https://bar/?x=%20&y=@;z=!#ab(c)',
+        'https://bar/',
+        "https://bar/with'quote",
+    );
+    my $text = qq{\e[34mfoo "$links[0]" <$links[1]> $links[2]\e[0m} =~ s/'/\\'/gr;
+    my $html = $driver->execute_script(qq{return ansiToHtml('$text')});
+    my @matched = $html =~ m/href="(.*?)"/g;
+    is $matched[$_], $links[$_] =~ s/&/&amp;/gr, "linkify $_: $links[$_]" for (0..$#links);
+};
+
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 subtest 'scheduled job' => sub {


### PR DESCRIPTION
This doesn't check for really well formed URLs, but it limits the matching to only allowed characters in URIs.
It makes up for escapeForHtml() being already called, so it matches `&amp;` separately.

Tested with:

    # "> should be excluded
    "https://github.com/os-autoinst/openQA.git"
    <https://github.com/os-autoinst/os-autoinst.git>
    # ) should be included
    https://de.wikipedia.org/wiki/Queen_(Band)
    # query strings should be included
    https://github.com/os-autoinst/openQA?foo=1%20&bar=*2

Single quotes actually can be part of URIs so that's something we should adapt
in our code (and use double quotes, or I remember back in usenet times we used
`<http://...>` whenever referring to a URL in plain text).

We could use this as a workaround until an according PR to https://github.com/IonicaBizau/anser has been made.
There is a related issue: https://github.com/IonicaBizau/anser/issues/63

Alternative to
* https://github.com/os-autoinst/os-autoinst/pull/2544

Issue: https://progress.opensuse.org/issues/166676