### PR TITLE
Avoid unhandled output in `t/20-stale-job…` after 8c5a3a43

### DIFF
--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -25,7 +25,8 @@ $jobs->find(99963)->update({assigned_worker_id => 1});
 $jobs->find(99961)->update({assigned_worker_id => 2});
 $jobs->find(80000)->update({state => ASSIGNED, result => NONE, assigned_worker_id => 1});
 
-OpenQA::App->set_singleton(my $app = OpenQA::Scheduler->new);
+$ENV{OPENQA_CONFIG} = $FindBin::Bin;    # avoid reading config from system
+OpenQA::App->set_singleton(my $app = OpenQA::Scheduler->new(log => undef));
 $app->setup;
 $app->log(undef);
 


### PR DESCRIPTION
* Undefine the initial logger to avoid `Reading openqa config from: …`
    * Keep `$app->log(undef)` as `$app->setup` will assign a logger again
* Avoid picking up config from system (was also like this before 8c5a3a43) to avoid messages like `Deprecated use …`
* See https://progress.opensuse.org/issues/179359