### PR TITLE
feat(ui): remove empty query parameters from /tests/overview URL

### DIFF
--- a/assets/javascripts/filter_form.js
+++ b/assets/javascripts/filter_form.js
@@ -41,7 +41,13 @@ function setupFilterForm(options) {
         }
       });
 
-      const newQuery = new URLSearchParams(formData).toString();
+      const params = new URLSearchParams(formData);
+      const keysToDelete = [];
+      params.forEach((val, key) => {
+        if (val === '') keysToDelete.push(key);
+      });
+      keysToDelete.forEach(key => params.delete(key));
+      const newQuery = params.toString();
 
       if (newQuery !== currentQuery) {
         // show progress indication


### PR DESCRIPTION
Cleans up the URL after submitting the filter form by removing
parameters with empty values.

Related progress issue: https://progress.opensuse.org/issues/184264