### PR TITLE
Replace deprecated ingress class annotation with ingressClassName

### DIFF
--- a/container/helm/charts/webui/templates/ingress.yml
+++ b/container/helm/charts/webui/templates/ingress.yml
@@ -2,9 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "webui.fullname" . }}-ingress
-  annotations:
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
     - host: {{ .Values.baseUrl }}
       http:


### PR DESCRIPTION
https://progress.opensuse.org/issues/183056
```
annotation "[kubernetes.io/ingress.class](http://kubernetes.io/ingress.class)" is deprecated, please use 'spec.ingressClassName' instead
```