### PR TITLE
Reproducer of weird test failure

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -132,6 +132,7 @@ sub create ($self) {
     my $text = $validation->param('text');
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
     my $txn_guard = $self->schema->txn_scope_guard;
+    warn __PACKAGE__.':'.__LINE__.": !!!!!!!!!!!!! will make test fail\n";
     my $comment = $comments->create(
         {
             text => href_to_bugref($text),

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -219,6 +219,7 @@ my $SIGCHLD_HANDLER = sub {
         my $exit_signal = $exit_status & 127;
         _fail_and_exit "sub process $child_name terminated by signal $exit_signal", $exit_signal if $exit_signal;
         my $exit_code = ($exit_status >> 8);
+        Test::More::diag("############## exit with $exit_code");
         _fail_and_exit "sub process $child_name terminated with exit code $exit_code", $exit_code if $exit_code;
     }
 };

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -196,6 +196,8 @@ subtest 'commenting in the group overview' => sub {
     test_comment_editing(0);
 };
 
+done_testing; exit;
+
 subtest 'URL auto-replace' => sub {
     my $build_url = $driver->get_current_url();
     $build_url =~ s/\?.*//;


### PR DESCRIPTION
    t/ui/15-comments.t
    [error] [pid:6463] Stopping openqa-webapi process because a Perl warning occurred: OpenQA::WebAPI::Controller::API::V1::Comment:136: !!!!!!!!!!!!! will make test fail
            # ############## exit with 42
            not ok 2 - sub process openqa-webapi terminated with exit code 42

            #   Failed test 'sub process openqa-webapi terminated with exit code 42'
            #   at /home/tina/openqa-toolbox/repos/openQA/t/ui/../lib/OpenQA/Test/Utils.pm line 210.
            1..2

    A context appears to have been destroyed without first calling release().
    Based on $@ it does not look like an exception was thrown (this is not always
    a reliable test)

    This is a problem because the global error variables ($!, $@, and $?) will
    not be restored. In addition some release callbacks will not work properly from
    inside a DESTROY method.

    Here are the context creation details, just in case a tool forgot to call
    release():
      File: ./t/ui/15-comments.t
      Line: 140
      Tool: Test::More::subtest

    Cleaning up the CONTEXT stack...
    A context appears to have been destroyed without first calling release().
    Based on $@ it does not look like an exception was thrown (this is not always
    a reliable test)

    This is a problem because the global error variables ($!, $@, and $?) will
    not be restored. In addition some release callbacks will not work properly from
    inside a DESTROY method.

    Here are the context creation details, just in case a tool forgot to call
    release():
      File: ./t/ui/15-comments.t
      Line: 197
      Tool: Test::More::subtest

    Cleaning up the CONTEXT stack...