### PR TITLE
UI: Clarify that virtio_console.log is renamed

### DIFF
--- a/templates/webapi/test/live.html.ep
+++ b/templates/webapi/test/live.html.ep
@@ -222,7 +222,7 @@
 
 <div class="card filter-panel-bottom" id="live-terminal-panel">
     <div class="card-header">
-        <strong>Serial output</strong> (serial0.txt, serial_terminal.txt and serial_terminal_user.txt)
+        <strong>Serial output</strong> (serial0.txt, serial_terminal.txt/virtio_console.log and serial_terminal_user.txt)
         <span>click to toggle</span>
     </div>
     <div class="card-body">


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/175168