### PR TITLE
Improve error handling when creating jobs from settings

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -119,7 +119,6 @@ sub create_from_settings {
     my $result_source = $self->result_source;
     my $schema = $result_source->schema;
     my $job_settings = $schema->resultset('JobSettings');
-    my $txn_guard = $result_source->storage->txn_scope_guard;
 
     my @invalid_keys = grep { $_ =~ /^(PUBLISH_HDD|FORCE_PUBLISH_HDD|STORE_HDD)\S+(\d+)$/ && $settings{$_} =~ /\// }
       keys %settings;
@@ -207,7 +206,6 @@ sub create_from_settings {
     log_info('Ignoring invalid group ' . encode_json($group_args) . ' when creating new job ' . $job->id)
       if keys %$group_args && !$group;
     $job->calculate_blocked_by;
-    $txn_guard->commit;
     return $job;
 }
 


### PR DESCRIPTION
**Avoid nested transaction when creating jobs from settings**

The transaction in the function `create_from_settings` was introduced by
https://github.com/os-autoinst/openQA/commit/b03aa8d6c68eb631151243d2f262dbdd8471625e. At this point this function was likely not always called within
`txn_do`. It is now, though. So I suppose this extra nested transaction is
not useful anymore.

This nested transaction also doesn't act as a useful save point as the
errors we saw in https://progress.opensuse.org/issues/177048 indicate.

---

**Use a proper save point when creating jobs from settings**

The nested transaction that was previously used did not lead to a sensible
rollback leading to follow-up errors when creating dependencies. This was
presumably the case because all jobs that have been created since the outer
transaction was started were rolled back.

As an example, the initial error:
```
OpenQA::Schema::Result::Jobs::register_assets_from_settings(): DBI Exception: DBD::Pg::st execute failed: ERROR:  deadlock detected\nDETAIL:  Process 8553 waits for ShareLock on transaction 2490096299; blocked by process 21248.\nProcess 21248 waits for ShareLock on transaction 2490096379; blocked by process 8553.\nHINT:  See server log for query details.\nCONTEXT:  while inserting index tuple (795,49) in relation \"assets\" [for Statement \"INSERT INTO assets (type, name, t_created, t_updated)\n            VALUES (?,    ?,    now(),     now())\n    ON CONFLICT DO NOTHING RETURNING id\n\" with ParamValues: 1='hdd', 2='SLES-12-SP5-x86_64-mru-install-desktop-with-addons-Build20250211-1.qcow2'] at /usr/share/openqa/script/../lib/OpenQA/Schema/ResultSet/Jobs.pm line 205\n
```
was followed by:
```
DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::Pg::st execute failed: ERROR:  insert or update on table \"job_dependencies\" violates foreign key constraint \"job_dependencies_fk_child_job_id\"\nDETAIL:  Key (child_job_id)=(16732338) is not present in table \"jobs\". [for Statement \"INSERT INTO job_dependencies ( child_job_id, dependency, parent_job_id) VALUES ( ?, ?, ? )\" with ParamValues: 1='16732338', 2='1', 3='16732331'] at /usr/share/openqa/script/../lib/OpenQA/Schema/Result/ScheduledProducts.pm line 703\n
```
indicating that all jobs since that have been created since the initial
error were rolled back (and not just the job that ran into that error).

This change fixes the follow-up errors (but not the initial error) by using
explicit save points like we already do in the Gru plugin. See commit
https://github.com/os-autoinst/openQA/commit/5cdc48c0e7b24b996003594bb5ec921a07ea1eec for details.

See https://progress.opensuse.org/issues/177048 for more examples and
further context.