### PR TITLE
fix(apparmor) allow tty access to hooks

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -8,6 +8,7 @@
   #include <abstractions/nameservice>
   #include <abstractions/perl>
 
+  /dev/tty wr,
   /etc/gitconfig r,
   /etc/openqa/client.conf r,
   /etc/openqa/client.conf.d/ r,


### PR DESCRIPTION
    apparmor=DENIED operation=open class="file"
        profile=/usr/share/openqa/script/openqa name=/dev/tty
        pid=1976574 comm=sh requested_mask=wr denied_mask=wr
        fsuid=geekotest ouid=root
    apparmor=DENIED operation=open class="file"
        profile=/usr/share/openqa/script/openqa name=/dev/tty
        pid=1976066 comm=openqa-label-kn requested_mask=wr denied_mask=wr
        fsuid=geekotest ouid=root

See: https://progress.opensuse.org/issues/200393