### PR TITLE
Change text body on build absent in parent_group_overview

### DIFF
--- a/templates/webapi/main/group_builds_functionality_view.html.ep
+++ b/templates/webapi/main/group_builds_functionality_view.html.ep
@@ -47,7 +47,7 @@
     % }
     % if ($has_jobs eq 0) {
       <div class="ml-3 text-body-secondary">
-        No builds
+        The last <%= $limit_builds %> builds do not include this group. Increase the limit of the number of builds to potentially see more.
       </div>
     % }
   </div>


### PR DESCRIPTION
The parent_group_overview says `No builds` when the limit_builds are exceeded
as part of another group. However this leads to confusion. For now, try just
to provide a better explaination.

https://progress.opensuse.org/issues/179296