### PR TITLE
Redirect test assets to file_domain if configured

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -138,11 +138,16 @@ sub test_asset ($self) {
       if ($path =~ /\/\.\./ || $path =~ /\.\.\//);
 
     # map to URL - mojo will canonicalize
-    $path = $self->url_for('download_asset', assetpath => $path);
-    $self->app->log->debug("redirect to $path");
+    my $url = $self->url_for('download_asset', assetpath => $path);
+
+    # redirect to file domain if configured
+    my $file_domain = $self->app->config->{global}->{file_domain};
+    $url->host($file_domain) if ($file_domain);
+
+    $self->app->log->debug("redirect to $url");
     # pass the redirect to the reverse proxy - might come back to use
     # in case there is no proxy (e.g. in tests)
-    return $self->redirect_to($path);
+    return $self->redirect_to($url);
 }
 
 sub _set_headers ($self, $path) {

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -147,6 +147,9 @@ subtest 'redirection to different domain' => sub {
     $config->{file_domain} = 'openqa-files';
     $t->get_ok('/assets/repo/testrepo/README.html')->status_is(302);
     $t->header_like(Location => qr|^http://openqa-files(:\d+)?/assets/repo/testrepo/README.html$|);
+
+    $t->get_ok('/tests/99961/asset/repo/testrepo/README')->status_is(302);
+    $t->header_like(Location => qr|^//openqa-files(:\d+)?/assets/repo/testrepo/README$|);
 };
 
 done_testing();


### PR DESCRIPTION
This will ensure all assets are served via file_domain if it is set.
Ticket: https://progress.opensuse.org/issues/188226