### PR TITLE
Show note about sorting on group overview pages

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -6,6 +6,7 @@ use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Feature::Compat::Try;
 
 use Date::Format;
+use OpenQA::Constants qw(BUILD_SORT_BY_NAME BUILD_SORT_BY_NEWEST_JOB BUILD_SORT_BY_OLDEST_JOB);
 use OpenQA::Jobs::Constants;
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::BuildResults;
@@ -71,6 +72,18 @@ sub _respond_error_for_group_overview ($self, $error) {
         html => {template => 'main/specific_not_found', status => 400},
     );
 }
+
+sub _sort_info_time ($new_old) { "Builds are sorted by the creation time of the <em>$new_old</em> job." }
+
+sub _sort_help_timestamps ($new_old) {
+"This means the timestamps are the creation time of the <em>$new_old</em> job in that build (accross all architectures).";
+}
+
+my %SORTING_NOTE = (
+    BUILD_SORT_BY_NAME() => {info => 'Builds are sorted by <em>name</em>.', help => _sort_help_timestamps('oldest')},
+    BUILD_SORT_BY_NEWEST_JOB() => {info => _sort_info_time('newest'), help => _sort_help_timestamps('newest')},
+    BUILD_SORT_BY_OLDEST_JOB() => {info => _sort_info_time('oldest'), help => _sort_help_timestamps('oldest')},
+);
 
 sub _group_overview ($self, $resultset, $template) {
     my $validation = $self->validation;
@@ -154,6 +167,7 @@ sub _group_overview ($self, $resultset, $template) {
     }
     $self->stash(
         group => $group_hash,
+        sorting_note => $SORTING_NOTE{$group->build_version_sort},
         limit_builds => $limit_builds,
         only_tagged => $only_tagged,
         comments => \@comments,

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -120,12 +120,12 @@ my $opensuse_group = $job_groups->find({name => 'opensuse'});
 $opensuse_group->update({parent_id => $test_parent->id});
 
 $t->get_ok('/group_overview/' . $opensuse_group->id)->status_is(200);
-@h2 = $t->tx->res->dom->find('h2')->map('all_text')->each;
-like(
-    $h2[0],
-    qr/[ \n]*Last Builds for[ \n]*Test parent[ \n]*\/[ \n]*opensuse[ \n]*/,
-    'parent name also shown on group overview'
-);
+my $dom = $t->tx->res->dom;
+like
+  $dom->find('h2')->map('all_text')->join,
+  qr/[ \n]*Last Builds for[ \n]*Test parent[ \n]*\/[ \n]*opensuse[ \n]*/,
+  'parent name also shown on group overview';
+like $dom->find('#sorting-note')->map('all_text')->join, qr/Builds are sorted by name/, 'note about sorting present';
 
 $t->get_ok('/dashboard_build_results')->status_is(200);
 @h2 = $t->tx->res->dom->find('h2 a')->map(sub ($e) { $e->text . ($e->attr('title') // '') })->each;

--- a/templates/webapi/main/group_builds.html.ep
+++ b/templates/webapi/main/group_builds.html.ep
@@ -1,3 +1,9 @@
+% if (my $note = stash('sorting_note')) {
+<p id="sorting-note">
+    %== $note->{info}
+    %= help_popover 'Sorting and timestamps', "<p>$note->{help}</p><p>Sorting can be changed via \"Edit job group\".</p>"
+</p>
+% }
 % for my $build_res (@$build_results) {
     % my $version = $build_res->{version};
     % my $build = $build_res->{build};


### PR DESCRIPTION
Now with three different sorting options and one of them affecting time stamps it makes sense to add an according note on the group overview page.

Related ticket: https://progress.opensuse.org/issues/185566

---

This is how it looks like:

<img width="690" height="453" alt="screenshot_20250728_162824" src="https://github.com/user-attachments/assets/e938a673-cd25-4874-863d-d1db2a861c59" />

This screenshot shows that the sorting doesn't fully work as one would expect, though. At least I would expect the build from 2 hours ago to be at the top. Possibly the version is also taken into account somehow in this case on my local instance.