### PR TITLE
Fix generation of PDF documentation

### DIFF
--- a/tools/generate-documentation
+++ b/tools/generate-documentation
@@ -206,6 +206,7 @@ install_asciidoctor() {
         gem install css_parser -v 1.12.0   # newer versions need Ruby 2.7
         gem install ttfunk -v 1.7.0
         gem install Ascii85 -v 1.1.1         # newer versions need Ruby 2.7
+        gem install afm -v 0.2.2             # newer versions need Ruby 3.2.0
         gem install asciidoctor-pdf -v 1.6.2 # newer versions need Ruby 2.7
     }
     cpanm -M https://cpan.metacpan.org --install Pod::AsciiDoctor


### PR DESCRIPTION
Pin afm to version 0.2.2

Issue: https://progress.opensuse.org/issues/187266