### PR TITLE
style: Enforce perlcritic policy Miscellanea::ProhibitUselessNoCritic

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple

--- a/lib/OpenQA/Schema/Result/JobNextPrevious.pm
+++ b/lib/OpenQA/Schema/Result/JobNextPrevious.pm
@@ -3,7 +3,6 @@
 
 package OpenQA::Schema::Result::JobNextPrevious;
 
-## no critic (OpenQA::RedundantStrictWarning)
 use Mojo::Base 'DBIx::Class::Core', -signatures;
 
 use Moose;

--- a/lib/OpenQA/Schema/Result/Needles.pm
+++ b/lib/OpenQA/Schema/Result/Needles.pm
@@ -3,7 +3,6 @@
 
 package OpenQA::Schema::Result::Needles;
 
-## no critic (OpenQA::RedundantStrictWarning)
 use 5.018;
 
 use Mojo::Base 'DBIx::Class::Core', -signatures;

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -3,7 +3,6 @@
 
 package OpenQA::Schema::Result::ScheduledProducts;
 
-## no critic (OpenQA::RedundantStrictWarning)
 use Mojo::Base 'DBIx::Class::Core', -signatures;
 
 use DBIx::Class::Timestamps 'now';


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

Policy description:
> Sometimes, you may need to use a "## no critic" annotation to work around a
> false-positive bug in Perl::Critic. But eventually, that bug might get fixed,
> leaving your code with extra "## no critic" annotations lying about. Or you
> may use them to locally disable a Policy, but then later decide to
> permanently remove that Policy entirely from your profile, making some of
> those "## no critic" annotations pointless. Or, you may accidentally disable
> too many Policies at once, creating an opportunity for new violations to slip
> in unnoticed.