### PR TITLE
perf(cleanup): replace N+1 per-group queries with single batch query

### DIFF
--- a/lib/OpenQA/Schema/ResultSet/Assets.pm
+++ b/lib/OpenQA/Schema/ResultSet/Assets.pm
@@ -141,28 +141,15 @@ sub status ($self, %options) {
             END_SQL
     }
 
-    # define a query to find the latest job for each asset by group
-    my $max_job_by_group_query;
-    if ($options{compute_max_job_by_group}) {
-        $max_job_by_group_query = <<~'END_SQL';
-            select a.id as asset_id, max(j.id) as max_job
-            from jobs_assets ja
-              join jobs j on j.id=ja.job_id
-              join assets a on a.id=ja.asset_id
-              where group_id = ?
-            group by a.id;
-            END_SQL
-    }
-    else {
-        $max_job_by_group_query = <<~'END_SQL';
-            select a.id as asset_id
-            from jobs_assets ja
-              join jobs j on j.id=ja.job_id
-              join assets a on a.id=ja.asset_id
-              where group_id = ?
-            group by a.id;
-            END_SQL
-    }
+    # fetch all asset-group associations in a single batch query
+    my $max_job_by_group_query = <<~'END_SQL';
+        select a.id as asset_id, j.group_id, max(j.id) as max_job
+        from jobs_assets ja
+          join jobs j on j.id=ja.job_id
+          join assets a on a.id=ja.asset_id
+          where j.group_id IS NOT NULL
+        group by a.id, j.group_id;
+        END_SQL
     my $max_job_by_group_prepared_query = $dbh->prepare($max_job_by_group_query);
 
     # define variables; add "zero group" for groupless assets
@@ -217,6 +204,13 @@ sub status ($self, %options) {
                 push @assets, \%asset;
             }
 
+            # query all asset-group associations in one batch
+            $max_job_by_group_prepared_query->execute();
+            my %group_assets;
+            while (my $result = $max_job_by_group_prepared_query->fetchrow_hashref) {
+                $group_assets{$result->{group_id}}{$result->{asset_id}} = $result->{max_job};
+            }
+
             # query list of job groups to show assets by job group
             # note: We collect data required for /admin/assets *and* the limit_assets task.
             my $groups = $schema->resultset('JobGroups');
@@ -249,12 +243,12 @@ sub status ($self, %options) {
                     group => $group->full_name,
                 };
 
-                # add the max job ID for this group
-                $max_job_by_group_prepared_query->execute($group_id);
-                while (my $result = $max_job_by_group_prepared_query->fetchrow_hashref) {
-                    my $asset_info = $asset_info{$result->{asset_id}} or next;
+                # populate asset-group associations from the pre-fetched batch
+                my $assets_for_group = $group_assets{$group_id} // {};
+                for my $asset_id (keys %$assets_for_group) {
+                    my $asset_info = $asset_info{$asset_id} or next;
                     my $init_max_job = $asset_info->{max_job} || 0;
-                    my $res_max_job = $result->{max_job};
+                    my $res_max_job = $assets_for_group->{$asset_id};
                     $asset_info->{groups}->{$group_id} = $res_max_job;
                     $asset_info->{parents}->{$parent_id} = 1 if defined $parent_id;
 

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -64,7 +64,6 @@ sub _limit ($app, $job) {
 
         my $asset_status = $schema->resultset('Assets')->status(
             compute_pending_state_and_max_job => 1,
-            compute_max_job_by_group => 1,
             fail_on_inconsistent_status => 1,
             skip_cache_file => 1,
         );
@@ -127,10 +126,7 @@ sub _limit ($app, $job) {
         _update_exclusively_kept_asset_size($dbh, job_group_parents => $asset_status->{parents});
 
         # recompute the status (after the cleanup) and produce cache file for /admin/assets
-        $schema->resultset('Assets')->status(
-            compute_pending_state_and_max_job => 0,
-            compute_max_job_by_group => 0,
-        );
+        $schema->resultset('Assets')->status(compute_pending_state_and_max_job => 0);
     }
     catch ($e) {
         # retry on errors which are most likely caused by race conditions (we want to avoid locking the tables here)

--- a/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
+++ b/lib/OpenQA/WebAPI/Controller/Admin/Asset.pm
@@ -41,10 +41,7 @@ sub status_json ($self) {
     }
 
     # generate new static JSON file
-    $assets->status(
-        compute_pending_state_and_max_job => $force_refresh,
-        compute_max_job_by_group => 0,
-    );
+    $assets->status(compute_pending_state_and_max_job => $force_refresh);
 
     return !!$self->rendered if $self->_serve_status_json_from_cache;
     $self->render(json => {error => 'Cache file for asset status could not be generated.'}, status => 500);

--- a/t/37-limit_assets.t
+++ b/t/37-limit_assets.t
@@ -440,10 +440,7 @@ subtest 'asset registration considers chained and directly chained parent jobs' 
 subtest 'asset status with pending state, max_job and max_job by group' => sub {
     my $asset_status;
     stdout_like {
-        $asset_status = $schema->resultset('Assets')->status(
-            compute_pending_state_and_max_job => 1,
-            compute_max_job_by_group => 1,
-        )
+        $asset_status = $schema->resultset('Assets')->status(compute_pending_state_and_max_job => 1)
     }
     qr/Skipping asset $empty_asset_id because its name is empty/, 'warning about skipped asset';
     my ($assets_with_max_job, $assets_without_max_job) = prepare_asset_status($asset_status);
@@ -466,20 +463,13 @@ subtest 'asset status without pending state, max_job and max_job by group' => su
     for my $asset (@expected_assets_with_max_job) {
         $asset->{pending} = undef;
         $asset->{last_job} = undef;
-        my $groups = $asset->{groups};
-        for my $group_id (keys %$groups) {
-            $groups->{$group_id} = undef;
-        }
     }
     for my $asset_name (keys %expected_assets_without_max_job) {
         my $asset = $expected_assets_without_max_job{$asset_name};
         $asset->{pending} = undef;
     }
 
-    my $asset_status = $schema->resultset('Assets')->status(
-        compute_pending_state_and_max_job => 0,
-        compute_max_job_by_group => 0,
-    );
+    my $asset_status = $schema->resultset('Assets')->status(compute_pending_state_and_max_job => 0);
     my ($assets_with_max_job, $assets_without_max_job) = prepare_asset_status($asset_status);
     $assets_with_max_job->[5]->{id} = undef;    # might vary
     is_deeply $assets_with_max_job, \@expected_assets_with_max_job, 'assets with max job'


### PR DESCRIPTION
The status() method in ResultSet::Assets previously executed one SQL query per job group to fetch asset-group associations. With 100+ job groups, this meant 100+ queries inside a single REPEATABLE READ transaction.

Replace this N+1 pattern with a single batch query that fetches all (asset_id, group_id, max_job) tuples at once, stored in a hash and looked up per group. This reduces the query count from N+2 to 2.

The compute_max_job_by_group option is removed since the batch query always includes max_job. Previously this option controlled whether max(j.id) appeared in the per-group SELECT:

- When true (_limit caller): max_job was used for the inconsistency check ($res_max_job > $init_max_job -> die) and stored in $asset_info->{groups}->{$group_id}.
- When false (Admin/Asset.pm, second status() call): the query only returned asset_id to populate group membership without max_job.

The batch query now always returns max_job for all callers. This is harmless for the non _limit callers because the inconsistency check only fires when `fail_on_inconsistent_status` is true, which only the _limit code path sets.