### PR TITLE
feat(ui): add bulk action checkboxes to test overview filters

### DIFF
--- a/assets/javascripts/filter_form.js
+++ b/assets/javascripts/filter_form.js
@@ -26,6 +26,56 @@ function setupFilterForm(options) {
       );
     }
   });
+
+  $('#filter-reset-button').on('click', function () {
+    const form = $('#filter-form');
+    form.find('input[type="text"], input[type="number"]').val('');
+    form.find('input[type="checkbox"]').prop('checked', false).prop('indeterminate', false);
+    form.find('input[hidden]').remove();
+    form.find('select').val([]).trigger('chosen:updated');
+    $('#filter-panel .card-header span').text('no filter present, click to toggle filter form');
+  });
+
+  const updateMasterCheckbox = function (container) {
+    const master = container.find('.filter-bulk-master');
+    if (!master.length) return;
+    const checkboxes = container.find('input[type="checkbox"]:not(.filter-bulk-master)');
+    const checkedCount = checkboxes.filter(':checked').length;
+
+    if (checkedCount === 0) {
+      master.prop('checked', false);
+      master.prop('indeterminate', false);
+    } else if (checkedCount === checkboxes.length) {
+      master.prop('checked', true);
+      master.prop('indeterminate', false);
+    } else {
+      master.prop('checked', false);
+      master.prop('indeterminate', true);
+    }
+  };
+
+  $('#filter-results, #filter-states').on('click', '.filter-bulk-master', function () {
+    const container = $(this).closest('.mb-3');
+    const isChecked = $(this).prop('checked');
+    container.find('input[type="checkbox"]:not(.filter-bulk-master)').prop('checked', isChecked);
+  });
+
+  $('#filter-results, #filter-states').on('change', 'input[type="checkbox"]:not(.filter-bulk-master)', function () {
+    updateMasterCheckbox($(this).closest('.mb-3'));
+  });
+
+  $('#filter-results, #filter-states').on('click', '.filter-bulk-invert', function (e) {
+    e.preventDefault();
+    const container = $(this).closest('.mb-3');
+    container.find('input[type="checkbox"]:not(.filter-bulk-master)').each(function () {
+      $(this).prop('checked', !$(this).prop('checked'));
+    });
+    updateMasterCheckbox(container);
+  });
+
+  $('#filter-results, #filter-states').each(function () {
+    updateMasterCheckbox($(this));
+  });
 }
 
 function parseFilterArguments(paramHandler) {

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -85,13 +85,25 @@
         <div class="card-body">
             <form action="#" method="get" id="filter-form">
                 <div class="mb-3" id="filter-results">
-                    <strong>Job result</strong>
+                    <div class="d-flex align-items-center mb-1">
+                        <input type="checkbox" class="filter-bulk-master form-check-input me-2" title="Select all / None">
+                        <strong class="me-2">Job result</strong>
+                        <span class="small">
+                            <a href="#" class="filter-bulk-invert text-decoration-none" title="Invert selection"><i class="fa fa-refresh"></i></a>
+                        </span>
+                    </div>
                     % for my $result (OpenQA::Jobs::Constants::RESULTS) {
                         <label class="form-label"><input value="<%= $result %>" name="result" type="checkbox" id="filter-<%= $result %>"> <%= ucfirst $result =~ s/_/ /r %></label>
                     % }
                 </div>
                 <div class="mb-3" id="filter-states">
-                    <strong>Job state</strong>
+                    <div class="d-flex align-items-center mb-1">
+                        <input type="checkbox" class="filter-bulk-master form-check-input me-2" title="Select all / None">
+                        <strong class="me-2">Job state</strong>
+                        <span class="small">
+                            <a href="#" class="filter-bulk-invert text-decoration-none" title="Invert selection"><i class="fa fa-refresh"></i></a>
+                        </span>
+                    </div>
                     % for my $state (OpenQA::Jobs::Constants::STATES) {
                         <label class="form-label"><input value="<%= $state %>" name="state" type="checkbox" id="filter-<%= $state %>"> <%= ucfirst $state =~ s/_/ /r %></label>
                     % }


### PR DESCRIPTION
Inspired by github notification selection checkboxes I implemented bulk
action checkboxes allowing to select "All" and "None". Also I added an
additional button to invert the current selection, e.g. to go from
"Passed" to "All but Passed".

## Select all
<img width="381" height="165" alt="Screenshot_20260131_131920_filter_box_all" src="https://github.com/user-attachments/assets/aa6873d7-98ee-4eac-8f7f-9517e1198bc9" />

## Select none
<img width="381" height="165" alt="Screenshot_20260131_131847_filter_box_none" src="https://github.com/user-attachments/assets/4b086fc2-d69f-4bcd-b829-3da11bf0e5ca" />

## Some selected
<img width="381" height="165" alt="Screenshot_20260131_131905_filter_box_some" src="https://github.com/user-attachments/assets/3abd696f-7da7-4020-90f0-a14e232b3145" />

## Invert curent selection
<img width="381" height="165" alt="Screenshot_20260131_131937_invert" src="https://github.com/user-attachments/assets/fcd41377-29ee-4f4d-8f7d-89f39b668b7b" />
