### PR TITLE
Return 0/1 explicitly as the client expects it

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2233,7 +2233,12 @@ sub dependencies ($self, $children_list = undef, $parents_list = undef) {
         push(@{$children{$s->to_string}}, $s->child_job_id);
     }
 
-    return {parents => \%parents, has_parents => $has_parents, parents_ok => $parents_ok, children => \%children};
+    return {
+        parents => \%parents,
+        has_parents => $has_parents,
+        parents_ok => ($parents_ok ? 1 : 0),
+        children => \%children,
+    };
 }
 
 sub result_stats ($self) {


### PR DESCRIPTION
t/ui/10-tests_overview.t was failing under perl 5.40:

    # Subtest: job dependencies displayed on 'Test result overview' page
        ok 1 - job href is shown correctly
        not ok 2 - dependency is shown correctly

        #   Failed test 'dependency is shown correctly'
        #   at t/ui/10-tests_overview.t line 594.
        #          got: '1 parallel parent
        # dependency failed'
        #     expected: '1 parallel parent
        # dependency passed'

In newer perl versions booleans are preserved, and when Mojolicious sends JSON to the client, it will return it as `true`. To support both older and newer versions, we explicitly return 0 or 1.