### PR TITLE
Reject jobs if worker is broken when receiving a new job

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -360,7 +360,7 @@ sub calculate_status_update_interval ($self) {
 }
 
 # sends the overall worker status
-sub send_status ($self) {
+sub send_status ($self, %args) {
     # ensure an ongoing timer is cancelled in case send_status has been called manually
     if (my $send_status_timer = delete $self->{_send_status_timer}) {
         Mojo::IOLoop->remove($send_status_timer);
@@ -370,7 +370,7 @@ sub send_status ($self) {
     my $websocket_connection = $self->websocket_connection;
     return undef unless $websocket_connection;
     my $status = $self->{_last_worker_status} = $self->worker->status;
-    $websocket_connection->send({json => $status});
+    $websocket_connection->send({json => $status}) if !$args{on_error} || defined $status->{reason};
 }
 
 sub send_status_delayed ($self) {

--- a/t/lib/OpenQA/Test/FakeWorker.pm
+++ b/t/lib/OpenQA/Test/FakeWorker.pm
@@ -28,7 +28,7 @@ has is_executing_single_job => 1;
 
 sub stop_current_job ($self, $reason) { $self->stop_current_job_called($reason) }
 sub stop ($self) { $self->is_stopping(1) }
-sub status ($self) { {fake_status => 1, reason => 'some error'} }
+sub status ($self) { {fake_status => 1, reason => $self->current_error} }
 
 sub accept_job ($self, $client, $job_info) {
     $self->current_job(OpenQA::Worker::Job->new($self, $client, $job_info));


### PR DESCRIPTION
* Do a last-minute availability check before accepting a job and reject the job if that check fails
* See https://progress.opensuse.org/issues/189096

---

I tested it manually via `OPENQA_LOAD_AVG_FILE=/tmp/loadfile` and changing the contents of that file right before a new job is scheduled. ~~The new job was not rejected. I guess this needs further tweaking, hence converting back to a draft.~~ It works now. The problem was that this kind of availability check is actually considered non-fatal (so the worker doesn't interrupt directly chained dependencies) but here we of course still don't want to accept new jobs regardless of that.