### PR TITLE
fix: try to resolve package conflicts with zypper

### DIFF
--- a/tools/ci/build_cache.sh
+++ b/tools/ci/build_cache.sh
@@ -8,6 +8,7 @@ set -ex
 sudo zypper ar -f -p 90 https://download.opensuse.org/repositories/devel:/openQA:/Leap:/16.0/16.0 openQA
 sudo zypper ar -f -p 95 http://download.opensuse.org/repositories/devel:openQA/16.0 devel
 tools/retry sudo zypper --gpg-auto-import-keys ref
-sudo zypper -n install --download-only $(sed -e 's/\r//' < tools/ci/ci-packages.txt)
-sudo rpm -i -f $(find /var/cache/zypp/packages/ | grep '.rpm$')
+ci_packages=$(sed -e 's/\r//' < tools/ci/ci-packages.txt)
+touch /var/cache/zypp/packages/.keep_packages
+sudo zypper -n in $ci_packages
 echo "build_cache.sh done"


### PR DESCRIPTION
Lately circleCI failed to install packages in our CI environment with
weird errors which are likely resolvable and avoidable if we use zypper
instead of raw rpm.