### PR TITLE
refactor: Use Feature::Compat::Try consistently

### DIFF
--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -13,7 +13,7 @@ use OpenQA::Log qw(log_debug);
 use OpenQA::Test::TimeLimit '37';
 use OpenQA::Test::Case;
 use OpenQA::SeleniumTest;
-use Syntax::Keyword::Try;
+use Feature::Compat::Try;
 
 my $test_case = OpenQA::Test::Case->new;
 my $schema_name = OpenQA::Test::Database::generate_schema_name;
@@ -79,7 +79,7 @@ sub write_comment ($text, $desc) {
             wait_for_ajax msg => $desc;
             return undef;
         }
-        catch ($e) { $error = $e }
+        catch ($e) { $error = $e }    # uncoverable statement
         die $error if ($error !~ qr/unexpected alert/i) || ($attempts >= $max_write_attempts);   # uncoverable statement
 
         # try to dismiss the alert "The comment text mustn't be empty." that is for some reason possibly shown


### PR DESCRIPTION
Syntax::Keyword::Try provides a try feature that is compatible with the try function builtin in newer perl versions. Feature::Compat::Try is a module that uses Syntax::Keyword::Try in older versions and automatically uses the builtin try in newer versions, and that is what we use elsewhere as well.

I had simply confused the two modules in this file.

I had to mark one `catch` block as uncoverable. This is probably due to
Devel::Cover missing features regarding those Syntax::Keyword modules, which
previously considered this line falsely as covered.