### PR TITLE
Follow symlinks but only delete files with dump-db script

### DIFF
--- a/script/dump-db
+++ b/script/dump-db
@@ -5,4 +5,4 @@ DAYS_TO_KEEP=${DAYS_TO_KEEP:-"7"}
 [[ ${1-} = '-h' ]] || [[ ${1-} = '--help' ]] && echo "Dump the openQA postgresql database to ${DUMP_FOLDER} and clean-up backups older than ${DAYS_TO_KEEP} days." && exit
 
 ionice -c3 nice -n19 pg_dump -Fc -c openqa -f "${DUMP_FOLDER}/$(date -Idate).dump"
-find "${DUMP_FOLDER}" -mtime "+${DAYS_TO_KEEP}" -print0 -delete
+find -L "${DUMP_FOLDER}" -type f -mtime "+${DAYS_TO_KEEP}" -print0 -delete


### PR DESCRIPTION
This allows `$backup_dir` to be a symlink to a different location and should also increase stability a bit by only considering files to delete on cleanup.

Opposing to the suggestion in https://progress.opensuse.org/issues/181301#note-20 I decided *against* using a trailing `backup_dir/` to avoid a similar problem like we faced previously (variable being empty and then only having `/` as path remaining)