### PR TITLE
Update PostgreSQL version used in Helm charts

### DIFF
--- a/container/helm/charts/openqa/Chart.lock
+++ b/container/helm/charts/openqa/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.5.38
+  version: 16.7.27
 - name: worker
   repository: file://../worker/
   version: 0.1.0
-digest: sha256:b8d33fe53bfb3cba746a17cbd13c29167fae37b44414b8769de3182c6a69adc6
-generated: "2025-06-10T15:13:53.917940726+02:00"
+digest: sha256:0eb1a53cdbbed8bc78066984feddfe993fde87d08c882f58c06d79e7abc10b90
+generated: "2025-09-29T16:05:13.224586625+02:00"

--- a/container/helm/charts/openqa/Chart.yaml
+++ b/container/helm/charts/openqa/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: ~0.1.0
     condition: webui.enabled
   - name: postgresql
-    version: 15.5.38
+    version: 16.7.27
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: worker

--- a/container/helm/charts/webui/Chart.lock
+++ b/container/helm/charts/webui/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.5.38
-digest: sha256:6dbed6171e0b736f43c92dadf97cfc4014555bfc0a4a2a760c4207b8b1b3095e
-generated: "2025-06-10T15:13:34.283281249+02:00"
+  version: 16.7.27
+digest: sha256:ab3541612e8857c2d08d46f83cab79fa87b6ae6148e2d64d7d2b06729a520ce1
+generated: "2025-09-29T16:05:49.936603484+02:00"

--- a/container/helm/charts/webui/Chart.yaml
+++ b/container/helm/charts/webui/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 version: 0.1.0
 dependencies:
   - name: postgresql
-    version: 15.5.38
+    version: 16.7.27
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
Maybe this helps with https://progress.opensuse.org/issues/188982.