### PR TITLE
style: Enforce perlcritic policy Subroutines::RequireArgUnpacking

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple

--- a/script/create_admin
+++ b/script/create_admin
@@ -30,7 +30,6 @@ sub usage ($rc) {
     print "  --key       : API key (will be randomly generated if not set).\n";
     print "  --secret    : API secret (will be randomly generated if not set).\n";
     print "  user        : User ID (e.g. OpenID URL).\n";
-    print "usage: $rc\n";
     exit $rc;
 }
 

--- a/script/create_admin
+++ b/script/create_admin
@@ -4,8 +4,7 @@
 # Copyright 2015-2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use strict;
-use warnings;
+use Mojo::Base -signatures;
 
 use FindBin qw($RealBin);
 use lib "$RealBin/../lib";
@@ -23,7 +22,7 @@ my $secret = '';
 my $user = $ARGV[0];
 my $help;
 
-sub usage {
+sub usage ($rc) {
     print "Usage: $0 user [options]\n\n";
     print "  --email     : Email address.\n";
     print "  --nickname  : Nickname.\n";
@@ -31,8 +30,8 @@ sub usage {
     print "  --key       : API key (will be randomly generated if not set).\n";
     print "  --secret    : API secret (will be randomly generated if not set).\n";
     print "  user        : User ID (e.g. OpenID URL).\n";
-    print "usage: $_[0]\n";
-    exit $_[0];
+    print "usage: $rc\n";
+    exit $rc;
 }
 
 # need to count this *before* calling GetOptions

--- a/script/initdb
+++ b/script/initdb
@@ -3,11 +3,10 @@
 # Copyright 2014-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+use Mojo::Base -signatures;
 use FindBin qw($RealBin);
 use lib "$RealBin/../lib";
 
-use strict;
-use warnings;
 use DBIx::Class::DeploymentHandler;
 use File::Basename qw(dirname);
 use OpenQA::Schema;
@@ -31,7 +30,7 @@ my $result = GetOptions(
     'dir=s' => \$script_directory,
 );
 
-sub usage {
+sub usage ($rc) {
     print "Usage: $0 [flags]\n\n";
     print "  --prepare_init   : Create the deployment files used to initialize the database.\n";
     print "                     Don't forget to increase the version before using this\n";
@@ -45,7 +44,7 @@ sub usage {
     print "  --dir=directory  : Create deployment and migration scripts in this directory.\n";
     print "                     Default is '$default_script_directory'\n";
     print "  --help           : This help message.\n";
-    exit $_[0];
+    exit $rc;
 }
 
 usage 0 if $help;

--- a/script/upgradedb
+++ b/script/upgradedb
@@ -3,11 +3,10 @@
 # Copyright 2014-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+use Mojo::Base -signatures;
 use FindBin qw($RealBin);
 use lib "$RealBin/../lib";
 
-use strict;
-use warnings;
 use aliased 'DBIx::Class::DeploymentHandler' => 'DH';
 use OpenQA::Schema;
 use Getopt::Long;
@@ -31,7 +30,7 @@ my $result = GetOptions(
     'force' => \$force
 );
 
-sub usage {
+sub usage ($rc) {
     print "Usage: $0 [flags]\n\n";
     print "  --prepare_upgrades : Create the deployment files used to upgrade the database.\n";
     print "                       Don't forget to increase the version before using this\n";
@@ -43,7 +42,7 @@ sub usage {
     print "  --dir=directory    : Create deployment and migration scripts in this directory.\n";
     print "                       Default is '$default_script_directory'\n";
     print "  --help             : This help message.\n";
-    exit $_[0];
+    exit $rc;
 }
 
 usage 0 if $help;

--- a/script/worker
+++ b/script/worker
@@ -114,7 +114,7 @@ $options{instance} ||= 1;
 my $worker = OpenQA::Worker->new(\%options);
 $worker->log_setup_info();
 
-sub catch_exit { $worker->handle_signal(@_) }    # uncoverable statement
+sub catch_exit (@args) { $worker->handle_signal(@args) }    # uncoverable statement
 $SIG{HUP} = \*catch_exit;
 $SIG{TERM} = \*catch_exit;
 $SIG{INT} = \*catch_exit;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -82,8 +82,8 @@ subtest 'API' => sub {
     is $awake, 2, 'scheduler has been woken up again';
 };
 
-sub list_jobs {
-    [map { $_->to_hash(assets => 1) } $jobs->complex_query(@_)->all]
+sub list_jobs (@args) {
+    [map { $_->to_hash(assets => 1) } $jobs->complex_query(@args)->all]
 }
 sub job_get { $jobs->find({id => shift}) }
 

--- a/t/05-scheduler-cancel.t
+++ b/t/05-scheduler-cancel.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Mojo::Base -signatures;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
@@ -183,8 +184,8 @@ my %settings = (
     ARCH => 'x86_64',
 );
 
-sub _job_create {
-    my $job = $schema->resultset('Jobs')->create_from_settings(@_);
+sub _job_create (@args) {
+    my $job = $schema->resultset('Jobs')->create_from_settings(@args);
     # reload all values from database so we can check against default values
     $job->discard_changes;
     return $job;

--- a/t/05-scheduler-capabilities.t
+++ b/t/05-scheduler-capabilities.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Mojo::Base -signatures;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
@@ -132,9 +133,7 @@ $settingsI{WORKER_CLASS} = 'client,qemu_x86_64';
 $settingsJ{TEST} = 'J';
 $settingsJ{WORKER_CLASS} = 'qemu_x86_64';
 
-sub job_create {
-    return $schema->resultset('Jobs')->create_from_settings(@_);
-}
+sub job_create (@args) { $schema->resultset('Jobs')->create_from_settings(@args) }
 
 my $jobA = job_create(\%settingsA);
 my $jobB = job_create(\%settingsB);

--- a/t/10-jobs-results.t
+++ b/t/10-jobs-results.t
@@ -32,8 +32,8 @@ my %settings = (
     ARCH => 'x86_64',
 );
 
-sub _job_create {
-    my $job = $jobs->create_from_settings(@_);
+sub _job_create (@args) {
+    my $job = $jobs->create_from_settings(@args);
     # reload all values from database so we can check against default values
     $job->discard_changes;
     return $job;

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -68,8 +68,8 @@ my %settings = (
     ARCH => 'x86_64',
 );
 
-sub _job_create {
-    my $job = $jobs->create_from_settings(@_);
+sub _job_create (@args) {
+    my $job = $jobs->create_from_settings(@args);
     # reload all values from database so we can check against default values
     $job->discard_changes;
     return $job;

--- a/t/16-utils-runcmd.t
+++ b/t/16-utils-runcmd.t
@@ -281,9 +281,9 @@ subtest 'saving needle via Git' => sub {
     package Test::FakeMinionJob {
         sub finish { }
 
-        sub fail {
+        sub fail (@args) {    # uncoverable statement
             Test::Most::fail 'Minion job should not have failed.';    # uncoverable statement
-            Test::Most::note Data::Dumper::Dumper(\@_);    # uncoverable statement
+            Test::Most::note Data::Dumper::Dumper(\@args);    # uncoverable statement
         }
     }    # uncoverable statement
 

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -127,7 +127,7 @@ package Test::FakeClient {
         Mojo::IOLoop->next_tick(sub { $args{callback}->(\%cb_args) }) if $args{callback} && $args{callback} ne 'no';
     }
     sub reset_last_error { shift->last_error(undef) }
-    sub send_status { push @{shift->sent_messages}, @_ }
+    sub send_status ($self, @args) { push @{$self->sent_messages}, @args }
     sub register { shift->register_called(1) }
 
     sub add_context_to_last_error {
@@ -135,7 +135,7 @@ package Test::FakeClient {
         $self->last_error($self->last_error . " on $context");
     }
     sub _retry_delay { 0 }
-    sub evaluate_error { OpenQA::Worker::WebUIConnection::evaluate_error(@_) }
+    sub evaluate_error (@args) { OpenQA::Worker::WebUIConnection::evaluate_error(@args) }
 }    # uncoverable statement count:1
 
 package Test::FakeEngine {

--- a/t/26-controllerrunning.t
+++ b/t/26-controllerrunning.t
@@ -301,8 +301,8 @@ sub get_property { shift->{WORKER_TMPDIR} }
 
 package Mojo::Transaction::Fake;
 use Mojo::Base 'Mojo::Transaction', -signatures;
-sub resume { ++$_[0]{writing} and return $_[0]->emit('resume') }
-sub connection { shift->{fakestream} }
+sub resume ($self) { ++$self->{writing} and return $self->emit('resume') }
+sub connection ($self) { $self->{fakestream} }
 sub remote_address { '::1' }
 sub error { $fake_error }
 sub finish ($self) { $self->emit(finish => $self) }

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Mojo::Base -signatures;
 use Test::Warnings ':report_warnings';
 
 use FindBin;
@@ -13,7 +14,7 @@ use Digest::SHA 'sha1_base64';
 use Mojo::File qw(path tempfile tempdir);
 use OpenQA::Test::TimeLimit '15';
 
-sub file_path { OpenQA::File->new(file => path(@_)) }
+sub file_path (@args) { OpenQA::File->new(file => path(@args)) }
 
 subtest 'base' => sub {
     my $file = file_path($FindBin::Bin, 'data', 'ltp_test_result_format.json');

--- a/t/40-openqa-clone-job.t
+++ b/t/40-openqa-clone-job.t
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Mojo::Base -signatures;
 use Test::Warnings qw(warning :report_warnings);
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
@@ -12,10 +13,10 @@ use Test::MockModule;
 
 $ENV{OPENQA_CONFIG} = "$FindBin::Bin/data";
 
-sub test_once {
+sub test_once (@args) {
     # Report failure at the callsite instead of the test function
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    test_cmd('script/openqa-clone-job', @_);
+    test_cmd('script/openqa-clone-job', @args);
 }
 
 require "$FindBin::Bin/../script/openqa-clone-job";

--- a/t/40-script_load_dump_templates.t
+++ b/t/40-script_load_dump_templates.t
@@ -20,16 +20,16 @@ use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 
 
-sub test_once {
+sub test_once (@args) {
     # Report failure at the callsite instead of the test function
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    test_cmd(path(curfile->dirname, '../script/openqa-load-templates')->realpath, @_);
+    test_cmd(path(curfile->dirname, '../script/openqa-load-templates')->realpath, @args);
 }
 
-sub dump_templates {
+sub dump_templates (@args) {
     # Report failure at the callsite instead of the test function
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    test_cmd(path(curfile->dirname, '../script/openqa-dump-templates')->realpath, @_);
+    test_cmd(path(curfile->dirname, '../script/openqa-dump-templates')->realpath, @args);
 }
 
 sub decode { Cpanel::JSON::XS->new->relaxed->decode(path(shift)->slurp); }

--- a/t/40-script_openqa-clone-custom-git-refspec.t
+++ b/t/40-script_openqa-clone-custom-git-refspec.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Mojo::Base -signatures;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
@@ -14,12 +15,12 @@ use OpenQA::Test::Utils qw(run_cmd test_cmd);
 # prevent all network access to stay local
 my $cmd = 'unshare -r -n script/openqa-clone-custom-git-refspec';
 
-sub run_once { run_cmd($cmd, @_) }
+sub run_once (@args) { run_cmd($cmd, @args) }
 
-sub test_once {
+sub test_once (@args) {
     # Report failure at the callsite instead of the test function
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    test_cmd($cmd, @_);
+    test_cmd($cmd, @args);
 }
 
 # instruct openqa-clone-custom-git-refspec to use dry-run modes for all calls

--- a/t/api/14-plugin_obs_rsync_async.t
+++ b/t/api/14-plugin_obs_rsync_async.t
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Mojo::Base -signatures;
 
 use IPC::Run qw(start);
 use FindBin;
@@ -29,13 +30,13 @@ sub start_gru {
 # we need gru running to test response 200
 my $gru = start_gru();
 
-sub _jobs {
-    my $results = $t->app->minion->backend->list_jobs(0, 400, {tasks => ['obs_rsync_run'], states => \@_});
+sub _jobs (@args) {
+    my $results = $t->app->minion->backend->list_jobs(0, 400, {tasks => ['obs_rsync_run'], states => \@args});
     return $results->{total}, $results->{jobs};
 }
 
-sub _jobs_cnt {
-    (my $cnt, undef) = _jobs(@_);
+sub _jobs_cnt (@args) {
+    (my $cnt, undef) = _jobs(@args);
     return $cnt;
 }
 
@@ -73,16 +74,16 @@ sub sleep_until_all_jobs_finished {
 
 # this function communicates with t/data/openqa-trigger-from-obs/script/rsync.sh
 # when file .$project-ready is created, then rsync process should finish
-sub signal_rsync_ready {
-    foreach (@_) {
+sub signal_rsync_ready (@args) {
+    foreach (@args) {
         my $filename = Mojo::File->new($home, 'script', ".$_-ready")->to_string;
         open my $fh, '>', $filename || die "Cannot create file $filename: $!";
         close $fh;
     }
 }
 
-sub unlink_signal_rsync_ready {
-    foreach (@_) {
+sub unlink_signal_rsync_ready (@args) {
+    foreach (@args) {
         my $filename = Mojo::File->new($home, 'script', ".$_-ready")->to_string;
         -f $filename || next;
         unlink $filename || die "Cannot unlink file $filename: $!";

--- a/t/lib/CoverageWorkaround.pm
+++ b/t/lib/CoverageWorkaround.pm
@@ -75,7 +75,8 @@ my $patched_pp_leave;    # apply 134812 fix below
     *B::Deparse::pp_leave = \&pp_leave;
 }
 
-sub pp_leave {    # fix https://rt.cpan.org/Ticket/Display.html?id=134812
+# fix https://rt.cpan.org/Ticket/Display.html?id=134812
+sub pp_leave {    ## no critic (Subroutines::RequireArgUnpacking)
     my $self = shift;
     my ($op) = @_;
 

--- a/t/ui/27-plugin_obs_rsync_gru.t
+++ b/t/ui/27-plugin_obs_rsync_gru.t
@@ -21,8 +21,8 @@ package FakeMinionJob {
     has id => 0;
     has app => sub { $app };
     has retries => 200;
-    sub finish { $_[0]->{state} = 'finished'; $_[0]->{result} = $_[1] }
-    sub info { {notes => {project_lock => 1}} }
+    sub finish ($self, $result) { $self->{state} = 'finished'; $self->{result} = $result }
+    sub info (@) { {notes => {project_lock => 1}} }
 }    # uncoverable statement
 
 $t->post_ok('/admin/obs_rsync/Proj1/runs' => $params)->status_is(201, 'trigger rsync');


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies
can ensure a coherent style and avoid common mistakes.

https://metacpan.org/pod/Perl::Critic::Policy::Subroutines::RequireArgUnpacking

Policy description:
> Subroutines that use `@_` directly instead of unpacking the arguments to
> local variables first have two major problems. First, they are very hard to
> read. If you're going to refer to your variables by number instead of by
> name, you may as well be writing assembler code! Second, `@_` contains
> aliases to the original variables! If you modify the contents of a `@_`
> entry, then you are modifying the variable outside of your subroutine.