### PR TITLE
feat: add "badge" option to openqa-clone-job for markdown output

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -316,8 +316,15 @@ sub handle_tx ($tx, $url_handler, $options, $jobs) {
         print Cpanel::JSON::XS->new->pretty->encode($cloned_jobs) and return $cloned_jobs if $options->{'json-output'};
         if (my $job_count = keys %$cloned_jobs) {
             my $base_url = openqa_baseurl($url_handler->{local_url});
-            say $job_count == 1 ? '1 job has been created:' : "$job_count jobs have been created:";
-            say " - $jobs->{$_}->{name} -> $base_url/tests/$cloned_jobs->{$_}" for sort keys %$cloned_jobs;
+            if ($options->{badge}) {
+                say
+"* [![$jobs->{$_}->{name}]($base_url/tests/$cloned_jobs->{$_}/badge?label=$jobs->{$_}->{name})]($base_url/tests/$cloned_jobs->{$_})"
+                  for sort keys %$cloned_jobs;
+            }
+            else {
+                say $job_count == 1 ? '1 job has been created:' : "$job_count jobs have been created:";
+                say " - $jobs->{$_}->{name} -> $base_url/tests/$cloned_jobs->{$_}" for sort keys %$cloned_jobs;
+            }
         }
         return $cloned_jobs;
     }

--- a/script/openqa-clone-job
+++ b/script/openqa-clone-job
@@ -184,6 +184,11 @@ Prints an `openqa-cli` command to create the jobs instead of creating them
 directly. This is useful to customize the API call or to review it before
 submitting.
 
+=item B<--badge>
+
+Instead of the normal plain text scenario name and URL outputs a markdown list
+entry of labeled badges and links.
+
 =item B<--reproduce>
 
 Ensure the cloned jobs use the same version of the test code and needles as the
@@ -229,10 +234,11 @@ sub parse_options () {
     GetOptions(
         \%options, 'from=s', 'host=s', 'dir=s',
         'apikey:s', 'apisecret:s', 'verbose|v', 'json-output|j',
-        'skip-deps', 'skip-chained-deps', 'skip-download', 'parental-inheritance',
-        'help|h', 'show-progress', 'within-instance|w=s', 'clone-children',
-        'max-depth:i', 'repeat|r:i', 'retry:i', 'ignore-missing-assets',
-        'export-command', 'skip-checks', 'check-repos', 'reproduce',
+        'badge', 'skip-deps', 'skip-chained-deps', 'skip-download',
+        'parental-inheritance', 'help|h', 'show-progress', 'within-instance|w=s',
+        'clone-children', 'max-depth:i', 'repeat|r:i', 'retry:i',
+        'ignore-missing-assets', 'export-command', 'skip-checks', 'check-repos',
+        'reproduce',
     ) or usage(1);
     usage(0) if $options{help};
     usage(1) if $options{help} || ($options{'within-instance'} && $options{from});

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -544,4 +544,17 @@ subtest 'determining base URL' => sub {
     is openqa_baseurl(Mojo::URL->new('http://foo:9526/bar')), 'http://foo:9526', 'custom port preserved';
 };
 
+subtest 'badge output' => sub {
+    my $clone_mock = Test::MockModule->new('OpenQA::Script::CloneJob');
+    $clone_mock->unmock_all;
+    my $res = Test::MockObject->new->set_always(json => {ids => {42 => 43}});
+    my $tx = Test::MockObject->new->set_false('error')->set_always(res => $res);
+    my %url_handler = (local_url => Mojo::URL->new('https://base-url/foo/bar'));
+    my $options = {badge => 1};
+    my $jobs = {42 => {name => 'testjob'}};
+    combined_like { OpenQA::Script::CloneJob::handle_tx($tx, \%url_handler, $options, $jobs) }
+    qr|^\* \[!\[testjob\]\(https://base-url/tests/43/badge\?label=testjob\)\]\(https://base-url/tests/43\)$|m,
+      'badge output format';
+};
+
 done_testing();


### PR DESCRIPTION
Design Choices:
- Added 'badge' to GetOptions in script/openqa-clone-job.

Benefits:
- Native support for markdown badge output.
- Cleaner output when including results in markdown reports.