### PR TITLE
Lower the prio of archiving jobs to avoid piling up finalize jobs

### DIFF
--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -53,7 +53,7 @@ sub _limit ($job, $args = undef) {
 
     my $groups = $schema->resultset('JobGroups');
     my $gru = $app->gru;
-    my %options = (priority => 0, ttl => 2 * ONE_DAY);
+    my %options = (priority => -20, ttl => 2 * ONE_DAY);
     while (my $group = $groups->next) {
         my $preserved_important_jobs;
         $group->limit_results_and_logs(\$preserved_important_jobs);


### PR DESCRIPTION
This reverses the prio of archiving and finalize jobs so finalize jobs are now more important. This makes sense because finalize jobs are also invoking hook scripts and are therefore more important than archiving which has less notable consequences if delayed.

Related ticket: https://progress.opensuse.org/issues/190344