### PR TITLE
Add Client folder to codecov.yaml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,7 @@ coverage:
         target: 100.0
         threshold: 0
         paths:
+          - lib/OpenQA/Client/
           - lib/OpenQA/Worker/
           - lib/OpenQA/Worker.pm
           - lib/OpenQA/Utils.pm


### PR DESCRIPTION
openQA Codecov coverage: add `openQA/Client/` folder to `codecov.yaml`

ticket: https://progress.opensuse.org/issues/193735