### PR TITLE
Include log in IPA results

### DIFF
--- a/lib/OpenQA/Parser/Format/IPA.pm
+++ b/lib/OpenQA/Parser/Format/IPA.pm
@@ -60,6 +60,7 @@ sub parse ($self, $json) {
         my $details = {result => $result->{result}};
         my $text_fn = "IPA-$t_name.txt";
         my $content = join "\n", $t_name, $result->{result};
+        $content .= "\nlog:\t$res->{test}->{log}" if (defined $res->{test}->{log});
 
         $details->{text} = $text_fn;
         $details->{title} = $t_name;


### PR DESCRIPTION
Current implementation of `OpenQA::Parser::Format::IPA` shows very limited information in OpenQA results, both in the `Details` tab and in the `External Results` tab. It causes it to render in both tabs, only 2 lines:

* A first line with the test name
* A second line with the result

However, the parser also supports a log to be included in the external JSON results file which can be uploaded, but not rendered anywhere.

This commit adds to the results' content the log if it is defined, so that is rendered both in `Details` (the first few lines) and in `External Results` tabs (full log).

* Related Ticket: https://jira.suse.com/browse/TEAM-11107
* Run without changes: http://mango.qe.nue2.suse.org/tests/7719
* Run **with** changes: http://mango.qe.nue2.suse.org/tests/7730

Before changes, IPA results will be shown in the `Details` tab like this:

<img width="511" height="523" alt="Screenshot from 2026-05-04 11-53-28" src="https://github.com/user-attachments/assets/0cc073b9-65c0-4fab-9492-d8c3b2f90b25" />

Similarly, in the `External Results` tab information is limited to 2 lines:

<img width="1533" height="349" alt="Screenshot from 2026-05-04 11-54-58" src="https://github.com/user-attachments/assets/7a6db950-786b-4583-b36b-1ee33c6570f4" />

With the changes, results would include the first few lines of the log in the `Details` tab:
<img width="835" height="550" alt="Screenshot from 2026-05-04 11-53-53" src="https://github.com/user-attachments/assets/d7d2ac01-584a-423c-a9b0-2d235c6d20a7" />

And the full log is shown in the `External Results` tab:

<img width="1245" height="647" alt="Screenshot from 2026-05-04 11-54-22" src="https://github.com/user-attachments/assets/c2889257-cce5-46e4-aba6-dcf16785aa07" />

