### PR TITLE
Restrict SYNC_ASSETS_HOOK to worker settings

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -237,7 +237,7 @@ sub start {
     # delete settings we better not allow to be set on job-level (and instead should only be set within the
     # worker config)
     my $job_settings = $self->info->{settings} // {};
-    delete $job_settings->{$_} for qw(GENERAL_HW_CMD_DIR GIT_CACHE_DIR GIT_CACHE_DIR_LIMIT);
+    delete $job_settings->{$_} for qw(GENERAL_HW_CMD_DIR GIT_CACHE_DIR GIT_CACHE_DIR_LIMIT SYNC_ASSETS_HOOK);
     for my $key (keys %$job_settings) {
         delete $job_settings->{$key} if rindex($key, 'EXTERNAL_VIDEO_ENCODER', 0) == 0;
     }


### PR DESCRIPTION
SYNC_ASSETS_HOOK was added in #6131

Since it is a setting supposed for the workers.ini, we should disallow it in the job settings.