### PR TITLE
Reduce resource usage of fullstack scheduler test in CI

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -215,7 +215,7 @@ subtest 'Simulation of heavy unstable load' => sub {
 
     # duplicate latest jobs ignoring failures
     my @duplicated = map { my $dup = $_->auto_duplicate; ref $dup ? $dup : () } $schema->resultset('Jobs')->latest_jobs;
-    my $nr = $ENV{OPENQA_SCHEDULER_TEST_UNRESPONSIVE_COUNT} // 50;
+    my $nr = $ENV{OPENQA_SCHEDULER_TEST_UNRESPONSIVE_COUNT} // ($ENV{CI} ? 10 : 50);
     @workers = map { unresponsive_worker(@$worker_settings, $_) } (1 .. $nr);
     my $i = 2;
     wait_for_worker($schema, ++$i) for 1 .. $nr;


### PR DESCRIPTION
This might help with workers being forcefully terminated leading to test failing with:
```
not ok 36 - sub process openqa-worker-unstable terminated with exit code 9
```

Related ticket: https://progress.opensuse.org/issues/177775