### PR TITLE
Revert "Update CircleCI image to Leap 16.0" as Leap 16.0 containers base don't exist yet

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,7 +4,7 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:16.0
+FROM opensuse/leap:15.6
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use


### PR DESCRIPTION
Reverts os-autoinst/openQA#6573 as Leap 16.0 containers base don't exist yet as visible now in https://build.opensuse.org/package/show/home:okurz:branches:devel:openQA:ci_leap16/base