### PR TITLE
Fix Too few arguments for subroutine error on close_connection

### DIFF
--- a/lib/OpenQA/Shared/Controller/Running.pm
+++ b/lib/OpenQA/Shared/Controller/Running.pm
@@ -113,8 +113,9 @@ sub streamtext ($self, $file_name, $start_hook = undef, $close_hook = undef) {
     # Setup utility function to close the connection if something goes wrong
     my $timer_id;
     my $close_connection = sub ($self) {
+        my $worker_id = $worker->id;
+        log_debug "Connection to worker with ID $worker_id will be closed because $logfile changed";
         Mojo::IOLoop->remove($timer_id);
-        $close_hook->();
         $self->finish;
         close $log;
     };

--- a/lib/OpenQA/Shared/Controller/Running.pm
+++ b/lib/OpenQA/Shared/Controller/Running.pm
@@ -130,7 +130,7 @@ sub streamtext ($self, $file_name, $start_hook = undef, $close_hook = undef) {
             # Zero tolerance for any shenanigans with the logfile, such as
             # truncation, rotation, etc.
             my @st = stat $logfile;
-            return $close_connection->() unless @st && $st[1] == $ino && $st[3] > 0 && $st[7] >= $size;
+            return $close_connection->($self) unless @st && $st[1] == $ino && $st[3] > 0 && $st[7] >= $size;
 
             # If there's new data, read it all and send it out. Then
             # seek to the current position to reset EOF.

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -85,9 +85,15 @@ subtest streaming => sub {
         ok $size > (10 * 1024), 'test file size is greater than 10 * 1024';
         like $controller->tx->res->content->{body_buffer}, qr/data: \["A\\n"\]/, 'body buffer contains "A"';
         Mojo::IOLoop->one_tick;
+
+        $controller->streamtext('test.txt');
+        $t_file->remove();
+        Mojo::IOLoop->one_tick;
+        ok $c_finished, 'controller has closed after file removed';
     };
 
     subtest image => sub {
+        $c_finished = 0;
         $app->attr(schema => sub { FakeSchema->new() });
         my $controller = OpenQA::Shared::Controller::Running->new(app => $app);
         my $faketx = Mojo::Transaction::Fake->new(fakestream => $id);

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -88,7 +88,9 @@ subtest streaming => sub {
 
         $controller->streamtext('test.txt');
         $t_file->remove();
-        Mojo::IOLoop->one_tick;
+        combined_like { Mojo::IOLoop->one_tick }
+        qr{Connection to worker .* will be closed because /tmp/.+/test.txt changed},
+          'connection termination is logged when log is truncated';
         ok $c_finished, 'controller has closed after file removed';
     };
 


### PR DESCRIPTION
To prevent `Timer failed: Too few arguments for subroutine`, the `$self` can be removed from the close_connection function because the variable is still accessible within the closure, so it is not needed.

Not directly connected to the issue but related
poo: https://progress.opensuse.org/issues/187014