### PR TITLE
Ensure destination dir for asset downloads exists when cloning jobs

### DIFF
--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -134,7 +134,7 @@ sub _download_asset ($self, $url, $jobid, $path, $type, $file) {
 
     # Assume that we're in the working directory
     my $destination_directory = $path->child($type)->make_path;
-    die "can't write in $path/$type directory" unless -w "$destination_directory";
+    die "Cannot write in $path/$type directory" unless -w "$destination_directory";
     $file = $destination_directory->child($file);
 
     # Ensure we are requesting the right file, so call basename

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -158,7 +158,7 @@ sub clone_job_download_assets ($jobid, $job, $url_handler, $options) {
             $from->path(sprintf '/tests/%d/asset/%s/%s', $jobid, $type, $file);
             $from = $from->to_string;
 
-            die "can't write $dst_dir\n" unless -w $dst_dir;
+            die "Cannot write $dst_dir\n" unless -w $dst_dir;
 
             print STDERR "downloading\n$from\nto\n$dst\n";
             my $r = $ua->mirror($from, $dst);

--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -152,12 +152,13 @@ sub clone_job_download_assets ($jobid, $job, $url_handler, $options) {
                 next unless $parent_publishes_uefi_vars;
             }
             $dst =~ s,.*/,,;
-            $dst = join('/', $options->{dir}, $type, $dst);
+            my $dst_dir = path($options->{dir}, $type)->make_path;
+            $dst = $dst_dir->child($dst)->to_string;
             my $from = $remote_url->clone;
             $from->path(sprintf '/tests/%d/asset/%s/%s', $jobid, $type, $file);
             $from = $from->to_string;
 
-            die "can't write $options->{dir}/$type\n" unless -w "$options->{dir}/$type";
+            die "can't write $dst_dir\n" unless -w $dst_dir;
 
             print STDERR "downloading\n$from\nto\n$dst\n";
             my $r = $ua->mirror($from, $dst);

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -125,6 +125,7 @@ subtest 'asset download' => sub {
         },
         missing_assets => \@missing_assets
     );
+    $temp_assetdir->child($_)->make_path->chmod(0555) for qw(iso hdd);    # test with unwritable asset folders
     my $clone_mock = Test::MockModule->new('OpenQA::Script::CloneJob');
     $clone_mock->redefine(
         clone_job_get_job => sub ($job_id, $url_handler, $options) {
@@ -141,10 +142,10 @@ subtest 'asset download' => sub {
     );
 
     throws_ok { clone_job_download_assets($job_id, \%job, \%url_handler, \%options) }
-    qr/can't write $temp_assetdir/, 'error because folder does not exist';
+    qr/can't write $temp_assetdir/, 'error because folder is not writable';
 
     # assume an asset download fails
-    $temp_assetdir->child($_)->make_path for qw(iso hdd);
+    $temp_assetdir->child($_)->remove_tree for qw(iso hdd);    # test with missing asset folders (will be created)
     $fake_ua->missing(1);
     throws_ok {
         combined_like { clone_job_download_assets($job_id, \%job, \%url_handler, \%options) }

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -142,7 +142,7 @@ subtest 'asset download' => sub {
     );
 
     throws_ok { clone_job_download_assets($job_id, \%job, \%url_handler, \%options) }
-    qr/can't write $temp_assetdir/, 'error because folder is not writable';
+    qr/Cannot write $temp_assetdir/, 'error because folder is not writable';
 
     # assume an asset download fails
     $temp_assetdir->child($_)->remove_tree for qw(iso hdd);    # test with missing asset folders (will be created)


### PR DESCRIPTION
* Avoid running into errors like `can't write /hdd/openqa-devel/openqa/share/factory/hdd` when this directory just doesn't exist; try to create the directory instead
* Keep the `-w $dst_dir` check so one still gets the usual error message when trying to download assets under e.g. `/var/lib/openqa` with a user that cannot write there
* See https://progress.opensuse.org/issues/184909

---

I tested this locally by running `openqa-clone-job` with different users and different `--dir` parameters.