### PR TITLE
test: Extend tests for controller handling live view

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,7 @@ coverage:
           - lib/OpenQA/Worker.pm
           - lib/OpenQA/Utils.pm
           - lib/OpenQA/WebAPI/Controller/
+          - lib/OpenQA/Shared/Controller/Running.pm
       tests:
         target: 100.0
         threshold: 0


### PR DESCRIPTION
Not sure whether the code for showing a special image when the backend has terminated makes actually sense; it probably needs further improvement so I created https://progress.opensuse.org/issues/196466 for that. The new test will fail if the relevant code path contains e.g. a `die` so it it a step in the right direction and can be adapted as needed when working on https://progress.opensuse.org/issues/196466.

Related ticket: https://progress.opensuse.org/issues/178954