### PR TITLE
Allow querying the state of scheduled products by distri/version/flavor

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
@@ -30,4 +30,90 @@ sub cancel_by_webhook_id ($self, $webhook_id, $reason) {
     return {jobs_cancelled => $count};
 }
 
+sub job_statistics ($self, $distri, $version, $flavor) {
+    my $sth = $self->result_source->schema->storage->dbh->prepare(
+        <<~'END_SQL'
+        WITH RECURSIVE
+        -- get the initial set of jobs in the scheduled product
+        initial_job_ids AS (
+            SELECT
+                jobs.id AS job_id,
+                jobs.scheduled_product_id AS scheduled_product_id
+            FROM
+                jobs
+            WHERE
+                jobs.scheduled_product_id in (
+                    SELECT
+                        max(id)
+                    FROM
+                        scheduled_products
+                    WHERE
+                        status in ('new', 'scheduling', 'scheduled') and distri = ? and version = ? and flavor = ?
+                    GROUP BY
+                        arch
+                )
+        ),
+        -- find more recent jobs for each initial job recursively
+        latest_id_resolver AS (
+            -- start with each job_id from initial_job_ids
+            SELECT
+                ij.job_id,
+                ij.job_id AS latest_job_id,
+                ij.scheduled_product_id AS scheduled_product_id,
+                1 AS level
+            FROM
+                initial_job_ids AS ij
+            UNION ALL
+            -- find the clone_id for the current latest_job_id
+            SELECT
+                lir.job_id,
+                j.clone_id AS latest_job_id,
+                lir.scheduled_product_id AS scheduled_product_id,
+                lir.level + 1 AS level
+            FROM
+                jobs AS j
+            JOIN latest_id_resolver AS lir ON lir.latest_job_id = j.id
+            -- limit the recursion
+            WHERE
+                lir.level < 50
+        ),
+        -- filter jobs to only get the latest
+        most_recent_jobs AS (
+            SELECT DISTINCT ON (job_id)
+                job_id as initial_job_id,
+                latest_job_id,
+                mrj.state as latest_job_state,
+                mrj.result as latest_job_result,
+                mrj.scheduled_product_id as scheduled_product_id,
+                level as chain_length
+            FROM
+                latest_id_resolver
+            JOIN jobs AS mrj ON mrj.id = latest_job_id
+            WHERE
+                latest_job_id IS NOT NULL
+            ORDER BY
+                job_id,
+                level DESC
+        )
+        SELECT
+            latest_job_state,
+            latest_job_result,
+            array_agg(latest_job_id) as job_ids,
+            array_agg(DISTINCT scheduled_product_id) as scheduled_product_ids
+        FROM
+            most_recent_jobs
+        WHERE
+            latest_job_id IS NOT NULL
+        GROUP BY
+            latest_job_state,
+            latest_job_result
+        END_SQL
+    );
+    $sth->bind_param(1, $distri);
+    $sth->bind_param(2, $version);
+    $sth->bind_param(3, $flavor);
+    $sth->execute;
+    return $sth->fetchall_hashref([qw(latest_job_state latest_job_result)]);
+}
+
 1;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -379,6 +379,7 @@ sub startup ($self) {
     $api_ro->post('/isos')->name('apiv1_create_iso')->to('iso#create');
     $api_ra->delete('/isos/#name')->name('apiv1_destroy_iso')->to('iso#destroy');
     $api_ro->post('/isos/#name/cancel')->name('apiv1_cancel_iso')->to('iso#cancel');
+    $api_ro->get('/isos/job_stats')->name('apiv1_scheduled_product_job_stats')->to('iso#job_statistics');
 
     # api/v1/webhooks
     $api_ro->post('/webhooks/product')->name('apiv1_evaluate_webhook_product')->to('webhook#product');


### PR DESCRIPTION
This will allow us to check whether all jobs we scheduled for a certain purpose (e.g. product increment) are done and whether they have passed.

The details of the lookup are explained in the added API documentation.

The query for this is not super efficient as we don't have an index on the required columns on the scheduled products table. However, it seemed to be fast enough when I tested this with production data.

Related ticket: https://progress.opensuse.org/issues/184690

---

This is an alternative to https://github.com/os-autoinst/openQA/pull/6589 which I have started for a hook script based approach. The code is only slightly different, though.

With the approach taken by this PR here we don't need any other changes on the openQA side except for what is provided by the PR right now. Some cron job (e.g. as part of `qem-bot`) will have to do the checking periodically if there's a pending product increment. However, checking e.g. every hour periodically is probably not that bad compared to adding a hook or event. This is because for a hook/event we would need to check after each job has finished whether the whole assigned scheduled product is finished - which is also lots of checks. (As mentioned on https://github.com/os-autoinst/openQA/pull/6589#issuecomment-3077597014 this would probably not scale very well.)

This approach also solves the problem of considering only the most recent relevant product. With a hook-based or event-based approach this still needed to be solved in the hook script or event handler with a similar query/request than what is done in this PR with the nested query on scheduled products.

Considering the simplest solution seems to involve only adding a single route to openQA I was also checking whether we might just use an existing route.
I guess the best candidate is this one: https://openqa.suse.de/tests/overview.json?distri=sle&version=15.99&flavor=Online-Increments

I see a few downsides, though:
* It is not an actual API and [the API we have](https://openqa.suse.de/api/v1/jobs/overview?distri=sle&version=15.99&flavor=Online-Increments) doesn't provide grouping/accumulation by state/result. In fact it doesn't return any state/result info at all.
* The info under `aggregated` could be used to check whether all jobs have passed or whether there are failures. However, we probably also want to mention a list of all failures somewhere and for this we would need to go though a much more nested structure here.
* If the scheduled product is re-scheduled and some jobs are no longer present (e.g. because a test suite has been renamed or removed) then we would still consider jobs from the previous scheduled product.
* We would have to watch out for not accidentally considering other jobs, e.g. investigation jobs. This could be done by specifying relevant group IDs (e.g. `&groupid=661`).

I don't think any of these downsides would be a strong enough argument to not just use `overview.json`. However, together they add up so I tend to say that adding the new route is worthwhile.