### PR TITLE
Add requirement dependency via symlinks to webui service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,8 @@ install-generic: generate-assets
 	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-scheduler.service.requires/postgresql.service
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-websockets.service.requires
 	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-websockets.service.requires/postgresql.service
+	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-webui.service.requires
+	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-webui.service.requires/postgresql.service
 	install -D -m 644 usr/lib/sysctl.d/01-openqa-reload-worker-auto-restart.conf "$(DESTDIR)"/usr/lib/sysctl.d/01-openqa-reload-worker-auto-restart.conf
 #
 # install openQA apparmor profile

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -614,6 +614,7 @@ fi
 # init
 %dir %{_unitdir}
 %{_unitdir}/openqa-webui.service
+%dir %{_unitdir}/openqa-webui.service.requires
 %{_unitdir}/openqa-livehandler.service
 %{_unitdir}/openqa-gru.service
 %dir %{_unitdir}/openqa-gru.service.requires
@@ -823,6 +824,7 @@ fi
 %{_unitdir}/openqa-gru.service.requires/postgresql.service
 %{_unitdir}/openqa-scheduler.service.requires/postgresql.service
 %{_unitdir}/openqa-websockets.service.requires/postgresql.service
+%{_unitdir}/openqa-webui.service.requires/postgresql.service
 %{_datadir}/openqa/script/setup-db
 %{_datadir}/openqa/script/dump-db
 %{_bindir}/openqa-setup-db


### PR DESCRIPTION
Use a symlinks to set dependency to the openqa_webui as it was done in https://github.com/os-autoinst/openQA/pull/4976/files in order to restart the webui when the database is restarted.

It seems that something changed since
https://github.com/os-autoinst/openQA/pull/4976 which makes the webui to not behave as it was at the time of that commit and adding it now ensures that the sequence of restarts will take place as expected.

poo: https://progress.opensuse.org/issues/183302