### PR TITLE
feat: add scheduling skip reasons to the webUI

### DIFF
--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -79,10 +79,14 @@ function renderTestName(data, type, row) {
   if (row.result !== 'none') {
     html += '<i class="status fa-solid fa-circle result_' + row.result + '" title="Done: ' + row.result + '"></i>';
   } else if (row.state === 'scheduled') {
+    let title = 'Scheduled';
+    if (row.reason) {
+      title += ': ' + row.reason;
+    }
     if (typeof row.blocked_by_id === 'number') {
       html += '<i class="status fa-solid fa-circle state_blocked" title="Blocked"></i>';
     } else {
-      html += '<i class="status fa-solid fa-circle state_scheduled" title="Scheduled"></i>';
+      html += '<i class="status fa-solid fa-circle state_scheduled" title="' + htmlEscape(title) + '"></i>';
     }
   } else if (row.state === 'assigned') {
     html += '<i class="status fa-solid fa-circle state_running" title="Assigned"></i>';
@@ -323,9 +327,13 @@ function renderTestLists() {
       dataSrc: function (json) {
         // update heading when JSON is available
         let blockedCount = 0;
-        jQuery.each(json.data, function (index, row) {
-          if (row && typeof row.blocked_by_id === 'number') {
+        const reasons = {};
+        json.data.forEach(row => {
+          if (row && row.blocked_by_id) {
             ++blockedCount;
+          }
+          if (row && row.reason) {
+            reasons[row.reason] = (reasons[row.reason] || 0) + 1;
           }
         });
         let text = json.data.length + ' scheduled jobs';
@@ -334,6 +342,26 @@ function renderTestLists() {
         }
         $('#scheduled_jobs_heading').text(text);
         $('#scheduled_jobs_warning').toggleClass('d-none', !json.job_skipped_by_disk_limits);
+
+        const reasonKeys = Object.keys(reasons).sort();
+        const popoverContent = reasonKeys.length
+          ? `<ul>${reasonKeys.map(r => '<li>' + reasons[r] + ' job(s): ' + htmlEscape(r) + '</li>').join('')}</ul>`
+          : 'No scheduling issues detected';
+
+        const popoverIcon = document.getElementById('scheduled_jobs_help_icon');
+        if (popoverIcon) {
+          popoverIcon.classList.toggle('text-muted', !reasonKeys.length);
+          popoverIcon.setAttribute('data-bs-content', popoverContent);
+
+          // Update active instance if it exists
+          if (window.bootstrap && bootstrap.Popover) {
+            const popover = bootstrap.Popover.getInstance(popoverIcon);
+            if (popover) {
+              popover.setContent({'.popover-body': popoverContent});
+            }
+          }
+        }
+
         return json.data;
       }
     },

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -55,15 +55,19 @@ sub effective_job_limit ($self) {
 sub _allocate_jobs ($self, $free_workers) {
     my ($allocated_workers, $allocated_jobs) = ({}, {});
     my $scheduled_jobs = $self->scheduled_jobs;
+    $scheduled_jobs->{$_}->{current_reason} = undef for keys %$scheduled_jobs;
+
     my $schema = OpenQA::Schema->singleton;
     my $running = $schema->resultset('Jobs')->count({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]});
     my $limit = $self->effective_job_limit;
     if (storage_below_threshold()) {
         log_debug('Skipping job scheduling: free storage space in results directory below threshold');
+        $_->{current_reason} = 'storage space below threshold' for values %$scheduled_jobs;
         return ({}, {});
     }
     if ($limit >= 0 && $running >= $limit) {
         log_debug("job limit ($limit) exceeded, scheduling no additional jobs");
+        $_->{current_reason} = "job limit reached (max_running_jobs=$limit)" for values %$scheduled_jobs;
         return ({}, {});
     }
     my $max_allocate = $limit >= 0 ? min(MAX_JOB_ALLOCATION, $limit - $running) : MAX_JOB_ALLOCATION;
@@ -73,7 +77,10 @@ sub _allocate_jobs ($self, $free_workers) {
     for my $id (keys %$scheduled_jobs) {
         my $jobinfo = $scheduled_jobs->{$id};
         $jobinfo->{matching_workers} = _matching_workers($jobinfo, $free_workers, \%rejected);
-        delete $scheduled_jobs->{$id} unless @{$jobinfo->{matching_workers}};
+        if (!@{$jobinfo->{matching_workers}}) {
+            my @needed = sort @{$jobinfo->{worker_classes}};
+            $jobinfo->{current_reason} = @needed ? "no free workers for class @needed" : 'no workers online';
+        }
     }
     if (keys %rejected) {
         my @rejected = sort { $rejected{$b} <=> $rejected{$a} || $a cmp $b } keys %rejected;
@@ -94,10 +101,14 @@ sub _allocate_jobs ($self, $free_workers) {
     my %checked_jobs;
     for my $j (@sorted) {
         my $job_id = $j->{id};
-        next if $checked_jobs{$job_id} || defined $allocated_jobs->{$job_id} || !@{$j->{matching_workers}};
+        if ($checked_jobs{$job_id} || defined $allocated_jobs->{$job_id} || !@{$j->{matching_workers}}) {
+            $checked_jobs{$job_id} = 1;
+            next;
+        }
         my $tobescheduled = _to_be_scheduled($j, $scheduled_jobs);
         if (!defined $tobescheduled) {
             log_debug "Skipping job $job_id because dependent jobs are not ready";
+            $j->{current_reason} = 'parallel dependencies not ready';
             next;
         }
         OpenQA::Scheduler::WorkerSlotPicker->new($tobescheduled)->pick_slots_with_common_worker_host;
@@ -125,6 +136,7 @@ sub _allocate_jobs ($self, $free_workers) {
                     my ($picked_worker, $job_info) = @{$taken{$worker}};
                     $self->_allocate_worker_with_priority($prio, $job_info, $j, $allocated_workers, $picked_worker);
                 }
+                $_->{current_reason} = 'incomplete parallel cluster' for @tobescheduled;
                 %taken = ();
                 last;
             }
@@ -144,6 +156,10 @@ sub _allocate_jobs ($self, $free_workers) {
             my $free_worker_count = @$free_workers;
             log_debug('limit reached, scheduling no additional jobs'
                   . " (job_limit=$limit, free workers=$free_worker_count, running=$running, allocated=$busy)");
+            for my $id (keys %$scheduled_jobs) {
+                next if defined $allocated_jobs->{$id} || $checked_jobs{$id};
+                $scheduled_jobs->{$id}->{current_reason} //= "scheduling limit reached (max_running_jobs=$limit)";
+            }
             last;
         }
     }
@@ -183,7 +199,7 @@ sub _assign_multiple_jobs ($self, $schema, $worker, $worker_id, $jobs, $directly
     #       need to set it here immediately to be sure the scheduler does not consider the worker
     #       free anymore.
     return $self->_assign_single_job($schema, $worker, $jobs->[0]) if @$jobs == 1;
-    my %worker_assignment = (state => ASSIGNED, t_started => undef, assigned_worker_id => $worker_id);
+    my %worker_assignment = (state => ASSIGNED, t_started => undef, assigned_worker_id => $worker_id, reason => undef);
     $schema->txn_do(
         sub {
             $_->update(\%worker_assignment) for @$jobs;
@@ -211,6 +227,7 @@ sub schedule ($self) {
 
     my ($allocated_workers, $allocated_jobs) = $self->_allocate_jobs($free_workers);
 
+    $self->_update_job_reasons_in_db($schema, $scheduled_jobs);
     my @successfully_allocated;
 
     # assign the allocated job-worker pairs
@@ -332,6 +349,26 @@ sub schedule ($self) {
     $self->emit('conclude');
 
     return (\@successfully_allocated);
+}
+
+sub _update_job_reasons_in_db ($self, $schema, $scheduled_jobs) {
+    # batch update job reasons if they changed
+    my %reasons_to_update;
+    for my $id (keys %$scheduled_jobs) {
+        my $info = $scheduled_jobs->{$id};
+        my $curr = $info->{current_reason};
+        my $last = $info->{last_reason};
+        if (($curr // '') ne ($last // '')) {
+            push @{$reasons_to_update{$curr // 'NULL'}}, $id;
+            $info->{last_reason} = $curr;
+        }
+    }
+    my $jobs = $schema->resultset('Jobs');
+    for my $reason (keys %reasons_to_update) {
+        my $ids = $reasons_to_update{$reason};
+        my $val = $reason eq 'NULL' ? undef : $reason;
+        $jobs->search({id => {-in => $ids}})->update({reason => $val});
+    }
 }
 
 sub singleton ($class = undef) { state $jobs ||= ($class // __PACKAGE__)->new }

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -332,7 +332,7 @@ sub reschedule_state ($self, $state = OpenQA::Jobs::Constants::SCHEDULED) {
     #       already be SETUP/RUNNING after all. In this case we need to abort.
     my $jobs = $self->result_source->schema->resultset('Jobs');
     my %cond = (id => $self->id, state => {-in => [SCHEDULED, ASSIGNED]});
-    my %update = (state => $state, result => NONE, t_started => undef, assigned_worker_id => undef);
+    my %update = (state => $state, result => NONE, t_started => undef, assigned_worker_id => undef, reason => undef);
     return 0 if $jobs->search(\%cond)->update(\%update) == 0;
 
     # cleanup
@@ -358,6 +358,7 @@ sub set_assigned_worker ($self, $worker) {
             state => ASSIGNED,
             t_started => undef,
             assigned_worker_id => $worker_id,
+            reason => undef,
         });
     log_debug("Assigned job '$job_id' to worker ID '$worker_id'");
 }

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -18,7 +18,7 @@ use Mojo::File 'path';
 use File::Basename;
 use POSIX 'strftime';
 use Mojo::JSON qw(to_json decode_json);
-use List::Util qw(first min);
+use List::Util qw(any first min);
 use HTTP::Status qw(:constants);
 
 use constant DEPENDENCY_DEBUG_INFO => $ENV{OPENQA_DEPENDENCY_DEBUG_INFO};
@@ -366,7 +366,7 @@ sub list_scheduled_ajax ($self) {
         columns => [
             qw(id MACHINE DISTRI VERSION FLAVOR ARCH BUILD TEST
               state clone_id result group_id t_finished t_started t_created t_updated
-              blocked_by_id priority
+              blocked_by_id priority reason
             )
         ],
 
@@ -383,10 +383,12 @@ sub list_scheduled_ajax ($self) {
         $job_data->{blocked_by_id} = $_->blocked_by_id;
         $job_data->{prio} = $_->priority;
         $job_data->{prio_explanation} = $_->settings_hash->{_PRIORITY_EXPLANATION};
+        $job_data->{reason} = $_->reason;
         $job_data;
     } @jobs;
     my %response = (data => \@scheduled);
-    $response{job_skipped_by_disk_limits} = 1 if storage_below_threshold();
+    $response{job_skipped_by_disk_limits} = 1
+      if any { ($_->{reason} // '') eq 'storage space below threshold' } @scheduled;
     $self->render(json => \%response);
 }
 

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -104,7 +104,12 @@ subtest 'Scheduler worker job allocation' => sub {
     my $allocated = $job_model->schedule;
     is @$allocated, 0, 'no jobs allocated for no active workers';
 
+    my $jobs = $schema->resultset('Jobs');
+    is $jobs->search({state => SCHEDULED})->first->reason, 'no workers online',
+      'unallocated job has a scheduling reason in the DB';
+
     note 'starting two workers';
+    my $new_job = $schema->resultset('Jobs')->find(80000)->auto_duplicate({settings => {WORKER_CLASS => 'foo'}});
     @workers = map { create_worker(@$worker_settings, $_) } (1, 2);
     wait_for_worker($schema, 3);
     wait_for_worker($schema, 4);
@@ -119,8 +124,15 @@ subtest 'Scheduler worker job allocation' => sub {
     my $different_jobs = isnt $job_id1, $job_id2, 'each of the two jobs allocated to one of the workers';
     always_explain $allocated unless $different_workers && $different_jobs;
 
+    note 'verify scheduling reason for unallocated jobs';
+    is $new_job->discard_changes->reason, 'no free workers for class foo',
+      'unallocated job has a scheduling reason in the DB';
+
     $allocated = $job_model->schedule;
     is @$allocated, 0, 'no more jobs need to be allocated';
+
+    # cleanup
+    $new_job->delete;
 
     stop_workers;
     dead_workers($schema);
@@ -133,7 +145,7 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
 
     my $jobs = $schema->resultset('Jobs');
     my @latest = $jobs->latest_jobs;
-    shift(@latest)->auto_duplicate();
+    my $duplicated_id = shift(@latest)->auto_duplicate()->id;
 
     # try to allocate to previous worker and fail!
     my $allocated = $job_model->schedule;
@@ -160,12 +172,12 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
         note "scheduler could not yet assign to rejective worker, try: $_";    # uncoverable statement
     }
     is @$allocated, 1, 'one job allocated'
-      and is @{$allocated}[0]->{job}, 99982, 'right job allocated'
+      and is @{$allocated}[0]->{job}, $duplicated_id, 'right job allocated'
       and is @{$allocated}[0]->{worker}, 5, 'job allocated to expected worker';
     my $job_assigned = 0;
     my $job_scheduled = 0;
     for (0 .. 100) {
-        my $job_state = $jobs->find(99982)->state;
+        my $job_state = $jobs->find($duplicated_id)->state;
         if ($job_state eq ASSIGNED) {
             note 'job is assigned' unless $job_assigned;    # uncoverable statement
             $job_assigned = 1;    # uncoverable statement
@@ -190,19 +202,19 @@ subtest 're-scheduling and incompletion of jobs when worker rejects jobs or goes
         note "scheduler could not yet assign to broken worker, try: $_";    # uncoverable statement
     }
     is @$allocated, 1, 'one job allocated'
-      and is @{$allocated}[0]->{job}, 99982, 'right job allocated'
+      and is @{$allocated}[0]->{job}, $duplicated_id, 'right job allocated'
       and is @{$allocated}[0]->{worker}, 5, 'job allocated to expected worker';
 
     # kill the worker but assume the job has been actually started and is running
     # note: Also setting back assigned_worker_id and result because the worker might have actually picked up the job.
     stop_workers;
-    $jobs->find(99982)->update({assigned_worker_id => 5, state => RUNNING, result => NONE});
+    $jobs->find($duplicated_id)->update({assigned_worker_id => 5, state => RUNNING, result => NONE});
 
     @workers = unstable_worker(@$worker_settings, 3, -1);
     wait_for_worker($schema, 5);
-    wait_for { $jobs->find(99982)->state eq DONE } 'job 99982 is incompleted', {timeout => 20};
+    wait_for { $jobs->find($duplicated_id)->state eq DONE } "job $duplicated_id is incompleted", {timeout => 20};
 
-    my $job = $jobs->find(99982);
+    my $job = $jobs->find($duplicated_id);
     is $job->state, DONE, 'running job set to done if its worker re-connects claiming not to work on it anymore';
     is $job->result, INCOMPLETE, 'running job incompleted if its worker re-connects claiming not to work on it anymore';
     like $job->reason, qr/abandoned: associated worker .+:\d+ re-connected but abandoned the job/, 'reason is set';

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -69,7 +69,7 @@
                         <abbr class="timeago" title="<%= $job->t_created->datetime() %>Z"><%= format_time($job->t_created) %></abbr>
                     % }
                     % if (my $reason = $job->reason) {
-                        <br>Reason: <%= $reason %>
+                        <br><%= $job->state eq SCHEDULED ? 'Scheduling info' : 'Reason' %>: <%= $reason %>
                     % }
                 </div>
                 % if (my $developer_session = $job->developer_session) {

--- a/templates/webapi/test/list.html.ep
+++ b/templates/webapi/test/list.html.ep
@@ -29,7 +29,9 @@
 </div>
 
 <div>
-    <h2 id="scheduled_jobs_heading">Scheduled jobs</h2>
+    <h2 id="scheduled_jobs_heading" style="display: inline-block">Scheduled jobs</h2><%=
+      help_popover 'Why is my test not getting executed?' => 'No scheduling issues detected',
+      undef, undef, undef, id => 'scheduled_jobs_help_icon', style => 'vertical-align: text-top'; %>
     <div id="scheduled_jobs_warning" class="alert alert-primary alert-dismissible d-none" role="alert">
         Jobs will not be assigned because storage is almost full.
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>


### PR DESCRIPTION
Motivation:
When openQA jobs remain in the scheduled state, users have no way to know why
they are not being assigned. Surfacing scheduler skip reasons reduces
confusion and support requests.

Design Choices:
- Used the existing "reason" column in the "jobs" table to store per-job
  scheduling skip reasons.
- Implemented a write-on-change strategy in the scheduler to update the
  reasons only when they change, minimizing database write load.
- Replaced the direct "df" call in the WebUI with a check on the aggregated
  job reasons to improve efficiency.
- Added a popover next to the "Scheduled jobs" heading and tooltips on job
  status icons to display the reasons.

Benefits:
- Provides immediate, per-job feedback to users about scheduling delays.
- Decouples the WebUI from low-level system checks like disk space.
- Leverages existing database schema for zero-migration implementation.

<img width="439" height="109" alt="Screenshot_20260328_221952_oqa_scheduling_no_issues" src="https://github.com/user-attachments/assets/11564857-dc86-4920-8e39-203bd32fd595" />

<img width="577" height="201" alt="Screenshot_20260328_235656_oqa_scheduling_however_all_tests" src="https://github.com/user-attachments/assets/b325faff-9fee-49fe-89d3-490b8796edc1" />

<img width="577" height="201" alt="Screenshot_20260328_235718_oqa_scheduling_popover" src="https://github.com/user-attachments/assets/b6447975-e5c0-4c87-99a9-f5c3df7d42f2" />

<img width="411" height="154" alt="Screenshot_20260328_235735_oqa_details_scheduling_info" src="https://github.com/user-attachments/assets/972e98ae-858a-480d-ada4-17f2d7456f0c" />


Related issue: https://progress.opensuse.org/issues/198647