### PR TITLE
fix(apparmor) allow ssh access to ssh_config.d

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -109,6 +109,7 @@
     #include <abstractions/nameservice>
 
     /{usr/,}etc/ssh/ssh_config r,
+    /{usr/,}etc/ssh/ssh_config.d/ r,
     /{usr/,}etc/ssh/ssh_config.d/** r,
     /etc/ssh/ssh_known_hosts r,
     /etc/ssl/openssl.cnf r,


### PR DESCRIPTION
    apparmor=DENIED operation=open class="file"
        profile=/usr/share/openqa/script/openqa///usr/bin/ssh
        name=/usr/etc/ssh/ssh_config.d/ pid=1976574 comm=ssh
        requested_mask=r denied_mask=r fsuid=geekotest ouid=root

See: https://progress.opensuse.org/issues/200393