### PR TITLE
Remove unused method in OpenQA::WebAPI::Controller::Test

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -113,10 +113,6 @@ sub referer_check ($self) {
     return 1;
 }
 
-sub list {
-    my ($self) = @_;
-}
-
 sub _load_test_preset ($self, $preset_key) {
     return undef unless defined $preset_key;
     # avoid reading INI file again on subsequent calls


### PR DESCRIPTION
The 'list' API target still exists and is unchanged.