### PR TITLE
Update openQA containers to Leap 16.0

### DIFF
--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_webui:latest opensuse/openqa-webui:latest opensuse/openqa-webui:%PKG_VERSION% opensuse/openqa-webui:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-webui
 LABEL org.opencontainers.image.title="openQA webui container"
@@ -14,13 +14,10 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 ENV LC_ALL=C.UTF-8
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
-    # openQA might need rubygem:sass to compile assets in this context due to
-    # unknown reasons even though the package should use the precompiled
-    # assets from cache.tar
-    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m 'rubygem(sass)>=3.7.4' && \
+    zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m perl-CSS-Sass && \
     zypper clean && \
     gensslcert && \
     /usr/share/openqa/script/configure-web-proxy && \

--- a/container/webui/Dockerfile-lb
+++ b/container/webui/Dockerfile-lb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_webui_lb:latest opensuse/openqa-webui-lb:latest opensuse/openqa-webui-lb:%PKG_VERSION% opensuse/openqa-webui-lb:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-webui-lb
 LABEL org.opencontainers.image.title="openQA load-balancer webui container"
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y openQA nginx && \
     zypper clean

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: openqa_worker:latest opensuse/openqa-worker:latest opensuse/openqa-worker:%PKG_VERSION% opensuse/openqa-worker:%PKG_VERSION%.%RELEASE%
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
 # labelprefix=org.opensuse.openqa-worker
 LABEL org.opencontainers.image.title="openQA worker container"
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/15.6 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:15.6/15.6 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -yl ca-certificates-mozilla curl gzip rsync xz && \
     zypper in -yl openQA-worker os-autoinst-s390-deps os-autoinst-ipmi-deps && \


### PR DESCRIPTION
Those container are missing from the registry and as we have moved on
and noticed with other upgrades, we can also upgrade those ones.
    
- drop obsolete 'rubygem(sass)>=3.7.4' replacing with perl-CSS-Sass
    
This also required and intends to fix the helm charts in a followup
commit(s)
    

related-issue: https://progress.opensuse.org/issues/180731