### PR TITLE
Avoid adding non-fatal API errors as reason of incomplete jobs

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -660,7 +660,7 @@ sub set_current_error_based_on_availability ($self) {
 
 sub _handle_client_status_changed ($self, $client, $event_data) {
     my $status = $event_data->{status};
-    my $error_message = $event_data->{error_message};
+    my $error_message = $event_data->{error_message} // $event_data->{ws_error_message};
     my $webui_host = $client->webui_host;
     return log_info("Registering with openQA $webui_host") if $status eq 'registering';
     return log_info('Establishing ws connection via ' . $event_data->{url}) if $status eq 'establishing_ws';

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -62,7 +62,7 @@ $client->on(
             @happened_events,
             {
                 status => $event_data->{status},
-                error_message => $event_data->{error_message},
+                error_message => $event_data->{error_message} // $event_data->{ws_error_message},
             });
     });
 
@@ -187,6 +187,7 @@ subtest 'attempt to setup websocket connection' => sub {
     $client->_setup_websocket_connection;
 
     # attempt to connect running into connection error
+    $client->reset_last_error;
     $client->worker_id(42);
     $client->_setup_websocket_connection;
     $client->once(status_changed => sub ($status, @) { Mojo::IOLoop->stop if $status eq 'failed' });

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -192,6 +192,16 @@ subtest 'attempt to setup websocket connection' => sub {
     $client->once(status_changed => sub ($status, @) { Mojo::IOLoop->stop if $status eq 'failed' });
     Mojo::IOLoop->start;
     is_deeply \@happened_events, \@expected_events, 'events emitted' or always_explain \@happened_events;
+    is $client->last_error, 'Unable to upgrade to ws connection via http://test-host/api/v1/ws/42', 'last error set';
+};
+
+subtest 'clearning errors' => sub {
+    $client->_set_status(connected => {});
+    is $client->last_error, undef, 'last error from ws connection cleared once connected again';
+
+    $client->_set_status(failed => {error_message => 'other error'});
+    $client->_set_status(connected => {});
+    is $client->last_error, 'other error', 'other errors not cleared once connected again';
 };
 
 subtest 'retry behavior' => sub {


### PR DESCRIPTION
* Track web socket error individually to be able to clear them in case the
  web socket connection could be re-established after all (improving what
  the previous commit has already begun)
* Record only failing API errors of critical requests with no retry
  attempts remaining as last error (which would later potentially be added
  as reason)
* See https://progress.opensuse.org/issues/184022