### PR TITLE
fix(test overview): Bring query for "Aborted" in-line with accounting

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -115,7 +115,7 @@ my %SUMMARY_CATEGORY_QUERY = (
     scheduled => {result => undef, state => [PRE_EXECUTION_STATES]},
     running => {result => undef, state => [EXECUTION_STATES]},
     cancelled => {result => undef, state => [CANCELLED]},
-    aborted => {result => [ABORTED_RESULTS], state => undef},
+    aborted => {result => [ABORTED_RESULTS], state => [DONE]},
     # "none" includes all jobs with unknown states/results (or jobs in state DONE and unknown result), not just NONE
     none => {
         result__not => [COMPLETE_RESULTS, NOT_COMPLETE_RESULTS, ABORTED_RESULTS],


### PR DESCRIPTION
We count only jobs in state `done` as "Aborted" so this change brings the filtering query in-line with that.

Note that this was already the case before recent improvements. (Before those improvements, jobs in state `cancelled` were counted as "None" so "Aborted" was always just jobs in state `done`.)

Related ticket: https://progress.opensuse.org/issues/200594