### PR TITLE
fix(docs): fix mobile view rendering by ensuring CSS override

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,5 +1,4 @@
 /* openQA Documentation Style (Mimicking Asciidoctor) */
-
 body {
   font-family: 'Open Sans', 'DejaVu Sans', sans-serif;
   color: #333;
@@ -7,9 +6,7 @@ body {
   margin: 0;
   display: flex;
   overflow-wrap: break-word;
-  word-wrap: break-word;
 }
-
 /* Sidebar TOC */
 #TOC {
   position: fixed;
@@ -23,15 +20,12 @@ body {
   font-size: 0.9em;
   z-index: 1000;
 }
-
 /* Add dots after section numbers */
-.toc-section-number::after,
-.header-section-number::after {
+.toc-section-number::after, .header-section-number::after {
   content: '. ';
 }
-
 /* Responsive design */
-@media (max-width: 800px) {
+@media (width <= 800px) {
   body {
     flex-direction: column;
   }
@@ -47,25 +41,20 @@ body {
     padding: 20px;
   }
 }
-
 #TOC ul {
   list-style: none;
   padding-left: 20px;
 }
-
 #TOC > ul {
   padding-left: 0;
 }
-
 #TOC a {
   text-decoration: none;
   color: #0056b3;
 }
-
 #TOC a:hover {
   text-decoration: underline;
 }
-
 /* Main Content */
 main {
   margin-left: 300px;
@@ -74,19 +63,12 @@ main {
   flex-grow: 1;
   min-width: 0;
 }
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   color: #ba3925;
   font-weight: 300;
   margin-top: 1.5em;
   margin-bottom: 0.5em;
 }
-
 h1 {
   font-size: 2.2em;
   border-bottom: 1px solid #eee;
@@ -100,7 +82,6 @@ h2 {
 h3 {
   font-size: 1.4em;
 }
-
 /* Section Anchors */
 .anchor {
   margin-left: 10px;
@@ -109,16 +90,9 @@ h3 {
   font-size: 0.8em;
   text-decoration: none;
 }
-
-h1:hover .anchor,
-h2:hover .anchor,
-h3:hover .anchor,
-h4:hover .anchor,
-h5:hover .anchor,
-h6:hover .anchor {
+h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, h4:hover .anchor, h5:hover .anchor, h6:hover .anchor {
   visibility: visible;
 }
-
 /* Code blocks */
 pre {
   background: #f4f4f4;
@@ -127,7 +101,6 @@ pre {
   border-radius: 4px;
   overflow-x: auto;
 }
-
 code {
   font-family: 'Droid Sans Mono', 'Courier New', monospace;
   background: #fdf6f2;
@@ -135,13 +108,11 @@ code {
   border-radius: 3px;
   color: #ba3925;
 }
-
 pre code {
   background: transparent;
   padding: 0;
   color: inherit;
 }
-
 /* Admonitions */
 blockquote {
   margin: 1.5em 0;
@@ -149,18 +120,12 @@ blockquote {
   border-left: 5px solid #ccc;
   background: #f9f9f9;
 }
-
 /* Specific styling for Note/Warning/Tip */
-p > strong:first-child:contains('Note:'),
-p > strong:first-child:contains('Warning:'),
-p > strong:first-child:contains('Tip:'),
-p > strong:first-child:contains('Important:'),
-p > strong:first-child:contains('Caution:') {
+p > strong:first-child:contains('Note:'), p > strong:first-child:contains('Warning:'), p > strong:first-child:contains('Tip:'), p > strong:first-child:contains('Important:'), p > strong:first-child:contains('Caution:') {
   display: block;
   margin-bottom: 5px;
   text-transform: uppercase;
 }
-
 /* We use a different approach since :contains is not standard CSS */
 .admonition-note {
   border-left-color: #1f70c2;
@@ -174,7 +139,6 @@ p > strong:first-child:contains('Caution:') {
   border-left-color: #28a745;
   background: #f6fff6;
 }
-
 /* Images */
 img {
   max-width: 100%;
@@ -182,7 +146,6 @@ img {
   display: block;
   margin: 1em 0;
 }
-
 footer {
   margin-top: 50px;
   font-size: 0.8em;

--- a/docs/style.css
+++ b/docs/style.css
@@ -24,23 +24,6 @@ body {
 .toc-section-number::after, .header-section-number::after {
   content: '. ';
 }
-/* Responsive design */
-@media (width <= 800px) {
-  body {
-    flex-direction: column;
-  }
-  #TOC {
-    position: static;
-    width: 100%;
-    height: auto;
-    border-right: none;
-    border-bottom: 1px solid #ddd;
-  }
-  main {
-    margin-left: 0;
-    padding: 20px;
-  }
-}
 #TOC ul {
   list-style: none;
   padding-left: 20px;
@@ -152,4 +135,21 @@ footer {
   color: #777;
   border-top: 1px solid #eee;
   padding-top: 20px;
+}
+/* Responsive design */
+@media (width <= 800px) {
+  body {
+    display: block;
+  }
+  #TOC {
+    position: static;
+    width: 100%;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid #ddd;
+  }
+  main {
+    margin-left: 0;
+    padding: 20px;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Testing Framework",
   "scripts": {
-    "lint": "eslint \"assets/javascripts/**/*.js\" && stylelint \"assets/stylesheets/**/*.{scss,css}\"",
-    "fix": "eslint --fix \"assets/javascripts/**/*.js\" && stylelint --fix \"assets/stylesheets/**/*.{scss,css}\""
+    "lint": "eslint \"assets/javascripts/**/*.js\" && stylelint \"assets/stylesheets/**/*.{scss,css}\" \"docs/*.css\"",
+    "fix": "eslint --fix \"assets/javascripts/**/*.js\" && stylelint --fix \"assets/stylesheets/**/*.{scss,css}\" \"docs/*.css\""
   },
   "license": "GPL-2.0",
   "bugs": {


### PR DESCRIPTION
Motivation:
The documentation page was unreadable on mobile devices because base styles
(specifically a 300px left margin) were overriding the mobile media query
rules. This resulted in the text being squeezed into a single-character column.

Design Choices:
- Moved the "Responsive design" media query block to the end of style.css.
  This ensures the mobile layout rules properly override the base desktop
  rules in the CSS cascade.
- Kept the layout change from flex to block on mobile for robustness against
  potential sizing issues in smaller containers.

Benefits:
- Restores readability of the documentation on mobile devices.
- Adheres to CSS best practices regarding cascade order.

Fixed view on the transition between TOC and first body content:
<img width="364" height="782" alt="Screenshot_20260428_174333_oqa_docs_fixed_mobile" src="https://github.com/user-attachments/assets/1705bf16-03ec-4a9d-93f5-dd69927e3b34" />
