### PR TITLE
feat: Handle deleted/altered system user more gracefully

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2046,7 +2046,8 @@ sub handle_retry ($self) {
     return 0 unless looks_like_number $retry;
     my $ancestors = $self->ancestors;
     return 0 if $ancestors >= $retry;
-    my $system_user_id = $self->result_source->schema->resultset('Users')->system->id;
+    return 0 unless my $system_user = $self->result_source->schema->resultset('Users')->system({select => ['id']});
+    my $system_user_id = $system_user->id;
     my $msg = "Restarting because RETRY is set to $retry (and only restarted $ancestors times so far)";
     $self->comments->create({text => $msg, user_id => $system_user_id});
     return 1;

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -558,7 +558,7 @@ sub mark_job_linked ($self, $jobid, $referer_url) {
     return undef if !$job || ($referer->path_query =~ /^\/?$/);
     my $comments = $job->comments;
     return undef if $comments->search({text => {like => 'label:linked%'}}, {rows => 1})->first;
-    my $user = $self->result_source->schema->resultset('Users')->system({select => ['id']});
+    return undef unless my $user = $self->result_source->schema->resultset('Users')->system({select => ['id']});
     my $bugref = href_to_bugref($referer_url);
     my $label = $referer_url eq $bugref ? "label:linked $referer" : "label:linked:$bugref";
     $comments->create_with_event({text => "$label mentions this job", user_id => $user->id});

--- a/lib/OpenQA/Schema/ResultSet/Users.pm
+++ b/lib/OpenQA/Schema/ResultSet/Users.pm
@@ -4,6 +4,10 @@
 package OpenQA::Schema::ResultSet::Users;
 
 use Mojo::Base 'DBIx::Class::ResultSet', -signatures;
+use OpenQA::Log qw(log_error);
+
+use constant SYSTEM_USER_ERROR =>
+'Unable to find the "system" user (username: "system", provider: "") so automatic commenting and retrying does not work.';
 
 sub create_user ($self, $id, %attrs) {
     return unless $id;
@@ -28,6 +32,9 @@ sub create_user ($self, $id, %attrs) {
     return $user;
 }
 
-sub system ($self, $attrs = undef) { $self->find({username => 'system', provider => ''}, $attrs) }
+sub system ($self, $attrs = undef) {
+    log_error SYSTEM_USER_ERROR unless my $user = $self->find({username => 'system', provider => ''}, $attrs);
+    return $user;
+}
 
 1;

--- a/t/06-users.t
+++ b/t/06-users.t
@@ -11,10 +11,12 @@ require OpenQA::Test::Database;
 use OpenQA::Test::TimeLimit '10';
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
+use Test::Output 'combined_like';
 
 OpenQA::Test::Database->new->create;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
-my $users = $t->app->schema->resultset('Users');
+my $schema = $t->app->schema;
+my $users = $schema->resultset('Users');
 
 subtest 'new users are not ops and admins' => sub {
     my $mordred_id = 'https://openid.badguys.uk/mordred';
@@ -29,6 +31,13 @@ subtest 'system user presence' => sub {
     ok !$system_user->is_admin, 'system user is not an admin';
     ok !$system_user->is_operator, 'system user is not an operator';
     is $system_user->email, 'noemail@open.qa', 'system user`s email uses open.qa domain';
+    subtest 'deleted system user handled' => sub {
+        $schema->txn_begin;
+        $users->search({username => 'system', provider => ''})->delete;
+        combined_like { is $users->system, undef, 'system returns undef if user has been deleted' }
+        qr/automatic commenting.*does not work/, 'warning logged if system user is missing';
+        $schema->txn_rollback;
+    };
 };
 
 subtest 'new user is admin if no admin is present' => sub {


### PR DESCRIPTION
* Avoid 500 responses
* Log an error message that states the problem and consequences so admins are alerted, e.g. using `openqa-logwarn`
* Do *not* just create a new system user on the fly because the existing system user might just have been altered (as it was recently in production) and we want to avoid ending up with two system user accounts

Related ticket: https://progress.opensuse.org/issues/199664