### PR TITLE
Allow empty values in openqa-cli parameters

### DIFF
--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -98,7 +98,7 @@ sub run ($self, @args) {
     my %options = (pretty => 0, quiet => 0, links => 0, verbose => 0);
     OpenQA::CLI::get_opt(global => \@args, ['pass_through'], \%options);
     for (qw(apibase apikey apisecret name)) {
-        $self->$_($options{$_}) if $options{$_};
+        $self->$_($options{$_}) if defined $options{$_};
     }
     my $host = $options{host};
     $self->host($host =~ m!^/|://! ? $host : "https://$host") if $host;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -110,6 +110,10 @@ subtest 'API' => sub {
     throws_ok { $api->run(@auth) } qr/Usage: openqa-cli api/, 'usage';
     is $api->apikey, 'ARTHURKEY01', 'apikey';
     is $api->apisecret, 'EXCALIBUR', 'apisecret';
+
+    $api = OpenQA::CLI::api->new;
+    throws_ok { $api->run('--apibase', '') } qr/Usage: openqa-cli api/, 'usage';
+    is $api->apibase, '', 'set apibase to an empty string';
 };
 
 subtest 'Client' => sub {


### PR DESCRIPTION
    openqa-cli --apibase ''

did not set the parameter as expected

Issue: https://progress.opensuse.org/issues/186146

Bug introduced in 47c3c7bec