### PR TITLE
Allow web UI services to read client config

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -9,6 +9,9 @@
   #include <abstractions/perl>
 
   /etc/gitconfig r,
+  /etc/openqa/client.conf r,
+  /etc/openqa/client.conf.d/ r,
+  /etc/openqa/client.conf.d/** r,
   /etc/openqa/database.ini r,
   /etc/openqa/database.ini.d/ r,
   /etc/openqa/database.ini.d/** r,
@@ -32,6 +35,9 @@
   /usr/bin/unzip{,-plain} rix,
   /usr/bin/git rix,
   /usr/bin/git-lfs rix,
+  /usr/etc/openqa/client.conf r,
+  /usr/etc/openqa/client.conf.d/ r,
+  /usr/etc/openqa/client.conf.d/** r,
   /usr/etc/openqa/database.ini r,
   /usr/etc/openqa/database.ini.d/ r,
   /usr/etc/openqa/database.ini.d/** r,


### PR DESCRIPTION
This seems to be required when scheduling an ISO in the way the openQA-in-openQA test does, see
https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/234#issuecomment-2783160391.

Related ticket: https://progress.opensuse.org/issues/179359