### PR TITLE
perf(IssueReporter): Cache regression_links

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/Context.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/Context.pm
@@ -30,6 +30,9 @@ sub get_context ($c) {
 
 # this takes the logic from the external_reporting.html.ep
 sub get_regression_links ($c, $job) {
+    if (my $regression_links = $c->stash('regression_links')) {
+        return @$regression_links;
+    }
     my $build_link = sub ($j) {
         my $turl = $c->url_for('test', testid => $j->id)->to_abs;
         return '[' . $j->BUILD . "]($turl)";
@@ -45,6 +48,7 @@ sub get_regression_links ($c, $job) {
         }
         $first_known_bad = $build_link->($prev);
     }
+    $c->stash(regression_links => [$first_known_bad, $last_good]);
     return ($first_known_bad, $last_good);
 }
 


### PR DESCRIPTION
I realized that the same SQL was executed 3 times when retrieving `get_details_ajax`.

OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseIssueReporter is calling the `actions()` function of several plugin classes, which all call `get_regression_links` for the same job.
The same SQL is executed 3 times.

On master an example `get_details_ajax` takes about 128ms, with this PR 63ms.

With the "select less columns" PR #7288 together it takes 45ms.