### PR TITLE
fix: stabilize and isolate helm chart tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ test-helm-lint: ## Lint helm chart
 	tools/test_helm_chart lint
 
 .PHONY: test-helm-install
-test-helm-install: ## Install helm chart for testing
+test-helm-install: test-helm-lint ## Install helm chart for testing
 	RETRY=${RETRY} timeout --foreground -s SIGINT -k 5 -v ${TIMEOUT_RETRIES} tools/retry tools/test_helm_chart install
 
 .PHONY: update-deps

--- a/container/helm/openqa/templates/deployment.yaml
+++ b/container/helm/openqa/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
             - name: MOJO_LISTEN
               value: "http://0.0.0.0:9526"
             - name: MOJO_CLIENT_DEBUG
-              value: ${MOJO_CLIENT_DEBUG}
+              value: {{ .Values.mojoClientDebug | quote }}
           ports:
             - containerPort: 9526
           readinessProbe:

--- a/container/helm/openqa/values.yaml
+++ b/container/helm/openqa/values.yaml
@@ -3,6 +3,7 @@ baseUrl: openqa.internal
 useHttps: false
 key: 1234567890ABCDEF
 secret: 1234567890ABCDEF
+mojoClientDebug: "0"
 image:
   name: registry.opensuse.org/devel/openqa/containers16.0/openqa_webui
   pullPolicy: Always

--- a/container/webui/docker-compose.yaml
+++ b/container/webui/docker-compose.yaml
@@ -115,6 +115,9 @@ services:
     environment:
       MODE: "webui"
       MOJO_LISTEN: "http://0.0.0.0:9526"
+    depends_on:
+      db:
+        condition: service_healthy
     entrypoint: "sh -c 'chmod -R a+rwX /data/{factory,images,testresults}; /root/run_openqa.sh'"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9526/login"]
@@ -133,12 +136,7 @@ services:
     volumes:
       - ./workdir/db:/var/lib/postgresql:Z
     healthcheck:
-      test:
-        - CMD-SHELL
-        - >-
-          pg_isready -U openqa -d openqa
-          && echo 'select * from api_keys;'
-          | psql -U openqa -v 'ON_ERROR_STOP=1' openqa
+      test: ["CMD-SHELL", "pg_isready -U openqa -d openqa"]
       interval: 10s
       timeout: 10s
       retries: 3

--- a/tools/test_helm_chart
+++ b/tools/test_helm_chart
@@ -4,24 +4,29 @@ set -euo pipefail
 which helm > /dev/null || echo "Error: Helm is not installed"
 which ct > /dev/null || echo "Error: ct is not installed"
 
-cd container/helm/
+# Create a temporary directory for isolated testing
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
 
-ct_common_args=()
+# Copy the helm chart files to the temporary directory
+cp -a container/helm/. "$tmp_dir/"
+cd "$tmp_dir"
+
+ct_lint_args=()
 # Reference schema files from the installed package if they are not in the default locations
 for schema in chart_schema.yaml lintconf.yaml; do
     if [[ ! -f "$schema" && ! -f "$HOME/.ct/$schema" && ! -f "/etc/ct/$schema" ]]; then
         pkg_schema="/usr/share/doc/packages/chart-testing/$schema"
         if [[ -f "$pkg_schema" ]]; then
             if [[ "$schema" == "chart_schema.yaml" ]]; then
-                ct_common_args+=(--chart-yaml-schema "$pkg_schema")
+                ct_lint_args+=(--chart-yaml-schema "$pkg_schema")
             else
-                ct_common_args+=(--lint-conf "$pkg_schema")
+                ct_lint_args+=(--lint-conf "$pkg_schema")
             fi
         fi
     fi
 done
 
 ct_extra=(--helm-extra-set-args "--set=gateway.enabled=false --set=image.pullPolicy=IfNotPresent --set=worker.image.pullPolicy=IfNotPresent")
-ct_install_args=("${ct_common_args[@]}")
-[[ "${1:-lint}" != "lint" ]] && ct_install_args+=("${ct_extra[@]}")
+[[ "${1:-lint}" == "lint" ]] && ct_install_args=("${ct_lint_args[@]}") || ct_install_args=("${ct_extra[@]}")
 ct "${1:-lint}" --debug --all --config ct.yaml "${ct_install_args[@]}"

--- a/tools/test_helm_chart
+++ b/tools/test_helm_chart
@@ -1,8 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
-which helm > /dev/null || echo "Error: Helm is not installed"
-which ct > /dev/null || echo "Error: ct is not installed"
+for cmd in helm ct; do
+    if ! command -v "$cmd" > /dev/null; then
+        echo "Error: $cmd is not installed" >&2
+        exit 1
+    fi
+done
+if [[ "${1:-lint}" != "lint" ]]; then
+    if ! command -v kubectl > /dev/null; then
+        echo "Error: kubectl is not installed" >&2
+        exit 1
+    fi
+fi
 
 # Create a temporary directory for isolated testing
 tmp_dir=$(mktemp -d)

--- a/tools/test_helm_chart
+++ b/tools/test_helm_chart
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-for cmd in helm ct; do
+for cmd in helm ct yamale yamllint; do
     if ! command -v "$cmd" > /dev/null; then
         echo "Error: $cmd is not installed" >&2
         exit 1


### PR DESCRIPTION
* test: simplify postgres healthcheck in docker-compose
* fix: correctly handle MOJO_CLIENT_DEBUG in Helm chart
* test: add yamale and yamllint to test_helm_chart dependencies
* test: use IfNotPresent pull policy for postgres init container
* test: fail early in test_helm_chart if dependencies are missing
* test: use isolated environment for helm chart tests
* test: serialize helm chart test execution
