### PR TITLE
Revert "Make loading nested config files work with our RPM packaging (no symlink)"

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -382,6 +382,9 @@ export LANG=en_US.UTF-8
 rm -rf %{buildroot}/%{_sysusersdir}
 %endif
 
+mkdir -p %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa
+ln -s %{_sysconfdir}/openqa/openqa.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
+ln -s %{_sysconfdir}/openqa/database.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 mkdir -p %{buildroot}%{_bindir}
 ln -s %{_datadir}/openqa/script/client %{buildroot}%{_bindir}/openqa-client
 ln -s %{_datadir}/openqa/script/openqa-cli %{buildroot}%{_bindir}/openqa-cli
@@ -566,6 +569,10 @@ fi
 %config(noreplace) %attr(-,geekotest,root) %{_sysconfdir}/openqa/openqa.ini
 %config(noreplace) %attr(-,geekotest,root) %{_sysconfdir}/openqa/database.ini
 %dir %{_datadir}/openqa
+%dir %{_datadir}/openqa/etc
+%dir %{_datadir}/openqa%{_sysconfdir}/openqa
+%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
+%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 %config %{_sysconfdir}/logrotate.d
 # apache vhost
 %dir %{_sysconfdir}/apache2

--- a/t/config.t
+++ b/t/config.t
@@ -26,8 +26,7 @@ sub read_config {
 }
 
 subtest 'Test configuration default modes' => sub {
-    # set OPENQA_CONFIG to an existing directory that has no config files to test defaults
-    local $ENV{OPENQA_CONFIG} = $FindBin::Bin;
+    local $ENV{OPENQA_CONFIG} = undef;
 
     my $app = Mojolicious->new();
     $app->mode("test");


### PR DESCRIPTION
Reverts os-autoinst/openQA#6324 as it broke the o3 deployment.