### PR TITLE
PART 2: fix: improve process cleanup in 'make run-test-env' - After #7476

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,16 @@ define RUN_SERVICE_TEST_ENV
 	$(1)
 endef
 
+.PHONY: run-test-env
+run-test-env: setup-database ## Run all local test services (webui, websockets, scheduler, worker, gru)
+	trap 'kill 0' SIGINT SIGTERM; \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-webui-daemon) & \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-websockets-daemon) & \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-scheduler-daemon) & \
+	$(call RUN_SERVICE_TEST_ENV,script/worker) & \
+	$(call RUN_SERVICE_TEST_ENV,script/openqa-gru) & \
+	wait
+
 .PHONY: run-webui-test-env
 run-webui-test-env: setup-database ## Run a local web UI instance using a test environment
 	$(call RUN_SERVICE_TEST_ENV,script/openqa-webui-daemon)

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ endef
 
 .PHONY: run-test-env
 run-test-env: setup-database ## Run all local test services (webui, websockets, scheduler, worker, gru)
-	trap 'kill 0' SIGINT SIGTERM; \
+	trap 'trap "" SIGINT SIGTERM EXIT; kill 0; wait' SIGINT SIGTERM EXIT; \
 	$(call RUN_SERVICE_TEST_ENV,script/openqa-webui-daemon) & \
 	$(call RUN_SERVICE_TEST_ENV,script/openqa-websockets-daemon) & \
 	$(call RUN_SERVICE_TEST_ENV,script/openqa-scheduler-daemon) & \

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,8 @@ setup-database: ## Set up the test database
 	test -d $(TEST_PG_PATH) && (pg_ctl -D $(TEST_PG_PATH) -s status >&/dev/null || pg_ctl -D $(TEST_PG_PATH) -s start) || ./t/test_postgresql $(TEST_PG_PATH)
 
 define RUN_SERVICE_TEST_ENV
-	OPENQA_BASEDIR=t/data \
+	OPENQA_BASEDIR="$(CURDIR)/t/data" \
+	OPENQA_CONFIG="$(CURDIR)/t/data" \
 	OPENQA_DATABASE=test \
 	OPENQA_WEBUI_MODE=test \
 	TEST_PG="DBI:Pg:dbname=openqa_test;host=$(TEST_PG_PATH)" \

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -575,7 +575,10 @@ sub enqueue_jobs_and_accept_first ($self, $client, $job_info) {
 
 sub _inform_webuis_before_stopping ($self, $callback) {
     my $clients_by_webui_host = $self->clients_by_webui_host;
-    return undef unless defined $clients_by_webui_host;
+    if (!defined $clients_by_webui_host || !keys %$clients_by_webui_host) {
+        Mojo::IOLoop->next_tick($callback) if $callback;
+        return undef;
+    }
     my $outstanding_transactions = scalar keys %$clients_by_webui_host;
     for my $host (keys %$clients_by_webui_host) {
         log_debug("Informing $host that we are going offline");

--- a/t/data/client.conf
+++ b/t/data/client.conf
@@ -1,3 +1,7 @@
 [testapi]
 key = PERCIVALKEY02
 secret = PERCIVALSECRET02
+
+[localhost]
+key = 1234567890ABCDEF
+secret = 1234567890ABCDEF


### PR DESCRIPTION
Motivation:
Aborting 'make run-test-env' with Ctrl-C sometimes left behind orphan
processes or caused race conditions during shutdown.

Design Choices:
Updated the trap to:
1. Disable further traps immediately to avoid recursive signals.
2. Include the EXIT signal to catch all termination paths.
3. Explicitly wait for children processes after signaling them with
   'kill 0'.

Benefits:
More robust cleanup of the local test environment services.

PART 2: After
* #7476