### PR TITLE
Use direct link to subdomain for the test assets

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -381,6 +381,27 @@ sub register ($self, $app, $config) {
             }
             return $regex_problem && $context ? "$context: $regex_problem" : $regex_problem;
         });
+
+    $app->helper(
+        asset_url => sub ($c, $asset, $testid) {
+            my $url
+              = $c->url_for('test_asset_name', testid => $testid, assettype => $asset->type, assetname => $asset->name);
+            return _domain_url_for($c, $url);
+        });
+
+    $app->helper(
+        log_url => sub ($c, $testid, $resultfile) {
+            my $url = $c->url_for('test_file', testid => $testid, filename => $resultfile);
+            return _domain_url_for($c, $url);
+        });
+}
+
+sub _domain_url_for ($c, $url) {
+    if (my $file_domain = $c->app->config->{global}->{file_domain}) {
+        $url->host($file_domain);
+        $url->scheme($c->req->url->scheme // 'http');
+    }
+    return $url;
 }
 
 # returns the search args for the job overview according to the parameter of the specified controller

--- a/t/ui/07-file.t
+++ b/t/ui/07-file.t
@@ -141,6 +141,15 @@ $t->get_ok('/assets/iso/../iso/openSUSE-13.1-DVD-i586-Build0091-Media.iso')->sta
 $t->get_ok('/assets/hdd/foo.qcow2')->status_is(200)->content_type_is('application/octet-stream');
 $t->get_ok('/assets/repo/testrepo/doesnotexist')->status_is(404);
 
+subtest 'asset links to different domain' => sub {
+    my $config = $t->app->config->{global};
+    $config->{file_security_policy} = 'domain:openqa-files';
+    $config->{file_domain} = 'openqa-files';
+    $t->get_ok('/tests/99938/downloads_ajax')->status_is(200);
+    my $link = $t->tx->res->dom->find('a')->grep(qr/vars.json/)->map(attr => 'href')->first;
+    like $link, qr{^http://openqa-files/}, 'Asset link uses file domain subdomain';
+};
+
 subtest 'redirection to different domain' => sub {
     my $config = $t->app->config->{global};
     $config->{file_security_policy} = 'domain:openqa-files';

--- a/templates/webapi/step/viewaudio.html.ep
+++ b/templates/webapi/step/viewaudio.html.ep
@@ -1,1 +1,1 @@
-<audio style="margin: 0 10px; padding-top: 10px;" src="<%= url_for('test_file', filename => $module_detail->{'audio'}) %>" controls="controls"></audio>
+<audio style="margin: 0 10px; padding-top: 10px;" src="<%= log_url($testid, $module_detail->{'audio'}) %>" controls="controls"></audio>

--- a/templates/webapi/test/autoinst_log_within_details.html.ep
+++ b/templates/webapi/test/autoinst_log_within_details.html.ep
@@ -1,4 +1,4 @@
 <div>
     Likely error from autoinst-log.txt:<br>
-    <div class="embedded-logfile" data-src="<%= url_for('test_file', testid => $testid, filename => 'autoinst-log.txt') %>"></div>
+    <div class="embedded-logfile" data-src="<%= log_url($testid, 'autoinst-log.txt') %>"></div>
 </div>

--- a/templates/webapi/test/downloads.html.ep
+++ b/templates/webapi/test/downloads.html.ep
@@ -14,7 +14,7 @@
         % content_for 'asset_box' => begin
             <li>
                 % if (defined $asset->size) {
-                    %= link_to url_for('test_asset_name', testid => $testid, assettype => $asset->type, assetname => $asset->name) => (id => "asset_".$asset->id) => begin
+                    %= link_to asset_url($asset, $testid) => (id => "asset_".$asset->id) => begin
                     %= $asset->name
                     % end
                     (<%= human_readable_size($asset->size) %>)

--- a/templates/webapi/test/logfile.html.ep
+++ b/templates/webapi/test/logfile.html.ep
@@ -8,7 +8,7 @@
     filterEmbeddedLogFiles();
 % end
 
-% my $url = url_for('test_file', testid => $testid, filename => $filename);
+% my $url = log_url($testid, $filename);
 <div class="corner-buttons" style="margin-top: -5px;">
 <span id="filter-info"></span>
 <input id="filter-log-file" placeholder="substring or /regex/i" type="search">

--- a/templates/webapi/test/result_file_list.html.ep
+++ b/templates/webapi/test/result_file_list.html.ep
@@ -17,12 +17,12 @@
         % }
         % else {
             <i class="fa fa-file-o"></i>
-            <a href="<%= url_for('test_file', testid => $testid, filename => $resultfile) %>">
+            <a href="<%= log_url($testid, $resultfile) %>">
                 <%= $resultfile %>
             </a>
             % next;
         % }
-        <a href="<%= url_for('test_file', testid => $testid, filename => $resultfile) %>" target="blank" title="Raw/download">
+        <a href="<%= log_url($testid, $resultfile) %>" target="blank" title="Raw/download">
             <i class="fa fa-download"></i>
         </a>
     </li>

--- a/templates/webapi/test/video.html.ep
+++ b/templates/webapi/test/video.html.ep
@@ -5,7 +5,7 @@
 % end
 
 <figure id="video_viewer">
-    <video id="video" src="<%= url_for('test_file', testid => $testid, filename => param 'filename')->fragment('t=' . (param('t') // 0)) %>" controls>
-        <track default="" kind="subtitles" srclang="en" label="Timestamps" src="<%= url_for('test_file', testid => $testid, filename => 'video_time.vtt') %>">
+    <video id="video" src="<%= log_url($testid, param 'filename')->fragment('t=' . (param('t') // 0)) %>" controls>
+        <track default="" kind="subtitles" srclang="en" label="Timestamps" src="<%= log_url($testid, 'video_time.vtt') %>">
     </video>
 </figure>


### PR DESCRIPTION
Replace the `url_for with helper functions which return the domain name whenever this is applicable based on the setting.

- Link to domain for download assets like iso and `Uploaded logs` (includes also vars.json)
- No change in the redirection, assuming that this is out of scope here, and that in general it stays despite the direct link in the href.

issue: https://progress.opensuse.org/issues/189888