### PR TITLE
Do not invoke Mojo::IOLoop->remove twice

### DIFF
--- a/lib/OpenQA/Shared/Controller/Running.pm
+++ b/lib/OpenQA/Shared/Controller/Running.pm
@@ -111,9 +111,7 @@ sub streamtext ($self, $file_name) {
     my $close_connection = sub ($self) {
         my $worker_id = $worker->id;
         log_debug "Connection to worker with ID $worker_id will be closed because $logfile changed";
-        Mojo::IOLoop->remove($timer_id);
         $self->finish;
-        close $log;
     };
     $timer_id = Mojo::IOLoop->recurring(
         TEXT_STREAMING_INTERVAL() => sub (@) {
@@ -143,7 +141,11 @@ sub streamtext ($self, $file_name) {
         });
 
     # Stop monitoring the logfile when the connection closes
-    $self->on(finish => sub (@) { Mojo::IOLoop->remove($timer_id); });
+    $self->on(
+        finish => sub (@) {
+            Mojo::IOLoop->remove($timer_id);
+            close $log;
+        });
 }
 
 sub livelog ($self) {
@@ -196,7 +198,6 @@ sub streaming ($self) {
     # setup a function to stop streaming again
     my $timer_id;
     my $close_connection = sub ($self, @) {
-        Mojo::IOLoop->remove($timer_id);
         $self->finish;
     };
 


### PR DESCRIPTION
Seems that one of the calls can be removed. When `close_connection` is called, jumps into `$self->finish` which does exactly the same.