### PR TITLE
Mark some one line catch statements uncoverable

### DIFF
--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -167,7 +167,7 @@ sub track_asset ($self, $asset) {
         $db->query($sql, $asset);
         $tx->commit;
     }
-    catch ($e) { $self->log->error("Tracking asset failed: $e") }
+    catch ($e) { $self->log->error("Tracking asset failed: $e") }    # uncoverable statement
 }
 
 sub metrics ($self) {
@@ -303,7 +303,7 @@ sub _check_limits ($self, $needed, $to_preserve = undef) {
                 last if !$self->_exceeds_limit($needed);
             }
         }
-        catch ($e) { $log->error("Checking cache limit failed: $e") }
+        catch ($e) { $log->error("Checking cache limit failed: $e") }    # uncoverable statement
     }
 }
 
@@ -317,7 +317,7 @@ sub _delete_pending_assets ($self) {
             $self->purge_asset($filename);
         }
     }
-    catch ($e) { $log->error("Checking for pending leftovers failed: $e") }
+    catch ($e) { $log->error("Checking for pending leftovers failed: $e") }    # uncoverable statement
 }
 
 1;

--- a/lib/OpenQA/CacheService/Model/Downloads.pm
+++ b/lib/OpenQA/CacheService/Model/Downloads.pm
@@ -22,7 +22,7 @@ sub add ($self, $lock, $job_id) {
 
         $tx->commit;
     }
-    catch ($e) { croak "Couldn't add download: $e" }
+    catch ($e) { croak "Couldn't add download: $e" }    # uncoverable statement
 }
 
 sub find ($self, $lock) {

--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -50,7 +50,7 @@ sub _extract_asset ($self, $to_extract, $target) {
     if ($to_extract =~ qr/\.tar(\..*)?/) {
         # invoke bsdtar to extract (compressed) tar archives
         try { $target->make_path }
-        catch ($e) { return $e }
+        catch ($e) { return $e }    # uncoverable statement
         $cmd = "bsdtar -x --directory '$target' -f '$to_extract' 2>&1";
     }
     else {
@@ -116,7 +116,9 @@ sub _get ($self, $url, $target, $options) {
                 $ret = $code;
                 $log->error(qq{Extracting "$tempfile" failed: $err});
                 try { $target->remove_tree }
-                catch ($e) { $log->error("Unable to remove leftovers after failed extraction: $e") }
+                catch ($e) {
+                    $log->error("Unable to remove leftovers after failed extraction: $e")    # uncoverable statement
+                }
             }
         }
         else { $asset->move_to($target) }

--- a/lib/OpenQA/Git.pm
+++ b/lib/OpenQA/Git.pm
@@ -214,7 +214,7 @@ sub cache_ref ($self, $ref, $url, $relative_path, $output_file, $allow_arbitrary
             path($output_file)->touch;
             return undef;
         }
-        catch ($e) { return $e }
+        catch ($e) { return $e }    # uncoverable statement
     }
 
     $self->app->log->debug(

--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -157,7 +157,7 @@ sub restore_tree_section {
             $hash->[$key] = restore_el($value) if reftype $hash eq 'ARRAY';
         };
     }
-    catch ($e) { confess $e }
+    catch ($e) { confess $e }    # uncoverable statement
 }
 
 sub _load_tree {
@@ -176,7 +176,7 @@ sub _load_tree {
             }
         }
     }
-    catch ($e) { confess "Failed parsing tree: $e" }
+    catch ($e) { confess "Failed parsing tree: $e" }    # uncoverable statement
     return $self;
 }
 

--- a/lib/OpenQA/Resource/Locks.pm
+++ b/lib/OpenQA/Resource/Locks.pm
@@ -96,7 +96,7 @@ sub barrier_create ($name = undef, $jobid = undef, $expected_jobs = undef) {
     my $dbh = OpenQA::Schema->singleton->storage->dbh;
     my $sth = $dbh->prepare('INSERT INTO job_locks (name, owner, count) VALUES (?, ?, ?) ON CONFLICT DO NOTHING');
     try { $sth->execute($name, $jobid, $expected_jobs) }
-    catch ($e) { die "Unable to create barrier for job $jobid with name '$name': $e" }
+    catch ($e) { die "Unable to create barrier for job $jobid with name '$name': $e" }    # uncoverable statement
     return $sth->rows > 0;
 }
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1622,7 +1622,7 @@ sub allocate_network ($self, $name) {
         log_debug "at vlan $name:$vlan";
         next if $used{$vlan};
         try { $sth->execute($job_id, $name, $vlan) }
-        catch ($e) { die "Failed to create new vlan tag '$vlan' for job $job_id: $e\n" }
+        catch ($e) { die "Failed to create new vlan tag '$vlan' for job $job_id: $e\n" }    # uncoverable statement
         die "Unable to allocate network for job $job_id: network '$name' already exists" unless $sth->rows;
         log_debug "Created network for $job_id: $vlan";
         for my $cluster_job_id (keys %{$self->cluster_jobs}) {
@@ -1783,7 +1783,7 @@ sub carry_over_bugrefs ($self) {
             my %newone = (text => $text, user_id => $comment->user_id);
             my $comment = $self->comments->create_with_event(\%newone, {taken_over_from_job_id => $prev_id});
             try { $comment->handle_special_contents }
-            catch ($e) { log_info "Unable to evaluate contents of taken-over comment: $e" }
+            catch ($e) { log_info "Unable to evaluate contents of taken-over comment: $e" }    # uncoverable statement
             return 1;
         }
     }

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -210,7 +210,7 @@ sub schedule_iso ($self, $args, $guard) {
     $self->discard_changes;
     my $result = do {
         try { $self->_schedule_iso($args, $guard) }
-        catch ($e) { {error => $e} }
+        catch ($e) { {error => $e} }    # uncoverable statement
     };
     $self->set_done($result);
 

--- a/lib/OpenQA/ScreenshotDeletion.pm
+++ b/lib/OpenQA/ScreenshotDeletion.pm
@@ -37,8 +37,8 @@ sub delete_screenshot {
     #       only some of the deletions if the Minion job is aborted.
     my $signal_blocker = OpenQA::SignalBlocker->new;
     try { $self->{_deletion_query}->execute($screenshot_id) unless $dry }
-    catch ($e) { return undef }
-    # keep track of the deleted size
+    catch ($e) { return undef }    # uncoverable statement
+                                   # keep track of the deleted size
     my ($deleted_size, $screenshot_size, $thumb_size) = $self->{_deleted_size};
     if ($deleted_size) {
         $screenshot_size = -s $screenshot_path;

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Asset.pm
@@ -150,7 +150,7 @@ sub delete {
     ) if $asset->count == 0;
     my $rs;
     try { $rs = $asset->delete_all }
-    catch ($e) { return $self->render(json => {error => $e}, status => 409) }
+    catch ($e) { return $self->render(json => {error => $e}, status => 409) }    # uncoverable statement
     $self->emit_event('openqa_asset_delete', \%args);
     $self->render(json => {count => $rs}, status => 200);
 }

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -65,7 +65,7 @@ and test suite (id and name).
 sub list ($self) {
     my @templates;
     try { @templates = $self->_get_templates }
-    catch ($e) { return $self->render(json => {error => $e}, status => 404) }
+    catch ($e) { return $self->render(json => {error => $e}, status => 404) }    # uncoverable statement
     $self->render(json => {JobTemplates => [map { $_->to_hash } @templates]});
 }
 
@@ -363,7 +363,7 @@ sub create ($self) {
             group_id => $group_id,
             test_suite_id => $validation->param('test_suite_id')};
         try { push @ids, $schema->resultset('JobTemplates')->create($values)->id }
-        catch ($e) { $error = $e }
+        catch ($e) { $error = $e }    # uncoverable statement
     }
     elsif ($validation->param('prio_only')) {
         for my $param (qw(group_id test_suite_id)) {
@@ -380,7 +380,7 @@ sub create ($self) {
             push @ids, $_->id for $job_templates->all;
             $job_templates->update({prio => $prio});
         }
-        catch ($e) { $error = $e }
+        catch ($e) { $error = $e }    # uncoverable statement
     }
     else {
         for my $param (qw(group_name machine_name test_suite_name arch distri flavor version)) {
@@ -399,7 +399,7 @@ sub create ($self) {
             prio => $prio,
             test_suite => {name => $validation->param('test_suite_name')}};
         try { push @ids, $schema->resultset('JobTemplates')->create($values)->id }
-        catch ($e) { $error = $e }
+        catch ($e) { $error = $e }    # uncoverable statement
     }
 
     my $status;
@@ -442,7 +442,7 @@ sub destroy ($self) {
     elsif ($job_template) {
         my $rs;
         try { $rs = $job_template->delete }
-        catch ($e) { $json->{error} = $e }
+        catch ($e) { $json->{error} = $e }    # uncoverable statement
         if ($rs) {
             $json->{result} = int($rs);
             $self->emit_event('openqa_jobtemplate_delete', {id => $self->param('job_template_id')});

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Table.pm
@@ -127,7 +127,7 @@ sub list ($self) {
                 offset => $offset
             });
     }
-    catch ($e) { return $self->render(json => {error => $e}, status => 404) }
+    catch ($e) { return $self->render(json => {error => $e}, status => 404) }    # uncoverable statement
 
     # Pagination
     pop @all if my $has_more = @all > $limit;

--- a/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Needle.pm
@@ -63,7 +63,7 @@ sub ajax ($self) {
             push(@filter_conds, {last_matched_time => _translate_cond($match_query)});
         }
     }
-    catch ($e) { return $self->render(json => {error => ($e =~ s/ at .*//sr)}, status => 400) }
+    catch ($e) { return $self->render(json => {error => ($e =~ s/ at .*//sr)}, status => 400) }  # uncoverable statement
 
     OpenQA::WebAPI::ServerSideDataTable::render_response(
         controller => $self,

--- a/lib/OpenQA/WebAPI/Controller/ApiKey.pm
+++ b/lib/OpenQA/WebAPI/Controller/ApiKey.pm
@@ -25,11 +25,11 @@ sub create ($self) {
 
     if (!$error && $validation->is_valid('t_expiration')) {
         try { $expiration = DateTime::Format::Pg->parse_datetime($validation->param('t_expiration')) }
-        catch ($e) { $error = $e }
+        catch ($e) { $error = $e }    # uncoverable statement
     }
     unless ($error) {
         try { $self->schema->resultset('ApiKeys')->create({user_id => $user->id, t_expiration => $expiration}) }
-        catch ($e) { $error = $e }
+        catch ($e) { $error = $e }    # uncoverable statement
     }
     if ($error) {
         my $msg = "Error adding the API key: $error";

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -395,7 +395,7 @@ sub src ($self) {
     return $self->reply->not_found unless $scriptpath && -e $scriptpath;
     my $script;
     try { $script = path($scriptpath)->slurp }
-    catch ($e) { return $self->reply->not_found }
+    catch ($e) { return $self->reply->not_found }    # uncoverable statement
     $self->render(script => decode_utf8($script), scriptpath => $scriptpath);
 }
 

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
@@ -117,7 +117,7 @@ sub update_obs_builds_text ($job, $args) {
             $exit_code = $?;
             return ($exit_code, $error);
         }
-        catch ($e) { return ($exit_code, $error // $e); }
+        catch ($e) { return ($exit_code, $error // $e); }    # uncoverable statement
     };
 
     my ($exit_code, $error) = $helper->for_every_batch($alias, $sub);

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -633,7 +633,7 @@ sub is_qemu_running ($self) {
 
 sub is_ovs_dbus_service_running ($self) {
     try { defined &Net::DBus::system or require Net::DBus }
-    catch ($e) { return 0 }
+    catch ($e) { return 0 }    # uncoverable statement
     unless (defined $self->{_system_dbus}) {
         $self->{_system_dbus} = Net::DBus->system(nomainloop => 1);
         # this avoids piling up signals we never do anything with - POO #183833
@@ -827,7 +827,7 @@ sub _setup_pool_directory ($self) {
     return 'No pool directory assigned.' unless $pool_directory;
 
     try { $self->{_pool_directory_lock_fd} = $self->_lock_pool_directory }
-    catch ($e) { return 'Unable to lock pool directory: ' . $e }
+    catch ($e) { return 'Unable to lock pool directory: ' . $e }    # uncoverable statement
     return undef;
 }
 

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -99,7 +99,7 @@ sub start_driver ($mojoport) {
         $_driver->get("http://localhost:$mojoport/");
 
     }
-    catch ($e) { die $e }
+    catch ($e) { die $e }    # uncoverable statement
 
     return $_driver;
 }


### PR DESCRIPTION
Between perl 5.26 / 5.42 and Syntax::Keyword::Try 0.280 / 0.300
the behaviour of coverage changed. An opening
```
catch ($e) {
```
on its own line is now not counted as code anymore, but
```
catch ($e) { something }
```
is counted as code, whereas it was automatically counted as covered
before.

Related issue: https://progress.opensuse.org/issues/180731