### PR TITLE
perf: optimize compute_build_results with DB-level aggregation

### DIFF
--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -9,8 +9,9 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Constants qw(BUILD_SORT_BY_NAME BUILD_SORT_BY_NEWEST_JOB BUILD_SORT_BY_OLDEST_JOB);
 use OpenQA::Schema::Result::Jobs;
 use OpenQA::Utils;
-use OpenQA::Log qw(log_error);
 use Date::Format;
+use DateTime::Format::Pg;
+use List::Util qw(any);
 use Sort::Versions;
 use Time::Seconds;
 
@@ -30,43 +31,6 @@ sub init_job_figures ($job_result) {
     $job_result->{total} = 0;
 }
 
-sub count_job ($job, $jr, $labels) {
-    $jr->{total}++;
-    if ($job->state eq OpenQA::Jobs::Constants::DONE) {
-        if ($job->result eq OpenQA::Jobs::Constants::PASSED) {
-            $jr->{passed}++;
-            return;
-        }
-        if ($job->result eq OpenQA::Jobs::Constants::SOFTFAILED) {
-            $jr->{softfailed}++;
-            return;
-        }
-        if (grep { $job->result eq $_ } OpenQA::Jobs::Constants::ABORTED_RESULTS) {
-            $jr->{skipped}++;
-            return;
-        }
-        if (grep { $job->result eq $_ } OpenQA::Jobs::Constants::NOT_OK_RESULTS) {
-            my $comment_data = $labels->{$job->id};
-            $jr->{failed}++;
-            if ($comment_data) {
-                $jr->{labeled}++ if $comment_data->{reviewed};
-                $jr->{comments}++ if $comment_data->{comments} || $comment_data->{reviewed};
-            }
-            return;
-        }
-        # note: Incompletes and timeouts are accounted to both categories - failed and skipped.
-    }
-    if ($job->state eq OpenQA::Jobs::Constants::CANCELLED) {
-        $jr->{skipped}++;
-        return;
-    }
-    my $state = $job->state;
-    log_error('Encountered not-implemented state:' . $job->state . ' result:' . $job->result)
-      unless grep { /$state/ } (OpenQA::Jobs::Constants::PENDING_STATES);
-    $jr->{unfinished}++;
-    return;
-}
-
 sub add_review_badge ($build_res) {
     $build_res->{all_passed} = $build_res->{passed} + $build_res->{softfailed} >= $build_res->{total} ? 1 : 0;
     $build_res->{reviewed} = $build_res->{labeled} >= $build_res->{failed} ? 1 : 0;
@@ -74,7 +38,6 @@ sub add_review_badge ($build_res) {
 }
 
 sub find_child_groups ($group, $subgroup_filter) {
-    # handle regular (non-parent) groups
     return {
         group_ids => [$group->id],
         children => [],
@@ -91,6 +54,12 @@ sub find_child_groups ($group, $subgroup_filter) {
         group_ids => [map { $_->id } @children],
         children => \@children,
     };
+}
+
+sub _get_latest_job_ids ($jobs_resultset, $version, $buildnr, $group_ids) {
+    return map { $_->id } $jobs_resultset->search(
+        {VERSION => $version, BUILD => $buildnr, group_id => {in => $group_ids}, clone_id => undef},
+        {select => [{max => 'id'}], as => ['id'], group_by => [qw(TEST ARCH FLAVOR MACHINE)]})->all;
 }
 
 sub compute_build_results (
@@ -177,18 +146,12 @@ sub compute_build_results (
         }
         last if defined $limit && (--$limit < 0);
         my ($version, $buildnr) = ($build->VERSION, $build->BUILD);
-        my $remaining = defined $max_jobs_limit ? $max_jobs_limit - $total_jobs_seen : undef;
-        my %search_opts = (order_by => 'me.id DESC');
-        $search_opts{rows} = $remaining + 1 if defined $remaining;
-        my $jobs = $jobs_resultset->search(
-            {
-                VERSION => $version,
-                BUILD => $buildnr,
-                group_id => {in => $group_ids},
-                clone_id => undef,
-            },
-            \%search_opts
-        );
+        my @latest_ids = _get_latest_job_ids($jobs_resultset, $version, $buildnr, $group_ids);
+        if (defined $max_jobs_limit && $total_jobs_seen + scalar(@latest_ids) > $max_jobs_limit) {
+            $limit_exceeded = 1;
+            splice @latest_ids, $max_jobs_limit - $total_jobs_seen;
+        }
+        next unless @latest_ids;
         my %jr = (
             key => $build->{key},
             build => $buildnr,
@@ -197,36 +160,71 @@ sub compute_build_results (
         );
         init_job_figures(\%jr);
         init_job_figures($jr{children}->{$_->id} = {}) for @$children;
-        my %seen;
-        my @all_jobs = $jobs->all;
-        if (defined $remaining && @all_jobs > $remaining) {
-            $limit_exceeded = 1;
-            pop @all_jobs;
-        }
-        my @jobs = map {
-            my $key = $_->TEST . '-' . $_->ARCH . '-' . $_->FLAVOR . '-' . ($_->MACHINE // '');
-            $seen{$key}++ ? () : $_;
-        } @all_jobs;
-        next unless @jobs;
-        my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs($jobs);
-        for my $job (@jobs) {
-            $jr{distris}->{$job->DISTRI} = 1;
+        my $stats_rs = $jobs_resultset->search(
+            {id => {-in => \@latest_ids}},
+            {
+                select =>
+                  [qw(state result DISTRI group_id), {count => '*'}, {($newest ? 'max' : 'min') => 't_created'}],
+                as => [qw(state result DISTRI group_id count t_created_agg)],
+                group_by => [qw(state result DISTRI group_id)],
+            });
+        while (my $stat = $stats_rs->next) {
+            my $count = $stat->get_column('count');
+            $jr{total} += $count;
+            $jr{distris}->{$stat->DISTRI} = 1;
+            my $t_agg = $stat->get_column('t_created_agg');
+            if ($t_agg && !ref $t_agg) {
+                $t_agg = DateTime::Format::Pg->parse_datetime($t_agg);
+            }
             if ($newest) {
-                $jr{oldest_newest} //= $job->t_created;
+                $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg > $jr{oldest_newest};
             }
             else {
-                $jr{oldest_newest} = $job->t_created;
+                $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg < $jr{oldest_newest};
             }
-            count_job($job, \%jr, $comment_data);
-            if ($jr{children}) {
-                my $child = $jr{children}->{$job->group_id};
-                $child->{distris}->{$job->DISTRI} = 1;
-                $child->{version} //= $job->VERSION;
-                $child->{build} //= $job->BUILD;
-                count_job($job, $child, $comment_data);
-                add_review_badge($child);
+            my $cat = 'unfinished';
+            if ($stat->state eq OpenQA::Jobs::Constants::DONE) {
+                if ($stat->result eq OpenQA::Jobs::Constants::PASSED) { $cat = 'passed' }
+                elsif ($stat->result eq OpenQA::Jobs::Constants::SOFTFAILED) { $cat = 'softfailed' }
+                elsif (any { $stat->result eq $_ } OpenQA::Jobs::Constants::ABORTED_RESULTS) {
+                    $cat = 'skipped';
+                }
+                elsif (any { $stat->result eq $_ } OpenQA::Jobs::Constants::NOT_OK_RESULTS) {
+                    $cat = 'failed';
+                }
+            }
+            elsif ($stat->state eq OpenQA::Jobs::Constants::CANCELLED) { $cat = 'skipped' }
+            $jr{$cat} += $count;
+            if ($jr{children} && (my $child = $jr{children}->{$stat->group_id})) {
+                $child->{total} += $count;
+                $child->{$cat} += $count;
+                $child->{distris}->{$stat->DISTRI} = 1;
+                $child->{version} //= $version;
+                $child->{build} //= $buildnr;
             }
         }
+        my $failed_rs = $jobs_resultset->search(
+            {
+                id => {-in => \@latest_ids},
+                state => OpenQA::Jobs::Constants::DONE,
+                result => {in => [OpenQA::Jobs::Constants::FAILED, OpenQA::Jobs::Constants::NOT_COMPLETE_RESULTS]},
+            },
+            {select => [qw(id group_id)]});
+        my $failed_id_to_group = {map { $_->id => $_->group_id } $failed_rs->all};
+        if (keys %$failed_id_to_group) {
+            my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs($failed_rs);
+            for my $id (keys %$comment_data) {
+                my $cd = $comment_data->{$id};
+                next unless $cd->{reviewed} || $cd->{comments};
+                $jr{labeled}++ if $cd->{reviewed};
+                $jr{comments}++ if $cd->{comments} || $cd->{reviewed};
+                if ($jr{children} && (my $child = $jr{children}->{$failed_id_to_group->{$id}})) {
+                    $child->{labeled}++ if $cd->{reviewed};
+                    $child->{comments}++ if $cd->{comments} || $cd->{reviewed};
+                }
+            }
+        }
+        add_review_badge($_) for values %{$jr{children} // {}};
         $total_jobs_seen += $jr{total};
         $jr{date} = delete $jr{oldest_newest};
         $jr{escaped_version} = $jr{version};

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -616,28 +616,6 @@ subtest 're-routing' => sub {
     $t->attr_like('#all_tests .nav-link', 'href', qr|/base/tests|s, 'base applied to navbar link');
 };
 
-subtest 'job skipped count' => sub {
-    my $job_skipped_hash = {
-        id => 12345,
-        BUILD => '0048@0815',
-        DISTRI => 'opensuse',
-        VERSION => 'Factory',
-        FLAVOR => 'tape',
-        ARCH => 'x86_64',
-        MACHINE => 'xxx',
-        TEST => 'dummy',
-        state => OpenQA::Jobs::Constants::DONE,
-        result => OpenQA::Jobs::Constants::SKIPPED,
-    };
-    $jobs->create($job_skipped_hash);
-    my $job_skipped = $jobs->find({id => 12345});
-    my $jr = {skipped => 0, total => 0};
-    OpenQA::BuildResults::count_job($job_skipped, $jr, {});
-
-    is $jr->{skipped}, 1, 'Job with aborted result correctly increments skipped count';
-    is $jr->{total}, 1, 'Total jobs incremented';
-};
-
 subtest 'Group overview limit' => sub {
     $t->get_ok('/group_overview/1001')->status_is(200)->element_exists_not('#max-jobs-limit');
     $t->app->config->{misc_limits}->{job_groups_overview_max_jobs} = 1;
@@ -796,6 +774,60 @@ subtest 'Ignore job groups' => sub {
     };
 
     $t->app->schema->txn_rollback;
+};
+
+subtest 'OpenQA::BuildResults::compute_build_results coverage' => sub {
+    my $group = $job_groups->find(1001);
+    $group->update({build_version_sort => OpenQA::Constants::BUILD_SORT_BY_NAME});
+    my $res = OpenQA::BuildResults::compute_build_results($group, 10, undef, undef, [], undef);
+    ok @{$res->{build_results}}, 'compute_build_results newest=0';
+
+    $group->update({build_version_sort => OpenQA::Constants::BUILD_SORT_BY_NEWEST_JOB});
+    $res = OpenQA::BuildResults::compute_build_results($group, 10, undef, undef, [], undef);
+    ok @{$res->{build_results}}, 'compute_build_results newest=1';
+
+    $res = OpenQA::BuildResults::compute_build_results($group, 10, undef, undef, [], undef, 1);
+    is $res->{limit_exceeded}, 1, 'limit exceeded';
+
+    my $build = 'COVERAGE_BUILD';
+    my $common = {
+        group_id => 1001,
+        VERSION => '13.1',
+        BUILD => $build,
+        ARCH => 'x86_64',
+        FLAVOR => 'DVD',
+        MACHINE => '64bit',
+        DISTRI => 'opensuse',
+    };
+    $jobs->create({%$common, TEST => 'cancelled_job', state => CANCELLED});
+    $jobs->create({%$common, TEST => 'skipped_job', state => DONE, result => SKIPPED});
+    my $failed_job = $jobs->create({%$common, TEST => 'failed_job', state => DONE, result => FAILED});
+    $t->app->schema->resultset('Comments')
+      ->create({job_id => $failed_job->id, user_id => 99901, text => 'some comment'});
+    my $labeled_job = $jobs->create({%$common, TEST => 'labeled_job', state => DONE, result => FAILED});
+    $t->app->schema->resultset('Comments')
+      ->create({job_id => $labeled_job->id, user_id => 99901, text => 'label:reviewed_label'});
+
+    $res = OpenQA::BuildResults::compute_build_results($group, 10, undef, undef, [], undef);
+    my $found = (grep { $_->{build} eq $build } @{$res->{build_results}})[0];
+    is $found->{skipped}, 2, 'skipped jobs counted';
+    is $found->{comments}, 2, 'comments counted';
+    is $found->{labeled}, 1, 'labeled job counted';
+
+    my $parent = $parent_groups->create(
+        {name => 'coverage_parent', build_version_sort => OpenQA::Constants::BUILD_SORT_BY_NAME});
+    $group->update({parent_id => $parent->id});
+    $parent->discard_changes;
+
+    $res = OpenQA::BuildResults::compute_build_results($parent, 10, undef, undef, [], undef);
+    $found = (grep { $_->{build} eq $build } @{$res->{build_results}})[0];
+    ok $found->{children}->{$group->id}, 'child group results';
+    is $found->{children}->{$group->id}->{failed}, 2, 'child group failed jobs';
+
+    my $t_str = '2026-04-20 12:00:00';
+    $jobs->create({%$common, TEST => 'time1', DISTRI => 'd1', t_created => $t_str, state => DONE, result => PASSED});
+    $jobs->create({%$common, TEST => 'time2', DISTRI => 'd2', t_created => $t_str, state => DONE, result => PASSED});
+    ok OpenQA::BuildResults::compute_build_results($parent, 10, undef, undef, [], undef), 'same timestamp';
 };
 
 done_testing;


### PR DESCRIPTION
Motivation:
Fetching and iterating all job objects for huge job groups causes significant
performance degradation and memory issues. The lack of database-level
aggregation makes the system vulnerable to excessive resource consumption.

Design Choices:
1. Replaced the Perl-level job deduplication and iteration with a database-level
   group_by query (aggregation).
2. Introduced _get_latest_job_ids helper to handle scenario-based job
   deduplication entirely in the database.
3. Optimized comment data fetching by only targeting failed job IDs instead of
   all jobs in a build.
4. Preserved existing parent-group rollup behavior while leveraging the new
   aggregated data structure.

Verified manually on openqa.opensuse.org with the Tumbleweed job group
overview calling

```
runs=3 count-fail-ratio curl \
        https://openqa.opensuse.org/api/v1/job_groups/1/build_results
```

* Before: mean runtime: 1255±52.37 ms
* After: mean runtime: 832±26.79 ms

That is a relative speedup of approximately 1.5x, a 34% reduction in
execution time.

Benefits:
Significantly reduces processing time and potentially memory footprint
for builds with many scenarios. Hydrating fewer job objects results in
faster response times for group overview and dashboard pages.

Related progress issue: https://progress.opensuse.org/issues/196913