### PR TITLE
Avoid `Transaction already destroyed` being logged as error

### DIFF
--- a/t/25-serverstartup.t
+++ b/t/25-serverstartup.t
@@ -23,10 +23,11 @@ use OpenQA::Assets;
 use OpenQA::Log 'setup_log';
 use OpenQA::Setup;
 use OpenQA::Utils;
+use OpenQA::WebAPI;
 use Mojolicious;
 use Mojo::File qw(tempfile path);
 use Mojo::Home;
-use Test::Output qw(combined_from);
+use Test::Output qw(combined_from combined_like);
 
 subtest 'Setup logging to file' => sub {
     local $ENV{OPENQA_LOGFILE} = undef;
@@ -69,6 +70,13 @@ subtest 'Setup logging to STDOUT' => sub {
     like $buffer, qr/\[fatal\] Fatal error\n/, 'right fatal message';
     like $buffer, qr/\[debug\] It works\n/, 'right debug message';
     like $buffer, qr/\[info\] Works too\n/, 'right info message';
+};
+
+subtest 'global exception handling' => sub {
+    combined_like { OpenQA::WebAPI::_handle_exception(undef, 'foo') } qr/error.*foo/,
+      'exceptions generally logged as errors';
+    combined_like { OpenQA::WebAPI::_handle_exception(undef, 'Transaction already destroyed') }
+    qr/debug.*abort processing/, 'destroyed transactions logged as debug message';
 };
 
 subtest 'Setup logging to file (ENV)' => sub {


### PR DESCRIPTION
This exception that is normally logged as error is not really due to an error condition but because the client has already closed the connection so and thus processing the request is aborted.

This change replaces the default error handler of Mojolicious to avoid this exception being logged as error and turns it instead into a debug message which is hopefully easier to understand.

Related ticket: https://progress.opensuse.org/issues/184486

---

By the way, I just wanted to check the Mojolicious code to see whether it already handles some exceptions in a special way. Then it would have been easy for us to create an upstream PR after all (as it would just be another case). However, I instead found that one can "unsubscribe" the default handler of Mojolicious and provide a custom one instead. So we can actually address this downstream after all.