### PR TITLE
Track the relevant scheduled product when a job is obsoleted

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -380,7 +380,7 @@ sub _schedule_iso {
                     data => {scheduled_product_id => $self->id},
                     user_id => $user_id
                 );
-                $schema->resultset('Jobs')->cancel_by_settings(\%cond, 1, $deprioritize, $deprioritize_limit);
+                $schema->resultset('Jobs')->cancel_by_settings(\%cond, 1, $deprioritize, $deprioritize_limit, $self);
             }
             catch {
                 my $error = shift;


### PR DESCRIPTION
* Add the ID of the new scheduled product that is obsoleting jobs as reason so we know whether a job has been canceled due when scheduling a product and by which
* Improve and extend test code, e.g. fix wrong 'two jobs cancelled …' when it should be 'three …'
* See https://progress.opensuse.org/issues/174583