### PR TITLE
feat: faster comment_data_for_jobs

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -206,7 +206,7 @@ sub compute_build_results ($group, $limit, $time_limit_days, $tags, $subgroup_fi
             $seen{$key}++ ? () : $_;
         } @all_jobs;
         next unless @jobs;
-        my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs(\@jobs);
+        my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs($jobs);
         for my $job (@jobs) {
             $jr{distris}->{$job->DISTRI} = 1;
             if ($newest) {

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -99,8 +99,9 @@ if you need the Bug objects themselves.
 =cut
 
 sub comment_data_for_jobs ($self, $jobs, $args = {}) {
-    my @job_ids = map { $_->id } ref $jobs eq 'ARRAY' ? @$jobs : $jobs->all;
-    my $comments = $self->search({job_id => {in => \@job_ids}}, {order_by => 'me.id', select => [qw(text job_id)]});
+    my $job_id_clause = ref $jobs eq 'ARRAY' ? [map { $_->id } @$jobs] : $jobs->get_column('id')->as_query;
+    my %args = (order_by => 'me.id', select => [qw(text job_id)]);
+    my $comments = $self->search({job_id => {in => $job_id_clause}}, \%args);
     my $bugs = $self->result_source->schema->resultset('Bugs');
 
     my (%res, %bugdetails);


### PR DESCRIPTION
Most of the time spent in the dashboard calculation was due to passing thousands of IDs as `WHERE ID IN ($1, $2, $3, ...., $33567)`.

If $jobs is a result set, it's much faster to use the source query directly
instead of fetching all ids and passing them individually.

There is a theoretical change in behaviour: If the database changes in
between the jobs and comments queries, it may now miss comments for jobs
that no longer match the query.

This improves performance noticably:

Before:
```
> time curl -s http://fussheizung/dashboard_build_results?group=Investigation >/dev/null

real    0m29,465s
user    0m0,005s
sys     0m0,008s
```

After:

```
> time curl -s http://fussheizung/dashboard_build_results?group=Investigation >/dev/null

real    0m7,773s
user    0m0,008s
sys     0m0,002s
```