### PR TITLE
Make loading nested config files work with our RPM packaging

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -382,9 +382,8 @@ export LANG=en_US.UTF-8
 rm -rf %{buildroot}/%{_sysusersdir}
 %endif
 
-mkdir -p %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa
-ln -s %{_sysconfdir}/openqa/openqa.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
-ln -s %{_sysconfdir}/openqa/database.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
+mkdir -p %{buildroot}%{_datadir}/openqa%{_sysconfdir}
+ln -s %{_sysconfdir}/openqa %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa
 mkdir -p %{buildroot}%{_bindir}
 ln -s %{_datadir}/openqa/script/client %{buildroot}%{_bindir}/openqa-client
 ln -s %{_datadir}/openqa/script/openqa-cli %{buildroot}%{_bindir}/openqa-cli
@@ -570,9 +569,7 @@ fi
 %config(noreplace) %attr(-,geekotest,root) %{_sysconfdir}/openqa/database.ini
 %dir %{_datadir}/openqa
 %dir %{_datadir}/openqa/etc
-%dir %{_datadir}/openqa%{_sysconfdir}/openqa
-%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
-%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
+%{_datadir}/openqa%{_sysconfdir}/openqa
 %config %{_sysconfdir}/logrotate.d
 # apache vhost
 %dir %{_sysconfdir}/apache2


### PR DESCRIPTION
Make the full `/etc/openqa` directory (where config files are installed to by the `Makefile` install target) available to the Mojo app home directory (where the Mojo app actually looks for the config) like it is done in Debian packaging.