### PR TITLE
Fix regression handling retention of important jobs

### DIFF
--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -241,7 +241,7 @@ sub _find_expired_jobs ($self, $keep_in_days, $keep_important_in_days, $preserve
 
     # define condition for expired jobs in important builds
     my ($important_timestamp, @important_cond);
-    if ($keep_important_in_days && $keep_important_in_days > $keep_in_days) {
+    if ($keep_important_in_days) {
         $important_timestamp = time2str('%Y-%m-%d %H:%M:%S', $now - ONE_DAY * $keep_important_in_days, 'UTC');
         @important_cond = (
             -or => [


### PR DESCRIPTION
The retentions of regular and important jobs had no interaction with each other for the longest time. If one specified a shorter duration for important jobs than for normal jobs this would simply cause important jobs to be stored shorter than regular jobs. This made sense even though a warning about this probable misconfiguration would have been useful.

Commit d7838c56a changed the behavior so important jobs are only cleaned up if the storage duration for important jobs is greater than the one for regular jobs. This is a regression because it leads to unexpected behavior, e.g. if one specifies the same duration for important and regular jobs the important jobs would be kept forever.

This change restores and test the old behavior. Afterwards it would make sense to extend the API and UI to explain the behavior and make a probable misconfiguration more clear (in form of a validation warning or even error).

Related ticket: https://progress.opensuse.org/issues/187698