### PR TITLE
Make cache service work with authenticated asset downloads

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -108,6 +108,7 @@ sub get_asset ($self, $host, $job, $type, $asset) {
     # Keep temporary files on the same partition as the cache
     my $log = $self->log;
     my $downloader = $self->downloader->log($log)->tmpdir($self->_realpath->child('tmp')->to_string);
+    $downloader->ua->configure_credentials($url->host);
 
     my $start;
     my $options = {

--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -5,9 +5,9 @@ package OpenQA::Downloader;
 use Mojo::Base -base, -signatures;
 
 use Mojo::Loader 'load_class';
-use Mojo::UserAgent;
 use Mojo::File 'path';
 use Mojo::URL;
+use OpenQA::UserAgent;
 use OpenQA::Utils 'human_readable_size';
 use Try::Tiny;
 use Time::HiRes 'sleep';
@@ -15,7 +15,7 @@ use Time::HiRes 'sleep';
 has attempts => 5;
 has [qw(log tmpdir)];
 has sleep_time => 5;
-has ua => sub { Mojo::UserAgent->new(max_redirects => 5, max_response_size => 0) };
+has ua => sub { OpenQA::UserAgent->new(max_redirects => 5, max_response_size => 0) };
 has res => undef;
 
 sub download ($self, $url, $target, $options = {}) {

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -155,8 +155,9 @@ sub _key_auth ($self, $reason, $key) {
     if (my $api_key = $self->schema->resultset('ApiKeys')->find({key => $key})) {
         $log->trace(sprintf 'Key is for user "%s"', $api_key->user->username);
 
-        my $msg = $self->req->url->to_string;
         my $headers = $self->req->headers;
+        my $url = $self->req->url;
+        my $msg = $url->path eq '/api/v1/auth' ? ($headers->header('X-Original-URI') // $url) : $url;
         my $hash = $headers->header('X-API-Hash');
         my $remote_timestamp = $headers->header('X-API-Microtime');
         my $our_timestamp = time;

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -14,10 +14,8 @@ has [qw(apikey apisecret base_url)];
 sub new {
     my $self = shift->SUPER::new(@_);
     my %args = @_;
-
     for my $i (qw(apikey apisecret)) {
-        next unless $args{$i};
-        $self->$i($args{$i});
+        $self->$i($args{$i}) if $args{$i};
     }
 
     $self->configure_credentials($args{api});
@@ -29,10 +27,8 @@ sub new {
     # Some urls might redirect to https and then there are internal redirects for assets
     $self->max_redirects(3);
 
-    $self->on(
-        start => sub {
-            $self->_add_auth_headers(@_);
-        });
+    $self->on(start => sub ($ua, $tx) { $self->_add_auth_headers($ua, $tx) });
+
     #read proxy environment variables
     $self->proxy->detect;
 
@@ -60,9 +56,7 @@ sub configure_credentials ($self, $host) {
     }
 }
 
-sub _add_auth_headers {
-    my ($self, $ua, $tx) = @_;
-
+sub _add_auth_headers ($self, $ua, $tx) {
     my $timestamp = time;
     my %headers = (
         Accept => 'application/json',

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -58,19 +58,12 @@ sub configure_credentials ($self, $host) {
 
 sub _add_auth_headers ($self, $ua, $tx) {
     my $timestamp = time;
-    my %headers = (
-        Accept => 'application/json',
-        'X-API-Microtime' => $timestamp,
-    );
+    my $headers = $tx->req->headers;
+    $headers->accept('application/json') unless defined $headers->accept;
+    $headers->header('X-API-Microtime', $timestamp);
     if ($self->apisecret && $self->apikey) {
-        $headers{'X-API-Key'} = $self->apikey;
-        $headers{'X-API-Hash'} = hmac_sha1_sum($self->_path_query($tx) . $timestamp, $self->apisecret);
-    }
-
-    my $set_headers = $tx->req->headers;
-    foreach my $key (keys %headers) {
-        # don't overwrite headers that were set manually
-        $set_headers->header($key, $headers{$key}) unless defined $set_headers->header($key);
+        $headers->header('X-API-Key', $self->apikey);
+        $headers->header('X-API-Hash', hmac_sha1_sum($self->_path_query($tx) . $timestamp, $self->apisecret));
     }
 }
 


### PR DESCRIPTION
This PR incorporates https://github.com/os-autoinst/openQA/pull/6114 which should probably be merged first.

It will tweak the cache service and the openQA user agent in general so both work when authenticated asset downloads are enabled. See https://progress.opensuse.org/issues/170380 and individual commit messages for details.

If wanted I can also extend tests. (Maybe I'll have to adapt tests anyway.) I tested this locally. Before this change it didn't work and with it it works when connecting directly and when using NGINX.