### PR TITLE
Enable auto updates of tests/needles by default again

### DIFF
--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -378,9 +378,9 @@ clone a subdirectory under `/var/lib/openqa/tests` for each test distribution
 you need, e.g. `/var/lib/openqa/tests/opensuse` for openSUSE tests.
 
 The repositories will be kept up-to-date if `git_auto_update` is enabled in
-`openqa.ini`. The updating is triggered when new tests are scheduled. For a
-periodic update (to avoid getting too far behind) you can enable the systemd
-unit `openqa-enqueue-git-auto-update.timer`.
+`openqa.ini` (which is the default). The updating is triggered when new tests
+are scheduled. For a periodic update (to avoid getting too far behind) you can
+enable the systemd unit `openqa-enqueue-git-auto-update.timer`.
 
 You can get openSUSE tests and needles from
 https://github.com/os-autoinst/os-autoinst-distri-opensuse[GitHub]. To make it

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -115,8 +115,8 @@
 #do_push = no
 ## whether to clone CASEDIR or NEEDLES_DIR on the web UI if that var points to a Git repo
 #git_auto_clone = yes
-## enable automatic updates of all test code and needles managed via Git (still experimental, currently still breaks scheduling parallel clusters)
-#git_auto_update = no
+## enable automatic updates of all test code and needles managed via Git
+#git_auto_update = yes
 ## specifies how to handle errors on automatic updates via git_auto_update
 ## - when set to "best-effort" openQA jobs are started even if the update failed
 ## - when set to "strict" openQA jobs will be blocked until the update succeeded or set to incomplete when the retries for updating are exhausted

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -115,7 +115,7 @@ sub read_config ($app) {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
-            git_auto_update => 'no',
+            git_auto_update => 'yes',
             git_auto_update_method => 'best-effort',
         },
         scheduler => {

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -48,13 +48,15 @@ my $schema = OpenQA::Test::Database->new->create;
 my $jobs = $schema->resultset('Jobs');
 my $workers = $schema->resultset('Workers');
 my $t = Test::Mojo->new('OpenQA::Scheduler');
-OpenQA::App->set_singleton(OpenQA::WebAPI->new);
+my $app = OpenQA::WebAPI->new;
+OpenQA::App->set_singleton($app);
+$app->config->{'scm git'}->{git_auto_update} = 'no';
 
 subtest 'Authentication' => sub {
-    $t->get_ok('/test')->status_is(404)->content_like(qr/Not found/);
     my $app = $t->app;
+    $t->get_ok('/test')->status_is(404)->content_like(qr/Not found/);
     $t->get_ok('/')->status_is(200)->json_is({name => $app->defaults('appname')});
-    local $t->app->config->{no_localhost_auth} = 0;
+    local $app->config->{no_localhost_auth} = 0;
     $t->get_ok('/')->status_is(403)->json_is({error => 'Not authorized'});
 };
 

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -31,6 +31,7 @@ my $job_dependencies = $schema->resultset('JobDependencies');
 my $job_settings = $schema->resultset('JobSettings');
 my $workers = $schema->resultset('Workers');
 my $t = Test::Mojo->new('OpenQA::WebAPI');
+$t->app->config->{'scm git'}->{git_auto_update} = 'no';
 embed_server_for_testing(
     server_name => 'OpenQA::WebSockets',
     client => OpenQA::WebSockets::Client->singleton,

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -52,11 +52,12 @@ my $api_key = $api_credentials->key;
 my $api_secret = $api_credentials->secret;
 
 # create web UI and websocket server
-setup_mojo_app_with_default_worker_timeout('OpenQA::WebAPI');
+my $app = setup_mojo_app_with_default_worker_timeout('OpenQA::WebAPI');
 my $mojoport = service_port 'webui';
 my $ws = create_websocket_server(undef, 0, 1);
 my $webapi = create_webapi($mojoport, sub { });
 my @workers;
+$app->config->{'scm git'}->{git_auto_update} = 'no';
 
 # setup share and result dir
 my $sharedir = setup_share_dir($ENV{OPENQA_BASEDIR});

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -21,8 +21,8 @@ use Test::Warnings ':report_warnings';
 
 my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 06-job_dependencies.pl');
 my $t = Test::Mojo->new('OpenQA::WebAPI');
+$t->app->config->{'scm git'}->{git_auto_update} = 'no';
 assume_all_assets_exist;
-
 embed_server_for_testing(
     server_name => 'OpenQA::WebSockets',
     client => OpenQA::WebSockets::Client->singleton,

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -25,6 +25,7 @@ my $host = "localhost:$mojoport";
 my @common_options = (host => $host, from => $host, apikey => 'foo', apisecret => 'bar');
 my $webapi = create_webapi($mojoport, sub { });
 END { stop_service $webapi; }
+$t->app->config->{'scm git'}->{git_auto_update} = 'no';
 
 my $schema = $t->app->schema;
 my $products = $schema->resultset("Products");

--- a/t/config.t
+++ b/t/config.t
@@ -67,7 +67,7 @@ subtest 'Test configuration default modes' => sub {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
-            git_auto_update => 'no',
+            git_auto_update => 'yes',
             git_auto_update_method => 'best-effort',
         },
         'scheduler' => {

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -70,8 +70,9 @@ our (@EXPORT, @EXPORT_OK);
 # Potentially this approach can also be used in production code.
 
 sub setup_mojo_app_with_default_worker_timeout ($class = 'Mojolicious') {
-    OpenQA::App->set_singleton(
-        $class->new(config => {global => {worker_timeout => DEFAULT_WORKER_TIMEOUT}}, log => undef));
+    my $app = $class->new(config => {global => {worker_timeout => DEFAULT_WORKER_TIMEOUT}}, log => undef);
+    OpenQA::App->set_singleton($app);
+    return $app;
 }
 
 sub cache_minion_worker {
@@ -384,6 +385,7 @@ sub setup_fullstack_temp_dir {
     my $config = $configdir->child('openqa.ini')->slurp;
     $config =~ s/^#\Q[scm git]/[scm git]/m;
     $config =~ s/^#git_auto_clone = .*/git_auto_clone = no/m;
+    $config =~ s/^#git_auto_update = .*/git_auto_update = no/m;
     $configdir->child('openqa.ini')->spew($config);
     note("OPENQA_BASEDIR: $basedir\nOPENQA_CONFIG: $configdir");
     $ENV{OPENQA_BASEDIR} = $basedir;


### PR DESCRIPTION
* Reapply "Enable automatic updates of test code and needles by default" (commit 40ae05a38ed2ee6c686eba7fde715a04cb00e33e) again after fixing problems with scheduling and restarting of parallel clusters
* See https://progress.opensuse.org/issues/168379