### PR TITLE
Fix config drop-in path to upstream specifications

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -51,7 +51,7 @@ sub _load_config ($app, $defaults, $mode_specific_defaults) {
     my $config_path = $ENV{OPENQA_CONFIG} ? path($ENV{OPENQA_CONFIG}) : $app->home->child('etc', 'openqa');
     my $main_config_file = $config_path->child('openqa.ini');
     my @config_file_paths = -e $main_config_file ? ($main_config_file) : ();
-    push @config_file_paths, @{$config_path->child('openqa.d')->list->grep(qr/\.ini$/)->sort};
+    push @config_file_paths, @{$config_path->child('openqa.ini.d')->list->grep(qr/\.ini$/)->sort};
 
     # read config files
     my $config_file;

--- a/t/config.t
+++ b/t/config.t
@@ -296,7 +296,7 @@ subtest 'Validation of worker timeout' => sub {
 
 subtest 'Multiple config files' => sub {
     my $t_dir = tempdir;
-    my $openqa_d = $t_dir->child('openqa.d')->make_path;
+    my $openqa_d = $t_dir->child('openqa.ini.d')->make_path;
     local $ENV{OPENQA_CONFIG} = $t_dir;
     my $app = Mojolicious->new();
     my $data_main = "[global]\nappname =  openQA main config\nhide_asset_types = repo iso\n";
@@ -306,8 +306,8 @@ subtest 'Multiple config files' => sub {
     $openqa_d->child('01-appname-and-scm.ini')->spew($data_01);
     $openqa_d->child('02-appname.ini')->spew($data_02);
     my $global_config = OpenQA::Setup::read_config($app)->{global};
-    is $global_config->{appname}, 'openQA override 2', 'appname overriden by config from openqa.d, last one wins';
-    is $global_config->{scm}, 'bazel', 'scm set by config from openqa.d, not overriden';
+    is $global_config->{appname}, 'openQA override 2', 'appname overriden by config from openqa.ini.d, last one wins';
+    is $global_config->{scm}, 'bazel', 'scm set by config from openqa.ini.d, not overriden';
     is $global_config->{hide_asset_types}, 'repo iso', 'types set from main config, not overriden';
 };
 


### PR DESCRIPTION
See
* https://uapi-group.org/specifications/specs/configuration_files_specification/
* https://en.opensuse.org/openSUSE:Packaging_UsrEtc

The .d/ directory must be in the same directory as the .ini/.conf file
and use the complete name of the overridden config file path including
extension.

As the drop-in config directory is not documented yet and only has
implementation we should be ok to just change that :)

Related progress issue: https://progress.opensuse.org/issues/179359