### PR TITLE
fix: allow worker to start without API keys

### DIFF
--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -49,8 +49,6 @@ sub new ($class, $webui_host, $cli_options) {
     # we do
     $ua->max_connections(0)->max_redirects(3);
 
-    die "API key and secret are needed for the worker connecting $webui_host\n" unless ($ua->apikey && $ua->apisecret);
-
     return $class->SUPER::new(
         webui_host => $webui_host,
         url => $url,

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -39,10 +39,8 @@ OpenQA::App->set_singleton(Mojolicious->new);
 my $app = OpenQA::App->singleton;
 $app->log->level('info');
 
-throws_ok {
-    OpenQA::Worker::WebUIConnection->new('http://127.0.0.1:1', {});
-}
-qr{API key and secret are needed for the worker connecting http://127\.0\.0\.1:1.*}, 'auth required';
+my $client_no_auth = OpenQA::Worker::WebUIConnection->new('http://127.0.0.1:1', {});
+isa_ok $client_no_auth, 'OpenQA::Worker::WebUIConnection', 'auth not strictly required for instantiation';
 
 my $client = OpenQA::Worker::WebUIConnection->new(
     'http://127.0.0.1:1',


### PR DESCRIPTION
Motivation:
A regression introduced in 9f0fc46d9 caused openQA workers to crash on startup
when using the 'None' authentication provider. While the 'None' provider allows
unauthenticated API access, the worker's internal logic strictly enforced the
presence of an API key and secret, leading to a fatal error.

Design Choices:
Removed the client-side 'die' in lib/OpenQA/Worker/WebUIConnection.pm that
mandated credentials. This defers authentication enforcement to the server API,
which the worker already handles gracefully via standard 4xx HTTP responses.
Updated t/24-worker-webui-connection.t to verify that instantiation without keys
now succeeds.

Benefits:
- Resolves worker startup crashes in environments using 'None' authentication.
- Simplifies configuration for automated CI and local development setups.
- Aligns worker behavior with the intended functionality of unauthenticated
  access.

Related issue: https://progress.opensuse.org/issues/194786