### PR TITLE
Consider all config files in unit for auto-reloading workers

### DIFF
--- a/systemd/openqa-reload-worker-auto-restart@.path
+++ b/systemd/openqa-reload-worker-auto-restart@.path
@@ -1,7 +1,14 @@
 # see https://www.freedesktop.org/software/systemd/man/systemd.path.html#PathExists=
 
 [Path]
+PathChanged=/usr/etc/openqa/workers.ini
+PathChanged=/usr/etc/openqa/workers.ini.d
+PathChanged=/usr/etc/openqa/client.conf
+PathChanged=/usr/etc/openqa/client.conf.d
 PathChanged=/etc/openqa/workers.ini
+PathChanged=/etc/openqa/workers.ini.d
+PathChanged=/etc/openqa/client.conf
+PathChanged=/etc/openqa/client.conf.d
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With this the worker is also reloaded when drop-in config files are changed, when config files under `/usr/etc` are changed and when the client config is changed.

I tested locally whether this works for directories and it does. So the worker is reloaded when drop-in config files are added, changed or removed.

Related ticket: https://progress.opensuse.org/issues/179359