### PR TITLE
Ensure a failing cache service is seen as such by the worker/scheduler

### DIFF
--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -55,7 +55,7 @@ sub startup {
         'reply.exception' => sub {
             my ($c, $error) = @_;
             $error = $c->$code($error)->stash('exception');
-            return unless $error =~ qr/(database disk image is malformed|no such (table|column))/;
+            return unless $error =~ qr/(database|no such (table|column))/;
 
             my $app = $c->app;
             $app->exit_code(1);    # ensure the return code is non-zero


### PR DESCRIPTION
The service `openqa-worker-cacheservice-minion.service` already fails quickly if running into some database errors. With this change the same applies to `openqa-worker-cacheservice.service`. It will now also fail if any kind of database error happens. To make this work in as most cases as possible the event loop is now stopped immediately.

With this the availability check of the worker can now detect a broken cache service when the disk where the cache directory is stored is broken (and hence database errors occurs). This way the worker will no longer try to run jobs that would only end up with a cache service error anyway.

Note that before this change `openqa-worker-cacheservice.service` would stay running but fail to process the unavailability of `openqa-worker-cacheservice-minion.service` and thus might keep telling the worker that there's a functioning Minion worker. Hence we had many jobs running into `Cache service enqueue error 500`, see https://progress.opensuse.org/issues/189300.

Note that the systemd services are configured for automatic restarts but in my tests the services nevertheless fail very quickly with messages like `openqa-worker-cacheservice.service: Start request repeated too quickly.` in cases like this. So regardless of this change there will also almost immediately be at least one failing systemd unit.