### PR TITLE
Disable Helm Chart CI checks temporarily

### DIFF
--- a/.github/workflows/check-helm-chart.yml
+++ b/.github/workflows/check-helm-chart.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Run chart-testing
         run: make test-helm-lint
   install-chart:
+    if: false  # disabled due to https://progress.opensuse.org/issues/188982
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ pull_request_rules:
           # "unresolvable" is not reported in general:
           # https://trello.com/c/0N3jHq5M/2257-report-back-to-scm-when-build-results-arent-failed-and-succeeded
           # So we need to require the number of tests explicitly:
-          - "#check-success>=45"
+          - "#check-success>=51"
           - status-success=static-check-containers
           - status-success=webui-docker-compose
           - "#check-failure=0"


### PR DESCRIPTION
We have to adapt to the change mentioned in the notice on https://github.com/bitnami/charts/blob/main/bitnami/postgresql/README.md before we can run this CI check again.

Related ticket: https://progress.opensuse.org/issues/188982