### PR TITLE
Avoid installing unwanted package versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
       - restore_cache: *restore_npm_cache
       - run:
           name: "Install npm dependencies"
-          command: npm install
+          command: npm clean-install --ignore-scripts
       - save_cache: *save_npm_cache
 
   checkstyle: &test-template

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: npm install
-        run: npm i
+      - name: npm clean-install
+        run: npm clean-install --ignore-scripts
       - name: npm run lint
         run: npm run lint

--- a/Makefile
+++ b/Makefile
@@ -208,10 +208,10 @@ endif
 # Ensure npm packages are installed and up-to-date (unless local-npm-registry is installed; in this case we can
 # assume installing npm packages is taken care of separately, e.g. in builds on OBS)
 # note: Excluding dev dependencies like `eslint` via `--omit=dev` to pull in only dependencies needed at runtime (and for
-#       regular tests). Development tests/tooling like `js-tidy` will invoke `npm install …` to install missing dependencies
-#       on its own anyway.
+#       regular tests). Development tests/tooling like `js-tidy` will invoke `npm clean-install …` to install missing
+#       dependencies on its own anyway.
 node_modules: package-lock.json
-	@which local-npm-registry >/dev/null 2>&1 || npm install --no-audit --no-fund --ignore-scripts --omit=dev
+	@which local-npm-registry >/dev/null 2>&1 || npm clean-install --no-audit --no-fund --ignore-scripts --omit=dev
 	@touch node_modules
 
 .PHONY: test

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -432,10 +432,11 @@ This section should give you a general idea how to start daemons manually for
 development after you setup a PostgreSQL database as mentioned in the previous
 section.
 
-You have to install/update web-related dependencies first using `npm install --ignore-scripts`.
-To start the webserver for development, use `scripts/openqa daemon`. The other
-daemons (mentioned in the link:images/architecture.svg[architecture diagram])
-are started in the same way, e.g. `script/openqa-scheduler daemon`.
+You have to install/update web-related dependencies first using
+`npm clean-install --ignore-scripts`. To start the webserver for development,
+use `scripts/openqa daemon`. The other daemons (mentioned in the
+link:images/architecture.svg[architecture diagram]) are started in the same way,
+e.g. `script/openqa-scheduler daemon`.
 
 You can also have a look at the systemd unit files. Although it likely makes
 not much sense to use them directly you can have a look at them to see how the
@@ -1226,7 +1227,7 @@ easily via `npm`.
 
 [source,sh]
 --------------------------------------------------------------------------------
-npm install jshint
+npm install --no-save --ignore-scripts jshint
 node_modules/jshint/bin/jshint path/to/javascript.js
 --------------------------------------------------------------------------------
 

--- a/tools/js-tidy
+++ b/tools/js-tidy
@@ -28,5 +28,5 @@ if ! command -v npm > /dev/null 2>&1; then
     exit 1
 fi
 
-npm install --ignore-scripts
+npm clean-install --ignore-scripts
 npm run fix


### PR DESCRIPTION
The command `npm install` might modify `package.json` or the package-locks as explained in `npm help clean-install`. We should avoid this and only do updates explicitly (using Dependabot). Hence `npm clean-install` should be our default for installing npm packages.

The only occasion where `npm install` makes sense is when installing `jshint` as an additional package we normally don't track. Then we have to use `--no-save` to avoid modifying `package.json`, though. (To avoid this exception, we might consider adding `jshint` as proper dev dependency in the future - even though it is rarely needed.)

This change also ensures that all `npm install` or `npm clean-install` commands use the `--ignore-scripts` argument for better security.

Related ticket: https://progress.opensuse.org/issues/191193