### PR TITLE
Avoid database error when more than one limit parameter is specified

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -395,7 +395,8 @@ sub _compose_job_overview_search_args ($c) {
     $v->optional('limit', 'not_empty')->num(0, undef);
 
     # add simple query params to search args
-    for my $arg (qw(distri version flavor test limit)) {
+    $search_args{limit} = $v->param('limit') if $v->is_valid('limit');
+    for my $arg (qw(distri version flavor test)) {
         next unless $v->is_valid($arg);
         my $params = $v->every_param($arg);
         my $param_count = scalar @$params;

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -150,6 +150,14 @@ subtest 'time parameter' => sub {
     like(get_summary, qr/at the time of.*show latest.*Incomplete: 1$/s, 'jobs newer than time parameter shown');
 };
 
+subtest 'limit parameter' => sub {
+    $t->get_ok(
+        '/tests/overview?distri=opensuse&version=Factory&limit=2&limit=2',
+        'no database error when specifying more than one limit'
+    );
+    is $t->tx->res->dom->find('table.overview td.name')->size, 2, 'number of jobs limited';
+};
+
 # Advanced query parameters can be forwarded
 $form = {distri => 'opensuse', version => '13.1', result => 'passed'};
 $t->get_ok('/tests/overview' => form => $form)->status_is(200);


### PR DESCRIPTION
* Do not treat the limit parameter as a column (where searching for more than one value is possible)
* See https://progress.opensuse.org/issues/183026