### PR TITLE
Switch overly verbose "Updating seen from worker" messages to trace

### DIFF
--- a/lib/OpenQA/WebSockets/Controller/Worker.pm
+++ b/lib/OpenQA/WebSockets/Controller/Worker.pm
@@ -160,7 +160,7 @@ sub _message ($self, $json) {
 
         # log that we 'saw' the worker
         try {
-            log_debug("Updating seen of worker $worker_id from worker_status ($current_worker_status)");
+            log_trace("Updating seen of worker $worker_id from worker_status ($current_worker_status)");
             $worker->seen({error => $current_worker_error});
 
             # Tell the worker that we saw it (used for tests and debugging)


### PR DESCRIPTION
As observed on openqa.suse.de the component openqa-websockets is by far
the systemd unit logging the most. And within openqa-websockets logs the
message "Updating seen from worker" is logged the most. In this commit I
propose to move the message to the "trace" log level so that by default
it would not be logged anymore for instances using a log level of up to
"debug" only. However this means that for idle workers we probably will
not see a message during normal operation anymore only in cases of a
worker picking up jobs and such like this:

```
openqa-websockets-daemon[9246]: [debug] [pid:9246] Started to send message to 2565 for job(s) 17768162
openqa-websockets-daemon[9246]: [debug] [pid:9246] Worker 2480 accepted job 17768169
```

The alternative is to change our openQA instance openqa.suse.de to only
log up to level "info", not "debug".

Related progress issue: https://progress.opensuse.org/issues/182318