### PR TITLE
Ensure tidyall is available in CI after 28c5dd1

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -114,6 +114,7 @@ on 'test' => sub {
 };
 
 on 'develop' => sub {
+    requires 'Code::TidyAll';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Freenode';
     requires 'Perl::Tidy', '== 20240511.0.0';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -205,5 +205,6 @@ style_check_requires:
   python3-yamllint:
   perl(Perl::Critic):
   perl(Perl::Critic::Freenode):
+  perl(Code::TidyAll):
   ShellCheck:
   shfmt:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -81,7 +81,7 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define style_check_requires ShellCheck perl(Perl::Critic) perl(Perl::Critic::Freenode) python3-yamllint shfmt
+%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Freenode) python3-yamllint shfmt
 # The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -514,15 +514,11 @@ subtest 'misc details: title, favicon, go back, go to source view, go to log vie
 };
 
 subtest ansiToHtml => sub {
-    my @links = (
-        'https://bar/?x=%20&y=@;z=!#ab(c)',
-        'https://bar/',
-        "https://bar/with'quote",
-    );
+    my @links = ('https://bar/?x=%20&y=@;z=!#ab(c)', 'https://bar/', "https://bar/with'quote");
     my $text = qq{\e[34mfoo "$links[0]" <$links[1]> $links[2]\e[0m} =~ s/'/\\'/gr;
     my $html = $driver->execute_script(qq{return ansiToHtml('$text')});
     my @matched = $html =~ m/href="(.*?)"/g;
-    is $matched[$_], $links[$_] =~ s/&/&amp;/gr, "linkify $_: $links[$_]" for (0..$#links);
+    is $matched[$_], $links[$_] =~ s/&/&amp;/gr, "linkify $_: $links[$_]" for (0 .. $#links);
 };
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');


### PR DESCRIPTION
* Ensure `openQA-devel` depends on `perl(Code::TidyAll)` so that package is
  available in the CI
* Add the package only to style check dependencies (and not test
  dependencies) so the package build does not depend on it
* See https://progress.opensuse.org/issues/166817

---

Note that I have already prepared a [branch](https://github.com/os-autoinst/openQA/compare/master...Martchus:openQA:tidy?expand=1) to merge https://github.com/os-autoinst/os-autoinst-common/pull/55. For now I excluded this commit because we'll have to wait for the OBS package build on `devel:openQA` and the nightly job on CircleCI for this to become effective.