### PR TITLE
feat: implement "None" authentication provider

### DIFF
--- a/container/openqa_data/data.template/conf/openqa.ini
+++ b/container/openqa_data/data.template/conf/openqa.ini
@@ -27,7 +27,7 @@ branding = plain
 
 ## Authentication method to use for user management
 [auth]
-# method = Fake|OpenID
+# method = Fake|OpenID|OAuth2|None
 method = OpenID
 
 [logging]

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -571,8 +571,8 @@ password = somepassword
 [[authentication]]
 === User authentication
 
-openQA supports three different authentication methods: OpenID (default),
-OAuth2 and Fake (for development).
+openQA supports four different authentication methods: OpenID (default),
+OAuth2, Fake (for development) and None (no authentication).
 
 Use the `auth` section in
 <<GettingStarted.asciidoc#_configuration,the web UI configuration>> to configure
@@ -655,11 +655,16 @@ to use different providers.
 
 ==== Fake
 
-For development purposes only! Fake authentication bypass any authentication and
-automatically allow any login requests as 'Demo user' with administrator privileges
-and without password. To ease worker testing, API key and secret is created (or updated)
-with validity of one day during login.
-You can then use following as `/etc/openqa/client.conf`:
+For development purposes only! This method is a "mock" authentication provider
+designed for openQA developers to test permissions and role-based access
+control (RBAC). It requires an explicit visit to the `/login` route but allows
+simulating different user roles (e.g. `?user=nobody` for a non-privileged
+user).
+
+To ease worker testing, an API key and secret are created (or updated) for the
+'Demo user' with administrator privileges and a validity of one day during
+login.
+You can then use the following as `/etc/openqa/client.conf`:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -672,8 +677,26 @@ key = 1234567890ABCDEF
 secret = 1234567890ABCDEF
 --------------------------------------------------------------------------------
 
-If you switch authentication method from Fake to any other, review your API keys!
-You may be vulnerable for up to a day until Fake API key expires.
+If you switch the authentication method from Fake to any other, review your
+API keys! You may be vulnerable for up to a day until the Fake API key
+expires.
+
+
+==== None
+
+This method bypasses any authentication entirely and automatically treats
+every visitor as an 'admin' user with administrator privileges. No explicit
+login is required. It is ideal for private, local, or trusted network
+instances where any form of login (even a "Fake" one) is considered
+unnecessary, for example in automated CI setups. Do not use for any exposed
+instances!
+
+[source,ini]
+--------------------------------------------------------------------------------
+[auth]
+# method name is case sensitive!
+method = None
+--------------------------------------------------------------------------------
 
 
 [[priority-throttling]]

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -173,7 +173,7 @@
 
 ## Authentication method to use for user management
 [auth]
-#method = Fake|OpenID|OAuth2
+#method = Fake|OpenID|OAuth2|None
 ## whether authentication is required to access assets; caveats:
 ## - Does NOT affect assets made available outside the scope of the openQA service (e.g. via Apache, NGINX or NFS).
 ## - Might not work well with other features like openqa-clone-job and the cache service.

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -51,8 +51,17 @@ sub _current_user ($c) {
     # If the value is not in the stash
     my $current_user = $c->stash('current_user');
     unless ($current_user && ($current_user->{no_user} || defined $current_user->{user})) {
-        my $id = $c->session->{user};
+        my $auth_method = $c->app->config->{auth}->{method} // '';
+        my $id = $c->session->{user} // ($auth_method eq 'None' ? 'admin' : undef);
         my $user = $id ? $c->schema->resultset('Users')->find({username => $id}) : undef;
+        if (!$user && $auth_method eq 'None') {
+            $user = $c->schema->resultset('Users')
+              ->create_user('admin', fullname => 'Administrator', email => 'admin@example.com');
+            $user->update({is_admin => 1, is_operator => 1});
+        }
+        if ($user && $auth_method eq 'None' && !($user->is_admin && $user->is_operator)) {
+            $user->update({is_admin => 1, is_operator => 1});
+        }
         $c->stash(current_user => $current_user = $user ? {user => $user} : {no_user => 1});
     }
 

--- a/lib/OpenQA/WebAPI/Auth/None.pm
+++ b/lib/OpenQA/WebAPI/Auth/None.pm
@@ -1,0 +1,27 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Auth::None;
+use Mojo::Base -base, -signatures;
+use Time::Seconds;
+
+sub auth_setup ($app) {
+    my $key_val = $ENV{OPENQA_AUTH_NONE_KEY} // 'DEADBEEFDEADBEEF';
+    my $secret_val = $ENV{OPENQA_AUTH_NONE_SECRET} // 'DEADBEEFDEADBEEF';
+    my $user = $app->schema->resultset('Users')->create_user(
+        'admin',
+        fullname => 'Administrator',
+        email => 'admin@example.com'
+    );
+    $user->update({is_admin => 1, is_operator => 1});
+    my $key = $user->api_keys->find_or_create({key => $key_val, secret => $secret_val});
+    $key->update({t_expiration => DateTime->from_epoch(epoch => time + ONE_DAY * 3650)});
+}
+
+sub auth_login ($self) {
+    auth_setup($self->app);
+    $self->session->{user} = 'admin';
+    return (error => 0);
+}
+
+1;

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -65,6 +65,45 @@ subtest 'restricted asset downloads with setting `[auth] require_for_assets = 1`
     $t->content_unlike(qr/asset-ok/, 'asset via test not accessible when logged out');
 };
 
+subtest None => sub {
+    my $t = test_auth_method_startup('None');
+    $t->get_ok('/session/test')->status_is(200)->content_like(qr/you are admin/);
+    $t->get_ok('/admin/users')->status_is(200)->content_like(qr/Administrator/);
+
+    my $user = $t->app->schema->resultset('Users')->find({username => 'admin'});
+    ok $user, 'admin user exists';
+    my $key = $user->api_keys->find({key => 'DEADBEEFDEADBEEF'});
+    ok $key, 'admin API key exists';
+    is $key->secret, 'DEADBEEFDEADBEEF', 'admin API secret matches';
+
+    $t->get_ok('/api/v1/auth' => {Authorization => 'Bearer admin:DEADBEEFDEADBEEF:DEADBEEFDEADBEEF'})->status_is(200)
+      ->content_is('ok');
+
+    $user->audit_events->delete;
+    $user->api_keys->delete;
+    $user->delete;
+    $t->get_ok('/session/test')->status_is(200)->content_like(qr/you are admin/);
+    $user = $t->app->schema->resultset('Users')->find({username => 'admin'});
+    ok $user, 'admin user re-created';
+    ok $user->is_admin && $user->is_operator, 're-created user has admin/operator permissions';
+
+    $user->update({is_admin => 0, is_operator => 0});
+    $t->get_ok('/session/test')->status_is(200)->content_like(qr/you are admin/);
+    $user->discard_changes;
+    ok $user->is_admin && $user->is_operator, 'helper restored admin/operator permissions';
+
+    $t->get_ok('/')->status_is(200)->content_unlike(qr/Logout/);
+
+    {
+        local $ENV{OPENQA_AUTH_NONE_KEY} = 'CUSTOMKEY';
+        local $ENV{OPENQA_AUTH_NONE_SECRET} = 'CUSTOMSECRET';
+        my $t2 = test_auth_method_startup('None');
+        my $key2 = $t2->app->schema->resultset('ApiKeys')->find({key => 'CUSTOMKEY'});
+        ok $key2, 'custom API key exists';
+        is $key2->secret, 'CUSTOMSECRET', 'custom API secret matches';
+    }
+};
+
 subtest OpenID => sub {
     # OpenID relies on external server which we mock to not rely on external dependencies
     my $openid_mock = Test::MockModule->new('Net::OpenID::Consumer');

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -33,7 +33,7 @@ subtest 'system user presence' => sub {
 
 subtest 'new user is admin if no admin is present' => sub {
     my $admins = $users->search({is_admin => 1});
-    $_->update({is_admin => 0}) while $admins->next;
+    while (my $admin = $admins->next) { $admin->update({is_admin => 0}) }
     ok !$users->search({is_admin => 1})->all, 'no admin is present';
     my $user = $users->create_user('test_user');
     ok $user->is_admin, 'new user is admin by default if there was no admin';

--- a/templates/webapi/layouts/navbar.html.ep
+++ b/templates/webapi/layouts/navbar.html.ep
@@ -100,9 +100,12 @@
                   % if (config->{global}{mcp_enabled} eq 'read-only') {
                       %= link_to 'MCP help' => url_for('mcp_help') => class => 'dropdown-item'
                   % }
-                  %= link_to 'Changelog' => url_for('changelog') => class => 'dropdown-item'
-                  %= link_to 'Logout' => url_for('logout') => 'data-method' => 'delete' => class => 'dropdown-item'
-                </div>
+                   %= link_to 'Changelog' => url_for('changelog') => class => 'dropdown-item'
+                   % if (config->{auth}->{method} ne 'None') {
+                       %= link_to 'Logout' => url_for('logout') => 'data-method' => 'delete' => class => 'dropdown-item'
+                   % }
+                 </div>
+
             </li>
         % } else {
             <li class='nav-item' id="user-action">


### PR DESCRIPTION
Motivation:
Support openQA instances without any authentication requirements,
specifically for simplified local setups or private instances.

Design Choices:
- Added OpenQA::WebAPI::Auth::None module to comply with the auth plugin
  interface.
- Implemented `auth_setup` in the None provider to automatically provision
  an 'admin' user and functional API credentials (defaulting to
  'DEADBEEFDEADBEEF') upon startup.
- Modified `_current_user` helper in `SharedHelpers.pm` to automatically
  identify as 'admin' when the "None" method is active.
- Updated documentation in `Installing.asciidoc` to explain the difference
  between "Fake" (mocking/development) and "None" (usability/convenience).
- Added comprehensive tests in `t/03-auth.t` to verify both UI-based and
  API-based authentication using the "None" provider.

Benefits:
- Truly zero-effort setup for private or local instances.
- Functional API access out of the box without manual configuration.
- Clearer distinction between development-oriented and deployment-oriented
  authentication bypasses.

Related issue: https://progress.opensuse.org/issues/194786