### PR TITLE
Show jobs that have been cloned when `t` parameter is used on overview

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -836,10 +836,6 @@ sub _add_distri_and_version_to_summary ($array_to_add_parts_to, $distri, $versio
 sub overview ($self) {
     my ($search_args, $groups) = $self->compose_job_overview_search_args;
     my $config = OpenQA::App->singleton->config;
-    my $validation = $self->validation;
-    $validation->optional('t')->datetime;
-    my $until = $validation->param('t');
-    $search_args->{until} = $until;
     my $distri = $search_args->{distri};
     my $version = $search_args->{version};
     my $jobs_rs = $self->schema->resultset('Jobs');
@@ -889,7 +885,7 @@ sub overview ($self) {
         results => $results,
         aggregated => $aggregated,
         job_ids => $job_ids,
-        until => $until,
+        until => $search_args->{until},
         parallel_children_collapsable_results_sel => $config->{global}->{parallel_children_collapsable_results_sel},
         summary_parts => \@summary_parts,
         only_distri => $only_distri,

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -411,6 +411,7 @@ sub _compose_job_overview_search_args ($c) {
     $v->optional('modules', 'comma_separated');
     $v->optional('flavor', 'comma_separated');
     $v->optional('limit', 'not_empty')->num(1, undef);
+    $v->optional('t')->datetime;
 
     # add simple query params to search args
     for my $arg (qw(distri version flavor test)) {
@@ -486,8 +487,9 @@ sub _compose_job_overview_search_args ($c) {
     my $configured_limit = $c->app->config->{misc_limits}->{tests_overview_max_jobs};
     $search_args{limit} = ($v->is_valid('limit') ? min($configured_limit, $v->param('limit')) : $configured_limit) + 1;
 
-    # exclude jobs which are already cloned by setting scope for OpenQA::Jobs::complex_query()
-    $search_args{scope} = 'current';
+    # exclude jobs which are already cloned by setting scope for OpenQA::Jobs::complex_query() unless t param is used
+    if (my $until = $v->param('t')) { $search_args{until} = $until }
+    else { $search_args{scope} = 'current' }
 
     # allow filtering by job ID
     my $ids = $v->every_param('id');

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -134,6 +134,9 @@ like($summary, qr/Summary of opensuse Factory build 87.5011/);
 like($summary, qr/Incomplete: 1/);
 
 subtest 'time parameter' => sub {
+    # assume 99926 is a clone; this should not prevent it from showing up with the t= parameter
+    $jobs->find(99926)->update({clone_id => 99927});
+
     my $link_to_fixed = $t->tx->res->dom->at('#summary .time-params a');
     if (isnt($link_to_fixed, undef, 'link to "fixed" present')) {
         my $params = Mojo::Parameters->new(substr($link_to_fixed->attr('href') // '', 1));


### PR DESCRIPTION
The `t` parameter is meant to show historical data so setting the scope to "current" which excludes jobs that have already been cloned does not make much sense. At least that is not what users expected in https://progress.opensuse.org/issues/193348. So with this commit the scope is only set to "current" if the `t` parameter is not present.