### PR TITLE
Do not show empty groups when has no builds on parent_group_overview

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -52,6 +52,10 @@ function addFlash(status, text, container) {
   return div;
 }
 
+function clearFlash() {
+  document.querySelectorAll('#flash-messages .alert.alert-primary.alert-dismissible').forEach(e => e.remove());
+}
+
 function addUniqueFlash(status, id, text, container) {
   // add hash to store present flash messages
   if (!window.uniqueFlashMessages) {

--- a/assets/javascripts/parent_group_overview.js
+++ b/assets/javascripts/parent_group_overview.js
@@ -31,6 +31,7 @@ function setupParentGroupOverviewAssets(group_id) {
   }
 
   function updateGroupedByClasses() {
+    clearFlash(); // Do not let the notification messages hanging when group is updated
     if (window.location.hash === undefined || window.location.hash === '#grouped_by_build') {
       document
         .getElementById('grouped_by_group_tab')
@@ -41,6 +42,16 @@ function setupParentGroupOverviewAssets(group_id) {
         .getElementById('grouped_by_build_tab')
         .classList.remove('active', 'show', 'parent_group_overview_grouping_active');
       document.getElementById('grouped_by_group_tab').classList.add('active', 'parent_group_overview_grouping_active');
+      hiddenBuilds = document.querySelectorAll('.no-build-data');
+      if (hiddenBuilds.length > 0) {
+        hiddenBuilds.forEach(elem => {
+          console.log(elem.dataset.buildName);
+        });
+        addFlash(
+          'info',
+          `Parent group has ${hiddenBuilds.length} more builds with no results in the current build limits.`
+        );
+      }
     }
   }
 

--- a/t/ui/14-dashboard-parents.t
+++ b/t/ui/14-dashboard-parents.t
@@ -142,6 +142,7 @@ subtest 'filtering subgroups' => sub {
 
 subtest 'View grouped by group' => sub {
     $driver->get('/parent_group_overview/' . $parent_groups->find({name => 'Test parent'})->id);
+    my $grouped_builds = $driver->find_elements('.d-xl-flex flex-row build-row');
     $driver->find_element_by_id('grouped_by_group_tab')->click();
     is(
         $driver->find_element_by_id('grouped_by_group_tab')->get_attribute('class'),
@@ -153,7 +154,19 @@ subtest 'View grouped by group' => sub {
         'active parent_group_overview_grouping_active',
         'grouped by group link remains active'
     );
+    my $grouped_groups = $driver->find_elements('.d-xl-flex flex-row build-row');
     $driver->find_element_by_id('grouped_by_group')->is_displayed();
+    $driver->get('parent_group_overview/'
+          . $parent_groups->find({name => 'Test parent'})->id
+          . '?limit_builds=2#grouped_by_group');
+    my $groups_without_jobs = $driver->find_elements('.no-build-data');
+    is(scalar @$groups_without_jobs, 1, 'correct amount of groups without jobs found');
+    is(scalar @$grouped_groups, scalar @$grouped_builds, 'both groups display the same amount of builds');
+    is(
+        $driver->find_element('#flash-messages .alert-primary span')->get_text(),
+        'Parent group has 1 more builds with no results in the current build limits.',
+        'Notification is shown for jobless groups'
+    );
 };
 
 kill_driver();

--- a/templates/webapi/main/group_builds_functionality_view.html.ep
+++ b/templates/webapi/main/group_builds_functionality_view.html.ep
@@ -9,6 +9,10 @@
     % }
   % }
 
+  % if (!$has_jobs) {
+      <div class="no-build-data" data-build-name="<%= $child->{name} %>" hidden></div>
+  % }
+  % else {
   <div class="mb-2">
     <div class="h4 <%= $title_class_mod %> mb-2">
       %= link_to $child->{name} => url_for('group_overview', groupid => $child->{id})
@@ -45,10 +49,7 @@
             </div>
         </div>
     % }
-    % if ($has_jobs eq 0) {
-      <div class="ml-3 text-body-secondary">
-        No builds
-      </div>
-    % }
+  
   </div>
+  % }
 % }


### PR DESCRIPTION
The problem with parent_group_overview is that offers two ways of grouping a set of data. The design of the query seems to serve the purpose of the grouped_by_build interface. When it comes to the grouped_by_group, though, there should be another query to achieve the expected output in the view. That would likely be, the latest build of each group within the build_limits.

The solution presented in this commit is to visualuze only the groups which carry some builds from the query, but let user know that more builds are provided in that parent groups.
To address this problem, another solution would be to add another endpoint in the API and invoke the resultset from this query.
The idea of modifying the message left out because it would not provide a better user experience at the end, leaving still a unsatisfied feeling.

The reason for the `clearFlash` is that the panel remains between the change from one group to another, and otherwise would need to be closed manually.

https://progress.opensuse.org/issues/179296