### PR TITLE
Prevent warning from `DBIx::Class::Storage::TxnScopeGuard`

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -141,6 +141,7 @@ sub create ($self) {
 
     try { $comment->handle_special_contents($self) }
     catch ($e) {
+        local $@ = $e;
         undef $txn_guard;
         return $self->render(json => {error => $e}, status => 400);
     }
@@ -193,6 +194,7 @@ sub create_many ($self) {
             push @created, $comment->event_data;
         }
         catch ($e) {
+            local $@ = $e;
             undef $txn_guard;
             push @failed, {job_id => $job_id};
         }
@@ -237,6 +239,7 @@ sub update ($self) {
     my $res = $comment->update({text => href_to_bugref($text)});
     try { $res->handle_special_contents($self) }
     catch ($e) {
+        local $@ = $e;
         undef $txn_guard;
         return $self->render(json => {error => $e}, status => 400);
     }


### PR DESCRIPTION
When running `t/ui/15-comments.t` locally with Perl v5.42.0 I run into the following error:

```
[error] [pid:26242] Stopping openqa-webapi process because a Perl warning occurred: DBIx::Class::Storage::TxnScopeGuard::DESTROY(): A DBIx::Class::Storage::TxnScopeGuard went out of scope without explicit commit or error. Rolling back. at /hdd/openqa-devel/repos/openQA/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm line 144
not ok 2 - sub process openqa-webapi terminated with exit code 42
```

This error is actually just a warning but treated as an error so the test fails.

I probably only run into this locally as it probably only happens with recent versions of Perl. Maybe the reliance on `Feature::Compat::Try` due to the old Perl version we use in the CI (which uses a Leap 15.6 container) prevents us from running into this issue in CI checks.

`DBIx::Class::Storage::TxnScopeGuard` uses the check `is_exception $@` to determine whether an exception is handled to suppress the warning if that's the case. It seems like depending on the Perl version `$@` is not necessarily set when using `try … catch` so we need to make sure that the variable is set if we want to use `TxnScopeGuard` in this way.