### PR TITLE
Fix syntax error in nginx config

### DIFF
--- a/etc/nginx/vhosts.d/openqa-locations.inc
+++ b/etc/nginx/vhosts.d/openqa-locations.inc
@@ -7,4 +7,4 @@
 #    #return 301 http://file.$host$request_uri;
 #}
 
-include vhosts.d/openqa-endpoints.inc
+include vhosts.d/openqa-endpoints.inc;


### PR DESCRIPTION
This should fix https://progress.opensuse.org/issues/188208 and the [currently failing openqa-in-openqa tests](https://openqa.opensuse.org/tests/5284271/#step/openqa_webui/15).