### PR TITLE
feat: Ensure temporary directory exists when caching assets

### DIFF
--- a/lib/OpenQA/Downloader.pm
+++ b/lib/OpenQA/Downloader.pm
@@ -20,11 +20,13 @@ has ua => sub { OpenQA::UserAgent->new(max_redirects => 5, max_response_size => 
 has res => undef;
 
 sub download ($self, $url, $target, $options = {}) {
-    my $log = $self->log;
-
-    local $ENV{MOJO_TMPDIR} = $self->tmpdir;
+    my $tmpdir = path($self->tmpdir);
+    try { $tmpdir->make_path }
+    catch ($e) { return "Unable to create temporary directory: $e" }
+    local $ENV{MOJO_TMPDIR} = $tmpdir;
 
     my $remaining_attempts = $self->attempts;
+    my $log = $self->log;
     my ($code, $err);
     while (1) {
         $options->{on_attempt}->() if $options->{on_attempt};

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -5,6 +5,7 @@
 
 use Test::Most;
 use Test::Warnings ':report_warnings';
+use Mojo::Base -signatures;
 use utf8;
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
@@ -20,6 +21,7 @@ use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Test::Utils qw(fake_asset_server wait_for_or_bail_out);
 use OpenQA::Test::TimeLimit '10';
 use Mojo::File qw(tempdir);
+use Test::MockModule;
 
 my $port = Mojo::IOLoop::Server->generate_port;
 my $host = "127.0.0.1:$port";
@@ -66,6 +68,12 @@ my $tempdir = tempdir;
 my $to = $tempdir->child('test.qcow');
 
 $ua->connect_timeout(0.25)->inactivity_timeout(0.25);
+
+subtest 'Unable to create temporary directory' => sub {
+    my $file_mock = Test::MockModule->new('Mojo::File');
+    $file_mock->redefine(make_path => sub ($self) { die 'fake error' });
+    like $downloader->download('from', 'to'), qr/temp.*dir.*fake error/, 'error returned';
+};
 
 subtest 'Connection refused' => sub {
     my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";


### PR DESCRIPTION
`OpenQA::Downloader` is used in various places (where `setup_mojo_tmpdir` is not used like the worker cache service). So it makes sense that `OpenQA::Downloader` ensures that the temporary directory it needs exists. This helps preventing errors like:

```
Mojo::Reactor::Poll: I/O watcher failed: Error in tempfile() using template
/var/lib/openqa/cache/tmp/mojo.tmp.XXXXXXXXXXXXXXXX: Parent directory
(/var/lib/openqa/cache/tmp/) does not exist …
```