### PR TITLE
Make activity view accessible to operators

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -480,12 +480,12 @@ function renderJobStatus(item, id) {
   request.send();
 }
 
-function renderActivityView(ajaxUrl, currentUser) {
+function renderActivityView(ajaxUrl) {
   const spinner = document.getElementById('progress-indication');
   spinner.style.display = 'block';
   const request = new XMLHttpRequest();
   const query = new URLSearchParams();
-  query.append('search[value]', 'user:' + encodeURIComponent(currentUser) + ' event:job_');
+  query.append('search[value]', 'event:job_');
   query.append('order[0][column]', '0'); // t_created
   query.append('order[0][dir]', 'desc');
   request.open('GET', ajaxUrl + '?' + query.toString());

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -245,7 +245,8 @@ sub startup ($self) {
     my $pub_admin_r = $admin->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::Admin');
 
     # operators accessible tables
-    $admin_r->get('/activity_view')->name('activity_view')->to('activity_view#user');
+    $pub_admin_r->get('/activity_view')->name('activity_view')->to('activity_view#user');
+    $pub_admin_r->get('/activity_view/ajax')->name('activity_view_ajax')->to('audit_log#ajax_current_user');
     $pub_admin_r->get('/products')->name('admin_products')->to('product#index');
     $pub_admin_r->get('/machines')->name('admin_machines')->to('machine#index');
     $pub_admin_r->get('/test_suites')->name('admin_test_suites')->to('test_suite#index');

--- a/t/ui/06-operator_links.t
+++ b/t/ui/06-operator_links.t
@@ -50,14 +50,17 @@ $driver->refresh;
 $driver->get($driver->get_current_url =~ s/users//r);
 
 $driver->find_element('#user-action a')->click();
-note 'we should see test templates, groups, machines';
-for my $item ('Medium types', 'Machines', 'Workers', 'Assets', 'Scheduled products') {
-    ok($driver->find_element_by_link_text($item), "can see $item");
-}
-note 'we should not see users, audit';
-for my $item ('Users', 'Needles', 'Audit log') {
-    ok(!scalar @{$driver->find_elements($item, 'link_text')}, "can not see $item");
-}
+
+subtest 'we see activity view, test templates, groups, machines' => sub {
+    for my $item ('Activity View', 'Medium types', 'Machines', 'Workers', 'Assets', 'Scheduled products') {
+        ok $driver->find_element_by_link_text($item), "can see $item";
+    }
+};
+subtest 'we do not see users, audit' => sub {
+    for my $item ('Users', 'Needles', 'Audit log') {
+        ok !scalar @{$driver->find_elements($item, 'link_text')}, "can not see $item";
+    }
+};
 
 kill_driver();
 done_testing();

--- a/templates/webapi/admin/activity_view/user.html.ep
+++ b/templates/webapi/admin/activity_view/user.html.ep
@@ -2,8 +2,7 @@
 % title 'Personal Activity View';
 
 % content_for ready_function => begin
-  % my $user = $self->current_user;
-  renderActivityView("<%= url_for('audit_ajax') %>", "<%= $user ? $user->nickname : '' %>");
+  renderActivityView("<%= url_for('activity_view_ajax') %>");
 % end
 
 <div>

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -60,7 +60,9 @@
                    title="Contains the Activity View and various configuration pages">Logged in as <%= $current_user->name %></a>
                 <div class="dropdown-menu">
                   %= tag 'h3' => class => 'dropdown-header' => 'Operators Menu'
-                  %= link_to 'Activity View' => url_for('activity_view') => class => 'dropdown-item' => id => 'activity_view', title => 'Gives you an overview of your current jobs'
+                  % if (is_operator) {
+                    %= link_to 'Activity View' => url_for('activity_view') => class => 'dropdown-item' => id => 'activity_view', title => 'Gives you an overview of your current jobs'
+                  % }
                   %= link_to 'Medium types' => url_for('admin_products') => class => 'dropdown-item'
                   %= link_to 'Machines' => url_for('admin_machines') => class => 'dropdown-item'
                   %= link_to 'Test suites' => url_for('admin_test_suites') => class => 'dropdown-item'


### PR DESCRIPTION
* Allow anyone to access the activity view but show the menu item only to
  operators because only those users will have any activity (that the
  activity view supports, so comments don't count)
* Add additional (internal) route to query only audit events for the current
  user to avoid having to expose all audit events to more users
* See https://progress.opensuse.org/issues/167818