### PR TITLE
feat: Allow to configure key+secret with env variables

### DIFF
--- a/docs/Client.asciidoc
+++ b/docs/Client.asciidoc
@@ -82,8 +82,12 @@ key = 1234567890ABCDEF
 secret = ABCDEF1234567890
 ----
 
-For ad-hoc use all `openqa-cli` subcommands use the `--apikey` and `--apisecret`
-options. Which will override whatever the config files may contain.
+Alternatively specify key and secret in environment variables `OPENQA_API_KEY`
+and `OPENQA_API_SECRET`.
+
+For ad-hoc use all `openqa-cli` subcommands use the `--apikey` and
+`--apisecret` options which will override whatever the environment or config
+files may contain.
 
 [source,sh]
 ----

--- a/lib/OpenQA/UserAgent.pm
+++ b/lib/OpenQA/UserAgent.pm
@@ -15,6 +15,8 @@ has [qw(apikey apisecret base_url)];
 sub new {
     my $self = shift->SUPER::new(@_);
     my %args = @_;
+    $args{apikey} //= $ENV{OPENQA_API_KEY};
+    $args{apisecret} //= $ENV{OPENQA_API_SECRET};
     for my $i (qw(apikey apisecret)) {
         $self->$i($args{$i}) if $args{$i};
     }

--- a/public/openqa-cli.yaml
+++ b/public/openqa-cli.yaml
@@ -22,10 +22,11 @@ description: |2
 
 
         Configuration:
-          API key and secret are read from "client.conf" if not specified via CLI
-          arguments. The config file is checked for under "$OPENQA_CONFIG",
-          "~/.config/openqa" and "/etc/openqa" in this order. It must look like
-          this:
+          API key and secret are read from "client.conf" or environment
+          variables "OPENQA_API_KEY" and "OPENQA_API_SECRET" if not specified
+          via CLI arguments. The config file is checked for under
+          "$OPENQA_CONFIG", "~/.config/openqa" and "/etc/openqa" in this
+          order. It must look like this:
 
             [openqa.opensuse.org]
             key = 45ABCEB4562ACB04
@@ -36,8 +37,10 @@ description: |2
 
 options:
   - apibase=s       --API base, defaults to /api/v1
-  - apikey=s        --API key
-  - apisecret=s     --API secret
+  - apikey=s        --API key. Use is discouraged due to risk of leaking
+                      credentials. Prefer config file or env variables.
+  - apisecret=s     --API secret. Use is discouraged due to risk of leaking
+                      credentials. Prefer config file or env variables.
   - host=s          --Target host, defaults to http://localhost
   - help|h          --Get more information on a specific command
   - osd             --Set target host to http://openqa.suse.de

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -58,9 +58,9 @@ parameters C<--from> or C<--within-instance>. The job ID can be specified as
 part of the URL or as its own parameter.
 
 API key and secret are read from "client.conf" if not specified via CLI
-arguments. The config file is checked for under "$OPENQA_CONFIG",
-"~/.config/openqa" and "/etc/openqa" in this order. It must look like
-this:
+arguments or environment variables "OPENQA_API_KEY" and "OPENQA_API_SECRET".
+The config file is checked for under "$OPENQA_CONFIG", "~/.config/openqa" and
+"/etc/openqa" in this order. It must look like this:
 
   [openqa.opensuse.org]
   key = 45ABCEB4562ACB04
@@ -181,11 +181,15 @@ submitting.
 
 =item B<--apikey> <value>
 
-Specifies the public key needed for API authentication.
+Specifies the public key needed for API authentication. Overrides config file
+setting and environment variable C<OPENQA_API_KEY>. Use is discouraged due to
+risk of leaking credentials.
 
 =item B<--apisecret> <value>
 
-Specifies the secret key needed for API authentication.
+Specifies the secret key needed for API authentication. Overrides config file
+setting and environment variable C<OPENQA_API_SECRET>. Use is discouraged due
+to risk of leaking credentials.
 
 =item B<--verbose, -v>
 

--- a/script/openqa-dump-templates
+++ b/script/openqa-dump-templates
@@ -25,9 +25,9 @@ Set API base URL component, default: '/api/v1'
 
 =item B<--apikey> KEY, B<--apisecret> SECRET
 
-Specify api key and secret to use, overrides use of config file ~/.config/openqa/client.conf
-
-override values from config file
+Specify api key and secret to use, overrides use of config file
+~/.config/openqa/client.conf and environment variable C<OPENQA_API_KEY>. Use
+is discouraged due to risk of leaking credentials.
 
 =item B<--group> GROUP
 

--- a/script/openqa-load-templates
+++ b/script/openqa-load-templates
@@ -25,9 +25,9 @@ Set API base URL component, default: '/api/v1'
 
 =item B<--apikey> KEY, B<--apisecret> SECRET
 
-Specify api key and secret to use, overrides use of config file ~/.config/openqa/client.conf
-
-override values from config file
+Specify api key and secret to use, overrides use of config file
+~/.config/openqa/client.conf and environment variable C<OPENQA_API_KEY>. Use
+is discouraged due to risk of leaking credentials.
 
 =item B<--clean>
 

--- a/script/worker
+++ b/script/worker
@@ -24,11 +24,15 @@ specify instance number, ie pool directory to use
 
 =item B<--apikey> <value>
 
-specify the public key needed for API authentication
+specify the public key needed for API authentication. Overrides config file
+setting and environment variable C<OPENQA_API_KEY>. Use is discouraged due to
+risk of leaking credentials.
 
 =item B<--apisecret> <value>
 
-specify the secret key needed for API authentication
+specify the secret key needed for API authentication. Overrides config file
+setting and environment variable C<OPENQA_API_SECRET>. Use is discouraged due
+to risk of leaking credentials.
 
 =item B<--isotovideo> PATH
 

--- a/t/api/03-auth.t
+++ b/t/api/03-auth.t
@@ -49,6 +49,16 @@ subtest 'authentication routes for plugins' => sub {
 
 client($t, apikey => undef, apisecret => undef);
 
+subtest 'key+secret from env variables' => sub {
+    my $t_new = Test::Mojo->new('OpenQA::WebAPI');
+    $t_new->delete_ok('/api/v1/assets/1')->status_is(403, 'clean user agent has no credentials');
+    local $ENV{OPENQA_API_KEY} = 'LANCELOTKEY01';
+    local $ENV{OPENQA_API_SECRET} = 'MANYPEOPLEKNOW';
+    client($t_new, apikey => undef, apisecret => undef);
+    $t_new->delete_ok('/api/v1/assets/1')->status_is(403)
+      ->json_is('/error' => 'Administrator level required', 'key read from env (but missing administrator level)');
+};
+
 subtest 'access limiting for non authenticated users' => sub {
     $t->get_ok('/api/v1/jobs')->status_is(200);
     is $t->tx->res->headers->access_control_allow_origin, '*', 'CORS header set for non authenticated routes';


### PR DESCRIPTION
This is a better variant to
https://github.com/os-autoinst/openQA/pull/6767 which only adds the
support in the worker authentication. If we change the user agent then
we can enable clients as well as workers to use environment variables.

This commit adds support for optional environment variables
OPENQA_API_KEY and OPENQA_API_SECRET which if specified take precedence
over config file entries. Command line arguments take precedence over
environment variables but are now explicitly discouraged in help texts
and documentation to reduce the risk of leaking credentials.