### PR TITLE
Use CSS::Sass instead of rubygem-sass

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -14,7 +14,7 @@ RUN zypper -n in tar gzip sudo
 RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
 
 # openQA dependencies
-RUN zypper install -y 'rubygem(sass)>=3.7.4' ruby-devel npm python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-tools tar xorg-x11-fonts sudo make
+RUN zypper install -y 'perl(CSS::Sass)' npm python3-base python3-requests git-core rsync curl postgresql-devel postgresql-server qemu qemu-tools tar xorg-x11-fonts sudo make
 
 # openQA chromedriver for Selenium tests
 RUN zypper install -y chromedriver

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -17,10 +17,10 @@ ENV LC_ALL C.UTF-8
 RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
     zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    # openQA might need rubygem:sass to compile assets in this context due to
+    # openQA might need perl(CSS::Sass) to compile assets in this context due to
     # unknown reasons even though the package should use the precompiled
     # assets from cache.tar
-    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m 'rubygem(sass)>=3.7.4' && \
+    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m 'perl(CSS::Sass)' && \
     zypper clean && \
     gensslcert && \
     a2enmod headers && \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -26,7 +26,7 @@ assetpack_requires:
   perl(YAML::PP): '>= 0.026'
 
 build_requires:
-  rubygem(sass): '>= 3.7.4'
+  perl(CSS::Sass):
   npm:
   '%assetpack_requires':
 

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -68,7 +68,7 @@
 # The following line is generated from dependencies.yaml
 %define worker_requires bsdtar openQA-client optipng os-autoinst perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.7 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
-%define build_requires %assetpack_requires npm rubygem(sass) >= 3.7.4
+%define build_requires %assetpack_requires npm perl(CSS::Sass)
 
 # All requirements needed by the tests executed during build-time.
 # Do not require on this in individual sub-packages except for the devel


### PR DESCRIPTION
rubygem-sass is not supported anymore

Issue: https://progress.opensuse.org/issues/162500