### PR TITLE
chore: Use `https://download.opensuse.org` consistently

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -8,7 +8,7 @@
 FROM opensuse/tumbleweed
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f 'http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA && \
+RUN zypper ar -p 95 -f 'https://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y os-autoinst-devel openQA-devel nodejs-default perl-TAP-Harness-JUnit && \
     zypper clean -a

--- a/container/webui/Dockerfile
+++ b/container/webui/Dockerfile
@@ -14,8 +14,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 ENV LC_ALL=C.UTF-8
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f https://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f https://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y ca-certificates-mozilla curl openQA-local-db apache2 apache2-utils hostname which w3m perl-CSS-Sass && \
     zypper clean && \

--- a/container/webui/Dockerfile-lb
+++ b/container/webui/Dockerfile-lb
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f https://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f https://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y openQA nginx && \
     zypper clean

--- a/container/worker/Dockerfile
+++ b/container/worker/Dockerfile
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 # endlabelprefix
 
 # hadolint ignore=DL3037
-RUN zypper ar -p 95 -f http://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
-    zypper ar -p 90 -f http://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
+RUN zypper ar -p 95 -f https://download.opensuse.org/repositories/devel:openQA/16.0 devel_openQA && \
+    zypper ar -p 90 -f https://download.opensuse.org/repositories/devel:openQA:Leap:16.0/16.0 devel_openQA_Leap && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -yl ca-certificates-mozilla curl gzip rsync xz && \
     zypper in -yl openQA-worker os-autoinst-s390-deps os-autoinst-ipmi-deps && \

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -334,11 +334,11 @@ To add the development repository to your system, you can use these commands.
 
 ``` sh
 # openSUSE Tumbleweed
-zypper ar -p 95 -f 'http://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA
+zypper ar -p 95 -f 'https://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA
 
 # openSUSE Leap/SLE
-zypper ar -p 95 -f 'http://download.opensuse.org/repositories/devel:openQA/$releasever' devel_openQA
-zypper ar -p 90 -f 'http://download.opensuse.org/repositories/devel:openQA:Leap:$releasever/$releasever' devel_openQA_Leap
+zypper ar -p 95 -f 'https://download.opensuse.org/repositories/devel:openQA/$releasever' devel_openQA
+zypper ar -p 90 -f 'https://download.opensuse.org/repositories/devel:openQA:Leap:$releasever/$releasever' devel_openQA_Leap
 ```
 
 If you installed openQA from the official repository first, you may need to change the vendor of the dependencies.

--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -230,7 +230,7 @@ First, download a suitable image and launch a VM in the same way `os-autoinst`
 would do for MM jobs:
 
 ```sh
-wget http://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2
+wget https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2
 qemu-system-x86_64 -m 2048 -enable-kvm -vnc :42 -snapshot \
 -netdev tap,id=qanet0,ifname=tap40,script=no,downscript=no \
 -device virtio-net,netdev=qanet0,mac=52:54:00:13:0b:4a \

--- a/script/openqa-bootstrap-container
+++ b/script/openqa-bootstrap-container
@@ -23,9 +23,9 @@ fi
 
 ARCH="${ARCH:=$(arch)}"
 if [ "$ARCH" = "x86_64" ]; then
-    DEFAULT_REPO="${DEFAULT_REPO:="http://download.opensuse.org/tumbleweed/repo/oss/"}"
+    DEFAULT_REPO="${DEFAULT_REPO:="https://download.opensuse.org/tumbleweed/repo/oss/"}"
 else
-    DEFAULT_REPO="${DEFAULT_REPO:="http://download.opensuse.org/ports/$ARCH/tumbleweed/repo/oss/"}"
+    DEFAULT_REPO="${DEFAULT_REPO:="https://download.opensuse.org/ports/$ARCH/tumbleweed/repo/oss/"}"
 fi
 
 # Workaround for https://bugzilla.suse.com/show_bug.cgi?id=1248857#c9


### PR DESCRIPTION
I've created this due to https://github.com/os-autoinst/openQA/pull/7431/changes#r3235336606 as I wouldn't know what speaks against this and using TLS probably won't hurt. Not sure what's the best practice here considering packages are normally verified via GPG anyway.