### PR TITLE
Workaround `scheduler_step` showing up as uncovered

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -97,7 +97,7 @@ sub wait_for_worker {
     note "No worker with ID $id active";    # uncoverable statement
 }
 
-sub scheduler_step { OpenQA::Scheduler::Model::Jobs->singleton->schedule() }
+sub scheduler_step { OpenQA::Scheduler::Model::Jobs->singleton->schedule() }    # uncoverable statement
 
 my $worker_settings = [$api_key, $api_secret, "http://localhost:$mojoport"];
 


### PR DESCRIPTION
This line shows consistently up as uncovered on Codecov and and in the HTML report (downloadable via artifacts). The line is however definitely covered and when executing the tests locally it also appears as such in the HTML report. The test is also definitely not skipped in the CI. To avoid the failing checks on all of our PRs I am marking the line as uncoverable for now.

Related ticket: https://progress.opensuse.org/issues/167272