### PR TITLE
Avoid hardcoding of /tmp to ensure compatibility with different environments. 

### DIFF
--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -23,7 +23,7 @@ my $file_api_mock = Test::MockModule->new('OpenQA::WebAPI::Controller::File');
 $file_api_mock->redefine(download_asset => sub ($self) { $self->render(text => 'asset-ok') });
 $file_api_mock->redefine(test_asset => sub ($self) { $self->redirect_to('/assets/iso/test.iso') });
 
-my $tempdir = tempdir("/tmp/$FindBin::Script-XXXX")->make_path;
+my $tempdir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
 $ENV{OPENQA_CONFIG} = $tempdir;
 OpenQA::Test::Database->new->create;
 

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -33,7 +33,7 @@ my @auth = ('--apikey', 'ARTHURKEY01', '--apisecret', 'EXCALIBUR', @host);
 
 my $cli = OpenQA::CLI->new;
 my $archive = OpenQA::CLI::archive->new;
-my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+my $dir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
 
 subtest 'Help' => sub {
     my ($stdout, @result) = capture_stdout sub { $cli->run('help', 'archive') };

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -34,7 +34,7 @@ use Digest::MD5;
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl 05-job_modules.pl');
 
 # avoid polluting checkout
-my $tempdir = tempdir("/tmp/$FindBin::Script-XXXX")->make_path;
+my $tempdir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
 $ENV{OPENQA_BASEDIR} = $tempdir;
 note("OPENQA_BASEDIR: $tempdir");
 path($tempdir, '/openqa/testresults')->make_path;


### PR DESCRIPTION
Follow-up of: https://progress.opensuse.org/issues/178207