### PR TITLE
Distribute openqa_devel container with podman

### DIFF
--- a/container/devel/Dockerfile
+++ b/container/devel/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper in -y os-autoinst-devel openQA-devel vim nodejs-default git mc perl-Devel-REPL perl-Term-ReadKey && \
+RUN zypper in -y os-autoinst-devel openQA-devel vim nodejs-default git mc perl-Devel-REPL perl-Term-ReadKey podman && \
     zypper clean -a
 
 ENV OPENQA_DIR /opt/openqa


### PR DESCRIPTION
Running the openqa_devel as it is described, there is a complication of running scripts, which whatever their intention it should not fail. one of them is the `static_check_containers` which runs by default with podman but the container lacks the executable.