### PR TITLE
Proof of Concept: Use CSS::Sass

### DIFF
--- a/tools/ci/run_unit_tests.sh
+++ b/tools/ci/run_unit_tests.sh
@@ -23,4 +23,11 @@ export OPENQA_TEST_TIMEOUT_SCALE_CI=3
 export EXTRA_PROVE_ARGS="-v"
 export OPENQA_FULLSTACK_TEMP_DIR=$PWD/test-results/fullstack
 export PROVE="tools/prove_wrapper"
+
+# https://progress.opensuse.org/issues/162500
+cpanm -n -l /tmp/css-sass CSS::Sass
+find /tmp/css-sass
+export PERL5LIB=/tmp/css-sass/lib/perl5
+perl -wE'use CSS::Sass 3.6.4'
+
 make test-$target


### PR DESCRIPTION
For now installing from CPAN, as the module is not in Factory.

As soon as CSS::Sass is installed, Mojolicious::Plugin::AssetPack will use it automatically.
It's not possible to configure it.

Issue: https://progress.opensuse.org/issues/162500