### PR TITLE
Rollback retries applied for full-stack test preventing ci from failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ test-unstable: node_modules
 
 .PHONY: test-fullstack
 test-fullstack: node_modules
-	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=30 PROVE_ARGS="$$HARNESS t/full-stack.t t/33-developer_mode.t" RETRY=7
+	$(MAKE) test-with-database FULLSTACK=1 TIMEOUT_M=30 PROVE_ARGS="$$HARNESS t/full-stack.t t/33-developer_mode.t"
 
 .PHONY: test-fullstack-unstable
 test-fullstack-unstable: node_modules


### PR DESCRIPTION
The retry commit is now possible to rever thanks to the merged pr of Dominik Heidler #2676

This will revert the changes made by prs that mitigate the problem: #6244 and #6115

related: https://progress.opensuse.org/issues/175060