### PR TITLE
fix: Calculate upload speed correctly by including milliseconds

### DIFF
--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -25,7 +25,7 @@ use Mojo::File 'path';
 use Scalar::Util 'looks_like_number';
 use File::Map 'map_file';
 use List::Util 'max';
-use Time::HiRes qw(usleep);
+use Time::HiRes qw(time usleep);
 use Feature::Compat::Try;
 
 use constant DEFAULT_UPLOAD_CHUNK_SIZE => 1_000_000;
@@ -1001,7 +1001,7 @@ sub _upload_asset ($self, $upload_parameter) {
         'upload_chunk.finish' => sub ($upload, $piece) {
             my $index = $piece->index;
             my $total = $piece->total;
-            my $spent = (time() - $t_start) || 1;
+            my $spent = (time - $t_start) || 1;
             my $kbytes = ($piece->end - $piece->start) / 1024;
             my $speed = sprintf '%.3f', $kbytes / $spent;
             my $show_in_autoinst_log = $index % 10 == 0 || $piece->is_last;


### PR DESCRIPTION
I was always wondering why the upload in the worker log always showed the exact same number (except the last, smaller chunk):

    [info] ....qcow2: Processing chunk 681/709, avg. speed ~4882.812 KiB/s
    [info] ....qcow2: Processing chunk 682/709, avg. speed ~4882.812 KiB/s
    ...

When I experimented with UPLOAD_CHUNK_SIZE, it got even weirder. The Number simply increased to 5 times, when I multiplied the chunk size by 5.

It all makes sense considering that `time` normally just returns an integer. Then `time - $t_start` is almost always 0 or 1, so `$spent` would be always 1.

With Time::HiRes::time() we now get seconds with fractions. We should see much more realistic numbers now.