### PR TITLE
Support OpenID Connect better in the OAuth2 'custom' provider.

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -148,7 +148,11 @@
 #user_url  = https://salsa.debian.org/api/v4/user
 #token_scope = read_user
 #token_label = Bearer
+#id_from = id
 #nickname_from = username
+#
+# The default value for `id_from` is "id" for backwards compatibility.
+# For OpenID Connect, the value should be "sub", following the OpenID Connect ID Token standard.
 
 [logging]
 ## logging is to stderr (so systemd journal) by default

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -96,6 +96,7 @@ sub read_config ($app) {
             token_label => '',
             nickname_from => '',
             unique_name => '',
+            id_from => 'id',
         },
         hypnotoad => {
             listen => ['http://localhost:9526/'],

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -116,7 +116,7 @@ subtest OAuth2 => sub {
     $ua_mock->redefine(get => sub { shift; push @get_args, [@_]; $get_tx });
 
     my %main_cfg = (provider => 'custom');
-    my %provider_cfg = (user_url => 'http://does-not-exist', token_label => 'bar', nickname_from => 'login');
+    my %provider_cfg = (user_url => 'http://does-not-exist', token_label => 'bar', id_from => 'id', nickname_from => 'login');
     my %data = (access_token => 'some-token');
     my %expected_user = (username => 42, provider => 'oauth2@custom', nickname => 'Demo');
     my $users = $t->app->schema->resultset('Users');

--- a/t/config.t
+++ b/t/config.t
@@ -87,6 +87,7 @@ subtest 'Test configuration default modes' => sub {
             user_url => '',
             token_scope => '',
             token_label => '',
+            id_from => 'id',
             nickname_from => '',
             unique_name => '',
         },


### PR DESCRIPTION
The OpenID Connect standard specifies that `sub` contains the user ID. Until now, openQA only looked for a field named `id`.

When using Keycloak as identity provider there is no such field, it returns only `sub` as expected in OpenID Connect.

To avoid breaking any existing configs, this patch adds a new `id_from` config field which defaults to `id`, so existing behaviour is preserved. Set `id_from = sub` in the OAuth2 provider config to get the new behaviour.