### PR TITLE
CI: Enable Leap 16.0 OBS build checks

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -30,6 +30,14 @@ pr:
               - target_project: devel:openQA:Leap:15.6
                 target_repository: '15.6'
             architectures: [ x86_64 ]
+          - name: openSUSE_Leap_16.0
+            paths:
+              - target_project: devel:openQA:Leap:16.0
+                target_repository: '16.0'
+              - target_project: devel:openQA
+                target_repository: '16.0'
+            architectures: [ x86_64 ]
+
   filters:
     event: pull_request
 


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/180737