### PR TITLE
feat: Use CASEDIR to avoiding manual symlinking for running test

### DIFF
--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -154,9 +154,6 @@ if [[ -z $skip_suse_tests ]]; then
         export needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror.git"
     fi
     "$OPENQA_DIR/script/fetchneedles"
-    if [[ ! -e /var/lib/openqa/tests/sle ]]; then
-        ln -s opensuse /var/lib/openqa/tests/sle
-    fi
 
     if ping -c1 gitlab.suse.de.; then
         sles_needles_giturl="https://gitlab.suse.de/openqa/os-autoinst-needles-sles.git"


### PR DESCRIPTION
if CASEDIR is set to a non-URL relative path, it's used as the effective distri instead of DISTRI. This avoids the need to manually create symlinks like aeon -> opensuse when cloning/triggering jobs.

find related changes also os-autoinst/openQA#7006

related-issue: https://progress.opensuse.org/issues/196856