### PR TITLE
Draft: Introduce new initial job state "new"

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -190,6 +190,9 @@
 ! logo-scheduled-16.png
 < images/logo-scheduled-16.png
 
+! logo-new-16.png
+< images/logo-blocked-16.png
+
 ! logo-blocked-16.png
 < images/logo-blocked-16.png
 
@@ -222,6 +225,9 @@
 
 ! logo-scheduled.svg
 < images/logo-scheduled.svg
+
+! logo-new.svg
+< images/logo-blocked.svg
 
 ! logo-blocked.svg
 < images/logo-blocked.svg

--- a/assets/javascripts/create_tests.js
+++ b/assets/javascripts/create_tests.js
@@ -54,7 +54,7 @@ function createTests(form) {
     success: function (response) {
       const id = response.scheduled_product_id;
       const url = `${form.dataset.productlogUrl}?id=${id}`;
-      addFlash('info', `Tests have been scheduled, checkout the <a href="${url}">product log</a> for details.`);
+      addFlash('info', `Tests have been created, checkout the <a href="${url}">product log</a> for details.`);
     },
     error: function (xhr, ajaxOptions, thrownError) {
       addFlash('danger', 'Unable to create tests: ' + (xhr.responseJSON?.error ?? xhr.responseText ?? thrownError));

--- a/assets/javascripts/job_next_previous.js
+++ b/assets/javascripts/job_next_previous.js
@@ -75,7 +75,7 @@ function renderJobResults(data, type, row) {
   // job status
   html += '<span id="res-' + row.id + '">';
   html += '<a href="' + urlWithBase('/tests/' + row.id) + '">';
-  if (row.result == 'none' && (row.state == 'running' || row.state == 'scheduled')) {
+  if (row.result == 'none' && (row.state === 'running' || row.state === 'scheduled' || row.state === 'new')) {
     html += '<i class="status fa fa-circle state_' + row.state + '" title="' + row.state + '"></i>';
   } else {
     html += '<i class="status fa fa-circle result_' + row.result + '" title="Done: ' + row.result + '"></i>';
@@ -130,7 +130,7 @@ function renderFinishTime(data, type, row) {
     html += '<abbr class="timeago" title="' + data + '">' + jQuery.timeago(data) + ' </abbr>';
     html += '( ' + row.duration + ' )';
   } else {
-    if (row.state == 'running' || row.state == 'scheduled') {
+    if (row.state === 'running' || row.state === 'scheduled' || row.state === 'new') {
       html += 'Not yet: ' + row.state;
     }
   }

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -399,7 +399,7 @@ function renderSearchResults(query, url) {
 function testStateHTML(job) {
   var className = 'status fa fa-circle';
   var title;
-  if (job.state === 'running' || job.state === 'scheduled') {
+  if (job.state === 'running' || job.state === 'scheduled' || job.state === 'new') {
     if (job.state === 'scheduled' && job.blocked_by_id) {
       className += ' state_blocked';
       title = 'blocked';

--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -126,6 +126,7 @@ function setupOverview() {
   $('.cancel').bind('ajax:success', function (event, xhr, status) {
     $(this).text(''); // hide the icon
     var icon = $(this).parents('td').find('.status');
+    // FIXME
     icon.removeClass('state_scheduled').removeClass('state_running');
     icon.addClass('state_cancelled');
     icon.attr('title', 'Cancelled');
@@ -147,6 +148,7 @@ function setupOverview() {
       restarted.text(''); // hide the icon
       var icon = restarted.parents('td').find('.status');
       icon.removeClass('state_done').removeClass('state_cancelled');
+      // FIXME
       icon.addClass('state_scheduled');
       icon.attr('title', 'Scheduled');
       // remove the result class

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -78,11 +78,13 @@ function renderTestName(data, type, row) {
   html += '<a href="' + urlWithBase('/tests/' + row.id) + '">';
   if (row.result !== 'none') {
     html += '<i class="status fa fa-circle result_' + row.result + '" title="Done: ' + row.result + '"></i>';
-  } else if (row.state === 'scheduled') {
+  } else if (row.state === 'new' || row.state === 'scheduled') {
     if (typeof row.blocked_by_id === 'number') {
       html += '<i class="status fa fa-circle state_blocked" title="Blocked"></i>';
-    } else {
+    } else if (row.state === 'scheduled') {
       html += '<i class="status fa fa-circle state_scheduled" title="Scheduled"></i>';
+    } else {
+      html += '<i class="status fa fa-circle state_new" title="New"></i>';
     }
   } else if (row.state === 'assigned') {
     html += '<i class="status fa fa-circle state_running" title="Assigned"></i>';
@@ -255,7 +257,7 @@ function renderTestLists() {
     }
   });
 
-  // initialize data tables for running, scheduled and finished jobs
+  // initialize data tables for running, new/scheduled/blocked and finished jobs
   var runningTable = $('#running').DataTable({
     order: [], // no initial resorting
     ajax: {
@@ -307,7 +309,7 @@ function renderTestLists() {
             ++blockedCount;
           }
         });
-        var text = json.data.length + ' scheduled jobs';
+        var text = json.data.length + ' new or scheduled jobs';
         if (blockedCount > 0) {
           text += ' (' + blockedCount + ' blocked by other jobs)';
         }

--- a/assets/stylesheets/dependency_graph.scss
+++ b/assets/stylesheets/dependency_graph.scss
@@ -75,7 +75,7 @@
                 color: white;
                 background-color: $color-incomplete;
             }
-            &.blocked {
+            &.new, &.blocked {
                 background-color: $color-state-blocked;
             }
             &.scheduled {

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -90,7 +90,7 @@ div.flags {
 .state_scheduled.fa {
     color: $color-state-scheduled;
 }
-.state_blocked.fa {
+.state_new.fa, .state_blocked.fa {
     color: $color-state-blocked;
 }
 .state_obsolete.fa, .state_cancelled.fa {

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -150,8 +150,9 @@ Every job is labeled with a numeric identifier and has several associated
 A job goes through several states. Here is (an incomplete list) of these
 states:
 
-* *scheduled* Initial state for newly created jobs. Queued for future
-  execution.
+* *new* Initial state for newly created jobs. Those jobs will transition to the
+  scheduled state as soon as all required preparation tasks have been completed.
+* *scheduled* Queued for future execution.
 * *setup*/*running*/*uploading* In progress.
 * *cancelled* The job was explicitly cancelled by the user or was
   replaced by a clone (see below) and the worker has not acknowledged the
@@ -378,7 +379,7 @@ clone a subdirectory under `/var/lib/openqa/tests` for each test distribution
 you need, e.g. `/var/lib/openqa/tests/opensuse` for openSUSE tests.
 
 The repositories will be kept up-to-date if `git_auto_update` is enabled in
-`openqa.ini`. The updating is triggered when new tests are scheduled. For a
+`openqa.ini`. The updating is triggered when new tests are created. For a
 periodic update (to avoid getting too far behind) you can enable the systemd
 unit `openqa-enqueue-git-auto-update.timer`.
 

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1407,8 +1407,7 @@ If the size limit for assets of a group is exceeded, openQA will remove
 assets which belong to that group:
 
 * Assets belonging to old jobs are preferred.
-* Assets belonging to jobs which are still scheduled or running are not
-  considered.
+* Assets belonging to jobs which are still pending are not considered.
 * Assets which have been accounted to another group that has still space
   left are not considered.
 

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -8,7 +8,9 @@ use Exporter 'import';
 
 # job states
 use constant {
-    # initial job state; the job is supposed to be assigned to a worker by the scheduler
+    # initial job state; the job has been created but not ready to be scheduled due to pending tasks
+    NEW => 'new',
+    # the job is supposed to be assigned to a worker by the scheduler
     SCHEDULED => 'scheduled',
     # the job has been sent to worker but worker has not acknowledged yet; the state might be reverted to
     # SCHEDULED in some conditions
@@ -27,7 +29,7 @@ use constant {
     # or the job has been cancelled due to failed parallel dependencies (result PARALLEL_FAILED is set)
     DONE => 'done',
 };
-use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, DONE, CANCELLED);
+use constant STATES => (NEW, SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, DONE, CANCELLED);
 
 # note regarding CANCELLED vs. DONE:
 # There is an overlap between CANCELLED and DONE (considering that some results are possibly assigned in either of these
@@ -37,10 +39,10 @@ use constant STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING, DONE, CA
 # That is usually the case for jobs SKIPPED due to failed chained dependencies (*not* directly chained dependencies).
 
 # "meta" states
-use constant PENDING_STATES => (SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING);
+use constant PENDING_STATES => (NEW, SCHEDULED, ASSIGNED, SETUP, RUNNING, UPLOADING);
 use constant EXECUTION_STATES => (ASSIGNED, SETUP, RUNNING, UPLOADING);
-use constant PRE_EXECUTION_STATES => (SCHEDULED);
-use constant PRISTINE_STATES => (SCHEDULED, ASSIGNED);    # no worker reported any updates/results so far
+use constant PRE_EXECUTION_STATES => (NEW, SCHEDULED);
+use constant PRISTINE_STATES => (NEW, SCHEDULED, ASSIGNED);    # no worker reported any updates/results so far
 use constant FINAL_STATES => (DONE, CANCELLED);
 use constant {
     PRE_EXECUTION => 'pre_execution',
@@ -135,6 +137,7 @@ our @EXPORT = qw(
   USER_CANCELLED
   USER_RESTARTED
   MODULE_RESULTS
+  NEW
   COMMON_RESULT_FILES
   TIMEOUT_EXCEEDED
   DEFAULT_JOB_PRIORITY

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -19,6 +19,8 @@ use OpenQA::Utils qw(:DEFAULT prjdir);
 # after bumping the version please look at the instructions in the docs/Contributing.asciidoc file
 # on what scripts should be run and how
 our $VERSION = $ENV{OPENQA_SCHEMA_VERSION_OVERRIDE} // 100;
+# FIXME: bump this and generate deployment files
+#        to change `state character varying DEFAULT 'scheduled' NOT NULL,` to `state character varying DEFAULT 'new' NOT NULL,`
 
 __PACKAGE__->load_namespaces;
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Mm.pm
@@ -45,7 +45,7 @@ sub get_children_status {
         $state = OpenQA::Jobs::Constants::RUNNING;
     }
     elsif ($state eq 'scheduled') {
-        $state = OpenQA::Jobs::Constants::SCHEDULED;
+        $state = OpenQA::Jobs::Constants::SCHEDULED; # FIXME: does this need adjustment?
     }
     else {
         $state = OpenQA::Jobs::Constants::DONE;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Worker.pm
@@ -136,7 +136,7 @@ sub _incomplete_previous_job {
     my $job_id = $job->id;
     return 0 if $jobs_worker_says_it_works_on->{$job_id};
     my $job_state = $job->state;
-    return 1 if $job_state eq OpenQA::Jobs::Constants::SCHEDULED;
+    return 1 if $job_state eq NEW || $job_state eq SCHEDULED;
 
     # set jobs which were only assigned anyways back to scheduled
     if ($job_state eq OpenQA::Jobs::Constants::ASSIGNED) {

--- a/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Influxdb.pm
@@ -38,9 +38,11 @@ sub jobs ($self) {
 
     my $schema = $self->schema;
     my $jobs = $schema->resultset('Jobs');
-    my $rs = $jobs->search({state => OpenQA::Jobs::Constants::SCHEDULED, blocked_by_id => undef});
+    my $rs = $jobs->search({state => NEW, blocked_by_id => undef});
+    _queue_sub_stats($rs, 'new', $result);
+    $rs = $jobs->search({state => SCHEDULED, blocked_by_id => undef});
     _queue_sub_stats($rs, 'scheduled', $result);
-    $rs = $jobs->search({state => OpenQA::Jobs::Constants::SCHEDULED, -not => {blocked_by_id => undef}});
+    $rs = $jobs->search({state => [NEW, SCHEDULED], -not => {blocked_by_id => undef}});
     _queue_sub_stats($rs, 'blocked', $result);
     $rs = $jobs->search({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]});
     _queue_sub_stats($rs, 'running', $result);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -32,6 +32,7 @@ my %BADGE_RESULT_COLORS = (
     incomplete => '#AF1E11',
     timeout_exceeded => '#AF1E11',
     blocked => '#9167b7',
+    new => '#9167b7',
     scheduled => '#67A2B7',
     cancelled => '#aaaaaa',
     user_cancelled => '#aaaaaa',
@@ -697,6 +698,7 @@ sub _prepare_job_results ($self, $all_jobs, $limit) {
         failed => 0,
         not_complete => 0,
         aborted => 0,
+        new => 0,
         scheduled => 0,
         running => 0,
         unknown => 0

--- a/templates/webapi/test/list.html.ep
+++ b/templates/webapi/test/list.html.ep
@@ -29,7 +29,7 @@
 </div>
 
 <div>
-    <h2 id="scheduled_jobs_heading">Scheduled jobs</h2>
+    <h2 id="scheduled_jobs_heading">New and Scheduled jobs</h2>
     <table id="scheduled" class="display table table-striped" style="width: 100%">
         <thead>
             <tr>

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -50,9 +50,9 @@
             </button>
             % }
             % my @badges = qw(success secondary  warning     danger info      primary light   light);
-            % my @labels = qw(Passed  Incomplete Soft-Failed Failed Scheduled Running Aborted None);
+            % my @labels = qw(Passed  Incomplete Soft-Failed Failed New Scheduled Running Aborted None);
             % my $index  = 0;
-            % for my $category (qw(passed not_complete softfailed failed scheduled running aborted none)) {
+            % for my $category (qw(passed not_complete softfailed failed new scheduled running aborted none)) {
                 % my ($label, $badge) = ($labels[$index], $badges[$index++]);
                 % next unless my $count = delete $aggregated->{$category};
                 <%= $label %>: <span class="badge text-bg-<%= $badge %>"><%= $count %></span>

--- a/templates/webapi/test/tr_job_result.html.ep
+++ b/templates/webapi/test/tr_job_result.html.ep
@@ -21,8 +21,8 @@
                      <i class="status fa fa-circle result_<%= $res->{overall} %>" title="Done: <%= $res->{overall} %>"></i>
                  </a>
          % }
-         % elsif ($state eq SCHEDULED) {
-             % my $substate = $res->{blocked} ? 'blocked' : 'scheduled';
+         % elsif ($state eq NEW || $state eq SCHEDULED) {
+             % my $substate = $res->{blocked} ? 'blocked' : $state;
              <a href="<%= url_for('test', 'testid' => $jobid) %>">
                  <i class="status state_<%= $substate %> fa fa-circle" title="<%= $substate %>@<%= $res->{priority} %>"></i>
              </a>


### PR DESCRIPTION
This draft shows what places one needed to adjust just for the sake of having a new state at all.

What is still missing:
* Several tests need to be adjusted.
* The actual database migration needs to be provided.
* The transition from "new" to "scheduled" when jobs are created or when related Minion jobs have finished.

Related ticket: https://progress.opensuse.org/issues/176067