### PR TITLE
Fix enqueueing of Minion jobs breaking `PARALLEL_ONE_HOST_ONLY=1`

### DIFF
--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -4,6 +4,7 @@
 package OpenQA::Schema::Result::Comments;
 use Mojo::Base 'DBIx::Class::Core', -signatures;
 
+use OpenQA::App;
 use OpenQA::Jobs::Constants;
 use OpenQA::Utils qw(find_labels find_flags find_bugref find_bugrefs);
 use OpenQA::Markdown qw(markdown_to_html);

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -693,13 +693,12 @@ sub _create_clones ($self, $jobs, $comments, $comment_text, $comment_user_id, @c
         $res->register_assets_from_settings;
     }
 
-    # calculate blocked_by
-    $clones{$_}->calculate_blocked_by for @original_job_ids;
-
-    # add a reference to the clone within $jobs
-    for my $job (@original_job_ids) {
-        my $clone = $clones{$job};
-        $jobs->{$job}->{clone} = $clone->id if $clone;
+    for my $original_job_id (@original_job_ids) {
+        my $cloned_job = $clones{$original_job_id};
+        # calculate blocked_by
+        $cloned_job->calculate_blocked_by;
+        # add a reference to the clone within $jobs
+        $jobs->{$original_job_id}->{clone} = $cloned_job->id;
     }
 
     # create comments on original jobs

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -250,7 +250,7 @@ sub enqueue_git_update_all ($self) {
 }
 
 sub enqueue_git_clones ($self, $clones, $job_ids) {
-    return unless %$clones;
+    return unless keys %$clones;
     return unless OpenQA::App->singleton->config->{'scm git'}->{git_auto_clone} eq 'yes';
     # $clones is a hashref with paths as keys and git urls as values
     # $job_id is used to create entries in a related table (gru_dependencies)

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -7,6 +7,7 @@ use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use Minion;
 use DBIx::Class::Timestamps 'now';
+use OpenQA::App;
 use OpenQA::Schema;
 use OpenQA::Shared::GruJob;
 use OpenQA::Log qw(log_debug log_info);

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -16,7 +16,6 @@ use Test::MockModule;
 use DateTime;
 use File::Which;
 use IPC::Run qw(start);
-use Mojolicious;
 use Mojo::IOLoop::Server;
 use Mojo::File qw(path tempfile);
 use Time::HiRes 'sleep';
@@ -26,6 +25,7 @@ use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT DB_TIMESTAMP_ACCURACY);
 use OpenQA::Jobs::Constants;
 use OpenQA::Scheduler::Client;
 use OpenQA::Scheduler::Model::Jobs;
+use OpenQA::WebAPI;
 use OpenQA::Worker::WebUIConnection;
 use OpenQA::Utils;
 require OpenQA::Test::Database;
@@ -42,9 +42,6 @@ use OpenQA::Test::TimeLimit '150';
 # treat this test like the fullstack test
 plan skip_all => "set FULLSTACK=1 (be careful)" unless $ENV{FULLSTACK};
 
-setup_mojo_app_with_default_worker_timeout;
-OpenQA::Setup::read_config(OpenQA::App->singleton);
-
 my $load_avg_file = simulate_load('0.93 0.95 3.25 2/2207 1212', '05-scheduler-full');
 
 # setup directories and database
@@ -55,6 +52,7 @@ my $api_key = $api_credentials->key;
 my $api_secret = $api_credentials->secret;
 
 # create web UI and websocket server
+setup_mojo_app_with_default_worker_timeout('OpenQA::WebAPI');
 my $mojoport = service_port 'webui';
 my $ws = create_websocket_server(undef, 0, 1);
 my $webapi = create_webapi($mojoport, sub { });

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -62,6 +62,7 @@ $ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
 
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
 my $cfg = $t->app->config;
+$cfg->{'scm git'}->{git_auto_clone} = 'no';
 $cfg->{'scm git'}->{git_auto_update} = 'no';
 is $cfg->{audit}->{blocklist}, 'job_grab', 'blocklist updated';
 
@@ -1614,7 +1615,7 @@ subtest 'handle FOO_URL' => sub {
 };
 
 subtest 'handle git_clone with CASEDIR' => sub {
-    OpenQA::App->singleton->config->{'scm git'}->{git_auto_clone} = 'yes';
+    $cfg->{'scm git'}->{git_auto_clone} = 'yes';
     $testsuites->create(
         {
             name => 'handle_foo_casedir',
@@ -1645,7 +1646,7 @@ subtest 'handle git_clone with CASEDIR' => sub {
 };
 
 subtest 'handle git_clone without CASEDIR' => sub {
-    OpenQA::App->singleton->config->{'scm git'}->{git_auto_update} = 'yes';
+    $cfg->{'scm git'}->{git_auto_update} = 'yes';
     $testsuites->create(
         {
             name => 'handle_git_clone',

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -25,7 +25,6 @@ use Mojo::Util 'dumper';
 use Mojo::URL;
 use Cwd qw(abs_path getcwd);
 use IPC::Run qw(start);
-use Mojolicious;
 use Mojo::Util qw(b64_decode gzip);
 use Test::Output 'combined_like';
 use Mojo::IOLoop;
@@ -70,9 +69,8 @@ our (@EXPORT, @EXPORT_OK);
 #
 # Potentially this approach can also be used in production code.
 
-sub setup_mojo_app_with_default_worker_timeout {
-    OpenQA::App->set_singleton(
-        Mojolicious->new(config => {global => {worker_timeout => DEFAULT_WORKER_TIMEOUT}}, log => undef));
+sub setup_mojo_app_with_default_worker_timeout ($class = 'Mojolicious') {
+    OpenQA::App->set_singleton($class->new(config => {global => {worker_timeout => DEFAULT_WORKER_TIMEOUT}}, log => undef));
 }
 
 sub cache_minion_worker {


### PR DESCRIPTION
When restarting openQA jobs, additional Minion jobs are enqueued (of
`git_clone` task, this is happening especially often when `git_auto_clone`
is enabled). So far this didn't happen in a transaction. So the scheduler
might see the openQA jobs but not the Minion jobs they are blocked by. This
is problematic because the scheduler might assign jobs too soon to a
worker. This is especially problematic if it does not happen consistently
across a parallel job cluster as it then breaks the
`PARALLEL_ONE_HOST_ONLY=1` feature.

Related ticket: https://progress.opensuse.org/issues/169342