### PR TITLE
Deprecate skip-checks and add check-repos option

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -327,7 +327,7 @@ sub clone_job ($jobid, $url_handler, $options, $post_params = {}, $jobs = {}, $d
     if (my $group_id = $job->{group_id}) { $settings->{_GROUP_ID} = $group_id }
     clone_job_apply_settings($options->{args}, $relation eq 'children' ? 0 : $depth, $settings, $options);
     OpenQA::Script::CloneJobSUSE::detect_maintenance_update($jobid, $url_handler, $settings)
-      unless $options->{'skip-checks'};
+      if $options->{'check-repos'};
     clone_job_download_assets($jobid, $job, $url_handler, $options) unless $options->{'skip-download'};
 }
 

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -112,7 +112,12 @@ $OPENQA_SHAREDIR/factory).
 
 =item B<--skip-checks>
 
-Skips additional checks like maintenance update availability.
+Deprecated option. The logic was inverted, so currently the check is skipped by default.
+If you were using it, just remove it and the behavior will remain the same.
+
+=item B<--check-repos>
+
+Enables additional checks for availability of maintenance update repositories (SUSE specific check).
 
 =item B<--skip-deps>
 
@@ -215,10 +220,13 @@ sub parse_options () {
         "skip-deps", "skip-chained-deps", "skip-download", "parental-inheritance",
         "help|h", "show-progress", "within-instance|w=s", "clone-children",
         "max-depth:i", "repeat|r:i", "ignore-missing-assets", "export-command",
-        "skip-checks",
+        "skip-checks", "check-repos",
     ) or usage(1);
     usage(0) if $options{help};
     usage(1) if $options{help} || ($options{'within-instance'} && $options{from});
+    warn
+"--skip-checks is deprecated and will be dropped soon. Just remove it because checks are not executed by default anymore"
+      if $options{'skip-checks'};
     if ($options{'within-instance'}) {
         ($options{'within-instance'}, $jobid) = split_jobid($options{'within-instance'});
         $options{'skip-download'} = 1;


### PR DESCRIPTION
--skip-checks option was disabling opt out checks of maintenance updates repositories.
    This has several flaws:
    1. It is questionable how much common situation from which check is trying to protect,
    so it make sense to invert logic to opt in allowing user to decide whether they need it
    or not
    2. Only check currently covered by this option is SUSE specific and it is another reason
    to switch to opt in
    3. skip-checks is confusing name because in a fact there is one and only check of maintenance
    repositories
    To address this problems two changes were done:
    - invert logic from opt out to opt in
    - deprecate skip-checks option because it is not needed anymore ( not to do check
      from now on is default behavior
    - introduce new command line option check-repos which has more accurate
      description and trigger check on user demand
