### PR TITLE
fix(apparmor): allow access to all Python 3 versions

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -162,7 +162,7 @@
   /usr/bin/openqa-cli rix,
   /usr/bin/perl ix,
   /usr/bin/python3 ix,
-  /usr/bin/python3.6 ix,
+  /usr/bin/python3* ix,
   /usr/bin/rm rix,
   /usr/bin/rsync mrix,
   /usr/bin/sed mrix,


### PR DESCRIPTION
As observed on o3 after upgrade to Leap 16.0 with new Python