### PR TITLE
dist: Add missing copyright header

### DIFF
--- a/dist/rpm/openQA-client-test.spec
+++ b/dist/rpm/openQA-client-test.spec
@@ -1,3 +1,5 @@
+# Copyright SUSE LLC
+
 %define         short_name openQA-client
 Name:           %{short_name}-test
 Version:        5

--- a/dist/rpm/openQA-devel-test.spec
+++ b/dist/rpm/openQA-devel-test.spec
@@ -1,3 +1,5 @@
+# Copyright SUSE LLC
+
 %define         short_name openQA-devel
 Name:           %{short_name}-test
 Version:        5

--- a/dist/rpm/openQA-test.spec
+++ b/dist/rpm/openQA-test.spec
@@ -1,3 +1,5 @@
+# Copyright SUSE LLC
+
 %define         short_name openQA
 Name:           %{short_name}-test
 Version:        5

--- a/dist/rpm/openQA-worker-test.spec
+++ b/dist/rpm/openQA-worker-test.spec
@@ -1,3 +1,5 @@
+# Copyright SUSE LLC
+
 %define         short_name openQA-worker
 Name:           %{short_name}-test
 Version:        5


### PR DESCRIPTION
This should fix an apparent new check in OBS check scripts denying
acceptance to openSUSE:Factory.

See https://build.opensuse.org/requests/1255613 for context which was
declined with "openQA-client-test.spec does not appear to contain a
Copyright comment. Please stick to the format # Copyright (c) 2022
Unsong Hero or use osc service runall format_spec_file"