### PR TITLE
Improve minion guards for needle tasks

### DIFF
--- a/lib/OpenQA/Task/Needle/Delete.pm
+++ b/lib/OpenQA/Task/Needle/Delete.pm
@@ -6,6 +6,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 
 use OpenQA::Utils;
 use Scalar::Util 'looks_like_number';
+use Time::Seconds 'ONE_HOUR';
 
 sub register {
     my ($self, $app) = @_;
@@ -15,10 +16,6 @@ sub register {
 sub _delete_needles {
     my ($app, $minion_job, $args) = @_;
 
-    # prevent multiple save_needle and delete_needles tasks to run in parallel
-    return $minion_job->finish({error => 'Another save or delete needle job is ongoing. Try again later.'})
-      unless my $guard = $app->minion->guard('limit_needle_task', 7200);
-
     my $schema = $app->schema;
     my $needles = $schema->resultset('Needles');
     my $user = $schema->resultset('Users')->find($args->{user_id});
@@ -26,30 +23,46 @@ sub _delete_needles {
 
     my (@removed_ids, @errors);
 
+    my %to_remove;
     for my $needle_id (@$needle_ids) {
         my $needle = looks_like_number($needle_id) ? $needles->find($needle_id) : undef;
         if (!$needle) {
-            push(
-                @errors,
-                {
-                    id => $needle_id,
-                    message => "Unable to find needle with ID \"$needle_id\"",
-                });
+            push @errors,
+              {
+                id => $needle_id,
+                message => "Unable to find needle with ID \"$needle_id\"",
+              };
             next;
         }
+        push @{$to_remove{$needle->directory->path}}, $needle;
+    }
 
-        if (my $error = $needle->remove($user)) {
-            push(
-                @errors,
-                {
+    for my $dir (sort keys %to_remove) {
+        my $needles = $to_remove{$dir};
+        # prevent multiple git tasks to run in parallel
+        my $guard;
+        unless ($guard = $app->minion->guard("git_clone_${dir}_task", 2 * ONE_HOUR)) {
+            push @errors,
+              {
+                id => $_,
+                message => "Another git task for $dir is ongoing. Try again later.",
+              }
+              for map { $_->id } @$needles;
+            next;
+        }
+        for my $needle (@$needles) {
+            my $needle_id = $needle->id;
+            if (my $error = $needle->remove($user)) {
+                push @errors,
+                  {
                     id => $needle_id,
                     display_name => $needle->filename,
                     message => $error,
-                });
-            next;
+                  };
+                next;
+            }
+            push @removed_ids, $needle_id;
         }
-
-        push(@removed_ids, $needle_id);
     }
 
     return $minion_job->finish(


### PR DESCRIPTION
In OpenQA::Task::Needle::Save, OpenQA::Task::Needle::Delete and
OpenQA::Task::Git::Clone we are now using a guard for the individual directory
`git_clone_${needledir}_task` instead of a global guard limit_needle_task.

Issue: https://progress.opensuse.org/issues/164898