### PR TITLE
Prevent logging AMQP credentials in debug output

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -58,14 +58,15 @@ sub publish_amqp ($self, $topic, $event_data, $headers = {}, $remaining_attempts
     # create publisher and keep reference to avoid early destruction
     log_debug("Sending AMQP event: $topic");
     my $config = $self->{config}->{amqp};
-    my $url = Mojo::URL->new($config->{url});
-    $url->query({exchange => $config->{exchange}});
+    my $unsanitized_url = Mojo::URL->new($config->{url});
+    $unsanitized_url->query({exchange => $config->{exchange}});
     # append optional parameters
-    $url->query([cacertfile => $config->{cacertfile}]) if ($config->{cacertfile});
-    $url->query([certfile => $config->{certfile}]) if ($config->{certfile});
-    $url->query([keyfile => $config->{keyfile}]) if ($config->{keyfile});
-    $url = $url->to_unsafe_string;
-    my $publisher = Mojo::RabbitMQ::Client::Publisher->new(url => $url);
+    $unsanitized_url->query([cacertfile => $config->{cacertfile}]) if ($config->{cacertfile});
+    $unsanitized_url->query([certfile => $config->{certfile}]) if ($config->{certfile});
+    $unsanitized_url->query([keyfile => $config->{keyfile}]) if ($config->{keyfile});
+    my $url = $unsanitized_url->clone;
+    $unsanitized_url = $unsanitized_url->to_unsafe_string;
+    my $publisher = Mojo::RabbitMQ::Client::Publisher->new(url => $unsanitized_url);
     log_debug("AMQP URL: $url");
 
     $remaining_attempts //= $config->{publish_attempts};

--- a/t/23-amqp.t
+++ b/t/23-amqp.t
@@ -276,7 +276,8 @@ my $amqp = OpenQA::WebAPI::Plugin::AMQP->new;
 $amqp->register($app);
 
 subtest 'amqp_publish call without headers' => sub {
-    $amqp->publish_amqp('some.topic', 'some message');
+    combined_like { $amqp->publish_amqp('some.topic', 'some message') } qr/AMQP URL: amqp:\/\/localhost:5672/,
+      'URL is logged without credentials';
     is($last_publisher->url, 'amqp://guest:guest@localhost:5672/?exchange=pubsub', 'url specified');
     is($published{body}, 'some message', 'message body correctly passed');
     is_deeply($published{headers}, {}, 'headers is empty hashref');


### PR DESCRIPTION
The AMQP URL containing username and password was being logged in plain text via log_debug(), exposing sensitive credentials. This refactors the URL handling to remove the credentials on the debug log and renames the variable to reflect their scope.