### PR TITLE
style: Add quotes in openqa-bootstrap

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -112,8 +112,8 @@ su postgres -c "$OPENQA_DIR/script/setup-db" "$dbuser" "$dbname"
 proxy_args=""
 [[ -n "$setup_web_proxy" ]] && proxy_args="--proxy=$setup_web_proxy"
 setup=$OPENQA_DIR/script/configure-web-proxy
-if command -v $setup; then
-    bash -ex $setup "$proxy_args"
+if command -v "$setup"; then
+    bash -ex "$setup" "$proxy_args"
 else
     curl -s https://raw.githubusercontent.com/os-autoinst/openQA/master/script/configure-web-proxy | bash -ex -s -- "$proxy_args"
 fi


### PR DESCRIPTION
In shellcheck 0.10 which is in Leap 16, it complains about this line.

Issue: https://progress.opensuse.org/issues/180731

    + make test-checkstyle shellcheck -x $(file --mime-type script/* t/* container/worker/*.sh tools/* | sed -n 's/^\(.*\):.*text\/x-shellscript.*$/\1/p')

    In script/openqa-bootstrap line 115:
    if command -v $setup; then
                  ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean:
    if command -v "$setup"; then

    In script/openqa-bootstrap line 116:
        bash -ex $setup "$proxy_args"
                 ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean:
        bash -ex "$setup" "$proxy_args"

    For more information:
      https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ... make: *** [Makefile:363: test-shellcheck] Error 1