### PR TITLE
Add loading indicator to the test liveview

### DIFF
--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -321,13 +321,16 @@ var last_event;
 function loadCanvas(canvas, dataURL) {
   var context = canvas.getContext('2d');
 
-  // load image from data url
+  // load image from data URL
   var scrn = new Image();
   scrn.onload = function () {
     canvas.width = this.width;
     canvas.height = this.height;
     context.clearRect(0, 0, this.width, this.width);
     context.drawImage(this, 0, 0);
+
+    // hide loading animation after the first image is loaded
+    document.getElementById('liveview-loading').style.display = 'none';
   };
   scrn.src = dataURL;
 }

--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -84,6 +84,7 @@
 }
 
 #canholder {
+    position: relative;
     text-align: center;
     width: 100%;
     margin-top: 10pt;
@@ -93,6 +94,14 @@
         max-width: 100%;
         border: #ddd 1px solid;
     }
+}
+
+#liveview-loading {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10; /* Ensure it's above the canvas */
 }
 
 .needle-info-table {

--- a/templates/webapi/test/live.html.ep
+++ b/templates/webapi/test/live.html.ep
@@ -193,6 +193,13 @@
 </div>
 
 <div id="canholder">
+  <div id="liveview-loading">
+    <div class="d-flex justify-content-center">
+      <i class="fa fa-circle-o-notch fa-spin fa-4x" role="status">
+        <span class="sr-only">Loading…</span>
+      </i>
+    </div>
+  </div>
   <canvas id="livestream" data-url="/liveviewhandler/tests/<%= $testid %>/streaming">
   </canvas>
 </div>


### PR DESCRIPTION
This PR adds a loading animation indicating that the liveview is being loaded. Currently only a empty box is displayed, visible in the webui before liveview content is received by the responsible canvas element.
Test cases are also added to confirm the elements are displayed and hidden as expected.

Related Issue: https://progress.opensuse.org/issues/134840

![loading_animation](https://github.com/user-attachments/assets/b5826a6e-030a-4f54-b7cc-6d0815977281)
