### PR TITLE
feat: Link to log and source code location from details step view

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -184,9 +184,21 @@ function renderModuleRow(module, snippets) {
       box.push(E('span', [content], {class: 'resborder ' + resborder}));
     }
     if (step.text && title !== 'Soft Failed') {
+      const params = new URLSearchParams({
+        filename: 'autoinst-log.txt',
+        filter: `[step:${module.category},${module.name},${step.num}]`
+      });
+      const logHref = `${window.location.pathname}/logfile?${params.toString()}`;
+      const linkText = E('i', [''], {
+        class: 'fa-solid fa-file-lines fa-xl',
+        title: 'View Logfile',
+        style: 'color: #0077ff'
+      });
+      const sourceLink = E('a', [linkText], {href: logHref});
       const stepActions = E('span', [], {class: 'step_actions', style: 'float: right'});
       stepActions.innerHTML = renderTemplate(snippets.bug_actions, {MODULE: module.name, STEP: step.num});
       const textresult = E('pre', [textData]);
+      stepActions.prepend(sourceLink);
       let html = stepActions.outerHTML;
       html += textresult.outerHTML;
       const txt = escape(html);

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -1,6 +1,8 @@
 // jshint multistr: true
 // jshint esversion: 6
 
+const testGitInfoRe = /TEST_GIT_HASH=([a-fA-F0-9]+) TEST_GIT_URL=([^\p{Cc}]+)/u;
+
 const testStatus = {
   state: null,
   result: null,
@@ -616,6 +618,17 @@ function delay(callback, ms) {
   };
 }
 
+let testGitHash = '';
+let testGitUrl = '';
+
+function findGitHash(line) {
+  const found = line.match(testGitInfoRe);
+  if (found) {
+    testGitHash = found[1];
+    testGitUrl = found[2];
+  }
+}
+
 function filterLogLines(input, viaSearchBox = true) {
   if (input === undefined) {
     return;
@@ -639,6 +652,9 @@ function filterLogLines(input, viaSearchBox = true) {
     let matchingLines = 0;
     if (string.length > 0) {
       for (const line of lines) {
+        if (!testGitHash) {
+          findGitHash(line);
+        }
         const lineAsText = ansiToText(line);
         if (regex ? lineAsText.match(regex) : lineAsText.includes(string)) {
           ++matchingLines;
@@ -667,6 +683,21 @@ function filterEmbeddedLogFiles() {
     }
   }
   loadEmbeddedLogFiles(filterLogLines.bind(null, searchBox, false));
+}
+
+const stepRe = / \[step:[a-zA-Z0-9-]+,[a-zA-Z0-9-]+,[0-9]+\] /;
+const sourceRe = /(?<= )(([a-zA-Z0-9_/.-]+\.p[my])):(\d+)/g;
+function createSourceLinks(lineContentElement) {
+  const baseUrl = testGitUrl + '/blob/' + testGitHash;
+  const found = lineContentElement.innerHTML.match(stepRe);
+  if (found) {
+    lineContentElement.innerHTML = lineContentElement.innerHTML.replace(
+      sourceRe,
+      (match, filePath, executionMatch, lineNumber) => {
+        return `<a href="${baseUrl}/${filePath}#L${lineNumber}" target="_blank"><i class="fa-solid fa-file-code fa-lg"></i> ${filePath}:${lineNumber}</a>`;
+      }
+    );
+  }
 }
 
 function showLogLines(logFileElement, lines, viaSearchBox = false) {
@@ -699,7 +730,13 @@ function showLogLines(logFileElement, lines, viaSearchBox = false) {
     if (hash === currentHash) {
       lineNumberLinkElement.onclick();
     }
+    if (!testGitHash) {
+      findGitHash(line);
+    }
     lineContentElement.innerHTML = ansiToHtml(line);
+
+    createSourceLinks(lineContentElement);
+
     lineNumberElement.appendChild(lineNumberLinkElement);
     lineElement.append(lineNumberElement, lineContentElement);
     tableElement.appendChild(lineElement);

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -745,7 +745,7 @@ function loadEmbeddedLogFiles(filter) {
         logFileElement.dataset.contentsLoaded = true;
       })
       .catch(error => {
-        log.error(error);
+        console.error(error);
         logFileElement.appendChild(document.createTextNode(`Unable to load logfile: ${error}`));
       });
   });

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -69,6 +69,13 @@ sub register ($self, $app, $config) {
         });
 
     $app->helper(
+        steploglink_for => sub ($c, $title, $url, $icon, $class = '') {
+            my $icons = $c->t(i => (class => "step_action fa-solid $icon fa-lg fa-stack-1x"));
+            my $content = $c->t(span => (class => 'fa-stack') => sub { $icons });
+            return $c->link_to($url => (title => $title, class => $class) => sub { $content });
+        });
+
+    $app->helper(
         stepvideolink_for => sub ($c, $testid, $file_name, $frametime) {
             my $t = sprintf '&t=%s,%s', $frametime->[0], $frametime->[1];
             my $url = $c->url_for('video', testid => $testid)->query(filename => $file_name) . $t;

--- a/templates/webapi/step/viewimg.html.ep
+++ b/templates/webapi/step/viewimg.html.ep
@@ -84,6 +84,7 @@
         </div>
     </span>
     <span class="step_actions">
+        %= steploglink_for 'Log' => url_for('logfile')->query(filename => 'autoinst-log.txt', filter => sprintf("[step:%s,%s,%d]", $module->category, $module->name, param 'stepid')), 'fa-file-lines', 'view_log'
         % if (is_operator) {
             %= stepaction_for 'Create new needle' => url_for('edit_step'), 'fa-thumb-tack', 'create_new_needle'
         % }


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/197177

This is how the link to the log looks like:
<img width="306" height="196" alt="details-log-link-grey" src="https://github.com/user-attachments/assets/c3872086-da37-4e34-8df6-640fbf445344" />


This is how the source links in the log currently look like:
<img width="1463" height="479" alt="autoinst-log-with-source-links" src="https://github.com/user-attachments/assets/e4e11e89-f32a-4b81-8e4e-5bebea16f152" />

