### PR TITLE
style: Rewrite some for loops in foreach style

### DIFF
--- a/lib/OpenQA/File.pm
+++ b/lib/OpenQA/File.pm
@@ -86,7 +86,7 @@ sub split ($self, $chunk_size = undef) {
     my $n_chunks = _chunk_size($self->size(), $chunk_size);
     my $files = OpenQA::Files->new();
 
-    for (my $i = 1; $i <= $n_chunks; $i++) {
+    for my $i (1 .. $n_chunks) {
         #$piece->generate_sum; # XXX: Generate sha here and ditch content?
         $files->add($self->_chunk($i, $n_chunks, $chunk_size, $residual, $total_cksum));
     }

--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -136,7 +136,7 @@ sub restore_tree_section ($ref) {
     try {
         walker $ref => sub ($key, $value, $keys, $parent) {
             my $hash = $ref;
-            for (my $i = 0; $i < scalar @$keys - 1; $i++) {
+            for my $i (0 .. $#$keys - 1) {
                 my ($type, $kk) = @{$keys->[$i]};
                 $hash = $hash->{$kk} if $type eq 'HASH';
                 $hash = $hash->[$kk] if $type eq 'ARRAY';

--- a/lib/OpenQA/Scheduler/WorkerSlotPicker.pm
+++ b/lib/OpenQA/Scheduler/WorkerSlotPicker.pm
@@ -42,7 +42,7 @@ sub _reduce_matching_workers ($self) {
     #       of those jobs and prioritize the jobs as usual via _allocate_worker_with_priority.
     my $picked_matching_worker_slots = $self->{_picked_matching_worker_slots};
     my $to_be_scheduled = $self->{_to_be_scheduled};
-    for (my $i = 0; $i != @$to_be_scheduled; ++$i) {
+    for my $i (0 .. $#$to_be_scheduled) {
         $to_be_scheduled->[$i]->{matching_workers} = [$picked_matching_worker_slots->[$i] // ()];
     }
     return $picked_matching_worker_slots;
@@ -91,7 +91,7 @@ sub _swap_slot_with_competitor_job ($self, $visited_worker_slots_by_host, $match
         next if $self->{_one_host_only} && $self->_worker_host($alternative_matching_worker) ne $host;
 
         # make the competitor job use the alternative we have just found
-        for (my $i = 0; $i != @$matching_worker_slots; ++$i) {
+        for my $i (0 .. $#$matching_worker_slots) {
             next unless $matching_worker_slots->[$i]->id == $id;
             $matching_worker_slots->[$i] = $alternative_matching_worker;
             last;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1859,7 +1859,7 @@ sub test_resultfile_list ($self) {
     }
 
     my $virtio_console_num = $self->settings_hash->{VIRTIO_CONSOLE_NUM} // 1;
-    for (my $i = 1; $i < $virtio_console_num; ++$i) {
+    for my $i (1 .. $virtio_console_num - 1) {
         my $f = "serial_terminal$i.txt";
         push @$filelist_existing, $f if -s "$testresdir/$f";
     }

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -862,7 +862,7 @@ sub _populate_wanted_jobs_for_parent_dependencies ($jobs, $wanted, $skip_chained
     $jobs = _sort_dep($jobs);
 
     # iterate in reverse order to go though children first and being able to easily delete from $jobs
-    for (my $i = $#{$jobs}; $i >= 0; --$i) {
+    for my $i (reverse 0 .. $#$jobs) {
         my $job = $jobs->[$i];
 
         # parse relevant parents from job settings

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -854,7 +854,7 @@ sub _restart ($self, %args) {
 
     my $duplicates = $res->{duplicates};
     my @urls;
-    for (my $i = 0; $i < @$duplicates; $i++) {
+    for my $i (0 .. $#$duplicates) {
         my $result = $duplicates->[$i];
         my %event_data = (id => $jobs->[$i], result => $result, auto => $auto);
         $event_data{comment} = $comment if defined $comment;

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -310,7 +310,7 @@ subtest 'Plugins handling' => sub {
         my ($key, $value, $keys) = @_;
 
         my $r_hash = \%reconstructed_hash;
-        for (my $i = 0; $i < scalar @$keys; $i++) {
+        for my $i (0 .. $#$keys) {
             $r_hash->{$keys->[$i]} //= {};
             $r_hash = $r_hash->{$keys->[$i]} if $i < (scalar @$keys) - 1;
         }

--- a/t/31-client_file.t
+++ b/t/31-client_file.t
@@ -170,7 +170,7 @@ sub compare {
 
     is OpenQA::File::_chunk_size($original->size, $chunk_size), $pieces->size, 'Size and pieces matches!';
 
-    for (my $i = 1; $i <= $pieces->size; $i++) {
+    for my $i (1 .. $pieces->size) {
         my $piece = $original->get_piece($i => $chunk_size);
         my $from_split = $pieces->get($i - 1);
         is_deeply $piece, $from_split, 'Structs are matching';

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -87,7 +87,7 @@ my $max_login_attempts = $ENV{OPENQA_DEVEL_MODE_TEST_MAX_LOGIN_ATTEMPTS} // 10;
 sub relogin_as ($user) {
     my $login_text = '';
     my $expected_login_text = 'Logged in as ' . $user;
-    for (my $attempts = 0; $attempts < $max_login_attempts; ++$attempts) {
+    for my $attempts (0 .. $max_login_attempts - 1) {
         if ($login_text ne 'Login') {
             $driver->get('/logout');
             $login_text = $driver->find_element('#user-action a')->get_text;

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -83,7 +83,7 @@ sub wait_for_result_panel ($driver, $result_panel, $context = undef, $fail_on_in
     my $msg = "Expected result for $context not found";
 
     my $timeout = OpenQA::Test::TimeLimit::scale_timeout(30) / $check_interval;
-    for (my $count = 0; $count < $timeout; $count++) {
+    for my $count (0 .. $timeout - 1) {
         wait_for_ajax(msg => "wait_for_result_panel: waiting for '$result_panel' (count $count of $timeout)");
         my $status_text = find_status_text($driver);
         return 1 if $status_text =~ $result_panel;

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -555,7 +555,7 @@ subtest 'Showing new needles limited to the 5 most recent ones' => sub {
 
     # add 6 new needles (makes 7 new needles in total since one has already been added)
     my $needle_name_input = $driver->find_element_by_id('needleeditor_name');
-    for (my $i = 0; $i != 7; ++$i) {
+    for my $i (0 .. 6) {
         # enter new needle name
         my $new_needle_name = "$needlename-$i";
         $needle_name_input->clear();


### PR DESCRIPTION
Could be enforced with the perlcritic policy
ControlStructures::ProhibitCStyleForLoops, but it complains about too many
loops that can't be rewritten with a simple `for my $i (@array)`
or `for my $i (1 .. 23)`

Issue: https://progress.opensuse.org/issues/188058

https://metacpan.org/pod/Perl::Critic::Policy::ControlStructures::ProhibitCStyleForLoops

Description:
> The 3-part for loop that Perl inherits from C is butt-ugly, and only really
> necessary if you need irregular counting. The very Perlish .. operator is
> much more elegant and readable.