### PR TITLE
feat: Add IP and hostname allow-list for assets

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -180,6 +180,10 @@
 ## - Does NOT affect assets made available outside the scope of the openQA service (e.g. via Apache, NGINX or NFS).
 ## - Might not work well with other features like openqa-clone-job and the cache service.
 #require_for_assets = 0
+## space-separated list of hostnames, domain suffixes (e.g. .suse.de) or IP
+## addresses that are allowed to access assets without authentication even if
+## require_for_assets is enabled. Default is 'localhost'.
+#assets_allowlist = localhost
 
 ## for GitHub, salsa.debian.org and providers listed on https://metacpan.org/pod/Mojolicious::Plugin::OAuth2#Configuration
 ## one can use:

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -137,6 +137,7 @@ sub default_config () {
         auth => {
             method => 'OpenID',
             require_for_assets => 0,
+            assets_allowlist => 'localhost',
         },
         'scm git' => {
             git_auto_commit => '',

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -9,6 +9,9 @@ use OpenQA::Log qw(log_trace);
 use Mojo::Util qw(hmac_sha1_sum secure_compare);
 use Mojo::URL;
 use Time::Seconds;
+use Socket
+  qw(AF_INET AF_INET6 inet_pton getnameinfo getaddrinfo NI_NAMEREQD NI_NUMERICHOST NI_NUMERICSERV SOCK_STREAM pack_sockaddr_in pack_sockaddr_in6);
+use List::Util 'any';
 
 sub check ($self) {
     my $config = $self->app->config;
@@ -92,6 +95,46 @@ sub auth ($self) {
 
     $self->render(json => {error => $reason}, status => 403);
     return 0;
+}
+
+sub auth_assets ($self) {
+    my $allowlist = $self->app->config->{auth}->{assets_allowlist} // 'localhost';
+    my $remote_address = $self->remote_address;
+    my @allowed_items = split /\s+/, $allowlist;
+
+    return 1 if any { $_ eq 'localhost' ? $self->is_local_request : $remote_address eq $_ } @allowed_items;
+
+    my @host_allowed = grep { $_ ne 'localhost' && $_ !~ /^[0-9.:]+$/ } @allowed_items;
+    if (@host_allowed) {
+        my $hostname = $self->_reverse_dns($remote_address);
+        if ($hostname && $self->_forward_dns_match($hostname, $remote_address)) {
+            return 1
+              if any {
+                my $host = $_;
+                $host =~ /^\./ ? $hostname =~ /\Q$host\E$/i : lc $hostname eq lc $host
+              } @host_allowed;
+        }
+    }
+
+    return $self->auth;
+}
+
+sub _forward_dns_match ($self, $hostname, $expected_ip) {
+    my ($err, @res) = getaddrinfo($hostname, '', {socktype => SOCK_STREAM});
+    return 0 if $err;
+    for my $res (@res) {
+        my ($err, $ip) = getnameinfo($res->{addr}, NI_NUMERICHOST | NI_NUMERICSERV);
+        return 1 if !$err && $ip eq $expected_ip;
+    }
+    return 0;
+}
+
+sub _reverse_dns ($self, $ip) {
+    my $family = $ip =~ /:/ ? AF_INET6 : AF_INET;
+    my $packed = inet_pton($family, $ip) or return undef;
+    my $sockaddr = $family == AF_INET ? pack_sockaddr_in(0, $packed) : pack_sockaddr_in6(0, $packed);
+    my ($err, $hostname) = getnameinfo($sockaddr, NI_NAMEREQD);
+    return $err ? undef : $hostname;
 }
 
 sub auth_operator ($self) {

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -21,6 +21,7 @@ sub register ($self, $app, @args) {
     $app->helper(is_admin => \&_is_admin);
     $app->helper(is_api_request => \&_is_api_request);
     $app->helper(is_local_request => \&_is_local_request);
+    $app->helper(remote_address => sub ($c) { $c->tx->remote_address });
     $app->helper(render_specific_not_found => \&_render_specific_not_found);
     $app->helper(via_domain => \&_via_domain);
 }
@@ -86,7 +87,7 @@ sub _is_api_request ($c) {
 
 sub _is_local_request ($c) {
     # IPv4 and IPv6 should be treated the same
-    my $address = $c->tx->remote_address;
+    my $address = $c->remote_address;
     return $address eq '127.0.0.1' || $address eq '::1';
 }
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -147,7 +147,8 @@ sub startup ($self) {
     # only provide a URL helper - this is overtaken by apache
     my $config = $app->config;
     my $require_auth_for_assets = $config->{auth}->{require_for_assets};
-    my $assets_r = $require_auth_for_assets ? $auth_any_user : $r;
+    my $assets_auth = $r->under('/')->to('Auth#auth_assets');
+    my $assets_r = $require_auth_for_assets ? $assets_auth : $r;
     $assets_r->get('/assets/*assetpath')->name('download_asset')->to('file#download_asset');
 
     my $test_path = '/tests/<testid:num>';

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -49,7 +49,7 @@ combined_like { test_auth_method_startup('Fake')->status_is(302) } mojo_has_requ
   'Plugin loaded';
 
 subtest 'restricted asset downloads with setting `[auth] require_for_assets = 1`' => sub {
-    my $t = test_auth_method_startup('Fake', "require_for_assets = 1\n");
+    my $t = test_auth_method_startup('Fake', "require_for_assets = 1\nassets_allowlist = \n");
     $t->get_ok('/session/test')->status_is(200)->content_like(qr/you are Demo/);
     $t->app->helper(valid_csrf => sub { 0 });
     $t->post_ok('/admin/users/1')->status_is(403)->content_like(qr/bad csrf token/i);
@@ -63,6 +63,97 @@ subtest 'restricted asset downloads with setting `[auth] require_for_assets = 1`
     $t->content_unlike(qr/asset-ok/, 'asset not accessible when logged out');
     $t->get_ok('/tests/42/asset/iso/test.iso')->status_is(403, '403 response via test when logged out');
     $t->content_unlike(qr/asset-ok/, 'asset via test not accessible when logged out');
+};
+
+sub check_asset_access ($t, $expected_status, $msg) {
+    my $test = $t->get_ok('/assets/iso/test.iso')->status_is($expected_status, $msg);
+    $test->content_is('asset-ok') if $expected_status == 200;
+}
+
+subtest 'allow-list configuration and host/IP matching' => sub {
+    my $remote_address = '127.0.0.1';
+    my $mocked_hostname = undef;
+
+    my $auth_mock = Test::MockModule->new('OpenQA::Shared::Controller::Auth');
+    $auth_mock->redefine(
+        _reverse_dns => sub { $mocked_hostname },
+        _forward_dns_match => sub { 1 });
+
+    my $create_t = sub (@options) {
+        my $t = test_auth_method_startup('Fake', @options);
+        $t->app->helper(remote_address => sub { $remote_address });
+        $t->get_ok('/logout');
+        return $t;
+    };
+
+    subtest 'allow-listed asset downloads via IP' => sub {
+        my $t = $create_t->("require_for_assets = 1\nassets_allowlist = 1.2.3.4 5.6.7.8\n");
+
+        my @cases = (
+            ['1.1.1.1', 403, 'Assets forbidden for unauthorized external IP address'],
+            ['1.2.3.4', 200, 'Assets accessible for IP address in allow-list'],
+            ['5.6.7.8', 200, 'Assets accessible for multiple IP addresses in allow-list'],
+        );
+        for my $case (@cases) {
+            $remote_address = $case->[0];
+            check_asset_access($t, $case->[1], $case->[2]);
+        }
+
+        $remote_address = '1.1.1.1';
+        $t->get_ok('/login')->status_is(302);
+        check_asset_access($t, 200, 'Assets allowed when logged in despite IP not being in allow-list');
+    };
+
+    subtest 'allow-listed asset downloads via Hostname and Domain' => sub {
+        my $t = $create_t->("require_for_assets = 1\nassets_allowlist = worker1.example.com .suse.de\n");
+
+        my @cases = (
+            ['10.0.0.1', 'worker1.example.com', 200, 'Assets accessible when reverse DNS matches allowed FQDN'],
+            ['10.0.0.2', 'worker2.example.com', 403, 'Assets forbidden when reverse DNS does not match allowed FQDN'],
+            ['10.160.0.1', 'somehost.suse.de', 200, 'Assets accessible when reverse DNS matches allowed domain suffix'],
+            [
+                '10.160.0.2', 'otherhost.suse.de.evil.com',
+                403, 'Assets forbidden when reverse DNS only contains allowed domain suffix as substring'
+            ],
+        );
+        for my $case (@cases) {
+            ($remote_address, $mocked_hostname) = @{$case}[0, 1];
+            check_asset_access($t, $case->[2], $case->[3]);
+        }
+    };
+
+    subtest 'default allow-list' => sub {
+        my $t = $create_t->("require_for_assets = 1\n");
+
+        my @cases = (
+            ['127.0.0.1', 200, 'Localhost IPv4 is allowed by default'],
+            ['::1', 200, 'Localhost IPv6 is allowed by default'],
+            ['1.1.1.1', 403, 'External IP is forbidden by default'],
+        );
+        for my $case (@cases) {
+            $remote_address = $case->[0];
+            check_asset_access($t, $case->[1], $case->[2]);
+        }
+    };
+
+    subtest 'explicit localhost in allow-list' => sub {
+        my $t = $create_t->("require_for_assets = 1\nassets_allowlist = localhost\n");
+
+        my @cases = (
+            ['127.0.0.1', 200, 'Localhost IPv4 allowed when explicitly configured'],
+            ['::1', 200, 'Localhost IPv6 allowed when explicitly configured'],
+        );
+        for my $case (@cases) {
+            $remote_address = $case->[0];
+            check_asset_access($t, $case->[1], $case->[2]);
+        }
+    };
+
+    subtest 'require_for_assets = 0' => sub {
+        my $t = $create_t->("require_for_assets = 0\n");
+        $remote_address = '1.1.1.1';
+        check_asset_access($t, 200, 'Assets publicly accessible when require_for_assets is disabled');
+    };
 };
 
 subtest None => sub {


### PR DESCRIPTION
Motivation:
Some hosts (e.g. openQA developer instances) need to access OSD assets
without authentication, even when require_for_assets is enabled. This
allow-list should also support hostnames and domains, with a secure
default of "localhost" to maintain ease of use for local installations.

Design Choices:
- Added a new configuration option `assets_allowlist` under the `[auth]`
  section in `openqa.ini` and set its default to "localhost" in
  `OpenQA::Setup`.
- Implemented `auth_assets` in `OpenQA::Shared::Controller::Auth` to
  bypass authentication if the remote IP or its resolved hostname
  matches an entry in the allow-list.
- Added a forward DNS lookup (`_forward_dns_match`) after reverse
  resolution to prevent DNS spoofing, ensuring the resolved IPs contain
  the original request IP.
- Refactored access checks using declarative `List::Util::any`.

Benefits:
Provides flexible, secure configuration for authorized access to assets
via IPs, hostnames, or domains without credentials. This simplifies
integration and mirroring for development purposes while maintaining
strict access control for other users. The test suite maintains zero
duplication and high maintainability.

Related issue: https://progress.opensuse.org/issues/176670