### PR TITLE
Improve help texts of `openqa-cli`

### DIFF
--- a/lib/OpenQA/CLI.pm
+++ b/lib/OpenQA/CLI.pm
@@ -6,7 +6,7 @@ use Mojo::Base 'Mojolicious::Commands';
 
 has hint => <<EOF;
 
-See 'openqa-cli help COMMAND' for more information on a specific command.
+See 'openqa-cli COMMAND --help' for more information on a specific command.
 EOF
 has message => sub { shift->extract_usage . "\nCommands:\n" };
 has namespaces => sub { ['OpenQA::CLI'] };

--- a/lib/OpenQA/CLI/monitor.pm
+++ b/lib/OpenQA/CLI/monitor.pm
@@ -56,6 +56,9 @@ sub command ($self, @args) {
 
   Usage: openqa-cli monitor [OPTIONS] [JOB_IDS]
 
+  Wait until all specified jobs have reached a final state and return a non-zero
+  exit code if at least one job is not ok (is not passed or softfailed).
+
   Options:
         --apibase <path>           API base, defaults to /api/v1
         --apikey <key>             API key

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -52,6 +52,8 @@ sub command ($self, @args) {
 
   Usage: openqa-cli schedule [OPTIONS] DISTRI=… VERSION=… FLAVOR=… ARCH=… [ISO=… …]
 
+  Schedule a set of jobs creating a scheduled product on the web UI ("posts an ISO").
+
   Options:
         --apibase <path>           API base, defaults to /api/v1
         --apikey <key>             API key


### PR DESCRIPTION
* Fix documentation of syntax for displaying help text of nested commands
* Add a short description of what the schedule and monitor commands do on their help texts