### PR TITLE
docs: Fix links in documentation generated via `generate-docs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,8 +470,13 @@ tidy-python: ## Format Python code
 	@command -v ruff >/dev/null 2>&1 || echo "Command 'ruff' not found, can not format python code"
 	@if [ -n "$(pyfiles)" ]; then ruff format $(pyfiles); fi
 
+.PHONY: tidy-sh
+tidy-sh: ## Format shell scripts with shfmt
+	@command -v shfmt >/dev/null 2>&1 || echo "Command 'shfmt' not found, can not format shell code"
+	shfmt --write -i 4 -bn -ci -sr $(shellfiles)
+
 .PHONY: tidy
-tidy: tidy-js tidy-perl tidy-python ## Format JavaScript, Perl and Python code
+tidy: tidy-js tidy-perl tidy-python tidy-sh ## Format JavaScript, Perl, Python and Shell code
 
 .PHONY: test-containers-compose
 test-containers-compose: ## Run docker-compose tests

--- a/tools/generate-docs
+++ b/tools/generate-docs
@@ -25,10 +25,9 @@ if pandoc --help | grep -q 'syntax-highlighting'; then
     syntax_highlight_opt="--syntax-highlighting=pygments"
 fi
 
-perl -ne 'if (/^include::([^\]]+)\[\]/) { open my $f, "<", $1 or die $!; print while <$f>; close $f } else { print }' index.md \
-    | pandoc -s -f gfm -o build/index.html \
-        --template=template.html \
-        -c style.css \
-        $syntax_highlight_opt \
-        --metadata title="openQA Documentation" \
-        --toc --number-sections
+../tools/process-docs | pandoc -s -f gfm -o build/index.html \
+    --template=template.html \
+    -c style.css \
+    $syntax_highlight_opt \
+    --metadata title="openQA Documentation" \
+    --toc --number-sections

--- a/tools/generate-documentation
+++ b/tools/generate-documentation
@@ -230,11 +230,10 @@ call_pandoc() {
     fi
 
     [[ ${formats[pdf]} ]] \
-        && perl -e 'sub p{my $f=shift;open my $h,"<",$f or die $!;while(<$h>){if(/^include::([^\]]+)\[\]/){p($1)}else{s/\[([^\]]+)\]\([\w-]+\.md(#[\w-]+)\)/[$1]($2)/g;s/\[([^\]]+)\]\(([\w-]+)\.md\)/"[$1](#".lc($2).")"/ge;print}}}p("index.md")' \
-        | pandoc -s -f gfm -o "${tmpwd}"/output/openqa-documentation-"${verbose_doc_name}".pdf --pdf-engine=weasyprint --number-sections
+        && ../tools/process-docs | pandoc -s -f gfm -o "${tmpwd}"/output/openqa-documentation-"${verbose_doc_name}".pdf \
+            --pdf-engine=weasyprint --number-sections
     [[ ${formats[html]} ]] \
-        && perl -e 'sub p{my $f=shift;open my $h,"<",$f or die $!;while(<$h>){if(/^include::([^\]]+)\[\]/){p($1)}else{s/\[([^\]]+)\]\([\w-]+\.md(#[\w-]+)\)/[$1]($2)/g;s/\[([^\]]+)\]\(([\w-]+)\.md\)/"[$1](#".lc($2).")"/ge;print}}}p("index.md")' \
-        | pandoc -s -f gfm -o "${tmpwd}"/output/openqa-documentation-"${verbose_doc_name}".html \
+        && ../tools/process-docs | pandoc -s -f gfm -o "${tmpwd}"/output/openqa-documentation-"${verbose_doc_name}".html \
             --template=template.html \
             -c style.css \
             --embed-resources --standalone \

--- a/tools/process-docs
+++ b/tools/process-docs
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+perl -e 'sub p{my $f=shift;open my $h,"<",$f or die $!;while(<$h>){if(/^include::([^\]]+)\[\]/){p($1)}else{s/\[([^\]]+)\]\([\w-]+\.md(#[\w-]+)\)/[$1]($2)/g;s/\[([^\]]+)\]\(([\w-]+)\.md\)/"[$1](#".lc($2).")"/ge;print}}}p("index.md")'

--- a/tools/process-docs
+++ b/tools/process-docs
@@ -10,7 +10,7 @@ sub process_file ($file) {
         if ($line =~ /^include::([^\]]+)\[\]/) { process_file($1) }
         else {
             $line =~ s/\[([^\]]+)\]\([\w-]+\.md(#[\w-]+)\)/[$1]($2)/g;
-            $line =~ s/\[([^\]]+)\]\(([\w-]+)\.md\)/"[$1](#".lc($2).")"/ge;
+            $line =~ s/\[([^\]]+)\]\(([\w-]+)\.md\)/[$1](#\L$2\E)/g;
             print $line;
         }
     }

--- a/tools/process-docs
+++ b/tools/process-docs
@@ -1,2 +1,20 @@
-#!/bin/bash -e
-perl -e 'sub p{my $f=shift;open my $h,"<",$f or die $!;while(<$h>){if(/^include::([^\]]+)\[\]/){p($1)}else{s/\[([^\]]+)\]\([\w-]+\.md(#[\w-]+)\)/[$1]($2)/g;s/\[([^\]]+)\]\(([\w-]+)\.md\)/"[$1](#".lc($2).")"/ge;print}}}p("index.md")'
+#!/bin/perl
+
+use strict;
+use warnings;
+use experimental 'signatures';
+
+sub process_file ($file) {
+    open my $handle, '<', $file or die $!;
+    while (my $line = <$handle>) {
+        if ($line =~ /^include::([^\]]+)\[\]/) { process_file($1) }
+        else {
+            $line =~ s/\[([^\]]+)\]\([\w-]+\.md(#[\w-]+)\)/[$1]($2)/g;
+            $line =~ s/\[([^\]]+)\]\(([\w-]+)\.md\)/"[$1](#".lc($2).")"/ge;
+            print $line;
+        }
+    }
+    close $handle;
+}
+
+process_file('index.md');


### PR DESCRIPTION
The simpler script `generate-docs` which really only generates docs does not process the Markdown files as needed to make links work. This change fixes that by using the code from `generate-documentation` in `generate-docs` as well. This also avoids repeating this not so trivial Perl command.