### PR TITLE
Consider `t/ui/01-list.t` stable again after 0b4f441

### DIFF
--- a/tools/unstable_tests.txt
+++ b/tools/unstable_tests.txt
@@ -1,5 +1,4 @@
 t/25-cache-service.t
 t/43-scheduling-and-worker-scalability.t
-t/ui/01-list.t
 t/ui/26-jobs_restart.t
 t/ui/13-admin.t


### PR DESCRIPTION
The test ran [200 times successfully in a row on CircleCI](https://github.com/os-autoinst/openQA/pull/6255#issuecomment-2703792827) after 0b4f441 so it seems stable now.

Related ticket: https://progress.opensuse.org/issues/178315