### PR TITLE
docs: Feature auto-generated deepwiki less prominently

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,7 +1,6 @@
 :circleci: image:https://circleci.com/gh/os-autoinst/openQA/tree/master.svg?style=svg["CircleCI", link="https://circleci.com/gh/os-autoinst/openQA/tree/master"]
 :codecov: image:https://codecov.io/gh/os-autoinst/openQA/branch/master/graph/badge.svg[link=https://codecov.io/gh/os-autoinst/openQA]
 :appliance: image:https://openqa.opensuse.org/tests/latest/badge?arch=x86_64&distri=openqa&flavor=dev&test=openqa_install%2Bpublish&version=Tumbleweed[link="https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=openqa&flavor=dev&machine=64bit-2G&test=openqa_install%2Bpublish&version=Tumbleweed"]
-:deepwiki: image:https://deepwiki.com/badge.svg["DeepWiki", link=https://deepwiki.com/os-autoinst/openQA]
 
 = openQA
 

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -120,6 +120,10 @@ configured in the repositories to encourage contributors to raise the tests
 coverage with every commit and pull request. New features and bug fixes are
 expected to be backed with the corresponding tests.
 
+For an architecture overview the AI generated openQA deepwiki can provide a good overview
+about the complete project but without a guarantee for correctness:
+https://deepwiki.com/os-autoinst/openQA
+
 == Technologies
 [id="technologies"]
 


### PR DESCRIPTION
The AI generated deepwiki can be a good entry point for a project
overview but without a guarantee for correctness. We should not feature
it that prominently and as the deepwiki does not have a dynamic status
we should not use a top-level badge. Just a simple link is fine.