### PR TITLE
Fix XUnit parser softfail scenario

### DIFF
--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -70,10 +70,6 @@ sub parse {
         $ts->children('testcase')->each(
             sub {
                 my $tc = shift;
-                my $tc_result = 'ok';
-                $tc_result = 'softfail' if ($tc->{softfailures} && $tc->{softfailures} > 0);
-                $tc_result = 'fail'
-                  if ($tc->{failures} && $tc->{failures} > 0) || ($tc->{errors} && $tc->{errors} > 0);
 
                 my $text_fn = "$ts_category-$ts_name-$num";
                 $text_fn =~ s/[\/.]/_/g;
@@ -81,8 +77,9 @@ sub parse {
                 my $content = '# Test messages ';
                 $content .= "# $tc->{name}\n" if $tc->{name};
 
+                my $tc_result = 'ok';
                 for my $out ($tc->children('skipped, passed, error, failure, softfailure')->each) {
-                    if (my $res = $TC_RESULT_BY_TAG{$out->tag}) { $tc_result //= $res }
+                    if (my $res = $TC_RESULT_BY_TAG{$out->tag}) { $tc_result = $res }
                     $content .= '# ' . $out->tag . ": \n\n";
                     $content .= $out->{message} . "\n" if $out->{message};
                     $content .= $out->text . "\n";

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -443,6 +443,8 @@ sub test_xunit_file {
 
     ok $parser->generated_tests_results->first()->time;
     ok $parser->generated_tests_results->first()->softfailures;
+    is $parser->results->first->softfailures, 555, 'The test suite header says 555 softfailures';
+
     ok $parser->generated_tests_results->first()->errors;
     ok $parser->generated_tests_results->first()->failures;
     ok $parser->generated_tests_results->first()->tests;
@@ -455,7 +457,7 @@ sub test_xunit_file {
       'Overall 11 testsuites, 2 tests does not have title containing bacon';
     is $parser->results->search_in_details("text", qr/bacon/)->size, 16,
       'Overall 11 testsuites, 15 tests are for bacon';
-    is $parser->generated_tests_output->size, 24, "23 Outputs";
+    is $parser->generated_tests_output->size, 24, "24 Outputs";
 
     my $resultsdir = tempdir;
     $parser->write_output($resultsdir);


### PR DESCRIPTION
The test case result was not properly set. This fixes it.

- Related ticket: [poo#177321](https://progress.opensuse.org/issues/177321)
- Related pull request: os-autoinst/os-autoinst-distri-opensuse#21304
- Previous pull request: #6227