### PR TITLE
dist: Add required "group(kvm)" for openQA-worker

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -205,6 +205,7 @@ Recommends:     pngquant
 Recommends:     openssh-common
 %if 0%{?suse_version} >= 1330
 Requires(pre):  group(nogroup)
+Requires(pre):  group(kvm)
 %endif
 
 %description worker


### PR DESCRIPTION
openSUSE Factory since about 20240928 seems to need an explicit addition
of the "kvm" group. This commit tries to fix that same as we do with
"nogroup".

Related progress issue: https://progress.opensuse.org/issues/167587