### PR TITLE
Add scanner for untracked screenshots

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Screenshots.pm
+++ b/lib/OpenQA/Schema/ResultSet/Screenshots.pm
@@ -1,4 +1,4 @@
-# Copyright 2019 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Schema::ResultSet::Screenshots;
@@ -6,7 +6,9 @@ package OpenQA::Schema::ResultSet::Screenshots;
 
 use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
 
-use OpenQA::Log qw(log_trace);
+use Mojo::File qw(path);
+use OpenQA::Log qw(log_trace log_error);
+use OpenQA::Utils qw(imagesdir);
 
 sub create_screenshot ($self, $img) {
     my $dbh = $self->result_source->schema->storage->dbh;
@@ -28,6 +30,28 @@ sub populate_images_to_job ($self, $imgs, $job_id) {
     }
     my @data = map { [$_, $job_id] } values %ids;
     $self->result_source->schema->resultset('ScreenshotLinks')->populate([[qw(screenshot_id job_id)], @data]);
+}
+
+# scans the image directories for untracked screenshots and deletes them
+# This can take a very long time to execute if $images_dir is big. So this is meant to be executed manually, e.g.:
+# OPENQA_LOGFILE=scan.log script/openqa eval 'say(STDERR app->schema->resultset("Screenshots")->scan_untracked_screenshots)' > to-delete.txt
+sub scan_untracked_screenshots ($self, $images_dir = imagesdir, $delete = 0) {
+    my $dbh = $self->result_source->schema->storage->dbh;
+    my $sth = $dbh->prepare('SELECT count(id) FROM screenshots WHERE filename = ?');
+    my $screenshots_path = path($images_dir);
+    my $screenshot_paths = $screenshots_path->list_tree({max_depth => 3})->grep(qr/.*\.png/i);
+    my $error_count = 0;
+    my $handle_error = sub ($msg) { log_error $msg; ++$error_count; return 0 };
+    for my $screenshot_path_abs (@$screenshot_paths) {
+        my $screenshot_path = $screenshot_path_abs->to_rel($screenshots_path);
+        $sth->execute($screenshot_path);
+        my ($count) = $sth->fetchrow_array;
+        $handle_error->("Unable to lookup $screenshot_path in DB: " . $sth->errstr) and next if defined $sth->err;
+        next if $count;
+        say $screenshot_path_abs;
+        unlink $screenshot_path_abs or $handle_error->("Unable to delete $screenshot_path_abs: $!") if $delete;
+    }
+    return $error_count;
 }
 
 1;


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/187953

---

I tested this also manually:

```
$ OPENQA_LOGFILE=delete-log.txt script/openqa eval 'say(STDERR app->schema->resultset("Screenshots")->scan_untracked_screenshots)' > to-delete.txt
0
$ cat to-delete.txt 
[INFO] Reading openqa config from: /hdd/openqa-devel/config/openqa.ini /hdd/openqa-devel/config/openqa.ini.d/01-test.ini
/hdd/openqa-devel/openqa/images/0a4/a66/0647f51a4bef105e96ad0fad32.png
/hdd/openqa-devel/openqa/images/f62/868/e3806bbf8f1fc12756a4dc6ab2.png
```

It isn't nice that we get this info message in the list of files but I guess that's another more general problem and we can live with that here. Otherwise, the list of files looks good. (I moved most of the images to a different directory so the list of present images becomes manageable. With this it found only 2 images which were really not in the DB anymore.)

I would probably run this only in dry mode in production, see what files are considered, do a sanity check on some of them and only delete the files afterwards.

I hope holding all those paths in memory at the same time isn't too much as we have 32 GiB of RAM in production and usually only use < 10 GiB.