### PR TITLE
Simplify WebAPI::Controller::API::V1::JobTemplate

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -420,7 +420,7 @@ sub create ($self) {
         json => {json => $json, status => $status},
         html => sub {
             if ($error) {
-                $self->flash('error', "Error adding the job template: $error");
+                $self->flash(error => "Error adding the job template: $error");
             }
             else {
                 $self->flash(info => 'Job template added');
@@ -477,7 +477,7 @@ sub destroy ($self) {
         json => {json => $json, status => $status},
         html => sub {
             if ($error) {
-                $self->flash('error', "Error deleting the job template: $error");
+                $self->flash(error => "Error deleting the job template: $error");
             }
             else {
                 $self->flash(info => 'Job template deleted');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -330,12 +330,8 @@ sub create ($self) {
 
     # validate/read priority
     my $prio_regex = qr/^(inherit|[0-9]+)\z/;
-    if ($has_product_id) {
-        $validation->optional('prio')->like($prio_regex);
-    }
-    else {
-        $validation->required('prio')->like($prio_regex);
-    }
+    my $f = $has_product_id ? 'optional' : 'required';
+    $validation->$f('prio')->like($prio_regex);
     $validation->optional('prio_only')->num(1);
     my $prio = $validation->param('prio');
     $prio = ((!$prio || $prio eq 'inherit') ? undef : $prio);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::WebAPI::Controller::API::V1::JobTemplate;
-use Mojo::Base 'Mojolicious::Controller';
+use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Try::Tiny;
 use OpenQA::App;
 use OpenQA::YAML qw(load_yaml dump_yaml);
@@ -42,9 +42,7 @@ and test suite (id and name).
 
 =cut
 
-sub list {
-    my $self = shift;
-
+sub list ($self) {
     my $schema = $self->schema;
     my $limits = OpenQA::App->singleton->config->{misc_limits};
     my $limit
@@ -88,9 +86,7 @@ Returns a YAML template representing the job group(s).
 
 =cut
 
-sub schedules {
-    my $self = shift;
-
+sub schedules ($self) {
     my $single = ($self->param('id') or $self->param('name'));
     my $yaml = $self->_get_job_groups($self->param('id'), $self->param('name'));
 
@@ -98,9 +94,7 @@ sub schedules {
         # only return the YAML of one group
         $yaml = (values %$yaml)[0];
     }
-    my $json_code = sub {
-        return $self->render(json => $yaml);
-    };
+    my $json_code = sub { $self->render(json => $yaml) };
     my $yaml_code = sub {
         # In the case of a single group we return the template directly
         # without encoding it to a string.
@@ -119,9 +113,7 @@ sub schedules {
     );
 }
 
-sub _get_job_groups {
-    my ($self, $id, $name) = @_;
-
+sub _get_job_groups ($self, $id, $name) {
     my %yaml;
     my $groups = $self->schema->resultset('JobGroups')->search(
         $id ? {id => $id} : ($name ? {name => $name} : undef),
@@ -207,9 +199,7 @@ in the response if any changes to the database were made.
 
 =cut
 
-sub update {
-    my $self = shift;
-
+sub update ($self) {
     my $validation = $self->validation;
     # Note: id is a regular param because it's part of the path
     $validation->required('name') unless $self->param('id');
@@ -333,9 +323,7 @@ block on success.
 
 =cut
 
-sub create {
-    my $self = shift;
-
+sub create ($self) {
     my $error;
     my @ids;
 
@@ -453,8 +441,7 @@ a 400 code on other errors or a 303 code on success.
 
 =cut
 
-sub destroy {
-    my $self = shift;
+sub destroy ($self) {
     my $job_templates = $self->schema->resultset('JobTemplates');
 
     my $status;


### PR DESCRIPTION
This is exploring some ideas to refactor WebAPI::Controller::API::V1::JobTemplate
based on what we discussed for
* #6199
* #6183


Individual changes
* Use function pointer in JobTemplate method
* Extract method from WebAPI::Controller::API::V1::JobTemplate::update
* Extract method in WebAPI::Controller::API::V1::JobTemplate
* Use proper big-comma style WebAPI::Controller::API::V1::JobTemplate
* Use signatures in WebAPI::Controller::API::V1::JobTemplate