### PR TITLE
feat(needle-editor): Validate that there is at least one match area

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -468,6 +468,10 @@ function updateToggleClickCoordinatesButton(hasClickCoorinates) {
   }
 }
 
+function hasMatchAreas(areas) {
+  return Array.isArray(areas) && areas.find(area => area.type === 'match');
+}
+
 function saveNeedle(overwrite) {
   const form = document.getElementById('save_needle_form');
   const errors = [];
@@ -477,8 +481,8 @@ function saveNeedle(overwrite) {
   }
   const areaSelection = window.needles[$('#area_select').val()];
   const takeMatches = $('#take_matches').prop('checked');
-  if ((!takeMatches && !areaSelection.area.length) || (takeMatches && !areaSelection.matches.length)) {
-    errors.push('No areas defined.');
+  if (!hasMatchAreas(takeMatches ? areaSelection.matches : areaSelection.area)) {
+    errors.push('At least one match area must be defined.');
   }
   if (errors.length) {
     addFlash('danger', '<strong>Unable to save needle:</strong><ul><li>' + errors.join('</li><li>') + '</li></ul>');

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -384,7 +384,7 @@ subtest 'Create new needle' => sub {
     wait_for_ajax(with_minion => $minion);
     is
       $driver->find_element('.alert-danger span')->get_text(),
-      "Unable to save needle:\nNo areas defined.",
+      "Unable to save needle:\nAt least one match area must be defined.",
       'areas verified via JavaScript when "Copy areas from: None" selected';
     # dismiss the alert (can't use click because of fade effect)
     $driver->execute_script('$(".alert-danger").remove()');
@@ -455,8 +455,8 @@ subtest 'Saving needle with only OCR areas' => sub {
     wait_for_ajax(msg => 'wait for needle with only OCR areas created', with_minion => $minion);
     like
       $driver->find_element('#flash-messages .alert:last-child span')->get_text(),
-      qr/Cannot create a needle with only OCR areas/,
-      'error displayed for OCR-only needle';
+      qr/At least one match area must be defined/,
+      'error displayed when only an OCR needle is present';
     $driver->find_element('#flash-messages .alert:last-child .btn-close')->click();
 };
 
@@ -619,7 +619,7 @@ subtest 'areas/tags verified via JavaScript' => sub {
     $driver->find_element_by_id('save')->click();
     is
       $driver->find_element('.alert-danger span')->get_text(),
-      "Unable to save needle:\nNo tags specified.\nNo areas defined.",
+      "Unable to save needle:\nNo tags specified.\nAt least one match area must be defined.",
       'areas/tags verified via JavaScript';
     $driver->find_element('.alert-danger button')->click();
 };


### PR DESCRIPTION
The needle editor already validates that areas are present at all. With this change it also validates that at least one match area is present which is required by os-autoinst.