### PR TITLE
Make the number of builds per group on the front page configurable

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -125,6 +125,9 @@
 ## resilient in case of a high load on the web UI. Lower values reduce this risk but
 ## can cause jobs to incomplete with "timestamp mismatch" error messages.
 #api_hmac_time_tolerance = 300
+## How many builds to show per job group on the web UI front page
+## Can be overridden with the limit_builds query param
+#frontpage_builds = 3
 
 ## Configuration related to actions openQA may perform on a git distri
 #[scm git]

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -96,6 +96,7 @@ sub read_config ($app) {
             service_port_delta => $ENV{OPENQA_SERVICE_PORT_DELTA} // 2,
             access_control_allow_origin_header => undef,
             api_hmac_time_tolerance => 300,
+            frontpage_builds => 3,
         },
         rate_limits => {
             search => 5,

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -23,7 +23,7 @@ sub dashboard_build_results ($self) {
     $validation->optional('group');
     return $self->reply->validation_error({format => $self->accepts('html', 'json')}) if $validation->has_error;
 
-    my $limit_builds = $validation->param('limit_builds') // 3;
+    my $limit_builds = $validation->param('limit_builds') // $self->app->config->{global}->{frontpage_builds};
     my $time_limit_days = $validation->param('time_limit_days') // 14;
     my $only_tagged = $validation->param('only_tagged') // 0;
     my $default_expanded = $validation->param('default_expanded') // 0;

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -147,12 +147,21 @@ is_deeply(\@h4, [qw(Build87.5011 Build0048@0815 Build0048)], 'builds on parent-l
 @h4 = $t->tx->res->dom->find('div.collapse .h4 a')->map('text')->each;
 is_deeply(\@h4, ['opensuse', 'opensuse', 'opensuse'], 'opensuse now shown as child group (for each build)');
 
-# check build limit
+# check config file build limit
+my $ogfpb = $t->app->config->{global}->{frontpage_builds};
+$t->app->config->{global}->{frontpage_builds} = 1;
+$t->get_ok('/dashboard_build_results')->status_is(200);
+@h4 = $t->tx->res->dom->find('div.children-collapsed .h4 a')->map('text')->each;
+is_deeply(\@h4, [qw(Build87.5011)], 'single build on parent-level shown (limit builds via config)');
+
+# check query param build limit works and overrides config file limit
 $t->get_ok('/dashboard_build_results?limit_builds=2')->status_is(200);
 @h4 = $t->tx->res->dom->find('div.children-collapsed .h4 a')->map('text')->each;
 is_deeply(\@h4, [qw(Build87.5011 Build0048@0815)], 'builds on parent-level shown (limit builds)');
 @h4 = $t->tx->res->dom->find('div.collapse .h4 a')->map('text')->each;
 is_deeply(\@h4, ['opensuse', 'opensuse'], 'opensuse now shown as child group (limit builds)');
+
+$t->app->config->{global}->{frontpage_builds} = $ogfpb;
 
 # also add opensuse test to parent to actually check the grouping
 my $opensuse_test_group = $job_groups->find({name => 'opensuse test'});

--- a/t/config.t
+++ b/t/config.t
@@ -66,6 +66,7 @@ subtest 'Test configuration default modes' => sub {
             parallel_children_collapsable_results_sel => ' .status:not(.result_passed):not(.result_softfailed)',
             auto_clone_limit => 20,
             api_hmac_time_tolerance => 300,
+            frontpage_builds => 3,
         },
         rate_limits => {
             search => 5,


### PR DESCRIPTION
The number of builds to show per job group on the front page of the web UI is hardcoded to 3.

SUSE's openQA has a ton of job groups so only showing three per group makes sense, but not every instance has so many groups, and the front page can look unnecessarily empty. This allows the instance maintainer to set an appropriate value.

The value can be overridden for a single query with the limit_builds query param, but that's unwieldy and doesn't solve things for casual views of the home page.