### PR TITLE
Allow for structured variables on the scheduled product page

### DIFF
--- a/assets/javascripts/audit_log.js
+++ b/assets/javascripts/audit_log.js
@@ -191,6 +191,7 @@ function renderScheduledProductSettings(settings) {
     const keyTd = document.createElement('td');
     const valueTd = document.createElement('td');
     keyTd.append(key);
+    valueTd.style.whiteSpace = 'pre-wrap';
     valueTd.append(renderHttpUrlAsLink(value));
     tr.append(keyTd, valueTd);
     tbody.append(tr);

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -577,19 +577,38 @@ function renderComments(row) {
 }
 
 function renderHttpUrlAsLink(value) {
-  const span = document.createElement('span');
-  for (let match; (match = value.match(/https?:\/\/[^\s,]*/)); ) {
-    const url = match[0];
-    const link = document.createElement('a');
-    link.href = url;
-    link.target = 'blank';
-    link.appendChild(document.createTextNode(url));
-    span.appendChild(document.createTextNode(value.substr(0, match.index)));
-    span.appendChild(link);
-    value = value.substr(match.index + url.length);
+  if (!value) {
+    return document.createTextNode('');
   }
-  span.appendChild(document.createTextNode(value));
-  return span;
+  const fragment = document.createDocumentFragment();
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      fragment.appendChild(renderHttpUrlAsLink(item));
+      if (index < value.length - 1) {
+        fragment.appendChild(document.createTextNode(', ')); // seperator between items
+      }
+    });
+    return fragment;
+  }
+  if (typeof value !== 'string') {
+    value = String(value);
+  }
+  const urlRegex = /https?:\/\/[^\s,]*/g;
+  let lastIndex = 0;
+  let match;
+  while ((match = urlRegex.exec(value)) !== null) {
+    if (match.index > lastIndex) {
+      fragment.appendChild(document.createTextNode(value.substring(lastIndex, match.index)));
+    }
+    const a = document.createElement('a');
+    a.href = a.textContent = match[0];
+    fragment.appendChild(a);
+    lastIndex = urlRegex.lastIndex;
+  }
+  if (lastIndex < value.length) {
+    fragment.appendChild(document.createTextNode(value.substring(lastIndex)));
+  }
+  return fragment.hasChildNodes() ? fragment : document.createTextNode(value);
 }
 
 function getXhrError(jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
This PR fixes the scheduled product page loading issues, which occur when job settings contain arrays, mentioned in https://progress.opensuse.org/issues/166154

example:
![Screenshot from 2024-10-09 17-14-31](https://github.com/user-attachments/assets/e9939dae-8d83-448c-bc5e-6e6a5956c53c)
