### PR TITLE
Update url query only with the selected option

### DIFF
--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -94,13 +94,22 @@ is(
 
 $driver->find_element_by_link_text('400')->click();
 is($driver->find_element('#more_builds b')->get_text(), 400, 'limited to the selected number');
+like($driver->get_current_url(), qr/1001\?limit_builds=400/, 'url shows the selected build_limits');
+$driver->find_element_by_link_text('50')->click();
+my $actual_url = $driver->get_current_url();
+unlike($actual_url, qr/limit_builds=400/, 'url query doesnt show previous limit_builds');
+like($actual_url, qr/1001\?limit_builds=50/, 'url query has unique limit_builds entry');
 $driver->find_element_by_link_text('tagged')->click();
 is(scalar @{$driver->find_elements('.h4', 'css')}, 0, 'no tagged builds exist');
+$driver->find_element_by_link_text('400')->click();
+$actual_url = $driver->get_current_url();
+unlike($actual_url, qr/limit_builds=50/, 'url query updates only limit_builds entry and old selection is removed');
+like($actual_url, qr/limit_builds=400/, 'url query updates only limit_builds entry and shows new selection');
+like($actual_url, qr/only_tagged=1/, 'url query contains tag settings');
 
 $driver->get('/group_overview/1001');
 my $res = OpenQA::Test::Case::trim_whitespace($driver->find_element_by_id('more_builds')->get_text);
 is($res, q{Limit to 10 / 20 / 50 / 100 / 400 builds, only tagged / all}, 'more builds can be requested');
-
 is($driver->get('/?group=opensuse'), 1, 'group parameter is not exact by default');
 wait_for_ajax;
 is(scalar @{$driver->find_elements('h2', 'css')}, 2, 'both job groups shown');

--- a/t/ui/14-dashboard.t
+++ b/t/ui/14-dashboard.t
@@ -28,7 +28,7 @@ plan skip_all => 'Install Selenium::Remote::WDKeys to run this test'
 #
 $driver->title_is("openQA", "on main page");
 my @build_headings = $driver->find_elements('.h4', 'css');
-is(scalar @build_headings, 4, '4 builds shown');
+is scalar @build_headings, 4, '4 builds shown';
 
 subtest 'Back to top button' => sub {
     my $check_visibility
@@ -48,85 +48,76 @@ subtest 'Back to top button' => sub {
 
 # click on last build which should be Build0091
 $driver->find_child_element($build_headings[-1], 'a', 'css')->click();
-like(
-    $driver->find_element_by_id('summary')->get_text(),
-    qr/Overall Summary of opensuse test build 0091/,
-    'we are on build 91'
-);
+like $driver->find_element_by_id('summary')->get_text(),
+  qr/Overall Summary of opensuse test build 0091/,
+  'we are on build 91';
 
-is($driver->get('/?limit_builds=1'), 1, 'index page accepts limit_builds parameter');
+is $driver->get('/?limit_builds=1'), 1, 'index page accepts limit_builds parameter';
 wait_for_ajax;
-is(scalar @{$driver->find_elements('.h4', 'css')}, 2, 'only one build per group shown');
-is($driver->get('/?time_limit_days=0.02&limit_builds=100000'), 1, 'index page accepts time_limit_days parameter');
+is scalar @{$driver->find_elements('.h4', 'css')}, 2, 'only one build per group shown';
+is $driver->get('/?time_limit_days=0.02&limit_builds=100000'), 1, 'index page accepts time_limit_days parameter';
 wait_for_ajax;
-is(scalar @{$driver->find_elements('.h4', 'css')}, 0, 'no builds shown');
-is($driver->get('/?time_limit_days=0.05&limit_builds=100000'), 1, 'index page accepts time_limit_days parameter');
+is scalar @{$driver->find_elements('.h4', 'css')}, 0, 'no builds shown';
+is $driver->get('/?time_limit_days=0.05&limit_builds=100000'), 1, 'index page accepts time_limit_days parameter';
 wait_for_ajax;
-is(scalar @{$driver->find_elements('.h4', 'css')}, 2, 'only the one hour old builds is shown');
+is scalar @{$driver->find_elements('.h4', 'css')}, 2, 'only the one hour old builds are shown';
 
 # group overview
 $driver->find_element_by_link_text('opensuse')->click();
 my $build_url = $driver->get_current_url();
 $build_url =~ s/\?.*//;
 log_debug('build_url: ' . $build_url);
-is(scalar @{$driver->find_elements('.h4', 'css')}, 5, 'number of builds for opensuse');
-is(
-    $driver->find_element_by_id('group_description')->get_text(),
-    "Test description\nwith bugref  bsc#1234",    # second space comes from using non-breaking space in bugref span
-    'description shown'
-);
-is(
-    $driver->find_element('#group_description a')->get_attribute('href'),
-    'https://bugzilla.suse.com/show_bug.cgi?id=1234',
-    'bugref in description rendered as link'
-);
+is scalar @{$driver->find_elements('.h4', 'css')}, 5, 'number of builds for opensuse';
+is $driver->find_element_by_id('group_description')->get_text(),
+  "Test description\nwith bugref  bsc#1234",    # second space comes from using non-breaking space in bugref span
+  'description shown';
+is $driver->find_element('#group_description a')->get_attribute('href'),
+  'https://bugzilla.suse.com/show_bug.cgi?id=1234',
+  'bugref in description rendered as link';
 $driver->get('/group_overview/1002');
-is(scalar @{$driver->find_elements('#group_description', 'css')},
-    0, 'no well for group description shown if none present');
-is($driver->get($build_url . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too');
+is scalar @{$driver->find_elements('#group_description', 'css')},
+  0, 'group description frame is not shown if none present';
+is $driver->get($build_url . '?limit_builds=2'), 1, 'group overview page accepts query parameter, too';
 $driver->get($build_url . '?limit_builds=0');
-is(scalar @{$driver->find_elements('div.build-row .h4', 'css')}, 0, 'all builds filtered out');
-is(
-    $driver->find_element('h2')->get_text(),
-    'Last Builds for opensuse',
-    'group name shown correctly when all builds filtered out'
-);
+is scalar @{$driver->find_elements('div.build-row .h4', 'css')}, 0, 'all builds filtered out';
+is $driver->find_element('h2')->get_text(), 'Last Builds for opensuse',
+  'group name shown correctly when all builds filtered out';
 
 $driver->find_element_by_link_text('400')->click();
-is($driver->find_element('#more_builds b')->get_text(), 400, 'limited to the selected number');
-like($driver->get_current_url(), qr/1001\?limit_builds=400/, 'url shows the selected build_limits');
+is $driver->find_element('#more_builds b')->get_text(), 400, 'limited to the selected number';
+like $driver->get_current_url(), qr/1001\?limit_builds=400/, 'url shows the selected build_limits';
 $driver->find_element_by_link_text('50')->click();
 my $actual_url = $driver->get_current_url();
-unlike($actual_url, qr/limit_builds=400/, 'url query doesnt show previous limit_builds');
-like($actual_url, qr/1001\?limit_builds=50/, 'url query has unique limit_builds entry');
+unlike $actual_url, qr/limit_builds=400/, 'url query does not show previous limit_builds';
+like $actual_url, qr/1001\?limit_builds=50/, 'url query has unique limit_builds entry';
 $driver->find_element_by_link_text('tagged')->click();
-is(scalar @{$driver->find_elements('.h4', 'css')}, 0, 'no tagged builds exist');
+is scalar @{$driver->find_elements('.h4', 'css')}, 0, 'no tagged builds exist';
 $driver->find_element_by_link_text('400')->click();
 $actual_url = $driver->get_current_url();
-unlike($actual_url, qr/limit_builds=50/, 'url query updates only limit_builds entry and old selection is removed');
-like($actual_url, qr/limit_builds=400/, 'url query updates only limit_builds entry and shows new selection');
-like($actual_url, qr/only_tagged=1/, 'url query contains tag settings');
+unlike $actual_url, qr/limit_builds=50/, 'url query updates only limit_builds entry and old selection is removed';
+like $actual_url, qr/limit_builds=400/, 'url query updates only limit_builds entry and shows new selection';
+like $actual_url, qr/only_tagged=1/, 'url query contains tag settings';
 
 $driver->get('/group_overview/1001');
 my $res = OpenQA::Test::Case::trim_whitespace($driver->find_element_by_id('more_builds')->get_text);
-is($res, q{Limit to 10 / 20 / 50 / 100 / 400 builds, only tagged / all}, 'more builds can be requested');
-is($driver->get('/?group=opensuse'), 1, 'group parameter is not exact by default');
+is $res, q{Limit to 10 / 20 / 50 / 100 / 400 builds, only tagged / all}, 'more builds can be requested';
+is $driver->get('/?group=opensuse'), 1, 'group parameter is not exact by default';
 wait_for_ajax;
-is(scalar @{$driver->find_elements('h2', 'css')}, 2, 'both job groups shown');
-is($driver->get('/?group=test'), 1, 'group parameter filters as expected');
+is scalar @{$driver->find_elements('h2', 'css')}, 2, 'both job groups shown';
+is $driver->get('/?group=test'), 1, 'group parameter filters as expected';
 wait_for_ajax;
-is(scalar @{$driver->find_elements('h2', 'css')}, 1, 'only one job group shown');
-is($driver->find_element_by_link_text('opensuse test')->get_text, 'opensuse test');
-is($driver->get('/?group=opensuse$'), 1, 'group parameter can be used for exact matching, though');
+is scalar @{$driver->find_elements('h2', 'css')}, 1, 'only one job group shown';
+is $driver->find_element_by_link_text('opensuse test')->get_text, 'opensuse test';
+is $driver->get('/?group=opensuse$'), 1, 'group parameter can be used for exact matching, though';
 wait_for_ajax;
-is(scalar @{$driver->find_elements('h2', 'css')}, 1, 'only one job group shown');
-is($driver->find_element_by_link_text('opensuse')->get_text, 'opensuse');
-is($driver->get('/?group=opensuse$&group=test'), 1, 'multiple group parameter can be used to ease building queries');
+is scalar @{$driver->find_elements('h2', 'css')}, 1, 'only one job group shown';
+is $driver->find_element_by_link_text('opensuse')->get_text, 'opensuse';
+is $driver->get('/?group=opensuse$&group=test'), 1, 'multiple group parameter can be used to ease building queries';
 wait_for_ajax;
-is(scalar @{$driver->find_elements('h2', 'css')}, 2, 'both job groups shown');
+is scalar @{$driver->find_elements('h2', 'css')}, 2, 'both job groups shown';
 $driver->get('/?group=');
 wait_for_ajax;
-is(scalar @{$driver->find_elements('h2', 'css')}, 2, 'a single, empty group parameter has no affect');
+is scalar @{$driver->find_elements('h2', 'css')}, 2, 'a single, empty group parameter has no affect';
 
 subtest 'filter form' => sub {
     $driver->get('/');
@@ -145,12 +136,12 @@ subtest 'filter form' => sub {
     $driver->find_element('#filter-apply-button')->click();
     wait_for_ajax;
     $url .= '?group=SLE%2012%20SP2&limit_builds=38&time_limit_days=142&interval=';
-    is($driver->get_current_url, $url, 'URL parameters for filter are correct');
+    is $driver->get_current_url, $url, 'URL parameters for filter are correct';
 };
 
 # JSON representation of index page
 $driver->get('/dashboard_build_results.json');
-like($driver->get_page_source(), qr("key":"Factory-0048"), 'page rendered as JSON');
+like $driver->get_page_source(), qr("key":"Factory-0048"), 'page rendered as JSON';
 
 # parent group overview: tested in t/22-dashboard.t
 

--- a/templates/webapi/main/more_builds.html.ep
+++ b/templates/webapi/main/more_builds.html.ep
@@ -1,11 +1,11 @@
 <div id="more_builds">
     Limit to
-    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query([limit_builds => $_])) } (10, 20, 50, 100, 400));
+    %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query({limit_builds => $_})) } (10, 20, 50, 100, 400));
     builds, only
     % my %tagged = (tagged => 1, all => 0);
     % my %rtagged = reverse %tagged;
     % my $selected = $rtagged{$only_tagged};
-    %= b join(' / ', map { $_ eq $selected ? "<b>$_</b>" : link_to($_ => url_with->query([only_tagged => $tagged{$_}])) } reverse sort keys %tagged);
+    %= b join(' / ', map { $_ eq $selected ? "<b>$_</b>" : link_to($_ => url_with->query({only_tagged => $tagged{$_}})) } reverse sort keys %tagged);
 </div>
 
 <div id="mode_section">
@@ -15,7 +15,7 @@
     % } else {
       <%= link_to url_for->query(fullscreen => 0)->to_abs => begin %>default view<% end %>
       | Auto refresh every
-      %= b join(' / ', map { $_ == $interval ? "<b>$_</b>" : link_to($_ => url_with->query([interval => $_])) } (30, 60, 90, 120, 180));
+      %= b join(' / ', map { $_ == $interval ? "<b>$_</b>" : link_to($_ => url_with->query({interval => $_})) } (30, 60, 90, 120, 180));
       seconds
     % }
 </div>


### PR DESCRIPTION
dashboard provides filter for limits and tags.
`url_with` extends the query when options are selected. Which creates a long queries like `?limit_builds=20&only_tagged=1&only_tagged=0&limit_builds=10`. Ideally it should have unique entries with clear a clear query as described in the documentation https://docs.mojolicious.org/Mojolicious/Controller#url_for and seems like it needs a hash instead of a list. This updates the current request as expected.