### PR TITLE
perltidy: Use new --pack-operator-types option

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -11,6 +11,4 @@
 -bt=2    # no spaces around []
 -sbt=2   # no spaces around {}
 -sct     # stack closing tokens )}
-# Prevent excessive line-wrapping
-# See https://github.com/perltidy/perltidy/issues/171
---freeze-newlines
+--pack-operator-types='->' # allow chained method calls on one line

--- a/lib/OpenQA/Git.pm
+++ b/lib/OpenQA/Git.pm
@@ -104,7 +104,8 @@ sub commit ($self, $args = undef) {
 
         my $msg = 'Unable to push Git commit';
         if ($res->{return_code} == 128 and $res->{stderr} =~ m/Authentication failed for .http/) {
-            $msg .= '. See https://open.qa/docs/#_setting_up_git_support on how to setup git support and possibly push via ssh.';
+            $msg
+              .= '. See https://open.qa/docs/#_setting_up_git_support on how to setup git support and possibly push via ssh.';
         }
         return $self->_format_git_error($res, $msg);
     }

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -117,7 +117,8 @@ sub _allocate_jobs ($self, $free_workers) {
             my ($picked_worker, $job_info) = @{$taken{$picked_worker_id}};
             my $job_id = $job_info->{id};
             $allocated_workers->{$picked_worker_id} = $job_id;
-            $allocated_jobs->{$job_id} = {job => $job_id, worker => $picked_worker_id, priority_offset => \$j->{priority_offset}};
+            $allocated_jobs->{$job_id}
+              = {job => $job_id, worker => $picked_worker_id, priority_offset => \$j->{priority_offset}};
         }
         # we make sure we schedule clusters no matter what,
         # but we stop if we're over the limit
@@ -383,8 +384,13 @@ sub _pick_siblings_of_running ($self, $allocated_jobs, $allocated_workers) {
         for my $matching_worker (@{$jobinfo->{matching_workers}}) {
             my $matching_worker_id = $matching_worker->id;
             next if $allocated_workers->{$matching_worker_id};
-            if (($worker_one_host_only || $jobinfo->{one_host_only} || $matching_worker->get_property('PARALLEL_ONE_HOST_ONLY'))
-                && ($matching_worker->host ne $worker_host)) {
+            if (
+                (
+                       $worker_one_host_only
+                    || $jobinfo->{one_host_only}
+                    || $matching_worker->get_property('PARALLEL_ONE_HOST_ONLY'))
+                && ($matching_worker->host ne $worker_host))
+            {
                 log_debug "Cannot assign job $job_id on $matching_worker_id, cluster already runs on host $worker_host";
                 next;
             }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -379,7 +379,7 @@ sub prepare_for_work ($self, $worker = undef, $worker_properties = {}) {
     @{$job_hashref->{settings}}{keys %$updated_settings} = values %$updated_settings
       if $updated_settings;
 
-    if ($job_hashref->{settings}->{NICTYPE}
+    if (   $job_hashref->{settings}->{NICTYPE}
         && !defined $job_hashref->{settings}->{NICVLAN}
         && $job_hashref->{settings}->{NICTYPE} ne 'user')
     {

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -402,7 +402,8 @@ sub _schedule_iso {
             sub {
                 $self->_create_jobs_in_database($jobs, \@failed_job_info, $skip_chained_deps, $include_children,
                     \@successful_job_ids);
-            }, sub { (@successful_job_ids, @failed_job_info) = () });
+            },
+            sub { (@successful_job_ids, @failed_job_info) = () });
     }
     catch {
         my $error = shift;
@@ -763,7 +764,7 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, $include_children, @l
             next unless defined $products;
             next unless my $product = $products->{$product_name};
             next
-              if ($product->{distri} ne _distri_key($args)
+              if ( $product->{distri} ne _distri_key($args)
                 || $product->{flavor} ne $args->{FLAVOR}
                 || ($product->{version} ne '*' && $product->{version} ne $args->{VERSION})
                 || $product->{arch} ne $args->{ARCH});

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -350,7 +350,14 @@ sub complex_query ($self, %args) {
     return $jobs;
 }
 
-sub cancel_by_settings ($self, $settings, $newbuild = undef, $deprioritize = undef, $deprio_limit = undef, $related_scheduled_product = undef) {
+sub cancel_by_settings (
+    $self, $settings,
+    $newbuild = undef,
+    $deprioritize = undef,
+    $deprio_limit = undef,
+    $related_scheduled_product = undef
+  )
+{
     $deprio_limit //= 100;
     my $rsource = $self->result_source;
     my $schema = $rsource->schema;
@@ -395,7 +402,8 @@ sub cancel_by_settings ($self, $settings, $newbuild = undef, $deprioritize = und
     my $cancelled_jobs = 0;
     my $priority_increment = 10;
     my $job_result = $newbuild ? OBSOLETED : USER_CANCELLED;
-    my $reason = $related_scheduled_product
+    my $reason
+      = $related_scheduled_product
       ? 'cancelled by scheduled product ' . $related_scheduled_product->id
       : 'cancelled based on job settings';
     my $cancel_or_deprioritize = sub ($job) {

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -190,9 +190,10 @@ sub create_lwp_user_agent ($host, $options) {
 
     my $apikey = ($cfg->val($host, 'key'))[-1];
     my $apisecret = ($cfg->val($host, 'secret'))[-1];
-    $ua->add_handler(request_prepare => sub ($request, $ua, $handler) {
+    $ua->add_handler(
+        request_prepare => sub ($request, $ua, $handler) {
             OpenQA::UserAgent::add_auth_headers($request, Mojo::URL->new($request->uri), $apikey, $apisecret);
-    }) if $apikey && $apisecret;
+        }) if $apikey && $apisecret;
 
     return $ua;
 }
@@ -220,7 +221,7 @@ sub openqa_baseurl ($local_url) {
     my $port = '';
     if (
         $local_url->port
-        && (($local_url->scheme eq 'http' && $local_url->port != 80)
+        && (   ($local_url->scheme eq 'http' && $local_url->port != 80)
             || ($local_url->scheme eq 'https' && $local_url->port != 443)))
     {
         $port = ':' . $local_url->port;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -35,7 +35,8 @@ sub _read_config_file ($config, $config_file, $defaults, $mode_defaults) {
             }
         }
         for my $k (@known_keys) {
-            my $v = $config_file
+            my $v
+              = $config_file
               ? ($config_file->val($section, $k))
               : ($mode_defaults->{$section}->{$k} // $section_defaults->{$k});
             $config->{$section}->{$k} //= trim $v if defined $v;

--- a/lib/OpenQA/Shared/Controller/Session.pm
+++ b/lib/OpenQA/Shared/Controller/Session.pm
@@ -28,7 +28,8 @@ sub ensure_admin {
     unless ($self->current_user) {
         if (($self->tx->req->headers->accept // '') eq 'application/json') {
             $self->render(json => {'error' => 'No valid user session'}, status => 401);
-        } else {
+        }
+        else {
             $self->redirect_to($self->url_for('login')->query(return_page => $self->req->url));
         }
         return undef;

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -117,7 +117,7 @@ sub _limit {
             my $age_in_days = $age->delta_days($now)->in_units('days');
             if ($age_in_days >= $limit_in_days) {
                 _remove_if($schema, $asset,
-                    "Removing asset $asset_name (not in any group, age "
+                        "Removing asset $asset_name (not in any group, age "
                       . "($age_in_days days) exceeds limit ($limit_in_days days)");
             }
             else {

--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -57,7 +57,7 @@ sub _git_clone_all ($job, $clones) {
         my $max_retries = $ENV{OPENQA_GIT_CLONE_RETRIES} // 10;
         my $max_best_effort_retries = min($max_retries, $ENV{OPENQA_GIT_CLONE_RETRIES_BEST_EFFORT} // 2);
         my $gru_task_id = $job->info->{notes}->{gru_id};
-        if ($is_path_only
+        if (   $is_path_only
             && defined($gru_task_id)
             && ($error =~ m/disconnect|curl|stream.*closed|/i)
             && $git_config->{git_auto_update_method} eq 'best-effort'

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -339,10 +339,18 @@ sub run_cmd_with_log_return_error ($cmd, %args) {
         my $ipc_run_succeeded = IPC::Run::run($cmd, \$stdin, \$stdout, \$stderr);
         my $error_code = $?;
         my $return_code = ($error_code & 127) ? (undef) : ($error_code >> 8);
-        my $message = defined $return_code ? ("cmd returned $return_code") : sprintf('cmd died with signal %d', $error_code & 127);
+        my $message
+          = defined $return_code
+          ? ("cmd returned $return_code")
+          : sprintf('cmd died with signal %d', $error_code & 127);
         my $expected_return_codes = $args{expected_return_codes};
         chomp $stderr;
-        if ($expected_return_codes ? (defined($return_code) && $expected_return_codes->{$return_code}) : $ipc_run_succeeded) {
+        if (
+            $expected_return_codes
+            ? (defined($return_code) && $expected_return_codes->{$return_code})
+            : $ipc_run_succeeded
+          )
+        {
             OpenQA::Log->can("log_$stdout_level")->($stdout);
             OpenQA::Log->can("log_$stderr_level")->($stderr);
             log_info $message;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -981,7 +981,7 @@ sub _generate_job_setting ($self, $args) {
     my %params = (input_args => $args, settings => \%settings);
 
     # Populated with Product settings if there are DISTRI, VERSION, FLAVOR, ARCH in arguments.
-    if (defined $args->{DISTRI}
+    if (   defined $args->{DISTRI}
         && defined $args->{VERSION}
         && defined $args->{FLAVOR}
         && defined $args->{ARCH})

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -249,7 +249,7 @@ sub update {
             (($table eq 'TestSuites' || $table eq 'Machines') && $rc->name ne $self->param('name'))
             || (
                 $table eq 'Products'
-                && ($rc->arch ne $self->param('arch')
+                && (   $rc->arch ne $self->param('arch')
                     || $rc->distri ne $self->param('distri')
                     || $rc->flavor ne $self->param('flavor')
                     || $rc->version ne $self->param('version'))))

--- a/lib/OpenQA/WebAPI/Controller/Admin/User.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/User.pm
@@ -43,7 +43,8 @@ sub update {
 
     if (($self->tx->req->headers->accept // '') eq 'application/json') {
         return $self->render(json => {$err ? 'error' : 'status' => $msg}, status => ($err ? $err : '200'));
-    } else {
+    }
+    else {
         $self->flash($err ? 'error' : 'info', $msg);
         $self->redirect_to($self->url_for('admin_users'));
     }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -711,7 +711,7 @@ sub _prepare_job_results ($self, $all_jobs, $limit) {
     my $machines = $self->param_hash('machine');
 
     my @jobs = grep {
-        (not $states or $states->{$_->state})
+              (not $states or $states->{$_->state})
           and (not $results or $results->{$_->result})
           and (not $archs or $archs->{$_->ARCH})
           and (not $machines or $machines->{$_->MACHINE})
@@ -757,7 +757,7 @@ sub _prepare_job_results ($self, $all_jobs, $limit) {
 
         # Append machine name to TEST if it does not match the most frequently used MACHINE
         # for the jobs architecture
-        if ($job->MACHINE
+        if (   $job->MACHINE
             && $preferred_machines->{$job->ARCH}
             && $preferred_machines->{$job->ARCH} ne $job->MACHINE)
         {
@@ -972,7 +972,7 @@ sub module_fails {
 sub _add_dependency_to_graph ($dependency_data, $parent_job_id, $child_job_id, $dependency_type) {
 
     # add edge for chained dependencies
-    if ($dependency_type eq OpenQA::JobDependencies::Constants::CHAINED
+    if (   $dependency_type eq OpenQA::JobDependencies::Constants::CHAINED
         || $dependency_type eq OpenQA::JobDependencies::Constants::DIRECTLY_CHAINED)
     {
         push(@{$dependency_data->{edges}}, {from => $parent_job_id, to => $child_job_id});

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -205,7 +205,7 @@ sub _message {
 
             # skip any further actions if worker just does the one job we expected it to do
             return undef
-              if (defined $job_id
+              if ( defined $job_id
                 && defined $current_job_id
                 && defined $job_token
                 && defined $registered_job_token

--- a/t/01-style.t
+++ b/t/01-style.t
@@ -17,8 +17,10 @@ is qx{git grep --all-match -e '^use Mojo::Base' -e 'use base'}, '', 'No redundan
 is qx{git grep -I --all-match -e '^use Mojo::Base' -e 'use \\(strict\\|warnings\\);' ':!docs'}, '',
   'Only combined Mojo::Base+strict+warnings';
 is qx{git grep -I -L '^use Test::Warnings' t/**.t ':!t/01-style.t'}, '', 'All tests use Test::Warnings';
-is qx{git grep -I -l '^use Test::\\(Exception\\|Fatal\\)' t/**.t}, '', 'Test::Most already includes Test::Exception, no need to use Test::Exception or Test::Fatal';
-is qx{git grep -I -l '^\\(throws\\|dies\\|lives\\)_ok.*\<sub\>' t/**.t}, '', 'Only use simplified prototyped Test::Exception functions';
+is qx{git grep -I -l '^use Test::\\(Exception\\|Fatal\\)' t/**.t}, '',
+  'Test::Most already includes Test::Exception, no need to use Test::Exception or Test::Fatal';
+is qx{git grep -I -l '^\\(throws\\|dies\\|lives\\)_ok.*\<sub\>' t/**.t}, '',
+  'Only use simplified prototyped Test::Exception functions';
 is qx{git grep -I -l 'like.*\$\@' t/**.t}, '', 'Use throws_ok instead of manual checks of exceptions';
 is qx{git grep -I -l 'sub [a-z_A-Z0-9]\\+()' ':!docs/'}, '',
   'Consistent space before function signatures (this is not ensured by perltidy)';

--- a/t/03-auth-openid.t
+++ b/t/03-auth-openid.t
@@ -29,7 +29,7 @@ is(($users->call_args(2))[1], 'mordred', 'new user created with details');
 $c->set_always(
     req => Test::MockObject->new->set_always(
         params => Test::MockObject->new->set_always(pairs => ['openid.op_endpoint', 'https://www.opensuse.org/openid/'])
-)->set_always(url => Test::MockObject->new->set_always(base => 'openqa')))
+    )->set_always(url => Test::MockObject->new->set_always(base => 'openqa')))
   ->set_always(
     app => Test::MockObject->new->set_always(config => {})->set_always(log => Test::MockObject->new->set_true('error')))
   ->set_true('flash');
@@ -47,7 +47,7 @@ $mock_openid_consumer->redefine(
 $c->set_always(
     req => Test::MockObject->new->set_always(
         params => Test::MockObject->new->set_always(pairs => ['openid.op_endpoint', 'https://www.opensuse.org/openid/'])
-)->set_always(url => Test::MockObject->new->set_always(base => 'openqa')))
+    )->set_always(url => Test::MockObject->new->set_always(base => 'openqa')))
   ->set_always(
     app => Test::MockObject->new->set_always(config => {})->set_always(log => Test::MockObject->new->set_true('debug')))
   ->set_true('flash');

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -116,7 +116,8 @@ subtest OAuth2 => sub {
     $ua_mock->redefine(get => sub { shift; push @get_args, [@_]; $get_tx });
 
     my %main_cfg = (provider => 'custom');
-    my %provider_cfg = (user_url => 'http://does-not-exist', token_label => 'bar', id_from => 'id', nickname_from => 'login');
+    my %provider_cfg
+      = (user_url => 'http://does-not-exist', token_label => 'bar', id_from => 'id', nickname_from => 'login');
     my %data = (access_token => 'some-token');
     my %expected_user = (username => 42, provider => 'oauth2@custom', nickname => 'Demo');
     my $users = $t->app->schema->resultset('Users');

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -1189,7 +1189,8 @@ subtest 'parallel siblings of running jobs are allocated' => sub {
         $scheduled_jobs{99998}->{matching_workers} = [$relevant_worker];
         combined_like {
             $schedule->_pick_siblings_of_running($allocated_jobs, $allocated_workers)
-        } qr/Cannot assign job 99998 on 7, cluster already runs on host host$/, 'debug message logged';
+        }
+        qr/Cannot assign job 99998 on 7, cluster already runs on host host$/, 'debug message logged';
         ok !exists $allocated_jobs->{99998}, 'job 99998 not allocated' or always_explain $allocated_jobs;
         # pretend that the already running job has the PARALLEL_ONE_HOST_ONLY worker property property set
         $relevant_worker->set_property(PARALLEL_ONE_HOST_ONLY => 0);
@@ -1198,7 +1199,8 @@ subtest 'parallel siblings of running jobs are allocated' => sub {
         $job_99999->update({assigned_worker_id => $worker_on_different_host_id_2});
         combined_like {
             $schedule->_pick_siblings_of_running($allocated_jobs, $allocated_workers)
-        } qr/Cannot assign job 99998 on 7, cluster already runs on host host3$/, 'debug message logged again';
+        }
+        qr/Cannot assign job 99998 on 7, cluster already runs on host host3$/, 'debug message logged again';
         ok !exists $allocated_jobs->{99998}, 'job 99998 still not allocated' or always_explain $allocated_jobs;
         is @{$scheduled_jobs{99998}->{matching_workers}}, 0, 'matching workers of relevant job emptied';
         is @{$scheduled_jobs{99997}->{matching_workers}}, 13, 'matching workers of other job still populated';

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -172,7 +172,7 @@ subtest 'restart with (directly) chained child' => sub {
         99938 => {is_parent_or_initial_job => 0, @empty_deps, directly_chained_parents => [99937]},
     );
     is_deeply(job_get_rs(99937)->cluster_jobs, \%expected_cluster,
-        '99937 has one directly chained child and one directly chained parent; '
+            '99937 has one directly chained child and one directly chained parent; '
           . 'parent considered for restarting but not siblings');
     $job_before_restart = job_get(99937);
 

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -407,14 +407,20 @@ subtest 'delete_needles' => sub {
         run_cmd_with_log_return_error => sub ($cmd, %args) {
             push @cmds, "@$cmd";
             if (grep m/push/, @$cmd) {
-                return {status => 0, return_code => 128, stderr => q{fatal: Authentication failed for 'https://github.com/lala}, stdout => ''};
+                return {
+                    status => 0,
+                    return_code => 128,
+                    stderr => q{fatal: Authentication failed for 'https://github.com/lala},
+                    stdout => ''
+                };
             }
             return {status => 1};
         });
     $args{needle_ids} = [4];
     stderr_like { $res = run_gru_job(@gru_args) } qr{Git command failed: .*push}, 'Got error on stderr';
     is $res->{state}, 'finished', 'git job finished';
-    like $res->{result}->{errors}->[0]->{message}, qr{Unable to push Git commit. See .*_setting_up_git_support on how to setup}, 'Got error for push';
+    like $res->{result}->{errors}->[0]->{message},
+      qr{Unable to push Git commit. See .*_setting_up_git_support on how to setup}, 'Got error for push';
 
     $openqa_git->redefine(
         run_cmd_with_log_return_error => sub ($cmd, %args) {

--- a/t/16-utils-job-templates.t
+++ b/t/16-utils-job-templates.t
@@ -28,7 +28,8 @@ my $template = {
 };
 my $errors = validate_data(%default_args, data => $template,);
 is scalar @$errors, 0, "Empty template - no errors";
-throws_ok { validate_data(schema_file => $invalid_schema, data => $template) } qr{JSON::Validator}, "Invalid schema file";
+throws_ok { validate_data(schema_file => $invalid_schema, data => $template) } qr{JSON::Validator},
+  "Invalid schema file";
 
 $errors = validate_data(schema_file => 'does-not-exist', data => $template);
 is scalar @$errors, 1, "non-existent schema file error" or diag "Error: $_" for @$errors;

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -79,7 +79,8 @@ sub _run_engine ($job) {
 subtest 'isotovideo version' => sub {
     throws_ok {
         OpenQA::Worker::Engines::isotovideo::set_engine_exec('/bogus/location');
-    } qr{Path to isotovideo invalid}, 'isotovideo version path invalid';
+    }
+    qr{Path to isotovideo invalid}, 'isotovideo version path invalid';
 
     # init does not fail without isotovideo parameter
     # note that this might set the isotovideo version because the isotovideo path defaults

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -273,8 +273,7 @@ subtest 'Interrupted WebSocket connection (before we can tell the WebUI that we 
     is $job->status, 'accepting', 'job is now being accepted';
     $job->stop_if_out_of_acceptance_attempts;
     is $job->status, 'stopped', 'job is abandoned if unable to confirm to the web UI that we are working on it';
-    throws_ok { $job->start } qr/attempt to start job which is not accepted/,
-      'starting job prevented unless accepted';
+    throws_ok { $job->start } qr/attempt to start job which is not accepted/, 'starting job prevented unless accepted';
 
     is_deeply(
         $client->websocket_connection->sent_messages,
@@ -286,8 +285,7 @@ subtest 'Interrupted WebSocket connection (before we can tell the WebUI that we 
 
 subtest 'Job without id' => sub {
     my $job = OpenQA::Worker::Job->new($worker, $client, {id => undef, URL => $engine_url});
-    throws_ok { $job->start } qr/attempt to start job without ID and job info/,
-      'starting job without id prevented';
+    throws_ok { $job->start } qr/attempt to start job without ID and job info/, 'starting job without id prevented';
 };
 
 subtest 'Clean up pool directory' => sub {

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -35,8 +35,8 @@ $app->log->level('info');
 
 throws_ok {
     OpenQA::Worker::WebUIConnection->new('http://test-host', {});
-} qr{API key and secret are needed for the worker connecting http://test-host.*},
-  'auth required';
+}
+qr{API key and secret are needed for the worker connecting http://test-host.*}, 'auth required';
 
 my $client = OpenQA::Worker::WebUIConnection->new(
     'http://test-host',

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -214,7 +214,8 @@ subtest 'Cache Requests' => sub {
     is_deeply $asset_request->to_array, [qw(922756 hdd test open.qa)], 'asset request array';
 
     my $base = OpenQA::CacheService::Request->new;
-    throws_ok { $base->lock } qr/lock\(\) not implemented in OpenQA::CacheService::Request/, 'lock() not implemented in base request';
+    throws_ok { $base->lock } qr/lock\(\) not implemented in OpenQA::CacheService::Request/,
+      'lock() not implemented in base request';
     throws_ok { $base->to_array } qr/to_array\(\) not implemented in OpenQA::CacheService::Request/,
       'to_array() not implemented in base request';
 };
@@ -345,7 +346,8 @@ subtest 'Race for same asset' => sub {
     is $q->done->size, $tot_proc, 'Queue consumed ' . $tot_proc . ' processes';
     $q->done->each(
         sub {
-            is $_->return_status, 1, "Asset exists after worker got released from cache service" or die always_explain $_;
+            is $_->return_status, 1, "Asset exists after worker got released from cache service"
+              or die always_explain $_;
         });
 
     ok($cache_client->asset_exists('localhost', $asset), 'Asset downloaded') or die diag "Failed - no asset is there";

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -133,14 +133,10 @@ subtest 'Update configuration from Plugin requirements' => sub {
     $ini_config->newval("foofoo", "is_there", "wohoo");
 
     # Check if  Config::IniFiles object returns the right values
-    is $ini_config->val("auth", "method"), "foobar",
-      "Ini parser contains the right data for OpenQA::FakePlugin::Foo";
-    is $ini_config->val("bar", "foo"), "test",
-      "Ini parser contains the right data for OpenQA::FakePlugin::FooBar";
-    is $ini_config->val("baz", "foo"), "test2",
-      "Ini parser contains the right data for OpenQA::FakePlugin::FooBaz";
-    is $ini_config->val("baz", "test"), "bartest",
-      "Ini parser contains the right data for OpenQA::FakePlugin::Fuzz";
+    is $ini_config->val("auth", "method"), "foobar", "Ini parser contains the right data for OpenQA::FakePlugin::Foo";
+    is $ini_config->val("bar", "foo"), "test", "Ini parser contains the right data for OpenQA::FakePlugin::FooBar";
+    is $ini_config->val("baz", "foo"), "test2", "Ini parser contains the right data for OpenQA::FakePlugin::FooBaz";
+    is $ini_config->val("baz", "test"), "bartest", "Ini parser contains the right data for OpenQA::FakePlugin::Fuzz";
     is $ini_config->val("bazzer", "realfoo"), "win",
       "Ini parser contains the right data for OpenQA::FakePlugin::Fuzzer";
     is $ini_config->val("foofoo", "is_there"), "wohoo",

--- a/t/27-websockets.t
+++ b/t/27-websockets.t
@@ -186,7 +186,7 @@ subtest 'web socket message handling' => sub {
         }
         qr/Job 42 reset to state scheduled/s, 'info logged when worker rejects job';
         is($jobs->find(42)->state, SCHEDULED,
-            'job is immediately set back to scheduled if assigned worker goes offline '
+                'job is immediately set back to scheduled if assigned worker goes offline '
               . 'gracefully before starting to work on the job');
         $worker->discard_changes;
         ok($worker->dead, 'worker considered immediately dead when it goes offline gracefully');

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -144,15 +144,18 @@ subtest 'Parser base class object' => sub {
     my $meant_to_fail = OpenQA::Parser->new;
     throws_ok { $meant_to_fail->parse() } qr/parse\(\) not implemented by base class/, 'Base class does not parse data';
     throws_ok { $meant_to_fail->load() } qr/You need to specify a file/, 'load croaks if no file is specified';
-    throws_ok { $meant_to_fail->load('thiswontexist') } qr/Can't open file \"thiswontexist\"/, 'load confesses if file is invalid';
+    throws_ok { $meant_to_fail->load('thiswontexist') } qr/Can't open file \"thiswontexist\"/,
+      'load confesses if file is invalid';
 
     use Mojo::File 'tempfile';
     my $tmp = tempfile;
     throws_ok { $meant_to_fail->load($tmp) } qr/Failed reading file $tmp/, 'load confesses if file is invalid';
 
     my $good_parser = parser('Base');
-    throws_ok { $good_parser->write_output() } qr/You need to specify a directory/, 'write_output needs a directory as argument';
-    throws_ok { $good_parser->write_test_result() } qr/You need to specify a directory/, 'write_test_result needs a directory as argument';
+    throws_ok { $good_parser->write_output() } qr/You need to specify a directory/,
+      'write_output needs a directory as argument';
+    throws_ok { $good_parser->write_test_result() } qr/You need to specify a directory/,
+      'write_test_result needs a directory as argument';
 
     $good_parser->results->add({foo => 1});
     is $good_parser->results->size, 1;
@@ -899,8 +902,7 @@ subtest functional_interface => sub {
     {
         package OpenQA::Parser::Format::Broken;    # uncoverable statement
         sub new { die 'boo' }
-    }
-    ;
+    };
     throws_ok { p("Broken") } qr/Invalid parser supplied: boo/, 'Croaked correctly';
 
     my $default = p();

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -441,12 +441,13 @@ subtest 'overall cloning with parallel and chained dependencies' => sub {
 subtest 'auth with lwp' => sub {
     note 'config path: ' . ($ENV{OPENQA_CONFIG} = "$FindBin::Bin/data");
     my $ua = OpenQA::Script::CloneJob::create_lwp_user_agent('testapi', {});
-    $ua->add_handler(request_send => sub ($request, $ua, $handler) {
+    $ua->add_handler(
+        request_send => sub ($request, $ua, $handler) {
             ok looks_like_number($request->header('X-API-Microtime')), 'microtime set';
             is $request->header('X-API-Key'), 'PERCIVALKEY02', 'api key set';
             is length($request->header('X-API-Hash')), 40, 'hash set';
             return HTTP::Response->new(200);    # terminate the processing
-    });
+        });
     $ua->get('http://foobar/some/path');
 };
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1360,7 +1360,8 @@ subtest 'Parse extra tests results - LTP' => sub {
             extra_test => 1,
             script => 'test'
         })->status_is(400, 'request considered invalid (foo)');
-    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (foo)') or always_explain $t->tx->res->content;
+    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (foo)')
+      or always_explain $t->tx->res->content;
     ok !-e path($basedir, 'details-LTP_syscalls_accept01.json'), 'detail from LTP was NOT written';
 
     $t->post_ok(
@@ -1393,7 +1394,8 @@ subtest 'Parse extra tests results - xunit' => sub {
             extra_test => 1,
             script => 'test'
         })->status_is(400, 'request considered invalid (LTP)');
-    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (LTP)') or always_explain $t->tx->res->content;
+    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (LTP)')
+      or always_explain $t->tx->res->content;
 
     $t->post_ok(
         "/api/v1/jobs/$jobid/artefact" => form => {
@@ -1402,7 +1404,8 @@ subtest 'Parse extra tests results - xunit' => sub {
             extra_test => 1,
             script => 'test'
         })->status_is(400, 'request considered invalid (foo)');
-    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (foo)') or always_explain $t->tx->res->content;
+    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (foo)')
+      or always_explain $t->tx->res->content;
     ok !-e path($basedir, 'details-unkn.json'), 'detail from junit was NOT written';
 
     $t->post_ok(
@@ -1435,7 +1438,8 @@ subtest 'Parse extra tests results - junit' => sub {
             extra_test => 1,
             script => 'test'
         })->status_is(400, 'request considered invalid (foo)');
-    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (foo)') or always_explain $t->tx->res->content;
+    $t->json_is('/error' => 'Unable to parse extra test', 'error returned (foo)')
+      or always_explain $t->tx->res->content;
     ok !-e path($basedir, 'details-1_running_upstream_tests.json'), 'detail from junit was NOT written';
 
     $t->post_ok(

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -938,7 +938,7 @@ subtest 'Create and modify groups with YAML' => sub {
         $t->status_is(400, 'Post rejected because scenarios are ambiguous')->json_is(
             '' => {
                 error => [
-                    'Job template name \'foobar\' is defined more than once. '
+                        'Job template name \'foobar\' is defined more than once. '
                       . 'Use a unique name and specify \'testsuite\' to reuse test suites in multiple scenarios.'
                 ],
                 error_status => 400,

--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -48,7 +48,7 @@ sub sleep_until_job_start {
         (undef, my $jobs) = _jobs($status);
         for my $other_job (@$jobs) {
             return 1
-              if ($other_job->{args}
+              if ( $other_job->{args}
                 && ($other_job->{args}[0]->{project} eq $project)
                 && $other_job->{notes}{project_lock});
         }

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -70,7 +70,8 @@ our (@EXPORT, @EXPORT_OK);
 # Potentially this approach can also be used in production code.
 
 sub setup_mojo_app_with_default_worker_timeout ($class = 'Mojolicious') {
-    OpenQA::App->set_singleton($class->new(config => {global => {worker_timeout => DEFAULT_WORKER_TIMEOUT}}, log => undef));
+    OpenQA::App->set_singleton(
+        $class->new(config => {global => {worker_timeout => DEFAULT_WORKER_TIMEOUT}}, log => undef));
 }
 
 sub cache_minion_worker {

--- a/t/ui/09-users-list.t
+++ b/t/ui/09-users-list.t
@@ -46,7 +46,10 @@ $t->get_ok('/admin/users')->status_is(200)->content_like(qr/User lance updated/)
 is($t->tx->res->dom->at('#user_99902 .role')->attr('data-order'), '11');
 
 # try something with a non existent user
-$t->post_ok('/admin/users/999021111', {'X-CSRF-Token' => $token, Accept => 'application/json'}, form => {role => 'admin'})->status_is(404)->json_is('/error', "Can't find that user");
+$t->post_ok(
+    '/admin/users/999021111',
+    {'X-CSRF-Token' => $token, Accept => 'application/json'},
+    form => {role => 'admin'})->status_is(404)->json_is('/error', "Can't find that user");
 
 # We can even update both fields in one request
 $t->post_ok('/admin/users/99902', {'X-CSRF-Token' => $token} => form => {role => 'operator'})->status_is(302);

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -513,8 +513,10 @@ subtest 'New needle instantly visible after reloading needle editor' => sub {
 
     my $warnings = $driver->find_element('#editor_warnings span')->get_text;
     my $exp_msg = 'new needle with matching tags has been created since the job started';
-    like $warnings, qr/$exp_msg: $needlename\.json.*ENV-VIDEOMODE-text, inst-timezone, test-newtag, test-overwritetag/, 'warning about new needle displayed (1)';
-    like $warnings, qr/$exp_msg: $needlename_from_candidate\.json.*ENV-VIDEOMODE-text, inst-timezone/, 'warning about new needle displayed (2)';
+    like $warnings, qr/$exp_msg: $needlename\.json.*ENV-VIDEOMODE-text, inst-timezone, test-newtag, test-overwritetag/,
+      'warning about new needle displayed (1)';
+    like $warnings, qr/$exp_msg: $needlename_from_candidate\.json.*ENV-VIDEOMODE-text, inst-timezone/,
+      'warning about new needle displayed (2)';
 
     my $based_on_option = assert_needle_appears_in_selection('tags_select', $needlename);
     my $image_option = assert_needle_appears_in_selection('image_select', $needlename);
@@ -562,7 +564,7 @@ subtest 'Showing new needles limited to the 5 most recent ones' => sub {
         # add expected warnings and needle names for needle
         if ($i >= 2) {
             unshift(@expected_needle_warnings,
-                "A new needle with matching tags has been created since the job started: $new_needle_name.json"
+                    "A new needle with matching tags has been created since the job started: $new_needle_name.json"
                   . ' (tags: ENV-VIDEOMODE-text, inst-timezone, test-newtag, test-overwritetag)');
             splice(@expected_needle_names, 2, 0, 'new: ' . $new_needle_name);
         }
@@ -636,7 +638,7 @@ subtest 'open needle editor for running test' => sub {
     my $t = Test::Mojo->new('OpenQA::WebAPI');
     $t->ua->max_redirects(1);
     warnings { $t->get_ok('/tests/99980/edit') };
-    note('ignoring warning "DateTime objects passed to search() are not supported properly"'
+    note(   'ignoring warning "DateTime objects passed to search() are not supported properly"'
           . ' at lib/OpenQA/WebAPI/Controller/Step.pm line 211');
     $t->status_is(200);
     $t->text_is(title => 'openQA: Needle Editor', 'needle editor shown for running test');

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -509,7 +509,8 @@ subtest 'edit job templates' => sub() {
     # Expansion
     $driver->find_element_by_id('expand-template')->click();
     wait_for_ajax;
-    like($result->get_text(), qr/Result of expanding the YAML/, 'expansion shown') or always_explain $result->get_text();
+    like($result->get_text(), qr/Result of expanding the YAML/, 'expansion shown')
+      or always_explain $result->get_text();
     like($result->get_text(), qr/settings: \{\}/, 'expanded YAML has empty settings')
       or always_explain $result->get_text();
     unlike($result->get_text(), qr/defaults:/, 'expanded YAML has no defaults')
@@ -549,7 +550,8 @@ subtest 'edit job templates' => sub() {
     $driver->find_element_by_id('save-template')->click();
     wait_for_ajax;
     like($result->get_text(), qr/YAML saved!/, 'saving confirmed') or always_explain $result->get_text();
-    like($result->get_text(), qr/No changes were made!/, 'saved, nothing changed') or always_explain $result->get_text();
+    like($result->get_text(), qr/No changes were made!/, 'saved, nothing changed')
+      or always_explain $result->get_text();
 
     # Legacy UI is hidden and no longer available
     ok($driver->find_element_by_id('toggle-yaml-editor')->is_hidden(), 'editor toggle hidden');

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -101,7 +101,7 @@ sub find_candidate_needles {
 
             is(scalar @needle_parts, 3, 'exactly three parts per needle present (percentage, name, diff buttons)');
             push(@needles,
-                OpenQA::Test::Case::trim_whitespace($needle_parts[0]->get_text()) . '%: '
+                    OpenQA::Test::Case::trim_whitespace($needle_parts[0]->get_text()) . '%: '
                   . OpenQA::Test::Case::trim_whitespace($needle_parts[1]->get_text()));
         }
 

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -582,7 +582,8 @@ subtest 'process state changes from os-autoinst/worker' => sub {
         );
         element_visible('#developer-panel .card-header', qr/paused at module: some test/, qr/current module/);
         my $options_state = map_elements('#developer-pause-on-mismatch option', 'e.selected');
-        ok $options_state->[1]->[0], 'selection for pausing on screen mismatch updated' or always_explain $options_state;
+        ok $options_state->[1]->[0], 'selection for pausing on screen mismatch updated'
+          or always_explain $options_state;
     };
 
     subtest 'upload progress handled' => sub {


### PR DESCRIPTION
It was added in version 20250214.

See https://github.com/perltidy/perltidy/issues/171

We temporarily used `---freeze-newlines` to disable wrapping chained method calles.