### PR TITLE
style: Enforce perlcritic policy TestingAndDebugging::ProhibitNoWarnings

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters ControlStructures::ProhibitCascadingIfElse Subroutines::ProhibitExcessComplexity Modules::ProhibitConditionalUseStatements CodeLayout::ProhibitHardTabs Community::ConditionalImplicitReturn Variables::ProhibitPackageVars
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators CodeLayout::ProhibitQuotedWordLists RegularExpressions::ProhibitSingleCharAlternation BuiltinFunctions::RequireBlockGrep RegularExpressions::ProhibitUselessTopic Variables::ProtectPrivateVars Subroutines::RequireArgUnpacking Modules::ProhibitExcessMainComplexity Miscellanea::ProhibitUselessNoCritic BuiltinFunctions::ProhibitUselessTopic Documentation::RequirePackageMatchesPodName ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters ControlStructures::ProhibitCascadingIfElse Subroutines::ProhibitExcessComplexity Modules::ProhibitConditionalUseStatements CodeLayout::ProhibitHardTabs Community::ConditionalImplicitReturn Variables::ProhibitPackageVars TestingAndDebugging::ProhibitNoWarnings
 
 # ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 # No operators like < =~ ! allowed in 'unless' or 'until', only simple
@@ -64,3 +64,6 @@ max_mccabe = 63
 
 [Variables::ProhibitPackageVars]
 add_packages = Config::IniFiles
+
+[TestingAndDebugging::ProhibitNoWarnings]
+allow = redefine

--- a/t/lib/CoverageWorkaround.pm
+++ b/t/lib/CoverageWorkaround.pm
@@ -82,7 +82,7 @@ sub pp_leave {    ## no critic (Subroutines::RequireArgUnpacking)
 
     my $enter = $op->first;
     no strict 'subs';    ## no critic (TestingAndDebugging::ProhibitNoStrict, TestingAndDebugging::ProhibitProlongedStrictureOverride)
-    no warnings;
+    no warnings;    ## no critic (TestingAndDebugging::ProhibitNoWarnings)
     return $self->$orig_pp_leave(@_) if $enter->type != OP_ENTER;
 
     my $meth = ref $enter->sibling eq 'B::COP' ? $orig_pp_leave : $patched_pp_leave;


### PR DESCRIPTION
https://metacpan.org/pod/Perl::Critic::Policy::TestingAndDebugging::ProhibitNoWarnings

Issue: https://progress.opensuse.org/issues/188058

Enforcing https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic policies can ensure a coherent style and avoid common mistakes.

Policy description:
> There are good reasons for disabling certain kinds of warnings. But if you
> were wise enough to use warnings in the first place, then it doesn't make
> sense to disable them completely. By default, any `no warnings` statement
> will violate this policy. However, you can configure this Policy to allow
> certain types of warnings to be disabled (See "CONFIGURATION"). A bare `no
> warnings` statement will always raise a violation.