### PR TITLE
Revert "Block all distri git operations unless `scm = git` is set" due to unexpected change of default behaviour

### DIFF
--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -725,14 +725,8 @@ section.
 
 === Setting up git support
 
-If your tests and needles are stored in git, openQA can perform various operations:
-
-* Automatically commit needles created in the web UI editor back to the repository
-* Automatically update the repository when scheduling tests
-* Clone tests and needles from git repos specified in a job's `CASEDIR` and `NEEDLES_DIR`
-variables
-
-To enable these features, you need to enable git support by setting
+Editing needles from web can optionally commit new or changed needles
+automatically to git. To do so, you need to enable git support by setting
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -740,22 +734,8 @@ To enable these features, you need to enable git support by setting
 scm = git
 --------------------------------------------------------------------------------
 in <<GettingStarted.asciidoc#_configuration,the web UI configuration>>.
-Once you do so and restart the web interface, all of the above features will be enabled.
-
-To disable individual features, you can use these config settings:
-
-[source,ini]
---------------------------------------------------------------------------------
-[scm git]
-git_auto_commit = no
-git_auto_clone = no
-git_auto_update = no
---------------------------------------------------------------------------------
-
-`git_auto_commit` controls whether needles created or edited in the webUI editor are
-automatically committed. `git_auto_update` controls automatic test/needle updating
-when scheduling tests. `git_auto_clone` controls the automatic cloning of repos
-referenced by `CASEDIR` and `NEEDLES_DIR`.
+Once you do so and restart the web interface, openQA will automatically commit
+new needles to the git repository.
 
 You may want to add some description to automatic commits coming from the web
 UI.

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -104,11 +104,7 @@
 ## can cause jobs to incomplete with "timestamp mismatch" error messages.
 #api_hmac_time_tolerance = 300
 
-## Configuration related to actions openQA may perform on a git distri
-## if 'scm' is set to 'git' in [global]
 #[scm git]
-## whether to automatically commit needles created in the editor back to git
-#git_auto_commit = yes
 ## name of remote to get updates from before committing changes (e.g. origin, leave out-commented to disable remote update)
 #update_remote = origin
 ## name of branch to rebase against before committing changes (e.g. origin/master, leave out-commented to disable rebase)

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -176,7 +176,7 @@ sub remove ($self, $user) {
     $app->log->debug("Remove needle $fname and $screenshot");
 
     my $git = OpenQA::Git->new({app => $app, dir => $self->directory->path, user => $user});
-    if ($git->enabled && $git->config->{git_auto_commit} eq 'yes') {
+    if ($git->enabled) {
         my $directory = $self->directory;
         my $error = $git->commit(
             {

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -100,7 +100,6 @@ sub read_config ($app) {
             require_for_assets => 0,
         },
         'scm git' => {
-            git_auto_commit => 'yes',
             update_remote => '',
             update_branch => '',
             do_push => 'no',

--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -235,9 +235,8 @@ sub enqueue_download_jobs ($self, $downloads, $minion_ids = undef) {
 }
 
 sub enqueue_git_update_all ($self) {
-    my $conf = OpenQA::App->singleton->config;
-    return if ($conf->{global}->{scm} // '') ne 'git';
-    return if $conf->{'scm git'}->{git_auto_update} ne 'yes';
+    my $conf = OpenQA::App->singleton->config->{'scm git'};
+    return if $conf->{git_auto_clone} ne 'yes' || $conf->{git_auto_update} ne 'yes';
     my %clones;
     my $testdir = path(sharedir() . '/tests');
     for my $distri ($testdir->list({dir => 1})->each) {
@@ -264,8 +263,7 @@ sub enqueue_git_update_all ($self) {
 
 sub enqueue_git_clones ($self, $clones, $job_ids, $minion_ids = undef) {
     return unless keys %$clones;
-    my $conf = OpenQA::App->singleton->config;
-    return unless ($conf->{global}->{scm} // '') eq 'git';
+    return unless OpenQA::App->singleton->config->{'scm git'}->{git_auto_clone} eq 'yes';
     # $clones is a hashref with paths as keys and git urls as values
     # $job_id is used to create entries in a related table (gru_dependencies)
 

--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -101,7 +101,7 @@ sub _save_needle {
 
     # ensure needle dir is up-to-date
     my $git = OpenQA::Git->new({app => $app, dir => $needledir, user => $user});
-    if ($git->enabled && $git->config->{git_auto_commit} eq 'yes') {
+    if ($git->enabled) {
         my $error = $git->set_to_latest_master;
         if ($error) {
             $app->log->error($error);
@@ -136,7 +136,7 @@ sub _save_needle {
     return $minion_job->fail({error => "<strong>Error creating/updating needle:</strong><br>$!."}) unless $success;
 
     # commit needle in Git repository
-    if ($git->enabled && $git->config->{git_auto_commit} eq 'yes') {
+    if ($git->enabled) {
         my $error = $git->commit(
             {
                 add => ["$needlename.json", "$needlename.png"],

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -535,25 +535,20 @@ sub create_downloads_list ($job_settings) {
 
 sub create_git_clone_list ($job_settings, $clones = {}) {
     my $distri = $job_settings->{DISTRI};
-    my $config = OpenQA::App->singleton->config;
-    return $clones if (($config->{global}->{scm} // '') ne 'git');
-    if ($config->{'scm git'}->{git_auto_update} eq 'yes') {
+    if (OpenQA::App->singleton->config->{'scm git'}->{git_auto_update} eq 'yes') {
         # Potential existing git clones to update without having CASEDIR or NEEDLES_DIR
         not $job_settings->{CASEDIR} and $clones->{testcasedir($distri)} = undef;
         not $job_settings->{NEEDLES_DIR} and $clones->{needledir($distri)} = undef;
     }
-    if ($config->{'scm git'}->{git_auto_clone} eq 'yes') {
-        # Check CASEDIR and NEEDLES_DIR
-        my $case_url = Mojo::URL->new($job_settings->{CASEDIR} // '');
-        my $needles_url = Mojo::URL->new($job_settings->{NEEDLES_DIR} // '');
-        if ($case_url->scheme) {
-            $case_url->fragment($job_settings->{TEST_GIT_REFSPEC}) if ($job_settings->{TEST_GIT_REFSPEC});
-            $clones->{testcasedir($distri)} = $case_url;
-        }
-        if ($needles_url->scheme) {
-            $needles_url->fragment($job_settings->{NEEDLES_GIT_REFSPEC}) if ($job_settings->{NEEDLES_GIT_REFSPEC});
-            $clones->{needledir($distri)} = $needles_url;
-        }
+    my $case_url = Mojo::URL->new($job_settings->{CASEDIR} // '');
+    my $needles_url = Mojo::URL->new($job_settings->{NEEDLES_DIR} // '');
+    if ($case_url->scheme) {
+        $case_url->fragment($job_settings->{TEST_GIT_REFSPEC}) if ($job_settings->{TEST_GIT_REFSPEC});
+        $clones->{testcasedir($distri)} = $case_url;
+    }
+    if ($needles_url->scheme) {
+        $needles_url->fragment($job_settings->{NEEDLES_GIT_REFSPEC}) if ($job_settings->{NEEDLES_GIT_REFSPEC});
+        $clones->{needledir($distri)} = $needles_url;
     }
     return $clones;
 }

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -107,7 +107,6 @@ sub view ($self) {
 
 sub _get_needles_ref_and_url ($self, $job) {
     # Return tuple of git ref hash and url of needles or undef on error.
-    return undef unless ($self->app->config->{global}->{scm} // '') eq 'git';
     return undef unless $self->app->config->{'scm git'}->{checkout_needles_sha} eq 'yes';
     my $json_path = path($job->result_dir, 'vars.json');
     my $vars = defined $job->result_dir && -e $json_path ? decode_json($json_path->slurp) : undef;
@@ -263,8 +262,7 @@ sub edit ($self) {
             tags => $tags,
             default_needle => $default_needle,
             error_messages => \@error_messages,
-            git_enabled => ($app->config->{global}->{scm} // '') eq 'git'
-              && $app->config->{'scm git'}->{git_auto_commit} eq 'yes',
+            git_enabled => ($app->config->{global}->{scm} // '') eq 'git',
         });
     $self->render('step/edit');
 }

--- a/t/21-needles.t
+++ b/t/21-needles.t
@@ -210,7 +210,6 @@ setup_fullstack_temp_dir('21-needles');
 subtest 'controller->_get_needles_ref_and_url' => sub {
     my $controller = OpenQA::WebAPI::Controller::Step->new;
     $controller->app($t->app);
-    $controller->app->config->{global}->{scm} = 'git';
     $controller->app->config->{'scm git'} = {checkout_needles_sha => 'yes'};
 
     subtest 'without fragment and needles_git_hash in vars' => sub {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -62,7 +62,6 @@ $ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
 
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
 my $cfg = $t->app->config;
-$cfg->{global}->{scm} = 'git';
 $cfg->{'scm git'}->{git_auto_clone} = 'no';
 $cfg->{'scm git'}->{git_auto_update} = 'no';
 is $cfg->{audit}->{blocklist}, 'job_grab', 'blocklist updated';

--- a/t/config.t
+++ b/t/config.t
@@ -78,7 +78,6 @@ subtest 'Test configuration default modes' => sub {
             do_push => 'no',
             do_cleanup => 'no',
             git_auto_clone => 'yes',
-            git_auto_commit => 'yes',
             git_auto_update => 'yes',
             git_auto_update_method => 'best-effort',
             checkout_needles_sha => 'no',


### PR DESCRIPTION
Reverts os-autoinst/openQA#6414 due to unexpected change of default behaviour. I tried to ensure that git auto-clone+update are still enabled by default with #6421 by setting the global config key `scm` by default to `git` however that also means that automatic git commits of needles are enabled. #6414 introduced a new config for automatic git commits but disabling that by default also breaks compatibility with existing instances so I see no better option than to fully revert #6414