### PR TITLE
Improve scalability

### DIFF
--- a/lib/OpenQA/WebSockets/Controller/API.pm
+++ b/lib/OpenQA/WebSockets/Controller/API.pm
@@ -6,7 +6,6 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use OpenQA::Constants qw(WORKER_COMMAND_GRAB_JOB WORKER_COMMAND_GRAB_JOBS);
 use OpenQA::WebSockets;
-use OpenQA::WebSockets::Model::Status;
 
 sub send_msg {
     my ($self) = @_;

--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -10,7 +10,6 @@ use OpenQA::Log qw(log_debug log_error log_info log_warning log_trace);
 use OpenQA::Constants qw(WEBSOCKET_API_VERSION MIN_TIMER);
 use OpenQA::WebSockets::Model::Status;
 use OpenQA::Jobs::Constants;
-use OpenQA::Scheduler::Client;
 use DateTime;
 use Data::Dump 'pp';
 use Feature::Compat::Try;

--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Worker::CommandHandler;
-use Mojo::Base 'Mojo::EventEmitter';
+use Mojo::Base 'Mojo::EventEmitter', -signatures;
 
 use OpenQA::Constants qw(WORKER_STOP_COMMANDS WORKER_LIVE_COMMANDS);
 use OpenQA::Log qw(log_error log_debug log_warning log_info);
@@ -110,6 +110,10 @@ sub handle_command {
 
     # WS messages of type "info" can be sent for debugging
     log_warning("Ignoring WS message with unknown type $type from $webui_host:\n" . pp($json)) if $type ne 'info';
+}
+
+sub _handle_command_info ($json, $client, $worker, $webui_host, $current_job) {
+    $client->send_status_delayed if $json->{seen};
 }
 
 sub _handle_command_livelog_start {


### PR DESCRIPTION
This worked for me when testing it locally with 1500 workers with the database on a very slow HDD. The performance was still not optimal as it took a while until all workers were connected. I also only had up to 100 jobs running in parallel. However, this is a huge improvement to before where no jobs were assigned anymore at all.

See individual commit messages and https://progress.opensuse.org/issues/168178 for details.