### PR TITLE
Move finished jobs filter subtest to correct file

### DIFF
--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -426,6 +426,19 @@ subtest 'filter-finished' => sub {
     cmp_ok scalar $driver->find_elements('#results tbody tr', 'css'), '>', scalar @jobs, 'all jobs shown again';
 };
 
+subtest 'result filter does not affect scheduled and running jobs' => sub {
+    $driver->get('/tests?resultfilter=Failed');
+
+    my @running_jobs = $driver->find_elements('#running tbody tr');
+    is scalar @running_jobs, 3, 'Running jobs are displayed';
+
+    my @scheduled_jobs = $driver->find_elements('#scheduled tbody tr');
+    is scalar @scheduled_jobs, 3, 'Scheduled jobs are displayed';
+
+    my @finished_jobs = $driver->find_elements('#results tbody tr');
+    is scalar @finished_jobs, 3, 'Finished jobs table is correctly filtered';
+};
+
 subtest 'match parameter' => sub {
     $driver->get('/tests?match=staging_e');
     wait_for_ajax msg => '"All tests" with match parameter';

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -623,19 +623,6 @@ subtest "job dependencies displayed on 'Test result overview' page" => sub {
       'parent job was highlighted correctly';
 };
 
-subtest 'result filter does not affect scheduled and running jobs' => sub {
-    $driver->get('/tests?resultfilter=Failed');
-
-    my @running_jobs = $driver->find_elements('#running tbody tr');
-    is scalar @running_jobs, 2, 'Running jobs are displayed';
-
-    my @scheduled_jobs = $driver->find_elements('#scheduled tbody tr');
-    is scalar @scheduled_jobs, 4, 'Scheduled jobs are displayed';
-
-    my @finished_jobs = $driver->find_elements('#results tbody tr');
-    is scalar @finished_jobs, 6, 'Finished jobs table is correctly filtered';
-};
-
 kill_driver();
 
 done_testing();


### PR DESCRIPTION
This commit moves the subtest `result filter does not affect scheduled and running jobs` to t/ui/01-list.t, which tests the /tests page.