### PR TITLE
Validate needle timestamp upon saving

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -472,6 +472,10 @@ function updateToggleClickCoordinatesButton(hasClickCoorinates) {
 function saveNeedle(overwrite) {
   var form = document.getElementById('save_needle_form');
   var errors = [];
+  var needle_name = document.getElementById('needleeditor_name').value;
+  if (!/-\d{8}$/.test(needle_name)) {
+    errors.push('No valid timestamp');
+  }
   var tagSelection = window.needles[$('#tags_select').val()];
   if (!tagSelection.tags.length) {
     errors.push('No tags specified.');

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -16,6 +16,7 @@ use Test::Warnings qw(:all :report_warnings);
 use OpenQA::Test::TimeLimit '120';
 use OpenQA::Test::Case;
 use OpenQA::Test::Utils qw(assume_all_assets_exist shared_hash prepare_clean_needles_dir prepare_default_needle);
+use OpenQA::Utils qw(ensure_timestamp_appended);
 use Cwd 'abs_path';
 use Mojo::File qw(path tempdir);
 use Mojo::JSON 'decode_json';
@@ -343,7 +344,7 @@ subtest 'Needle editor layout' => sub {
 };
 
 my $needlename = 'test-newneedle';
-my $needlename_from_candidate = "$needlename-from-candidate";
+my $needlename_from_candidate = ensure_timestamp_appended("$needlename-from-candidate");
 my $xoffset = my $yoffset = 200;
 
 subtest 'Create new needle' => sub {
@@ -612,13 +613,15 @@ subtest 'Deletion of needle is handled gracefully' => sub {
     ) or always_explain \@warnings;
 };
 
-subtest 'areas/tags verified via JavaScript' => sub {
+subtest 'areas/tags/timestamp verified via JavaScript' => sub {
     $driver->get('/tests/99938/modules/logpackages/steps/1/edit');
+    $driver->find_element_by_id('needleeditor_name')->clear();
+    $driver->find_element_by_id('needleeditor_name')->send_keys('no-timestamp');
     $driver->find_element_by_id('save')->click();
     is(
         $driver->find_element('.alert-danger span')->get_text(),
-        "Unable to save needle:\nNo tags specified.\nNo areas defined.",
-        'areas/tags verified via JavaScript'
+        "Unable to save needle:\nNo valid timestamp.\nNo tags specified.\nNo areas defined.",
+        'areas/tags/timestamp verified via JavaScript'
     );
     $driver->find_element('.alert-danger button')->click();
 };


### PR DESCRIPTION
The suffix should always be - and a timestamp.

See: https://progress.opensuse.org/issues/188865