### PR TITLE
Avoid blocking openQA jobs on Git updates

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -117,6 +117,10 @@
 #git_auto_clone = yes
 ## enable automatic updates of all test code and needles managed via Git (still experimental, currently still breaks scheduling parallel clusters)
 #git_auto_update = no
+## specifies how to handle errors on automatic updates via git_auto_update
+## - when set to "best-effort" openQA jobs are started even if the update failed
+## - when set to "strict" openQA jobs will be blocked until the update succeeded or set to incomplete when the retries for updating are exhausted
+#git_auto_update_method = best-effort
 
 ## Authentication method to use for user management
 [auth]

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -53,9 +53,9 @@
 ## web UI. Default is 'repo'
 #hide_asset_types = repo iso
 
-## Recognized referers contains list of hostnames separated by space. When
-## openQA detects (via 'Referer' header) that test job was accessed from
-## this domain, this job is labeled as linked and considered as important
+## space-separated list of domains recognized by job labeling
+## If openQA detects (via 'Referer' header) that a test job was accessed from a
+## domain on that list, this job is labeled as linked and considered as important.
 #recognized_referers = bugzilla.suse.com bugzilla.opensuse.org progress.opensuse.org github.com
 
 ## A regex in a string of test settings to ignore for "job investigation"
@@ -219,7 +219,7 @@ concurrent = 0
 [minion_task_triggers]
 ## Specify one or more task names (space-separated), by default these are not enabled.
 ## Good candidates would be limit_assets or limit_results_and_logs.
-## This is analoguous to triggering tasks via systemd timers using
+## This is analogous to triggering tasks via systemd timers using
 ## openqa-enqueue-asset-cleanup or openqa-enqueue-result-cleanup except
 ## it's triggered whenever a job is done rather than periodically.
 #on_job_done = limit_results_and_logs limit_assets

--- a/lib/OpenQA/Schema/Result/GruTasks.pm
+++ b/lib/OpenQA/Schema/Result/GruTasks.pm
@@ -4,7 +4,7 @@
 package OpenQA::Schema::Result::GruTasks;
 
 
-use Mojo::Base 'DBIx::Class::Core';
+use Mojo::Base 'DBIx::Class::Core', -signatures;
 
 use Mojo::JSON qw(decode_json encode_json);
 use OpenQA::Parser::Result::OpenQA;
@@ -63,8 +63,7 @@ sub encode_json_to_db {
     encode_json($args);
 }
 
-sub fail {
-    my ($self, $reason) = @_;
+sub fail ($self, $reason = undef) {
     $reason //= 'Unknown';
     my $deps = $self->jobs->search;
     my $detail_text = 'Minion-GRU.txt';

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -69,6 +69,7 @@ sub read_config ($app) {
             do_cleanup => 'no',
             git_auto_clone => 'yes',
             git_auto_update => 'no',
+            git_auto_update_method => 'best-effort',
         },
         scheduler => {
             max_job_scheduled_time => 7,

--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -51,7 +51,7 @@ sub _git_clone_all ($job, $clones) {
         eval { _git_clone($app, $job, $ctx, $path, $url) };
         next unless my $error = $@;
 
-        # unblock openQA jobs despite the error under best-effort configuration
+        # unblock openQA jobs despite network errors under best-effort configuration
         my $retries = $job->retries;
         my $git_config = $app->config->{'scm git'};
         my $max_retries = $ENV{OPENQA_GIT_CLONE_RETRIES} // 10;
@@ -59,6 +59,7 @@ sub _git_clone_all ($job, $clones) {
         my $gru_task_id = $job->info->{notes}->{gru_id};
         if (   $is_path_only
             && defined($gru_task_id)
+            && ($error =~ m/disconnect|curl|stream.*closed|/i)
             && $git_config->{git_auto_update_method} eq 'best-effort'
             && $retries >= $max_best_effort_retries)
         {

--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -6,6 +6,7 @@ use Mojo::Base 'Mojolicious::Plugin', -signatures;
 use Mojo::Util 'trim';
 
 use Mojo::File;
+use List::Util qw(min);
 use OpenQA::Log qw(log_debug);
 use Time::Seconds 'ONE_HOUR';
 
@@ -27,8 +28,10 @@ sub _git_clone_all ($job, $clones) {
     my $retry_delay = {delay => 30 + int(rand(10))};
     # Prevent multiple git_clone tasks for the same path to run in parallel
     my @guards;
+    my $is_path_only = 1;
     for my $path (sort keys %$clones) {
         $path = Mojo::File->new($path)->realpath if -e $path;    # resolve symlinks
+        $is_path_only &&= !(defined $clones->{$path});
         my $guard_name = "git_clone_${path}_task";
         my $guard = $app->minion->guard($guard_name, 2 * ONE_HOUR);
         unless ($guard) {
@@ -47,8 +50,22 @@ sub _git_clone_all ($job, $clones) {
         die "Don't even think about putting '..' into '$path'." if $path =~ /\.\./;
         eval { _git_clone($app, $job, $ctx, $path, $url) };
         next unless my $error = $@;
+
+        # unblock openQA jobs despite the error under best-effort configuration
+        my $retries = $job->retries;
+        my $git_config = $app->config->{'scm git'};
         my $max_retries = $ENV{OPENQA_GIT_CLONE_RETRIES} // 10;
-        return $job->retry($retry_delay) if $job->retries < $max_retries;
+        my $max_best_effort_retries = min($max_retries, $ENV{OPENQA_GIT_CLONE_RETRIES_BEST_EFFORT} // 2);
+        my $gru_task_id = $job->info->{notes}->{gru_id};
+        if (   $is_path_only
+            && defined($gru_task_id)
+            && $git_config->{git_auto_update_method} eq 'best-effort'
+            && $retries >= $max_best_effort_retries)
+        {
+            $app->schema->resultset('GruDependencies')->search({gru_task_id => $gru_task_id})->delete;
+        }
+
+        return $job->retry($retry_delay) if $retries < $max_retries;
         return $job->fail($error);
     }
 }

--- a/t/config.t
+++ b/t/config.t
@@ -67,6 +67,7 @@ subtest 'Test configuration default modes' => sub {
             do_cleanup => 'no',
             git_auto_clone => 'yes',
             git_auto_update => 'no',
+            git_auto_update_method => 'best-effort',
         },
         'scheduler' => {
             max_job_scheduled_time => 7,


### PR DESCRIPTION
* Unblock openQA jobs if Git updates failed for two times
    * Change the behavior with `git_auto_update = yes` to be more like it
      was with the `fetchneedles` approach (that also did not block jobs in
      case of failures)
    * Avoid running into timeouts in openQA-in-openQA tests which expect
      jobs to be scheduled in a more timely manner, see
      https://progress.opensuse.org/issues/169204
* Keep blocking openQA jobs if any of the repositories required by the
  scheduled jobs was explicitly specified

---

~~Still a draft as I still need to restrict it to network issues.~~