### PR TITLE
refactor: Improve code for `None` auth method

### DIFF
--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -51,16 +51,13 @@ sub _current_user ($c) {
     # If the value is not in the stash
     my $current_user = $c->stash('current_user');
     unless ($current_user && ($current_user->{no_user} || defined $current_user->{user})) {
-        my $auth_method = $c->app->config->{auth}->{method} // '';
-        my $id = $c->session->{user} // ($auth_method eq 'None' ? 'admin' : undef);
-        my $user = $id ? $c->schema->resultset('Users')->find({username => $id}) : undef;
-        if (!$user && $auth_method eq 'None') {
-            $user = $c->schema->resultset('Users')
-              ->create_user('admin', fullname => 'Administrator', email => 'admin@example.com');
-            $user->update({is_admin => 1, is_operator => 1});
-        }
-        if ($user && $auth_method eq 'None' && !($user->is_admin && $user->is_operator)) {
-            $user->update({is_admin => 1, is_operator => 1});
+        my $is_auth_method_none = ($c->app->config->{auth}->{method} // '') eq 'None';
+        my $id = $c->session->{user} // ($is_auth_method_none ? 'admin' : undef);
+        my $users = $c->schema->resultset('Users');
+        my $user = $id ? $users->find({username => $id}) : undef;
+        if ($is_auth_method_none) {
+            $user ||= $users->create_user('admin', fullname => 'Administrator', email => 'admin@example.com');
+            $user->update({is_admin => 1, is_operator => 1}) unless $user->is_admin && $user->is_operator;
         }
         $c->stash(current_user => $current_user = $user ? {user => $user} : {no_user => 1});
     }


### PR DESCRIPTION
* Simplify conditions
* Avoid duplication of `$user->update({is_admin => 1, is_operator => 1});`
* Avoid duplication of `$auth_method eq 'None'`
* Avoid duplication of `$c->schema->resultset('Users')`