### PR TITLE
Avoid permission errors when flagging a Git server outage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install-generic:
 		install -m 644 -D --target-directory="$(DESTDIR)/usr/share/openqa/$${f%/*}" "$$f";\
 	done
 
-	for i in db images testresults pool ; do \
+	for i in db images testresults pool/1 cache webui/cache; do \
 		mkdir -p "$(DESTDIR)"/var/lib/openqa/$$i ;\
 	done
 # shared dirs between openQA web and workers + compatibility links

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -422,11 +422,6 @@ done
 install -D -m 644 /dev/null %{buildroot}%{_localstatedir}/log/openqa
 install -m 0644 %{_sourcedir}/openQA.changes %{buildroot}%{_datadir}/openqa/public/Changelog
 #
-mkdir %{buildroot}%{_localstatedir}/lib/openqa/pool/1
-mkdir %{buildroot}%{_localstatedir}/lib/openqa/cache
-mkdir %{buildroot}%{_localstatedir}/lib/openqa/webui
-mkdir %{buildroot}%{_localstatedir}/lib/openqa/webui/cache
-#
 %fdupes %{buildroot}/%{_prefix}
 
 %if 0%{?suse_version} > 1500

--- a/lib/OpenQA/Git/ServerAvailability.pm
+++ b/lib/OpenQA/Git/ServerAvailability.pm
@@ -18,7 +18,7 @@ use constant {
 };
 
 sub _state_file ($app, $server_name) {
-    return path(($ENV{OPENQA_GIT_SERVER_OUTAGE_FILE} // prjdir . '/git_server_outage') . ".$server_name.flag");
+    return path(($ENV{OPENQA_GIT_SERVER_OUTAGE_FILE} // prjdir . '/webui/git_server_outage') . ".$server_name.flag");
 }
 
 sub report_server_available ($app, $server_name) {


### PR DESCRIPTION
* Use the usual `webui` sub directory where the web UI services already
  have write permissions
* Install all relevant dirs under /var/lib/openqa via Makefile, see separate commit for details
* See https://progress.opensuse.org/issues/179038