### PR TITLE
Avoid showing AJAX	error on index page when user is navigating elsewhere

### DIFF
--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -1,3 +1,7 @@
+window.onbeforeunload = function () {
+  window.unloading = true;
+};
+
 function setupIndexPage() {
   setupFilterForm({preventLoadingIndication: true});
 
@@ -105,6 +109,9 @@ function loadBuildResults(queryParams) {
       window.buildResultStatus = 'success';
     })
     .catch(error => {
+      if (window.unloading) {
+        return;
+      }
       const message = error ? htmlEscape(error) : 'Unable to fetch build results.';
       showBuildResults(
         '<div class="alert alert-danger" role="alert">' +


### PR DESCRIPTION
I tested this locally in Firefox (where the problem is reproducible in contrast do Chromium) with a `sleep` in `dashboard_build_results` to ensure reproducibility. With this change the error is no longer shown when the user is just navigating elsewhere, e.g. clicking on "All tests".

The error is still shown as expected when the web UI is stopped whiel the AJAX request is still ongoing.

Related ticket: https://progress.opensuse.org/issues/185116