### PR TITLE
Ensure the error responsible for API failures is always added

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -67,6 +67,8 @@ sub _set_status ($self, $status, $event_data) {
     $event_data->{client} = $self;
     $event_data->{status} = $status;
     $self->status($status);
+    # set the error message from the event data as last error so it can added to the reason when setting the job done
+    if (my $event_error_message = $event_data->{error_message}) { $self->{_last_error} = $event_error_message }
     $self->emit(status_changed => $event_data);
 }
 
@@ -108,7 +110,6 @@ sub register ($self) {
         $status = 'failed'
           if $error_message
           =~ /timestamp mismatch - check whether clocks on the local host and the web UI host are in sync/;
-        $self->{_last_error} = $error_message;
         $self->_set_status($status => {error_message => $error_message});
         return undef;
     }

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -566,6 +566,9 @@ subtest 'last error' => sub {
     $client->reset_last_error;
     $client->add_context_to_last_error('setup');
     is($client->last_error, undef, 'add_context_to_last_error does nothing if there is no last error');
+
+    $client->_set_status(failed => {error_message => 'foo'});
+    is $client->last_error, 'foo', 'error message set as last error if no other error recorded';
 };
 
 subtest 'tear down' => sub {


### PR DESCRIPTION
So far the "last error" was only tracked for REST-API calls (used e.g. for worker registration and uploads) but not in other cases (e.g. web socket related errors). This change extends tracking for to cover those cases by setting the last error to the error messages that is always passed to `_set_status`. This way they are available to be added to the reason when declaring the job as incomplete.

Related ticket: https://progress.opensuse.org/issues/163781