### PR TITLE
Allow plus signs in test names for scope settings

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -39,7 +39,7 @@ sub clone_job_apply_settings ($argv, $depth, $settings, $options) {
 
     for my $arg (@$argv) {
         # split arg into key and value
-        unless ($arg =~ /([A-Z0-9_]+)(:([\w-]+?))?(\+)?=(.*)/) {
+        unless ($arg =~ /([A-Z0-9_]+)(:([\w]+(?:[\w+-]+\w)?))?(\+)?=(.*)/) {
             warn "command-line argument '$arg' is no valid setting and will be ignored\n";
             next;
         }


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/176886

    WORKER_CLASS:wsl2-main+systemd=...

was resulting in an error.

This change allows plus signs in test names now, but not at the beginning or
end. It also forbids minus signs at the beginning or end.