### PR TITLE
Handle links on test_log for different url in .git/config

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -230,11 +230,12 @@ If the I<.git> directory not found it returns an empty string.
 sub git_commit_url ($repo_url) {
     return '' unless defined $repo_url;
     if ($repo_url =~ m/^http(s?)/) {
-        $repo_url =~ s{\.git$}{/commit/};
-        return $repo_url;
+        $repo_url =~ s{\.git$}{};
+        return $repo_url . '/commit/';
     }
     my @url_tokenized = split /:/, $repo_url;
-    $url_tokenized[1] =~ s{\.git$}{/commit/};
+    $url_tokenized[1] =~ s{\.git$}{};
+    $url_tokenized[1] .= '/commit/';
     my @githost = split('@', $url_tokenized[0]);
     return "https://$githost[1]/$url_tokenized[1]";
 }

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -410,6 +410,10 @@ subtest 'project directory functions' => sub {
         is git_commit_url("git\@github.com:$repo.git"), "https://github.com/$repo/commit/", 'correct git url for ssh';
         is git_commit_url("https://github.com/$repo.git"), "https://github.com/$repo/commit/",
           'correct git url for http';
+        is git_commit_url("git\@github.com:$repo"), "https://github.com/$repo/commit/",
+          'correct ssh url without .git extension';
+        is git_commit_url("https://github.com/$repo"), "https://github.com/$repo/commit/",
+          'correct https url without .git extension';
     };
     subtest 'custom OPENQA_BASEDIR and OPENQA_SHAREDIR' => sub {
         local $ENV{OPENQA_BASEDIR} = '/tmp/test';


### PR DESCRIPTION
The investigation function creates links to commits using the URL from the .git/config file. This URL is expected to have a `.git` extension. However, manual intervention when cloning the repo can result in a URL without the extension, which breaks the constructed commit links.

This commit introduces an enhancement to handle both cases.

related-issue: https://progress.opensuse.org/issues/191914