### PR TITLE
CloneJob: Follow redirects when downloading assets for cloning

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -161,6 +161,11 @@ sub clone_job_download_assets ($jobid, $job, $url_handler, $options) {
 
             print STDERR "downloading\n$from\nto\n$dst\n";
             my $r = $ua->mirror($from, $dst);
+
+            # Follow redirection manually for behaviour LWP < 6.48, see
+            # https://github.com/libwww-perl/libwww-perl/pull/349
+            $r = $ua->mirror($r->header('Location'), $dst) if ($r->code == 308);
+
             unless ($r->is_success || $r->code == 304) {
                 print STDERR "$jobid failed: $file, ", $r->status_line, "\n";
                 die "Can't clone due to missing assets: ", $r->status_line, " \n"


### PR DESCRIPTION
This is a workaround for behaviour LWP < 6.48, see https://github.com/libwww-perl/libwww-perl/pull/349.

This happen to clone jobs from o3 on openSUSE Leap 15.6, which has perl-libwww-perl-6.31-1.17.

Originally posted as https://github.com/os-autoinst/openQA/pull/5335.

I've been using this workaround for nearly 2 years, it should be safe to upstream it.