### PR TITLE
Print error messages to stderr

### DIFF
--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -131,7 +131,7 @@ sub retry_tx ($self, $client, $tx, $retries = undef, $delay = undef) {
         my $res_code = $new_tx->res->code // 0;
         return $self->handle_result($new_tx, $tx) unless $res_code =~ /^(50[23]|0)$/ && $retries > 0;
         my $waited = time - $start;
-        print encode('UTF-8',
+        print STDERR encode('UTF-8',
 "Request failed, hit error $res_code, retrying up to $retries more times after waiting … (delay: $delay; waited ${waited}s)\n"
         );
         sleep $delay;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -453,20 +453,22 @@ EOF
     is $stdout, "Error: 502\n", 'request body';
 
     ($stdout, $stderr, @result) = capture sub { $api->run('--retries', '1', @params) };
-    like $stdout, qr/failed.*retrying.*Error: 502/s, 'requests are retried on error if requested';
+    like $stdout, qr/Error: 502/s, '(stdout) requests are retried on error if requested';
+    like $stderr, qr/failed.*retrying/s, '(stderr) requests are retried on error if requested';
     is $result[0], 1, 'exited with non-zero return code after all retries are exhausted';
 
     $error_count = 0;
     @params = (@params, 'status2=200');
     ($stdout, $stderr, @result) = capture sub { $api->run('--retries', '1', @params) };
     unlike $stdout, qr/Error: 502/, 'response from failing request suppressed';
-    like $stdout, qr/failed, hit error 502.*retrying.*Error: 200/s, 'request can succeed after failing before';
+    like $stdout, qr/Error: 200/s, '(stdout) request can succeed after failing before';
+    like $stderr, qr/failed, hit error 502.*retrying/s, '(stderr) request can succeed after failing before';
     is $result[0], 0, 'exited with zero return code after success on 2nd attempt';
 
     @params = ('--host', 'http://localhost:123456', '--retries', 1, 'api', 'test');
     ($stdout, $stderr, @result) = capture sub { $api->run(@params) };
     like $stderr, qr/Connection refused/, 'aborts on connection refused';
-    like $stdout, qr/failed.*retrying/, 'requests are retried on error if requested';
+    like $stderr, qr/failed.*retrying/, 'requests are retried on error if requested';
 };
 
 subtest 'Pretty print JSON' => sub {


### PR DESCRIPTION
Otherwise they will end up as content which subsequent processes cannot parse, e.g. if they expect JSON

Issue: https://progress.opensuse.org/issues/167833