### PR TITLE
Apply TIMEOUT_SCALE twice when needed

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -222,7 +222,7 @@ sub start ($self) {
     # update settings received from web UI with worker-specific stuff
     my $worker = $self->worker;
     my $global_worker_settings = $worker->settings->global_settings;
-    # TIMEOUT_SCALE: apply the factors from both the job settings and the worker settings
+    # apply the time scale factors from both the job settings and the worker settings
     my $timeout_scale = $global_worker_settings->{TIMEOUT_SCALE} // 1;
     $timeout_scale *= $job_settings->{TIMEOUT_SCALE} // 1;
     @{$job_settings}{keys %$global_worker_settings} = values %$global_worker_settings;


### PR DESCRIPTION
When TIMEOUT_SCALE is set for a worker and the command line also provides the value, apply both.