### PR TITLE
Clean up streamtext signature from unused params

### DIFF
--- a/lib/OpenQA/Shared/Controller/Running.pm
+++ b/lib/OpenQA/Shared/Controller/Running.pm
@@ -75,14 +75,10 @@ sub edit ($self) {
     $self->redirect_to('edit_step', moduleid => $running_module->name(), stepid => $stepid);
 }
 
-sub streamtext ($self, $file_name, $start_hook = undef, $close_hook = undef) {
+sub streamtext ($self, $file_name) {
     my $job = $self->stash('job');
     my $worker = $job->worker;
-    $start_hook ||= sub (@) { };
-    $close_hook ||= sub (@) { };
     my $logfile = $worker->get_property('WORKER_TMPDIR') . "/$file_name";
-
-    $start_hook->($worker, $job);
     $self->render_later;
     Mojo::IOLoop->stream($self->tx->connection)->timeout(900);
     my $res = $self->res;
@@ -113,10 +109,7 @@ sub streamtext ($self, $file_name, $start_hook = undef, $close_hook = undef) {
     # Setup utility function to close the connection if something goes wrong
     my $timer_id;
     my $close_connection = sub ($self) {
-        Mojo::IOLoop->remove($timer_id);
-        $close_hook->();
         $self->finish;
-        close $log;
     };
     $timer_id = Mojo::IOLoop->recurring(
         TEXT_STREAMING_INTERVAL() => sub (@) {
@@ -149,7 +142,7 @@ sub streamtext ($self, $file_name, $start_hook = undef, $close_hook = undef) {
     $self->on(
         finish => sub (@) {
             Mojo::IOLoop->remove($timer_id);
-            $close_hook->($worker, $job);
+            close $log;
         });
 }
 


### PR DESCRIPTION
The signature introduced in https://github.com/os-autoinst/openQA/pull/1019 which was also implemented the underline functions and seems had different design, until https://github.com/os-autoinst/openQA/pull/5060. The functions used websockets to send to the worker a $command. Both were replaced in some point and the corresponding functions can be found as `start_livelog` and `stop_livelog` in the Jobs.pm. They are assigned to the some contant variables and mainly are triggered by `streaming` function via `_send_livestream_command_to_worker`.

All this time the `$start_hook` and `$close_hook` were noop apparently, without any defect, AFAIT. Removing it comes with a small tidy and moving everything from close_connection to finish.