### PR TITLE
Prevent SIGCHLD handler override within tests

### DIFF
--- a/lib/OpenQA/Assets.pm
+++ b/lib/OpenQA/Assets.pm
@@ -20,6 +20,7 @@ sub setup ($server) {
     $server->asset->store->retries(5) if $Mojolicious::Plugin::AssetPack::VERSION > 2.13;
 
     # -> read assets/assetpack.def
+    local $SIG{CHLD};
     eval { $server->asset->process };
     if (my $assetpack_error = $@) {    # uncoverable statement
         $assetpack_error    # uncoverable statement


### PR DESCRIPTION
This should prevent _setup_sigchld_handler overriding the handler for IPC::Run3 inside AssetPack. Without this, the sass process is not handled correctly inside the tests and the assets are not correctly compiled by the AssetPack.

Reference: https://progress.opensuse.org/issues/174607