### PR TITLE
Avoid race condition in `t/ui/21-admin-needles.t`

### DIFF
--- a/t/ui/21-admin-needles.t
+++ b/t/ui/21-admin-needles.t
@@ -351,6 +351,7 @@ subtest 'custom needles search' => sub {
     is($needle_tds[1]->get_text(), 'seven_month-undef.json', 'search seven_month-undef needle correctly');
 
     $last_seen_options[0]->click();
+    wait_for_data_table($needles_table, 3);    # minimize chance for race condition, see poo#167611
     $last_match_options[6]->click();
     wait_for_data_table($needles_table, 4);
     @needle_trs = $driver->find_elements('#needles tbody tr');


### PR DESCRIPTION
* Wait for intermediate state when selecting options to minimize the chance for a race condition leading to sometimes observing the intermediate state in further checks (and thus failing the test)
* See https://progress.opensuse.org/issues/167611#note-6