### PR TITLE
feat: Add symlink for aeon in openqa-bootstrap script

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -149,6 +149,9 @@ if [[ -z $skip_suse_tests ]]; then
     if [[ ! -e /var/lib/openqa/tests/sle ]]; then
         ln -s opensuse /var/lib/openqa/tests/sle
     fi
+    if [[ ! -e /var/lib/openqa/tests/aeon ]]; then
+        ln -s opensuse /var/lib/openqa/tests/aeon
+    fi
 
     if ping -c1 gitlab.suse.de.; then
         sles_needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git"


### PR DESCRIPTION
Related to PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/24395

I created a new product for aeon, but openQA by default will try to use `/var/lib/openqa/tests/aeon` but that doesn't exist; it's located under `/var/lib/openqa/tests/opensuse`. A symlink from `/var/lib/openqa/tests/aeon -> opensuse` fixes this. 

(There's already a similar link `/var/lib/openqa/tests/sle -> opensuse` for SLE, for the same reason.)

This PR extends the `openqa-bootstrap` script to create this symlink.
