### PR TITLE
Add nice and ionice to dump-db script

### DIFF
--- a/script/dump-db
+++ b/script/dump-db
@@ -4,5 +4,5 @@ DUMP_FOLDER=${DUMP_FOLDER:-"/var/lib/openqa/SQL-DUMPS"}
 DAYS_TO_KEEP=${DAYS_TO_KEEP:-"7"}
 [[ $1 = '-h' ]] || [[ $1 = '--help' ]] && echo "Dump the openQA postgresql database to ${DUMP_FOLDER} and clean-up backups older than ${DAYS_TO_KEEP} days." && exit
 
-pg_dump -Fc -c openqa -f "${DUMP_FOLDER}/$(date -Idate).dump"
+ionice -c3 nice -n19 pg_dump -Fc -c openqa -f "${DUMP_FOLDER}/$(date -Idate).dump"
 find "${DUMP_FOLDER}" -mtime "+${DAYS_TO_KEEP}" -print0 -delete


### PR DESCRIPTION
This runs the database backup with lower IO and CPU priority thus impacting the system less for users while a backup is running.

This is what openqa.suse.de is using - a openQA instance which is a little more loaded so it might make sense to include it by default in our script here as well.