### PR TITLE
Render the SUSE "review:acceptable_for" button on overview as well

### DIFF
--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -597,6 +597,8 @@ subtest 'SUSE branding' => sub {
     my $btn_sel = '#commentForm .comment-toolbar a.fa-unlink';
     $t->attr_like($btn_sel, 'title', qr/Add marker.*approved/, 'button title for adding review marker');
     $t->attr_like($btn_sel, 'data-template', qr/\@review:acceptable_for/, 'button template for adding review marker');
+    $t->get_ok('/tests/overview?build=0091&result=none')->status_is(200, 'test overview page');
+    $t->attr_like('a.fa-unlink', 'data-template', qr/\@review:acceptable_for/, 'review marker on test overview page');
 };
 
 subtest 're-routing' => sub {

--- a/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
+++ b/templates/webapi/branding/openqa.suse.de/commenting_tools.html.ep
@@ -1,5 +1,4 @@
-% my $current_job = stash 'job';
-% if ($current_job && !$current_job->is_ok) {
+% if (!$group_comment) {
     <a class="help_popover fa fa-unlink" title="Add marker so the specified maintenance incident will be approved despite this job"
        role="button" data-template="@review:acceptable_for:incident_<incident_id>:<reason>" onclick="insertTemplate(this)"></a>
     <br>


### PR DESCRIPTION
This was brought up by colleague Ricardo Branco who expected the button
for the template text. Thanks Ricardo!