### PR TITLE
feat: Add `pyproject.toml` as in other repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 unstables := $(shell cat tools/unstable_tests.txt | tr '\n' :)
 shellfiles := $$(file --mime-type script/* t/* container/worker/*.sh tools/* | sed -n 's/^\(.*\):.*text\/x-shellscript.*$$/\1/p')
-pyfiles ?= $(shell git ls-files | xargs file --mime-type 2>/dev/null | grep -E 'text/x-script\.python|text/x-python' | grep --invert-match -E '^(t/data|container/openqa_data/|docs/.*\.md)' | cut -d: -f1)
+pyfiles ?= $(shell git ls-files | xargs file --mime-type 2>/dev/null | grep -E 'text/x-script\.python|text/x-python' | grep --invert-match -E '^(t/data|container/openqa_data/)' | cut -d: -f1)
 
 # tests need these environment variables to be unset
 OPENQA_BASEDIR =

--- a/Makefile
+++ b/Makefile
@@ -455,8 +455,13 @@ tidy-js: ## Format JavaScript code
 tidy-perl: ## Format Perl code
 	tools/tidyall -a
 
+.PHONY: tidy-python
+tidy-python: ## Format Python code
+	@command -v ruff >/dev/null 2>&1 || echo "Command 'ruff' not found, can not format python code"
+	@if [ -n "$(pyfiles)" ]; then ruff format $(pyfiles); fi
+
 .PHONY: tidy
-tidy: tidy-js tidy-perl ## Format both JS and Perl code
+tidy: tidy-js tidy-perl tidy-python ## Format JavaScript, Perl and Python code
 
 .PHONY: test-containers-compose
 test-containers-compose: ## Run docker-compose tests

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 unstables := $(shell cat tools/unstable_tests.txt | tr '\n' :)
 shellfiles := $$(file --mime-type script/* t/* container/worker/*.sh tools/* | sed -n 's/^\(.*\):.*text\/x-shellscript.*$$/\1/p')
+pyfiles ?= $(shell git ls-files | xargs file --mime-type 2>/dev/null | grep -E 'text/x-script\.python|text/x-python' | grep --invert-match -E '^(t/data|container/openqa_data/|docs/.*\.md)' | cut -d: -f1)
 
 # tests need these environment variables to be unset
 OPENQA_BASEDIR =
@@ -390,7 +391,7 @@ setup-hooks: ## Install pre-commit git hooks
 
 # all additional checks not called by prove
 .PHONY: test-checkstyle-standalone
-test-checkstyle-standalone: test-shellcheck test-yaml test-shfmt test-gitlint ## Run all style and static analysis checks
+test-checkstyle-standalone: test-shellcheck test-yaml test-shfmt test-gitlint test-python-static-checks ## Run all style and static analysis checks
 ifeq ($(CONTAINER_TEST),1)
 test-checkstyle-standalone: test-check-containers
 endif
@@ -418,6 +419,22 @@ test-yaml: ## Run yamllint on YAML files
 test-shfmt: ## Run shfmt on scripts
 	@command -v shfmt >/dev/null 2>&1 || (echo "Command 'shfmt' not found, can not execute bash script syntax checks" && false)
 	shfmt -d -i 4 -bn -ci -sr $(shellfiles)
+
+.PHONY: test-python-static-checks ## Run all static checks on Python scripts
+test-python-static-checks: test-ruff test-python-conventions
+
+.PHONY: test-ruff
+test-ruff: ## Run `ruff format --check` and `ruff check` on Python scripts
+	@command -v ruff >/dev/null 2>&1 || echo "Command 'ruff' not found, can not execute python style checks"
+	@if [ -n "$(pyfiles)" ]; then ruff format --check $(pyfiles) && ruff check $(pyfiles); fi
+
+.PHONY: test-python-conventions
+test-python-conventions: ## Checks whether Python scripts follow certain coding conventions
+	@if [[ -d tests/ ]] && git grep -nE '^\s*@(unittest\.mock\.|mock\.)?patch' tests/; then \
+		echo "Error: @patch decorator detected. Avoid to prevent argument ordering bugs."; \
+		echo "   Fix: Use the 'mocker' fixture (pytest-mock) or a 'with patch():' context manager."; \
+		exit 1; \
+	fi
 
 .PHONY: test-gitlint
 test-gitlint: ## Run commit message checks using gitlint

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -106,7 +106,7 @@
 Name:           openQA
 Version:        5
 Release:        0
-Summary:        Automated web-frontend testing framework, scheduler and tools
+Summary:        Framework for automated system-level testing (web-frontend, scheduler and tools)
 Group:          Development/Tools/Other
 License:        GPL-2.0-or-later
 Url:            http://os-autoinst.github.io/openQA/

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -67,8 +67,8 @@ are the right way to contribute improvements and fixes.
 make tidy
 ```
 
-to ensure your Perl and JavaScript code changes are consistent with the style
-rules.
+to ensure your Perl, JavaScript and Python code changes are consistent with the
+style rules.
 
 - All tests are passed. This is ensured by a CI system. You can also run local
   tests in your development environment to verify everything works as

--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -237,16 +237,14 @@ from testapi import *
 
 # [...] omitted for brevity
 
+
 def run(self):
-    perl.require('x11utils')
+    perl.require("x11utils")
 
     # Start vncviewer - notice the named arguments passed as positional arguments
     # Formatted in pairs for better visibility.
 
-    perl.x11utils.x11_start_program('vncviewer :0',
-        'target_match', 'virtman-gnome_virt-install',
-        'match_timeout', 100
-    )
+    perl.x11utils.x11_start_program("vncviewer :0", "target_match", "virtman-gnome_virt-install", "match_timeout", 100)
     # [...] omitted for brevity
 ```
 
@@ -425,31 +423,35 @@ Test for the openQA web UI written in Python
 ```python
 from testapi import *
 
+
 def run(self):
-    assert_screen('openqa-logged-in')
-    assert_and_click('openqa-search')
-    type_string('shutdown.pm')
-    send_key('ret')
-    assert_screen('openqa-search-results')
+    assert_screen("openqa-logged-in")
+    assert_and_click("openqa-search")
+    type_string("shutdown.pm")
+    send_key("ret")
+    assert_screen("openqa-search-results")
 
     # import further Perl-based libraries (besides `testapi`)
-    perl.require('x11utils')
+    perl.require("x11utils")
 
     # use imported Perl-based libraries; call Perl function that would be called via "named arguments" in Perl
     # note: In Perl the call would have been: x11_start_program('flatpak run com.obsproject.Studio', target_match => 'obsproject-wizard')
     #
     # See the explanation in the "Notes on the Python API" section.
-    perl.x11utils.x11_start_program('flatpak run com.obsproject.Studio', 'target_match', 'obsproject-wizard')
+    perl.x11utils.x11_start_program("flatpak run com.obsproject.Studio", "target_match", "obsproject-wizard")
+
 
 def switch_to_root_console():
-    send_key('ctrl-alt-f3')
+    send_key("ctrl-alt-f3")
+
 
 def post_fail_hook(self):
     switch_to_root_console()
-    assert_script_run('openqa-cli api experimental/search q=shutdown.pm')
+    assert_script_run("openqa-cli api experimental/search q=shutdown.pm")
+
 
 def test_flags(self):
-    return {'fatal': 1}
+    return {"fatal": 1}
 ```
 
 ### Example Lua test module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openQA"
 dynamic = ["version"]
-description = "openQA web-frontend, scheduler and tools."
+description = "Framework for automated system-level testing (web-frontend, scheduler and tools)"
 readme = "README.md"
 requires-python = ">=3.6"
 license = "GPL-2-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,149 @@
+[project]
+name = "openQA"
+dynamic = ["version"]
+description = "openQA web-frontend, scheduler and tools."
+readme = "README.md"
+requires-python = ">=3.6"
+license = "GPL-2-or-later"
+authors = [
+    { name = "SUSE LLC" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+]
+
+[project.urls]
+Homepage = "https://open.qa"
+
+[dependency-groups]
+dev = [
+    "ruff",
+    "vulture",
+    "ty>=0.0.21",
+]
+
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+skip_covered = true
+
+[tool.pytest.ini_options]
+addopts = "-p no:anyio -p no:doctest -p no:pastebin -p no:nose"
+testpaths = ["tests"]
+python_files = "test_*.py"
+markers = ["qem_behavior(mode): configure the fake_qem fixture behavior"]
+
+[tool.setuptools]
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.packages]
+find = {}
+
+[tool.ruff]
+line-length = 120
+exclude = ["t/data"]
+preview = true
+
+[tool.ruff.lint]
+# E, F: Standard pycodestyle and Pyflakes (default flake8)
+# D: pydocstyle (for D100, D101, etc.)
+# Q: flake8-quotes (for Q000)
+# PL: Pylint
+extend-select =[
+    "E", "F", "D", "Q", "PL",
+    "T100", # https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
+    "T2", # https://docs.astral.sh/ruff/rules/#flake8-print-t20
+    "TD", # https://docs.astral.sh/ruff/rules/#flake8-todos-td
+    "W",
+    "I", # https://docs.astral.sh/ruff/rules/#isort-i
+    "ERA",
+    "B",
+    "SIM",
+    "C4",
+    "T10",
+    "FIX",
+    "ISC",
+    "ICN",
+    "INP",
+    "PIE",
+    "T20",
+    "RSE",
+    "RET",
+    "SLF",
+    "FURB",
+    "EXE",
+    "BLE",
+    "A",
+    "DTZ",
+    "LOG",
+    "G",
+    "C90",
+    "PERF",
+    "PGH",
+    "ARG",
+    "RUF",
+    "ANN",
+    "S", # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    "FBT", # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
+    "TRY", # https://docs.astral.sh/ruff/rules/#tryceratops-try
+    "DOC", # https://docs.astral.sh/ruff/rules/#pydoclint-doc
+    "YTT", # https://docs.astral.sh/ruff/rules/#flake8-2020-ytt
+    "ASYNC", # https://docs.astral.sh/ruff/rules/#flake8-async-async
+    "COM", # https://docs.astral.sh/ruff/rules/#flake8-commas-com
+    "CPY", # https://docs.astral.sh/ruff/rules/#flake8-copyright-cpy
+    "EM", # https://docs.astral.sh/ruff/rules/#flake8-errmsg-em
+    "INT", # https://docs.astral.sh/ruff/rules/#flake8-gettext-int
+    "PYI", # https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi
+    "PT", # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
+    "SLOT", # https://docs.astral.sh/ruff/rules/#flake8-slots-slot
+    "TID", # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
+    "TC", # https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc
+    "PTH", # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "FLY", # https://docs.astral.sh/ruff/rules/#flynt-fly
+    "NPY", # https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy
+    "PD", # https://docs.astral.sh/ruff/rules/#pandas-vet-pd
+    "N", # https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "PLE", # https://docs.astral.sh/ruff/rules/#error-ple
+    "PLR", # https://docs.astral.sh/ruff/rules/#refactor-plr
+    "PLW", # https://docs.astral.sh/ruff/rules/#warning-plw
+    "FA", # https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa
+    "UP", # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+]
+
+ignore = [
+    "D203",   # incorrect-blank-line-before-class
+    "PLC1802", # use-implicit-booleaness-not-len
+    "D213", # multi-line-summary-second-line
+    "PLR0904", # too-many-public-methods
+    "DOC201", # docstring-missing-returns
+    "DOC501", # docstring-missing-exception
+    "COM812", # missing-trailing-comma
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 9
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["PLR2004", "ANN401", "PLR0913", "S101", "S105", "S106", "PLR0917", "D103"]
+
+[tool.ruff.format]
+# Enable reformatting of code snippets in docstrings.
+docstring-code-format = true
+
+[tool.ruff.lint.flake8-copyright]
+author = "SUSE LLC"
+notice-rgx = "Copyright"
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"os.system".msg = "Use `subprocess.run` or `sh` library instead."
+"subprocess.call".msg = "Use `subprocess.run` with `check=True`."
+
+[tool.ty.terminal]
+error-on-warning = true

--- a/script/openqa-label-all
+++ b/script/openqa-label-all
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 
+# Copyright SUSE LLC
+# SPDX-License-Identifier: MIT
+"""Script to label openQA jobs."""
+
 import argparse
 import json
 import logging
-import requests
-import subprocess
+import subprocess  # noqa: S404
 import sys
 from urllib.parse import urljoin
+
+import requests
 
 logging.basicConfig()
 log = logging.getLogger(sys.argv[0] if __name__ == "__main__" else __name__)
@@ -14,19 +19,16 @@ openqa_cmd = ""
 args = ""
 
 
-class CustomFormatter(
-    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
-):
+class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
     """Preserve multi-line __doc__ and provide default arguments in help strings."""
 
-    pass
 
-def get_parser():
+def _setup_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog='openqa-label-all',
-        description=""".B openqa-label-all
-allows comments to be applied to a set jobs, which match the specified options, on the specified server.""",
-        formatter_class=CustomFormatter
+        prog="openqa-label-all",
+        description="""openqa-label-all allows comments to be applied to a set jobs, which match the
+specified options, on the specified server.""",
+        formatter_class=CustomFormatter,
     )
     parser.add_argument(
         "-v",
@@ -35,79 +37,68 @@ allows comments to be applied to a set jobs, which match the specified options, 
         action="count",
         default=1,
     )
-    parser.add_argument(
-        "--build", help="The build for which to look for a failing module"
-    )
-    parser.add_argument(
-        "--module", required=True, help="The failing module to look for"
-    )
-    parser.add_argument(
-        "--groupid", default=None, help="Limits labeling to this group only"
-    )
+    parser.add_argument("--build", help="The build for which to look for a failing module")
+    parser.add_argument("--module", required=True, help="The failing module to look for")
+    parser.add_argument("--groupid", default=None, help="Limits labeling to this group only")
     parser.add_argument(
         "--openqa-host",
         default="https://openqa.suse.de",
         help="The openQA host to act on",
     )
-    parser.add_argument(
-        "--result", help="The result of the jobs to look for", default="failed"
-    )
-    parser.add_argument(
-        "--label", default="", help="The label to write as comment for each found job"
-    )
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Do not do any action on openQA"
-    )
+    parser.add_argument("--result", help="The result of the jobs to look for", default="failed")
+    parser.add_argument("--label", default="", help="The label to write as comment for each found job")
+    parser.add_argument("--dry-run", action="store_true", help="Do not do any action on openQA")
     parser.add_argument(
         "--no-restart",
         action="store_true",
         help="Do not restart the jobs after labelling",
     )
+    parser.add_argument("--timeout", type=float, default=60, help="Timeout for HTTP requests")
     return parser
 
-def parse_args():
-    parser = get_parser()
+
+def _parse_args() -> argparse.Namespace:
+    parser = _setup_parser()
     args = parser.parse_args()
     verbose_to_log = {
         0: logging.CRITICAL,
         1: logging.ERROR,
-        2: logging.WARN,
+        2: logging.WARNING,
         3: logging.INFO,
         4: logging.DEBUG,
     }
-    logging_level = logging.DEBUG if args.verbose > 4 else verbose_to_log[args.verbose]
+    logging_level = logging.DEBUG if args.verbose > len(verbose_to_log) else verbose_to_log[args.verbose]
     log.setLevel(logging_level)
     return args
 
 
-def call(cmds, dry_run=False):
-    log.debug("call: %s" % cmds)
-    return subprocess.call((["echo", "Simulating: "] if dry_run else []) + cmds)
+def _call(cmds: list, args: argparse.Namespace) -> int:
+    log.debug("call: %s", cmds)
+    return subprocess.run((["echo", "Simulating: "] if args.dry_run else []) + cmds, check=True).returncode  # noqa: S603
 
 
-def openqa_call(cmds):
-    return call(openqa_cmd + cmds, args.dry_run)
+def _openqa_call(cmds: list) -> int:
+    return _call(openqa_cmd + cmds, args)
 
 
-def comments(job):
-    log.debug("Retrieving comments on job %s" % job["id"])
-    cmd = " ".join((openqa_cmd + ["jobs/%s/comments" % job["id"]]))
-    job_comments = subprocess.getoutput(cmd)
+def _comments(job: dict) -> list:
+    log.debug("Retrieving comments on job %s", job["id"])
+    completed_process = subprocess.run([*openqa_cmd, f"jobs/{job['id']}/comments"], capture_output=True, check=True)  # noqa: S603
+    job_comments = completed_process.stdout
     comments = " ".join([i["text"] for i in json.loads(job_comments)])
-    log.debug("Comments: %s" % comments)
+    log.debug("Comments: %s", comments)
     return comments
 
 
-def needs_label(label, job):
-    has_label = label in comments(job)
-    log.debug("%s has label: %s" % (job["id"], has_label))
+def _needs_label(label: str, job: dict) -> bool:
+    has_label = label in _comments(job)
+    log.debug("%s has label: %s", job["id"], has_label)
     return not has_label
 
 
-def main():
-    global args
-    global openqa_cmd
-    args = parse_args()
+def _main() -> int:
+    global args, openqa_cmd  # noqa: PLW0603
+    args = _parse_args()
     request_params = {"result": args.result, "latest": 1, "scope": "relevant"}
 
     openqa_cmd = ["openqa-cli", "api", "--host", args.openqa_host]
@@ -118,46 +109,35 @@ def main():
     if args.build:
         request_params.update({"build": args.build})
 
-    log.debug("args: %s" % args)
-    host = (
-        args.openqa_host
-        if args.openqa_host.startswith("https://")
-        else "https://" + args.openqa_host
-    )
+    log.debug("args: %s", args)
+    host = args.openqa_host if args.openqa_host.startswith("https://") else "https://" + args.openqa_host
     url = "api/v1/jobs"
 
-    r = requests.get(urljoin(host, url), params=request_params)
+    r = requests.get(urljoin(host, url), params=request_params, timeout=args.timeout)
     r.raise_for_status()
     jobs = r.json()["jobs"]
 
     if len(jobs) <= 0:
-        log.error("No jobs found for: %s" % r.url)
+        log.error("No jobs found for: %s", r.url)
         return 61
 
     jobs_with_failed_module = [
-        j
-        for j in jobs
-        if [
-            m
-            for m in j["modules"]
-            if m["name"] == args.module and m["result"] == args.result
-        ]
+        j for j in jobs if [m for m in j["modules"] if m["name"] == args.module and m["result"] == args.result]
     ]
 
-    unlabeled_jobs = (
-        job["id"] for job in jobs_with_failed_module if needs_label(args.label, job)
-    )
+    unlabeled_jobs = (job["id"] for job in jobs_with_failed_module if _needs_label(args.label, job))
 
     for i in unlabeled_jobs:
-        openqa_call(["-X", "post", "jobs/%s/comments" % i, "text=%s" % args.label])
+        _openqa_call(["-X", "post", f"jobs/{i}/comments", f"text={args.label}"])
 
     if args.no_restart:
         log.debug("Not restarting jobs")
     else:
         log.debug("Restarting jobs")
         for i in (j["id"] for j in jobs_with_failed_module):
-            openqa_call(["-X", "post", "jobs/%s/restart" % i])
+            _openqa_call(["-X", "post", f"jobs/{i}/restart"])
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    _main()


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/198023

---

There's no CI job yet because there are no files this would apply to anyway.

I could create a separate PR enabling this for `container/openqa_data/scripts/client-conf` which is the only Python script I found in the repository. This file is not used by us and has no tests. So making it fulfill all the rules we set here would be quite some work and we probably don't want to spend that effort. (That's how the changes would look like: https://github.com/os-autoinst/openQA/commit/e0e56112414fc37e34db738c05ff32da8b19ecde - but there are still 33 remaining errors including to use type hints everywhere.)

So I'm not sure whether it makes sense to proceed with this at this point where we simply don't really use Python anyway.