### PR TITLE
Improve test of failure behavior for multiple parallel children

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -796,7 +796,7 @@ sub cluster_jobs ($self, @args) {
             my $cwset = $settings->{PARALLEL_CANCEL_WHOLE_CLUSTER};
             $job->{one_host_only} = 1 if $settings->{PARALLEL_ONE_HOST_ONLY};
             $cancelwhole = 0 if (defined $cwset && !$cwset);
-            if ($args{cancelmode} && !$cancelwhole) {
+            if ($cancelmode && !$cancelwhole) {
                 # skip calling cluster_jobs (so cancelling it and its other
                 # related jobs) if job has pending children we are not
                 # cancelling

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -352,7 +352,7 @@ subtest 'parallel child with one parent fails -> parent is cancelled' => sub {
     is($jobA->state, OpenQA::Jobs::Constants::CANCELLED, 'A state is cancelled');
 };
 
-subtest 'failure behaviour for multiple parallel children' => sub {
+subtest 'cancellation behaviour of parallel cluster when one job is skipped or fails' => sub {
     my %settingsA = (%settings, TEST => 'A');
     my %settingsB = (%settings, TEST => 'B');
     my %settingsC = (%settings, TEST => 'C');
@@ -362,14 +362,30 @@ subtest 'failure behaviour for multiple parallel children' => sub {
     my $jobB = _job_create(\%settingsB);
     my $jobC = _job_create(\%settingsC);
 
-    # set B as failed and reload A and C from database
-    $jobB->done(result => OpenQA::Jobs::Constants::FAILED);
-    $jobA->discard_changes;
-    $jobC->discard_changes;
+    # set B as failed and reload jobs from database
+    $jobB->done(result => FAILED);
+    $_->discard_changes for $jobA, $jobB, $jobC;
 
     # A and C should be cancelled
-    is($jobA->state, OpenQA::Jobs::Constants::CANCELLED, 'A state is cancelled');
-    is($jobC->state, OpenQA::Jobs::Constants::CANCELLED, 'C state is cancelled');
+    is $jobA->state, CANCELLED, 'A state is cancelled';
+    is $jobB->state, DONE, 'B state is done';
+    is $jobC->state, CANCELLED, 'C state is cancelled';
+
+    # skip the parallel parent
+    $jobA = _job_create(\%settingsA);
+    $settingsB{_PARALLEL_JOBS} = [$jobA->id];
+    $settingsC{_PARALLEL_JOBS} = [$jobA->id];
+    $jobB = _job_create(\%settingsB);
+    $jobC = _job_create(\%settingsC);
+
+    # skip A and reload jobs from database
+    $jobA->done(result => SKIPPED);
+    $_->discard_changes for $jobA, $jobB, $jobC;
+
+    # B and C should be cancelled
+    is $jobA->state, DONE, 'A state is done as we skipped it';
+    is $jobB->state, CANCELLED, 'B state is cancelled after parallel parent was skipped';
+    is $jobC->state, CANCELLED, 'C state is cancelled after parallel parent was skipped';
 
     # now test in 'do not cancel parent and other children' mode
     $settingsA{PARALLEL_CANCEL_WHOLE_CLUSTER} = '0';
@@ -379,21 +395,21 @@ subtest 'failure behaviour for multiple parallel children' => sub {
     $jobB = _job_create(\%settingsB);
     $jobC = _job_create(\%settingsC);
 
-    # set B as failed and reload A and C from database
-    $jobB->done(result => OpenQA::Jobs::Constants::FAILED);
-    $jobA->discard_changes;
-    $jobC->discard_changes;
+    # set B as failed and reload jobs from database
+    $jobB->done(result => FAILED);
+    $_->discard_changes for $jobA, $jobB, $jobC;
 
     # this time A and C should still be scheduled (*not* cancelled)
-    is($jobA->state, OpenQA::Jobs::Constants::SCHEDULED, 'new A state is scheduled');
-    is($jobC->state, OpenQA::Jobs::Constants::SCHEDULED, 'new C state is scheduled');
+    is $jobA->state, SCHEDULED, 'new A state is scheduled';
+    is $jobB->state, DONE, 'B state is done';
+    is $jobC->state, SCHEDULED, 'new C state is scheduled';
 
     # now set C as failed and reload A
-    $jobC->done(result => OpenQA::Jobs::Constants::FAILED);
+    $jobC->done(result => FAILED);
     $jobA->discard_changes;
 
     # now A *should* be cancelled
-    is($jobA->state, OpenQA::Jobs::Constants::CANCELLED, 'new A state is cancelled');
+    is $jobA->state, CANCELLED, 'new A state is cancelled';
 };
 
 done_testing();


### PR DESCRIPTION
* Convert to our current coding style
* Check the state of the job that is set to DONE as well
* Test the case when the parent job is skipped as well