### PR TITLE
Allow os-autoinst >= 5

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -165,7 +165,7 @@ main_requires:
   perl(YAML::XS):        # Required by JSON::Validator as a runtime dependency
 
 worker_requires:
-  os-autoinst: '< 5'
+  os-autoinst:
   openQA-client:
   optipng:
   sqlite3: '>= 3.24.0'   # for INSERT INTO … ON CONFLICT … DO UPDATE SET … required by cache service

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -66,7 +66,7 @@
 # The following line is generated from dependencies.yaml
 %define client_requires curl git-core jq perl(Getopt::Long::Descriptive) perl(IO::Socket::SSL) >= 2.009 perl(IPC::Run) perl(JSON::Validator) perl(LWP::Protocol::https) perl(LWP::UserAgent) perl(Test::More) perl(YAML::PP) >= 0.020 perl(YAML::XS)
 # The following line is generated from dependencies.yaml
-%define worker_requires bsdtar openQA-client optipng os-autoinst < 5 perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.7 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
+%define worker_requires bsdtar openQA-client optipng os-autoinst perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.7 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
 %define build_requires %assetpack_requires npm rubygem(sass) >= 3.7.4
 


### PR DESCRIPTION
The requirement for os-autoinst < 5 was introduced within 757cdbd1a for
no apparent reason. We can just get rid of this to allow to pull in the
new os-autoinst.