### PR TITLE
Avoid errors about deadlocks

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -422,7 +422,7 @@ sub create ($self) {
     my $event_data = $self->{_event_data} = [];
     my $dependencies = $self->{_dependencies} = [];
     try {
-        $self->schema->txn_do(sub { $self->_create_jobs($global_params, $grouped_params) });
+        $self->schema->txn_do_retry_on_deadlock(sub { $self->_create_jobs($global_params, $grouped_params) });
         OpenQA::Scheduler::Client->singleton->wakeup;
     }
     catch {


### PR DESCRIPTION
* Retry the transaction for creating jobs (when a single set of jobs is posted or when a product is scheduled) in case of a deadlock (as it is hard to ensure a consistent order to prevent deadlocks from happening in the first place)
* Add test provoking deadlocks when registering assets on job creation
* Mark certain statements as uncoverable to avoid inconsistent test coverage as the test is only able to reproduce deadlocks *almost* always
* See https://progress.opensuse.org/issues/177048