### PR TITLE
worker: disconnect dbus from NameOwnerChanged signal (POO #183833)

### DIFF
--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -81,10 +81,16 @@ my $guard = scope_guard sub { chdir $FindBin::Bin };
     has availability_error => 'Cache service info error: Connection refused';
 }
 {
+    package Test::FakeDBusObject;
+    use Mojo::Base -base, -signatures;
+    sub disconnect_from_signal ($self, $signal, $id) { }
+}
+{
     package Test::FakeDBus;    # uncoverable statement count:2
     use Mojo::Base -base, -signatures;
     has mock_service_value => 1;
     sub get_service ($self, $service_name) { $self->mock_service_value }
+    sub get_bus_object ($self) { Test::FakeDBusObject->new }
 }
 
 my $dbus_mock = Test::MockModule->new('Net::DBus', no_auto => 1);


### PR DESCRIPTION
This avoids us piling up signals we never handle and eventually exceeding a dbus quota limit and causing all subsequent tap jobs to fail.

New Net::DBus instances are automatically connected to this signal on creation, you cannot change this. If the instance is kept around but nothing iterates the dbus event loop once in a while, that signal will just keep piling up messages indefinitely. We encountered this once before in os-autoinst and "solved" it by not persisting the dbus connection, but in this case it doesn't seem a good idea to re-initialize that connection every time we want to check on the status of a tap worker. So instead let's disconnect it from the signal.

The 1 here is a bit magical. The Net::DBus connect_to_signal method issues signal numbers on a first-come, first-served basis, starting at 1 (0 is never used), and returns the number it issued. When Net::DBus _new calls it, though, it doesn't record the return value. So we have to know/guess that this will always be the first signal connected.

Related ticket: https://progress.opensuse.org/issues/183833