### PR TITLE
Adapt use of `local-npm-registry` to version 1.1.0

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -318,8 +318,7 @@ statistics.
 %prep
 %setup -q
 sed -e 's,/bin/env python,/bin/python,' -i script/openqa-label-all
-rm package-lock.json
-local-npm-registry %{_sourcedir} install --also=dev --legacy-peer-deps
+local-npm-registry %{_sourcedir} install --also=dev --legacy-peer-deps --no-package-lock
 
 %build
 %make_build


### PR DESCRIPTION
As of version 1.1.0 `local-npm-registry` always invokes `npm` with `--no-package-lock`. This means we no longer need to clean up `package-lock.json` and also must not do it because the file will otherwise be missing later on. This change adds the `--no-package-lock` explicitly so we get the same behavior regardless of the `local-npm-registry` version.

Related ticket: https://progress.opensuse.org/issues/177901