### PR TITLE
feat: allow operators to fetch unredacted settings + warn non-operators about redacted settings

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -109,8 +109,15 @@ sub _get_vars ($jobid, $url_handler, $options) {
 sub clone_job_get_job ($jobid, $url_handler, $options) {
     my $url = $url_handler->{remote_url}->clone;
     $url->path("jobs/$jobid");
+    $url->query->merge(unredacted => 1);
     $url->query->merge(check_assets => 1) unless $options->{'ignore-missing-assets'};
     my $job = _get_with_retry($url_handler, $url, $jobid, 'job', $options)->{job};
+
+    if (my @redacted = grep { ($job->{settings}->{$_} // '') eq '[redacted]' } keys %{$job->{settings}}) {
+        warn "Job $jobid has redacted secrets: " . join(', ', sort @redacted) . "\n";
+        warn "These clone as '[redacted]'. Use operator credentials for actual secrets.\n";
+    }
+
     print STDERR Cpanel::JSON::XS->new->pretty->encode($job) if $options->{verbose};
     $job->{vars} = _get_vars($jobid, $url_handler, $options) if $options->{reproduce};
     return $job;

--- a/lib/OpenQA/Shared/Controller/Auth.pm
+++ b/lib/OpenQA/Shared/Controller/Auth.pm
@@ -52,11 +52,22 @@ sub check ($self) {
 }
 
 sub auth ($self) {
+    return 1 if $self->_auth;
+    $self->render(json => {error => $self->stash('auth_error') // 'Not authorized'}, status => 403);
+    return 0;
+}
+
+sub auth_maybe ($self) {
+    $self->_auth;
+    return 1;
+}
+
+sub _auth ($self) {
     my $log = $self->app->log;
 
     # Prevent authentication via file domain (where potentially untrusted HTML is served)
     if ($self->via_domain($self->config->{global}->{file_domain})) {
-        $self->render(json => {error => 'Forbidden via file domain'}, status => 403);
+        $self->stash(auth_error => 'Forbidden via file domain');
         return 0;
     }
 
@@ -66,8 +77,8 @@ sub auth ($self) {
         if ($self->req->method ne 'GET' && !$self->valid_csrf) {
             # Invalidate session-based auth if CSRF is missing; fallback to API headers if present
             $user = undef;
-            $self->render(json => {error => 'Bad CSRF token!'}, status => 403) and return 0
-              unless $self->is_api_request;
+            $self->stash(auth_error => 'Bad CSRF token!');
+            return 0 unless $self->is_api_request;
         }
     }
 
@@ -101,7 +112,7 @@ sub auth ($self) {
         return 1;
     }
 
-    $self->render(json => {error => $reason}, status => 403);
+    $self->stash(auth_error => $reason);
     return 0;
 }
 

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -78,6 +78,8 @@ sub startup ($self) {
       = $api_public->under('/')->to('Auth#auth_admin')->name('api_ensure_admin');
     my $api_auth_any_user
       = $api_public->under('/')->to('Auth#auth')->name('api_ensure_user');
+    my $api_maybe_auth = $api_public->under('/')->to('Auth#auth_maybe');
+
 
     OpenQA::Setup::setup_template_search_path($self);
     OpenQA::Setup::load_plugins($self, $auth);
@@ -289,6 +291,8 @@ sub startup ($self) {
     my $api_ro = $api_auth_operator->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     my $api_ra = $api_auth_admin->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
     my $api_public_r = $api_public->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+    my $api_maybe_auth_r = $api_maybe_auth->any('/')->to(namespace => 'OpenQA::WebAPI::Controller::API::V1');
+
 
     $api_public_r->get('/routes')->name('api_v1_list_routes')->to('routes#list');
     push @api_routes, $api_ru, $api_ro, $api_ra, $api_public_r;
@@ -323,8 +327,8 @@ sub startup ($self) {
     $api_ra->delete('/parent_groups/<group_id:num>')->name('apiv1_delete_parent_group')->to('job_group#delete');
 
     # api/v1/jobs
-    $api_public_r->get('/jobs')->name('apiv1_jobs')->to('job#list');
-    $api_public_r->get('/jobs/overview')->name('apiv1_jobs_overview')->to('job#overview');
+    $api_maybe_auth_r->get('/jobs')->name('apiv1_jobs')->to('job#list');
+    $api_maybe_auth_r->get('/jobs/overview')->name('apiv1_jobs_overview')->to('job#overview');
     $api_ro->post('/jobs')->name('apiv1_create_job')->to('job#create');
     $api_ro->post('/jobs/cancel')->name('apiv1_cancel_jobs')->to('job#cancel');
     $api_ro->post('/jobs/restart')->name('apiv1_restart_jobs')->to('job#restart');
@@ -334,9 +338,10 @@ sub startup ($self) {
 
     my $job_r = $api_ro->any('/jobs/<jobid:num>');
     push @api_routes, $job_r;
-    $api_public_r->any('/jobs/<jobid:num>')->name('apiv1_job')->to('job#show');
+    $api_maybe_auth_r->any('/jobs/<jobid:num>')->name('apiv1_job')->to('job#show');
     $api_public_r->get('/experimental/jobs/<jobid:num>/status')->name('apiv1_get_status')->to('job#get_status');
-    $api_public_r->any('/jobs/<jobid:num>/details')->name('apiv1_job')->to('job#show', details => 1);
+    $api_maybe_auth_r->any('/jobs/<jobid:num>/details')->name('apiv1_job')->to('job#show', details => 1);
+
     $job_r->put('/')->name('apiv1_put_job')->to('job#update');
     $job_r->delete('/')->name('apiv1_delete_job')->to('job#destroy');
     $job_r->post('/prio')->name('apiv1_job_prio')->to('job#prio');

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -451,6 +451,7 @@ sub show ($self) {
     my $details = $self->stash('details') || 0;
     my $check_assets = !!$self->param('check_assets');
     my $follow = $self->param('follow');
+    my $unredacted = $self->param('unredacted') && $self->is_operator;
     return unless my $job = $self->find_job_or_render_not_found($job_id, $follow ? {prefetch => 'settings'} : {});
     $job = $job->latest_job if $follow;
     $job = $job->to_hash(
@@ -459,6 +460,7 @@ sub show ($self) {
         deps => 1,
         details => $details,
         parent_group => 1,
+        unredacted => $unredacted,
     );
     $job->{followed_id} = $job_id if ($job_id != $job->{id});
     $self->render(json => {job => $job});

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
-use Test::Warnings qw(:report_warnings warning);
+use Test::Warnings qw(:report_warnings warning warnings);
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
@@ -78,20 +78,39 @@ subtest 'running command' => sub {
 subtest 'getting job' => sub {
     my $clone_mock = Test::MockModule->new('OpenQA::Script::CloneJob');
     $clone_mock->redefine(_handle_unexpected_return_code => sub ($tx) { die 'unexpected return code' });
-    my $fake_res = Test::FakeResult->new(is_success => 0, code => 400, json => {FOO => 'bar'});
-    my $fake_txn = Test::MockObject->new->set_always(res => $fake_res)->set_always(error => undef);
-    my $fake_ua = Test::MockObject->new->set_always(build_tx => $fake_txn);
-    $fake_ua->set_always(max_redirects => $fake_ua);
+    $clone_mock->redefine(
+        _get_with_retry => sub ($url_handler, $url, $jobid, $ctx, $options) {
+            return {job => {settings => {}}} if $ctx eq 'job';
+            return {FOO => 'bar'} if $ctx eq 'vars.json of job';
+            die "Unexpected ctx: $ctx";
+        });
+
     my %fake_params = (host => 'host', from => 'from', apikey => 'key', apisecret => 'secret');
     my $url_handler = OpenQA::Script::CloneJob::create_url_handler(\%fake_params);
-    $url_handler->{remote} = $fake_ua;
     $url_handler->{remote_url} = Mojo::URL->new('foo');
     my $options = {'ignore-missing-assets' => 1, reproduce => 1};
-    throws_ok { clone_job_get_job(42, $url_handler, $options) } qr/unexpected return code/,
-      'unexpected return code handled';
-    $fake_res->is_success(1)->code(200);
+
     my $job = clone_job_get_job(42, $url_handler, $options);
-    is_deeply $job, {vars => {FOO => 'bar'}}, 'vars assigned' or always_explain $job;
+    is_deeply $job, {settings => {}, vars => {FOO => 'bar'}}, 'vars assigned' or always_explain $job;
+    throws_ok { OpenQA::Script::CloneJob::_get_with_retry(undef, undef, undef, 'invalid', undef) }
+    qr/Unexpected ctx: invalid/, 'Mock throws on unexpected ctx';
+};
+
+subtest 'getting job with redacted secrets' => sub {
+    my $clone_mock = Test::MockModule->new('OpenQA::Script::CloneJob');
+    $clone_mock->redefine(
+        _get_with_retry => sub {
+            return {job => {id => 42, settings => {_SECRET_VAR => '[redacted]', NORMAL_VAR => 'visible'}}};
+        });
+    $clone_mock->redefine(_get_vars => sub { {} });
+
+    my $url_handler = {remote_url => Mojo::URL->new('http://remote')};
+    my $options = {'ignore-missing-assets' => 1};
+
+    my @w = warnings { clone_job_get_job(42, $url_handler, $options) };
+    like $w[0], qr/Job 42 has redacted secrets: _SECRET_VAR/,
+      'warning is emitted when settings contain redacted secrets'
+      or diag explain \@w;
 };
 
 subtest 'clone job apply settings tests' => sub {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -2010,4 +2010,30 @@ subtest 'server-side limit has precedence over user-specified limit' => sub {
 $t->delete_ok('/api/v1/jobs/99937')->status_is(200);
 $t->get_ok('/api/v1/jobs/99937')->status_is(404);
 
-done_testing();
+subtest 'redacted settings' => sub {
+    my $job = $jobs->find(99926);
+    $job->set_property('_SECRET_PASSWORD', 'supersecret');
+
+    my $t_guest = Test::Mojo->new('OpenQA::WebAPI');
+    $t_guest->get_ok('/api/v1/jobs/99926', 'guest: GET /api/v1/jobs/99926')->status_is(200);
+    is $t_guest->tx->res->json->{job}->{settings}->{_SECRET_PASSWORD}, '[redacted]', 'guest: secrets are redacted';
+
+    $t->get_ok('/api/v1/jobs/99926', 'operator: GET /api/v1/jobs/99926')->status_is(200);
+    is $t->tx->res->json->{job}->{settings}->{_SECRET_PASSWORD}, '[redacted]',
+      'operator: secrets are redacted by default';
+
+    $t->get_ok('/api/v1/jobs/99926?unredacted=1', 'operator: GET /api/v1/jobs/99926?unredacted=1')->status_is(200);
+    is $t->tx->res->json->{job}->{settings}->{_SECRET_PASSWORD}, 'supersecret',
+      'operator: secrets are revealed when requested';
+
+    my $t_non_op = client(Test::Mojo->new('OpenQA::WebAPI'), apikey => 'LANCELOTKEY01', apisecret => 'MANYPEOPLEKNOW');
+    $t_non_op->get_ok('/api/v1/jobs/99926?unredacted=1', 'non-operator: GET /api/v1/jobs/99926?unredacted=1')
+      ->status_is(200);
+    is $t_non_op->tx->res->json->{job}->{settings}->{_SECRET_PASSWORD}, '[redacted]',
+      'non-operator: secrets remain redacted even if requested';
+
+    $job->settings->find({key => '_SECRET_PASSWORD'})->delete;
+};
+
+done_testing;
+


### PR DESCRIPTION
* feat: request unredacted settings in openqa-clone-job and warn
* feat: allow authenticated operators to fetch unredacted job settings
