### PR TITLE
navbar: add new item in menu to link MCP documentation

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -203,6 +203,7 @@ sub startup ($self) {
     $r->get('/dashboard_build_results' => [format => ['json', 'html']])->name('dashboard_build_results')
       ->to('main#dashboard_build_results', format => undef);
     $r->get('/api_help' => sub ($c) { $c->render('admin/api_help') })->name('api_help');
+    $r->get('/mcp_help' => sub ($c) { $c->render('admin/mcp_help') })->name('mcp_help');
 
     # Default route
     $r->get('/' => sub ($c) { $c->render('main/index') })->name('index');

--- a/t/ui/05-auth_mcp.t
+++ b/t/ui/05-auth_mcp.t
@@ -1,0 +1,41 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use FindBin;
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '8';
+use OpenQA::Test::Case;
+
+my $test_case = OpenQA::Test::Case->new;
+$test_case->init_data(fixtures_glob => '03-users.pl');
+
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+subtest 'First access no login' => sub {
+    $t->get_ok('/tests')->status_is(200);
+    my $actions = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#user-action')->all_text);
+    is $actions, 'Login', 'no-one logged in';
+};
+
+subtest 'MCP disabled' => sub {
+    $test_case->login($t, 'percival');
+    $t->app->config->{global}{mcp_enabled} = 'no';
+    my $mcp_help = '';
+    $t->get_ok('/tests')->status_is(200);
+    my $actions = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#user-action')->all_text);
+    like $actions, qr/API help ${mcp_help}Changelog Logout/, 'no MCP entry shown for operator when MCP not enabled';
+};
+
+subtest 'MCP enabled' => sub {
+    $t->app->config->{global}{mcp_enabled} = 'read_only';
+    my $mcp_help = 'MCP help ';
+    $t->get_ok('/tests')->status_is(200);
+    my $actions = OpenQA::Test::Case::trim_whitespace($t->tx->res->dom->at('#user-action')->all_text);
+    like $actions, qr/API help ${mcp_help}Changelog Logout/, 'MCP entry is shown for operator when MCP is enabled';
+};
+
+done_testing();

--- a/templates/webapi/admin/mcp_help.html.ep
+++ b/templates/webapi/admin/mcp_help.html.ep
@@ -1,0 +1,8 @@
+% layout 'bootstrap';
+% title 'MCP help';
+  <h2><%= title %></h2>
+  %= include 'layouts/info'
+  <p>
+      To configure an MCP client to connect to openQA, check out the
+      <%= link_to 'documentation about MCP support' => url_for('https://open.qa/docs/#_mcp_support') %>.
+  </p>

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -97,6 +97,9 @@
                   % }
                   %= link_to "Appearance" => url_for('appearance') => class => 'dropdown-item'
                   %= link_to "API help" => url_for('api_help') => class => 'dropdown-item'
+                  % if (config->{global}{mcp_enabled} eq 'read_only') {
+                      %= link_to 'MCP help' => url_for('mcp_help') => class => 'dropdown-item'
+                  % }
                   %= link_to 'Changelog' => url_for('changelog') => class => 'dropdown-item'
                   %= link_to 'Logout' => url_for('logout') => 'data-method' => 'delete' => class => 'dropdown-item'
                 </div>


### PR DESCRIPTION
Add in the _openQA webUI_, in the rightmost drop-down menu, a new item to launch a link pointing to *MCP Support* paragraph of the open.qa documentation, to help configuring openQA MCP in AI clients.

- Ticket:  https://progress.opensuse.org/issues/189069
