### PR TITLE
feat: set no expiration for "None" auth API keys

### DIFF
--- a/lib/OpenQA/WebAPI/Auth/None.pm
+++ b/lib/OpenQA/WebAPI/Auth/None.pm
@@ -3,7 +3,6 @@
 
 package OpenQA::WebAPI::Auth::None;
 use Mojo::Base -base, -signatures;
-use Time::Seconds;
 
 sub auth_setup ($app) {
     my $key_val = $ENV{OPENQA_AUTH_NONE_KEY} // 'DEADBEEFDEADBEEF';
@@ -15,7 +14,7 @@ sub auth_setup ($app) {
     );
     $user->update({is_admin => 1, is_operator => 1});
     my $key = $user->api_keys->find_or_create({key => $key_val, secret => $secret_val});
-    $key->update({t_expiration => DateTime->from_epoch(epoch => time + ONE_DAY * 3650)});
+    $key->update({t_expiration => undef});
 }
 
 sub auth_login ($self) {

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -75,6 +75,7 @@ subtest None => sub {
     my $key = $user->api_keys->find({key => 'DEADBEEFDEADBEEF'});
     ok $key, 'admin API key exists';
     is $key->secret, 'DEADBEEFDEADBEEF', 'admin API secret matches';
+    is $key->t_expiration, undef, 'admin API key has no expiration';
 
     $t->get_ok('/api/v1/auth' => {Authorization => 'Bearer admin:DEADBEEFDEADBEEF:DEADBEEFDEADBEEF'})->status_is(200)
       ->content_is('ok');


### PR DESCRIPTION
Motivation:
The "None" authentication provider is intended for simplified local setups
where security constraints like API key expiration are not necessary and
can be confusing.

Design Choices:
1. Updated lib/OpenQA/WebAPI/Auth/None.pm to set t_expiration to undef.
2. Removed unused Time::Seconds import from None.pm.
3. Updated t/03-auth.t to verify the change.

Benefits:
Provides a more seamless experience for local/private openQA instances
without requiring periodic maintenance of API keys.