### PR TITLE
Avoid sporadic test failures in `t/ui/15-comments.t`

### DIFF
--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -323,10 +323,9 @@ Can you see status circles after the URLs?
 EOM
         write_comment $urls, 'comment with job status icons';
         $driver->refresh;
-        wait_for_ajax msg => 'comment with status icons loaded';
-        my @i = $driver->find_elements('div.comment-body span.openqa-testref i.status');
-        is $i[0]->get_attribute('class'), 'status fa fa-circle result_passed', 'Icon for success is shown';
-        is $i[1]->get_attribute('class'), 'status fa fa-circle result_failed', 'Icon for failure is shown';
+        my $status_sel = 'div.comment-body span.openqa-testref i.status';
+        ok wait_for_element(selector => "$status_sel.result_passed"), 'icon for passed job shown';
+        ok wait_for_element(selector => "$status_sel.result_failed"), 'icon for failed job shown';
     };
 
     subtest 'check comment availability sign on test result overview' => sub {


### PR DESCRIPTION
It seems that `wait_for_ajax` is not enough here as we sometimes run into this error in the CI:

```
Can't call method "get_attribute" on an undefined value at t/ui/15-comments.t line 328.
```

This change replaces `wait_for_ajax` with `wait_for_element` which will definitely wait until the elements are present.

Related ticket: https://progress.opensuse.org/issues/186092