### PR TITLE
Add STABILITY_ALLOW_FAILURE option for script/retry

### DIFF
--- a/tools/retry
+++ b/tools/retry
@@ -2,6 +2,7 @@
 # shellcheck disable=SC2048,SC2086
 
 RETRY="${RETRY:-3}"
+STABILITY_ALLOW_FAILURE="${STABILITY_ALLOW_FAILURE:-0}"
 STABILITY_TEST="${STABILITY_TEST:-0}"
 # Pass a hook command which is executed if a retry occurs
 HOOK="${HOOK:-}"
@@ -16,6 +17,7 @@ if [ "$RETRY" = "0" ]; then
     run_once "$@"
 else
     n=1
+    FAILURE_COUNTER=0
     while :; do
         if [ "$STABILITY_TEST" = "0" ]; then
             [ $n -le "$RETRY" ] || exit 1
@@ -23,8 +25,19 @@ else
             run_once "$@" && break
         else
             [ $n -le "$RETRY" ] || exit 0
-            run_once "$@" || exit
-            echo "Rerun $n of $RETRY …"
+            if ! run_once "$@"; then
+                if [ "$STABILITY_ALLOW_FAILURE" = "1" ]; then
+                    FAILURE_COUNTER=$((FAILURE_COUNTER + 1))
+                else
+                    exit 1
+                fi
+            fi
+            MESSAGE="Rerun $n of $RETRY …"
+            if [ "$STABILITY_ALLOW_FAILURE" = "1" ]; then
+                FAILURE_PERCENTAGE=$((FAILURE_COUNTER * 100 / n))
+                MESSAGE="$MESSAGE with failures: $FAILURE_COUNTER ($FAILURE_PERCENTAGE%)"
+            fi
+            echo "$MESSAGE"
         fi
         if [ -n "$HOOK" ]; then
             echo "Calling retry hook $HOOK"


### PR DESCRIPTION
This could be use in stability tests in order to run over and over again a job to check if is stable and if not in what percentage. This is an example of output you can get if the option is enabled `Rerun 59 of 200 … with failures: 16 (27%)`.

Followup of #6293 