### PR TITLE
fix: Apply force result label correctly if `force_result_regex` is empty

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -103,9 +103,9 @@
 ## The maximum amount of times a job will be restarted if the auto_clone_regex matches
 #auto_clone_limit = 20
 
-## A regex pattern that a "force_result" label description in job comments
-## must match to be accepted. If undefined and by default no rules are applied
-## and no description is expected
+## A regex pattern that a "force_result" label description in job comments must
+## match to be applied. If empty (the default), all "force_result" labels are
+## applied.
 #force_result_regex =
 
 ## Job results to collapse by default as parallel children on the test result

--- a/lib/OpenQA/Schema/Result/Comments.pm
+++ b/lib/OpenQA/Schema/Result/Comments.pm
@@ -199,7 +199,7 @@ sub _control_job_result ($self, $c) {
     die "force_result labels only allowed for operators\n" if $c && !$c->is_operator;
     my $force_result_re = OpenQA::App->singleton->config->{global}->{force_result_regex} // '';
     die "force_result description '$description' does not match pattern '$force_result_re'\n"
-      unless ($description // '') =~ /$force_result_re/;
+      if $force_result_re && (($description // '') !~ /$force_result_re/);
     my $job = $self->job;
     die "force_result only allowed on finished jobs\n"
       unless OpenQA::Jobs::Constants::meta_state($job->state) eq OpenQA::Jobs::Constants::FINAL;

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -138,7 +138,7 @@ $schema->txn_rollback;
 $schema->txn_begin;
 
 subtest 'failed->failed flag:carryover comments are carried over' => sub {
-    my $comment_text = 'flag:carryover label:force_result:softfailed:bsc#1257825';
+    my $comment_text = "flag:carryover label:force_result:softfailed:bsc#1257825\nAutomatic carryover";
     $t->post_ok("/api/v1/jobs/$old_job/comments", $auth => form => {text => $comment_text})->status_is(200);
     $t->post_ok("/api/v1/jobs/$job/set_done", $auth => form => {result => FAILED})->status_is(200);
     my @comments_new = @{comments("/tests/$job")};

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -138,10 +138,13 @@ $schema->txn_rollback;
 $schema->txn_begin;
 
 subtest 'failed->failed flag:carryover comments are carried over' => sub {
-    $t->post_ok("/api/v1/jobs/$old_job/comments", $auth => form => {text => 'flag:carryover'})->status_is(200);
-    $t->post_ok("/api/v1/jobs/$job/set_done", $auth => form => {result => 'failed'})->status_is(200);
+    my $comment_text = 'flag:carryover label:force_result:softfailed:bsc#1257825';
+    $t->post_ok("/api/v1/jobs/$old_job/comments", $auth => form => {text => $comment_text})->status_is(200);
+    $t->post_ok("/api/v1/jobs/$job/set_done", $auth => form => {result => FAILED})->status_is(200);
     my @comments_new = @{comments("/tests/$job")};
-    like join('', @comments_new), qr(flag:carryover), 'Comment with flag:carryover present in new job';
+    my $expected_text = qr(flag:carryover.*label:force_result:softfailed);
+    like join('', @comments_new), $expected_text, 'Comment with flag:carryover present in new job';
+    is $jobs->find($job)->result, SOFTFAILED, 'force_result label from carried over comment is applied';
 };
 
 # Reset to a clean state


### PR DESCRIPTION
This seems to work as-is. I also temporarily removed the code responsible for this in `sub carry_over_bugrefs` which caused the newly added checks to fail.

Related ticket: https://progress.opensuse.org/issues/199124