### PR TITLE
Use consistent temporary database path

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -248,7 +248,7 @@ the system service. E.g.
 
 [source,sh]
 ----
-t/test_postgresql /dev/shm/tpg
+t/test_postgresql
 ----
 
 To check the coverage by individual test files easily call e.g.
@@ -392,7 +392,7 @@ test database setup and data directory:
 
 [source,sh]
 ----
-t/test_postgresql /dev/shm/tpg
+t/test_postgresql
 TEST_PG='DBI:Pg:dbname=openqa_test;host=/dev/shm/tpg' OPENQA_DATABASE=test OPENQA_BASEDIR=t/data script/openqa daemon
 ----
 
@@ -598,8 +598,7 @@ install chromedriver and either chrome or chromium for the UI tests.
 
 To execute the testsuite use `make test`. This will also initialize a
 temporary PostgreSQL database used for testing. To do this step manually run
-`t/test_postgresql /dev/shm/tpg` to initialize a temporary PostgreSQL database
-and export the environment variable as instructed by that script.
+`t/test_postgresql` to initialize a temporary PostgreSQL database.
 It is also possible to run a particular test, for example
 `prove t/api/01-workers.t`. When using `prove` directly, make sure an English
 locale is set (e.g. `export LC_ALL=C.utf8 LANGUAGE=` before initializing the database

--- a/t/test_postgresql
+++ b/t/test_postgresql
@@ -1,11 +1,7 @@
 #!/bin/sh -e
 
-DIR=$1
-if test -z "$DIR"; then
-    DIR=$(mktemp -d)
-else
-    DIR=$(readlink -f "$DIR")
-fi
+DIR=${1:-/dev/shm/tpg}
+DIR=$(readlink -f "$DIR")
 if test -e "$DIR"/postmaster.pid; then
     pg_ctl -D "$DIR" stop
 fi


### PR DESCRIPTION
As we already use /dev/shm/tpg mostly everywhere we can simplify the
call to t/test_postgresql by creating the temporary database in the same
path by default. This way to manually execute tests relying on a
database one can just call "t/test_postgresql && prove -l …".