### PR TITLE
style: Enforce perlcritic policy Subroutines::ProhibitExcessComplexity

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters ControlStructures::ProhibitCascadingIfElse
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters ControlStructures::ProhibitCascadingIfElse Subroutines::ProhibitExcessComplexity
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple
@@ -57,3 +57,7 @@ max_mccabe = 83
 [ControlStructures::ProhibitCascadingIfElse]
 # Reduce me!
 max_elsif = 5
+
+[Subroutines::ProhibitExcessComplexity]
+# Reduce me!
+max_mccabe = 63


### PR DESCRIPTION
This PR sets a high threshold for the complexity so that it won't currently fail, and we can gradually lower the threshold in a followup ticket.


https://metacpan.org/pod/Perl::Critic::Policy::Subroutines::ProhibitExcessComplexity

Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

Policy Description:
> All else being equal, complicated code is more error-prone and more expensive
> to maintain than simpler code. The first step towards managing complexity is
> to establish formal complexity metrics. One such metric is the McCabe score,
> which describes the number of possible paths through a subroutine. This
> Policy approximates the McCabe score by summing the number of conditional
> statements and operators within a subroutine. Research has shown that a
> McCabe score higher than 20 is a sign of high-risk, potentially untestable
> code. See http://en.wikipedia.org/wiki/Cyclomatic_complexity for some
> discussion about the McCabe number and other complexity metrics.