### PR TITLE
apparmor: Add jsonnet to worker profile

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -117,6 +117,7 @@
   /usr/bin/isotovideo rix,
   /usr/bin/isoinfo rix,
   /usr/bin/jq rix,
+  /usr/bin/jsonnet rix,
   /usr/bin/podman rix,
   /usr/bin/lscpu rCx,
   /{usr/,}bin/mkdir rix,


### PR DESCRIPTION
This would fix [execution denial](https://openqa.opensuse.org/tests/5879908/logfile?filename=autoinst-log.txt#line-5814) when running jobs on o3, found out by chance as we don't normally use `libsonnet` profiles at the moment.

This was missing from #6842
