### PR TITLE
feat: Make assignment of fullname on login via OAuth2 configurable

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -200,6 +200,7 @@
 #token_scope = read_user
 #token_label = Bearer
 #id_from = id
+#fullname_from = name
 #nickname_from = username
 #
 # The default value for `id_from` is "id" for backwards compatibility.

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -202,6 +202,7 @@
 #id_from = id
 #fullname_from = name
 #nickname_from = username
+#email_from = email
 #
 # The default value for `id_from` is "id" for backwards compatibility.
 # For OpenID Connect, the value should be "sub", following the OpenID Connect ID Token standard.

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -180,6 +180,7 @@ sub default_config () {
             user_url => '',
             token_scope => '',
             token_label => '',
+            fullname_from => 'name',
             nickname_from => '',
             unique_name => '',
             id_from => 'id',

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -182,6 +182,7 @@ sub default_config () {
             token_label => '',
             fullname_from => 'name',
             nickname_from => '',
+            email_from => 'email',
             unique_name => '',
             id_from => 'id',
         },

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -64,6 +64,11 @@ sub auth_setup ($server) {
     $app->plugin(OAuth2 => {$provider => \%provider_args});
 }
 
+sub _render_error ($controller, $details) {
+    log_debug 'OAuth2 user provider returned: ' . dumper($details);
+    return $controller->render(text => 'User data returned by OAuth2 provider is insufficient', status => 403);
+}
+
 sub update_user ($controller, $main_config, $provider_config, $data) {
     return undef unless $data;    # redirect to ID provider
 
@@ -76,22 +81,17 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
         return $controller->render(text => $msg, status => 403);    # return always 403 for consistency
     }
     my $details = $tx->res->json;
-    my $id_field = $provider_config->{id_from} // 'id';
-    my $fullname_field = $provider_config->{fullname_from} // 'name';
-    my $nickname_field = $provider_config->{nickname_from};
-    my $email_field = $provider_config->{email_from} // 'email';
-    if (ref $details ne 'HASH' || !$details->{$id_field} || !$details->{$nickname_field}) {
-        log_debug('OAuth2 user provider returned: ' . dumper($details));
-        return $controller->render(text => 'User data returned by OAuth2 provider is insufficient', status => 403);
-    }
+    return _render_error($controller, $details) if ref $details ne 'HASH';
+    my $id = $details->{$provider_config->{id_from} // 'id'};
+    my $full = $details->{$provider_config->{fullname_from} // 'name'};
+    my $nick = $details->{$provider_config->{nickname_from}};
+    my $email = $details->{$provider_config->{email_from} // 'email'};
+    return _render_error($controller, $details) unless $id && $nick;
     my $provider_name = $main_config->{provider};
     $provider_name = $provider_config->{unique_name} || $provider_name if $provider_name eq 'custom';
-    my $user = $controller->schema->resultset('Users')->create_user(
-        $details->{$id_field},
-        provider => "oauth2\@$provider_name",
-        nickname => $details->{$nickname_field},
-        fullname => $details->{$fullname_field},
-        email => $details->{$email_field});
+    my $provider = "oauth2\@$provider_name";
+    my $users = $controller->schema->resultset('Users');
+    my $user = $users->create_user($id, provider => $provider, nickname => $nick, fullname => $full, email => $email);
 
     my $session = $controller->session;
     $session->{user} = $user->username;

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -79,6 +79,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
     my $id_field = $provider_config->{id_from} // 'id';
     my $fullname_field = $provider_config->{fullname_from} // 'name';
     my $nickname_field = $provider_config->{nickname_from};
+    my $email_field = $provider_config->{email_from} // 'email';
     if (ref $details ne 'HASH' || !$details->{$id_field} || !$details->{$nickname_field}) {
         log_debug('OAuth2 user provider returned: ' . dumper($details));
         return $controller->render(text => 'User data returned by OAuth2 provider is insufficient', status => 403);
@@ -90,7 +91,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
         provider => "oauth2\@$provider_name",
         nickname => $details->{$nickname_field},
         fullname => $details->{$fullname_field},
-        email => $details->{email});
+        email => $details->{$email_field});
 
     my $session = $controller->session;
     $session->{user} = $user->username;

--- a/lib/OpenQA/WebAPI/Auth/OAuth2.pm
+++ b/lib/OpenQA/WebAPI/Auth/OAuth2.pm
@@ -77,6 +77,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
     }
     my $details = $tx->res->json;
     my $id_field = $provider_config->{id_from} // 'id';
+    my $fullname_field = $provider_config->{fullname_from} // 'name';
     my $nickname_field = $provider_config->{nickname_from};
     if (ref $details ne 'HASH' || !$details->{$id_field} || !$details->{$nickname_field}) {
         log_debug('OAuth2 user provider returned: ' . dumper($details));
@@ -88,7 +89,7 @@ sub update_user ($controller, $main_config, $provider_config, $data) {
         $details->{$id_field},
         provider => "oauth2\@$provider_name",
         nickname => $details->{$nickname_field},
-        fullname => $details->{name},
+        fullname => $details->{$fullname_field},
         email => $details->{email});
 
     my $session = $controller->session;


### PR DESCRIPTION
Other assignments are already configurable. This might help to populate the fullname field after migrating to SUSEID which doesn't set `name`.

Related ticket: https://progress.opensuse.org/issues/199913