### PR TITLE
Use backticks in docs for querying job settings

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1031,9 +1031,9 @@ settings, here is one way to achieve this with `openqa-cli api`:
 openqa-cli api job_settings/jobs key="*_TEST_ISSUES" list_value=39911
 ----
 
-It is possible to use a literal string or a glob for C<key> as shown in the
-examples. C<list_value> does not support globbing, though.
-openQA configuration sets C<job_settings_max_recent_jobs> which limits
+It is possible to use a literal string or a glob for `key` as shown in the
+examples. `list_value` does not support globbing, though.
+openQA configuration sets `job_settings_max_recent_jobs` which limits
 the results.
 
 === Triggering tests


### PR DESCRIPTION
The `C<>` syntax is Perl, not asciidoc.

See: https://progress.opensuse.org/issues/180296