### PR TITLE
Fix rpm build on non-openSUSE distributions that are not SLES

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -103,7 +103,8 @@ BuildRequires:  fdupes
 # for install-opensuse in Makefile
 %if 0%{?is_opensuse}
 BuildRequires:  openSUSE-release
-%else
+%endif
+%if 0%{?sle_version} && !0%{?is_opensuse}
 BuildRequires:  sles-release
 %endif
 BuildRequires:  %{build_requires}


### PR DESCRIPTION
* Allow building against SLFO which is not openSUSE but also does not provide the `sles-release` package; packaging for SLFO will not contain SUSE-specific systemd/timer files for now
* See https://progress.opensuse.org/issues/167245