### PR TITLE
chore(AGENTS.md): refine coverage requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ JavaScript (Bootstrap).
   `eslint/prettier`).
 - `make test-checkstyle`: Must pass before committing.
 - `make test-unit-and-integration TESTS=t/your_test.t`: Run specific tests.
+- `COVERAGE=1 make test-unit-and-integration TESTS=t/your_test.t`: Run
+  specific tests with statement coverage enabled.
+- `cover -report text -select_re 'path/to/modified_file'`: Generate and view a
+  fast text-based coverage report restricted to the specific file you changed
+  (run this after generating the coverage database).
 - `make test`: Full test suite.
 
 ## Conventions
@@ -25,6 +30,11 @@ JavaScript (Bootstrap).
 - **Verification:** Every code change must have corresponding test adaptations
   or new tests. `make tidy` and `make test-checkstyle` must pass before
   creating git commits.
+- **Strict Statement Coverage:** Full statement coverage is a hard
+  requirement. You MUST run tests with `COVERAGE=1` for your specific test
+  adaptations and verify that all new/modified lines are covered using `cover
+  -report text` before creating git commits. Do not wait for CI/Codecov in PRs
+  to catch missing coverage.
 
 ## Constraints
 


### PR DESCRIPTION
Meanwhile the openQA project ensures and requires full statement
coverage in the complete project so we should adjust our AGENTS
guidelines accordingly.

Related issue: https://progress.opensuse.org/issues/165393