### PR TITLE
Allow running single instance container with local changes

### DIFF
--- a/container/single-instance-devel/Dockerfile
+++ b/container/single-instance-devel/Dockerfile
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+#!BuildTag: openqa-single-instance-devel:latest opensuse/openqa-single-instance-devel:latest opensuse/openqa-single-instance-devel:%PKG_VERSION% opensuse/openqa-single-instance-devel:%PKG_VERSION%.%RELEASE%
+
+# hadolint ignore=DL3006
+FROM opensuse/openqa_devel
+
+# labelprefix=org.opensuse.openqa-single-instance-devel
+LABEL org.opencontainers.image.title="openQA developer single-instance container"
+LABEL org.opencontainers.image.description="A complete openQA developer instance composed of all necessary components to execute openQA tests including an openQA worker"
+LABEL org.opencontainers.image.version="%PKG_VERSION%.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/opensuse/openqa-single-instance-devel:%PKG_VERSION%.%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
+
+COPY . /opt/openqa
+WORKDIR /opt/openqa
+
+RUN make node_modules
+
+EXPOSE 80 443 9526
+ENV skip_suse_specifics=1
+ENV skip_suse_tests=1
+ENV OPENQA_SERVICE_PORT_DELTA=0
+ENV LC_ALL C.UTF-8
+
+ENTRYPOINT ["/opt/openqa/script/openqa-bootstrap"]


### PR DESCRIPTION
This change adds support for running the single-instance container
using local source tree instead of the system zypper package.

this can help testing changes to openQA code inside the container
without requiring package installation.

## TODOs

- [ ] fix error related to not authorized and registration web ui failure
```
   + su _openqa-worker -c '/opt/openqa/script/worker --instance 1'
[INFO] workers.ini not found, using default settings
[info] worker 1:
 - config file:
 - name used to register:            7f7cc3de60bf
 - worker address (WORKER_HOSTNAME): localhost
 - isotovideo version:               44
 - websocket API version:            1
 - web UI hosts:                     localhost
 - class:                            ?
 - no cleanup:                       no
 - pool directory:                   /var/lib/openqa/pool/1
[info] Project dir for host localhost is /var/lib/openqa/share
[info] Registering with openQA localhost
[error] Failed to register at localhost - 403 response: Not authorized - ignoring server
[error] Stopping because registration with all configured web UI hosts failed
```
- [ ] documentation