### PR TITLE
Run `optipng` for real and handle errors if it fails

### DIFF
--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -58,10 +58,11 @@ be delayed. This can lead to problems if the executed tests do not foresee an
 appropriate timeout margin.
 
 On some less powerful systems (like Raspberry Pi), reducing screenshots size
-with optipng may take significant amount of time. In this case, you can switch
-to `pngquant` which is significantly faster, but uses lossy compression. To do
-that, install `pngquant` package and set `USE_PNGQUANT=1` in worker or job
-settings.
+with `optipng` may take a significant amount of time. In this case, you can
+switch to `pngquant` which is significantly faster, but uses lossy compression.
+To do that, install `pngquant` package and set `USE_PNGQUANT=1` in worker or job
+settings. Alternatively, you may disable optimizing images altogether via the
+setting `OPTIMIZE_IMAGES=0`.
 
 [[db-migration]]
 == DB migration from SQlite to postgreSQL

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -873,14 +873,16 @@ sub _upload_results_step_2_1_upload_images ($self) {
 }
 
 my $OPTIMIZE_ERROR = 'Unable to optimize image:';
+my $OPTIMIZE_SUGGESTION = 'You may disable optimizations via OPTIMIZE_IMAGES=0.';
 
 sub _upload_results_step_2_2_upload_images ($self, $callback, $error) {
     $self->{_images_to_send} = {};
     $self->{_files_to_send} = {};
     return $callback->() unless $error;
     chomp $error;
+    $error =~ s/\s+(at.*line|OpenQA::).*//s;    # avoid too lengthy log message so $OPTIMIZE_SUGGESTION is not elided
     my $is_optimize_error = index($error, $OPTIMIZE_ERROR) == 0;
-    $error = "Unable to upload images: $error" unless $is_optimize_error;
+    $error = $is_optimize_error ? "$error - $OPTIMIZE_SUGGESTION" : "Unable to upload images: $error";
     log_error($self->{_result_upload_error} = $error);
     return $callback->() unless $is_optimize_error;
     $self->{_result_upload_internal_error} = $error;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1089,6 +1089,7 @@ subtest 'Internal error occurrred during upload' => sub {
     }
     qr/Unable to optimize image: foobar/, 'error is logged';
     is $job->status, 'stopped', 'errors when optimizing are considered fatal so job is stopped';
+    like $job->{_result_upload_internal_error}, qr/Unable to optimize.*disable.*OPTIMIZE_IMAGES/, 'disabling suggested';
     ok $callback_invoked, 'upload callback is invoked on fatal errors as well';
 };
 


### PR DESCRIPTION
The `openQA-worker` package already has a hard requirement on `optipng` so it doesn't need to be adjusted. `optipng` also seems already available in the CI environment for full test coverage.

Related ticket: https://progress.opensuse.org/issues/189564