### PR TITLE
Add endpoint for listing all WebAPI routes

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -310,6 +310,8 @@ sub startup ($self) {
     my $api_ro = $api_auth_operator->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     my $api_ra = $api_auth_admin->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     my $api_public_r = $api_public->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+
+    $api_public_r->get('/routes')->name('api_v1_list_routes')->to('routes#list');
     push @api_routes, $api_ru, $api_ro, $api_ra, $api_public_r;
     # this is fallback redirect if one does not use apache
     $api_public_r->websocket(

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Routes.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Routes.pm
@@ -1,0 +1,54 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Controller::API::V1::Routes;
+use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+=pod
+
+=head1 NAME
+
+OpenQA::WebAPI::Controller::API::V1::Routes
+
+=head1 SYNOPSIS
+
+  use OpenQA::WebAPI::Controller::API::V1::Routes;
+
+=head1 DESCRIPTION
+
+
+=head1 METHODS
+
+=over 4
+
+=item list()
+
+Lists all WebAPI routes
+
+=back
+
+=cut
+
+sub list ($self) {
+    my $routes = $self->app->routes->children;
+    my %hash;
+    _walk($_, \%hash, '') for @$routes;
+    my @list;
+    for my $route (sort keys %hash) {
+        my $methods = $hash{$route};
+        push @list, {path => $route, methods => [sort keys %$methods]};
+    }
+    $self->render(json => {routes => \@list});
+}
+
+sub _walk ($route, $hash, $path) {
+    my $pattern = $route->pattern->unparsed || '';
+    my $methods = $route->can('methods') ? $route->methods : $route->via;
+    my $endpoint = "$path$pattern" || '/';
+    $hash->{$endpoint}->{$_} = 1 for @{$methods || []};
+    for my $child (@{$route->children || []}) {
+        _walk($child, $hash, "$path$pattern");
+    }
+}
+
+1;

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -108,6 +108,9 @@ subtest 'Changelog' => sub {
 
 $t->get_ok('/health')->status_is(200)->content_is('ok', 'health check route just returns plain ok');
 
+$t->get_ok('/api/v1/routes')->status_is(200)
+  ->json_is('/routes/1/path', '/admin', 'simple check for listing WebAPI routes');
+
 $t->get_ok('/dashboard_build_results')->status_is(200);
 @h2 = $t->tx->res->dom->find('h2 a')->map('text')->each;
 is_deeply(\@h2, ['opensuse', 'opensuse test'], 'empty parent group not shown');


### PR DESCRIPTION
```
% openqa-cli api routes | jq
{                 
  "routes": [                     
    {             
      "methods": [
        "GET"                                     
      ],                                 
      "path": "/"
    },                                              
...
    {
      "methods": [
        "DELETE",                 
        "GET"     
      ],          
      "path": "/api/v1/assets/<id:num>"           
    },                                   
```
I find it cumbersome to find out routes currently. The webpage 404 page, e.g. https://openqa.opensuse.org/foo , is very long and I lose the overview under which top level route I am.

This could also be useful later for creating dynamic completion, e.g. `openqa-cli api j<TAB>`