### PR TITLE
Revert "CI: Enable Leap 16.0 OBS build checks" as build results are not yet stable

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -30,14 +30,6 @@ pr:
               - target_project: devel:openQA:Leap:15.6
                 target_repository: '15.6'
             architectures: [ x86_64 ]
-          - name: openSUSE_Leap_16.0
-            paths:
-              - target_project: devel:openQA:Leap:16.0
-                target_repository: '16.0'
-              - target_project: devel:openQA
-                target_repository: '16.0'
-            architectures: [ x86_64 ]
-
   filters:
     event: pull_request
 


### PR DESCRIPTION
Reverts os-autoinst/openQA#6477 as build results are not yet stable.
We need to fix build issues already apparent in https://build.opensuse.org/project/monitor/devel:openQA?arch_x86_64=1&defaults=0&repo_16_0=1&unresolvable=1 before re-introducing this.