### PR TITLE
fix: address remaining XSS vulnerabilities using safe DOM APIs

### DIFF
--- a/assets/javascripts/create_tests.js
+++ b/assets/javascripts/create_tests.js
@@ -54,7 +54,14 @@ function createTests(form) {
     success: function (response) {
       const id = response.scheduled_product_id;
       const url = `${form.dataset.productlogUrl}?id=${id}`;
-      addFlash('info', `Tests have been scheduled, checkout the <a href="${url}">product log</a> for details.`);
+      addFlash(
+        'info',
+        createElement('span', [
+          'Tests have been scheduled, checkout the ',
+          createElement('a', ['product log'], {href: url}),
+          ' for details.'
+        ])
+      );
     },
     error: function (xhr, ajaxOptions, thrownError) {
       addFlash('danger', 'Unable to create tests: ' + (xhr.responseJSON?.error ?? xhr.responseText ?? thrownError));

--- a/assets/javascripts/job_templates.js
+++ b/assets/javascripts/job_templates.js
@@ -502,7 +502,11 @@ function submitTemplateEditor(button) {
 function showSubmitResults(form, result) {
   form.find('.buttons').show();
   form.find('.properties-progress-indication').hide();
-  form.find('.properties-status').html(result);
+  const statusElement = form.find('.properties-status')[0];
+  if (statusElement) {
+    statusElement.textContent = '';
+    statusElement.appendChild(result);
+  }
 }
 
 // adds/removes "is-invalid"/"invalid-feedback" classes/elements within the specified form for the specified response
@@ -590,17 +594,28 @@ function submitProperties(form) {
       if (overallError) {
         showSubmitResults(
           editorForm,
-          `<i class="fa-solid fa-circle-exclamation"></i> Unable to apply changes: <strong>${overallError}</strong>`
+          createElement('span', [
+            createElement('i', [], {class: 'fa-solid fa-circle-exclamation'}),
+            ' Unable to apply changes: ',
+            createElement('strong', [overallError])
+          ])
         );
         return;
       }
       if (!response.ok) throw `Server returned ${response.status}: ${response.statusText}`;
       const warnings = json?.warnings_by_field;
-      const remark =
-        typeof warnings === 'object' && Object.keys(warnings).length > 0
-          ? ', but <strong>there are warnings</strong> (see highlighted fields)'
-          : '';
-      showSubmitResults(editorForm, `<i class="fa-solid fa-floppy-disk"></i> Changes applied${remark}`);
+      const hasWarnings = typeof warnings === 'object' && Object.keys(warnings).length > 0;
+      const remark = hasWarnings
+        ? [', but ', createElement('strong', ['there are warnings']), ' (see highlighted fields)']
+        : [];
+      showSubmitResults(
+        editorForm,
+        createElement('span', [
+          createElement('i', [], {class: 'fa-solid fa-floppy-disk'}),
+          ' Changes applied',
+          ...remark
+        ])
+      );
 
       // show new name
       const newJobName = $('#editor-name').val();
@@ -615,7 +630,11 @@ function submitProperties(form) {
     .catch(error => {
       showSubmitResults(
         editorForm,
-        `<i class="fa-solid fa-circle-exclamation"></i> Unable to apply changes: <strong>${error}</strong>`
+        createElement('span', [
+          createElement('i', [], {class: 'fa-solid fa-circle-exclamation'}),
+          ' Unable to apply changes: ',
+          createElement('strong', [error])
+        ])
       );
     })
     .finally(() => {

--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -481,7 +481,16 @@ function saveNeedle(overwrite) {
     errors.push('No areas defined.');
   }
   if (errors.length) {
-    addFlash('danger', '<strong>Unable to save needle:</strong><ul><li>' + errors.join('</li><li>') + '</li></ul>');
+    addFlash(
+      'danger',
+      createElement('span', [
+        createElement('strong', ['Unable to save needle:']),
+        createElement(
+          'ul',
+          errors.map(e => createElement('li', [e]))
+        )
+      ])
+    );
     return false;
   }
 

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -35,22 +35,52 @@ function fetchWithCSRF(resource, options) {
   return window.fetch(resource, options);
 }
 
+function createElement(tag, content = [], attrs = {}, options = {}) {
+  const elem = document.createElement(tag);
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value !== undefined) {
+      elem.setAttribute(key, value);
+    }
+  }
+
+  elem.append(...content);
+  if (options.preWrap) {
+    elem.style.whiteSpace = 'pre-wrap';
+  }
+  return elem;
+}
+
 function makeFlashElement(text) {
-  return typeof text === 'string' ? '<span>' + text + '</span>' : text;
+  return typeof text === 'string' ? createElement('span', [text]) : text;
 }
 
 function addFlash(status, text, container, method = 'append') {
   // add flash messages by default on top of the page
-  if (!container) {
-    container = $('#flash-messages');
-  }
+  const flashContainer =
+    container instanceof jQuery ? container[0] : container || document.getElementById('flash-messages');
 
-  const div = $('<div class="alert alert-primary alert-dismissible fade show" role="alert"></div>');
-  div.append(makeFlashElement(text));
-  div.append('<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>');
-  div.addClass('alert-' + status);
-  container[method](div);
-  return div;
+  const div = createElement(
+    'div',
+    [
+      makeFlashElement(text),
+      createElement('button', [], {
+        type: 'button',
+        class: 'btn-close',
+        'data-bs-dismiss': 'alert',
+        'aria-label': 'Close'
+      })
+    ],
+    {
+      class: `alert alert-${status} alert-dismissible fade show`,
+      role: 'alert'
+    }
+  );
+
+  const target = method === 'prepend' && flashContainer.firstChild ? flashContainer.firstChild : null;
+  flashContainer.insertBefore(div, target);
+
+  return $(div);
 }
 
 function addUniqueFlash(status, id, text, container, method = 'append') {
@@ -175,7 +205,7 @@ function renderList(items) {
   const ul = document.createElement('ul');
   items.forEach(function (item) {
     const li = document.createElement('li');
-    li.innerHTML = item;
+    li.textContent = item;
     li.style.whiteSpace = 'pre-wrap';
     ul.appendChild(li);
   });
@@ -246,13 +276,10 @@ function restartJob(ajaxUrl, jobIds, comment) {
     jobIds = [jobIds];
   }
   const showError = function (reason) {
-    let errorMessage = '<strong>Unable to restart job';
-    if (reason) {
-      errorMessage += ':</strong> ' + reason;
-    } else {
-      errorMessage += '.</strong>';
-    }
-    addFlash('danger', errorMessage);
+    addFlash(
+      'danger',
+      createElement('span', [createElement('strong', ['Unable to restart job']), reason ? `: ${reason}` : '.'])
+    );
   };
   const body = new FormData();
   if (comment !== undefined) {
@@ -300,7 +327,11 @@ function restartJob(ajaxUrl, jobIds, comment) {
         if (Array.isArray(newJobUrl)) {
           addFlash(
             'info',
-            'The jobs have been restarted. <a href="javascript: location.reload()">Reload</a> the page to show changes.'
+            createElement('span', [
+              'The jobs have been restarted. ',
+              createElement('a', ['Reload'], {href: 'javascript: location.reload()'}),
+              ' the page to show changes.'
+            ])
           );
         } else {
           window.location.replace(newJobUrl);

--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -133,7 +133,7 @@ function setupOverview(options) {
   });
   $('.restart').bind('ajax:success', function (event, xhr, status) {
     if (typeof xhr !== 'object' || !Array.isArray(xhr.result)) {
-      addFlash('danger', '<strong>Unable to restart job.</strong>');
+      addFlash('danger', createElement('span', [createElement('strong', ['Unable to restart job.'])]));
       return;
     }
     showJobRestartResults(xhr, undefined, forceJobRestartViaRestartLink.bind(undefined, event.currentTarget));

--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -1,21 +1,5 @@
 // jshint esversion: 9
 
-function createElement(tag, content = [], attrs = {}, options = {}) {
-  const elem = document.createElement(tag);
-
-  for (const [key, value] of Object.entries(attrs)) {
-    if (value !== undefined) {
-      elem.setAttribute(key, value);
-    }
-  }
-
-  elem.append(...content);
-  if (options.preWrap) {
-    elem.style.whiteSpace = 'pre-wrap';
-  }
-  return elem;
-}
-
 function renderTemplate(template, args = {}) {
   if (!template) {
     return '';

--- a/assets/javascripts/tests.js
+++ b/assets/javascripts/tests.js
@@ -475,7 +475,7 @@ function setupTestButtons() {
       const responseJSON = xhr.responseJSON;
       const flashTarget = $('#flash-messages-finished-jobs');
       if (typeof responseJSON !== 'object' || !Array.isArray(responseJSON.test_url)) {
-        addFlash('danger', '<strong>Unable to restart job.</strong>', flashTarget);
+        addFlash('danger', createElement('span', [createElement('strong', ['Unable to restart job.'])]), flashTarget);
         return;
       }
       showJobRestartResults(

--- a/assets/javascripts/ws_console.js
+++ b/assets/javascripts/ws_console.js
@@ -17,7 +17,7 @@ function sendAndLogCommand(ws, command) {
 }
 
 function logStatus(msg) {
-  document.logElement.append('status: ' + msg + '\n');
+  document.logElement.append(document.createTextNode('status: ' + msg + '\n'));
   followLog();
 }
 


### PR DESCRIPTION
Motivation:
CodeQL identified cross-site scripting (XSS) vulnerabilities where
untrusted exception messages and server responses were rendered as HTML.
The previous approach of manually escaping at every call site was
error-prone and hard to maintain.

Design Choices:
1.  Moved the `createElement` helper to `openqa.js` to make it globally
    available for safe UI construction.
2.  Refactored `makeFlashElement` to use `textContent` by default for
    strings, ensuring all text passed to `addFlash` is safely escaped.
3.  Updated `addFlash` to accept both safe strings and DOM elements,
    providing a concise but secure API for callers.
4.  Refactored `job_templates.js`, `tests.js`, `overview.js`,
    `needleeditor.js`, and `create_tests.js` to use the `createElement`
    helper instead of interpolated HTML strings for status messages.
5.  Removed redundant `htmlEscape` calls where standard DOM APIs now
    handle the escaping implicitly.

Benefits:
-   Eliminates XSS vulnerabilities by securing the underlying DOM sinks.
-   Reduces code duplication and boilerplate through centralized helpers.
-   Improves long-term maintainability by adopting a consistent, safe
    pattern for dynamic UI updates across the project.

Related issue: https://github.com/os-autoinst/openQA/security/code-scanning/11
Related issue: https://github.com/os-autoinst/openQA/security/code-scanning/12