### PR TITLE
Adjust limit_builds in parent_group_overview results

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -181,7 +181,7 @@ sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_fi
     my $max_jobs = 0;
     my $now = DateTime->now;
     for my $build (@builds) {
-        last if defined($limit) && (--$limit < 0);
+        #last if defined($limit) && (--$limit < 0);
 
         my ($version, $buildnr) = ($build->VERSION, $build->BUILD);
         my $jobs = $jobs_resultset->search(

--- a/templates/webapi/main/group_builds.html.ep
+++ b/templates/webapi/main/group_builds.html.ep
@@ -1,4 +1,5 @@
 % for my $build_res (@$build_results) {
+    % last if (--$limit_builds < 0);
     % my $version = $build_res->{version};
     % my $build = $build_res->{build};
     % my $label = $build_res->{version_count} <= 1 ? "Build$build" : "$version-Build$build";

--- a/templates/webapi/main/group_builds_functionality_view.html.ep
+++ b/templates/webapi/main/group_builds_functionality_view.html.ep
@@ -1,4 +1,5 @@
 % for my $child (@{$children}) {
+  % my $group_limits = $limit_builds;
   % my $has_jobs = 0;
   % my $title_class_mod = "text-body-secondary";
 
@@ -15,8 +16,10 @@
     </div>
 
     % for my $build_res (@$build_results) {
+      % last if ($group_limits < 0);
       % my $child_res = $build_res->{children}->{$child->{id}};
       % next unless $child_res->{total};
+      % --$group_limits;
       % my $group_build_id = $group->{id} . '-' . $build_res->{escaped_id};
       % my %child_progress_bar_params = (url => url_for('tests_overview'), query_params => [(distri  => [sort keys %{$child_res->{distris}}], version => $child_res->{version}, build => $build_res->{build}), groupid => $child->{id}]);
 
@@ -47,7 +50,7 @@
     % }
     % if ($has_jobs eq 0) {
       <div class="ml-3 text-body-secondary">
-        No builds
+        No builds found with the current parameters.
       </div>
     % }
   </div>


### PR DESCRIPTION
With this commit, the limit_builds check is moved into the responsible template. This gives some flexibility over the resultset but it lets the compute_build_results to parse, prepare and return all of them. By default the function query the database for the first 400 jobs unless a bigger value is requested.

What change is
- *before*: when limit_builds is 10, by_builds lists the 10 latest builds. the by_group lists the same %result filtering by group. That was ignoring the latest jobs of the children group.
- *now": when limit_builds is 10, by_builds lists the 10 latest builds but the by_group lists the latest jobs within the limit_builds which have results for all the groups.

relative ticket: https://progress.opensuse.org/issues/179296