### PR TITLE
ci: ensure full statement coverage

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ pull_request_rules:
           # "unresolvable" is not reported in general:
           # https://trello.com/c/0N3jHq5M/2257-report-back-to-scm-when-build-results-arent-failed-and-succeeded
           # So we need to require the number of tests explicitly:
-          - "#check-success>=50"
+          - "#check-success>=47"
           - status-success=static-check-containers
           - status-success=webui-docker-compose
           - "#check-failure=0"

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,21 +13,8 @@ coverage:
     changes: false
     project:
       default:
-        target: 98
-        threshold: 0
-      fully_covered:
         target: 100.0
         threshold: 0
-        paths:
-          - lib/
-          - script/
-      tests:
-        target: 100.0
-        threshold: 0
-        paths:
-          - t/
     patch:
       default:
-        target: 100.0
-        threshold: 0
         branches: null


### PR DESCRIPTION
After all paths show full coverage we can simplify codecov to ensure
full statement coverage in the complete project.

Related issue: https://progress.opensuse.org/issues/178933