### PR TITLE
feat(api): filter job statistics by group globs

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/ResultSet/ScheduledProducts.pm
@@ -53,9 +53,16 @@ sub update_note ($self, $distri, $version, $flavor, $arch, $build, $note) {
     return {updated_product_id => $sth->fetchrow_arrayref->[0]};
 }
 
-sub job_statistics ($self, $distri, $version, $flavor, $arch, $build) {
+sub job_statistics ($self, $distri, $version, $flavor, $arch, $build, $group_ids = undef, $include_null_groups = 0) {
+    my $group_filter = '';
+    my @binds;
+    if ($group_ids && @$group_ids) {
+        $group_filter = 'AND (mrj.group_id = ANY(?)' . ($include_null_groups ? ' OR mrj.group_id IS NULL' : '') . ')';
+        @binds = ($group_ids);
+    }
+
     my $sth = $self->result_source->schema->storage->dbh->prepare(
-        <<~'END_SQL'
+        <<~"END_SQL"
         WITH RECURSIVE
         -- get the initial set of jobs in the scheduled product
         initial_job_ids AS (
@@ -114,6 +121,7 @@ sub job_statistics ($self, $distri, $version, $flavor, $arch, $build) {
             JOIN jobs AS mrj ON mrj.id = latest_job_id
             WHERE
                 latest_job_id IS NOT NULL
+                $group_filter
             ORDER BY
                 job_id,
                 level DESC
@@ -132,12 +140,7 @@ sub job_statistics ($self, $distri, $version, $flavor, $arch, $build) {
             latest_job_result
         END_SQL
     );
-    $sth->bind_param(1, $distri);
-    $sth->bind_param(2, $version);
-    $sth->bind_param(3, $flavor);
-    $sth->bind_param(4, $arch);
-    $sth->bind_param(5, $build);
-    $sth->execute;
+    $sth->execute($distri, $version, $flavor, $arch, $build, @binds);
     return $sth->fetchall_hashref([qw(latest_job_state latest_job_result)]);
 }
 

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -91,8 +91,13 @@ could also be used to generate a more detailed report.
 
 sub job_statistics ($self) {
     return undef unless my $params = $self->_get_iso_params_and_validate;
+    my $groups = $self->groups_for_globs;
+    return $self->render(json => {}) if !defined $groups;
+    my $group_ids = @$groups ? [map { $_->id } @$groups] : undef;
+    my $include_null_groups
+      = ($self->validation->param('not_group_glob') && !$self->validation->param('group_glob')) ? 1 : 0;
     my $scheduled_products = $self->app->schema->resultset('ScheduledProducts');
-    $self->render(json => $scheduled_products->job_statistics(@$params));
+    $self->render(json => $scheduled_products->job_statistics(@$params, $group_ids, $include_null_groups));
 }
 
 =over 4

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -330,6 +330,34 @@ subtest 'job statistics can be queried about the scheduled product' => sub {
       'scheduled jobs';
 };
 
+subtest 'job statistics can be filtered by job groups' => sub {
+    $schema->txn_begin;
+    my $dev_group = $schema->resultset('JobGroups')->create({name => 'Development Group', sort_order => 10});
+    my $prod_group = $schema->resultset('JobGroups')->create({name => 'Production Group', sort_order => 20});
+
+    $jobs->find(99985)->update({state => DONE, result => INCOMPLETE, group_id => $dev_group->id});
+    $jobs->find(99988)->update({state => DONE, result => FAILED, group_id => $prod_group->id});
+    $jobs->find(99993)->update({state => DONE, result => PASSED, group_id => undef});
+
+    $t->get_ok("/api/v1/isos/job_stats?$params")->status_is(200);
+    is_deeply [sort keys %{$t->tx->res->json->{done}}], [FAILED, INCOMPLETE, PASSED],
+      'statistics include all jobs when no group filters are applied';
+
+    $t->get_ok("/api/v1/isos/job_stats?$params&not_group_glob=Development*")->status_is(200);
+    is_deeply [sort keys %{$t->tx->res->json->{done}}], [FAILED, PASSED],
+      'negative group glob filters out development jobs but keeps ungrouped jobs';
+
+    $t->get_ok("/api/v1/isos/job_stats?$params&group_glob=Development*")->status_is(200);
+    is_deeply [sort keys %{$t->tx->res->json->{done}}], [INCOMPLETE],
+      'positive group glob includes only matching development jobs and excludes ungrouped jobs';
+
+    $t->get_ok("/api/v1/isos/job_stats?$params&group_glob=NonExistent*")->status_is(200);
+    is_deeply $t->tx->res->json, {}, 'empty statistics result for non-matching group glob';
+
+    $schema->txn_rollback;
+};
+
+
 subtest 'note can be updated by distri, version, flavor, arch and build parameters' => sub {
     $t->put_ok("/api/v1/experimental/isos/note?$params");
     $t->status_is(400, 'error returned if parameter missing');


### PR DESCRIPTION
Motivation
Users need to filter out jobs in development job groups from the statistics
returned by the /api/v1/isos/job_stats endpoint, similar to what is currently
available for the /tests and /tests/overview endpoints.

Design Choices
We reused the existing `groups_for_globs` helper in the Iso API controller to
parse the `group_glob` and `not_group_glob` parameters. This helper provides
a list of matching job groups. We extract the group IDs and pass them to the
ScheduledProducts resultset's `job_statistics` method. The SQL query is then
dynamically constructed to filter by the target group IDs in the
`most_recent_jobs` block.

To ensure consistency with other filtered views in openQA, jobs without a
group (group_id IS NULL) are included when using only negative filters
(not_group_glob), but excluded when explicit positive filters (group_glob)
are applied.

Benefits
This enhancement gives users consistent and flexible filtering capabilities
across different endpoints, allowing them to isolate or ignore specific
environments (like "Development") and obtain more relevant job statistics.

This also helps me for qem-bot's handling of increment-approve, see
https://progress.opensuse.org/issues/198728