### PR TITLE
ci: Set postgres container version to 16 to ensure compatibility

### DIFF
--- a/container/webui/docker-compose.yaml
+++ b/container/webui/docker-compose.yaml
@@ -126,7 +126,8 @@ services:
       start_period: 5s
 
   db:
-    image: postgres
+    # Teporary fix version https://progress.opensuse.org/issues/167524
+    image: postgres:16
     restart: always
     environment:
       POSTGRES_PASSWORD: openqa


### PR DESCRIPTION
Apparently this would otherwise pull version 17 right now, while we install postgresql16 in the webui, and the psql 16 client is not compatible with version 17.

Issue: https://progress.opensuse.org/issues/167524