### PR TITLE
mergify: Allow more time for dependabot update reaction

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,12 +55,12 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-  - name: Wait for 2 days before validating merge
+  - name: Wait for some days before validating merge
     actions:
       label:
         add: [ waited ]
         remove: [ waiting ]
     conditions:
       - and:
-          - updated-at<2 days ago
+          - updated-at<4 days ago
           - author=dependabot[bot]


### PR DESCRIPTION
Based on our experiences from recent NPM supply chain attacks we want to
have a bit more time than just two days for optional reviews of
dependabot updates while still reasonably fast to automatically bring in
updates which is also necessary to guard against other security issues.

Related progress issue: https://progress.opensuse.org/issues/189195