### PR TITLE
Skip symlinks in enqueue_git_update_all

### DIFF
--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -173,12 +173,12 @@ sub enqueue_git_update_all ($self) {
     my %clones;
     my $testdir = path(sharedir() . '/tests');
     for my $distri ($testdir->list({dir => 1})->each) {
-        next unless -d $distri;    # no symlinks
+        next if -l $distri;    # no symlinks
         next unless -e $distri->child('.git');
         $clones{$distri} = undef;
         if (-e $distri->child('products')) {
             for my $product ($distri->child('products')->list({dir => 1})->each) {
-                next unless -d $product;    # no symlinks
+                next if -l $product;    # no symlinks
                 my $needle = $product->child('needles');
                 next unless -e $needle->child('.git');
                 $clones{$needle} = undef;


### PR DESCRIPTION
I forgot that `-d` is actually true for symlinks.

It resulted in the gru task processing over the same realpaths, trying
to get a guard for the same path multiple times, which failed and ran
int an endless retry.

Issue: https://progress.opensuse.org/issues/164898

I tested it locally with symlinks and could now reproduce the problem. It tries to get a guard for the same directory multiple times and runs into an endless retry.