### PR TITLE
Remove uncoverable comment from one statement

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -274,7 +274,7 @@ sub _create_jobs_in_database ($self, $jobs, $failed_job_info, $skip_chained_deps
         }
         catch ($e) {
             $schema->svp_rollback('try_create_job_from_settings');
-            die $e if $schema->is_deadlock($e);    # uncoverable statement
+            die $e if $schema->is_deadlock($e);
             push @$failed_job_info, {job_name => $settings->{TEST}, error_message => $e};
         }
     }


### PR DESCRIPTION
The line itself is actually covered, just that the if isn't always true.

Seen during working on https://progress.opensuse.org/issues/176862