### PR TITLE
ci: Ensure all required dependencies are part of the devel container

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ pull_request_rules:
           # "unresolvable" is not reported in general:
           # https://trello.com/c/0N3jHq5M/2257-report-back-to-scm-when-build-results-arent-failed-and-succeeded
           # So we need to require the number of tests explicitly:
-          - "#check-success>=47"
+          - "#check-success>=45"
           - status-success=static-check-containers
           - status-success=webui-docker-compose
           - "#check-failure=0"

--- a/container/devel/Dockerfile
+++ b/container/devel/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper in -y os-autoinst-devel openQA-devel vim nodejs-default git mc perl-Devel-REPL perl-Term-ReadKey && \
+RUN zypper in -y os-autoinst-devel openQA-devel vim nodejs-default git mc perl-Devel-REPL perl-Term-ReadKey perl-TAP-Harness-JUnit && \
     zypper clean -a
 
 ENV OPENQA_DIR=/opt/openqa

--- a/cpanfile
+++ b/cpanfile
@@ -121,6 +121,7 @@ on 'develop' => sub {
     requires 'Perl::Critic::Community';
     requires 'Perl::Tidy', '== 20260204.0.0';
     requires 'Pod::Markdown';
+    requires 'TAP::Harness::JUnit';
     requires 'Test::CheckGitStatus';
     requires 'Test::Perl::Critic';
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -85,8 +85,11 @@ devel_no_selenium_requires:
   sudo:
   tar:
   xorg-x11-fonts:
+  pandoc:  # for generating HTML documentation
+  python3-weasyprint:  # for generating PDF documentation
   perl(Perl::Tidy): '== 20260204.0.0'
   perl(Test::CheckGitStatus):
+  perl(TAP::Harness::JUnit):  # for JUnit-compatible test results
 
 devel_requires:
   '%devel_no_selenium_requires':
@@ -217,7 +220,6 @@ style_check_requires:
   perl(Perl::Critic::Community):
   perl(Code::TidyAll):
   perl(Pod::Markdown):
-  pandoc:
   ShellCheck:
   shfmt:
   python3-gitlint:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -90,11 +90,11 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define style_check_requires ShellCheck pandoc perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-yamllint shfmt
+%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-yamllint shfmt
 # The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml
-%define devel_no_selenium_requires %build_requires %cover_requires %qemu %style_check_requires %test_requires curl make perl(Perl::Tidy) perl(Test::CheckGitStatus) postgresql-devel rsync sudo tar xorg-x11-fonts
+%define devel_no_selenium_requires %build_requires %cover_requires %qemu %style_check_requires %test_requires curl make pandoc perl(Perl::Tidy) perl(TAP::Harness::JUnit) perl(Test::CheckGitStatus) postgresql-devel python3-weasyprint rsync sudo tar xorg-x11-fonts
 # The following line is generated from dependencies.yaml
 %define devel_requires %devel_no_selenium_requires chromedriver
 

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -47,7 +47,12 @@
 %bcond_with devel_package
 %bcond_with munin_package
 %else
+# exclude devel sub package on Leap < 16 as not all develoment dependencies are present anymore
+%if 0%{?is_opensuse} && 0%{?suse_version} < 1600
+%bcond_with devel_package
+%else
 %bcond_without devel_package
+%endif
 %bcond_without munin_package
 %endif
 # runtime requirements that also the testsuite needs


### PR DESCRIPTION
* Move `pandoc` from style requires to devel requires as it is used for
  generating documentation (and not just for style checks)
* Add `python3-weasyprint` as it is required for generating PDF documentation
  and the script to generate documentation fails with a hard error if it is
  missing
* Add `perl(TAP::Harness::JUnit)` as we use it in the CI environment to generate
  JUnit-compatible test results
    * Add it only to the devel container (and not `openQA-devel`) as it is not
      strictly required for normal development and might not be available on all
      targets we build `openQA-devel` for.
    * It is still small enough to add it to the devel container without causing
      too much bloat. This way we can use the devel container in the CI env, not
      needing a separate container.

Related ticket: https://progress.opensuse.org/issues/200609