### PR TITLE
feat: Make allowed hosts for SCENARIO_DEFINITIONS_YAML_FILE configurable

### DIFF
--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -1266,7 +1266,9 @@ If the YAML document already exists on the openQA host, you can also use
 on the openQA host. One can also specify an HTTP/HTTPs URL via that variable
 when `async=1` is used (see
 <<UsersGuide.asciidoc#_spawning_multiple_jobs_based_on_templates_isos_post>>
-for details). Then this file is downloaded by the openQA host.
+for details). Then this file is downloaded by the openQA host. The specified
+host name must be allowed via the configuration setting
+`scenario_definitions_allowed_hosts`.
 
 The YAML document itself should define at least one or more job templates:
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -129,6 +129,10 @@
 ## Can be overridden with the limit_builds query param
 #frontpage_builds = 3
 
+## List of hosts (space-separated) where scenario definitions specified via
+## `SCENARIO_DEFINITIONS_YAML_FILE=https://…` are allowed to be downloaded from
+#scenario_definitions_allowed_hosts = github.com raw.githubusercontent.com
+
 ## Configuration related to actions openQA may perform on a git distri
 #[scm git]
 ## whether to automatically commit needles created in the editor back to git

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -112,6 +112,7 @@ sub read_config ($app) {
             access_control_allow_origin_header => undef,
             api_hmac_time_tolerance => 300,
             frontpage_builds => 3,
+            scenario_definitions_allowed_hosts => 'github.com raw.githubusercontent.com',
         },
         rate_limits => {
             search => 5,

--- a/t/config.t
+++ b/t/config.t
@@ -68,6 +68,7 @@ subtest 'Test configuration default modes' => sub {
             auto_clone_limit => 20,
             api_hmac_time_tolerance => 300,
             frontpage_builds => 3,
+            scenario_definitions_allowed_hosts => 'github.com raw.githubusercontent.com',
         },
         rate_limits => {
             search => 5,


### PR DESCRIPTION
So far we only allow downloads from `raw.githubusercontent.com`. With this change we also allow downloads from `github.com`. That makes writing GitHub actions without hardcoding URLs easier because only the latter is available as variable (`GITHUB_SERVER_URL`).

With this change the list of allowed hosts is now also configurable and the fact that not all hosts are allowed by default is documented.

Related ticket: https://progress.opensuse.org/issues/195584