### PR TITLE
fix: ensure priority increases for job groups with NULL description

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -216,8 +216,8 @@ sub _apply_prio_throttling ($settings, $new_job_args, $group = undef) {
     if ($config && $group && (my $group_throttling = $config->{misc_limits}->{prio_group_data})) {
         for my $rule (@$group_throttling) {
             my $prop = $rule->{property};
-            my $val = $group->$prop;
-            if (defined $val && $val =~ $rule->{regex}) {
+            my $val = $group->$prop // '';
+            if ($val =~ $rule->{regex}) {
                 $new_job_args->{priority} += $rule->{increment};
                 my $sign = $rule->{increment} >= 0 ? '+' : '';
                 push @throttling_info, "$sign$rule->{increment} because job group $prop matches $rule->{regex}";

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1134,6 +1134,21 @@ subtest 'priority correctly assigned when posting job' => sub {
         $t->app->config->{misc_limits}->{prio_group_data} = undef;
     };
 
+    subtest 'priority adjustment based on empty job group description' => sub {
+        my $group = $schema->resultset('JobGroups')->find({name => 'opensuse'});
+        $group->update({description => undef});
+        my %new_job_args = (priority => $default_prio);
+        $t->app->config->{misc_limits}->{prio_group_parameters} = 'description:^$:73';
+        $t->app->config->{misc_limits}->{prio_group_data}
+          = OpenQA::Setup::_load_prio_group_throttling($t->app, $t->app->config);
+        OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling({}, \%new_job_args, $group);
+        is $new_job_args{priority}, $default_prio + 73, 'priority increased based on empty group description';
+
+        # reset for following tests
+        $t->app->config->{misc_limits}->{prio_group_parameters} = '';
+        $t->app->config->{misc_limits}->{prio_group_data} = undef;
+    };
+
     subtest 'priority scaled up due to QEMURAM demand' => sub {
         my %new_job_args = (priority => $default_prio);
         my $add = 20;


### PR DESCRIPTION
Motivation:
Job groups with a NULL description should be treated as having an empty
description for the purpose of priority scaling. Previously, the logic only
handled defined empty strings, skipping NULL values. This prevented the
intended behavior of increasing priority for groups with missing descriptions
to highlight missing metadata.

Design Choices:
Modified the priority adjustment logic in _apply_prio_throttling to treat
undefined group properties as empty strings () when matching against
configured regex rules. This ensures that a regex like ^$ matches both NULL
and empty string values in the database.

Benefits:
The priority scaling feature now correctly supports job groups with missing
descriptions, encouraging better documentation and ownership of job groups as
intended by the original feature.

Related issue: https://progress.opensuse.org/issues/198623