### PR TITLE
Potentially improve stability of `t/ui/16-tests_job_next_previous.t`

### DIFF
--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -78,10 +78,8 @@ driver_missing unless my $driver = call_driver;
 disable_timeout;
 
 sub goto_next_previous_tab {
-    wait_for_element(
-        trigger_function => sub { $driver->find_element_by_link_text('Next & previous results')->click },
-        selector => '.dt-container'
-    );
+    my $tab_link = wait_for_element(selector => 'Next & previous results', method => 'link_text');
+    wait_for_element(trigger_function => sub { $tab_link->click }, selector => '.dt-container');
     wait_for_ajax(msg => 'Next & previous table ready');
 }
 


### PR DESCRIPTION
Give the "Next & previous results" tab link a short amount of time to show up. I'm not sure why this is required, though. There is no asynchronous JavaScript code involved as the tab link is directly rendered as part of the main HTML document.

Related ticket: https://progress.opensuse.org/issues/191590

---

Note that I couldn't reproduce this failure locally.