### PR TITLE
Block all distri git operations unless `scm = git` is set, add `git_auto_commit` setting, disentangle `git_auto_clone` and `git_auto_update`

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -725,8 +725,14 @@ section.
 
 === Setting up git support
 
-Editing needles from web can optionally commit new or changed needles
-automatically to git. To do so, you need to enable git support by setting
+If your tests and needles are stored in git, openQA can perform various operations:
+
+* Automatically commit needles created in the web UI editor back to the repository
+* Automatically update the repository when scheduling tests
+* Clone tests and needles from git repos specified in a job's `CASEDIR` and `NEEDLES_DIR`
+variables
+
+To enable these features, you need to enable git support by setting
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -734,8 +740,22 @@ automatically to git. To do so, you need to enable git support by setting
 scm = git
 --------------------------------------------------------------------------------
 in <<GettingStarted.asciidoc#_configuration,the web UI configuration>>.
-Once you do so and restart the web interface, openQA will automatically commit
-new needles to the git repository.
+Once you do so and restart the web interface, all of the above features will be enabled.
+
+To disable individual features, you can use these config settings:
+
+[source,ini]
+--------------------------------------------------------------------------------
+[scm git]
+git_auto_commit = no
+git_auto_clone = no
+git_auto_update = no
+--------------------------------------------------------------------------------
+
+`git_auto_commit` controls whether needles created or edited in the webUI editor are
+automatically committed. `git_auto_update` controls automatic test/needle updating
+when scheduling tests. `git_auto_clone` controls the automatic cloning of repos
+referenced by `CASEDIR` and `NEEDLES_DIR`.
 
 You may want to add some description to automatic commits coming from the web
 UI.

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -104,7 +104,11 @@
 ## can cause jobs to incomplete with "timestamp mismatch" error messages.
 #api_hmac_time_tolerance = 300
 
+## Configuration related to actions openQA may perform on a git distri
+## if 'scm' is set to 'git' in [global]
 #[scm git]
+## whether to automatically commit needles created in the editor back to git
+#git_auto_commit = yes
 ## name of remote to get updates from before committing changes (e.g. origin, leave out-commented to disable remote update)
 #update_remote = origin
 ## name of branch to rebase against before committing changes (e.g. origin/master, leave out-commented to disable rebase)

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -176,7 +176,7 @@ sub remove ($self, $user) {
     $app->log->debug("Remove needle $fname and $screenshot");
 
     my $git = OpenQA::Git->new({app => $app, dir => $self->directory->path, user => $user});
-    if ($git->enabled) {
+    if ($git->enabled && $git->config->{git_auto_commit} eq 'yes') {
         my $directory = $self->directory;
         my $error = $git->commit(
             {

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -100,6 +100,7 @@ sub read_config ($app) {
             require_for_assets => 0,
         },
         'scm git' => {
+            git_auto_commit => 'yes',
             update_remote => '',
             update_branch => '',
             do_push => 'no',

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -235,8 +235,10 @@ sub enqueue_download_jobs ($self, $downloads, $minion_ids = undef) {
 }
 
 sub enqueue_git_update_all ($self) {
-    my $conf = OpenQA::App->singleton->config->{'scm git'};
-    return if $conf->{git_auto_clone} ne 'yes' || $conf->{git_auto_update} ne 'yes';
+    my $conf = OpenQA::App->singleton->config;
+    return if ($conf->{global}->{scm} // '') ne 'git';
+    return if $conf->{'scm git'}->{git_auto_clone} ne 'yes';
+    return if $conf->{'scm git'}->{git_auto_update} ne 'yes';
     my %clones;
     my $testdir = path(sharedir() . '/tests');
     for my $distri ($testdir->list({dir => 1})->each) {
@@ -263,7 +265,9 @@ sub enqueue_git_update_all ($self) {
 
 sub enqueue_git_clones ($self, $clones, $job_ids, $minion_ids = undef) {
     return unless keys %$clones;
-    return unless OpenQA::App->singleton->config->{'scm git'}->{git_auto_clone} eq 'yes';
+    my $conf = OpenQA::App->singleton->config;
+    return unless ($conf->{global}->{scm} // '') eq 'git';
+    return unless $conf->{'scm git'}->{git_auto_clone} eq 'yes';
     # $clones is a hashref with paths as keys and git urls as values
     # $job_id is used to create entries in a related table (gru_dependencies)
 

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -266,7 +266,6 @@ sub enqueue_git_clones ($self, $clones, $job_ids, $minion_ids = undef) {
     return unless keys %$clones;
     my $conf = OpenQA::App->singleton->config;
     return unless ($conf->{global}->{scm} // '') eq 'git';
-    return unless $conf->{'scm git'}->{git_auto_clone} eq 'yes';
     # $clones is a hashref with paths as keys and git urls as values
     # $job_id is used to create entries in a related table (gru_dependencies)
 

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -237,7 +237,6 @@ sub enqueue_download_jobs ($self, $downloads, $minion_ids = undef) {
 sub enqueue_git_update_all ($self) {
     my $conf = OpenQA::App->singleton->config;
     return if ($conf->{global}->{scm} // '') ne 'git';
-    return if $conf->{'scm git'}->{git_auto_clone} ne 'yes';
     return if $conf->{'scm git'}->{git_auto_update} ne 'yes';
     my %clones;
     my $testdir = path(sharedir() . '/tests');

--- a/lib/OpenQA/Task/Git/Clone.pm
+++ b/lib/OpenQA/Task/Git/Clone.pm
@@ -26,6 +26,9 @@ sub register ($self, $app, @) {
 sub _git_clone_all ($job, $clones) {
     my $app = $job->app;
     my $job_id = $job->id;
+    # failsafe check - we should never actually get here with git
+    # disabled, but just in case
+    return if (($app->config->{global}->{scm} // '') ne 'git');
 
     my $retry_delay = {delay => 30 + int(rand(10))};
     # Prevent multiple git_clone tasks for the same path to run in parallel
@@ -75,14 +78,13 @@ sub _git_clone_all ($job, $clones) {
 
         # unblock openQA jobs despite network errors under best-effort configuration
         my $retries = $job->retries;
-        my $git_config = $app->config->{'scm git'};
         my $max_retries = $ENV{OPENQA_GIT_CLONE_RETRIES} // 10;
         my $max_best_effort_retries = min($max_retries, $ENV{OPENQA_GIT_CLONE_RETRIES_BEST_EFFORT} // 2);
         my $gru_task_id = $job->info->{notes}->{gru_id};
         if (   $is_path_only
             && defined($gru_task_id)
             && ($error =~ m/disconnect|curl|stream.*closed|/i)
-            && $git_config->{git_auto_update_method} eq 'best-effort'
+            && $git->config->{git_auto_update_method} eq 'best-effort'
             && $retries >= $max_best_effort_retries)
         {
             $app->schema->resultset('GruDependencies')->search({gru_task_id => $gru_task_id})->delete;

--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -101,7 +101,7 @@ sub _save_needle {
 
     # ensure needle dir is up-to-date
     my $git = OpenQA::Git->new({app => $app, dir => $needledir, user => $user});
-    if ($git->enabled) {
+    if ($git->enabled && $git->config->{git_auto_commit} eq 'yes') {
         my $error = $git->set_to_latest_master;
         if ($error) {
             $app->log->error($error);
@@ -136,7 +136,7 @@ sub _save_needle {
     return $minion_job->fail({error => "<strong>Error creating/updating needle:</strong><br>$!."}) unless $success;
 
     # commit needle in Git repository
-    if ($git->enabled) {
+    if ($git->enabled && $git->config->{git_auto_commit} eq 'yes') {
         my $error = $git->commit(
             {
                 add => ["$needlename.json", "$needlename.png"],

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -535,7 +535,8 @@ sub create_downloads_list ($job_settings) {
 
 sub create_git_clone_list ($job_settings, $clones = {}) {
     my $distri = $job_settings->{DISTRI};
-    if (OpenQA::App->singleton->config->{'scm git'}->{git_auto_update} eq 'yes') {
+    my $config = OpenQA::App->singleton->config;
+    if (($config->{global}->{scm} // '') eq 'git' && $config->{'scm git'}->{git_auto_update} eq 'yes') {
         # Potential existing git clones to update without having CASEDIR or NEEDLES_DIR
         not $job_settings->{CASEDIR} and $clones->{testcasedir($distri)} = undef;
         not $job_settings->{NEEDLES_DIR} and $clones->{needledir($distri)} = undef;

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -263,7 +263,8 @@ sub edit ($self) {
             tags => $tags,
             default_needle => $default_needle,
             error_messages => \@error_messages,
-            git_enabled => ($app->config->{global}->{scm} // '') eq 'git',
+            git_enabled => ($app->config->{global}->{scm} // '') eq 'git'
+              && $app->config->{'scm git'}->{git_auto_commit} eq 'yes',
         });
     $self->render('step/edit');
 }

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -107,6 +107,7 @@ sub view ($self) {
 
 sub _get_needles_ref_and_url ($self, $job) {
     # Return tuple of git ref hash and url of needles or undef on error.
+    return undef unless ($self->app->config->{global}->{scm} // '') eq 'git';
     return undef unless $self->app->config->{'scm git'}->{checkout_needles_sha} eq 'yes';
     my $json_path = path($job->result_dir, 'vars.json');
     my $vars = defined $job->result_dir && -e $json_path ? decode_json($json_path->slurp) : undef;

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -458,6 +458,7 @@ subtest 'delete_needles' => sub {
 
     # now enable git
     $t->app->config->{global}->{scm} = 'git';
+    $t->app->config->{git_auto_commit} = 'yes';
     $t->app->config->{'scm git'}->{do_push} = 'yes';
     my $openqa_git = Test::MockModule->new('OpenQA::Git');
     my @cmds;

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -289,6 +289,8 @@ subtest 'git_update_all' => sub {
     $t->app->config->{global}->{scm} = '';
     my $git_config = $t->app->config->{'scm git'};
     $git_config->{git_auto_update} = 'no';
+    # test that this never disables update_all, it shouldn't
+    $git_config->{git_auto_clone} = 'no';
 
     my $result = $t->app->gru->enqueue_git_update_all;
     is $result, undef, 'gru task not created yet';
@@ -304,7 +306,8 @@ subtest 'git_update_all' => sub {
     $result = $t->app->gru->enqueue_git_update_all;
     is $result, undef, 'gru task not created yet';
 
-    # now enable both
+    # now enable both, but leave auto_clone disabled, it should not
+    # interfere
     $t->app->config->{global}->{scm} = 'git';
     $result = $t->app->gru->enqueue_git_update_all;
     my $minion = $t->app->minion;

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -359,24 +359,11 @@ subtest 'enqueue_git_clones' => sub {
 
     # disable git, first
     $t->app->config->{global}->{scm} = '';
-    my $git_config = $t->app->config->{'scm git'};
-    $git_config->{git_auto_clone} = 'no';
 
     my $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
     is $result, undef, 'gru task not created yet';
 
-    # now enable git but leave auto_clone disabled
-    $t->app->config->{global}->{scm} = 'git';
-    $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
-    is $result, undef, 'gru task not created yet';
-
-    # now enable auto_clone but disable git
-    $t->app->config->{global}->{scm} = '';
-    $git_config->{git_auto_clone} = 'yes';
-    $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
-    is $result, undef, 'gru task not created yet';
-
-    # now enable both
+    # now enable it
     $t->app->config->{global}->{scm} = 'git';
     $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
 

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -50,6 +50,9 @@ my $webapi = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
 # prevent writing to a log file to enable use of combined_like in the following tests
 $t->app->log(Mojo::Log->new(level => 'info'));
 
+# ensure git is enabled
+$t->app->config->{global}->{scm} = 'git';
+
 subtest 'git clone' => sub {
     my $openqa_git = Test::MockModule->new('OpenQA::Git');
     my @mocked_git_calls;
@@ -271,8 +274,6 @@ subtest 'git_update_all' => sub {
     my $openqa_git = Test::MockModule->new('OpenQA::Git');
     $openqa_git->redefine(get_origin_url => 'foo');
 
-    my $git_config = $t->app->config->{'scm git'};
-    $git_config->{git_auto_update} = 'yes';
     my $testdir = $workdir->child('openqa/share/tests');
     $testdir->make_path;
     my @clones;
@@ -283,8 +284,30 @@ subtest 'git_update_all' => sub {
     local $ENV{OPENQA_BASEDIR} = $workdir;
     local $ENV{OPENQA_GIT_CLONE_RETRIES} = 4;
     local $ENV{OPENQA_GIT_CLONE_RETRIES_BEST_EFFORT} = 2;
-    my $minion = $t->app->minion;
+
+    # disable git, first
+    $t->app->config->{global}->{scm} = '';
+    my $git_config = $t->app->config->{'scm git'};
+    $git_config->{git_auto_update} = 'no';
+
     my $result = $t->app->gru->enqueue_git_update_all;
+    is $result, undef, 'gru task not created yet';
+
+    # now enable git but leave auto_update disabled
+    $t->app->config->{global}->{scm} = 'git';
+    $result = $t->app->gru->enqueue_git_update_all;
+    is $result, undef, 'gru task not created yet';
+
+    # now enable auto_update but disable git
+    $t->app->config->{global}->{scm} = '';
+    $git_config->{git_auto_update} = 'yes';
+    $result = $t->app->gru->enqueue_git_update_all;
+    is $result, undef, 'gru task not created yet';
+
+    # now enable both
+    $t->app->config->{global}->{scm} = 'git';
+    $result = $t->app->gru->enqueue_git_update_all;
+    my $minion = $t->app->minion;
     my $job = $minion->job($result->{minion_id});
     my $args = $job->info->{args}->[0];
     my $gru_id = $result->{gru_id};
@@ -330,7 +353,30 @@ subtest 'enqueue_git_clones' => sub {
     my $clones = {x => 'y'};
     my @j = map { $schema->resultset('Jobs')->create({state => 'scheduled', TEST => "t$_"}); } 1 .. 5;
     my $jobs = [$j[0]->id, $j[1]->id];
+
+    # disable git, first
+    $t->app->config->{global}->{scm} = '';
+    my $git_config = $t->app->config->{'scm git'};
+    $git_config->{git_auto_clone} = 'no';
+
     my $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
+    is $result, undef, 'gru task not created yet';
+
+    # now enable git but leave auto_clone disabled
+    $t->app->config->{global}->{scm} = 'git';
+    $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
+    is $result, undef, 'gru task not created yet';
+
+    # now enable auto_clone but disable git
+    $t->app->config->{global}->{scm} = '';
+    $git_config->{git_auto_clone} = 'yes';
+    $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
+    is $result, undef, 'gru task not created yet';
+
+    # now enable both
+    $t->app->config->{global}->{scm} = 'git';
+    $result = $t->app->gru->enqueue_git_clones($clones, $jobs);
+
     my $minion_job = $minion->job($result->{minion_id});
     my $job_id = $minion_job->id;
     my $task = $schema->resultset('GruTasks')->find($result->{gru_id});
@@ -378,6 +424,10 @@ qr{GruTask 999 already gone.*insert or update on table "gru_dependencies" violat
 $t->app->log(Mojo::Log->new(level => 'info'));
 
 subtest 'delete_needles' => sub {
+    # disable git to start with, as the ad hoc distris we create are
+    # not yet git repos, so if it's enabled the delete_needles task
+    # fails
+    $t->app->config->{global}->{scm} = '';
     my $needledirs = $schema->resultset('NeedleDirs');
     my $needles = $schema->resultset('Needles');
     $needledirs->create({id => 1, path => 't/data/openqa/share/tests/archlinux/needles', 'name' => 'test'});
@@ -406,6 +456,7 @@ subtest 'delete_needles' => sub {
     $error = $res->{result}->{errors}->[0];
     like $error->{message}, qr{Unable to find needle.*99}, 'expected error for not existing needle';
 
+    # now enable git
     $t->app->config->{global}->{scm} = 'git';
     $t->app->config->{'scm git'}->{do_push} = 'yes';
     my $openqa_git = Test::MockModule->new('OpenQA::Git');

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -210,6 +210,7 @@ setup_fullstack_temp_dir('21-needles');
 subtest 'controller->_get_needles_ref_and_url' => sub {
     my $controller = OpenQA::WebAPI::Controller::Step->new;
     $controller->app($t->app);
+    $controller->app->config->{global}->{scm} = 'git';
     $controller->app->config->{'scm git'} = {checkout_needles_sha => 'yes'};
 
     subtest 'without fragment and needles_git_hash in vars' => sub {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -62,6 +62,7 @@ $ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
 
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
 my $cfg = $t->app->config;
+$cfg->{global}->{scm} = 'git';
 $cfg->{'scm git'}->{git_auto_clone} = 'no';
 $cfg->{'scm git'}->{git_auto_update} = 'no';
 is $cfg->{audit}->{blocklist}, 'job_grab', 'blocklist updated';

--- a/t/config.t
+++ b/t/config.t
@@ -78,6 +78,7 @@ subtest 'Test configuration default modes' => sub {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
+            git_auto_commit => 'yes',
             git_auto_update => 'yes',
             git_auto_update_method => 'best-effort',
             checkout_needles_sha => 'no',


### PR DESCRIPTION
This is my attempt to resolve the issues I found diving into the `git_auto_update` and `git_auto_clone` stuff, which is new to me (haven't updated Fedora's openQA since last year). See https://github.com/os-autoinst/openQA/pull/6039#issuecomment-2845218269 for the notes that led me to this.

Most importantly, this attempts to disable all git cloning shenanigans if the global config section does not have `scm = git`, because the older automatic-needle-commit feature kinda establishes that expectation. Beyond that, we add a `git_auto_commit` setting so you can have autoclone and/or autoupdate enabled without autocommit, and try to disentangle `git_auto_clone` and `git_auto_update` so you can have `auto_update` working fully without `auto_clone` (which I don't think is currently possible).