### PR TITLE
Replace Perl::Critic::Freenode with Perl::Critic::Community

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -116,7 +116,7 @@ on 'test' => sub {
 on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic';
-    requires 'Perl::Critic::Freenode';
+    requires 'Perl::Critic::Community';
     requires 'Perl::Tidy', '== 20250105.0.0';
 
 };

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -204,7 +204,7 @@ test_requires:
 style_check_requires:
   python3-yamllint:
   perl(Perl::Critic):
-  perl(Perl::Critic::Freenode):
+  perl(Perl::Critic::Community):
   perl(Code::TidyAll):
   ShellCheck:
   shfmt:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -81,7 +81,7 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Freenode) python3-yamllint shfmt
+%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Community) python3-yamllint shfmt
 # The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml


### PR DESCRIPTION
It was renamed long ago, and with the next release the old alias will be removed