### PR TITLE
fix(packaging): avoid repeating package name in Summary

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -106,7 +106,7 @@
 Name:           openQA
 Version:        5
 Release:        0
-Summary:        The openQA web-frontend, scheduler and tools
+Summary:        Automated web-frontend testing framework, scheduler and tools
 License:        GPL-2.0-or-later
 Url:            http://os-autoinst.github.io/openQA/
 Source0:        %{name}-%{version}.tar.xz


### PR DESCRIPTION
rpmlint flags name-repeated-in-summary when the package name appears in the Summary field. Reworded to describe the package without repeating "openQA".

Issue: https://progress.opensuse.org/issues/65837