### PR TITLE
RFC: Allow multiple machines per job template

### DIFF
--- a/public/schema/JobScenarios-01.yaml
+++ b/public/schema/JobScenarios-01.yaml
@@ -66,7 +66,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      ^[\p{Word} _*.+-]+$:
+      ^[\p{Word} _*.+-]+(\@\([\w,-]+\))?$:
         type: object
         description: The name of the job template
         additionalProperties: false
@@ -74,6 +74,10 @@ properties:
           product:
             type: string
           machine:
-            type: string
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  - type: string
           settings: *settings-definition
           priority: *priority-definition


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/188310
This is just a proof of concept on how we could allow multple machines per job template in SCENARIO_DEFINITIONs.

It came up because we possibly want to run openqa-in-openqa jobs for both machines, and it's a useful feature in general.

Here it how our scenario file would look like:
https://github.com/perlpunk/os-autoinst-distri-openQA/blob/multiple-machines/scenario-definitions.yaml

Two possibilities to define machines per job template:
```
job_templates:

  # define traditionally as mapping key, as a string or an array of strings
  openqa_from_git:
    machine: [64bit-2G , uefi-2G]
    <<: *common
    settings:
      DESKTOP: minimalx
      OPENQA_FROM_GIT: "1"

  # define as template suffix
  openqa_from_containers@(64bit-2G,uefi2G):
    <<: *common
    settings:
      DESKTOP: minimalx
      LOAD_PYTHON_TEST_MODULES: "0"
      OPENQA_CONTAINERS: "1"
      OPENQA_FROM_GIT: "1"
```