### PR TITLE
dist: Add headers expected by OBS checks

### DIFF
--- a/dist/rpm/openQA-client-test.spec
+++ b/dist/rpm/openQA-client-test.spec
@@ -1,4 +1,20 @@
+#
+# spec file for package openQA-client-test
+#
 # Copyright SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
 
 %define         short_name openQA-client
 Name:           %{short_name}-test

--- a/dist/rpm/openQA-devel-test.spec
+++ b/dist/rpm/openQA-devel-test.spec
@@ -1,4 +1,20 @@
+#
+# spec file for package openQA-devel-test
+#
 # Copyright SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
 
 %define         short_name openQA-devel
 Name:           %{short_name}-test

--- a/dist/rpm/openQA-test.spec
+++ b/dist/rpm/openQA-test.spec
@@ -1,4 +1,20 @@
+#
+# spec file for package openQA-test
+#
 # Copyright SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
 
 %define         short_name openQA
 Name:           %{short_name}-test

--- a/dist/rpm/openQA-worker-test.spec
+++ b/dist/rpm/openQA-worker-test.spec
@@ -1,4 +1,20 @@
+#
+# spec file for package openQA-worker-test
+#
 # Copyright SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
 
 %define         short_name openQA-worker
 Name:           %{short_name}-test


### PR DESCRIPTION
https://build.opensuse.org/requests/1256193 was declined with 'does not
appear to have a license. The file needs to contain a free software
license'. This commit takes over mostly what "osc service runall
format_spec_file" adds automatically with exception of the "(c) 2025"
which is not strictly needed and I would like to avoid. If it turns out
to be necessary after all then we should add it later on.