### PR TITLE
Add signal guard for schedule_iso minion tasks

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -157,7 +157,7 @@ sub create {
     return $self->render(json => $scheduled_product->enqueue_minion_job(\%params)) if $async;
 
     # schedule jobs synchronously (hopefully within the timeout)
-    my $scheduled_jobs = $scheduled_product->schedule_iso(\%params);
+    my $scheduled_jobs = $scheduled_product->schedule_iso(\%params, undef);
     my $error = $scheduled_jobs->{error};
     return $self->render(
         json => {


### PR DESCRIPTION
Similar to cd99074 to prevent `Job terminated unexpectedly` on results. This ensures that the minion job will retry in case of interruptions, like network glitch in the system, without kill the process.

https://progress.opensuse.org/issues/108983