### PR TITLE
Show correct needle versions in test result step matches

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -18,7 +18,7 @@
 
 # can't use linebreaks here!
 %define openqa_main_service openqa-webui.service
-%define openqa_extra_services openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer openqa-enqueue-asset-cleanup.service openqa-enqueue-git-auto-update.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.service openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.service openqa-enqueue-bug-cleanup.timer openqa-enqueue-git-auto-update.timer
+%define openqa_extra_services openqa-gru.service openqa-websockets.service openqa-scheduler.service openqa-enqueue-audit-event-cleanup.service openqa-enqueue-audit-event-cleanup.timer openqa-enqueue-asset-cleanup.service openqa-enqueue-git-auto-update.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.service openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.service openqa-enqueue-bug-cleanup.timer openqa-enqueue-git-auto-update.timer openqa-enqueue-needle-ref-cleanup.service openqa-enqueue-needle-ref-cleanup.timer
 %define openqa_services %{openqa_main_service} %{openqa_extra_services}
 %define openqa_worker_services openqa-worker.target openqa-slirpvde.service openqa-vde_switch.service openqa-worker-cacheservice.service openqa-worker-cacheservice-minion.service
 %if %{undefined tmpfiles_create}
@@ -611,6 +611,8 @@ fi
 %{_unitdir}/openqa-enqueue-result-cleanup.timer
 %{_unitdir}/openqa-enqueue-bug-cleanup.service
 %{_unitdir}/openqa-enqueue-bug-cleanup.timer
+%{_unitdir}/openqa-enqueue-needle-ref-cleanup.service
+%{_unitdir}/openqa-enqueue-needle-ref-cleanup.timer
 %{_tmpfilesdir}/openqa-webui.conf
 # web libs
 %dir %{_datadir}/openqa
@@ -647,6 +649,7 @@ fi
 %{_datadir}/openqa/script/openqa-webui-daemon
 %{_datadir}/openqa/script/upgradedb
 %{_datadir}/openqa/script/modify_needle
+%{_datadir}/openqa/script/openqa-enqueue-needle-ref-cleanup
 # TODO: define final user
 %defattr(-,geekotest,root)
 # attention: never package subdirectories owned by a user other

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -121,6 +121,16 @@
 ## - when set to "best-effort" openQA jobs are started even if the update failed
 ## - when set to "strict" openQA jobs will be blocked until the update succeeded or set to incomplete when the retries for updating are exhausted
 #git_auto_update_method = best-effort
+## whether openQA should attempt to display needles according to the original commits in the web UI
+## on test result step view
+## warning: This causes extra Git checkouts and increased response times of the test result step view.
+##          You probably also want to enable `openqa-enqueue-needle-ref-cleanup.service`.
+#checkout_needles_sha = no
+## whether openQA should fetch needles (via checkout_needles_sha) from foreign remote URLs
+## warning: this will hit performance even further and fetching from arbitrary URLs might have security aspects
+#allow_arbitrary_url_fetch = no
+## retention for storing temporary needle refs in minutes
+#temp_needle_refs_retention = 120
 
 ## Authentication method to use for user management
 [auth]

--- a/lib/OpenQA/Needles.pm
+++ b/lib/OpenQA/Needles.pm
@@ -1,0 +1,63 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Needles;
+use Mojo::Base -strict, -signatures;
+
+use Exporter qw(import);
+use File::Basename;
+use File::Spec;
+use OpenQA::App;
+use OpenQA::Git;
+use OpenQA::Log qw(log_error);
+use OpenQA::Utils qw(prjdir sharedir);
+use Mojo::File qw(path);
+
+our @EXPORT_OK = qw(temp_dir is_in_temp_dir needle_temp_dir locate_needle _locate_needle_for_ref);
+
+my $tmp_dir = prjdir() . '/webui/cache/needle-refs';
+
+sub temp_dir () { $tmp_dir }
+
+sub is_in_temp_dir ($file_path) { index($file_path, $tmp_dir) == 0 }
+
+sub needle_temp_dir ($dir, $ref) { path($tmp_dir, basename(dirname($dir)), $ref, 'needles') }
+
+sub _locate_needle_for_ref ($relative_needle_path, $needles_dir, $needles_ref, $needle_url) {
+    # checkout needle from git - return absolute path to json file on success and undef on error
+    return undef unless defined $needles_ref;
+    my $app = OpenQA::App->singleton;
+    my $allow_arbitrary_url_fetch = $app->config->{'scm git'}->{allow_arbitrary_url_fetch} eq 'yes';
+    my $temp_needles_dir = needle_temp_dir($needles_dir, $needles_ref);
+    my $subdir = dirname($relative_needle_path);
+    my $git = OpenQA::Git->new(app => $app, dir => $needles_dir);
+    my $temp_json_path = "$temp_needles_dir/$relative_needle_path";
+    my $basename = basename($relative_needle_path, '.json');
+    my $relative_png_path = "$subdir/$basename.png";
+    my $temp_png_path = "$temp_needles_dir/$relative_png_path";
+    my $error
+      = $git->cache_ref($needles_ref, $needle_url, $relative_needle_path, $temp_json_path, $allow_arbitrary_url_fetch)
+      // $git->cache_ref($needles_ref, $needle_url, $relative_png_path, $temp_png_path, $allow_arbitrary_url_fetch);
+    log_error "An error occurred when looking for ref '$needles_ref' of '$relative_needle_path': $error"
+      if defined $error;
+    return (defined $error) ? undef : $temp_json_path;
+}
+
+sub locate_needle ($relative_needle_path, $needles_dir, $needles_ref = undef, $needle_url = undef) {
+    # return absolute path to needle - if possible via tmp checkout of needle from git at requested ref
+    # else just the current needle in the <$needles_dir>
+    # if that fails as well return undef
+    my $location_for_ref = _locate_needle_for_ref($relative_needle_path, $needles_dir, $needles_ref, $needle_url);
+    return $location_for_ref if defined $location_for_ref;
+    my $absolute_filename = path($needles_dir, $relative_needle_path);
+    my $needle_exists = -f $absolute_filename;
+    if (!$needle_exists) {
+        $absolute_filename = path(sharedir(), $relative_needle_path);
+        $needle_exists = -f $absolute_filename;
+    }
+    return $absolute_filename if $needle_exists;
+    log_error "Needle file $relative_needle_path not found within $needles_dir.";
+    return undef;
+}
+
+1;

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -16,7 +16,7 @@ use OpenQA::App;
 use OpenQA::Git;
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
-use OpenQA::Utils qw(locate_needle);
+use OpenQA::Needles qw(locate_needle);
 
 __PACKAGE__->table('needles');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime Timestamps));

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -117,6 +117,9 @@ sub read_config ($app) {
             git_auto_clone => 'yes',
             git_auto_update => 'yes',
             git_auto_update_method => 'best-effort',
+            checkout_needles_sha => 'no',
+            allow_arbitrary_url_fetch => 'no',
+            temp_needle_refs_retention => 120,
         },
         scheduler => {
             max_job_scheduled_time => 7,

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -32,7 +32,10 @@ sub register_tasks ($self) {
       OpenQA::Task::Asset::Download
       OpenQA::Task::Asset::Limit
       OpenQA::Task::Git::Clone
-      OpenQA::Task::Needle::Scan OpenQA::Task::Needle::Save OpenQA::Task::Needle::Delete
+      OpenQA::Task::Needle::Scan
+      OpenQA::Task::Needle::Save
+      OpenQA::Task::Needle::Delete
+      OpenQA::Task::Needle::LimitTempRefs
       OpenQA::Task::Job::Limit
       OpenQA::Task::Job::ArchiveResults
       OpenQA::Task::Job::FinalizeResults

--- a/lib/OpenQA/Task/Needle/LimitTempRefs.pm
+++ b/lib/OpenQA/Task/Needle/LimitTempRefs.pm
@@ -1,0 +1,39 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Task::Needle::LimitTempRefs;
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
+
+use File::Find;
+use File::stat;
+use Fcntl qw(S_ISDIR);
+use OpenQA::Needles;
+use OpenQA::Task::SignalGuard;
+use Time::Seconds;
+
+my $retention;
+
+sub register ($self, $app, $job) {
+    $retention = $app->config->{'scm git'}->{temp_needle_refs_retention} * ONE_MINUTE;
+    $app->minion->add_task(limit_temp_needle_refs => sub ($job) { _limit($app, $job) });
+}
+
+sub _limit ($app, $job) {
+    my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
+
+    return $job->finish({error => 'Another job to remove needle versions is running. Try again later.'})
+      unless my $guard = $app->minion->guard('limit_needle_versions_task', 2 * ONE_HOUR);
+
+    # remove all temporary needles which haven't been accessed in time period specified in config
+    my $temp_dir = OpenQA::Needles::temp_dir;
+    return undef unless -d $temp_dir;
+    my $now = time;
+    my $wanted = sub {
+        return undef unless my $lstat = lstat $File::Find::name;
+        return rmdir $File::Find::name if S_ISDIR($lstat->mode);    # remove all empty dirs
+        return unlink $File::Find::name if ($now - $lstat->mtime) > $retention;
+    };
+    find({no_chdir => 1, bydepth => 1, wanted => $wanted}, $temp_dir);
+}
+
+1;

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -6,6 +6,7 @@ use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 BEGIN { $ENV{MAGICK_THREAD_LIMIT} = 1; }
 
+use OpenQA::Needles;
 use OpenQA::Utils qw(:DEFAULT prjdir assetdir imagesdir);
 use File::Basename;
 use File::Spec;
@@ -29,11 +30,14 @@ sub needle ($self) {
 
     # make sure the directory of the file parameter is a real subdir of testcasedir before
     # using it to find needle subdirectory, to prevent access outside of the zoo
-    if ($jsonfile && !is_in_tests($jsonfile)) {
+    if ($jsonfile && !is_in_tests($jsonfile) && !OpenQA::Needles::is_in_temp_dir($jsonfile)) {
         my $prjdir = prjdir();
         warn "$jsonfile is not in a subdir of $prjdir/share/tests or $prjdir/tests";
         return $self->render(text => 'Forbidden', status => 403);
     }
+    # If the json file is not in the tests we may be using a temporary
+    # directory for needles from a different git SHA
+    $needledir = dirname($jsonfile) if ($jsonfile && OpenQA::Needles::is_in_temp_dir($jsonfile));
     # Reject directory traversal breakouts here...
     if (index($jsonfile, '..') != -1) {
         warn "jsonfile value $jsonfile is invalid, cannot contain ..";

--- a/script/openqa-enqueue-needle-ref-cleanup
+++ b/script/openqa-enqueue-needle-ref-cleanup
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Enqueue openQA needle ref cleanup" && exit
+exec "$(dirname "$0")"/openqa eval -m production -V 'app->gru->enqueue(limit_temp_needle_refs => [], {priority => 5, ttl => 172800, limit => 1})' "$@"

--- a/systemd/openqa-enqueue-needle-ref-cleanup.service
+++ b/systemd/openqa-enqueue-needle-ref-cleanup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Enqueues a needle ref cleanup task for openQA.
+After=postgresql.service openqa-setup-db.service
+Wants=openqa-setup-db.service
+
+[Service]
+Type=oneshot
+User=geekotest
+ExecStart=/usr/share/openqa/script/openqa-enqueue-needle-ref-cleanup

--- a/systemd/openqa-enqueue-needle-ref-cleanup.timer
+++ b/systemd/openqa-enqueue-needle-ref-cleanup.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Enqueues a needle refs task for openQA every hour.
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/t/config.t
+++ b/t/config.t
@@ -69,6 +69,9 @@ subtest 'Test configuration default modes' => sub {
             git_auto_clone => 'yes',
             git_auto_update => 'yes',
             git_auto_update_method => 'best-effort',
+            checkout_needles_sha => 'no',
+            allow_arbitrary_url_fetch => 'no',
+            temp_needle_refs_retention => 2 * ONE_MINUTE,
         },
         'scheduler' => {
             max_job_scheduled_time => 7,


### PR DESCRIPTION
This is a limited part of https://github.com/os-autoinst/openQA/pull/5175
taken out to go step by step.

The needle version is only read from vars.json and only supports hashrefs - no branches/tags.
Network interaction by git on showing a needle is limited to the absolute minimum.
Also the needle editor is not changed, yet.

Ticket: https://progress.opensuse.org/issues/162035