### PR TITLE
fix(ci): Avoid conflict when building cache with `crypto-policies-scripts-*`

### DIFF
--- a/tools/ci/build_cache.sh
+++ b/tools/ci/build_cache.sh
@@ -7,7 +7,11 @@ set -ex
 
 sudo zypper ar -f -p 90 https://download.opensuse.org/repositories/devel:/openQA:/Leap:/16.0/16.0 openQA
 sudo zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/16.0 devel
+sudo zypper mr --keep-packages --all
 tools/retry sudo zypper --gpg-auto-import-keys ref
-sudo zypper -n install --download-only $(sed -e 's/\r//' < tools/ci/ci-packages.txt)
-sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
+sudo zypper -n install $(sed -e 's/\r//' < tools/ci/ci-packages.txt)
+if [[ "$(find /var/cache/zypp/packages/ | wc -l)" == 0 ]]; then
+    echo "no packages cached"
+    exit 1
+fi
 echo "build_cache.sh done"

--- a/tools/ci/build_or_install_from_cache.sh
+++ b/tools/ci/build_or_install_from_cache.sh
@@ -4,5 +4,5 @@ if [ -z "$CIRCLE_WORKFLOW_ID" ]; then
     bash "$(dirname "$0")"/build_cache.sh
 else
     packages=$(find /var/cache/zypp/packages/ | grep '.rpm$') || { echo "No RPM packages found. The cache is empty. Please trigger a cache.fullstack job manually to ensure a cache is available for the latest version." && exit 1; }
-    sudo rpm -i -f $packages
+    sudo zypper -n install $packages
 fi

--- a/tools/ci/ci-packages.txt
+++ b/tools/ci/ci-packages.txt
@@ -2,7 +2,6 @@ bsdtar-3.8.1
 chrony-4.6.1
 chrony-pool-openSUSE-4.6.1
 cmark-0.31.0
-crypto-policies-scripts-20250124.4d262e7
 expat-2.7.1
 file-5.46
 file-magic-5.46


### PR DESCRIPTION
This will hopefully fix errors when building the cache, e.g.:

```
file /usr/share/crypto-policies/BSI/opensslcnf.txt from install of
crypto-policies-20250714.cd6043a-160000.1.1.noarch conflicts with file from
package crypto-policies-20250124.4d262e7-160000.2.1.noarch
```