### PR TITLE
tidy: Enforce blank lines before subs

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -3,7 +3,7 @@
 --character-encoding=none
 --no-valign
 -l=120   # 120 characters per line
--fbl     # don't change blank lines
+--noblanks-before-comments
 -nsfs    # no spaces before semicolons
 -baao    # space after operators
 -bbao    # space before operators
@@ -12,3 +12,6 @@
 -sbt=2   # no spaces around {}
 -sct     # stack closing tokens )}
 --pack-operator-types='->' # allow chained method calls on one line
+--blanks-before-subs
+--keep-old-blank-lines=2 # keep all blank lines
+--noblanks-before-blocks

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -168,6 +168,7 @@ my %META_RESULT_MAPPING = (
 );
 sub meta_state ($state) { $META_STATE_MAPPING{$state} // NONE }
 sub meta_result ($result) { $META_RESULT_MAPPING{$result} // NONE }
+
 sub is_ok_result ($result) {
     !!grep { $result eq $_ } OK_RESULTS;
 }

--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -87,8 +87,7 @@ sub parse {
     $self;
 }
 
-{
-    package OpenQA::Parser::Result::IPA::Info;
+package OpenQA::Parser::Result::IPA::Info {
     use Mojo::Base 'OpenQA::Parser::Result';
 
     has [qw(distro platform image instance region results_file log_file timestamp)];

--- a/lib/OpenQA/Parser/Format/JUnit.pm
+++ b/lib/OpenQA/Parser/Format/JUnit.pm
@@ -13,6 +13,7 @@ has include_results => 0;
 
 # Override to use specific OpenQA Result class.
 sub _add_single_result { shift->generated_tests_results->add(OpenQA::Parser::Result::OpenQA->new(@_)) }
+
 sub _add_result {
     my $self = shift;
     my %opts = ref $_[0] eq 'HASH' ? %{$_[0]} : @_;

--- a/lib/OpenQA/Parser/Format/LTP.pm
+++ b/lib/OpenQA/Parser/Format/LTP.pm
@@ -82,8 +82,7 @@ sub parse {
 }
 
 # Schema
-{
-    package OpenQA::Parser::Result::LTP::Test;
+package OpenQA::Parser::Result::LTP::Test {
     use Mojo::Base 'OpenQA::Parser::Result::OpenQA';
 
     has environment => sub { OpenQA::Parser::Result::LTP::Environment->new() };
@@ -92,15 +91,13 @@ sub parse {
 }
 
 # Additional data structure - they get mapped automatically
-{
-    package OpenQA::Parser::Result::LTP::SubTest;
+package OpenQA::Parser::Result::LTP::SubTest {
     use Mojo::Base 'OpenQA::Parser::Result::Test';
 
     has [qw(log duration result)];
 }
 
-{
-    package OpenQA::Parser::Result::LTP::Environment;
+package OpenQA::Parser::Result::LTP::Environment {
     use Mojo::Base 'OpenQA::Parser::Result';
 
     has [qw(gcc product revision kernel ltp_version harness libc arch)];

--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -103,16 +103,14 @@ sub parse {
 }
 
 # Schema
-{
-    package OpenQA::Parser::Result::XUnit;
+package OpenQA::Parser::Result::XUnit {
     use Mojo::Base 'OpenQA::Parser::Result::OpenQA';
     has properties => sub { OpenQA::Parser::Results->new };
 
     has [qw(errors tests softfailures failures time)];
 }
 
-{
-    package OpenQA::Parser::Result::XUnit::Property;
+package OpenQA::Parser::Result::XUnit::Property {
     use Mojo::Base 'OpenQA::Parser::Result';
 
     has [qw(name value)];

--- a/lib/OpenQA/Resource/Jobs.pm
+++ b/lib/OpenQA/Resource/Jobs.pm
@@ -28,6 +28,7 @@ Handle job restart by user (using API or WebUI). Job is only restarted when eith
 or done. Scheduled jobs can't be restarted.
 
 =cut
+
 sub job_restart ($jobids, %args) {
     my (@duplicates, @comments, @processed, @errors, @warnings);
     my %res = (

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -499,6 +499,7 @@ sub _serialize_directly_chained_job_sequence ($first_job_id, $cluster_info, $sor
         $cluster_info, $sort_function // sub { return shift });
     return ($sequence, [keys %visited]);
 }
+
 sub _serialize_directly_chained_job_sub_sequence ($output_array, $visited, $child_job_ids, $cluster_info,
     $sort_function)
 {

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -104,6 +104,7 @@ sub bugrefs ($self) { find_bugrefs($self->text) }
 
 Returns label value if C<$self> is label, e.g. 'label:my_label' returns 'my_label'
 =cut
+
 sub label ($self) {
     return find_labels($self->text)->[0];
 }
@@ -112,6 +113,7 @@ sub label ($self) {
 
 Returns flag values if C<$self> has flags, e.g. 'flag:carryover flag:foobar' returns a hashref with the keys 'carryover' and 'foobar'
 =cut
+
 sub text_flags ($self) {
     my $flags = find_flags($self->text);
     my %flag_hash;
@@ -143,6 +145,7 @@ comments not on test comments. The description is optional.
 Returns C<build_nr>, C<type> and optionally C<description> if C<$self> is tag,
 e.g. 'tag:0123:important:GM' returns a list of '0123', 'important' and 'GM'.
 =cut
+
 sub tag ($self) {
     $self->text
       =~ /\btag:(((?<version>[-.@\d\w]+)-)?(?<build>[-.@\d\w]+)|"((?<version>[-.@\d\w]+)-)?(?<build>[-.@\d\w\s\+:]+)"):(?<type>[-@\d\w]+)(:(?<description>[-.@\d\w]+))?\b/;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -604,6 +604,7 @@ sub extract_group_args_from_settings ($settings) {
 Internal function, needs to be executed in a transaction to perform
 optimistic locking on clone_id
 =cut
+
 sub _create_clone ($self, $cluster_job_info, $clone, $prio, $skip_ok_result_children, $settings) {
     # Skip cloning 'ok' jobs which are only pulled in as children if that flag is set
     return ()
@@ -903,6 +904,7 @@ for DIRECTLY_CHAINED dependencies:
  + if child is clone, find the latest clone and clone it
 
 =cut
+
 sub duplicate ($self, $args = {}) {
     # If the job already has a clone, none is created
     my ($orig_id, $clone_id) = ($self->id, $self->clone_id);
@@ -966,6 +968,7 @@ Handle individual job restart including dependent jobs and asset dependencies. N
 the caller is responsible to notify the workers about the new job.
 
 =cut
+
 sub auto_duplicate ($self, $args = {}) {
     my $clones = $self->duplicate($args);
     return $clones unless ref $clones eq 'HASH';
@@ -1694,6 +1697,7 @@ sub _failure_reason ($self) {
 Returns the hook script for this job depending on its result and settings and the global configuration.
 
 =cut
+
 sub hook_script ($self) {
     my $trigger_hook = $self->settings_hash->{_TRIGGER_JOB_DONE_HOOK};
     return undef if defined $trigger_hook && !$trigger_hook;
@@ -1753,6 +1757,7 @@ carry over bugrefs (i.e. special comments) from previous jobs to current
 result in the same scenario.
 
 =cut
+
 sub carry_over_bugrefs ($self) {
     try {
         if (my $group = $self->group) { return undef unless $group->carry_over_bugrefs }
@@ -2109,6 +2114,7 @@ if result is not set (expected default situation) result is computed from the re
 test modules
 
 =cut
+
 sub done ($self, %args) {
     # read specified result or calculate result from module results if none specified
     my $result;

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -217,9 +217,11 @@ sub to_json ($self) {
 }
 
 my $fmt = '%Y-%m-%dT%H:%M:%S%z';    # with offset
+
 sub last_seen_time_fmt ($self) {
     $self->last_seen_time ? $self->last_seen_time->strftime($fmt) : 'never';
 }
+
 sub last_matched_time_fmt ($self) {
     $self->last_matched_time ? $self->last_matched_time->strftime($fmt) : 'never';
 }

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -38,6 +38,7 @@ job that matches the settings provided as argument. Useful to find the
 latest build for a given pair of distri and version.
 
 =cut
+
 sub latest_build ($self, %args) {
     my @conds;
     my %attrs;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -37,6 +37,7 @@ use List::Util qw(min);
 my $FRAG_REGEX = FRAGMENT_REGEX;
 
 my (%BUGREFS, %BUGURLS, $MARKER_REFS, $MARKER_URLS, $BUGREF_REGEX);
+
 BEGIN {
     %BUGREFS = (
         bnc => 'https://bugzilla.suse.com/show_bug.cgi?id=',
@@ -226,6 +227,7 @@ needles or tests.
 If the I<.git> directory not found it returns an empty string.
 
 =cut
+
 sub gitrepodir (@args) {
     my %args = (distri => '', version => '', @args);
     my $path = $args{needles} ? needledir($args{distri}, $args{version}) : testcasedir($args{distri}, $args{version});

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -512,6 +512,7 @@ sub comments ($self) {
 }
 
 my $ANCESTORS_LIMIT = 10;
+
 sub _stash_clone_info ($self, $job) {
     $self->stash(
         {

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -663,6 +663,7 @@ sub is_backend_running {
 # starts/stops the livelog
 sub start_livelog ($self) { $self->_add_livelog_viewers(1) }
 sub stop_livelog ($self) { $self->_add_livelog_viewers(-1) }
+
 sub _add_livelog_viewers ($self, $viewer_count_diff) {
     my $viewer_count_after = $self->{_livelog_viewers} = max(0, $self->{_livelog_viewers} + $viewer_count_diff);
     return undef unless $self->is_backend_running;    # skip evaluating viewers if backend has not been started yet

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -80,6 +80,7 @@ sub list_jobs {
     [map { $_->to_hash(assets => 1) } $jobs->complex_query(@_)->all]
 }
 sub job_get { $jobs->find({id => shift}) }
+
 sub job_get_hash {
     my ($id) = @_;
 

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -50,6 +50,7 @@ my %default_job_settings = (
     ARCH => 'x86_64',
     NICTYPE => 'tap',
 );
+
 sub _job_create {
     my ($settings, $parallel_jobs, $start_after_jobs, $start_directly_after_jobs) = @_;
     $settings = {%default_job_settings, TEST => $settings} unless ref $settings;
@@ -60,6 +61,7 @@ sub _job_create {
     $job->discard_changes;    # reload all values from database so we can check against default values
     return $job;
 }
+
 sub _jobs_update_state {
     my ($jobs, $state, $result) = @_;
     for my $job (@$jobs) {
@@ -69,6 +71,7 @@ sub _jobs_update_state {
     }
 }
 sub _job_deps { $jobs->find(shift, {prefetch => [qw(settings parents children)]})->to_hash(deps => 1) }
+
 sub _schedule {
     my $scheduling_info = OpenQA::Scheduler::Model::Jobs->singleton->schedule();
     _jobs_update_state([$jobs->find($_->{job})], RUNNING) for @$scheduling_info;
@@ -276,6 +279,7 @@ my %exp_cluster_jobs = (
         state => RUNNING,
     },
 );
+
 sub exp_cluster_jobs_for {
     my ($job) = @_;
 
@@ -292,6 +296,7 @@ sub exp_cluster_jobs_for {
     $exp_cluster_jobs{$jobF->id}{is_parent_or_initial_job} = ($job eq 'F') ? 1 : 0;
     return \%exp_cluster_jobs;
 }
+
 sub log_job_info {
     my %jobs = (A => $jobA, B => $jobB, C => $jobC, D => $jobD, E => $jobE, F => $jobF);    # uncoverable statement
     note 'job IDs:';    # uncoverable statement
@@ -1000,6 +1005,7 @@ subtest 'clone chained parent with chained sub-tree' => sub {
         _jobs_update_state([$job], $state, PASSED);
         return $job;
     }
+
     sub _job_cloned_and_related {
         my ($jobA, $jobB) = @_;
         ok($jobA->clone, 'jobA has a clone');

--- a/t/05-scheduler-restart-and-duplicate.t
+++ b/t/05-scheduler-restart-and-duplicate.t
@@ -30,9 +30,11 @@ embed_server_for_testing(
 
 my $jobs_rs = $schema->resultset('Jobs');
 sub job_get_rs ($id) { $jobs_rs->find({id => $id}) }
+
 sub list_jobs () {
     return [map { $_->to_hash() } $jobs_rs->all];
 }
+
 sub job_get ($id) {
     return undef unless my $job = job_get_rs($id);
     return $job->to_hash;

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -269,8 +269,10 @@ subtest 'git commands with mocked run_cmd_with_log_return_error' => sub {
 subtest 'saving needle via Git' => sub {
     my $utils_mock = Test::MockModule->new('OpenQA::Git');
     $utils_mock->redefine(run_cmd_with_log_return_error => \&_run_cmd_mock);
+
     package Test::FakeMinionJob {
         sub finish { }
+
         sub fail {
             Test::Most::fail("Minion job shouldn't have failed.");    # uncoverable statement
             Test::Most::note(Data::Dumper::Dumper(\@_));    # uncoverable statement
@@ -306,6 +308,7 @@ subtest 'saving needle via Git' => sub {
 };
 
 subtest 'signal guard aborts when git is disabled and do_cleanup is "no"' => sub {
+
     package My::FakeSignalGuard {
         use Mojo::Base -base, -signatures;
         has 'abort' => sub { 0 };
@@ -326,6 +329,7 @@ subtest 'signal guard aborts when git is disabled and do_cleanup is "no"' => sub
 };
 
 subtest 'save_needle returns and logs error when set_to_latest_master fails' => sub {
+
     package Test::FailingMinionJob {
         sub finish { }
         sub fail($self, $args) { $self->{fail_message} = $args }

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -7,9 +7,11 @@ use Test::Warnings ':report_warnings';
 
 # define test helper to check for exit code
 our $exit_handler = sub { CORE::exit $_[0] };
+
 BEGIN {
     *CORE::GLOBAL::exit = sub (;$) { $exit_handler->(@_ ? 0 + $_[0] : 0) }
 }
+
 sub exit_code(&) {
     my $exit_code;
     local $exit_handler = sub { $exit_code = $_[0] };

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -32,6 +32,7 @@ my $comment_must
 '<span class="openqa-bugref" title="Bug referenced: bsc#1234"><a href="https://bugzilla.suse.com/show_bug.cgi?id=1234"><i class="test-label label_bug fa fa-bug"></i>&nbsp;bsc#1234</a></span>(Automatic carryover from <a href="/tests/99962">t#99962</a>)'
   )->to_string;
 my $carry_over_note = "\n(The hook script will not be executed.)";
+
 sub comments ($url) {
     $t->get_ok("$url/comments_ajax")->status_is(200)->tx->res->dom->find('.media-comment > p')->map('content');
 }

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -515,6 +515,7 @@ subtest 'proper build sorting for dotted build number' => sub {
 subtest 'job groups with multiple version and builds' => sub {
     my $group = $job_groups->create({name => 'multi version group'});
     $job_hash->{group_id} = $group->id;
+
     sub create_job_version_build {
         my ($version, $build) = @_;
         $job_hash->{VERSION} = $version;

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -36,36 +36,29 @@ my $guard = scope_guard sub { chdir $FindBin::Bin };
 dircopy "$FindBin::Bin/$_", "$workdir/t/$_" or BAIL_OUT($!) for qw(data);
 
 # define fake packages for testing asset caching
-{
-    # uncoverable statement count:1
-    # uncoverable statement count:2
-    package Test::FakeJob;
+package Test::FakeJob {
     use Mojo::Base -base;
     has id => 42;
     has worker => undef;
     has client => sub { Test::FakeClient->new };
     sub post_setup_status { 1 }
     sub is_stopped_or_stopping { 0 }
-}
-{
-    # uncoverable statement count:1
-    # uncoverable statement count:2
-    package Test::FakeRequest;
+}    # uncoverable statement
+
+package Test::FakeRequest {
     use Mojo::Base -base;
     has minion_id => 13;
-}
+}    # uncoverable statement
 
 # Fake client
-{
-    # uncoverable statement count:1
-    # uncoverable statement count:2
-    package Test::FakeClient;
+# uncoverable statement count:1
+package Test::FakeClient {
     use Mojo::Base -base;
     has worker_id => 1;
     has webui_host => 'localhost';
     has service_port_delta => 2;
     has testpool_server => 'fake-testpool-server';
-}
+}    # uncoverable statement
 
 $ENV{OPENQA_CONFIG} = "$FindBin::Bin/data/24-worker-overall";
 $ENV{OPENQA_HOSTNAME} = "localhost";

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -89,10 +89,8 @@ sub wait_until_uploading_logs_and_assets_concluded {
 }
 
 # Fake client and engine
-{
-    # uncoverable statement count:1
-    # uncoverable statement count:2
-    package Test::FakeClient;
+# uncoverable statement count:1
+package Test::FakeClient {
     use Mojo::Base -base;
     has worker_id => 1;
     has service_port_delta => 2;
@@ -108,6 +106,7 @@ sub wait_until_uploading_logs_and_assets_concluded {
     has fail_job_duplication => 0;
     has configured_retries => 5;
     has fake_result => undef;
+
     sub send {
         my ($self, $method, $path, %args) = @_;
         my $params = $args{params};
@@ -128,23 +127,22 @@ sub wait_until_uploading_logs_and_assets_concluded {
     sub reset_last_error { shift->last_error(undef) }
     sub send_status { push(@{shift->sent_messages}, @_) }
     sub register { shift->register_called(1) }
+
     sub add_context_to_last_error {
         my ($self, $context) = @_;
         $self->last_error($self->last_error . " on $context");
     }
     sub _retry_delay { 0 }
     sub evaluate_error { OpenQA::Worker::WebUIConnection::evaluate_error(@_) }
-}
-{
-    # uncoverable statement count:1
-    # uncoverable statement count:2
-    package Test::FakeEngine;
+}    # uncoverable statement count:1
+
+package Test::FakeEngine {
     use Mojo::Base -base;
     has pid => 1;
     has errored => 0;
     has is_running => 1;
     sub stop { shift->is_running(0) }
-}
+}    # uncoverable statement count:1
 
 my $isotovideo = Test::FakeEngine->new;
 my $worker = OpenQA::Test::FakeWorker->new(settings => OpenQA::Worker::Settings->new(1, {}));
@@ -208,6 +206,7 @@ $engine_mock->redefine(
 # Mock log file and asset uploads to collect diagnostics
 my $job_mock = Test::MockModule->new('OpenQA::Worker::Job');
 my $upload_stats = {upload_result => 1, uploaded_files => [], uploaded_assets => []};
+
 sub upload_mock ($key, $self, @args) {
     push @{$upload_stats->{$key}}, \@args;
     return $upload_stats->{upload_result};

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -34,26 +34,26 @@ chdir $workdir;
 my $guard = scope_guard sub { chdir $FindBin::Bin };
 
 # define fake isotovideo
-{
-    package Test::FakeProcess;    # uncoverable statement count:1
+package Test::FakeProcess {    # uncoverable statement count:1
     use Mojo::Base -base;
     has is_running => 1;
     sub stop { shift->is_running(0) }
-}
-{
-    package Test::FakeClient;    # uncoverable statement count:2
+}    # uncoverable statement
+
+package Test::FakeClient {    # uncoverable statement count:2
     use Mojo::Base -base;
     has webui_host => 'fake';
     has worker_id => 42;
     has service_port_delta => 2;
     has api_calls => sub { [] };
+
     sub send {
         my ($self, $method, $path, %args) = @_;
         push(@{shift->api_calls}, $method, $path, $args{params});
     }
-}
-{
-    package Test::FakeJob;    # uncoverable statement count:2
+}    # uncoverable statement
+
+package Test::FakeJob {    # uncoverable statement count:2
     use Mojo::Base 'Mojo::EventEmitter';
     has id => 42;
     has status => 'running';
@@ -61,12 +61,14 @@ my $guard = scope_guard sub { chdir $FindBin::Bin };
     has is_accepted => 0;
     has client => sub { Test::FakeClient->new; };
     has name => 'test-job';
+
     sub skip {
         my ($self) = @_;
         $self->is_skipped(1);
         $self->emit(status_changed => {job => $self, status => 'stopped', reason => 'skipped'});
         return 1;
     }
+
     sub accept {
         my ($self) = @_;
         $self->is_accepted(1);
@@ -74,24 +76,24 @@ my $guard = scope_guard sub { chdir $FindBin::Bin };
         return 1;
     }
     sub start { }
-}
-{
-    package Test::FakeCacheServiceClientInfo;
+}    # uncoverable statement
+
+package Test::FakeCacheServiceClientInfo {
     use Mojo::Base -base;
     has availability_error => 'Cache service info error: Connection refused';
-}
-{
-    package Test::FakeDBusObject;
+}    # uncoverable statement
+
+package Test::FakeDBusObject {
     use Mojo::Base -base, -signatures;
     sub disconnect_from_signal ($self, $signal, $id) { }
-}
-{
-    package Test::FakeDBus;    # uncoverable statement count:2
+}    # uncoverable statement
+
+package Test::FakeDBus {
     use Mojo::Base -base, -signatures;
     has mock_service_value => 1;
     sub get_service ($self, $service_name) { $self->mock_service_value }
     sub get_bus_object ($self) { Test::FakeDBusObject->new }
-}
+}    # uncoverable statement
 
 my $dbus_mock = Test::MockModule->new('Net::DBus', no_auto => 1);
 $dbus_mock->define(system => sub (@) { Test::FakeDBus->new });

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -207,28 +207,29 @@ subtest 'clearning errors' => sub {
 
 subtest 'retry behavior' => sub {
     # use fake Mojo::UserAgent and Mojo::Transaction
-    {
-        package Test::FakeTransaction;
+    package Test::FakeTransaction {
         use Mojo::Base -base;
         has error => undef;
         has res => undef;
     }
-    {
-        package Test::FakeUserAgent;
+
+    package Test::FakeUserAgent {
         use Mojo::Base -base;
         has fake_error => undef;
         has start_count => 0;
+
         sub build_tx {
             my ($self, @args) = @_;
             return Test::FakeTransaction->new;
         }
+
         sub start {
             my ($self, $tx, $callback) = @_;
             $tx->error($self->fake_error);
             $self->start_count($self->start_count + 1);
             $callback->($self, $tx);
         }
-    }
+    }    # uncoverable statement
     my $fake_error = {message => 'some timeout'};
     my $fake_ua = Test::FakeUserAgent->new(fake_error => $fake_error);
     my $default_ua = $client->ua;

--- a/t/25-cache-client.t
+++ b/t/25-cache-client.t
@@ -7,6 +7,7 @@ use Test::Warnings ':report_warnings';
 
 my $sleep_count = 0;
 my $tempdir;
+
 BEGIN {
     use Mojo::File qw(path tempdir);
 

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -8,6 +8,7 @@ use Time::Seconds;
 $ENV{MOJO_LOG_LEVEL} = 'info';
 
 my $tempdir;
+
 BEGIN {
     use Mojo::File qw(path tempdir);
 

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -5,6 +5,7 @@
 use Test::Most;
 
 my ($tempdir, $cached, $cachedir, $db_file);
+
 BEGIN {
     use Mojo::File qw(path tempdir);
 

--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -5,15 +5,17 @@ use Test::Most;
 use Test::Warnings ':report_warnings';
 
 BEGIN {
-    package OpenQA::FakePlugin::Fuzz;
-    use Mojo::Base -base;
 
-    has 'configuration_fields' => sub {
-        {
-            baz => {
-                test => 1
-            }};
-    };
+    package OpenQA::FakePlugin::Fuzz {
+        use Mojo::Base -base;
+
+        has 'configuration_fields' => sub {
+            {
+                baz => {
+                    test => 1
+                }};
+        };
+    }
 }
 
 use FindBin;

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -224,6 +224,7 @@ subtest edit => sub {
 done_testing;
 
 package Job;
+
 sub new {
     my ($class) = @_;
     my $self = bless({}, $class);
@@ -240,6 +241,7 @@ sub name { "foobar" }
 
 package Worker;
 use Mojo::File 'tempdir';
+
 sub new {
     my ($class) = @_;
     my $self = bless({}, $class);
@@ -261,6 +263,7 @@ sub finish ($self) { $self->emit(finish => $self) }
 
 package FakeSchema;
 use Mojo::Base -signatures;
+
 sub new {
     my ($class) = @_;
     my $self = bless({}, $class);

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -52,8 +52,8 @@ subtest 'Results base class object' => sub {
     is $deserialized->first->{bar}, 'baz' or always_explain $deserialized;
 };
 
-{
-    package Dummy;    # uncoverable statement
+package Dummy {    # uncoverable statement
+
     sub new {
         my $class = shift;
         my $self = {};
@@ -61,10 +61,9 @@ subtest 'Results base class object' => sub {
         $self->{test} = 1;
         return $self;
     }
-}
+}    # uncoverable statement
 
-{
-    package Dummy2;    # uncoverable statement count:2
+package Dummy2 {    # uncoverable statement count:2
 
     sub new {
         my $class = shift;
@@ -73,10 +72,10 @@ subtest 'Results base class object' => sub {
         @{$self} = qw(1 2 3);
         return $self;
     }
-}
+}    # uncoverable statement
 
-{
-    package Dummy2to;    # uncoverable statement count:2
+package Dummy2to {    # uncoverable statement count:2
+
     sub new {
         my $class = shift;
         my $self = [];
@@ -85,10 +84,10 @@ subtest 'Results base class object' => sub {
         return $self;
     }
     sub to_array { [@{shift()}] }
-}
+}    # uncoverable statement
 
-{
-    package Dummy3to;    # uncoverable statement count:2
+package Dummy3to {    # uncoverable statement count:2
+
     sub new {
         my $class = shift;
         my $self = {};
@@ -97,10 +96,9 @@ subtest 'Results base class object' => sub {
         return $self;
     }
     sub to_hash { return {%{shift()}} }
-}
+}    # uncoverable statement
 
-{
-    package Dummy3;    # uncoverable statement count:2
+package Dummy3 {    # uncoverable statement count:2
     use Symbol;
 
     sub new {
@@ -109,15 +107,13 @@ subtest 'Results base class object' => sub {
         bless $self, $class;
         return $self;
     }
-}
+}    # uncoverable statement
 
-{
-    package NestedResults;    # uncoverable statement count:2
+package NestedResults {    # uncoverable statement count:2
     use Mojo::Base 'OpenQA::Parser::Results';
-}
+}    # uncoverable statement
 
-{
-    package NestedResult;
+package NestedResult {
     use Mojo::Base 'OpenQA::Parser::Result';
 
     # uncoverable statement count:2
@@ -125,7 +121,7 @@ subtest 'Results base class object' => sub {
     # uncoverable statement count:2
     has result2 => sub { NestedResult->new() };
     has 'val';
-}
+}    # uncoverable statement
 
 subtest 'Parser base class object' => sub {
     my $res = parser('Base');
@@ -899,10 +895,11 @@ subtest functional_interface => sub {
     is ref($ltp), 'OpenQA::Parser::Format::LTP', 'Parser found';
 
     throws_ok { p("Doesn'tExist!") } qr/Parser not found!/, 'Croaked correctly';
-    {
-        package OpenQA::Parser::Format::Broken;    # uncoverable statement
+
+    package OpenQA::Parser::Format::Broken {
         sub new { die 'boo' }
-    };
+    }    # uncoverable statement
+
     throws_ok { p("Broken") } qr/Invalid parser supplied: boo/, 'Croaked correctly';
 
     my $default = p();
@@ -964,14 +961,12 @@ subtest nested_parsers => sub {
 
 done_testing;
 
-{
-    package OpenQA::Parser::Format::Dummy;    # uncoverable statement
+package OpenQA::Parser::Format::Dummy {    # uncoverable statement
     use Mojo::Base 'OpenQA::Parser::Format::JUnit';
     sub parse { shift->_add_result(name => 'test'); }
-}
+}    # uncoverable statement
 
-{
-    package OpenQA::Parser::UnstructuredDummy;    # uncoverable statement count:2
+package OpenQA::Parser::UnstructuredDummy {    # uncoverable statement count:2
     use Mojo::Base 'OpenQA::Parser::Format::Base';
     use Mojo::JSON 'decode_json';
 
@@ -987,8 +982,7 @@ done_testing;
         }
         $self;
     }
-
-}
+}    # uncoverable statement
 
 __DATA__
 {

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -46,6 +46,7 @@ my $worker;
 my $ws;
 my $livehandler;
 my $scheduler;
+
 sub turn_down_stack {
     stop_service($_) for ($worker, $ws, $livehandler, $scheduler);
 }
@@ -82,6 +83,7 @@ $livehandler = create_live_view_handler;
 
 # logs out and logs in again as the specified user; tries multiple times to workaround poo#128807
 my $max_login_attempts = $ENV{OPENQA_DEVEL_MODE_TEST_MAX_LOGIN_ATTEMPTS} // 10;
+
 sub relogin_as ($user) {
     my $login_text = '';
     my $expected_login_text = 'Logged in as ' . $user;

--- a/t/34-developer_mode-unit.t
+++ b/t/34-developer_mode-unit.t
@@ -71,6 +71,7 @@ sub set_fake_status_java_script_transactions {
 
 my $finished_handled_mock = Test::MockModule->new('OpenQA::LiveHandler::Controller::LiveViewHandler');
 my $finished_handled;
+
 sub prepare_waiting_for_finished_handled {
     my $subroutine_name = 'handle_disconnect_from_java_script_client';
     $finished_handled = 0;
@@ -80,6 +81,7 @@ sub prepare_waiting_for_finished_handled {
             $finished_handled = 1;
         });
 }
+
 sub wait_for_finished_handled {
     # wait until the finished event is handled (but at most 5 seconds)
     my $timer = Mojo::IOLoop->timer(5.0 => sub { });

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -20,18 +20,18 @@ use Mojo::Transaction;
 use Scalar::Util qw(looks_like_number);
 
 # define fake client
-{
-    package Test::FakeLWPUserAgentMirrorResult;
+package Test::FakeLWPUserAgentMirrorResult {
     use Mojo::Base -base, -signatures;
     has is_success => 1;
     has code => 304;
     has status_line => 'some status';
-}
-{
-    package Test::FakeLWPUserAgent;
+}    # uncoverable statement
+
+package Test::FakeLWPUserAgent {
     use Mojo::Base -base, -signatures;
     has mirrored => sub { {} };
     has missing => 0;
+
     sub mirror ($self, $from, $dest) {
         my @res
           = ($self->missing || $from !~ qr{http://foo/tests/1/asset/iso/(foo|bar)\.iso})
@@ -40,7 +40,7 @@ use Scalar::Util qw(looks_like_number);
         $self->mirrored->{$from} = $dest;
         Test::FakeLWPUserAgentMirrorResult->new(@res);
     }
-}
+}    # uncoverable statement
 
 my @argv = (
     qw(WORKER_CLASS=local HDD_1=new.qcow2 HDDSIZEGB=40 FOO=value:with:colon),

--- a/t/35-script_clone_job_suse.t
+++ b/t/35-script_clone_job_suse.t
@@ -13,17 +13,16 @@ use OpenQA::Script::CloneJobSUSE;
 use Mojo::URL;
 
 # define fake client
-{
-    package Test::FakeLWPUserAgentMirrorResult;
+package Test::FakeLWPUserAgentMirrorResult {
     use Mojo::Base -base, -signatures;
     has is_success => 1;
-}
-{
-    package Test::FakeLWPUserAgent;
+}    # uncoverable statement
+
+package Test::FakeLWPUserAgent {
     use Mojo::Base -base, -signatures;
     has is_validrepo => 1;
     sub get ($self, $url) { Test::FakeLWPUserAgentMirrorResult->new(is_success => $self->is_validrepo) }
-}
+}    # uncoverable statement
 
 subtest 'maintenance update detect' => sub {
     my $job_id = 1;

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -19,8 +19,7 @@ use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry);
 use OpenQA::Utils qw(:DEFAULT assetdir);
 use OpenQA::WebAPI::Controller::API::V1::Iso;
 
-{
-    package Test::FakeJob;
+package Test::FakeJob {
     use Mojo::Base -base;
     has app => undef;
     has fail => undef;

--- a/t/41-audit-log.t
+++ b/t/41-audit-log.t
@@ -55,16 +55,19 @@ $events->create(
 sub all_events_ids {
     return [sort map { $_->id } $events->all];
 }
+
 sub make_time {
     my ($days_ago) = @_;
     my $seconds_per_day = 60 * 60 * 24;
     return time2str('%Y-%m-%d %H:%M:%S', time - ($seconds_per_day * $days_ago), 'UTC');
 }
+
 sub assume_all_events_before_x_days {
     my ($days_ago) = @_;
     my $date = make_time($days_ago);
     $events->search({})->update({t_created => $date});
 }
+
 sub assume_events_being_deleted {
     my (@event_ids) = @_;
     delete $fake_events{$_} for (@event_ids);

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -96,6 +96,7 @@ note("Result dir: $resultdir");
 
 # spawn workers
 note("Spawning $worker_count workers");
+
 sub spawn_worker {
     my ($instance) = @_;
 
@@ -109,6 +110,7 @@ my @workers = map { spawn_worker($_) } (1 .. $worker_count);
 
 # create jobs
 note("Creating $job_count jobs");
+
 sub log_jobs {
     # uncoverable sub only used in case of failures
     my @job_info

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -57,6 +57,7 @@ plan skip_all => 'set FULLSTACK=1 (be careful)' unless $ENV{FULLSTACK};
 my $worker;
 my $ws;
 my $livehandler;
+
 sub turn_down_stack {
     stop_service($_) for ($worker, $ws, $livehandler);
 }
@@ -92,6 +93,7 @@ sub status_text { find_status_text($driver) }
 # add a function to verify the test setup before trying to run a job
 my $setup_timeout = 0;    # actually initialized further down after subtest 'testhelper'
 my $setup_poll_interval = 0;    # actually initialized further down after subtest 'testhelper'
+
 sub check_scheduled_job_and_wait_for_free_worker ($worker_class) {
     # check whether the job we expect to be scheduled is actually scheduled
     # note: After all this is a test so it might uncover problems and then it is useful to have further
@@ -140,6 +142,7 @@ sub assign_jobs ($worker_class = undef) {
     }
     fail "Unable to assign $to_be_scheduled jobs after $elapsed seconds";    # uncoverable statement
 }
+
 sub start_worker_and_assign_jobs ($worker_class = undef) {
     $worker = start_worker get_connect_args;
     ok $worker, "Worker started as $worker";

--- a/t/lib/OpenQA/FakePlugin/FooFoo.pm
+++ b/t/lib/OpenQA/FakePlugin/FooFoo.pm
@@ -6,6 +6,7 @@ has 'configuration_fields' => sub {
             is_there => 1
         }};
 };
+
 sub register {
     1;
 }

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -288,9 +288,11 @@ sub element_not_present ($selector, $test_description = undef) {
 sub element_prop ($element_id, $property = 'value') {
     return $_driver->execute_script("return document.getElementById('$element_id').$property;");
 }
+
 sub element_prop_by_selector ($element_selector, $property = 'value') {
     return $_driver->execute_script("return document.querySelector('$element_selector').$property;");
 }
+
 sub map_elements ($selector, $mapping) {
     return $_driver->execute_script("return Array.from(document.querySelectorAll('$selector')).map(e => [$mapping]);");
 }

--- a/t/lib/OpenQA/Test/FakeWorker.pm
+++ b/t/lib/OpenQA/Test/FakeWorker.pm
@@ -1,8 +1,7 @@
 package OpenQA::Test::FakeWorker;
 use Mojo::Base -base, -signatures;
 
-{
-    package Test::FakeSettings;
+package Test::FakeSettings {
     use Mojo::Base -base;
     has global_settings => sub { {RETRIES => 3, RETRY_DELAY => 10, RETRY_DELAY_IF_WEBUI_BUSY => 90} };
     has webui_host_specific_settings => sub { {} };
@@ -30,13 +29,16 @@ has is_executing_single_job => 1;
 sub stop_current_job ($self, $reason) { $self->stop_current_job_called($reason) }
 sub stop ($self) { $self->is_stopping(1) }
 sub status ($self) { {fake_status => 1, reason => 'some error'} }
+
 sub accept_job ($self, $client, $job_info) {
     $self->current_job(OpenQA::Worker::Job->new($self, $client, $job_info));
 }
+
 sub enqueue_jobs_and_accept_first ($self, $client, $job_info) {
     $self->enqueued_job_info($job_info);
 }
 sub skip_job ($self, $job_id, $type) { push @{$self->skipped_jobs}, [$job_id, $type] }
+
 sub find_current_or_pending_job ($self, $job_id) {
     return undef unless my $current_job = $self->current_job;
     return $current_job if $current_job->id eq $job_id;

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -223,6 +223,7 @@ my $SIGCHLD_HANDLER = sub {
         _fail_and_exit "sub process $child_name terminated with exit code $exit_code", $exit_code if $exit_code;
     }
 };
+
 sub _pids_from_ipc_run_harness {
     my ($ipc_run_harness, $error_message) = @_;
     my $children = ref $ipc_run_harness->{KIDS} eq 'ARRAY' ? $ipc_run_harness->{KIDS} : [];
@@ -230,6 +231,7 @@ sub _pids_from_ipc_run_harness {
     BAIL_OUT($error_message) if $error_message && !@pids;
     return \@pids;
 }
+
 sub _setup_sigchld_handler {
     # adds the PIDs from the specified $ipc_run_harness to the PIDs considered by $SIGCHLD_HANDLER and
     # ensures $SIGCHLD_HANDLER is called
@@ -452,10 +454,12 @@ sub unresponsive_worker ($apikey, $apisecret, $host, $instance) {
     note("Starting unresponsive worker. Instance: $instance for host $host");
     c_worker($apikey, $apisecret, $host, $instance, 1);
 }
+
 sub broken_worker ($apikey, $apisecret, $host, $instance, $error) {
     note("Starting broken worker. Instance: $instance for host $host");
     c_worker($apikey, $apisecret, $host, $instance, 0, error => $error);
 }
+
 sub rejective_worker ($apikey, $apisecret, $host, $instance, $reason) {
     note("Starting rejective worker. Instance: $instance for host $host");
     c_worker($apikey, $apisecret, $host, $instance, 1, rejection_reason => $reason);

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -345,6 +345,7 @@ sub get_effective_cell_background ($row_id) {
             .map(e => getComputedStyle(e).backgroundColor)))"
     );
 }
+
 sub check_no_highlighting {
     is scalar @{$driver->find_elements('#job_99937.highlight_parent')}, 0, 'parent not highlighted';
     is scalar @{$driver->find_elements('#job_99938.highlight_child')}, 0, 'child not highlighted';

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -64,6 +64,7 @@ my $user_name = 'Demo';
 
 # fills out the comment form and submits
 my $max_write_attempts = $ENV{OPENQA_COMMENTS_TEST_MAX_WRITE_ATTEMPTS} // 10;
+
 sub write_comment ($text, $desc) {
     for (my $attempts = 1;; ++$attempts) {
         eval {
@@ -446,6 +447,7 @@ subtest 'editing when logged in as regular user' => sub {
             0, "edit not displayed for other users comments");
         is(@{$driver->find_elements('button.remove-edit-button', 'css')}, 0, "removal not displayed for regular user");
     }
+
     sub only_edit_for_own_comments_expected {
         is(@{$driver->find_elements('button.trigger-edit-button', 'css')}, 1, "own comments can be edited");
         is(@{$driver->find_elements('button.remove-edit-button', 'css')}, 0,

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -75,6 +75,7 @@ prepare_database;
 
 my $last_job_id;
 sub update_last_job_id () { $last_job_id = $jobs->search(undef, {rows => 1, order_by => {-desc => 'id'}})->first->id }
+
 sub expected_job_id_regex ($offset = 1) {
     my $expected_job_id = $last_job_id + $offset;
     return qr|tests/$expected_job_id|;

--- a/t/ui/27-plugin_obs_rsync_gru.t
+++ b/t/ui/27-plugin_obs_rsync_gru.t
@@ -14,16 +14,13 @@ my ($t, $tempdir, $home, $params) = setup_obs_rsync_test;
 my $app = $t->app;
 my $minion = $app->minion;
 
-{
-    # uncoverable statement count:1
-    # uncoverable statement count:2
-    package FakeMinionJob;
+package FakeMinionJob {
     use Mojo::Base -base, -signatures;
     has id => 0;
     has app => sub { $app };
     sub finish { $_[0]->{state} = 'finished'; $_[0]->{result} = $_[1] }
     sub info { {notes => {project_lock => 1}} }
-}
+}    # uncoverable statement
 
 $t->post_ok('/admin/obs_rsync/Proj1/runs' => $params)->status_is(201, 'trigger rsync');
 $t->get_ok('/admin/obs_rsync/queue')->status_is(200, 'jobs list')->content_like(qr/Proj1/, 'get project queue');


### PR DESCRIPTION
For that I had to remove --fbl, but added --keep-old-blank-lines and --noblanks-before-blocks

I used the modern `package ... {` syntax because it also adds blank lines before packages.

Also it adds blank lines before pod

Motivation: mostly because I was annoyed by missing blank lines between pod and subs