### PR TITLE
Avoid inconsistent coverage of drain callback in streaming code

### DIFF
--- a/lib/OpenQA/Shared/Controller/Running.pm
+++ b/lib/OpenQA/Shared/Controller/Running.pm
@@ -251,7 +251,7 @@ sub streaming ($self) {
             # skip if the worker is not present anymore or already working on a different job
             # note: This is of course not entirely race-free. The worker will ignore messages which
             #       are not relevant anymore. This is merely to keep those messages to a minimum.
-            my $worker = OpenQA::Schema->singleton->resultset('Workers')->find($worker_id);
+            my $worker = $self->app->schema->resultset('Workers')->find($worker_id);
             return undef unless $worker;
             return undef unless defined $worker->job_id && $worker->job_id == $job_id;
 

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -4,6 +4,7 @@
 
 BEGIN {
     $ENV{OPENQA_IMAGE_STREAMING_INTERVAL} = 0.0;
+    $ENV{OPENQA_TEXT_STREAMING_INTERVAL} = 0.0;
 }
 
 use Test::Most;
@@ -83,6 +84,7 @@ subtest streaming => sub {
         my $size = -s $t_file;
         ok $size > (10 * 1024), "test file size is greater than 10 * 1024";
         like $controller->tx->res->content->{body_buffer}, qr/data: \["A\\n"\]/, 'body buffer contains "A"';
+        Mojo::IOLoop->one_tick;
     };
 
     subtest image => sub {


### PR DESCRIPTION
* Ensure code section mentioned in https://progress.opensuse.org/issues/167803 is consistently covered
* See further commit messages for other improvements; this PR will generally improve the coverage of streaming-related code