### PR TITLE
Add softfail to XUnit parser

### DIFF
--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -11,6 +11,8 @@ sub _add_single_result { shift->results->add(OpenQA::Parser::Result::XUnit->new(
 
 sub addproperty { shift->{properties}->add(OpenQA::Parser::Result::XUnit::Property->new(shift)) }
 
+my %TC_RESULT_BY_TAG = (softfailure => 'softfail', failure => 'fail', error => 'fail');
+
 sub parse {
     my ($self, $xml) = @_;
     confess 'No XML given/loaded' unless $xml;
@@ -30,6 +32,7 @@ sub parse {
 
         $result->{errors} = exists $ts->{errors} ? $ts->{errors} : undef;
         $result->{tests} = exists $ts->{tests} ? $ts->{tests} : undef;
+        $result->{softfailures} = exists $ts->{softfailures} ? $ts->{softfailures} : undef;
         $result->{failures} = exists $ts->{failures} ? $ts->{failures} : undef;
         $result->{time} = exists $ts->{time} ? $ts->{time} : undef;
 
@@ -56,6 +59,7 @@ sub parse {
             });
 
         my $ts_result = 'ok';
+        $ts_result = 'softfail' if ($ts->{softfailures} && $ts->{softfailures} > 0);
         $ts_result = 'fail' if ($ts->{failures} && $ts->{failures} > 0) || ($ts->{errors} && $ts->{errors} > 0);
         $result->{result} = $ts_result;
         $result->{dents} = 0;
@@ -67,6 +71,7 @@ sub parse {
             sub {
                 my $tc = shift;
                 my $tc_result = 'ok';
+                $tc_result = 'softfail' if ($tc->{softfailures} && $tc->{softfailures} > 0);
                 $tc_result = 'fail'
                   if ($tc->{failures} && $tc->{failures} > 0) || ($tc->{errors} && $tc->{errors} > 0);
 
@@ -76,8 +81,8 @@ sub parse {
                 my $content = '# Test messages ';
                 $content .= "# $tc->{name}\n" if $tc->{name};
 
-                for my $out ($tc->children('skipped, passed, error, failure')->each) {
-                    $tc_result = 'fail' if ($out->tag =~ m/failure|error/);
+                for my $out ($tc->children('skipped, passed, error, failure, softfailure')->each) {
+                    if (my $res = $TC_RESULT_BY_TAG{$out->tag}) { $tc_result //= $res }
                     $content .= '# ' . $out->tag . ": \n\n";
                     $content .= $out->{message} . "\n" if $out->{message};
                     $content .= $out->text . "\n";
@@ -106,7 +111,7 @@ sub parse {
     use Mojo::Base 'OpenQA::Parser::Result::OpenQA';
     has properties => sub { OpenQA::Parser::Results->new };
 
-    has [qw(errors tests failures time)];
+    has [qw(errors tests softfailures failures time)];
 }
 
 {

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -442,6 +442,7 @@ sub test_xunit_file {
     is $parser->generated_tests_results->first()->properties->last->value, 'd';
 
     ok $parser->generated_tests_results->first()->time;
+    ok $parser->generated_tests_results->first()->softfailures;
     ok $parser->generated_tests_results->first()->errors;
     ok $parser->generated_tests_results->first()->failures;
     ok $parser->generated_tests_results->first()->tests;
@@ -450,15 +451,15 @@ sub test_xunit_file {
       'Generated 11 openQA tests results';    # 9 testsuites with all cumulative results for openQA
     is $parser->generated_tests_results->size, 11, 'Object contains 11 testsuites';
 
-    is $parser->results->search_in_details("title", qr/bacon/)->size, 13,
+    is $parser->results->search_in_details("title", qr/bacon/)->size, 14,
       'Overall 11 testsuites, 2 tests does not have title containing bacon';
-    is $parser->results->search_in_details("text", qr/bacon/)->size, 15,
+    is $parser->results->search_in_details("text", qr/bacon/)->size, 16,
       'Overall 11 testsuites, 15 tests are for bacon';
-    is $parser->generated_tests_output->size, 23, "23 Outputs";
+    is $parser->generated_tests_output->size, 24, "23 Outputs";
 
     my $resultsdir = tempdir;
     $parser->write_output($resultsdir);
-    is $resultsdir->list_tree->size, 23, '23 test outputs were written';
+    is $resultsdir->list_tree->size, 24, '24 test outputs were written';
     $resultsdir->list_tree->each(
         sub {
             fail('Output result was written correctly') unless ($_->slurp =~ /^# Test messages /);

--- a/t/data/xunit_format_example.xml
+++ b/t/data/xunit_format_example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
     <testsuites>
         <!-- standard test suite -->
-        <testsuite name="bacon" errors="666" tests="777" failures="888" time="0.021">
+        <testsuite name="bacon" softfailures="555" errors="666" tests="777" failures="888" time="0.021">
             <!-- standard props -->
             <properties>
                 <property name="x" value="y" />
@@ -17,6 +17,9 @@
             <!-- each kind of test case with a full message -->
             <testcase assertions="0" classname="bacon" name="bacon 1" time="0.001">
                 <passed message="message" type="type">inner massage</passed>
+            </testcase>
+            <testcase assertions="0" classname="bacon" name="bacon 1" time="0.001">
+                <softfailure message="message" type="type">inner massage</passed>
             </testcase>
             <testcase assertions="0" classname="bacon" name="bacon 2" time="0.001">
                 <error message="message" type="type">inner massage</error>


### PR DESCRIPTION
Hello,

we use `XUnit` parser to parse `pytest` output and we would like openQA to softfail in situations the `pytest` testcase encounters known bug (which is documented and referenced).
Currently those testcases are reported as `skipped` which makes them less visible than `softfailures`.

- Related ticket: [poo#177321](https://progress.opensuse.org/issues/177321)
- Related pull request: os-autoinst/os-autoinst-distri-opensuse#21304