### PR TITLE
Return timestamps with offset to client for needle info

### DIFF
--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -216,4 +216,12 @@ sub to_json ($self) {
     };
 }
 
+my $fmt = '%Y-%m-%dT%H:%M:%S%z';    # with offset
+sub last_seen_time_fmt ($self) {
+    $self->last_seen_time ? $self->last_seen_time->strftime($fmt) : 'never';
+}
+sub last_matched_time_fmt ($self) {
+    $self->last_matched_time ? $self->last_matched_time->strftime($fmt) : 'never';
+}
+
 1;

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -290,8 +290,8 @@ sub register ($self, $app, $config) {
         populate_hash_with_needle_timestamps_and_urls => sub {
             my ($c, $needle, $hash) = @_;
 
-            $hash->{last_seen} = $needle ? $needle->last_seen_time || 'never' : 'unknown';
-            $hash->{last_match} = $needle ? $needle->last_matched_time || 'never' : 'unknown';
+            $hash->{last_seen} = $needle ? $needle->last_seen_time_fmt : 'unknown';
+            $hash->{last_match} = $needle ? $needle->last_matched_time_fmt : 'unknown';
             return $hash unless $needle;
             if (my $last_seen_module_id = $needle->last_seen_module_id) {
                 $hash->{last_seen_link} = $c->url_for(

--- a/t/fixtures/07-needles.pl
+++ b/t/fixtures/07-needles.pl
@@ -13,12 +13,12 @@ use warnings;
         last_seen_module_id => 10,
         # keep the timestamps aligned with 05-job_modules
         # (and don't use UTC as we use it in browser tests)
-        last_seen_time => time2str('%Y-%m-%d %H:%M:%S', time - 100000),
+        last_seen_time => time2str('%Y-%m-%d %H:%M:%S', time - 100000, 'UTC'),
         last_matched_module_id => 9,
-        last_matched_time => time2str('%Y-%m-%d %H:%M:%S', time - 50000),
+        last_matched_time => time2str('%Y-%m-%d %H:%M:%S', time - 50000, 'UTC'),
         file_present => 1,
-        t_created => time2str('%Y-%m-%d %H:%M:%S', time - 200000),
-        t_updated => time2str('%Y-%m-%d %H:%M:%S', time - 200000),
+        t_created => time2str('%Y-%m-%d %H:%M:%S', time - 200000, 'UTC'),
+        t_updated => time2str('%Y-%m-%d %H:%M:%S', time - 200000, 'UTC'),
     }
 
 ]

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -658,8 +658,9 @@ subtest 'test candidate list' => sub {
         qr/Last match.*T.*Last seen.*T.*/s,
         'last match and last seen shown',
     );
-    $driver->find_element_by_id('candidatesMenu')->click();
+    $driver->find_element('#needlediff_selector .show-needle-info')->click();
     wait_until_element_gone('.needle-info-table');
+    $driver->find_element('#candidatesMenu')->click();
 };
 
 # set job 99963 to done via API to tests whether worker is still displayed then

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -2,8 +2,6 @@
 # Copyright 2014-2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-BEGIN { $ENV{TZ} = 'UTC' }    # make sure Selenium uses the same timezone as the server
-
 use Test::Most;
 
 use FindBin;

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -145,12 +145,12 @@ subtest 'dereference symlink when displaying needles info' => sub {
             dir_id => $real_needle_dir_id,
             filename => 'bootloader.json',
             last_seen_module_id => 10,
-            last_seen_time => time2str('%Y-%m-%d %H:%M:%S', time - 100000),
+            last_seen_time => time2str('%Y-%m-%d %H:%M:%S', time - 100000, 'UTC'),
             last_matched_module_id => 9,
-            last_matched_time => time2str('%Y-%m-%d %H:%M:%S', time - 50000),
+            last_matched_time => time2str('%Y-%m-%d %H:%M:%S', time - 50000, 'UTC'),
             file_present => 1,
-            t_created => time2str('%Y-%m-%d %H:%M:%S', time - 200000),
-            t_updated => time2str('%Y-%m-%d %H:%M:%S', time - 200000),
+            t_created => time2str('%Y-%m-%d %H:%M:%S', time - 200000, 'UTC'),
+            t_updated => time2str('%Y-%m-%d %H:%M:%S', time - 200000, 'UTC'),
         });
     push @need_deleted_needles, $real_needle;
 
@@ -168,7 +168,7 @@ subtest 'dereference symlink when displaying needles info' => sub {
     is($last_used_td->get_text(), 'a day ago', 'symlink needle last use is displayed correctly');
     is(
         $last_used_td->child('a')->get_attribute('title'),
-        $real_needle->last_seen_time . 'Z',
+        $real_needle->last_seen_time . '+0000Z',
         'symlink needle last use tooltip is displayed correctly'
     );
     like(


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/167635

Unfortunately this makes `t/ui/18-tests-details.t` fail, because of a UI problem. The popup is bigger and somehow prevents the click to close the candidates menu.
I can't reproduce it in non headless mode, because I don't know which size the window would have.