### PR TITLE
cli: List 'arch' and 'machine' as supported in API help

### DIFF
--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -99,7 +99,7 @@ use constant VIDEO_FILE_NAME_REGEX => qr/^.*\/video\.[^\/]*$/;
 use constant FRAGMENT_REGEX => qr'(#([-?/:@.~!$&\'()*+,;=\w]|%[0-9a-fA-F]{2})*)*';
 
 use constant JOBS_OVERVIEW_SEARCH_CRITERIA =>
-  (qw(distri version flavor build test modules modules_result module_re group groupid id));
+  (qw(distri version flavor arch build test machine modules modules_result module_re group groupid id));
 
 our @EXPORT_OK = qw(
   WEBSOCKET_API_VERSION DEFAULT_WORKER_TIMEOUT


### PR DESCRIPTION
Since commit [f19726339710](https://github.com/os-autoinst/openQA/commit/f19726339710e9d9deaf55c0ea2b5a84426f9aad) ("Support parameters `arch` and `machine` in job overview API"), user can filter using those. Add them to the constant shown to the user in `openqa-cli api -h`.

Links:
https://github.com/os-autoinst/openQA/pull/4402
https://progress.opensuse.org/issues/103864
