### PR TITLE
feat(ui): make test overview summary counts clickable for quick filtering

### DIFF
--- a/assets/stylesheets/overview.scss
+++ b/assets/stylesheets/overview.scss
@@ -21,12 +21,11 @@
     margin-left: 0.5rem;
 }
 
+#summary .badge-btn.btn-outline-light {
+    color: black;
+}
 #summary .badge {
-    font-size: 90%;
-    padding: 4px 6px 4px;
-    border-radius: 0.5rem;
-    color: #fff;
-    background-color: #bbb;
+    top: 0px;
 }
 #summary .time-params {
     font-weight: lighter;

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -106,6 +106,17 @@ my %BADGE_CHARLENS = (
     '[0-9]' => 0.64
 );
 
+my %SUMMARY_CATEGORY_QUERY = (
+    passed => {result => PASSED, state => undef},
+    softfailed => {result => SOFTFAILED, state => undef},
+    failed => {result => FAILED, state => undef},
+    not_complete => {result => [NOT_COMPLETE_RESULTS], state => undef},
+    scheduled => {result => undef, state => SCHEDULED},
+    running => {result => undef, state => [EXECUTION_STATES]},
+    aborted => {result => [ABORTED_RESULTS], state => undef},
+    none => {result => NONE, state => undef},
+);
+
 sub referer_check ($self) {
     return $self->reply->not_found if (!defined $self->param('testid'));
     my $referer = $self->req->headers->header('Referer') // '';
@@ -904,6 +915,7 @@ sub overview ($self) {
         until => $search_args->{until},
         parallel_children_collapsable_results_sel => $config->{global}->{parallel_children_collapsable_results_sel},
         summary_parts => \@summary_parts,
+        summary_category_query => \%SUMMARY_CATEGORY_QUERY,
         only_distri => $only_distri,
         limit_exceeded => $exceeded_limit,
     );

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -49,17 +49,18 @@
                 </span>
             </button>
             % }
-            % my @badges = qw(success secondary  warning     danger info      primary light   light);
-            % my @labels = qw(Passed  Incomplete Soft-Failed Failed Scheduled Running Aborted None);
+            % my @badges = qw(success warning     danger secondary  info      primary light   light);
+            % my @labels = qw(Passed  Soft-Failed Failed Incomplete Scheduled Running Aborted None);
             % my $index  = 0;
-            % for my $category (qw(passed not_complete softfailed failed scheduled running aborted none)) {
+            % for my $category (qw(passed softfailed failed not_complete scheduled running aborted none)) {
                 % my ($label, $badge) = ($labels[$index], $badges[$index++]);
                 % next unless my $count = delete $aggregated->{$category};
-                <%= $label %>: <span class="badge text-bg-<%= $badge %>"><%= $count %></span>
+                <a href="<%= url_with->query($summary_category_query->{$category}) %>" class="badge-btn btn btn-sm btn-outline-<%= $badge %> mb-1 d-inline-flex align-items-center"><%= $label %>: <span class="badge text-bg-<%= $badge %> ms-1"><%= $count %></span></a>
             % }
             % if (my $unknown_count = sum values %$aggregated) {
                 Unknown: <span class="badge text-bg-light"><%= $unknown_count %></span>
             % }
+            <a href="<%= url_with->query({result => undef, state => undef}) %>" class="btn btn-sm btn-outline-secondary mb-1 d-inline-flex align-items-center">All</a>
         </div>
     </div>
     <div class="card" id="filter-panel">


### PR DESCRIPTION
The job counts in the "Overall Summary" section of the test overview
page are now buttons that link to the same page with appropriate
'result' or 'state' filters applied. This allows for quick filtering
of jobs by their status.

An "All" button was also added to clear these filters.

https://github.com/user-attachments/assets/b0735c25-a17f-4919-bf64-62232c07aa50

Related progress issue: https://progress.opensuse.org/issues/184264

Before:
* #6978 