### PR TITLE
refactor(create_admin): switch to Getopt::Long::Descriptive

### DIFF
--- a/script/create_admin
+++ b/script/create_admin
@@ -12,45 +12,37 @@ use lib "$RealBin/../lib";
 use OpenQA::Schema::Result::ApiKeys;
 use OpenQA::Schema;
 use OpenQA::Utils 'random_hex';
-use Getopt::Long;
+use Getopt::Long::Descriptive;
 
-my $email = 'admin@example.com';
-my $nickname = 'admin';
-my $fullname = 'Administrator';
-my $key = '';
-my $secret = '';
-my $user = $ARGV[0];
-my $help;
+my ($opt, $usage) = describe_options(
+    <<"EOM",
+$0 %o <user>
 
-sub usage ($rc) {
-    print "Usage: $0 user [options]\n\n";
-    print "  --email     : Email address.\n";
-    print "  --nickname  : Nickname.\n";
-    print "  --fullname  : Full name.\n";
-    print "  --key       : API key (will be randomly generated if not set).\n";
-    print "  --secret    : API secret (will be randomly generated if not set).\n";
-    print "  user        : User ID (e.g. OpenID URL).\n";
-    exit $rc;
-}
-
-# need to count this *before* calling GetOptions
-my $numargs = scalar @ARGV;
-
-my $result = GetOptions(
-    'email=s' => \$email,
-    'nickname=s' => \$nickname,
-    'fullname=s' => \$fullname,
-    'key=s' => \$key,
-    'secret=s' => \$secret,
-    'help' => \$help,
+Create the initial admin account. The mandatory <user> argument is the
+user ID (e.g. an OpenID URL).
+EOM
+    ['email|e=s', 'Email address', {default => 'admin@example.com'}],
+    ['nickname|n=s', 'Nickname', {default => 'admin'}],
+    ['fullname|f=s', 'Full name', {default => 'Administrator'}],
+    ['key|k=s', 'API key (will be randomly generated if not set)', {default => ''}],
+    ['secret|s=s', 'API secret (will be randomly generated if not set)', {default => ''}],
+    ['help|h', 'Print usage message and exit', {shortcircuit => 1}],
 );
 
-usage 0 if $help;
-usage 1 if !($result && $user && $numargs > 1);
+if ($opt->help) {
+    print $usage->text;
+    exit 0;
+}
 
-if (($key || $secret)
-    && !($key =~ /^[[:xdigit:]]{16}$/ && $secret =~ /^[[:xdigit:]]{16}$/))
-{
+my $user = shift @ARGV;
+unless ($user) {
+    print STDERR $usage->text;
+    exit 1;
+}
+
+my $key = $opt->key;
+my $secret = $opt->secret;
+if (($key || $secret) && !($key =~ /^[[:xdigit:]]{16}$/ && $secret =~ /^[[:xdigit:]]{16}$/)) {
     die "--key and --secret must both be 16 digit hexadecimals.\n";
 }
 
@@ -69,11 +61,10 @@ if (scalar @admins != 0) {
 }
 my $account = $schema->resultset('Users')->create_user(
     $user,
-    email => $email,
-    nickname => $nickname,
-    fullname => $fullname,
+    email => $opt->email,
+    nickname => $opt->nickname,
+    fullname => $opt->fullname,
     is_admin => 1
 );
 
 $schema->resultset('ApiKeys')->create({user_id => $account->id, key => $key, secret => $secret});
-

--- a/t/44-scripts-create_admin.t
+++ b/t/44-scripts-create_admin.t
@@ -49,4 +49,27 @@ subtest 'attempt to supply an invalid key/secret' => sub {
     like $output, qr/must.*be.*hexadecimals/i, 'expected explanation';
 };
 
+subtest 'no positional argument' => sub {
+    my $output = qx{"$cmd" --email someone\@example.com 2>&1};
+    is $? >> 8, 1, 'command exited with return code 1';
+    like $output, qr/usage/i, 'usage shown when user argument is missing';
+};
+
+subtest '--help prints usage and exits cleanly' => sub {
+    my $output = qx{"$cmd" --help 2>&1};
+    is $? >> 8, 0, 'command exited with return code 0';
+    like $output, qr/usage/i, 'usage shown';
+    like $output, qr/--email/, 'email option documented';
+    like $output, qr/--nickname/, 'nickname option documented';
+};
+
+subtest 'options before the positional argument are accepted' => sub {
+    # The Getopt::Long permute behavior allows options to be interspersed with
+    # positional arguments which is more user friendly than requiring a strict
+    # order.
+    my $output = qx{"$cmd" --email leading\@example.com test-user3 2>&1};
+    is $? >> 8, 1, 'command exited with return code 1 because admin already exists';
+    like $output, qr/already exists/i, 'admin check still triggered, proving the user argument was parsed';
+};
+
 done_testing;


### PR DESCRIPTION
## Motivation

The previous implementation captured the user argument from `$ARGV[0]`
*before* calling `GetOptions` and gated the script on a confusing
`$numargs > 1` check that effectively required at least one option to
be provided. This made the required arguments difficult to discern
from reading the source and produced surprising results: invoking the
script as `create_admin --email foo bar` left `$user` set to `--email`
rather than to `bar`, and the script then attempted to create a user
literally named `--email`.

The suggestion to switch to `Getopt::Long::Descriptive` originated in
https://github.com/os-autoinst/openQA/pull/7233#discussion_r3022124606.

## Design Choices

Use `Getopt::Long::Descriptive::describe_options` which parses options
out of `@ARGV` first. The remaining argument is then taken as the user
positional argument. The option specification doubles as the help
text, which removes the need to maintain a separate `usage` subroutine
and ensures the documented options stay in sync with what the script
actually accepts. Short aliases (`-e`, `-n`, `-f`, `-k`, `-s`, `-h`)
are also exposed since the dependency makes them essentially free.

The `shortcircuit` flag on `--help` exits parsing as soon as the help
option is seen which avoids spurious errors when the user has not
supplied any other arguments.

## Benefits

- The required positional argument is now obvious from the synopsis.
- Options may appear before, after or between positional arguments.
- An empty invocation no longer silently sets `$user` to an option
  name; it cleanly prints the usage and exits with status 1.
- The help text is generated, removing duplication.

## Test adaptations

The existing test coverage is preserved. Additional subtests verify
that (a) running with no positional argument prints the usage and
exits non-zero, (b) `--help` succeeds and lists the supported options,
and (c) options provided before the user argument are still
recognised thanks to the Getopt::Long permute behavior.

Closes https://github.com/os-autoinst/openQA/issues/7237