### PR TITLE
Add MCP tool annotations for Claude connector compliance

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -50,7 +50,7 @@ requires 'JSON::Validator';
 requires 'JavaScript::Minifier::XS', '>= 0.11';
 requires 'LWP::Protocol::https';
 requires 'LWP::UserAgent';
-requires 'MCP';
+requires 'MCP', '>= 0.80.0';
 requires 'Minion', '>= 10.25';
 requires 'Minion::Backend::SQLite', '>= 5.0.7';
 requires 'Module::Load::Conditional';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -180,7 +180,7 @@ worker_requires:
   psmisc:
 
 mcp_requires:
-  perl(MCP):
+  perl(MCP): '>= 0.80.0'
 
 test_requires:
   '%common_requires':

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -68,7 +68,7 @@
 # The following line is generated from dependencies.yaml
 %define worker_requires bsdtar openQA-client optipng os-autoinst perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.7 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
-%define mcp_requires perl(MCP)
+%define mcp_requires perl(MCP) >= 0.80.0
 %if 0%{?suse_version} < 1570
 # SLE <= 15 has older Perl not providing a sufficiently recent
 # ExtUtils::ParseXS needed by ExtUtils::CppGuess

--- a/lib/OpenQA/WebAPI/Plugin/MCP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MCP.pm
@@ -16,31 +16,64 @@ sub register ($self, $app, $config) {
 
     $mcp->tool(
         name => 'openqa_get_info',
+        title => 'Get openQA Server Info',
         description => 'Get information about the openQA server, connected workers and the current user',
+        input_schema => {type => 'object', properties => {}, additionalProperties => \0},
+        annotations => {
+            title => 'Get openQA Server Info',
+            readOnlyHint => \1,
+            destructiveHint => \0,
+            idempotentHint => \1,
+            openWorldHint => \0,
+        },
         code => \&tool_openqa_get_info
     );
 
     $mcp->tool(
         name => 'openqa_get_job_info',
-        description => 'Get information about a specific openQA job',
+        title => 'Get openQA Job Details',
+        description => 'Get any information about a specific openQA job, like logs, scheduling etc.',
         input_schema => {
             type => 'object',
-            properties => {job_id => {type => 'integer', minimum => 1}},
+            properties =>
+              {job_id => {type => 'integer', minimum => 1, description => 'The job ID of any openQA test suite.'}},
             required => ['job_id'],
+            additionalProperties => \0,
+        },
+        annotations => {
+            title => 'Get openQA Job Details',
+            readOnlyHint => \1,
+            destructiveHint => \0,
+            idempotentHint => \1,
+            openWorldHint => \0,
         },
         code => \&tool_openqa_get_job_info
     );
 
     $mcp->tool(
         name => 'openqa_get_log_file',
+        title => 'Get openQA Job Log File',
         description => 'Get the content of a specific log file for an openQA job',
         input_schema => {
             type => 'object',
             properties => {
-                job_id => {type => 'integer', minimum => 1},
-                file_name => {type => 'string', minLength => 1}
+                job_id => {type => 'integer', minimum => 1, description => 'The job ID of the openQA job'},
+                file_name => {
+                    type => 'string',
+                    minLength => 1,
+                    description =>
+                      'Name of the log file to lookup (e.g., autoinst-log.txt, serial0.txt). Only text logs for now'
+                }
             },
             required => ['job_id', 'file_name'],
+            additionalProperties => \0,
+        },
+        annotations => {
+            title => 'Get openQA Job Log File',
+            readOnlyHint => \1,
+            destructiveHint => \0,
+            idempotentHint => \1,
+            openWorldHint => \0,
         },
         code => \&tool_openqa_get_log_file
     );


### PR DESCRIPTION
Enhance MCP tool definitions with comprehensive metadata to comply with Claude connector submission requirements and MCP safety principles. All tools are annotated as `read-only` and `non-destructive`. you can visit #security-and-trust-&-safety on
https://modelcontextprotocol.io/specification/2025-03-26 for reference.

related-issue: https://progress.opensuse.org/issues/193555

UPDATE: If you have `perl-MCP-0.70.0-1.1` you can test it out