### PR TITLE
Have filter options only affect finished jobs

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -402,6 +402,10 @@ function renderTestLists() {
 
   // add a handler for the actual filtering
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
+    if (settings.nTable.getAttribute('id') !== 'results') {
+      return true; // Do not filter other tables
+    }
+
     var selectedResults = finishedJobsResultFilter.find('option:selected');
     // don't apply filter if no result is selected
     if (!selectedResults.length) {

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -607,6 +607,19 @@ subtest "job dependencies displayed on 'Test result overview' page" => sub {
       'parent job was highlighted correctly';
 };
 
+subtest 'result filter does not affect scheduled and running jobs' => sub {
+    $driver->get('/tests?resultfilter=Failed');
+
+    my @running_jobs = $driver->find_elements('#running tbody tr');
+    is scalar @running_jobs, 2, 'Running jobs are displayed';
+
+    my @scheduled_jobs = $driver->find_elements('#scheduled tbody tr');
+    is scalar @scheduled_jobs, 4, 'Scheduled jobs are displayed';
+
+    my @finished_jobs = $driver->find_elements('#results tbody tr');
+    is scalar @finished_jobs, 6, 'Finished jobs table is correctly filtered';
+};
+
 kill_driver();
 
 done_testing();


### PR DESCRIPTION
This PR ensures the result filter options only affects the finished jobs table, meaning the scheduled and running jobs tables are no longer affected.

Related Issue: https://progress.opensuse.org/issues/65205

![example_screenshot](https://github.com/user-attachments/assets/c0a77d41-37d9-4d8f-99e8-bc05b50c25d8)
