### PR TITLE
Make 'Broken' workers show as 'Unavailable' instead

### DIFF
--- a/assets/javascripts/admin_worker.js
+++ b/assets/javascripts/admin_worker.js
@@ -46,7 +46,7 @@ function loadWorkerTable() {
           select.append('<option value="Idle">Idle</option>');
           select.append('<option value="Offline">Offline</option>');
           select.append('<option value="Working">Working</option>');
-          select.append('<option value="Broken">Broken</option>');
+          select.append('<option value="Unavailable">Unavailable</option>');
           select.val('Idle');
         });
       this.api().column(4).search('Idle').draw();

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -767,7 +767,8 @@ sub _check_system_utilization (
     return undef unless $threshold && @$load >= 3;
     # look at the load evolution over time to react quick enough if the load
     # rises but accept a falling edge
-    return "The average load (@$load) is exceeding the configured threshold of $threshold."
+    return
+"The average load (@$load) is exceeding the configured threshold of $threshold. The worker will temporarily not accept new jobs until the load is lower again."
       if max(@$load) > $threshold && ($load->[0] > $load->[1] || $load->[0] > $load->[2] || min(@$load) > $threshold);
     return undef;
 }

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -136,9 +136,9 @@ subtest 'worker overview' => sub {
     $driver->find_element("tr#worker_$broken_worker_id .help_popover")->click();
     is(
         $driver->find_element("tr#worker_$broken_worker_id .status")->get_text(),
-        'Broken', "worker $broken_worker_id is broken",
+        'Unavailable', "worker $broken_worker_id is broken and displayed as unavailable",
     );
-    like($driver->find_element('.popover')->get_text(), qr/Error\nout of order/, 'reason for brokenness shown');
+    like($driver->find_element('.popover')->get_text(), qr/Details\nout of order/, 'reason for brokenness shown');
 };
 
 # test delete offline worker function

--- a/templates/webapi/admin/workers/worker_status.html.ep
+++ b/templates/webapi/admin/workers/worker_status.html.ep
@@ -15,7 +15,7 @@
         )
     %>
 % } elsif ($worker->{status} eq 'broken') {
-    Broken <%= help_popover(Error => $worker->{error}) %>
+    Unavailable <%= help_popover(Details => $worker->{error}) %>
 % } elsif ($worker->{alive}) {
     Idle
 % } else {


### PR DESCRIPTION
This PR displays "Broken" workers as instead "Unavailable", as the previous wording was e.g. not including workers which where unavailable due to 'too high load'.
It also replaces the 'Error' title of the worker states hover popup with 'Details' and enhances the 'too high load' output.

Example:
![Screenshot From 2024-12-02 21-17-21](https://github.com/user-attachments/assets/45f3b8cb-4ef1-4701-be1c-317c1e0d7572)

Related Ticket: https://progress.opensuse.org/issues/164084