### PR TITLE
Update checkstyle invocation in run-tests-within-container script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,6 @@ node_modules: package-lock.json
 	@touch node_modules
 
 .PHONY: test
-ifeq ($(TRAVIS),true)
-test: run-tests-within-container
-else
 ifeq ($(CHECKSTYLE),0)
 checkstyle_tests =
 else
@@ -194,7 +191,6 @@ endif
 ifeq ($(HELM_TEST),1)
 ifeq ($(TESTS),)
 test: test-helm-chart
-endif
 endif
 endif
 

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -643,6 +643,11 @@ Run tests by spawning a container manually, e.g.:
 
 Replace `OPENQA_LOCAL_CODE` with the location where you have the openQA code.
 
+NOTE: `run-tests-within-container` runs with CONTAINER_TEST enabled by default.
+It is used to run scripts which are not meant to run inside *openqa_devel* and
+the image itself does not contain any container engine. Consider disabling it
+to run any tests in a container.
+
 The command line to run tests manually reveals that the Makefile target
 `run-tests-within-container` is used to run the tests *inside* the container.
 It does some preparations to be able to run the full stack test within a

--- a/tools/run-tests-within-container
+++ b/tools/run-tests-within-container
@@ -44,7 +44,7 @@ run_fullstack_test() {
 if [ "$FULLSTACK" = 1 ]; then
     run_fullstack_test t/full-stack.t t/05-scheduler-full.t t/33-developer_mode.t
 elif [ "$CHECKSTYLE" = 1 ]; then
-    make checkstyle || touch tests_failed
+    make test-checkstyle || touch tests_failed
 else
     if [ "$UITESTS" = 1 ]; then
         list=$(find ./t/ui -name '*.t' | sort)

--- a/tools/run-tests-within-container
+++ b/tools/run-tests-within-container
@@ -3,10 +3,12 @@ INSTALL_FROM_CPAN="${INSTALL_FROM_CPAN:-0}"
 
 export OPENQA_LOGFILE=/opt/openqa/openqa-debug.log
 
+TESTS_FAILED_FLAG=0
+
 run_test() {
     # Allow command line options without quotes
     # shellcheck disable=SC2086
-    prove -l ${PROVE_ARGS} "$@" || touch tests_failed
+    prove -l ${PROVE_ARGS} "$@" || TESTS_FAILED_FLAG=1
 }
 
 prepare_fullstack_test() {
@@ -35,7 +37,7 @@ run_fullstack_test() {
 
     export PERL5OPT="$PERL5OPT $HARNESS_PERL_SWITCHES"
     if ! prove -l "${PROVE_ARGS}" "$@"; then
-        touch tests_failed
+        TESTS_FAILED_FLAG=1
         find '/tmp' -path '*/t/full-stack.d/openqa/testresults/*/autoinst-log.txt' \
             -exec echo 'contents of' {} \; -exec cat {} \; 2> /dev/null > '/opt/openqa/autoinst-log.txt'
     fi
@@ -44,7 +46,7 @@ run_fullstack_test() {
 if [ "$FULLSTACK" = 1 ]; then
     run_fullstack_test t/full-stack.t t/05-scheduler-full.t t/33-developer_mode.t
 elif [ "$CHECKSTYLE" = 1 ]; then
-    make test-checkstyle || touch tests_failed
+    make test-checkstyle || TESTS_FAILED_FLAG=1
 else
     if [ "$UITESTS" = 1 ]; then
         list=$(find ./t/ui -name '*.t' | sort)
@@ -56,5 +58,4 @@ else
     run_test -r $list
 fi
 
-[ -r tests_failed ] && exit 1
-exit 0
+exit "$TESTS_FAILED_FLAG"

--- a/tools/run-tests-within-container
+++ b/tools/run-tests-within-container
@@ -57,6 +57,4 @@ else
 fi
 
 [ -r tests_failed ] && exit 1
-if test -n "$TRAVIS"; then
-    cp -a assets/cache/* /opt/openqa/assets/cache
-fi
+exit 0


### PR DESCRIPTION
- Rename to the corresponding phony command in the run-tests-within-containe
- replace tests_failed with a variable flag
- Add note in the documentation for transparency of CONTAINER_TEST impact
- Remove deprecated TRAVIS variable

I hope those changes provide a small improvement. if you run now `podman run --rm -v /home/iob/openqadev/openQA/:/opt/openqa -e CHECKSTYLE=1 -e CONTAINER_TEST=0  openqa_devel:latest make run-tests-within-container` it should run successfully the checkstyle tests. CONTAINER_TEST will still be required as by default is enabled and this didnt change. hopefully the documentation makes this a bit obvious