### PR TITLE
Avoid error when emiting an AMQP job event when the job does not exist

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -87,8 +87,7 @@ sub on_job_event {
 
     my ($user_id, $connection_id, $event, $event_data) = @$args;
     my $jobs = $self->{app}->schema->resultset('Jobs');
-    my $job = $jobs->find({id => $event_data->{id}})
-      or die "Could not find job '$event_data->{id}' in database";
+    return undef unless my $job = $jobs->find({id => $event_data->{id}});
 
     # find count of pending jobs for the same build to know whether all tests for a build are done
     $event_data->{remaining} = $jobs->search(


### PR DESCRIPTION
* Ignore non-existing jobs when trying to emit an AMQP event
    * This can happen when the job has been deleted meanwhile, e.g. via the API or during cleanup. It makes no sense to emit e.g. a `job_done` event when the job has already been deleted anyway.
    * This can also happen on concurrent deletions where one event is enough.
* Treat non-existing jobs similar to non-existing comments which we already ignore
* Avoid error observed in https://progress.opensuse.org/issues/178126