### PR TITLE
fix(apparmor): allow write to /dev/tty necessary for Leap 16

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -8,7 +8,7 @@
   #include <abstractions/nameservice>
   #include <abstractions/perl>
 
-  /dev/tty r,
+  /dev/tty rw,
   /etc/gitconfig r,
   /etc/openqa/client.conf r,
   /etc/openqa/client.conf.d/ r,


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/200393