### PR TITLE
feat: support inverted result filters in /tests/overview

### DIFF
--- a/assets/javascripts/filter_form.js
+++ b/assets/javascripts/filter_form.js
@@ -25,9 +25,22 @@ function setupFilterForm(options) {
 
   const filterForm = document.getElementById('filter-form');
   if (filterForm) {
-    filterForm.addEventListener('submit', function () {
+    filterForm.addEventListener('submit', function (event) {
+      event.preventDefault();
       const currentQuery = window.location.search.substring(1);
       const formData = new FormData(filterForm);
+
+      // optimize results and states to use negative filters if shorter
+      ['result', 'state'].forEach(key => {
+        const checkboxes = Array.from(filterForm.querySelectorAll(`input[name="${key}"]`));
+        const checked = checkboxes.filter(cb => cb.checked);
+        const unchecked = checkboxes.filter(cb => !cb.checked);
+        if (checked.length > 1 && unchecked.length > 0 && unchecked.length < checked.length) {
+          formData.delete(key);
+          unchecked.forEach(cb => formData.append(`${key}__not`, cb.value));
+        }
+      });
+
       const newQuery = new URLSearchParams(formData).toString();
 
       if (newQuery !== currentQuery) {
@@ -40,6 +53,7 @@ function setupFilterForm(options) {
           progress.innerHTML = '<i class="fa fa-cog fa-spin fa-2x fa-fw"></i> <span>Applying filter…</span>';
           cardBody.appendChild(progress);
         }
+        window.location.search = newQuery;
       }
     });
   }

--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -223,6 +223,18 @@ function setupOverview() {
     if (key === 'result' || key === 'state') {
       flags[key][val] = true;
       return formatFilter(val);
+    } else if (key === 'result__not' || key === 'state__not') {
+      const baseKey = key.slice(0, -5);
+      const isFirst = !flags[baseKey].__inverted;
+      flags[baseKey].__inverted = true;
+      document.querySelectorAll(`#filter-${baseKey}s input[name="${baseKey}"]`).forEach(cb => {
+        if (isFirst) {
+          flags[baseKey][cb.value] = cb.value !== val;
+        } else if (cb.value === val) {
+          flags[baseKey][cb.value] = false;
+        }
+      });
+      return 'NOT ' + formatFilter(val);
     } else if (key === 'todo') {
       form.todo.checked = val !== '0';
       return 'TODO';


### PR DESCRIPTION
* feat: support inverted result filters in /tests/overview
* feat(ui): use clickable test overview summary counts for quick filtering

## Only "failed" selected
<img width="533" height="529" alt="Screenshot_20260208_201556_failed" src="https://github.com/user-attachments/assets/f136dc6b-a1d7-4f1e-9078-301d18c0eedc" />

## All but "failed" selected with updated URL
<img width="546" height="490" alt="Screenshot_20260217_161617_openQA_not_failed" src="https://github.com/user-attachments/assets/30a61cd9-06b2-4426-bc9a-0130904537f9" />


After:
* #6971