### PR TITLE
Allow scheduling a (example) product via the web UI

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -114,6 +114,7 @@
 < ../node_modules/ace-builds/src-min/mode-perl.js
 < ../node_modules/ace-builds/src-min/mode-yaml.js
 < ../node_modules/ace-builds/src-min/mode-diff.js
+< ../node_modules/ace-builds/src-min/mode-ini.js
 
 ! step_edit.js
 < javascripts/needleeditor.js
@@ -160,6 +161,9 @@
 < javascripts/needlediff.js
 < javascripts/running.js
 < javascripts/disable_status_updates.js [mode==test]
+
+! create_tests.js
+< javascripts/create_tests.js
 
 ! job_next_previous.js
 < javascripts/job_next_previous.js

--- a/assets/javascripts/create_tests.js
+++ b/assets/javascripts/create_tests.js
@@ -1,0 +1,63 @@
+function getNonEmptyFormParams(form) {
+  const formData = new FormData(form);
+  const queryParams = new URLSearchParams();
+  for (const [key, value] of formData) {
+    if (value.length > 0) {
+      queryParams.append(key, value);
+    }
+  }
+  return queryParams;
+}
+
+function setupAceEditor(elementID, mode) {
+  const element = document.getElementById(elementID);
+  const initialValue = element.textContent;
+  const editor = ace.edit(element, {
+    mode: mode,
+    maxLines: Infinity,
+    tabSize: 2,
+    useSoftTabs: true
+  });
+  editor.session.setUseWrapMode(true);
+  editor.initialValue = initialValue;
+  return editor;
+}
+
+function setupCreateTestsForm() {
+  window.scenarioDefinitionsEditor = setupAceEditor('create-tests-scenario-definitions', 'ace/mode/yaml');
+  window.settingsEditor = setupAceEditor('create-tests-settings', 'ace/mode/ini');
+}
+
+function resetCreateTestsForm() {
+  window.scenarioDefinitionsEditor.setValue(window.scenarioDefinitionsEditor.initialValue, -1);
+  window.settingsEditor.setValue(window.settingsEditor.initialValue, -1);
+}
+
+function createTests(form) {
+  event.preventDefault();
+
+  const scenarioDefinitions = window.scenarioDefinitionsEditor.getValue();
+  const queryParams = getNonEmptyFormParams(form);
+  window.settingsEditor
+    .getValue()
+    .split('\n')
+    .map(line => line.split('=', 2))
+    .forEach(setting => queryParams.append(setting[0].trim(), (setting[1] ?? '').trim()));
+  queryParams.append('async', true);
+  if (scenarioDefinitions.length > 0) {
+    queryParams.append('SCENARIO_DEFINITIONS_YAML', scenarioDefinitions);
+  }
+  $.ajax({
+    url: form.dataset.postUrl,
+    method: form.method,
+    data: queryParams.toString(),
+    success: function (response) {
+      const id = response.scheduled_product_id;
+      const url = `${form.dataset.productlogUrl}?id=${id}`;
+      addFlash('info', `Tests have been scheduled, checkout the <a href="${url}">product log</a> for details.`);
+    },
+    error: function (xhr, ajaxOptions, thrownError) {
+      addFlash('danger', 'Unable to create tests: ' + (xhr.responseJSON?.error ?? xhr.responseText ?? thrownError));
+    }
+  });
+}

--- a/assets/javascripts/create_tests.js
+++ b/assets/javascripts/create_tests.js
@@ -61,3 +61,22 @@ function createTests(form) {
     }
   });
 }
+
+function cloneTests(link) {
+  const loadingIndication = document.createElement('span');
+  loadingIndication.append('Cloning test distribution …');
+  link.parentNode.replaceWith(loadingIndication);
+  $.ajax({
+    url: document.getElementById('flash-messages').dataset.cloneUrl,
+    method: 'POST',
+    success: function (response) {
+      location.reload();
+    },
+    error: function (xhr, ajaxOptions, thrownError) {
+      const retryButton = '<br/><a class="btn btn-primary" href="#" onclick="cloneTests(this)">Retry</a>';
+      const error = xhr.responseJSON?.error ?? xhr.responseText ?? thrownError;
+      loadingIndication.parentNode.classList.replace('alert-primary', 'alert-danger');
+      loadingIndication.innerHTML = `Unable to clone: ${error} ${retryButton}`;
+    }
+  });
+}

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -325,3 +325,11 @@ concurrent = 0
 # home =
 # username = openqa-user
 # ssh_key_file = ~/.ssh/id_rsa
+
+# Override form values for creating example test
+#[test_preset example]
+#title = Create example test
+#info = Some info that will show up on the "Create … -> Example test" page
+#casedir = https://github.com/os-autoinst/os-autoinst-distri-example.git
+#distri = example
+#build = openqa

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -247,10 +247,7 @@ sub read_config ($app) {
         }
         for my $k (@known_keys) {
             my $v = $cfg && $cfg->val($section, $k);
-            $v
-              //= exists $mode_defaults{$app->mode}{$section}->{$k}
-              ? $mode_defaults{$app->mode}{$section}->{$k}
-              : $defaults{$section}->{$k};
+            $v //= $mode_defaults{$app->mode}{$section}->{$k} // $defaults{$section}->{$k};
             $config->{$section}->{$k} = trim $v if defined $v;
         }
     }

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -198,8 +198,15 @@ sub read_config ($app) {
         influxdb => {
             ignored_failed_minion_jobs => '',
         },
-        carry_over => \%CARRY_OVER_DEFAULTS
-    );
+        carry_over => \%CARRY_OVER_DEFAULTS,
+        'test_preset example' => {
+            title => 'Create example test',
+            info => 'Parameters to create an example test have been pre-filled in the following form. '
+              . 'You can simply submit the form as-is to test your openQA setup.',
+            casedir => 'https://github.com/os-autoinst/os-autoinst-distri-example.git',
+            distri => 'example',
+            build => 'openqa',
+        });
 
     # in development mode we use fake auth and log to stderr
     my %mode_defaults = (

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -119,6 +119,7 @@ sub startup ($self) {
     $r->get('/search')->name('search')->to(template => 'search/search');
 
     $r->get('/tests')->name('tests')->to('test#list');
+    $r->get('/tests/create')->name('tests_create')->to('test#create');
     # we have to set this and some later routes up differently on Mojo
     # < 9 and Mojo >= 9.11
     if ($Mojolicious::VERSION > 9.10) {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -120,6 +120,7 @@ sub startup ($self) {
 
     $r->get('/tests')->name('tests')->to('test#list');
     $r->get('/tests/create')->name('tests_create')->to('test#create');
+    $op_auth->post('/tests/clone')->name('tests_clone')->to('test#clone');
     # we have to set this and some later routes up differently on Mojo
     # < 9 and Mojo >= 9.11
     if ($Mojolicious::VERSION > 9.10) {

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -27,7 +27,7 @@ if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     exit
 fi
 
-dir="/var/lib/openqa/share/tests"
+dir="${OPENQA_BASEDIR:-/var/lib}/openqa/share/tests"
 if [ -w / ]; then
     if [ ! -e "$dir/$dist" ]; then
         mkdir -p "$dir/$dist"

--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -5,7 +5,7 @@
 : "${dist_name:=${dist:-"openSUSE"}}" # the display name, for the help message
 : "${dist:="opensuse"}"
 : "${giturl:="https://github.com/os-autoinst/os-autoinst-distri-opensuse.git"}"
-: "${branch:="master"}"
+: "${branch:=""}"
 : "${email:="openqa@$HOST"}"
 : "${username:="openQA web UI"}"
 : "${product:="$dist"}"
@@ -13,7 +13,7 @@
 : "${git_lfs:="0"}"
 : "${needles_separate:="1"}"
 : "${needles_giturl:="https://github.com/os-autoinst/os-autoinst-needles-opensuse.git"}"
-: "${needles_branch:="master"}"
+: "${needles_branch:=""}"
 
 : "${updateall:="0"}"
 : "${force:="0"}"
@@ -72,14 +72,28 @@ deal_with_stale_lockfile() {
     fi
 }
 
+# Determine the "main branch" for the remote origin unless a branch has been specified explicitly
+# note: This relies on a file called `refs/remotes/origin/HEAD` with contents like `ref: refs/remotes/origin/master` being
+#       present under the `.git` directory. This should be the case for all recently cloned Git repositories. Otherwise
+#       one can just create the file making it point to the desired branch.
+get_git_base() {
+    branch=$1
+    if [ "$branch" ]; then
+        echo "origin/$branch"
+    else
+        git rev-parse --abbrev-ref refs/remotes/origin/HEAD
+    fi
+}
+
 git_update() {
-    branch="${1:-"master"}"
     deal_with_stale_lockfile
     git gc --auto --quiet
     git fetch -q origin
+
     # Clear any uncommitted changes that would prevent a rebase
     [ "$force" = 1 ] && git reset -q --hard HEAD
-    git rebase -q origin/"$branch" || fail 'Use force=1 to discard uncommitted changes before rebasing'
+    base=$(get_git_base "$1")
+    git rebase -q "$base" || fail 'Use force=1 to discard uncommitted changes before rebasing'
 }
 
 # For needles repos because of needle saving we might end up in conflict, i.e.
@@ -87,9 +101,11 @@ git_update() {
 git_update_needles() {
     git_update "$needles_branch"
     if [ "$(git rev-parse --abbrev-ref --symbolic-full-name HEAD)" = "HEAD" ]; then
+        base=$(get_git_base "$needles_branch")
+        needles_branch=${base#origin/}
         git branch -D "$needles_branch"
         git checkout -b "$needles_branch"
-        git branch "--set-upstream-to=origin/$needles_branch" "$needles_branch"
+        git branch "--set-upstream-to=$base" "$needles_branch"
         git push origin "HEAD:$needles_branch"
     fi
 }

--- a/t/17-build_tagging.t
+++ b/t/17-build_tagging.t
@@ -110,26 +110,29 @@ subtest 'tag on non-existent build does not show up' => sub {
     is(scalar @tags, 1, 'only first build tagged');
 };
 
+my $tags_on_group = '#content a[href^=/tests/]';
+my $tags_on_dashboard = 'a[href^=/tests/]';
+
 subtest 'builds first tagged important, then unimportant disappear (poo#12028)' => sub {
     post_comment_1001 'tag:0091:important';
     post_comment_1001 'tag:0091:-important';
     $t->get_ok('/group_overview/1001?limit_builds=1')->status_is(200);
-    my @tags = $t->tx->res->dom->find('a[href^=/tests/]')->map('text')->each;
+    my @tags = $t->tx->res->dom->find($tags_on_group)->map('text')->each;
     is(scalar @tags, 2, 'only one build');
     is($tags[0], 'Build87.5011', 'only newest build present');
 };
 
 subtest 'only_tagged=1 query parameter shows only tagged (poo#11052)' => sub {
     $t->get_ok('/group_overview/1001?only_tagged=1')->status_is(200);
-    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 3, 'only one tagged build is shown (on group overview)');
+    is(scalar @{$t->tx->res->dom->find($tags_on_group)}, 3, 'three tagged builds shown (on group overview)');
     $t->get_ok('/group_overview/1001?only_tagged=0')->status_is(200);
-    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 13, 'all builds shown again (on group overview)');
+    is(scalar @{$t->tx->res->dom->find($tags_on_group)}, 13, 'all builds shown again (on group overview)');
 
     $t->get_ok('/dashboard_build_results?only_tagged=1')->status_is(200);
-    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 3, 'only one tagged build is shown (on index page)');
+    is(scalar @{$t->tx->res->dom->find($tags_on_dashboard)}, 3, 'three tagged builds shown (on index page)');
     is(scalar @{$t->tx->res->dom->find('h2')}, 1, 'only one group shown anymore');
     $t->get_ok('/dashboard_build_results?only_tagged=0')->status_is(200);
-    is(scalar @{$t->tx->res->dom->find('a[href^=/tests/]')}, 9, 'all builds shown again (on index page)');
+    is(scalar @{$t->tx->res->dom->find($tags_on_dashboard)}, 9, 'all builds shown again (on index page)');
     is(scalar @{$t->tx->res->dom->find('h2')}, 2, 'two groups shown again');
 };
 

--- a/t/config.t
+++ b/t/config.t
@@ -184,6 +184,7 @@ subtest 'Test configuration default modes' => sub {
     $test_config->{logging}->{level} = "debug";
     $test_config->{global}->{service_port_delta} = 2;
     is ref delete $config->{global}->{auto_clone_regex}, 'Regexp', 'auto_clone_regex parsed as regex';
+    ok delete $config->{'test_preset example'}, 'default values for example tests assigned';
     is_deeply $config, $test_config, '"test" configuration';
 
     # Test configuration generation with "development" mode
@@ -193,6 +194,7 @@ subtest 'Test configuration default modes' => sub {
     $test_config->{_openid_secret} = $config->{_openid_secret};
     $test_config->{global}->{service_port_delta} = 2;
     delete $config->{global}->{auto_clone_regex};
+    delete $config->{'test_preset example'};
     is_deeply $config, $test_config, 'right "development" configuration';
 
     # Test configuration generation with an unknown mode (should fallback to default)
@@ -203,6 +205,7 @@ subtest 'Test configuration default modes' => sub {
     $test_config->{auth}->{method} = "OpenID";
     $test_config->{global}->{service_port_delta} = 2;
     delete $config->{global}->{auto_clone_regex};
+    delete $config->{'test_preset example'};
     delete $test_config->{logging};
     is_deeply $config, $test_config, 'right default configuration';
 };

--- a/t/data/openqa.ini
+++ b/t/data/openqa.ini
@@ -1,1 +1,4 @@
-../../etc/openqa/openqa.ini
+[test_preset bar]
+title = Some preset
+distri = does-not-exist
+casedir = http://foo.git

--- a/t/data/openqa/share/tests/example/scenario-definitions.yaml
+++ b/t/data/openqa/share/tests/example/scenario-definitions.yaml
@@ -1,0 +1,10 @@
+---
+products:
+  example:
+    distri: "example"
+    flavor: "DVD"
+    arch: "x86_64"
+    version: '0'
+job_templates:
+  simple_boot:
+    product: "example"

--- a/t/ui/29-create_tests.t
+++ b/t/ui/29-create_tests.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+
+use FindBin;
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '15';
+use OpenQA::Test::Case;
+use OpenQA::SeleniumTest;
+
+my $schema = OpenQA::Test::Case->new->init_data;
+driver_missing unless my $driver = call_driver;
+my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+
+subtest 'navigation to form' => sub {
+    $driver->get("$url/login");
+    $driver->find_element_by_id('create-tests-action')->click;
+    $driver->find_element_by_link_text('Example test')->click;
+    $driver->title_is('openQA: Create example test', 'on page to create example test');
+};
+
+subtest 'form is pre-filled' => sub {
+    my $flash_messages = $driver->find_element_by_id('flash-messages');
+    like $flash_messages->get_text, qr/create.*example test.*pre-filled/i, 'note about example present';
+    $driver->find_element('#flash-messages button')->click;    # dismiss
+    my %expected_values = (
+        'create-tests-distri' => 'example',
+        'create-tests-version' => '0',
+        'create-tests-flavor' => 'DVD',
+        'create-tests-arch' => 'x86_64',
+        'create-tests-build' => 'openqa',
+        'create-tests-test' => 'simple_boot',
+        'create-tests-casedir' => 'https://github.com/os-autoinst/os-autoinst-distri-example.git',
+        'create-tests-needlesdir' => '',
+    );
+    is element_prop($_), $expected_values{$_}, "$_ is pre-filled" for keys %expected_values;
+};
+
+subtest 'form can be submitted' => sub {
+    $driver->find_element('#create-tests-settings-container textarea')->send_keys("_PRIORITY=42\nISO=foo.iso");
+    $driver->find_element('#create-tests-form button[type="submit"]')->click;
+    wait_for_ajax msg => 'test creation';
+    my $flash_messages = $driver->find_element_by_id('flash-messages');
+    like $flash_messages->get_text, qr/scheduled.*product log/i, 'note about success';
+};
+
+subtest 'settings shown in product log' => sub {
+    $driver->find_element_by_link_text('product log')->click;
+    $driver->title_is('openQA: Scheduled products log', 'on product log details page');
+
+    my $settings = $driver->find_element('.settings-table')->get_text;
+    like $settings, qr/ARCH x86_64/, 'ARCH present';
+    like $settings, qr/BUILD openqa/, 'BUILD present';
+    like $settings, qr/CASEDIR http.*\.git/, 'CASEDIR present';
+    like $settings, qr/DISTRI example/, 'DISTRI present';
+    like $settings, qr/FLAVOR DVD/, 'FLAVOR present';
+    like $settings, qr/SCENARIO_DEFINITIONS_YAML ---.*products:.*job_templates:/s, 'SCENARIO_DEFINITIONS_YAML present';
+    like $settings, qr/TEST simple_boot/, 'TEST present';
+    like $settings, qr/VERSION 0/, 'VERSION present';
+    like $settings, qr/_PRIORITY 42/, '_PRIORITY present';
+    like $settings, qr/ISO foo.iso/, 'ISO present';
+};
+
+subtest 'preset not found' => sub {
+    $driver->get("$url/tests/create?preset=foo");
+    my $flash_messages = $driver->find_element_by_id('flash-messages');
+    like $flash_messages->get_text, qr/'foo' does not exist/i, 'error if preset does not exist';
+};
+
+subtest 'preset information can be loaded from INI file, error about non-existing scenario definitions' => sub {
+    $driver->get("$url/tests/create?preset=bar");
+    my $flash_messages = $driver->find_element_by_id('flash-messages')->get_text;
+    unlike $flash_messages, qr/does not exist/i, 'preset defined in INI file is available';
+    like $flash_messages,
+      qr|can't open.*tests/does-not-exist/scenario-definitions\.yaml|i,
+      'error about missing scneario definitions, senario definitions looked up under expected location';
+};
+
+kill_driver;
+done_testing;

--- a/t/ui/29-create_tests.t
+++ b/t/ui/29-create_tests.t
@@ -71,13 +71,18 @@ subtest 'preset not found' => sub {
     like $flash_messages->get_text, qr/'foo' does not exist/i, 'error if preset does not exist';
 };
 
-subtest 'preset information can be loaded from INI file, error about non-existing scenario definitions' => sub {
+subtest 'preset information can be loaded from INI file, note about non-existing scenario definitions' => sub {
     $driver->get("$url/tests/create?preset=bar");
     my $flash_messages = $driver->find_element_by_id('flash-messages')->get_text;
     unlike $flash_messages, qr/does not exist/i, 'preset defined in INI file is available';
+
     like $flash_messages,
-      qr|can't open.*tests/does-not-exist/scenario-definitions\.yaml|i,
-      'error about missing scneario definitions, senario definitions looked up under expected location';
+      qr|You first need to clone the does-not-exist test distribution|i,
+      'note about cloning test distribution shown';
+
+    $driver->find_element_by_link_text('clone the does-not-exist test distribution')->click;
+    my $error_message = wait_for_element selector => '#flash-messages .alert-danger', description => 'error message';
+    like $error_message->get_text, qr/No Minion worker available/i, 'expected error shown';
 };
 
 kill_driver;

--- a/templates/webapi/layouts/flash_messages.html.ep
+++ b/templates/webapi/layouts/flash_messages.html.ep
@@ -1,4 +1,4 @@
-% if (my $msg = flash('info')) {
+% if (my $msg = flash('info') || stash('flash_info')) {
     <div class="alert alert-primary alert-dismissible fade show" role="alert">
         <span><%= $msg %></span>
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -1,3 +1,4 @@
+% my $current_user = current_user;
 <nav class="navbar navbar-expand-lg navbar-light">
   <div class="container-fluid">
      <a class="navbar-brand" href="/"><img src="<%= icon_url 'logo.svg'%>" alt="openQA"></a>
@@ -9,7 +10,17 @@
          <li class='nav-item' id="all_tests">
             %= link_to 'All Tests' => url_for('tests') => class => 'nav-link', title => 'Lists all tests grouped by state'
          </li>
-
+          % if ($current_user && $current_user->is_operator) {
+          <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button"
+                 id="create-tests-action" title="Creates one or multiple tests"
+                 aria-haspopup="true" aria-expanded="false">Create …</a>
+              <div class="dropdown-menu">
+                %= link_to 'Example test' => url_for('tests_create')->query({preset => 'example'}) => class => 'dropdown-item'
+                %= link_to 'Tests from scenario definitions' => url_for('tests_create') => class => 'dropdown-item'
+              </div>
+         </li>
+          % }
          <li class="nav-item dropdown" id="job_groups">
             <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button"
                aria-haspopup="true" aria-expanded="false" data-submenu
@@ -42,11 +53,11 @@
                     <input type="search" name="q" id="global-search" class="form-control navbar-input" value="<%= $self->param('q') %>" placeholder="Type to search" aria-label="Global search input">
                 </form>
             </li>
-        % if (current_user) {
+        % if ($current_user) {
             <li class="nav-item dropdown" id="user-action">
                 <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button"
                    aria-haspopup="true" aria-expanded="false"
-                   title="Contains the Activity View and various configuration pages">Logged in as <%= current_user->name %></a>
+                   title="Contains the Activity View and various configuration pages">Logged in as <%= $current_user->name %></a>
                 <div class="dropdown-menu">
                   %= tag 'h3' => class => 'dropdown-header' => 'Operators Menu'
                   %= link_to 'Activity View' => url_for('activity_view') => class => 'dropdown-item' => id => 'activity_view', title => 'Gives you an overview of your current jobs'

--- a/templates/webapi/test/create.html.ep
+++ b/templates/webapi/test/create.html.ep
@@ -11,7 +11,7 @@
 
 <h2><%= title %></h2>
 
-<div id="flash-messages">
+<div id="flash-messages" data-clone-url="<%= url_for('tests_clone')->query(preset => param('preset')) %>">
     %= include 'layouts/flash_messages';
 </div>
 

--- a/templates/webapi/test/create.html.ep
+++ b/templates/webapi/test/create.html.ep
@@ -1,0 +1,78 @@
+% layout 'bootstrap';
+% title $preset->{title} // 'Create tests';
+% content_for 'head' => begin
+  %= asset 'ace.js'
+  %= asset 'ace.css'
+  %= asset 'create_tests.js'
+% end
+% content_for 'ready_function' => begin
+  setupCreateTestsForm();
+% end
+
+<h2><%= title %></h2>
+
+<div id="flash-messages">
+    %= include 'layouts/flash_messages';
+</div>
+
+<form id="create-tests-form" class="row g-3" method="post" onsubmit="createTests(this)" onreset="resetCreateTestsForm(this)" data-post-url="<%= url_for('apiv1_create_iso') %>" data-productlog-url="<%= url_for('admin_product_log') %>">
+    <div class="col-md-6">
+      <label for="create-tests-distri" class="form-label"><strong>Distribution (<code>DISTRI</code>)</strong></label>
+      <%= help_popover('Distribution' => '<p>Creates only tests for the specified distribution. This is a mandatory parameter.</p>', undef, undef, 'left') %>
+      <input type="text" class="form-control" id="create-tests-distri" value="<%= $preset->{distri} // '' %>" name="DISTRI">
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-version" class="form-label"><strong>Version (<code>VERSION</code>)</strong></label>
+      <%= help_popover('Version' => '<p>Creates only tests with the specified version. This is a mandatory parameter.</p>', undef, undef, 'left') %>
+      <input type="text" class="form-control" id="create-tests-version" value="<%= $preset->{version} // '' %>" name="VERSION">
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-flavor" class="form-label"><strong>Flavor (<code>FLAVOR</code>)</strong></label>
+      <%= help_popover('Flavor' => '<p>Creates only tests with the specified flavor (e.g. "DVD" or "NET"). This is a mandatory parameter.</p>', undef, undef, 'left') %>
+      <input type="text" class="form-control" id="create-tests-flavor" value="<%= $preset->{flavor} // '' %>" name="FLAVOR">
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-arch" class="form-label"><strong>Architecture (<code>ARCH</code>)</strong></label>
+      <%= help_popover('Architecture' => '<p>Creates only tests with the specified architecture. This is a mandatory parameter.</p>', undef, undef, 'left') %>
+      <input type="text" class="form-control" id="create-tests-arch" value="<%= $preset->{arch} // '' %>" name="ARCH">
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-build" class="form-label"><strong>Build (<code>BUILD</code>)</strong></label>
+      <%= help_popover('Build' => '<p>Sets the <code>BUILD</code> setting of all created tests.</p>', undef, undef, 'left') %>
+      <input type="text" class="form-control" id="create-tests-build" value="<%= $preset->{build} // '' %>" name="BUILD">
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-test" class="form-label"><strong>Test names (comman-separated, <code>TEST</code>)</strong></label>
+      <%= help_popover('Test names' => '<p>This setting allows to creates only a specific set of tests from the scenario definitions by specifying the names of the tests to create specifically.</p>', undef, undef, 'left') %>
+      <input type="text" class="form-control" id="create-tests-test" value="<%= $preset->{test} // '' %>" name="TEST">
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-casedir" class="form-label"><strong>Test repository (<code>CASEDIR</code>)</strong></label>
+      <%= help_popover('Test repository' => '<p>Specifies the URL of the Git repository containing tests. May also be left blank or point to a local directory.</p>',
+        'https://open.qa/docs/#_triggering_tests_based_on_an_any_remote_git_refspec_or_open_github_pull_request', 'the documentation', 'left') %>
+      <input type="text" class="form-control" id="create-tests-casedir" value="<%= $preset->{casedir} // '' %>" name="CASEDIR">
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-needlesdir" class="form-label"><strong>Needles repository (<code>NEEDLES_DIR</code>)</strong></label>
+      <%= help_popover('Test repository' => '<p>Specifies the URL of the Git repository containing needles if those are provided in a separate repository.  The same rules as for the test repository apply.</p>',
+        undef, undef, 'left') %>
+      <input type="text" class="form-control" id="create-tests-needlesdir" value="<%= $preset->{needles_dir} // '' %>" name="NEEDLES_DIR">
+    </div>
+    <div class="col-md-6" id="create-tests-settings-container">
+      <label for="create-tests-settings" class="form-label"><strong>Additional settings</strong></label>
+      <%= help_popover('Test repository' => '<p>Specifies additional settings as <code>KEY=value</code>-pairs that will be assigned to each job. ' .
+        'Some settings also influence the job creation itself, e.g. <code>_OBSOLETE</code>.</p>',
+        'https://open.qa/docs/#_spawning_multiple_jobs_based_on_templates_isos_post', 'the documentation', 'left') %>
+      <textarea type="text" class="form-control key-value-pairs" id="create-tests-settings" rows="15"></textarea>
+    </div>
+    <div class="col-md-6">
+      <label for="create-tests-scenario-definitions" class="form-label"><strong>Scenario definitions</strong></label>
+      <%= help_popover('Scenario definitions' => '<p>A YAML document that defines sets of settings. These settings are then combined to create one or more test jobs.</p>',
+        'https://open.qa/docs/#scenarios_yaml', 'the documentation', 'left') %>
+      <textarea type="text" class="form-control" id="create-tests-scenario-definitions" rows="15"><%= $preset->{scenario_definitions} // '' %></textarea>
+    </div>
+    <div class="col-12">
+      <button type="submit" class="btn btn-primary">Create tests</button>
+      <button type="reset" class="btn btn-light">Reset form</button>
+    </div>
+</form>


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/166658

---

~~Still a draft because I need to add UI tests and move the so far hard-coded data into `openqa.ini`. It already reads scenario definitions and certain parameters directly from the example distribution, though.~~ Of course this only works if there's a checkout of the example distribution. Maybe we should offer the user to create that checkout in case it is missing (which wouldn't be very hard to do; we'd just add a link on the web UI that'll internally spawn a checkout Minion job we recently implemented anyway).

---

This is how the menu, the form and success/error messages look like in one screenshot:

![grafik](https://github.com/user-attachments/assets/06959fd5-8e7d-4be3-9760-143c26ff88d5)