### PR TITLE
feat(ui): add "Reset Filters" button to test overview page

### DIFF
--- a/assets/javascripts/filter_form.js
+++ b/assets/javascripts/filter_form.js
@@ -26,6 +26,15 @@ function setupFilterForm(options) {
       );
     }
   });
+
+  $('#filter-reset-button').on('click', function () {
+    const form = $('#filter-form');
+    form.find('input[type="text"], input[type="number"]').val('');
+    form.find('input[type="checkbox"]').prop('checked', false);
+    form.find('input[hidden]').remove();
+    form.find('select').val([]).trigger('chosen:updated');
+    $('#filter-panel .card-header span').text('no filter present, click to toggle filter form');
+  });
 }
 
 function parseFilterArguments(paramHandler) {

--- a/t/ui/10-tests_overview.t
+++ b/t/ui/10-tests_overview.t
@@ -315,6 +315,16 @@ subtest 'filtering by flavor' => sub {
     }
 };
 
+subtest 'reset filters' => sub {
+    $driver->get('/tests/overview?distri=opensuse&version=13.1&build=0091&flavor=DVD');
+    like $driver->get_current_url, qr/flavor=DVD/, 'url contains flavor filter';
+    $driver->find_element('#filter-panel .card-header')->click();
+    $driver->find_element('#filter-reset-button')->click();
+    is $driver->find_element('#filter-flavor')->get_attribute('value'), '', 'flavor filter cleared in form';
+    $driver->find_element('#filter-form button[type="submit"]')->click();
+    unlike $driver->get_current_url, qr/flavor=DVD/, 'url no longer contains flavor filter after reset and apply';
+};
+
 sub check_textmode_test ($test_row) {
     wait_for_element selector => '#flavor_DVD_arch_i586', like => qr/i586/;
     my @job_rows = map { $_->get_text } @{$driver->find_elements('#content tbody tr')};

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -197,6 +197,7 @@
                     </div>
                 </div>
                 <button type="submit" class="btn btn-primary">Apply</button>
+                <button type="button" class="btn btn-secondary" id="filter-reset-button">Reset Filters</button>
             </form>
         </div>
     </div>


### PR DESCRIPTION
The button allows users to quickly clear all applied filter selections in the
filter box on the /tests/overview page without completely removing filter parameters that identify a build
<img width="1408" height="566" alt="Screenshot_20260129_114142_openqa_filter_box" src="https://github.com/user-attachments/assets/9630eed1-f9c1-450a-9a4e-4070b32076db" />