### PR TITLE
fix(apparmor): allow hooks access to os-autoinst-scripts

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -131,6 +131,7 @@
   /opt/openqa-trigger-from-obs/*:*/*products* rw,
   /opt/openqa-trigger-from-obs/*:*/*/*products* rw,
 
+  /opt/os-autoinst-scripts/ r,
   /opt/os-autoinst-scripts/** rix,
   /usr/share/openqa/script/openqa-cli px,
   /usr/share/openqa/script/openqa-clone-job mrix,


### PR DESCRIPTION
    apparmor=DENIED operation=open class="file"
        profile=/usr/share/openqa/script/openqa
        name=/opt/os-autoinst-scripts/ pid=1759680
        comm=openqa-llm-inve requested_mask=r denied_mask=r
        fsuid=geekotest ouid=geekotest

See: https://progress.opensuse.org/issues/200393