### PR TITLE
Add option to restart jobs upon comment submission

### DIFF
--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -95,3 +95,11 @@
     display: none;
     width: 100%;
 }
+
+.group-comment-icon-stack {
+  font-size: 0.9em;
+}
+
+.group-comment-icon-stack .fa-undo {
+  color: #0c4374;
+}

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -156,7 +156,6 @@ like($driver->find_elements('.failedmodule', 'css')->[1]->get_attribute('href'),
 
 my @descriptions = $driver->find_elements('td.name a', 'css');
 is(scalar @descriptions, 2, 'only test suites with description content are shown as links');
-disable_bootstrap_animations;
 $descriptions[0]->click();
 is($driver->find_element('.popover-header')->get_text, 'kde', 'description popover shows content');
 
@@ -546,7 +545,7 @@ subtest 'filter by result and state' => sub {
 subtest "job template names displayed on 'Test result overview' page" => sub {
     $driver->get('/group_overview/1002');
     is($driver->find_element('.progress-bar-unfinished')->get_text(),
-        '1 unfinished', 'The number of unfinished jobs is right');
+        '1 unfinished', 'expected number of unfinished jobs');
 
     $driver->get('/tests/overview?distri=opensuse&version=13.1&build=0091&groupid=1002');
     my @tds = $driver->find_elements('#results_DVD tbody tr .name');
@@ -554,7 +553,6 @@ subtest "job template names displayed on 'Test result overview' page" => sub {
 
     my @descriptions = $driver->find_elements('td.name a', 'css');
     is(scalar @descriptions, 2, 'only test suites with description content are shown as links');
-    disable_bootstrap_animations;
     $descriptions[0]->click();
     is(wait_for_element(selector => '.popover-header')->get_text, 'kde_variant', 'description popover shows content');
 };
@@ -565,7 +563,6 @@ subtest 'add comments' => sub {
 
     $driver->find_element_by_link_text('Login')->click;
     $driver->get('/tests/overview?state=done&result=failed');
-    disable_bootstrap_animations;
     $driver->find_element('button[title="Restart or comment jobs"]')->click;
     my $comment_text = 'comment via add-comments';
     my $submit_button = $driver->find_element('#add-comments-controls button[id="commentJobsBtn"]');
@@ -584,17 +581,18 @@ subtest 'add comments' => sub {
 
     subtest 'restart jobs with comment' => sub {
         $driver->get('/tests/overview?state=done&result=failed');
-        disable_bootstrap_animations;
         $driver->find_element('button[title="Restart or comment jobs"]')->click;
         my $comment_text = 'comment current jobs and restart';
-        my $submit_button = $driver->find_element('#add-comments-controls button[id="restartAndCommentJobsBtn"]');
+        my $submit_button = $driver->find_element('#restartAndCommentJobsBtn');
         $driver->find_element_by_id('text')->send_keys($comment_text);
         is $submit_button->get_text, 'Restart and comment on 2 jobs', 'submit button displayed with number of jobs';
         $submit_button->click;
         wait_for_ajax msg => 'comments created';
-        like $driver->find_element_by_id('flash-messages')->get_text, qr/Reload the page to show restarted jobs/,
+        like $driver->find_element_by_id('flash-messages')->get_text, qr/Reload the page to show changes/,
           'info about successful restart shown';
         my @failed_job_ids = map { $_->id } $jobs->search({result => FAILED})->all;
+        is $comments->search({job_id => {-in => \@failed_job_ids}, text => $comment_text})->count, 2,
+          'comments created on all relevant jobs';
         is $comments->search({job_id => {-not_in => \@failed_job_ids}, text => $comment_text})->count, 0,
           'comments not created on other jobs';
         my $running_job_ids = map { $_->id } $jobs->search({state => RUNNING})->all;

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -543,33 +543,8 @@ subtest 'filter by result and state' => sub {
     ok !$driver->find_element_by_id('filter-failed')->is_selected, 'other checkbox not checked';
 };
 
-subtest 'add comments' => sub {
-    my @buttons = $driver->find_elements('button[title="Add comments"]');
-    is @buttons, 0, 'button for adding comments not present if not logged-in';
-
-    $driver->find_element_by_link_text('Login')->click;
-    $driver->get('/tests/overview?state=done&result=failed');
-    disable_bootstrap_animations;
-    $driver->find_element('button[title="Add comments"]')->click;
-    my $comment_text = 'comment via add-comments';
-    my $submit_button = $driver->find_element('#add-comments-controls button[type="submit"]');
-    $driver->find_element_by_id('text')->send_keys($comment_text);
-    is $submit_button->get_text, 'Submit comment on all 2 jobs', 'submit button displayed with number of jobs';
-    $submit_button->click;
-    wait_for_ajax msg => 'comments created';
-    like $driver->find_element_by_id('flash-messages')->get_text, qr/The comments have been created. Reload/,
-      'info about success shown';
-
-    my @failed_job_ids = map { $_->id } $jobs->search({result => FAILED})->all;
-    is $comments->search({job_id => {-in => \@failed_job_ids}, text => $comment_text})->count, 2,
-      'comments created on all relevant jobs';
-    is $comments->search({job_id => {-not_in => \@failed_job_ids}, text => $comment_text})->count, 0,
-      'comments not created on other jobs';
-};
-
 subtest "job template names displayed on 'Test result overview' page" => sub {
     $driver->get('/group_overview/1002');
-    is($driver->find_element('.progress-bar-failed')->get_text(), '1 failed', 'The number of failed jobs is right');
     is($driver->find_element('.progress-bar-unfinished')->get_text(),
         '1 unfinished', 'The number of unfinished jobs is right');
 
@@ -582,6 +557,49 @@ subtest "job template names displayed on 'Test result overview' page" => sub {
     disable_bootstrap_animations;
     $descriptions[0]->click();
     is(wait_for_element(selector => '.popover-header')->get_text, 'kde_variant', 'description popover shows content');
+};
+
+subtest 'add comments' => sub {
+    my @buttons = $driver->find_elements('button[title="Restart or comment jobs"]');
+    is @buttons, 0, 'button for adding comments not present if not logged-in';
+
+    $driver->find_element_by_link_text('Login')->click;
+    $driver->get('/tests/overview?state=done&result=failed');
+    disable_bootstrap_animations;
+    $driver->find_element('button[title="Restart or comment jobs"]')->click;
+    my $comment_text = 'comment via add-comments';
+    my $submit_button = $driver->find_element('#add-comments-controls button[id="commentJobsBtn"]');
+    $driver->find_element_by_id('text')->send_keys($comment_text);
+    is $submit_button->get_text, 'Comment on all 2 jobs', 'submit button displayed with number of jobs';
+    $submit_button->click;
+    wait_for_ajax msg => 'comments created';
+    like $driver->find_element_by_id('flash-messages')->get_text, qr/The comments have been created. Reload/,
+      'info about success shown';
+
+    my @failed_job_ids = map { $_->id } $jobs->search({result => FAILED})->all;
+    is $comments->search({job_id => {-in => \@failed_job_ids}, text => $comment_text})->count, 2,
+      'comments created on all relevant jobs';
+    is $comments->search({job_id => {-not_in => \@failed_job_ids}, text => $comment_text})->count, 0,
+      'comments not created on other jobs';
+
+    subtest 'restart jobs with comment' => sub {
+        $driver->get('/tests/overview?state=done&result=failed');
+        disable_bootstrap_animations;
+        $driver->find_element('button[title="Restart or comment jobs"]')->click;
+        my $comment_text = 'comment current jobs and restart';
+        my $submit_button = $driver->find_element('#add-comments-controls button[id="restartAndCommentJobsBtn"]');
+        $driver->find_element_by_id('text')->send_keys($comment_text);
+        is $submit_button->get_text, 'Restart and comment on 2 jobs', 'submit button displayed with number of jobs';
+        $submit_button->click;
+        wait_for_ajax msg => 'comments created';
+        like $driver->find_element_by_id('flash-messages')->get_text, qr/Reload the page to show restarted jobs/,
+          'info about successful restart shown';
+        my @failed_job_ids = map { $_->id } $jobs->search({result => FAILED})->all;
+        is $comments->search({job_id => {-not_in => \@failed_job_ids}, text => $comment_text})->count, 0,
+          'comments not created on other jobs';
+        my $running_job_ids = map { $_->id } $jobs->search({state => RUNNING})->all;
+        is $running_job_ids, 2, 'all relevant jobs restarted';
+    };
 };
 
 subtest "job dependencies displayed on 'Test result overview' page" => sub {

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -42,11 +42,10 @@
         <div class="card-body">
             % my $allow_commenting = @$job_ids && current_user;
             % if ($allow_commenting) {
-            <button type="button" class="btn btn-secondary btn-circle btn-sm
-            trigger-edit-button" onclick="showAddCommentsDialog()" title="Restart or comment jobs">
-                <span class="fa-stack" style="font-size: 0.9em" >
+            <button type="button" class="btn btn-secondary btn-circle btn-sm trigger-edit-button" onclick="showAddCommentsDialog()" title="Restart or comment jobs">
+                <span class="fa-stack group-comment-icon-stack">
 		  <i class="fa fa-comment fa-stack-2x text-danger-info" aria-hidden="true"></i>
-		  <i class="fa fa-undo fa-stack-1x" style="color: #0c4374;" aria-hidden="true"></i>
+		  <i class="fa fa-undo fa-stack-1x" aria-hidden="true"></i>
 		</span>
             </button>
             % }
@@ -219,40 +218,39 @@
 
 % if ($allow_commenting) {
 <div class="modal fade" id="add-comments-modal">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <form method="post" onsubmit="restartOrCommentJobs(this); return false;">
-                <div class="modal-header">
-                    <h4 class="modal-title">Add comment on all currently shown jobs</h4>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    %= include 'comments/add_comment_form_groups', group_comment => 0, nosubmit => 1
-                </div>
-                <div class="modal-footer">
-                    <div id="add-comments-progress-indication">
-                        <div class="flex-fill"><i class="fa fa-cog fa-spin fa-fw"></i> Saving…</div>
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                    </div>
-                    <div id="add-comments-controls">
-                      <button type="submit" name="bulkAction" class="btn btn-warning"
-                              value="commentJobs" id="commentJobsBtn"
-                              formaction="<%= url_for('apiv1_post_comments')->query(job_id=>$job_ids) %>"
-                              onclick="form.clickedButton = this;">
-                        <i class="fa fa-comment"></i> Comment on all <%= scalar @$job_ids %> jobs
-                      </button>
-                      <button type="submit" name="bulkAction" class="btn btn-danger"
-                              value="restartAndCommentJobs"
-                              id="restartAndCommentJobsBtn"
-                              formaction="<%= url_for('apiv1_restart_jobs')->query(jobs => $job_ids) %>"
-                              onclick="form.clickedButton = this;">
-                        <i class="fa fa-play-circle-o"></i> Restart and comment on <%= scalar @$job_ids %> jobs
-                      </button>
-                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
-                    </div>
-                </div>
-            </form>
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <form method="post">
+        <div class="modal-header">
+          <h4 class="modal-title">Add comment on all currently shown jobs</h4>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
         </div>
+        <div class="modal-body">
+          %= include 'comments/add_comment_form_groups', group_comment => 0, nosubmit => 1
+        </div>
+        <div class="modal-footer">
+          <div id="add-comments-progress-indication">
+            <div class="flex-fill"><i class="fa fa-cog fa-spin fa-fw"></i> Saving…</div>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          </div>
+          <div id="add-comments-controls">
+            <button type="button" class="btn btn-warning" id="commentJobsBtn"
+                    data-url="<%= url_for('apiv1_post_comments')->query(job_id=>$job_ids) %>"
+                    onclick="addComments(this);">
+              <i class="fa fa-comment"></i> Comment on all <%= scalar @$job_ids %> jobs
+            </button>
+            <button type="button" class="btn btn-danger" id="restartAndCommentJobsBtn"
+                    data-jobs="<%= join(',', @$job_ids) %>"
+                    data-url="<%= url_for('apiv1_restart_jobs')->query(jobs=>$job_ids) %>"
+                    onclick="restartJobsWithComment(this);">
+              <i class="fa fa-play-circle-o"></i> Restart and comment on <%= scalar @$job_ids %> jobs
+            </button>
+            <button type="button" class="btn btn-secondary"
+                    data-bs-dismiss="modal">Discard</button>
+          </div>
+        </div>
+      </form>
     </div>
+  </div>
 </div>
 % }

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -42,8 +42,12 @@
         <div class="card-body">
             % my $allow_commenting = @$job_ids && current_user;
             % if ($allow_commenting) {
-            <button type="button" class="btn btn-secondary btn-circle btn-sm trigger-edit-button" onclick="showAddCommentsDialog()" title="Add comments">
-                <i class="fa fa-comment" aria-hidden="true"></i>
+            <button type="button" class="btn btn-secondary btn-circle btn-sm
+            trigger-edit-button" onclick="showAddCommentsDialog()" title="Restart or comment jobs">
+                <span class="fa-stack" style="font-size: 0.9em" >
+		  <i class="fa fa-comment fa-stack-2x text-danger-info" aria-hidden="true"></i>
+		  <i class="fa fa-undo fa-stack-1x" style="color: #0c4374;" aria-hidden="true"></i>
+		</span>
             </button>
             % }
             % my @badges = qw(success secondary  warning     danger info      primary light   light);
@@ -217,7 +221,7 @@
 <div class="modal fade" id="add-comments-modal">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form action="<%= url_for('apiv1_post_comments')->query(job_id => $job_ids) %>" method="post" onsubmit="addComments(this); return false;">
+            <form method="post" onsubmit="restartOrCommentJobs(this); return false;">
                 <div class="modal-header">
                     <h4 class="modal-title">Add comment on all currently shown jobs</h4>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -231,10 +235,20 @@
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                     </div>
                     <div id="add-comments-controls">
-                        <button type="submit" class="btn btn-danger">
-                            <i class="fa fa-comment"></i> Submit comment on all <%= scalar @$job_ids %> jobs
-                        </button>
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
+                      <button type="submit" name="bulkAction" class="btn btn-warning"
+                              value="commentJobs" id="commentJobsBtn"
+                              formaction="<%= url_for('apiv1_post_comments')->query(job_id=>$job_ids) %>"
+                              onclick="form.clickedButton = this;">
+                        <i class="fa fa-comment"></i> Comment on all <%= scalar @$job_ids %> jobs
+                      </button>
+                      <button type="submit" name="bulkAction" class="btn btn-danger"
+                              value="restartAndCommentJobs"
+                              id="restartAndCommentJobsBtn"
+                              formaction="<%= url_for('apiv1_restart_jobs')->query(jobs => $job_ids) %>"
+                              onclick="form.clickedButton = this;">
+                        <i class="fa fa-play-circle-o"></i> Restart and comment on <%= scalar @$job_ids %> jobs
+                      </button>
+                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
Refactor restartJob in order to make sure that is able to handle request for
multiple restarts. This follows up with some changes to the form and the
javascript part of the overview.html.ep, which triggers the restart with the
use of restartJob, as opposed of reimplement the logic.
The advantage is that we have one common behavior and error handling on the
restart operation.
    
- An optional comment can be passed not to restartJob, which is included to
the request.
- restartJob handles both single and multible job restarts.
- The form is designed to handle each occasion in separate functions making
the code becomes more modular and easier to maintain.
- The overvies's restartJobs function will restart only jobs with valid id.- Renamed `addComments` to `bulkJobsAction` to handle both commenting and restarting jobs.

- Updated HTML to include "Restart and Comment" and "Comment" buttons with individual data URLs.


These updates enhance the user experience by allowing users to either comment on jobs, or perform restart with a comment simultaneously from the overview page. Comments always add to the original job of the overview page. By integrating this functionality we provide a workflow for users managing multiple jobs on the overview page.

https://progress.opensuse.org/issues/166559