### PR TITLE
Update CircleCI image to Leap 16.0

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,27 +4,30 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use
-RUN zypper -n in tar gzip sudo
+# Apply `no-refresh` to work around 
+# https://github.com/openSUSE/obs-build/issues/1107
+RUN zypper -n --no-refresh in tar gzip sudo
 
 # these are autoinst dependencies
-RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
+RUN zypper --no-refresh install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
 
 # openQA dependencies
-RUN zypper install -y 'rubygem(sass)>=3.7.4' ruby-devel npm python3-base python3-requests git-core rsync curl 'postgresql-devel>=14' 'postgresql-server>=14' qemu qemu-tools tar xorg-x11-fonts sudo make
+RUN zypper --no-refresh install -y perl-CSS-Sass ruby-devel npm python3-requests git-core rsync curl 'postgresql-devel>=14' 'postgresql-server>=14' qemu qemu-tools xorg-x11-fonts
 
 # openQA chromedriver for Selenium tests
-RUN zypper install -y chromedriver
+RUN zypper --no-refresh install -y chromedriver
 
 ENV LANG=en_US.UTF-8
 
 ENV NORMAL_USER=squamata
 ENV USER=squamata
 
-RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$NORMAL_USER && \
+    chmod 0440 /etc/sudoers.d/$NORMAL_USER
 RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER
 # Create default directory to prevent keyboxd usage for GPG >= 2.4, see https://github.com/codecov/codecov-circleci-orb/issues/157 for details
 RUN sudo -u $NORMAL_USER mkdir -p /home/$NORMAL_USER/.gnupg


### PR DESCRIPTION
Some changes:
- drop obsolete 'rubygem(sass)>=3.7.4' replacing with perl-CSS-Sass
- Remove some duplicated packages from zypper
- fix paths which are related to the new usr-merge structure
- Apply workaround to openSUSE/obs-build#1107 using `--no-refresh` on zypper.
- Make sure 440 permission on /etc/sudoers.d/squamata

related-issue: https://progress.opensuse.org/issues/180731