### PR TITLE
feat: ignore "Investigations" job group on dashboard by default

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -126,7 +126,7 @@
 ## can cause jobs to incomplete with "timestamp mismatch" error messages.
 #api_hmac_time_tolerance = 300
 ## space-separated list of job groups to ignore on the dashboard
-#ignored_job_groups =
+#ignored_job_groups = Investigations
 ## How many builds to show per job group on the web UI front page
 ## Can be overridden with the limit_builds query param
 #frontpage_builds = 3

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -129,7 +129,7 @@ sub default_config () {
             frontpage_builds => 3,
             frontpage_time_limit_days => 14,
             scenario_definitions_allowed_hosts => 'github.com raw.githubusercontent.com',
-            ignored_job_groups => '',
+            ignored_job_groups => 'Investigations',
         },
         rate_limits => {
             search => 5,


### PR DESCRIPTION
Motivation:
Automatic investigation jobs often create many job groups that clutter the
dashboard evaluation and might lead to performance issues or 502 errors.
Hiding them by default improves the initial user experience and dashboard
load time.

Design Choices:
- Updated `ignored_job_groups` default in `lib/OpenQA/Setup.pm` to include
  "Investigations".
- Updated the example in `etc/openqa/openqa.ini` to reflect this default.

Benefits:
- Cleaner dashboard by default.
- Potentially reduced load on the main page by ignoring common but
  irrelevant job groups for general evaluation.

Related issue: https://progress.opensuse.org/issues/199427