### PR TITLE
Reduce the number of required checks for Mergify again

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ pull_request_rules:
           # "unresolvable" is not reported in general:
           # https://trello.com/c/0N3jHq5M/2257-report-back-to-scm-when-build-results-arent-failed-and-succeeded
           # So we need to require the number of tests explicitly:
-          - "#check-success>=51"
+          - "#check-success>=50"
           - status-success=static-check-containers
           - status-success=webui-docker-compose
           - "#check-failure=0"


### PR DESCRIPTION
On e.g. https://github.com/os-autoinst/openQA/pull/6790 there are just 50 checks but all packages have been built on OBS and were reported back. There were 51 checks on
https://github.com/os-autoinst/openQA/pull/6788 (where I took the 51 in my previous change from) but only because it changed the Mergify configuration and thus triggered the additional check "Configuration changed The new Mergify configuration is valid".

Note that one of the 50 checks is still the summary of Mergify itself but I guess the summary should be counted as well as it is a successful check (even if the merge conditions aren't satisfied) and always present.