### PR TITLE
Optimize Job Group dropdown database query

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/JobGroupParents.pm
+++ b/lib/OpenQA/Schema/ResultSet/JobGroupParents.pm
@@ -10,7 +10,8 @@ use Mojo::Base 'DBIx::Class::ResultSet';
 sub job_groups_and_parents {
     my $self = shift;
 
-    my @parents = $self->search({}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})->all;
+    my $params = {order_by => [{-asc => 'me.sort_order'}, {-asc => 'me.name'}], prefetch => 'children'};
+    my @parents = $self->search({}, $params)->all;
     my $schema = $self->result_source->schema;
     my @groups_without_parent = $schema->resultset('JobGroups')
       ->search({parent_id => undef}, {order_by => [{-asc => 'sort_order'}, {-asc => 'name'}]})->all;


### PR DESCRIPTION
Without the prefetch we are doing one SELECT per parent job group to get the children.
Now we only have two SELECTs, for job_groups and job_group_parents. Children are fetched automatically.

https://metacpan.org/pod/DBIx::Class::ResultSet#prefetch

On my machine, this saves about 60ms on average per webui request.