### PR TITLE
feat: Restore styling and TOC for API documentation

### DIFF
--- a/tools/generate-documentation
+++ b/tools/generate-documentation
@@ -129,10 +129,18 @@ update_api() {
     cd api
     "${scriptroot}"/generate-documentation-genapi
 
-    find . -name '*.md' -not -name 'header' -exec pandoc -s -f gfm -o {}.html {} \;
-    while IFS= read -r -d '' file; do
-        mv "$file" "${file%.md.html}.html"
-    done < <(find . -name '*.md.html' -print0)
+    for f in *.md; do
+        [[ -e "$f" ]] || continue
+        [[ "$f" == "header.md" ]] && continue
+        filename=$(basename -s .md "$f")
+        pandoc -s -f gfm -o "$filename.html" "$f" \
+            --template="${scriptroot}/../docs/template.html" \
+            -c ../style.css \
+            --embed-resources --standalone \
+            $syntax_highlight_opt \
+            --metadata title="openQA $filename API" \
+            --toc
+    done
 
     while IFS= read -r -d '' file; do
         header_template "$file" > "$file.tmp"
@@ -214,6 +222,7 @@ call_pandoc() {
     cd docs
     mkdir "${tmpwd}"/output 2> /dev/null || true # we don't care if the directory already exists
     cp -r images "${tmpwd}"/output
+    cp style.css "${tmpwd}"/output/
 
     syntax_highlight_opt=""
     if pandoc --help | grep -q 'syntax-highlighting'; then


### PR DESCRIPTION
Motivation:
Documentation for testapi lost its styling and Table of Contents (TOC) during the
transition from AsciiDoc to Markdown because the generation script used a
simplified pandoc call for API files.

Design Choices:
- Updated tools/generate-documentation to use the pandoc template and custom
  CSS introduced in 53d1a15a5 for API documentation as well.
- Enabled TOC generation and resource embedding in the standalone API HTML
  files.
- Ensured style.css is available in the output directory during API doc
  generation.

Benefits:
- Restores consistent styling across the entire documentation site.
- Re-introduces the sticky sidebar TOC for improved navigation in the API
  documentation.

Related issue: https://github.com/os-autoinst/openQA/pull/7290

Output visible in:
https://okurz.github.io/openQA/api/testapi/