### PR TITLE
fix(packaging): replace obsolete packageand() with boolean Supplements

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -252,7 +252,7 @@ Summary:        Helper package to ease setup of postgresql DB
 Requires:       %{name} = %{version}
 Requires:       postgresql-server
 BuildRequires:  postgresql-server
-Supplements:    packageand(%name:postgresql-server)
+Supplements:    (%{name} and postgresql-server)
 
 %description local-db
 You only need this package if you have a local postgresql server


### PR DESCRIPTION
The rpmlint check suse-zypp-packageand flags the packageand(pkg1:pkg2) syntax as obsolete. Replaced with the boolean dependency form as suggested by rpmlint.

Issue: https://progress.opensuse.org/issues/65837