### PR TITLE
Fix quoting of git ssh arguments

### DIFF
--- a/lib/OpenQA/Git.pm
+++ b/lib/OpenQA/Git.pm
@@ -32,7 +32,7 @@ sub _run_cmd ($self, $args, $options = {}) {
     my $include_git_path = $options->{include_git_path} // 1;
     my $ssh_batchmode = $options->{ssh_batchmode} // 0;
     my @cmd;
-    push @cmd, 'env', 'GIT_SSH_COMMAND="ssh -oBatchMode=yes"' if $ssh_batchmode;
+    push @cmd, 'env', 'GIT_SSH_COMMAND=ssh -oBatchMode=yes' if $ssh_batchmode;
     push @cmd, $self->_prepare_git_command($include_git_path), @$args;
 
     my $result = run_cmd_with_log_return_error(\@cmd);

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -94,18 +94,18 @@ subtest 'git clone' => sub {
         ['get-url'        => 'git -C /branch/ remote get-url origin'],
         ['check dirty'    => 'git -C /branch/ diff-index HEAD --exit-code'],
         ['current branch' => 'git -C /branch/ branch --show-current'],
-        ['fetch branch'   => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /branch/ fetch origin foobranch'],
+        ['fetch branch'   => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git -C /branch/ fetch origin foobranch'],
 
         # /default/
         ['get-url'        => 'git -C /default/ remote get-url origin'],
         ['check dirty'    => 'git -C /default/ diff-index HEAD --exit-code'],
-        ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://localhost/foo.git HEAD'],
+        ['default remote' => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git ls-remote --symref http://localhost/foo.git HEAD'],
         ['current branch' => 'git -C /default/ branch --show-current'],
-        ['fetch default'  => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /default/ fetch origin master'],
+        ['fetch default'  => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git -C /default/ fetch origin master'],
         ['reset'          => 'git -C /default/ reset --hard origin/master'],
 
         # /this_directory_does_not_exist/
-        ['clone' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone http://localhost/bar.git /this_directory_does_not_exist/'],
+        ['clone' => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git clone http://localhost/bar.git /this_directory_does_not_exist/'],
     ];
     #>>> no perltidy
     for my $i (0 .. $#$expected_calls) {
@@ -174,17 +174,17 @@ subtest 'git clone' => sub {
             # /opensuse
             ['get-url'        => 'git -C /opensuse remote get-url origin'],
             ['check dirty'    => 'git -C /opensuse diff-index HEAD --exit-code'],
-            ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://osado HEAD'],
+            ['default remote' => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git ls-remote --symref http://osado HEAD'],
             ['current branch' => 'git -C /opensuse branch --show-current'],
-            ['fetch default ' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /opensuse fetch origin master'],
+            ['fetch default ' => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git -C /opensuse fetch origin master'],
             ['reset'          => 'git -C /opensuse reset --hard origin/master'],
 
             # /opensuse/needles
             ['get-url'        => 'git -C /opensuse/needles remote get-url origin'],
             ['check dirty'    => 'git -C /opensuse/needles diff-index HEAD --exit-code'],
-            ['default remote' => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git ls-remote --symref http://osado HEAD'],
+            ['default remote' => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git ls-remote --symref http://osado HEAD'],
             ['current branch' => 'git -C /opensuse/needles branch --show-current'],
-            ['fetch branch'   => 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git -C /opensuse/needles fetch origin master'],
+            ['fetch branch'   => 'env GIT_SSH_COMMAND=ssh -oBatchMode=yes git -C /opensuse/needles fetch origin master'],
             ['reset'          => 'git -C /opensuse/needles reset --hard origin/master'],
         ];
         #>>> no perltidy


### PR DESCRIPTION
    Error detecting remote default branch name for "some git":
        "ssh -oBatchMode=yes": ssh -oBatchMode=yes: command not found

Since we are passing an array ref to IPC::Run::run, we should not add quotes. git is trying to call `"ssh ..."` including the quotes.

Issues:
* https://progress.opensuse.org/issues/164898
* https://progress.opensuse.org/issues/164886

