### PR TITLE
Add MCP support as an optional feature

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -222,7 +222,7 @@ Summary:        Additional MCP package for AI support in openQA
 Requires:       %{mcp_requires}
 
 %description mcp
-This package contains additional resources for AI support in openQA.
+This package contains a plugin for AI support in openQA.
 
 %package client
 Summary:        Client tools for remote openQA management
@@ -642,6 +642,7 @@ fi
 %{_datadir}/openqa/lib/OpenQA/Scheduler/
 %{_datadir}/openqa/lib/OpenQA/Schema/
 %{_datadir}/openqa/lib/OpenQA/WebAPI/
+%exclude %{_datadir}/openqa/lib/OpenQA/WebAPI/Plugin/MCP.pm
 %{_datadir}/openqa/lib/OpenQA/WebSockets/
 %{_datadir}/openqa/templates
 %{_datadir}/openqa/public
@@ -861,5 +862,6 @@ fi
 %endif
 
 %files mcp
+%{_datadir}/openqa/lib/OpenQA/WebAPI/Plugin/MCP.pm
 
 %changelog

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1919,6 +1919,81 @@ SUSE distribution's serial terminal utility library). However some programs
 ignore this, but piping there output into `tee` is usually enough to stop them
 outputting non-printable characters.
 
+=== MCP Support
+
+The https://modelcontextprotocol.io/[Model Context Protocol] (MCP) is a standard
+that allows Large Language Models (LLMs) to interact with web services. MCP is
+supported natively by openQA, but still considered experimental, and therefore
+needs to be enabled manually in `openqa.ini`.
+
+[source,ini]
+----
+[global]
+mcp_enabled = read-only
+----
+
+Once enabled the experimental MCP endpoint becomes available under the path
+`/experimental/mcp`. At the moment all implemented MCP tools are read-only,
+that means LLMs can review infomation provided by openQA, but are unable to
+make changes or trigger actions. Once write operations become available
+with future updates, they will have to be enabled with a different setting
+in `openqa.ini` for security reasons.
+
+Most MCP clients today support Bearer token authentication, so that is what
+openQA relies on as well. More authentication mechanisms will be added as
+the technology evolves.
+
+This example configuration in the `mcp.json` format, which is commonly used
+by MCP clients, shows how to include an openQA personal access token by
+setting the `Authorization` HTTP header:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "openqa": {
+      "url": "http://127.0.0.1:9526/experimental/mcp",
+      "headers": {
+        "Authorization": "Bearer USER:KEY:SECRET"
+      }
+    }
+  }
+}
+----
+
+==== 3rd Party MCP Clients
+===== gemini-cli
+
+Once you have installed and set up
+https://github.com/google-gemini/gemini-cli[gemini-cli], you can use the
+`gemini mcp` command to add openQA:
+
+[source,shell]
+----
+gemini mcp add openqa http://127.0.0.1:9526/experimental/mcp -H 'Authorization: Bearer USER:KEY:SECRET' -t http
+----
+
+After restarting gemini-cli, it will automatically discover available openQA
+tools and make use of them on its own:
+
+[source]
+----
+╭────────────────────────────────────────────────────╮
+│  > give me a brief summary for openQA job 5265754  │
+╰────────────────────────────────────────────────────╯
+
+ ╭───────────────────────────────────────────────────────────────────╮
+ │ ✔ openqa_get_job_info (openqa MCP Server) openqa_get_job_info...  │
+ │                                                                   │
+ │    ...                                                            │
+ ╰───────────────────────────────────────────────────────────────────╯
+✦ Job 5265754 was a passed test named opensuse-Tumbleweed-DVD-x86_64-
+  Build20250825-ltp_net_features@64bit. It ran on August 26, 2025,
+  and took about 21 minutes to complete. The job tested the
+  ltp_net_features test suite on the x86_64 architecture. Most of the
+   tests passed, with a few being skipped.
+----
+
 
 == Test Development tricks
 === Trigger new tests by modifying settings from existing test runs

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -41,6 +41,12 @@
 ##   So don't enable this plugin in production.
 #monitoring_enabled = 0
 
+## Set to read-only to enable MCP support
+## * A Model Context Protocol endpoint will be available to all users under
+##   /experimental/mcp route.
+## * Do not enable this feature for openQA instances with special security requirements!
+#mcp_enabled = no
+
 ## space-separated list of extra plugins to load; plugin must be under
 ## OpenQA::WebAPI::Plugin and correctly-cased module name given here,
 ## this example loads OpenQA::WebAPI::Plugin::AMQP
@@ -317,6 +323,8 @@ concurrent = 0
 #worker_limit_retry_delay = 900
 ## Maximum number of retries with exponential back-off for GruJobs to wait for a GruTask to appear in the database
 #wait_for_grutask_retries = 6
+## Maximum size of MCP results in bytes (to prevent performance issues)
+# mcp_max_result_size = 500000
 
 [archiving]
 ## Moves logs of jobs which are preserved during the cleanup because they are considered important

--- a/lib/OpenQA/Schema/ResultSet/Workers.pm
+++ b/lib/OpenQA/Schema/ResultSet/Workers.pm
@@ -1,0 +1,23 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Schema::ResultSet::Workers;
+use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
+
+sub stats ($self) {
+    my $total = $self->count;
+    my $total_online = grep { !$_->dead } $self->all();
+    my $free_active_workers = grep { !$_->dead } $self->search({job_id => undef, error => undef})->all();
+    my $free_broken_workers = grep { !$_->dead } $self->search({job_id => undef, error => {'!=' => undef}})->all();
+    my $busy_workers = grep { !$_->dead } $self->search({job_id => {'!=' => undef}})->all();
+
+    return {
+        total => $total,
+        total_online => $total_online,
+        free_active_workers => $free_active_workers,
+        free_broken_workers => $free_broken_workers,
+        busy_workers => $busy_workers,
+    };
+}
+
+1;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -77,6 +77,7 @@ sub read_config ($app) {
             max_rss_limit => 0,
             profiling_enabled => 0,
             monitoring_enabled => 0,
+            mcp_enabled => 'no',
             plugins => undef,
             hide_asset_types => 'repo',
             file_security_policy => 'download-prompt',
@@ -236,6 +237,7 @@ sub read_config ($app) {
             max_online_workers => 1000,
             wait_for_grutask_retries => 6,    # exponential, ~4 minutes
             worker_limit_retry_delay => ONE_HOUR / 4,
+            mcp_max_result_size => 500000,
         },
         archiving => {
             archive_preserved_important_jobs => 0,
@@ -409,6 +411,7 @@ sub load_plugins ($server, $monitoring_root_route = undef, %options) {
     push @{$server->plugins->namespaces}, 'OpenQA::WebAPI::Plugin';
     $server->plugin($_) for qw(Helpers MIMETypes CSRF REST Gru YAML);
     $server->plugin('AuditLog') if $server->config->{global}{audit_enabled};
+    $server->plugin('MCP') if $server->config->{global}{mcp_enabled} eq 'read-only';
     # Load arbitrary plugins defined in config: 'plugins' in section
     # '[global]' can be a space-separated list of plugins to load, by
     # module name under OpenQA::WebAPI::Plugin::

--- a/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Workers.pm
@@ -29,12 +29,7 @@ sub _extend_info ($w) {
 
 sub index ($self) {
     my $workers_db = $self->schema->resultset('Workers');
-    my $total_online = grep { !$_->dead } $workers_db->all();
-    my $total = $workers_db->count;
-    my $free_active_workers = grep { !$_->dead } $workers_db->search({job_id => undef, error => undef})->all();
-    my $free_broken_workers
-      = grep { !$_->dead } $workers_db->search({job_id => undef, error => {'!=' => undef}})->all();
-    my $busy_workers = grep { !$_->dead } $workers_db->search({job_id => {'!=' => undef}})->all();
+    my $worker_stats = $workers_db->stats;
 
     my %workers;
     while (my $w = $workers_db->next) {
@@ -42,11 +37,11 @@ sub index ($self) {
         $workers{$w->name} = _extend_info($w);
     }
     $self->stash(
-        workers_online => $total_online,
-        total => $total,
-        workers_active_free => $free_active_workers,
-        workers_broken_free => $free_broken_workers,
-        workers_busy => $busy_workers,
+        workers_online => $worker_stats->{total_online},
+        total => $worker_stats->{total},
+        workers_active_free => $worker_stats->{free_active_workers},
+        workers_broken_free => $worker_stats->{free_broken_workers},
+        workers_busy => $worker_stats->{busy_workers},
         is_admin => !!$self->is_admin,
         workers => \%workers
     );

--- a/lib/OpenQA/WebAPI/Plugin/MCP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MCP.pm
@@ -1,0 +1,175 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Plugin::MCP;
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
+
+use MCP::Server;
+use Mojo::Template;
+use Mojo::Loader qw(data_section);
+use Mojo::File qw(path);
+
+sub register ($self, $app, $config) {
+    my $mcp = MCP::Server->new;
+    $mcp->name('openQA');
+    $mcp->version('1.0.0');
+
+    $mcp->tool(
+        name => 'openqa_get_info',
+        description => 'Get information about the openQA server, connected workers and the current user',
+        code => \&tool_openqa_get_info
+    );
+
+    $mcp->tool(
+        name => 'openqa_get_job_info',
+        description => 'Get information about a specific openQA job',
+        input_schema => {
+            type => 'object',
+            properties => {job_id => {type => 'integer', minimum => 1}},
+            required => ['job_id'],
+        },
+        code => \&tool_openqa_get_job_info
+    );
+
+    $mcp->tool(
+        name => 'openqa_get_log_file',
+        description => 'Get the content of a specific log file for an openQA job',
+        input_schema => {
+            type => 'object',
+            properties => {
+                job_id => {type => 'integer', minimum => 1},
+                file_name => {type => 'string', minLength => 1}
+            },
+            required => ['job_id', 'file_name'],
+        },
+        code => \&tool_openqa_get_log_file
+    );
+
+    my $mcp_auth = $app->routes->under('/')->to('Auth#auth')->name('mcp_ensure_user');
+    $mcp_auth->any('/experimental/mcp' => $mcp->to_action)->name('mcp');
+}
+
+sub tool_openqa_get_info ($tool, $args) {
+    my $c = _get_controller($tool);
+    my $user = _get_user($tool);
+    my $schema = _get_schema($tool);
+
+    my $worker_stats = $schema->resultset('Workers')->stats;
+    my $vars = {
+        app_name => $c->stash->{appname},
+        app_version => $c->stash->{current_version} // 'n/a',
+        user_name => $user->name,
+        user_id => $user->id,
+        is_admin => $user->is_admin ? 'yes' : 'no',
+        is_operator => $user->is_operator ? 'yes' : 'no',
+        workers_total => $worker_stats->{total},
+        workers_total_online => $worker_stats->{total_online},
+        workers_offline => $worker_stats->{total} - $worker_stats->{total_online},
+        active_workers => $worker_stats->{free_active_workers},
+        broken_workers => $worker_stats->{free_broken_workers},
+        busy_workers => $worker_stats->{busy_workers},
+    };
+    return _render_from_data_section('openqa_get_info.txt.ep', $vars);
+}
+
+sub tool_openqa_get_job_info ($tool, $args) {
+    my $job_id = $args->{job_id};
+
+    my $schema = _get_schema($tool);
+    return $tool->text_result('Job does not exist', 1)
+      unless my $job = $schema->resultset('Jobs')->find(int($job_id));
+    my @comments = map { $_->extended_hash } $job->search_related(comments => {})->all;
+
+    my $info = $job->to_hash(assets => 1, check_assets => 1, deps => 1, details => 1, parent_group => 1);
+    return _render_from_data_section('openqa_get_job_info.txt.ep', {job => $info, comments => \@comments});
+}
+
+sub tool_openqa_get_log_file ($tool, $args) {
+    my $job_id = $args->{job_id};
+    my $file_name = $args->{file_name};
+
+    # Prevent directory traversal attacks
+    return $tool->text_result('Invalid file name', 1) unless $file_name =~ /^[\w.\-]+$/;
+
+    # Only text logs for now
+    return $tool->text_result('File type not yet supported via MCP', 1) if $file_name !~ /\.txt$/;
+
+    my $schema = _get_schema($tool);
+    return $tool->text_result('Job does not exist', 1)
+      unless my $job = $schema->resultset('Jobs')->find(int($job_id));
+
+    my $dir = $job->result_dir;
+    my $file = path($dir, $file_name);
+    return $tool->text_result('Log file does not exist', 1) unless -r $file;
+
+    my $c = _get_controller($tool);
+    my $max = $c->app->config->{misc_limits}{mcp_max_result_size};
+    return $tool->text_result('File too large to be transmitted via MCP', 1) if -s $file > $max;
+    return $tool->text_result($file->slurp);
+}
+
+sub _get_controller ($tool) { $tool->context->{controller} }
+sub _get_schema ($tool) { _get_controller($tool)->schema }
+sub _get_user ($tool) { _get_controller($tool)->stash->{current_user}{user} }
+
+sub _render_from_data_section ($template_name, $vars) {
+    my $template = data_section(__PACKAGE__, $template_name);
+    return Mojo::Template->new->vars(1)->render($template, $vars);
+}
+
+1;
+__DATA__
+@@ openqa_get_info.txt.ep
+Server: <%= $app_name %> (<%= $app_version %>)
+Current User: <%= $user_name %> (id: <%= $user_id %>, admin: <%= $is_admin %>, operator: <%= $is_operator %>)
+Workers: <%= $workers_total %>
+  - online: <%= $workers_total_online %>
+  - offline: <%= $workers_offline %>
+  - idle: <%= $active_workers %>
+  - busy: <%= $busy_workers %>
+  - broken: <%= $broken_workers %>
+
+@@ openqa_get_job_info.txt.ep
+Job ID:   <%= $job->{id}         // 'Unknown' %>
+Name:     <%= $job->{name}       // 'Unknown' %>
+Group:   <%= $job->{group}       // 'Unknown' %>
+Priority: <%= $job->{priority}   // 'Unknown' %>
+State:    <%= $job->{state}      // 'Unknown' %>
+Result:   <%= $job->{result}     // 'Unknown' %>
+Started:  <%= $job->{t_started}  // 'Never' %>
+Finished: <%= $job->{t_finished} // 'Never' %>
+
+Test Results:
+% if (@{$job->{testresults}}) {
+  % for my $result (@{$job->{testresults}}) {
+  - <%= $result->{name} %>: <%= $result->{result} %>
+  % }
+% }
+% else {
+  No test results available yet
+% }
+
+Test Settings:
+% for my $setting (sort keys %{$job->{settings}}) {
+  - <%= $setting %>: <%= $job->{settings}{$setting} %>
+% }
+
+Available Logs:
+% if (@{$job->{logs}}) {
+  % for my $log (@{$job->{logs}}) {
+  - <%= $log %>
+  % }
+% }
+% else {
+  No logs available
+% }
+
+Comments:
+% if (@$comments) {
+  % for my $comment (@$comments) {
+  - <%= $comment->{userName} %> (<%= $comment->{created} %>): <%= $comment->{renderedMarkdown} %>
+  % }
+% }
+% else {
+  No comments yet
+% }

--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -1,0 +1,161 @@
+#!/usr/bin/env perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use utf8;
+use FindBin;
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use Mojo::Base -signatures;
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use Test::MockModule;
+use OpenQA::Test::TimeLimit '30';
+use OpenQA::Test::Case;
+use OpenQA::Test::Client 'client';
+use MCP::Client;
+
+OpenQA::Test::Case->new(config_directory => "$FindBin::Bin/../data/17-mcp")
+  ->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
+
+my $PERSONAL_ACCESS_TOKEN = 'lance:LANCELOTKEY01:MANYPEOPLEKNOW';
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+my $client = MCP::Client->new(ua => $t->ua, url => $t->ua->server->url->path('/experimental/mcp'));
+
+subtest 'Authentication' => sub {
+    $t->get_ok('/experimental/mcp')->status_is(403)->json_is({error => 'no api key'});
+
+    $t->ua->on(start => sub ($ua, $tx) { $tx->req->headers->authorization("Bearer $PERSONAL_ACCESS_TOKEN") });
+    $t->get_ok('/experimental/mcp')->status_is(405);
+};
+
+subtest 'Start session' => sub {
+    is $client->session_id, undef, 'no session id';
+    my $result = $client->initialize_session;
+    is $result->{serverInfo}{name}, 'openQA', 'server name';
+    is $result->{serverInfo}{version}, '1.0.0', 'server version';
+    ok $result->{capabilities}, 'has capabilities';
+    ok $client->session_id, 'session id set';
+};
+
+subtest 'List tools' => sub {
+    my $result = $client->list_tools;
+    is scalar @{$result->{tools}}, 3, 'three tools available';
+    is $result->{tools}[0]{name}, 'openqa_get_info', 'right tool name';
+    is $result->{tools}[1]{name}, 'openqa_get_job_info', 'right tool name';
+    is $result->{tools}[2]{name}, 'openqa_get_log_file', 'right tool name';
+};
+
+subtest 'openqa_get_info tool' => sub {
+    my $result = $client->call_tool('openqa_get_info');
+    ok !$result->{isError}, 'not an error';
+    my $text = $result->{content}[0]{text};
+    like $text, qr/Server: openQA \(.+\)/, 'openQA server';
+    like $text, qr/Current User: lance \(id: 99902, admin: no, operator: no\)/, 'current user';
+    like $text, qr/Workers: 2/, 'total workers';
+    like $text, qr/- online: 0/, 'online workers';
+    like $text, qr/- offline: 2/, 'offline workers';
+    like $text, qr/- idle: 0/, 'idle workers';
+    like $text, qr/- busy: 0/, 'busy workers';
+    like $text, qr/- broken: 0/, 'broken workers';
+};
+
+subtest 'openqa_get_job_info tool' => sub {
+    subtest 'Failed job' => sub {
+        my $result = $client->call_tool('openqa_get_job_info', {job_id => 99938});
+        ok !$result->{isError}, 'not an error';
+        my $text = $result->{content}[0]{text};
+        like $text, qr/Job ID: +99938/, 'has job id';
+        like $text, qr/Name: +opensuse-Factory-DVD-x86_64-Build0048-doc\@64bit/, 'has name';
+        like $text, qr/Group: +opensuse/, 'has group';
+        like $text, qr/Priority: +36/, 'has priority';
+        like $text, qr/State: +done/, 'has state';
+        like $text, qr/Result: +failed/, 'has result';
+        like $text, qr/Started: +\d+-\d+-\d+T\d+:\d+:\d+/, 'has started time';
+        like $text, qr/Finished: +\d+-\d+-\d+T\d+:\d+:\d+/, 'has finished time';
+        like $text, qr/- autoinst-log\.txt/s, 'has log files listed';
+        like $text, qr/No test results available yet/s, 'no test results yet';
+        like $text, qr/DISTRI: opensuse/, 'settings are present';
+        like $text, qr/VERSION: Factory/, 'settings are present';
+        like $text, qr/No comments yet/, 'no comments yet';
+    };
+
+    subtest 'Passed job' => sub {
+        subtest 'Add comment to test job' => sub {
+            $t->post_ok("/api/v1/jobs/99764/comments" => form => {text => 'Just a test comment'})->status_is(200);
+        };
+
+        my $result = $client->call_tool('openqa_get_job_info', {job_id => 99764});
+        ok !$result->{isError}, 'not an error';
+        my $text = $result->{content}[0]{text};
+        like $text, qr/Job ID: +99764/, 'has job id';
+        like $text, qr/Name: +opensuse-13.1-DVD-x86_64-Build0091-console_tests\@64bit/, 'has name';
+        like $text, qr/Group: +Unknown/, 'unknown group';
+        like $text, qr/Priority: +35/, 'has priority';
+        like $text, qr/State: +done/, 'has state';
+        like $text, qr/Result: +passed/, 'has result';
+        like $text, qr/Started: +\d+-\d+-\d+T\d+:\d+:\d+/, 'has started time';
+        like $text, qr/Finished: +\d+-\d+-\d+T\d+:\d+:\d+/, 'has finished time';
+        like $text, qr/No logs available/s, 'no log files listed';
+        like $text, qr/No test results available yet/s, 'no test results yet';
+        like $text, qr/DISTRI: opensuse/, 'settings are present';
+        like $text, qr/VERSION: 13\.1/, 'settings are present';
+        like $text, qr/lance.+Just a test comment/, 'has comments';
+    };
+
+    subtest 'Input validation failed' => sub {
+        eval { $client->call_tool('openqa_get_job_info', {job_id => 'abc'}) };
+        like $@, qr/Error -32602: Invalid arguments/, 'right error message';
+    };
+};
+
+subtest 'openqa_get_log_file tool' => sub {
+    subtest 'Failed job' => sub {
+        my $result = $client->call_tool('openqa_get_log_file', {job_id => 99938, file_name => 'autoinst-log.txt'});
+        ok !$result->{isError}, 'not an error';
+        my $text = $result->{content}[0]{text};
+        like $text, qr/starting: \/usr\/bin\/qemu-kvm/, 'has log content from start';
+        like $text, qr/test logpackages died/, 'has log content from end';
+    };
+
+    subtest 'Input validation failed' => sub {
+        eval { $client->call_tool('openqa_get_log_file', {job_id => 'abc', file_name => 'autoinst-log.txt'}) };
+        like $@, qr/Error -32602: Invalid arguments/, 'right error message';
+        eval { $client->call_tool('openqa_get_log_file', {job_id => 99938, file_name => ''}) };
+        like $@, qr/Error -32602: Invalid arguments/, 'right error message';
+    };
+
+    subtest 'Path traversal attack' => sub {
+        my $result = $client->call_tool('openqa_get_log_file', {job_id => 99938, file_name => '../../etc/passwd'});
+        ok $result->{isError}, 'is an error';
+        my $text = $result->{content}[0]{text};
+        like $text, qr/Invalid file name/, 'error message';
+    };
+
+    subtest 'Job does not exist' => sub {
+        local $t->app->config->{misc_limits}{mcp_max_result_size} = 100;
+        my $result = $client->call_tool('openqa_get_log_file', {job_id => 999999999, file_name => 'autoinst-log.txt'});
+        ok $result->{isError}, 'is an error';
+        my $text = $result->{content}[0]{text};
+        like $text, qr/Job does not exist/, 'error message';
+    };
+
+    subtest 'Unsupported file type' => sub {
+        my $result = $client->call_tool('openqa_get_log_file', {job_id => 99938, file_name => 'video.ogv'});
+        ok $result->{isError}, 'is an error';
+        my $text = $result->{content}[0]{text};
+        like $text, qr/File type not yet supported via MCP/, 'error message';
+    };
+
+    subtest 'File too large' => sub {
+        local $t->app->config->{misc_limits}{mcp_max_result_size} = 100;
+        my $result = $client->call_tool('openqa_get_log_file', {job_id => 99938, file_name => 'autoinst-log.txt'});
+        ok $result->{isError}, 'is an error';
+        my $text = $result->{content}[0]{text};
+        like $text, qr/File too large to be transmitted via MCP/, 'error message';
+    };
+};
+
+done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -52,6 +52,7 @@ subtest 'Test configuration default modes' => sub {
             max_rss_limit => 0,
             profiling_enabled => 0,
             monitoring_enabled => 0,
+            mcp_enabled => 'no',
             hide_asset_types => 'repo',
             file_security_policy => 'download-prompt',
             recognized_referers => [],
@@ -188,6 +189,7 @@ subtest 'Test configuration default modes' => sub {
             max_online_workers => 1000,
             wait_for_grutask_retries => 6,
             worker_limit_retry_delay => ONE_HOUR / 4,
+            mcp_max_result_size => 500000,
         },
         archiving => {
             archive_preserved_important_jobs => 0,

--- a/t/data/17-mcp/openqa.ini
+++ b/t/data/17-mcp/openqa.ini
@@ -1,0 +1,2 @@
+[global]
+mcp_enabled = read-only


### PR DESCRIPTION
This is a recreated pull request based on
* #6685

as well as
* #6708

which brings in the dependency but as a non-problematic sub-package so that tests not relying on MCP can continue unchanged.

This patch adds MCP support with three tools as an optional feature that
needs to be enabled in the `openqa.ini`:
```
[global]
mcp_enabled = read-only
```

For starters i have added three read-only tools. The first (`openqa_get_info`)
provides information about the openQA server and the current user. The second
(`openqa_get_job_info`) information about a specific job. And the third
(`openqa_get_log_file`) returns the content of a job specific log file. The
returned information is formatted with templates and very easy to modify.
Current gen LLMs prefer plain text information, but that can of course change
as the technology evolves.

Example conversation with `openqa_get_info` tool:
```
You
Who am i?

gemma-3-12b-it
openqa_get_info({})
Arguments: {}
Result
[...]

You are a demo user in openQA with ID 1092. You have both administrator and operator privileges.
```

Example conversation with `openqa_get_job_info` tool:
```
You
What can you tell me about openQA job 5266406?

gemma-3-12b-it
openqa_get_job_info({"job_id":5266406}…})
Arguments: {"job_id":5266406}
Result
[...]

OpenQA job 5266406 is a test of the
opensuse-Tumbleweed-JeOS-for-kvm-and-xen-sdboot-aarch64 build, specifically
targeting an ARM architecture. It ran on August 26, 2025, and ultimately
failed. The failure appears to be related to verify_setup, with a bug
reference (poo#184444) indicating the system booted into an emergency shell.
Several other tests also failed including image_checks, record_machine_id,
and force_scheduled_tasks. The job used qemu as its backend and was
configured with several specific settings related to disk size,
repositories, and UEFI boot.

You
Is this a known error?

gemma-3-12b-it
Yes, according to the comments associated with the job result, it's a
known issue referenced by bug poo#184444. The comment explicitly states
"test fails in verify_setup - system boots into emergency shell" and
links to the bug report on progress.opensuse.org. It also notes that
this is a carryover from a previous test (t#5191155).
```

Of course this is just a starting point to allow openQA users to
experiment with LLM driven openQA workflows. And i expect this feature
to change a lot before it leaves experimental status.

Progress: https://progress.opensuse.org/issues/184798