### PR TITLE
Stop logging confusing exception when GruTask is gone

### DIFF
--- a/lib/OpenQA/Shared/Plugin/Gru.pm
+++ b/lib/OpenQA/Shared/Plugin/Gru.pm
@@ -166,7 +166,7 @@ sub _add_jobs_to_gru_task ($self, $gru_id, $job_ids) {
                       =~ m/insert or update on table "gru_dependencies" violates foreign key constraint "gru_dependencies_fk_gru_task_id"/i;
                     # if the GruTask was already deleted meanwhile, we can skip
                     # the rest of the jobs, since the wanted task was done
-                    log_debug("GruTask $gru_id already gone, skip assigning jobs (message: $e)");
+                    log_debug("GruTask $gru_id already gone, skip assigning jobs");
                     last;
                 }
             }

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -378,8 +378,7 @@ subtest 'enqueue_git_clones' => sub {
         $t->app->log(Mojo::Log->new(level => 'debug'));
         my $jobs = [$j[4]->id];
         stderr_like { $t->app->gru->_add_jobs_to_gru_task(999, $jobs) }
-qr{GruTask 999 already gone.*insert or update on table "gru_dependencies" violates foreign key constraint "gru_dependencies_fk_gru_task_id"},
-          'expected log output if GruTask deleted in between';
+        qr{GruTask 999 already gone, skip assigning jobs}, 'expected log output if GruTask deleted in between';
         my @deps = $task->jobs;
         is scalar @deps, 3, 'no job was added to GruTask';
     };


### PR DESCRIPTION
The exception is misleading as this is expected.

See: https://progress.opensuse.org/issues/188007