### PR TITLE
style: Enforce perlcritic policy Subroutines::ProhibitManyArgs

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters ControlStructures::ProhibitCascadingIfElse Subroutines::ProhibitExcessComplexity Modules::ProhibitConditionalUseStatements CodeLayout::ProhibitHardTabs Community::ConditionalImplicitReturn Variables::ProhibitPackageVars TestingAndDebugging::ProhibitNoWarnings ClassHierarchies::ProhibitOneArgBless Community::POSIXImports InputOutput::ProhibitReadlineInForLoop Subroutines::ProhibitReturnSort Community::OpenArgs InputOutput::ProhibitTwoArgOpen BuiltinFunctions::ProhibitUniversalIsa
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters ControlStructures::ProhibitCascadingIfElse Subroutines::ProhibitExcessComplexity Modules::ProhibitConditionalUseStatements CodeLayout::ProhibitHardTabs Community::ConditionalImplicitReturn Variables::ProhibitPackageVars TestingAndDebugging::ProhibitNoWarnings ClassHierarchies::ProhibitOneArgBless Community::POSIXImports InputOutput::ProhibitReadlineInForLoop Subroutines::ProhibitReturnSort Community::OpenArgs InputOutput::ProhibitTwoArgOpen BuiltinFunctions::ProhibitUniversalIsa Subroutines::ProhibitManyArgs
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple
@@ -67,3 +67,9 @@ add_packages = Config::IniFiles
 
 [TestingAndDebugging::ProhibitNoWarnings]
 allow = redefine
+
+[Subroutines::ProhibitManyArgs]
+# Reduce me!
+max_arguments = 10
+# Ignore first arg if called $self or $class
+skip_object = 1

--- a/cpanfile
+++ b/cpanfile
@@ -117,7 +117,7 @@ on 'test' => sub {
 
 on 'develop' => sub {
     requires 'Code::TidyAll';
-    requires 'Perl::Critic';
+    requires 'Perl::Critic', '>= 1.156.0';
     requires 'Perl::Critic::Community';
     requires 'Perl::Tidy', '== 20260204.0.0';
     requires 'Pod::Markdown';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -216,7 +216,7 @@ test_requires:
 style_check_requires:
   python3-yamllint:
   perl(Test::Perl::Critic):
-  perl(Perl::Critic):
+  perl(Perl::Critic): '>= 1.156.0'
   perl(Perl::Critic::Community):
   perl(Code::TidyAll):
   perl(Pod::Markdown):

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -95,7 +95,7 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-ruff python3-yamllint shfmt
+%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) >= 1.156.0 perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-ruff python3-yamllint shfmt
 # The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml


### PR DESCRIPTION
This PR sets a high threshold for the allowed number so that it won't currently fail, and we can gradually lower the threshold in a followup ticket.

https://metacpan.org/pod/Perl::Critic::Policy::Subroutines::ProhibitManyArgs

Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

Policy description:
> Subroutines that expect large numbers of arguments are hard to use because
> programmers routinely have to look at documentation to remember the order of
> those arguments. Many arguments is often a sign that a subroutine should be
> refactored or that an object should be passed to the routine.