### PR TITLE
Avoid creating stale needle entries in needle editor when symlinks used

### DIFF
--- a/lib/OpenQA/Task/Needle/Save.pm
+++ b/lib/OpenQA/Task/Needle/Save.pm
@@ -4,6 +4,7 @@
 package OpenQA::Task::Needle::Save;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
+use Cwd 'realpath';
 use File::Copy;
 use Encode 'encode_utf8';
 use OpenQA::Git;
@@ -64,7 +65,7 @@ sub _save_needle ($app, $minion_job, $args) {
     my $imagedistri = $args->{imagedistri};
     my $imagename = $args->{imagename};
     my $imageversion = $args->{imageversion};
-    my $needledir = $args->{needledir};
+    my $needledir = realpath($args->{needledir});
     my $needlename = $args->{needlename};
     my $commit_message = $args->{commit_message};
 

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -286,12 +286,12 @@ subtest 'saving needle via Git' => sub {
     is_deeply(
         \@executed_commands,
         [
-            [qw(git -C), $empty_tmp_dir, qw(remote update origin)],
-            [qw(git -C), $empty_tmp_dir, qw(reset --hard HEAD)],
-            [qw(git -C), $empty_tmp_dir, qw(rebase origin/master)],
-            [qw(git -C), $empty_tmp_dir, qw(add), "foo.json", "foo.png"],
+            [qw(git -C), "$empty_tmp_dir", qw(remote update origin)],
+            [qw(git -C), "$empty_tmp_dir", qw(reset --hard HEAD)],
+            [qw(git -C), "$empty_tmp_dir", qw(rebase origin/master)],
+            [qw(git -C), "$empty_tmp_dir", qw(add), "foo.json", "foo.png"],
             [
-                qw(git -C), $empty_tmp_dir,
+                qw(git -C), "$empty_tmp_dir",
                 qw(commit -q -m),
                 'foo for opensuse-Factory-staging_e-x86_64-Build87.5011-minimalx@32bit',
                 '--author=Percival <percival@example.com>',


### PR DESCRIPTION
When the path of a needle directory contains a symlink we generally still always refer to the needle under its real path when updating the needles database table.

The only exception (I am aware of so far) is the needle editor which will create needle entries in the database for symlinked locations. Those will never be updated (e.g. `last_seen_time` will never be set) as the code updating needles always updates the entries for the needles under the real path. This change removes this exception and thus avoids creating entries which are never updated.

This is related to https://progress.opensuse.org/issues/184765 as those entries disturb the sort order.