### PR TITLE
parser: ktap: Don't add skipped subtests to output

### DIFF
--- a/lib/OpenQA/Parser/Format/KTAP.pm
+++ b/lib/OpenQA/Parser/Format/KTAP.pm
@@ -70,6 +70,7 @@ sub _parse_subtest ($self, $result) {
         $steps->{result} = 'softfail';
     }
 
+    return if $line =~ /#\s*SKIP\b/i;
     $self->_add_output({file => $filename, content => $line});
     $self->state->{m} = $m + 1;
 }


### PR DESCRIPTION
Verification runs:
- Before: https://rmarliere-openqa.qe.prg2.suse.org/tests/1555
- After: https://rmarliere-openqa.qe.prg2.suse.org/tests/1556