### PR TITLE
Fix two more sporadic test failures in `t/ui/10-tests_overview.t`

### DIFF
--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -132,7 +132,7 @@ $driver->find_element('#filter-panel .card-header')->click();
 $driver->find_element_by_id('filter-todo')->click();
 $driver->find_element_by_id('filter-passed')->click();
 $driver->find_element_by_id('filter-failed')->click();
-$driver->find_element('#filter-form button')->click();
+apply_filter('failed');    # failed selected, passed and todo unselected
 $driver->find_element_by_id('res_DVD_x86_64_doc');
 my @filtered_out = $driver->find_elements('#res_DVD_x86_64_kde', 'css');
 is(scalar @filtered_out, 0, 'result filter correctly applied');
@@ -144,7 +144,10 @@ my $url_with_escaped_parameters
 $driver->get($url_with_escaped_parameters);
 $driver->find_element('#filter-panel .card-header')->click();
 $driver->find_element('#filter-form button')->click();
-is($driver->get_current_url(), $url_with_escaped_parameters . '#', 'escaped URL parameters are passed correctly');
+my $url_after_filter = "$url_with_escaped_parameters#";
+my $desc = 'escaped URL parameters are passed correctly';
+wait_until sub { $driver->get_current_url eq $url_after_filter }, $desc, 10;
+is $driver->get_current_url, $url_after_filter, $desc;
 
 # Test failed module info async update
 $driver->get($baseurl . 'tests/overview?distri=opensuse&version=13.1&build=0091&groupid=1001');


### PR DESCRIPTION
Those are two more instances of the same problem already fixed in other places in 13055cd6. The problem is again that after clicking the submit button of the filter form subsequent checks still observe the state of the page before the page reloads (with filters applied). The old state of the page even includes the URL as the check using `$driver->get_current_url` shows. This checked failed on CircleCI:

```
[16:47:29] t/ui/10-tests_overview.t ................... 2/? 
#   Failed test 'escaped URL parameters are passed correctly'
#   at t/ui/10-tests_overview.t line 147.
#          got: 'http://localhost:55837/tests/overview?arch=&flavor=&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001'
#     expected: 'http://localhost:55837/tests/overview?arch=&flavor=&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&distri=opensuse&build=0091&version=Staging%3AI&groupid=1001#'
[16:47:29] t/ui/10-tests_overview.t ................... 26/? # Looks like you failed 1 test of 26.
```

I think these kinds of sporadic failures are not a problem we have forever. Maybe and update of Chromium changed something under the hood and now we some kind of lack synchronization we previously took for granted.