### PR TITLE
KTAP: Properly hide details of a skipped subtest

### DIFF
--- a/lib/OpenQA/Parser/Format/KTAP.pm
+++ b/lib/OpenQA/Parser/Format/KTAP.pm
@@ -94,6 +94,7 @@ sub _testgroup_finalize ($self, $result) {
     }
     elsif ($line =~ /#\s*SKIP\b/i) {
         $steps->{result} = 'skip';
+        $steps->{details} = [];
     }
 
     $steps->{name} = $self->test->{name};


### PR DESCRIPTION
It is possible for a subtest to have a result line containing the "# SKIP" pattern while still having detailed lines which are parsed. Make sure to remove them because they should not be showed.