### PR TITLE
Allow using different test distributions without symlinks

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -1,6 +1,7 @@
 [global]
 ## Web site name for tab titles and bookmarks
 #appname = openQA
+distribution_dir = opensuse
 
 ## type of branding - [ openSUSE, plain, openqa.suse.de ]
 #branding = plain

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -11,7 +11,7 @@ use OpenQA::Log qw(log_trace log_debug log_info log_warning log_error);
 use OpenQA::Utils (
     qw(create_git_clone_list parse_assets_from_settings locate_asset),
     qw(resultdir assetdir read_test_modules find_bugref random_string),
-    qw(run_cmd_with_log_return_error needledir testcasedir git_commit_url find_video_files)
+    qw(run_cmd_with_log_return_error needledir testcasedir git_commit_url find_video_files resolve_distribution_dir)
 );
 use OpenQA::App;
 use OpenQA::Jobs::Constants;
@@ -372,6 +372,12 @@ sub prepare_for_work ($self, $worker = undef, $worker_properties = {}) {
     my $job_token = $worker_properties->{JOBTOKEN} // random_string();
     $worker->set_property(JOBTOKEN => $job_token);
     $job_hashref->{settings}->{JOBTOKEN} = $job_token;
+
+    unless (exists $job_hashref->{settings}->{DISTRIBUTION_DIR}) {
+        if (my $dist_dir = OpenQA::App->singleton->config->{global}->{distribution_dir}) {
+            $job_hashref->{settings}->{DISTRIBUTION_DIR} = $dist_dir;
+        }
+    }
 
     my $updated_settings = $self->register_assets_from_settings();
 
@@ -1659,7 +1665,8 @@ sub release_networks ($self) { $self->networks->delete }
 
 sub needle_dir ($self) {
     unless ($self->{_needle_dir}) {
-        my $distri = $self->DISTRI;
+        my $settings = $self->settings_hash;
+        my $distri = resolve_distribution_dir($settings);
         my $version = $self->VERSION;
         $self->{_needle_dir} = OpenQA::Utils::needledir($distri, $version);
     }

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -65,6 +65,7 @@ sub read_config ($app) {
     my %defaults = (
         global => {
             appname => 'openQA',
+            distribution_dir => 'opensuse',
             base_url => undef,
             branding => 'openSUSE',
             download_domains => undef,

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -97,6 +97,7 @@ our @EXPORT = qw(
   needledir
   productdir
   testcasedir
+  resolve_distribution_dir
   git_commit_url
   is_in_tests
   save_base64_png
@@ -212,6 +213,27 @@ sub testcasedir ($distri = undef, $version = undef, $rootfortests = undef) {
     my $dir = catdir($rootfortests, $distri);
     $dir .= "-$version" if $version && -e "$dir-$version";
     return $dir;
+}
+
+
+=head2 resolve_distribution_dir
+
+  resolve_distribution_dir($vars, $worker_global_settings)
+
+I<resolve_distribution_dir> returns the resolved distribution directory name
+as a string, following a senquantial order:
+
+job settings > App global settings > worker config > DISTRI variable
+
+=cut
+
+sub resolve_distribution_dir ($vars, $worker_global_settings = undef) {
+    my $app = OpenQA::App->singleton;
+    my $global_conf = $app ? $app->config->{global}->{distribution_dir} : undef;
+    my $distri_dir = $vars->{DISTRIBUTION_DIR} // $global_conf
+      // ($worker_global_settings ? $worker_global_settings->{DISTRIBUTION_DIR} : undef) // $vars->{DISTRI};
+    log_debug "resolve distribution_dir to $distri_dir";
+    return $distri_dir;
 }
 
 =head2 git_commit_url

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -7,7 +7,7 @@ use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_
 use OpenQA::JobSettings;
 use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle format_settings);
 use OpenQA::Utils
-  qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme testcasedir productdir needledir);
+  qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme testcasedir productdir needledir resolve_distribution_dir);
 use POSIX qw(:sys_wait_h strftime uname _exit);
 use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();
@@ -390,7 +390,9 @@ sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback)
 
     # ensure a CASEDIR and a PRODUCTDIR is assigned and create a symlink if required
     my $absolute_paths = $vars->{ABSOLUTE_TEST_CONFIG_PATHS};
-    my @vars_for_default_dirs = ($vars->{DISTRI}, $vars->{VERSION}, $shared_cache);
+    my $global_settings = $job->worker->settings->global_settings;
+    my $distri = resolve_distribution_dir($vars, $global_settings);
+    my @vars_for_default_dirs = ($distri, $vars->{VERSION}, $shared_cache);
     my $default_casedir = testcasedir(@vars_for_default_dirs);
     my $default_productdir = productdir(@vars_for_default_dirs);
     my $target_name = path($default_casedir)->basename;

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -22,7 +22,7 @@ sub exit_code (&) {
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Utils (qw(:DEFAULT prjdir sharedir resultdir assetdir imagesdir base_host random_string random_hex),
-    qw(download_rate download_speed usleep_backoff));
+    qw(download_rate download_speed usleep_backoff resolve_distribution_dir));
 use OpenQA::SignalBlocker;
 use OpenQA::Task::SignalGuard;
 use OpenQA::Test::TimeLimit '10';
@@ -378,6 +378,37 @@ subtest parse_assets_from_settings => sub {
     $refassets->{KERNEL} = {type => 'other', name => '/path/vmlinuz'};
     is_deeply $assets, $refassets, 'correct with absolute KERNEL';
 
+};
+
+subtest 'resolve_distribution_dir' => sub {
+    use OpenQA::App;
+    use Mojolicious;
+    use Test::Output 'combined_like';
+
+    my $vars = {DISTRI => 'aeon'};
+    my $worker_global_settings = {};
+    is resolve_distribution_dir($vars, $worker_global_settings), 'aeon', 'fallback to DISTRI when no other settings';
+    $vars = {DISTRI => 'aeon', DISTRIBUTION_DIR => 'opensuse'};
+    is resolve_distribution_dir($vars, $worker_global_settings), 'opensuse', 'DISTRIBUTION_DIR in vars takes priority';
+    $vars = {DISTRI => 'aeon'};
+    $worker_global_settings = {DISTRIBUTION_DIR => 'fedora'};
+    is resolve_distribution_dir($vars, $worker_global_settings), 'fedora', 'worker DISTRIBUTION_DIR overrides DISTRI';
+    $vars = {DISTRI => 'aeon', DISTRIBUTION_DIR => 'opensuse'};
+    is resolve_distribution_dir($vars, $worker_global_settings), 'opensuse', 'job setting overrides worker setting';
+
+    subtest 'test with app config' => sub {
+        my $app = Mojolicious->new;
+        $app->config->{global}->{distribution_dir} = 'tumbleweed';
+        OpenQA::App->set_singleton($app);
+
+        $vars = {DISTRI => 'aeon'};
+        $worker_global_settings = {};
+        is resolve_distribution_dir($vars, $worker_global_settings), 'tumbleweed', 'app config is used when available';
+        $vars = {DISTRI => 'aeon', DISTRIBUTION_DIR => 'opensuse'};
+        $worker_global_settings = {DISTRIBUTION_DIR => 'fedora'};
+        combined_like { resolve_distribution_dir($vars, $worker_global_settings) }
+        qr/resolve distribution_dir to opensuse/, 'log message contains resolved distribution directory';
+    };
 };
 
 subtest 'base_host' => sub {

--- a/t/config.t
+++ b/t/config.t
@@ -46,6 +46,7 @@ subtest 'Test configuration default modes' => sub {
     my $test_config = {
         global => {
             appname => 'openQA',
+            distribution_dir => 'opensuse',
             branding => 'openSUSE',
             hsts => 365,
             audit_enabled => 1,


### PR DESCRIPTION
Added DISTRIBUTION_DIR global variable to run tests from different test
distribution. This removes the need to create symlinks for any new DISTRI
which uses the same test repo.
    
The variable supports to be set in 4 different ways. In this order
  - Job settings
  - global settings
  - settings in the worker
  - or the way that it was before aka DISTRI
    
Added resolve_distribution_dir() helper that works in both workers and API to
avoid code duplication and handle the priority chain in one place, and support
the configuration in both webui and workers.
    
If DISTRIBUTION_DIR is not set, it should use DISTRI like before, so existing
setups with symlinks should continue working. However, this could be a
breaking change for needles matching. Needles might not load correctly after
this applied. And there may be other test variables that depend on DISTRI
matching the path which it hasn't fully investigated yet.
   

related-issue: https://progress.opensuse.org/issues/195437

*The new approach is https://github.com/os-autoinst/openQA/pull/6998*