### PR TITLE
feat(search): Add job id to search results response

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -127,7 +127,7 @@ sub _search_job_modules ($self, $keywords, $limit) {
             next;
         }
         $last_job = $job_module->job_id;
-        push @results, {occurrence => $job_module->job->name, contents => $contents};
+        push @results, {occurrence => $job_module->job->name, contents => $contents, job_id => $job_module->job_id};
     }
     return \@results;
 }

--- a/t/api/15-search.t
+++ b/t/api/15-search.t
@@ -69,7 +69,8 @@ subtest 'Job modules' => sub {
     $t->json_is(
         '/data/results/modules/0' => {
             occurrence => 'lorem',
-            contents => "tests/lorem/ipsum.pm\n" . 'tests/lorem/ipsum_dolor.py'
+            contents => "tests/lorem/ipsum.pm\n" . 'tests/lorem/ipsum_dolor.py',
+            job_id => $job->id
         },
         'job module found'
     );


### PR DESCRIPTION
Often I need to find out in which job was a module last run, in the current state I need to use the webUI to navigate to the correct job group which is not optimal, having the job id at least exposed via api makes it easier to find what I'm looking for, so I can build scripts on top
