### PR TITLE
chore(ci): bump checkout v4->v6

### DIFF
--- a/.github/workflows/check-containers.yml
+++ b/.github/workflows/check-containers.yml
@@ -8,6 +8,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test our container definitions
         run: make test-check-containers

--- a/.github/workflows/check-helm-chart.yml
+++ b/.github/workflows/check-helm-chart.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -35,7 +35,7 @@ jobs:
       REGISTRY_PATH: registry.opensuse.org/devel/openqa/containers16.0
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -10,7 +10,7 @@ jobs:
     name: Checklist job
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checklist
         uses: wyozi/contextual-qa-checklist-action@master
         with:

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Verify that containers can be composed
         run: make test-containers-compose

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [22]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node (version ${{ matrix.node-version }})
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/obs-helper.yaml
+++ b/.github/workflows/obs-helper.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Report OBS URL
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: debug
         run: |
           env | sort

--- a/.github/workflows/perl-critic.yml
+++ b/.github/workflows/perl-critic.yml
@@ -12,5 +12,5 @@ jobs:
     container:
       image: perldocker/perl-tester
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make test-critic

--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: bash -x tools/ci/build_cache.sh
       - name: Build os-autoinst


### PR DESCRIPTION
This also fixes a warning about outdated nodejs