### PR TITLE
Remove version property from docker-compose

### DIFF
--- a/container/webui/docker-compose.yaml
+++ b/container/webui/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   scheduler:
     image: openqa_webui

--- a/container/worker/docker-compose.yaml
+++ b/container/worker/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   worker:
     image: openqa_worker


### PR DESCRIPTION
The top-level version property is not used anymore from docker-compose and it throws a warning. More info
https://docs.docker.com/reference/compose-file/version-and-name/