### PR TITLE
style: Enforce perlcritic policy ProhibitSingleCharAlternation

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -157,7 +157,7 @@ subtest 'cycle in directly chained dependencies is handled' => sub {
     is $scheduled_jobs->{99928}->{priority}, 46, 'regular prio for job 99928 assumed';
     is $scheduled_jobs->{$_}->{priority_offset}, 0, "job $_ not deprioritized yet" for (99927, 99928);
     combined_like { $scheduler->schedule }
-    qr/Unable to serialize directly chained job sequence of 9992(7|8): detected cycle at 9992(7|8)/,
+    qr/Unable to serialize directly chained job sequence of 9992[78]: detected cycle at 9992[78]/,
       'info about cycle logged';
     $scheduler->_update_scheduled_jobs;    # apply deprioritization
     is $scheduled_jobs->{99927}->{priority}, 46, 'reduced prio for job 99927 assumed';
@@ -1290,7 +1290,7 @@ subtest 'starvation of parallel jobs prevented' => sub {
     my $free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers();
     my $allocated_workers;
     combined_like { $allocated_workers = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($free_workers) }
-    qr/Need to schedule 3 parallel jobs for job 1.*Discarding job (1|2|3).*Discarding job (1|2|3)/s,
+    qr/Need to schedule 3 parallel jobs for job 1.*Discarding job [123].*Discarding job [123]/s,
       'discarding jobs due to incomplete parallel cluster';
     is $mocked_jobs{1}->{priority_offset}, 10, 'priority of parallel parent increased (once per child)';
     is_deeply $allocated_workers, {}, 'no workers "held" so far while still increased prio'
@@ -1299,7 +1299,7 @@ subtest 'starvation of parallel jobs prevented' => sub {
     # run the scheduler again assuming highest prio for parallel parent; worker supposed to be "held"
     $mocked_jobs{1}->{priority} = 0;
     combined_like { ($allocated_workers) = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($free_workers) }
-    qr/Holding worker .* for job (1|2|3) to avoid starvation.*Holding worker .* for job (1|2|3) to avoid starvation/s,
+    qr/Holding worker .* for job [123] to avoid starvation.*Holding worker .* for job [123] to avoid starvation/s,
       'holding 2 workers (for 2 of our parallel jobs while 3rd worker is unavailable)';
     is_deeply [sort keys %$allocated_workers], [map { $_->id } @mocked_free_workers], 'both free workers "held"';
     ok $_ >= 1 && $_ <= 3, "worker held for expected job ($_)" for values %$allocated_workers;

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -153,7 +153,7 @@ walker(
     $t3 => sub {
         my ($k, $v, $ks, $what) = @_;
         next if reftype $what eq 'HASH' && exists $what->{_data};
-        like $_[0], qr/bar|baz|foo|0|1|fish$|fish2|boring/, 'Walked';
+        like $_[0], qr/bar|baz|foo|[01]|fish$|fish2|boring/, 'Walked';
 
         $what->[$k] = {_type => ref $v, _data => $v} if reftype $what eq 'ARRAY';
         $what->{$k} = {_type => ref $v, _data => $v} if reftype $what eq 'HASH';

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -512,7 +512,7 @@ subtest 'Catch cycles in chained dependencies' => sub {
     is $res->json->{count}, 0, 'no jobs scheduled if cycle detected';
     like
       $res->json->{failed}->[0]->{error_messages}->[0],
-      qr/There is a cycle in the dependencies of chained-(a|b|c|d)/,
+      qr/There is a cycle in the dependencies of chained-[abcd]/,
       'cycle reported';
     $schema->txn_rollback;
 };
@@ -583,7 +583,7 @@ subtest 'Handling different WORKER_CLASS in directly chained dependency chains' 
 
         my $res = schedule_iso($t, {%iso, _GROUP => 'opensuse test'});
         is $res->json->{count}, 0, 'none of the jobs has been scheduled';
-        like $_->{error_messages}->[0], qr/chained-(c|d|e) \(bar,baz\) does not match .* \(foo\)/, 'error reported'
+        like $_->{error_messages}->[0], qr/chained-[cde] \(bar,baz\) does not match .* \(foo\)/, 'error reported'
           for @{$res->json->{failed}};
         $schema->txn_rollback;
     };

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -238,11 +238,11 @@ sub check_report_links ($failed_module, $failed_step, $container = undef) {
     like $url[0], qr{bugzilla.*enter_bug.*tests%2F99937}, 'bugzilla link referencing current test';
     like $url[0], qr{in\+scenario\+%60opensuse-13\.1-DVD-i586-kde}, 'bugzilla link contains scenario marked verbatim';
     like $url[1], qr{bugzilla.*enter_bug}, 'kernel product bug uses bugzilla enter_bug';
-    like $url[1], qr{(?:\?|&)product=openSUSE\+Distribution(?:&|$)}, 'kernel product bug sets product';
+    like $url[1], qr{[?&]product=openSUSE\+Distribution(?:&|$)}, 'kernel product bug sets product';
     like $url[1],
-      qr{(?:\?|&)short_desc=%5BQE%5D%5BBuild\+0091%5D\+Kernel\+test\+fails\+in\+bootloader},
+      qr{[?&]short_desc=%5BQE%5D%5BBuild\+0091%5D\+Kernel\+test\+fails\+in\+bootloader},
       'kernel short_desc correct';
-    like $url[1], qr{(?:\?|&)comment=}, 'kernel product bug has comment template';
+    like $url[1], qr{[?&]comment=}, 'kernel product bug has comment template';
     like $url[2], qr{progress.*new}, 'progress/redmine link for reporting test issues';
     like $url[2], qr{in\+scenario\+%60opensuse-13\.1-DVD-i586-kde}, 'progress/redmine link contains scenario';
     like $url[2],


### PR DESCRIPTION
RegularExpressions::ProhibitSingleCharAlternation

Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies
can ensure a coherent style and avoid common mistakes.

https://metacpan.org/pod/Perl::Critic::Policy::RegularExpressions::ProhibitSingleCharAlternation

Policy description:
> Character classes (like `[abc]`) are significantly faster than single
> character alternations (like `(?:a|b|c)`). This policy complains if you have
> more than one instance of a single character in an alternation. So
> `(?:a|the)` is allowed, but `(?:a|e|i|o|u)` is not.