### PR TITLE
Allow configuring subdomain for serving logs/assets more securely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ install-generic:
 	done
 
 	install -d -m 755 "$(DESTDIR)"/etc/nginx/vhosts.d
-	for i in openqa-locations.inc openqa-upstreams.inc openqa.conf.template; do \
+	for i in openqa-assets.inc openqa-endpoints.inc openqa-locations.inc openqa-upstreams.inc openqa.conf.template; do \
 		install -m 644 etc/nginx/vhosts.d/$$i "$(DESTDIR)"/etc/nginx/vhosts.d ;\
 	done
 

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -593,6 +593,8 @@ fi
 %dir %{_sysconfdir}/nginx
 %dir %{_sysconfdir}/nginx/vhosts.d
 %config %{_sysconfdir}/nginx/vhosts.d/openqa.conf.template
+%config(noreplace) %{_sysconfdir}/nginx/vhosts.d/openqa-assets.inc
+%config(noreplace) %{_sysconfdir}/nginx/vhosts.d/openqa-endpoints.inc
 %config(noreplace) %{_sysconfdir}/nginx/vhosts.d/openqa-locations.inc
 %config(noreplace) %{_sysconfdir}/nginx/vhosts.d/openqa-upstreams.inc
 # apparmor profile

--- a/etc/nginx/vhosts.d/openqa-assets.inc
+++ b/etc/nginx/vhosts.d/openqa-assets.inc
@@ -1,0 +1,12 @@
+alias /var/lib/openqa/share/factory/;
+## Optional to require authentication for asset downloads
+#auth_request /api/v1/auth;
+autoindex          on;
+tcp_nopush         on;
+sendfile           on;
+sendfile_max_chunk 1m;
+
+# Enforce download of assets so HTML assets cannot highjack session
+# note: Can be disabled when using the alternative of making a redirect to a
+#       different subdomain mentioned in "openqa-locations.inc".
+add_header Content-Disposition 'attachment; filename="$1"';

--- a/etc/nginx/vhosts.d/openqa-endpoints.inc
+++ b/etc/nginx/vhosts.d/openqa-endpoints.inc
@@ -1,0 +1,68 @@
+root /usr/share/openqa/public;
+
+client_max_body_size 0;
+
+# The "client_body_buffer_size" value should usually be larger
+# than the UPLOAD_CHUNK_SIZE used by openQA workers, so there is
+# no excessive buffering to disk
+client_body_buffer_size 2m;
+
+# Default is exact which would need an exact match of Last-Modified
+if_modified_since before;
+
+## Optional to make use of auth_request to require authentication for asset downloads
+#location /api/v1/auth {
+#    internal;
+#    proxy_pass http://webui;
+#    tcp_nodelay        on;
+#    proxy_read_timeout 900;
+#    proxy_send_timeout 900;
+#    proxy_pass_request_body off;
+#    proxy_set_header Content-Length "";
+#    proxy_set_header Host $host;
+#    proxy_set_header X-Original-URI $request_uri;
+#    proxy_set_header X-Forwarded-Host $host:$server_port;
+#    proxy_set_header X-Forwarded-Server $host;
+#    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#    proxy_set_header X-Forwarded-Proto $scheme;
+#}
+
+## Optional faster image downloads for large deployments
+#location /image {
+#    alias /var/lib/openqa/images/;
+#    tcp_nopush         on;
+#    sendfile           on;
+#    sendfile_max_chunk 1m;
+#}
+
+location /api/v1/ws/ {
+    proxy_pass http://websocket;
+    proxy_http_version 1.1;
+    proxy_read_timeout 3600;
+    proxy_send_timeout 3600;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+}
+
+location /liveviewhandler/ {
+    proxy_pass http://livehandler;
+    proxy_http_version 1.1;
+    proxy_read_timeout 3600;
+    proxy_send_timeout 3600;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+}
+
+location / {
+    proxy_pass "http://webui";
+    tcp_nodelay        on;
+    proxy_read_timeout 900;
+    proxy_send_timeout 900;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host:$server_port;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}

--- a/etc/nginx/vhosts.d/openqa-locations.inc
+++ b/etc/nginx/vhosts.d/openqa-locations.inc
@@ -1,82 +1,10 @@
-root /usr/share/openqa/public;
-
-client_max_body_size 0;
-
-# The "client_body_buffer_size" value should usually be larger
-# than the UPLOAD_CHUNK_SIZE used by openQA workers, so there is
-# no excessive buffering to disk
-client_body_buffer_size 2m;
-
-# Default is exact which would need an exact match of Last-Modified
-if_modified_since before;
-
 ## Optional faster assets downloads for large deployments
 #location /assets {
-#    alias /var/lib/openqa/share/factory/;
-#    # Optional to require authentication for asset downloads
-#    #auth_request /api/v1/auth;
-#    autoindex          on;
-#    tcp_nopush         on;
-#    sendfile           on;
-#    sendfile_max_chunk 1m;
+#    include vhosts.d/openqa-assets.inc;
 #
-#    # Enforce download of assets so HTML assets cannot highjack session
-#    add_header Content-Disposition 'attachment; filename="$1"';
+#    ## Alternatively, make a redirect to a different subdomain in accordance
+#    ## with the file_subdomain in openQA config
+#    #return 301 http://file.$host$request_uri;
 #}
 
-## Optional to make use of auth_request to require authentication for asset downloads
-#location /api/v1/auth {
-#    internal;
-#    proxy_pass http://webui;
-#    tcp_nodelay        on;
-#    proxy_read_timeout 900;
-#    proxy_send_timeout 900;
-#    proxy_pass_request_body off;
-#    proxy_set_header Content-Length "";
-#    proxy_set_header Host $host;
-#    proxy_set_header X-Original-URI $request_uri;
-#    proxy_set_header X-Forwarded-Host $host:$server_port;
-#    proxy_set_header X-Forwarded-Server $host;
-#    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#    proxy_set_header X-Forwarded-Proto $scheme;
-#}
-
-## Optional faster image downloads for large deployments
-#location /image {
-#    alias /var/lib/openqa/images/;
-#    tcp_nopush         on;
-#    sendfile           on;
-#    sendfile_max_chunk 1m;
-#}
-
-location /api/v1/ws/ {
-    proxy_pass http://websocket;
-    proxy_http_version 1.1;
-    proxy_read_timeout 3600;
-    proxy_send_timeout 3600;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-}
-
-location /liveviewhandler/ {
-    proxy_pass http://livehandler;
-    proxy_http_version 1.1;
-    proxy_read_timeout 3600;
-    proxy_send_timeout 3600;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-}
-
-location / {
-    proxy_pass "http://webui";
-    tcp_nodelay        on;
-    proxy_read_timeout 900;
-    proxy_send_timeout 900;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Host $host:$server_port;
-    proxy_set_header X-Forwarded-Server $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-}
+include vhosts.d/openqa-endpoints.inc

--- a/etc/nginx/vhosts.d/openqa.conf.template
+++ b/etc/nginx/vhosts.d/openqa.conf.template
@@ -17,3 +17,27 @@ server {
 #    ssl_certificate_key /etc/dehydrated/certs/openqa.example.com/privkey.pem;
 #    include vhosts.d/openqa-locations.inc;
 #}
+
+# Provide different servers for serving assets under a different subdomain
+# (enable these in accordance to "Optional faster asset downloads …" in
+# "openqa-locations.inc")
+#server {
+#    listen       80;
+#    listen       [::]:80;
+#    # Set server_name in accordance with the file_subdomain in openQA config
+#    server_name  file.openqa.example.com;
+#    location /assets {
+#        include vhosts.d/openqa-assets.inc;
+#    }
+#    include vhosts.d/openqa-endpoints.inc;
+#}
+#server {
+#    listen       443;
+#    listen       [::]:443;
+#    # Set server_name in accordance with the file_subdomain in openQA config
+#    server_name  file.openqa.example.com;
+#    location /assets {
+#        include vhosts.d/openqa-assets.inc;
+#    }
+#    include vhosts.d/openqa-endpoints.inc;
+#}

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -56,9 +56,17 @@
 ##   avoid potentially malicious JavaScript code from hijacking the user session.
 ## * Set to "insecure-browsing" so these files can be browsed directly. This is
 ##   insecure as potentially malicious JavaScript can hijack the user session.
+## * Set to "subdomain:…" to let openQA redirect these files to another
+##   subdomain, e.g. "subdomain:file" will redirect file downloads from e.g.
+##   "example.openqa.org" to "file.example.openqa.org". The files will no longer
+##   be served as attachments to HTML files can be browsed conveniently and
+##   securely from that subdomain.
 ## note: Does *not* affect files served via a reverse proxy. The default NGINX
 ##       config contained by the openQA repo shows how to enforce a download
-##       prompt for assets served via NGINX.
+##       prompt for assets served via NGINX. It also shows how to setup
+##       redirections to a different subdomain which is a little bit more config
+##       effort and you also need to make sure your certificate is valid for
+##       this subdomain.
 #file_security_policy = download-prompt
 
 ## space-separated list of domains recognized by job labeling

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -72,6 +72,7 @@ sub read_config ($app) {
             # deprecated alternate for git_auto_commit below
             scm => undef,
             hsts => 365,
+            file_subdomain => undef,
             audit_enabled => 1,
             max_rss_limit => 0,
             profiling_enabled => 0,
@@ -307,7 +308,10 @@ sub _validate_worker_timeout ($app) {
 }
 
 sub _validate_security_policy ($app, $config) {
-    if ($config->{file_security_policy} !~ m/^(download-prompt|insecure-browsing)$/) {
+    if ($config->{file_security_policy} =~ m/^(download-prompt|insecure-browsing|subdomain:(.+))$/) {
+        if (defined(my $subdomain = $2)) { $config->{file_subdomain} = "$subdomain." }
+    }
+    else {
         $config->{file_security_policy} = 'download-prompt';
         $app->log->warn('Invalid file_security_policy specified, defaulting to "download-prompt"');
     }

--- a/lib/OpenQA/Shared/Controller/Session.pm
+++ b/lib/OpenQA/Shared/Controller/Session.pm
@@ -53,8 +53,11 @@ sub destroy {
 sub create {
     my ($self) = @_;
     my $ref = $self->req->headers->referrer;
-    my $auth_method = $self->app->config->{auth}->{method};
+    my $config = $self->app->config;
+    my $auth_method = $config->{auth}->{method};
     my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";
+    return $self->render(text => 'Forbidden via file subdomain', status => 403)
+      if $self->via_subdomain($config->{global}->{file_subdomain});
 
     # prevent redirecting loop when referrer is login page
     $ref = 'index' if !$ref or $ref eq $self->url_for('login');

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -21,6 +21,7 @@ sub register ($self, $app, @) {
     $app->helper(is_admin => \&_is_admin);
     $app->helper(is_local_request => \&_is_local_request);
     $app->helper(render_specific_not_found => \&_render_specific_not_found);
+    $app->helper(via_subdomain => \&_via_subdomain);
 }
 
 # returns the isotovideo command server web socket URL and the VNC argument for the given job or undef if not available
@@ -77,6 +78,11 @@ sub _is_local_request ($c) {
 sub _render_specific_not_found ($c, $title, $error_message) {
     $c->res->headers->content_type('text/plain');
     return $c->render(status => 404, text => "$title - $error_message");
+}
+
+sub _via_subdomain ($c, $subdomain) {
+    return 0 unless defined $subdomain;
+    return index($c->req->url->to_abs->host, $subdomain) == 0;
 }
 
 1;

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -12,6 +12,7 @@ use Test::Mojo;
 use Test::Warnings qw(:all :report_warnings);
 use Mojo::URL;
 use Mojo::Util qw(encode hmac_sha1_sum);
+use OpenQA::Shared::Controller::Auth;
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Case;
 use OpenQA::Test::Client 'client';
@@ -248,6 +249,25 @@ subtest 'personal access token (with reverse proxy)' => sub {
     # HTTPS but invalid key
     $t->$forwarded('artie:INVALID:EXCALIBUR', '192.168.2.1', 'https')->delete_ok('/api/v1/assets/1')->status_is(403)
       ->json_is({error => 'invalid personal access token'});
+};
+
+subtest 'auth forbidden via subdomain' => sub {
+    my $rendered;
+    my $req = Mojo::Message::Request->new;
+    $req->url->parse('http://foobar.openqa.de/test/42');
+    my $controller_mock = Test::MockModule->new('Mojolicious::Controller');
+    $controller_mock->redefine(req => $req);
+    $controller_mock->redefine(render => sub ($c, @args) { $rendered = [@args] });
+    my $c = OpenQA::Shared::Controller::Auth->new(app => $t->app, req => $req);
+    $c->config->{global}->{file_subdomain} = 'foobar.';
+    is $c->auth, 0, 'auth denied via subdomain';
+    my %expected_json = (error => 'Forbidden via file subdomain');
+    my @expected = (json => \%expected_json, status => 403);
+    is_deeply $rendered, \@expected, 'expected error and status';
+    $req->url->parse('http://openqa.de/test/42');
+    is $c->auth, 0, 'auth denied via regular domain';
+    $expected_json{error} = 'no api key';
+    is_deeply $rendered, \@expected, 'normal auth error via regular domain';
 };
 
 done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -333,6 +333,10 @@ subtest 'Validation of file_security_policy' => sub {
     $config{file_security_policy} = 'wrong';
     combined_like { OpenQA::Setup::_validate_security_policy($app, \%config) } qr/Invalid.*security/, 'warning logged';
     is $config{file_security_policy}, 'download-prompt', 'default to "download-prompt" on invalid value';
+    is $config{file_subdomain}, undef, 'file_subdomain not populated yet';
+    $config{file_security_policy} = 'subdomain:foo';
+    OpenQA::Setup::_validate_security_policy($app, \%config);
+    is $config{file_subdomain}, 'foo.', 'file_subdomain populated via "subdomain:"';
 };
 
 subtest 'Multiple config files' => sub {

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -141,4 +141,12 @@ $t->get_ok('/assets/iso/../iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->sta
 $t->get_ok('/assets/hdd/foo.qcow2')->status_is(200)->content_type_is('application/octet-stream');
 $t->get_ok('/assets/repo/testrepo/doesnotexist')->status_is(404);
 
+subtest 'redirection to different subdomain' => sub {
+    my $config = $t->app->config->{global};
+    $config->{file_security_policy} = 'subdomain:file';
+    $config->{file_subdomain} = 'file.';
+    $t->get_ok('/assets/repo/testrepo/README.html')->status_is(302);
+    $t->header_like(Location => qr|^http://file\.[^/]*/assets/repo/testrepo/README.html$|);
+};
+
 done_testing();


### PR DESCRIPTION
* Based on https://github.com/os-autoinst/openQA/pull/6667 so it makes
   most sense to review only the 2nd commit here (after reviewing #6667)
* Allow configuring a redirection to a configurable subdomain
* Update NINGX templates to cover files served directly via NGINX as well
    * Move most of `openqa-locations.inc` to a separate file to be able to
      include it separately (without asset locations); none of the code in
      `openqa-endpoints.inc` is therefore new
    * Keep asset location in `openqa-locations.inc` to avoid breaking
      too much; this way one can still include `openqa-locations.inc` as
      before covering assets and endpoints
* See https://progress.opensuse.org/issues/184456