### PR TITLE
Update openqa containers to Leap16

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,7 +4,7 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use

--- a/container/openqa_data/Dockerfile
+++ b/container/openqa_data/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 LABEL maintainer="Jan Sedlak <jsedlak@redhat.com>, Josef Skladanka <jskladan@redhat.com>, wnereiz <wnereiz@eienteiland.org>, Sergio Lindo Mansilla <slindomansilla@suse.com>"
 LABEL version="0.3"
 

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_webui:latest opensuse/openqa-webui:latest opensuse/openqa-webui:%PKG_VERSION% opensuse/openqa-webui:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-webui
 LABEL org.opencontainers.image.title="openQA webui container"
@@ -14,13 +14,13 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 ENV LC_ALL=C.UTF-8
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     # openQA might need rubygem:sass to compile assets in this context due to
     # unknown reasons even though the package should use the precompiled
     # assets from cache.tar
-    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m 'rubygem(sass)>=3.7.4' && \
+    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m perl-CSS-Sass && \
     zypper clean && \
     gensslcert && \
     /usr/share/openqa/script/configure-web-proxy && \

--- a/container/webui/Dockerfile-lb
+++ b/container/webui/Dockerfile-lb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_webui_lb:latest opensuse/openqa-webui-lb:latest opensuse/openqa-webui-lb:%PKG_VERSION% opensuse/openqa-webui-lb:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-webui-lb
 LABEL org.opencontainers.image.title="openQA load-balancer webui container"
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y openQA nginx && \
     zypper clean

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_worker:latest opensuse/openqa-worker:latest opensuse/openqa-worker:%PKG_VERSION% opensuse/openqa-worker:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-worker
 LABEL org.opencontainers.image.title="openQA worker container"
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -yl ca-certificates-mozilla curl gzip rsync xz && \
     zypper in -yl openQA-worker os-autoinst-s390-deps os-autoinst-ipmi-deps && \


### PR DESCRIPTION
As a side effect this should fix also the problem with the postgres incompatibility.