### PR TITLE
feat: disable dashboard inclusion checkbox if ignored by config

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -177,6 +177,20 @@ sub register ($self, $app, $config) {
         });
 
     $app->helper(
+        job_group_ignored_info => sub ($c, $group, $is_parent) {
+            my $ignored_groups = $c->app->ignored_groups;
+            my $ignored_by_config = $ignored_groups->{$group->name}
+              || (!$is_parent && $group->parent && $ignored_groups->{$group->parent->name});
+            my $ignored_title = 'Exclude from evaluation for the main dashboard page';
+            if ($ignored_by_config) {
+                my $reason = $ignored_groups->{$group->name} ? 'the group name' : 'the parent group name';
+                $ignored_title
+                  = "Excluded from evaluation for the main dashboard page because $reason is configured in the 'ignored_job_groups' ini file setting";
+            }
+            return {ignored_by_config => $ignored_by_config, ignored_title => $ignored_title};
+        });
+
+    $app->helper(
         # emit_event helper, adds user, connection to events
         emit_event => sub ($c, $event, $data = undef) {
             die 'Missing event name' unless $event;

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -748,6 +748,13 @@ subtest 'Ignore job groups' => sub {
         ok !grep({ $_ eq 'IgnoreMe1' } @group_names), 'IgnoreMe1 is hidden when configured in openqa.ini';
         ok grep({ $_ eq 'IgnoreMe2' } @group_names), 'IgnoreMe2 remains visible when IgnoreMe1 is ignored';
 
+        $test_case->login($t, 'arthur');
+        $t->get_ok('/admin/job_templates/' . $g1->id)->status_is(200)
+          ->element_exists('input#editor-ignore-on-dashboard[disabled="disabled"]')
+          ->element_exists('input#editor-ignore-on-dashboard[checked="checked"]')
+          ->element_exists('label[for="editor-ignore-on-dashboard"][title*="the group name is configured"]');
+        $test_case->login($t, 'percival');
+
         $t->app->ignored_groups({IgnoreMe1 => 1, IgnoreMe2 => 1});
         $res = $t->get_ok('/dashboard_build_results.json')->status_is(200)->tx->res->json;
         @group_names = map { $_->{group}->{name} } @{$res->{results}};
@@ -775,6 +782,14 @@ subtest 'Ignore job groups' => sub {
         ok !grep({ $_ eq 'IgnoreMe1' } @child_names),
           'Child IgnoreMe1 is hidden in parent overview when ignored globally';
         ok grep({ $_ eq 'IgnoreMe2' } @child_names), 'Child IgnoreMe2 remains visible in parent overview';
+
+        $t->app->ignored_groups({'Test Parent Config' => 1});
+        $test_case->login($t, 'arthur');
+        $t->get_ok('/admin/job_templates/' . $g1->id)->status_is(200)
+          ->element_exists('input#editor-ignore-on-dashboard[disabled="disabled"]')
+          ->element_exists('input#editor-ignore-on-dashboard[checked="checked"]')
+          ->element_exists('label[for="editor-ignore-on-dashboard"][title*="the parent group name is configured"]');
+        $test_case->login($t, 'percival');
         $t->app->ignored_groups({});
     };
 

--- a/templates/webapi/admin/group/group_property_editor.html.ep
+++ b/templates/webapi/admin/group/group_property_editor.html.ep
@@ -180,7 +180,7 @@
                 </div>
                 <div class="mb-3 row">
                     <label for="editor-keep-important-logs-in-days"
-                    class="form-label col-sm-2 control-label" data-bs-toggle="tooltip" title="Number of days to keep logs of important jobs" title="currently not used">Keep important logs for</label>
+                    class="form-label col-sm-2 control-label" data-bs-toggle="tooltip" title="Number of days to keep logs of important jobs">Keep important logs for</label>
                     <div class="col-sm-10">
                         <input type="number" min="0" class="form-control" id="editor-keep-important-logs-in-days" name="keep_important_logs_in_days" value="<%= $group->keep_important_logs_in_days %>"> days
                         <%= include 'admin/group/cleanup_help' %>

--- a/templates/webapi/admin/group/group_property_editor.html.ep
+++ b/templates/webapi/admin/group/group_property_editor.html.ep
@@ -53,15 +53,21 @@
                     %>
                 </div>
             </div>
+            % my $ignored_info = job_group_ignored_info($group, $is_parent);
+            % my $ignored_by_config = $ignored_info->{ignored_by_config};
+            % my $ignored_title = $ignored_info->{ignored_title};
             <div class="mb-3 row">
-                <label for="editor-ignore-on-dashboard" class="form-label col-sm-2 control-label" data-bs-toggle="tooltip" title="Exclude from evaluation for the main dashboard page">Ignore on dashboard</label>
-                <div class="col-sm-10">
+                <label for="editor-ignore-on-dashboard" class="form-label col-sm-2 control-label" data-bs-toggle="tooltip" title="<%= $ignored_title %>">Ignore on dashboard</label>
+                <div class="col-sm-10" <% if ($ignored_by_config) { %> data-bs-toggle="tooltip" title="<%= $ignored_title %>" <% } %>>
                     <input type="hidden" name="ignore_on_dashboard" value="0">
                     <input type="checkbox"
                            id="editor-ignore-on-dashboard" name="ignore_on_dashboard"
                            value="1"
-                        % if ($group->ignore_on_dashboard) {
+                        % if ($group->ignore_on_dashboard || $ignored_by_config) {
                             checked="checked"
+                        % }
+                        % if ($ignored_by_config) {
+                            disabled="disabled"
                         % }
                     >
                     <%= help_popover 'Ignore on dashboard' =>


### PR DESCRIPTION
Motivation:
Job groups can be ignored from the dashboard via .ini configuration. To
visualize that explicitly in the web UI, the "Ignore on dashboard"
checkbox should be disabled and reflect the effective state if a group
is already ignored via configuration.

Design Choices:
- Updated the group property editor template to check against the
  ignored_groups configuration.
- The disabled state is also inherited from parent groups if they are
  configured to be ignored.
- Added tooltips to explain why the checkbox is disabled.

Related issue: https://progress.opensuse.org/issues/199427