### PR TITLE
feat: include parent job group name in priority check

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -407,10 +407,10 @@ concurrent = 0
 ## Throttling based on job group properties (e.g. name, description).
 ## Format: property:regex:priority_increment[,...]
 ## By default, job groups with "Development" in the name add +50 to the priority.
-## For example, "prio_group_parameters = name:Development:50,description:^$:100"
+## For example, "prio_group_parameters = full_name:Development:50,description:^$:100"
 ## would add 50 for development groups and 100 for groups with an empty description,
 ## because ownership and purpose of a job group are unclear if the description is missing.
-#prio_group_parameters = name:Development:50
+#prio_group_parameters = full_name:Development:50
 
 [archiving]
 ## Moves logs of jobs which are preserved during the cleanup because they are

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -296,7 +296,7 @@ sub default_config () {
             throttle_failing_job_history_length => 20,
             prio_throttling_parameters => 'MAX_JOB_TIME:0.007',
             prio_throttling_data => undef,
-            prio_group_parameters => 'name:Development:50',
+            prio_group_parameters => 'full_name:Development:50',
             prio_group_data => undef,
         },
         archiving => {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1129,6 +1129,16 @@ subtest 'priority correctly assigned when posting job' => sub {
         OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling($jobs, {}, \%new_job_args, $group);
         is $new_job_args{priority}, $default_prio + 15, 'priority increased by multiple matching rules';
 
+        my $parent_group = $schema->resultset('JobGroupParents')->create({name => 'Development'});
+        $group->update({parent_id => $parent_group->id});
+        %new_job_args = (priority => $default_prio);
+        $t->app->config->{misc_limits}->{prio_group_parameters} = 'full_name:Development:12';
+        $t->app->config->{misc_limits}->{prio_group_data}
+          = OpenQA::Setup::_load_prio_group_throttling($t->app, $t->app->config);
+        OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling($jobs, {}, \%new_job_args, $group);
+        is $new_job_args{priority}, $default_prio + 12, 'priority increased based on full group name';
+        $group->update({parent_id => undef});
+
         # reset for following tests
         $t->app->config->{misc_limits}->{prio_group_parameters} = '';
         $t->app->config->{misc_limits}->{prio_group_data} = undef;

--- a/t/config.t
+++ b/t/config.t
@@ -77,7 +77,8 @@ subtest 'Test configuration default modes' => sub {
     $test_config->{logging}->{level} = 'debug';
     $test_config->{global}->{service_port_delta} = 2;
     $test_config->{misc_limits}->{prio_throttling_data} = {MAX_JOB_TIME => {scale => '0.007', reference => 0}};
-    $test_config->{misc_limits}->{prio_group_data} = [{property => 'name', regex => qr/Development/, increment => 50}];
+    $test_config->{misc_limits}->{prio_group_data}
+      = [{property => 'full_name', regex => qr/Development/, increment => 50}];
     is ref delete $config->{global}->{auto_clone_regex}, 'Regexp', 'auto_clone_regex parsed as regex';
     ok delete $config->{'test_preset example'}, 'default values for example tests assigned';
     is_deeply $config, $test_config, '"test" configuration';


### PR DESCRIPTION
Motivation:
Job group priority adjustment based on name regex failed when the
matching string was only present in the parent job group name. For
example, a "Functional" group under "Development" wouldn't match a
"Development" regex rule.

Design Choices:
Modified OpenQA::Schema::ResultSet::Jobs to prefer the 'full_<property>'
method if it exists on the job group object. Since 'full_name' is already
implemented in OpenQA::Schema::Result::JobGroups, this correctly
includes the parent name (e.g., "Development / Functional"). A 'can'
check ensures compatibility with properties that don't have a 'full_'
variant.

Benefits:
Allows more flexible and intuitive priority rules that can target
entire hierarchies of job groups by matching on parent names.

Related issue: https://progress.opensuse.org/issues/198551