### PR TITLE
Add API route to show all not-ok jobs

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -321,6 +321,7 @@ sub startup ($self) {
 
     # api/v1/job_settings/jobs
     $api_public_r->get('/job_settings/jobs')->name('apiv1_get_jobs_for_job_settings')->to('job_settings#jobs');
+    $api_public_r->get('/job_settings/blocked_jobs')->name('apiv1_get_blocked_jobs')->to('job_settings#failed_jobs');
 
     my $job_r = $api_ro->any('/jobs/<jobid:num>');
     push @api_routes, $job_r;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobSettings.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobSettings.pm
@@ -3,6 +3,7 @@
 
 package OpenQA::WebAPI::Controller::API::V1::JobSettings;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
+use OpenQA::Jobs::Constants qw(NOT_OK_RESULTS);
 
 sub jobs ($self) {
     my $validation = $self->validation;
@@ -13,6 +14,20 @@ sub jobs ($self) {
     my $key = $validation->param('key');
     my $list_value = $validation->param('list_value');
     my $jobs = $self->schema->resultset('JobSettings')->jobs_for_setting({key => $key, list_value => $list_value});
+    $self->render(json => {jobs => $jobs});
+}
+
+sub failed_jobs ($self) {
+    my $validation = $self->validation;
+    $validation->required('key')->like(qr/^[\w\*]+$/);
+    $validation->required('list_value')->like(qr/^\w+$/);
+    return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
+
+    my $key = $validation->param('key');
+    my $list_value = $validation->param('list_value');
+    my @list_result = NOT_OK_RESULTS;
+    my $jobs = $self->schema->resultset('JobSettings')
+      ->jobs_for_setting({key => $key, list_value => $list_value, list_result => \@list_result});
     $self->render(json => {jobs => $jobs});
 }
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -321,6 +321,18 @@ subtest 'jobs for job settings' => sub {
       ->json_is({jobs => [99981]});
     $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26103})->status_is(200)
       ->json_is({jobs => [99926]});
+
+
+    subtest 'get blocked jobs' => sub {
+        #default
+        $t->get_ok('/api/v1/job_settings/blocked_jobs' => form => {key => 'INCIDENT', list_value => 3456})
+          ->status_is(200)->json_is({jobs => [99962]});
+        # passed not returned
+        $t->get_ok('/api/v1/job_settings/blocked_jobs' => form => {key => '*_TEST_ISSUES', list_value => 26122})
+          ->status_is(200)->json_is({jobs => []});
+        $t->get_ok('/api/v1/job_settings/blocked_jobs' => form => {key => 'INCIDENT', list_value => 1234})
+          ->status_is(200)->json_is({jobs => [99962, 99938]});
+    };
 };
 
 $schema->txn_begin;

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -180,6 +180,7 @@ use Time::Seconds;
             {key => 'ISO_MAXSIZE', value => '4700372992'},
             {key => 'ISO', value => 'openSUSE-Factory-DVD-x86_64-Build0048-Media.iso'},
             {key => 'QEMUCPU', value => 'qemu64'},
+            {key => 'INCIDENT', value => '1234'},
             {key => 'FOO', value => 'foo/foo.txt'}]
     },
     Jobs => {
@@ -417,7 +418,8 @@ use Time::Seconds;
         ARCH => 'x86_64',
         result_dir => '00099962-opensuse-13.1-DVD-x86_64-Build0091-kde',
         settings => [
-            {key => 'DESKTOP', value => 'kde'},
+            {key => 'DESKTOP', value => 'kde'}, {key => 'INCIDENT', value => '1234,3456'},
+
             {key => 'ISO_MAXSIZE', value => '4700372992'},
             {key => 'ISO', value => 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso'},
             {key => 'DVD', value => '1'},


### PR DESCRIPTION
The PR is not ready, but I had to share where I am heading. I was just experiment so far. 

What you will find currently:
- an API endpoint and a smoke test. The name must change, but I couldnt think anything for now. 
- modified the sql query, in order to _join_ jobs to filter for the result, without change/break the way it work at the moment 
- adjustment in the test because I added another Job in fixtures. I should have been able to avoid to have some of the test impacted but I didnt manage to do so. need to improve)

So later I am planning the following changes:
- the endpoint reuse the `/job_settings/jobs` passing an optional parameter for the result value (failed, incomplete, etc). I think the end target is that the endpoint should return this by default.


https://progress.opensuse.org/issues/156547