### PR TITLE
Prevent download prompt on plain text files with Chromium

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -154,8 +154,10 @@ sub _serve_static ($self, $asset) {
         my $headers = $self->res->headers;
         if ($filename =~ m/\.([^\.]+)$/) {
             my $ext = $1;
-            my $filetype = $self->app->types->type($ext);
-            $headers->content_type($filetype) if $filetype;
+            if (my $filetype = $self->app->types->type($ext)) {
+                $headers->content_type($filetype);
+                $headers->header('X-Content-Type-Options', 'nosniff') if $filetype =~ qr|^text/plain;?|;
+            }
 
             # force saveAs
             $headers->content_disposition("attachment; filename=$filename;") if $ext eq 'iso';

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -35,9 +35,13 @@ $t->get_ok('/tests/99938/images/thumb/doesntexist.png')->status_is(404);
 
 $t->get_ok('/tests/99938/file/video.ogv')->status_is(200)->content_type_is('video/ogg');
 
-$t->get_ok('/tests/99938/file/serial0.txt')->status_is(200)->content_type_is('text/plain;charset=UTF-8');
+$t->get_ok('/tests/99938/file/serial0.txt')->status_is(200);
+$t->content_type_is('text/plain;charset=UTF-8', 'content type for text file returned');
+$t->header_is('X-Content-Type-Options' => 'nosniff', 'nosniff header added to prevent download prompt for text file');
 
-$t->get_ok('/tests/99938/file/y2logs.tar.bz2')->status_is(200)->content_type_is('application/x-bzip2');
+$t->get_ok('/tests/99938/file/y2logs.tar.bz2')->status_is(200);
+$t->content_type_is('application/x-bzip2', 'content type for archive returned');
+$t->header_isnt('X-Content-Type-Options' => 'nosniff', 'nosniff header not added for archive/binary file');
 
 $t->get_ok('/tests/99938/file/ulogs/y2logs.tar.bz2')->status_is(404);
 


### PR DESCRIPTION
* Add `X-Content-Type-Options: nosniff` to avoid a download prompt on plain text files with Chromium
* See https://stackoverflow.com/questions/9660514/content-type-of-text-plain-causes-browser-to-download-of-file/9660578#9660578