### PR TITLE
docs: Fix broken references in several documentation files

### DIFF
--- a/assets/javascripts/create_tests.js
+++ b/assets/javascripts/create_tests.js
@@ -54,7 +54,7 @@ function createTests(form) {
     success: function (response) {
       const id = response.scheduled_product_id;
       const url = `${form.dataset.productlogUrl}?id=${id}`;
-      addFlash('info', `Tests have been scheduled, checkout the <a href="${url}">product log</a> for details.`);
+      addFlash('info', `Tests have been scheduled, check out the <a href="${url}">product log</a> for details.`);
     },
     error: function (xhr, ajaxOptions, thrownError) {
       addFlash('danger', 'Unable to create tests: ' + (xhr.responseJSON?.error ?? xhr.responseText ?? thrownError));

--- a/assets/javascripts/running.js
+++ b/assets/javascripts/running.js
@@ -959,7 +959,7 @@ function handleWebsocketConnectionClosed(wsConnection) {
 
 function addLivehandlerFlash(status, id, text) {
   text +=
-    '<p><hr>For troubleshooting, checkout the <a href="https://open.qa/docs/#debugdevelmode" \
+    '<p><hr>For troubleshooting, check out the <a href="https://open.qa/docs/#debugdevelmode" \
     target="blank">documentation about debugging the developer mode setup</a>.</p>';
   addUniqueFlash(status, id, text, $('#developer-flash-messages'));
 }

--- a/docs/ContainerizedSetup.md
+++ b/docs/ContainerizedSetup.md
@@ -48,9 +48,9 @@ container (so you do not have any dependency on your host system) or to leave
 out the `openqa_data` container altogether (so you have only `webui` and
 `worker` containers and data is loaded and saved completely into your host
 system). If this is what you prefer, check out the sections
-[Keeping all data in the Data Volume Container](ContainerizedSetup.md#keeping_all_data_in_the_data_volume_container)
+[Keeping all data in the Data Volume Container](ContainerizedSetup.md#keeping-all-data-in-the-data-volume-container)
 and
-[Keeping all data on the host system](ContainerizedSetup.md#keeping_all_data_on_the_host_system)
+[Keeping all data on the host system](ContainerizedSetup.md#keeping-all-data-on-the-host-system)
 respectively.
 
 Otherwise, when you want to have the big files (isos and disk images, tests and
@@ -327,7 +327,7 @@ If you decided to keep all the data in the Volume container (`openqa_data`), run
     podman exec openqa_data chmod -R 777 data/factory/{iso,hdd} data/tests
 
 In the
-[section about running the web UI and data container](ContainerizedSetup.md#run_the_data_and_web_ui_containers),
+[section about running the web UI and data container](ContainerizedSetup.md#run-the-data-and-web-ui-containers),
 use the `openqa_data`
 container like this instead:
 
@@ -350,14 +350,14 @@ a Volume Container, run the following commands:
     chcon -Rt svirt_sandbox_file_t data
 
 In the
-[section about running the web UI and data container](ContainerizedSetup.md#run_the_data_and_web_ui_containers),
+[section about running the web UI and data container](ContainerizedSetup.md#run-the-data-and-web-ui-containers),
 do **not** run the `openqa_data`
 container and run the `webui` container like this instead: podman run -d -h openqa_webui -v `pwd`/data:/data --name openqa_webui -p 443:443 -p 80:80 fedoraqa/openqa_webui:4.1-3.12 Change OpenID provider in `data/conf/openqa.ini` under `provider` in
 `[openid]` section and then put Key and Secret under both sections in
 `data/conf/client.conf`.
 
 In the
-[run worker container section](ContainerizedSetup.md#run_the_worker_container),
+[run worker container section](ContainerizedSetup.md#run-the-worker-container),
 run the worker as:
 
     podman run -h openqa_worker_1 --name openqa_worker_1 -d --link openqa_webui:openqa_webui -v `pwd`/data:/data --volumes-from openqa_webui --privileged fedoraqa/openqa_worker:4.1-3.12 1

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -500,7 +500,7 @@ Of course you can ignore the user specified in these unit files and instead
 start everything as your regular user as mentioned above. However, you need to
 ensure that your user has the permission to the "openQA base directory". That
 is not the case by default so it makes sense to
-[customize it](Contributing.md#customize_base_directory).
+[customize it](Contributing.md#customize-base-directory).
 
 You do **not** need to setup an additional web server because the daemons
 already provide one. The port under which a service is available is logged on
@@ -519,7 +519,7 @@ This creates an empty temporary database and starts the web application using
 that specific database (ignoring the configuration from `database.ini`). Be aware that this may cause unwanted changes in the `t/data` directory.
 
 Also find more details in
-[Run tests without Container](Contributing.md#run_tests_without_container).
+[Run tests without Container](Contributing.md#run-tests-without-container).
 
 #### Further tips
 
@@ -869,12 +869,12 @@ either `./script/initdb --init_database` or `./script/upgradedb --upgrade_databa
 
 Migrations that affect possibly big tables should be tested against a local import of
 a production database to see how much time they need. Check out the
-[Importing production data](Contributing.md#importing_production_data) section
+[Importing production data](Contributing.md#importing-production-data) section
 for details.
 
 A migration can cause the analyser to regress so it produces worse query plans leading
 to impaired performance. Check out the
-[Working on database-related performance problems](Installing.md#working_on_database_related_performance_problems)
+[Working on database-related performance problems](Installing.md#working-on-database-related-performance-problems)
 section for how to tackle this problem.
 
 ### How to add fixtures to the database

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -469,14 +469,14 @@ sudo sudo -u postgres openqa-setup-db your_username openqa-local
 
 Assuming you have already followed steps 1. to 4. above:
 
-1.  Create a separate database: `createdb -O your_username openqa-o3` where  `openqa-o3` is the name you want to use for the database
-
+1.  Create a separate database: `createdb -O your_username openqa-o3` where
+    `openqa-o3` is the name you want to use for the database
 2.  The next steps must be run as the user you start your local openQA
-    instance with, i.e. the `your_username` user. 3.  Import dump: `pg_restore -c -d openqa-o3 path/to/dump`
+    instance with, i.e. the `your_username` user.
+3.  Import dump: `pg_restore -c -d openqa-o3 path/to/dump`
     Note that errors of the form `ERROR: role "geekotest" does not exist` are
     due to the users in the production setup and can safely be ignored.
     Everything will be owned by `your_username`.
-
 4.  Configure openQA to use that database as in step 7. above.
 
 ### Manual daemon setup

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,7 +28,7 @@ become a happy user.
 
 For a quick start, if you already have an openQA instance available you can
 refer to the section
-[Cloning existing jobs - openqa-clone-job](UsersGuide.md#cloning_existing_jobs_openqa_clone_job)
+[Cloning existing jobs - openqa-clone-job](UsersGuide.md#cloning-existing-jobs---openqa-clone-job)
 directly to trigger a new test based on already existing job. For a quick
 installation refer directly to
 [Quick bootstrapping under openSUSE](Installing.md#bootstrapping) or
@@ -327,7 +327,7 @@ can place default values deviating from upstream defaults.
 The client configuration can also be put under `~/.config/openqa/client.conf`.
 
 For development, check out the section about
-[customizing the configuration directory](Contributing.md#customize_configuration_directory).
+[customizing the configuration directory](Contributing.md#customize-configuration-directory).
 
 #### Drop-in configurations
 

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -88,7 +88,7 @@ podman run -e skip_suse_specifics= -e skip_suse_tests= \
 
 The `skip_suse_specifics=` and `skip_suse_tests=` options ensure the test files
 and needles required for openSUSE/SUSE tests are downloaded. Refer to the
-[example video above](Installing.md#how_to_run_a_test_with_single_instance_container_in_5_minutes)
+[example video above](Installing.md#how-to-run-a-test-with-single-instance-container-in-5-minutes)
 and the [get testing](GettingStarted.md#get-testing) section for more
 details.
 
@@ -209,7 +209,7 @@ The above command will bootstrap an openQA installation and immediately
 afterwards start a local test job clone from a test job from a remote instance
 with optional, overridden parameters. More information about
 `openqa-clone-job` can be found in
-[Cloning existing jobs - openqa-clone-job](UsersGuide.md#cloning_existing_jobs_openqa_clone_job).
+[Cloning existing jobs - openqa-clone-job](UsersGuide.md#cloning-existing-jobs---openqa-clone-job).
 
 You can also run `openqa-bootstrap` repeatedly. For example when you stop a
 container and the openQA daemons and database are stopped, calling
@@ -1138,7 +1138,7 @@ The messages consist of a topic and a body.
 The body contains json encoded info about the event.
 See [amqp_infra](https://github.com/openSUSE/suse_msg/blob/master/amqp_infra.md)
 for more info about the server and the message topic format or take a look at
-[Consuming AMQP events from openQA](UsersGuide.md#amqp_events) to find
+[Consuming AMQP events from openQA](UsersGuide.md#consuming-amqp-events-from-openqa) to find
 detailed instructions how to configure the AMQP server.
 
 To let openQA send messages to an AMQP message bus,
@@ -1754,7 +1754,7 @@ are using indexes (and not just sequential scans).
 
 Tests, needles, assets, results and working directories (a.k.a. "pool directories") are located in certain
 subdirectories within `/var/lib/openqa`. This directory is configurable (see
-[Customize base directory](Contributing.md#customize_base_directory)). Here we assume the default is in place.
+[Customize base directory](Contributing.md#customize-base-directory)). Here we assume the default is in place.
 
 
 

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1243,7 +1243,7 @@ need to be defined before on the corresponding pages of the web UI (accessible
 to operators from the user menu). The
 [section on job templates](UsersGuide.md#job_templates) already explains
 details about these tables. Alternatively, these settings can be
-supplied via a [YAML document](UsersGuide.md#scenarios_yaml).
+supplied via a [YAML document](UsersGuide.md#defining-test-scenarios-in-yaml).
 
 Additionally to the necessary template matching parameters `DISTRI`, `VERSION`,
 `FLAVOR` and `ARCH` more parameters can be specified. Those additional
@@ -1531,7 +1531,7 @@ the test will be uploaded back to the web-UI and stored under the name
 
 > **NOTE:**
 > When using this mechanism you will often also want to use the
-> [variable expansion](UsersGuide.md#variable_expansion) mechanism.
+> [variable expansion](UsersGuide.md#variable-expansion) mechanism.
 
 #### Private assets
 
@@ -1553,7 +1553,7 @@ naming conflicts.
 
 ## Cleanup of assets, results and other data
 
-The cleanup of [assets](UsersGuide.md#asset_handling), test results
+The cleanup of [assets](UsersGuide.md#asset-handling), test results
 and certain other data is automated. That means openQA removes assets, job
 results and other data automatically according to configurable limits.
 
@@ -1565,7 +1565,7 @@ unless `concurrent` is set to `1` in the `[cleanup]` settings of
 cleanup-related settings can be found within the web UI configuration as well,
 e.g. the `[…_limits]` sections contain various tweaks and allow to change certain
 defaults. Check out the sub section
-[Timers and triggers](UsersGuide.md#timers_and_triggers) to learn more
+[Timers and triggers](UsersGuide.md#timers-and-triggers) to learn more
 about how those jobs are triggered.
 
 The cleanup of **assets** and job **results** (and certain other data) is happening
@@ -1611,7 +1611,7 @@ after they finished. This limit only applies if it's higher than regular jobs.
 
 Further remarks:
 
-- Checkout the [Build tagging](UsersGuide.md#build_tagging) section for
+- Checkout the [Build tagging](UsersGuide.md#build-tagging) section for
   how to mark a job as important on job group level. Jobs can also be marked as
   important by adding a "link label" (e.g.
   `label:linked Job mentioned on https://…`) in a job comment. - New groups use the limits configured in the `[default_group_limits]`

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1611,7 +1611,7 @@ after they finished. This limit only applies if it's higher than regular jobs.
 
 Further remarks:
 
-- Checkout the [Build tagging](UsersGuide.md#build-tagging) section for
+- Check out the [Build tagging](UsersGuide.md#build-tagging) section for
   how to mark a job as important on job group level. Jobs can also be marked as
   important by adding a "link label" (e.g.
   `label:linked Job mentioned on https://…`) in a job comment. - New groups use the limits configured in the `[default_group_limits]`

--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -2224,7 +2224,7 @@ An example using GitHub actions and the official container image we provide for
 > [scenario definitions](https://github.com/os-autoinst/os-autoinst-distri-example/blob/master/scenario-definitions.yaml)
 > in a way that is independent from openQA's normal scheduling tables. This
 > feature is explained in further detail in the corresponding
-> [users guide section](UsersGuide.md#scenarios_yaml).
+> [users guide section](UsersGuide.md#defining-test-scenarios-in-yaml).
 
 It is also possible to create a GitHub workflow that will clone and monitor an
 openQA job which is mentioned in the PR description or comment. The scripts

--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -2144,12 +2144,11 @@ sub post_run_hook {}
 ```
 
 For example this can be used in bug investigations or trying out new test
-modules which are hard to test locally.
-The
-section "Asset handling" in the [Users Guide](UsersGuide.md#usersguide)
-describes how downloadable assets can be specified. It is important to note
-that the specified asset is only downloaded once. New versions must be
-supplied as new, unambiguous download target file names.
+modules which are hard to test locally. The section
+[Asset handling](UsersGuide.md#asset-handling) describes how downloadable assets
+can be specified. It is important to note that the specified asset is only
+downloaded once. New versions must be supplied as new, unambiguous download
+target file names.
 
 <a id="triggering_tests_based_on_an_any_remote_git_refspec_or_open_github_pull_request"></a>
 ### Triggering tests based on an any remote Git refspec or open GitHub pull request

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -744,7 +744,7 @@ sub cluster_jobs ($self, @args) {
 
     # handle re-visiting job
     if (defined $job) {
-        # checkout the children after all when revisiting this job without $skip_children but children
+        # check out the children after all when revisiting this job without $skip_children but children
         # have previously been skipped
         return $self->_cluster_children($jobs, $cancelmode) if !$skip_children && delete $job->{children_skipped};
         # otherwise skip the already visisted job

--- a/templates/webapi/admin/group/cleanup_help.html.ep
+++ b/templates/webapi/admin/group/cleanup_help.html.ep
@@ -19,6 +19,6 @@
 </ul>
 <p>
     There is also separate retentions for <strong>important</strong> jobs so these jobs can be stored longer. Jobs can be marked as important on job group level
-    via <a href="https://open.qa/docs/#build_tagging">build tagging</a> and on job level via "link labels", e.g. <code>label:linked Job mentioned on https://…</code>.
+    via <a href="https://open.qa/docs/#build-tagging">build tagging</a> and on job level via "link labels", e.g. <code>label:linked Job mentioned on https://…</code>.
 </p>
 '; %>

--- a/templates/webapi/test/create.html.ep
+++ b/templates/webapi/test/create.html.ep
@@ -68,7 +68,7 @@
     <div class="col-md-6">
       <label for="create-tests-scenario-definitions" class="form-label"><strong>Scenario definitions</strong></label>
       <%= help_popover('Scenario definitions' => '<p>A YAML document that defines sets of settings. These settings are then combined to create one or more test jobs.</p>',
-        'https://open.qa/docs/#scenarios_yaml', 'the documentation', 'left') %>
+        'https://open.qa/docs/#defining-test-scenarios-in-yaml', 'the documentation', 'left') %>
       <textarea class="form-control" id="create-tests-scenario-definitions" rows="15"><%= $preset->{scenario_definitions} // q(---
 # example
 


### PR DESCRIPTION
Those were broken by the Markdown migration. This change doesn't cover all broken references yet.