### PR TITLE
fix: update fast-uri to address security vulnerabilities (boo#1264376)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1678,9 +1678,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Motivation:
The npm audit report identified a high-severity vulnerability in the
fast-uri dependency (path traversal and host confusion).

Benefits:
Resolves GHSA-q3j6-qgpj-74h6 and GHSA-v39h-62p7-jpjc

Related issue: https://bugzilla.suse.com/show_bug.cgi?id=1264376