### PR TITLE
apparmor: Allow read access to device-tree files

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -79,6 +79,7 @@
   /sys/devices/system/cpu/** r,
   /sys/devices/system/node/** r,
   /sys/firmware/devicetree/base/ r,
+  /sys/firmware/devicetree/base/** r,
   /sys/fs/cgroup/systemd/openqa.slice/** rw,
   /sys/kernel/mm/transparent_hugepage/enabled r,
   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,


### PR DESCRIPTION
qemu-system-ppc64 needs this for host CPU type determination.

Failure: https://openqa.opensuse.org/tests/5115505
Verification run: https://openqa.opensuse.org/tests/5115519