### PR TITLE
Fix PostgreSQL startup failure in non-systemd environments

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -18,6 +18,9 @@ fi
 
 start-database() {
     if [[ -z $running_systemd ]]; then
+        # ensure /run/postgresql exists for PostgreSQL to create lock socket
+        mkdir -p /run/postgresql
+        chown postgres:postgres /run/postgresql
         su postgres -c '/usr/share/postgresql/postgresql-script stop' || true
         su postgres -c '/usr/share/postgresql/postgresql-script start'
     else


### PR DESCRIPTION
PostgreSQL fails to start in non-systemd environments (e.g. Docker, GitLab Runner) because it cannot create the socket lock file at /run/postgresql/.s.PGSQL.5432.lock if the directory does not exist. This will also block openQA bootstrap process.

The specific error is:
    pg_ctl: could not start server
    Examine the log output.

Reproduce:
    docker run -it --rm --name openqa-test opensuse/tumbleweed bash
    zypper --non-interactive install openQA-bootstrap
    /usr/share/openqa/script/openqa-bootstrap