### PR TITLE
Reload only specific AppArmor profiles on updates

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -112,6 +112,7 @@ BuildRequires:  openSUSE-release
 BuildRequires:  sles-release
 %endif
 BuildRequires:  %{build_requires}
+BuildRequires:  apparmor-rpm-macros
 BuildRequires:  local-npm-registry
 Requires:       perl(Minion) >= 10.0
 Requires:       %{main_requires}
@@ -531,10 +532,14 @@ if [ -x /usr/bin/systemctl ] && [ $1 -ge 1 ]; then
 fi
 # restart other services
 %service_del_postun %{openqa_extra_services}
-%restart_on_update apparmor
+# reload AppArmor profiles
+%apparmor_reload %{_sysconfdir}/apparmor.d/usr.share.openqa.script.openqa
+%apparmor_reload %{_sysconfdir}/apparmor.d/local/usr.share.openqa.script.openqa
 
 %postun worker
-%restart_on_update apparmor
+# reload AppArmor profiles
+%apparmor_reload %{_sysconfdir}/apparmor.d/usr.share.openqa.script.worker
+%apparmor_reload %{_sysconfdir}/apparmor.d/local/usr.share.openqa.script.worker
 # restart worker services on updates; does *not* include services for worker slots unless openqa-worker.target
 # is running at the time of the update
 %service_del_postun %{openqa_worker_services}


### PR DESCRIPTION
As suggested by darix in SR:

> do not restart apparmor during update, you want
> `%apparmor_reload /etc/apparmor.d/yourprofile`

(see https://build.opensuse.org/request/show/1268562)

Related ticket: https://progress.opensuse.org/issues/179359