### PR TITLE
feat: Consider archive as well in df-based cleanup of job results

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1513,11 +1513,12 @@ the retention for important jobs it is still subject to cleanup.
 === Space-aware cleanup ===
 The cleanup of logs/results uses time-based retentions and hence is independent
 of actually available space on any assigned storage volumes. To ensure enough
-free space on file system storing results one can use the configuration settings
-`…_min_free_disk_space_percentage` to control automatic cleanup behavior. These
-percentages extend the cleanup of logs/results so that they are deleted until
-the specified percentage of file system space is free. This extended deletion
-happens independently of configured thresholds.
+free space on the file systems storing results one can use the configuration
+settings `…_min_free_disk_space_percentage` to control automatic cleanup
+behavior. These percentages extend the cleanup of logs/results so that they are
+deleted until the specified percentage of file system space is free. This
+extended deletion happens independently of configured time-based retention
+thresholds.
 
 The deletion happens in the following order:
 
@@ -1532,9 +1533,9 @@ It is also possible to abort cleanup tasks early in case there is still
 enough headroom on relevant file systems anyway. This can be enabled using the
 configuration settings `…_cleanup_max_free_percentage`.
 
-WARNING: The space-aware cleanup relies on `df` reporting a valid file system
-space usage. The algorithms also assume that screenshots and test results are
-stored on the same file system. The `…_min_free_disk_space_percentage` settings
+NOTE: The space-aware cleanup relies on `df` reporting a valid file system space
+usage. The algorithms also assume that screenshots and test results are stored
+on the same file system. The `…_min_free_disk_space_percentage` settings
 specifically are still experimental.
 
 [id="asset_cleanup"]

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1479,6 +1479,18 @@ Further remarks:
   section of <<GettingStarted.asciidoc#_configuration,the web UI configuration>>.
   Jobs outside of any group use the limits configured in the `[no_group_limits]`
   section of the web UI configuration.
+* The cleanup of logs/results uses time-based retentions and hence is
+  independant of actually available space on any assigned storage volumes. To
+  ensure enough free space on filesystem storing results one can use the
+  configuration settings `…_min_free_disk_space_percentage` to control automatic
+  cleanup behavior. These percentages extend the cleanup of logs/results so that
+  they are deleted until the specified percentage of filesystem space is free.
+  This extended deletion happens independently of configured thresholds. Old
+  jobs are deleted first. Videos are deleted first; further results are only
+  deleted if deleting videos is not sufficient. Un-important jobs are deleted
+  first; important jobs are only deleted if deleting un-important jobs is not
+  sufficient. The algorithm assumes that screenshots are stored on the same
+  partition test results are stored. This feature is still experimental.
 * The <<Installing.asciidoc#auditing,Auditing>> section explains the cleanup of
   the audit log.
 

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1510,7 +1510,7 @@ This means a job is "in the archive" if:
 NOTE: Archiving does *not* prevent cleanup. If an archived important job exceeds
 the retention for important jobs it is still subject to cleanup.
 
-=== Space-aware cleanup of job results ===
+=== Space-aware cleanup ===
 The cleanup of logs/results uses time-based retentions and hence is independent
 of actually available space on any assigned storage volumes. To ensure enough
 free space on filesystem storing results one can use the configuration settings
@@ -1528,9 +1528,14 @@ The deletion happens in the following order:
 
 Within each group the oldest jobs are deleted first.
 
-WARNING: This feature is still experimental. It relies on `df` reporting a valid
-file system space usage. The algorithm also assumes that screenshots and test
-results are stored on the same file system.
+It is also possible to abort cleanup tasks early in case there is still
+enough headroom on relevant filesystems anyway. This can be enabled using the
+configuration settings `…_cleanup_max_free_percentage`.
+
+WARNING: The space-aware cleanup relies on `df` reporting a valid file system
+space usage. The algorithms also assume that screenshots and test results are
+stored on the same file system. The `…_min_free_disk_space_percentage` settings
+specifically are still experimental.
 
 [id="asset_cleanup"]
 === Cleanup strategy for assets ===

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1479,18 +1479,6 @@ Further remarks:
   section of <<GettingStarted.asciidoc#_configuration,the web UI configuration>>.
   Jobs outside of any group use the limits configured in the `[no_group_limits]`
   section of the web UI configuration.
-* The cleanup of logs/results uses time-based retentions and hence is
-  independant of actually available space on any assigned storage volumes. To
-  ensure enough free space on filesystem storing results one can use the
-  configuration settings `…_min_free_disk_space_percentage` to control automatic
-  cleanup behavior. These percentages extend the cleanup of logs/results so that
-  they are deleted until the specified percentage of filesystem space is free.
-  This extended deletion happens independently of configured thresholds. Old
-  jobs are deleted first. Videos are deleted first; further results are only
-  deleted if deleting videos is not sufficient. Un-important jobs are deleted
-  first; important jobs are only deleted if deleting un-important jobs is not
-  sufficient. The algorithm assumes that screenshots are stored on the same
-  partition test results are stored. This feature is still experimental.
 * The <<Installing.asciidoc#auditing,Auditing>> section explains the cleanup of
   the audit log.
 
@@ -1521,6 +1509,28 @@ This means a job is "in the archive" if:
 
 NOTE: Archiving does *not* prevent cleanup. If an archived important job exceeds
 the retention for important jobs it is still subject to cleanup.
+
+=== Space-aware cleanup of job results ===
+The cleanup of logs/results uses time-based retentions and hence is independent
+of actually available space on any assigned storage volumes. To ensure enough
+free space on filesystem storing results one can use the configuration settings
+`…_min_free_disk_space_percentage` to control automatic cleanup behavior. These
+percentages extend the cleanup of logs/results so that they are deleted until
+the specified percentage of filesystem space is free. This extended deletion
+happens independently of configured thresholds.
+
+The deletion happens in the following order:
+
+1. Videos of unimportant jobs
+2. Results of unimportant jobs
+3. Videos of important jobs
+4. Results of important jobs
+
+Within each group the oldest jobs are deleted first.
+
+WARNING: This feature is still experimental. It relies on `df` reporting a valid
+file system space usage. The algorithm also assumes that screenshots and test
+results are stored on the same file system.
 
 [id="asset_cleanup"]
 === Cleanup strategy for assets ===

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1326,7 +1326,7 @@ and downloaded directly (though there is a configuration option to hide some or 
 from public view in the web-UI).
 
 Assets may be shared between the web-UI and the workers by having them literally use a shared
-filesystem (this used to be the only option), or by having the workers download them from the
+file system (this used to be the only option), or by having the workers download them from the
 server when needed and cache them locally. Checkout the documentation about
 <<Installing.asciidoc#asset-caching,asset caching>> for more on this.
 
@@ -1513,10 +1513,10 @@ the retention for important jobs it is still subject to cleanup.
 === Space-aware cleanup ===
 The cleanup of logs/results uses time-based retentions and hence is independent
 of actually available space on any assigned storage volumes. To ensure enough
-free space on filesystem storing results one can use the configuration settings
+free space on file system storing results one can use the configuration settings
 `…_min_free_disk_space_percentage` to control automatic cleanup behavior. These
 percentages extend the cleanup of logs/results so that they are deleted until
-the specified percentage of filesystem space is free. This extended deletion
+the specified percentage of file system space is free. This extended deletion
 happens independently of configured thresholds.
 
 The deletion happens in the following order:
@@ -1529,7 +1529,7 @@ The deletion happens in the following order:
 Within each group the oldest jobs are deleted first.
 
 It is also possible to abort cleanup tasks early in case there is still
-enough headroom on relevant filesystems anyway. This can be enabled using the
+enough headroom on relevant file systems anyway. This can be enabled using the
 configuration settings `…_cleanup_max_free_percentage`.
 
 WARNING: The space-aware cleanup relies on `df` reporting a valid file system

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -277,7 +277,7 @@ concurrent = 0
 [misc_limits]
 #untracked_assets_storage_duration = 14
 ## Performs the cleanup of results/assets only if the free disk space on the
-## relevant filesystem is below the specified percentage (and aborts early
+## relevant file system is below the specified percentage (and aborts early
 ## otherwise)
 #result_cleanup_max_free_percentage = 100
 #asset_cleanup_max_free_percentage = 100
@@ -292,10 +292,10 @@ concurrent = 0
 ## Extend the job result cleanup via experimental
 ## `…_min_free_disk_space_percentage` settings to ensure storage does not become
 ## too full (relies on df)
-## Specifies the threshold for the for filesystem where job results are
+## Specifies the threshold for the for file system where job results are
 ## regularly stored on
 #results_min_free_disk_space_percentage = 0
-## Specifies the threshold for the filesystem where job results are archived
+## Specifies the threshold for the file system where job results are archived
 #archive_min_free_disk_space_percentage = 0
 ## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -276,9 +276,8 @@ concurrent = 0
 
 [misc_limits]
 #untracked_assets_storage_duration = 14
-## Performs the cleanup of results/assets only if the free disk space on the
-## relevant file system is below the specified percentage (and aborts early
-## otherwise)
+## Performs the cleanup of results/assets only if the free space on the relevant
+## file system is below the specified percentage (and aborts early otherwise)
 #result_cleanup_max_free_percentage = 100
 #asset_cleanup_max_free_percentage = 100
 ## Specify the screenshot ID range to query at once from the database (reduce to
@@ -291,11 +290,13 @@ concurrent = 0
 #screenshot_cleanup_batches_per_minion_job = 450
 ## Extend the job result cleanup via experimental
 ## `…_min_free_disk_space_percentage` settings to ensure storage does not become
-## too full (relies on df)
-## Specifies the threshold for the for file system where job results are
-## regularly stored on
+## too full (see documentation section "Space-aware cleanup" for details)
+## Specifies the threshold for the file system where job results are regularly
+## stored on, zero keeps regularly stored results as long as configured per
+## retentions
 #results_min_free_disk_space_percentage = 0
-## Specifies the threshold for the file system where job results are archived
+## Specifies the threshold for the file system where job results are archived,
+## zero keeps archived results as long as configured per retentions
 #archive_min_free_disk_space_percentage = 0
 ## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -276,7 +276,7 @@ concurrent = 0
 
 [misc_limits]
 #untracked_assets_storage_duration = 14
-## Performs the cleanup of results/assets only if the free disk space on the relevant partition is below the specified percentage (and aborts early otherwise)
+## Performs the cleanup of results/assets only if the free disk space on the relevant filesystem is below the specified percentage (and aborts early otherwise)
 #result_cleanup_max_free_percentage = 100
 #asset_cleanup_max_free_percentage = 100
 ## Specify the screenshot ID range to query at once from the database (reduce to avoid big queries, increase to lower query overhead)
@@ -285,9 +285,9 @@ concurrent = 0
 ## job (reduce to avoid Minion jobs from running very long and possibly being interrupted, increase to reduce the number of Minion jobs)
 #screenshot_cleanup_batches_per_minion_job = 450
 ## Extend the job result cleanup via experimental `…_min_free_disk_space_percentage` settings to ensure storage does not become too full (relies on df)
-## Specifies the threshold for the for partition where job results are regularly stored on
+## Specifies the threshold for the for filesystem where job results are regularly stored on
 #results_min_free_disk_space_percentage = 0
-## Specifies the threshold for the partition where job results are archived
+## Specifies the threshold for the filesystem where job results are archived
 #archive_min_free_disk_space_percentage = 0
 ## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -276,74 +276,100 @@ concurrent = 0
 
 [misc_limits]
 #untracked_assets_storage_duration = 14
-## Performs the cleanup of results/assets only if the free disk space on the relevant filesystem is below the specified percentage (and aborts early otherwise)
+## Performs the cleanup of results/assets only if the free disk space on the
+## relevant filesystem is below the specified percentage (and aborts early
+## otherwise)
 #result_cleanup_max_free_percentage = 100
 #asset_cleanup_max_free_percentage = 100
-## Specify the screenshot ID range to query at once from the database (reduce to avoid big queries, increase to lower query overhead)
+## Specify the screenshot ID range to query at once from the database (reduce to
+## avoid big queries, increase to lower query overhead)
 #screenshot_cleanup_batch_size = 200000
-## Specify the number of screenshot ID ranges (with a size as configured by screenshot_cleanup_batch_size) to process in a single Minion
-## job (reduce to avoid Minion jobs from running very long and possibly being interrupted, increase to reduce the number of Minion jobs)
+## Specify the number of screenshot ID ranges (with a size as configured by
+## screenshot_cleanup_batch_size) to process in a single Minion
+## job (reduce to avoid Minion jobs from running very long and possibly being
+## interrupted, increase to reduce the number of Minion jobs)
 #screenshot_cleanup_batches_per_minion_job = 450
-## Extend the job result cleanup via experimental `…_min_free_disk_space_percentage` settings to ensure storage does not become too full (relies on df)
-## Specifies the threshold for the for filesystem where job results are regularly stored on
+## Extend the job result cleanup via experimental
+## `…_min_free_disk_space_percentage` settings to ensure storage does not become
+## too full (relies on df)
+## Specifies the threshold for the for filesystem where job results are
+## regularly stored on
 #results_min_free_disk_space_percentage = 0
 ## Specifies the threshold for the filesystem where job results are archived
 #archive_min_free_disk_space_percentage = 0
 ## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800
-## Default number of templates to include in job_templates api response (to prevent performance issues)
+## Default number of templates to include in job_templates api response (to
+## prevent performance issues)
 #generic_default_limit = 10000
-## Maximum number of templates to include in job_templates api response (to prevent performance issues)
+## Maximum number of templates to include in job_templates api response (to
+## prevent performance issues)
 #generic_max_limit = 100000
-## Maximum number of jobs to include in tests overview page (to prevent performance issues)
+## Maximum number of jobs to include in tests overview page (to prevent
+## performance issues)
 #tests_overview_max_jobs = 2000
-## Default number of jobs to include in table of finished jobs on "All tests" page
+## Default number of jobs to include in table of finished jobs on "All tests"
+## page
 #all_tests_default_finished_jobs = 500
-## Maximum number of jobs to include in table of finished jobs on "All tests" page
+## Maximum number of jobs to include in table of finished jobs on "All tests"
+## page
 #all_tests_max_finished_jobs = 10000
-## Default number of templates to include in job_templates api response (to prevent performance issues)
+## Default number of templates to include in job_templates api response (to
+## prevent performance issues)
 #list_templates_default_limit = 5000
-## Maximum number of templates to include in job_templates api response (to prevent performance issues)
+## Maximum number of templates to include in job_templates api response (to
+## prevent performance issues)
 #list_templates_max_limit = 20000
-## Default number of next jobs to include in jobs request (to prevent performance issues)
+## Default number of next jobs to include in jobs request (to prevent
+## performance issues)
 #next_jobs_default_limit = 500
-## Maximum number of next jobs to include in jobs request (to prevent performance issues)
+## Maximum number of next jobs to include in jobs request (to prevent
+## performance issues)
 #next_jobs_max_limit = 10000
-## Default number of previous jobs to include in jobs request (to prevent performance issues)
+## Default number of previous jobs to include in jobs request (to prevent
+## performance issues)
 #previous_jobs_default_limit = 500
-## Maximum number of previous jobs to include in jobs request (to prevent performance issues)
+## Maximum number of previous jobs to include in jobs request (to prevent
+## performance issues)
 #previous_jobs_max_limit = 10000
-## Maximum number of recent jobs to consider when returning jobs for a settings query (to prevent performance issues)
+## Maximum number of recent jobs to consider when returning jobs for a settings
+## query (to prevent performance issues)
 #job_settings_max_recent_jobs = 20000
-## Default number of assets to include in asset listing request (to prevent performance issues)
+## Default number of assets to include in asset listing request (to prevent
+## performance issues)
 #assets_default_limit = 100000
-## Maximum number of next jobs to include asset listing request (to prevent performance issues)
+## Maximum number of next jobs to include asset listing request (to prevent
+## performance issues)
 #assets_max_limit = 200000
 ## Maximum number of online workers (to prevent performance issues)
 ## Set to a low enough number if the openQA scheduler does not assign jobs
-## anymore or if openqa-scheduler reports errors about unresponsive
-## websockets server
+## anymore or if openqa-scheduler reports errors about unresponsive websockets
+## server
 #max_online_workers = 1000
 ## Retry delay for limited workers in seconds
 #worker_limit_retry_delay = 900
-## Maximum number of retries with exponential back-off for GruJobs to wait for a GruTask to appear in the database
+## Maximum number of retries with exponential back-off for GruJobs to wait for a
+## GruTask to appear in the database
 #wait_for_grutask_retries = 6
 ## Maximum size of MCP results in bytes (to prevent performance issues)
 # mcp_max_result_size = 500000
-## To encourage job scenarios with shorter runtime: If MAX_JOB_TIME is greater than
-## DEFAULT_MAX_JOB_TIME, MAX_JOB_TIME divided by this number is added to the
-## job priority. Can be 0 to disable and negative to prioritize long running job
-## scenarios.
+## To encourage job scenarios with shorter runtime: If MAX_JOB_TIME is greater
+## than DEFAULT_MAX_JOB_TIME, MAX_JOB_TIME divided by this number is added to
+## the job priority. Can be 0 to disable and negative to prioritize long running
+## job scenarios.
 #max_job_time_prio_scale = 100
 ## Minimum storage duration for scheduled products
-## Scheduled products are kept as long as the jobs they have created exist. So their retention is controlled by the
-## retention of their jobs and you normally don't need to tweak this value. It only serves as a minimum retention
-## so scheduled products without any jobs (e.g. due to errors) are not immediately cleaned up.
+## Scheduled products are kept as long as the jobs they have created exist. So
+## their retention is controlled by the retention of their jobs and you normally
+## don't need to tweak this value. It only serves as a minimum retention so
+## scheduled products without any jobs (e.g. due to errors) are not immediately
+## cleaned up.
 #scheduled_product_min_storage_duration = 34
 
 [archiving]
-## Moves logs of jobs which are preserved during the cleanup because they are considered important
-## to "${OPENQA_ARCHIVEDIR:-${OPENQA_BASEDIR:-/var/lib}/openqa/archive}/testresults"
+## Moves logs of jobs which are preserved during the cleanup because they are
+## considered important to
+## "${OPENQA_ARCHIVEDIR:-${OPENQA_BASEDIR:-/var/lib}/openqa/archive}/testresults"
 #archive_preserved_important_jobs = 0
 
 [job_settings_ui]

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -284,9 +284,11 @@ concurrent = 0
 ## Specify the number of screenshot ID ranges (with a size as configured by screenshot_cleanup_batch_size) to process in a single Minion
 ## job (reduce to avoid Minion jobs from running very long and possibly being interrupted, increase to reduce the number of Minion jobs)
 #screenshot_cleanup_batches_per_minion_job = 450
-## Extends the job result cleanup to ensure the partition results are stored on does not become too full
-## (still experimental, relies on df)
+## Extend the job result cleanup via experimental `…_min_free_disk_space_percentage` settings to ensure storage does not become too full (relies on df)
+## Specifies the threshold for the for partition where job results are regularly stored on
 #results_min_free_disk_space_percentage = 0
+## Specifies the threshold for the partition where job results are archived
+#archive_min_free_disk_space_percentage = 0
 ## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800
 ## Default number of templates to include in job_templates api response (to prevent performance issues)

--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -23,7 +23,7 @@
 #CACHELIMIT = 50
 
 # Limit size of CACHEDIRECTORY to preserve the specified percentage of free disk
-# space on the filesystem it is located on (the default is NO limit; the 10 %
+# space on the file system it is located on (the default is NO limit; the 10 %
 # are just an example)
 #CACHE_MIN_FREE_PERCENTAGE = 10
 

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -220,6 +220,7 @@ sub read_config ($app) {
             screenshot_cleanup_batch_size => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
             results_min_free_disk_space_percentage => undef,
+            archive_min_free_disk_space_percentage => undef,
             minion_job_max_age => ONE_WEEK,
             generic_default_limit => 10000,
             generic_max_limit => 100000,

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -189,7 +189,9 @@ subtest 'deleting screenshots of a single job' => sub {
 
     ok -d (my $result_dir = path($job->create_result_dir)), 'result directory created';
     $result_dir->child('foo')->spew('-----');
-    is $job->delete_results, 2 * (2 + 3) + 5, 'size of deleted results returned';
+    my ($deleted_results, $deleted_screenshots) = $job->delete_results;
+    is $deleted_results, 5, 'size of deleted results returned';
+    is $deleted_screenshots, 2 * (2 + 3), 'size of deleted screenshots returned';
     $job->discard_changes;
     is $job->logs_present, 0, 'logs not considered present anymore';
     is $job->result_size, 0, 'result size cleared';

--- a/templates/webapi/admin/group/group_property_editor.html.ep
+++ b/templates/webapi/admin/group/group_property_editor.html.ep
@@ -254,7 +254,8 @@
                 <div class="col-sm-10">
                     <span id="editor-info">
                         <div>All time-related properties (measured in days) can be set to <em>0</em> to denote infinity.</div>
-                        % if (app->config->{misc_limits}->{results_min_free_disk_space_percentage}) {
+                        % my $limits = app->config->{misc_limits};
+                        % if ($limits->{results_min_free_disk_space_percentage} || $limits->{archive_min_free_disk_space_percentage}) {
                         <div>
                             Results and logs might be deleted earlier than configured to prevent running out of disk space. In this case only videos are deleted at
                             first and only if that is not sufficient the results are deleted. Important jobs are only considered if deleting other jobs was not sufficient.


### PR DESCRIPTION
* Apply the deletion logic for non-archived jobs also to archived jobs considering the free disk space within the archive directory
* Introduce `archive_min_free_disk_space_percentage` to configure this
* See https://progress.opensuse.org/issues/193999