### PR TITLE
fix: work around DBD::Pg bug regarding INSERT ON CONFLICT row count

### DIFF
--- a/lib/OpenQA/Resource/Locks.pm
+++ b/lib/OpenQA/Resource/Locks.pm
@@ -93,10 +93,13 @@ sub barrier_create ($name = undef, $jobid = undef, $expected_jobs = undef) {
     my $barriers = _get_lock($name, $jobid, 'all');
     return 0 if $barriers && $barriers->single;
     my $dbh = OpenQA::Schema->singleton->storage->dbh;
+    # note: Using execute() return value instead of $sth->rows which is unreliable for ON CONFLICT DO NOTHING
+    # https://github.com/bucardo/dbdpg/issues/194
     my $sth = $dbh->prepare('INSERT INTO job_locks (name, owner, count) VALUES (?, ?, ?) ON CONFLICT DO NOTHING');
-    try { $sth->execute($name, $jobid, $expected_jobs) }
+    my $rows;
+    try { $rows = $sth->execute($name, $jobid, $expected_jobs) }
     catch ($e) { die "Unable to create barrier for job $jobid with name '$name': $e" }    # uncoverable statement
-    return $sth->rows > 0;
+    return $rows > 0;
 }
 
 sub barrier_wait ($name = undef, $jobid = undef, $where = undef, $check_dead_job = 0) {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1116,7 +1116,9 @@ sub insert_module ($self, $tm, $skip_jobs_update = undef) {
     # execute query to insert job module
     # note: We have 'important' in the DB but 'ignore_failure' in the flags for historical reasons (see #1266).
     my $flags = $tm->{flags};
-    $insert_sth->execute(
+    # note: Using execute() return value instead of $sth->rows which is unreliable for ON CONFLICT DO NOTHING
+    # https://github.com/bucardo/dbdpg/issues/194
+    my $rows = $insert_sth->execute(
         $self->id, @required_fields,
         $flags->{milestone} ? 1 : 0,
         $flags->{ignore_failure} ? 0 : 1,
@@ -1124,7 +1126,7 @@ sub insert_module ($self, $tm, $skip_jobs_update = undef) {
         $flags->{always_rollback} ? 1 : 0,
         $flags->{always_run} ? 1 : 0,
     );
-    return 0 unless $insert_sth->rows;
+    return 0 if $rows <= 0;
 
     # update job module statistics for that job (jobs with default result NONE are accounted as skipped)
     $self->update({skipped_module_count => \'skipped_module_count + 1'}) unless $skip_jobs_update;
@@ -1619,9 +1621,12 @@ sub allocate_network ($self, $name) {
     for ($vlan = 1;; ++$vlan) {
         log_debug "at vlan $name:$vlan";
         next if $used{$vlan};
-        try { $sth->execute($job_id, $name, $vlan) }
+        # note: Using execute() return value instead of $sth->rows which is unreliable for ON CONFLICT DO NOTHING
+        # https://github.com/bucardo/dbdpg/issues/194
+        my $rows;
+        try { $rows = $sth->execute($job_id, $name, $vlan) }
         catch ($e) { die "Failed to create new vlan tag '$vlan' for job $job_id: $e\n" }    # uncoverable statement
-        die "Unable to allocate network for job $job_id: network '$name' already exists" unless $sth->rows;
+        die "Unable to allocate network for job $job_id: network '$name' already exists" if $rows <= 0;
         log_debug "Created network for $job_id: $vlan";
         for my $cluster_job_id (keys %{$self->cluster_jobs}) {
             # apply it for the whole cluster so that the vlan only appears if all of the cluster is gone

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -674,10 +674,10 @@ subtest 'allocating network' => sub {
         #       a transaction (as of 3c52abbe3d6364c02f73c6f9fe4afe44f89688f6) makes one think it may be
         #       necassary. If we ever encounter this error in production we should find out what exactly is
         #       causing it and what behavior would make most sense in that situation.
-        my $jobs_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
-        $jobs_mock->redefine(_find_network => undef);
+        $mock_result->redefine(_find_network => undef);
         throws_ok { $job->prepare_for_work($worker) } qr/unable to alloc.*foo.*already exists/i,
           'explicit error if network to be created already exists';
+        $mock_result->unmock('_find_network');
         $networks = _get_job_networks($job_networks);
         is_deeply $networks, \@expected_networks, 'still only 2 job networks' or always_explain $networks;
     };


### PR DESCRIPTION
DBD::Pg returns -1 from $sth->rows() for INSERT ... ON CONFLICT DO
NOTHING statements when using prepared statements, instead of the
correct value of 0. This broke t/10-jobs.t and t/04-scheduler.t.

The fix uses the return value of `$sth->execute` instead, which
also returns the row count and doesn't seem to be affected by
the bug.

bucardo/dbdpg#194
Issue: https://progress.opensuse.org/issues/201279

---
Same as #7465 but with corrected commit message and more useful split of commits. Commit author is still @d3flex 