### PR TITLE
style: Enforce erlcritic policy Modules::ProhibitExcessMainComplexity

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple
@@ -50,3 +50,6 @@ equivalent_modules = Test::Most
 [ValuesAndExpressions::RequireNumberSeparators]
 min_value = 1000000
 
+[Modules::ProhibitExcessMainComplexity]
+# Reduce me!
+max_mccabe = 83


### PR DESCRIPTION
This PR sets a high threshold for the complexity so that it won't currently fail, and we can gradually lower the threshold in a followup ticket.

Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

https://metacpan.org/pod/Perl::Critic::Policy::Modules::ProhibitExcessMainComplexity

Policy Description:
> All else being equal, complicated code is more error-prone and more expensive
> to maintain than simpler code. The first step towards managing complexity is
> to establish formal complexity metrics. One such metric is the McCabe score,
> which describes the number of possible paths through a block of code. This
> Policy approximates the McCabe score by summing the number of conditional
> statements and operators within a block of code. Research has shown that a
> McCabe score higher than 20 is a sign of high-risk, potentially untestable
> code. See http://en.wikipedia.org/wiki/Cyclomatic_complexity for some
> discussion about the McCabe number and other complexity metrics.