### PR TITLE
PART 2: feat: support filtering by meta-results and meta-states in /tests/overview - After #6979

### DIFF
--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -120,7 +120,7 @@ function stackParallelChildren(depElement, dependencyInfo) {
     initCollapsedParallelChildren(relatedRow, relatedTable, dependencyInfo.parents.Parallel);
 }
 
-function setupOverview() {
+function setupOverview(options) {
   setupLazyLoadingFailedSteps();
   $('.timeago').timeago();
   $('.cancel').bind('ajax:success', function (event, xhr, status) {
@@ -198,7 +198,7 @@ function setupOverview() {
   ensureParallelParentsComeFirst();
   collapseOkParallelChildren();
 
-  setupFilterForm();
+  setupFilterForm(options);
   const form = document.getElementById('filter-form');
   form.todo = false;
 

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -57,6 +57,7 @@ use constant {
     EXECUTION => 'execution',
     FINAL => 'final',
 };
+use constant META_STATES => (PRE_EXECUTION, EXECUTION, FINAL);
 
 # results for the overall job
 use constant {
@@ -92,6 +93,24 @@ use constant {
     COMPLETE => 'complete',
     NOT_COMPLETE => 'not_complete',
     ABORTED => 'aborted',
+    OK => 'ok',
+    NOT_OK => 'not_ok',
+};
+use constant META_RESULTS => (COMPLETE, NOT_COMPLETE, ABORTED, OK, NOT_OK);
+
+use constant META_MAPPING => {
+    state => {
+        PRE_EXECUTION() => [PRE_EXECUTION_STATES],
+        EXECUTION() => [EXECUTION_STATES],
+        FINAL() => [FINAL_STATES],
+    },
+    result => {
+        COMPLETE() => [COMPLETE_RESULTS],
+        NOT_COMPLETE() => [NOT_COMPLETE_RESULTS],
+        ABORTED() => [ABORTED_RESULTS],
+        OK() => [OK_RESULTS],
+        NOT_OK() => [NOT_OK_RESULTS],
+    },
 };
 
 # results for particular job modules
@@ -120,21 +139,29 @@ our @EXPORT = qw(
   CANCELLED
   COMPLETE_RESULTS
   DONE
+  EXECUTION
   EXECUTION_STATES
   FAILED
+  FINAL
   FINAL_STATES
   INCOMPLETE
+  NOT_COMPLETE
   NOT_COMPLETE_RESULTS
   ABORTED
   ABORTED_RESULTS
-  NONE
-  NOT_OK_RESULTS
-  OBSOLETED
+  COMPLETE
+  COMPLETE_RESULTS
+  OK
   OK_RESULTS
+  NOT_OK
+  NOT_OK_RESULTS
+  NONE
+  OBSOLETED
   PARALLEL_FAILED
   PARALLEL_RESTARTED
   PASSED
   PENDING_STATES
+  PRE_EXECUTION
   PRE_EXECUTION_STATES
   PRISTINE_STATES
   RESULTS
@@ -148,6 +175,9 @@ our @EXPORT = qw(
   USER_CANCELLED
   USER_RESTARTED
   MODULE_RESULTS
+  META_RESULTS
+  META_STATES
+  META_MAPPING
   COMMON_RESULT_FILES
   TIMEOUT_EXCEEDED
   DEFAULT_JOB_PRIORITY

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -918,6 +918,7 @@ sub overview ($self) {
         summary_category_query => \%SUMMARY_CATEGORY_QUERY,
         only_distri => $only_distri,
         limit_exceeded => $exceeded_limit,
+        meta_mapping => META_MAPPING,
     );
     $self->stash(\%stash);
     $self->respond_to(json => {json => \%stash}, html => {template => 'test/overview'});

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -9,7 +9,13 @@ use OpenQA::Constants qw(JOBS_OVERVIEW_SEARCH_CRITERIA);
 use OpenQA::Schema;
 use OpenQA::Utils qw(bugurl human_readable_size render_escaped_refs href_to_bugref);
 use OpenQA::Events;
-use OpenQA::Jobs::Constants qw(EXECUTION_STATES PRE_EXECUTION_STATES ABORTED_RESULTS FAILED NOT_COMPLETE_RESULTS);
+use OpenQA::Jobs::Constants qw(
+  EXECUTION_STATES PRE_EXECUTION_STATES ABORTED_RESULTS FAILED NOT_COMPLETE_RESULTS
+  COMPLETE NOT_COMPLETE ABORTED COMPLETE_RESULTS
+  OK NOT_OK OK_RESULTS NOT_OK_RESULTS
+  PRE_EXECUTION EXECUTION FINAL FINAL_STATES
+  META_RESULTS META_STATES META_MAPPING
+);
 use Text::Glob qw(glob_to_regex_string);
 use List::Util qw(any min);
 use Feature::Compat::Try;
@@ -518,6 +524,16 @@ sub _compute_overview_filtering_params ($c) {
     my $results = $c->every_non_empty_param('result');
     my $states_not = $c->every_non_empty_param('state__not');
     my $results_not = $c->every_non_empty_param('result__not');
+
+    # expansion of meta-values
+    my $expand = sub ($params, $meta) {
+        [map { $meta->{$_} ? @{$meta->{$_}} : $_ } @$params]
+    };
+    $states = $expand->($states, META_MAPPING->{state});
+    $results = $expand->($results, META_MAPPING->{result});
+    $states_not = $expand->($states_not, META_MAPPING->{state});
+    $results_not = $expand->($results_not, META_MAPPING->{result});
+
     my $archs = $c->every_non_empty_param('arch');
     my $machines = $c->every_non_empty_param('machine');
     my $failed_modules = $c->every_non_empty_param('failed_modules');

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -467,6 +467,19 @@ subtest 'Inverted filters' => sub {
     like($summary, qr/Scheduled: 2/i, 'Scheduled jobs remain');
 };
 
+subtest 'Meta-filters' => sub {
+    $t->get_ok('/tests/overview?distri=opensuse&version=13.1&build=0091&result=complete')->status_is(200);
+    my $summary = get_summary;
+    like($summary, qr/Passed: 3/i, 'Passed jobs are included via "complete" meta-result');
+    $t->get_ok('/tests/overview?distri=opensuse&version=13.1&build=0091&state=final')->status_is(200);
+    $summary = get_summary;
+    like($summary, qr/Passed: 3/i, 'Done jobs are included via "final" meta-state');
+    $t->get_ok('/tests/overview?distri=opensuse&version=13.1&build=0091&result__not=complete')->status_is(200);
+    $summary = get_summary;
+    unlike($summary, qr/Passed: [1-9]/i, 'Passed jobs are excluded via NOT "complete"');
+    like($summary, qr/Scheduled: 2 Running: 2/i, 'Other categories remain');
+};
+
 subtest 'Maximum jobs limit' => sub {
     $t->get_ok('/tests/overview')->status_is(200)->element_exists_not('#max-jobs-limit')
       ->element_count_is('table.overview td.name', 7);

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -6,7 +6,7 @@
 
 % content_for 'ready_function' => begin
   window.overviewParallelChildrenCollapsableResultsSel = '<%= $parallel_children_collapsable_results_sel %>';
-  setupOverview();
+  setupOverview({metaMapping: <%== Mojo::JSON::to_json($meta_mapping) %>});
 % end
 
 % if ($limit_exceeded) {
@@ -96,6 +96,10 @@
                     % for my $result (OpenQA::Jobs::Constants::RESULTS) {
                         <label class="form-label"><input value="<%= $result %>" name="result" type="checkbox" id="filter-<%= $result %>"> <%= ucfirst $result =~ s/_/ /r %></label>
                     % }
+                    <hr class="my-1">
+                    % for my $result (OpenQA::Jobs::Constants::META_RESULTS) {
+                        <label class="form-label" title="Meta-category: <%= $result %>"><input value="<%= $result %>" name="result" type="checkbox" id="filter-<%= $result %>" class="filter-meta"> <strong><%= ucfirst $result =~ s/_/ /r %></strong></label>
+                    % }
                 </div>
                 <div class="mb-3" id="filter-states">
                     <div class="d-flex align-items-center mb-1">
@@ -107,6 +111,10 @@
                     </div>
                     % for my $state (OpenQA::Jobs::Constants::STATES) {
                         <label class="form-label"><input value="<%= $state %>" name="state" type="checkbox" id="filter-<%= $state %>"> <%= ucfirst $state =~ s/_/ /r %></label>
+                    % }
+                    <hr class="my-1">
+                    % for my $state (OpenQA::Jobs::Constants::META_STATES) {
+                        <label class="form-label" title="Meta-category: <%= $state %>"><input value="<%= $state %>" name="state" type="checkbox" id="filter-<%= $state %>" class="filter-meta"> <strong><%= ucfirst $state =~ s/_/ /r %></strong></label>
                     % }
                 </div>
                 <div class="row" id="filter-arch-flavor">


### PR DESCRIPTION

<img width="793" height="341" alt="Screenshot_20260209_085313_fiter_meta_results_and_meta_states" src="https://github.com/user-attachments/assets/8b2cc635-4035-470f-8ec6-0b46a061f6bb" />

After:
* #6979 