### PR TITLE
Fix non-custom OAuth2 providers

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -70,7 +70,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
         return $controller->render(text => $msg, status => 403);    # return always 403 for consistency
     }
     my $details = $tx->res->json;
-    my $id_field = $provider_config->{id_from};
+    my $id_field = $provider_config->{id_from} // 'id';
     my $nickname_field = $provider_config->{nickname_from};
     if (ref $details ne 'HASH' || !$details->{$id_field} || !$details->{$nickname_field}) {
         log_debug('OAuth2 user provider returned: ' . dumper($details));


### PR DESCRIPTION
The fb002508a commit introduced usage of 'id_from' config parameter. And
while the commit messsage says it defaults to the old value 'id', in
fact the parameter is set only for the custom provider, and in all the
other cases it isn't included in $provider_config at all.

Fix this by having default/fallback value also where the variable is
actually used, thus avoiding the need to set it in every supported
provider.

This un-breaks authentication via Github, among other things.

Fixes: fb002508a "Support OpenID Connect better in the OAuth2 'custom' provider"