### PR TITLE
ci: Add distinct container image for CI

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+#!BuildTag: opensuse/openqa_ci:latest opensuse/openqa_ci:%PKG_VERSION% opensuse/openqa_ci:%PKG_VERSION%.%RELEASE%
+
+# Match chromium architectures
+#!ExclusiveArch:  x86_64 aarch64 riscv64
+
+# hadolint ignore=DL3006
+FROM opensuse/tumbleweed
+
+# hadolint ignore=DL3037
+RUN zypper ar -p 95 -f 'http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA && \
+    zypper --gpg-auto-import-keys ref && \
+    zypper in -y os-autoinst-devel openQA-devel nodejs-default perl-TAP-Harness-JUnit && \
+    zypper clean -a
+
+ENV OPENQA_DIR=/opt/openqa
+VOLUME $OPENQA_DIR
+WORKDIR $OPENQA_DIR


### PR DESCRIPTION
This container installs packages from `devel:openQA` (instead of only from `openSUSE:Tumbleweed`). This has the advantage that we don't have to wait for package submissions to be accepted to add a new dependency for our CI environment. This container also avoids dependencies like `mc` and `vim` that might be useful for development but are not needed in a CI environment.

Commit 1a8dbebc8 added `perl-TAP-Harness-JUnit` to the devel container. We can remove that package from there again after configuring the new container added by this commit.

Related ticket: https://progress.opensuse.org/issues/200609