### PR TITLE
test: Add `python3-ruff` for static checks of Python scripts

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -223,3 +223,4 @@ style_check_requires:
   ShellCheck:
   shfmt:
   python3-gitlint:
+  python3-ruff:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -95,7 +95,7 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-yamllint shfmt
+%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-ruff python3-yamllint shfmt
 # The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml


### PR DESCRIPTION
So far this is only about `openqa-label-all`. Static tests will be added for this script part of https://progress.opensuse.org/issues/198023.