### PR TITLE
Allow using list and range specifiers in worker config file

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -590,10 +590,17 @@ BAR = this value has precedence over the one from the "class:foo" section below
 [3]
 # WORKER_CLASS is not set
 
+[4-10,20-25,30]
+WORKER_CLASS = yet-another-class
+
 [class:foo]
 FOO = this value is present on all instances where WORKER_CLASS contains foo
 BAR = this value is would be present in the same way but is overridden by slot 2
 --------------------------------------------------------------------------------
+
+It is possible to specify comma-separated lists of instance numbers and ranges.
+So in the example above the instances 4 to 10 (inclusive), 20 to 25 (inclusive)
+and 30 will have the `WORKER_CLASS` set to `yet-another-class`.
 
 As shown it is also possible to specify a section with the name `[class:…]` to
 specify `WORKER_CLASS`-specific values. Note that values in the concrete

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -593,6 +593,9 @@ BAR = this value has precedence over the one from the "class:foo" section below
 [4-10,20-25,30]
 WORKER_CLASS = yet-another-class
 
+[4-6]
+WORKER_CLASS += appended-worker-class
+
 [class:foo]
 FOO = this value is present on all instances where WORKER_CLASS contains foo
 BAR = this value is would be present in the same way but is overridden by slot 2
@@ -601,6 +604,11 @@ BAR = this value is would be present in the same way but is overridden by slot 2
 It is possible to specify comma-separated lists of instance numbers and ranges.
 So in the example above the instances 4 to 10 (inclusive), 20 to 25 (inclusive)
 and 30 will have the `WORKER_CLASS` set to `yet-another-class`.
+
+Values specified in additional sections override values specified in preceding
+sections. One can use `+=` to append sections instead. So in this example slots
+4 to 6 will have the `WORKER_CLASS` set to
+`yet-another-class,appended-worker-class`.
 
 As shown it is also possible to specify a section with the name `[class:…]` to
 specify `WORKER_CLASS`-specific values. Note that values in the concrete

--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -70,23 +70,12 @@ sub new ($class, $instance_number = undef, $cli_options = {}) {
     return $self;
 }
 
-sub _is_uint ($value) { $value =~ m/^\d+$/ }
-
 sub _is_section_relevant ($section_name, $instance_number) {
     return 1 if $section_name eq $instance_number;
-    return 0 unless _is_uint $instance_number;
-    my @section_bounds = map {
-        [map { trim $_ } split '-', $_, 2]
-    } split ',', $section_name;
-    for my $bounds (@section_bounds) {
-        my ($lower_bound, $upper_bound) = @$bounds;
-        return 1
-          if defined $upper_bound
-          && _is_uint($lower_bound)
-          && _is_uint($upper_bound)
-          && $instance_number >= $lower_bound
-          && $instance_number <= $upper_bound;
-        return 1 if _is_uint($lower_bound) && $instance_number == $lower_bound;
+    return 0 unless $instance_number =~ m/^\d+$/;
+    for my $range (split m/ *, */, $section_name) {
+        next unless $range =~ m/^(\d+) *(?:- *(\d+))?$/;
+        return 1 if $instance_number >= $1 && $instance_number <= ($2 // $1);
     }
     return 0;
 }

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -22,21 +22,19 @@ chdir $workdir;
 my $guard = scope_guard sub { chdir $FindBin::Bin };
 
 my $settings = OpenQA::Worker::Settings->new;
+my @common_settings = (
+    CRITICAL_LOAD_AVG_THRESHOLD => 40,
+    GLOBAL => 'setting',
+    WORKER_HOSTNAME => '127.0.0.1',
+    LOG_LEVEL => 'test',
+    LOG_DIR => 'log/dir',
+    RETRY_DELAY => 5,
+    RETRY_DELAY_IF_WEBUI_BUSY => 60,
+);
 
-is_deeply(
-    $settings->global_settings,
-    {
-        CRITICAL_LOAD_AVG_THRESHOLD => 40,
-        GLOBAL => 'setting',
-        WORKER_HOSTNAME => '127.0.0.1',
-        LOG_LEVEL => 'test',
-        LOG_DIR => 'log/dir',
-        RETRY_DELAY => 5,
-        RETRY_DELAY_IF_WEBUI_BUSY => 60,
-        TERMINATE_AFTER_JOBS_DONE => 1,
-    },
-    'global settings, spaces trimmed'
-) or always_explain $settings->global_settings;
+is_deeply $settings->global_settings, {@common_settings, TERMINATE_AFTER_JOBS_DONE => 1},
+  'global settings, spaces trimmed'
+  or always_explain $settings->global_settings;
 
 is($settings->file_path, "$FindBin::Bin/data/24-worker-settings/workers.ini", 'file path set');
 is_deeply($settings->parse_errors, [], 'no parse errors occurred');
@@ -85,38 +83,38 @@ subtest 'apply settings to app' => sub {
 };
 
 subtest 'instance-specific and WORKER_CLASS-specific settings' => sub {
-    my $settings1 = OpenQA::Worker::Settings->new(1);
-    is_deeply(
-        $settings1->global_settings,
+    my @expected_settings = (
         {
-            CRITICAL_LOAD_AVG_THRESHOLD => 40,
-            GLOBAL => 'setting',
-            WORKER_HOSTNAME => '127.0.0.1',
+            @common_settings,
             WORKER_CLASS => 'qemu_i386,qemu_x86_64',
-            LOG_LEVEL => 'test',
-            LOG_DIR => 'log/dir',
-            RETRY_DELAY => 5,
-            RETRY_DELAY_IF_WEBUI_BUSY => 60,
+            LIST_KEY => 'set-via-list',    # via section using list specifier
+            RANGE_AND_LIST_KEY => 'set-via-range-and-list',    # via combined specifier
         },
-        'global settings (instance 1)'
-    ) or always_explain $settings1->global_settings;
-    my $settings2 = OpenQA::Worker::Settings->new(2);
-    is_deeply(
-        $settings2->global_settings,
         {
-            CRITICAL_LOAD_AVG_THRESHOLD => 40,
-            GLOBAL => 'setting',
-            WORKER_HOSTNAME => '127.0.0.1',
+            @common_settings,
             WORKER_CLASS => 'special-hardware,qemu_aarch64',
-            LOG_LEVEL => 'test',
-            LOG_DIR => 'log/dir',
             FOO => 'setting from slot has precedence',
             BAR => 'aarch64-specific-setting',
             RETRY_DELAY => 10,
             RETRY_DELAY_IF_WEBUI_BUSY => 120,
+            LIST_KEY => 'set-via-list',    # via section using range specifier
+            RANGE_KEY => 'set-via-range',    # via section using range specifier
         },
-        'global settings (instance 2)'
-    ) or always_explain $settings2->global_settings;
+        {
+            @common_settings,
+            WORKER_CLASS => 'yet-another-class',
+            RANGE_KEY => 'set-via-range',    # via section using range specifier
+            RANGE_AND_LIST_KEY => 'set-via-range-and-list',    # via combined specifier
+        },
+        {@common_settings, RANGE_KEY => 'set-via-range', RANGE_AND_LIST_KEY => 'set-via-range-and-list'},
+        {@common_settings, RANGE_AND_LIST_KEY => 'set-via-range-and-list'},
+        {@common_settings, RANGE_AND_LIST_KEY => 'set-via-range-and-list'},
+        {@common_settings});
+    for my $i (1 .. 7) {
+        my $settings = OpenQA::Worker::Settings->new($i);
+        is_deeply $settings->global_settings, $expected_settings[$i - 1], "global settings (instance $i)"
+          or always_explain $settings->global_settings;
+    }
 };
 
 subtest 'settings file with errors' => sub {

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -7,6 +7,7 @@ use Test::Warnings ':report_warnings';
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use Mojo::Base -signatures;
 use OpenQA::Test::TimeLimit '8';
 use OpenQA::Worker::Settings;
 use OpenQA::Worker::App;
@@ -45,12 +46,8 @@ is_deeply($settings->webui_hosts, ['http://localhost:9527', 'https://remotehost'
 is_deeply(
     $settings->webui_host_specific_settings,
     {
-        'http://localhost:9527' => {
-            HOST_SPECIFIC => 'setting (localhost)',
-        },
-        'https://remotehost' => {
-            HOST_SPECIFIC => 'specific setting (remotehost)',
-        },
+        'http://localhost:9527' => {HOST_SPECIFIC => 'setting (localhost)'},
+        'https://remotehost' => {HOST_SPECIFIC => 'specific setting (remotehost)'},
     },
     'web UI host specific settings'
 ) or always_explain $settings->webui_host_specific_settings;
@@ -69,11 +66,7 @@ subtest 'check for local worker' => sub {
 subtest 'apply settings to app' => sub {
     my ($setup_log_called, $setup_log_app);
     my $mock = Test::MockModule->new('OpenQA::Worker::Settings');
-    $mock->redefine(
-        setup_log => sub {
-            $setup_log_app = shift;
-            $setup_log_called = 1;
-        });
+    $mock->redefine(setup_log => sub ($app, @) { $setup_log_app = $app; $setup_log_called = 1 });
     my $app = OpenQA::Worker::App->new;
     $settings->apply_to_app($app);
     is($app->level, 'test', 'log level applied');

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -85,7 +85,7 @@ subtest 'instance-specific and WORKER_CLASS-specific settings' => sub {
         },
         {
             @common_settings,
-            WORKER_CLASS => 'special-hardware,qemu_aarch64',
+            WORKER_CLASS => 'special-hardware,qemu_aarch64,worker-class-via-range',
             FOO => 'setting from slot has precedence',
             BAR => 'aarch64-specific-setting',
             RETRY_DELAY => 10,
@@ -95,11 +95,16 @@ subtest 'instance-specific and WORKER_CLASS-specific settings' => sub {
         },
         {
             @common_settings,
-            WORKER_CLASS => 'yet-another-class',
+            WORKER_CLASS => 'yet-another-class,worker-class-via-range',
             RANGE_KEY => 'set-via-range',    # via section using range specifier
             RANGE_AND_LIST_KEY => 'set-via-range-and-list',    # via combined specifier
         },
-        {@common_settings, RANGE_KEY => 'set-via-range', RANGE_AND_LIST_KEY => 'set-via-range-and-list'},
+        {
+            @common_settings,
+            WORKER_CLASS => 'worker-class-via-range',
+            RANGE_KEY => 'set-via-range',
+            RANGE_AND_LIST_KEY => 'set-via-range-and-list',
+        },
         {@common_settings, RANGE_AND_LIST_KEY => 'set-via-range-and-list'},
         {@common_settings, RANGE_AND_LIST_KEY => 'set-via-range-and-list'},
         {@common_settings});

--- a/t/data/24-worker-settings/workers.ini
+++ b/t/data/24-worker-settings/workers.ini
@@ -26,6 +26,7 @@ LIST_KEY = set-via-list
 # additional spaces before and after numbers are ok
 [2 - 4]
 RANGE_KEY = set-via-range
+WORKER_CLASS += worker-class-via-range
 
 # range and list syntax can be combined
 [3-6,1]

--- a/t/data/24-worker-settings/workers.ini
+++ b/t/data/24-worker-settings/workers.ini
@@ -16,6 +16,21 @@ FOO = setting from slot has precedence
 RETRY_DELAY = 10
 RETRY_DELAY_IF_WEBUI_BUSY = 120
 
+[3]
+WORKER_CLASS = yet-another-class
+
+# a list of instance numbers can be specified
+[1,2]
+LIST_KEY = set-via-list
+
+# additional spaces before and after numbers are ok
+[2 - 4]
+RANGE_KEY = set-via-range
+
+# range and list syntax can be combined
+[3-6,1]
+RANGE_AND_LIST_KEY = set-via-range-and-list
+
 [http://localhost:9527]
 HOST_SPECIFIC = setting (localhost)
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/183101

---

This is so far only introducing list and range specifiers. It doesn't change the overriding behavior. So the behavior is still as follows:

The section `global` is read first. Other sections are read in the order they are defined and values from previous sections are overridden. This is what we want except that it should be possible to concatenate worker classes (instead of overriding). ~~For this I'd go for a `+=` syntax because concatenating by default and only clearing when an empty value occurs would not be backwards compatible/consistent with our current behavior of overriding (even though it only happened between the global and instance-specific section (and perhaps the web UI specific).~~ The `+=` syntax has now been implemented.