### PR TITLE
fix: only report job limit in UI when globally reached

### DIFF
--- a/lib/OpenQA/Scheduler/DynamicLimit.pm
+++ b/lib/OpenQA/Scheduler/DynamicLimit.pm
@@ -60,23 +60,18 @@ sub _resolve_threshold ($configured, $factor) {
 # DynamicLimit to the config key names.
 sub _extract_config ($config) {
     my $defaults = DEFAULTS();
+    my %cfg = map { $_ => $config->{$_} // $defaults->{$_} } keys %$defaults;
     return {
-        threshold => _resolve_threshold(
-            $config->{dynamic_job_limit_load_threshold} // $defaults->{dynamic_job_limit_load_threshold},
-            $config->{dynamic_job_limit_load_threshold_factor} // $defaults->{dynamic_job_limit_load_threshold_factor}
-        ),
-        critical => _resolve_threshold(
-            $config->{dynamic_job_limit_load_critical} // $defaults->{dynamic_job_limit_load_critical},
-            $config->{dynamic_job_limit_load_critical_factor} // $defaults->{dynamic_job_limit_load_critical_factor}
-        ),
-        step => $config->{dynamic_job_limit_step} // $defaults->{dynamic_job_limit_step},
-        min => $config->{dynamic_job_limit_min} // $defaults->{dynamic_job_limit_min},
-        max => $config->{max_running_jobs} // $defaults->{max_running_jobs},
-        interval => $config->{dynamic_job_limit_interval} // $defaults->{dynamic_job_limit_interval},
-        scale_up_hysteresis => $config->{dynamic_job_limit_scale_up_hysteresis}
-          // $defaults->{dynamic_job_limit_scale_up_hysteresis},
-        fast_ramp_up_load_factor => $config->{dynamic_job_limit_fast_ramp_up_load_factor}
-          // $defaults->{dynamic_job_limit_fast_ramp_up_load_factor},
+        threshold =>
+          _resolve_threshold($cfg{dynamic_job_limit_load_threshold}, $cfg{dynamic_job_limit_load_threshold_factor}),
+        critical =>
+          _resolve_threshold($cfg{dynamic_job_limit_load_critical}, $cfg{dynamic_job_limit_load_critical_factor}),
+        step => $cfg{dynamic_job_limit_step},
+        min => $cfg{dynamic_job_limit_min},
+        max => $cfg{max_running_jobs},
+        interval => $cfg{dynamic_job_limit_interval},
+        scale_up_hysteresis => $cfg{dynamic_job_limit_scale_up_hysteresis},
+        fast_ramp_up_load_factor => $cfg{dynamic_job_limit_fast_ramp_up_load_factor},
     };
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -343,14 +343,26 @@ sub list_running_ajax ($self) {
         $job_data;
     } @jobs;
     my %response = (data => \@running);
-    my $config = OpenQA::App->singleton->config->{scheduler};
+    my $app = OpenQA::App->singleton;
+    my $config = $app->config->{scheduler};
     my $max_running = $config->{max_running_jobs};
+    my $has_filters
+      = $self->get_match_param
+      || $self->param('comment')
+      || $self->param('groupid')
+      || %{$self->every_key_value_param('job_setting')};
+    my $global_running
+      = $has_filters
+      ? $self->schema->resultset('Jobs')->count({state => [OpenQA::Jobs::Constants::EXECUTION_STATES]})
+      : scalar @jobs;
     if ($config->{dynamic_job_limit_enabled}) {
-        my $effective = OpenQA::App->singleton->dynamic_limit->current_limit($config);
-        $response{dynamic_job_limit} = $effective if $effective >= 0 && @running >= $effective;
-        $response{max_running_jobs} = $max_running if $max_running >= 0;
+        my $effective = $app->dynamic_limit->current_limit($config);
+        if ($effective >= 0 && $global_running >= $effective) {
+            $response{dynamic_job_limit} = $effective;
+            $response{max_running_jobs} = $max_running if $max_running >= 0;
+        }
     }
-    elsif ($max_running >= 0 && @running >= $max_running) {
+    elsif ($max_running >= 0 && $global_running >= $max_running) {
         $response{max_running_jobs} = $max_running;
     }
     $self->render(json => \%response);

--- a/t/26-dynamic-job-limit.t
+++ b/t/26-dynamic-job-limit.t
@@ -116,7 +116,7 @@ my @cases = (
 
 test_dynamic_limit(%$_) for @cases;
 
-subtest 'auto-detects threshold from nproc when configured as 0' => sub {
+subtest 'auto-detect threshold (nproc * factor) and fast ramp-up' => sub {
     my $mock_dl = Test::MockModule->new('OpenQA::Scheduler::DynamicLimit');
     $mock_dl->mock(_nproc => sub { 4 });    # 4 CPUs; threshold = 4*0.85 = 3.4; load 1.0 < 3.4*0.3=1.02 => fast up
     test_dynamic_limit(

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -210,16 +210,57 @@ $t->content_like(qr/State.*running/, 'Running jobs are marked');
 
 $t->get_ok('/tests/list_running_ajax')->status_is(200);
 
+my $app = OpenQA::App->singleton;
+my $scheduler_config = $app->config->{scheduler};
+
 subtest 'running jobs list with static limit' => sub {
-    local OpenQA::App->singleton->config->{scheduler}->{dynamic_job_limit_enabled} = 0;
-    local OpenQA::App->singleton->config->{scheduler}->{max_running_jobs} = 2;
+    local $scheduler_config->{dynamic_job_limit_enabled} = 0;
+    local $scheduler_config->{max_running_jobs} = 2;
     $t->get_ok('/tests/list_running_ajax')->status_is(200);
     my $json = $t->tx->res->json;
     is $json->{max_running_jobs}, 2, 'max_running_jobs included in response when static limit reached';
 };
 
+subtest 'running jobs list limit info based on global count' => sub {
+    my $dl = $app->dynamic_limit;
+
+    local $scheduler_config->{dynamic_job_limit_enabled} = 1;
+    local $scheduler_config->{dynamic_job_limit_min} = 3;
+    local $scheduler_config->{max_running_jobs} = 10;
+    local $scheduler_config->{dynamic_job_limit_load_threshold} = 100;
+    $dl->effective_limit(3);
+    $dl->block_adjustment_for(9999);
+
+    # Global count is 3 (99961, 99963, 99970). Filter by groupid=1001 (99963).
+    $t->get_ok('/tests/list_running_ajax?groupid=1001')->status_is(200);
+    my $json = $t->tx->res->json;
+    is scalar @{$json->{data}}, 1, 'only one job matches filter (group 1001)';
+    is $json->{dynamic_job_limit}, 3,
+      'dynamic_job_limit included based on global count even when filtered list is smaller';
+
+    # Global count (3) is below limit (4).
+    local $scheduler_config->{dynamic_job_limit_min} = 4;
+    $dl->effective_limit(4);
+    $t->get_ok('/tests/list_running_ajax')->status_is(200);
+    $json = $t->tx->res->json;
+    ok !exists $json->{dynamic_job_limit}, 'dynamic_job_limit omitted when global count is below limit';
+    ok !exists $json->{max_running_jobs},
+      'max_running_jobs omitted when below dynamic limit to avoid misleading "limited by server config"';
+
+    subtest 'static limit behavior when dynamic limit is disabled' => sub {
+        local $scheduler_config->{dynamic_job_limit_enabled} = 0;
+        local $scheduler_config->{max_running_jobs} = 3;
+        $t->get_ok('/tests/list_running_ajax')->status_is(200);
+        is $t->tx->res->json->{max_running_jobs}, 3, 'max_running_jobs included when reached';
+
+        local $scheduler_config->{max_running_jobs} = 4;
+        $t->get_ok('/tests/list_running_ajax')->status_is(200);
+        ok !exists $t->tx->res->json->{max_running_jobs}, 'max_running_jobs omitted when below limit';
+    };
+};
+
 subtest 'all tests server-side limit has precedence over user-specified limit' => sub {
-    my $limits = OpenQA::App->singleton->config->{misc_limits};
+    my $limits = $app->config->{misc_limits};
     $limits->{all_tests_max_finished_jobs} = 5;    # set low low maximum limit
     $limits->{all_tests_default_finished_jobs} = 2;    # set low default limit
 


### PR DESCRIPTION
Motivation:
The /tests page often displayed "(limited by server config)" even when far
below the actual limit. This happened because the backend was reporting the
limit based on filtered job counts rather than global counts, and was
unconditionally sending the static limit parameter when dynamic limits were
enabled.

Design Choices:
- Updated list_running_ajax to calculate the global count of running jobs.
- Only include dynamic_job_limit or max_running_jobs in the API response when
  the global count actually reaches or exceeds the respective limit.
- Deduplicated configuration extraction in DynamicLimit.pm by mapping over
  the DEFAULTS hash.
- Refactored t/ui/01-list.t to reduce repetition of the scheduler config path
  by using a shared $scheduler_config variable.
- Improved test description strings in t/ui/01-list.t and
  t/26-dynamic-job-limit.t to be self-explanatory, eliminating the need for
  in-file comments.
- Added comprehensive subtests to verify limit reporting behavior with
  filters and both dynamic/static configurations.

Benefits:
- Eliminates misleading "limited by server config" messages.
- Provides accurate server-wide limit status to users even in filtered views.
- Cleaner and more maintainable test and implementation code.

Related issue: https://progress.opensuse.org/issues/198770