### PR TITLE
Fix LegacyKeyValueFormat on openqa_data/Dockerfile

### DIFF
--- a/container/openqa_data/Dockerfile
+++ b/container/openqa_data/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse/leap:15.6
-LABEL maintainer Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>
+LABEL maintainer="Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>"
 LABEL version="0.3"
 
 # hadolint ignore=DL3037


### PR DESCRIPTION
Based on
https://docs.docker.com/reference/build-checks/legacy-key-value-format/ to prevents the warning in the build