### PR TITLE
Revert "Enable automatic updates of test code and needles by default"

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -378,9 +378,9 @@ clone a subdirectory under `/var/lib/openqa/tests` for each test distribution
 you need, e.g. `/var/lib/openqa/tests/opensuse` for openSUSE tests.
 
 The repositories will be kept up-to-date if `git_auto_update` is enabled in
-`openqa.ini` (which is the default). The updating is triggered when new tests
-are scheduled. For a periodic update (to avoid getting too far behind) you can
-enable the systemd unit `openqa-enqueue-git-auto-update.timer`.
+`openqa.ini`. The updating is triggered when new tests are scheduled. For a
+periodic update (to avoid getting too far behind) you can enable the systemd
+unit `openqa-enqueue-git-auto-update.timer`.
 
 You can get openSUSE tests and needles from
 https://github.com/os-autoinst/os-autoinst-distri-opensuse[GitHub]. To make it

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -115,8 +115,8 @@
 #do_push = no
 ## whether to clone CASEDIR or NEEDLES_DIR on the web UI if that var points to a Git repo
 #git_auto_clone = yes
-## enable automatic updates of all test code and needles managed via Git
-#git_auto_update = yes
+## enable automatic updates of all test code and needles managed via Git (still experimental, currently still breaks scheduling parallel clusters)
+#git_auto_update = no
 
 ## Authentication method to use for user management
 [auth]

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -68,7 +68,7 @@ sub read_config ($app) {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
-            git_auto_update => 'yes',
+            git_auto_update => 'no',
         },
         scheduler => {
             max_job_scheduled_time => 7,

--- a/t/config.t
+++ b/t/config.t
@@ -66,7 +66,7 @@ subtest 'Test configuration default modes' => sub {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
-            git_auto_update => 'yes',
+            git_auto_update => 'no',
         },
         'scheduler' => {
             max_job_scheduled_time => 7,


### PR DESCRIPTION
This partially reverts commit a4047efc021d385dee08f370c59da2ebb1f467e0 and e932030be54505949dfefb8b838b5b57cbaa48e8 as they likely cause problems with scheduling parallel clusters using the `PARALLEL_ONE_HOST_ONLY=1` setting which is sometimes not taken into account anymore.

This is presumably not caused by the automatic Git updates themselves but by the the handling of related Minion jobs: If an openQA job has pending Minion jobs then the openQA job is not considered at all by the scheduler. This presumably leads to parallel clusters being only partially considered when assigning jobs to workers breaking the `PARALLEL_ONE_HOST_ONLY=1` setting.

Related ticket: https://progress.opensuse.org/issues/168379