### PR TITLE
KernelBug: Extend the kernel bug template

### DIFF
--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -234,7 +234,7 @@ sub check_report_links ($failed_module, $failed_step, $container = undef) {
     like($url[1], qr{(?:\?|&)product=openSUSE\+Distribution(?:&|$)}, 'kernel product bug sets product');
     like(
         $url[1],
-        qr{(?:\?|&)short_desc=%5BBuild\+0091%5D\+Kernel\+test\+fails\+in\+bootloader},
+        qr{(?:\?|&)short_desc=%5BQE%5D%5BBuild\+0091%5D\+Kernel\+test\+fails\+in\+bootloader},
         'kernel short_desc correct'
     );
     like($url[1], qr{(?:\?|&)comment=}, 'kernel product bug has comment template');


### PR DESCRIPTION
QE-kernel team is discussing how to accommodate the feedback from the kernel devs, so that the kernel bug reports could be improved.

See: https://progress.opensuse.org/issues/194744

deployed here: https://rmarliere-openqa.qe.prg2.suse.org/tests/1735#step/io_uring/77