### PR TITLE
Support all config features for `workers.ini` as well

### DIFF
--- a/lib/OpenQA/Config.pm
+++ b/lib/OpenQA/Config.pm
@@ -9,16 +9,18 @@ use Exporter qw(import);
 use OpenQA::Log qw(log_info);
 use Mojo::File qw(path);
 
-our @EXPORT = qw(lookup_config_files parse_config_files parse_config_files_as_hash);
+our @EXPORT = qw(config_dir_within_app_home lookup_config_files parse_config_files parse_config_files_as_hash);
 
-sub _config_dirs ($home) {
-    return [[$ENV{OPENQA_CONFIG} // ()], [$home], ['/etc/openqa', '/usr/etc/openqa']];
+sub _config_dirs ($config_dir_within_home) {
+    return [[$ENV{OPENQA_CONFIG} // ()], [$config_dir_within_home // ()], ['/etc/openqa', '/usr/etc/openqa']];
 }
 
-sub lookup_config_files ($home, $name, $silent = 0) {
+sub config_dir_within_app_home ($app) { $app->child('etc', 'openqa') }
+
+sub lookup_config_files ($config_dir_within_home, $name, $silent = 0) {
     my $config_name;
     my @config_file_paths;
-    for my $paths (@{_config_dirs($home)}) {
+    for my $paths (@{_config_dirs($config_dir_within_home)}) {
         for my $path (@$paths) {
             my $config_path = path($path);
             my $main_config_file = $config_path->child($name);

--- a/lib/OpenQA/Schema.pm
+++ b/lib/OpenQA/Schema.pm
@@ -14,6 +14,7 @@ use Feature::Compat::Try;
 use FindBin '$Bin';
 use Fcntl ':flock';
 use File::Spec::Functions 'catfile';
+use OpenQA::App;
 use OpenQA::Config;
 use OpenQA::Utils qw(:DEFAULT prjdir);
 use Mojo::File qw(path);
@@ -40,8 +41,9 @@ sub connect_db (%args) {
         $SINGLETON = __PACKAGE__->connect($ENV{TEST_PG} // 'DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg');
     }
     else {
-        my $home = path($Bin)->dirname->child('etc', 'openqa');
-        my $database_config_paths = lookup_config_files($home, 'database.ini', $args{silent});
+        my $home_dir = $args{from_script} ? path($Bin, '..') : OpenQA::App->singleton->home;
+        my $home_config_dir = config_dir_within_app_home($home_dir);
+        my $database_config_paths = lookup_config_files($home_config_dir, 'database.ini', $args{silent});
         my $database_config = parse_config_files_as_hash($database_config_paths);
         my $database_config_for_mode = $database_config ? $database_config->{$mode} : {dsn => 'DBI:Pg:dbname=openqa'};
         die "Could not find database section '$mode' in @$database_config_paths\n" unless $database_config_for_mode;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -46,7 +46,7 @@ sub _read_config_file ($config, $config_file, $defaults, $mode_defaults) {
 }
 
 sub _load_config ($app, $defaults, $mode_specific_defaults) {
-    my $config_file = parse_config_files(lookup_config_files($app->home->child('etc', 'openqa'), 'openqa.ini'));
+    my $config_file = parse_config_files(lookup_config_files(config_dir_within_app_home($app->home), 'openqa.ini'));
     my $mode_defaults = $mode_specific_defaults->{$app->mode} // {};
     my $config = $app->config;
     if ($config_file) {

--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -4,7 +4,6 @@
 package OpenQA::Worker::Settings;
 use Mojo::Base -base, -signatures;
 
-use FindBin '$Bin';
 use Mojo::File 'path';
 use Mojo::URL;
 use Mojo::Util 'trim';
@@ -22,7 +21,7 @@ has 'webui_host_specific_settings';
 use constant VNCPORT_OFFSET => $ENV{VNCPORT_OFFSET} // 90;
 
 sub new ($class, $instance_number = undef, $cli_options = {}) {
-    my $config_paths = lookup_config_files(path($Bin)->dirname->child('etc', 'openqa'), 'workers.ini', 1);
+    my $config_paths = lookup_config_files(undef, 'workers.ini', 1);
     my $cfg = parse_config_files($config_paths);
     my @parse_errors = @$config_paths ? (@Config::IniFiles::errors) : ('No config file found.');
 

--- a/script/initdb
+++ b/script/initdb
@@ -62,7 +62,7 @@ if ($user) {
 }
 
 my @databases = qw( PostgreSQL );
-my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1);
+my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1, from_script => 1);
 
 if ($prepare_init) {
     my $dh = DBIx::Class::DeploymentHandler->new(

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -59,7 +59,7 @@ if ($user) {
     setuid($uid) || die "can't suid to $user";
 }
 
-my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1);
+my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1, from_script => 1);
 
 my @databases = qw( PostgreSQL );
 

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -121,11 +121,11 @@ subtest 'settings file with errors' => sub {
 };
 
 subtest 'settings file not found' => sub {
-    $ENV{OPENQA_CONFIG} = "$FindBin::Bin/data/24-worker-setting";
+    my $config_mock = Test::MockModule->new('OpenQA::Config');
+    $config_mock->redefine(_config_dirs => [['does not exist']]);
     my $settings = OpenQA::Worker::Settings->new(1);
-    is($settings->file_path, undef, 'no file path present');
-    is_deeply($settings->parse_errors, ["Config file not found at '$FindBin::Bin/data/24-worker-setting/workers.ini'."],
-        'error logged')
+    ok !$settings->file_path, 'no file path present';
+    is_deeply $settings->parse_errors, ['No config file found.'], 'error logged'
       or always_explain $settings->parse_errors;
 };
 

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -35,7 +35,7 @@ sub ensure_schema_is_created_and_empty {
     $dbh->do("create schema deploy");
     $dbh->do("SET search_path TO deploy");
 }
-my $schema = OpenQA::Schema::connect_db(mode => 'test', deploy => 0);
+my $schema = OpenQA::Schema::connect_db(mode => 'test', deploy => 0, from_script => 1);
 ensure_schema_is_created_and_empty $schema;
 
 my $dh = DBIx::Class::DeploymentHandler->new(
@@ -54,7 +54,7 @@ is($dh->version_storage->database_version, $dh->schema_version, 'Schema at corre
 is($ret, 2, 'Expected return value (2) for a deployment');
 
 OpenQA::Schema::disconnect_db;
-$schema = OpenQA::Schema::connect_db(mode => 'test', deploy => 0);
+$schema = OpenQA::Schema::connect_db(mode => 'test', deploy => 0, from_script => 1);
 ensure_schema_is_created_and_empty $schema;
 
 # redeploy DB to the oldest still supported version and check if deployment upgrades the DB


### PR DESCRIPTION
* Locate the worker config just like the web UI and client config files to support
    * Locating the config under `/usr/etc`
    * Drop-in configuration files
    * Reading the config file from the Git checkout for development without having to set `OPENQA_CONFIG`
* See https://progress.opensuse.org/issues/179359

---

There's no ticket for this but when working on https://progress.opensuse.org/issues/179359 I noticed that I would have to weirdly exclude the worker config from Makefile/specfile/documentation changes. So it make sense to bring the worker in-line with everything else first.