### PR TITLE
RFC: Show changelog on web UI via GitHub

### DIFF
--- a/assets/stylesheets/admin-pages.scss
+++ b/assets/stylesheets/admin-pages.scss
@@ -368,22 +368,6 @@ table#users {
     }
 }
 
-// changelog
-.changelog {
-    ul {
-        font-weight: bold;
-
-        p {
-            margin-top: 10px;
-            margin-bottom: 0px;
-        }
-
-        ul, span {
-            font-weight: normal;
-        }
-    }
-}
-
 // status info (used on worker details)
 .status-info div span {
     min-width: 20%;

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -414,6 +414,12 @@ install -m 644 contrib/munin/config/minion.config %{buildroot}/%{_sysconfdir}/mu
 install -m 755 contrib/munin/utils/munin-mail %{buildroot}/%{_datadir}/openqa/script/munin-mail
 %endif
 
+# install file containing package version to display it on the web UI
+version=%{version}
+version=${version%-*}
+version=${version##*.}
+echo "%{version}" > %{buildroot}/%{_datadir}/openqa/version.txt
+
 cd %{buildroot}
 grep -rl %{_bindir}/env . | while read file; do
     sed -e 's,%{_bindir}/env perl,%{_bindir}/perl,' -i $file
@@ -588,6 +594,7 @@ fi
 %{_datadir}/doc/openqa/examples/openqa.ini
 %{_datadir}/doc/openqa/examples/database.ini
 %dir %{_datadir}/openqa
+%{_datadir}/openqa/version.txt
 %config %{_sysconfdir}/logrotate.d
 # apache vhost
 %dir %{_sysconfdir}/apache2

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -77,7 +77,6 @@ sub read_config ($app) {
             plugins => undef,
             hide_asset_types => 'repo',
             recognized_referers => '',
-            changelog_file => '/usr/share/openqa/public/Changelog',
             job_investigate_ignore => '"(JOBTOKEN|NAME)"',
             job_investigate_git_log_limit => 200,
             job_investigate_git_timeout => 20,

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -652,19 +652,17 @@ sub parse_tags_from_comments ($group, $res) {
 }
 
 sub detect_current_version ($path) {
-    # Get application version
     my $current_version = undef;
-    my $changelog_file = path($path, 'public', 'Changelog');
+    my $version_file = $path->child('version.txt');
+    if (-e $version_file) {
+        $current_version = $version_file->slurp;
+        chomp $current_version;
+        return $current_version;
+    }
+
     my $head_file = path($path, '.git', 'refs', 'heads', 'master');
     my $refs_file = path($path, '.git', 'packed-refs');
-
-    if (-e $changelog_file) {
-        my $changelog = $changelog_file->slurp;
-        if ($changelog && $changelog =~ /Update to version (\d+\.\d+\.(\b[0-9a-f]{5,40}\b))\:/mi) {
-            $current_version = $1;
-        }
-    }
-    elsif (-e $head_file && -e $refs_file) {
+    if (-e $head_file && -e $refs_file) {
         my $master_head = $head_file->slurp;
         my $packed_refs = $refs_file->slurp;
 

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -183,12 +183,6 @@ sub _group_overview ($self, $resultset, $template) {
 sub job_group_overview ($self) { $self->_group_overview('JobGroups', 'main/group_overview') }
 sub parent_group_overview ($self) { $self->_group_overview('JobGroupParents', 'main/parent_group_overview') }
 
-sub changelog ($self) {
-    my $file = path($self->app->config->{global}->{changelog_file});
-    my $changelog = -r $file ? $file->slurp : 'No changelog available.';
-    $self->render(changelog => $changelog);
-}
-
 # Inspired by https://testfully.io/blog/api-health-check-monitoring/
 sub health ($self) {
     $self->render(text => 'ok');

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -381,6 +381,11 @@ sub register ($self, $app, $config) {
             }
             return $regex_problem && $context ? "$context: $regex_problem" : $regex_problem;
         });
+
+    $app->helper(url_for_changelog => sub ($c, $v) {
+        $v =~ s/.*-//;
+        return "https://github.com/os-autoinst/openQA/commits/$v";
+    });
 }
 
 # returns the search args for the job overview according to the parameter of the specified controller

--- a/t/config.t
+++ b/t/config.t
@@ -54,7 +54,6 @@ subtest 'Test configuration default modes' => sub {
             monitoring_enabled => 0,
             hide_asset_types => 'repo',
             recognized_referers => [],
-            changelog_file => '/usr/share/openqa/public/Changelog',
             job_investigate_ignore => '"(JOBTOKEN|NAME)"',
             job_investigate_git_timeout => 20,
             job_investigate_git_log_limit => 200,

--- a/templates/webapi/layouts/bootstrap.html.ep
+++ b/templates/webapi/layouts/bootstrap.html.ep
@@ -70,7 +70,7 @@
                   %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
                   % if ($current_version) {
                       - Version
-                      %= link_to $current_version => url_for('changelog')
+                      %= link_to $current_version => url_for_changelog($current_version)
                   % }
               </div>
             </div>

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -97,7 +97,9 @@
                   % }
                   %= link_to "Appearance" => url_for('appearance') => class => 'dropdown-item'
                   %= link_to "API help" => url_for('api_help') => class => 'dropdown-item'
-                  %= link_to 'Changelog' => url_for('changelog') => class => 'dropdown-item'
+                  % if ($current_version) {
+                    %= link_to 'Changelog' => url_for_changelog($current_version) => class => 'dropdown-item'
+                  % }
                   %= link_to 'Logout' => url_for('logout') => 'data-method' => 'delete' => class => 'dropdown-item'
                 </div>
             </li>

--- a/templates/webapi/main/changelog.html.ep
+++ b/templates/webapi/main/changelog.html.ep
@@ -1,9 +1,0 @@
-% layout 'bootstrap';
-% title 'Changelog';
-
-%= include 'layouts/info'
-
-<h2>Changelog for web UI</h2>
-<div class="changelog">
-    <pre><%= $changelog %></pre>
-</div>


### PR DESCRIPTION
* Avoid parsing the RPM changelog
* Avoid having our own page for displaying the changelog (which does not handle non-ASCII characters well at this point)
* Simplify/remove our code
* See https://progress.opensuse.org/issues/180068

---

Not tested yet; this is just a draft so you can see how it would look like in code. There's probably more code which can be removed, e.g. tests of the changelog parsing.