### PR TITLE
fix: Set correct settings for scheduling example test

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -69,6 +69,7 @@ openqa-cli schedule --monitor async=1 \
     DISTRI=example VERSION=0 FLAVOR=DVD ARCH=x86_64 \
     TEST=simple_boot _GROUP_ID=0 BUILD=test \
     CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-example.git \
+    PRODUCTDIR=. \
     NEEDLES_DIR=%%CASEDIR%%/needles
 
 openqa-clone-job https://openqa.opensuse.org/tests/1

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -319,6 +319,8 @@ sub default_config () {
             casedir => 'https://github.com/os-autoinst/os-autoinst-distri-example.git',
             distri => 'example',
             build => 'openqa',
+            needles_dir => '%%CASEDIR%%/needles',
+            settings => 'PRODUCTDIR=.',
         }};
 }
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -137,7 +137,7 @@ sub _load_test_preset ($self, $preset_key) {
     state %presets;
     return $presets{$preset_key} if exists $presets{$preset_key};
     $presets{$preset_key} = undef;
-    # read preset from an INI section [test_presets/…] or fallback to defaults assigned on setup
+    # read preset from an INI section [test_preset …] or fallback to defaults assigned on setup
     my $config = $self->app->config;
     my $ini_key = "test_preset $preset_key";
     my $ini_config = $config->{ini_config};

--- a/t/ui/29-create_tests.t
+++ b/t/ui/29-create_tests.t
@@ -40,9 +40,12 @@ subtest 'form is pre-filled' => sub {
         'create-tests-build' => 'openqa',
         'create-tests-test' => 'simple_boot',
         'create-tests-casedir' => 'https://github.com/os-autoinst/os-autoinst-distri-example.git',
-        'create-tests-needlesdir' => '',
+        'create-tests-needlesdir' => '%%CASEDIR%%/needles',
     );
     is element_prop($_), $expected_values{$_}, "$_ is pre-filled" for keys %expected_values;
+    my $get_settings = "return document.querySelector('#create-tests-settings-container pre').innerText";
+    like $driver->execute_script($get_settings), qr/PRODUCTDIR=\./, 'settings pre-filled';
+
 };
 
 subtest 'form can be submitted' => sub {

--- a/templates/webapi/test/create.html.ep
+++ b/templates/webapi/test/create.html.ep
@@ -63,7 +63,7 @@
       <%= help_popover('Test repository' => '<p>Specifies additional settings as newline-separated <code>KEY=value</code>-pairs that will be assigned to each job. ' .
         'Some settings also influence the job creation itself, e.g. <code>_OBSOLETE</code>.</p>',
         'https://open.qa/docs/#spawning-multiple-jobs-based-on-templates---isos-post', 'the documentation', 'left') %>
-      <textarea class="form-control key-value-pairs" id="create-tests-settings" rows="15"></textarea>
+      <textarea class="form-control key-value-pairs" id="create-tests-settings" rows="15"><%= $preset->{settings} // '' %></textarea>
     </div>
     <div class="col-md-6">
       <label for="create-tests-scenario-definitions" class="form-label"><strong>Scenario definitions</strong></label>


### PR DESCRIPTION
* Set `NEEDLES_DIR=%%CASEDIR%%/needles` as the worker otherwise assigns
  `$OPENQA_BASEDIR/openqa/share/tests/example/products/example/needles` as
  per documentation for the sake of compatibility but here it leads to
  `The source directory …/tests/example/products/example/needles does not
  exist` as the needles directory is directly under `CASEDIR`
    * We already do this in the example command in the "Installing"
      documentation.

* Set `PRODUCTDIR=.` as the worker otherwise assigns `products/example` for
  the sake of compatibility but here it leads to `unable to load main.pm`
  as `main.pm` is directly under `CASEDIR`
    * This is not explicitly documented but in-line with the behavior for
      assigning `NEEDLES_DIR`. So for now I'm considering this behavior as
      given; we might want to reconsider this, though.
    * We don't do this in the example command in the "Installing" section
      so it runs into the same error when executed as-is. So this commit
      adds the required setting there as well.

* Note that this once worked out of the box as far as I remember; we have
  probably tweaked the behavior since then to restore compatibility with
  other use cases
    * We might want to reconsider this but here I'm focusing on getting the
      example test working again without affecting anything else.

Related ticket: https://progress.opensuse.org/issues/201546