### PR TITLE
Remove outdated comment in worker error handling

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -293,12 +293,8 @@ sub init ($self) {
             my $fatal_error = 'Another error occurred when trying to stop gracefully due to an error';
             if (!$self->{_shall_terminate} || $self->{_finishing_off}) {
                 try {
-                    # log error using print because logging utils might have caused the exception
-                    # (no need to repeat $err, it is printed anyways)
                     log_error('Stopping because a critical error occurred.');
-
-                    # try to stop the job nicely
-                    return $self->stop('exception');
+                    return $self->stop('exception');    # try to stop the job nicely
                 }
                 catch ($e) { $fatal_error = "$fatal_error: $e" }
             }


### PR DESCRIPTION
This code initially used `print` (see 34d13d690f) but as of 512e43c4a1 it actually uses the logging utility function. Considering this wasn't a problem so far there's no reason to change it back so I'm just removing the outdated comment.