### PR TITLE
fix: Create user directory without sudo

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -27,7 +27,9 @@ ENV USER=squamata
 RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER
 # Create default directory to prevent keyboxd usage for GPG >= 2.4, see https://github.com/codecov/codecov-circleci-orb/issues/157 for details
-RUN sudo -u $NORMAL_USER mkdir -p /home/$NORMAL_USER/.gnupg
+USER $NORMAL_USER
+RUN mkdir -p /home/$NORMAL_USER/.gnupg
+USER root
 
 RUN mkdir -p /opt/testing_area
 RUN chown -R $NORMAL_USER:users /opt/testing_area


### PR DESCRIPTION
Otherwise we'll get

    STEP 11/15: RUN sudo -u $NORMAL_USER mkdir -p /home/$NORMAL_USER/.gnupg
    root is not in the sudoers file.

Issue: https://progress.opensuse.org/issues/180731

I thought that the Dockerfile for 16.0 had been tested before. I tried this out locally now and it works.