### PR TITLE
openqa-dump-templates: Reproducible output

### DIFF
--- a/script/openqa-dump-templates
+++ b/script/openqa-dump-templates
@@ -240,7 +240,7 @@ handle_table($_) for keys %result;
 if ($options{json}) {
     use Mojo::JSON;    # booleans
     use Cpanel::JSON::XS;
-    print Cpanel::JSON::XS->new->ascii->pretty->encode(\%result);
+    print Cpanel::JSON::XS->new->ascii->pretty->canonical(1)->encode(\%result);
 }
 else {
     dd \%result;


### PR DESCRIPTION
The output file in JSON format is now reproducible, because all keys will be sorted before the JSON file is written.
The JSON spec states that objects are unordered, but for the purpose of storing the JSON version of the dump in a VCS it helps that the difference between consecutive commits is minimal.