### PR TITLE
fix: parse URL-derived settings for cloned jobs

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -321,6 +321,9 @@ sub _create_job ($self, $global_params, $job_suffix, $job_specific_params, $mini
         die "$result->{error_message}\n" if defined $result->{error_message};
         $job_settings = $result->{settings_result};
     }
+    else {
+        OpenQA::JobSettings::parse_url_settings($job_settings);
+    }
     my $downloads = create_downloads_list($job_settings);
     $self->_eval_dependency($job_suffix, $job_settings, _START_AFTER => CHAINED);
     $self->_eval_dependency($job_suffix, $job_settings, _START_DIRECTLY_AFTER => DIRECTLY_CHAINED);

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1938,6 +1938,41 @@ subtest 'handle git_clone without CASEDIR' => sub {
     };
 };
 
+subtest 'handle is_clone_job with ISO_URL' => sub {
+    my %base_params = (
+        MACHINE => '64bit',
+        DISTRI => 'opensuse',
+        is_clone_job => 1,
+    );
+    my @test_cases = (
+        {
+            name => 'ISO variable deduced from ISO_URL',
+            params => {%base_params, TEST => 'deduce', ISO_URL => 'http://localhost/cloned.iso'},
+            expected_iso => 'cloned.iso',
+        },
+        {
+            name => 'explicit ISO override preserved',
+            params =>
+              {%base_params, TEST => 'override', ISO_URL => 'http://localhost/cloned.iso', ISO => 'explicit.iso'},
+            expected_iso => 'explicit.iso',
+        },
+        {
+            name => 'explicit ISO clearing preserved',
+            params => {%base_params, TEST => 'clear', ISO_URL => 'http://localhost/cloned.iso', ISO => ''},
+            expected_iso => '',
+        },
+    );
+
+    for my $case (@test_cases) {
+        subtest $case->{name} => sub {
+            $t->post_ok('/api/v1/jobs', form => $case->{params})->status_is(200);
+            my $job_id = $t->tx->res->json->{id};
+            my $job_settings = $jobs->find($job_id)->settings_hash;
+            is $job_settings->{ISO}, $case->{expected_iso}, $case->{name};
+        };
+    }
+};
+
 subtest 'show parent group name and id when getting job details' => sub {
     my $parent_group = $schema->resultset('JobGroupParents')->create({name => 'Foo'});
     my $parent_group_id = $parent_group->id;


### PR DESCRIPTION
Motivation:
Cloned jobs (using `is_clone_job => 1`) skip `_generate_job_setting` to
avoid overriding cloned settings with database defaults. However, this
also bypasses `parse_url_settings`, meaning that if a user provides an
`ISO_URL` override while cloning, the corresponding `ISO` variable is
not automatically deduced. This leads to jobs that download the ISO but
fail to inform the test backend which ISO to use.

Design Choices:
Explicitly call `OpenQA::JobSettings::parse_url_settings` for cloned
jobs in `_create_job`. This ensures that URL-derived settings are
populated from any provided `*_URL` variables without interfering with
the cloning process's goal of avoiding database defaults.

Benefits:
Ensures uniform behavior for `*_URL` variables across all job creation
paths. Users can now override `ISO_URL` during cloning and expect the
`ISO` variable to be correctly set, matching the documented behavior.

Related issue: https://github.com/openSUSE/qem-bot/pull/522