### PR TITLE
feat: automatically add configurable worker classes to jobs

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -510,3 +510,11 @@ concurrent = 0
 #casedir = https://github.com/os-autoinst/os-autoinst-distri-example.git
 #distri = example
 #build = openqa
+
+## Configuration for automatically adding worker classes to jobs based on patterns
+[worker_class_auto_assignment]
+## Automatically add a worker class to a job if no existing worker class matches the pattern.
+## Format: pattern -> class
+## The pattern is a regex.
+## This can be specified multiple times.
+#add_worker_class_if_missing = size-.* -> size-large

--- a/lib/OpenQA/Config.pm
+++ b/lib/OpenQA/Config.pm
@@ -6,16 +6,45 @@ use Mojo::Base -strict, -signatures;
 
 use Config::IniFiles;
 use Exporter qw(import);
-use OpenQA::Log qw(log_info);
+use OpenQA::Log qw(log_info log_warning);
 use Mojo::File qw(path);
+use Feature::Compat::Try;
 
-our @EXPORT = qw(config_dir_within_app_home lookup_config_files parse_config_files parse_config_files_as_hash);
+our @EXPORT
+  = qw(config_dir_within_app_home lookup_config_files parse_config_files parse_config_files_as_hash parse_worker_class_auto_assignment);
 
 sub _config_dirs ($config_dir_within_home) {
     return [[$ENV{OPENQA_CONFIG} // ()], [$config_dir_within_home // ()], ['/etc/openqa', '/usr/etc/openqa']];
 }
 
 sub config_dir_within_app_home ($app) { $app->child('etc', 'openqa') }
+
+sub _parse_auto_assignment_entry ($entry) {
+    my ($pattern_str, $class) = split /\s*->\s*/, $entry, 2;
+    if (!defined $class) {
+        log_warning("Missing delimiter ' -> ' in worker_class_auto_assignment: $entry");
+        return ();
+    }
+    my $pattern_regex;
+    try { $pattern_regex = qr/$pattern_str/ }
+    catch ($e) {
+        log_warning("Invalid regex pattern in worker_class_auto_assignment: $pattern_str");
+        return ();
+    }
+    return {pattern => $pattern_regex, class => $class};
+}
+
+sub parse_worker_class_auto_assignment ($config) {
+    return $config->{_worker_class_auto_assignment_rules} if $config->{_worker_class_auto_assignment_rules};
+
+    my $section = $config->{worker_class_auto_assignment} or return [];
+    my $entries = $section->{add_worker_class_if_missing} or return [];
+    $entries = [$entries] unless ref $entries eq 'ARRAY';
+
+    my $rules = [map { _parse_auto_assignment_entry($_) } grep { $_ } @$entries];
+    $config->{_worker_class_auto_assignment_rules} = $rules;
+    return $rules;
+}
 
 sub lookup_config_files ($config_dir_within_home, $name, $silent = 0) {
     my $config_name;
@@ -32,7 +61,7 @@ sub lookup_config_files ($config_dir_within_home, $name, $silent = 0) {
             last if $has_main_config;
         }
         if (@config_file_paths) {
-            log_info "Reading $config_name config from: @config_file_paths" unless $silent;
+            log_info("Reading $config_name config from: @config_file_paths") unless $silent;
             last;
         }
     }

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -9,6 +9,7 @@ use Date::Format 'time2str';
 use Encode qw(decode_utf8);
 use File::Basename 'basename';
 use IPC::Run;
+use OpenQA::Config;
 use OpenQA::App;
 use OpenQA::Jobs::Constants;
 use OpenQA::Constants qw(DEFAULT_MAX_JOB_TIME);
@@ -24,7 +25,7 @@ use Mojolicious::Validator;
 use Mojolicious::Validator::Validation;
 use Time::HiRes 'time';
 use DateTime;
-use List::Util qw(any);
+use List::Util qw(any uniq);
 use Scalar::Util qw(looks_like_number);
 
 =head2 latest_build
@@ -102,6 +103,35 @@ sub latest_jobs ($self, $until = undef) {
     return @latest;
 }
 
+sub _apply_auto_worker_class_assignment ($settings_ref) {
+    my $app = OpenQA::App->singleton or return undef;
+    my $rules = OpenQA::Config::parse_worker_class_auto_assignment($app->config // {});
+    return unless @$rules;
+
+    my @existing = grep { $_ } split qr/,/, $settings_ref->{WORKER_CLASS} // '';
+    my @to_add = grep {
+        my $pattern = $_->{pattern};
+        !any { $_ =~ $pattern } @existing;
+    } @$rules;
+    return unless @to_add;
+
+    for my $rule (@to_add) {
+        log_info("Auto-assigning worker class '$rule->{class}' to job (no match for pattern '$rule->{pattern}')");
+    }
+    $settings_ref->{WORKER_CLASS} = join ',', sort(uniq(@existing, map { $_->{class} } @to_add));
+}
+
+sub _build_job_settings ($settings_ref) {
+    my $now = now;
+    my @job_settings;
+    for my $key (keys %$settings_ref) {
+        my $val = $settings_ref->{$key};
+        push @job_settings, map { {t_created => $now, t_updated => $now, key => $key, value => $_} }
+          grep { defined $_ } $key =~ qr/(^WORKER_CLASS|\[\])$/ ? split(m/,/, $val // '') : ($val);
+    }
+    return \@job_settings;
+}
+
 sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
     my %settings = %$settings;
     my %new_job_args;
@@ -112,8 +142,8 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
 
     # validate special settings
     my %special_settings = (TEST => delete $settings{TEST}, _PRIORITY => delete $settings{_PRIORITY});
-    my $validator = Mojolicious::Validator->new;
-    my $v = Mojolicious::Validator::Validation->new(validator => $validator, input => \%special_settings);
+    my $v
+      = Mojolicious::Validator::Validation->new(validator => Mojolicious::Validator->new, input => \%special_settings);
     my $test = $v->required('TEST')->like(TEST_NAME_REGEX)->param;
     my $prio = $v->optional('_PRIORITY')->num->param;
     die 'The following settings are invalid: ' . join(', ', @{$v->failed}) . "\n" if $v->has_error;
@@ -141,20 +171,9 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
         if (my $value = delete $settings{$key}) { $new_job_args{$key} = $value }
     }
 
-    # assign default for WORKER_CLASS
     $settings{WORKER_CLASS} ||= 'qemu_' . ($new_job_args{ARCH} // 'x86_64');
+    _apply_auto_worker_class_assignment(\%settings);
 
-    # Apply auto-assignment rules
-    if (my $app = OpenQA::App->singleton) {
-        my $auto_assignment_rules = OpenQA::Config::parse_worker_class_auto_assignment($app->config // {});
-        if (@$auto_assignment_rules) {
-            my @existing_classes = split qr/,/, $settings{WORKER_CLASS};
-            my @classes_to_add = map { _apply_auto_assignment_rule($_, \@existing_classes) } @$auto_assignment_rules;
-            $settings{WORKER_CLASS} = join ',', sort @existing_classes, @classes_to_add if @classes_to_add;
-        }
-    }
-
-    # assign scheduled product
     $new_job_args{scheduled_product_id} = $scheduled_product_id;
 
     my $debug_msg = $self->_apply_prio_throttling(\%settings, \%new_job_args, $group);
@@ -163,16 +182,7 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
     my $job = $self->create(\%new_job_args);
     log_debug(sprintf "(Job %d) $debug_msg", $job->id) if $debug_msg;
 
-    # add job settings
-    my @job_settings;
-    my $now = now;
-    for my $key (keys %settings) {
-        my @values = $key =~ qr/(^WORKER_CLASS|\[\])$/ ? split(m/,/, $settings{$key}) : ($settings{$key});
-        push @job_settings, {t_created => $now, t_updated => $now, key => $key, value => $_} for @values;
-    }
-    $job->settings->populate(\@job_settings);
-
-    # associate currently available assets with job
+    $job->settings->populate(_build_job_settings(\%settings));
     $job->register_assets_from_settings;
 
     log_info('Ignoring invalid group ' . encode_json($group_args) . ' when creating new job ' . $job->id)
@@ -181,12 +191,6 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
     return $job;
 }
 
-sub _apply_auto_assignment_rule ($rule, $existing_classes) {
-    my $pattern = $rule->{pattern};
-    return () if any { $_ =~ $pattern } @$existing_classes;
-    log_info("Auto-assigning worker class '$rule->{class}' to job (no match for pattern '$pattern')");
-    return $rule->{class};
-}
 
 sub _update_priority ($value, $throt_config, $job_args) {
     my $scale = $throt_config->{scale} // 0;

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -144,6 +144,16 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
     # assign default for WORKER_CLASS
     $settings{WORKER_CLASS} ||= 'qemu_' . ($new_job_args{ARCH} // 'x86_64');
 
+    # Apply auto-assignment rules
+    if (my $app = OpenQA::App->singleton) {
+        my $auto_assignment_rules = OpenQA::Config::parse_worker_class_auto_assignment($app->config // {});
+        if (@$auto_assignment_rules) {
+            my @existing_classes = split qr/,/, $settings{WORKER_CLASS};
+            my @classes_to_add = map { _apply_auto_assignment_rule($_, \@existing_classes) } @$auto_assignment_rules;
+            $settings{WORKER_CLASS} = join ',', sort @existing_classes, @classes_to_add if @classes_to_add;
+        }
+    }
+
     # assign scheduled product
     $new_job_args{scheduled_product_id} = $scheduled_product_id;
 
@@ -169,6 +179,13 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
       if keys %$group_args && !$group;
     $job->calculate_blocked_by;
     return $job;
+}
+
+sub _apply_auto_assignment_rule ($rule, $existing_classes) {
+    my $pattern = $rule->{pattern};
+    return () if any { $_ =~ $pattern } @$existing_classes;
+    log_info("Auto-assigning worker class '$rule->{class}' to job (no match for pattern '$pattern')");
+    return $rule->{class};
 }
 
 sub _update_priority ($value, $throt_config, $job_args) {

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -13,6 +13,8 @@ use OpenQA::Test::Utils 'setup_mojo_app_with_default_worker_timeout';
 use OpenQA::WebAPI::Controller::API::V1::Worker;
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
+use Test::MockModule;
+use Test::MockObject;
 use Mojo::Util 'monkey_patch';
 use OpenQA::Test::TimeLimit '10';
 
@@ -202,5 +204,34 @@ $job = $sent->{$w9_id}->{job}->to_hash;
 is $job->{id}, $jobI->id, 'this worker can do jobI, child - client';
 
 # job G is not grabbed because there is no worker with class 'special'
+
+subtest 'auto_worker_class' => sub {
+    my $mock_app = Test::MockModule->new('OpenQA::App', no_auto => 1);
+    my $mock_app_obj = Test::MockObject->new;
+    $mock_app_obj->set_always(
+        config => {
+            global => {worker_timeout => 60},
+            misc_limits => {
+                throttle_failing_job_threshold => 0,
+                throttle_failing_job_prio_step => 0,
+                throttle_failing_job_history_length => 0,
+            },
+            worker_class_auto_assignment => {
+                add_worker_class_if_missing => 'size-.* -> size-large'
+            }});
+    my $mock_log = Test::MockObject->new;
+    $mock_log->set_always(info => 1);
+    $mock_log->set_always(level => 'info');
+    $mock_app_obj->set_always(log => $mock_log);
+    $mock_app->redefine(singleton => $mock_app_obj);
+
+    my $job = job_create({TEST => 'auto_class_test', ARCH => 'x86_64'});
+    my @classes = sort map { $_->value } $job->settings->search({key => 'WORKER_CLASS'})->all;
+    is_deeply \@classes, ['qemu_x86_64', 'size-large'], 'auto-assigned size-large';
+
+    $job = job_create({TEST => 'auto_class_test_existing', ARCH => 'x86_64', WORKER_CLASS => 'size-small,qemu_x86_64'});
+    @classes = sort map { $_->value } $job->settings->search({key => 'WORKER_CLASS'})->all;
+    is_deeply \@classes, ['qemu_x86_64', 'size-small'], 'kept existing size-small';
+};
 
 done_testing();

--- a/t/config.t
+++ b/t/config.t
@@ -357,6 +357,42 @@ subtest 'check throttling configuration validation and application' => sub {
             qr/Wrong format/, 'warning logged';
         };
     };
+
+    subtest 'parse_worker_class_auto_assignment' => sub {
+        my $config = {
+            worker_class_auto_assignment => {
+                add_worker_class_if_missing =>
+                  ['size-.* -> size-large', 'gpu-.* -> gpu-none', 'invalid line', 'bad regex ( -> size-error',]}};
+
+        my $mock_config = Test::MockModule->new('OpenQA::Config');
+        my @warnings;
+        $mock_config->redefine(log_warning => sub { push @warnings, $_[0] });
+
+        my $rules = OpenQA::Config::parse_worker_class_auto_assignment($config);
+
+        is scalar @$rules, 2, 'parsed 2 valid rules';
+        is $rules->[0]{class}, 'size-large', 'first rule class';
+        ok 'size-small' =~ $rules->[0]{pattern}, 'first rule pattern matches';
+
+        is $rules->[1]{class}, 'gpu-none', 'second rule class';
+        ok 'gpu-anything' =~ $rules->[1]{pattern}, 'second rule pattern matches';
+
+        is scalar @warnings, 2, 'got 2 warnings for invalid lines';
+        like $warnings[0], qr/Missing delimiter/, 'warning for missing delimiter';
+        like $warnings[1], qr/Invalid regex pattern/, 'warning for invalid regex';
+
+        subtest 'single value' => sub {
+            my $config = {worker_class_auto_assignment => {add_worker_class_if_missing => 'size-.* -> size-large'}};
+            my $rules = OpenQA::Config::parse_worker_class_auto_assignment($config);
+            is scalar @$rules, 1, 'parsed 1 rule from single value';
+        };
+
+        subtest 'empty' => sub {
+            is_deeply OpenQA::Config::parse_worker_class_auto_assignment({}), [], 'empty config returns empty array';
+            is_deeply OpenQA::Config::parse_worker_class_auto_assignment({worker_class_auto_assignment => {}}), [],
+              'empty section returns empty array';
+        };
+    };
 };
 
 done_testing();


### PR DESCRIPTION
Motivation:
Provide a mechanism to automatically assign default worker classes to
jobs based on configuration in openqa.ini. This allows administrators to
ensure that jobs meet certain infrastructure requirements (e.g. resource
limits, specific hardware availability) without requiring explicit
user input for every job.

Design Choices:
- Configuration is read from [worker_class_auto_assignment] section.
- Pattern is a regex matched against the job's existing worker classes.
- If no existing class matches the pattern, the specified class is added.
- Logic is implemented in lib/OpenQA/Config.pm for parsing and
  lib/OpenQA/Schema/ResultSet/Jobs.pm for application during job creation.

Benefits:
- Decouples infrastructure requirements from test definitions.
- Allows instance-wide defaults for worker class assignment.
- Reduces manual configuration errors during job submission.

Related issue: https://progress.opensuse.org/issues/191650