### PR TITLE
fix: Avoid gap between caret and preview container

### DIFF
--- a/assets/stylesheets/result_preview.scss
+++ b/assets/stylesheets/result_preview.scss
@@ -54,7 +54,7 @@
   display: none;
   position: absolute;
   color: #a9a9a9;
-  bottom: -22px;
+  bottom: -25px;
   left: 21px;
   font-size: 35px;
 }


### PR DESCRIPTION
This gap was probably a regression from changing from Fork Awesome to Font Awesome.