### PR TITLE
PART 2: refactor: leverage polymorphism for unauthenticated access fallback - After #7331

### DIFF
--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -85,13 +85,18 @@ sub auth ($self) {
         elsif (my $key = $self->req->headers->header('X-API-Key')) {
             ($user, $reason) = $self->_key_auth($reason, $key);
         }
-        elsif ($self->_auth_method_is_none()) {
-            $user = $self->schema->resultset('Users')->find({username => DEFAULT_ADMIN});
-            $reason = undef;
-        }
+        # Fallback for unauthenticated access (polymorphic)
         else {
-            $log->trace('No API key from client');
-            $reason = 'no api key';
+            my $auth_method = $self->app->config->{auth}->{method} // '';
+            my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";
+            if (my $sub = $auth_module->can('unauthenticated_user')) {
+                $user = $auth_module->$sub($self->app);
+                $reason = undef if $user;
+            }
+            unless ($user) {
+                $log->trace('No API key from client');
+                $reason = 'no api key';
+            }
         }
     }
 

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -96,13 +96,11 @@ sub _auth ($self) {
         elsif (my $key = $self->req->headers->header('X-API-Key')) {
             ($user, $reason) = $self->_key_auth($reason, $key);
         }
-        elsif ($self->_auth_method_is_none()) {
-            $user = $self->schema->resultset('Users')->find({username => DEFAULT_ADMIN});
-            $reason = undef;
-        }
         else {
-            $log->trace('No API key from client');
-            $reason = 'no api key';
+            my $auth_module = 'OpenQA::WebAPI::Auth::' . ($self->app->config->{auth}->{method} // '');
+            $user = $auth_module->can('unauthenticated_user') ? $auth_module->unauthenticated_user($self->app) : undef;
+            $reason = $user ? undef : 'no api key';
+            $log->trace('No API key from client') unless $user;
         }
     }
 

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -53,17 +53,16 @@ sub _current_user ($c) {
     # If the value is not in the stash
     my $current_user = $c->stash('current_user');
     unless ($current_user && ($current_user->{no_user} || defined $current_user->{user})) {
-        my $is_auth_method_none = ($c->app->config->{auth}->{method} // '') eq 'None';
-        # Avoid auto-login as admin for requests with API credentials.
-        # Otherwise, the 'auth' method would reject the request due to a
-        # missing CSRF token before it even checks the API credentials.
-        my $id = $c->session->{user} // ($is_auth_method_none && !$c->is_api_request ? DEFAULT_ADMIN : undef);
-        my $users = $c->schema->resultset('Users');
-        my $user = $id ? $users->find({username => $id}) : undef;
-        if ($is_auth_method_none && $id && $id eq DEFAULT_ADMIN) {
-            $user ||= $users->create_user(DEFAULT_ADMIN, fullname => 'Administrator', email => 'admin@example.com');
-            $user->update({is_admin => 1, is_operator => 1}) unless $user->is_admin && $user->is_operator;
+        my $auth_method = $c->app->config->{auth}->{method} // '';
+        my $auth_module = "OpenQA::WebAPI::Auth::$auth_method";
+        my $fallback_user;
+        if (!$c->is_api_request && (my $sub = $auth_module->can('unauthenticated_user'))) {
+            $fallback_user = $auth_module->$sub($c->app);
         }
+        }
+
+        my $id = $c->session->{user};
+        my $user = $id ? $c->schema->resultset('Users')->find({username => $id}) : $fallback_user;
         $c->stash(current_user => $current_user = $user ? {user => $user} : {no_user => 1});
     }
 

--- a/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
+++ b/lib/OpenQA/Shared/Plugin/SharedHelpers.pm
@@ -53,17 +53,12 @@ sub _current_user ($c) {
     # If the value is not in the stash
     my $current_user = $c->stash('current_user');
     unless ($current_user && ($current_user->{no_user} || defined $current_user->{user})) {
-        my $is_auth_method_none = ($c->app->config->{auth}->{method} // '') eq 'None';
-        # Avoid auto-login as admin for requests with API credentials.
-        # Otherwise, the 'auth' method would reject the request due to a
-        # missing CSRF token before it even checks the API credentials.
-        my $id = $c->session->{user} // ($is_auth_method_none && !$c->is_api_request ? DEFAULT_ADMIN : undef);
-        my $users = $c->schema->resultset('Users');
-        my $user = $id ? $users->find({username => $id}) : undef;
-        if ($is_auth_method_none && $id && $id eq DEFAULT_ADMIN) {
-            $user ||= $users->create_user(DEFAULT_ADMIN, fullname => 'Administrator', email => 'admin@example.com');
-            $user->update({is_admin => 1, is_operator => 1}) unless $user->is_admin && $user->is_operator;
-        }
+        my $auth_module = 'OpenQA::WebAPI::Auth::' . ($c->app->config->{auth}->{method} // '');
+        my $fallback_user = !$c->is_api_request
+          && $auth_module->can('unauthenticated_user') ? $auth_module->unauthenticated_user($c->app) : undef;
+
+        my $id = $c->session->{user};
+        my $user = $id ? $c->schema->resultset('Users')->find({username => $id}) : $fallback_user;
         $c->stash(current_user => $current_user = $user ? {user => $user} : {no_user => 1});
     }
 

--- a/lib/OpenQA/WebAPI/Auth/None.pm
+++ b/lib/OpenQA/WebAPI/Auth/None.pm
@@ -21,4 +21,12 @@ sub auth_login ($self) {
     return (error => 0);
 }
 
+sub unauthenticated_user ($self, $app) {
+    my $user = $app->schema->resultset('Users')->find({username => DEFAULT_ADMIN});
+    if ($user && (!$user->is_admin || !$user->is_operator)) {
+        $user->update({is_admin => 1, is_operator => 1});
+    }
+    return $user;
+}
+
 1;

--- a/lib/OpenQA/WebAPI/Auth/None.pm
+++ b/lib/OpenQA/WebAPI/Auth/None.pm
@@ -21,4 +21,12 @@ sub auth_login ($self) {
     return (error => 0);
 }
 
+sub unauthenticated_user ($self, $app) {
+    my $users = $app->schema->resultset('Users');
+    my $user = $users->find({username => DEFAULT_ADMIN})
+      || $users->create_user(DEFAULT_ADMIN, fullname => 'Administrator', email => 'admin@example.com');
+    $user->update({is_admin => 1, is_operator => 1}) unless $user->is_admin && $user->is_operator;
+    return $user;
+}
+
 1;


### PR DESCRIPTION
Motivation:
Avoid hardcoding specific authentication methods like 'None' in core
controllers and helpers.

Design Choices:
- Introduced 'unauthenticated_user' method in Auth providers.
- Updated Auth controller and SharedHelpers to use this method if
  present.
- Moved 'admin' user auto-login logic for 'None' provider into the
  None.pm module.

Benefits:
Cleaner code, better maintainability, and easier to add future providers
with similar unauthenticated access needs.

After:
* #7331