### PR TITLE
perf: Select only needed columns in _previous_scenario_jobs

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1660,7 +1660,7 @@ sub needle_dir ($self) {
 }
 
 # return the last X complete jobs of the same scenario
-sub _previous_scenario_jobs ($self, $rows = undef) {
+sub _previous_scenario_jobs ($self, $rows = undef, $search_attrs = {}) {
     my $schema = $self->result_source->schema;
     my $conds = [{'me.state' => 'done'}, {'me.result' => [COMPLETE_RESULTS]}, {'me.id' => {'<', $self->id}}];
     for my $key (SCENARIO_WITH_MACHINE_KEYS) {
@@ -1668,7 +1668,8 @@ sub _previous_scenario_jobs ($self, $rows = undef) {
     }
     my %attrs = (
         order_by => ['me.id DESC'],
-        rows => $rows
+        rows => $rows,
+        %$search_attrs,
     );
     return $schema->resultset('Jobs')->search({-and => $conds}, \%attrs)->all;
 }

--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/Context.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/Context.pm
@@ -41,7 +41,7 @@ sub get_regression_links ($c, $job) {
     my $first_known_bad = $build_link->($job) . ' (current job)';
     my $last_good = '(unknown)';
 
-    for my $prev ($job->_previous_scenario_jobs) {
+    for my $prev ($job->_previous_scenario_jobs(undef, {select => [qw/ me.id me.BUILD me.result /]})) {
         if (($prev->result // '') =~ /(passed|softfailed)/) {
             $last_good = $build_link->($prev);
             last;


### PR DESCRIPTION
This query can return a lot of rows, and in the case of the IssueReporter plugin really only 3 columns are used.

On master an example `get_details_ajax` takes 128ms, with this PR 68ms.

With the "cache regression_links" PR #7289  together it takes 45ms.