### PR TITLE
Filter job stats of scheduled products also by arch and build

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
@@ -30,7 +30,7 @@ sub cancel_by_webhook_id ($self, $webhook_id, $reason) {
     return {jobs_cancelled => $count};
 }
 
-sub job_statistics ($self, $distri, $version, $flavor) {
+sub job_statistics ($self, $distri, $version, $flavor, $arch, $build) {
     my $sth = $self->result_source->schema->storage->dbh->prepare(
         <<~'END_SQL'
         WITH RECURSIVE
@@ -48,7 +48,7 @@ sub job_statistics ($self, $distri, $version, $flavor) {
                     FROM
                         scheduled_products
                     WHERE
-                        status in ('new', 'scheduling', 'scheduled') and distri = ? and version = ? and flavor = ?
+                        status in ('new', 'scheduling', 'scheduled') and distri = ? and version = ? and flavor = ? and arch = ? and build = ?
                     GROUP BY
                         arch
                 )
@@ -112,6 +112,8 @@ sub job_statistics ($self, $distri, $version, $flavor) {
     $sth->bind_param(1, $distri);
     $sth->bind_param(2, $version);
     $sth->bind_param(3, $flavor);
+    $sth->bind_param(4, $arch);
+    $sth->bind_param(5, $build);
     $sth->execute;
     return $sth->fetchall_hashref([qw(latest_job_state latest_job_result)]);
 }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -60,9 +60,9 @@ sub show_scheduled_product {
 
 =item job_statistics()
 
-Returns job statistics about the most recent scheduled products for each ARCH
-matching the specified DISTRI, VERSION and FLAVOR. Scheduled products that are
-cancelling/cancelled are not considered.
+Returns job statistics about the most recent scheduled products matching the
+specified DISTRI, VERSION, FLAVOR, ARCH and BUILD parameters. Scheduled products
+that are cancelling/cancelled are not considered.
 
 This allows to determine whether all jobs that have been scheduled for a
 certain purpose are done and whether the jobs have passed. If jobs have been
@@ -90,7 +90,7 @@ could also be used to generate a more detailed report.
 
 sub job_statistics ($self) {
     my $validation = $self->validation;
-    my @param_keys = (qw(distri version flavor));
+    my @param_keys = (qw(distri version flavor arch build));
     $validation->required($_) for @param_keys;
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;
     my @params = map { $validation->param($_) } @param_keys;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -317,7 +317,7 @@ subtest 'job statistics can be queried about the scheduled product' => sub {
     $jobs->find(99988)->update({state => DONE, result => FAILED});
     $jobs->find(99993)->update({state => DONE, result => PASSED});
     $jobs->find(99994)->update({state => DONE, result => PASSED});
-    $t->get_ok('/api/v1/isos/job_stats?distri=opensuse&version=13.1&flavor=DVD')->status_is(200);
+    $t->get_ok('/api/v1/isos/job_stats?distri=opensuse&version=13.1&flavor=DVD&arch=i586&build=0091')->status_is(200);
     $schema->txn_rollback;
     my $json = $t->tx->res->json;
     is_deeply [sort keys %$json], [DONE, SCHEDULED], 'expected states present';


### PR DESCRIPTION
We probably shouldn't mix architectures. Filtering by build is also
required to be able to consider only scheduled products that correspond to
the current product increment.

This PR is required by https://github.com/openSUSE/qem-bot/pull/234.

Related ticket: https://progress.opensuse.org/issues/190251