### PR TITLE
Reapply "Update CircleCI image to Leap 16.0"

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,27 +4,27 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use
-RUN zypper -n in tar gzip sudo
+RUN zypper -n --no-refresh in tar gzip sudo
 
 # these are autoinst dependencies
-RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
+RUN zypper --no-refresh install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
 
 # openQA dependencies
-RUN zypper install -y 'rubygem(sass)>=3.7.4' ruby-devel npm python3-base python3-requests git-core rsync curl 'postgresql-devel>=14' 'postgresql-server>=14' qemu qemu-tools tar xorg-x11-fonts sudo make
+RUN zypper --no-refresh install -y perl-CSS-Sass ruby-devel npm python3-requests git-core rsync curl 'postgresql-devel>=14' 'postgresql-server>=14' qemu qemu-tools xorg-x11-fonts
 
 # openQA chromedriver for Selenium tests
-RUN zypper install -y chromedriver
+RUN zypper --no-refresh install -y chromedriver
 
 ENV LANG=en_US.UTF-8
 
 ENV NORMAL_USER=squamata
 ENV USER=squamata
 
-RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$NORMAL_USER
 RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER
 # Create default directory to prevent keyboxd usage for GPG >= 2.4, see https://github.com/codecov/codecov-circleci-orb/issues/157 for details
 RUN sudo -u $NORMAL_USER mkdir -p /home/$NORMAL_USER/.gnupg

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_webui:latest opensuse/openqa-webui:latest opensuse/openqa-webui:%PKG_VERSION% opensuse/openqa-webui:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-webui
 LABEL org.opencontainers.image.title="openQA webui container"
@@ -14,13 +14,10 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 ENV LC_ALL=C.UTF-8
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    # openQA might need rubygem:sass to compile assets in this context due to
-    # unknown reasons even though the package should use the precompiled
-    # assets from cache.tar
-    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m 'rubygem(sass)>=3.7.4' && \
+    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m perl-CSS-Sass && \
     zypper clean && \
     gensslcert && \
     /usr/share/openqa/script/configure-web-proxy && \

--- a/container/webui/Dockerfile-lb
+++ b/container/webui/Dockerfile-lb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_webui_lb:latest opensuse/openqa-webui-lb:latest opensuse/openqa-webui-lb:%PKG_VERSION% opensuse/openqa-webui-lb:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-webui-lb
 LABEL org.opencontainers.image.title="openQA load-balancer webui container"
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y openQA nginx && \
     zypper clean

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_worker:latest opensuse/openqa-worker:latest opensuse/openqa-worker:%PKG_VERSION% opensuse/openqa-worker:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-worker
 LABEL org.opencontainers.image.title="openQA worker container"
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -yl ca-certificates-mozilla curl gzip rsync xz && \
     zypper in -yl openQA-worker os-autoinst-s390-deps os-autoinst-ipmi-deps && \


### PR DESCRIPTION
This reverts commit 92ce446a0b2c944237fc786aead4d6a62a591ddf. Some changes:
- drop obsolete 'rubygem(sass)>=3.7.4' replacing with perl-CSS-Sass
- Remove some duplicated packages from zypper
- fix paths which are related to the new usr-merge structure

related-issue: https://progress.opensuse.org/issues/180731