### PR TITLE
feat(scheduled products): Allow adding note to result data

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
@@ -4,6 +4,7 @@
 package OpenQA::Schema::ResultSet::ScheduledProducts;
 
 use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
+use Mojo::JSON qw(encode_json);
 use OpenQA::Schema::Result::ScheduledProducts qw(CANCELLED);
 use OpenQA::App;
 
@@ -28,6 +29,28 @@ sub cancel_by_webhook_id ($self, $webhook_id, $reason) {
     my $count = 0;
     $count += $_->cancel($reason) for $self->search({webhook_id => $webhook_id, -not => {status => CANCELLED}});
     return {jobs_cancelled => $count};
+}
+
+sub update_note ($self, $distri, $version, $flavor, $arch, $build, $note) {
+    my $sth = $self->result_source->schema->storage->dbh->prepare(
+        <<~'END_SQL'
+        UPDATE scheduled_products SET results['note'] = ? where id = (
+            SELECT id
+            FROM scheduled_products
+            WHERE distri = ? and version = ? and flavor = ? and arch = ? and build = ?
+            ORDER BY id DESC
+            LIMIT 1
+        ) RETURNING id;
+        END_SQL
+    );
+    $sth->bind_param(1, encode_json($note));
+    $sth->bind_param(2, $distri);
+    $sth->bind_param(3, $version);
+    $sth->bind_param(4, $flavor);
+    $sth->bind_param(5, $arch);
+    $sth->bind_param(6, $build);
+    $sth->execute;
+    return {updated_product_id => $sth->fetchrow_arrayref->[0]};
 }
 
 sub job_statistics ($self, $distri, $version, $flavor, $arch, $build) {

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -380,6 +380,7 @@ sub startup ($self) {
     $api_ra->delete('/isos/#name')->name('apiv1_destroy_iso')->to('iso#destroy');
     $api_ro->post('/isos/#name/cancel')->name('apiv1_cancel_iso')->to('iso#cancel');
     $api_ro->get('/isos/job_stats')->name('apiv1_scheduled_product_job_stats')->to('iso#job_statistics');
+    $api_ro->put('/experimental/isos/note')->name('apiv1_scheduled_product_note')->to('iso#update_note');
 
     # api/v1/webhooks
     $api_ro->post('/webhooks/product')->name('apiv1_evaluate_webhook_product')->to('webhook#product');


### PR DESCRIPTION
The note will be displayed on the web UI like the other result data. It can be used by tools like qem-bot to display additional information, e.g. "Not approving maintenance request X".

Related ticket: https://progress.opensuse.org/issues/193843