### PR TITLE
Add config option to restrict asset downloads to logged-in users

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -125,6 +125,8 @@
 ## Authentication method to use for user management
 [auth]
 #method = Fake|OpenID|OAuth2
+## whether authentication is required to access assets; does NOT affect assets made available directly via e.g. Apache or NGINX
+#require_for_assets = 0
 
 ## for GitHub, salsa.debian.org and providers listed on https://metacpan.org/pod/Mojolicious::Plugin::OAuth2#Configuration
 ## one can use:

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -61,6 +61,7 @@ sub read_config ($app) {
         },
         auth => {
             method => 'OpenID',
+            require_for_assets => 0,
         },
         'scm git' => {
             update_remote => '',

--- a/t/config.t
+++ b/t/config.t
@@ -59,6 +59,7 @@ subtest 'Test configuration default modes' => sub {
         },
         auth => {
             method => 'Fake',
+            require_for_assets => 0,
         },
         'scm git' => {
             update_remote => '',


### PR DESCRIPTION
This PR is now only covering the web app and probably not useful on its own. You can still see how the approach using basic auth/htpasswd would look like on https://github.com/Martchus/openQA/tree/asset-auth-nginx-basic-auth.

---

See https://progress.opensuse.org/issues/170380