### PR TITLE
Use MCP to connect openQA with AI

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -134,6 +134,7 @@ main_requires:
   perl(IPC::Run):
   perl(JSON::Validator):
   perl(LWP::UserAgent):
+  perl(MCP): '>= 0.04'
   perl(Module::Load::Conditional):
   perl(Module::Pluggable):
   perl(Mojo::Base):

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -56,7 +56,10 @@ sub auth ($self) {
     else {
 
         # Personal access token
-        if (my $userinfo = $self->req->url->to_abs->userinfo) {
+        if (($self->req->headers->authorization // '') =~ /^Bearer\s+(.+)$/) {
+            ($user, $reason) = $self->_token_auth($reason, $1);
+        }
+        elsif (my $userinfo = $self->req->url->to_abs->userinfo) {
             ($user, $reason) = $self->_token_auth($reason, $userinfo);
         }
 

--- a/lib/OpenQA/WebAPI/MCP.pm
+++ b/lib/OpenQA/WebAPI/MCP.pm
@@ -1,0 +1,31 @@
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::MCP;
+use Mojo::Base 'MCP::Server', -signatures;
+
+sub new ($class) {
+    my $self = $class->SUPER::new;
+
+    $self->name('openQA');
+    $self->version('1.0.0');
+
+    $self->tool(
+        name => 'current_user',
+        description => 'Get the openQA name and id of the current user',
+        code => \&tool_current_user
+    );
+
+    return $self;
+}
+
+sub tool_current_user ($tool, $args) {
+    my $user = _get_user($tool);
+    return "name: @{[$user->name]}, id: @{[$user->id]}";
+}
+
+sub _get_user ($tool) {
+    return $tool->context->{controller}->stash->{current_user}{user};
+}
+
+1;

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -213,6 +213,24 @@ subtest 'personal access token' => sub {
 
     # Valid access token (again)
     $t->$userinfo('artie:ARTHURKEY01:EXCALIBUR')->delete_ok('/api/v1/assets/1')->status_is(404);
+
+    subtest 'Bearer token' => sub {
+        # Valid token
+        $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer lance:LANCELOTKEY01:MANYPEOPLEKNOW'} => form =>
+              {version => 100})->status_is(200);
+
+        # Invalid username
+        $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer invalid:LANCELOTKEY01:MANYPEOPLEKNOW'} => form =>
+              {version => 100})->status_is(403)->json_is({error => 'invalid personal access token'});
+
+        # Invalid key
+        $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer lance:LANCELOTKEY02:MANYPEOPLEKNOW'} => form =>
+              {version => 100})->status_is(403)->json_is({error => 'invalid personal access token'});
+
+        # Invalid secret
+        $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer lance:LANCELOTKEY01:MANYPEOPLEKNOWS'} => form =>
+              {version => 100})->status_is(403)->json_is({error => 'invalid personal access token'});
+    };
 };
 
 subtest 'personal access token (with reverse proxy)' => sub {

--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env perl
+
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use utf8;
+use FindBin;
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use Mojo::Base -signatures;
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use Test::MockModule;
+use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::Case;
+use OpenQA::Test::Client 'client';
+use MCP::Client;
+
+OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
+
+# Bearer token authentication
+my $bearer_token = 'Bearer lance:LANCELOTKEY01:MANYPEOPLEKNOW';
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+my $client = MCP::Client->new(ua => $t->ua, url => $t->ua->server->url->path('/experimental/mcp'));
+
+subtest 'Authentication' => sub {
+    $t->get_ok('/experimental/mcp')->status_is(403)->json_is({error => 'no api key'});
+
+    $t->ua->on(start => sub ($ua, $tx) { $tx->req->headers->authorization($bearer_token) });
+    $t->get_ok('/experimental/mcp')->status_is(405);
+};
+
+subtest 'Start session' => sub {
+    is $client->session_id, undef, 'no session id';
+    my $result = $client->initialize_session;
+    is $result->{serverInfo}{name}, 'openQA', 'server name';
+    is $result->{serverInfo}{version}, '1.0.0', 'server version';
+    ok $result->{capabilities}, 'has capabilities';
+    ok $client->session_id, 'session id set';
+};
+
+subtest 'List tools' => sub {
+    my $result = $client->list_tools;
+    is scalar @{$result->{tools}}, 1, 'one tool available';
+    is $result->{tools}[0]{name}, 'current_user', 'right tool name';
+};
+
+subtest 'Current user tool' => sub {
+    my $result = $client->call_tool('current_user');
+    is_deeply $result->{content}, [{type => 'text', text => 'name: lance, id: 99902'}], 'right content';
+    ok !$result->{isError}, 'not an error';
+};
+
+done_testing();


### PR DESCRIPTION
This patch adds the basic infrastructure for native MCP support in openQA. Most MCP clients use bearer token authentication at the moment, so i've added that to the existing token authentication mechanism that already existed in openQA. Future versions of the MCP specification will most likely require more sophisticated authentication mechanisms.

For clients that use the standard `mcp.json` format, a configuration should look something like this:
```
{
  "mcpServers": {
    "openqa": {
      "url": "http://127.0.0.1:9526/experimental/mcp",
      "headers": {
        "Authorization": "Bearer USER:KEY:SECRET"
      }
    }
  }
}
```

For starters i have only added a single tool called `current_user`, which an LLM can use to identify the openQA user.

Here is an example conversation with Gemma 3 where it makes a tool call to identify me:
```
You:
Who am i?

gemma-3-12b-it:
current_user({})
Arguments
{}
Result
[
  {
    "type": "text",
    "text": "name: Demo, id: 2"
  }
]

You are Demo.

You:
Do i have a user id too?

gemma-3-12b-it:
Yes, your user ID is 2.
```

There are many alternative ways in which MCP support could be added to openQA. But i believe this one will perform best.

Choosing what other tools to add will be the most important next step. And not an easy one, since the LLM context window size is a finite resource, we need to be picky about which tools are really necessary, and which information they will include in their responses.

Progress: https://progress.opensuse.org/issues/184798