### PR TITLE
Enable prove to run tests relying on default test database

### DIFF
--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -34,7 +34,7 @@ sub connect_db (%args) {
 
     my $mode = $args{mode} || $ENV{OPENQA_DATABASE} || 'production';
     if ($mode eq 'test') {
-        $SINGLETON = __PACKAGE__->connect($ENV{TEST_PG});
+        $SINGLETON = __PACKAGE__->connect($ENV{TEST_PG} // 'DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg');
     }
     else {
         my %ini;

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -3,7 +3,7 @@
 
 package OpenQA::Test::Database;
 use Test::Most;
-use Mojo::Base -base;
+use Mojo::Base -base, -signatures;
 
 use Date::Format;    # To allow fixtures with relative dates
 use DateTime;    # To allow fixtures using InflateColumn::DateTime
@@ -19,13 +19,9 @@ has fixture_path => 't/fixtures';
 
 plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 
-sub generate_schema_name {
-    return 'tmp_' . random_string();
-}
+sub generate_schema_name () { 'tmp_' . random_string() }
 
-sub create {
-    my ($self, %options) = @_;
-
+sub create ($self, %options) {
     # create new database connection
     my $schema = OpenQA::Schema::connect_db(mode => 'test', deploy => 0);
 
@@ -55,16 +51,12 @@ sub create {
     return $schema;
 }
 
-sub insert_fixtures {
-    my ($self, $schema, $fixtures_glob) = @_;
-
+sub insert_fixtures ($self, $schema, $fixtures_glob = '*.pl') {
     # Store working dir
     my $cwd = getcwd;
 
     chdir $self->fixture_path;
     my %ids;
-
-    $fixtures_glob //= '*.pl';
     foreach my $fixture (glob "$fixtures_glob") {
 
         my $info = eval path($fixture)->slurp;    ## no critic
@@ -105,8 +97,7 @@ sub insert_fixtures {
     }
 }
 
-sub disconnect {
-    my $schema = shift;
+sub disconnect ($schema) {
     my $dbh = $schema->storage->dbh;
     if (my $search_path = $schema->search_path_for_tests) { $dbh->do("drop schema $search_path") }
     return $dbh->disconnect;

--- a/t/lib/OpenQA/Test/Database.pm
+++ b/t/lib/OpenQA/Test/Database.pm
@@ -9,11 +9,11 @@ use Date::Format;    # To allow fixtures with relative dates
 use DateTime;    # To allow fixtures using InflateColumn::DateTime
 use Carp;
 use Cwd qw( abs_path getcwd );
+use Feature::Compat::Try;
 use OpenQA::Schema;
 use OpenQA::Log 'log_info';
 use OpenQA::Utils 'random_string';
 use Mojo::File 'path';
-use Try::Tiny;
 
 has fixture_path => 't/fixtures';
 
@@ -89,9 +89,9 @@ sub insert_fixtures {
                 my $row = $schema->resultset($class)->create($ri);
                 $ids{$row->result_source->from} = $ri->{id} if $ri->{id};
             }
-            catch {
-                croak "Could not insert fixture " . path($fixture)->to_rel($cwd) . ": $_";
-            };
+            catch ($e) {
+                croak "Could not insert fixture " . path($fixture)->to_rel($cwd) . ": $e";
+            }
         }
     }
 

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -20,7 +20,7 @@ use OpenQA::Test::Utils qw(assume_all_assets_exist);
 use OpenQA::Jobs::Constants qw(NONE RUNNING);
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $fixtures = '01-jobs.pl 03-users.pl 04-products.pl 05-job_modules.pl 06-job_dependencies.pl';
 my $schema = $test_case->init_data(schema_name => $schema_name, fixtures_glob => $fixtures);
 

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -16,7 +16,7 @@ use OpenQA::Jobs::Constants;
 use OpenQA::JobDependencies::Constants qw(PARALLEL);
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(
     schema_name => $schema_name,
     fixtures_glob => '01-jobs.pl 02-workers.pl 04-products.pl 05-job_modules.pl 06-job_dependencies.pl'

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -24,7 +24,7 @@ use Date::Format 'time2str';
 use POSIX 'strftime';
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(
     schema_name => $schema_name,
     fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl 04-products.pl 05-job_modules.pl'

--- a/t/ui/13-admin.t
+++ b/t/ui/13-admin.t
@@ -21,7 +21,7 @@ use File::Path qw(make_path remove_tree);
 use Module::Load::Conditional qw(can_load);
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(
     schema_name => $schema_name,
     fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl 04-products.pl'

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -15,7 +15,7 @@ use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '01-jobs.pl 02-workers.pl');
 my $parent_groups = $schema->resultset('JobGroupParents');
 

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -21,7 +21,7 @@ my $online_worker_id = 6;
 my $offline_worker_id = 8;
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema
   = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
 assume_all_assets_exist;

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -15,7 +15,7 @@ use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema
   = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 my $comments = $schema->resultset('Comments');

--- a/t/ui/16-activity-view.t
+++ b/t/ui/16-activity-view.t
@@ -21,7 +21,7 @@ use Time::Seconds;
 use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '01-jobs.pl');
 my $demo_user;
 

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -19,7 +19,7 @@ use OpenQA::JobDependencies::Constants qw(CHAINED DIRECTLY_CHAINED);
 use OpenQA::Jobs::Constants;
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(
     schema_name => $schema_name,
     fixtures_glob => '01-jobs.pl 05-job_modules.pl 06-job_dependencies.pl'

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -12,7 +12,7 @@ use OpenQA::Test::Case;
 use Date::Format 'time2str';
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(
     schema_name => $schema_name,
     fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl 05-job_modules.pl 07-needles.pl'

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -16,7 +16,7 @@ use OpenQA::Test::Client 'client';
 use OpenQA::SeleniumTest;
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $fixtures = '01-jobs.pl 03-users.pl 04-products.pl';
 my $schema = $test_case->init_data(schema_name => $schema_name, fixtures_glob => $fixtures);
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -23,7 +23,7 @@ use OpenQA::SeleniumTest;
 use Module::Load::Conditional qw(can_load);
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema = $test_case->init_data(
     schema_name => $schema_name,
     fixtures_glob =>

--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -19,7 +19,7 @@ use Cwd qw(getcwd);
 use DateTime;
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $schema
   = $test_case->init_data(schema_name => $schema_name, fixtures_glob => '01-jobs.pl 05-job_modules.pl 07-needles.pl');
 

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -17,7 +17,7 @@ use OpenQA::JobDependencies::Constants;
 use Date::Format 'time2str';
 
 my $test_case = OpenQA::Test::Case->new;
-my $schema_name = OpenQA::Test::Database->generate_schema_name;
+my $schema_name = OpenQA::Test::Database::generate_schema_name;
 my $fixtures = '01-jobs.pl 06-job_dependencies.pl';
 my $schema = $test_case->init_data(schema_name => $schema_name, fixtures_glob => $fixtures);
 my $jobs = $schema->resultset('Jobs');


### PR DESCRIPTION
Within our Makefile we had the default database path "/dev/shm/tpg" which is
used to create a temporary test database. When calling "prove" or just the test
modules as Perl applications it was necessary to have TEST_PG_PATH exported in
the calling environment. Instead we can set the default already in our test
code and inform the caller if the database can not be found. This allows to
save some time during development by calling a quicker bare "prove" without
needing to rely on make all the time.

Instead of the previous message

```
skipped: set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test
```

this will provide a more verbose message, something like

```
DBIx::Class::Storage::DBI::catch {...} (): DBI Connection failed: DBI connect('dbname=openqa_test;host=/dev/shm/tpg','',...) failed: connection to server on socket "/dev/shm/tpg/.s.PGSQL.5432" failed: No such file or directory
       Is the server running locally and accepting connections on that socket? at ...
t/... .. skipped: set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test
```