### PR TITLE
Fix pagination in server-side tables

### DIFF
--- a/lib/OpenQA/WebAPI/ServerSideDataTable.pm
+++ b/lib/OpenQA/WebAPI/ServerSideDataTable.pm
@@ -45,7 +45,8 @@ sub render_response (%args) {
         push(@order_by_params, {'-' . $column_order => $columns->[$column_index]});
         ++$index;
     }
-    $params->{order_by} = \@order_by_params if @order_by_params;
+    push @order_by_params, 'me.id';
+    $params->{order_by} = \@order_by_params;
 
     # add parameter for paging
     my $first_row = $controller->param('start');


### PR DESCRIPTION
Ensure that rows are always sorted by ID, at least as the last ordering criteria. Otherwise, when the main ordering criteria is ambiguous across different pages¹ it is up to chance on what page those rows will appear. So the same row might appear on e.g. page 1 and then page 2 again and some rows might not appear on any page.

So this fixes the second problem mentioned in
https://progress.opensuse.org/issues/184765#note-6 (but not the whole issue).

---

¹ e.g. when sorting needles by `last_seen_time` and a bunch of needles have
  the same value for this column