### PR TITLE
Restart: handle subclassed AMQP plugin

### DIFF
--- a/lib/OpenQA/Task/Job/Restart.pm
+++ b/lib/OpenQA/Task/Job/Restart.pm
@@ -56,13 +56,13 @@ sub _restart_job ($minion_job, @args) {
 }
 
 sub _init_amqp_plugin ($app) {
-    return undef unless $app->config->{amqp}->{enabled};
-    $app->plugin('AMQP');    # Needs to be loaded again from forked process
+    return undef unless $app->config->{amqp}->{plugin};
+    $app->plugin($app->config->{amqp}->{plugin});    # Needs to be loaded again from forked process
     Mojo::IOLoop->singleton->one_tick;
 }
 
 sub _wait_for_event_publish ($app) {
-    return undef unless $app->config->{amqp}->{enabled};
+    return undef unless $app->config->{amqp}->{plugin};
     OpenQA::Events->singleton->once(amqp_handled => sub { Mojo::IOLoop->stop });
     Mojo::IOLoop->start;
 }

--- a/lib/OpenQA/WebAPI/Plugin/AMQP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/AMQP.pm
@@ -29,7 +29,11 @@ sub register ($self, $app, @args) {
     $self->{app} = $app;
     $self->{config} = $app->config;
     my $config = $self->{config}->{amqp};
-    $config->{enabled} = 1;    # Needed for reloading the plugin later in the forked process
+    # this gives us the plugin's name; we need to know it to reload
+    # the correct plugin later in the forked process, and it may not
+    # be AMQP, it may be a subclass like FedoraMessaging
+    $config->{plugin} = (split /::/, ref $self)[-1];
+    log_debug 'AMQP plugin name discovered as: ' . $config->{plugin};
     Mojo::IOLoop->singleton->next_tick(
         sub {
             # register for events

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -963,7 +963,7 @@ subtest 'AMQP event emission for job restarts within Minion tasks' => sub {
     # use a new app; otherwise it runs slowly, maybe trying to run none-mocked stuff
     my $t = Test::Mojo->new('OpenQA::WebAPI');
     my $minion = $t->app->minion;
-    is $t->app->config->{amqp}->{enabled}, 1, 'AMQP enabled from config file';
+    is $t->app->config->{amqp}->{plugin}, 'AMQP', 'AMQP enabled from config file';
 
     my %retry_settings = %settings;
     $retry_settings{TEST} = 'test_amqp_restart';


### PR DESCRIPTION
This code, introduced in #6816, assumed the plugin called AMQP was only ever used as itself. However, Fedora has a plugin called FedoraMessaging which subclasses AMQP, using its `register` sub unmodified and wrapping its `publish_amqp` sub to add some more fields. #6816 broke this setup because it causes openQA to load the AMQP plugin even when the configured plugin is actually FedoraMessaging, and publish messages without the extra fields, which confuses Fedora's messaging system.

This should fix the problem in a generic way (it'll work for any other similar subclassed message publisher plugin) by having `register` stash the plugin's name rather than just a boolean, then having the load code read in that name and load that plugin.