### PR TITLE
Document traceability and reproducibility of tests

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -474,9 +474,34 @@ sub run {
 }
 --------------------------------------------------------------
 
-=== Logging package versions used for test
+=== Traceability and reproducibility of tests
+openQA allows keeping track of the test environment, the version of the test
+code and needles, the test configuration and what specific system was tested.
 
+==== General remarks on tracing
+The test configuration of a specific test run can be viewed in form of job
+settings on the test details page. Those settings contain the specific test
+configuration. The specific system that was tested is also listed there in via
+the corresponding <<UsersGuide.asciidoc#_asset_handling,asset variables>>.
+
+In addition to that, the following variables can be found in the file
+`vars.json` when Git is used:
+
+* `TEST_GIT_HASH`: The specific version of the tests that were executed.
+* `NEEDLES_GIT_HASH`: The specific version of the needles that were used during
+  the test run.
+
+This file is upload when a test run has concluded and can be found under the
+"Logs & Assets" tab.
+
+There is also the "Investigation" tab on failed tests. It shows what has changed
+since the last good test run.
+
+The next section explains how to keep track of the test environment.
+
+==== Logging package versions used for test
 There are two sets of packages that can be included in test logs:
+
 1. Packages installed on the worker itself - stored as `worker_packages.txt`.
 2. Packages installed on SUT - stored as `sut_packages.txt`.
 
@@ -504,6 +529,36 @@ sub run {
     ...
 }
 --------------------------------------------------------------
+
+==== General remarks on reproducibility
+Clicking the restart button on a concrete test run will create a new test job
+with the same configuration. The new test will however use the latest version of
+the test code and needles unless `CASEDIR`/`NEEDLES_DIR` specify a concrete
+version via a Git URL. The test environment of restarted jobs might differ as
+well, e.g. because the worker host has been updated or a completely different
+worker host has been chosen to run the job.
+
+To re-run a test again under the same conditions it might be useful to clone it
+with a command like
+`openqa-clone-job --within-instance … CASEDIR=… NEEDLES_DIR=… WORKER_CLASS=…`
+instead of using the restart button. This way one can specify a concrete commit
+hash for tests and/or needles (see
+<<WritingTests.asciidoc#_triggering_tests_based_on_an_any_remote_git_refspec_or_open_github_pull_request,Triggering … based on Git refspec …>>
+for details) and a concrete worker host (see
+<<WritingTests.asciidoc#_assigning_jobs_to_workers,Assigning jobs to workers>>).
+The script
+https://github.com/os-autoinst/scripts/blob/master/README.md#openqa-investigate---automatic-investigation-jobs-with-failure-analysis-in-openqa[`openqa-investigate`] helps automating retries like this. It will also
+automatically create
+https://github.com/os-autoinst/scripts/blob/master/README.md#more-details-and-examples-about-openqa-investigate-comments[a comment]
+with the findings.
+
+To improve reproducibility one should also avoid relying on any external
+resource like online repositories because those are not controlled by openQA
+test variables.
+
+Sometimes issues are sporadic and therefore hard to reproduce. The section about
+<<UsersGuide.asciidoc#_statistical_investigation,statistical investigation>>
+might be helpful in this case.
 
 === Assigning jobs to workers
 


### PR DESCRIPTION
* Explain relevant variables
* Improve formatting of list in section about logging package versions
* Mention the behavior of the restart button with regard to reproducibility
* Mention `openqa-investigate`
* See https://progress.opensuse.org/issues/173878