### PR TITLE
fix: Configure sudoers correctly in Leap 16

### DIFF
--- a/container/devel:openQA:ci/base/Dockerfile
+++ b/container/devel:openQA:ci/base/Dockerfile
@@ -24,7 +24,8 @@ ENV LANG=en_US.UTF-8
 ENV NORMAL_USER=squamata
 ENV USER=squamata
 
-RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN echo "$NORMAL_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$NORMAL_USER && \
+  chmod 0440 /etc/sudoers.d/$NORMAL_USER
 RUN useradd -r -d /home/$NORMAL_USER -m -g users --uid=1000 $NORMAL_USER
 # Create default directory to prevent keyboxd usage for GPG >= 2.4, see https://github.com/codecov/codecov-circleci-orb/issues/157 for details
 USER $NORMAL_USER


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/180731

The difference is that in Leap 16, there is no `/etc/sudoers` file anymore by default, and if it doesn't exist, `root` can just sudo.
But when we add a line for `$NORMAL_USER` to it, then it exists but doesn't contain root, so it complains we we call `sudo` as root.
That's the reason why we should add files to `/etc/sudoers.d/` only instead.