### PR TITLE
Use body parameters in POST request

### DIFF
--- a/assets/javascripts/admin_needle.js
+++ b/assets/javascripts/admin_needle.js
@@ -103,7 +103,7 @@ function setupAdminNeedles() {
     var outstandingList = $('#outstanding-needles');
     var failedList = $('#failed-needles');
     var deletionProgressElement = $('#deletion-progress');
-    var url = $('#confirm_delete').data('delete-url') + '?id=';
+    var url = $('#confirm_delete').data('delete-url');
 
     // hide/show elements
     $('#deletion-question').hide();
@@ -158,7 +158,11 @@ function setupAdminNeedles() {
         deleteBunchOfNeedles();
       };
 
-      fetchWithCSRF(url + nextIDs.join('&id='), {method: 'DELETE'})
+      const body = new FormData();
+      $.each(nextIDs, function (index, id) {
+        body.append('id', id);
+      });
+      fetchWithCSRF(url, {method: 'DELETE', body: body})
         .then(response => {
           return response
             .json()

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -192,7 +192,9 @@ function changeJobPrio(jobId, delta, linkElement) {
 
   var newPrio = currentPrio + delta;
 
-  fetchWithCSRF(urlWithBase(`/api/v1/jobs/${jobId}/prio?prio=${newPrio}`), {method: 'POST'})
+  const body = new FormData();
+  body.append('prio', newPrio);
+  fetchWithCSRF(urlWithBase(`/api/v1/jobs/${jobId}/prio`), {method: 'POST', body: body})
     .then(response => {
       return response
         .json()


### PR DESCRIPTION
While it's not forbidden to have query parameters in POST requests, it's a good convention to only allow parameters in the body (or at least not BOTH in query OR body). That will make the OpenAPI specification less complicated.

Related issue: https://progress.opensuse.org/issues/188742