### PR TITLE
Update subrepo external/os-autoinst-common

### DIFF
--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = f74e4f8e87c67ef7331695735e27d10b55e2913b
+	commit = 307bc360346b4d0948bc92b7d13bd673c08d835b
 	parent = e60c89e329806c69bc16d495417532c3b408a8be
 	method = merge
-	cmdver = 0.4.9
+	cmdver = 0.4.6

--- a/external/os-autoinst-common/cpanfile
+++ b/external/os-autoinst-common/cpanfile
@@ -17,7 +17,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Community';
-    requires 'Perl::Tidy', '== 20250311';
+    requires 'Perl::Tidy', '== 20260109';
 
 };
 

--- a/external/os-autoinst-common/dependencies.yaml
+++ b/external/os-autoinst-common/dependencies.yaml
@@ -17,7 +17,7 @@ main_requires:
   perl(Module::CPANfile):
 
 develop_requires:
-  perl(Perl::Tidy): '== 20250311'
+  perl(Perl::Tidy): '== 20260109'
   perl(Code::TidyAll):
   perl(Perl::Critic):
   perl(Perl::Critic::Community):

--- a/external/os-autoinst-common/lib/OpenQA/Test/PatchDeparse.pm
+++ b/external/os-autoinst-common/lib/OpenQA/Test/PatchDeparse.pm
@@ -1,5 +1,6 @@
 package OpenQA::Test::PatchDeparse;
 use Test::Most;
+# Can be removed once support for Perl <= 5.26 is dropped
 
 # Monkeypatch B::Deparse
 # https://progress.opensuse.org/issues/40895
@@ -54,12 +55,6 @@ no strict 'refs';
 # ----> PATCH
 #>>>
 
-}
-elsif ($B::Deparse::VERSION) {
-    # when we update to a new perl version, this will remind us about checking
-    # if the bug is still there
-    diag
-      "Using B::Deparse v$B::Deparse::VERSION. If you see 'uninitialized' warnings, update patch in t/lib/OpenQA/Test/PatchDeparse.pm";
 }
 ## use critic
 1;

--- a/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/HashKeyQuotes.pm
+++ b/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/HashKeyQuotes.pm
@@ -9,6 +9,7 @@ use experimental 'signatures';
 use base 'Perl::Critic::Policy';
 
 use Perl::Critic::Utils qw( :severities :classification :ppi );
+use Scalar::Util qw(looks_like_number);
 
 our $VERSION = '0.0.1';
 
@@ -29,6 +30,8 @@ sub violates ($self, $elem, $document) {
     my $k = $elem->can('literal') ? $elem->literal : $elem->string;
 
     # skip anything that has a special symbol in the content
+    return () if looks_like_number $k;
+    return () if $k =~ m/^[0-9_]+$/;
     return () unless $k =~ m/^\w+$/;
 
     # report violation

--- a/external/os-autoinst-common/t/OpenQA/HashKeyQuotes.run
+++ b/external/os-autoinst-common/t/OpenQA/HashKeyQuotes.run
@@ -8,6 +8,9 @@ $h{"line\nbreak"} = 2;
 $h{'special!'} = 3;
 $h{'concatenate_' . 'strings'} = 4;
 $h{bare2 } = 5;
+$h{"0123"} = 6;
+$h{"Inf"} = 7;
+$h{"3_14"} = 7;
 
 ## name Failing
 ## failures 4


### PR DESCRIPTION
This includes deprecating the B::Deparse patch.

I didn't see any warnings in Leap 16.0 anymore.
So this was fixed in some perl version > 5.26.
We should remove the diag message here so we can upgrade without having unhandled output.
After having switched consistently we can delete it.