### PR TITLE
Check for consistent solver.dupAllowVendorChange for auto/continuous-update

### DIFF
--- a/script/openqa-check-devel-repo
+++ b/script/openqa-check-devel-repo
@@ -34,6 +34,10 @@ log_error() {
 
 [[ $VERSION ]] || . /etc/os-release
 [[ $ARCH ]] || ARCH=$(uname -i)
+if ! grep -q '^solver.dupAllowVendorChange\s*=\s*true' /etc/zypp/zypp.conf; then
+    result="/etc/zypp/zypp.conf needs to have '^solver.dupAllowVendorChange = true' for devel:openQA repositories. See https://progress.opensuse.org/issues/188235 for details"
+    false
+fi
 result="$(curl -sS "${REPO_URL:-https://api.opensuse.org/public/build/devel:openQA}/_result?repository=${VERSION}&arch=${ARCH}")"
 
 echo -e "$result" | grep -q "project.*state=.published."


### PR DESCRIPTION
The error message would look like this

```
devel:openQA looks bad for Leap  (x86_64):
/etc/zypp/zypp.conf needs to have '^solver.dupAllowVendorChange = true' for devel:openQA repositories. See https://progress.opensuse.org/issues/188235 for details
```

Related progress issue: https://progress.opensuse.org/issues/188235