### PR TITLE
Rollback of pull request #6107: full-stack.t removed from unstable_tests

### DIFF
--- a/tools/unstable_tests.txt
+++ b/tools/unstable_tests.txt
@@ -1,4 +1,3 @@
-t/full-stack.t
 t/25-cache-service.t
 t/43-scheduling-and-worker-scalability.t
 t/ui/01-list.t


### PR DESCRIPTION
This reverts commit https://github.com/os-autoinst/openQA/commit/b6a5681c4c8be9bf343e1d2979a5b4ae2975d48e, reversing
changes made to https://github.com/os-autoinst/openQA/commit/83f2e292d7bda9e9e48740811a82a3f8f682a73b.

https://progress.opensuse.org/issues/175060