### PR TITLE
fix: Use new apachectl command

### DIFF
--- a/container/webui/run_openqa.sh
+++ b/container/webui/run_openqa.sh
@@ -46,7 +46,7 @@ function all_together_apache() {
     su geekotest -c /usr/share/openqa/script/openqa-websockets-daemon &
     su geekotest -c /usr/share/openqa/script/openqa-gru &
     su geekotest -c /usr/share/openqa/script/openqa-livehandler-daemon &
-    apache2ctl start
+    apachectl start
     su geekotest -c /usr/share/openqa/script/openqa-webui-daemon
 }
 


### PR DESCRIPTION
Already in Leap 15.6 /usr/sbin/apache2ctl was a symlink to apachectl. In 16.0 it has been removed, so only /usr/sbin/apachectl exists.

Issue: https://progress.opensuse.org/issues/180731