### PR TITLE
Fix build overview timestamps

### DIFF
--- a/templates/webapi/main/group_builds.html.ep
+++ b/templates/webapi/main/group_builds.html.ep
@@ -15,8 +15,7 @@
                     %= link_to $label => url_for('tests_overview')->query(@tests_overview_url_data, groupid => $group->{id})
                 % }
 
-				% my $date_mode = ($build_res->{date_mode} eq "oldest_job") ? "Oldest job: " : "Newest job: ";
-                <span class="smaller-font">(<abbr class="timeago" title="<%= $date_mode . ($build_res->{date}->datetime()) %>Z">
+                <span class="smaller-font">(<abbr class="timeago" title="<%= $build_res->{date}->datetime() %>Z">
                     %= $build_res->{date}
                 </abbr>)</span>
 

--- a/templates/webapi/main/group_builds_functionality_view.html.ep
+++ b/templates/webapi/main/group_builds_functionality_view.html.ep
@@ -36,8 +36,7 @@
                 % }
             </div>
             <div class="px-2 text-nowrap smaller-font ps-4">
-				% my $date_mode = ($build_res->{date_mode} eq "oldest_job") ? "Oldest job: " : "Newest job: ";
-                <abbr class="timeago" title="<%= $date_mode . ($build_res->{date}->datetime()) %>Z">
+                <abbr class="timeago" title="<%= $build_res->{date}->datetime() %>Z">
                     %= $build_res->{date}
                 </abbr>
             </div>


### PR DESCRIPTION
by partially reverting 1ddc9da47cd98352ae713272af9febab1bd678c7

Issue: https://progress.opensuse.org/issues/90545

The "Oldest/Newest Job" prefix in the title was overwritten by the timeago jqyery plugin anyway, but apparently in Firefox the prefix leads to just showing the absolute time.