### PR TITLE
fix(test): Enable helm install-chart test again

### DIFF
--- a/.github/workflows/check-helm-chart.yml
+++ b/.github/workflows/check-helm-chart.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Run chart-testing
         run: make test-helm-lint
   install-chart:
-    if: false  # disabled due to https://progress.opensuse.org/issues/188982
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/container/helm/charts/openqa/Chart.lock
+++ b/container/helm/charts/openqa/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.5.38
+  version: 18.0.7
 - name: worker
   repository: file://../worker/
   version: 0.1.0
-digest: sha256:b8d33fe53bfb3cba746a17cbd13c29167fae37b44414b8769de3182c6a69adc6
-generated: "2025-06-10T15:13:53.917940726+02:00"
+digest: sha256:abdc0186dca79f8f26e51322602ddd98d45a5bc0449be84b3f356caeec4d23ca
+generated: "2026-02-17T23:02:54.843483778+01:00"

--- a/container/helm/charts/openqa/Chart.yaml
+++ b/container/helm/charts/openqa/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: ~0.1.0
     condition: webui.enabled
   - name: postgresql
-    version: 15.5.38
+    version: 18.0.7
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: worker

--- a/container/helm/charts/webui/Chart.lock
+++ b/container/helm/charts/webui/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.5.38
-digest: sha256:6dbed6171e0b736f43c92dadf97cfc4014555bfc0a4a2a760c4207b8b1b3095e
-generated: "2025-06-10T15:13:34.283281249+02:00"
+  version: 18.0.7
+digest: sha256:56d6c3cc7d96775a6df56e46fae9a8c035f8e1e6907cddf703548f3a4aee51ef
+generated: "2026-02-17T23:03:33.311291007+01:00"

--- a/container/helm/charts/webui/Chart.yaml
+++ b/container/helm/charts/webui/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 version: 0.1.0
 dependencies:
   - name: postgresql
-    version: 15.5.38
+    version: 18.0.7
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
Upgrade to the latest postgresql bitnami chart.

We assume the bitnami problem was temporary and we probably could have already enabled it earlier.

Issue: https://progress.opensuse.org/issues/189807

Note:
This PR is just a Proof of Concept showing that just enabling the check with the newest postgresql works, which is only implicitly done in
* #7000