### PR TITLE
coverage: Avoid B::Deparse warning with Syntax::Keyword::Try::Deparse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,14 @@ COVERDB_SUFFIX ?=
 # We use JSON::PP because there is a bug producing a (harmless) 'redefined'
 # warning when using Devel::Cover and Cpanel::JSON::XS
 # https://progress.opensuse.org/issues/90371
-COVEROPT ?= -mJSON::PP -MDevel::Cover=-select_re,'^/lib',+ignore_re,lib/perlcritic/Perl/Critic/Policy,-coverage,statement,-db,cover_db$(COVERDB_SUFFIX),
+#
+# CoverageWorkaround: We use a workaround with Syntax::Keyword::Try::Deparse
+# because we would get warnings:
+#     unexpected OP_CUSTOM (catch) at .../B/Deparse.pm line 1667.
+# because Feature::Compat::Try uses OP_CUSTOM for perl < 5.40
+# https://metacpan.org/pod/Feature::Compat::Try#COMPATIBILITY-NOTES
+# https://rt.cpan.org/Transaction/Display.html?id=1992941
+COVEROPT ?= -mJSON::PP -It/lib -MCoverageWorkaround -MDevel::Cover=-select_re,'^/lib',+ignore_re,lib/perlcritic/Perl/Critic/Policy|t/lib/CoverageWorkaround,-coverage,statement,-db,cover_db$(COVERDB_SUFFIX),
 endif
 
 .PHONY: coverage

--- a/t/lib/CoverageWorkaround.pm
+++ b/t/lib/CoverageWorkaround.pm
@@ -1,0 +1,91 @@
+package CoverageWorkaround;
+use strict;
+use warnings;
+
+=head1 DESCRIPTION
+
+A wrapper around Devel::Cover, configuring some things to enable covering some
+things default D::C misses, and to make it less noisy. Run this to generate a
+coverage report on the tests:
+
+    cover -delete && HARNESS_PERL_SWITCHES='-Ilib -MACover' prove -r t && cover
+
+=cut
+
+# prevent these two from interfering with coverage
+BEGIN { $INC{$_}++ for qw( DB/Skip.pm UDAG/VendorBox/Log/Auto.pm ) }
+
+#use Devel::Cover qw' -ignore ^t/ -coverage statement branch condition path subroutine ';
+
+# this is for the sketched pushmark/leaveasync cover fixes below
+# use Module::Runtime 'use_module';
+# our $IS_ASYNC = 0;
+
+# this silences warnings about some dynamically generated code
+#no warnings 'uninitialized';
+#$Devel::Cover::DB::Ignore_filenames = qr@
+#	$Devel::Cover::DB::Ignore_filenames
+#
+#	| # SpecIO
+#	(?: ^Specio::\S+-\> )
+#	| # Moose
+#	(?: ^reader\ Moose::Meta::Class:: )
+#	| # Moose
+#	(?: ^inline\ delegation\ in )
+#	| # SSLeay
+#	(?: blib/lib/Net/SSLeay.pm )
+#    |
+#	(?: exportable\ function )
+#    |
+#	(?: compiled\ check )
+#    |
+#	(?: compiled\ assertion )
+#    |
+#	(?: compiled\ coercion )
+#    |
+#	(?: generated\ by\ Specio:: )
+#    |
+#	(?: inlined\ sub\ for )
+#@x;
+
+sub B::Deparse::pp_await {    # fix await parsing
+    my ($self, $op, $cx) = @_;
+    return $self->maybe_parens_unop("await", $op->first, $cx);
+}
+
+# dumb way to handle these, simply silences them instead of deparsing them
+# optimally the code below would be implemented
+sub B::Deparse::pp_leaveasync { "XXX;" }
+sub B::Deparse::pp_pushmark { "XXX;" }
+
+package Syntax::Keyword::Try::DeparseUDFix;
+use strict;
+use warnings;
+
+use B::Deparse;    # keep original pp_leave sub for 134812 fix below
+my $orig_pp_leave;
+BEGIN { $orig_pp_leave = \&B::Deparse::pp_leave; }
+
+use Syntax::Keyword::Try::Deparse;    # enable try/catch deparsing for coverage
+
+my $patched_pp_leave;    # apply 134812 fix below
+{
+    $patched_pp_leave = \&B::Deparse::pp_leave;
+    no warnings 'redefine';
+    *B::Deparse::pp_leave = \&pp_leave;
+}
+
+sub pp_leave {    # fix https://rt.cpan.org/Ticket/Display.html?id=134812
+    my $self = shift;
+    my ($op) = @_;
+
+    my $enter = $op->first;
+    no strict 'subs';
+    no warnings;
+    return $self->$orig_pp_leave(@_) if $enter->type != OP_ENTER;
+
+    my $meth = ref $enter->sibling eq "B::COP" ? $orig_pp_leave : $patched_pp_leave;
+    return $self->$meth(@_);
+}
+
+1;


### PR DESCRIPTION
See https://metacpan.org/pod/Feature::Compat::Try#COMPATIBILITY-NOTES and https://rt.cpan.org/Transaction/Display.html

We are already seeing this warning in some tests: https://app.circleci.com/pipelines/github/os-autoinst/openQA/15835/workflows/04b2d0e0-d43c-4b80-a064-36ef5bcfcda7/jobs/152282 because Feature::Compat::Try is used indirectly

Issue: https://progress.opensuse.org/issues/176862

Thanks @wchristian for this patch!