### PR TITLE
Prevent big empty liveview in early state of running

### DIFF
--- a/templates/webapi/test/live.html.ep
+++ b/templates/webapi/test/live.html.ep
@@ -193,7 +193,7 @@
 </div>
 
 <div id="canholder">
-  <canvas id="livestream" width="1024" height="768" data-url="/liveviewhandler/tests/<%= $testid %>/streaming">
+  <canvas id="livestream" data-url="/liveviewhandler/tests/<%= $testid %>/streaming">
   </canvas>
 </div>
 


### PR DESCRIPTION
- This PR makes the box significantly smaller while its empty, i've tested displaying it without fixed size and it was still displayed correctly

Related issue: https://progress.opensuse.org/issues/134840
