### PR TITLE
fix: Fix rendering bugrefs as links in lists and other structures

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -35,7 +35,7 @@ use List::Util qw(all min);
 
 my $FRAG_REGEX = FRAGMENT_REGEX;
 
-my (%BUGREFS, %BUGURLS, $MARKER_REFS, $MARKER_URLS, $BUGREF_REGEX);
+my (%BUGREFS, %BUGURLS, $MARKER_REFS, $MARKER_URLS, $BUGREF_REGEX, $AFTER_TAG_LOOKBEHIND);
 
 BEGIN {
     %BUGREFS = (
@@ -78,10 +78,12 @@ BEGIN {
 
     # <marker>[#<project/repo>]#<id>
     $BUGREF_REGEX = qr{(?<match>(?<marker>$MARKER_REFS)\#?(?<repo>[^#\s<>,]+)?\#(?<id>([A-Z]+-)?\d+))};
+
+    $AFTER_TAG_LOOKBEHIND = qr{(?<=<\w{1}>)|(?<=<\w{2}>)|(?<=<\w{3}>)|(?<=<\w{4}>)|(?<=<\w{5}>)|(?<=<\w{6}>)};
 }
 
 use constant UNCONSTRAINED_BUGREF_REGEX => $BUGREF_REGEX;
-use constant BUGREF_REGEX => qr{(?:^|(?<=<p>)|(?<=\s|,))$BUGREF_REGEX(?![\w\"])};
+use constant BUGREF_REGEX => qr{(?:^|$AFTER_TAG_LOOKBEHIND|(?<=\s|,))$BUGREF_REGEX(?![\w\"])};
 use constant LABEL_REGEX => qr/\blabel:(?<match>([\w:#\/-]+))\b/;
 use constant FLAG_REGEX => qr/\bflag:(?<match>([\w:#]+))\b/;
 


### PR DESCRIPTION
The regex hard-codes `<p>` but bugrefs might also occur directly inside other elements like `<li>` when inside a list or `<strong>` when marked as important.

This change allows bugrefs to start after most elements so there is still a link rendered in those cases. It does not allow bugrefs to start after links because this would lead to rendering a link inside a link which would be invalid and rendered incorrectly.

Note that using variable length quantifiers in lookbehind expressions is experimental and leads to the following warning:

> Variable length positive lookbehind with capturing is experimental in regex

Using a quantifier that *can* exceed 255 characters even leads to a hard error:

> Lookbehind longer than 255 not implemented in regex

Hence this change uses separate lookbehind expressions to cover HTML element names from 1 to 6 characters. This should be sufficient to cover most uses and as stated before we want to exclude links with `href="…"` anyway.