### PR TITLE
Fix sporadic test failure in `t/ui/10-tests_overview.t`

### DIFF
--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -336,7 +336,7 @@ sub wait_for_element (%args) {
             }
             return defined $element;
         },
-        $args{description} // ($selector . ' present'),
+        $args{description} // $args{desc} // ($selector . ' present'),
         $args{timeout},
         $args{check_interval},
     );

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -457,8 +457,8 @@ subtest "filtering by machine" => sub {
         $driver->find_element('#filter-machine')->send_keys('64bit,uefi');
         $driver->find_element('#filter-panel button[type="submit"]')->click();
 
-        wait_for_element(selector => '#flavor_DVD_arch_x86_64', like => qr/x86_64/, desc => 'DVD/x86_64 still present');
         wait_for_element(selector => '#flavor_NET_arch_x86_64', like => qr/x86_64/, desc => 'NET/x86_64 present');
+        wait_for_element(selector => '#flavor_DVD_arch_x86_64', like => qr/x86_64/, desc => 'DVD/x86_64 still present');
         element_not_present("#$_") for qw(flavor_DVD_arch_i586 flavor_GNOME-Live_arch_i686);
     };
 };

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -445,7 +445,7 @@ subtest "filtering by machine" => sub {
         $driver->find_element('#filter-machine')->send_keys('uefi');
         $driver->find_element('#filter-panel button[type="submit"]')->click();
 
-        like wait_for_element(selector => '#flavor_DVD_arch_x86_64')->get_text, qr/x86_64/, 'DVD/x86_64 present';
+        wait_for_element(selector => '#flavor_DVD_arch_x86_64', like => qr/x86_64/, desc => 'DVD/x86_64 present');
         element_not_present("#$_") for qw(flavor_DVD_arch_i586 flavor_GNOME-Live_arch_i686 flavor_NET_arch_x86_64);
         is element_prop('filter-machine'), 'uefi', 'machine filter still visible in form';
 
@@ -457,8 +457,8 @@ subtest "filtering by machine" => sub {
         $driver->find_element('#filter-machine')->send_keys('64bit,uefi');
         $driver->find_element('#filter-panel button[type="submit"]')->click();
 
-        like wait_for_element(selector => '#flavor_DVD_arch_x86_64')->get_text, qr/x86_64/, 'DVD/x86_64 still present';
-        like wait_for_element(selector => '#flavor_NET_arch_x86_64')->get_text, qr/x86_64/, 'NET/x86_64 present';
+        wait_for_element(selector => '#flavor_DVD_arch_x86_64', like => qr/x86_64/, desc => 'DVD/x86_64 still present');
+        wait_for_element(selector => '#flavor_NET_arch_x86_64', like => qr/x86_64/, desc => 'NET/x86_64 present');
         element_not_present("#$_") for qw(flavor_DVD_arch_i586 flavor_GNOME-Live_arch_i686);
     };
 };


### PR DESCRIPTION
This test sometimes runs into:

```
getElementText: stale element reference: stale element not found at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm:77 at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm line 80.
OpenQA::SeleniumTest::__ANON__(Test::Selenium::Chrome=HASH(0x561a52552560), "Error while executing command: getElementText: stale element "..., HASH(0x561a528c1030)) called at /usr/lib/perl5/vendor_perl/5.26.1/Selenium/Remote/Driver.pm line 356
Selenium::Remote::Driver::catch {...} ("Error while executing command: getElementText: stale element "...) called at /usr/lib/perl5/vendor_perl/5.26.1/Try/Tiny.pm line 123
…
Selenium::Remote::WebElement::_execute_command(Test::Selenium::Remote::WebElement=HASH(0x561a528b82b0), HASH(0x561a528c1030)) called at /usr/lib/perl5/vendor_perl/5.26.1/Selenium/Remote/WebElement.pm line 358
Selenium::Remote::WebElement::get_text(Test::Selenium::Remote::WebElement=HASH(0x561a528b82b0)) called at t/ui/10-tests_overview.t line 460
…
Test::Builder::subtest(Test::Builder=HASH(0x561a46ef9a28), "filter for specific machine", CODE(0x561a528b5b00)) called at /usr/lib/perl5/5.26.1/Test/More.pm line 807
Test::More::subtest("filter for specific machine", CODE(0x561a528b5b00)) called at t/ui/10-tests_overview.t line 463
…
Test::Builder::subtest(Test::Builder=HASH(0x561a46ef9a28), "filtering by machine", CODE(0x561a52888920)) called at /usr/lib/perl5/5.26.1/Test/More.pm line 807
Test::More::subtest("filtering by machine", CODE(0x561a52888920)) called at t/ui/10-tests_overview.t line 464
```

There is no AJAX or dynamic loading of these elements at play. So the
problem is perhaps that the `wait_for_element` still finds the element
before the reload is done and then accessing the text of the element is no
longer possible when the page has actually reloaded. If this is true then
simply reordering the `wait_for_element` calls will help as the test now
looks for the element that is not present before reloading first.