### PR TITLE
Ensure fullstack tests run even under high load

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -298,6 +298,9 @@ CACHEDIRECTORY = $cache_location
 CACHELIMIT = 50
 LOCAL_UPLOAD = 0
 
+# Ensure fullstack tests run even under high load.
+CRITICAL_LOAD_AVG_THRESHOLD = 0
+
 [1]
 WORKER_CLASS = qemu_i386,qemu_x86_64
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/182168

I double checked it by setting CRITICAL_LOAD_AVG_THRESHOLD to 0.1 and it failed.

c0c0d8a8dc595d7da33f9e6f5714f565e1eb83d9 did this change in t/data/workers.ini, but here full-stack.t uses a different file