### PR TITLE
Openapi validator

### DIFF
--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -409,6 +409,13 @@ sub load_plugins ($server, $monitoring_root_route = undef, %options) {
     $server->plugin(NYTProf => {nytprof => {}}) if $server->config->{global}{profiling_enabled};
     $server->plugin(Status => {route => $monitoring_root_route->get('/monitoring')})
       if $monitoring_root_route && $server->config->{global}{monitoring_enabled};
+    $server->plugin("OpenAPI" => {url => $server->home->rel_file("public/openapi.yaml")});
+    $server->plugin(
+        SwaggerUI => {
+            route => $server->routes()->any('api/docs'),
+            url => "/api/v1",
+            title => "OpenQA App"
+        });
     # load auth module
     my $auth_method = $server->config->{auth}->{method};
     my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -52,7 +52,11 @@ sub startup ($self) {
     OpenQA::Schema->singleton;
 
     # Some controllers are shared between openQA micro services
-    my $r = $self->routes->namespaces(['OpenQA::Shared::Controller', 'OpenQA::WebAPI::Controller', 'OpenQA::WebAPI', 'OpenQA::WebAPI::Controller::API::V1']);
+    my $r = $self->routes->namespaces(
+        [
+            'OpenQA::Shared::Controller', 'OpenQA::WebAPI::Controller',
+            'OpenQA::WebAPI', 'OpenQA::WebAPI::Controller::API::V1'
+        ]);
 
     # register basic routes
     my $logged_in = $r->under('/')->to('session#ensure_user');

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -52,7 +52,7 @@ sub startup ($self) {
     OpenQA::Schema->singleton;
 
     # Some controllers are shared between openQA micro services
-    my $r = $self->routes->namespaces(['OpenQA::Shared::Controller', 'OpenQA::WebAPI::Controller', 'OpenQA::WebAPI']);
+    my $r = $self->routes->namespaces(['OpenQA::Shared::Controller', 'OpenQA::WebAPI::Controller', 'OpenQA::WebAPI', 'OpenQA::WebAPI::Controller::API::V1']);
 
     # register basic routes
     my $logged_in = $r->under('/')->to('session#ensure_user');
@@ -325,12 +325,12 @@ sub startup ($self) {
 
     my $job_r = $api_ro->any('/jobs/<jobid:num>');
     push @api_routes, $job_r;
-    $api_public_r->any('/jobs/<jobid:num>')->name('apiv1_job')->to('job#show');
+    #$api_public_r->any('/jobs/<jobid:num>')->name('apiv1_job')->to('job#show');
     $api_public_r->get('/experimental/jobs/<jobid:num>/status')->name('apiv1_get_status')->to('job#get_status');
     $api_public_r->any('/jobs/<jobid:num>/details')->name('apiv1_job')->to('job#show', details => 1);
     $job_r->put('/')->name('apiv1_put_job')->to('job#update');
     $job_r->delete('/')->name('apiv1_delete_job')->to('job#destroy');
-    $job_r->post('/prio')->name('apiv1_job_prio')->to('job#prio');
+    #$job_r->post('/prio')->name('apiv1_job_prio')->to('job#prio');
     $job_r->post('/set_done')->name('apiv1_set_done')->to('job#done');
     $job_r->post('/status')->name('apiv1_update_status')->to('job#update_status');
     $job_r->post('/artefact')->name('apiv1_create_artefact')->to('job#create_artefact');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -80,6 +80,8 @@ Limit the number of jobs.
 
 sub list ($self) {
     my $validation = $self->validation;
+    #$self->openapi->valid_input or return;
+    #my $validation = $self->openapi->validator;
     $validation->optional('scope')->in('current', 'relevant');
     $validation->optional('latest')->num(1);
     $validation->optional('limit')->num;
@@ -455,6 +457,8 @@ Pass follow=1 as query param to follow job clones and report most recent result 
 =cut
 
 sub show ($self) {
+    # manually triggers validation - unclear if this is how it should be
+    $self->openapi->valid_input or return;
     my $job_id = int($self->stash('jobid'));
     my $details = $self->stash('details') || 0;
     my $check_assets = !!$self->param('check_assets');
@@ -463,7 +467,7 @@ sub show ($self) {
     $job = $job->latest_job if $follow;
     $job = $job->to_hash(assets => 1, check_assets => $check_assets, deps => 1, details => $details, parent_group => 1);
     $job->{followed_id} = $job_id if ($job_id != $job->{id});
-    $self->render(json => {job => $job});
+    $self->render(openapi => {job => $job});
 }
 
 =over 4
@@ -494,10 +498,14 @@ Sets priority for a given job.
 =cut
 
 sub prio ($self) {
+    
     return unless my $job = $self->find_job_or_render_not_found($self->stash('jobid'));
-    my $v = $self->validation;
-    my $prio = $v->required('prio')->num->param;
-    return $self->reply->validation_error({format => 'json'}) if $v->has_error;
+    # seems this is the default behavior
+    $self->openapi->valid_input or return;
+    #my $v = $self->validation;
+    #my $prio = $v->required('prio')->num->param;
+    my $prio = $self->param('prio');
+    #return $self->reply->validation_error({format => 'json'}) if $v->has_error;
 
     # Referencing the scalar will result in true or false (see http://mojolicio.us/perldoc/Mojo/JSON)
     $self->render(json => {result => \$job->set_prio($prio)});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -467,7 +467,7 @@ sub show ($self) {
     $job = $job->latest_job if $follow;
     $job = $job->to_hash(assets => 1, check_assets => $check_assets, deps => 1, details => $details, parent_group => 1);
     $job->{followed_id} = $job_id if ($job_id != $job->{id});
-    $self->render(openapi => {job => $job});
+    $self->render(json => {job => $job});
 }
 
 =over 4
@@ -499,9 +499,9 @@ Sets priority for a given job.
 
 sub prio ($self) {
     
-    return unless my $job = $self->find_job_or_render_not_found($self->stash('jobid'));
     # seems this is the default behavior
     $self->openapi->valid_input or return;
+    return unless my $job = $self->find_job_or_render_not_found($self->stash('jobid'));
     #my $v = $self->validation;
     #my $prio = $v->required('prio')->num->param;
     my $prio = $self->param('prio');
@@ -509,6 +509,7 @@ sub prio ($self) {
 
     # Referencing the scalar will result in true or false (see http://mojolicio.us/perldoc/Mojo/JSON)
     $self->render(json => {result => \$job->set_prio($prio)});
+    #$self->render(openapi => {result => \$job->set_prio($prio)});
 }
 
 =over 4

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -467,7 +467,7 @@ sub show ($self) {
     $job = $job->latest_job if $follow;
     $job = $job->to_hash(assets => 1, check_assets => $check_assets, deps => 1, details => $details, parent_group => 1);
     $job->{followed_id} = $job_id if ($job_id != $job->{id});
-    $self->render(json => {job => $job});
+    $self->render(openapi => {job => $job});
 }
 
 =over 4
@@ -508,8 +508,7 @@ sub prio ($self) {
     #return $self->reply->validation_error({format => 'json'}) if $v->has_error;
 
     # Referencing the scalar will result in true or false (see http://mojolicio.us/perldoc/Mojo/JSON)
-    $self->render(json => {result => \$job->set_prio($prio)});
-    #$self->render(openapi => {result => \$job->set_prio($prio)});
+    $self->render(openapi => {result => \$job->set_prio($prio)});
 }
 
 =over 4

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -523,7 +523,7 @@ sub _param_hash ($c, $name) {
 sub _find_job_or_render_not_found ($c, $job_id, $query_settings = {}) {
     my $job = $c->schema->resultset('Jobs')->find(int($job_id), $query_settings);
     return $job if $job;
-    $c->render(json => {error => 'Job does not exist'}, status => 404);
+    $c->render(openapi => {error => 'Job does not exist'}, status => 404);
     return undef;
 }
 

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -41,16 +41,16 @@ paths:
                   jobs:
                     type: array
                     items: {}
-        # '404':
-        #   description: 'Not Found.'
-        #   content:
-        #     application/json:
-        #       schema:
-        #         type: object
-        #         example: 'Scheduled product to clone settings from not found.'
-        #         properties:
-        #           error:
-        #             type: string
+        '404':
+          description: 'Not Found.'
+          content:
+            application/json:
+              schema:
+                type: object
+                example: 'Scheduled product to clone settings from not found.'
+                properties:
+                  error:
+                    type: string
       #   '400':
       #     description: Erroneous parameters (key invalid, list_value invalid)
       #     content:

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,232 @@
+openapi: 3.0.3
+info:
+  version: '1.0'
+  title: OpenQA API
+externalDocs:
+  description: The official OpenQA doc
+  url: https://open.qa/docs/
+servers:
+  - url: /api/v1
+tags:
+  - name: public
+    description: Those API routes which are public (no auth)
+  - name: ro
+    description: read-only routes
+security:
+  - basicAuth: []
+paths:
+  /jobs/{jobid}:
+    get:
+      tags:
+        - public
+      summary: Filters jobs based on a single setting key/value pair.
+      operationId: apiv1_job
+      x-mojo-name: apiv1_job
+      x-mojo-to: 'job#show'
+      #   $validation->optional('scope')->in('current', 'relevant');
+      # $validation->optional('latest')->num(1);
+      # $validation->optional('limit')->num;
+      # $validation->optional('offset')->num;
+      # $validation->optional('groupid')->num;
+      # $validation->optional('not_groupid')->num
+      parameters:
+        - name: jobid
+          in: path
+          required: true
+          schema:
+            type: integer
+
+      responses:
+        '200':
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items: {}
+        # '404':
+        #   description: 'Not Found.'
+        #   content:
+        #     text/plain:
+        #       schema:
+        #         type: string
+        #         example: 'Scheduled product to clone settings from not found.'
+      #   '400':
+      #     description: Erroneous parameters (key invalid, list_value invalid)
+      #     content:
+      #       application/json:
+      #         schema:
+      #           type: object
+      #           properties:
+      #             error_status:
+      #               type: integer
+      #             error:
+      #               type: string
+      #               example: Erroneous parameters (key invalid, list_value invalid)
+      #       text/plain:
+      #         schema:
+      #           type: string
+      #           example: Erroneous parameters (key invalid, list_value invalid)
+  /jobs/{jobid}/prio:
+    post:
+      tags:
+        - ro
+      summary: 'Sets priority for a given job.'
+      description: |
+        'Sets priority for a given job.'
+      operationId: 'apiv1_job_prio'
+      x-mojo-name: 'apiv1_job_prio'
+      x-mojo-to: 'job#prio'
+      parameters:
+        - name: jobid
+          in: path
+          required: true
+          description: 'The ID of the job to update.'
+          schema:
+            type: integer
+        # - $ref: '#/components/parameters/CSRFHeader'
+        # - in: cookie
+        #   name: csrftoken
+        #   schema:
+        #     type: string
+      requestBody:
+        description: 'new priority'
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              requires:
+                - prio
+              properties:
+                prio:
+                  type: integer
+                  description: 'The new priority value. Higher is more important.'
+                  example: 50
+      responses:
+        '200':
+          description: 'OK. The jobs were scheduled synchronously.'
+          content:
+            application/json:
+              schema:
+                #$ref: '#/components/schemas/IsoSyncResponse'
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 'True if the update was successful.'
+        # '202':
+        #   description: 'Accepted. The job scheduling was enqueued to run asynchronously.'
+        #   content:
+        #     application/json:
+        #       schema:
+        #         $ref: '#/components/schemas/IsoAsyncResponse'
+        # '400':
+        #   description: 'Bad Request with something is missing or invalid.'
+        #   content:
+        #     text/plain:
+        #       schema:
+        #         type: string
+        #         example: 'Specified scheduled_product_id is invalid.'
+        # '404':
+        #   description: 'Not Found.'
+        #   content:
+        #     text/plain:
+        #       schema:
+        #         type: string
+        #         example: 'Scheduled product to clone settings from not found.'
+components:
+  parameters:
+    CSRFHeader:
+      name: X-Requested-With
+      in: header
+      description: 'Required header to bypass CSRF check for API clients.'
+      required: true
+      schema:
+        type: string
+        default: XMLHttpRequest
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: "HTTP Basic Authentication using your username and a composite password of 'API_KEY:API_SECRET'."
+    oauth2Auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://id.opensuse.org/login/ldap
+          scopes:
+            admin: admin
+            operator: operator
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT # optional, arbitrary value for documentation purposes
+  schemas:
+    isosSync:
+      type: object
+      required:
+        - DISTRI
+        - VERSION
+        - FLAVOR
+        - ARCH
+      properties:
+        DISTRI:
+          type: string
+          description: 'The Linux distribution.'
+          example: 'opensuse'
+        VERSION:
+          type: string
+          description: 'The distribution version.'
+          example: '15.4'
+        FLAVOR:
+          type: string
+          description: 'The build flavor, e.g., DVD, Live, etc.'
+          example: 'DVD'
+        ARCH:
+          type: string
+          description: 'The processor architecture.'
+          example: 'x86_64'
+        async:
+          type: boolean
+          description: 'If true, the operation runs as a background job.'
+
+    isosAsync:
+      type: object
+      required:
+        - scheduled_product_clone_id
+      properties:
+        scheduled_product_clone_id:
+          type: integer
+          description: 'ID of a previous product to clone settings from.'
+          example: 12345
+        async:
+          type: boolean
+          description: 'If true, the operation runs as a background job.'
+      additionalProperties: {}
+
+    IsoSyncResponse:
+      type: object
+      properties:
+        scheduled_product_id:
+          type: integer
+        count:
+          type: integer
+        ids:
+          type: array
+          items:
+            type: integer
+        failed:
+          type: object
+          additionalProperties: true
+
+    IsoAsyncResponse:
+      type: object
+      properties:
+        job_id:
+          type: integer
+        scheduled_product_id:
+          type: integer

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -23,12 +23,6 @@ paths:
       operationId: apiv1_job
       x-mojo-name: apiv1_job
       x-mojo-to: 'job#show'
-      #   $validation->optional('scope')->in('current', 'relevant');
-      # $validation->optional('latest')->num(1);
-      # $validation->optional('limit')->num;
-      # $validation->optional('offset')->num;
-      # $validation->optional('groupid')->num;
-      # $validation->optional('not_groupid')->num
       parameters:
         - name: jobid
           in: path
@@ -50,10 +44,13 @@ paths:
         # '404':
         #   description: 'Not Found.'
         #   content:
-        #     text/plain:
+        #     application/json:
         #       schema:
-        #         type: string
+        #         type: object
         #         example: 'Scheduled product to clone settings from not found.'
+        #         properties:
+        #           error:
+        #             type: string
       #   '400':
       #     description: Erroneous parameters (key invalid, list_value invalid)
       #     content:
@@ -92,6 +89,7 @@ paths:
         #   name: csrftoken
         #   schema:
         #     type: string
+
       requestBody:
         description: 'new priority'
         required: true
@@ -99,7 +97,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               type: object
-              requires:
+              required:
                 - prio
               properties:
                 prio:
@@ -116,8 +114,8 @@ paths:
                 type: object
                 properties:
                   result:
-                    type: boolean
-                    description: 'True if the update was successful.'
+                    #type: {} #???????
+                    description: 'True if the update was successful'
         # '202':
         #   description: 'Accepted. The job scheduling was enqueued to run asynchronously.'
         #   content:
@@ -127,7 +125,7 @@ paths:
         # '400':
         #   description: 'Bad Request with something is missing or invalid.'
         #   content:
-        #     text/plain:
+        #     application/json:
         #       schema:
         #         type: string
         #         example: 'Specified scheduled_product_id is invalid.'

--- a/t/api/17-openapi.t
+++ b/t/api/17-openapi.t
@@ -1,0 +1,30 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later.
+
+use Test::Most;
+use Test::Warnings qw(:report_warnings);
+use Mojo::Base -strict, -signatures;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+
+use OpenQA::Test::Case;
+use OpenQA::Test::TimeLimit '10';
+use Test::Mojo;
+
+OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl');
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+$t->app->log->level('trace');
+
+subtest jobs => sub {
+    $t->get_ok('/api/v1/jobs/23')->status_is(404)->json_is('/error', 'Job does not exist');
+    $t->get_ok('/api/v1/jobs/23a')->status_is(400)->json_like('/errors/0/message', qr{Expected integer - got string});
+
+    $t->get_ok('/api/v1/jobs/80000')->status_is(200)->json_is('/job/id', '80000')->json_is('/job/testresults', undef);
+
+    $t->post_ok('/api/v1/jobs/80000/prio', form => {prio => 99})->status_is(200);
+    #$t->post_ok('/api/v1/jobs/80000/prio', form => {prio => 'not a number'})->status_is(400)->json_like('/error', qr{Erroneous parameters.*prio});
+};
+
+done_testing;

--- a/t/api/17-openapi.t
+++ b/t/api/17-openapi.t
@@ -4,7 +4,7 @@
 use Test::Most;
 use Test::Warnings qw(:report_warnings);
 use Mojo::Base -strict, -signatures;
-
+use Data::Dumper;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 
@@ -24,7 +24,10 @@ subtest jobs => sub {
     $t->get_ok('/api/v1/jobs/80000')->status_is(200)->json_is('/job/id', '80000')->json_is('/job/testresults', undef);
 
     $t->post_ok('/api/v1/jobs/80000/prio', form => {prio => 99})->status_is(200);
-    #$t->post_ok('/api/v1/jobs/80000/prio', form => {prio => 'not a number'})->status_is(400)->json_like('/error', qr{Erroneous parameters.*prio});
+    #warn "*** " . Dumper($t->tx->res);
+    # openapi validator executed. no output from the controller
+    $t->post_ok('/api/v1/jobs/80000/prio', form => {prio => 'not a number'})->status_is(400)
+      ->json_like('/errors/0/message', qr{Expected integer});
 };
 
 done_testing;


### PR DESCRIPTION
There are two commits with the very basic changes.
which provides:
- validation on requests
- validation on responses

Two packages are required `cpanm Mojolicious::Plugin::OpenAPI` and 
`cpanm Mojolicious::Plugin::SwaggerUI`. Remove the lines in the Setup for the second if you do not need it for now. 
If not, when you start the server you should see the API documentation with the Swagger UI (go to http://127.0.0.1/api/docs)

My understanding is that there are two ways to perform the validation. this is the not-automatic way. 
You can ignore the components section as well. it is not used. 
