### PR TITLE
docs: fix broken references to former .asciidoc files

### DIFF
--- a/docs/ContainerizedSetup.md
+++ b/docs/ContainerizedSetup.md
@@ -251,7 +251,7 @@ consecutive numbers for the `--instance` parameter:
 
 You have to put your tests under `data/tests` directory and ISOs under
 `data/factory/iso` directory. For testing openSUSE, follow
-[this guide](https://github.com/os-autoinst/openQA/blob/master/docs/GettingStarted.asciidoc#testing-opensuse-or-fedora).
+[this guide](GettingStarted.md#get-testing).
 
 The test distribution might have additional dependencies which need to be
 installed into the worker container before tests can run. To install those

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -263,7 +263,7 @@ for quicker installation of all Perl modules.
 
 For openSUSE you need the packages `openQA` and `os-autoinst`.
 That should be everything necessary to run an openQA instance. For more
-details check \<\<Installing.asciidoc#\_installation,Installation\>.
+details check [Installation](Installing.md#installation).
 
 If you have to manually install packages, look into the `dependencies.yaml`
 file or the spec file, e.g. `dist/rpm/openQA.spec` (or `dist/rpm/*.spec` in general). You can leave out sections starting with `test_requires` for example.
@@ -300,8 +300,8 @@ for a container with all dependencies.
 The following explains in detail what is necessary to develop openQA code.
 
 For a setup with containers you can check out the
-\<\<Contributing.asciidoc#quick-container-development-setup,Quick container
-development setup\>\> below with a complete list of instructions.
+[Quick container development setup](#quick-container-development-setup)
+below with a complete list of instructions.
 
 Otherwise follow the detailed steps below. This setup is applicable to a
 container environment as well as without.

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -1270,7 +1270,7 @@ several hosts in a single site (that is remote from the main openQA webui
 instance) it results in downloading the same assets several times. In
 such case, one can setup local cache on their own (without using
 openqa-worker-cacheservice service) and share it with workers using
-some network filesystem (see [Installing.asciidoc#Configuring remote workers](Installing.md#Configuring remote workers)
+some network filesystem (see [Configuring remote workers](Installing.md#configuring_remote_workers)
 section above).
 Such setups can use `SYNC_ASSETS_HOOK` in
 [the web UI configuration](GettingStarted.md#configuration) to ensure the

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1371,7 +1371,7 @@ If the YAML document already exists on the openQA host, you can also use
 `SCENARIO_DEFINITIONS_YAML_FILE` which expects the file path of the YAML document
 on the openQA host. One can also specify an HTTP/HTTPs URL via that variable
 when `async=1` is used (see
-[UsersGuide.asciidoc#\_spawning_multiple_jobs_based_on_templates_isos_post](UsersGuide.md#spawning_multiple_jobs_based_on_templates_isos_post)
+[Spawning multiple jobs based on templates - isos post](UsersGuide.md#spawning_multiple_jobs_based_on_templates_isos_post)
 for details). Then this file is downloaded by the openQA host. The specified
 host name must be allowed via the configuration setting
 `scenario_definitions_allowed_hosts`.


### PR DESCRIPTION
Motivation: In previous commits (4e47ce9d5, d5aaf475e, 611e154a4, 278e742de),
.asciidoc documents were migrated to markdown, but some references still
pointed to the old files and used Asciidoc syntax.

Design Choices:
- Updated broken links to point to the new .md files.
- Converted Asciidoc-style cross-references (<<File.asciidoc#anchor,Text>>) to
  standard Markdown links ([Text](File.md#anchor)).
- Used explicit anchors (<a id="...">) where available in the target files.
- Fixed an absolute GitHub URL to a relative one.

Benefits:
- Restores working documentation links.
- Consistent use of Markdown syntax across the docs.

Related issue: 4e47ce9d5, d5aaf475e, 611e154a4, 278e742de