### PR TITLE
Add munin alert email wrapper

### DIFF
--- a/contrib/munin/utils/munin-mail
+++ b/contrib/munin/utils/munin-mail
@@ -1,0 +1,22 @@
+#!/usr/bin/perl
+# script to be used for sending munin alert emails. This lets us add
+# useful information and links for certain alerts.
+# configuration in munin.conf:
+# contact.o3admins.command /path/to/munin-mail "${var:group} ${var:host} ${var:plugin} ${var:graph_category} '${var:graph_title}'" email-address
+
+use strict;
+use warnings;
+
+my ($subject, $email) = @ARGV;
+my $content = '';
+while (<STDIN>) {
+    $content .= $_;
+}
+if ($subject =~ m/systemd_(units|status)/) {
+    $content .= "\n" . qx{systemctl --failed};
+}
+
+open my $pipe, '|-', 'mail', '-s', $subject, '-r', $email, $email or die "Could not open pipe: $?";
+print $pipe $content or die "Could not print: $!";;
+close $pipe or die "Could not close pipe: $?";
+

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -404,6 +404,7 @@ install -d -m 755 %{buildroot}/%{_prefix}/lib/munin/plugins
 install -m 755 contrib/munin/plugins/minion %{buildroot}/%{_prefix}/lib/munin/plugins/openqa_minion_
 install -d -m 755 %{buildroot}/%{_sysconfdir}/munin/plugin-conf.d
 install -m 644 contrib/munin/config/minion.config %{buildroot}/%{_sysconfdir}/munin/plugin-conf.d/openqa-minion
+install -m 755 contrib/munin/utils/munin-mail %{buildroot}/%{_datadir}/openqa/script/munin-mail
 %endif
 
 cd %{buildroot}
@@ -807,11 +808,13 @@ fi
 %files munin
 %defattr(-,root,root)
 %doc contrib/munin/config/minion.config
+%dir %{_datadir}/openqa/script
 %dir %{_prefix}/lib/munin
 %dir %{_prefix}/lib/munin/plugins
 %dir %{_sysconfdir}/munin
 %dir %{_sysconfdir}/munin/plugin-conf.d
 %{_prefix}/lib/munin/plugins/openqa_minion_
+%{_datadir}/openqa/script/munin-mail
 %config(noreplace) %{_sysconfdir}/munin/plugin-conf.d/openqa-minion
 %endif
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/166739

The only question is to which path this should be deployed as part of the openQA-munin package