### PR TITLE
refactor(investigation): Use TEST_GIT_URL and NEEDLES_GIT_URL

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1928,6 +1928,8 @@ sub investigate ($self, %args) {
     my %inv;
     return {error => 'No result directory available for current job'} unless $self->result_dir();
     my $ignore = OpenQA::App->singleton->config->{global}->{job_investigate_ignore};
+    my $self_file = eval { Mojo::File->new($self->result_dir(), 'vars.json')->slurp };
+    my $self_vars = decode_json($self_file // '{}');
     for my $prev (@previous) {
         if ($prev->should_show_investigation) {
             $inv{first_bad} = {type => 'link', link => '/tests/' . $prev->id, text => $prev->id};
@@ -1936,10 +1938,7 @@ sub investigate ($self, %args) {
         next unless $prev->result =~ /(?:passed|softfailed)/;
         $inv{last_good} = {type => 'link', link => '/tests/' . $prev->id, text => $prev->id};
         last unless $prev->result_dir;
-        my ($prev_file, $self_file) = map {
-            eval { Mojo::File->new($_->result_dir(), 'vars.json')->slurp }
-              // undef
-        } ($prev, $self);
+        my $prev_file = eval { Mojo::File->new($prev->result_dir(), 'vars.json')->slurp };
         $inv{diff_packages_to_last_good} = $self->packages_diff($prev, $ignore, 'worker_packages.txt');
         $inv{diff_sut_packages_to_last_good} = $self->packages_diff($prev, $ignore, 'sut_packages.txt');
         last unless $self_file && $prev_file;
@@ -1947,18 +1946,18 @@ sub investigate ($self, %args) {
         # files missing. This is a best-effort approach.
         my $diff = eval { diff(\$prev_file, \$self_file, {CONTEXT => 0}) };
         $inv{diff_to_last_good} = join("\n", grep { !/(^@@|$ignore)/ } split(/\n/, $diff));
-        my ($before, $after) = map { decode_json($_) } ($prev_file, $self_file);
+        my $prev_vars = decode_json($prev_file // '{}');
         my $dir = testcasedir($self->DISTRI, $self->VERSION);
-        my $refspec_range = "$before->{TEST_GIT_HASH}..$after->{TEST_GIT_HASH}";
+        my $refspec_range = "$prev_vars->{TEST_GIT_HASH}..$self_vars->{TEST_GIT_HASH}";
         my $diff_limit = $args{git_limit} ? $args{git_limit} / 2 : undef;
         $inv{test_log} = $self->git_log_diff($dir, $refspec_range, $args{git_limit});
         $inv{test_log} ||= 'No test changes recorded, test regression unlikely';
         $inv{test_diff_stat} = $self->git_diff($dir, $refspec_range, $diff_limit) if $inv{test_log};
         # no need for duplicating needles git log if the git repo is the same
         # as for tests
-        if ($after->{TEST_GIT_HASH} ne $after->{NEEDLES_GIT_HASH}) {
+        if ($self_vars->{TEST_GIT_HASH} ne $self_vars->{NEEDLES_GIT_HASH}) {
             $dir = needledir($self->DISTRI, $self->VERSION);
-            my $refspec_needles_range = "$before->{NEEDLES_GIT_HASH}..$after->{NEEDLES_GIT_HASH}";
+            my $refspec_needles_range = "$prev_vars->{NEEDLES_GIT_HASH}..$self_vars->{NEEDLES_GIT_HASH}";
             $inv{needles_log} = $self->git_log_diff($dir, $refspec_needles_range, $args{git_limit});
             $inv{needles_log} ||= 'No needle changes recorded, test regression due to needles unlikely';
             $inv{needles_diff_stat} = $self->git_diff($dir, $refspec_needles_range, $diff_limit) if $inv{needles_log};
@@ -1966,8 +1965,8 @@ sub investigate ($self, %args) {
         last;
     }
     $inv{last_good} //= 'not found';
-    $inv{testgiturl} = git_commit_url(distri => $self->DISTRI);
-    $inv{needlegiturl} = git_commit_url(distri => $self->DISTRI, needles => 1);
+    $inv{testgiturl} = git_commit_url($self_vars->{TEST_GIT_URL});
+    $inv{needlegiturl} = git_commit_url($self_vars->{NEEDLES_GIT_URL});
     return \%inv;
 }
 

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -23,7 +23,6 @@ use Exporter 'import';
 use OpenQA::App;
 use OpenQA::Constants qw(VIDEO_FILE_NAME_START VIDEO_FILE_NAME_REGEX FRAGMENT_REGEX);
 use OpenQA::Log qw(log_info log_debug log_warning log_error);
-use Config::Tiny;
 use Time::HiRes qw(tv_interval);
 use File::Basename;
 use File::Spec;
@@ -228,18 +227,13 @@ If the I<.git> directory not found it returns an empty string.
 
 =cut
 
-sub git_commit_url (@args) {
-    my %args = (distri => '', version => '', @args);
-    my $path = $args{needles} ? needledir($args{distri}, $args{version}) : testcasedir($args{distri}, $args{version});
-    my $filename = (-e path($path, '.git')) ? path($path, '.git', 'config') : '';
-    my $config = Config::Tiny->read($filename, 'utf8');
-    return '' unless defined $config;
-    if ($config->{'remote "origin"'}{url} =~ /^http(s?)/) {
-        my $repo_url = $config->{'remote "origin"'}{url};
+sub git_commit_url ($repo_url) {
+    return '' unless defined $repo_url;
+    if ($repo_url =~ m/^http(s?)/) {
         $repo_url =~ s{\.git$}{/commit/};
         return $repo_url;
     }
-    my @url_tokenized = split(':', $config->{'remote "origin"'}{url});
+    my @url_tokenized = split /:/, $repo_url;
     $url_tokenized[1] =~ s{\.git$}{/commit/};
     my @githost = split('@', $url_tokenized[0]);
     return "https://$githost[1]/$url_tokenized[1]";

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -397,7 +397,7 @@ subtest 'project directory functions' => sub {
         is resultdir, '/var/lib/openqa/testresults', 'resultdir';
         is assetdir, '/var/lib/openqa/share/factory', 'assetdir';
         is imagesdir, '/var/lib/openqa/images', 'imagesdir';
-        is git_commit_url, '', 'no git_commit_url when distri is not defined';
+        is git_commit_url(undef), '', 'no git_commit_url when distri is not defined';
     };
     subtest 'custom OPENQA_BASEDIR' => sub {
         local $ENV{OPENQA_BASEDIR} = '/tmp/test';
@@ -406,16 +406,10 @@ subtest 'project directory functions' => sub {
         is resultdir, '/tmp/test/openqa/testresults', 'resultdir';
         is assetdir, '/tmp/test/openqa/share/factory', 'assetdir';
         is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
-        my $mocked_git = path(sharedir . '/tests/opensuse/.git');
-        $mocked_git->remove_tree if -e $mocked_git;
-        is git_commit_url(distri => $distri), '', 'empty when .git is missing';
-        $mocked_git->make_path;
-        $mocked_git->child('config')
-          ->spew(qq{[remote "origin"]\n        url = git\@github.com:fakerepo/os-autoinst-distri-opensuse.git});
-        is git_commit_url(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
-        $mocked_git->child('config')
-          ->spew(qq{[remote "origin"]\n        url = https://github.com/fakerepo/os-autoinst-distri-opensuse.git});
-        is git_commit_url(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
+        my $repo = 'fakerepo/os-autoinst-distri-opensuse';
+        is git_commit_url("git\@github.com:$repo.git"), "https://github.com/$repo/commit/", 'correct git url for ssh';
+        is git_commit_url("https://github.com/$repo.git"), "https://github.com/$repo/commit/",
+          'correct git url for http';
     };
     subtest 'custom OPENQA_BASEDIR and OPENQA_SHAREDIR' => sub {
         local $ENV{OPENQA_BASEDIR} = '/tmp/test';
@@ -425,8 +419,6 @@ subtest 'project directory functions' => sub {
         is resultdir, '/tmp/test/openqa/testresults', 'resultdir';
         is assetdir, '/tmp/share/factory', 'assetdir';
         is imagesdir, '/tmp/test/openqa/images', 'imagesdir';
-        is git_commit_url, '', 'no git_commit_url when distri is not defined';
-        is git_commit_url(distri => $distri) =~ /github\.com.+os-autoinst-distri-opensuse\/commit/, 1, 'correct git url';
     };
 };
 


### PR DESCRIPTION
We are reading vars.json anyway, so there is no need to read .git/config.
TEST_GIT_URL/NEEDLES_GIT_URL should always be set (automatically by
os-autoinst) if the test is in a git clone.

Ticket: https://progress.opensuse.org/issues/191914

Before or after:
* #6940
