### PR TITLE
Fix weird validation errors of date time on API keys page

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -438,6 +438,11 @@ sub set_secure_flag_on_cookies_of_https_connection ($server) {
 }
 
 sub setup_validator_check_for_datetime ($server) {
+    $server->validator->add_filter(
+        seconds_optional => sub ($v, $name, $value) {
+            # add seconds if missing so they become optional
+            return m/^\d{4}(-\d{2}){2}T\d{2}:\d{2}$/ ? "$value:00" : $value;
+        });
     $server->validator->add_check(
         datetime => sub ($validation, $name, $value) {
             try { DateTime::Format::Pg->parse_datetime($value) }

--- a/lib/OpenQA/WebAPI/Controller/ApiKey.pm
+++ b/lib/OpenQA/WebAPI/Controller/ApiKey.pm
@@ -16,7 +16,7 @@ sub create ($self) {
     my $user = $self->current_user;
     my $expiration;
     my $validation = $self->validation;
-    $validation->optional('t_expiration')->datetime;
+    $validation->optional('t_expiration', 'seconds_optional')->datetime;
 
     my $error;
     if ($validation->has_error) {
@@ -24,7 +24,7 @@ sub create ($self) {
     }
 
     if (!$error && $validation->is_valid('t_expiration')) {
-        try { $expiration = DateTime::Format::Pg->parse_datetime($self->param('t_expiration')) }
+        try { $expiration = DateTime::Format::Pg->parse_datetime($validation->param('t_expiration')) }
         catch ($e) { $error = $e }
     }
     unless ($error) {

--- a/templates/webapi/api_key/index.html.ep
+++ b/templates/webapi/api_key/index.html.ep
@@ -11,7 +11,7 @@
                 <div class="mb-3">
                     <label class="form-label" for="expiration">Expiration</label>
                     <input type="checkbox" id="expiration" checked onchange="toggleExpiration(this)">
-                    %= datetime_field 't_expiration', id => 'expiration-datetime-field', size => 14, class => 'form-control', value => DateTime->now()->add(years => 1)
+                    %= datetime_field 't_expiration', id => 'expiration-datetime-field', size => 14, class => 'form-control', value => DateTime->now()->add(years => 1)->strftime('%FT%H:%M')
                 </div>
                 <div class="mb-3">
                     %= submit_button 'Create', class => 'btn btn-primary'


### PR DESCRIPTION
* Remove seconds from the default value so the date time picker is only allowing to select date, hour and minute and will no longer complain about invalid values
* Allow specifying a date time value without seconds in the corresponding API route as removing seconds from the default value would otherwise lead to validation errors
* Note that I could only reproduce the validation errors with Chromium when previously selecting a specific second via the menu of the date time picker; so adding UI tests for this is probably difficult
* See https://progress.opensuse.org/issues/118894