### PR TITLE
CI: Fix SLE_15_SP6_Backports repo lookup order

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -25,10 +25,10 @@ pr:
             architectures: [ x86_64 ]
           - name: SLE_15_SP6_Backports
             paths:
-              - target_project: openSUSE:Backports:SLE-15-SP6:Update
-                target_repository: standard
               - target_project: devel:openQA:Leap:15.6
                 target_repository: '15.6'
+              - target_project: openSUSE:Backports:SLE-15-SP6:Update
+                target_repository: standard
             architectures: [ x86_64 ]
           - name: '16.0'
             paths:


### PR DESCRIPTION
41996ed introduced the issue that the product repo is not overriden by
devel:openQA:Leap:15.6 as is necessary whenever we need to add override
dependencies as happened now for perl-MCP. This commit fixes the order
in the OBS check definition so that the same as for other checks is done
with the target product repo last.