### PR TITLE
Restart AppArmor service when updating workers

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -534,6 +534,7 @@ fi
 %restart_on_update apparmor
 
 %postun worker
+%restart_on_update apparmor
 # restart worker services on updates; does *not* include services for worker slots unless openqa-worker.target
 # is running at the time of the update
 %service_del_postun %{openqa_worker_services}


### PR DESCRIPTION
Otherwise changes to the AppArmor profile are only available after a manual restart of the service.

Related ticket: https://progress.opensuse.org/issues/179359