### PR TITLE
fix: avoid permission denied on cgroup creation for v2

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -341,28 +341,26 @@ sub engine_workit ($job, $callback) {
 }
 
 sub _configure_cgroupv2 ($job_info) {
-    # create cgroup within /sys/fs/cgroup/systemd
+    # create cgroup for current job within detected slice
     log_info('Preparing cgroup to start isotovideo');
     my $carp_guard;
     if (is_loaded('Carp::Always')) {
         $carp_guard = scope_guard sub { Carp::Always->import };    # uncoverable statement
         Carp::Always->unimport;    # uncoverable statement
     }
-    my $cgroup_name = 'systemd';
     my $cgroup_slice = CGROUP_SLICE;
     if (!defined $cgroup_slice) {
         # determine cgroup slice of the current process
         try {
-            my $pid = $$;
-            $cgroup_slice = (grep { /name=$cgroup_name:/ } split /\n/, path('/proc', $pid, 'cgroup')->slurp)[0]
-              if defined $pid;
-            $cgroup_slice =~ s/^.*name=$cgroup_name:/$cgroup_name/g if defined $cgroup_slice;
+            my $cgroups = path('/proc/self/cgroup')->slurp;
+            ($cgroup_slice) = $cgroups =~ /name=systemd:(.*)/;
+            ($cgroup_slice) = $cgroups =~ /^0::(.*)/m unless defined $cgroup_slice;
         }
         catch ($e) { }
     }
     my $cgroup;
     try {
-        $cgroup = cgroupv2(name => $cgroup_name)->from($cgroup_slice // '')->child($job_info->{id})->create;
+        $cgroup = cgroupv2(parent => path($cgroup_slice // '')->child($job_info->{id})->to_string);
         my $query_cgroup_path = $cgroup->can('_cgroup');
         log_info('Using cgroup ' . $query_cgroup_path->($cgroup)) if $query_cgroup_path;
     }


### PR DESCRIPTION
Motivation:
On modern Linux systems using pure cgroups v2, the openQA worker fails to
initialize cgroups because it explicitly looks for the 'systemd' controller
and attempts to create a directory under /sys/fs/cgroup/systemd, which
doesn't exist and isn't writable by the user.

Design Choices:
Updated the slice detection logic to support the cgroup v2 unified
hierarchy format (0::/...). Instantiation of the cgroupv2 object now
bypasses the 'name' parameter to avoid eager directory creation of
non-existent controllers and uses the 'parent' parameter to directly
target the correct slice.

Benefits:
- Eliminates the 'Permission denied' warning on worker startup.
- Enables cgroup-based resource isolation for jobs on v2 systems.
- Maintains compatibility with cgroup v1 environments.