### PR TITLE
Fix LegacyKeyValueFormat in Dockerfiles

### DIFF
--- a/container/devel/Dockerfile
+++ b/container/devel/Dockerfile
@@ -23,6 +23,6 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 RUN zypper in -y os-autoinst-devel openQA-devel vim nodejs-default git mc perl-Devel-REPL perl-Term-ReadKey && \
     zypper clean -a
 
-ENV OPENQA_DIR /opt/openqa
+ENV OPENQA_DIR=/opt/openqa
 VOLUME $OPENQA_DIR
 WORKDIR $OPENQA_DIR

--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -19,10 +19,10 @@ RUN zypper install -y 'rubygem(sass)>=3.7.4' ruby-devel npm python3-base python3
 # openQA chromedriver for Selenium tests
 RUN zypper install -y chromedriver
 
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
-ENV NORMAL_USER squamata
-ENV USER squamata
+ENV NORMAL_USER=squamata
+ENV USER=squamata
 
 RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER

--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -24,7 +24,7 @@ EXPOSE 80 443 9526
 ENV skip_suse_specifics=1
 ENV skip_suse_tests=1
 ENV OPENQA_SERVICE_PORT_DELTA=0
-ENV LC_ALL C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 ENTRYPOINT ["/usr/share/openqa/script/openqa-bootstrap"]
 HEALTHCHECK CMD curl -f http://localhost || exit 1

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
-ENV LC_ALL C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 # hadolint ignore=DL3037
 RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \


### PR DESCRIPTION
As per https://docs.docker.com/reference/build-checks/legacy-key-value-format/ to prevent the corresponding warning in builds.