### PR TITLE
Append worker.ini configuration to avoid warning

### DIFF
--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -20,6 +20,11 @@ RUN zypper in -y openQA-single-instance openQA-bootstrap \
     qemu-arm qemu-ppc qemu-x86 qemu-tools sudo iputils os-autoinst-distri-opensuse-deps \
     qemu-hw-display-virtio-gpu qemu-hw-display-virtio-gpu-pci && \
     zypper clean -a
+RUN cat > /etc/openqa/workers.ini <<EOF
+[global]
+HOST = http://localhost:9526
+EOF
+
 EXPOSE 80 443 9526
 ENV skip_suse_specifics=1
 ENV skip_suse_tests=1


### PR DESCRIPTION
This is more a mitigation than a real resolution, I know not the most beautiful resolution of the problem, but it work!

Related to: https://progress.opensuse.org/issues/181409

This is the output without the warning:

```
+ su _openqa-worker -c '/usr/share/openqa/script/worker --instance 1'
[info] worker 1:
 - config file:                      /etc/openqa/workers.ini
 - name used to register:            4419550c1aab
 - worker address (WORKER_HOSTNAME): localhost
 - isotovideo version:               44
 - websocket API version:            1
 - web UI hosts:                     http://localhost:9526
 - class:                            ?
 - no cleanup:                       no
 - pool directory:                   /var/lib/openqa/pool/1
[info] Project dir for host http://localhost:9526 is /var/lib/openqa/share
[info] Registering with openQA http://localhost:9526
[info] Establishing ws connection via ws://localhost:9526/api/v1/ws/1
[info] Registered and connected via websockets with openQA host http://localhost:9526 and worker ID 1
```

This solve both AC1 and AC2 so the ticket could be closed, but I'm looking to find a better resolution.