### PR TITLE
Allow specifying a full domain via `file_security_policy`

### DIFF
--- a/etc/nginx/vhosts.d/openqa-assets.inc
+++ b/etc/nginx/vhosts.d/openqa-assets.inc
@@ -8,5 +8,5 @@ sendfile_max_chunk 1m;
 
 # Enforce download of assets so HTML assets cannot highjack session
 # note: Can be disabled when using the alternative of making a redirect to a
-#       different subdomain mentioned in "openqa-locations.inc".
+#       different domain mentioned in "openqa-locations.inc".
 add_header Content-Disposition 'attachment; filename="$1"';

--- a/etc/nginx/vhosts.d/openqa-locations.inc
+++ b/etc/nginx/vhosts.d/openqa-locations.inc
@@ -2,9 +2,9 @@
 #location /assets {
 #    include vhosts.d/openqa-assets.inc;
 #
-#    ## Alternatively, make a redirect to a different subdomain in accordance
-#    ## with the file_subdomain in openQA config
-#    #return 301 http://file-$host$request_uri;
+#    ## Alternatively, make a redirect to a different domain in accordance with
+#    ## the file_security_policy in openQA config
+#    #return 301 http://$host-files$request_uri;
 #}
 
 include vhosts.d/openqa-endpoints.inc;

--- a/etc/nginx/vhosts.d/openqa.conf.template
+++ b/etc/nginx/vhosts.d/openqa.conf.template
@@ -18,14 +18,14 @@ server {
 #    include vhosts.d/openqa-locations.inc;
 #}
 
-# Provide different servers for serving assets under a different subdomain
+# Provide different servers for serving assets under a different domain
 # (enable these in accordance to "Optional faster asset downloads …" in
 # "openqa-locations.inc")
 #server {
 #    listen       80;
 #    listen       [::]:80;
-#    # Set server_name in accordance with the file_subdomain in openQA config
-#    server_name  files-openqa.example.com;
+#    # Set server_name in accordance with the file_security_policy in openQA config
+#    server_name  openqa-files.example.com;
 #    location /assets {
 #        include vhosts.d/openqa-assets.inc;
 #    }
@@ -34,8 +34,8 @@ server {
 #server {
 #    listen       443;
 #    listen       [::]:443;
-#    # Set server_name in accordance with the file_subdomain in openQA config
-#    server_name  files-openqa.example.com;
+#    # Set server_name in accordance with the file_security_policy in openQA config
+#    server_name  openqa-files.example.com;
 #    location /assets {
 #        include vhosts.d/openqa-assets.inc;
 #    }

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -56,17 +56,17 @@
 ##   avoid potentially malicious JavaScript code from hijacking the user session.
 ## * Set to "insecure-browsing" so these files can be browsed directly. This is
 ##   insecure as potentially malicious JavaScript can hijack the user session.
-## * Set to "subdomain:…" to let openQA redirect these files to another
-##   subdomain, e.g. "subdomain:files-" will redirect file downloads from e.g.
-##   "openqa.org" to "files-openqa.org". The files will no longer
-##   be served as attachments to HTML files can be browsed conveniently and
-##   securely from that subdomain.
+## * Set to "domain:…" to let openQA redirect these files to another domain,
+##   e.g. "domain:openqa-files.org" can be used to redirect file downloads from
+##   e.g. "openqa.org" to "openqa-files.org". The files will no longer be served
+##   as attachments so HTML files can be browsed conveniently and securely from
+##   that second domain.
 ## note: Does *not* affect files served via a reverse proxy. The default NGINX
 ##       config contained by the openQA repo shows how to enforce a download
 ##       prompt for assets served via NGINX. It also shows how to setup
-##       redirections to a different subdomain which is a little bit more config
-##       effort and you also need to make sure your certificate is valid for
-##       this subdomain.
+##       redirections to a different domain which is a little bit more config
+##       effort and you also need to make sure you have a valid certificate for
+##       the other domain.
 #file_security_policy = download-prompt
 
 ## space-separated list of domains recognized by job labeling

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -308,8 +308,8 @@ sub _validate_worker_timeout ($app) {
 }
 
 sub _validate_security_policy ($app, $config) {
-    if ($config->{file_security_policy} =~ m/^(download-prompt|insecure-browsing|subdomain:(.+))$/) {
-        if (defined(my $subdomain = $2)) { $config->{file_subdomain} = $subdomain }
+    if ($config->{file_security_policy} =~ m/^(download-prompt|insecure-browsing|domain:(.+))$/) {
+        if (defined(my $domain = $2)) { $config->{file_domain} = $domain }
     }
     else {
         $config->{file_security_policy} = 'download-prompt';

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -12,7 +12,7 @@ use Mojo::URL;
 sub check ($self) {
     my $config = $self->app->config;
     return 1 if $config->{no_localhost_auth} && $self->is_local_request;
-    return 0 if $self->via_subdomain($config->{global}->{file_subdomain});
+    return 0 if $self->via_domain($config->{global}->{file_domain});
 
     my $req = $self->req;
     my $headers = $req->headers;
@@ -46,9 +46,9 @@ sub check ($self) {
 sub auth ($self) {
     my $log = $self->app->log;
 
-    # Prevent authentication via file subdomain (where potentially untrusted HTML is served)
-    if ($self->via_subdomain($self->config->{global}->{file_subdomain})) {
-        $self->render(json => {error => 'Forbidden via file subdomain'}, status => 403);
+    # Prevent authentication via file domain (where potentially untrusted HTML is served)
+    if ($self->via_domain($self->config->{global}->{file_domain})) {
+        $self->render(json => {error => 'Forbidden via file domain'}, status => 403);
         return 0;
     }
 

--- a/lib/OpenQA/Shared/Controller/Session.pm
+++ b/lib/OpenQA/Shared/Controller/Session.pm
@@ -56,8 +56,8 @@ sub create {
     my $config = $self->app->config;
     my $auth_method = $config->{auth}->{method};
     my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";
-    return $self->render(text => 'Forbidden via file subdomain', status => 403)
-      if $self->via_subdomain($config->{global}->{file_subdomain});
+    return $self->render(text => 'Forbidden via file domain', status => 403)
+      if $self->via_domain($config->{global}->{file_domain});
 
     # prevent redirecting loop when referrer is login page
     $ref = 'index' if !$ref or $ref eq $self->url_for('login');

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -21,7 +21,7 @@ sub register ($self, $app, @) {
     $app->helper(is_admin => \&_is_admin);
     $app->helper(is_local_request => \&_is_local_request);
     $app->helper(render_specific_not_found => \&_render_specific_not_found);
-    $app->helper(via_subdomain => \&_via_subdomain);
+    $app->helper(via_domain => \&_via_domain);
 }
 
 # returns the isotovideo command server web socket URL and the VNC argument for the given job or undef if not available
@@ -80,9 +80,6 @@ sub _render_specific_not_found ($c, $title, $error_message) {
     return $c->render(status => 404, text => "$title - $error_message");
 }
 
-sub _via_subdomain ($c, $subdomain) {
-    return 0 unless defined $subdomain;
-    return index($c->req->url->to_abs->host, $subdomain) == 0;
-}
+sub _via_domain ($c, $domain) { defined $domain && $c->req->url->to_abs->host eq $domain }
 
 1;

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -173,13 +173,11 @@ sub _set_headers ($self, $path) {
 
 sub _redirect_if_configured ($self, $is_text) {
     # skip harmless text files as the viewer doesn't follow redirects and those files are not problematic anyway
-    return 0 if $is_text || !defined(my $subdomain = $self->app->config->{global}->{file_subdomain});
-    # redirect to configured subdomain so potentially dangerious HTML files cannot use the current session
+    return 0 if $is_text || !defined(my $domain = $self->app->config->{global}->{file_domain});
+    # redirect to configured domain so potentially dangerious HTML files cannot use the current session
     my $url = $self->req->url->to_abs;
-    my $host = $url->host;
-    # skip if already redirected
-    return 0 unless index($host, $subdomain) == -1;
-    $url->host($subdomain . $host);
+    return 0 if $url->host eq $domain;    # skip if already redirected
+    $url->host($domain);
     $self->redirect_to($url);
     return 1;
 }

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -273,7 +273,7 @@ subtest 'personal access token (with reverse proxy)' => sub {
       ->json_is({error => 'invalid personal access token'});
 };
 
-subtest 'auth forbidden via subdomain' => sub {
+subtest 'auth forbidden via domain' => sub {
     my $rendered;
     my $req = Mojo::Message::Request->new;
     $req->url->parse('http://foobar-openqa.de/test/42');
@@ -281,9 +281,9 @@ subtest 'auth forbidden via subdomain' => sub {
     $controller_mock->redefine(req => $req);
     $controller_mock->redefine(render => sub ($c, @args) { $rendered = [@args] });
     my $c = OpenQA::Shared::Controller::Auth->new(app => $t->app, req => $req);
-    $c->config->{global}->{file_subdomain} = 'foobar-';
-    is $c->auth, 0, 'auth denied via subdomain';
-    my %expected_json = (error => 'Forbidden via file subdomain');
+    $c->config->{global}->{file_domain} = 'foobar-openqa.de';
+    is $c->auth, 0, 'auth denied via domain';
+    my %expected_json = (error => 'Forbidden via file domain');
     my @expected = (json => \%expected_json, status => 403);
     is_deeply $rendered, \@expected, 'expected error and status';
     $req->url->parse('http://openqa.de/test/42');

--- a/t/config.t
+++ b/t/config.t
@@ -333,10 +333,10 @@ subtest 'Validation of file_security_policy' => sub {
     $config{file_security_policy} = 'wrong';
     combined_like { OpenQA::Setup::_validate_security_policy($app, \%config) } qr/Invalid.*security/, 'warning logged';
     is $config{file_security_policy}, 'download-prompt', 'default to "download-prompt" on invalid value';
-    is $config{file_subdomain}, undef, 'file_subdomain not populated yet';
-    $config{file_security_policy} = 'subdomain:foo-';
+    is $config{file_domain}, undef, 'file_domain not populated yet';
+    $config{file_security_policy} = 'domain:openqa-foo';
     OpenQA::Setup::_validate_security_policy($app, \%config);
-    is $config{file_subdomain}, 'foo-', 'file_subdomain populated via "subdomain:"';
+    is $config{file_domain}, 'openqa-foo', 'file_domain populated via "domain:"';
 };
 
 subtest 'Multiple config files' => sub {

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -141,12 +141,12 @@ $t->get_ok('/assets/iso/../iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->sta
 $t->get_ok('/assets/hdd/foo.qcow2')->status_is(200)->content_type_is('application/octet-stream');
 $t->get_ok('/assets/repo/testrepo/doesnotexist')->status_is(404);
 
-subtest 'redirection to different subdomain' => sub {
+subtest 'redirection to different domain' => sub {
     my $config = $t->app->config->{global};
-    $config->{file_security_policy} = 'subdomain:files-';
-    $config->{file_subdomain} = 'files-';
+    $config->{file_security_policy} = 'domain:openqa-files';
+    $config->{file_domain} = 'openqa-files';
     $t->get_ok('/assets/repo/testrepo/README.html')->status_is(302);
-    $t->header_like(Location => qr|^http://files-[^/]*/assets/repo/testrepo/README.html$|);
+    $t->header_like(Location => qr|^http://openqa-files(:\d+)?/assets/repo/testrepo/README.html$|);
 };
 
 done_testing();


### PR DESCRIPTION
With this, files can be served from any additional domain and not just from domains with some additional prefix. This of course means that one now also has to specify the full domain always. However, that probably not a big
deal and we have other settings such as `download_domains` which are already similar.

This replaces the previous `subdomain:…` syntax to avoid providing too many options and having too complex code.

Related ticket: https://progress.opensuse.org/issues/184456