### PR TITLE
feat: add run-test-env target to start all local services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,16 @@ define RUN_SERVICE_TEST_ENV
 	$(1)
 endef
 
+.PHONY: run-test-env
+run-test-env: setup-database ## Run all local test services (webui, websockets, scheduler, worker, gru)
+	trap 'kill 0' SIGINT SIGTERM; \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-webui-daemon) & \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-websockets-daemon) & \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-scheduler-daemon) & \
+	$(call RUN_SERVICE_TEST_ENV,script/worker) & \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-gru) & \
+	wait
+
 .PHONY: run-webui-test-env
 run-webui-test-env: setup-database ## Run a local web UI instance using a test environment
 	$(call RUN_SERVICE_TEST_ENV,script/openqa-webui-daemon)

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,8 @@ setup-database: ## Set up the test database
 	test -d $(TEST_PG_PATH) && (pg_ctl -D $(TEST_PG_PATH) -s status >&/dev/null || pg_ctl -D $(TEST_PG_PATH) -s start) || ./t/test_postgresql $(TEST_PG_PATH)
 
 define RUN_SERVICE_TEST_ENV
-	OPENQA_BASEDIR=t/data \
+	OPENQA_BASEDIR="$(CURDIR)/t/data" \
+	OPENQA_CONFIG="$(CURDIR)/t/data" \
 	OPENQA_DATABASE=test \
 	OPENQA_WEBUI_MODE=test \
 	TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)" \

--- a/t/data/client.conf
+++ b/t/data/client.conf
@@ -1,3 +1,7 @@
 [testapi]
 key = PERCIVALKEY02
 secret = PERCIVALSECRET02
+
+[localhost]
+key = 1234567890ABCDEF
+secret = 1234567890ABCDEF


### PR DESCRIPTION
Motivation:
Starting each openQA service individually is tedious and error-prone.

Design Choices:
Added a 'run-test-env' target that launches all necessary daemons
(webui, websockets, scheduler, worker, gru) in the background and
uses 'wait' with a 'trap' to ensure they all exit when the main
process is interrupted.

Benefits:
Single command to bring up a full local development/test environment.