### PR TITLE
fix: resolve 'Too many open files' by clearing AssetPack FD cache

### DIFF
--- a/lib/OpenQA/Assets.pm
+++ b/lib/OpenQA/Assets.pm
@@ -33,6 +33,13 @@ sub setup ($server) {
           if $e =~ qr/could not find input asset.*node_modules/i;    # uncoverable statement
         die $e;    # uncoverable statement
     }
+
+    # Clean up file handles to avoid "Too many open files"
+    for my $asset (map { @$_ } values %{$server->asset->{by_topic} // {}}) {
+        delete $asset->{_asset}{handle} if $asset->{_asset} && $asset->{_asset}->isa('Mojo::Asset::File');
+    }
+    delete $server->asset->{input};
+    delete $server->asset->store->{assets};
 }
 
 sub _path ($url) { path('assets', ref $url eq 'Mojo::URL' ? $url->path : $url)->realpath->to_rel }


### PR DESCRIPTION
Motivation:
Adding numerous favicons and SCSS assets increased the baseline file
descriptor usage of every openQA web process to over 200. This left
insufficient headroom for concurrent uploads and log processing, leading
to 'Too many open files' crashes during heavy load.

Design Choices:
Leverage RAII by dropping references to the cached IO::File handles
inside Mojo::Asset::File objects immediately after the AssetPack
processing phase. This ensures descriptors are closed but allows
Mojolicious to reopen files on-demand if needed. Redundant input
and store caches are also cleared to free memory.

Manual verification:

```
perl -Ilib -MOpenQA::Assets -E '
    $ENV{MOJO_MODE} = "production";
    use Mojolicious::Lite;
    OpenQA::Assets::setup(app);
    say `ls -1 /proc/$$/fd | wc -l`;
'
```

showed a significant reduction of open file handles.

Benefits:
Reduces baseline FD usage per worker from ~217 to <10, preventing
exhaustion crashes and improving system stability.

Related issue: https://progress.opensuse.org/issues/201282