### PR TITLE
docs: Use node_modules target

### DIFF
--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -436,9 +436,9 @@ This section should give you a general idea how to start daemons manually for
 development after you setup a PostgreSQL database as mentioned in the previous
 section.
 
-You have to install/update web-related dependencies first using
-`npm clean-install --ignore-scripts`. To start the webserver for development,
-use `scripts/openqa daemon`. The other daemons (mentioned in the
+You have to install/update web-related dependencies first, using
+`make node_modules`. To start the web server for development, use
+`scripts/openqa daemon`. The other daemons (mentioned in the
 link:images/architecture.svg[architecture diagram]) are started in the same way,
 e.g. `script/openqa-scheduler daemon`.
 


### PR DESCRIPTION
Replace `npm clean-install` with `make node_modules` in Contributing.asciidoc: Manual daemon setup.

- Ticket poo#[193456](https://progress.opensuse.org/issues/193456)
