### PR TITLE
fix+improve CSRF token handling when using None authentication provider

### DIFF
--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -56,12 +56,16 @@ sub auth ($self) {
     # Browser with a logged in user
     my ($user, $reason) = (undef, 'Not authorized');
     if ($user = $self->current_user) {
-        ($user, $reason) = (undef, 'Bad CSRF token!') unless $self->req->method eq 'GET' || $self->valid_csrf;
+        if ($self->req->method ne 'GET' && !$self->valid_csrf) {
+            # Invalidate session-based auth if CSRF is missing; fallback to API headers if present
+            $user = undef;
+            $self->render(json => {error => 'Bad CSRF token!'}, status => 403) and return 0
+              unless $self->is_api_request;
+        }
     }
 
     # No session (probably not a browser)
-    else {
-
+    if (!$user) {
         # Personal access token
         if (($self->req->headers->authorization // '') =~ /^Bearer\s+(.+)$/) {
             ($user, $reason) = $self->_token_auth($reason, $1);
@@ -196,6 +200,7 @@ sub _key_auth ($self, $reason, $key) {
 }
 
 sub _valid_hmac ($self, $hash, $request, $our_timestamp, $remote_timestamp, $api_key) {
+    return 0 unless defined $hash;
     return 0 unless $self->_is_timestamp_valid($our_timestamp, $remote_timestamp);
     return 0 if _is_expired($api_key);
     return 0 unless $api_key->secret;

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -19,6 +19,7 @@ sub register ($self, $app, @args) {
     $app->helper(current_user => \&_current_user);
     $app->helper(is_operator => \&_is_operator);
     $app->helper(is_admin => \&_is_admin);
+    $app->helper(is_api_request => \&_is_api_request);
     $app->helper(is_local_request => \&_is_local_request);
     $app->helper(render_specific_not_found => \&_render_specific_not_found);
     $app->helper(via_domain => \&_via_domain);
@@ -52,10 +53,13 @@ sub _current_user ($c) {
     my $current_user = $c->stash('current_user');
     unless ($current_user && ($current_user->{no_user} || defined $current_user->{user})) {
         my $is_auth_method_none = ($c->app->config->{auth}->{method} // '') eq 'None';
-        my $id = $c->session->{user} // ($is_auth_method_none ? 'admin' : undef);
+        # Avoid auto-login as admin for requests with API credentials.
+        # Otherwise, the 'auth' method would reject the request due to a
+        # missing CSRF token before it even checks the API credentials.
+        my $id = $c->session->{user} // ($is_auth_method_none && !$c->is_api_request ? 'admin' : undef);
         my $users = $c->schema->resultset('Users');
         my $user = $id ? $users->find({username => $id}) : undef;
-        if ($is_auth_method_none) {
+        if ($is_auth_method_none && $id && $id eq 'admin') {
             $user ||= $users->create_user('admin', fullname => 'Administrator', email => 'admin@example.com');
             $user->update({is_admin => 1, is_operator => 1}) unless $user->is_admin && $user->is_operator;
         }
@@ -73,6 +77,11 @@ sub _is_operator ($c, $user = undef) {
 sub _is_admin ($c, $user = undef) {
     $user //= $c->current_user;
     return ($user && $user->is_admin);
+}
+
+sub _is_api_request ($c) {
+    my $h = $c->req->headers;
+    return !!($h->authorization || $h->header('X-API-Key'));
 }
 
 sub _is_local_request ($c) {

--- a/lib/OpenQA/WebAPI/Auth/Fake.pm
+++ b/lib/OpenQA/WebAPI/Auth/Fake.pm
@@ -34,10 +34,9 @@ sub auth_login ($self) {
         $userinfo->{username},
         email => $userinfo->{email},
         nickname => $userinfo->{username},
-        fullname => $userinfo->{fullname});
-    $user->is_admin($userinfo->{admin});
-    $user->is_operator($userinfo->{operator});
-    $user->update;
+        fullname => $userinfo->{fullname},
+        is_admin => $userinfo->{admin},
+        is_operator => $userinfo->{operator});
 
     my $key = $user->api_keys->find_or_create({key => $userinfo->{key}, secret => SECRET});
     # expire in a day after login

--- a/lib/OpenQA/WebAPI/Auth/None.pm
+++ b/lib/OpenQA/WebAPI/Auth/None.pm
@@ -4,22 +4,29 @@
 package OpenQA::WebAPI::Auth::None;
 use Mojo::Base -base, -signatures;
 
+use constant DEFAULT_ADMIN => 'admin';
+
 sub auth_setup ($app) {
     my $key_val = $ENV{OPENQA_AUTH_NONE_KEY} // 'DEADBEEFDEADBEEF';
     my $secret_val = $ENV{OPENQA_AUTH_NONE_SECRET} // 'DEADBEEFDEADBEEF';
     my $user = $app->schema->resultset('Users')->create_user(
-        'admin',
+        DEFAULT_ADMIN,
         fullname => 'Administrator',
-        email => 'admin@example.com'
+        email => 'admin@example.com',
+        is_admin => 1,
+        is_operator => 1,
     );
-    $user->update({is_admin => 1, is_operator => 1});
-    my $key = $user->api_keys->find_or_create({key => $key_val, secret => $secret_val});
-    $key->update({t_expiration => undef});
+    $user->api_keys->update_or_create(
+        {
+            key => $key_val,
+            secret => $secret_val,
+            t_expiration => undef,
+        });
 }
 
 sub auth_login ($self) {
     auth_setup($self->app);
-    $self->session->{user} = 'admin';
+    $self->session->{user} = DEFAULT_ADMIN;
     return (error => 0);
 }
 

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -67,31 +67,34 @@ subtest 'restricted asset downloads with setting `[auth] require_for_assets = 1`
 
 subtest None => sub {
     my $t = test_auth_method_startup('None');
+    my $key_val = 'DEADBEEFDEADBEEF';
+    my $bearer_token = "Bearer admin:$key_val:$key_val";
     $t->get_ok('/session/test')->status_is(200)->content_like(qr/you are admin/);
     $t->get_ok('/admin/users')->status_is(200)->content_like(qr/Administrator/);
 
     my $user = $t->app->schema->resultset('Users')->find({username => 'admin'});
     ok $user, 'admin user exists';
-    my $key = $user->api_keys->find({key => 'DEADBEEFDEADBEEF'});
+    my $key = $user->api_keys->find({key => $key_val});
     ok $key, 'admin API key exists';
-    is $key->secret, 'DEADBEEFDEADBEEF', 'admin API secret matches';
+    is $key->secret, $key_val, 'admin API secret matches';
     is $key->t_expiration, undef, 'admin API key has no expiration';
 
-    $t->get_ok('/api/v1/auth' => {Authorization => 'Bearer admin:DEADBEEFDEADBEEF:DEADBEEFDEADBEEF'})->status_is(200)
-      ->content_is('ok');
+    $t->get_ok('/api/v1/auth' => {Authorization => $bearer_token})->status_is(200)->content_is('ok');
 
     $user->audit_events->delete;
     $user->api_keys->delete;
     $user->delete;
+    $t->get_ok('/login' => 'login as admin')->status_is(302);
     $t->get_ok('/session/test')->status_is(200)->content_like(qr/you are admin/);
     $user = $t->app->schema->resultset('Users')->find({username => 'admin'});
     ok $user, 'admin user re-created';
     ok $user->is_admin && $user->is_operator, 're-created user has admin/operator permissions';
 
     $user->update({is_admin => 0, is_operator => 0});
+    $t->get_ok('/login' => 're-login as admin')->status_is(302);
     $t->get_ok('/session/test')->status_is(200)->content_like(qr/you are admin/);
     $user->discard_changes;
-    ok $user->is_admin && $user->is_operator, 'helper restored admin/operator permissions';
+    ok $user->is_admin && $user->is_operator, 'login restored admin/operator permissions';
 
     $t->get_ok('/')->status_is(200)->content_unlike(qr/Logout/);
 
@@ -102,7 +105,36 @@ subtest None => sub {
         my $key2 = $t2->app->schema->resultset('ApiKeys')->find({key => 'CUSTOMKEY'});
         ok $key2, 'custom API key exists';
         is $key2->secret, 'CUSTOMSECRET', 'custom API secret matches';
+
+        $t2->post_ok(
+            '/api/v1/jobs/cancel',
+            {'X-API-Key' => 'CUSTOMKEY', 'X-API-Microtime' => time},
+            'fail auth on forged API header instead of bypassing CSRF'
+        )->status_is(403)->content_unlike(qr/Bad CSRF token/i);
     }
+
+    subtest 'CSRF security' => sub {
+        my $t = test_auth_method_startup('None');
+        my $url = '/api/v1/jobs/cancel';
+        $t->get_ok('/login' => 'establish session')->status_is(302);
+        $t->get_ok('/session/test' => 'logged in as admin')->status_is(200)->content_like(qr/you are admin/);
+
+        $t->post_ok($url, {'X-API-Key' => 'JUNK_KEY'}, 'fail auth on forged API header instead of bypassing CSRF')
+          ->status_is(403)->content_unlike(qr/Bad CSRF token/i);
+
+        $t->post_ok(
+            $url,
+            {Authorization => 'Bearer JUNK_TOKEN'},
+            'fail auth on forged Bearer header instead of bypassing CSRF'
+        )->status_is(403)->content_unlike(qr/Bad CSRF token/i);
+        $t->get_ok(
+            '/api/v1/auth',
+            {Authorization => $bearer_token},
+            'pass auth on valid Bearer header despite existing session and missing CSRF'
+        )->status_is(200)->content_is('ok');
+        $t->post_ok($url, 'fail on missing CSRF token without API headers')->status_is(403)
+          ->content_like(qr/Bad CSRF token/i);
+    };
 };
 
 subtest OpenID => sub {


### PR DESCRIPTION
* refactor: improve CSRF and auth logic for better maintainability
* fix: prevent "Bad CSRF token!" when using "None" authentication provider

Related issue: https://progress.opensuse.org/issues/194786