### PR TITLE
Avoid incomplete jobs when restarting Minion while syncing tests

### DIFF
--- a/lib/OpenQA/CacheService/Task/Sync.pm
+++ b/lib/OpenQA/CacheService/Task/Sync.pm
@@ -3,6 +3,7 @@
 
 package OpenQA::CacheService::Task::Sync;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
+use OpenQA::Task::SignalGuard;
 
 use Mojo::URL;
 use Time::Seconds;
@@ -14,6 +15,8 @@ use constant RSYNC_RETRY_PERIOD => $ENV{OPENQA_RSYNC_RETRY_PERIOD} // 3;
 sub register ($self, $app, $conf) { $app->minion->add_task(cache_tests => \&_cache_tests) }
 
 sub _cache_tests ($job, $from = undef, $to = undef) {
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
+
     my $app = $job->app;
     my $job_id = $job->id;
     my $lock = $job->info->{notes}{lock};


### PR DESCRIPTION
* Use a signal guard like we already do in the `cache_asset` task (also part of the cache service)
* Tested by sending SIGTERM to a running `cache_tests` tasks; it went temporarily into the "inactive" state and the openQA job could still run after the Minion job was eventually finished
* See https://progress.opensuse.org/issues/167797