### PR TITLE
feat(search): Add link to job in job modules search

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -383,6 +383,12 @@ function renderSearchResults(query, url) {
           contents.appendChild(document.createTextNode(value.contents));
           item.appendChild(contents);
         }
+        if (value.job_id) {
+          const link = document.createElement('a');
+          link.href = urlWithBase('/tests/' + value.job_id);
+          link.text = 'Go to job';
+          item.appendChild(link);
+        }
         results.append(item);
       });
     });


### PR DESCRIPTION
Follows #7395 

Now that the search api returns the job id, it can also be used to point
to the job in the search UI:

<img width="684" height="82" alt="image" src="https://github.com/user-attachments/assets/a58f164b-07cd-4530-b5dc-026e25e1ce0c" />

I was thinking to change the h5 all together so the "name" could be the link, but that would have made the code a bit cumbersome.


