### PR TITLE
t: Also use default test database in full-stack+deploy

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -40,7 +40,7 @@ use OpenQA::Test::FullstackUtils;
 use OpenQA::SeleniumTest;
 
 plan skip_all => 'set FULLSTACK=1 (be careful)' unless $ENV{FULLSTACK};
-plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
+
 
 my $worker;
 my $ws;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -20,7 +20,6 @@ use OpenQA::Test::Case;
 use Mojo::File 'path';
 use List::Util 'min';
 
-plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 
 # find the oldest still supported schema version which is defined by the oldest deploy folder
 # which is still present

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -53,7 +53,6 @@ use OpenQA::Test::Utils
 use OpenQA::Test::FullstackUtils;
 
 plan skip_all => 'set FULLSTACK=1 (be careful)' unless $ENV{FULLSTACK};
-plan skip_all => 'set TEST_PG to e.g. "DBI:Pg:dbname=test" to enable this test' unless $ENV{TEST_PG};
 
 my $worker;
 my $ws;


### PR DESCRIPTION
As introduced in 9e598d3f0 the environment variable TEST_PG is not
strictly needed. Some tests still explicitly check for that. We can just
remove the test and the default database will be used if found.