### PR TITLE
style: Enforce perlcritic policy Variables::ProtectPrivateVars

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1148,7 +1148,7 @@ $job_mock->unmock($_) for qw(_upload_results _upload_results_step_1_post_status 
 
 subtest 'Dynamic schedule' => sub {
     my $job_mock = Test::MockModule->new('OpenQA::Worker::Job');
-    my $orig = \&OpenQA::Worker::Job::_read_json_file;
+    my $orig = \&OpenQA::Worker::Job::_read_json_file;    ## no critic (Variables::ProtectPrivateVars)
     my $read_schedule = 0;
     $job_mock->redefine(
         _read_json_file => sub {
@@ -1228,7 +1228,7 @@ subtest 'Dynamic schedule' => sub {
 };
 
 subtest 'image optimization' => sub {
-    my $opt = \&OpenQA::Worker::Job::_optimize_image;
+    my $opt = \&OpenQA::Worker::Job::_optimize_image;    ## no critic (Variables::ProtectPrivateVars)
     local $ENV{OPENQA_LOGFILE} = undef;
     combined_like {
         is $opt->('foo', {OPTIMIZE_IMAGES => 0}), 0, 'image optimization can be skipped';

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -52,7 +52,7 @@ my %parent_settings = (
 );
 
 subtest 'running command' => sub {
-    my $run = \&OpenQA::Script::CloneJob::_run_cmd;
+    my $run = \&OpenQA::Script::CloneJob::_run_cmd;    ## no critic (Variables::ProtectPrivateVars)
     combined_like {
         like $run->('does-not-exist'), qr/Failed.*does-not-exist.*No such/i, 'error if command does not exist'
     }
@@ -61,7 +61,7 @@ subtest 'running command' => sub {
     is $run->('true'), '', 'no error if command succeeds';
 
     subtest 'get URL from command' => sub {
-        my $url_from_cmd = \&OpenQA::Script::CloneJob::_url_from_cmd;
+        my $url_from_cmd = \&OpenQA::Script::CloneJob::_url_from_cmd;    ## no critic (Variables::ProtectPrivateVars)
         my $res = $url_from_cmd->(echo => qw(-n http://foo/bar));
         is $res, 'http://foo/bar', 'got URL';
         is ref $res, 'Mojo::URL', 'URL returned as Mojo::URL ref';

--- a/t/api/10-jobgroups.t
+++ b/t/api/10-jobgroups.t
@@ -597,7 +597,7 @@ subtest 'update default_keep_logs_in_days and default_keep_results_in_days' => s
 };
 
 subtest 'helper for removing test suite defaults' => sub {
-    my $helper = \&OpenQA::Schema::Result::JobGroups::_remove_test_suite_defaults;
+    my $helper = \&OpenQA::Schema::Result::JobGroups::_remove_test_suite_defaults;    ## no critic (Variables::ProtectPrivateVars)
     my $group = {scenarios => {x86_64 => {product => [{foo => {machine => '64bit'}}]}}};
     my $test_suites = {x86_64 => {foo => 1}};
     my $scenarios = [];

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -304,8 +304,8 @@ sub create_websocket_server ($port, $bogus, $with_embedded_scheduler = undef, $n
         if ($bogus) {
             monkey_patch 'OpenQA::WebSockets::Controller::Worker', ws => sub {
                 my $c = shift;
-                $c->on(json => \&OpenQA::WebSockets::Controller::Worker::_message);
-                $c->on(finish => \&OpenQA::WebSockets::Controller::Worker::_finish);
+                $c->on(json => \&OpenQA::WebSockets::Controller::Worker::_message);    ## no critic (Variables::ProtectPrivateVars)
+                $c->on(finish => \&OpenQA::WebSockets::Controller::Worker::_finish);    ## no critic (Variables::ProtectPrivateVars)
             };
         }
         local @ARGV = ('daemon');


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

https://metacpan.org/pod/Perl::Critic::Policy::Variables::ProtectPrivateVars

Description:
> By convention Perl authors (like authors in many other languages) indicate
> private methods and variables by inserting a leading underscore before the
> identifier. This policy catches attempts to access private variables from
> outside the package itself.

We currently only violate that in tests, which is ok