### PR TITLE
Extend variable expansion to consider variables from worker config

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -193,19 +193,22 @@ by different means:
 
 
 === Variable expansion
+Any job setting can refer to another variable using this syntax: `%NAME%`. When
+the test job is created, the string will be substituted with the value of the
+specified variable at that time.
 
-Any variable defined in Test Suite, Machine, Product or Job Template table can
-refer to another variable using this syntax: `%NAME%`. When the test job is created,
-the string will be substituted with the value of the specified variable at that time.
+The variable expansion applies to job settings defined in test suites, machines,
+products and job templates. It also applies to job settings specified when
+creating a single set of jobs.
 
-For example this variable defined for Test Suite:
+Consider this example where a variable is defined within a test suite:
 
 [source,sh]
 --------------------------------------------------------------------------------
 PUBLISH_HDD_1 = %DISTRI%-%VERSION%-%ARCH%-%DESKTOP%.qcow2
 --------------------------------------------------------------------------------
 
-may be expanded to this job variable:
+It may expanded to this job setting:
 
 [source,sh]
 --------------------------------------------------------------------------------

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -199,7 +199,7 @@ specified variable at that time.
 
 The variable expansion applies to job settings defined in test suites, machines,
 products and job templates. It also applies to job settings specified when
-creating a single set of jobs.
+creating a single set of jobs and to variables specified in the worker config.
 
 Consider this example where a variable is defined within a test suite:
 
@@ -214,6 +214,12 @@ It may expanded to this job setting:
 --------------------------------------------------------------------------------
 PUBLISH_HDD_1 = opensuse-13.1-i586-kde.qcow2
 --------------------------------------------------------------------------------
+
+NOTE: Variables from the worker config are not considered if such a variable is
+also present in any of the other mentioned places. To give variable values from
+the worker config precedence, use double percentage signs. Expansions by the
+worker will *not* be shown in the "Settings" tab on the web UI. They are only
+present in `vars.json` and `worker-log.txt`.
 
 === Variable precedence
 It is possible to define the same variable in multiple places that would all be

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -216,8 +216,7 @@ PUBLISH_HDD_1 = opensuse-13.1-i586-kde.qcow2
 --------------------------------------------------------------------------------
 
 === Variable precedence
-
-It's possible to define the same variable in multiple places that would all be
+It is possible to define the same variable in multiple places that would all be
 used for a single job - for instance, you may have a variable defined in both
 a test suite and a product that appear in the same job template. The precedence
 order for variables is as follows (from lowest to highest):

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -4,6 +4,7 @@
 package OpenQA::Worker::Engines::isotovideo;
 use Mojo::Base -signatures;
 use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE WORKER_SR_DIED);
+use OpenQA::JobSettings;
 use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle format_settings);
 use OpenQA::Utils
   qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme testcasedir productdir needledir);
@@ -319,6 +320,10 @@ sub engine_workit ($job, $callback) {
         WORKER_ID => $workerid,
         %$job_settings
     );
+
+    # do final variable expansion so placeholders of variables defined in worker config are replaced as well
+    OpenQA::JobSettings::expand_placeholders(\%vars, 0);
+
     log_debug "Job settings:\n" . format_settings(\%vars);
 
     # cache/locate assets, set ASSETDIR

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -353,7 +353,7 @@ subtest 'syncing tests' => sub {
     is $result, 'cache-dir/webuihost/tests', 'returns synced test directory on success' or diag explain $result;
 };
 
-subtest 'symlink testrepo, logging behavior' => sub {
+subtest 'symlink testrepo, logging behavior, variable expansion' => sub {
     my $pool_directory = tempdir('poolXXXX');
     my $worker = OpenQA::Test::FakeWorker->new(pool_directory => $pool_directory);
     my $client = Test::FakeClient->new;
@@ -393,7 +393,8 @@ subtest 'symlink testrepo, logging behavior' => sub {
     };
 
     my @custom_casedir_settings = (
-        CASEDIR => 'https://github.com/foo/os-autoinst-distri-example.git#master',
+        CASEDIR_DOMAIN => 'github.com',
+        CASEDIR => 'https://%CASEDIR_DOMAIN%/foo/os-autoinst-distri-example.git#master',
         NEEDLES_DIR => 'fedora/needles',
         DISTRI => 'fedora',
         JOBTOKEN => 'token99916',


### PR DESCRIPTION
* Allow substituting placeholders that refer to variables that are only
  defined in `workers.ini` for the particular worker slot that picked up
  the job
* Keep placeholders of non-existing keys when doing the variable
  substitution during job creation on the web UI side (instead of removing
  them) so the worker still sees the placeholder and can do a final
  substitution (removing placeholders of non-existing keys, so the overall
  behavior does not change)
* Do *not* propagate settings from the final substitution back to the web
  UI as the job might be restarted and then run on a different worker where
  settings might be different
* Extend relevant documentation
* See https://progress.opensuse.org/issues/169159

---

@foursixnine @okurz  I have not implemented a default value as suggested in https://progress.opensuse.org/issues/169159 to avoid further complexity. This has already turned out to be a little bit more involved than I expected without it. However, let me know if you need it. Since we're talking about OSD here where all workers are Salt-controlled it is not a big deal to simply set the variable on all workers, though. Alternatively one could also set a default within OSADO unless this is also about ISO/HDD assets (because for those the cache service already needed to know the default).