### PR TITLE
style: Enforce perlcritic policy CodeLayout::ProhibitQuotedWordLists

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -976,7 +976,7 @@ sub _upload_asset ($self, $upload_parameter) {
     my $local_upload = $global_settings->{LOCAL_UPLOAD} // 1;
     my $ua = $self->client->ua;
     my @channels_worker_only = ('worker');
-    my @channels_both = ('autoinst', 'worker');
+    my @channels_both = qw(autoinst worker);
     my $error;
 
     log_info("Uploading $filename using multiple chunks", channels => \@channels_worker_only, default => 1);

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -24,7 +24,7 @@ my $jobs = $schema->resultset('Jobs');
 
 sub prepare_database () {
     # Populate more cluster jobs
-    my @test_names = ('create_hdd', 'support_server', 'master_node', 'slave_node');
+    my @test_names = qw(create_hdd support_server master_node slave_node);
     for my $n (0 .. 3) {
         my $new = {
             id => 99900 + $n,


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/188058
    
Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies
can ensure a coherent style and avoid common mistakes.
    
https://metacpan.org/pod/Perl::Critic::Policy::CodeLayout::ProhibitQuotedWordLists
    
Policy description:
> Conway doesn't mention this, but I think qw() is an underused feature of
> Perl.  Whenever you need to declare a list of one-word literals, the qw()
> operator is wonderfully concise, and makes it easy to add to the list in the
> future.
