### PR TITLE
Allow showing finished jobs blocking an incident on "All tests" page

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -257,9 +257,12 @@ function renderTestLists() {
       this[paramName] = paramValues[0];
     }
   };
-  jQuery.each(['limit', 'groupid', 'match', 'group_glob', 'not_group_glob', 'comment'], (index, paramName) => {
-    ajaxQueryParams.addFirstParam(paramName);
-  });
+  jQuery.each(
+    ['limit', 'groupid', 'match', 'group_glob', 'not_group_glob', 'job_setting', 'comment'],
+    (index, paramName) => {
+      ajaxQueryParams.addFirstParam(paramName);
+    }
+  );
   delete ajaxQueryParams.addFirstParam;
   filters.forEach(filter => {
     const param = pageQueryParams[filter];

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -327,13 +327,15 @@ sub _prepare_complex_query_search_args ($self, $args) {
         push @conds, \['(select id from comments where job_id = me.id and text like ? limit 1) is not null', "%$c%"];
     }
 
-    push(@conds, @{$args->{additional_conds}}) if $args->{additional_conds};
+    if (my $additional_conds = $args->{additional_conds}) { push @conds, @$additional_conds }
+    if (my $additional_joins = $args->{additional_joins}) { push @joins, @$additional_joins }
     my %attrs;
     $attrs{columns} = $args->{columns} if $args->{columns};
     $attrs{prefetch} = $args->{prefetch} if $args->{prefetch};
     $attrs{rows} = $args->{limit} if $args->{limit};
     $attrs{offset} = $args->{offset} if $args->{offset};
     $attrs{order_by} = $args->{order_by} || ['me.id DESC'];
+    if (my $group_by = $args->{group_by}) { $attrs{group_by} = $group_by }
     $attrs{join} = \@joins if @joins;
     return (\@conds, \%attrs);
 }

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -218,6 +218,15 @@ subtest 'scheduled jobs server-side limit has precedence over user-specified lim
     $schema->txn_rollback;
 };
 
+subtest 'filtering by job settings' => sub {
+    $driver->get('/tests?job_setting=^HDD_1$=x86_64.hd.?$');
+    wait_for_ajax(msg => 'DataTables on "All tests" page for filtered jobs');
+    my $s
+      = "return Array.from(document.querySelectorAll('#results td:nth-child(2)').values().map(e => e.textContent.trim()))";
+    my $tests = $driver->execute_script($s);
+    is_deeply $tests, ['kde@64bit', 'kde@64bit-uefi', 'textmode@32bit'], 'expected set of tests present';
+};
+
 subtest 'available comments shown' => sub {
     $driver->get('/tests');
     wait_for_ajax(msg => 'DataTables on "All tests" page for comments');


### PR DESCRIPTION
See particular commit messages and https://progress.opensuse.org/issues/156553

---

It is perhaps not ideal to pass the regex unsanitized to to the database. Hence this is still a draft but I suppose it is sufficient as spike solution. (I first tried with a simple glob but I don't think this would be sufficient here, see the 2nd commit message.)

The performance is also problematic but this was of course expected. At least the performance is only impacted when the query parameter is used and when I tested it locally with OSD production data is was returning results after several seconds.