### PR TITLE
parser: ktap: Don't write diagnostic data into subtest name

### DIFF
--- a/lib/OpenQA/Parser/Format/KTAP.pm
+++ b/lib/OpenQA/Parser/Format/KTAP.pm
@@ -48,7 +48,7 @@ sub _parse_subtest ($self, $result) {
     $self->test or return;
 
     my $line = $result->as_string;
-    return unless $line =~ /^#\s*(?<status>ok|not ok)\s+\d+\s+(?<name>.+)/;
+    return unless $line =~ /^#\s*(?<status>ok|not ok)\s+\d+\s+(?<name>[^#]*)/;
     my ($status, $subtest_name) = @+{qw(status name)};
 
     my $has_todo = $line =~ /#\s*TODO\b/i;


### PR DESCRIPTION
Verification runs:
- Before: https://rmarliere-openqa.qe.prg2.suse.org/tests/1539#external
- After: https://rmarliere-openqa.qe.prg2.suse.org/tests/1545#external