### PR TITLE
fix(apparmor): allow worker to execute "df"

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -96,6 +96,7 @@
   /usr/bin/cksum rix,
   /usr/bin/cp rix,
   /usr/bin/date rix,
+  /usr/bin/df rix,
   /usr/bin/dirname rix,
   /usr/bin/eatmydata rix,
   /usr/bin/env rix,


### PR DESCRIPTION
As needed for https://github.com/os-autoinst/os-autoinst/pull/2887,
potentially even earlier.