### PR TITLE
MCP: Add support for Bearer token authentication

### DIFF
--- a/docs/Client.asciidoc
+++ b/docs/Client.asciidoc
@@ -96,9 +96,9 @@ openqa-cli api --host http://openqa.example.com --apikey 1234567890ABCDEF \
 The authentication mechanism used by `openqa-cli` was specifically designed to
 allow secure access to the REST API even via unencrypted HTTP connections. But
 when your openQA server has been deployed with HTTPS (and for HTTP connections
-originating from localhost) you can also use plain old Basic authentication
-with a personal access token. That allows for almost any HTTP client to be used
-with openQA.
+originating from localhost) you can also use plain old Basic or Bearer token
+authentication with a personal access token. That allows for almost any HTTP
+client to be used with openQA.
 
 This access token is made up of your username, and the same key/secret combo
 the `openqa-cli` authentication mechanism uses. All you have to do is combine
@@ -109,6 +109,16 @@ admin REST endpoints (depending on user privileges of course).
 ----
 curl -u arthur:1234567890ABCDEF:ABCDEF1234567890 -X DELETE \
     https://openqa.example.com/api/v1/assets/1
+----
+
+And for HTTP clients that don't support Basic authentication or where the use
+of plain HTTP headers might be more convenient, you can also send the
+personal access token in the form of a Bearer token.
+
+[source,sh]
+----
+curl -H 'Authorization: Bearer arthur:1234567890ABCDEF:ABCDEF1234567890'\
+    -X DELETE https://openqa.example.com/api/v1/assets/1
 ----
 
 == Features

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -56,7 +56,10 @@ sub auth ($self) {
     else {
 
         # Personal access token
-        if (my $userinfo = $self->req->url->to_abs->userinfo) {
+        if (($self->req->headers->authorization // '') =~ /^Bearer\s+(.+)$/) {
+            ($user, $reason) = $self->_token_auth($reason, $1);
+        }
+        elsif (my $userinfo = $self->req->url->to_abs->userinfo) {
             ($user, $reason) = $self->_token_auth($reason, $userinfo);
         }
 

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -213,6 +213,28 @@ subtest 'personal access token' => sub {
 
     # Valid access token (again)
     $t->$userinfo('artie:ARTHURKEY01:EXCALIBUR')->delete_ok('/api/v1/assets/1')->status_is(404);
+
+    subtest 'Bearer token' => sub {
+        subtest 'Valid token' => sub {
+            $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer lance:LANCELOTKEY01:MANYPEOPLEKNOW'} => form =>
+                  {version => 100})->status_is(200);
+        };
+
+        subtest 'Invalid username' => sub {
+            $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer invalid:LANCELOTKEY01:MANYPEOPLEKNOW'} => form =>
+                  {version => 100})->status_is(403)->json_is({error => 'invalid personal access token'});
+        };
+
+        subtest 'Invalid key' => sub {
+            $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer lance:LANCELOTKEY02:MANYPEOPLEKNOW'} => form =>
+                  {version => 100})->status_is(403)->json_is({error => 'invalid personal access token'});
+        };
+
+        subtest 'Invalid secret' => sub {
+            $t->post_ok('/api/v1/feature' => {Authorization => 'Bearer lance:LANCELOTKEY01:MANYPEOPLEKNOWS'} => form =>
+                  {version => 100})->status_is(403)->json_is({error => 'invalid personal access token'});
+        };
+    };
 };
 
 subtest 'personal access token (with reverse proxy)' => sub {


### PR DESCRIPTION
This patch adds bearer token authentication to the existing personal access token mechanism. It is meant to prepare openQA for the addition of MCP support. Almost all MCP clients use bearer token authentication at the moment. Future versions of the MCP specification will most likely require more sophisticated authentication mechanisms.

For clients that use the standard `mcp.json` format, a configuration using bearer token authentication should look something like this:
```
{
  "mcpServers": {
    "openqa": {
      "url": "http://127.0.0.1:9526/experimental/mcp",
      "headers": {
        "Authorization": "Bearer USER:KEY:SECRET"
      }
    }
  }
}
```

More patches with the actual MCP functionality will follow.

Progress: https://progress.opensuse.org/issues/184798