### PR TITLE
Avoid unbound variable error in dump-db script

### DIFF
--- a/script/dump-db
+++ b/script/dump-db
@@ -2,7 +2,7 @@
 set -euo pipefail
 DUMP_FOLDER=${DUMP_FOLDER:-"/var/lib/openqa/SQL-DUMPS"}
 DAYS_TO_KEEP=${DAYS_TO_KEEP:-"7"}
-[[ $1 = '-h' ]] || [[ $1 = '--help' ]] && echo "Dump the openQA postgresql database to ${DUMP_FOLDER} and clean-up backups older than ${DAYS_TO_KEEP} days." && exit
+[[ ${1-} = '-h' ]] || [[ ${1-} = '--help' ]] && echo "Dump the openQA postgresql database to ${DUMP_FOLDER} and clean-up backups older than ${DAYS_TO_KEEP} days." && exit
 
 ionice -c3 nice -n19 pg_dump -Fc -c openqa -f "${DUMP_FOLDER}/$(date -Idate).dump"
 find "${DUMP_FOLDER}" -mtime "+${DAYS_TO_KEEP}" -print0 -delete


### PR DESCRIPTION
With the recently added bash restrictions the help text function has to be adjusted to not cause a "unbound variable" error on normal invocation because $1 is unbound without any arguments. Unlike `:-`, this only sets $1 to an empty value if unset.