### PR TITLE
Log less verbose error message for missing files

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -1129,10 +1129,14 @@ sub _read_json_file {
     my ($self, $name) = @_;
 
     my $file_name = $self->_result_file_path($name);
+    unless (-f $file_name) {
+        log_debug("$file_name does not exist");
+        return undef;
+    }
     my $json_data = do {
         try { path($file_name)->slurp }
         catch ($e) {
-            log_debug("Unable to read $name: $e");
+            log_debug("Unable to read $file_name: $e");
             return undef;
         }
     };


### PR DESCRIPTION
It can happen that json files are missing, especially for result files.

We don't need a stack trace if the file doesn't exist.

Issue: https://progress.opensuse.org/issues/184336