### PR TITLE
README: Fix openQA badge after switch to UEFI

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,6 +1,6 @@
 :circleci: image:https://circleci.com/gh/os-autoinst/openQA/tree/master.svg?style=svg["CircleCI", link="https://circleci.com/gh/os-autoinst/openQA/tree/master"]
 :codecov: image:https://codecov.io/gh/os-autoinst/openQA/branch/master/graph/badge.svg[link=https://codecov.io/gh/os-autoinst/openQA]
-:appliance: image:https://openqa.opensuse.org/tests/latest/badge?arch=x86_64&distri=openqa&flavor=dev&machine=64bit-2G&test=openqa_install%2Bpublish&version=Tumbleweed[link="https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=openqa&flavor=dev&machine=64bit-2G&test=openqa_install%2Bpublish&version=Tumbleweed"]
+:appliance: image:https://openqa.opensuse.org/tests/latest/badge?arch=x86_64&distri=openqa&flavor=dev&test=openqa_install%2Bpublish&version=Tumbleweed[link="https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=openqa&flavor=dev&machine=64bit-2G&test=openqa_install%2Bpublish&version=Tumbleweed"]
 
 = openQA
 


### PR DESCRIPTION
With
https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/254
the openQA-in-openQA tests switched to UEFI due to the changed default
in openSUSE Tumbleweed. Hence the badge must also not reference the
obsolete 64bit-2G. Instead of hardcoding uefi we can just leave out the
machine definition so that we look up whatever is "last".