### PR TITLE
dist: Simplify dependency for /etc/os-release (boo#1244139)

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -108,12 +108,7 @@ Source2:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 BuildRequires:  fdupes
 # for install-opensuse in Makefile
-%if 0%{?is_opensuse}
-BuildRequires:  openSUSE-release
-%endif
-%if 0%{?suse_version} && !0%{?is_opensuse}
-BuildRequires:  sles-release
-%endif
+BuildRequires:  distribution-release
 BuildRequires:  %{build_requires}
 BuildRequires:  apparmor-rpm-macros
 BuildRequires:  local-npm-registry


### PR DESCRIPTION
It seems all
https://build.opensuse.org/projects/openSUSE:Leap:16.0/packages/000release-packages/files/Leap-release.spec?expand=1
and
https://build.suse.de/projects/SUSE:SLE-15-SP7:GA/packages/000release-packages/files/SLES-release.spec?expand=1
and
https://build.opensuse.org/projects/openSUSE:Factory/packages/000release-packages/files/openSUSE-release.spec?expand=1
and even something old like
https://build.opensuse.org/projects/openSUSE:Leap:15.3/packages/000release-packages/files/Leap-release.spec?expand=1
provide "distribution-release". So if we require that then we can
simplify our build time dependencies as well as hopefully prevent
further problems in SLE PackageHub.

Related issue: https://bugzilla.opensuse.org/show_bug.cgi?id=1244139