### PR TITLE
Skip caching for KERNEL INITRD variables

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -33,6 +33,7 @@ use Feature::Compat::Try;
 use constant CGROUP_SLICE => $ENV{OPENQA_CGROUP_SLICE};
 use constant CACHE_SERVICE_POLL_DELAY => $ENV{OPENQA_CACHE_SERVICE_POLL_DELAY} // 5;
 use constant CACHE_SERVICE_TEST_SYNC_ATTEMPTS => $ENV{OPENQA_CACHE_SERVICE_TEST_SYNC_ATTEMPTS} // 3;
+my %ASSETS_TO_SKIP = map { $_ => 1 } qw(UEFI_PFLASH_VARS KERNEL INITRD);
 
 my $isotovideo = '/usr/bin/isotovideo';
 my $workerpid;
@@ -64,7 +65,7 @@ sub detect_asset_keys ($vars) {
         # test (which we should treat as an hdd asset), or it may point
         # to an absolute filesystem location of e.g. a template file from
         # edk2 (which we shouldn't).
-        next if $key eq 'UEFI_PFLASH_VARS' && $value =~ m,^/,;
+        next if exists $ASSETS_TO_SKIP{$key} && $value =~ m,^/,;
         my $type = asset_type_from_setting($key, $value);
 
         # Exclude repo assets for now because the cache service does not

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -327,6 +327,8 @@ subtest asset_type_from_setting => sub {
     is asset_type_from_setting('UEFI_PFLASH_VARS'), 'hdd', 'simple from UEFI_PFLASH_VARS';
     is asset_type_from_setting('UEFI_PFLASH_VARS', 'relative'), 'hdd', 'relative from UEFI_PFLASH_VARS';
     is asset_type_from_setting('UEFI_PFLASH_VARS', '/absolute'), '', 'absolute from UEFI_PFLASH_VARS';
+    is asset_type_from_setting('KERNEL', '/vmlinuz'), 'other', 'absolute from KERNEL';
+    is asset_type_from_setting('KERNEL', 'vmlinuz'), 'other', 'relative from KERNEL';
 };
 
 subtest parse_assets_from_settings => sub {
@@ -370,6 +372,12 @@ subtest parse_assets_from_settings => sub {
     $assets = parse_assets_from_settings($settings);
     $refassets->{UEFI_PFLASH_VARS} = {type => 'hdd', name => 'uefi_pflash_vars.qcow2'};
     is_deeply $assets, $refassets, 'correct with relative UEFI_PFLASH_VARS';
+    # KERNEL/INITRD are treated similar to UEFI_PFLASH_VARS
+    $settings->{KERNEL} = '/path/vmlinuz';
+    $assets = parse_assets_from_settings($settings);
+    $refassets->{KERNEL} = {type => 'other', name => '/path/vmlinuz'};
+    is_deeply $assets, $refassets, 'correct with absolute KERNEL';
+
 };
 
 subtest 'base_host' => sub {

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -147,6 +147,20 @@ subtest 'asset settings' => sub {
 
     $got = OpenQA::Worker::Engines::isotovideo::detect_asset_keys($settings);
     is_deeply($got, $expected, 'Asset settings are correct (no UEFI or NUMDISKS)') or always_explain $got;
+
+    subtest 'absolute path on KERNEL and INITRD' => sub {
+        my $test_settings = {
+            KERNEL => '/usr/share/qemu/vmlinuz',
+            INITRD => '/usr/share/qemu/initrd',
+            ISO => 'test.iso',
+        };
+
+        my $test_expected = {'ISO' => 'iso'};
+
+        my $test_got = OpenQA::Worker::Engines::isotovideo::detect_asset_keys($test_settings);
+        is_deeply($test_got, $test_expected, 'KERNEL and INITRD with absolute paths are skipped from caching')
+          or always_explain $test_got;
+    }
 };
 
 subtest 'caching' => sub {


### PR DESCRIPTION
Treat KERNEL and INITRD similar to UEFI_PFLASH_VARS. The variables might be assigned with absolute paths. There are not used as regular variables and when they do they are meant to be used in replace of UEFI_PFLASH_VARS.

The change, mainly, prevents the given asset to try be downloaded to the cache directory. Together with `ABSOLUTE_TEST_CONFIG_PATHS=1` they allow to be used in booting a custom kernle for testing purposes.

related_issue: https://progress.opensuse.org/issues/190056