### PR TITLE
oauth2: use openQA base_url to create redirect URI if set

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -93,7 +93,9 @@ sub auth_login ($controller) {
     croak 'Config was not parsed' unless my $main_config = $controller->app->config->{oauth2};
     croak 'Setup was not called' unless my $provider_config = $main_config->{provider_config};
 
-    my $get_token_args = {redirect_uri => $controller->url_for('login')->userinfo(undef)->to_abs};
+    my $base_url = $controller->app->config->{global}->{base_url};
+    my $host = $base_url ? Mojo::URL->new($base_url)->host : $controller->req->url->host;
+    my $get_token_args = {redirect_uri => $controller->url_for('login')->userinfo(undef)->host($host)->to_abs};
     $get_token_args->{scope} = $provider_config->{token_scope};
     $controller->oauth2->get_token_p($main_config->{provider} => $get_token_args)
       ->then(sub { update_user($controller, $main_config, $provider_config, shift) })


### PR DESCRIPTION
I'm setting up oauth2 auth for Fedora ATM (up till now we used OpenID auth, but we're shutting that off). One problem I hit was that this redirect URI generation used the wrong hostname. Our staging instance is at https://openqa.stg.fedoraproject.org. The machine that serves it has the hostname
openqa-lab01.iad2.fedoraproject.org. The redirect_uri was using the machine's hostname, so it was coming out as
https://openqa-lab01.iad2.fedoraproject.org/login , which is not going to work.

This tweaks the redirect URI generation to use the hostname from the openQA config base_url, if it's set. If not, it falls back to the hostname from the request.