### PR TITLE
Move database dump script

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -401,6 +401,7 @@ ln -s %{_datadir}/openqa/script/openqa-load-templates %{buildroot}%{_bindir}/ope
 ln -s %{_datadir}/openqa/script/openqa-clone-custom-git-refspec %{buildroot}%{_bindir}/openqa-clone-custom-git-refspec
 ln -s %{_datadir}/openqa/script/openqa-validate-yaml %{buildroot}%{_bindir}/openqa-validate-yaml
 ln -s %{_datadir}/openqa/script/setup-db %{buildroot}%{_bindir}/openqa-setup-db
+ln -s %{_datadir}/openqa/script/dump-db %{buildroot}%{_bindir}/openqa-dump-db
 %if %{with python_scripts}
 ln -s %{_datadir}/openqa/script/openqa-label-all %{buildroot}%{_bindir}/openqa-label-all
 %endif
@@ -817,7 +818,9 @@ fi
 %{_unitdir}/openqa-scheduler.service.requires/postgresql.service
 %{_unitdir}/openqa-websockets.service.requires/postgresql.service
 %{_datadir}/openqa/script/setup-db
+%{_datadir}/openqa/script/dump-db
 %{_bindir}/openqa-setup-db
+%{_bindir}/openqa-dump-db
 
 %files single-instance
 

--- a/script/dump-db
+++ b/script/dump-db
@@ -1,5 +1,6 @@
 #!/bin/bash
-# must run as geekotest
+set -euo pipefail
 
-pg_dump -Fc -c openqa  -f ~/SQL-DUMPS/`date -Idate`.dump
-find ~/SQL-DUMPS/ -mtime +7 -print0 | xargs --no-run-if-empty -0 rm
+DUMP_FOLDER="/var/lib/openqa/SQL-DUMPS"
+pg_dump -Fc -c openqa -f "${DUMP_FOLDER}/$(date -Idate).dump"
+find "${DUMP_FOLDER}" -mtime +7 -print0 -delete

--- a/script/dump-db
+++ b/script/dump-db
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-DUMP_FOLDER="/var/lib/openqa/SQL-DUMPS"
-DAYS_TO_KEEP=7
-[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Dump the openQA postgresql database to ${DUMP_FOLDER} and clean-up backups older than ${DAYS_TO_KEEP} days." && exit
+DUMP_FOLDER=${DUMP_FOLDER:-"/var/lib/openqa/SQL-DUMPS"}
+DAYS_TO_KEEP=${DAYS_TO_KEEP:-"7"}
+[[ $1 = '-h' ]] || [[ $1 = '--help' ]] && echo "Dump the openQA postgresql database to ${DUMP_FOLDER} and clean-up backups older than ${DAYS_TO_KEEP} days." && exit
 
 pg_dump -Fc -c openqa -f "${DUMP_FOLDER}/$(date -Idate).dump"
-find "${DUMP_FOLDER}" -mtime +${DAYS_TO_KEEP} -print0 -delete
+find "${DUMP_FOLDER}" -mtime "+${DAYS_TO_KEEP}" -print0 -delete

--- a/script/dump-db
+++ b/script/dump-db
@@ -1,0 +1,5 @@
+#!/bin/bash
+# must run as geekotest
+
+pg_dump -Fc -c openqa  -f ~/SQL-DUMPS/`date -Idate`.dump
+find ~/SQL-DUMPS/ -mtime +7 -print0 | xargs --no-run-if-empty -0 rm

--- a/script/dump-db
+++ b/script/dump-db
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-
 DUMP_FOLDER="/var/lib/openqa/SQL-DUMPS"
+DAYS_TO_KEEP=7
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Dump the openQA postgresql database to ${DUMP_FOLDER} and clean-up backups older than ${DAYS_TO_KEEP} days." && exit
+
 pg_dump -Fc -c openqa -f "${DUMP_FOLDER}/$(date -Idate).dump"
-find "${DUMP_FOLDER}" -mtime +7 -print0 -delete
+find "${DUMP_FOLDER}" -mtime +${DAYS_TO_KEEP} -print0 -delete


### PR DESCRIPTION
Carbon copy of https://github.com/os-autoinst/sync-and-trigger/blob/2b891a67d7509aa589ac108f594d3235826f5ba9/dump-psql

Related issue: https://progress.opensuse.org/issues/181301

It would make sense to include this script here ~(and later package it as part of the [`openQA-local-db`-package](https://build.opensuse.org/projects/devel:openQA/packages/openQA/files/_service:obs_scm:openQA.spec?expand=1))~. I know there is a lot of improvement possible but for now I went with a pure copy to better trace the history of this script in the future.