### PR TITLE
Allow using different test distributions without symlinks

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -2296,7 +2296,9 @@ follows:
 * If `CASEDIR` or `NEEDLES_DIR` is customized the customized location is used
   instead of the default repository.
 * If only one of `CASEDIR` or `NEEDLES_DIR` is customized the other variable
-  will still be initialized to point to the default repository.
+  will still be initialized to point to the default repository. In case of 
+  undefined `CASEDIR` the variable will attempt to set the value of 
+  `DISTRIBUTION_DIR` from the openQA global settings.
 * A relative `NEEDLES_DIR` is treated to be relative to the default `CASEDIR`
   (even if `CASEDIR` is customized). To have it treated to be relative to the
   custom `CASEDIR`, prefix the relative path with `%CASEDIR%/`. So specifying

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -1,6 +1,8 @@
 [global]
 ## Web site name for tab titles and bookmarks
 #appname = openQA
+## Set the default CASEDIR if the distribution directory/symlink doesn't already exist
+#distribution_dir = opensuse
 
 ## type of branding - [ openSUSE, plain, openqa.suse.de ]
 #branding = plain

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -80,6 +80,7 @@ sub read_config ($app) {
     my %defaults = (
         global => {
             appname => 'openQA',
+            distribution_dir => 'opensuse',
             base_url => undef,
             branding => 'openSUSE',
             download_domains => undef,

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -206,12 +206,15 @@ sub testcasedir ($distri = undef, $version = undef, $rootfortests = undef) {
         $rootfortests ||= $dir if -d $dir;
     }
     $rootfortests ||= $defaultroot;
-    $distri //= '';
-    # TODO actually "distri" is misused here. It should rather be something
-    # like the name of the repository with all tests
-    my $dir = catdir($rootfortests, $distri);
-    $dir .= "-$version" if $version && -e "$dir-$version";
-    return $dir;
+    try {
+        my $dir = catdir($rootfortests, $distri);
+        $dir .= "-$version" if $version && -e "$dir-$version";
+        log_info "testcasedir path exists at $dir" if (-e $dir || -l $dir);
+        return $dir;
+    }
+    catch ($e) {
+        log_error "testcasdir failed using '$distri': $e";
+    }
 }
 
 =head2 git_commit_url

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -380,6 +380,37 @@ subtest parse_assets_from_settings => sub {
 
 };
 
+# subtest 'resolve_distribution_dir' => sub {
+#     use OpenQA::App;
+#     use Mojolicious;
+#     use Test::Output 'combined_like';
+
+#     my $vars = {DISTRI => 'aeon'};
+#     my $worker_global_settings = {};
+#     is resolve_distribution_dir($vars, $worker_global_settings), 'aeon', 'fallback to DISTRI when no other settings';
+#     $vars = {DISTRI => 'aeon', DISTRIBUTION_DIR => 'opensuse'};
+#     is resolve_distribution_dir($vars, $worker_global_settings), 'opensuse', 'DISTRIBUTION_DIR in vars takes priority';
+#     $vars = {DISTRI => 'aeon'};
+#     $worker_global_settings = {DISTRIBUTION_DIR => 'fedora'};
+#     is resolve_distribution_dir($vars, $worker_global_settings), 'fedora', 'worker DISTRIBUTION_DIR overrides DISTRI';
+#     $vars = {DISTRI => 'aeon', DISTRIBUTION_DIR => 'opensuse'};
+#     is resolve_distribution_dir($vars, $worker_global_settings), 'opensuse', 'job setting overrides worker setting';
+
+#     subtest 'test with app config' => sub {
+#         my $app = Mojolicious->new;
+#         $app->config->{global}->{distribution_dir} = 'tumbleweed';
+#         OpenQA::App->set_singleton($app);
+
+#         $vars = {DISTRI => 'aeon'};
+#         $worker_global_settings = {};
+#         is resolve_distribution_dir($vars, $worker_global_settings), 'tumbleweed', 'app config is used when available';
+#         $vars = {DISTRI => 'aeon', DISTRIBUTION_DIR => 'opensuse'};
+#         $worker_global_settings = {DISTRIBUTION_DIR => 'fedora'};
+#         combined_like { resolve_distribution_dir($vars, $worker_global_settings) }
+#         qr/resolve distribution_dir to opensuse/, 'log message contains resolved distribution directory';
+#     };
+# };
+
 subtest 'base_host' => sub {
     is base_host('http://opensuse.org'), 'opensuse.org';
     is base_host('www.opensuse.org'), 'www.opensuse.org';

--- a/t/config.t
+++ b/t/config.t
@@ -47,6 +47,7 @@ subtest 'Test configuration default modes' => sub {
     my $test_config = {
         global => {
             appname => 'openQA',
+            distribution_dir => 'opensuse',
             branding => 'openSUSE',
             hsts => 365,
             audit_enabled => 1,

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -24,6 +24,7 @@ use OpenQA::Test::Utils 'wait_for_or_bail_out';
 
 my $JOB_SETUP = {
     ISO => 'Core-7.2.iso',
+    CASEDIR => 'tinycore',
     DISTRI => 'tinycore',
     ARCH => 'i386',
     QEMU => 'i386',


### PR DESCRIPTION
Added DISTRIBUTION_DIR global variable to run tests from different test distribution. This removes the need to create symlinks for any new DISTRI which uses the same test repo.

The variable supports to be set the CASEDIR if this is undefined.

If DISTRIBUTION_DIR is not set, it should use DISTRI like before, so existing setups with symlinks should continue working.
This commit could be a potential breaking change for needles matching. And there may be other circumstance which they are not very obvious yet, However the use of CASEDIR and the way the change approach the solution should minimize the possibility of regressions.

related-issue: https://progress.opensuse.org/issues/195437