### PR TITLE
apparmor: Support CASEDIR with the needles included

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -81,6 +81,7 @@
   /sys/firmware/devicetree/base/ r,
   /sys/fs/cgroup/systemd/openqa.slice/** rw,
   /sys/kernel/mm/transparent_hugepage/enabled r,
+  /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   /tmp/** rwk,
   /usr/bin/Xvnc rCx,
   /{usr/,}bin/cat rix,


### PR DESCRIPTION
Fixes a hanging 'git clone' when CASEDIR is used and the git repository includes the needles