### PR TITLE
Decouple dependency of a functionwith duplicated logic on variables

### DIFF
--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -292,8 +292,8 @@ subtest 'jobs in archive considered via archive_min_free_disk_space_percentage' 
     $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 31;
 
     my @expected_messages = (
-        'Unable to cleanup enough results from results dir',
         'Done with archive after deleting results from important jobs',
+        'Unable to cleanup enough results from results dir',
     );
 
     my $job = job_log_like qr/
@@ -312,7 +312,7 @@ subtest 'archive cleanup skipped if archive not full; result dir cleanup still a
     # setup: as in the previous subtest but this time the archive is not full
     $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 30;
 
-    my @expected_messages = ('Unable to cleanup enough results from results dir', 'Nothing to do for archive');
+    my @expected_messages = ('Nothing to do for archive', 'Unable to cleanup enough results from results dir');
     my $job = job_log_like qr/
         Deleting\svideo\sof\sjob\s$unimportant_job_id.*
         Deleting\sresults\sof\sjob\s$unimportant_job_id.*
@@ -331,7 +331,7 @@ subtest 'deleted screenshots always accounted to main storage' => sub {
     %gained_disk_space_by_deleting_screenshots_of_job = ($important_job_id => 1);
     $dry_run_expected = 0;
 
-    my @expected_messages = ('Nothing to do for results dir', 'Unable to cleanup enough results from archive');
+    my @expected_messages = ('Unable to cleanup enough results from archive', 'Nothing to do for results dir',);
     my $job = job_log_like qr/
         Deleting\svideo\sof\simportant\sjob\s$important_job_id.*
         Deleting\sresults\sof\simportant\sjob\s$important_job_id.*


### PR DESCRIPTION
In https://github.com/os-autoinst/openQA/pull/6902/changes, `min_free_percentage` and `min_free_percentage_ar` variable introduced, which contain similar logic. This makes the function more complicated and difficult to follow or debug. The solution here begins with a design which allows:
- to simplify the `_ensure_results_below_threshold`
- handle the variables as one data structure and as such iterate over this structure instead of handling each variable separately
- following this design, reduce if/else
- the need for additional support variables (see any *_ar)
- makes it easier to add new logic

There is a small change at the tests but it should make sense, as it should follow the correct sequence, first archive then results. there was space for more refactoring (wrapping the `_delete_results` in a loop) but it should be simple enough at that point. The `_validate_storage_locations` could also be left out and use the `_get_storage_locations` for the validation, but that would require to pass `$job`. Providing two function, it keeps a clear design with SOLID in mind - doing on thing and without dependencies.