### PR TITLE
Skip all symlinks for git_auto_update service

### DIFF
--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -180,6 +180,7 @@ sub enqueue_git_update_all ($self) {
             for my $product ($distri->child('products')->list({dir => 1})->each) {
                 next if -l $product;    # no symlinks
                 my $needle = $product->child('needles');
+                next if -l $needle;    # no symlinks
                 next unless -e $needle->child('.git');
                 $clones{$needle} = undef;
             }


### PR DESCRIPTION
Products as well as the needle directories themselves can be symlinks.

Issue: https://progress.opensuse.org/issues/164898