### PR TITLE
fix(worker): handle missing D-Bus socket gracefully

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -639,7 +639,10 @@ sub is_ovs_dbus_service_running ($self) {
     try { defined &Net::DBus::system or require Net::DBus }
     catch ($e) { return 0 }    # uncoverable statement
     unless (defined $self->{_system_dbus}) {
-        $self->{_system_dbus} = Net::DBus->system(nomainloop => 1);
+        my $dbus;
+        try { $dbus = Net::DBus->system(nomainloop => 1) }
+        catch ($e) { return 0 }    # uncoverable statement
+        $self->{_system_dbus} = $dbus;
         # this avoids piling up signals we never do anything with - POO #183833
         $self->{_system_dbus}->get_bus_object->disconnect_from_signal('NameOwnerChanged', 1);
     }


### PR DESCRIPTION
When the WORKER_CLASS includes tap, is_ovs_dbus_service_running() was called but Net::DBus->system() threw an unhandled exception if the D-Bus socket was unavailable inside the container, preventing the worker from starting. Wrap the call in a try/catch and return 0 on failure.

Issue: https://progress.opensuse.org/issues/199619