### PR TITLE
style: enforce perlcritic policy ProhibitCascadingIfElse

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters ControlStructures::ProhibitCascadingIfElse
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple
@@ -53,3 +53,7 @@ min_value = 1000000
 [Modules::ProhibitExcessMainComplexity]
 # Reduce me!
 max_mccabe = 83
+
+[ControlStructures::ProhibitCascadingIfElse]
+# Reduce me!
+max_elsif = 5


### PR DESCRIPTION
https://metacpan.org/pod/Perl::Critic::Policy::ControlStructures::ProhibitCascadingIfElse

Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

Policy description:
> Long if-elsif chains are hard to digest, especially if they are longer than a
> single page or screen. If testing for equality, use a hash lookup instead.