### PR TITLE
fix: make TESTS selection work again (regression from cd76f31f3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ifeq ($(TESTS),)
 PROVE_ARGS ?= --trap -r ${EXTRA_PROVE_ARGS} t
 else
 CHECKSTYLE ?= 0
+COMPILE_TEST ?= 0
 PROVE_ARGS ?= --trap ${EXTRA_PROVE_ARGS} $(TESTS)
 endif
 PROVE_LIB_ARGS ?= -l
@@ -234,7 +235,14 @@ checkstyle_tests =
 else
 checkstyle_tests = test-checkstyle-standalone
 endif
-test: $(checkstyle_tests) test-compile test-with-database ## Run all tests (including checkstyle, compile test and database tests)
+
+ifeq ($(COMPILE_TEST),0)
+compile_tests =
+else
+compile_tests = test-compile
+endif
+
+test: $(checkstyle_tests) $(compile_tests) test-with-database ## Run all tests (including checkstyle, compile test and database tests)
 ifeq ($(CONTAINER_TEST),1)
 ifeq ($(TESTS),)
 test: test-containers-compose


### PR DESCRIPTION
Motivation:
Specifying individual tests via 'make test TESTS=...' should ideally
isolate execution and avoid the overhead of unrelated checks. A recent
modification (commit cd76f31f3) unconditionally added 'test-compile' to
the main 'test' target, causing it to run even when a user explicitly
requested only specific test files.

Design Choices:
- Introduced a 'COMPILE_TEST' variable to control the 'test-compile'
  target, similar to the existing 'CHECKSTYLE' variable.
- Added logic to implicitly set 'COMPILE_TEST=0' whenever 'TESTS' is
  specified.
- Updated the 'test' target to use the 'compile_tests' variable instead
  of a hardcoded 'test-compile' dependency.