### PR TITLE
Add restricting asset downloads via NGINX using subrequest auth

### DIFF
--- a/etc/nginx/vhosts.d/openqa-locations.inc
+++ b/etc/nginx/vhosts.d/openqa-locations.inc
@@ -13,12 +13,31 @@ if_modified_since before;
 ## Optional faster assets downloads for large deployments
 #location /assets {
 #    alias /var/lib/openqa/share/factory/;
+#    # Optional to require authentication for asset downloads
+#    #auth_request /api/v1/auth;
 #    autoindex          on;
 #    tcp_nopush         on;
 #    sendfile           on;
 #    sendfile_max_chunk 1m;
 #}
-#
+
+## Optional to make use of auth_request to require authentication for asset downloads
+#location /api/v1/auth {
+#    internal;
+#    proxy_pass http://webui;
+#    tcp_nodelay        on;
+#    proxy_read_timeout 900;
+#    proxy_send_timeout 900;
+#    proxy_pass_request_body off;
+#    proxy_set_header Content-Length "";
+#    proxy_set_header Host $host;
+#    proxy_set_header X-Original-URI $request_uri;
+#    proxy_set_header X-Forwarded-Host $host:$server_port;
+#    proxy_set_header X-Forwarded-Server $host;
+#    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#    proxy_set_header X-Forwarded-Proto $scheme;
+#}
+
 ## Optional faster image downloads for large deployments
 #location /image {
 #    alias /var/lib/openqa/images/;

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -49,7 +49,7 @@ sub auth ($self) {
     # Browser with a logged in user
     my ($user, $reason) = (undef, 'Not authorized');
     if ($user = $self->current_user) {
-        ($user, $reason) = (undef, 'Bad CSRF token!') unless $self->valid_csrf;
+        ($user, $reason) = (undef, 'Bad CSRF token!') unless $self->req->method eq 'GET' || $self->valid_csrf;
     }
 
     # No session (probably not a browser)

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -330,6 +330,7 @@ sub startup ($self) {
     my $api_r_job = $api_job_auth->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     push @api_routes, $api_job_auth, $api_r_job;
     $api_r_job->get('/whoami')->name('apiv1_jobauth_whoami')->to('job#whoami');    # primarily for tests
+    $api_ru->get('/auth' => sub ($c) { $c->render(text => 'ok') })->name('apiv1_jobauth_whoami');
 
     # api/v1/job_groups
     $api_public_r->get('/job_groups')->name('apiv1_list_job_groups')->to('job_group#list');

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -46,13 +46,11 @@ subtest 'restricted asset downloads with setting `[auth] require_for_assets = 1`
     $t->get_ok('/assets/iso/test.iso')->status_is(200)->content_is('asset-ok', 'can access asset when logged in');
     $t->get_ok('/tests/42/asset/iso/test.iso')->status_is(200);
     $t->content_is('test-asset-ok', 'can access test asset when logged in');
-    $t->get_ok('/logout')->status_is(302)->get_ok('/assets/iso/test.iso')->status_is(302);
-    $t->content_unlike(qr/asset-ok/, 'asset not accessible when logged out');
-    $t->header_is('Location', $expected_redirect, 'redirect to login when accessing asset');
     $t->get_ok('/logout')->status_is(302);
-    $t->get_ok('/tests/42/asset/iso/test.iso')->status_is(302);
-    $t->header_like('Location', qr|/login\?return_page=.*test.iso|, 'redirect to login when accessing test asset');
-    $t->content_unlike(qr/asset-ok/, 'test asset not accessible when logged out');
+    $t->get_ok('/assets/iso/test.iso')->status_is(403, '403 response when logged out');
+    $t->content_unlike(qr/asset-ok/, 'asset not accessible when logged out');
+    $t->get_ok('/tests/42/asset/iso/test.iso')->status_is(403, '403 response via test when logged out');
+    $t->content_unlike(qr/asset-ok/, 'asset via test not accessible when logged out');
 };
 
 subtest OpenID => sub {


### PR DESCRIPTION
See the individual commit messages and https://progress.opensuse.org/issues/174301 for details.

I found out the problem I previously struggled with (see problematic points on https://progress.opensuse.org/issues/174154). With that out of the way there was actually not that much I had to change. With this PR all ATs in https://progress.opensuse.org/issues/174301 work. (I also slightly extended them along the way to cover both relevant routes.)

I haven't tested the cache service yet.