### PR TITLE
KTAP: Define unparsed_lines and parsed_lines_count

### DIFF
--- a/lib/OpenQA/Parser/Format/KTAP.pm
+++ b/lib/OpenQA/Parser/Format/KTAP.pm
@@ -54,8 +54,8 @@ sub _parse_subtest ($self, $result) {
         push @{$steps->{unparsed_lines}}, $line;
         return;
     }
-    $steps->{parsed_lines_count}++;
     return if $line =~ /#\s*SKIP\b/i;
+    $steps->{parsed_lines_count}++;
     my ($status, $index, $subtest_name) = @+{qw(status index name)};
 
     my $has_todo = $line =~ /#\s*TODO\b/i;


### PR DESCRIPTION
There might be jobs without any lines, i.e. both attributes will be undef.

Fixes: 7b3f46b88025 ("parser: ktap: Show full output by default if no line was parsed")

VR:
- https://openqa.opensuse.org/tests/5508300#step/run_kselftests/3046 **before**
- https://rmarliere-openqa.qe.prg2.suse.org/tests/1644#step/selftests:bpf:test_tag/1 **after**