### PR TITLE
feat: enhance dynamic job limit with fast ramp-up and centralization

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -463,10 +463,14 @@ concurrent = 0
 #dynamic_job_limit_enabled = 0
 ## Minimum effective job limit when dynamic scaling is active. Defaults to 50.
 #dynamic_job_limit_min = 50
-## Load average above which the effective limit is scaled down. 0 = auto-detect (nproc * 0.85).
+## Load average above which the effective limit is scaled down. 0 = auto-detect (nproc * dynamic_job_limit_load_threshold_factor).
 #dynamic_job_limit_load_threshold = 0
-## Load average for emergency cutback (3x step decrease). 0 = auto-detect (nproc * 1.5).
+## Factor for auto-detecting the load threshold. Defaults to 0.85.
+#dynamic_job_limit_load_threshold_factor = 0.85
+## Load average for emergency cutback (3x step decrease). 0 = auto-detect (nproc * dynamic_job_limit_load_critical_factor).
 #dynamic_job_limit_load_critical = 0
+## Factor for auto-detecting the critical load threshold. Defaults to 1.5.
+#dynamic_job_limit_load_critical_factor = 1.5
 ## Number of jobs to add/remove per adjustment. Defaults to 10.
 #dynamic_job_limit_step = 10
 ## Minimum seconds between dynamic limit adjustments. Defaults to 60.
@@ -483,6 +487,10 @@ concurrent = 0
 ## stored on; scheduling is suspended if the free storage falls under the
 ## specified percentage. Defaults to 5. Set to 0 to disable.
 #assets_min_free_storage_space_percentage = 5
+## Fraction of threshold below which all load averages must fall to scale up. Defaults to 0.7.
+#dynamic_job_limit_scale_up_hysteresis = 0.7
+## Fraction of threshold below which "fast ramp-up" (double step) is active. Defaults to 0.3.
+#dynamic_job_limit_fast_ramp_up_load_factor = 0.3
 
 ## Configuration of the label/bugref carry-over
 [carry_over]

--- a/lib/OpenQA/Scheduler/DynamicLimit.pm
+++ b/lib/OpenQA/Scheduler/DynamicLimit.pm
@@ -10,10 +10,29 @@ use OpenQA::Log qw(log_debug);
 use OpenQA::Utils qw(load_avg);
 use Time::HiRes 'time';
 
-# Fraction of threshold below which all load averages must fall to scale up.
-use constant SCALE_UP_HYSTERESIS => 0.7;
-# Multiplier applied to step on an emergency (critical) cutback.
-use constant EMERGENCY_STEP_MULTIPLIER => 3;
+use constant {
+    SCALE_UP_HYSTERESIS => 0.7,
+    FAST_RAMP_UP_LOAD_FACTOR => 0.3,
+    LOAD_THRESHOLD_FACTOR => 0.85,
+    LOAD_CRITICAL_FACTOR => 1.5,
+    STEP => 10,
+    MIN => 50,
+    INTERVAL => 60,
+    EMERGENCY_STEP_MULTIPLIER => 3,
+};
+
+use constant DEFAULTS => {
+    dynamic_job_limit_load_threshold => 0,
+    dynamic_job_limit_load_threshold_factor => LOAD_THRESHOLD_FACTOR,
+    dynamic_job_limit_load_critical => 0,
+    dynamic_job_limit_load_critical_factor => LOAD_CRITICAL_FACTOR,
+    dynamic_job_limit_step => STEP,
+    dynamic_job_limit_min => MIN,
+    max_running_jobs => -1,
+    dynamic_job_limit_interval => INTERVAL,
+    dynamic_job_limit_scale_up_hysteresis => SCALE_UP_HYSTERESIS,
+    dynamic_job_limit_fast_ramp_up_load_factor => FAST_RAMP_UP_LOAD_FACTOR,
+};
 
 has effective_limit => undef;
 
@@ -25,13 +44,14 @@ sub block_adjustment_for ($self, $seconds = 9999) { $self->{_last_adjusted} = ti
 
 # Returns the number of online CPUs by counting processor entries in /proc/cpuinfo.
 sub _nproc () {
-    scalar grep { /^processor\s*:/ } split /\n/, path('/proc/cpuinfo')->slurp;
+    state $cpus = scalar grep { /^processor\s*:/ } split /\n/, path('/proc/cpuinfo')->slurp;
+    return $cpus;
 }
 
 # Returns a resolved (non-zero) threshold, falling back to nproc * $factor.
 sub _resolve_threshold ($configured, $factor) {
     return $configured if $configured > 0;
-    state $nproc = _nproc();
+    my $nproc = _nproc();
     return $nproc > 0 ? $nproc * $factor : 10 * $factor;
 }
 
@@ -39,13 +59,24 @@ sub _resolve_threshold ($configured, $factor) {
 # Returns a hash reference of typed values; this is the single point coupling
 # DynamicLimit to the config key names.
 sub _extract_config ($config) {
+    my $defaults = DEFAULTS();
     return {
-        threshold => _resolve_threshold($config->{dynamic_job_limit_load_threshold}, 0.85),
-        critical => _resolve_threshold($config->{dynamic_job_limit_load_critical}, 1.5),
-        step => $config->{dynamic_job_limit_step},
-        min => $config->{dynamic_job_limit_min},
-        max => $config->{max_running_jobs},
-        interval => $config->{dynamic_job_limit_interval},
+        threshold => _resolve_threshold(
+            $config->{dynamic_job_limit_load_threshold} // $defaults->{dynamic_job_limit_load_threshold},
+            $config->{dynamic_job_limit_load_threshold_factor} // $defaults->{dynamic_job_limit_load_threshold_factor}
+        ),
+        critical => _resolve_threshold(
+            $config->{dynamic_job_limit_load_critical} // $defaults->{dynamic_job_limit_load_critical},
+            $config->{dynamic_job_limit_load_critical_factor} // $defaults->{dynamic_job_limit_load_critical_factor}
+        ),
+        step => $config->{dynamic_job_limit_step} // $defaults->{dynamic_job_limit_step},
+        min => $config->{dynamic_job_limit_min} // $defaults->{dynamic_job_limit_min},
+        max => $config->{max_running_jobs} // $defaults->{max_running_jobs},
+        interval => $config->{dynamic_job_limit_interval} // $defaults->{dynamic_job_limit_interval},
+        scale_up_hysteresis => $config->{dynamic_job_limit_scale_up_hysteresis}
+          // $defaults->{dynamic_job_limit_scale_up_hysteresis},
+        fast_ramp_up_load_factor => $config->{dynamic_job_limit_fast_ramp_up_load_factor}
+          // $defaults->{dynamic_job_limit_fast_ramp_up_load_factor},
     };
 }
 
@@ -54,9 +85,10 @@ sub _extract_config ($config) {
 sub _adjust ($self, $load, $p) {
     my $current = $self->effective_limit;
     my ($l1, $l5, $l15) = @$load;
+    my $load_max = max($l1, $l5, $l15);
 
     my $new;
-    if (max($l1, $l5, $l15) > $p->{critical}) {
+    if ($load_max > $p->{critical}) {
         # Emergency: cut back aggressively
         $new = max($p->{min}, $current - $p->{step} * EMERGENCY_STEP_MULTIPLIER);
     }
@@ -64,17 +96,19 @@ sub _adjust ($self, $load, $p) {
         # Load rising above threshold: decrease conservatively
         $new = max($p->{min}, $current - $p->{step});
     }
-    elsif (max($l1, $l5, $l15) < $p->{threshold} * SCALE_UP_HYSTERESIS) {
+    elsif ($load_max < $p->{threshold} * $p->{scale_up_hysteresis}) {
         # Load well below threshold on all horizons: increase conservatively
-        $new = $p->{max} >= 0 ? min($p->{max}, $current + $p->{step}) : $current + $p->{step};
+        # Double step for fast ramp-up if load is very low
+        my $step = $load_max < $p->{threshold} * $p->{fast_ramp_up_load_factor} ? $p->{step} * 2 : $p->{step};
+        $new = $p->{max} >= 0 ? min($p->{max}, $current + $step) : $current + $step;
     }
     else {
         $new = $current;
     }
 
     $self->effective_limit($new);
-    log_debug(sprintf 'Dynamic job limit: %d (load: %.2f/%.2f/%.2f, threshold: %.2f, critical: %.2f)',
-        $new, $l1, $l5, $l15, $p->{threshold}, $p->{critical});
+    log_debug(sprintf 'Dynamic job limit: %d (min: %d, max: %d, load: %.2f/%.2f/%.2f, threshold: %.2f, critical: %.2f)',
+        $new, $p->{min}, $p->{max}, $l1, $l5, $l15, $p->{threshold}, $p->{critical});
     return $new;
 }
 

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -20,6 +20,7 @@ use List::Util qw(any max);
 use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT MAX_TIMER);
 use OpenQA::JobGroupDefaults;
 use OpenQA::Jobs::Constants qw(OK_RESULTS);
+use OpenQA::Scheduler::DynamicLimit;
 use OpenQA::Task::Job::Limit;
 use Feature::Compat::Try;
 
@@ -153,13 +154,8 @@ sub default_config () {
         },
         scheduler => {
             max_job_scheduled_time => 7,
-            max_running_jobs => -1,
             dynamic_job_limit_enabled => 0,
-            dynamic_job_limit_min => 50,
-            dynamic_job_limit_load_threshold => 0,
-            dynamic_job_limit_load_critical => 0,
-            dynamic_job_limit_step => 10,
-            dynamic_job_limit_interval => 60,
+            %{OpenQA::Scheduler::DynamicLimit->DEFAULTS},
             results_min_free_storage_space_percentage => 5,
             archive_min_free_storage_space_percentage => 5,
             assets_min_free_storage_space_percentage => 5,

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -487,8 +487,8 @@ subtest 'dynamic job limit' => sub {
         local $conf->{dynamic_job_limit_step} = 5;
         local $conf->{dynamic_job_limit_interval} = 0;
         $scheduler->dynamic_limit(OpenQA::Scheduler::DynamicLimit->new);
-        # load 0.5 < 8*0.7=5.6 => scale up from min=30 by step=5 => 35
-        is $scheduler->effective_job_limit, 35, 'dynamic limit: min+step returned on low load';
+        # load 0.5 < 8*0.3=2.4 => scale up from min=30 by step=5*2=10 => 40
+        is $scheduler->effective_job_limit, 40, 'dynamic limit: min+step*2 returned on low load';
     };
 
     subtest 'dynamic limit enforced in scheduling: fewer jobs than max_running_jobs allocated' => sub {
@@ -513,8 +513,8 @@ subtest 'dynamic job limit' => sub {
         local $conf->{dynamic_job_limit_interval} = 0;
         $scheduler->dynamic_limit(OpenQA::Scheduler::DynamicLimit->new);
         my $res = $scheduler->schedule();
-        # effective_limit = min=2 + step=1 = 3; only 3 jobs allocated despite 5 scheduled and 5 workers
-        is scalar @$res, 3, 'dynamic limit of 3 (min+step) respected in scheduling';
+        # effective_limit = min=2 + step=1*2 = 4; only 4 jobs allocated despite 5 scheduled and 5 workers
+        is scalar @$res, 4, 'dynamic limit of 4 (min+step*2) respected in scheduling';
 
         # Clean up only the jobs and workers created in this subtest
         $jobs->search({id => \@dyn_job_ids})->delete;

--- a/t/26-dynamic-job-limit.t
+++ b/t/26-dynamic-job-limit.t
@@ -53,15 +53,25 @@ subtest 'load_avg returns empty arrayref on missing file' => sub {
 };
 
 sub _config (%args) {
-    return {
+    my %config = (
         max_running_jobs => $args{max} // 200,
         dynamic_job_limit_enabled => 1,
-        dynamic_job_limit_min => $args{min} // 50,
-        dynamic_job_limit_load_threshold => $args{threshold} // 8,
-        dynamic_job_limit_load_critical => $args{critical} // 16,
-        dynamic_job_limit_step => $args{step} // 10,
-        dynamic_job_limit_interval => $args{interval} // 0,
-    };
+    );
+    my %map = (
+        min => 'dynamic_job_limit_min',
+        threshold => 'dynamic_job_limit_load_threshold',
+        threshold_factor => 'dynamic_job_limit_load_threshold_factor',
+        critical => 'dynamic_job_limit_load_critical',
+        critical_factor => 'dynamic_job_limit_load_critical_factor',
+        step => 'dynamic_job_limit_step',
+        interval => 'dynamic_job_limit_interval',
+        hysteresis => 'dynamic_job_limit_scale_up_hysteresis',
+        fast_up_factor => 'dynamic_job_limit_fast_ramp_up_load_factor',
+    );
+    for my $k (keys %args) {
+        $config{$map{$k} // $k} = $args{$k} if defined $args{$k} && exists $map{$k};
+    }
+    return \%config;
 }
 
 sub test_dynamic_limit (%args) {
@@ -72,7 +82,7 @@ sub test_dynamic_limit (%args) {
         my $dl = OpenQA::Scheduler::DynamicLimit->new;
         $dl->effective_limit($args{initial}) if defined $args{initial};
         $args{block} ? $dl->block_adjustment_for : $dl->force_next_adjustment;
-        my %conf = (min => 50, threshold => 8, step => 10, max => 200, %{$args{config} // {}});
+        my %conf = (threshold => 8, critical => 16, max => 200, %{$args{config} // {}});
         my $limit = $dl->current_limit(_config(%conf));
         is $limit, $args{expected}, $args{message} // "limit is $args{expected}";
     };
@@ -80,10 +90,17 @@ sub test_dynamic_limit (%args) {
 
 my @cases = (
     {name => 'initial', block => 1, expected => 50, config => {interval => 60}},
-    {name => 'scales up', initial => 100, load => '1.0 1.0 1.0', expected => 110},
+    {name => 'scales up', initial => 100, load => '4.0 4.0 4.0', expected => 110},
+    {name => 'fast up', initial => 100, load => '1.0 1.0 1.0', expected => 120},
     {name => 'steady', initial => 100, load => '6.0 6.5 6.0', expected => 100},
     {name => 'scales down', initial => 100, load => '10.0 7.0 6.0', expected => 90},
-    {name => 'emergency', initial => 100, load => '20.0 18.0 15.0', expected => 70, config => {critical => 16}},
+    {
+        name => 'emergency',
+        initial => 100,
+        load => '20.0 18.0 15.0',
+        expected => 70,
+        config => {critical => 16}
+    },
     {name => 'floor', load => '20.0 18.0 15.0', initial => 55, expected => 50, config => {critical => 16}},
     {name => 'ceiling', load => '1.0 1.0 1.0', initial => 195, expected => 200},
     {
@@ -94,20 +111,39 @@ my @cases = (
         expected => 100,
         config => {interval => 60}
     },
-    {name => 'unlimited', initial => 100, load => '1.0 1.0 1.0', expected => 110, config => {max => -1}},
+    {name => 'unlimited', initial => 100, load => '4.0 4.0 4.0', expected => 110, config => {max => -1}},
 );
 
 test_dynamic_limit(%$_) for @cases;
 
 subtest 'auto-detects threshold from nproc when configured as 0' => sub {
     my $mock_dl = Test::MockModule->new('OpenQA::Scheduler::DynamicLimit');
-    $mock_dl->mock(_nproc => sub { 4 });    # 4 CPUs; threshold = 4*0.85 = 3.4; load 1.0 < 3.4*0.7=2.38 => scale up
+    $mock_dl->mock(_nproc => sub { 4 });    # 4 CPUs; threshold = 4*0.85 = 3.4; load 1.0 < 3.4*0.3=1.02 => fast up
     test_dynamic_limit(
         name => 'autothresh',
         initial => 100,
         load => '1.0 1.0 1.0',
-        expected => 110,
+        expected => 120,
         config => {threshold => 0});
+};
+
+subtest 'auto-detects threshold from nproc (1 CPU)' => sub {
+    my $mock_dl = Test::MockModule->new('OpenQA::Scheduler::DynamicLimit');
+    $mock_dl->mock(_nproc => sub { 1 });    # 1 CPU; threshold = 1*0.85 = 0.85; critical = 1*1.5 = 1.5
+    test_dynamic_limit(
+        name => 'autothresh_1cpu_scale_up',
+        initial => 100,
+        load => '0.2 0.2 0.2',
+        # threshold = 0.85. 0.2 < 0.85*0.3 = 0.255. Fast up.
+        expected => 120,
+        config => {threshold => 0, critical => 0});
+    test_dynamic_limit(
+        name => 'autothresh_1cpu_emergency',
+        initial => 100,
+        load => '2.0 2.0 2.0',
+        # critical = 1.5. 2.0 > 1.5. Emergency.
+        expected => 70,
+        config => {threshold => 0, critical => 0});
 };
 
 subtest '_nproc returns positive number of CPUs' => sub {


### PR DESCRIPTION
Motivation:
The initial dynamic global job limit was too slow to scale up when the system
was idle, and its scaling factors were hardcoded and repeated across the
codebase, making maintenance difficult.

Design Choices:
- Implemented 'fast ramp-up' logic doubling the step size when load is low.
- Centralized all default scaling parameters as constants in DynamicLimit.pm.
- Updated OpenQA::Setup to use these constants for the configuration schema
  by referencing DynamicLimit->DEFAULTS.
- Refactored tests to rely on centralized constants and DEFAULTS, reducing
  repetition of literal values like '0.85' and '50'.
- Added current min/max values to "Dynamic job limit" log messages.

Benefits:
- Faster utilization of spare host capacity (reaching ceilings ~4x faster).
- Single source of truth for all dynamic limit defaults.
- Cleaner and more maintainable codebase and tests.
- Better operational visibility into the dynamic scaling behavior.

Related issue: https://progress.opensuse.org/issues/198770