### PR TITLE
Retry image optimizations

### DIFF
--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -9,6 +9,8 @@ use Test::Warnings ':report_warnings';
 BEGIN {
     $ENV{OPENQA_UPLOAD_DELAY} = 0;
     $ENV{OPENQA_WORKER_ACCEPT_ATTEMPTS} = 2;
+    $ENV{OPENQA_WORKER_OPTIMIZE_ATTEMPTS} = 2;
+    $ENV{OPENQA_WORKER_OPTIMIZE_RETRY_DELAY} = 0;
 }
 
 use FindBin;


### PR DESCRIPTION
The optimization can fail with `optipng` returning with a non-zero return code, see https://progress.opensuse.org/issues/190920. We don't know exactly why it fails sometimes. Perhaps it is because the image is actually still written when we invoke `optipng`. This change introduces a simple retry which should help if it is just that. If `optipng` cannot be executed at all (e.g. because it isn't installed) the worker will still fail immediately.

Related ticket: https://progress.opensuse.org/issues/190920