### PR TITLE
feat: Speed up asset uploads

### DIFF
--- a/etc/nginx/vhosts.d/openqa-endpoints.inc
+++ b/etc/nginx/vhosts.d/openqa-endpoints.inc
@@ -5,7 +5,7 @@ client_max_body_size 0;
 # The "client_body_buffer_size" value should usually be larger
 # than the UPLOAD_CHUNK_SIZE used by openQA workers, so there is
 # no excessive buffering to disk
-client_body_buffer_size 2m;
+client_body_buffer_size 12m;
 
 # Default is exact which would need an exact match of Last-Modified
 if_modified_since before;

--- a/lib/OpenQA/Client/Upload.pm
+++ b/lib/OpenQA/Client/Upload.pm
@@ -10,7 +10,7 @@ use Mojo::Asset::Memory;
 use Mojo::File qw(path);
 use Feature::Compat::Try;
 
-use constant DEFAULT_CHUNK_SIZE => 1_000_000;
+use constant DEFAULT_CHUNK_SIZE => 10_000_000;
 
 sub _upload_asset_fail ($self, $uri, $form) {
     $form->{state} = 'fail';

--- a/lib/OpenQA/Client/Upload.pm
+++ b/lib/OpenQA/Client/Upload.pm
@@ -6,11 +6,14 @@ use Mojo::Base 'OpenQA::Client::Handler', -signatures;
 
 use OpenQA::File;
 use Carp qw(croak);
+use Exporter qw(import);
 use Mojo::Asset::Memory;
 use Mojo::File qw(path);
 use Feature::Compat::Try;
 
 use constant DEFAULT_CHUNK_SIZE => 10_000_000;
+
+our @EXPORT_OK = qw(DEFAULT_CHUNK_SIZE);
 
 sub _upload_asset_fail ($self, $uri, $form) {
     $form->{state} = 'fail';

--- a/lib/OpenQA/Client/Upload.pm
+++ b/lib/OpenQA/Client/Upload.pm
@@ -4,16 +4,12 @@
 package OpenQA::Client::Upload;
 use Mojo::Base 'OpenQA::Client::Handler', -signatures;
 
+use OpenQA::Constants qw(DEFAULT_UPLOAD_CHUNK_SIZE);
 use OpenQA::File;
 use Carp qw(croak);
-use Exporter qw(import);
 use Mojo::Asset::Memory;
 use Mojo::File qw(path);
 use Feature::Compat::Try;
-
-use constant DEFAULT_CHUNK_SIZE => 10_000_000;
-
-our @EXPORT_OK = qw(DEFAULT_CHUNK_SIZE);
 
 sub _upload_asset_fail ($self, $uri, $form) {
     $form->{state} = 'fail';
@@ -43,7 +39,7 @@ sub asset ($self, $job_id, $opts) {
         return undef;
     }
 
-    my $chunk_size = $opts->{chunk_size} // DEFAULT_CHUNK_SIZE;
+    my $chunk_size = $opts->{chunk_size} // DEFAULT_UPLOAD_CHUNK_SIZE;
     my $parts = OpenQA::File->new(file => Mojo::File->new($opts->{file}))->split($chunk_size);
     $self->emit('upload_chunk.prepare', $parts);
 

--- a/lib/OpenQA/Constants.pm
+++ b/lib/OpenQA/Constants.pm
@@ -18,6 +18,8 @@ use constant WEBSOCKET_API_VERSION => 1;
 # Default worker timeout
 use constant DEFAULT_WORKER_TIMEOUT => 30 * ONE_MINUTE;
 
+use constant DEFAULT_UPLOAD_CHUNK_SIZE => 10_000_000;
+
 # Define worker commands; used to validate and differentiate commands
 use constant {
     # stop the current job(s), do *not* upload logs and assets
@@ -122,6 +124,7 @@ our @EXPORT_OK = qw(
   MAX_TIMER MIN_TIMER
   DEFAULT_MAX_JOB_TIME
   DEFAULT_MAX_SETUP_TIME
+  DEFAULT_UPLOAD_CHUNK_SIZE
   DB_TIMESTAMP_ACCURACY
   VIDEO_FILE_NAME_START VIDEO_FILE_NAME_REGEX
   FRAGMENT_REGEX

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -12,6 +12,7 @@ use OpenQA::Worker::Engines::isotovideo;
 use OpenQA::Worker::Isotovideo::Client;
 use OpenQA::Log qw(log_error log_warning log_debug log_info redact_settings_in_file);
 use OpenQA::Utils qw(find_video_files usleep_backoff);
+use OpenQA::Client::Upload qw(DEFAULT_CHUNK_SIZE);
 
 use Digest::MD5;
 use Fcntl;
@@ -27,8 +28,6 @@ use File::Map 'map_file';
 use List::Util 'max';
 use Time::HiRes qw(time usleep);
 use Feature::Compat::Try;
-
-use constant DEFAULT_UPLOAD_CHUNK_SIZE => 10_000_000;
 
 # define attributes for public properties
 has 'worker';
@@ -975,7 +974,7 @@ sub _upload_asset ($self, $upload_parameter) {
     my $filename = $upload_parameter->{file}->{filename};
     my $file = $upload_parameter->{file}->{file};
     my $global_settings = $self->worker->settings->global_settings;
-    my $chunk_size = $global_settings->{UPLOAD_CHUNK_SIZE} // DEFAULT_UPLOAD_CHUNK_SIZE;
+    my $chunk_size = $global_settings->{UPLOAD_CHUNK_SIZE} // DEFAULT_CHUNK_SIZE;
     my $retries = $global_settings->{UPLOAD_RETRIES} // 10;
     my $local_upload = $global_settings->{LOCAL_UPLOAD} // 1;
     my $ua = $self->client->ua;

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -28,7 +28,7 @@ use List::Util 'max';
 use Time::HiRes qw(time usleep);
 use Feature::Compat::Try;
 
-use constant DEFAULT_UPLOAD_CHUNK_SIZE => 1_000_000;
+use constant DEFAULT_UPLOAD_CHUNK_SIZE => 10_000_000;
 
 # define attributes for public properties
 has 'worker';

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -4,15 +4,14 @@
 package OpenQA::Worker::Job;
 use Mojo::Base 'Mojo::EventEmitter', -signatures;
 
-use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME DEFAULT_MAX_SETUP_TIME WORKER_COMMAND_ABORT WORKER_COMMAND_QUIT
-  WORKER_COMMAND_CANCEL WORKER_COMMAND_OBSOLETE WORKER_SR_BROKEN WORKER_SR_SETUP_FAILURE WORKER_SR_API_FAILURE WORKER_SR_TIMEOUT
-  WORKER_SR_DONE WORKER_SR_DIED);
+use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME DEFAULT_UPLOAD_CHUNK_SIZE DEFAULT_MAX_SETUP_TIME WORKER_COMMAND_ABORT
+  WORKER_COMMAND_QUIT WORKER_COMMAND_CANCEL WORKER_COMMAND_OBSOLETE WORKER_SR_BROKEN WORKER_SR_SETUP_FAILURE
+  WORKER_SR_API_FAILURE WORKER_SR_TIMEOUT WORKER_SR_DONE WORKER_SR_DIED);
 use OpenQA::Jobs::Constants;
 use OpenQA::Worker::Engines::isotovideo;
 use OpenQA::Worker::Isotovideo::Client;
 use OpenQA::Log qw(log_error log_warning log_debug log_info redact_settings_in_file);
 use OpenQA::Utils qw(find_video_files usleep_backoff);
-use OpenQA::Client::Upload qw(DEFAULT_CHUNK_SIZE);
 
 use Digest::MD5;
 use Fcntl;
@@ -974,7 +973,7 @@ sub _upload_asset ($self, $upload_parameter) {
     my $filename = $upload_parameter->{file}->{filename};
     my $file = $upload_parameter->{file}->{file};
     my $global_settings = $self->worker->settings->global_settings;
-    my $chunk_size = $global_settings->{UPLOAD_CHUNK_SIZE} // DEFAULT_CHUNK_SIZE;
+    my $chunk_size = $global_settings->{UPLOAD_CHUNK_SIZE} // DEFAULT_UPLOAD_CHUNK_SIZE;
     my $retries = $global_settings->{UPLOAD_RETRIES} // 10;
     my $local_upload = $global_settings->{LOCAL_UPLOAD} // 1;
     my $ua = $self->client->ua;

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -27,10 +27,9 @@ use Mojo::JSON qw(encode_json decode_json);
 use Mojo::UserAgent;
 use Mojo::URL;
 use Mojo::IOLoop;
-use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME DEFAULT_MAX_SETUP_TIME WORKER_COMMAND_CANCEL WORKER_COMMAND_QUIT
-  WORKER_COMMAND_OBSOLETE WORKER_SR_SETUP_FAILURE WORKER_SR_TIMEOUT WORKER_EC_ASSET_FAILURE WORKER_EC_CACHE_FAILURE
-  WORKER_SR_API_FAILURE WORKER_SR_DIED WORKER_SR_DONE WORKER_SR_BROKEN);
-use OpenQA::Client::Upload qw(DEFAULT_CHUNK_SIZE);
+use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME DEFAULT_MAX_SETUP_TIME DEFAULT_UPLOAD_CHUNK_SIZE WORKER_COMMAND_CANCEL
+  WORKER_COMMAND_QUIT WORKER_COMMAND_OBSOLETE WORKER_SR_SETUP_FAILURE WORKER_SR_TIMEOUT WORKER_EC_ASSET_FAILURE
+  WORKER_EC_CACHE_FAILURE WORKER_SR_API_FAILURE WORKER_SR_DIED WORKER_SR_DONE WORKER_SR_BROKEN);
 use OpenQA::Worker::Job;
 use OpenQA::Worker::Settings;
 use OpenQA::Test::FakeWebSocketTransaction;
@@ -1472,8 +1471,8 @@ subtest 'asset upload' => sub {
     my $upload_res;
     combined_like { $upload_res = $job->_upload_asset(\%params) } qr/fake error.*404.*Upload failed for chunk 3/s,
       'upload logged';
-    my %expected_params
-      = (asset => undef, chunk_size => DEFAULT_CHUNK_SIZE, file => 'foo', name => 'bar', local => 1, retries => 10);
+    my @chunking_params = (chunk_size => DEFAULT_UPLOAD_CHUNK_SIZE);
+    my %expected_params = (asset => undef, file => 'foo', name => 'bar', local => 1, retries => 10, @chunking_params);
     is $upload_res, 1, 'upload succeeded';
     is_deeply \@params, [[14, \%expected_params]], 'expected params passed' or always_explain \@params;
 

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -30,6 +30,7 @@ use Mojo::IOLoop;
 use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME DEFAULT_MAX_SETUP_TIME WORKER_COMMAND_CANCEL WORKER_COMMAND_QUIT
   WORKER_COMMAND_OBSOLETE WORKER_SR_SETUP_FAILURE WORKER_SR_TIMEOUT WORKER_EC_ASSET_FAILURE WORKER_EC_CACHE_FAILURE
   WORKER_SR_API_FAILURE WORKER_SR_DIED WORKER_SR_DONE WORKER_SR_BROKEN);
+use OpenQA::Client::Upload qw(DEFAULT_CHUNK_SIZE);
 use OpenQA::Worker::Job;
 use OpenQA::Worker::Settings;
 use OpenQA::Test::FakeWebSocketTransaction;
@@ -1471,11 +1472,10 @@ subtest 'asset upload' => sub {
     my $upload_res;
     combined_like { $upload_res = $job->_upload_asset(\%params) } qr/fake error.*404.*Upload failed for chunk 3/s,
       'upload logged';
+    my %expected_params
+      = (asset => undef, chunk_size => DEFAULT_CHUNK_SIZE, file => 'foo', name => 'bar', local => 1, retries => 10);
     is $upload_res, 1, 'upload succeeded';
-    is_deeply \@params,
-      [[14, {asset => undef, chunk_size => 10000000, file => 'foo', name => 'bar', local => 1, retries => 10}]],
-      'expected params passed'
-      or always_explain \@params;
+    is_deeply \@params, [[14, \%expected_params]], 'expected params passed' or always_explain \@params;
 
     $mock_failure = 1;
     my ($stdout, $stderr, @result) = capture sub { $job->_upload_asset(\%params) };

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1473,7 +1473,7 @@ subtest 'asset upload' => sub {
       'upload logged';
     is $upload_res, 1, 'upload succeeded';
     is_deeply \@params,
-      [[14, {asset => undef, chunk_size => 1000000, file => 'foo', name => 'bar', local => 1, retries => 10}]],
+      [[14, {asset => undef, chunk_size => 10000000, file => 'foo', name => 'bar', local => 1, retries => 10}]],
       'expected params passed'
       or always_explain \@params;
 


### PR DESCRIPTION
* Increase default upload junk size from 1 MB to 10 MB
* Adjust `client_body_buffer_size` setting as well adding a little bit of headroom
* Define the constant for the default upload junk size only in one place

Related ticket: https://progress.opensuse.org/issues/199397

---

I'm adding the "not-ready" label because ~~I still want to do some local tests and I also need to check whether the NGINX config needs to be changed manually in production~~. It looks like `/etc/nginx/vhosts.d/openqa-endpoints.inc` is modified on o3 and OSD so we'll have to change those files manually. So ~~I'll change~~ I changed the setting there manually.