### PR TITLE
perf: tweak jobs evaluated on job groups based on recent improvement

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -333,7 +333,7 @@ concurrent = 0
 
 ## Maximum number of jobs to include in job group overview and dashboard pages
 ## (to prevent performance issues)
-#job_groups_overview_max_jobs = 10000
+#job_groups_overview_max_jobs = 25000
 ## Default number of jobs to include in table of finished jobs on "All tests"
 ## page
 #all_tests_default_finished_jobs = 500

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -274,7 +274,7 @@ sub default_config () {
             generic_max_limit => 100000,
             tests_overview_max_jobs => 2000,
             tests_overview_summary_max_groups => 7,
-            job_groups_overview_max_jobs => 10000,
+            job_groups_overview_max_jobs => 25000,
             all_tests_default_finished_jobs => 500,
             all_tests_max_finished_jobs => 5000,
             list_templates_default_limit => 5000,


### PR DESCRIPTION
379aa88b4 recently introduced performance optimizations which allow us
to bump the default limit of maximum jobs that are evaluated on job
group pages. This also addresses a concern raised within the openSUSE
community in
https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/ZSHLUFUHMUMGX3AUQTTQB2YOPKVR6WRZ/

Tested and verified on o3 since 2026-04-25

Related issue: https://progress.opensuse.org/issues/196913