### PR TITLE
feat: Allow specifying `CASEDIR` to avoid symlinking

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -390,12 +390,14 @@ sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback)
 
     # ensure a CASEDIR and a PRODUCTDIR is assigned and create a symlink if required
     my $absolute_paths = $vars->{ABSOLUTE_TEST_CONFIG_PATHS};
-    my @vars_for_default_dirs = ($vars->{DISTRI}, $vars->{VERSION}, $shared_cache);
+    my $casedir = $vars->{CASEDIR};
+    my $effective_distri = defined $casedir && !looks_like_url_with_scheme($casedir) ? $casedir : $vars->{DISTRI};
+    my @vars_for_default_dirs = ($effective_distri, $vars->{VERSION}, $shared_cache);
     my $default_casedir = testcasedir(@vars_for_default_dirs);
     my $default_productdir = productdir(@vars_for_default_dirs);
     my $target_name = path($default_casedir)->basename;
-    my $has_custom_dir = $vars->{CASEDIR} || $vars->{PRODUCTDIR};
-    my $casedir = $vars->{CASEDIR} //= $absolute_paths ? $default_casedir : $target_name;
+    my $has_custom_dir = $casedir || $vars->{PRODUCTDIR};
+    $casedir = $vars->{CASEDIR} //= $absolute_paths ? $default_casedir : $target_name;
     unless (_is_job_only_relying_on_git($vars)) {
         if ($casedir eq $target_name) {
             $vars->{PRODUCTDIR} //= substr($default_productdir, rindex($default_casedir, $target_name));


### PR DESCRIPTION
Tested by cloning an Aeon job locally without having symlinking in place.

When just cloning the job it fails to locate tests as it assumes the directory `aeon` as per `DISTRI`. That was expected.

The idea of this change is to be able to set e.g. `CASEDIR=opensuse` in cases like this instead of creating a symlink. To test this I cloned an Aeaon job locally again, this time with that variable set:

```
openqa-clone-job https://openqa.opensuse.org/tests/5677313 CASEDIR=opensuse
```

With this I ran into the problem that the worker does not do the required symlinking of osado into the pool dir based on `CASEDIR`. It just looks at `DISTRI`. That is therefore what this change adjusts. After cloning the job again with this small change in place the test was able to start.

Note that the job I've cloned already specifies `NEEDLES_DIR` pointing to a Git repository. So combination with a Git repo for needles works.

I've also tested cloning with `NEEDLES_DIR=` (clearing the variable). Then the worker symlinked osado needles which is reasonable and in-line with the documentation.

I also tested cloning with `NEEDLES_DIR=%CASEDIR%/products/aeon` to cover the case if one wanted to use a distinct needle repo for Aeon but still not specify a Git URL. With this the worker created a symlink to `products/aeon` within the `opensuse` `CASEDIR`. So that also works as expected and is also in-line with the documentation.

Related ticket: https://progress.opensuse.org/issues/195437