### PR TITLE
Avoid sporadic failures of `t/ui/10-tests_overview.t`

### DIFF
--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -451,26 +451,20 @@ subtest "filtering by machine" => sub {
         $driver->find_element('#filter-panel button[type="submit"]')->click();
 
         like wait_for_element(selector => '#flavor_DVD_arch_x86_64')->get_text, qr/x86_64/, 'DVD/x86_64 present';
-        element_not_present('#flavor_DVD_arch_i586');
-        element_not_present('#flavor_GNOME-Live_arch_i686');
-        element_not_present('#flavor_NET_arch_x86_64');
+        element_not_present("#$_") for qw(flavor_DVD_arch_i586 flavor_GNOME-Live_arch_i686 flavor_NET_arch_x86_64);
+        is element_prop('filter-machine'), 'uefi', 'machine filter still visible in form';
 
-        my @row = $driver->find_element('#content tbody tr');
-        is(scalar @row, 1, 'The job its machine is uefi is shown');
+        my @job_rows = map { $_->get_text } @{$driver->find_elements('#content tbody tr')};
+        is_deeply \@job_rows, ['kde@uefi'], 'only the job with machine uefi is shown' or diag explain \@job_rows;
 
-        is($driver->find_element('#content tbody .name span')->get_text(), 'kde@uefi', 'Test suite name is shown');
         $driver->find_element('#filter-panel .card-header')->click();
-        is(element_prop('filter-machine'), 'uefi', 'machine text is correct');
-
         $driver->find_element('#filter-machine')->clear();
         $driver->find_element('#filter-machine')->send_keys('64bit,uefi');
         $driver->find_element('#filter-panel button[type="submit"]')->click();
 
         like wait_for_element(selector => '#flavor_DVD_arch_x86_64')->get_text, qr/x86_64/, 'DVD/x86_64 still present';
         like wait_for_element(selector => '#flavor_NET_arch_x86_64')->get_text, qr/x86_64/, 'NET/x86_64 present';
-        element_not_present('#flavor_GONME-Live_arch_i686');
-        element_not_present('#flavor_DVD_arch_i586');
-
+        element_not_present("#$_") for qw(flavor_DVD_arch_i586 flavor_GNOME-Live_arch_i686);
     };
 };
 

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -450,7 +450,7 @@ subtest "filtering by machine" => sub {
         $driver->find_element('#filter-machine')->send_keys('uefi');
         $driver->find_element('#filter-panel button[type="submit"]')->click();
 
-        element_visible('#flavor_DVD_arch_x86_64', qr/x86_64/);
+        like wait_for_element(selector => '#flavor_DVD_arch_x86_64')->get_text, qr/x86_64/, 'DVD/x86_64 present';
         element_not_present('#flavor_DVD_arch_i586');
         element_not_present('#flavor_GNOME-Live_arch_i686');
         element_not_present('#flavor_NET_arch_x86_64');
@@ -466,8 +466,8 @@ subtest "filtering by machine" => sub {
         $driver->find_element('#filter-machine')->send_keys('64bit,uefi');
         $driver->find_element('#filter-panel button[type="submit"]')->click();
 
-        element_visible('#flavor_DVD_arch_x86_64', qr/x86_64/);
-        element_visible('#flavor_NET_arch_x86_64', qr/x86_64/);
+        like wait_for_element(selector => '#flavor_DVD_arch_x86_64')->get_text, qr/x86_64/, 'DVD/x86_64 still present';
+        like wait_for_element(selector => '#flavor_NET_arch_x86_64')->get_text, qr/x86_64/, 'NET/x86_64 present';
         element_not_present('#flavor_GONME-Live_arch_i686');
         element_not_present('#flavor_DVD_arch_i586');
 


### PR DESCRIPTION
This might fix failures like:

```
[21:00:46] t/ui/10-tests_overview.t ................... 18/?
        #   Failed test '#flavor_DVD_arch_x86_64 present exactly once'
        #   at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm line 237.
        #          got: '0'
        #     expected: '1'
        #   Failed test '#flavor_DVD_arch_x86_64 exists'
        #   at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm line 240.
        # Looks like you failed 2 tests of 18.
    #   Failed test 'filter for specific machine'
    #   at t/ui/10-tests_overview.t line 474.
```

I could not reproduce the issue locally but probably it helps to use
`wait_for_element` here.

Related ticket: https://progress.opensuse.org/issues/166820