### PR TITLE
Discard needles under symlinked locations from needles table

### DIFF
--- a/lib/OpenQA/Schema/Result/NeedleDirs.pm
+++ b/lib/OpenQA/Schema/Result/NeedleDirs.pm
@@ -4,7 +4,8 @@
 package OpenQA::Schema::Result::NeedleDirs;
 
 
-use Mojo::Base 'DBIx::Class::Core';
+use Mojo::Base 'DBIx::Class::Core', -signatures;
+use Cwd 'realpath';
 
 __PACKAGE__->table('needle_dirs');
 __PACKAGE__->add_columns(
@@ -30,5 +31,7 @@ sub set_name_from_job {
 
     $self->name(sprintf('%s-%s', $job->DISTRI, $job->VERSION));
 }
+
+sub is_symlink ($self) { $self->path ne (realpath($self->path) // '') }
 
 1;

--- a/t/data/openqa/share/tests/test_symlink_dir
+++ b/t/data/openqa/share/tests/test_symlink_dir
@@ -1,0 +1,1 @@
+archlinux


### PR DESCRIPTION
Keep the needles table free from these entries which we can only show timestamps for with hacks anyway. (And these hacks break the sorting and filtering on the table.)

Related tickets:

* https://progress.opensuse.org/issues/184765
* https://progress.opensuse.org/issues/53762