### PR TITLE
Improve path handling for needles and OPENQA_BASEDIR

### DIFF
--- a/lib/OpenQA/Needles.pm
+++ b/lib/OpenQA/Needles.pm
@@ -19,7 +19,11 @@ my $tmp_dir = prjdir() . '/webui/cache/needle-refs';
 
 sub temp_dir () { $tmp_dir }
 
-sub is_in_temp_dir ($file_path) { index($file_path, $tmp_dir) == 0 }
+sub is_in_temp_dir ($file_path) {
+    my $abs_tmpdir = File::Spec->rel2abs($tmp_dir);
+    $file_path = File::Spec->rel2abs($file_path);
+    index($file_path, $abs_tmpdir) == 0;
+}
 
 sub needle_temp_dir ($dir, $ref) { path($tmp_dir, basename(dirname($dir)), $ref, 'needles') }
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -161,8 +161,10 @@ our @EXPORT_OK = qw(
 # override OPENQA_BASEDIR for tests
 if ($0 =~ /\.t$/) {
     # This should result in the 't' directory, even if $0 is in a subdirectory
-    my ($tdirname) = $0 =~ qr/((.*\/t\/|^t\/)).+$/;
-    $ENV{OPENQA_BASEDIR} ||= $tdirname . 'data';
+    my ($tdirname) = $0 =~ m{((.*/t/|^t/)).+$};
+    # remove ./
+    $tdirname = File::Spec->canonpath($tdirname);
+    $ENV{OPENQA_BASEDIR} ||= "$tdirname/data";
 }
 
 sub prjdir { ($ENV{OPENQA_BASEDIR} || '/var/lib') . '/openqa' }


### PR DESCRIPTION
Calling some tests with ./ in front would make the tests fail because
OPENQA_BASEDIR was set to ./t/data/...

    make test TESTS=./t/14-grutasks.t HEAVY=1
    make test TESTS=./t/21-needles.t

Issues:
* https://progress.opensuse.org/issues/178177
* https://progress.opensuse.org/issues/178180