### PR TITLE
feat: Improve CLI retry error feedback with detailed messages

### DIFF
--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -130,8 +130,13 @@ sub retry_tx ($self, $client, $tx, $retries = undef, $delay = undef) {
         my $res_code = $new_tx->res->code // 0;
         return $self->handle_result($new_tx, $tx) if $res_code !~ /^(50[23]|0)$/ || $retries <= 0;
         my $waited = time - $start;
+        my $error = $new_tx->error;
+        my $error_msg = $error ? " ($error->{message})" : '';
+        my $url = $new_tx->req->url;
+        my $port = $url->port // ($url->scheme && $url->scheme eq 'https' ? 443 : 80);
+        my $target = ($url->host || 'localhost') . ":$port";
         print STDERR encode('UTF-8',
-"Request failed, hit error $res_code, retrying up to $retries more times after waiting … (delay: $delay; waited ${waited}s)\n"
+"Request to $target failed, hit error $res_code$error_msg, retrying up to $retries more times after waiting … (delay: $delay; waited ${waited}s)\n"
         );
         sleep $delay;
         $delay *= $factor;


### PR DESCRIPTION
Motivation:
When an openQA CLI command (like openqa-clone-job) fails with a network
error (e.g. "Connection refused"), it currently only reports "hit error 0".
This is cryptic and doesn't tell the user why the connection failed or
which host:port was targeted.

Design Choices:
- Extract the error message from the Mojo::Transaction object.
- Extract and explicitly display the target host and port from the request URL.
- Include both the target and the error message in the retry warning output.
- Handle both network errors (where code is 0) and HTTP errors (like 502).

Benefits:
- Users get immediate, clear feedback on exactly which host:port failed and why.
- Easier troubleshooting of local environment setup issues (e.g. wrong port).

Related issue: https://github.com/os-autoinst/openQA/pull/7015