### PR TITLE
Improve error message when sub process in tests is terminated

### DIFF
--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -213,8 +213,11 @@ my $SIGCHLD_HANDLER = sub {
     # note: This function is supposed to be called from the SIGCHLD handler. It seems to have no effect to
     #       call die or BAIL_OUT from that handler so fail and _exit is used instead.
     while ((my $pid = waitpid(-1, WNOHANG)) > 0) {
-        my $exit_code = $?;
         next unless my $child_name = delete $RELEVANT_CHILD_PIDS{$pid};
+        my $exit_status = $?;
+        my $exit_signal = $exit_status & 127;
+        _fail_and_exit "sub process $child_name terminated by signal $exit_signal", $exit_signal if $exit_signal;
+        my $exit_code = ($exit_status >> 8);
         _fail_and_exit "sub process $child_name terminated with exit code $exit_code", $exit_code if $exit_code;
     }
 };


### PR DESCRIPTION
State when the process is terminated by a signal instead of wrongly stating the signal number was the exit code of the process.

Related ticket: https://progress.opensuse.org/issues/177775