### PR TITLE
openqa-bootstrap: Allow curl to follow redirects (boo#1245379)

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -163,7 +163,7 @@ grep -q "$(hostname)" /etc/hosts || echo "127.0.0.1 $(hostname)" >> /etc/hosts
 start-daemons
 
 # wait for webui to become available
-while ! curl -sI http://localhost/ | grep 200; do
+while ! curl -o /dev/null -w "%{http_code}" -sIL http://localhost/ | grep 200; do
     sleep 3
 done
 


### PR DESCRIPTION
We're mainly interested in the http response code but want to follow eventual redirects. To follow these redirects we can use curls `--location`/`-L`-option but this will cause multiple responses (until no redirect is left). Since `--head`/`-I` will always print all headers for all responses, we now need to redirect *everything* to /dev/null and print the actual, last response code with `--write-out`/`-w` only.