### PR TITLE
Fix unstable UI tests by waiting for popovers

### DIFF
--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -160,7 +160,7 @@ like($driver->find_elements('.failedmodule', 'css')->[1]->get_attribute('href'),
 my @descriptions = $driver->find_elements('td.name a', 'css');
 is(scalar @descriptions, 2, 'only test suites with description content are shown as links');
 $descriptions[0]->click();
-is($driver->find_element('.popover-header')->get_text, 'kde', 'description popover shows content');
+is wait_for_element(selector => '.popover-header')->get_text, 'kde', 'description popover shows content';
 
 # Test bug status
 my @closed_bugs = $driver->find_elements('#bug-99937 .bug_closed', 'css');

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -138,7 +138,7 @@ subtest 'worker overview' => sub {
         $driver->find_element("tr#worker_$broken_worker_id .status")->get_text(),
         'Unavailable', "worker $broken_worker_id is broken and displayed as unavailable",
     );
-    like($driver->find_element('.popover')->get_text(), qr/Details\nout of order/, 'reason for brokenness shown');
+    like wait_for_element(selector => '.popover')->get_text, qr/Details\nout of order/, 'reason for brokenness shown';
 };
 
 # test delete offline worker function

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -292,7 +292,7 @@ subtest 'commenting in test results including labels' => sub {
         disable_bootstrap_animations;
         my $help_icon = $driver->find_element('#commentForm .help_popover.fa-question-circle');
         $help_icon->click;
-        like($driver->find_element('.popover')->get_text, qr/Help for comments/, 'popover shown on click');
+        is wait_for_element(selector => '.popover-header')->get_text, 'Help for comments', 'popover shown on click';
         $help_icon->click;
     };
 

--- a/t/ui/25-developer_mode.t
+++ b/t/ui/25-developer_mode.t
@@ -326,7 +326,7 @@ subtest 'expand developer panel' => sub {
     my $popover_icon = $driver->find_element('#developer-form .help_popover');
     if (ok $popover_icon, 'popover icon(s) present') {
         $popover_icon->click;
-        ok $driver->find_element('body > .popover'), 'popover shown';
+        ok wait_for_element(selector => 'body > .popover'), 'popover shown';
     }
 };
 


### PR DESCRIPTION
This should fix errors like:
```
t/ui/15-comments.t ......................... 10/?
  Failed test 'commenting in test results including labels' at t/ui/15-comments.t line 429.
  findElement: no such element: Unable to locate element: {"method":"css selector","selector":".popover"} at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm:78 at /home/squamata/project/t/ui/../lib/OpenQA/SeleniumTest.pm line 81.
```

This is not a new issue. Commit a6dd3fee5a previously fixed other occurrences where we check popovers. This change applies the same to other occurrences.