### PR TITLE
Avoid Perl warning when showing group overview with e.g. `only_tagged=2`

### DIFF
--- a/templates/webapi/main/more_builds.html.ep
+++ b/templates/webapi/main/more_builds.html.ep
@@ -2,10 +2,8 @@
     Limit to
     %= b join(' / ', map { $_ == $limit_builds ? "<b>$_</b>" : link_to($_ => url_with->query({limit_builds => $_})) } (10, 20, 50, 100, 400));
     builds, only
-    % my %tagged = (tagged => 1, all => 0);
-    % my %rtagged = reverse %tagged;
-    % my $selected = $rtagged{$only_tagged};
-    %= b join(' / ', map { $_ eq $selected ? "<b>$_</b>" : link_to($_ => url_with->query({only_tagged => $tagged{$_}})) } reverse sort keys %tagged);
+    % my $selected = $only_tagged ? 'tagged' : 'all';
+    %= b join(' / ', map { $_ eq $selected ? "<b>$_</b>" : link_to($_ => url_with->query({only_tagged => ($_ eq 'tagged' ? 1 : 0)})) } qw(tagged all));
 </div>
 
 <div id="mode_section">


### PR DESCRIPTION
Prevent the following warning:
```
Apr 04 13:04:46 ariel openqa-webui-daemon[10280]: Use of uninitialized value $selected in string eq at template main/more_builds.html.ep line 8.
```

Treat `only_tagged` as boolean parameter; don't try to map it via a hash without validating whether a mapping was found.