### PR TITLE
Fix typo for Test names form field

### DIFF
--- a/templates/webapi/test/create.html.ep
+++ b/templates/webapi/test/create.html.ep
@@ -42,7 +42,7 @@
       <input type="text" class="form-control" id="create-tests-build" value="<%= $preset->{build} // '' %>" name="BUILD">
     </div>
     <div class="col-md-6">
-      <label for="create-tests-test" class="form-label"><strong>Test names (comman-separated, <code>TEST</code>)</strong></label>
+      <label for="create-tests-test" class="form-label"><strong>Test names (comma-separated, <code>TEST</code>)</strong></label>
       <%= help_popover('Test names' => '<p>This setting allows to creates only a specific set of tests from the scenario definitions by specifying the names of the tests to create specifically.</p>', undef, undef, 'left') %>
       <input type="text" class="form-control" id="create-tests-test" value="<%= $preset->{test} // '' %>" name="TEST">
     </div>


### PR DESCRIPTION
- Rectified typing error for Test names form field in new test creation template: templates/webapi/test/create.html.ep
- Changed "comman-separated" to "comma-separated"

Related: https://progress.opensuse.org/issues/167824