### PR TITLE
chore(ci): use consistent zypper calls instead of rpm

### DIFF
--- a/tools/ci/build_or_install_from_cache.sh
+++ b/tools/ci/build_or_install_from_cache.sh
@@ -4,5 +4,5 @@ if [ -z "$CIRCLE_WORKFLOW_ID" ]; then
     bash "$(dirname "$0")"/build_cache.sh
 else
     packages=$(find /var/cache/zypp/packages/ | grep '.rpm$') || { echo "No RPM packages found. The cache is empty. Please trigger a cache.fullstack job manually to ensure a cache is available for the latest version." && exit 1; }
-    sudo rpm -i -f $packages
+    sudo zypper -n in $packages
 fi


### PR DESCRIPTION
In c5f81e366 we changed a rpm call to zypper to fix package conflict
resolution problems. To prevent potential further problems and for
consistency we should use zypper also in the 2nd occurence.