### PR TITLE
feat: Prevent job assignments when running out of space by default

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -462,8 +462,8 @@ concurrent = 0
 #dynamic_job_limit_interval = 60
 ## Minimum percentage of free storage in the file system where job results are
 ## regularly stored on; scheduling is suspended if the free storage falls under
-## the specified percentage. Defaults to 0 which disables this check.
-#results_min_free_storage_space_percentage = 0
+## the specified percentage. Defaults to 5. Set to 0 to disable.
+#results_min_free_storage_space_percentage = 5
 
 ## Configuration of the label/bugref carry-over
 [carry_over]

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -159,6 +159,7 @@ sub default_config () {
             dynamic_job_limit_load_critical => 0,
             dynamic_job_limit_step => 10,
             dynamic_job_limit_interval => 60,
+            results_min_free_storage_space_percentage => 0,
         },
         logging => {
             level => undef,

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -159,7 +159,7 @@ sub default_config () {
             dynamic_job_limit_load_critical => 0,
             dynamic_job_limit_step => 10,
             dynamic_job_limit_interval => 60,
-            results_min_free_storage_space_percentage => 0,
+            results_min_free_storage_space_percentage => 5,
         },
         logging => {
             level => undef,
@@ -322,7 +322,12 @@ sub read_config ($app) {
     my $defaults = default_config();
 
     # in development and test mode we use fake auth and log to stderr
-    my %devel_and_test_defaults = (auth => {method => 'Fake'}, logging => {file => undef, level => 'debug'});
+    my %devel_and_test_defaults = (
+        auth => {method => 'Fake'},
+        logging => {file => undef, level => 'debug'},
+        # disable results_…_percentage for consistent results despite possibly limited storage in test env
+        scheduler => {results_min_free_storage_space_percentage => 0},
+    );
     my %mode_defaults = (development => \%devel_and_test_defaults, test => \%devel_and_test_defaults);
 
     my $config = _load_config($app, $defaults, \%mode_defaults);

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -935,7 +935,7 @@ sub load_avg ($path = $ENV{OPENQA_LOAD_AVG_FILE} // '/proc/loadavg') {
 
 sub results_storage_below_threshold () {
     my $percentage = OpenQA::App->singleton->config->{scheduler}->{results_min_free_storage_space_percentage};
-    return 0 unless defined $percentage;
+    return 0 unless $percentage;
     return 1 if $percentage == 100;
 
     my ($available_bytes, $total_bytes);

--- a/t/config.t
+++ b/t/config.t
@@ -52,6 +52,7 @@ subtest 'Test configuration default modes' => sub {
       = ' .status:not(.result_passed):not(.result_softfailed)';
     $test_config->{auth}->{method} = 'Fake';
     $test_config->{minion_task_triggers}->{on_job_done} = [];
+    $test_config->{scheduler}->{results_min_free_storage_space_percentage} = 0;
     for my $l ($test_config->{default_group_limits}, $test_config->{no_group_limits}) {
         $l->{result_storage_duration} = OpenQA::JobGroupDefaults::KEEP_RESULTS_IN_DAYS;
         $l->{important_result_storage_duration} = OpenQA::JobGroupDefaults::KEEP_IMPORTANT_RESULTS_IN_DAYS;
@@ -93,6 +94,7 @@ subtest 'Test configuration default modes' => sub {
     $test_config->{_openid_secret} = $config->{_openid_secret};
     $test_config->{auth}->{method} = 'OpenID';
     $test_config->{global}->{service_port_delta} = 2;
+    $test_config->{scheduler}->{results_min_free_storage_space_percentage} = 5;
     delete $config->{global}->{auto_clone_regex};
     delete $config->{'test_preset example'};
     delete $test_config->{logging};


### PR DESCRIPTION
Set a low default value of 5 % for `results_min_free_storage_space_percentage`. We usually set higher thresholds for cleanup and alerting so 5 % makes sense for this measure which should only be the *last* measure to prevent incomplete jobs and running completely out of storage space.

Related ticket: https://progress.opensuse.org/issues/198848