### PR TITLE
Revert "Update CircleCI image to Leap 16.0"

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -4,30 +4,27 @@
 # in one go
 # see https://progress.opensuse.org/issues/67855
 #!NoSquash
-FROM opensuse/leap:16.0
+FROM opensuse/leap:15.6
 
 # only dependencies for CircleCI to be able to load/save the package cache
 # and fix permissions for the unprivileged user we use
-# Apply `no-refresh` to work around 
-# https://github.com/openSUSE/obs-build/issues/1107
-RUN zypper -n --no-refresh in tar gzip sudo
+RUN zypper -n in tar gzip sudo
 
 # these are autoinst dependencies
-RUN zypper --no-refresh install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
+RUN zypper install -y gcc-c++ cmake ninja pkgconfig\(opencv4\) pkg-config perl\(Module::CPANfile\) pkgconfig\(fftw3\) pkgconfig\(libpng\) pkgconfig\(sndfile\) pkgconfig\(theoraenc\) tesseract-ocr
 
 # openQA dependencies
-RUN zypper --no-refresh install -y perl-CSS-Sass ruby-devel npm python3-requests git-core rsync curl 'postgresql-devel>=14' 'postgresql-server>=14' qemu qemu-tools xorg-x11-fonts
+RUN zypper install -y 'rubygem(sass)>=3.7.4' ruby-devel npm python3-base python3-requests git-core rsync curl 'postgresql-devel>=14' 'postgresql-server>=14' qemu qemu-tools tar xorg-x11-fonts sudo make
 
 # openQA chromedriver for Selenium tests
-RUN zypper --no-refresh install -y chromedriver
+RUN zypper install -y chromedriver
 
 ENV LANG=en_US.UTF-8
 
 ENV NORMAL_USER=squamata
 ENV USER=squamata
 
-RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$NORMAL_USER && \
-    chmod 0440 /etc/sudoers.d/$NORMAL_USER
+RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER
 # Create default directory to prevent keyboxd usage for GPG >= 2.4, see https://github.com/codecov/codecov-circleci-orb/issues/157 for details
 RUN sudo -u $NORMAL_USER mkdir -p /home/$NORMAL_USER/.gnupg


### PR DESCRIPTION
Reverts os-autoinst/openQA#6933

Since the 16.0 container is not working and all PRs fail, I think we have to revert, so that OBS is able to build a base ci container again.

https://progress.opensuse.org/issues/180731