### PR TITLE
Add SYNC_ASSETS_HOOK support

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -1027,6 +1027,27 @@ comment = openQA test distributions
 systemctl enable --now rsyncd
 --------------------------------------------------------------------------------
 
+=== Alternative caching implementations
+
+Caching described above works well for a single worker host, but in case of
+several hosts in a single site (that is remote from the main openQA webui
+instance) it results in downloading the same assets several times. In
+such case, one can setup local cache on their own (without using
+openqa-worker-cacheservice service) and share it with workers using
+some network filesystem (see <<Installing.asciidoc#Configuring remote workers>>
+section above).
+Such setups can use `SYNC_ASSETS_HOOK` in `/etc/openqa/workers.ini` to ensure
+the cache is up to date before starting the job (or resuming test in developer
+mode). The setting takes a shell command that is executed just before
+evaluating assets. It is up to the system administrator to decide what it
+should do, but there are few suggestions:
+
+* Call rsync, possibly via ssh on the cache host
+* Wait for a lock file signaling that cache download is in progress to disappear
+
+If the command exits with code 32, re-downloading needles in developer mode
+will be skipped.
+
 === Enable linking files referred by job settings
 
 Specific job settings might refer to files within the test distribution.

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -326,6 +326,12 @@ sub engine_workit ($job, $callback) {
 
     log_debug "Job settings:\n" . format_settings(\%vars);
 
+    # start pre-job hook if any
+    if ($job_settings->{SYNC_ASSETS_HOOK}) {
+        log_debug 'Running SYNC_ASSETS_HOOK';
+        system($job_settings->{SYNC_ASSETS_HOOK});
+    }
+
     # cache/locate assets, set ASSETDIR
     my $assetkeys = detect_asset_keys(\%vars);
     if (my $cache_dir = $global_settings->{CACHEDIRECTORY}) {

--- a/t/data/openqa/share/factory/hdd/symlink.qcow2
+++ b/t/data/openqa/share/factory/hdd/symlink.qcow2
@@ -1,1 +1,0 @@
-foo.qcow2


### PR DESCRIPTION
This is useful when having site-local cache shared among several worker
hosts. See added documentation for scenario details.

Question: Should this setting be also exclusive to workers.ini, similar to `GENERAL_HW_CMD_DIR` and few others?