### PR TITLE
Update perltiy and freeze newline wrapping

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -11,3 +11,6 @@
 -bt=2    # no spaces around []
 -sbt=2   # no spaces around {}
 -sct     # stack closing tokens )}
+# Prevent excessive line-wrapping
+# See https://github.com/perltidy/perltidy/issues/171
+--freeze-newlines

--- a/cpanfile
+++ b/cpanfile
@@ -117,7 +117,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Freenode';
-    requires 'Perl::Tidy', '== 20240903.0.0';
+    requires 'Perl::Tidy', '== 20250105.0.0';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -83,7 +83,7 @@ devel_no_selenium_requires:
   sudo:
   tar:
   xorg-x11-fonts:
-  perl(Perl::Tidy): '== 20240903.0.0'
+  perl(Perl::Tidy): '== 20250105.0.0'
 
 devel_requires:
   '%devel_no_selenium_requires':

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -249,7 +249,7 @@ sub update {
             (($table eq 'TestSuites' || $table eq 'Machines') && $rc->name ne $self->param('name'))
             || (
                 $table eq 'Products'
-                && (   $rc->arch ne $self->param('arch')
+                && ($rc->arch ne $self->param('arch')
                     || $rc->distri ne $self->param('distri')
                     || $rc->flavor ne $self->param('flavor')
                     || $rc->version ne $self->param('version'))))

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -197,7 +197,7 @@ sub register ($self, $app, $config) {
             my %d = ('bs-toggle' => 'popover', 'bs-trigger' => 'focus', 'bs-title' => $title, 'bs-content' => $content);
             $d{placement} = $placement if $placement;
             return $c->t(a => (tabindex => 0, class => $class, role => 'button', data => \%d, @args));
-        });
+          });
 
     $app->helper(
         help_popover_todo => sub ($c) {

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -205,7 +205,7 @@ sub _message {
 
             # skip any further actions if worker just does the one job we expected it to do
             return undef
-              if ( defined $job_id
+              if (defined $job_id
                 && defined $current_job_id
                 && defined $job_token
                 && defined $registered_job_token

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -172,7 +172,7 @@ subtest 'restart with (directly) chained child' => sub {
         99938 => {is_parent_or_initial_job => 0, @empty_deps, directly_chained_parents => [99937]},
     );
     is_deeply(job_get_rs(99937)->cluster_jobs, \%expected_cluster,
-            '99937 has one directly chained child and one directly chained parent; '
+        '99937 has one directly chained child and one directly chained parent; '
           . 'parent considered for restarting but not siblings');
     $job_before_restart = job_get(99937);
 

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -30,7 +30,7 @@ assume_all_assets_exist;
 my $comment_must
   = Mojo::DOM->new(
 '<span class="openqa-bugref" title="Bug referenced: bsc#1234"><a href="https://bugzilla.suse.com/show_bug.cgi?id=1234"><i class="test-label label_bug fa fa-bug"></i>&nbsp;bsc#1234</a></span>(Automatic carryover from <a href="/tests/99962">t#99962</a>)'
-)->to_string;
+  )->to_string;
 my $carry_over_note = "\n(The hook script will not be executed.)";
 sub comments ($url) {
     $t->get_ok("$url/comments_ajax")->status_is(200)->tx->res->dom->find('.media-comment > p')->map('content');

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -170,7 +170,7 @@ subtest 'asset caching' => sub {
         cache_assets =>
           sub ($cache_client, $job, $vars, $assets_to_cache, $assetkeys, $webui_host, $pooldir, $callback) {
             $callback->(undef);
-        });
+          });
     my $job = Test::MockObject->new;
     my $testpool_server;
     $job->mock(client => sub { Test::MockObject->new->set_bound(testpool_server => \$testpool_server) });

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -186,7 +186,7 @@ subtest 'web socket message handling' => sub {
         }
         qr/Job 42 reset to state scheduled/s, 'info logged when worker rejects job';
         is($jobs->find(42)->state, SCHEDULED,
-                'job is immediately set back to scheduled if assigned worker goes offline '
+            'job is immediately set back to scheduled if assigned worker goes offline '
               . 'gracefully before starting to work on the job');
         $worker->discard_changes;
         ok($worker->dead, 'worker considered immediately dead when it goes offline gracefully');

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -938,7 +938,7 @@ subtest 'Create and modify groups with YAML' => sub {
         $t->status_is(400, 'Post rejected because scenarios are ambiguous')->json_is(
             '' => {
                 error => [
-                        'Job template name \'foobar\' is defined more than once. '
+                    'Job template name \'foobar\' is defined more than once. '
                       . 'Use a unique name and specify \'testsuite\' to reuse test suites in multiple scenarios.'
                 ],
                 error_status => 400,

--- a/t/api/16-webhooks.t
+++ b/t/api/16-webhooks.t
@@ -108,7 +108,7 @@ $vcs_mock->redefine(
         is $params->{description}, $expected_ci_check_desc, 'check description';
         ++$status_reports;
         $callback ? $callback->($ua, $tx) : $tx;
-    });
+      });
 
 subtest 'scheduled product created via webhook' => sub {
     $t->post_ok($url, \%headers, json => $test_payload)->status_is(200, 'scheduled product has been created');

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -533,7 +533,7 @@ subtest 'Showing new needles limited to the 5 most recent ones' => sub {
         # add expected warnings and needle names for needle
         if ($i >= 2) {
             unshift(@expected_needle_warnings,
-                    "A new needle with matching tags has been created since the job started: $new_needle_name.json"
+                "A new needle with matching tags has been created since the job started: $new_needle_name.json"
                   . ' (tags: ENV-VIDEOMODE-text, inst-timezone, test-newtag, test-overwritetag)');
             splice(@expected_needle_names, 2, 0, 'new: ' . $new_needle_name);
         }
@@ -607,7 +607,7 @@ subtest 'open needle editor for running test' => sub {
     my $t = Test::Mojo->new('OpenQA::WebAPI');
     $t->ua->max_redirects(1);
     warnings { $t->get_ok('/tests/99980/edit') };
-    note(   'ignoring warning "DateTime objects passed to search() are not supported properly"'
+    note('ignoring warning "DateTime objects passed to search() are not supported properly"'
           . ' at lib/OpenQA/WebAPI/Controller/Step.pm line 211');
     $t->status_is(200);
     $t->text_is(title => 'openQA: Needle Editor', 'needle editor shown for running test');

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -101,7 +101,7 @@ sub find_candidate_needles {
 
             is(scalar @needle_parts, 3, 'exactly three parts per needle present (percentage, name, diff buttons)');
             push(@needles,
-                    OpenQA::Test::Case::trim_whitespace($needle_parts[0]->get_text()) . '%: '
+                OpenQA::Test::Case::trim_whitespace($needle_parts[0]->get_text()) . '%: '
                   . OpenQA::Test::Case::trim_whitespace($needle_parts[1]->get_text()));
         }
 

--- a/tools/ci/ci-packages.txt
+++ b/tools/ci/ci-packages.txt
@@ -173,7 +173,7 @@ perl-Perl-Critic-Community-1.0.3
 perl-Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.008
 perl-Perl-Critic-Pulp-99
 perl-PerlIO-utf8_strict-0.008
-perl-Perl-Tidy-20240903.0.0
+perl-Perl-Tidy-20250105.0.0
 perl-Pod-MinimumVersion-50
 perl-Pod-POM-2.01
 perl-Pod-Spell-1.26


### PR DESCRIPTION
perltidy 20250105 has a change that will wrap every chained method call to its own line if the line exceeds our maximum length.

To temporarily prevent this in order to accept the new package version, we can use --freeze-newlines

https://github.com/perltidy/perltidy/issues/171

Alternative to #6118 which seems to have more changes and fails checkstyle