### PR TITLE
Validate the test name when creating new jobs

### DIFF
--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -9,7 +9,7 @@ use Exporter 'import';
 # define regex for validating test names in accordance with `JobScenarios-01.yaml` and `JobTemplates-01.yaml`
 # note: In contrast to the YAML schema a few more characters are allowed here as they are useful for manually
 #       triggered jobs, e.g. via `openqa-clone-custom-git-refspec`.
-use constant TEST_NAME_REGEX => qr|^[A-Za-z 0-9_*.+,:/#@-]+\z|;
+use constant TEST_NAME_REGEX => qr|^[\p{Word} _*.+,:/#@-]+\z|;
 
 # job states
 use constant {

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -9,7 +9,7 @@ use Exporter 'import';
 # define regex for validating test names in accordance with `JobScenarios-01.yaml` and `JobTemplates-01.yaml`
 # note: In contrast to the YAML schema a few more characters are allowed here as they are useful for manually
 #       triggered jobs, e.g. via `openqa-clone-custom-git-refspec`.
-use constant TEST_NAME_REGEX => qr|^[A-Za-z 0-9_*.+,:/#@%"'-]+\z|;
+use constant TEST_NAME_REGEX => qr|^[A-Za-z 0-9_*.+,:/#@-]+\z|;
 
 # job states
 use constant {

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -9,7 +9,7 @@ use Exporter 'import';
 # define regex for validating test names in accordance with `JobScenarios-01.yaml` and `JobTemplates-01.yaml`
 # note: In contrast to the YAML schema a few more characters are allowed here as they are useful for manually
 #       triggered jobs, e.g. via `openqa-clone-custom-git-refspec`.
-use constant TEST_NAME_REGEX => qr|^[A-Za-z 0-9_*.+,:/#@%"'-]+$|;
+use constant TEST_NAME_REGEX => qr|^[A-Za-z 0-9_*.+,:/#@%"'-]+\z|;
 
 # job states
 use constant {

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -7,7 +7,9 @@ use Mojo::Base -base, -signatures;
 use Exporter 'import';
 
 # define regex for validating test names in accordance with `JobScenarios-01.yaml` and `JobTemplates-01.yaml`
-use constant TEST_NAME_REGEX => qr/^[A-Za-z 0-9_*.+-]+$/;
+# note: In contrast to the YAML schema a few more characters are allowed here as they are useful for manually
+#       triggered jobs, e.g. via `openqa-clone-custom-git-refspec`.
+use constant TEST_NAME_REGEX => qr|^[A-Za-z 0-9_*.+,:/#@%"'-]+$|;
 
 # job states
 use constant {

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -7,7 +7,7 @@ use Mojo::Base -base, -signatures;
 use Exporter 'import';
 
 # define regex for validating test names in accordance with `JobScenarios-01.yaml` and `JobTemplates-01.yaml`
-use constant TEST_NAME_REGEX => qr/^[A-Za-z\s0-9_*.+-]+$/;
+use constant TEST_NAME_REGEX => qr/^[A-Za-z 0-9_*.+-]+$/;
 
 # job states
 use constant {

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -6,6 +6,9 @@ use Mojo::Base -base, -signatures;
 
 use Exporter 'import';
 
+# define regex for validating test names in accordance with `JobScenarios-01.yaml` and `JobTemplates-01.yaml`
+use constant TEST_NAME_REGEX => qr/^[A-Za-z\s0-9_*.+-]+$/;
+
 # job states
 use constant {
     # initial job state; the job is supposed to be assigned to a worker by the scheduler
@@ -103,6 +106,7 @@ use constant DEFAULT_JOB_PRIORITY => 50;
 use constant TAG_ID_COLUMN => "concat(VERSION, '-', BUILD)";
 
 our @EXPORT = qw(
+  TEST_NAME_REGEX
   ASSIGNED
   CANCELLED
   COMPLETE_RESULTS

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -125,9 +125,10 @@ sub create_from_settings {
     die 'The ' . join(',', @invalid_keys) . " cannot include / in value\n" if @invalid_keys;
 
     # validate special settings
-    my %special_settings = (_PRIORITY => delete $settings{_PRIORITY});
+    my %special_settings = (TEST => delete $settings{TEST}, _PRIORITY => delete $settings{_PRIORITY});
     my $validator = Mojolicious::Validator->new;
     my $v = Mojolicious::Validator::Validation->new(validator => $validator, input => \%special_settings);
+    my $test = $v->required('TEST')->like(TEST_NAME_REGEX)->param;
     my $prio = $v->optional('_PRIORITY')->num->param;
     die 'The following settings are invalid: ' . join(', ', @{$v->failed}) . "\n" if $v->has_error;
 
@@ -176,9 +177,9 @@ sub create_from_settings {
         my $value = $settings{$key};
         $settings{$key} = decode_utf8 encode_json $value if (ref $value eq 'ARRAY' || ref $value eq 'HASH');
     }
-    $new_job_args{TEST} = $settings{TEST};
 
     # move important keys from the settings directly to the job
+    $new_job_args{TEST} = $test;
     for my $key (OpenQA::Schema::Result::Jobs::MAIN_SETTINGS) {
         if (my $value = delete $settings{$key}) { $new_job_args{$key} = $value }
     }

--- a/public/schema/JobScenarios-01.yaml
+++ b/public/schema/JobScenarios-01.yaml
@@ -15,7 +15,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      ^[A-Za-z0-9._*-]+$:
+      ^[\p{Word}._*-]+$:
         type: object
         description: The name of a product (medium)
         required:
@@ -47,7 +47,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      ^[A-Za-z0-9._*-]+$:
+      ^[\p{Word}._*-]+$:
         type: object
         description: The name of a machine
         required:
@@ -66,7 +66,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      ^[A-Za-z 0-9_*.+-]+$:
+      ^[\p{Word} _*.+-]+$:
         type: object
         description: The name of the job template
         additionalProperties: false

--- a/public/schema/JobScenarios-01.yaml
+++ b/public/schema/JobScenarios-01.yaml
@@ -66,7 +66,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      ^[A-Za-z\s0-9_*.+-]+$:
+      ^[A-Za-z 0-9_*.+-]+$:
         type: object
         description: The name of the job template
         additionalProperties: false

--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -34,7 +34,7 @@ properties:
                   description: A test suite with machine and/or priority value specified, or a custom job template name if testsuite was specified
                   additionalProperties: false
                   patternProperties:
-                    &testsuite-pattern ^[A-Za-z\s0-9_*.+-]+$:
+                    &testsuite-pattern ^[A-Za-z 0-9_*.+-]+$:
                       type: object
                       additionalProperties: false
                       properties:

--- a/public/schema/JobTemplates-01.yaml
+++ b/public/schema/JobTemplates-01.yaml
@@ -34,7 +34,7 @@ properties:
                   description: A test suite with machine and/or priority value specified, or a custom job template name if testsuite was specified
                   additionalProperties: false
                   patternProperties:
-                    &testsuite-pattern ^[A-Za-z 0-9_*.+-]+$:
+                    &testsuite-pattern ^[\p{Word} _*.+-]+$:
                       type: object
                       additionalProperties: false
                       properties:
@@ -82,7 +82,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      ^[A-Za-z0-9._*-]+$:
+      ^[\p{Word}._*-]+$:
         type: object
         description: The name of a product (medium)
         required:

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -827,7 +827,7 @@ subtest 'get job status' => sub {
 
 subtest 'validation of test name' => sub {
     my @disallowed = ('spam=eggs', "spam\teggs", "spam\neggs", "spam eggs\n");
-    my @allowed = ('spam.eggs', 'spam+eggs', 'spam:eggs', 'spam@eggs', 'spam eggs');
+    my @allowed = ('späm.eggs.垃圾郵件雞蛋', 'spam+eggs', 'sµam:eggs', 'spam@eggs', 'spam eggs 0123456789');
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(400, "test name $_ disallowed") for @disallowed;
     $t->json_is('/error' => 'The following settings are invalid: TEST', 'error for invalid test name returned');
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(200, "test name $_ allowed") for @allowed;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -826,7 +826,7 @@ subtest 'get job status' => sub {
 };
 
 subtest 'validation of test name' => sub {
-    my @disallowed = ('spam=eggs', "spam\teggs");
+    my @disallowed = ('spam=eggs', "spam\teggs", "spam\neggs", "spam eggs\n");
     my @allowed = ('spam.eggs', 'spam+eggs', 'spam:"eggs"', 'spam@eggs', "spam 'eggs'");
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(400, "test name $_ disallowed") for @disallowed;
     $t->json_is('/error' => 'The following settings are invalid: TEST', 'error for invalid test name returned');

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -827,7 +827,7 @@ subtest 'get job status' => sub {
 
 subtest 'validation of test name' => sub {
     my @disallowed = ('spam=eggs', "spam\teggs", "spam\neggs", "spam eggs\n");
-    my @allowed = ('spam.eggs', 'spam+eggs', 'spam:"eggs"', 'spam@eggs', "spam 'eggs'");
+    my @allowed = ('spam.eggs', 'spam+eggs', 'spam:eggs', 'spam@eggs', 'spam eggs');
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(400, "test name $_ disallowed") for @disallowed;
     $t->json_is('/error' => 'The following settings are invalid: TEST', 'error for invalid test name returned');
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(200, "test name $_ allowed") for @allowed;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -826,8 +826,8 @@ subtest 'get job status' => sub {
 };
 
 subtest 'validation of test name' => sub {
-    my @disallowed = ('spam@eggs', 'spam:eggs');
-    my @allowed = ('spam.eggs', 'spam+eggs');
+    my @disallowed = ('spam@eggs', 'spam:eggs', "spam\teggs");
+    my @allowed = ('spam.eggs', 'spam+eggs', 'spam eggs');
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(400, "test name $_ disallowed") for @disallowed;
     $t->json_is('/error' => 'The following settings are invalid: TEST', 'error for invalid test name returned');
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(200, "test name $_ allowed") for @allowed;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -826,8 +826,8 @@ subtest 'get job status' => sub {
 };
 
 subtest 'validation of test name' => sub {
-    my @disallowed = ('spam@eggs', 'spam:eggs', "spam\teggs");
-    my @allowed = ('spam.eggs', 'spam+eggs', 'spam eggs');
+    my @disallowed = ('spam=eggs', "spam\teggs");
+    my @allowed = ('spam.eggs', 'spam+eggs', 'spam:"eggs"', 'spam@eggs', "spam 'eggs'");
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(400, "test name $_ disallowed") for @disallowed;
     $t->json_is('/error' => 'The following settings are invalid: TEST', 'error for invalid test name returned');
     $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(200, "test name $_ allowed") for @allowed;

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -825,6 +825,16 @@ subtest 'get job status' => sub {
       ->json_is('/error_status' => 404, 'Status code correct')->json_is('/error' => 'Job does not exist');
 };
 
+subtest 'validation of test name' => sub {
+    my @disallowed = ('spam@eggs', 'spam:eggs');
+    my @allowed = ('spam.eggs', 'spam+eggs');
+    $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(400, "test name $_ disallowed") for @disallowed;
+    $t->json_is('/error' => 'The following settings are invalid: TEST', 'error for invalid test name returned');
+    $t->post_ok('/api/v1/jobs', form => {TEST => $_})->status_is(200, "test name $_ allowed") for @allowed;
+    is $jobs->search({TEST => {-in => \@disallowed}})->count, 0, 'no jobs with disallowed names created';
+    is $jobs->search({TEST => {-in => \@allowed}})->count, @allowed, 'all jobs with allowed names created';
+};
+
 subtest 'cancel job' => sub {
     $t->post_ok('/api/v1/jobs/99963/cancel')->status_is(200);
     is_deeply(

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -496,12 +496,12 @@ $yaml->{products}{$product}{version} = '42.1';
 # Add non-trivial test suites to exercise the validation
 $yaml->{scenarios}{'x86_64'}{$product} = [
     'spam',
-    "eg-G_S +133t*.\t",
+    "eg-G_S +133t*.",
     {
         'foo' => {},
     },
     {
-        "b-A_RRRR +133t*.\t" => {
+        "b-A_RRRR +133t*." => {
             machine => 'x86_64',
             priority => 33,
         },

--- a/t/data/job-templates/schema-invalid.yaml
+++ b/t/data/job-templates/schema-invalid.yaml
@@ -28,7 +28,7 @@ properties:
                   description: A test suite with machine and/or priority value specified, or a custom job template name if testsuite was specified
                   additionalProperties: false
                   patternProperties:
-                    ^[A-Za-z\s0-9_*.+-]+$:
+                    ^[A-Za-z 0-9_*.+-]+$:
                       type: object
                       additionalProperties: false
                       properties:
@@ -49,7 +49,7 @@ properties:
                               type: string
                         testsuite:
                           type: string
-                          pattern: ^[A-Za-z\s0-9_*.+-]+$
+                          pattern: ^[A-Za-z 0-9_*.+-]+$
                           description: The test suite this scenario is based on if a custom job template name was used
                         description:
                           type: string

--- a/t/data/job-templates/schema-invalid.yaml
+++ b/t/data/job-templates/schema-invalid.yaml
@@ -28,7 +28,7 @@ properties:
                   description: A test suite with machine and/or priority value specified, or a custom job template name if testsuite was specified
                   additionalProperties: false
                   patternProperties:
-                    ^[A-Za-z 0-9_*.+-]+$:
+                    ^[\p{Word} _*.+-]+$:
                       type: object
                       additionalProperties: false
                       properties:
@@ -49,7 +49,7 @@ properties:
                               type: string
                         testsuite:
                           type: string
-                          pattern: ^[A-Za-z 0-9_*.+-]+$
+                          pattern: ^[\p{Word} _*.+-]+$
                           description: The test suite this scenario is based on if a custom job template name was used
                         description:
                           type: string
@@ -86,7 +86,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      ^[A-Za-z0-9._*-]+$:
+      ^[\p{Word}._*-]+$:
         type: object
         description: The name of a product (medium)
         required:


### PR DESCRIPTION
* Use the same regex we already use when validating the YAML schema for job templates
* See https://progress.opensuse.org/issues/177267