### PR TITLE
chore(profiles): allow web UI to read loadavg

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -22,6 +22,7 @@
   /etc/openqa/templates/** r,
   /etc/mailname r,
   /etc/ssl/openssl.cnf r,
+  /proc/loadavg r,
   /proc/meminfo r,
   /tmp/** rwk,
   /usr/bin/bsdcat rix,


### PR DESCRIPTION
Needed for dynamic load limiting.

Related issue: https://progress.opensuse.org/issues/198770