### PR TITLE
fix(apparmor): adjust the /usr/bin/ssh child profile for 16.x

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -108,12 +108,14 @@
     #include <abstractions/consoles>
     #include <abstractions/nameservice>
 
-    /etc/ssh/ssh_config r,
+    /{usr/,}etc/ssh/ssh_config r,
+    /{usr/,}etc/ssh/ssh_config.d/** r,
     /etc/ssh/ssh_known_hosts r,
     /etc/ssl/openssl.cnf r,
     /proc/*/fd/ r,
     /proc/filesystems r,
     /usr/bin/ssh rix,
+    /usr/bin/ssh.hmac r,
     /var/lib/openqa/.ssh/* rw,
 
   }


### PR DESCRIPTION
For potential FIPS compatibility ssh.hmac is read and ssh_config is no longer a singular file.