### PR TITLE
Use dedicated option to download iso and hdd with archive subcommand

### DIFF
--- a/lib/OpenQA/CLI/archive.pm
+++ b/lib/OpenQA/CLI/archive.pm
@@ -21,7 +21,8 @@ sub command ($self, @args) {
             url => $url,
             archive => $path,
             'with-thumbnails' => $options{'with-thumbnails'},
-            'asset-size-limit' => $options{'asset-size-limit'}});
+            'asset-size-limit' => $options{'asset-size-limit'},
+            'no-limit' => $options{'no-limit'}});
 
     return 0;
 }

--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -18,7 +18,8 @@ sub run ($self, $options) {
     my $res = $req->res;
     my $default_max_asset_size = 1024 * 1024 * 200;
     $options->{'asset-size-limit'} //= $default_max_asset_size;
-    $self->client->max_response_size($options->{'asset-size-limit'});
+    $options->{'no-limit'} //= 0;
+    $self->client->max_response_size($options->{'no-limit'} ? 0 : $options->{'asset-size-limit'});
 
     my $code = $res->code;
     die "There's an error openQA client returned $code" unless $code eq 200;
@@ -32,7 +33,7 @@ sub run ($self, $options) {
     delete($job->{assets}->{repo});
 
     $path->child('testresults', 'thumbnails')->make_path if $options->{'with-thumbnails'};
-    $self->_download_assets($url, $job, $path);
+    $self->_download_assets($url, $job, $path) if $options->{'no-limit'};
     $self->_download_test_results($url, $job, $path, $options);
 }
 

--- a/public/openqa-cli.yaml
+++ b/public/openqa-cli.yaml
@@ -163,6 +163,7 @@ subcommands:
     options:
       - asset-size-limit|l=i   --Asset size limit in bytes
       - with-thumbnails|t      --Download thumbnails as well
+      - no-limit|u             --Download all assets without size limits
 
   schedule:
     summary: Schedules a set of jobs (via "isos post" creating a schedule product)

--- a/t/43-cli-archive.t
+++ b/t/43-cli-archive.t
@@ -15,6 +15,7 @@ use OpenQA::CLI;
 use OpenQA::CLI::archive;
 use OpenQA::Test::Case;
 use OpenQA::Test::TimeLimit '10';
+use OpenQA::Utils qw(assetdir);
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
 
@@ -144,6 +145,17 @@ subtest 'Archive job with thumbnails' => sub {
     ok -f $results->child('details-isosize.json'), 'details-isosize.json exists';
     ok -f $results->child('autoinst-log.txt'), 'autoinst-log.txt exists';
     ok -d $results->child('thumbnails'), 'thumbnails';
+};
+
+subtest 'Archive job with assets' => sub {
+    note('Asset directory: ' . assetdir());
+    my $target = $dir->child('archive-with-assets')->make_path;
+    my ($stdout, $stderr, @result)
+      = capture_stdout sub { $cli->run('archive', @host, '--no-limit', 99963, $target->to_string) };
+    like $stdout, qr{Downloading.*/iso/openSUSE-13.1-DVD-x86_64-Build0091-Media.iso}, 'download iso without size limit';
+    my $expected_iso = 'openSUSE-13.1-DVD-x86_64-Build0091-Media.iso';
+    my $iso_path = $target->child('iso', $expected_iso);
+    ok(-f $iso_path, "Asset was downloaded");
 };
 
 done_testing();


### PR DESCRIPTION
Based on the history this did not meant to download other assets than 'other'
assets and it is implemeted using the `asset-size-limit` parameter, which was
set in a quite small size.
https://github.com/os-autoinst/openQA/pull/1571#discussion_r165847808
    
With this size in place, the error is confusing and not intuitive. It makes
more sense to remove the limit in case you want to get the full assets.
    
- Introduce ~`--all`~ `no-limit` to skip _asset-size-limit_. short `-u` as unlimit
- keep _asset-size-limit_ for the 'other' assets
