### PR TITLE
Update RegEx to detect hyphenated test names

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -39,7 +39,7 @@ sub clone_job_apply_settings ($argv, $depth, $settings, $options) {
 
     for my $arg (@$argv) {
         # split arg into key and value
-        unless ($arg =~ /([A-Z0-9_]+)(:(\w+))?(\+)?=(.*)/) {
+        unless ($arg =~ /([A-Z0-9_]+)(:([\w-]+?))?(\+)?=(.*)/) {
             warn "command-line argument '$arg' is no valid setting and will be ignored\n";
             next;
         }


### PR DESCRIPTION
openqa-clone-job was ignoring test names with hyphens in it such as `WORKER_CLASS:ovs-server+=,openqaworker27`.
Modify the regular expression in clone_job_apply_settings function to detect and capture test names with any character