### PR TITLE
Update CircleCI image to Leap 16.0

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,7 +4,7 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use


### PR DESCRIPTION
Verification in https://build.opensuse.org/package/live_build_log/home:okurz:branches:devel:openQA:ci_leap16/base/containers/x86_64

Related progress issue: https://progress.opensuse.org/issues/180737