### PR TITLE
Fix source view for running tests

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -355,6 +355,7 @@ sub src ($self) {
                 my $vars = decode_json($vars_json);
                 $refspec = $vars->{TEST_GIT_HASH};
             };
+            $refspec ||= 'HEAD';
             my $module_path = '/blob/' . $refspec . '/' . $module->script;
             # github treats '.git' as optional extension which needs to be stripped
             $casedir_url->path($casedir_url->path =~ s/\.git//r . $module_path);

--- a/t/ui/03-source.t
+++ b/t/ui/03-source.t
@@ -40,6 +40,12 @@ subtest 'source view for jobs using VCS based tests' => sub {
         $settings_rs->find({key => 'CASEDIR'})->update({value => $casedir});
         $t->get_ok($src_url)->status_is(302)->header_like('Location' => $expected);
     };
+    subtest 'link to default branch without a refspec' => sub {
+        my $expected = qr@github.com/me/repo/blob/HEAD/tests.*/installer_timezone@;
+        $casedir = 'https://github.com/me/repo.git';
+        $settings_rs->find({key => 'CASEDIR'})->update({value => $casedir});
+        $t->get_ok($src_url)->status_is(302)->header_like('Location' => $expected);
+    };
 
     subtest 'unique git hash is read from vars.json if existant' => sub {
         $vars_file->spew('


### PR DESCRIPTION
During running tests we don't have the vars.json from the worker yet. If we don't have a refspec in the URL, we can link to the default branch by specifying `HEAD` in the url.

Issue: https://progress.opensuse.org/issues/167971