### PR TITLE
Make loading nested config files work with RPM packaging (2nd attempt)

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -382,9 +382,6 @@ export LANG=en_US.UTF-8
 rm -rf %{buildroot}/%{_sysusersdir}
 %endif
 
-mkdir -p %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa
-ln -s %{_sysconfdir}/openqa/openqa.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
-ln -s %{_sysconfdir}/openqa/database.ini %{buildroot}%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 mkdir -p %{buildroot}%{_bindir}
 ln -s %{_datadir}/openqa/script/client %{buildroot}%{_bindir}/openqa-client
 ln -s %{_datadir}/openqa/script/openqa-cli %{buildroot}%{_bindir}/openqa-cli
@@ -569,10 +566,6 @@ fi
 %config(noreplace) %attr(-,geekotest,root) %{_sysconfdir}/openqa/openqa.ini
 %config(noreplace) %attr(-,geekotest,root) %{_sysconfdir}/openqa/database.ini
 %dir %{_datadir}/openqa
-%dir %{_datadir}/openqa/etc
-%dir %{_datadir}/openqa%{_sysconfdir}/openqa
-%{_datadir}/openqa%{_sysconfdir}/openqa/openqa.ini
-%{_datadir}/openqa%{_sysconfdir}/openqa/database.ini
 %config %{_sysconfdir}/logrotate.d
 # apache vhost
 %dir %{_sysconfdir}/apache2

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -294,6 +294,10 @@ assets can need a big amount of disk space.
 WARNING: Be sure to *clear* that variable when running unit tests locally.
 
 === Customize configuration directory
+When running openQA from a Git checkout it will find configuration files from
+that checkout under `etc/openqa` and not use any system provided config files
+under e.g. `/etc/openqa`.
+
 It can be necessary during development to change the configuration.
 For example you have to edit `etc/openqa/database.ini` to use another database.
 It can also be useful to set the authentication method to `Fake` and increase

--- a/lib/OpenQA/Config.pm
+++ b/lib/OpenQA/Config.pm
@@ -1,0 +1,49 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Config;
+use Mojo::Base -strict, -signatures;
+
+use Config::IniFiles;
+use Exporter qw(import);
+use OpenQA::Log qw(log_info);
+use Mojo::File qw(path);
+
+our @EXPORT = qw(lookup_config_files parse_config_files parse_config_files_as_hash);
+
+sub lookup_config_files ($home, $name, $silent = 0) {
+    my @config_file_paths;
+    for my $path ($ENV{OPENQA_CONFIG}, $home, '/etc/openqa', '/usr/etc/openqa') {
+        next unless defined $path;
+        my $config_path = path($path);
+        my $main_config_file = $config_path->child($name);
+        my $extension = $main_config_file->extname;
+        my $config_name = $main_config_file->basename(".$extension");
+        push @config_file_paths, $main_config_file if -r $main_config_file;
+        push @config_file_paths, @{$config_path->child("$name.d")->list->grep(qr/\.$extension$/)->sort};
+        if (@config_file_paths) {
+            log_info "Reading $config_name config from: @config_file_paths" unless $silent;
+            last;
+        }
+    }
+    return \@config_file_paths;
+}
+
+sub parse_config_files ($config_file_paths) {
+    my $config_file;
+    for my $config_file_path (@$config_file_paths) {
+        my @import_args = $config_file ? (-import => $config_file) : ();
+        my $next_config_file = Config::IniFiles->new(-file => $config_file_path->to_string, @import_args);
+        $config_file = $next_config_file if $next_config_file;
+    }
+    return $config_file;
+}
+
+sub parse_config_files_as_hash ($config_file_paths) {
+    my %config_hash;
+    return \%config_hash unless my $config_file = parse_config_files($config_file_paths);
+    tie %config_hash, 'Config::IniFiles', (-import => $config_file);
+    return \%config_hash;
+}
+
+1;

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -4,8 +4,9 @@
 package OpenQA::UserAgent;
 use Mojo::Base 'Mojo::UserAgent', -signatures;
 
+use OpenQA::Config;
+use Mojo::File 'path';
 use Mojo::Util 'hmac_sha1_sum';
-use Config::IniFiles;
 use Scalar::Util ();
 use Carp;
 
@@ -37,14 +38,8 @@ sub new {
 
 sub open_config_file ($host) {
     return undef unless $host;
-    my @cfgpaths = ($ENV{OPENQA_CONFIG} // glob('~/.config/openqa'), '/etc/openqa');
-    for my $path (@cfgpaths) {
-        my $file = $path . '/client.conf';
-        next unless -r $file;
-        my $cfg = Config::IniFiles->new(-file => $file);
-        return $cfg && $cfg->SectionExists($host) ? $cfg : undef;
-    }
-    return undef;
+    my $cfg = parse_config_files(lookup_config_files(path(glob('~/.config/openqa')), 'client.conf', 1));
+    return $cfg && $cfg->SectionExists($host) ? $cfg : undef;
 }
 
 sub configure_credentials ($self, $host) {

--- a/script/initdb
+++ b/script/initdb
@@ -62,7 +62,7 @@ if ($user) {
 }
 
 my @databases = qw( PostgreSQL );
-my $schema = OpenQA::Schema::connect_db(deploy => 0);
+my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1);
 
 if ($prepare_init) {
     my $dh = DBIx::Class::DeploymentHandler->new(

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -59,7 +59,7 @@ if ($user) {
     setuid($uid) || die "can't suid to $user";
 }
 
-my $schema = OpenQA::Schema::connect_db(deploy => 0);
+my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1);
 
 my @databases = qw( PostgreSQL );
 

--- a/t/config.t
+++ b/t/config.t
@@ -26,7 +26,11 @@ sub read_config {
 }
 
 subtest 'Test configuration default modes' => sub {
-    local $ENV{OPENQA_CONFIG} = undef;
+    # test with a completely empty config file to check defaults
+    # note: We cannot use no config file at all because then the lookup would fallback to a system configuration.
+    my $t_dir = tempdir;
+    $t_dir->child('openqa.ini')->touch;
+    local $ENV{OPENQA_CONFIG} = $t_dir;
 
     my $app = Mojolicious->new();
     $app->mode("test");


### PR DESCRIPTION
* Read config files directly from `/etc/openqa` if the config directory
    doesn't exist under `OPENQA_CONFIG` or the app home
* Keep reading from `OPENQA_CONFIG` and the app home if a config directory
    exists under those locations as this is useful for development setups and
    running unit tests
* Read config files from `/usr/etc/openqa` if no config directory exists
    under any of the other locations to support
    https://en.opensuse.org/openSUSE:Packaging_UsrEtc#Variant_1_(ideal_case)
* Remove symlinks in our packaging so an installation from packages will in
    fact use all the files from `/etc/openqa` or `/usr/etc/openqa` and not be
    stuck with an only partially symlinked config
* See https://progress.opensuse.org/issues/179425
* See https://progress.opensuse.org/issues/179359