### PR TITLE
docs: show document levels in generated TOC

### DIFF
--- a/docs/Branding.md
+++ b/docs/Branding.md
@@ -1,4 +1,6 @@
 <a id="branding"></a>
+# Branding
+
 You can alter the appearance of the openQA web UI to some extent through
 the "branding" mechanism. The `branding` configuration setting in the `global`
 section of [the web UI configuration](GettingStarted.md#configuration)
@@ -12,7 +14,7 @@ installed). The subdirectory's name will be the name of your branding.
 You can copy the files from `branding/openSUSE` or `branding/plain` to
 use as starting points, and adjust as necessary.
 
-# Web UI template
+## Web UI template
 
 
 

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -1,4 +1,6 @@
 <a id="client"></a>
+# Client
+
 There are two ways to interact with openQA as a user. The web UI and the REST
 API. In this guide we will focus on the latter. You've probably already seen a
 few examples of its use with `openqa-cli` earlier in the documentation.
@@ -35,7 +37,7 @@ Our example above is quickly translated. The `api` subcommand of `openqa-cli`
 allows you to perform arbitrary HTTP requests against the REST API. The path
 will automatically get the correct version prefix applied (such as `/api/v1`), and query parameters can be passed along as `key=value` pairs.
 
-# Help
+## Help
 
 The `api` subcommand is not the only one available and more will be added over
 time. To get a complete list of all currently available subcommands you can use
@@ -52,7 +54,7 @@ well as many common usage examples.
 openqa-cli api --help
 ```
 
-# Authentication
+## Authentication
 
 Not all REST endpoints are public, many will return a `403 Forbidden` error if
 you try to access them without proper credentials. The credentials (or API keys)
@@ -79,7 +81,7 @@ openqa-cli api --host http://openqa.example.com --apikey 1234567890ABCDEF \
     --apisecret ABCDEF1234567890 -X POST jobs/2/comments text=hello
 ```
 
-## Personal access token
+### Personal access token
 
 The authentication mechanism used by `openqa-cli` was specifically designed to
 allow secure access to the REST API even via unencrypted HTTP connections. But
@@ -117,13 +119,13 @@ machine openqa.example.com login arthur password 1234567890ABCDEF:ABCDEF12345678
 For `curl` one needs to use `curl --netrc`. For `wget` it's `wget --auth-no-challenge` so that `wget` will provide the
 access credentials without being explicitly asked.
 
-# Features
+## Features
 
 Many of the `openqa-cli api` features are designed to be similar to other commonly used tools like `curl`. It helps a lot if you are already familiar with
 the [HTTP protocol](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) and
 [JSON](https://en.wikipedia.org/wiki/JSON). Both will be referenced extensively.
 
-## HTTP Methods
+### HTTP Methods
 
 The `--method` option (or `-X` for short) allows you to change the HTTP request method from `GET` to something else. In the openQA API you will most commonly encounter `POST`, `PUT` and `DELETE`. For example to start testing a new ISO image you would use `POST`.
 
@@ -133,7 +135,7 @@ openqa-cli api --host http://openqa.example.com -X POST isos \
     VERSION=Factory FLAVOR=NET ARCH=x86_64 BUILD=0053
 ```
 
-## HTTP Headers
+### HTTP Headers
 
 With the `--header` option (or `-a` for short) you can add one or more custom
 HTTP headers to your request. This feature is currently not used much, but can
@@ -145,7 +147,7 @@ openqa-cli api --host http://openqa.example.com -a 'Accept: application/json' \
     jobs/overview
 ```
 
-## HTTP Body
+### HTTP Body
 
 To change the HTTP request body there are multiple options available. The
 simplest being `--data` (or `-d` for short), which allows you to use a plain
@@ -172,7 +174,7 @@ echo '{"group_id":2}' | openqa-cli api --host http://openqa.example.com -X PUT \
     jobs/1
 ```
 
-## Forms
+### Forms
 
 Most data you pass to the openQA API will be key/value form parameters. Either
 in the query string, or encoded as `application/x-www-form-urlencoded` HTTP
@@ -211,7 +213,7 @@ openqa-cli api --host http://openqa.example.com --form --data '{"text":"abc"}' \
     -X POST jobs/2/comments
 ```
 
-## JSON
+### JSON
 
 The primary data exchange format in the openQA API is JSON. And you will even
 see error messages in JSON format most of the time.
@@ -247,7 +249,7 @@ openqa-cli api --host http://openqa.example.com -X PUT jobs/1 --json \
     --data '{"group_id":2}'
 ```
 
-## Unicode
+### Unicode
 
 Just use a UTF-8 locale for your terminal and Unicode will pretty much just
 work.
@@ -265,7 +267,7 @@ openqa-cli api --host http://openqa.example.com --form \
     -X POST jobs/2/comments
 ```
 
-## Host shortcuts
+### Host shortcuts
 
 Aside from the `--host` option, there are also a few shortcuts available. If you leave out the `--host` option completely, the default value will be [`http://localhost`](http://localhost), which is very convenient for debugging purposes.
 
@@ -280,7 +282,7 @@ also get their very own personalised shortcuts. Currently we have `--osd` for [`
 openqa-cli api --o3 jobs/overview
 ```
 
-## Debugging
+### Debugging
 
 Often times just seeing the HTTP response body might not be enough to debug a
 problem. With the `--verbose` option (or `-v` for short) you can also get
@@ -330,7 +332,7 @@ Just be aware that this is a feature the openQA team does not control, and the
 exact output as well as how it escapes control characters will change a bit over
 time.
 
-# Archiving individual job results
+## Archiving individual job results
 
 With the `archive` subcommand of `openqa-cli` you can download all the assets
 and test results of a job for archiving or debugging purposes.

--- a/docs/ContainerizedSetup.md
+++ b/docs/ContainerizedSetup.md
@@ -1,4 +1,6 @@
 <a id="containerizedsetup"></a>
+# Containerized Setup
+
 The installation guide already contains simple one-liners for starting
 the web UI and workers in the
 [Container based setup section](Installing.md#container_setup).
@@ -9,28 +11,28 @@ and the workers using `docker-compose` or `podman-compose`.
 There is also an approach using Fedora-based images mentioned but it is not
 supported by upstream.
 
-# Get container images
+## Get container images
 
 You can either build the images locally or use Fedora images from Docker Hub.
 
 For the `docker-compose` setup it is required to build the images locally. However, it is done via `docker-compose` and explained later so this section
 can be skipped.
 
-## Download Fedora-based images from the Docker Hub
+### Download Fedora-based images from the Docker Hub
 
     podman pull fedoraqa/openqa_data
     podman pull fedoraqa/openqa_webui
     podman pull fedoraqa/openqa_worker
 
-## Build openSUSE-based images locally
+### Build openSUSE-based images locally
 
     podman build -t openqa_data ./openqa_data
     podman build -t openqa_webui ./webui
     podman build -t openqa_worker ./worker
 
-# Setup with Fedora-based images
+## Setup with Fedora-based images
 
-## Data storage and directory structure
+### Data storage and directory structure
 
 Our intent was to create universal `webui` and `worker` containers and move all data storage and configurations to a third container, called `openqa_data`.
 `openqa_data` is a so called
@@ -62,7 +64,7 @@ setup SELinux properly. If you are having problems with it, run this command:
 
     chcon -Rt svirt_sandbox_file_t data
 
-## Update firewall rules
+### Update firewall rules
 
 There is a [bug in Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=1244124)
 with `docker-1.7.0-6` package that prevents containers to communicate with
@@ -75,7 +77,7 @@ docker, as a workaround, run:
 on the host machine.
 
 <a id="run_the_data_and_web_ui_containers"></a>
-## Run the data and web UI containers
+### Run the data and web UI containers
 
     podman run -d -h openqa_data --name openqa_data -v "$PWD"/data/factory:/data/factory -v "$PWD"/data/tests:/data/tests fedoraqa/openqa_data
     podman run -d -h openqa_webui --name openqa_webui --volumes-from openqa_data -p 80:80 -p 443:443 fedoraqa/openqa_webui
@@ -89,7 +91,7 @@ next two steps, you will set an OpenID provider (if necessary), create the API
 keys in the openQA's web interface, and store the configuration in the Data
 Container.
 
-### Generate and configure API credentials
+#### Generate and configure API credentials
 
 Go to <https://localhost/api_keys>, generate key and secret. Then run the following
 command substituting `KEY` and `SECRET` with the generated values:
@@ -97,7 +99,7 @@ command substituting `KEY` and `SECRET` with the generated values:
     exec -it openqa_data /scripts/client-conf set -l KEY SECRET
 
 <a id="run_the_worker_container"></a>
-## Run the worker container
+### Run the worker container
 
     podman run -d -h openqa_worker_1 --name openqa_worker_1 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
 
@@ -108,7 +110,7 @@ container name, so to add worker 2 use:
 
     podman run -d -h openqa_worker_2 --name openqa_worker_2 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
 
-## Enable services
+### Enable services
 
 Some systemd services are provided to start up the containers, so you do not
 have to keep doing it manually. To install and enable them:
@@ -122,7 +124,7 @@ have to keep doing it manually. To install and enable them:
 Of course, if you set up two workers, also do `sudo systemctl enable`
 `openqa-worker@2.service`, and so on.
 
-## Get tests, ISOs and create disks
+### Get tests, ISOs and create disks
 
 You have to put your tests under `data/tests` directory and ISOs under
 `data/factory/iso` directory. For testing Fedora, run:
@@ -156,12 +158,12 @@ where `VERSION` is the current stable Fedora version (its images will be created
 repository in `/tools` directory. Note that you have to have
 `libguestfs-tools` and `libguestfs-xfs` installed.
 
-# Setup openQA with openSUSE-based images and docker-compose
+## Setup openQA with openSUSE-based images and docker-compose
 
 All relative paths in this section are relative to a checkout of openQA's Git
 repository.
 
-## Configuration
+### Configuration
 
 The web UI will be available under <http://localhost> and <https://localhost>. So it
 is using default HTTP(S) ports. Make sure those ports are not used by
@@ -184,7 +186,7 @@ livehandler and gru.
 
 All the data which normally ends up under `/var/lib/openqa` in the default setup will be stored under `container/webui/workdir/data`. The database will be stored under `container/webui/workdir/db`.
 
-## Build images
+### Build images
 
 `docker-compose` will build images automatically. However, it is also possible
 to build images explicitly:
@@ -195,7 +197,7 @@ to build images explicitly:
     cd container/worker
     docker-compose build       # build worker images
 
-## Run the web UI containers in HA mode
+### Run the web UI containers in HA mode
 
 To start the containers, just run:
 
@@ -213,7 +215,7 @@ Further useful commands:
     docker-compose logs                        # access logs
     docker-compose exec db psql openqa openqa  # open psql shell
 
-## Generate and configure API credentials
+### Generate and configure API credentials
 
 Go to <https://localhost/api_keys> and generate a key/secret and configure it in
 `container/webui/conf/client.conf` **and** `container/worker/conf/client.conf` in
@@ -225,7 +227,7 @@ it is required to restart the web UI containers to apply the changes:
     cd container/webui
     docker-compose restart
 
-## Run the worker container
+### Run the worker container
 
 Configure the number of workers to start via the environment variable
 `OPENQA_WORKER_REPLICAS`. By default, one worker is started.
@@ -247,7 +249,7 @@ consecutive numbers for the `--instance` parameter:
     cd container/worker
     ./launch_workers_pool.sh --size=<number-of-workers>
 
-## Get tests, ISOs and create disks
+### Get tests, ISOs and create disks
 
 You have to put your tests under `data/tests` directory and ISOs under
 `data/factory/iso` directory. For testing openSUSE, follow
@@ -258,7 +260,7 @@ installed into the worker container before tests can run. To install those
 dependencies automatically on the container startup one can add a script called
 `install_deps.sh` in the root of the test distribution which would install the dependencies, e.g. via a `zypper` call.
 
-# Running jobs
+## Running jobs
 
 After performing the "setup" tasks above - do not forget about tests and ISOs.
 
@@ -269,11 +271,11 @@ Then you can use `openqa-cli` as usual with the containerized web UI. It is also
         --host http://localhost:9526 \
         https://openqa.opensuse.org/tests/1896520
 
-# Further configuration options
+## Further configuration options
 
 Most of these options do **not** apply to the docker-compose setup.
 
-## Change the OpenID provider
+### Change the OpenID provider
 
 <https://www.opensuse.org/openid/user/> is set as a default OpenID provider. To
 change it, run:
@@ -282,7 +284,7 @@ change it, run:
 
 and enter the provider's URL.
 
-## Adding workers on other hosts
+### Adding workers on other hosts
 
 You may want to add workers on other hosts, so you do not need one powerful
 host to run the UI and all the workers.
@@ -317,7 +319,7 @@ Worker instances always expect to find the server as `openqa_webui`; if this wil
 adjust these files if you use non-standard ports (see above).
 
 <a id="keeping_all_data_in_the_data_volume_container"></a>
-## Keeping all data in the Data Volume container
+### Keeping all data in the Data Volume container
 
 If you decided to keep all the data in the Volume container (`openqa_data`), run the following commands:
 
@@ -339,7 +341,7 @@ And finally, download the tests and ISOs directly into the container:
 The rest of the steps should be the same.
 
 <a id="keeping_all_data_on_the_host_system"></a>
-## Keeping all data on the host system
+### Keeping all data on the host system
 
 If you want to keep all the data in the host system and you prefer not to use
 a Volume Container, run the following commands:
@@ -362,7 +364,7 @@ run the worker as:
 
 Then continue with tests and ISOs downloading as before.
 
-## Developing tests with container setup
+### Developing tests with container setup
 
 With this setup, the needles created from the web UI will almost certainly have
 a different owner and group than your user account. As we have the tests in

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,5 +1,7 @@
 <a id="contributing"></a>
-# Introduction
+# Contributing
+
+## Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It's free software released
@@ -15,7 +17,7 @@ familiar with openQA and has already read the Starter Guide. All those documents
 are available at the
 [official repository](https://github.com/os-autoinst/openQA).
 
-# Development guidelines
+## Development guidelines
 
 <a id="guidelines"></a>
 
@@ -25,7 +27,7 @@ repositories can be found.
 
 
 
-## Repository URLs
+### Repository URLs
 
 - os-autoinst: <https://github.com/os-autoinst/os-autoinst>
   - the "backend" (thing that executes tests and starts/controls the SUT e.g. using QEMU)
@@ -51,7 +53,7 @@ repositories can be found.
 As in most projects hosted on GitHub, pull request are always welcome and
 are the right way to contribute improvements and fixes.
 
-## Rules for commits
+### Rules for commits
 
 <a id="rules_for_commits"></a>
 
@@ -87,7 +89,7 @@ rules.
 If this is too much hassle for you feel free to provide incomplete pull
 requests for consideration or create an issue with a code change proposal.
 
-## Code style suggestions
+### Code style suggestions
 
 <a id="code_style_suggestions"></a>
 
@@ -123,7 +125,7 @@ requests for consideration or create an issue with a code change proposal.
 
   - Do **not** combine sub attributes with signatures (requires Perl 5.28+), e.g. `sub foo :lvalue ($first) {`
 
-# Getting involved into development
+## Getting involved into development
 
 <a id="getting_involved"></a>
 
@@ -153,7 +155,7 @@ For an architecture overview the AI generated openQA deepwiki can provide a good
 about the complete project but without a guarantee for correctness:
 <https://deepwiki.com/os-autoinst/openQA>
 
-# Technologies
+## Technologies
 
 Most in openQA, from `os-autoinst` to the web frontend and from the tests to
 the support scripts is written in Perl in combination with other languages. So
@@ -190,7 +192,7 @@ should be backed by proper tests.
 [Test::Most](http://perldoc.perl.org/Test/Most.html) is used to implement those
 tests. As usual, tests are located under the `t/` directory.
 
-# Folder structure
+## Folder structure
 
 Meaning and purpose of the most important folders within openQA are:
 
@@ -236,7 +238,7 @@ HTML templates delivered by web UI
 tools
 Development tools
 
-# Dependencies
+## Dependencies
 
 Here we differentiate between these types of dependencies:
 
@@ -259,7 +261,7 @@ You can get those dependencies in several ways:
 We manage our dependencies via a central `dependencies.yaml` file per repository. We generate the `.spec` files for `rpm` as well as a `cpanfile`
 for quicker installation of all Perl modules.
 
-## Runtime Dependencies
+### Runtime Dependencies
 
 For openSUSE you need the packages `openQA` and `os-autoinst`.
 That should be everything necessary to run an openQA instance. For more
@@ -275,7 +277,7 @@ As alternative you can try out the
 [Single-Instance Container](Installing.md#single-instance-container) as
 a minimal runtime environment.
 
-## Development Dependencies
+### Development Dependencies
 
 For openSUSE:
 
@@ -295,7 +297,7 @@ you would not need the developer's dependencies, like `Perl::Tidy` and
 See [Run tests in a container](Contributing.md#run-tests-in-container)
 for a container with all dependencies.
 
-# Development setup
+## Development setup
 
 The following explains in detail what is necessary to develop openQA code.
 
@@ -314,7 +316,7 @@ Install the necessary
 [Development Dependencies](Contributing.md#development-dependencies)
 first.
 
-## Conducting tests
+### Conducting tests
 
 To execute all existing checks and tests simply call:
 
@@ -397,7 +399,7 @@ There are some ways to save some time when executing local tests:
   to be used for saving temporary data from the test, for example the log files
   from individual test job runs within the full stack test.
 
-## Customize base directory
+### Customize base directory
 
 It is possible to customize the openQA base directory (which is for instance
 used to store test results) by setting the environment variable
@@ -409,7 +411,7 @@ assets can need a big amount of disk space.
 > **WARNING:**
 > Be sure to **clear** that variable when running unit tests locally.
 
-## Customize configuration directory
+### Customize configuration directory
 
 When running openQA from a Git checkout it will find configuration files from
 that checkout under `etc/openqa` and not use any system provided config files under e.g. `/etc/openqa`.
@@ -428,7 +430,7 @@ export OPENQA_CONFIG=$PWD/etc/mine
 > **NOTE:**
 > `OPENQA_CONFIG` needs to point to the **directory** containing `openqa.ini`, > `database.ini`, `client.conf` and `workers.ini` (and **not** a specific file).
 
-## Setting up the PostgreSQL database
+### Setting up the PostgreSQL database
 
 Setting up a PostgreSQL database for openQA takes the following steps:
 
@@ -463,7 +465,7 @@ sudo sudo -u postgres openqa-setup-db your_username openqa-local
 > To remove the database again, you can use e.g. `dropdb openqa-local` as
 > your regular user.
 
-### Importing production data
+#### Importing production data
 
 Assuming you have already followed steps 1. to 4. above:
 
@@ -477,7 +479,7 @@ Assuming you have already followed steps 1. to 4. above:
 
 4.  Configure openQA to use that database as in step 7. above.
 
-## Manual daemon setup
+### Manual daemon setup
 
 This section should give you a general idea how to start daemons manually for
 development after you setup a PostgreSQL database as mentioned in the previous
@@ -519,7 +521,7 @@ that specific database (ignoring the configuration from `database.ini`). Be awar
 Also find more details in
 [Run tests without Container](Contributing.md#run_tests_without_container).
 
-### Further tips
+#### Further tips
 
 - It is also useful to start openQA with morbo which allows applying changes
   without restarting the server:
@@ -540,15 +542,15 @@ Also find more details in
   [openQA-helper repository](https://github.com/Martchus/openQA-helper).
 
 <a id="quick-container-development-setup"></a>
-## Quick container development setup
+### Quick container development setup
 
-### Requirements
+#### Requirements
 
 In these examples we use the following tools which are all in openSUSE Leap:
 
 - [`podman`](https://podman.io/) - [`distrobox`](https://en.opensuse.org/Distrobox) You can use similar tools like `docker`, `toolbox` etc. to achieve the same.
 
-### Intro
+#### Intro
 
 These instructions are ready to use without any changes. You only might want to
 change the `OPENQA_BASEDIR` location.
@@ -575,7 +577,7 @@ Some common settings we are using here:
 
 - Database container name: `postgres-openqa`
 
-### Environment Variables
+#### Environment Variables
 
 Create a file that you can `source` whenever you want to work in this
 environment:
@@ -611,7 +613,7 @@ export OPENQA_KEY=1234567890ABCDEF
 export OPENQA_SECRET=1234567890ABCDEF
 ```
 
-### Postgres Container
+#### Postgres Container
 
 To be able to reuse the database later when stopping the container, we create a
 named volume.
@@ -644,7 +646,7 @@ createuser --no-createdb --pwprompt geekotest
 createdb -O geekotest openqa-local
 ```
 
-### Distrobox
+#### Distrobox
 
 You can use a Leap container and install the requirements, but you can also
 build your own container with the requirements already installed.
@@ -677,7 +679,7 @@ zypper -n ref && zypper -n install ca-certificates-suse \
 Note: [`crudini`](https://github.com/pixelb/crudini) is a tool for manipulating
 values in ini files.
 
-### Git
+#### Git
 
 ```sh
 ### distrobox container ###
@@ -692,7 +694,7 @@ git clone git@github.com:os-autoinst/os-autoinst $OPENQA_REPOS/os-autoinst
 git clone git@github.com:os-autoinst/os-autoinst-scripts $OPENQA_REPOS/scripts
 ```
 
-### Config Files
+#### Config Files
 
 ```sh
 ### distrobox container ###
@@ -717,7 +719,7 @@ cp $OPENQA_REPOS/openQA/etc/openqa/openqa.ini $OPENQA_CONFIG/openqa.ini
 crudini --set $OPENQA_CONFIG/openqa.ini auth method Fake
 ```
 
-### Build openQA
+#### Build openQA
 
 ```sh
 ### distrobox container ###
@@ -735,7 +737,7 @@ make node_modules
 $OPENQA_REPOS/openQA/script/initdb --init_database
 ```
 
-### Run openQA
+#### Run openQA
 
 Ready!
 
@@ -765,9 +767,9 @@ worker --isotovideo "$OPENQA_REPOS/os-autoinst/isotovideo" --instance 1 --verbos
 
 For running unit tests, see [Conducting tests](Contributing.md#testing).
 
-# Handling of dependencies
+## Handling of dependencies
 
-## JavaScript and CSS
+### JavaScript and CSS
 
 Install third-party JavaScript and CSS files via their corresponding npm
 packages and add the paths of those files to `assets/assetpack.def`.
@@ -778,7 +780,7 @@ third-party code to the root directory of the repository. Do **not** duplicate
 common/existing licenses; extend the `Files:`-section at the beginning of those
 files instead.
 
-## Perl and other packages
+### Perl and other packages
 
 In openQA, there is a `dependencies.yaml` file including a list of
 dependencies, separated in groups. For example the openQA client does not need
@@ -793,7 +795,7 @@ development. New package dependencies can be submitted. Before merging the
 according change into the main openQA repo the dependency should be published
 as part of openSUSE Tumbleweed.
 
-## Remarks regarding CI
+### Remarks regarding CI
 
 - The CI of os-autoinst and openQA uses the container made using
   `container/devel:openQA:ci/base/Dockerfile` and further dependencies listed in `tools/ci/ci-packages.txt` (see
@@ -802,14 +804,14 @@ as part of openSUSE Tumbleweed.
 - There is an additional check running using OBS to check builds of packages
   against openSUSE Tumbleweed and openSUSE Leap.
 
-# Managing the database
+## Managing the database
 
 During the development process there are cases in which the database schema
 needs to be changed.
 there are some steps that have to be followed so that new database instances
 and upgrades include those changes.
 
-## When is it required to update the database schema?
+### When is it required to update the database schema?
 
 After modifying files in `lib/OpenQA/Schema/Result`. However, not all changes
 require to update the schema. Adding just another method or altering/adding
@@ -819,7 +821,7 @@ mentioned above. In doubt, just follow the instructions below. If an empty
 migration has been emitted (SQL file produced in step 3. does not contain
 any statements) you can just drop the migration again.
 
-## How to update the database schema
+### How to update the database schema
 
 1.  First, you need to increase the database version number in the `$VERSION`
     variable in the `lib/OpenQA/Schema.pm` file.
@@ -875,7 +877,7 @@ to impaired performance. Check out the
 [Working on database-related performance problems](Installing.md#working_on_database_related_performance_problems)
 section for how to tackle this problem.
 
-## How to add fixtures to the database
+### How to add fixtures to the database
 
 Note: This section is not about the fixtures for the testsuite. Those are located
 under t/fixtures.
@@ -898,7 +900,7 @@ variable.
 export DBIC_TRACE=1
 ```
 
-# Adding new authentication module
+## Adding new authentication module
 
 openQA comes with two authentication modules providing authentication methods:
 OpenID and Fake (see [User authentication](Installing.md#authentication)).
@@ -929,13 +931,13 @@ Authentication module is expected to return HASH:
 Authentication module is expected to create or update user entry in openQA database
 after user validation. See included modules for inspiration.
 
-# Running tests of openQA itself
+## Running tests of openQA itself
 
 Beside simply running the testsuite, it is also possible to use containers. Using containers,
 tests are executed in the same environment as on CircleCI. This allows to reproduce issues
 specific to that environment.
 
-## Run tests without container
+### Run tests without container
 
 <a id="run_tests_without_container"></a>
 
@@ -955,7 +957,7 @@ It is also possible to run a particular test, for example
 `KEEP_DB=1` to the make arguments. To access the test database, use
 `psql --host=/dev/shm/tpg openqa_test`. To watch the execution of the UI tests, set the environment variable `NOT_HEADLESS`.
 
-## Run tests within a container
+### Run tests within a container
 
 The container used in this section of the documentation is not identical with the container used
 within the CI. To run tests within the CI environment locally, check out the
@@ -999,7 +1001,7 @@ So by replacing VAR1 and VAR2 with those values one can trigger the different te
 
 Of course it is also possible to run (specific) tests directly via `prove` instead of using the Makefile targets.
 
-### Tips
+#### Tips
 
 Running UI tests in non-headless mode is also possible, eg.:
 
@@ -1017,7 +1019,7 @@ container if both environments provide different, incompatible library versions 
 In general, if starting the tests via a container seems to hang, it is a good idea to inspect the process tree to see which command is currently
 executed.
 
-## Logging behavior
+### Logging behavior
 
 Logs are redirected to a logfile when running tests within the CI. The output
 can therefore not be asserted using `Test::Output`. This can be worked around by temporarily assigning a different `Mojo::Log` object to the application. To
@@ -1029,7 +1031,7 @@ Note that redirecting the logs to a logfile only works for tests which run
 taken care that the test output is not cluttered by log messages which can be
 quite irritating.
 
-## Test runtime limits
+### Test runtime limits
 
 The test modules use `OpenQA
 
@@ -1074,19 +1076,19 @@ chromedriver instance the variable `OPENQA_SELENIUM_TEST_STARTUP_TIMEOUT` can
 be set to a higher value. See
 <https://metacpan.org/pod/Selenium>::Chrome#startup_timeout for details.
 
-# CircleCI workflow
+## CircleCI workflow
 
 The goal of the following workflow is to provide a way to run tests with a
 pre-approved list of dependencies both in the CI and locally.
 
-## Dependency artefacts
+### Dependency artefacts
 
 - ci-packages.txt lists dependencies to test against.
 
 - autoinst.sha contains sha of os-autoinst commit for integration testing.
   The testing will run against the latest master if empty.
 
-## Managing and troubleshooting dependencies
+### Managing and troubleshooting dependencies
 
 `ci-packages.txt` and `autoinst.sha` are aimed to represent those dependencies
 which change often. In normal workflow these files are generated automatically
@@ -1111,7 +1113,7 @@ Script `tools/ci/build_dependencies.sh` can be also modified when major
 changes are performed, e.g. different OS version or packages from forked OBS
 project, etc.
 
-## Run tests locally using a container
+### Run tests locally using a container
 
 One way is to build an image using the `build_local_container.sh` script, start a
 container and then use the same commands one would use to test locally.
@@ -1145,7 +1147,7 @@ podman stop -t 0 t1
 ```
 
 <a id="circleci-local-container"></a>
-## Run tests using the circleci tool
+### Run tests using the circleci tool
 
 After installing the `circleci` tool the following commands will be available.
 They will build the container and use committed changes from current local branch.
@@ -1155,7 +1157,7 @@ They will build the container and use committed changes from current local branc
     circleci local execute --job testfullstack
     circleci local execute --job testdeveloperfullstack
 
-## Changing config.cnf
+### Changing config.cnf
 
 Command to verify the YAML with the `circleci` tool:
 
@@ -1163,7 +1165,7 @@ Command to verify the YAML with the `circleci` tool:
 circleci config process .circleci/config.yml
 ```
 
-# Building plugins
+## Building plugins
 
 Not all code needs to be included in openQA itself. openQA also supports the use
 of 3rd party plugins that follow the standards for plugins used by the
@@ -1262,7 +1264,7 @@ $ make test
 And if you need code examples, there are some plugins
 [included with openQA](https://github.com/os-autoinst/openQA/tree/master/lib/OpenQA/WebAPI/Plugin).
 
-# Checking for JavaScript problems
+## Checking for JavaScript problems
 
 One can use the tool `jshint` to check for problems within JavaScript code. It can be installed easily via `npm`.
 
@@ -1271,7 +1273,7 @@ npm install --no-save --ignore-scripts jshint
 node_modules/jshint/bin/jshint path/to/javascript.js
 ```
 
-# Profiling the web UI
+## Profiling the web UI
 
 1.  Install NYTProf, under openSUSE Tumbleweed: `zypper in perl-Devel-NYTProf perl-Mojolicious-Plugin-NYTProf`
 
@@ -1283,12 +1285,12 @@ node_modules/jshint/bin/jshint path/to/javascript.js
 
 5.  Access profiling data via `/nytprof` route.
 
-## Note
+### Note
 
 Profiling data is extensive. Remove it if you do not need it anymore and disable the `profiling_enabled`
 configuration again if not needed anymore.
 
-# Making documentation changes
+## Making documentation changes
 
 After changing documentation, consider generating documentation locally to
 verify it is rendered correctly using `tools/generate-docs`. It is possible to

--- a/docs/ExternalResults.md
+++ b/docs/ExternalResults.md
@@ -1,5 +1,7 @@
 <a id="externalresults"></a>
-# Introduction
+# External Results
+
+## Introduction
 
 From time to time, a test developer might want to use openQA to execute a test
 suite from a different test harness than openQA, but still use openQA to setup test
@@ -22,13 +24,13 @@ The requirements to use this functionality, are quite simple:
 openQA will store these results in its own internal format for easier presentation,
 but still will allow the original file to be downloaded.
 
-# Usage
+## Usage
 
 If a test developer wishes to use the functional interface, after finishing the
 execution of the the testing too, calling `testapi::parse_extra_log` with the
 location to a the file generated.
 
-## openQA test distribution
+### openQA test distribution
 
 From within a common openQA test distribution, a developer can use `parse_extra_log`
 to upload a text file that contains a supported test output:
@@ -40,7 +42,7 @@ parse_extra_log('XUnit','junit-logging.xml');
 
 <a id="parser-formats"></a>
 
-# Available parser formats
+## Available parser formats
 
 Current parser formats:
 
@@ -49,9 +51,9 @@ Current parser formats:
 - OpenQA::Parser::Format::LTP
 - OpenQA::Parser::Format::XUnit,
 
-# Extending the parser
+## Extending the parser
 
-## OOP Interface
+### OOP Interface
 
 The parser is a base class that acts as a serializer/deserializer for the elements
 inside of it, it allows to be extended so new formats can be easily added.
@@ -62,7 +64,7 @@ would require to map the results correctly, 1 extra collection is provided for
 arbitrary data that can be exposed. The collections represents respectively:
 test results, test definition and test output.
 
-## Structured data
+### Structured data
 
 In structured data mode, elements of the collections are objects. They can be
 of any type, even though subclassing or objects of type of `OpenQA::Parser::Result`
@@ -115,7 +117,7 @@ my $json_serialization = $parser->to_json;
 my $from_json = OpenQA::Parser::Format::JUnit->from_json($json_serialization);
 ```
 
-## openQA internal test result storage
+### openQA internal test result storage
 
 It is important to know that openQA's internal mapping for test results works operating almost
 entirely on the filesystem, leaving only the test modules to be registered into the database, this

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,5 +1,7 @@
 <a id="gettingstarted"></a>
-# Introduction
+# Getting Started
+
+## Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It uses virtual machines to
@@ -38,7 +40,7 @@ existing instance see the [Users Guide](UsersGuide.md#usersguide).
 More advanced topics can be found in other documents. All documents are also
 available in the [official repository](https://github.com/os-autoinst/openQA).
 
-# Architecture
+## Architecture
 
 
 Although the project as a whole is referred to as openQA, there are in fact
@@ -76,9 +78,9 @@ Note that the diagram shown above is simplified. There exists
 complete and detailed. (The diagram can be edited via its underlying
 [GraphML file](images/architecture.graphml).)
 
-# Basic concepts
+## Basic concepts
 
-## Glossary
+### Glossary
 
 The following terms are used within the context of openQA:
 
@@ -148,7 +150,7 @@ e.g. "openSUSE-Tumbleweed-DVD-x86_64-gnome@64bit", nicknamed _koala_
 of _version_, e.g. "Build1234"; **CAUTION:** ambiguity: either with the prefix
 "Build" included or not
 
-## Jobs
+### Jobs
 
 One of the most important features of openQA is that it can be used to test
 several combinations of actions and configurations. For every one of those
@@ -216,7 +218,7 @@ From that point in time, the clone becomes the current version and the original
 job is considered outdated (and can be filtered in the listing) but its
 information and results (if any) are kept for future reference.
 
-## Needles
+### Needles
 
 One of the main mechanisms for openQA to know the state of the virtual machine
 is checking the presence of some elements in the machine's 'screen'.
@@ -249,7 +251,7 @@ tags.
 }
 ```
 
-### Areas
+#### Areas
 There are three kinds of areas:
 
 - **Regular areas** define relevant parts of the screenshot. Those must match
@@ -269,7 +271,7 @@ There are three kinds of areas:
   the concerning area.
   In the needle view exclude areas are displayed as gray boxes.
 
-### Click points
+#### Click points
 Each regular match area in a needle can optionally contain a **click point**.
 This is used with the `testapi::assert_and_click` function to match GUI
 elements such as buttons and then click inside the matched area.
@@ -286,7 +288,7 @@ Each click point can have an `id`, and if a needle contains multiple click point
 to use.
 
 <a id="configuration"></a>
-## Configuration
+### Configuration
 
 The different components of openQA read their configuration from the following
 files:
@@ -313,7 +315,7 @@ and in the
 Continue reading the next sections for where you can place the actual
 configuration files and the possibility of creating drop-in configuration files.
 
-### Locations
+#### Locations
 
 All configuration files can be placed under `/etc/openqa`, e.g. `/etc/openqa/openqa.ini`. That is where administrators are expected to
 store system-wide configuration.
@@ -327,7 +329,7 @@ The client configuration can also be put under `~/.config/openqa/client.conf`.
 For development, check out the section about
 [customizing the configuration directory](Contributing.md#customize_configuration_directory).
 
-### Drop-in configurations
+#### Drop-in configurations
 
 It is recommended to split the configuration into multiple files and store these
 "drop-in" configuration files in the `….d` sub directory, e.g.
@@ -339,7 +341,7 @@ from drop-in configurations override settings from the main config files.
 Drop-in configurations are read in alphabetical order and subsequent files
 override settings from preceding ones.
 
-## Access management
+### Access management
 
 Some actions in openQA require special privileges. openQA provides
 authentication through [openID](http://en.wikipedia.org/wiki/OpenID). By default,
@@ -377,7 +379,7 @@ of the openQA security model, refer to the
 [detailed
 blog post](http://lizards.opensuse.org/2014/02/28/about-openqa-and-authentication/) about the subject by the openQA development team.
 
-## Job groups
+### Job groups
 
 A job can belong to a job group. Those job groups are displayed on the index
 page when there are recent test results in these job groups and in the `Job`
@@ -393,14 +395,14 @@ inherit properties from the category. The categories are meant to combine job gr
 with common builds so test results for the same build can be shown together on
 the index page.
 
-## Cleanup
+### Cleanup
 
 openQA automatically archives and deletes data that it considers "old" based on
 different settings. For example old jobs and assets are deleted at some point.
 The settings can be adjusted on job-group-level and in the configuration file
 You can read the [Cleanup](UsersGuide.md#cleanup) section for details.
 
-# Using the client script
+## Using the client script
 
 
 
@@ -412,14 +414,14 @@ The personal configuration should be stored in a file
 `~/.config/openqa/client.conf` in the same format as previously described for the `client.conf`, i.e. sections for each machine, e.g. `localhost`.
 
 <a id="get-testing"></a>
-# Testing openSUSE or Fedora
+## Testing openSUSE or Fedora
 
 An easy way to start using openQA is to start testing openSUSE or Fedora as they
 have everything setup and prepared to ease the initial deployment. If you want
 to play deeper, you can configure the whole openQA manually from scratch, but
 this document should help you to get started faster.
 
-## Getting tests
+### Getting tests
 
 You can point `CASEDIR` and `NEEDLES_DIR` to Git repositories. openQA will
 check out those repositories automatically and no manual setup is needed.
@@ -449,7 +451,7 @@ cd ..
 chown -R geekotest fedora/
 ```
 
-## Getting openQA configuration
+### Getting openQA configuration
 
 To get everything configured to actually run the tests, there are plenty of
 options to set in the admin interface. If you plan to test openSUSE Factory, using
@@ -482,7 +484,7 @@ Some Fedora tests require special hard disk images to be present in
 repository can be used to create these. See the documentation in that repo
 for more information.
 
-## Adding a new ISO to test
+### Adding a new ISO to test
 
 To start testing a new ISO put it in `/var/lib/openqa/share/factory/iso` and call
 the following commands:
@@ -523,6 +525,6 @@ openqa-cli api -X POST isos \
 More details on triggering tests can also be found in the
 [Users Guide](UsersGuide.md#usersguide).
 
-# Pitfalls
+## Pitfalls
 
 Take a look at [Documented Pitfalls](Pitfalls.md#pitfalls).

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -1,5 +1,7 @@
 <a id="installing"></a>
-# Introduction
+# Installing
+
+## Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It is free software released
@@ -22,12 +24,12 @@ setup suitable to develop openQA itself, have a look at the
 [Development setup](Contributing.md#development-setup) section.
 
 <a id="container_setup"></a>
-# Container based setup
+## Container based setup
 
 openQA is provided in containers. Multiple variants exist.
 
 <a id="single-instance-container"></a>
-## Single-instance container
+### Single-instance container
 
 The easiest and quickest way to spawn a single instance of openQA with a
 single command line using the `podman` container engine is the following:
@@ -40,7 +42,7 @@ podman run --name openqa --device /dev/kvm -p 1080:80 -p 1443:443 --rm -it \
 Once the startup has finished, the web UI is accessible via <http://localhost:1080>
 or <https://localhost:1443>.
 
-### How to run a test with single-instance container in 5 minutes
+#### How to run a test with single-instance container in 5 minutes
 
 
 
@@ -48,7 +50,7 @@ or <https://localhost:1443>.
 
 
 
-### Triggering and cloning existing jobs within single-instance container
+#### Triggering and cloning existing jobs within single-instance container
 
 For triggering new tests or cloning existing ones you can use `openqa-cli`
 which is conveniently available inside the container. The quickest and easiest
@@ -90,7 +92,7 @@ and needles required for openSUSE/SUSE tests are downloaded. Refer to the
 and the [get testing](GettingStarted.md#get-testing) section for more
 details.
 
-## Separate web UI and worker containers
+### Separate web UI and worker containers
 
 As an alternative also separate containers are provided for both the web UI
 and worker.
@@ -108,7 +110,7 @@ The worker container can be pulled and started with:
 podman run --rm -it registry.opensuse.org/devel/openqa/containers16.0/openqa_worker:latest
 ```
 
-## Custom configuration for containers
+### Custom configuration for containers
 
 To supply a custom openQA config file, use the `-v` parameter. This also works
 for the database config file. Note that if a custom database config file is
@@ -164,12 +166,12 @@ Take a look at
 [openSUSE's registry](https://registry.opensuse.org/cgi-bin/cooverview?srch_term=project%3Ddevel%3AopenQA)
 for all available container images.
 
-## Kubernetes
+### Kubernetes
 
 Find a guide and the helm charts for Kubernetes deployment of openQA in
 [Helm README](https://github.com/os-autoinst/openQA/blob/master/container/helm/README.md).
 
-# Quick bootstrapping under openSUSE
+## Quick bootstrapping under openSUSE
 
 <a id="bootstrapping"></a>
 
@@ -179,7 +181,7 @@ script. It essentially automates the steps mentioned in the
 
 
 
-## Directly on your machine
+### Directly on your machine
 
 On openSUSE Leap and openSUSE Tumbleweed to setup openQA on your machine
 simply download and execute the openqa-bootstrap script as root - it will do
@@ -213,7 +215,7 @@ You can also run `openqa-bootstrap` repeatedly. For example when you stop a
 container and the openQA daemons and database are stopped, calling
 `openqa-bootstrap start` will start necessary daemons again.
 
-## openQA in a browser
+### openQA in a browser
 
 You can try out `openqa-bootstrap` in a container environment like
 [GitHub Codespaces](https://docs.github.com/en/codespaces).
@@ -233,7 +235,7 @@ webserver available on port 80.
 
 You can now use `openqa-clone-job` to run jobs in this instance.
 
-#### After stopping and resuming a codespace instance, run
+##### After stopping and resuming a codespace instance, run
 
 ```sh
 /usr/share/openqa/script/openqa-bootstrap start
@@ -244,7 +246,7 @@ to start the openQA daemons again.
 Be sure to delete codespace instances if you don't use them anymore, as even
 stopped instances will consume storage of your monthly limit.
 
-## openQA in a container
+### openQA in a container
 
 You can also setup a systemd-nspawn container with openQA with the following
 commands.
@@ -258,7 +260,7 @@ zypper in openQA-bootstrap
 systemd-run -tM openqa1 /bin/bash # start a shell in the container
 ```
 
-## openQA in a virtual machine
+### openQA in a virtual machine
 
 You can also set up a ready-to-use **openQA** instance as a virtual machine
 in your computer.
@@ -267,7 +269,7 @@ The images are available directly from the [o3](https://openqa.opensuse.org) sit
 Download the HDD image `opensuse-Tumbleweed-x86_64@uefi-4G-<…>.qcow2` (~3.2 GB)
 from the *Assets* in the test scenario [openqa_install+publish](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=openqa&flavor=dev&machine=uefi-4G&test=openqa_install%2Bpublish&version=Tumbleweed&result=passed#downloads).
 
-### The VM
+#### The VM
 
 The downloaded image can be used to launch a local VM from, running the
 *openSUSE Tumbleweed* system, a graphical user interface and a network access
@@ -280,7 +282,7 @@ You can also access the VM via SSH from a console on your machine
 (`ssh root@<VM_IP_ADDRESS>`), after properly configuring `ssh` in the VM and
 your computer.
 
-### The openQA instance
+#### The openQA instance
 
 The system features a pre-configured **openQA** instance, which includes the
 web UI at <http://localhost/>, a worker, and a PostgreSQL database. To check the
@@ -298,7 +300,7 @@ Other tests can be cloned via the VM console or an SSH session from your machine
 using `openqa-clone-job`, getting the job settings from o3 and instantiating the test execution on the local VM instance (`--from openqa.opensuse.org --host localhost`;
 refer to the `openqa-clone-job` documentation).
 
-# Custom installation - repositories and procedure
+## Custom installation - repositories and procedure
 
 <a id="custom_installation"></a>
 
@@ -313,7 +315,7 @@ not compatible with the version on Tumbleweed. And the package distributed
 with Tumbleweed may not be compatible with the version in the development
 package.
 
-## Official repositories
+### Official repositories
 
 The easiest way to install openQA is from distribution packages.
 
@@ -323,7 +325,7 @@ The easiest way to install openQA is from distribution packages.
 - For Fedora, packages are available in the official repositories for Fedora
   23 and later.
 
-## Development version repository
+### Development version repository
 
 You can find the development version of openQA in OBS in the
 [openQA:devel](https://build.opensuse.org/project/show/devel:openQA) repository.
@@ -349,10 +351,10 @@ zypper dup --from devel_openQA --allow-vendor-change
 zypper dup --from devel_openQA_Leap --allow-vendor-change
 ```
 
-## Installation
+### Installation
 
 <a id="preparations_on_sle"></a>
-### Preparations on SLE
+#### Preparations on SLE
 
 On SLE certain modules have to be enabled.
 Afterwards the instructions for openSUSE apply.
@@ -365,7 +367,7 @@ SUSEConnect -p sle-we/$VERSION_ID/$CPU -r $sled_key
 SUSEConnect -p PackageHub/$VERSION_ID/$CPU
 ```
 
-### Installing openQA
+#### Installing openQA
 
 You can install the main openQA server package using these commands.
 
@@ -388,7 +390,7 @@ Different convenience packages exist for convenience in openSUSE, for example:
 `openQA-local-db` to install the server including the setup of a local PostgreSQL database or `openQA-single-instance` which sets up a web UI server, a web proxy as well as a local worker. Install `openQA-client` if you only
 want to interact with existing, external openQA instances.
 
-### Installation from sources
+#### Installation from sources
 
 Installing is not required for development purposes and most components of
 openQA can be called directly from the repository checkout.
@@ -406,7 +408,7 @@ The directory prefix can be controlled with the optional environment variable
 
 From then on continue with the [Basic configuration](#basic-configuration).
 
-# System requirements
+## System requirements
 
 To run tests based on the default qemu backend the following hardware
 specifications are recommended per openQA worker instance:
@@ -418,7 +420,7 @@ specifications are recommended per openQA worker instance:
 - 40GB HDD (preferably SSD or NVMe)
 
 <a id="basic-configuration"></a>
-# Basic configuration
+## Basic configuration
 
 For a local instance setup you can simply execute the script:
 
@@ -440,7 +442,7 @@ If you wish to run openQA behind an http proxy (Apache, NGINX, …) then see the
 `/etc/httpd/conf.d` (Fedora) when using apache2 or the config files in
 `/etc/nginx/vhosts.d` for NGINX.
 
-## Apache proxy
+### Apache proxy
 
 To make everything work correctly on openSUSE when using Apache, you
 need to enable the 'headers', 'proxy', 'proxy_http', 'proxy_wstunnel' and 'rewrite'
@@ -464,7 +466,7 @@ This will direct all HTTP traffic to openQA.
 cp /etc/apache2/vhosts.d/openqa.conf.template /etc/apache2/vhosts.d/openqa.conf
 ```
 
-## NGINX proxy
+### NGINX proxy
 
 For a basic setup, you can copy **openqa.conf.template** to **openqa.conf**
 and modify the `server_name` setting if required.
@@ -486,7 +488,7 @@ memory segment according to the formula: page_size \* 8
 For openQA you need to set `httpsonly = 0` as described in the TLS/SSL section
 below, if you do not setup NGINX for SSL.
 
-## TLS/SSL
+### TLS/SSL
 
 By default openQA expects to be run with HTTPS. The `openqa-ssl.conf.template`
 Apache config file is available as a base for creating the Apache config; you
@@ -510,7 +512,7 @@ httpsonly = 0
 ```
 
 <a id="database"></a>
-## Database
+### Database
 
 openQA requires PostgreSQL 14 or newer. By default, a database with name
 `openqa` and `geekotest` user as owner is used. An automatic setup of a freshly
@@ -520,14 +522,14 @@ The database connection can be configured in
 (normally the `[production]` section is relevant). More info about the `dsn`
 value format can be found in the <https://metacpan.org/pod/DBD>::Pg#DBI-Class-Methods[DBD::Pg documentation].
 
-### Example for connecting to local PostgreSQL database
+#### Example for connecting to local PostgreSQL database
 
 ``` ini
 [production]
 dsn = dbi:Pg:dbname=openqa
 ```
 
-### Example for connecting to remote PostgreSQL database
+#### Example for connecting to remote PostgreSQL database
 
 ``` ini
 [production]
@@ -536,7 +538,7 @@ user = openqa
 password = somepassword
 ```
 
-## User authentication
+### User authentication
 
 openQA supports four different authentication methods: OpenID (default),
 OAuth2, Fake (for development) and None (no authentication).
@@ -566,7 +568,7 @@ need to be in sync. The best way to achieve that is to install a service that
 implements the time-sync target. Otherwise a "timestamp mismatch" may be
 reported when clocks are too far apart.
 
-### OpenID
+#### OpenID
 
 By default openQA uses OpenID with opensuse.org as OpenID provider.
 OpenID method has its own `openid` section in
@@ -586,7 +588,7 @@ httpsonly = 1
 
 This method supports OpenID version up to 2.0.
 
-### OAuth2
+#### OAuth2
 
 An additional Mojolicious plugin is required to use this feature:
 
@@ -616,7 +618,7 @@ owner(s).
 As shown in the comments of the default configuration file, it is also possible
 to use different providers.
 
-### Fake
+#### Fake
 
 For development purposes only! This method is a "mock" authentication provider
 designed for openQA developers to test permissions and role-based access
@@ -642,7 +644,7 @@ If you switch the authentication method from Fake to any other, review your
 API keys! You may be vulnerable for up to a day until the Fake API key
 expires.
 
-### None
+#### None
 
 This method bypasses any authentication entirely and automatically treats
 every visitor as an 'admin' user with administrator privileges. No explicit
@@ -657,7 +659,7 @@ instances!
 method = None
 ```
 
-## Job Priority Throttling
+### Job Priority Throttling
 
 Priority throttling of openQA test jobs can be configured based on specific
 parameter values found in the job settings. This mechanism is primarily designed
@@ -709,7 +711,7 @@ where:
 
 By default, job groups with "Development" in the name add +50 to the priority.
 
-# Run the web UI
+## Run the web UI
 
 To start openQA and enable it to run on each boot call
 
@@ -731,7 +733,7 @@ The openQA web UI should be available on <http://localhost/> now. To simply
 start openQA without enabling it permanently one can simply use `systemctl start`
 instead.
 
-## Additional considerations for zero-downtime upgrades
+### Additional considerations for zero-downtime upgrades
 
 The main openQA web UI service (the `openqa-webui-daemon` script which is usually started via the systemd unit `openqa-webui.service`) supports
 [zero-downtime upgrades](https://docs.mojolicious.org/Mojolicious/Guides/Cookbook#Zero-downtime-software-upgrades)
@@ -745,7 +747,7 @@ there is no corresponding setting for IPv6 but the setting for IPv4 seems to
 help with IPv6 connections as well.
 
 <a id="run_openqa_workers"></a>
-# Run openQA workers
+## Run openQA workers
 
 Workers are services running backends to perform the actual testing. The
 testing is commonly performed by running virtual machines but depending on the
@@ -811,14 +813,14 @@ If you start openQA workers on a different machine than the web UI host make
 sure to have synchronized clocks, for example using NTP, to prevent
 inconsistent test results.
 
-# Where to now?
+## Where to now?
 
 From this point on, you can refer to the [Getting Started](GettingStarted.md#get-testing) guide to
 fetch the tests cases and possibly take a look at [Test Developer Guide](WritingTests.md#writingtests)
 
-# Advanced configuration
+## Advanced configuration
 
-## Cleanup
+### Cleanup
 
 The automated cleanup is enabled and configured by default. Cleanup tasks are
 scheduled via systemd timer units and run via `openqa-gru.service`. The configuration
@@ -829,7 +831,7 @@ needs, have a look at the
 [Cleanup of assets, results and other data](UsersGuide.md#cleanup)
 section.
 
-## Setting up Git support
+### Setting up git support
 
 If your tests and needles are stored in Git, openQA can perform various operations:
 
@@ -865,7 +867,7 @@ checkout_needles_sha = yes|no
   variables indicating the needles came from a specific Git repository and ref, openQA will
   attempt to clone that ref and display the needles from it.
 
-### Configuration of automatic needle commit feature
+#### Configuration of automatic needle commit feature
 
 You may want to add some description to automatic commits coming from the web
 UI.
@@ -927,7 +929,7 @@ Or put it in the `~/.gitconfig` file manually:
 
 You can apply the same kind of thing for any other Git hosting provider.
 
-## Referer settings to auto-mark important jobs
+### Referer settings to auto-mark important jobs
 
 Automatic cleanup of old results (see GRU jobs) can sometimes render important
 tests useless. For example bug report with link to openQA job which no longer
@@ -944,7 +946,7 @@ List of recognized referrers is space separated list configured in
 recognized_referers = bugzilla.suse.com bugzilla.opensuse.org
 ```
 
-## Scheduler configuration
+### Scheduler configuration
 
 The openQA web UI scheduler supports a dynamic global job limit that scales the effective
 number of allowed running jobs up or down based on the system load of the openQA web UI host.
@@ -1003,7 +1005,7 @@ The scaling algorithm:
 
 The running jobs heading in the web UI reflects the current dynamic limit when it is active.
 
-## Worker settings
+### Worker settings
 
 Default behavior for all workers is to use the QEMU backend and connect to
 http://localhost. If you want to change some of those options, you can do so
@@ -1038,7 +1040,7 @@ Once you got workers running they should show up in the admin section of openQA 
 the workers section as 'idle'. When you get so far, you have your own instance
 of openQA up and running and all that is left is to set up some tests.
 
-## Further systemd units for the worker
+### Further systemd units for the worker
 
 The following information is partially openSUSE specific. The `openQA-worker`
 package provides further systemd units:
@@ -1067,7 +1069,7 @@ package provides further systemd units:
   automatically on configuration changes without interrupting jobs (see next
   section for details)
 
-### Stopping/restarting workers without interrupting currently running jobs
+#### Stopping/restarting workers without interrupting currently running jobs
 
 It is possible to stop a worker as soon as it becomes idle and immediately if it
 is already idling by sending `SIGHUP` to the worker process.
@@ -1099,7 +1101,7 @@ systemctl kill --kill-who=main --signal HUP openqa-worker-auto-restart@{1..28}
 ```
 
 <a id="configuring_remote_workers"></a>
-## Configuring remote workers
+### Configuring remote workers
 
 There are some additional requirements to get remote worker running. First is to
 ensure shared storage between openQA web UI and workers.
@@ -1121,7 +1123,7 @@ NFS clients are where openQA workers are running. Run following command:
 mount -t nfs openQA-webUI-host:/var/lib/openqa/share /var/lib/openqa/share
 ```
 
-## Configuring AMQP message emission
+### Configuring AMQP message emission
 
 You can configure openQA to send events (new comments, tests finished, …)
 to an AMQP message bus.
@@ -1154,7 +1156,7 @@ topic_prefix = suse
 
 For a TLS connection use `amqps://` and port `5671`.
 
-## Configuring worker to use more than one openQA server
+### Configuring worker to use more than one openQA server
 
 When there are multiple openQA web interfaces (openQA instances) available a worker
 can be configured to register and accept jobs from all of them.
@@ -1200,7 +1202,7 @@ It is possible to mix local openQA instance with remote instances or use only
 remote instances.
 
 <a id="asset-caching"></a>
-## Asset and test/needle caching
+### Asset and test/needle caching
 
 If your network is slow or you experience long time to load needles you might
 want to consider enabling caching on your remote workers. To enable caching,
@@ -1266,7 +1268,7 @@ comment = openQA test distributions
 systemctl enable --now rsyncd
 ```
 
-## Alternative caching implementations
+### Alternative caching implementations
 
 Caching described above works well for a single worker host, but in case of
 several hosts in a single site (that is remote from the main openQA webui
@@ -1289,7 +1291,7 @@ should do, but there are few suggestions:
 If the command exits with code 32, re-downloading needles in developer mode
 will be skipped.
 
-## Enable linking files referred by job settings
+### Enable linking files referred by job settings
 
 Specific job settings might refer to files within the test distribution.
 You can configure openQA to display links to these files within the job settings tab.
@@ -1306,7 +1308,7 @@ of `CASEDIR` or the data folder within `CASEDIR`.
 
 <a id="custom_hook_scripts_job_done"></a>
 <a id="enable_custom_hook_scripts_on_job_done_based_on_result"></a>
-## Enable custom hook scripts on "job done" based on result
+### Enable custom hook scripts on "job done" based on result
 
 If a job is done, especially if no label could be found for carry-over, often
 more steps are needed for the review of the test result or providing the
@@ -1380,7 +1382,7 @@ General status and stdout output is visible in the GRU minion job dashboard on t
 `/minion/jobs?offset=0&task=finalize_job_results` of the openQA instance.
 
 <a id="automatic_cloning_incomplete_jobs"></a>
-## Automatic cloning of incomplete jobs
+### Automatic cloning of incomplete jobs
 
 By default, when a worker reports an incomplete job due to a cache service related
 problem, the job is automatically cloned. It is possible to extend the regex to cover
@@ -1393,7 +1395,7 @@ cloning.
 Note that jobs marked as incomplete by the stale job detection are not affected by this
 configuration and cloned in any case.
 
-## Enable automatic database backup
+### Enable automatic database backup
 
 <a id="automatic_database_cleanup"></a>
 
@@ -1409,7 +1411,7 @@ systemctl enable --now openqa-dump-db.timer
 
 Backups are stored at `/var/lib/openqa/backup`.
 
-# Auditing - tracking openQA changes
+## Auditing - tracking openQA changes
 
 Auditing plugin enables openQA administrators to maintain overview about what is happening with the system.
 Plugin records what event was triggered by whom, when and what the request looked like. Actions done by openQA
@@ -1459,7 +1461,7 @@ Use `systemctl enable --now openqa-enqueue-audit-event-cleanup.timer` to schedul
 automatically every day. It is also possible to trigger the cleanup manually by invoking
 `/usr/share/openqa/script/openqa minion job -e limit_audit_events`.
 
-## List of events tracked by the auditing plugin
+### List of events tracked by the auditing plugin
 
 - Assets:
   - asset_register asset_delete
@@ -1488,7 +1490,7 @@ automatically every day. It is also possible to trigger the cleanup manually by 
 Some of these events are very common and may clutter audit database. For this reason `job_grab` and `job_done`
 events are on the blocklist by default.
 
-# Automatic system upgrades and reboots of openQA hosts
+## Automatic system upgrades and reboots of openQA hosts
 
 <a id="auto_upgrade"></a>
 
@@ -1514,7 +1516,7 @@ The distribution package `openQA-continuous-update` can be used to continuously 
 updates and if it does it will upgrade the whole system. This approach is
 independent of `openQA-auto-update` but can be used complementary. The configuration is analogous to `openQA-auto-update`.
 
-# Migrating from older databases
+## Migrating from older databases
 
 For older versions of openQA, you can migrate from SQLite to PostgreSQL
 according to
@@ -1522,7 +1524,7 @@ according to
 
 For migrating from older PostgreSQL versions read on.
 
-# Migrating PostgreSQL database on openSUSE
+## Migrating PostgreSQL database on openSUSE
 
 The PostgreSQL `data`-directory needs to be migrated in order to switch to a
 newer major version of PostgreSQL. The following instructions are specific to
@@ -1681,12 +1683,12 @@ need to be stopped during the (short) migration.
     sudo -u postgres rm -r /var/lib/pgsql/data.$oldver
     ```
 
-# Working on database-related performance problems
+## Working on database-related performance problems
 
 Without extra setup, PostgreSQL already gathers many statistics, check out
 [the official documentation](https://www.postgresql.org/docs/current/monitoring-stats.html).
 
-## Enable further statistics
+### Enable further statistics
 
 These statistics help to identify the most time-consuming queries.
 
@@ -1700,7 +1702,7 @@ These statistics help to identify the most time-consuming queries.
 
 4.  Enable the extension via `CREATE EXTENSION pg_stat_statements`.
 
-### Make use of these statistics
+#### Make use of these statistics
 
 Simply query the table `pg_stat_statements`. Use `x` in `psql` for extended mode or `substring()` on the `query` parameter for readable output. The columns
 are explained in the previously mentioned documentation. Here an example to show
@@ -1716,7 +1718,7 @@ After significant schema changes consider resetting query statistics (`SELECT`
 `BUFFERS) …`) for the slowest queries showing up afterwards to make sure they
 are using indexes (and not just sequential scans).
 
-## Further things to try
+### Further things to try
 
 1.  Try to tweak database configuration parameters. For example increasing
     `work_mem` in `postgresql.conf` might help with some heavy queries. 2.  Run `VACUUM VERBOSE ANALYZE table_name;` for any table that shows to be impacting
@@ -1724,7 +1726,7 @@ are using indexes (and not just sequential scans).
     performance in particular after bigger schema migrations for example type
     changes.
 
-## Further resources
+### Further resources
 
 - Check out
   [the official documentation](https://www.postgresql.org/docs/current/sql-explain.html)
@@ -1739,7 +1741,7 @@ are using indexes (and not just sequential scans).
 - Check out the following
   [documentation pages](https://www.postgresql.org/docs/current/performance-tips.html).
 
-# Filesystem layout
+## Filesystem layout
 
 <a id="filesystem"></a>
 
@@ -1804,7 +1806,7 @@ The worker needs to own `/var/lib/openqa/pool/$INSTANCE`, e.g.
 You can also give the whole pool directory to the `_openqa-worker` user and let
 the workers create their own instance directories.
 
-## Terms and variables for certain directories used by openQA and isotovideo
+### Terms and variables for certain directories used by openQA and isotovideo
 
 - the "base directory"
   - by default `/var/lib`
@@ -1861,6 +1863,7 @@ the workers create their own instance directories.
     `git_auto_clone` enabled, openQA will create a checkout of the repository
     under the mentioned default location if it does not already exist
 
+<<<<<<< HEAD
 ### Further notes
 - The mentioned `git_auto_clone` setting is part of the general
   [Git support](Installing.md#setting-up-git-support) and works best if used
@@ -1872,6 +1875,11 @@ the workers create their own instance directories.
     with e.g. `CASEDIR=https://github.com/…/…-distri-opensuse.git` and
     `DISTRI=microos` but no `NEEDLES_DIR`, needles will be missing despite being
     present for `DISTRI=opensuse`.
+||||||| parent of 642ae58d5 (docs: show document levels in generated TOC)
+### Further notes
+=======
+#### Further notes
+>>>>>>> 642ae58d5 (docs: show document levels in generated TOC)
 
 - Setting the test variables has only an influence on os-autoinst. The web UI on the other hand always relies
   on the directory structure described above. For the exact details how these paths are computed by the web UI
@@ -1880,7 +1888,7 @@ the workers create their own instance directories.
 - When enabling the worker cache, parts of the usual "share directory" are located in the specified cache
   directory on the worker host.
 
-# Automatic installation of the operating systems for openQA machines
+## Automatic installation of the operating systems for openQA machines
 
 <a id="auto_installation_machines"></a>
 
@@ -1896,13 +1904,13 @@ SSH and salt, e.g. to be used with
 <https://github.com/os-autoinst/salt-states-openqa/>, can be found in
 <https://github.com/os-autoinst/openQA/blob/master/contrib/ay-openqa-worker.xml>
 
-# Special network conditions
+## Special network conditions
 
 There might be certain situations where the openQA workers cannot reach the openQA webui directly.
 In this case a reverse connection via SSH or WireGuard might be useful allowing the openQA webui
 to connect to a worker opening a backchannel.
 
-## WireGuard
+### WireGuard
 
 For WireGuard using wg-quick is recommended.
 
@@ -1980,12 +1988,12 @@ secret = BAR
 > This is also the reason why host specific section headers need to
 > have double brackets (one for the ini format, one for the IPv6 host notation).
 
-# Security
+## Security
 
 This section describes available setup options administrators can consider when
 installing openQA to improve security and isolation.
 
-## Isolation
+### Isolation
 
 You may consider enabling AppArmor. Profiles are
 [provided by openQA](https://github.com/os-autoinst/openQA/tree/master/profiles/apparmor.d)
@@ -2003,7 +2011,7 @@ least still run as a distinct user (when using upstream-provided systemd unit
 files).
 
 <a id="authentication"></a>
-## Authentication
+### Authentication
 
 Authentication via OpenID is enabled by default. Do **not** change the
 authentication method to `Fake` unless access is otherwise restricted.
@@ -2013,7 +2021,7 @@ you need to be careful exposing an instance to the public even if authentication
 is enabled. To protect assets, the configuration setting
 `[auth] require_for_assets = 1` can be used. To prevent setting values from being logged, setting keys like *`SECRET`*`…` and `…_PASSWORD` can be used.
 
-## Configuration settings with security implications
+### Configuration settings with security implications
 
 The `download_domains` and `scenario_definitions_allowed_hosts` settings specify domains that will be trusted for downloads via `_URL` job settings and via
 `SCENARIO_DEFINITIONS_YAML_FILE=https://…` respectively. There are some defaults
@@ -2025,13 +2033,13 @@ running. Note that these settings only control the openQA web UI. The
 os-autoinst backend will still clone repositories specified via `CASEDIR` and
 `NEEDLES_DIR` **regardless** of the `[scm git]` settings. Other relevant settings: `hsts`, `file_security_policy`
 
-# Troubleshooting
+## Troubleshooting
 
-## Tests fail quickly
+### Tests fail quickly
 
 Check the log files in `/var/lib/openqa/testresults`
 
-## KVM does not work
+### KVM does not work
 
 - make sure you have a machine with kvm support
 
@@ -2045,7 +2053,7 @@ Check the log files in `/var/lib/openqa/testresults`
 
 - when running inside a vm make sure nested virtualization is enabled (pass nested=1 to your kvm module)
 
-## OpenID login times out
+### OpenID login times out
 
 www.opensuse.org's OpenID provider may have trouble with IPv6. openQA shows a message like this:
 
@@ -2058,7 +2066,7 @@ from trying to use IPv6 with www.opensuse.org:
 ip -6 r a to unreachable 2620:113:8044:66:130:57:66:6/128
 ```
 
-## Performance testing
+### Performance testing
 
 If openQA is very slow and e.g. the test setup times out because the asset
 caching downloads take too long it makes sense to cross-check the networking

--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -1,4 +1,6 @@
 <a id="networking"></a>
+# Networking
+
 For tests using the QEMU backend the networking type used is controlled by the
 `NICTYPE` variable. If unset or empty `NICTYPE` defaults to `user`, i.e.
 [QEMU User Networking](#qemu-user-networking) which requires no further configuration.
@@ -14,7 +16,7 @@ be ensured externally where needed as means for machines to be able to access
 each other.
 
 <a id="qemu-user-networking"></a>
-# QEMU User Networking
+## QEMU User Networking
 
 
 
@@ -24,7 +26,7 @@ the machine can be controlled with the `NICMAC` variable. If not set, it is
 `52:54:00:12:34:56`.
 
 <a id="tap-based-network"></a>
-# TAP Based Network
+## TAP Based Network
 
 os-autoinst can connect QEMU to TAP devices of the host system to
 leverage advanced network setups provided by the host by setting `NICTYPE=tap`. The TAP device to use can be configured with the `TAPDEV` variable. If not
@@ -46,7 +48,7 @@ The MAC address of each virtual NIC is controlled by the `NICMAC` variable or au
 In TAP mode the system administrator is expected to configure the network,
 required internet access, etc. on the host as described in the next section.
 
-## Multi-machine test setup
+### Multi-machine test setup
 
 The complete multi-machine test setup can be provided from the script
 `os-autoinst-setup-multi-machine` provided by "os-autoinst". The script can be
@@ -78,9 +80,9 @@ The script `os-autoinst-setup-multi-machine` can be run like this:
 instances=30 bash -x $(which os-autoinst-setup-multi-machine)
 ```
 
-### What os-autoinst-setup-multi-machine does
+#### What os-autoinst-setup-multi-machine does
 
-#### Set up Open vSwitch
+##### Set up Open vSwitch
 
 The script will install and configure Open vSwitch as well as
 a service called _os-autoinst-openvswitch.service_.
@@ -102,7 +104,7 @@ the same time with conflicting IP addresses. These intermediate IP addresses
 can then be NATed (again) to upstream networks by regular iptables/NFT
 masquerading rules.
 
-#### Configure virtual interfaces
+##### Configure virtual interfaces
 
 The script will add the bridge device and the tap devices for every
 multi-machine worker instance.
@@ -114,7 +116,7 @@ multi-machine worker instance.
 > multi-machine worker hosts. Refer to the [GRE tunnels](#gre-tunnels) section below
 > for further information.
 
-#### Configure NAT with firewalld
+##### Configure NAT with firewalld
 
 > **NOTE:** 
 > `os-autoinst-setup-multi-machine` can set this up for you, but using > plain NFT instead of firewalld (which `os-autoinst-setup-multi-machine` can
@@ -131,10 +133,10 @@ IP-Forwarding will be enabled.
 firewall-cmd --list-all-zones
 ```
 
-### What is left to do after running os-autoinst-setup-multi-machine
+#### What is left to do after running os-autoinst-setup-multi-machine
 
 <a id="gre-tunnels"></a>
-#### GRE tunnels
+##### GRE tunnels
 
 By default all multi-machine workers have to be on a single physical machine.
 You can join multiple physical machines and its OVS bridges together by a GRE
@@ -175,7 +177,7 @@ Ensure to make gre_tunnel_preup.sh executable.
 > that value on support_server itself and it does MTU advertisement for DHCP
 > clients as well.
 
-#### Configure openQA workers
+##### Configure openQA workers
 
 Allow worker instances to run multi-machine jobs by modifying
 [the worker configuration](GettingStarted.md#configuration):
@@ -196,7 +198,7 @@ Enable worker instances to be started on system boot:
 systemctl enable openqa-worker@{1..3}
 ```
 
-## Verify the setup
+### Verify the setup
 
 Simply run a MM test scenario. For openSUSE, you can find many relevant tests on
 [o3](https://openqa.opensuse.org), e.g. look for networking-related tests like
@@ -220,7 +222,7 @@ WORKER_CLASS:wicked_basic_sut+=,worker_bar
 Also be sure to reboot the worker host to make sure the setup is actually
 persistent.
 
-### Start test VMs manually
+#### Start test VMs manually
 
 You may also start VMs manually to verify the setup.
 
@@ -278,7 +280,7 @@ for details). When running ping you can add/remove machines to/from the GRE
 network to bisect problematic hosts/connections (via `ovs-vsctl add-port …` and
 `ovs-vsctl del-port …`).
 
-## Debugging Open vSwitch Configuration
+### Debugging Open vSwitch Configuration
 
 Boot sequence with wicked (version 0.6.23 and newer):
 
@@ -366,9 +368,9 @@ packet count in the forward chain between the br1 and external interface.
 > [counters](https://wiki.nftables.org/wiki-nftables/index.php/Counters) (which can
 > be [added to existing rules](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/getting-started-with-nftables_configuring-and-managing-networking#adding-a-counter-to-an-existing-rule_debugging-nftables-rules)).
 
-## Debugging GRE tunnels and MTU sizes
+### Debugging GRE tunnels and MTU sizes
 
-### Initial setup for all experiments
+#### Initial setup for all experiments
 
 ```sh
 # Enable ip forwarding
@@ -387,7 +389,7 @@ systemctl enable --now openvswitch
 > **NOTE:** 
 > instead of having two /24 networks, it is also possible to assign addresses from one bigger network (which have the benefit of not needing explicit route assignment).
 
-### Simple scenario
+#### Simple scenario
 
 Two servers with a single bridge on each side connected with GRE tunnel.
 
@@ -404,7 +406,7 @@ ping -c 3 -M do -s 1300 192.168.42.1
 ping -c 3 -M do -s 1300 192.168.43.1
 ```
 
-### Scenario with openvswitch
+#### Scenario with openvswitch
 
 Two servers with a one virtual bridge connected with GRE tunnel.
 
@@ -434,7 +436,7 @@ ping -c 3 -M do -s 1300 192.168.43.1
                     type: system
         ovs_version: "3.1.0"
 
-### GRE tunnel made in openvswitch
+#### GRE tunnel made in openvswitch
 
 openvswitch uses flow-based GRE tunneling, i.e. one interface `gre_sys` for all tunnels, the tunnel can be created by `ovs-vsctl`. After that, everything works as expected.
 
@@ -464,7 +466,7 @@ ping -c 3 -M do -s 1300 192.168.43.1
                     options: {remote_ip="192.0.2.2"}
         ovs_version: "3.1.0"
 
-# VDE Based Network
+## VDE Based Network
 
 Virtual Distributed Ethernet provides a software switch that runs in
 user space. It allows to connect several QEMU instances without
@@ -473,7 +475,7 @@ affecting the system's network configuration.
 The openQA workers need a vde_switch instance running. The workers
 reconfigure the switch as needed by the job.
 
-## Basic, Single Machine Tests
+### Basic, Single Machine Tests
 
 To start with a basic configuration like QEMU user mode networking,
 create a machine with the following settings:

--- a/docs/Pitfalls.md
+++ b/docs/Pitfalls.md
@@ -1,5 +1,7 @@
 <a id="pitfalls"></a>
-# Needle editing
+# Pitfalls
+
+## Needle editing
 
 - If a new needle is created based on a failed test, the new needle
   will not be listed in old tests. However, when opening the needle
@@ -13,7 +15,7 @@
 - If a needle is deleted, old tests may display an error when viewing
   them in the web UI.
 
-# 403 messages when using scripts
+## 403 messages when using scripts
 
 - If you come across messages displaying `ERROR: 403 - Forbidden`, make
   sure that the correct API key is present in client.conf file.
@@ -24,7 +26,7 @@
   you can simply logout and log in again in the webUI and the expiration will be automatically
   updated
 
-# Mixed production and development environment
+## Mixed production and development environment
 
 There are few things to take into account when running a development version and
 a packaged version of openqa:
@@ -38,7 +40,7 @@ This approach will lead to a problem when the openqa package is updated, since t
 directory permissions will be changed again, nothing a `chmod -R g+rwx /var/lib/openqa/`
 and `chgrp -R openqa /var/lib/openqa` can not fix.
 
-# Performance impact
+## Performance impact
 
 openQA workers can cause high I/O load, especially when creating VM snapshots.
 The impact therefore gets more severe when `MAKETESTSNAPSHOTS` is enabled.
@@ -61,7 +63,7 @@ settings. Alternatively, you may disable optimizing images altogether via the
 setting `OPTIMIZE_IMAGES=0`.
 
 <a id="db-migration"></a>
-# DB migration from SQlite to postgreSQL
+## DB migration from SQlite to postgreSQL
 
 As a first step to start using postgreSQL, please, configure postgreSQL database
 according to the
@@ -88,7 +90,7 @@ In case you need to migrate job groups, test suites, use openqa-dump-templates a
 openqa-load-templates scripts accordingly.
 
 <a id="debugdevelmode"></a>
-# Steps to debug developer mode setup
+## Steps to debug developer mode setup
 
 This is basically a checklist to go through in case the developer mode is broken in your setup
 (e.g. you are getting the error message `unable to upgrade ws to command server`):

--- a/docs/PrivacyPolicy.md
+++ b/docs/PrivacyPolicy.md
@@ -1,5 +1,7 @@
 <a id="privacypolicy"></a>
-# Introduction
+# Privacy Policy
+
+## Introduction
 
 openQA is an automated testing framework. This privacy policy describes how we
 collect, use, and protect your personal information when you use an openQA
@@ -8,9 +10,9 @@ instance.
 This policy applies to users of openQA. Individual openQA instance operators
 may have their own privacy practices.
 
-# Data We Collect
+## Data We Collect
 
-## Account Information
+### Account Information
 
 When you sign in to an openQA instance for the first time via an external
 authentication provider, an account is automatically created. We collect the
@@ -26,13 +28,13 @@ following information provided by that provider:
 
 - Role (operator, admin)
 
-## Authentication Data
+### Authentication Data
 
 - API keys and secrets (stored in hashed form)
 
 - Session data (login time, user ID)
 
-## Activity Data
+### Activity Data
 
 - Comments you post on jobs or test results
 
@@ -42,7 +44,7 @@ following information provided by that provider:
 
 - Developer session data when using the interactive debugging feature
 
-# How We Use Your Data
+## How We Use Your Data
 
 Your data is used for:
 
@@ -58,7 +60,7 @@ Your data is used for:
 
 - No marketing or advertising purposes
 
-# Data Protection
+## Data Protection
 
 We implement appropriate technical and organizational measures:
 
@@ -71,7 +73,7 @@ We implement appropriate technical and organizational measures:
 - When you delete your account, your personal data is anonymized while
   preserving historical records (see User Rights)
 
-# Data Sharing
+## Data Sharing
 
 We do not share your personal data with third parties except:
 
@@ -83,21 +85,21 @@ We do not share your personal data with third parties except:
 
 We do not sell your personal data.
 
-# User Rights
+## User Rights
 
 You have the following rights regarding your personal data:
 
-## Access
+### Access
 
 You can view your account information through the web interface or API.
 
-## Correction
+### Correction
 
 Account details (username, email, fullname, nickname) are retrieved from your
 external authentication provider. To update this information, please do so
 through that provider.
 
-## Deletion
+### Deletion
 
 You can delete your account, which will:
 
@@ -114,32 +116,32 @@ You can delete your account, which will:
 To exercise these rights, use the account deletion feature in your user
 settings or contact the instance administrator.
 
-## Data Portability
+### Data Portability
 
 You can export your data through the openQA API.
 
-## Contact
+### Contact
 
 For privacy inquiries, contact the administrator of your openQA instance.
 
-# Cookies and Tracking
+## Cookies and Tracking
 
 openQA uses session cookies for authentication. These cookies are necessary
 for the service to function and are not used for tracking or advertising.
 
 No third-party analytics or tracking services are used.
 
-# Policy Changes
+## Policy Changes
 
 This policy may be updated from time to time. The effective date is noted
 below. Significant changes will be communicated through the openQA instance's
 announcement channels.
 
-# Effective Date
+## Effective Date
 
 This policy was last updated: March 2026
 
-# Contact Information
+## Contact Information
 
 For questions about this privacy policy or to exercise your data rights,
 contact the openQA instance administrator.

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1,5 +1,7 @@
 <a id="usersguide"></a>
-# Introduction
+# Users Guide
+
+## Introduction
 
 This document provides additional information for use of the web interface or
 the REST API as well as administration information.
@@ -9,9 +11,9 @@ of components as well as the configuration of an installed instance.
 
 <a id="job_templates"></a>
 
-# Using job templates to automate jobs creation
+## Using job templates to automate jobs creation
 
-## The problem
+### The problem
 
 When testing an operating system, especially when doing continuous testing,
 there is always a certain combination of jobs, each one with its own
@@ -69,7 +71,7 @@ this example we could have the following test scenarios considering that the
 For every test scenario we need to configure a different instance of the test
 backend, for example `os-autoinst`, with a different set of parameters.
 
-## Machines
+### Machines
 
 You need to have at least one machine set up to be able to run any
 tests. Those machines represent virtual machine types that you want to
@@ -98,7 +100,7 @@ worker' connected that can fulfill those specifications.
     emulated USB stick.
 
 <a id="medium_types_products"></a>
-## Medium Types (products)
+### Medium Types (products)
 
 A medium type (product) in openQA is a simple description without any concrete
 meaning. It basically consists of a name and a set of variables that define or
@@ -126,7 +128,7 @@ medium with a concrete version and one with `*` at the same time is usually not 
 `for product …` (unless you actually have job templates for all these medium
 types).
 
-## Test Suites
+### Test Suites
 
 A test suite consists of a name and a set of test variables that are used
 inside this particular test together with an optional description. The test
@@ -174,7 +176,7 @@ and/or os-autoinst's own behavior are:
 - `RAIDLEVEL` RAID configuration variable
 - `QEMUVGA` parameter to declare the video hardware configuration in QEMU
 
-## Job Groups
+### Job Groups
 
 The job groups are the place where the actual test scenarios are defined by
 the selection of the medium type, the test suite and machine together with a
@@ -212,7 +214,7 @@ by different means:
 - Using declarative schedule definitions in the YAML format using REST API
   routes or an online-editor within the web UI including a syntax checker.
 
-## Variable expansion
+### Variable expansion
 
 Any job setting can refer to another variable using this syntax: `%NAME%`. When
 the test job is created, the string will be substituted with the value of the
@@ -241,7 +243,7 @@ PUBLISH_HDD_1 = opensuse-13.1-i586-kde.qcow2
 > worker will **not** be shown in the "Settings" tab on the web UI. They are only
 > present in `vars.json` and `worker-log.txt`.
 
-## Variable precedence
+### Variable precedence
 
 It is possible to define the same variable in multiple places that would all be
 used for a single job - for instance, you may have a variable defined in both
@@ -279,7 +281,7 @@ order described above will apply to those settings.
 Note that the `WORKER_CLASS` variable is not overridden in the way described above.
 Instead multiple occurrences are combined.
 
-# Use of the web interface
+## Use of the web interface
 
 In general the web UI should be intuitive or self-explanatory. Look out for the
 little blue help icons and click them for detailed help on specific sections.
@@ -292,7 +294,7 @@ builds or only show failed jobs or other settings. Additionally, the query
 parameters can be tweaked by hand if you want to provide a link to specific
 views.
 
-## Description of test suites
+### Description of test suites
 
 Test suites can be described using API commands or the admin table for any operator using the web UI.
 
@@ -316,7 +318,7 @@ If a description is defined, the name of the test suite on the tests overview pa
 
 
 
-## /tests/overview - Customizable test overview page
+### /tests/overview - Customizable test overview page
 
 The overview page is configurable by the filter box. Also, some additional
 query parameters can be provided which can be considered advanced or
@@ -339,7 +341,7 @@ build of each group. This can be useful to have a static URL for bookmarking.
 
 <a id="review_badges"></a>
 
-## Review badges
+### Review badges
 
 Based on comments in the individual job results for each build a certificate
 icon is shown on the group overview page as well as the index page to indicate
@@ -350,7 +352,7 @@ reason is stated:
 <img src="images/review_badges.png" alt="Review badges" />
 </figure>
 
-### Meaning of the different colors
+#### Meaning of the different colors
 
 - No icon is shown if at least one failure still need to be reviewed.
 
@@ -362,9 +364,9 @@ reason is stated:
 
 (To simplify, checking for false-negatives is not considered here.)
 
-## Bug references, labels and flags
+### Bug references, labels and flags
 
-### Bug references
+#### Bug references
 
 It is possible to reference a bug by writing `<bugtracker_shortname>#<bug_nr>`
 in a comment, e.g. `bsc#1234`. It is also possible to spell out the full URL, e.g. `https://bugzilla.suse.com/show_bug.cgi?id=1234` which will then be
@@ -407,7 +409,7 @@ see the figure below.
 > Also GitHub pull requests and issues can be linked. Use the generic format
 > `[#<project/repo>](marker)#<id>`, e.g. [`gh#os-autoinst/openQA#1234`](https://github.com/os-autoinst/openQA/issues/1234).
 
-### Labels
+#### Labels
 
 A comment can also contain labels. Use `label:<keyword>` where `<keyword>`
 can be any valid character up to the next whitespace, e.g. `false_positive`.
@@ -430,7 +432,7 @@ will be shown next to it in various places as shown in the figure below.
 > not a bugref. The bugref will still be rendered as a link. That means no bug
 > icon is shown and the comment does **not** become subject to carry over.
 
-#### Overwrite result of job
+##### Overwrite result of job
 
 One special label format is available which allows to forcefully overwrite the
 result of an openQA job using a convenient openQA comment. The expected format
@@ -444,17 +446,17 @@ operator permissions.
 > [carried over](UsersGuide.md#carry-over). However, the carry over will
 > only happen when the comment **also** contains a bug reference or `flag:carryover`.
 
-### Flags
+#### Flags
 
 Currently there is only one flag for job comments supported.
 
-#### flag:carryover
+##### flag:carryover
 
 Adding `flag:carryover` to a comment, will result in this comment being
 [carried over](UsersGuide.md#carry-over) to a new job failing for
 the same reason, without a bugref required.
 
-## Distinguish product and test issues bugref [gh#708](https://github.com/os-autoinst/openQA/pull/708)
+### Distinguish product and test issues bugref [gh#708](https://github.com/os-autoinst/openQA/pull/708)
 
 "progress.opensuse.org" is used to track test issues, bugzilla for product
 issues, at least for SUSE/openSUSE. openQA bugrefs distinguish this and show
@@ -464,9 +466,9 @@ corresponding icons
 <img src="images/tests-overview-issue_icon.png" alt="Different icons for product and test issues" />
 </figure>
 
-## Build tagging
+### Build tagging
 
-### Tag builds with special comments on group overview
+#### Tag builds with special comments on group overview
 
 Based on comments on the group overview individual builds can be tagged. As
 'build' by themselves do not own any data the job group is used to store this
@@ -496,7 +498,7 @@ corresponding option in the filter form at the bottom of the page.
 <img src="images/build_tagging.png" alt="Example of a tag comment and corresponding tagged build" />
 </figure>
 
-### Keeping important builds
+#### Keeping important builds
 
 As builds can now be tagged we come up with the convention that the
 'important' type - the only one for now - is used to tag every job that
@@ -504,7 +506,7 @@ corresponds to a build as 'important' and keep the logs for these jobs longer so
 we can always refer to the attached data, e.g. for milestone builds, final
 releases, jobs for which long-lasting bug reports exist, etc.
 
-## Filtering test results and builds
+### Filtering test results and builds
 
 At the top of the test results overview page is a form which allows filtering tests by result,
 architecture and TODO-status. "TODO" means that tests still [require review](#review_badges).
@@ -517,7 +519,7 @@ There is also a similar form at the bottom of the index page which allows filter
 group and customizing the limits.
 Also the 'All tests' table allows filtering by the TODO-status.
 
-## Highlighting job dependencies in 'All tests' table
+### Highlighting job dependencies in 'All tests' table
 
 When hovering over the branch icon after the test name children of the job will
 be highlighted blue and parents red. So far this only works for jobs displayed on
@@ -527,7 +529,7 @@ the same page of the table.
 <img src="images/highlighting_job_dependencies.png" alt="highlighted child jobs" />
 </figure>
 
-## Show previous results in test results page <a href="https://github.com/os-autoinst/openQA/pull/538" id="538">gh</a>
+### Show previous results in test results page <a href="https://github.com/os-autoinst/openQA/pull/538" id="538">gh</a>
 
 On a tests result page there is a tab for "Next & previous results" showing
 the result of test runs in the same scenario. This shows next and previous
@@ -551,7 +553,7 @@ Screenshot of the feature:
 <img src="images/test_details-next_and_previous.png" alt="Next and previous job results" />
 </figure>
 
-## Link to latest in scenario name <a href="https://github.com/os-autoinst/openQA/pull/836" id="836">gh</a>
+### Link to latest in scenario name <a href="https://github.com/os-autoinst/openQA/pull/836" id="836">gh</a>
 
 Find the always latest job in a scenario with the link after the
 scenario name in the tab "Next & previous results" Screenshot:
@@ -560,7 +562,7 @@ scenario name in the tab "Next & previous results" Screenshot:
 <img src="images/test_details-link_to_latest.png" alt="Link to latest in scenario" />
 </figure>
 
-## Add `latest' query route <a href="https://github.com/os-autoinst/openQA/pull/815" id="815">gh</a>
+### Add `latest' query route <a href="https://github.com/os-autoinst/openQA/pull/815" id="815">gh</a>
 
 Should always refer to most recent job for the specified scenario.
 
@@ -581,7 +583,7 @@ Examples:
 - `tests/latest?test=foobar` - this searches for the most recent job using test_suite `foobar' covering all distri, version, flavor, arch,
   machines. To be more specific, add the other query entries.
 
-## Allow group overview query by result <a href="https://github.com/os-autoinst/openQA/pull/531" id="531">gh</a>
+### Allow group overview query by result <a href="https://github.com/os-autoinst/openQA/pull/531" id="531">gh</a>
 
 This allows e.g. to show only failed builds. Could be included like in
 <http://lists.opensuse.org/opensuse-factory/2016-02/msg00018.html> for
@@ -590,7 +592,7 @@ This allows e.g. to show only failed builds. Could be included like in
 Example: Add query parameters like `…&result=failed&arch=x86_64` to show
 only failed for the single architecture selected.
 
-## Add web UI controls to select more builds in group_overview <a href="https://github.com/os-autoinst/openQA/pull/804" id="804">gh</a>
+### Add web UI controls to select more builds in group_overview <a href="https://github.com/os-autoinst/openQA/pull/804" id="804">gh</a>
 
 The query parameter `limit_builds' allows to show more than the default
 10 builds on demand. Just like we have for configuring previous results,
@@ -604,7 +606,7 @@ Example screenshot:
 <img src="images/job_group-limit_builds.png" alt="Select different limit for number of displayed builds" />
 </figure>
 
-## More query parameters for configuring last builds <a href="https://github.com/os-autoinst/openQA/pull/575" id="575">gh</a>
+### More query parameters for configuring last builds <a href="https://github.com/os-autoinst/openQA/pull/575" id="575">gh</a>
 
 By using advanced query parameters in the URLs you can configure the
 search for builds. Higher numbers would yield more complex database
@@ -619,7 +621,7 @@ group overview page:
 
     http://openqa/group_overview/1?time_limit_days=21&limit_builds=20
 
-## Web UI controls to filter only tagged or all builds <a href="https://github.com/os-autoinst/openQA/pull/807" id="807">gh</a>
+### Web UI controls to filter only tagged or all builds <a href="https://github.com/os-autoinst/openQA/pull/807" id="807">gh</a>
 
 Using a new query parameter `only_tagged=[0\|1]' the list can be
 filtered, e.g. show only tagged (important) builds.
@@ -632,7 +634,7 @@ Example screenshot:
 
 Related issue: <a href="https://progress.opensuse.org/issues/11052" id="11052">https://progress.opensuse.org/issues/11052</a>
 
-## Test result badges <a href="https://github.com/os-autoinst/openQA/pull/5022" id="5022">gh</a>
+### Test result badges <a href="https://github.com/os-autoinst/openQA/pull/5022" id="5022">gh</a>
 
 For build results or individual job results including the latest job result
 page, there is a corresponding route to get an SVG status badge that can e.g.
@@ -654,7 +656,7 @@ It supports the same query parameters as the overview page.
 There is an optional parameter `show_build=1` that will prefix the status with the build number (or `multi` if multiple builds are targeted). The parameter `label` can be used to set a custom label on the left side of the badge (instead of the default `openQA`). When a custom label is used, the openQA
 logo is omitted to provide more space for the text.
 
-## Build a continuous openQA monitoring dashboard
+### Build a continuous openQA monitoring dashboard
 
 With just some common tools a dashboard showing the openQA index page with
 continuously updated results can be setup. Example setup using the
@@ -697,7 +699,7 @@ autologin-timeout=0
 ```
 
 <a id="carry-over"></a>
-## Carry over of bug references from previous jobs in same scenario
+### Carry over of bug references from previous jobs in same scenario
 
 Many test failures within the same scenario might be due to the same reason.
 To avoid human reviewers having to add the same bug references again and
@@ -724,14 +726,14 @@ Jenkins.
 > in the job reason for incomplete jobs or job logs consider to
 > [Enable custom hook scripts on "job done" based on result](Installing.md#enable_custom_hook_scripts_on_job_done_based_on_result).
 
-## Pinning comments as group description
+### Pinning comments as group description
 
 This is possible by adding the keyword `pinned-description` anywhere in
 a comment on the group overview page. Then the comment will be shown at
 the top of the group overview page. However, it only works as operator
 or admin.
 
-## Dark mode
+### Dark mode
 
 A dark mode theme can be enabled via "Appearance" settings for all logged in users. It can either be forced with
 the "dark mode" setting, or left to browser detection. Switching automatically between light and dark mode is natively
@@ -742,7 +744,7 @@ supported by most modern browsers and can also be controlled manually via flags:
 For more information, see
 <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme" class="mozilla org/CSS/@media/prefers-color-scheme">developer</a>
 
-## Developer mode
+### Developer mode
 
 The developer mode allows to:
 
@@ -758,7 +760,7 @@ So I am not repeating that information here and rather explain the overall workf
 In case the developer mode in not working on your instance, try to follow the
 [steps for debugging the developer mode under 'Pitfalls'](Pitfalls.md#debugdevelmode).
 
-### Workflow for creating or updating needles
+#### Workflow for creating or updating needles
 
 1.  In case a new needles should be created, add the corresponding `assert_screen` calls
     to your test.
@@ -777,11 +779,11 @@ In case the developer mode in not working on your instance, try to follow the
 
 Steps 4. to 6. can be repeated for further needles without restarting the test.
 
-## Job group editor <a href="https://github.com/os-autoinst/openQA/pull/2111" id="2111">gh</a>
+### Job group editor <a href="https://github.com/os-autoinst/openQA/pull/2111" id="2111">gh</a>
 
 Scenarios are defined as part of a job group. The `Edit job group` button exposes the editor.
 
-### YAML job templates editor
+#### YAML job templates editor
 
 Settings can be specified as a key/value pair for each scenario. There is no
 equivalent in the table view so you need to migrate groups to use this feature.
@@ -794,7 +796,7 @@ it, otherwise that would create an inconsistent state.
 Job groups can be updated through the YAML editor or the YAML-related
 REST API routes.
 
-### Deprecated: Table-based (pre-migration)
+#### Deprecated: Table-based (pre-migration)
 
 In old versions openQA had a table-based UI for defining job templates, listed
 in a table per medium. Machines can be added by selecting the architecture
@@ -833,7 +835,7 @@ YAML directly.
 More generally the regular expression `[A-Za-z0-9._*-]+` could be used to
 check if a name is allowed for a product or test suite.
 
-# Configuring job groups via YAML documents
+## Configuring job groups via YAML documents
 
 A new job group starts out empty, which in YAML means that the two mandatory
 sections are present but contain nothing. This is what can be seen when
@@ -876,7 +878,7 @@ scenarios:
             QEMUVGA: cirrus
 ```
 
-## Defaults
+### Defaults
 
 Now there are two scenarios for `x86_64`, one by giving just the name of the
 test suite and another which has a machine, priority and settings. Both are
@@ -927,7 +929,7 @@ scenarios:
             FOO: '2'
 ```
 
-## YAML Aliases
+### YAML Aliases
 
 Even more flexibility can be achieved by using aliases in YAML, or in other
 words reusing a scenario by reference, such as to run the same scenarios in
@@ -964,7 +966,7 @@ scenarios:
       - gnome_staging: *gnome_staging
 ```
 
-## YAML Merge Keys
+### YAML Merge Keys
 
 Also [YAML Merge Keys](https://yaml.org/type/merge.html) are supported.
 This way you can reuse previously defined anchors and add other values to it.
@@ -1015,7 +1017,7 @@ scenarios:
             FOO: foo # overrides the value from the merge keys
 ```
 
-## General YAML documentation
+### General YAML documentation
 
 The job templates are written in [YAML
 1.2](https://yaml.org/spec/1.2/spec.html). In YAML, strings usually do not have to be quoted, except if it is a
@@ -1086,7 +1088,7 @@ If you need the literal string `<<` (for example as a value in the job
 settings), you have to quote it.
 
 <a id="rest_api"></a>
-# Use of the REST API
+## Use of the REST API
 
 openQA includes a _client_ script which - depending on the distribution - is
 packaged independently to allow interfacing with an existing openQA instance
@@ -1097,7 +1099,7 @@ This section focuses on particular API use-cases. Check out the
 [openQA client](Client.md#client) section for further information about
 the client itself, how authentication works and how plain `curl` can be used.
 
-## Finding tests
+### Finding tests
 
 The following example lists all jobs within the job group with the ID `1`
 and the setting `BUILD=20210707` on `openqa.opensuse.org`:
@@ -1137,7 +1139,7 @@ by adding additional query parameters, e.g.:
 - `scope=relevant`: Returns only jobs which have not been obsoleted yet and
   which have not been cloned yet. Clones which are still pending do **not** count.
 
-### Remarks
+#### Remarks
 
 - All parameters can be combined with each other unless stated otherwise.
 
@@ -1147,7 +1149,7 @@ by adding additional query parameters, e.g.:
 - All values are matched exactly, so e.g. `group=openSUSE+Leap+15` returns only jobs within the group `openSUSE Leap 15` but not jobs from the group  `openSUSE Leap 15 ARM`. This applies to parameters for filtering job settings
   as well.
 
-## Finding tests by querying particular job settings
+### Finding tests by querying particular job settings
 
 In case you are looking for a way to get a list of all the tests based on their
 settings, here is one way to achieve this with `openqa-cli api`:
@@ -1159,7 +1161,7 @@ openqa-cli api job_settings/jobs key="*_TEST_ISSUES" list_value=39911
 It is possible to use a literal string or a glob for `key` as shown in the examples. `list_value` does not support globbing, though. openQA configuration sets `job_settings_max_recent_jobs` which limits
 the results.
 
-### Array-like job settings
+#### Array-like job settings
 
 Settings where the key ends with `[]` are split on `,`. So e.g.
 `ISSUES[]=foo,bar,baz` will be stored as `ISSUES[]=foo`, `ISSUES[]=bar` and
@@ -1173,7 +1175,7 @@ openqa-cli api job_settings/jobs key=ISSUES value=foo
 Note that the suffix `[]` is still part of the setting key and always needs to be specified when referring to the setting. That also means that e.g. `ISSUES`
 and `ISSUES[]` are two completely different settings.
 
-### Using other API routes
+#### Using other API routes
 
 It is also possible to use the `jobs` and `jobs/overview` routes which support the `job_setting` parameter. More than one `job_setting` parameter can be
 specified and it can also be combined with other filtering parameters, e.g.:
@@ -1183,13 +1185,13 @@ openqa-cli api jobs result=none job_setting=ISSUES[]={foo,bar} limit=50
 ```
 
 <a id="triggering_tests"></a>
-## Triggering tests
+### Triggering tests
 
 Tests can be triggered over multiple ways, using `openqa-clone-job`,
 `jobs post`, `isos post` as well as retriggering existing jobs or whole media
 over the web UI.
 
-### Cloning existing jobs - openqa-clone-job
+#### Cloning existing jobs - openqa-clone-job
 
 If one wants to recreate an existing job from any publicly available openQA
 instance the script `openqa-clone-job` can be used to copy the necessary
@@ -1198,14 +1200,14 @@ be executed it has to be ensured that matching resources can be found, for
 example a worker with matching `WORKER_CLASS` must be registered. More details on `openqa-clone-job` can be found in
 [Writing Tests](WritingTests.md#writingtests).
 
-### Spawning single new jobs - jobs post
+#### Spawning single new jobs - jobs post
 
 Single jobs can be spawned using the `jobs post` API route. All necessary
 settings on a job must be supplied in the API request. The "openQA client" has
 examples for this.
 
 <a id="further_examples_for_advanced_dependency_handling"></a>
-#### Further examples for advanced dependency handling
+##### Further examples for advanced dependency handling
 
 It is possible to spawn a single set of jobs using just one API call, e.g.:
 
@@ -1227,7 +1229,7 @@ To use colons within a settings key, just add a trailing `:`, e.g.:
     openqa-cli api -X POST jobs TEST=test KEY:WITH:COLONS:=example
 
 <a id="spawning_multiple_jobs_based_on_templates_isos_post"></a>
-### Spawning multiple jobs based on templates - isos post
+#### Spawning multiple jobs based on templates - isos post
 
 The most common way of spawning jobs on production instances is using the
 `isos post` API route. Based on settings for media, job groups, machines and
@@ -1324,7 +1326,7 @@ This is recommended on big instances but means that the results (and
 possible errors) need to be polled via `openqa-cli api isos/$scheduled_product_id`.
 
 <a id="statistical_investigation"></a>
-#### Statistical investigation
+##### Statistical investigation
 
 In case issues appear sporadically and are therefore hard to reproduce it can
 help to trigger many more jobs on a production instance to gather more data
@@ -1343,7 +1345,7 @@ To get an overview about the fail ratio and confidence interval of sporadically
 failing applications you can also use a script like
 [this](https://github.com/okurz/scripts/blob/master/count_fail_ratio).
 
-#### Defining test scenarios in YAML
+##### Defining test scenarios in YAML
 
 Instead of relying on the tables for machines, mediums/products, test suites and
 job templates of the openQA instance, one can provide these definitions/settings
@@ -1402,13 +1404,13 @@ the full structure can be found in the
 These definitions are used like their openQA-instance-wide counterparts (so continue
 reading the next section for more details on job templates).
 
-### Remarks
+#### Remarks
 
 When scheduling a single test (variable `TEST` is specified) attempts to
 obsolete/deprioritize are prevented by default because this is likely not wanted.
 Use `_FORCE_OBSOLETE` or `_FORCE_DEPRIORITIZEBUILD` to nevertheless obsolete/deprioritize **all** jobs with matching `DISTRI`, `VERSION`, `FLAVOR` and `ARCH`.
 
-## Job template YAML
+### Job template YAML
 
 Job groups can be queried via the experimental REST API:
 
@@ -1427,7 +1429,7 @@ openqa-dump-templates --json --group test > test.json
 openqa-load-templates test.json
 ```
 
-# Asset handling
+## Asset handling
 
 Multiple parameters exist to reference "assets" to be used by tests. "Assets"
 are essentially content that is stored by the openQA web-UI and provided to the
@@ -1444,7 +1446,7 @@ file system (this used to be the only option), or by having the workers download
 server when needed and cache them locally. Check out the documentation about
 [asset caching](Installing.md#asset-caching) for more on this.
 
-## Specifying assets required by a job
+### Specifying assets required by a job
 
 The following job settings are specifying that an asset is required by a job:
 
@@ -1502,7 +1504,7 @@ and uncompressed as.
 
 
 
-## Specifying assets created by a job
+### Specifying assets created by a job
 
 Jobs can upload assets to the web-UI so other jobs can used them as `HDD_n` and
 `UEFI_PFLASH_VARS` assets as described in the previous section. To declare an asset to be uploaded, you can use the job settings `PUBLISH_HDD_n`
@@ -1526,7 +1528,7 @@ the test will be uploaded back to the web-UI and stored under the name
 > When using this mechanism you will often also want to use the
 > [variable expansion](UsersGuide.md#variable_expansion) mechanism.
 
-### Private assets
+#### Private assets
 
 There is a mechanism to alter an asset's file name automatically to associate
 it with the particular job that produced it (currently, by prepending the job ID
@@ -1544,7 +1546,7 @@ naming conflicts.
 > chain can still access the asset by explicitly prepending the ID of the creating
 > job.
 
-# Cleanup of assets, results and other data
+## Cleanup of assets, results and other data
 
 The cleanup of [assets](UsersGuide.md#asset_handling), test results
 and certain other data is automated. That means openQA removes assets, job
@@ -1615,7 +1617,7 @@ Further remarks:
 - The [Auditing](Installing.md#auditing) section explains the cleanup of
   the audit log.
 
-## Automatic archiving of old jobs
+### Automatic archiving of old jobs
 
 Archiving of important jobs can be enabled:
 
@@ -1645,7 +1647,7 @@ This means a job is "in the archive" if:
 > Archiving does **not** prevent cleanup. If an archived important job exceeds
 > the retention for important jobs it is still subject to cleanup.
 
-## Space-aware cleanup
+### Space-aware cleanup
 
 The cleanup of logs/results uses time-based retentions and hence is independent
 of actually available space on any assigned storage volumes. To ensure enough
@@ -1684,7 +1686,7 @@ as there is enough headroom on the relevant file systems.
 > specifically are still experimental.
 
 <a id="asset_cleanup"></a>
-## Cleanup strategy for assets
+### Cleanup strategy for assets
 
 To find out whether an asset should be removed, openQA determines by which
 groups the asset is used. If at least one job within a certain job group is
@@ -1726,7 +1728,7 @@ always be available for a test to work. Note that relative symlinks in the
 regular assets directory that point into the `fixed` subdirectory are also
 preserved.
 
-## Configuring limit for assets within job groups
+### Configuring limit for assets within job groups
 
 To configure the maximum size for the assets of a group, open 'Job groups'
 in the operators menu and select a group. The size limit for assets can be
@@ -1736,7 +1738,7 @@ assets which belong to that group and not to any other group.
 The default size limit for job groups can be adjusted in the
 `default_group_limits` section of the openQA config file.
 
-## Configuring limit for groupless assets
+### Configuring limit for groupless assets
 
 Assets not belonging to jobs within a group are deleted automatically
 after a certain number of days. That duration can be adjusted by setting
@@ -1761,7 +1763,7 @@ openSUSE.+x86_64 = 10
 Note that modifications to the file will count against the limit, so if an
 asset was updated within the timespan it will not be removed.
 
-## Timers and triggers
+### Timers and triggers
 
 Cleanup can be triggered in different ways. One option is to use
 `minion_task_triggers` and specify tasks via `on_job_done`. Another way to do that is to use the systemd timers `openqa-enqueue-*-cleanup` to periodically
@@ -1786,7 +1788,7 @@ repeatedly. Note that the tasks can still take considerable time computing
 what to delete, from seconds to minutes. The tasks can be enabled in the
 corresponding config file section.
 
-## Disabling cleanup
+### Disabling cleanup
 
 By default the cleanup is enabled with systemd timers if available. To
 completely disable cleanup make sure that no minion cleanup tasks are enabled
@@ -1797,7 +1799,7 @@ for example for the asset cleanup:
 systemctl mask openqa-enqueue-asset-cleanup.timer
 ```
 
-# Consuming AMQP events from openQA
+## Consuming AMQP events from openQA
 
 The message topic follows the format `SCOPE.APPLICATION.OBJECT.ACTION`, for example `opensuse.openqa.job.done` or `opensuse.openqa.comment.create`. The `topic_prefix` setting controls the `SCOPE` part; if left empty the topic starts with `openqa.` directly. Consumers can use `#` to match any number of words or `*` to match exactly one word. `opensuse.openqa.#` subscribes to all openQA events, for instance.
 
@@ -1854,13 +1856,13 @@ A real-world example of an AMQP consumer built on top of openQA events is
 pipelines and posts failure notifications to Slack. It subscribes to openQA job
 events and tracks job results per build and job group.
 
-# CLI interface
+## CLI interface
 
 Beside the `daemon` argument to run the actual web service the openQA startup script `/usr/share/openqa/script/openqa` supports further arguments. For a full list of those commands, just invoke `/usr/share/openqa/script/openqa -h`. This also works for sub-commands(e.g. `/usr/share/openqa/script/openqa minion -h`,
 `/usr/share/openqa/script/openqa minion job -h`). Note that `prefork` is only supported for the main web service but not for
 other services like the live view handler.
 
-# Suggested workflow for test review
+## Suggested workflow for test review
 
 If an openQA instance is only used by one or few individuals often no strict
 process needs to defined how openQA tests should be reviewed and how
@@ -1915,7 +1917,7 @@ and have a traceable documentation of the actions taken.
   comment format or use the comment template from the openqa.suse.de comment
   edit window.
 
-# Where to now?
+## Where to now?
 
 For test developers it is recommended to continue with the
 [Test Developer Guide](WritingTests.md#writingtests).

--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -1,5 +1,7 @@
 <a id="writingtests"></a>
-# Introduction
+# Writing Tests
+
+## Introduction
 
 openQA is an automated test tool that makes it possible to test the whole
 installation process of an operating system. It's free software released
@@ -12,7 +14,7 @@ openQA or to improve the existing ones. It's assumed that the reader is already
 familiar with openQA and has already read the Starter Guide, available at the
 [official repository](https://github.com/os-autoinst/openQA).
 
-# Basic
+## Basic
 
 This section explains the basic layout of an openQA test and the API available.
 Tests can be written in the programming languages **Perl**, \*Python\*¹ and \*Lua\*².
@@ -25,7 +27,7 @@ document assumes that the reader is already familiar with Perl, Python or Lua.
 
 ² requires the Perl module `Inline::Lua`
 
-# Test API
+## Test API
 
 <a id="api"></a>
 
@@ -34,9 +36,9 @@ look at the [test API documentation](http://open.qa/api/testapi) for further
 information. Note that this test API is sometimes also referred to as an openQA
 DSL, because in some contexts it can look like a domain specific language.
 
-# How to write tests
+## How to write tests
 
-## Test module interface
+### Test module interface
 
 An openQA test needs to implement at least the `run` subroutine containing the
 actual test code and the test needs to be loaded in the distribution's
@@ -92,7 +94,7 @@ def pre_run_hook(): -> None # *1
 def post_run_hook(): -> None # *1
 ```
 
-### `run`
+#### `run`
 
 Defines the actual steps to be performed during the module execution.
 
@@ -115,7 +117,7 @@ sub run {
 
 `assert_screen` & `send_key` are provided by [os-autoinst](https://github.com/os-autoinst/os-autoinst/blob/master/testapi.pm).
 
-### `test_flags`
+#### `test_flags`
 
 Specifies what should happen when test execution of the current test module is
 finished depending on the result.
@@ -154,7 +156,7 @@ function test_flags(self)
 end
 ```
 
-### `pre_run_hook`
+#### `pre_run_hook`
 
 It is called before the `run` function - mainly useful for a whole group of tests.
 It is useful to setup the start point of the test.
@@ -168,7 +170,7 @@ sub pre_run_hook {
 }
 ```
 
-### `post_fail_hook`
+#### `post_fail_hook`
 
 It is called after `run` failed. It is useful to upload log files or to
 determine the state of the machine.
@@ -182,7 +184,7 @@ sub post_fail_hook {
 }
 ```
 
-### `post_run_hook`
+#### `post_run_hook`
 
 It is called after `run` completes, regardless of its return value, but only if the `run` subroutine completes without any exceptions.
 
@@ -196,7 +198,7 @@ sub post_run_hook {
 }
 ```
 
-## Notes on the Python API
+### Notes on the Python API
 
 <a id="notes-python-api"></a>
 
@@ -252,7 +254,7 @@ Additionally, Python tests do not support `run_args` and treat the presence of
 `run_args` as error. This is because of the way `Inline::Python` does not pass
 references to complex Perl objects to Python.
 
-## Notes on the Lua API
+### Notes on the Lua API
 
 <a id="notes-lua-api"></a>
 
@@ -313,14 +315,14 @@ x11_start_program('vncviewer :0',
 )
 ```
 
-## Example Perl test modules
+### Example Perl test modules
 
 <a id="testmodule_perl_examples"></a>
 
 The following examples are short complete test modules written in Perl
 implementing the interface described above.
 
-### Boot to desktop
+#### Boot to desktop
 
 Boots into desktop when pressing enter at the boot loader screen.
 
@@ -349,7 +351,7 @@ sub test_flags {
 }
 ```
 
-### Install software via `zypper`
+#### Install software via `zypper`
 
 Console test that installs software from remote repository via zypper command
 
@@ -375,7 +377,7 @@ sub run {
 }
 ```
 
-### Sample X11 Test
+#### Sample X11 Test
 
 Typical X11 test testing kate
 
@@ -409,14 +411,14 @@ sub run {
 }
 ```
 
-## Example Python test modules
+### Example Python test modules
 
 <a id="testmodule_python_examples"></a>
 
 The following examples are short complete test modules written in Python
 implementing the interface described above.
 
-### openQA web UI sample test
+#### openQA web UI sample test
 
 Test for the openQA web UI written in Python
 
@@ -450,7 +452,7 @@ def test_flags(self):
     return {'fatal': 1}
 ```
 
-## Example Lua test module
+### Example Lua test module
 
 ```lua
 use("testapi")
@@ -473,7 +475,7 @@ function test_flags(self)
 end
 ```
 
-# Variables
+## Variables
 
 Test case behavior can be controlled via variables. Some basic variables like
 `DISTRI`, `VERSION`, `ARCH` are always set. Others like `DESKTOP` are defined by
@@ -483,10 +485,10 @@ on GitHub](https://github.com/os-autoinst/os-autoinst-distri-opensuse) for examp
 
 Variables are accessible via the **get_var** and **check_var** functions.
 
-# Advanced test features
+## Advanced test features
 
 <a id="changing_timeouts"></a>
-## Changing timeouts
+### Changing timeouts
 
 By default, tests are aborted after two hours by the worker. To change this
 limit, set the test variable `MAX_JOB_TIME` to the desired number of seconds.
@@ -497,7 +499,7 @@ the backend, for example the [test API](#api). This is supposed to be set
 within the worker settings on slow worker hosts. It has no influence on the
 video setting.
 
-## Capturing kernel exceptions and/or any other exceptions from the serial console
+### Capturing kernel exceptions and/or any other exceptions from the serial console
 
 Soft and hard failures can be triggered on demand by regular expressions when
 they match the serial output which is done after the test is executed. In case
@@ -550,12 +552,12 @@ sub run {
 }
 ```
 
-## Traceability and reproducibility of tests
+### Traceability and reproducibility of tests
 
 openQA allows keeping track of the test environment, the version of the test
 code and needles, the test configuration and what specific system was tested.
 
-### General remarks on tracing
+#### General remarks on tracing
 
 The test configuration of a specific test run can be viewed in form of job
 settings on the test details page. Those settings contain the specific test
@@ -576,7 +578,7 @@ since the last good test run.
 
 The next section explains how to keep track of the test environment.
 
-### Logging package versions used for test
+#### Logging package versions used for test
 
 There are two sets of packages that can be included in test logs:
 
@@ -605,7 +607,7 @@ sub run {
 }
 ```
 
-### General remarks on reproducibility
+#### General remarks on reproducibility
 
 Clicking the restart button on a concrete test run will create a new test job
 with the same configuration. The new test will however use the latest version of
@@ -642,7 +644,7 @@ Sometimes issues are sporadic and therefore hard to reproduce. The section about
 might be helpful in this case.
 
 <a id="assigning_jobs_to_workers"></a>
-## Assigning jobs to workers
+### Assigning jobs to workers
 
 By default, any worker can get any job with the matching architecture.
 
@@ -700,7 +702,7 @@ workers.ini
 WORKER_CLASS = planet-earth,continent-antarctica,location-my_station
 ```
 
-## Running a custom worker engine
+### Running a custom worker engine
 
 By default the openQA workers run the "isotovideo" application from PATH on the
 worker host, that is in most cases
@@ -710,7 +712,7 @@ For example to run isotovideo from a custom container image one could use the
 test variable setting
 `ISOTOVIDEO=podman run --pull=always --rm -it registry.example.org/my/container/isotovideo /usr/bin/isotovideo -d`
 
-## Automatic retries of jobs
+### Automatic retries of jobs
 
 You might encounter flaky openQA tests that fail sporadically. The best way to
 address flaky test code is of course to fix the test code itself. For example,
@@ -737,7 +739,7 @@ causing incomplete jobs.
 can be used to apply more elaborate issue detection and retriggering of tests.
 
 <a id="job_dependencies"></a>
-## Job dependencies
+### Job dependencies
 
 There are different dependency **types**, most importantly _chained_ and
 _parallel_ dependencies.
@@ -754,7 +756,7 @@ Additionally, dependencies can be machine-specific (see
 [Inter-machine dependencies](WritingTests.md#inter_machine_dependencies)
 section).
 
-### Declaring dependencies
+#### Declaring dependencies
 
 Dependencies are declared by adding a job setting on the child job specifying
 its parents. There is one variable for each dependency type.
@@ -772,7 +774,7 @@ explained in the
 [Further examples for advanced dependency handling](UsersGuide.md#further_examples_for_advanced_dependency_handling)
 section. The variables mentioned in the subsequent sections do **not** apply.
 
-#### Chained dependencies
+##### Chained dependencies
 
 _Chained_ dependencies declare that one test must only run after another test
 has concluded. For instance, extra tests relying on a successfully finished
@@ -804,7 +806,7 @@ on the same worker are considered an error.
 > cluster_. All jobs within the cluster will be assigned to a single worker-slot
 > at the same time by the scheduler.
 
-#### Parallel dependencies
+##### Parallel dependencies
 
 _Parallel_ dependencies declare that tests must be scheduled to run at the same
 time. An example are "multi-machine tests" which usually test some kind of
@@ -827,7 +829,7 @@ Otherwise the scheduler will cancel child jobs once parent is done.
 > avoid a parallel cluster from starvation its priority is increased gradually and
 > eventually workers can be held back for the cluster.
 
-##### Dependency pinning
+###### Dependency pinning
 
 It is possible to ensure that all jobs within the same _parallel_ cluster are
 executed on the same worker host. This is useful for connecting the SUTs without
@@ -843,7 +845,7 @@ of scheduling as well as in the worker configuration file `workers.ini`.
 > we explore ways to make it more flexible.
 
 <a id="inter_machine_dependencies"></a>
-### Inter-machine dependencies
+#### Inter-machine dependencies
 
 Those dependencies make it possible to create job dependencies between tests
 which are supposed to run on different machines.
@@ -865,7 +867,7 @@ suite(s). Keep in mind to place the machines which have been explicitly defined
 in a variable for each dependent test suite. Check out the following example
 sections to get a better understanding.
 
-### Handling of related jobs on failure / cancellation / restart
+#### Handling of related jobs on failure / cancellation / restart
 
 openQA tries to handle things sensibly when jobs with dependencies either fail,
 or are manually cancelled or restarted:
@@ -901,7 +903,7 @@ or are manually cancelled or restarted:
   failure of one does not imply that the tests run by the other children and the
   parent are invalid.
 
-#### Further notes
+##### Further notes
 
 - The API also allows to skip restarting parents via `skip_parents=1` and to skip restarting children via `skip_children=1`. It is also possible to skip
   restarting only passed and softfailed children via
@@ -912,7 +914,7 @@ or are manually cancelled or restarted:
   needs to restart the parent job instead. Use the mentioned
   `skip_ok_result_children=1` to restart only jobs which are not ok
 
-### Handling of dependencies when cloning jobs
+#### Handling of dependencies when cloning jobs
 
 Be sure to have read the [job dependencies](WritingTests.md#job-dependencies)
 section to have an understanding of different dependency types and the
@@ -935,7 +937,7 @@ cloned, especially with default parameters. Examples:
   "server" test). When cloning a parallel child, only _that_ child and the parent
   will be cloned but not the siblings (e.g. the other "client" tests).
 
-### Examples
+#### Examples
 
 Assume there is a test suite `A` supposed to run on machine `64bit-8G`.
 Additionally, test suite `B` supposed to run on machine `64bit-1G`.
@@ -947,7 +949,7 @@ results in the following dependency:
 A@64bit-8G --> B@64bit-1G
 ```
 
-#### Implicitly inherit machines from parent
+##### Implicitly inherit machines from parent
 
 Assume test suite `A` is supposed to run on the machines `64bit` and `ppc`. Additionally, test suite `B` is supposed to run on both of these machines as well. This can be achieved by simply adding the variable `START_AFTER_TEST=A` to test suite `B` (omitting the machine at all). openQA take the best matches. This
 results in the following dependencies:
@@ -955,7 +957,7 @@ results in the following dependencies:
     A@64bit --> B@64bit
     A@ppc --> B@ppc
 
-#### Conflicting machines prevent inheritance from parent
+##### Conflicting machines prevent inheritance from parent
 
 Assume test suite `A` is supposed to run on machine `64bit-8G`. Additionally, test suite `B` is supposed to run on machine `64bit-1G`. Adding the variable `START_AFTER_TEST=A` to test suite `B` will **not** work. That
 means openQA will **not** create a job dependency and instead shows an error
@@ -972,7 +974,7 @@ will result in the following dependencies:
 
 openQA will also show errors that test suite `A` is not necessary on the machines `64bit` and `s390x`.
 
-#### Implicitly creating a dependency on same machine
+##### Implicitly creating a dependency on same machine
 
 Assume the value of the variable `START_AFTER_TEST` or `PARALLEL_WITH` **only** contains a test suite name but no machine (e.g. `START_AFTER_TEST=A,B` or
 `PARALLEL_WITH=A,B`).
@@ -980,7 +982,7 @@ Assume the value of the variable `START_AFTER_TEST` or `PARALLEL_WITH` **only** 
 In this case openQA will create job dependencies that are scheduled on the same
 machine if all test suites are placed on the same machine.
 
-### Notes regarding directly chained dependencies
+#### Notes regarding directly chained dependencies
 
 Having multiple jobs with `START_DIRECTLY_AFTER_TEST` pointing to the same
 parent job is possible, e.g.:
@@ -1007,13 +1009,13 @@ This allows to create a dependency tree which contains multiple directly chained
 sub-trees. Be aware that these sub-trees might be executed on **different**
 workers and depending on the tree even be executed in parallel.
 
-### Worker requirements
+#### Worker requirements
 
 `CHAINED` and `DIRECTLY_CHAINED` dependencies require only one worker.
 `PARALLEL` dependencies on the other hand require as many free workers as jobs
 are present in the parallel cluster.
 
-#### Examples
+##### Examples
 
 **`CHAINED` - i.e. test basic functionality before going advanced - requires 1 worker**
 
@@ -1062,7 +1064,7 @@ and then define B,C,D with PARALLEL_WITH=A
 A is parent test suite for B, C, D (all can run in parallel).
 Children B, C, D can run and finish anytime, but A must run until all B, C, D finishes.
 
-## Writing multi-machine tests
+### Writing multi-machine tests
 
 Scenarios requiring more than one system under test (SUT), like High
 Availability testing, are covered as multi-machine tests (MM tests) in this
@@ -1096,7 +1098,7 @@ In short, writing multi-machine tests adds a few more layers of complexity:
 3.  Actual technical realization (i.e.
     [custom networking](Networking.md#networking))
 
-## Test synchronization and locking API
+### Test synchronization and locking API
 
 openQA provides a locking API. To use it in your test files import the `lockapi`
 package (_use lockapi;_). It provides the following functions: `mutex_create`,
@@ -1292,7 +1294,7 @@ sub run {
 }
 ```
 
-## Support Server based tests
+### Support Server based tests
 
 The idea is to have a dedicated "helper server" to allow advanced network based
 testing.
@@ -1302,7 +1304,7 @@ previous section, with the support server being the parent test 'A' and the test
 needing it being the child test 'B'. This ensures that the test 'B' always have
 the support server available.
 
-### Preparing the supportserver
+#### Preparing the supportserver
 
 The support server image is created by calling a special test, based on the
 autoyast test:
@@ -1322,7 +1324,7 @@ well as packages and the common configuration.
 More specific role the supportserver should take is then selected when the
 server is run in the actual test scenario.
 
-### Using the supportserver
+#### Using the supportserver
 
 In the Test suites, the supportserver is defined by setting:
 
@@ -1439,7 +1441,7 @@ diff -u test.txt test2.txt && echo "AUTOYAST OK"
 and the rest is done automatically, using already prepared test modules in
 `tests/autoyast` subdirectory.
 
-## Using text consoles and the serial terminal
+### Using text consoles and the serial terminal
 
 Typically the OS you are testing will boot into a graphical shell e.g. The
 Gnome desktop environment. This is fine if you wish to test a program with a
@@ -1516,7 +1518,7 @@ your code less portable.
 The command `wait_serial` watches the SUT's serial port for text output and matches it against a regex. `type_string` sends a string to the SUT like it was
 typed in by the user over VNC.
 
-### Using a serial terminal
+#### Using a serial terminal
 
 > **IMPORTANT:**
 > You need a QEMU version \>= 2.6.1 and to set the `VIRTIO_CONSOLE`
@@ -1699,7 +1701,7 @@ We choose to wait for the prompt just before sending a command, rather than
 after it, so that Step 5 can be deferred to a later time. In theory this allows
 the test script to perform some other work while the SUT is busy.
 
-### Sending new lines and continuation characters
+#### Sending new lines and continuation characters
 
 The following command will timeout: `script_run("echo "1n2"")`. The reason being `script_run` will call `wait_serial("echo "1n2"")` to check that the
 command was entered successfully and echoed back (see above for explanation of
@@ -1721,7 +1723,7 @@ In general you should be aware that, Perl, the guest kernel and the shell may
 transform whatever character sequence you enter. Transformations can be spotted
 by comparing the input string with what `wait_serial` actually finds.
 
-### Sending signals - ctrl-c and ctrl-d
+#### Sending signals - ctrl-c and ctrl-d
 
 On a VNC based console you simply use `send_key` like follows.
 
@@ -1757,7 +1759,7 @@ The `terminate_with` parameter just exists to display intention. It is also
 possible to send any character using the hex code like 'x0f' which may have the
 effect of pressing the magic SysRq key if you are lucky.
 
-### The virtio serial terminal implementation
+#### The virtio serial terminal implementation
 
 The os-autoinst package supports several types of 'consoles' of which the virtio
 serial terminal is one. The majority of code for this console is located in
@@ -1805,7 +1807,7 @@ SUSE distribution's serial terminal utility library). However some programs
 ignore this, but piping there output into `tee` is usually enough to stop them
 outputting non-printable characters.
 
-## MCP Support
+### MCP Support
 
 The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is a standard
 that allows Large Language Models (LLMs) to interact with web services. MCP is
@@ -1845,9 +1847,9 @@ setting the `Authorization` HTTP header:
 }
 ```
 
-### 3rd Party MCP Clients
+#### 3rd Party MCP Clients
 
-#### gemini-cli
+##### gemini-cli
 
 Once you have installed and set up
 [gemini-cli](https://github.com/google-gemini/gemini-cli), you can use the
@@ -1875,9 +1877,9 @@ tools and make use of them on its own:
       ltp_net_features test suite on the x86_64 architecture. Most of the
        tests passed, with a few being skipped.
 
-# Test Development tricks
+## Test Development tricks
 
-## Trigger new tests by modifying settings from existing test runs
+### Trigger new tests by modifying settings from existing test runs
 
 To trigger new tests with custom settings the command line client `openqa-cli`
 can be used. To trigger new tests relying on all settings from existing tests
@@ -1914,7 +1916,7 @@ and the job will not appear as a job in any job group, e.g.:
 openqa-clone-job --from localhost 42 _GROUP=0
 ```
 
-## Backend variables for faster test execution
+### Backend variables for faster test execution
 
 The `os-autoinst` backend offers multiple test variables which are helpful for
 test development. For example:
@@ -1928,7 +1930,7 @@ test development. For example:
   case of expected and known test fails, for examples when you need to create
   needles anyway
 
-## Using snapshots to speed up development of tests
+### Using snapshots to speed up development of tests
 
 <a id="snapshots"></a>
 
@@ -1936,7 +1938,7 @@ For lower turn-around times during test development based on virtual machines
 the QEMU backend provides a feature that allows a job to start from a snapshot
 which can help in this situation.
 
-### How snapshots work internally
+#### How snapshots work internally
 
 Snapshots use QEMU's block device overlay mechanism. Each snapshot creates an
 incremental overlay forming a chain:
@@ -1955,7 +1957,7 @@ incremental overlay forming a chain:
 When reverting (e.g., `SKIPTO=snapshot1`), all forward overlays are removed,
 the snapshot overlay is recreated, and execution continues from that state
 
-### Snapshot modes
+#### Snapshot modes
 
 Depending on the use case, there are two options to help:
 
@@ -1988,7 +1990,7 @@ flag as the behaviour is implied). In the latter mode every test module is also
 considered `fatal`. This means the job is aborted after the first failed test module (unless subsequent modules are marked with `always_run`).
 
 <a id="snapshots-for-each-module"></a>
-### Enable snapshots for each module
+#### Enable snapshots for each module
 
 - Run the worker with `--no-cleanup` parameter. This will preserve the hard
   disks after test runs. If the worker(s) are being started via the systemd
@@ -2013,7 +2015,7 @@ openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 SKIPTO=
 
 - Use `qemu-img snapshot -l something.img` to find out what snapshots are in the image. Snapshots are named `"test module category"-"test module name"` (e.g. `installation-start_install`).
 
-### Storing only the last successful snapshot
+#### Storing only the last successful snapshot
 
 - Run the worker with `--no-cleanup` parameter. This will preserve the hard
   disks after test runs.
@@ -2035,7 +2037,7 @@ openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 TESTDEB
 openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 TESTDEBUG=1 SKIPTO=consoletest-yast2_i
 ```
 
-## Defining a custom test schedule or custom test modules
+### Defining a custom test schedule or custom test modules
 
 Normally the test schedule, that is which test modules should be executed and
 which order, is prescribed by the `main.pm` file within the test distribution.
@@ -2052,7 +2054,7 @@ the intended test module.
 describes in detail the mentioned test parameters and more. Please consult
 this full reference as well.
 
-### EXCLUDE_MODULES
+#### EXCLUDE_MODULES
 
 If a job has the following schedule:
 
@@ -2075,7 +2077,7 @@ The schedule would be:
 > **NOTE:**
 > Excluding modules that are not scheduled does not raise an error.
 
-### INCLUDE_MODULES
+#### INCLUDE_MODULES
 
 If a job has the following schedule:
 
@@ -2099,7 +2101,7 @@ The schedule would be:
 > Including modules that are not scheduled does not raise an error, but they
 > are not scheduled.
 
-### SCHEDULE
+#### SCHEDULE
 
 Additionally it is possible to define a custom schedule using the test variable
 `SCHEDULE`.
@@ -2109,7 +2111,7 @@ Additionally it is possible to define a custom schedule using the test variable
 > **NOTE:**
 > Any existing test module within **CASEDIR** can be scheduled.
 
-### SCHEDULE + ASSET\_\<NR\>\_URL
+#### SCHEDULE + ASSET\_\<NR\>\_URL
 
 Test modules can be defined and overridden on-the-fly using a downloadable asset
 (combining **ASSET\_\<NR\>\_URL** and **SCHEDULE**).
@@ -2150,7 +2152,7 @@ that the specified asset is only downloaded once. New versions must be
 supplied as new, unambiguous download target file names.
 
 <a id="triggering_tests_based_on_an_any_remote_git_refspec_or_open_github_pull_request"></a>
-## Triggering tests based on an any remote Git refspec or open GitHub pull request
+### Triggering tests based on an any remote Git refspec or open GitHub pull request
 
 openQA also supports to trigger tests using test code from a pull request or
 any branch or Git refspec. That means that code changes that are not yet
@@ -2199,13 +2201,13 @@ parameter to `openqa-clone-custom-git-refspec` or via the `PRODUCTDIR` variable 
 special care must be taken if the schedule is modified (then it is safer to
 manually specify the schedule via the `SCHEDULE` variable).
 
-# Running openQA jobs as CI checks
+## Running openQA jobs as CI checks
 
 It is possible to run openQA jobs as CI checks of a repository, e.g. a test
 distribution or an arbitrary repository containing software with openQA tests
 as part of the test suite.
 
-## Create and monitor openQA jobs from within the CI runner
+### Create and monitor openQA jobs from within the CI runner
 
 The easiest approach is to create and monitor openQA jobs from within the CI
 runner. To make this easier, `openqa-cli` provides the `schedule` sub-command with the `--monitor` flag. This way you still need an openQA instance to run
@@ -2244,7 +2246,7 @@ script for further information and an example configuration.
 > definitions file one could use e.g.
 > `SCENARIO_DEFINITIONS_YAML_FILE=https://raw.githubusercontent.com/$GH_REPO/$GH_REF/.github/workflows/openqa.yml` > instead of `- uses: actions/checkout@v3` and > `--param-file SCENARIO_DEFINITIONS_YAML=scenario-definitions.yaml`.
 
-## Use webhooks and status reporting APIs of GitHub
+### Use webhooks and status reporting APIs of GitHub
 
 This approach is so far specific to GitHub and is a bit more effort to setup
 than the approach mentioned in the previous section. For this to work, GitHub
@@ -2261,7 +2263,7 @@ from the example distribution for an example. You may append a parameter like
 `SCENARIO_DEFINITIONS_YAML=path/of/yaml` to the query parameters of the webhook
 to change the lookup path of this file.
 
-## Run isotovideo directly in the CI runner
+### Run isotovideo directly in the CI runner
 
 It is also possible to avoid using openQA at all and run the backend
 `isotovideo` directly within the CI runner. This simplifies the setup as no
@@ -2270,7 +2272,7 @@ a web interface as usual. Check out the
 [README of the example test distribution](https://github.com/os-autoinst/os-autoinst-distri-example/blob/main/README.md#local-testing-and-ci-environment)
 for more information.
 
-### Setup a GitHub access token for openQA
+#### Setup a GitHub access token for openQA
 
 This setup is required for openQA to be able to report the status back to
 GitHub.
@@ -2293,7 +2295,7 @@ github_token = \$token
 > might respond with a 404 response (weirdly not necessarily 403) when submitting
 > the CI check status.
 
-### Setup webhook on GitHub
+#### Setup webhook on GitHub
 
 This setup is required for GitHub to be able to inform openQA that a PR has been
 created or updated.
@@ -2326,7 +2328,7 @@ created or updated.
     is setup correctly. Otherwise, check out the response of the delivery to
     investigate what is wrong.
 
-# Integrating test results from external systems
+## Integrating test results from external systems
 
 The openQA web UI is suitable as a test management and reporting platform.
 Next to the automated openQA tests one can integrate test results from


### PR DESCRIPTION
Motivation:
Currently, when generating the joint documentation (HTML/PDF), the contents of
all .md files are concatenated. Because all individual .md files use top-level
headings, the resulting document has over 80 top-level sections in the Table
of Contents, making it difficult to navigate.

Design Choices:
This commit refactors the 12 main Markdown files to ensure they each act
as a single "Chapter" with exactly one top-level heading. A single
top-level heading was added at the top of each file, after the existing
anchor, and every existing heading in the document was demoted by one
level.

Benefits:
The TOC concisely shows the ~12 main documents at the top level, significantly
improving navigation with a properly nested hierarchy. Furthermore, no changes
were required to the build scripts.

Comparison screenshots:
* Beginning of TOC. Old on left, new on right:

<img width="580" height="521" alt="Screenshot_20260508_172558_oqa_doc_top_before_after" src="https://github.com/user-attachments/assets/0fb9a6ce-2c28-4a73-a33c-fcfe6b130861" />

* End of TOC. Old on left, new on right:

<img width="580" height="521" alt="Screenshot_20260508_172629_oqa_doc_bottom_before_after" src="https://github.com/user-attachments/assets/8740d142-75a8-4366-bc73-f2f1f2eab6b9" />
