### PR TITLE
Check for existing job groups during openqa-load-templates

### DIFF
--- a/script/openqa-load-templates
+++ b/script/openqa-load-templates
@@ -120,16 +120,29 @@ sub post_entry ($table, $entry) {
     if ($table eq 'JobGroups') {
         # Create the group first
         my $job_groups_url = $url->clone->path($options{apibase} . '/job_groups');
-        my $res = $client->post($job_groups_url, form => {name => $entry->{group_name}})->res;
-        print_error $res unless $res->is_success;
-
+        my $existing_group_res = $client->get($job_groups_url, form => {name => $entry->{group_name}})->res;
+        print_error $existing_group_res unless $existing_group_res->is_success;
+        my $group_exists = 0;
+        for my $group (@{$existing_group_res->json}) {
+            next unless $group->{name} eq $entry->{group_name};
+            $group_exists = 1
+              if $options{update}
+              or die "Job group '$entry->{group_name}' already exists. Use --update to modify existing entries.";
+        }
+        unless ($group_exists) {
+            my $create_res = $client->post($job_groups_url, form => {name => $entry->{group_name}})->res;
+            print_error($create_res) unless $create_res->is_success;
+        }
         # Post the job template YAML
         my $job_templates_url = $url->clone->path($options{apibase} . '/job_templates_scheduling');
-        $res
-          = $client->post($job_templates_url,
-            form => {name => $entry->{group_name}, template => $entry->{template}, schema => 'JobTemplates-01.yaml'})
-          ->res;
-        print_error $res unless $res->is_success;
+        my $yaml_res = $client->post(
+            $job_templates_url,
+            form => {
+                name => $entry->{group_name},
+                template => $entry->{template},
+                schema => 'JobTemplates-01.yaml'
+            })->res;
+        print_error($yaml_res) unless $yaml_res->is_success;
         return 1;
     }
 

--- a/t/40-script_load_dump_templates.t
+++ b/t/40-script_load_dump_templates.t
@@ -60,7 +60,9 @@ my $base_args = "--host $host --apikey $apikey --apisecret $apisecret";
 $args = "$base_args $filename";
 my $expected = qr/JobGroups.+=> \{ added => 1, of => 1 \}/;
 test_once $args, $expected, 'Admin may load templates', 0, 'successfully loaded templates';
-test_once $args, qr/group with existing name/, 'Duplicate job group', 255, 'failed on duplicate job group';
+test_once $args, qr/Use --update to modify/, 'Duplicate job group', 255, 'failed on duplicate job group';
+$args = "$base_args --update $filename";
+test_once $args, $expected, 'Update with existing job group', 0, 'updated template with existing job group';
 
 subtest 'test changing existing entries' => sub {
     # delete job group so that we can load the template again without running into duplicate job group error


### PR DESCRIPTION
The `openqa-load-templates` script now checks if a job groups is already present when importing new template data. If a group already exists, there will be no attempt of creating it, but associated templates will still be loaded if the `--update` option is provided.
If the `--update` option is not provided, and a duplicate job group is found, the import will fail.

Related Issue: https://progress.opensuse.org/issues/174808