### PR TITLE
Treat SVG files as attachment for security reasons

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -160,7 +160,7 @@ sub _set_headers ($self, $path) {
                 $is_text = 1;
             }
             my $allow_insecure = $self->app->config->{global}->{file_security_policy} ne 'download-prompt';
-            $as_attachment = 0 if ($allow_insecure || $filetype !~ m|html|) && $ext ne 'iso';
+            $as_attachment = 0 if ($allow_insecure || $filetype !~ m/(html|svg)/) && $ext ne 'iso';
         }
         # force saveAs
         $headers->content_disposition("attachment; filename=$filename;") if $as_attachment;


### PR DESCRIPTION
It might be possible to execute javascript from SVG files.