### PR TITLE
style: Enforce perlcritic policy RequireNumberSeparators

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple
@@ -46,3 +46,7 @@ severity = 5
 # -- Superfluous use strict/warning.
 [OpenQA::RedundantStrictWarning]
 equivalent_modules = Test::Most
+
+[ValuesAndExpressions::RequireNumberSeparators]
+min_value = 1000000
+

--- a/lib/OpenQA/CacheService/Model/Cache.pm
+++ b/lib/OpenQA/CacheService/Model/Cache.pm
@@ -16,7 +16,7 @@ use Mojo::Util 'scope_guard';
 use Time::HiRes qw(gettimeofday);
 
 # Only consider files larger than 250 MB for metrics (rates for smaller files are unrealistic)
-use constant METRICS_DOWNLOAD_SIZE => $ENV{OPENQA_METRICS_DOWNLOAD_SIZE} // 262144000;
+use constant METRICS_DOWNLOAD_SIZE => $ENV{OPENQA_METRICS_DOWNLOAD_SIZE} // 262_144_000;
 
 has downloader => sub { OpenQA::Downloader->new };
 has [qw(location log sqlite min_free_percentage)];

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1423,7 +1423,7 @@ sub create_asset ($self, $asset, $scope, $local = undef) {
             # Perform weak check on the number of bytes if the file size is > 250 MB
             my $temp_final_str = $temp_final_file->to_string;
             my ($sum, $real_sum)
-              = $chunk->end > 250000000
+              = $chunk->end > 250_000_000
               ? ($chunk->end, -s $temp_final_str)
               : ($chunk->total_cksum, $chunk->file_digest($temp_final_str));
 

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -81,20 +81,21 @@ subtest 'random number generator' => sub {
 };
 
 subtest 'download speed' => sub {
-    is download_rate([1638459407, 528237], [1638459408, 628237], 1024), '930.91';
-    is download_rate([1638459407, 528237], [1638459408, 628237], 1024 * 1024 * 1024), '976128930.91';
-    is download_rate([1638459407, 528237], [1638459407, 528237], 1024), undef;
+    is download_rate([1_638_459_407, 528237], [1_638_459_408, 628237], 1024), '930.91';
+    is download_rate([1_638_459_407, 528237], [1_638_459_408, 628237], 1024 * 1024 * 1024), '976128930.91';
+    is download_rate([1_638_459_407, 528237], [1_638_459_407, 528237], 1024), undef;
 
-    is download_speed([1638459407, 528237], [1638459408, 628237], 1024), '930.91 Byte/s';
-    is download_speed([1638459407, 528237], [1638459408, 628237], 1024 * 1024), '931 KiB/s';
-    is download_speed([1638459407, 528237], [1638459408, 628237], 1024 * 1024 * 1024), '931 MiB/s';
-    is download_speed([1638459407, 528237], [1638459408, 628237], 1024 * 1024 * 1024 * 1024), '931 GiB/s';
-    is download_speed([1638459407, 528237], [1638459408, 628237], 1024 * 1024 * 1024 * 1024 * 1024), '953251 GiB/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_408, 628237], 1024), '930.91 Byte/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_408, 628237], 1024 * 1024), '931 KiB/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_408, 628237], 1024 * 1024 * 1024), '931 MiB/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_408, 628237], 1024 * 1024 * 1024 * 1024), '931 GiB/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_408, 628237], 1024 * 1024 * 1024 * 1024 * 1024),
+      '953251 GiB/s';
 
-    is download_speed([1638459407, 528237], [1638459508, 628237], 1024 * 1024 * 512), '5.1 MiB/s';
-    is download_speed([1638459407, 528237], [1638459407, 588237], 123456789), '1.9 GiB/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_508, 628237], 1024 * 1024 * 512), '5.1 MiB/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_407, 588237], 123_456_789), '1.9 GiB/s';
 
-    is download_speed([1638459407, 528237], [1638459407, 528237], 1024), '??/s';
+    is download_speed([1_638_459_407, 528237], [1_638_459_407, 528237], 1024), '??/s';
 };
 
 subtest 'labels' => sub {
@@ -534,10 +535,10 @@ subtest 'signal blocker' => sub {
 subtest 'human readable size' => sub {
     is human_readable_size(0), '0 Byte', 'zero';
     is human_readable_size(1), '1 Byte', 'one';
-    is human_readable_size(13443399680), '13 GiB', 'two digits GB';
-    is human_readable_size(8007188480), '7.5 GiB', 'smaller GB';
-    is human_readable_size(-8007188480), '-7.5 GiB', 'negative smaller GB';
-    is human_readable_size(717946880), '685 MiB', 'large MB';
+    is human_readable_size(13_443_399_680), '13 GiB', 'two digits GB';
+    is human_readable_size(8_007_188_480), '7.5 GiB', 'smaller GB';
+    is human_readable_size(-8_007_188_480), '-7.5 GiB', 'negative smaller GB';
+    is human_readable_size(717_946_880), '685 MiB', 'large MB';
     is human_readable_size(245760), '240 KiB', 'less than a MB';
 };
 

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -101,8 +101,8 @@ sub test_sync ($run) {
     my $dir2 = tempdir;
     my $rsync_request = $cache_client->rsync_request(from => $dir, to => $dir2);
 
-    my $t_dir = int rand 13432432;
-    my $data = int rand 348394280934820842093;
+    my $t_dir = int rand 13_432_432;
+    my $data = int rand 348_394_280_934_820_842_093;
     $dir->child($t_dir)->spew($data);
     my $expected = $dir2->child('tests')->child($t_dir);
 

--- a/t/32-openqa_client.t
+++ b/t/32-openqa_client.t
@@ -18,10 +18,10 @@ use Mojo::Util qw(scope_guard);
 plan skip_all => 'set HEAVY=1 to execute (takes longer)' unless $ENV{HEAVY};
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 02-workers.pl 03-users.pl');
-my $chunk_size = 10000000;
+my $chunk_size = 10_000_000;
 
 # allow up to 200MB - videos mostly
-$ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
+$ENV{MOJO_MAX_MESSAGE_SIZE} = 207_741_824;
 
 my $tempdir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
 chdir $tempdir;

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -816,7 +816,7 @@ subtest 're-schedule product' => sub {
 
     my $res = schedule_iso($t, {scheduled_product_clone_id => 'foobar'}, 400);
     like $res->body, qr/scheduled_product_id.*invalid/, 'error returned if scheduled product to clone from is invalid';
-    $res = schedule_iso($t, {scheduled_product_clone_id => 1234567}, 404);
+    $res = schedule_iso($t, {scheduled_product_clone_id => 1_234_567}, 404);
     like $res->body, qr/to clone.*not found/, 'error returned if scheduled product to clone from does not exist';
 
     $res = schedule_iso($t, {scheduled_product_clone_id => $scheduled_product_id}, 200, {async => 1});

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -48,7 +48,7 @@ $ENV{OPENQA_CONFIG} = $tempdir;
 my @data = ("[audit]\n", "blocklist = job_grab\n");
 $tempdir->child('openqa.ini')->spew(join '', @data);
 
-my $chunk_size = 10000000;
+my $chunk_size = 10_000_000;
 
 my $io_loop_mock = mock_io_loop(subprocess => 1);
 
@@ -60,7 +60,7 @@ sub calculate_file_md5 ($file) {
 }
 
 # allow up to 200MB - videos mostly
-$ENV{MOJO_MAX_MESSAGE_SIZE} = 207741824;
+$ENV{MOJO_MAX_MESSAGE_SIZE} = 207_741_824;
 
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
 my $cfg = $t->app->config;
@@ -333,7 +333,7 @@ subtest 'jobs for job settings' => sub {
     $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26103})->status_is(200)
       ->json_is({jobs => []});
 
-    local $t->app->config->{misc_limits}{job_settings_max_recent_jobs} = 1000000000;
+    local $t->app->config->{misc_limits}{job_settings_max_recent_jobs} = 1_000_000_000;
     $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26110})->status_is(200)
       ->json_is({jobs => [99981]});
     $t->get_ok('/api/v1/job_settings/jobs' => form => {key => '*_TEST_ISSUES', list_value => 26103})->status_is(200)

--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -136,7 +136,8 @@ subtest 'openqa_get_log_file tool' => sub {
 
     subtest 'Job does not exist' => sub {
         local $t->app->config->{misc_limits}{mcp_max_result_size} = 100;
-        my $result = $client->call_tool('openqa_get_log_file', {job_id => 999999999, file_name => 'autoinst-log.txt'});
+        my $result
+          = $client->call_tool('openqa_get_log_file', {job_id => 999_999_999, file_name => 'autoinst-log.txt'});
         ok $result->{isError}, 'is an error';
         my $text = $result->{content}[0]{text};
         like $text, qr/Job does not exist/, 'error message';

--- a/t/fixtures/01-jobs.pl
+++ b/t/fixtures/01-jobs.pl
@@ -61,7 +61,7 @@ use Time::Seconds;
         settings => [
             {key => 'DESKTOP', value => 'minimalx'},
             {key => 'ISO', value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'},
-            {key => 'ISO_MAXSIZE', value => 737280000},
+            {key => 'ISO_MAXSIZE', value => 737_280_000},
             {key => 'ISO_1', value => 'openSUSE-Factory-staging_e-x86_64-Build87.5011-Media.iso'},
             {key => 'BASE_TEST_ISSUES', value => '26103'}
         ],
@@ -429,7 +429,7 @@ use Time::Seconds;
         priority => 50,
         result => 'skipped',
         state => 'cancelled',
-        t_created => time2str('%Y-%m-%d %H:%M:%S', time - 3000100, 'UTC'),
+        t_created => time2str('%Y-%m-%d %H:%M:%S', time - 3_000_100, 'UTC'),
         t_started => undef,
         t_finished => undef,
         TEST => 'RAID0',

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -224,7 +224,7 @@ subtest 'build service ssh authentication' => sub {
 };
 
 subtest 'build service authentication: signature generation' => sub {
-    $mocked_time = 1664187470;
+    $mocked_time = 1_664_187_470;
     note 'time right now: ' . time;
     is time(), $mocked_time, 'Time is not frozen!';
     is $helper->is_status_dirty('ProjTestingSignature'), 1, 'signature matches fixture';


### PR DESCRIPTION
ValuesAndExpressions::RequireNumberSeparators

I set the minimum value to 1000000 because otherwise there would have been too many matches in test files, where it doesn't always make sense to add a underscore.