### PR TITLE
create_admin: fix for POO #179359 changes

### DIFF
--- a/script/create_admin
+++ b/script/create_admin
@@ -63,7 +63,7 @@ unless ($key) {
     print "Secret: $secret\n";
 }
 
-my $schema = OpenQA::Schema->singleton;
+my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1, from_script => 1);
 my $users = $schema->resultset('Users')->find({is_admin => 1});
 if ($users != 0) {
     warn "An admin user already exists! Use client or web UI to create further users.\n";


### PR DESCRIPTION
Since ff06373beb I don't think create_admin can ever work. It does not specify `from_script` when getting an OpenQA::Schema instance, so Schema's `connect_db` will try and do `OpenQA::App->singleton->home`, and that's never going to work because we don't really have an app singleton (nothing is ever going to have called `set_singleton` on this path, I don't think).

As a script, create_admin should clearly be using the from_script path, so let's change the way it gets a Schema instance to match all the other scripts and fix the problem.