### PR TITLE
Name should not be required when updating job group

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -302,7 +302,7 @@ sub update ($self) {
 
     my $validation = $self->validation;
     # Don't check group name if sorting group by dragging
-    $validation->required('name')->like(qr/^(?!\s*$).+/) unless $validation->optional('drag')->num(1)->is_valid;
+    $validation->optional('name')->like(qr/^(?!\s*$).+/) unless $validation->optional('drag')->num(1)->is_valid;
     $validation->optional('sort_order')->num(0);
     $self->_validate_common_properties;
     return $self->reply->validation_error({format => 'json'}) if $validation->has_error;


### PR DESCRIPTION
None of the other properties are required and the group is identified by its ID when updating an existing job group.