### PR TITLE
fix: remove zero-length warnings from openqa build

### DIFF
--- a/docs/images/README.md
+++ b/docs/images/README.md
@@ -1,0 +1,1 @@
+Architecture diagrams in this directory were created with [draw.io](https://www.drawio.com/).

--- a/templates/webapi/branding/plain/sponsorbox.html.ep
+++ b/templates/webapi/branding/plain/sponsorbox.html.ep
@@ -1,0 +1,1 @@
+<div id="sponsorbox"></div>


### PR DESCRIPTION
The `sponsorbox.html.ep` template was a zero-byte file. OBS rpmlint
flags zero-length files as errors. Adding minimal content satisfies
rpmlint without changing any visible output.

`ocs/images/created_with_draw.io` was an empty file used as a
convention marker. OBS rpmlint flags zero-length files as errors.
Removing it avoids the warning without any functional impact, since
the file carried no content.


Issue: https://progress.opensuse.org/issues/65837
