### PR TITLE
Improve "from" time label in /tests/overview

### DIFF
--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -145,9 +145,9 @@ subtest 'time parameter' => sub {
     my @params = (distri => 'opensuse', version => 'Factory', build => '87.5011');
     my $tp = '2020-01-01T00:00:00';
     $t->get_ok('/tests/overview' => form => {@params, t => $tp});
-    like(get_summary, qr/from $tp.*show latest jobs$/s, 'jobs newer than time parameter filtered out');
+    like(get_summary, qr/at the time of $tp.*show latest jobs$/s, 'jobs newer than time parameter filtered out');
     $t->get_ok('/tests/overview' => form => {@params, t => time2str('%Y-%m-%d %H:%M:%S', time, 'UTC')});
-    like(get_summary, qr/from.*show latest.*Incomplete: 1$/s, 'jobs newer than time parameter shown');
+    like(get_summary, qr/at the time of.*show latest.*Incomplete: 1$/s, 'jobs newer than time parameter shown');
 };
 
 # Advanced query parameters can be forwarded

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -30,7 +30,7 @@
             % }
             <div class="time-params">
                 % if ($until) {
-                    from <abbr class="timeago" title="<%= $until %>Z"><%= $until %>Z</abbr>,
+                    at the time of <abbr class="timeago" title="<%= $until %>Z"><%= $until %>Z</abbr>,
                     <a href="<%= url_with->query({t => undef}) %>">show latest jobs</a>
                 % }
                 % else {


### PR DESCRIPTION
The previous wording for example "from 2 days ago" could be understood
as showing jobs starting 2 days ago until now. This commit changes the
wording to make it clear that we mean jobs until that specified
timestamp. So in the above example the text would say "at the time of 2
days ago".