### PR TITLE
fix: prevent "Not enough storage" with consistent setting

### DIFF
--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -17,6 +17,8 @@ BEGIN {
 
     # ensure the web socket connection won't timeout
     $ENV{MOJO_INACTIVITY_TIMEOUT} = 10 * 60;
+
+    $ENV{OS_AUTOINST_STORAGE_KEEP_FREE_RATIO} = 0;
 }
 
 use Test::Warnings ':report_warnings';


### PR DESCRIPTION
os-autoinst in bb08a48 added a feature to prevent depleting available
storage. To provide consistent test results and prevent sporadic issues
in CI systems we must disable that feature in the openQA full-stack test
as well.

Related issue: https://progress.opensuse.org/issues/199061