### PR TITLE
style: Enforce perlcritic policy ProhibitUselessTopic

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple

--- a/lib/OpenQA/Log.pm
+++ b/lib/OpenQA/Log.pm
@@ -211,7 +211,7 @@ sub setup_log ($app, $logfile = undef, $logdir = undef, $level = undef) {
 }
 
 sub redact_settings ($vars) {
-    return {map { $_ !~ qr/(^_SECRET_|_PASSWORD)/ ? ($_ => $vars->{$_}) : ($_ => '[redacted]') } keys %$vars};
+    return {map { m/(^_SECRET_|_PASSWORD)/ ? ($_ => '[redacted]') : ($_ => $vars->{$_}) } keys %$vars};
 }
 
 sub redact_settings_in_file ($file) {

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -464,8 +464,8 @@ is used.
 sub _parse_dep_variable ($value, $job_settings) {
     return unless defined $value;
     return map {
-        if ($_ =~ /^(.+)\@([^@]+)$/) { [$1, $2] }
-        elsif ($_ =~ /^(.+):([^:]+)$/) { [$1, $2] }    # for backwards compatibility
+        if (m/^(.+)\@([^@]+)$/) { [$1, $2] }
+        elsif (m/^(.+):([^:]+)$/) { [$1, $2] }    # for backwards compatibility
         else { [$_, $job_settings->{MACHINE}] }
     } split /\s*,\s*/, $value;
 }

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -136,7 +136,7 @@ sub create_from_settings ($self, $settings, $scheduled_product_id = undef) {
     my %settings = %$settings;
     my %new_job_args;
 
-    my @invalid_keys = grep { $_ =~ /^(PUBLISH_HDD|FORCE_PUBLISH_HDD|STORE_HDD)\S+(\d+)$/ && $settings{$_} =~ /\// }
+    my @invalid_keys = grep { /^(PUBLISH_HDD|FORCE_PUBLISH_HDD|STORE_HDD)\S+(\d+)$/ && $settings{$_} =~ /\// }
       keys %settings;
     die 'The ' . join(',', @invalid_keys) . " cannot include / in value\n" if @invalid_keys;
 
@@ -338,7 +338,7 @@ sub _search_modules ($self, $module_re) {
         my $stderr;
         IPC::Run::run(\@cmd, \undef, \$stdout, \$stderr);
         next if $stderr;
-        push @results, map { $_ =~ s/\..*$//; basename $_ } split /\n/, $stdout;
+        push @results, map { s/\..*$//; basename $_ } split /\n/, $stdout;
     }
     return \@results;
 }

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -71,7 +71,7 @@ sub _load_prio_throttling ($app, $config) {
         $app->log->warn("Wrong format in openqa.ini 'prio_throttling_parameters': $throttling");
         return;
     }
-    my %hash = map { my ($k, $s, $r) = $_ =~ /$u/g; $k => {scale => $s, reference => $r // 0} }
+    my %hash = map { my ($k, $s, $r) = /$u/g; $k => {scale => $s, reference => $r // 0} }
       split /,/, $throttling;
     return \%hash;
 }

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -405,7 +405,7 @@ sub test_junit_file {
     $testdir->list_tree->each(
         sub {
             fail 'json result: filename expected to be like result-\d_.*\.json but is ' . $_
-              unless $_ =~ qr/result-\d_.*\.json/;
+              unless m/result-\d_.*\.json/;
             my $res = decode_json $_->slurp;
             is ref $res, 'HASH', 'json result: can be decoded' or always_explain $_->slurp;
             fail 'json result: exists $res->{result}' unless exists $res->{result};
@@ -488,7 +488,7 @@ sub test_xunit_file {
     $testdir->list_tree->each(
         sub {
             fail 'json result: filename expected to be like result-.*\.json but is ' . $_
-              unless $_ =~ qr/result-.*\.json/;
+              unless m/result-.*\.json/;
             my $res = decode_json $_->slurp;
             is ref $res, 'HASH', 'json result: can be decoded' or always_explain $_->slurp;
             fail 'json result: exists $res->{result}' unless exists $res->{result};

--- a/t/compile/01-compile-check-all.t
+++ b/t/compile/01-compile-check-all.t
@@ -37,7 +37,7 @@ if (-d '.git' and which('git')) {
     chomp @all_git_files;
     my %skip = map { $_ => undef } @$SKIP;
     @files = map { $root . $_ }
-      grep { !-l $_ && !exists $skip{$_} && $_ !~ /^(external|t|xt)\// } @all_git_files;    # Exclude files to skip
+      grep { !-l $_ && !exists $skip{$_} && !/^(external|t|xt)\// } @all_git_files;    # Exclude files to skip
 }
 else {
     @files = ($test->all_pm_files('lib'), $test->all_pl_files('script'));


### PR DESCRIPTION
RegularExpressions::ProhibitUselessTopic

Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

https://metacpan.org/pod/Perl::Critic::Policy::RegularExpressions::ProhibitUselessTopic

Policy description:
> It is not necessary to specify the topic variable $_ when matching against a
> regular expression.