### PR TITLE
Prevent fullstack test from failing early due to 4xx errors

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -212,9 +212,9 @@ sub javascript_console_has_no_warnings_or_errors ($test_name_suffix = '') {
             # WebSocket connection
         next if ($msg =~ qr/Data frame received after close/);    # uncoverable statement
 
-        # ignore when server replied with 400 response; this may be provoked when testing error cases and if it is
+        # ignore when server replied with 4xx response; this may be provoked when testing error cases and if it is
         # not expected tests would fail anyways
-        next if ($msg =~ qr/server responded with a status of 400/);    # uncoverable statement
+        next if ($msg =~ qr/server responded with a status of 4\d\d/);    # uncoverable statement
         push(@errors, $log_entry);    # uncoverable statement
     }
 


### PR DESCRIPTION
There can be 4xx errors present, e.g.:

```
# Unexpected Javascript console errors: [
…
#     level     => "SEVERE",
#     message   => "http://localhost:9526/tests/Unable%20to%20read%20image:%20Can't%20read%20from%20file%20%22/tmp/webui.worker-1.x3mbbKcC/%22:%20Is%20a%20directory%20at%20/home/squamata/project/lib/OpenQA/Shared/Controller/Running.pm%20line%20229. - Failed to load resource: the server responded with a status of 404 (Not Found)",
#     source    => "network",
…
```

This leads to `wait_for_result_panel` returning early causing follow-up failures like `not ok 7 - job 5 passed` when the job was still running and the normal timeout hasn't been exhausted yet, e.g.:

```
# Wait for jQuery successful: wait_for_result_panel: waiting for '(?^u:Result: passed)' (count 25 of 3240)
ok 5 - No unexpected js warnings
not ok 6 - Expected result not found
not ok 7 - job 5 passed
```

The only route that would reply with "Unable to read image: …" is never returning a 404 response explicitly. Probably the return code is made up by Chromium internally after the stream is finished with this error message by the server. Maybe this behavior has changed recently explaining why the test is only unstable now.

Related ticket: https://progress.opensuse.org/issues/167269