### PR TITLE
fix(apparmor): adapt snd2png path to os-autoinst#2881

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -134,7 +134,7 @@
   /usr/bin/rsync rix,
   /usr/bin/sha1sum rix,
   /usr/bin/slirpvde rix,
-  /usr/bin/snd2png rix,
+  /usr/{bin,lib/os-autoinst}/snd2png rix,
   /usr/bin/ssh rix,
   /usr/bin/ssh.hmac r,
   /usr/bin/ssh-keygen rix,


### PR DESCRIPTION
os-autoinst 607dccd in
https://github.com/os-autoinst/os-autoinst/pull/2881
changed the path of snd2png. This commit allows both the old and the new
path.