### PR TITLE
feat: watch worker auto-restart systemd drop-ins for reloads

### DIFF
--- a/systemd/openqa-reload-worker-auto-restart@.path
+++ b/systemd/openqa-reload-worker-auto-restart@.path
@@ -9,6 +9,7 @@ PathChanged=/etc/openqa/workers.ini
 PathChanged=/etc/openqa/workers.ini.d
 PathChanged=/etc/openqa/client.conf
 PathChanged=/etc/openqa/client.conf.d
+PathChanged=/etc/systemd/system/openqa-worker-auto-restart@.service.d
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/201351  

Updates `openqa-reload-worker-auto-restart@.path` to monitor the `/etc/systemd/system/openqa-worker-auto-restart@.service.d` directory.  
Any changes to systemd drop-in files will now automatically trigger a graceful worker reload without interrupting active jobs.