### PR TITLE
style: Enforce perlcritic policy BuiltinFunctions::RequireBlockGrep

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -82,15 +82,15 @@ subtest 'latest jobs' => sub {
 
     my $ids = $jobs->complex_query_latest_ids;
     # These two jobs have later clones in the fixture set, so should not appear
-    ok grep(!/^(99962|99945)$/, @$ids), 'jobs with later clones do not show up in latest jobs';
+    ok + (grep { !/^(99962|99945)$/ } @$ids), 'jobs with later clones do not show up in latest jobs';
     # These are the later clones, they should appear
-    ok grep(/^99963$/, @$ids), 'cloned jobs appear as latest job';
-    ok grep(/^99946$/, @$ids), 'cloned jobs appear as latest job (2nd)';
+    ok + (grep { /^99963$/ } @$ids), 'cloned jobs appear as latest job';
+    ok + (grep { /^99946$/ } @$ids), 'cloned jobs appear as latest job (2nd)';
 
     my $filtered_ids = $jobs->complex_query_latest_ids(filters => [{result => {-in => [FAILED, PASSED]}}]);
-    ok grep(!/^(99962|99945)$/, @$filtered_ids), 'jobs with later clones still not present';
-    ok grep(/^99946$/, @$filtered_ids), 'failed/passed job still returned';
-    ok grep(!/^99963$/, @$filtered_ids), 'running job filtered out';
+    ok + (grep { !/^(99962|99945)$/ } @$filtered_ids), 'jobs with later clones still not present';
+    ok + (grep { /^99946$/ } @$filtered_ids), 'failed/passed job still returned';
+    ok + (grep { !/^99963$/ } @$filtered_ids), 'running job filtered out';
 };
 
 

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -461,7 +461,7 @@ subtest 'delete_needles' => sub {
     $openqa_git->redefine(
         run_cmd_with_log_return_error => sub ($cmd, %args) {
             push @cmds, "@$cmd";
-            if (grep m/push/, @$cmd) {
+            if (grep { m/push/ } @$cmd) {
                 return {
                     status => 0,
                     return_code => 128,

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -287,12 +287,12 @@ subtest 'Plugins handling' => sub {
     is path_to_class('foo/bar.pm'), 'foo::bar';
     is path_to_class('foo/bar/baz.pm'), 'foo::bar::baz';
 
-    ok grep('OpenQA::Utils', loaded_modules), 'Can detect loaded modules';
-    ok grep('Test::Most', loaded_modules), 'Can detect loaded modules';
+    ok + (grep { $_ eq 'OpenQA::Utils' } loaded_modules), 'Can detect loaded modules';
+    ok + (grep { $_ eq 'Test::Most' } loaded_modules), 'Can detect loaded modules';
 
     is_deeply [loaded_plugins('OpenQA::Utils', 'Test::Most')], ['OpenQA::Utils', 'Test::Most', 'Test::Most::Exception'],
       'Can detect loaded plugins, filtering by namespace';
-    ok grep('Test::Most', loaded_plugins),
+    ok + (grep { $_ eq 'Test::Most' } loaded_plugins),
       'loaded_plugins() behave like loaded_modules() when no arguments are supplied';
 
     my $test_hash = {

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -368,13 +368,13 @@ subtest 'tracked assets' => sub {
     # Assets here include non-iso in iso, files in other, CURRENT repos
     for my $name (qw(iso/whatever.sha256 other/misc.xml repo/otherrepo-CURRENT)) {
         ok -e assetdir() . '/' . $name, "$name exists in the test folder";
-        ok grep(/$name$/, @tracked_assets), "$name picked up for cleanup"
+        ok + (grep { /$name$/ } @tracked_assets), "$name picked up for cleanup"
           || always_explain join ' ', sort @tracked_assets;
     }
     # Ignored assets include repo links, file links
     for my $name (qw(repo/somethingrepo other/misc2.xml)) {
         ok -e assetdir() . '/' . $name, "$name exists in the test folder";
-        ok !grep(/$name$/, @tracked_assets), "$name ignored" || always_explain join ' ', sort @tracked_assets;
+        ok !(grep { /$name$/ } @tracked_assets), "$name ignored" || always_explain join ' ', sort @tracked_assets;
     }
 };
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies
can ensure a coherent style and avoid common mistakes.

https://metacpan.org/pod/Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep

Policy description:
> The expression forms of grep and map are awkward and hard to read. Use the
> block forms instead.