### PR TITLE
feat(worker): Resolve share directory correctly for relative basedir

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -3,6 +3,7 @@
 
 package OpenQA::Worker;
 use Mojo::Base -base, -signatures;
+use Cwd qw(getcwd);
 use IPC::Run ();
 
 BEGIN {
@@ -101,6 +102,7 @@ sub new ($class, $cli_options) {
     $self->{_shall_terminate} = 0;
     $self->{_finishing_off} = undef;
     $self->{_ovs_dbus_service_name} = $ENV{OVS_DBUS_SERVICE_NAME} // 'org.opensuse.os_autoinst.switch';
+    $self->{_initial_working_dir} = getcwd() // '.';
 
     return $self;
 }
@@ -331,7 +333,9 @@ sub init ($self) {
 
         # find working directory for host
         # note: This is being also duplicated by OpenQA::Test::Utils since 49c06362d.
-        my @working_dirs = grep { $_ } ($host_settings->{SHARE_DIRECTORY}, catdir(prjdir(), 'share'));
+        my $base = $self->{_initial_working_dir};
+        my @possible_working_dirs = ($host_settings->{SHARE_DIRECTORY}, catdir(prjdir(), 'share'));
+        my @working_dirs = map { m|^/| ? $_ : "$base/$_" } grep { $_ } @possible_working_dirs;
         my ($working_dir) = grep { -d } @working_dirs;
         unless ($working_dir) {
             log_error("Ignoring host '$host': Working directory does not exist. (Checked: @working_dirs)");

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -111,7 +111,7 @@ my $global_settings = $settings->global_settings;
 delete $global_settings->{LOG_DIR};
 
 combined_like { is ${$worker->init}, 1, 'no working directory found returns 1' }
-qr{Ignoring host.*Working directory does not exist.*Checked: t/data/openqa/share.*Ignoring host .*remotehost.*Checked:}s,
+qr{Ignoring host.*Working directory does not exist.*Checked: $workdir/t/data/openqa/share.*Ignoring host .*remotehost.*Checked:}s,
   'hosts with non-existent working directory ignored and error logged';
 is $worker->app->level, 'debug', 'log level set to debug with verbose switch';
 my @webui_hosts = sort keys %{$worker->clients_by_webui_host};
@@ -1002,7 +1002,7 @@ subtest 'working_directory exists for one of two hosts' => sub {
     $mock_ws->redefine(webui_host_specific_settings => sub ($self) { $webui_host_specific_settings });
 
     combined_like { is ${$worker->init}, 0, 'at least one working directory found returns 0' }
-qr{Ignoring host.*Working directory does not exist.*Checked: t/data/openqa/share.*Project dir for host https://remotehost is /tmp}s,
+qr{Ignoring host.*Working directory does not exist.*Checked: $workdir/t/data/openqa/share.*Project dir for host https://remotehost is /tmp}s,
       'hosts with non-existent working directory ignored and error logged';
 };
 


### PR DESCRIPTION
If `OPENQA_BASEDIR` is relative, the share directory should be resolved using the initial working directory of the worker (and *not* the pool directory) so the worker can be started using e.g. `OPENQA_BASEDIR=t/data script/worker` from a checkout of the openQA repository.

It makes never sense that the share directory is within the pool directory which is cleaned after each job. So this change will probably not break any existing use case.

Related ticket: https://progress.opensuse.org/issues/199004