### PR TITLE
Enable automatic dependabot updates again after improvements

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,7 +19,7 @@ pull_request_rules:
           - "#check-failure=0"
           - "#check-pending=0"
           - linear-history
-      - and: &manual_review
+      - and:
           - "#approved-reviews-by>=2"
           - "#changes-requested-reviews-by=0"
           # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
@@ -52,7 +52,6 @@ pull_request_rules:
           - base=main
           - author=dependabot[bot]
           - label=waited
-      - and: *manual_review  # temporary measure due to ongoing supply chain attacks
     actions:
       merge:
         method: squash


### PR DESCRIPTION
This reverts commit 56709e76a5b156c7284596498aea3161ff5229e4.

To me it seems the situation has cooled down. We have reduced our attack
surface with --omit=dev for openQA and have reviewed other practices for
handling updates. In my understanding our previous approach of automated but
slightly delayed updates is still fine.