### PR TITLE
Make loading nested config files work with our RPM packaging (no symlink)

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -382,9 +382,6 @@ export LANG=en_US.UTF-8
 rm -rf %{buildroot}/%{_sysusersdir}
 %endif
 
-mkdir -p %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa
-ln -s %{_sysconfdir}/openqa/openqa.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
-ln -s %{_sysconfdir}/openqa/database.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 mkdir -p %{buildroot}%{_bindir}
 ln -s %{_datadir}/openqa/script/client %{buildroot}%{_bindir}/openqa-client
 ln -s %{_datadir}/openqa/script/openqa-cli %{buildroot}%{_bindir}/openqa-cli
@@ -569,10 +566,6 @@ fi
 %config(noreplace) %attr(-,geekotest,root) %{_sysconfdir}/openqa/openqa.ini
 %config(noreplace) %attr(-,geekotest,root) %{_sysconfdir}/openqa/database.ini
 %dir %{_datadir}/openqa
-%dir %{_datadir}/openqa/etc
-%dir %{_datadir}/openqa%{_sysconfdir}/openqa
-%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
-%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 %config %{_sysconfdir}/logrotate.d
 # apache vhost
 %dir %{_sysconfdir}/apache2

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -25,6 +25,20 @@ use Feature::Compat::Try;
 my %CARRY_OVER_DEFAULTS = (lookup_depth => 10, state_changes_limit => 3);
 sub carry_over_defaults () { \%CARRY_OVER_DEFAULTS }
 
+sub _lookup_config_files ($app) {
+    my @config_file_paths;
+    for my $path ($ENV{OPENQA_CONFIG}, $app->home->child('etc', 'openqa'), '/etc/openqa', '/usr/etc/openqa') {
+        next unless defined $path && -e $path;
+        my $config_path = path($path);
+        my $main_config_file = $config_path->child('openqa.ini');
+        push @config_file_paths, $main_config_file if -e $main_config_file;
+        push @config_file_paths, @{$config_path->child('openqa.ini.d')->list->grep(qr/\.ini$/)->sort};
+        last;
+    }
+    if (my $log = $app->log) { $app->log->info("Reading config from: @config_file_paths") }
+    return \@config_file_paths;
+}
+
 sub _read_config_file ($config, $config_file, $defaults, $mode_defaults) {
     for my $section (sort keys %$defaults) {
         my $section_defaults = $defaults->{$section};
@@ -46,20 +60,17 @@ sub _read_config_file ($config, $config_file, $defaults, $mode_defaults) {
 }
 
 sub _load_config ($app, $defaults, $mode_specific_defaults) {
-    my $config = $app->config;
-    my $mode_defaults = $mode_specific_defaults->{$app->mode} // {};
-    my $config_path = $ENV{OPENQA_CONFIG} ? path($ENV{OPENQA_CONFIG}) : $app->home->child('etc', 'openqa');
-    my $main_config_file = $config_path->child('openqa.ini');
-    my @config_file_paths = -e $main_config_file ? ($main_config_file) : ();
-    push @config_file_paths, @{$config_path->child('openqa.ini.d')->list->grep(qr/\.ini$/)->sort};
-
-    # read config files
+    # parse config files
     my $config_file;
-    for my $config_file_path (@config_file_paths) {
+    for my $config_file_path (@{_lookup_config_files($app)}) {
         my @import_args = $config_file ? (-import => $config_file) : ();
         my $next_config_file = Config::IniFiles->new(-file => $config_file_path->to_string, @import_args);
         $config_file = $next_config_file if $next_config_file;
     }
+
+    # read values from config files
+    my $mode_defaults = $mode_specific_defaults->{$app->mode} // {};
+    my $config = $app->config;
     if ($config_file) {
         _read_config_file($config, $config_file, $defaults, $mode_defaults);
         $config->{ini_config} = $config_file;

--- a/t/config.t
+++ b/t/config.t
@@ -26,7 +26,8 @@ sub read_config {
 }
 
 subtest 'Test configuration default modes' => sub {
-    local $ENV{OPENQA_CONFIG} = undef;
+    # set OPENQA_CONFIG to an existing directory that has no config files to test defaults
+    local $ENV{OPENQA_CONFIG} = $FindBin::Bin;
 
     my $app = Mojolicious->new();
     $app->mode("test");


### PR DESCRIPTION
Alternative to https://github.com/os-autoinst/openQA/pull/6323 that avoids the symlinking completely.

---

* Read config files directly from `/etc/openqa` if the config directory
  doesn't exist under `OPENQA_CONFIG` or the app home
* Keep reading from `OPENQA_CONFIG` and the app home if a config directory
  exists under those locations as this is useful for development setups and
  running unit tests
* Read config files from `/usr/etc/openqa` if no config directory exists
  under any of the other locations to support
  https://en.opensuse.org/openSUSE:Packaging_UsrEtc#Variant_1_(ideal_case)
* Remove symlinks in our packaging so an installation from packages will in
  fact use all the files from `/etc/openqa` or `/usr/etc/openqa` and not be
  stuck with an only partially symlinked config
* See https://progress.opensuse.org/issues/179425
* See https://progress.opensuse.org/issues/179359