### PR TITLE
Fix jobs sometimes ending up without group after retry on deadlocks

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -255,8 +255,6 @@ sub _create_jobs_in_database ($self, $jobs, $failed_job_info, $skip_chained_deps
     my %job_ids_by_test_machine;    # key: "TEST@MACHINE", value: "array of job ids"
 
     for my $settings (@{$jobs || []}) {
-        $settings->{_GROUP_ID} = delete $settings->{GROUP_ID};
-
         # create a new job with these parameters and count if successful, do not send job notifies yet
         $schema->svp_begin('try_create_job_from_settings');
         try {

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -130,6 +130,8 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
     die 'The following settings are invalid: ' . join(', ', @{$v->failed}) . "\n" if $v->has_error;
 
     # assign group ID and priority
+    my $group_id = delete $settings{GROUP_ID};
+    $settings{_GROUP_ID} = $group_id if defined $group_id;
     my ($group_args, $group) = OpenQA::Schema::Result::Jobs::extract_group_args_from_settings(\%settings);
     $new_job_args{priority} = $prio if defined $prio;
     if ($group) {


### PR DESCRIPTION
After adding a retry on deadlocks the function that inserts the jobs into the database might run multiple times. Hence it must not delete the group ID setting (or any other settings) from the previously computed hash. This change deletes the group ID only within `create_from_settings` which only works on a copy of the settings.

Related ticket: https://progress.opensuse.org/issues/180020