### PR TITLE
Add config option to restrict asset downloads to logged-in users

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -125,6 +125,10 @@
 ## Authentication method to use for user management
 [auth]
 #method = Fake|OpenID|OAuth2
+## whether authentication is required to access assets; caveats:
+## - Does NOT affect assets made available outside the scope of the openQA service (e.g. via Apache, NGINX or NFS).
+## - Might not work well with other features like openqa-clone-job and the cache service.
+#require_for_assets = 0
 
 ## for GitHub, salsa.debian.org and providers listed on https://metacpan.org/pod/Mojolicious::Plugin::OAuth2#Configuration
 ## one can use:

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -61,6 +61,7 @@ sub read_config ($app) {
         },
         auth => {
             method => 'OpenID',
+            require_for_assets => 0,
         },
         'scm git' => {
             update_remote => '',

--- a/t/config.t
+++ b/t/config.t
@@ -59,6 +59,7 @@ subtest 'Test configuration default modes' => sub {
         },
         auth => {
             method => 'Fake',
+            require_for_assets => 0,
         },
         'scm git' => {
             update_remote => '',


### PR DESCRIPTION
* Disallow unauthenticated access to assets in web application routes
* Does NOT cover access served via Apache/NGINX
* Does NOT cover adjusting the cache service and additional tooling like the `openqa-clone-job` script
* See https://progress.opensuse.org/issues/170380