### PR TITLE
feat(mcp): promote endpoint from /experimental/mcp to /mcp

### DIFF
--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -1938,7 +1938,7 @@ mcp_enabled = read-only
 ----
 
 Once enabled the experimental MCP endpoint becomes available under the path
-`/experimental/mcp`. At the moment all implemented MCP tools are read-only,
+`/mcp`. At the moment all implemented MCP tools are read-only,
 that means LLMs can review information provided by openQA, but are unable to
 make changes or trigger actions. Once write operations become available
 with future updates, they will have to be enabled with a different setting
@@ -1957,7 +1957,7 @@ setting the `Authorization` HTTP header:
 {
   "mcpServers": {
     "openqa": {
-      "url": "http://127.0.0.1:9526/experimental/mcp",
+      "url": "http://127.0.0.1:9526/mcp",
       "headers": {
         "Authorization": "Bearer USER:KEY:SECRET"
       }
@@ -1975,7 +1975,7 @@ https://github.com/google-gemini/gemini-cli[gemini-cli], you can use the
 
 [source,shell]
 ----
-gemini mcp add openqa http://127.0.0.1:9526/experimental/mcp -H 'Authorization: Bearer USER:KEY:SECRET' -t http
+gemini mcp add openqa http://127.0.0.1:9526/mcp -H 'Authorization: Bearer USER:KEY:SECRET' -t http
 ----
 
 After restarting gemini-cli, it will automatically discover available openQA

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -43,7 +43,7 @@
 
 ## Set to read-only to enable MCP support
 ## * A Model Context Protocol endpoint will be available to all users under
-##   /experimental/mcp route.
+##   /mcp route.
 ## * Do not enable this feature for openQA instances with special security requirements!
 #mcp_enabled = no
 

--- a/lib/OpenQA/WebAPI/Plugin/MCP.pm
+++ b/lib/OpenQA/WebAPI/Plugin/MCP.pm
@@ -79,7 +79,7 @@ sub register ($self, $app, $config) {
     );
 
     my $mcp_auth = $app->routes->under('/')->to('Auth#auth')->name('mcp_ensure_user');
-    $mcp_auth->any('/experimental/mcp' => $mcp->to_action)->name('mcp');
+    $mcp_auth->any('/mcp' => $mcp->to_action)->name('mcp');
 }
 
 sub tool_openqa_get_info ($tool, $args) {

--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -22,13 +22,13 @@ OpenQA::Test::Case->new(config_directory => "$FindBin::Bin/../data/17-mcp")
 my $PERSONAL_ACCESS_TOKEN = 'lance:LANCELOTKEY01:MANYPEOPLEKNOW';
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
-my $client = MCP::Client->new(ua => $t->ua, url => $t->ua->server->url->path('/experimental/mcp'));
+my $client = MCP::Client->new(ua => $t->ua, url => $t->ua->server->url->path('/mcp'));
 
 subtest 'Authentication' => sub {
-    $t->get_ok('/experimental/mcp')->status_is(403)->json_is({error => 'no api key'});
+    $t->get_ok('/mcp')->status_is(403)->json_is({error => 'no api key'});
 
     $t->ua->on(start => sub ($ua, $tx) { $tx->req->headers->authorization("Bearer $PERSONAL_ACCESS_TOKEN") });
-    $t->get_ok('/experimental/mcp')->status_is(405);
+    $t->get_ok('/mcp')->status_is(405);
 };
 
 subtest 'Start session' => sub {


### PR DESCRIPTION
Remove the "experimental" prefix from the MCP endpoint URL to signal production-readiness, as required by Claude connector certification. Update all references in the plugin, tests, documentation and default configuration accordingly.
Issue: https://progress.opensuse.org/issues/193555
