### PR TITLE
 Skip a build if there are no jobs

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -209,6 +209,7 @@ sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_fi
             my $key = $_->TEST . '-' . $_->ARCH . '-' . $_->FLAVOR . '-' . ($_->MACHINE // '');
             $seen{$key}++ ? () : $_;
         } $jobs->all;
+        next unless @jobs;
         my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs(\@jobs);
         for my $job (@jobs) {
             $jr{distris}->{$job->DISTRI} = 1;


### PR DESCRIPTION
My theory: due to a race condition there might not be any job left in a build,
when we start to process it, because all were jobs deleted meanwhile.

Issue: https://progress.opensuse.org/issues/192496