### PR TITLE
Fix inconsistent commenting style in openqa.ini

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -23,26 +23,26 @@
 ## base url [default: $self->req->url->base]
 #base_url = http://FIXME
 
-# days for Strict-Transport-Security, 0 to not add this header
-# http://en.wikipedia.org/wiki/Strict-Transport-Security
-# hsts = 365
+## days for Strict-Transport-Security, 0 to not add this header
+## http://en.wikipedia.org/wiki/Strict-Transport-Security
+#hsts = 365
 
 ## Set to 0 to disable auditing backend
-# audit_enabled = 1
+#audit_enabled = 1
 
 ## Set to 1 to enable profiling
 ## * Needs Mojolicious::Plugin::NYTProf
 ## * Profiling data will be PUBLICLY accessible under /nytprof route.
 ## * The plugin impairs performance and the generated profiling data might quickly
 ##   utilize a lot of disk space. So don't enable this plugin in production.
-# profiling_enabled = 0
+#profiling_enabled = 0
 
 ## Set to 1 to enable monitoring
 ## * Needs Mojolicious::Plugin::Status
 ## * Monitoring will be accessible to operators and admins under /monitoring route.
 ## * The plugin can impair performance significantly with prefork workers enabled.
 ##   So don't enable this plugin in production.
-# monitoring_enabled = 0
+#monitoring_enabled = 0
 
 ## space-separated list of extra plugins to load; plugin must be under
 ## OpenQA::WebAPI::Plugin and correctly-cased module name given here,
@@ -50,19 +50,19 @@
 #plugins = AMQP
 
 ## space-separated list of asset types *not* to show links for in the
-# web UI. Default is 'repo'
+## web UI. Default is 'repo'
 #hide_asset_types = repo iso
 
 ## Recognized referers contains list of hostnames separated by space. When
-# openQA detects (via 'Referer' header) that test job was accessed from
-# this domain, this job is labeled as linked and considered as important
-# recognized_referers = bugzilla.suse.com bugzilla.opensuse.org progress.opensuse.org github.com
+## openQA detects (via 'Referer' header) that test job was accessed from
+## this domain, this job is labeled as linked and considered as important
+#recognized_referers = bugzilla.suse.com bugzilla.opensuse.org progress.opensuse.org github.com
 
 ## A regex in a string of test settings to ignore for "job investigation"
 #job_investigate_ignore = "(JOBTOKEN|NAME)"
 
-# Specify the number of seconds until an unresponsive worker is considered offline
-# and its currently assigned jobs are taken care of by the stale job detection
+## Specify the number of seconds until an unresponsive worker is considered offline
+## and its currently assigned jobs are taken care of by the stale job detection
 #worker_timeout = 1800
 
 ## Timeout for the git command in "job investigation"
@@ -96,38 +96,38 @@
 ## The livehandler daemon is supposed to run under the <web UI port> + 2.
 ## If you want to keep using a reverse proxy while accessing the web UI through a custom port
 ## (e.g. 8080) then just set `service_port_delta = 0`.
-# service_port_delta = 2
+#service_port_delta = 2
 
 ## Allowed time difference in hmac validation in seconds.
 ## Higher values introduce higher risks for replay attacks but make API requests more
 ## resilient in case of a high load on the web UI. Lower values reduce this risk but
 ## can cause jobs to incomplete with "timestamp mismatch" error messages.
-# api_hmac_time_tolerance = 300
+#api_hmac_time_tolerance = 300
 
 #[scm git]
-# name of remote to get updates from before committing changes (e.g. origin, leave out-commented to disable remote update)
+## name of remote to get updates from before committing changes (e.g. origin, leave out-commented to disable remote update)
 #update_remote = origin
-# name of branch to rebase against before committing changes (e.g. origin/master, leave out-commented to disable rebase)
+## name of branch to rebase against before committing changes (e.g. origin/master, leave out-commented to disable rebase)
 #update_branch = origin/master
-# whether to do a hard reset of the local repository before rebasing
+## whether to do a hard reset of the local repository before rebasing
 #do_cleanup = no
-# whether committed changes should be pushed
+## whether committed changes should be pushed
 #do_push = no
-# whether to clone CASEDIR or NEEDLES_DIR on the web UI if that var points to a Git repo
+## whether to clone CASEDIR or NEEDLES_DIR on the web UI if that var points to a Git repo
 #git_auto_clone = yes
 
 ## Authentication method to use for user management
 [auth]
-# method = Fake|OpenID|OAuth2
+#method = Fake|OpenID|OAuth2
 
-# for GitHub, salsa.debian.org and providers listed on https://metacpan.org/pod/Mojolicious::Plugin::OAuth2#Configuration
-# one can use:
+## for GitHub, salsa.debian.org and providers listed on https://metacpan.org/pod/Mojolicious::Plugin::OAuth2#Configuration
+## one can use:
 #[oauth2]
 #provider = github|debian_salsa
 #key = ...
 #secret = ...
 
-# alternatively, one can specify parameters manually without relying on magic a provider name:
+## alternatively, one can specify parameters manually without relying on magic a provider name:
 #[oauth2]
 #provider = custom
 #unique_name = debian_salsa
@@ -141,8 +141,8 @@
 #nickname_from = username
 
 [logging]
-#logging is to stderr (so systemd journal) by default
-#if you use a file, remember the apparmor profile!
+## logging is to stderr (so systemd journal) by default
+## if you use a file, remember the apparmor profile!
 #file = /var/log/openqa
 #level = debug
 #sql_debug = true
@@ -156,13 +156,13 @@
 
 ## Configuration for auditing plugin
 [audit]
-# disable auditing of chatty events by default
+## disable auditing of chatty events by default
 blocklist = job_grab job_done
 
-# Sets the storage duration in days for the different audit event types
+## Sets the storage duration in days for the different audit event types
 [audit/storage_duration]
-# By default cleanup is disabled, see http://open.qa/docs/#_auditing_tracking_openqa_changes
-# The following categories with example values can be uncommented as needed
+## By default cleanup is disabled, see http://open.qa/docs/#_auditing_tracking_openqa_changes
+## The following categories with example values can be uncommented as needed
 #startup = 10
 #jobgroup = 365
 #jobtemplate = 365
@@ -187,14 +187,14 @@ blocklist = job_grab job_done
 #certfile =
 #keyfile =
 
-# Cleanup related configuration (besides limits)
+## Cleanup related configuration (besides limits)
 [cleanup]
-# Specifies whether different cleanup tasks can run in parallel. This option
-# makes particularly sense if assets and results are stored on different storage
-# locations or if your common storage solution is performant enough.
+## Specifies whether different cleanup tasks can run in parallel. This option
+## makes particularly sense if assets and results are stored on different storage
+## locations or if your common storage solution is performant enough.
 concurrent = 0
 
-# Limits for cleanup of jobs in groups with no limits configured explicitly (sizes are in GiB, durations in days, zero denotes infinity)
+## Limits for cleanup of jobs in groups with no limits configured explicitly (sizes are in GiB, durations in days, zero denotes infinity)
 [default_group_limits]
 #asset_size_limit is only used on job group level (parent groups have no default)
 #asset_size_limit = 100
@@ -203,7 +203,7 @@ concurrent = 0
 #result_storage_duration = 365
 #important_result_storage_duration = 0
 
-# Limits for cleanup of jobs outside of groups (sizes are in GiB, durations in days, zero denotes infinity)
+## Limits for cleanup of jobs outside of groups (sizes are in GiB, durations in days, zero denotes infinity)
 [no_group_limits]
 #log_storage_duration = 30
 #important_log_storage_duration = 120
@@ -211,122 +211,122 @@ concurrent = 0
 #important_result_storage_duration = 0
 
 [minion_task_triggers]
-# Specify one or more task names (space-separated), by default these are not enabled.
-# Good candidates would be limit_assets or limit_results_and_logs.
-# This is analoguous to triggering tasks via systemd timers using
-# openqa-enqueue-asset-cleanup or openqa-enqueue-result-cleanup except
-# it's triggered whenever a job is done rather than periodically.
+## Specify one or more task names (space-separated), by default these are not enabled.
+## Good candidates would be limit_assets or limit_results_and_logs.
+## This is analoguous to triggering tasks via systemd timers using
+## openqa-enqueue-asset-cleanup or openqa-enqueue-result-cleanup except
+## it's triggered whenever a job is done rather than periodically.
 #on_job_done = limit_results_and_logs limit_assets
 
 [misc_limits]
 #untracked_assets_storage_duration = 14
-# Performs the cleanup of results/assets only if the free disk space on the relevant partition is below the specified percentage (and aborts early otherwise)
+## Performs the cleanup of results/assets only if the free disk space on the relevant partition is below the specified percentage (and aborts early otherwise)
 #result_cleanup_max_free_percentage = 100
 #asset_cleanup_max_free_percentage = 100
-# Specify the screenshot ID range to query at once from the database (reduce to avoid big queries, increase to lower query overhead)
+## Specify the screenshot ID range to query at once from the database (reduce to avoid big queries, increase to lower query overhead)
 #screenshot_cleanup_batch_size = 200000
-# Specify the number of screenshot ID ranges (with a size as configured by screenshot_cleanup_batch_size) to process in a single Minion
-# job (reduce to avoid Minion jobs from running very long and possibly being interrupted, increase to reduce the number of Minion jobs)
+## Specify the number of screenshot ID ranges (with a size as configured by screenshot_cleanup_batch_size) to process in a single Minion
+## job (reduce to avoid Minion jobs from running very long and possibly being interrupted, increase to reduce the number of Minion jobs)
 #screenshot_cleanup_batches_per_minion_job = 450
-# Extends the job result cleanup to ensure the partition results are stored on does not become too full
-# (still experimental, relies on df)
+## Extends the job result cleanup to ensure the partition results are stored on does not become too full
+## (still experimental, relies on df)
 #results_min_free_disk_space_percentage = 0
-# Duration to keep minion jobs in the database, in seconds
+## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800
-# Default number of templates to include in job_templates api response (to prevent performance issues)
+## Default number of templates to include in job_templates api response (to prevent performance issues)
 #generic_default_limit = 10000
-# Maximum number of templates to include in job_templates api response (to prevent performance issues)
+## Maximum number of templates to include in job_templates api response (to prevent performance issues)
 #generic_max_limit = 100000
-# Maximum number of jobs to include in tests overview page (to prevent performance issues)
+## Maximum number of jobs to include in tests overview page (to prevent performance issues)
 #tests_overview_max_jobs = 2000
-# Default number of jobs to include in table of finished jobs on "All tests" page
+## Default number of jobs to include in table of finished jobs on "All tests" page
 #all_tests_default_finished_jobs = 500
-# Maximum number of jobs to include in table of finished jobs on "All tests" page
+## Maximum number of jobs to include in table of finished jobs on "All tests" page
 #all_tests_max_finished_jobs = 10000
-# Default number of templates to include in job_templates api response (to prevent performance issues)
+## Default number of templates to include in job_templates api response (to prevent performance issues)
 #list_templates_default_limit = 5000
-# Maximum number of templates to include in job_templates api response (to prevent performance issues)
+## Maximum number of templates to include in job_templates api response (to prevent performance issues)
 #list_templates_max_limit = 20000
-# Default number of next jobs to include in jobs request (to prevent performance issues)
+## Default number of next jobs to include in jobs request (to prevent performance issues)
 #next_jobs_default_limit = 500
-# Maximum number of next jobs to include in jobs request (to prevent performance issues)
+## Maximum number of next jobs to include in jobs request (to prevent performance issues)
 #next_jobs_max_limit = 10000
-# Default number of previous jobs to include in jobs request (to prevent performance issues)
+## Default number of previous jobs to include in jobs request (to prevent performance issues)
 #previous_jobs_default_limit = 500
-# Maximum number of previous jobs to include in jobs request (to prevent performance issues)
+## Maximum number of previous jobs to include in jobs request (to prevent performance issues)
 #previous_jobs_max_limit = 10000
-# Maximum number of recent jobs to consider when returning jobs for a settings query (to prevent performance issues)
+## Maximum number of recent jobs to consider when returning jobs for a settings query (to prevent performance issues)
 #job_settings_max_recent_jobs = 20000
-# Default number of assets to include in asset listing request (to prevent performance issues)
+## Default number of assets to include in asset listing request (to prevent performance issues)
 #assets_default_limit = 100000
-# Maximum number of next jobs to include asset listing request (to prevent performance issues)
+## Maximum number of next jobs to include asset listing request (to prevent performance issues)
 #assets_max_limit = 200000
 
 [archiving]
-# Moves logs of jobs which are preserved during the cleanup because they are considered important
-# to "${OPENQA_ARCHIVEDIR:-${OPENQA_BASEDIR:-/var/lib}/openqa/archive}/testresults"
+## Moves logs of jobs which are preserved during the cleanup because they are considered important
+## to "${OPENQA_ARCHIVEDIR:-${OPENQA_BASEDIR:-/var/lib}/openqa/archive}/testresults"
 #archive_preserved_important_jobs = 0
 
 [job_settings_ui]
-# Specify the keys of job settings which reference a file and should therefore be rendered
-# as links to those files within the job settings tab.
-# Directories should be under the `CASEDIR` root path or under the `data` folder of the `CASEDIR`. The `data`
-# folder is used as default but it can be configured to cover needs of any test distribution. To change it, add the
-# `default_data_dir` variable with the name of the directory.
+## Specify the keys of job settings which reference a file and should therefore be rendered
+## as links to those files within the job settings tab.
+## Directories should be under the `CASEDIR` root path or under the `data` folder of the `CASEDIR`. The `data`
+## folder is used as default but it can be configured to cover needs of any test distribution. To change it, add the
+## `default_data_dir` variable with the name of the directory.
 #keys_to_render_as_links=YAML_SCHEDULE,AUTOYAST
 
 [hooks]
-# Specify a custom hook script to be executed when a job *with*
-# `_TRIGGER_JOB_DONE_HOOK=1` is done. The hook can also be enabled for jobs
-# *without* `_TRIGGER_JOB_DONE_HOOK=0` that are done with a certain result (see
-# further settings).
+## Specify a custom hook script to be executed when a job *with*
+## `_TRIGGER_JOB_DONE_HOOK=1` is done. The hook can also be enabled for jobs
+## *without* `_TRIGGER_JOB_DONE_HOOK=0` that are done with a certain result (see
+## further settings).
 #job_done_hook = my-openqa-hook
 
-# Specify that `job_done_hook` should be executed when a job is done with the a
-# certain result (unless the job setting `_TRIGGER_JOB_DONE_HOOK=0` is present).
-# Note that `failed` in the following example can be replaced with any job
-# result.
+## Specify that `job_done_hook` should be executed when a job is done with the a
+## certain result (unless the job setting `_TRIGGER_JOB_DONE_HOOK=0` is present).
+## Note that `failed` in the following example can be replaced with any job
+## result.
 #job_done_hook_enable_failed = 1
 
-# Specify a custom hook script in the format `job_done_hook_$result` to be
-# called when a job is done with the a certain result (unless the job setting
-# `_TRIGGER_JOB_DONE_HOOK=0` is present) . Any executable specified in the
-# variable as absolute path or executable name in `$PATH` is called with the job
-# ID as first and only parameter corresponding to the `$result`, for example:
+## Specify a custom hook script in the format `job_done_hook_$result` to be
+## called when a job is done with the a certain result (unless the job setting
+## `_TRIGGER_JOB_DONE_HOOK=0` is present) . Any executable specified in the
+## variable as absolute path or executable name in `$PATH` is called with the job
+## ID as first and only parameter corresponding to the `$result`, for example:
 #job_done_hook_failed = my-openqa-hook-failed
 
-# Configuration for InfluxDB routes
+## Configuration for InfluxDB routes
 [influxdb]
-# Specify Minion task names which should never be counted towards the total of number failed Minion jobs.
+## Specify Minion task names which should never be counted towards the total of number failed Minion jobs.
 #ignored_failed_minion_jobs = influxdb-minion-fail-job-task-name
 
-# Configuration for scheduler
+## Configuration for scheduler
 [scheduler]
-# Specify how many days a job can stay in 'SCHEDULED' state, defaults to 7 days
-# max_job_scheduled_time = 7
-# Specify how many jobs in total can run per webui instance. Defaults to -1 (no limit)
-# max_running_jobs = -1
+## Specify how many days a job can stay in 'SCHEDULED' state, defaults to 7 days
+#max_job_scheduled_time = 7
+## Specify how many jobs in total can run per webui instance. Defaults to -1 (no limit)
+#max_running_jobs = -1
 
-# Configuration of the label/bugref carry-over
+## Configuration of the label/bugref carry-over
 [carry_over]
-# The carry over goes though the list of previous jobs to search for comments to carry over.
-# Specify at with depth this search will be aborted:
-# lookup_depth = 10
-# Specify at how many state changes the search will be aborted (state = combination of failed/softfailed/skipped modules):
-# state_changes_limit = 3
+## The carry over goes though the list of previous jobs to search for comments to carry over.
+## Specify at with depth this search will be aborted:
+#lookup_depth = 10
+## Specify at how many state changes the search will be aborted (state = combination of failed/softfailed/skipped modules):
+#state_changes_limit = 3
 
-# Configuration for the OBS rsync plugin
+## Configuration for the OBS rsync plugin
 [obs_rsync]
-# project_status_url = %obs_instance%/build/%%PROJECT/_result;
-# concurrency = 2
-# queue_limit = 200
-# retry_interval = 60
-# retry_max_count = 2
-# home =
-# username = openqa-user
-# ssh_key_file = ~/.ssh/id_rsa
+#project_status_url = %obs_instance%/build/%%PROJECT/_result;
+#concurrency = 2
+#queue_limit = 200
+#retry_interval = 60
+#retry_max_count = 2
+#home =
+#username = openqa-user
+#ssh_key_file = ~/.ssh/id_rsa
 
-# Override form values for creating example test
+## Override form values for creating example test
 #[test_preset example]
 #title = Create example test
 #info = Some info that will show up on the "Create … -> Example test" page


### PR DESCRIPTION
This commit fixes all entries in openqa.ini to follow a consistent style
for the comment with two leading "#" and a space for separation and for
disabled config entries a single "#" with no space for separation.