### PR TITLE
openqa-bootstrap: Replace hardcoded openqa directory path with configurable variable

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -3,6 +3,8 @@
 
 set -xeuo pipefail
 
+OPENQA_DIR=${OPENQA_DIR:=/usr/share/openqa}
+
 dbname="${dbname:="openqa"}"
 dbuser="${dbuser:="geekotest"}"
 running_systemd=
@@ -26,7 +28,7 @@ start-database() {
 start-worker() {
     if [[ -z $running_systemd ]]; then
         /usr/bin/install -d -m 0755 -o _openqa-worker /var/lib/openqa/pool/1
-        su _openqa-worker -c '/usr/share/openqa/script/worker --instance 1' &
+        su _openqa-worker -c "$OPENQA_DIR/script/worker --instance 1" &
     else
         systemctl enable --now openqa-worker@1
     fi
@@ -34,16 +36,16 @@ start-worker() {
 
 start-daemons() {
     if [[ -z $running_systemd ]]; then
-        pgrep -f openqa-scheduler-daemon > /dev/null || su geekotest -c /usr/share/openqa/script/openqa-scheduler-daemon &
-        pgrep -f openqa-websockets-daemon > /dev/null || su geekotest -c /usr/share/openqa/script/openqa-websockets-daemon &
-        pgrep -f openqa-gru > /dev/null || su geekotest -c /usr/share/openqa/script/openqa-gru &
-        pgrep -f openqa-livehandler-daemon > /dev/null || su geekotest -c /usr/share/openqa/script/openqa-livehandler-daemon &
+        pgrep -f openqa-scheduler-daemon > /dev/null || su geekotest -c "$OPENQA_DIR/script/openqa-scheduler-daemon" &
+        pgrep -f openqa-websockets-daemon > /dev/null || su geekotest -c "$OPENQA_DIR/script/openqa-websockets-daemon" &
+        pgrep -f openqa-gru > /dev/null || su geekotest -c "$OPENQA_DIR/script/openqa-gru" &
+        pgrep -f openqa-livehandler-daemon > /dev/null || su geekotest -c "$OPENQA_DIR/script/openqa-livehandler-daemon" &
         if [[ $setup_web_proxy == "nginx" ]]; then
             nginx
         else
             /usr/sbin/start_apache2 -k start
         fi
-        pgrep -f openqa-webui-daemon > /dev/null || su geekotest -c /usr/share/openqa/script/openqa-webui-daemon &
+        pgrep -f openqa-webui-daemon > /dev/null || su geekotest -c "$OPENQA_DIR/script/openqa-webui-daemon" &
     else
         if [[ $setup_web_proxy == "nginx" ]]; then
             systemctl enable --now nginx
@@ -101,12 +103,12 @@ retry -e -s 30 -r 7 -- sh -c "zypper -n --gpg-auto-import-keys ref && zypper -n 
 # setup database
 chown -R postgres: /var/lib/pgsql/ # fix broken postgres working dir permissions in the nspawn container
 start-database
-su postgres -c "/usr/share/openqa/script/setup-db" "$dbuser" "$dbname"
+su postgres -c "$OPENQA_DIR/script/setup-db" "$dbuser" "$dbname"
 
 # setup webserver and fake-auth
 proxy_args=""
 [[ -n "$setup_web_proxy" ]] && proxy_args="--proxy=$setup_web_proxy"
-setup=/usr/share/openqa/script/configure-web-proxy
+setup=$OPENQA_DIR/script/configure-web-proxy
 if command -v $setup; then
     bash -ex $setup "$proxy_args"
 else
@@ -140,7 +142,7 @@ if [[ -z $skip_suse_tests ]]; then
         # use faster local mirror if run from within SUSE network
         export needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror.git"
     fi
-    /usr/share/openqa/script/fetchneedles
+    "$OPENQA_DIR/script/fetchneedles"
     if [[ ! -e /var/lib/openqa/tests/sle ]]; then
         ln -s opensuse /var/lib/openqa/tests/sle
     fi


### PR DESCRIPTION
This allows running the bootstrap script with an alternative openqa source directory, useful for local development