### PR TITLE
Improve error handling when handling status updates from worker

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1056,7 +1056,7 @@ sub calculate_result ($self) {
 }
 
 sub save_screenshot ($self, $screen) {
-    return unless length($screen->{name});
+    return unless ref $screen eq 'HASH' && length($screen->{name});
 
     my $tmpdir = $self->worker->get_property('WORKER_TMPDIR');
     return unless -d $tmpdir;    # we can't help
@@ -1084,7 +1084,7 @@ sub append_log ($self, $log, $file_name) {
 }
 
 sub update_backend ($self, $backend_info) {
-    $self->update({backend => $backend_info->{backend}});
+    $self->update({backend => $backend_info->{backend}}) if ref $backend_info eq 'HASH';
 }
 
 sub update_result ($self, $result, $state = undef) {
@@ -1126,7 +1126,7 @@ sub insert_module ($self, $tm, $skip_jobs_update = undef) {
 }
 
 sub insert_test_modules ($self, $testmodules) {
-    return undef unless scalar @$testmodules;
+    return undef unless ref $testmodules eq 'ARRAY' && scalar @$testmodules;
 
     # insert all test modules and update job module statistics uxing txn to avoid inconsistent job module
     # statistics in the error case
@@ -1481,10 +1481,9 @@ sub update_status ($self, $status) {
     $self->append_log($status->{serial_terminal}, 'serial-terminal-live.txt');
     $self->append_log($status->{serial_terminal_user}, 'serial-terminal-live.txt');
     # delete from the hash so it becomes dumpable for debugging
-    my $screen = delete $status->{screen};
-    $self->save_screenshot($screen) if $screen;
-    $self->update_backend($status->{backend}) if $status->{backend};
-    $self->insert_test_modules($status->{test_order}) if $status->{test_order};
+    $self->save_screenshot(delete $status->{screen});
+    $self->update_backend($status->{backend});
+    $self->insert_test_modules($status->{test_order});
     my %known_image;
     my %known_files;
     my @failed_modules;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1083,10 +1083,6 @@ sub append_log ($self, $log, $file_name) {
     }
 }
 
-sub update_backend ($self, $backend_info) {
-    $self->update({backend => $backend_info->{backend}}) if ref $backend_info eq 'HASH';
-}
-
 sub update_result ($self, $result, $state = undef) {
     my %values = (result => $result);
     $values{state} = $state if defined $state;
@@ -1482,7 +1478,6 @@ sub update_status ($self, $status) {
     $self->append_log($status->{serial_terminal_user}, 'serial-terminal-live.txt');
     # delete from the hash so it becomes dumpable for debugging
     $self->save_screenshot(delete $status->{screen});
-    $self->update_backend($status->{backend});
     $self->insert_test_modules($status->{test_order});
     my %known_image;
     my %known_files;

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -263,7 +263,7 @@ sub ensure_timestamp_appended ($str) {
 }
 
 sub save_base64_png ($dir, $newfile, $png) {
-    return unless $newfile;
+    return unless $newfile && defined($png);
     # sanitize
     $newfile =~ s,\.png,,;
     $newfile =~ tr/a-zA-Z0-9-/_/cs;

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -39,6 +39,11 @@ my $users = $t->app->schema->resultset('Users');
 # for "investigation" tests
 my $fake_git_log = 'deadbeef Break test foo';
 
+subtest 'adding job module without required fields' => sub {
+    my $res = $jobs->first->insert_module({name => undef, category => 'foo', script => 'unk'});
+    is 0, $res, 'no job module inserted if name missing';
+};
+
 subtest 'handling of concurrent deletions in code updating jobs' => sub {
     ok my $job = $jobs->find(99927), 'job exists in first place';
 


### PR DESCRIPTION
The code is already mainly just skipping invalid bits. These changes just make the checks for what's considered invalid a bit stricter to avoid Perl warnings and database errors. See the particular commit messages and https://progress.opensuse.org/issues/185497 for details.