### PR TITLE
systemd: Increase availability of openqa-webui with ordering

### DIFF
--- a/systemd/openqa-websockets.service
+++ b/systemd/openqa-websockets.service
@@ -2,7 +2,7 @@
 Description=The openQA WebSockets server
 Wants=openqa-setup-db.service
 Before=openqa-webui.service
-After=openqa-scheduler.service postgresql.service openqa-setup-db.service network.target nss-lookup.target remote-fs.target
+After=postgresql.service openqa-setup-db.service network.target nss-lookup.target remote-fs.target
 
 [Service]
 User=geekotest

--- a/systemd/openqa-webui.service
+++ b/systemd/openqa-webui.service
@@ -2,7 +2,7 @@
 Description=The openQA web UI
 Wants=openqa-setup-db.service openqa-livehandler.service openqa-websockets.service openqa-gru.service openqa-enqueue-asset-cleanup.timer openqa-enqueue-result-cleanup.timer openqa-enqueue-bug-cleanup.timer openqa-minion-restart.path
 After=postgresql.service openqa-setup-db.service nss-lookup.target remote-fs.target apache2.service nginx.service caddy.service
-Before=openqa-gru.service
+Before=openqa-gru.service openqa-scheduler.service openqa-livehandler.service
 
 [Service]
 User=geekotest


### PR DESCRIPTION
By starting openqa-webui before scheduler+livehandler which are less
time-critical we can increase the availability of openqa-webui which will be
effective on both startup of systems as well as during shutdown when the
openqa-webui is kept around longer after scheduler+livehandler have been
stopped first.

Verified manually on openqa.suse.de

Related progress issue: https://progress.opensuse.org/issues/181370