### PR TITLE
Update product name for SUSE Linux Micro

### DIFF
--- a/templates/webapi/branding/openSUSE/external_reporting.html.ep
+++ b/templates/webapi/branding/openSUSE/external_reporting.html.ep
@@ -20,7 +20,7 @@
 );%>
 <% my %distri_to_prod = (
     sle => 'SUSE Linux Enterprise',
-    'sle-micro' => 'SUSE Linux Enterprise',
+    'sle-micro' => 'SUSE Linux',
     opensuse => 'openSUSE',
     caasp => 'SUSE CaaS Platform',
     kubic => 'openSUSE',


### PR DESCRIPTION
Enterprise was removed from this product starting in 6.0
https://progress.opensuse.org/issues/176979