### PR TITLE
test: use isolated environment for helm chart tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ test-helm-lint: ## Lint helm chart
 	tools/test_helm_chart lint
 
 .PHONY: test-helm-install
-test-helm-install: ## Install helm chart for testing
+test-helm-install: test-helm-lint ## Install helm chart for testing
 	RETRY=${RETRY} timeout --foreground -s SIGINT -k 5 -v ${TIMEOUT_RETRIES} tools/retry tools/test_helm_chart install
 
 .PHONY: update-deps

--- a/tools/test_helm_chart
+++ b/tools/test_helm_chart
@@ -4,18 +4,25 @@ set -euo pipefail
 which helm > /dev/null || echo "Error: Helm is not installed"
 which ct > /dev/null || echo "Error: ct is not installed"
 
-cd container/helm/
+# Create a temporary directory for isolated testing
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Copy the helm chart files to the temporary directory
+cp -a container/helm/. "$tmp_dir/"
+cd "$tmp_dir"
 
 ct_common_args=()
+ct_lint_args=()
 # Reference schema files from the installed package if they are not in the default locations
 for schema in chart_schema.yaml lintconf.yaml; do
     if [[ ! -f "$schema" && ! -f "$HOME/.ct/$schema" && ! -f "/etc/ct/$schema" ]]; then
         pkg_schema="/usr/share/doc/packages/chart-testing/$schema"
         if [[ -f "$pkg_schema" ]]; then
             if [[ "$schema" == "chart_schema.yaml" ]]; then
-                ct_common_args+=(--chart-yaml-schema "$pkg_schema")
+                ct_lint_args+=(--chart-yaml-schema "$pkg_schema")
             else
-                ct_common_args+=(--lint-conf "$pkg_schema")
+                ct_lint_args+=(--lint-conf "$pkg_schema")
             fi
         fi
     fi
@@ -23,5 +30,6 @@ done
 
 ct_extra=(--helm-extra-set-args "--set=gateway.enabled=false --set=image.pullPolicy=IfNotPresent --set=worker.image.pullPolicy=IfNotPresent")
 ct_install_args=("${ct_common_args[@]}")
+[[ "${1:-lint}" == "lint" ]] && ct_install_args+=("${ct_lint_args[@]}")
 [[ "${1:-lint}" != "lint" ]] && ct_install_args+=("${ct_extra[@]}")
 ct "${1:-lint}" --debug --all --config ct.yaml "${ct_install_args[@]}"


### PR DESCRIPTION
Motivation:
Running tests directly in the source tree causes side effects like
modifying the versioned Chart.lock file and downloading dependencies
into the charts/ directory. While a "git restore" trap can undo some
of this, a truly isolated environment is more robust.

Design Choices:
- Modified the test script to create a temporary directory for each run.
- Copies the helm chart source into the temp directory and executes
  tests there.

Benefits:
Zero side effects on the source tree and better isolation between
test runs.