### PR TITLE
Ensure `…-restart@.path` units don't run into inotify limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ install-generic:
 	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-scheduler.service.requires/postgresql.service
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-websockets.service.requires
 	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-websockets.service.requires/postgresql.service
+	install -D -m 644 usr/lib/sysctl.d/01-openqa-reload-worker-auto-restart.conf "$(DESTDIR)"/usr/lib/sysctl.d/01-openqa-reload-worker-auto-restart.conf
 #
 # install openQA apparmor profile
 	install -d -m 755 "$(DESTDIR)"/etc/apparmor.d

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -762,6 +762,7 @@ fi
 %if 0%{?suse_version} > 1500
 %{_sysusersdir}/%{name}-worker.conf
 %endif
+%{_prefix}/lib/sysctl.d/01-openqa-reload-worker-auto-restart.conf
 
 %files client
 %dir %{_datadir}/openqa

--- a/usr/lib/sysctl.d/01-openqa-reload-worker-auto-restart.conf
+++ b/usr/lib/sysctl.d/01-openqa-reload-worker-auto-restart.conf
@@ -1,0 +1,1 @@
+fs.inotify.max_user_instances = 8192


### PR DESCRIPTION
After recent changes to the path units more inotify watches are requires. The default limit is quite low (at least on openSUSE) so we need to put a higher limit in place.

Related ticket: https://progress.opensuse.org/issues/179359