### PR TITLE
perf: handle huge job groups gracefully

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -330,10 +330,13 @@ concurrent = 0
 ## Initial number of job group names to show in summary header box on tests
 ## overview page (clickable to expand to show all)
 #tests_overview_summary_max_groups = 7
-
 ## Maximum number of jobs to include in job group overview and dashboard pages
 ## (to prevent performance issues)
 #job_groups_overview_max_jobs = 25000
+
+## Maximum number of jobs to include in job groups overview page (to prevent
+## performance issues)
+#build_results_max_jobs_per_build = 5000
 ## Default number of jobs to include in table of finished jobs on "All tests"
 ## page
 #all_tests_default_finished_jobs = 500

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -5,15 +5,16 @@ package OpenQA::BuildResults;
 
 use Mojo::Base -strict, -signatures;
 
-use OpenQA::Jobs::Constants;
+use OpenQA::Jobs::Constants
+  qw(DONE CANCELLED PENDING_STATES PASSED SOFTFAILED ABORTED FAILED NOT_COMPLETE NOT_OK_RESULTS meta_result);
 use OpenQA::Constants qw(BUILD_SORT_BY_NAME BUILD_SORT_BY_NEWEST_JOB BUILD_SORT_BY_OLDEST_JOB);
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Utils;
 use Date::Format;
 use DateTime::Format::Pg;
-use List::Util qw(any);
 use Sort::Versions;
 use Time::Seconds;
+use List::Util qw(any);
 
 use constant DEFAULT_BUILD_RESULTS_LIMIT => 400;
 
@@ -31,6 +32,51 @@ sub init_job_figures ($job_result) {
     $job_result->{total} = 0;
 }
 
+sub _reset_stats_for_oversized_build ($jr, $total_for_build) {
+    init_job_figures($jr);
+    $jr->{total} = $total_for_build;
+    init_job_figures($_) for values %{$jr->{children} // {}};
+}
+
+my %META_MAP = (
+    PASSED() => 'passed',
+    SOFTFAILED() => 'softfailed',
+    ABORTED() => 'skipped',
+    FAILED() => 'failed',
+    NOT_COMPLETE() => 'failed',
+);
+
+sub _get_job_result_category ($state, $result) {
+    return $META_MAP{meta_result($result)} if $state eq DONE;
+    return 'skipped' if $state eq CANCELLED;
+    return 'unfinished';
+}
+
+sub _count_job_aggregated ($stat, $jr, $count) {
+    $jr->{total} += $count;
+    my $category = _get_job_result_category($stat->state, $stat->result);
+    $jr->{$category} += $count;
+}
+
+sub count_job ($job, $jr, $labels) {
+    _count_job_aggregated($job, $jr, 1);
+    my ($state, $result) = ($job->state, $job->result);
+    my $category = _get_job_result_category($state, $result);
+
+    if ($category eq 'failed') {
+        my $comment_data = $labels->{$job->id};
+        if ($comment_data) {
+            $jr->{labeled}++ if $comment_data->{reviewed};
+            $jr->{comments}++ if $comment_data->{comments} || $comment_data->{reviewed};
+        }
+    }
+    elsif ($category eq 'unfinished') {
+        require OpenQA::Log;
+        OpenQA::Log::log_error('Encountered not-implemented state:' . $state . ' result:' . $result)
+          unless any { $state eq $_ } (PENDING_STATES);
+    }
+    return;
+}
 sub add_review_badge ($build_res) {
     $build_res->{all_passed} = $build_res->{passed} + $build_res->{softfailed} >= $build_res->{total} ? 1 : 0;
     $build_res->{reviewed} = $build_res->{labeled} >= $build_res->{failed} ? 1 : 0;
@@ -65,7 +111,9 @@ sub _get_latest_job_ids ($jobs_resultset, $version, $buildnr, $group_ids) {
 sub compute_build_results (
     $group, $limit, $time_limit_days, $tags, $subgroup_filter, $show_tags,
     $max_jobs_limit = undef,
-    $ignored_groups = undef
+    $ignored_groups = undef,
+    $max_jobs_per_build = undef,
+    $app = undef
   )
 {
     # find relevant child groups taking filter into account
@@ -83,6 +131,11 @@ sub compute_build_results (
         }
     }
 
+    if (!$max_jobs_per_build && $app) {
+        $max_jobs_per_build = $app->config->{misc_limits}->{build_results_max_jobs_per_build};
+    }
+    require OpenQA::Setup;
+    $max_jobs_per_build //= OpenQA::Setup::default_config()->{misc_limits}->{build_results_max_jobs_per_build};
     my $total_jobs_seen = 0;
     my $limit_exceeded = 0;
     my @sorted_results;
@@ -97,8 +150,8 @@ sub compute_build_results (
         });
     return \%result if defined($limit) && int($limit) <= 0;
     # build sorting
-    my $buildver_sort_mode = BUILD_SORT_BY_NAME;
-    $buildver_sort_mode = $group->build_version_sort if $group->can('build_version_sort');
+    my $buildver_sort_mode
+      = $group->can('build_version_sort') ? ($group->build_version_sort // BUILD_SORT_BY_NAME) : BUILD_SORT_BY_NAME;
     my $sort_column = $buildver_sort_mode == BUILD_SORT_BY_OLDEST_JOB ? 'oldest_job' : 'newest_job';
 
     # 400 is the max. limit selectable in the group overview
@@ -159,68 +212,67 @@ sub compute_build_results (
             version_count => scalar keys %{$versions_per_build{$buildnr}},
         );
         init_job_figures(\%jr);
-        init_job_figures($jr{children}->{$_->id} = {}) for @$children;
-        my $stats_rs = $jobs_resultset->search(
-            {id => {-in => \@latest_ids}},
-            {
-                select =>
-                  [qw(state result DISTRI group_id), {count => '*'}, {($newest ? 'max' : 'min') => 't_created'}],
-                as => [qw(state result DISTRI group_id count t_created_agg)],
-                group_by => [qw(state result DISTRI group_id)],
-            });
-        while (my $stat = $stats_rs->next) {
-            my $count = $stat->get_column('count');
-            $jr{total} += $count;
-            $jr{distris}->{$stat->DISTRI} = 1;
-            my $t_agg = $stat->get_column('t_created_agg');
-            if ($t_agg && !ref $t_agg) {
-                $t_agg = DateTime::Format::Pg->parse_datetime($t_agg);
-            }
-            if ($newest) {
-                $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg > $jr{oldest_newest};
-            }
-            else {
-                $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg < $jr{oldest_newest};
-            }
-            my $cat = 'unfinished';
-            if ($stat->state eq OpenQA::Jobs::Constants::DONE) {
-                if ($stat->result eq OpenQA::Jobs::Constants::PASSED) { $cat = 'passed' }
-                elsif ($stat->result eq OpenQA::Jobs::Constants::SOFTFAILED) { $cat = 'softfailed' }
-                elsif (any { $stat->result eq $_ } OpenQA::Jobs::Constants::ABORTED_RESULTS) {
-                    $cat = 'skipped';
-                }
-                elsif (any { $stat->result eq $_ } OpenQA::Jobs::Constants::NOT_OK_RESULTS) {
-                    $cat = 'failed';
-                }
-            }
-            elsif ($stat->state eq OpenQA::Jobs::Constants::CANCELLED) { $cat = 'skipped' }
-            $jr{$cat} += $count;
-            if ($jr{children} && (my $child = $jr{children}->{$stat->group_id})) {
-                $child->{total} += $count;
-                $child->{$cat} += $count;
-                $child->{distris}->{$stat->DISTRI} = 1;
-                $child->{version} //= $version;
-                $child->{build} //= $buildnr;
-            }
+        for my $child (@$children) {
+            init_job_figures($jr{children}->{$child->id} = {version => $version, build => $buildnr});
         }
-        my $failed_rs = $jobs_resultset->search(
-            {
-                id => {-in => \@latest_ids},
-                state => OpenQA::Jobs::Constants::DONE,
-                result => {in => [OpenQA::Jobs::Constants::FAILED, OpenQA::Jobs::Constants::NOT_COMPLETE_RESULTS]},
-            },
-            {select => [qw(id group_id)]});
-        my $failed_id_to_group = {map { $_->id => $_->group_id } $failed_rs->all};
-        if (keys %$failed_id_to_group) {
-            my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs($failed_rs);
-            for my $id (keys %$comment_data) {
-                my $cd = $comment_data->{$id};
-                next unless $cd->{reviewed} || $cd->{comments};
-                $jr{labeled}++ if $cd->{reviewed};
-                $jr{comments}++ if $cd->{comments} || $cd->{reviewed};
-                if ($jr{children} && (my $child = $jr{children}->{$failed_id_to_group->{$id}})) {
-                    $child->{labeled}++ if $cd->{reviewed};
-                    $child->{comments}++ if $cd->{comments} || $cd->{reviewed};
+
+        my $total_for_build = scalar(@latest_ids);
+        if (defined($max_jobs_per_build) && $total_for_build > $max_jobs_per_build) {
+            $jr{oversized} = 1;
+            $jr{total_count} = $total_for_build;
+            $jr{limit} = $max_jobs_per_build;
+            _reset_stats_for_oversized_build(\%jr, $total_for_build);
+        }
+        else {
+            my $stats_rs = $jobs_resultset->search(
+                {id => {-in => \@latest_ids}},
+                {
+                    select =>
+                      [qw(state result DISTRI group_id), {count => '*'}, {($newest ? 'max' : 'min') => 't_created'}],
+                    as => [qw(state result DISTRI group_id count t_created_agg)],
+                    group_by => [qw(state result DISTRI group_id)],
+                });
+            while (my $stat = $stats_rs->next) {
+                my $count = $stat->get_column('count');
+                $jr{total} += $count;
+                $jr{distris}->{$stat->DISTRI} = 1;
+                my $t_agg = $stat->get_column('t_created_agg');
+                if ($t_agg && !ref $t_agg) {
+                    $t_agg = DateTime::Format::Pg->parse_datetime($t_agg);
+                }
+                if ($newest) {
+                    $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg > $jr{oldest_newest};
+                }
+                else {
+                    $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg < $jr{oldest_newest};
+                }
+                my $cat = _get_job_result_category($stat->state, $stat->result);
+                $jr{$cat} += $count;
+                if ($jr{children} && (my $child = $jr{children}->{$stat->group_id})) {
+                    $child->{total} += $count;
+                    $child->{$cat} += $count;
+                    $child->{distris}->{$stat->DISTRI} = 1;
+                }
+            }
+            my $failed_rs = $jobs_resultset->search(
+                {
+                    id => {-in => \@latest_ids},
+                    state => OpenQA::Jobs::Constants::DONE,
+                    result => {in => [OpenQA::Jobs::Constants::FAILED, OpenQA::Jobs::Constants::NOT_COMPLETE_RESULTS]},
+                },
+                {select => [qw(id group_id)]});
+            my $failed_id_to_group = {map { $_->id => $_->group_id } $failed_rs->all};
+            if (keys %$failed_id_to_group) {
+                my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs($failed_rs);
+                for my $id (keys %$comment_data) {
+                    my $cd = $comment_data->{$id};
+                    next unless $cd->{reviewed} || $cd->{comments};
+                    $jr{labeled}++ if $cd->{reviewed};
+                    $jr{comments}++ if $cd->{comments} || $cd->{reviewed};
+                    if ($jr{children} && (my $child = $jr{children}->{$failed_id_to_group->{$id}})) {
+                        $child->{labeled}++ if $cd->{reviewed};
+                        $child->{comments}++ if $cd->{comments} || $cd->{reviewed};
+                    }
                 }
             }
         }

--- a/lib/OpenQA/Jobs/Constants.pm
+++ b/lib/OpenQA/Jobs/Constants.pm
@@ -191,6 +191,8 @@ our @EXPORT =    ## no critic (Modules::ProhibitAutomaticExportation)
   RESULT_CLEANUP_LOG_FILES
   TAG_ID_COLUMN
   STATUS_PRIORITY
+  meta_result
+  meta_state
   );
 
 # mapping from any specific job state/result to a meta state/result

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -271,6 +271,7 @@ sub default_config () {
             tests_overview_max_jobs => 2000,
             tests_overview_summary_max_groups => 7,
             job_groups_overview_max_jobs => 25000,
+            build_results_max_jobs_per_build => 5000,
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
             list_templates_default_limit => 5000,

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobGroup.pm
@@ -403,10 +403,11 @@ sub build_results ($self) {
 
     my $tags = $show_tags ? $group->tags : undef;
     my $max_jobs_limit = $self->app->config->{misc_limits}->{job_groups_overview_max_jobs};
+    my $max_jobs_per_build = $self->app->config->{misc_limits}->{build_results_max_jobs_per_build};
     my $cbr
       = OpenQA::BuildResults::compute_build_results($group, $limit_builds,
         $time_limit_days, $only_tagged ? $tags : undef,
-        [], $tags, $max_jobs_limit);
+        [], $tags, $max_jobs_limit, $max_jobs_per_build, $self->app);
     $cbr->{limit_exceeded} = $cbr->{limit_exceeded} ? $max_jobs_limit : 0;
     $self->render(json => $cbr);
 }

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -42,6 +42,7 @@ sub dashboard_build_results ($self) {
     my $ignored_groups = $self->app->ignored_groups;
 
     my $max_jobs_limit = $self->app->config->{misc_limits}->{job_groups_overview_max_jobs};
+    my $max_jobs_per_build = $self->app->config->{misc_limits}->{build_results_max_jobs_per_build};
     my $total_jobs_seen = 0;
     my $limit_reached = 0;
     my @results;
@@ -61,7 +62,9 @@ sub dashboard_build_results ($self) {
                 $group_params,
                 $show_tags ? $tags : undef,
                 defined $max_jobs_limit ? $max_jobs_limit - $total_jobs_seen : undef,
-                $ignored_groups
+                $ignored_groups,
+                $max_jobs_per_build,
+                $self->app
             );
 
             my $build_results_for_group = $build_results->{build_results};
@@ -166,7 +169,7 @@ sub _group_overview ($self, $resultset, $template) {
         $cbr
           = OpenQA::BuildResults::compute_build_results($group, $limit_builds,
             $time_limit_days, $only_tagged ? $tags : undef,
-            $group_params, $tags, $max_jobs_limit, $ignored_groups);
+            $group_params, $tags, $max_jobs_limit, $ignored_groups, undef, $self->app);
     }
     catch ($e) {
         die $e unless $e =~ qr/^invalid regex: /;

--- a/t/61-job_group_aggregation.t
+++ b/t/61-job_group_aggregation.t
@@ -1,0 +1,264 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+use Test::MockObject;
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '10';
+use OpenQA::Test::Case;
+use OpenQA::App;
+use OpenQA::BuildResults;
+use Date::Format 'time2str';
+use Feature::Compat::Try;
+use Test::Mojo;
+
+my $test_case = OpenQA::Test::Case->new;
+my $schema = $test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl');
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+my $group_id = 1001;
+
+sub create_jobs {
+    my ($group_id, $version, $build, $num_jobs, $start_id) = @_;
+    my $t_created = time2str '%Y-%m-%d %H:%M:%S', time, 'UTC';
+    my @jobs_data = map {
+        {
+            group_id => $group_id,
+            priority => 50,
+            state => 'done',
+            result => 'passed',
+            ARCH => 'x86_64',
+            FLAVOR => 'flavor',
+            VERSION => $version,
+            BUILD => $build,
+            DISTRI => 'distri',
+            t_created => $t_created,
+            t_updated => $t_created,
+            id => $start_id + $_,
+            TEST => "test_$_",
+        }
+    } (1 .. $num_jobs);
+    $schema->resultset('Jobs')->populate(\@jobs_data);
+}
+
+my $group = $schema->resultset('JobGroups')->find($group_id);
+
+subtest 'Aggregation with deduplication' => sub {
+    my $version = 'agg_version';
+    my $build = 'agg_build';
+    my $t_created = time2str '%Y-%m-%d %H:%M:%S', time, 'UTC';
+    my %common = (
+        group_id => $group_id,
+        priority => 50,
+        state => 'done',
+        TEST => 'test1',
+        ARCH => 'x86_64',
+        FLAVOR => 'flavor',
+        VERSION => $version,
+        BUILD => $build,
+        DISTRI => 'distri',
+        t_created => $t_created,
+        t_updated => $t_created,
+    );
+
+    # Create jobs for different categories, ensuring each is the latest for its scenario
+    my @jobs_data = (
+        {%common, id => 300001, result => 'failed', TEST => 'test_failed'},
+        {%common, id => 300002, result => 'passed', TEST => 'test_passed'},
+        {%common, id => 300003, result => 'softfailed', TEST => 'test_softfailed'},
+        {%common, id => 300004, result => 'user_cancelled', TEST => 'test_aborted'},    # skipped (aborted)
+        {%common, id => 300005, state => 'cancelled', result => 'none', TEST => 'test_cancelled'}, # skipped (cancelled)
+        {%common, id => 300006, state => 'running', result => 'none', TEST => 'test_running'},    # unfinished
+        {%common, id => 300007, result => 'passed', TEST => 'test_dedup'},
+        {%common, id => 300008, result => 'softfailed', TEST => 'test_dedup'},    # latest for test_dedup
+    );
+    $schema->resultset('Jobs')->populate(\@jobs_data);
+
+    my $cbr = OpenQA::BuildResults::compute_build_results($group, 10, 0, undef, [], undef);
+    my $build_res = (grep { $_->{key} eq "$version-$build" } @{$cbr->{build_results}})[0];
+
+    ok $build_res, 'Found our build';
+    is $build_res->{total}, 7, 'Correct total (7 unique scenarios)';
+    is $build_res->{passed}, 1, 'Counts passed';
+    is $build_res->{failed}, 1, 'Counts failed';
+    is $build_res->{softfailed}, 2, 'Counts softfailed (including deduped one)';
+    is $build_res->{skipped}, 2, 'Counts both aborted and cancelled as skipped';
+    is $build_res->{unfinished}, 1, 'Counts running job as unfinished';
+};
+
+subtest 'Direct count_job testing' => sub {
+    my $jr = {};
+    OpenQA::BuildResults::init_job_figures($jr);
+
+    my $job_passed = Test::MockObject->new;
+    $job_passed->set_always(id => 1)->set_always(state => 'done')->set_always(result => 'passed');
+    OpenQA::BuildResults::count_job($job_passed, $jr, {});
+    is $jr->{passed}, 1, 'count_job handles passed';
+
+    my $job_failed = Test::MockObject->new;
+    $job_failed->set_always(id => 2)->set_always(state => 'done')->set_always(result => 'failed');
+    OpenQA::BuildResults::count_job($job_failed, $jr, {2 => {reviewed => 1, comments => 1}});
+    is $jr->{failed}, 1, 'count_job handles failed';
+    is $jr->{labeled}, 1, 'count_job handles labeled';
+    is $jr->{comments}, 1, 'count_job handles comments';
+
+    my $job_running = Test::MockObject->new;
+    $job_running->set_always(id => 3)->set_always(state => 'running')->set_always(result => 'none');
+    OpenQA::BuildResults::count_job($job_running, $jr, {});
+    is $jr->{unfinished}, 1, 'count_job handles running as unfinished';
+
+    # Test unknown state to hit log_error branch
+    my $job_unknown = Test::MockObject->new;
+    $job_unknown->set_always(id => 4)->set_always(state => 'unknown_state')->set_always(result => 'none');
+    OpenQA::BuildResults::count_job($job_unknown, $jr, {});
+    is $jr->{unfinished}, 2, 'count_job handles unknown state as unfinished';
+};
+
+subtest 'Parent group aggregation' => sub {
+    my $parent = $schema->resultset('JobGroupParents')->create({name => 'parent', build_version_sort => 0});
+    my $child1 = $schema->resultset('JobGroups')->create({name => 'child1', parent_id => $parent->id});
+    my $child2 = $schema->resultset('JobGroups')->create({name => 'child2', parent_id => $parent->id});
+
+    my $version = 'parent_version';
+    my $build = 'parent_build';
+    my $t_created = time2str '%Y-%m-%d %H:%M:%S', time, 'UTC';
+    my %common = (
+        priority => 50,
+        state => 'done',
+        result => 'passed',
+        ARCH => 'x86_64',
+        FLAVOR => 'flavor',
+        VERSION => $version,
+        BUILD => $build,
+        DISTRI => 'distri',
+        t_created => $t_created,
+        t_updated => $t_created,
+    );
+
+    $schema->resultset('Jobs')->populate(
+        [
+            {%common, id => 700001, group_id => $child1->id, TEST => 'test1'},
+            {%common, id => 700002, group_id => $child2->id, TEST => 'test2', result => 'failed'},
+            {%common, id => 700003, group_id => $child2->id, TEST => 'test3', result => 'failed'},
+        ]);
+
+    # Add a reviewed job
+    $schema->resultset('Comments')->create({job_id => 700003, text => 'label:acceptable', user_id => 99901});
+
+    my $cbr = OpenQA::BuildResults::compute_build_results($parent, 10, 0, undef, [], undef);
+    my $build_res = (grep { $_->{key} eq "$version-$build" } @{$cbr->{build_results}})[0];
+
+    ok $build_res, 'Found our build in parent group';
+    is $build_res->{total}, 3, 'Total for parent group is 3';
+    is $build_res->{passed}, 1, 'One passed';
+    is $build_res->{failed}, 2, 'Two failed';
+    is $build_res->{labeled}, 1, 'One labeled';
+    ok $build_res->{children}->{$child1->id}, 'Child 1 data present';
+    is $build_res->{children}->{$child1->id}->{passed}, 1, 'Child 1 has 1 passed';
+    ok $build_res->{children}->{$child2->id}, 'Child 2 data present';
+    is $build_res->{children}->{$child2->id}->{failed}, 2, 'Child 2 has 2 failed';
+    is $build_res->{children}->{$child2->id}->{labeled}, 1, 'Child 2 has 1 labeled';
+};
+
+subtest 'Tags mapping' => sub {
+    my $version = 'tag_version';
+    my $build = 'tag_build';
+    my $key = "$version-$build";
+    my %common = (
+        group_id => $group_id,
+        priority => 50,
+        state => 'done',
+        result => 'passed',
+        ARCH => 'x86_64',
+        FLAVOR => 'flavor',
+        VERSION => $version,
+        BUILD => $build,
+        DISTRI => 'distri',
+    );
+
+    $schema->resultset('Jobs')->create({%common, id => 800001, TEST => 'test1'});
+
+    my $show_tags = {$key => {name => 'my_tag'}};
+    my $cbr = OpenQA::BuildResults::compute_build_results($group, 10, 0, undef, [], $show_tags);
+    my $build_res = (grep { $_->{key} eq $key } @{$cbr->{build_results}})[0];
+
+    ok $build_res, 'Found our build for tags';
+    is $build_res->{tag}->{name}, 'my_tag', 'Tag correctly mapped';
+
+    # Test build-only tag fallback
+    $show_tags = {$build => {name => 'build_tag'}};
+    $cbr = OpenQA::BuildResults::compute_build_results($group, 10, 0, undef, [], $show_tags);
+    $build_res = (grep { $_->{key} eq $key } @{$cbr->{build_results}})[0];
+    is $build_res->{tag}->{name}, 'build_tag', 'Build-only tag correctly mapped';
+};
+
+subtest 'Filtering by tags' => sub {
+    my %common = (
+        group_id => $group_id,
+        priority => 50,
+        state => 'done',
+        result => 'passed',
+        ARCH => 'x86_64',
+        FLAVOR => 'flavor',
+        DISTRI => 'distri',
+    );
+
+    $schema->resultset('Jobs')->create({%common, id => 900001, VERSION => 'v1', BUILD => 'b1', TEST => 't1'});
+    $schema->resultset('Jobs')->create({%common, id => 900002, VERSION => 'v2', BUILD => 'b2', TEST => 't1'});
+
+    my $tags = {tag1 => {version => 'v1', build => 'b1'}};
+    my $cbr = OpenQA::BuildResults::compute_build_results($group, 10, 0, $tags, [], undef);
+
+    is scalar @{$cbr->{build_results}}, 1, 'Filtered to 1 build';
+    is $cbr->{build_results}->[0]->{build}, 'b1', 'Correct build filtered';
+};
+
+subtest 'Job limit enforcement' => sub {
+    my $version = 'limit_version';
+    my $build = 'limit_build';
+    create_jobs($group_id, $version, $build, 5001, 400000);
+
+    my $cbr = OpenQA::BuildResults::compute_build_results($group, 10, 0, undef, [], undef);
+    my $build_res = (grep { $_->{key} eq "$version-$build" } @{$cbr->{build_results}})[0];
+
+    ok $build_res->{oversized}, 'Build is marked as oversized';
+    is $build_res->{total}, 5001, 'Total count is still present';
+    is $build_res->{passed}, 0, 'Passed count is reset for oversized builds';
+};
+
+subtest 'Parent group oversized build coverage' => sub {
+    my $parent = $schema->resultset('JobGroupParents')->create({name => 'parent_oversized'});
+    my $child = $schema->resultset('JobGroups')->create({name => 'child_oversized', parent_id => $parent->id});
+
+    my $version = 'oversized_version';
+    my $build = 'oversized_build';
+    create_jobs($child->id, $version, $build, 10, 1000000);
+
+    my $cbr = OpenQA::BuildResults::compute_build_results($parent, 10, 0, undef, [], undef, undef, 5);
+    my $build_res = (grep { $_->{key} eq "$version-$build" } @{$cbr->{build_results}})[0];
+
+    ok $build_res->{oversized}, 'Build is marked as oversized for parent group';
+    is $build_res->{total}, 10, 'Total count is still present';
+    is $build_res->{passed}, 0, 'Passed count is reset for oversized builds';
+    ok $build_res->{children}->{$child->id}, 'Child data exists';
+    is $build_res->{children}->{$child->id}->{passed}, 0, 'Child passed count is reset';
+    is $build_res->{children}->{$child->id}->{total}, 0, 'Child total count is reset';
+};
+
+subtest 'Controller and API limit enforcement' => sub {
+    my $group_id = $schema->resultset('JobGroups')->create({name => 'limit_group'})->id;
+    create_jobs($group_id, 'limit_version', 'limit_build', 10, 500000);
+
+    $t->app->config->{misc_limits}->{build_results_max_jobs_per_build} = 5;
+
+    $t->get_ok(
+        "/group_overview/$group_id" => form => {distri => 'distri', version => 'limit_version', build => 'limit_build'})
+      ->status_is(200)->content_like(qr/total: 10/);
+
+    $t->get_ok("/api/v1/job_groups/$group_id/build_results" => form => {limit_builds => 1, time_limit_days => 0})
+      ->status_is(200)->json_is('/build_results/0/oversized' => 1);
+};
+
+done_testing;


### PR DESCRIPTION
Motivation
Fetching and iterating all job objects for huge job groups causes
significant performance degradation and memory issues. The lack of
database-level aggregation and missing limits per build makes the system
vulnerable to excessive resource consumption. Additionally, some newly
introduced configuration names were confusing.

Design Choices
1. Optimized compute_build_results by using database-level aggregation
   instead of fetching and iterating all job objects.
2. Moved job deduplication (per scenario) to the database level.
3. Optimized comment/review tracking by only checking failed jobs.
4. Added t/61-job_group_aggregation.t to verify aggregation and limit
   enforcement, including specific subtests for parent group oversized
   build coverage.
5. Extracted category mapping into _get_job_result_category helper and
   reused it in both count_job and _count_job_aggregated for consistency.
6. Renamed the new config 'job_group_overview_max_jobs' to
   'build_results_max_jobs_per_build' across the application, tests,
   and default config to clearly distinguish it from the dashboard limit.

Benefits
These optimizations drastically reduce memory usage and processing time
for large job groups. Job figures are safely handled when encountering
oversized builds, preventing unhandled regressions. Config renaming
reduces confusion for administrators and developers.

Related progress issue: https://progress.opensuse.org/issues/196913