### PR TITLE
 fix(worker): reject jobs explicitly when worker is stopping

### DIFF
--- a/lib/OpenQA/Worker/CommandHandler.pm
+++ b/lib/OpenQA/Worker/CommandHandler.pm
@@ -148,14 +148,12 @@ sub _can_grab_job {
     # refuse new job(s) if the worker is in an error state or stopping
     if ($worker->is_stopping) {
         $reason_to_reject_job = 'currently stopping';
-        # note: Not rejecting the job here; declaring the worker as offline which is done in any case
-        #       should be sufficient.
     }
     elsif (my $current_error = _reevaluate_and_return_current_error($client, $worker)) {
         $reason_to_reject_job = $current_error;
-        $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
     }
     if (defined $reason_to_reject_job) {
+        $client->reject_jobs($job_ids_to_grab, $reason_to_reject_job);
         log_debug("Refusing to grab job from $webui_host: $reason_to_reject_job");
         return 0;
     }

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -505,6 +505,7 @@ qr/Ignoring WS message from http:\/\/127\.0\.0\.1:1 with type livelog_stop and j
         [
             \%fake_error_status, $rejection->([42], 'some error'),    # status + rejection due to error state
             \%fake_error_status, $rejection->([42], 'some error'),    # status + rejection due to error state
+            $rejection->([42], 'currently stopping'),    # rejection due to stopping state
             $rejection->(['but no settings'], 'the provided job is invalid'),
             $rejection->(['42'], 'job info lacks execution sequence'),
             $rejection->(['42'], 'already busy with a job from foo'),


### PR DESCRIPTION
Workers previously ignored new job assignments while finishing a previous job,
leading to stuck "assigned" jobs in the database.

Note that "$worker->is_stopping" is not a guarantee that the worker will
accomplish to stop. It just means that the current job is stopping.

This change ensures workers send a "rejected" message when in the "stopping"
state. Additionally, t/43-scheduling-and-worker-scalability.t is robustified to
handle rescheduled jobs during polling.

Fixes sporadic failures in t/43-scheduling-and-worker-scalability.t.

Related progress issue: https://progress.opensuse.org/issues/196295