### PR TITLE
feat(scheduling): Allow globbing in version specifications

### DIFF
--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -122,21 +122,23 @@ Some example variables used by openSUSE are:
 - `PROMO` marks the promotional product.
 - `RESCUECD` is set to 1 for rescue CD images.
 
-The version of a medium can contain the `*` character. This enables a fallback
-lookup using globbing in case no medium with an exactly matching version is
-present when scheduling a product. This can be useful in the following cases:
+#### Using Wildcards in Medium Versions
+You can use the `*` character within a medium version to enable a fallback
+lookup using globbing. This is particularly helpful for the following scenarios:
 
-- One can avoid having individual medium types per version by specifying `*` as
-  medium type version. Note that having a medium with a concrete version and one
-  with `*` at the same time is usually not a good idea as you will likely run
-  into the scheduling error `no templates found for product …` (unless you
-  actually have job templates for all these medium types).
-- One can schedule products with e.g. `VERSION=15-SP7:PR-1234` if those jobs
-  are not supposed to be considered for consecutive builds (to avoid e.g. wrong
-  carry over and a cluttered "Next & Previous" table). To make this work one can
-  specify a version like `15-SP7:PR-*` in the medium type. This medium type will
-  then be used for all scheduled products where the `VERSION` starts with
-  `15-SP7:PR-`.
+- *Consolidating generic medium types:* Instead of creating a unique medium
+  type for every single version, you can use `*` as a catch-all version.
+    - Tip: Avoid defining a concrete version (e.g., `16.1`) and a wildcard
+      version (`*`) within one schedule definition unless you have matching job
+      templates for both, as this can trigger a scheduling error
+      (`no templates found for product...`).
+- *Handling isolated tests for individual submissions (e.g. pull-requests):*
+  When testing such submissions, schedule the products with e.g.,
+  `VERSION=16.1:PR-1234`. This will avoid cluttering the "Next & Previous" table
+  and prevent unintended carry-overs. Then specify a partial-match as the medium
+  version. For example by specifying `16.1:PR-*` in the medium type, openQA will
+  automatically match and use this type for any scheduled product where the
+  `VERSION` begins with `16.1:PR-`.
 
 ### Test Suites
 

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -122,13 +122,21 @@ Some example variables used by openSUSE are:
 - `PROMO` marks the promotional product.
 - `RESCUECD` is set to 1 for rescue CD images.
 
-The version of a medium can be set to `*`. Then this medium is considered if a
-product is scheduled with a `VERSION` parameter that does not match any other
-medium. This allows having only one medium per version. Note that having a
-medium with a concrete version and one with `*` at the same time is usually not
-a good idea as you will likely run into the scheduling error `no templates found`
-`for product …` (unless you actually have job templates for all these medium
-types).
+The version of a medium can contain the `*` character. This enables a fallback
+lookup using globbing in case no medium with an exactly matching version is
+present when scheduling a product. This can be useful in the following cases:
+
+- One can avoid having individual medium types per version by specifying `*` as
+  medium type version. Note that having a medium with a concrete version and one
+  with `*` at the same time is usually not a good idea as you will likely run
+  into the scheduling error `no templates found for product …` (unless you
+  actually have job templates for all these medium types).
+- One can schedule products with e.g. `VERSION=15-SP7:PR-1234` if those jobs
+  are not supposed to be considered for consecutive builds (to avoid e.g. wrong
+  carry over and a cluttered "Next & Previous" table). To make this work one can
+  specify a version like `15-SP7:PR-*` in the medium type. This medium type will
+  then be used for all scheduled products where the `VERSION` starts with
+  `15-SP7:PR-`.
 
 ### Test Suites
 
@@ -1252,7 +1260,7 @@ against medium types (product definitions). Jobs will be generated for the
 matching medium types based on the relevant job templates for each job group.
 
 If there is no medium type matching the specified `VERSION`, the lookup falls
-back to matching any medium with version `*`. Check out
+back to using globbing. Check out
 [the section about medium types](UsersGuide.md#medium_types_products) for
 details.
 

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -520,6 +520,14 @@ sub _sort_dep ($list) {
     return \@out;
 }
 
+# define SQL code for WHERE-condition to search for products using globbing as fallback
+# - Escape present '%' and '_' characters so they are still matched literally.
+# - Replace '*' with '%' to support regular globbing via the SQL LIKE-expression.
+my $VERSION_COND_WITH_GLOBBING = <<~"END_SQL"
+    distri = ? and ? like replace(replace(replace(version, '%', '\%'), '_', '\_'), '*', '%') and flavor = ? and arch = ?
+    END_SQL
+  ;
+
 =over 4
 
 =item _generate_jobs()
@@ -535,23 +543,15 @@ method used in the B<schedule_iso()> method.
 sub _generate_jobs ($self, $args, $notes, $skip_chained_deps, $include_children) {
     my $ret = [];
     my $schema = $self->result_source->schema;
-    my @products = $schema->resultset('Products')->search(
-        {
-            distri => _distri_key($args),
-            version => $args->{VERSION},
-            flavor => $args->{FLAVOR},
-            arch => $args->{ARCH},
-        });
 
+    my $products = $schema->resultset('Products');
+    my $distri = _distri_key($args);
+    my @products = $products->search(
+        {distri => $distri, version => $args->{VERSION}, flavor => $args->{FLAVOR}, arch => $args->{ARCH}});
     unless (@products) {
-        push @$notes, qq|no products found for version "$args->{VERSION}", falling back to "*"|;
-        @products = $schema->resultset('Products')->search(
-            {
-                distri => _distri_key($args),
-                version => '*',
-                flavor => $args->{FLAVOR},
-                arch => $args->{ARCH},
-            });
+        push @$notes, qq|no products found for version "$args->{VERSION}", considering globbing via "*"|;
+        @products = $products->search(
+            \[$VERSION_COND_WITH_GLOBBING, $distri, $args->{VERSION}, $args->{FLAVOR}, $args->{ARCH}]);
     }
 
     if (!@products) {

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -1098,27 +1098,50 @@ subtest 'Expand specified variables when scheduling iso' => sub {
     $schema->txn_rollback;
 };
 
-my %prod_params = (distri => 'opensuse', version => '*', flavor => 'DVD', arch => 'i586', name => 'generic');
-my $product = $products->create(\%prod_params);
-my $job_template = $job_templates->create({@job_template_params, product_id => $product->id});
+my @prod_params = (distri => 'opensuse', flavor => 'DVD', arch => 'i586', name => 'generic');
 
-subtest 'fallback to version "*"' => sub {
-    my $res = schedule_iso($t, {%iso, VERSION => 'foobar', _GROUP => 'opensuse test'});
-    my $scheduled_product = $scheduled_products->find($res->json->{scheduled_product_id});
-    my $results = $scheduled_product->results;
-    is @{$results->{successful_job_ids}}, 1, 'job successfully scheduled';
-    is $results->{notes}->[0], 'no products found for version "foobar", falling back to "*"', 'note present'
-      or always_explain $results;
+sub create_product_and_schedule_iso (
+    $product_version, $scheduling_version,
+    $job_template_params = undef,
+    $scheduling_params = undef
+  )
+{
+    my $product = $products->create({@prod_params, version => $product_version});
+    $job_templates->create({@$job_template_params, product_id => $product->id}) if $job_template_params;
+    my $scheduling_settings = {%iso, VERSION => $scheduling_version, _GROUP => 'opensuse test'};
+    my $res = schedule_iso($t, $scheduling_settings, $scheduling_params ? @$scheduling_params : ());
+    return $scheduled_products->find($res->json->{scheduled_product_id})->results;
+}
+
+subtest 'version matching with "*"' => sub {
+    subtest 'globbing used at the end for "starts with" matching' => sub {
+        $schema->txn_begin;
+        my $res = create_product_and_schedule_iso('15.7:PR-*', '15.7:PR-0815', \@job_template_params);
+        like $res->{notes}->[0], qr/no products.*"15\.7:PR-0815".*globbing/, 'note present' or always_explain $res;
+        is @{$res->{successful_job_ids}}, 1, 'job successfully scheduled' or return;
+        ok my $job = $jobs->find($res->{successful_job_ids}->[0]), 'job created' or return;
+        is $job->VERSION, '15.7:PR-0815', 'job scheduled with full version';
+        $schema->txn_rollback;
+    };
+    subtest 'a single "*" can be used to match all versions' => sub {
+        $schema->txn_begin;
+        my $res = create_product_and_schedule_iso('*', 'foobar', \@job_template_params);
+        is @{$res->{successful_job_ids}}, 1, 'job successfully scheduled';
+        like $res->{notes}->[0], qr/no products.*"foobar".*globbing/, 'note present' or always_explain $res;
+        is $res->{notes}->[0], 'no products found for version "foobar", considering globbing via "*"', 'note present'
+          or always_explain $res;
+        $schema->txn_rollback;
+    };
 };
 
 subtest 'no templates found for product' => sub {
-    $job_template->delete;    # assume no job template exists
-    my $res = schedule_iso($t, {%iso, VERSION => 'foobar', _GROUP => 'opensuse test'}, 404);
-    my $scheduled_product = $scheduled_products->find($res->json->{scheduled_product_id});
-    my $results = $scheduled_product->results;
-    is @{$results->{successful_job_ids}}, 0, 'no jobs scheduled';
-    is $results->{error}, 'no templates found for product opensuse-*-DVD-i586', 'error contains considered product'
-      or always_explain $results;
+    $schema->txn_begin;
+    my $res = create_product_and_schedule_iso('*', 'foobar', undef, [404]);
+    is @{$res->{successful_job_ids}}, 0, 'no jobs scheduled';
+    is $res->{notes}, undef, 'no notes present';
+    like $res->{error}, qr/no templates.*opensuse-\*-DVD-i586/, 'error contains considered product'
+      or always_explain $res;
+    $schema->txn_rollback;
 };
 
 done_testing();


### PR DESCRIPTION
There is already a fallback to search for product definitions with the version `*` in case no product definition with an exact version match was found. This change extends this fallback so no only `*` is checked for.

With this change it is possible to create a product definition with a version like `15.7:PR-*`. When then scheduling a new product with e.g. `VERSION=15.7:PR-0815` this product definition will be considered as fallback.

This will allow us to create jobs with e.g. `VERSION=15.7:PR-0815` instead of just `VERSION=15.7` so these jobs are not wrongly considered to be for consecutive builds.

This change keeps the sub test `fallback to version "*"` essentially as-is. It is only renamed to `a single "*" can be used to match all versions` under `version matching with "*"` and the expected not has been slightly adjusted. The sub test `no templates found for product` also still tests the same behavior and was only adjusted to no longer rely on the now restructured inner-workings of the previous sub test.

I tested this change also manually by creating a medium type (product definition) with version `15.7:PR-*` and by creating a new job group with the following job templates:

```
defaults:
  x86_64:
    machine: 64bit
    priority: 50
products:
  distri-x86_64:
    distri: distri
    flavor: flavor
    version: '15.7:PR-*'
scenarios:
  x86_64:
    distri-x86_64:
      - test-suite:
          settings:
            FOO: bar
```

Then I scheduled tests via:
```
script/openqa-cli api … -X POST isos DISTRI=distri FLAVOR=flavor VERSION=15.7:PR-1234 ARCH=x86_64
```

Without this change I ran into `no products found for distri-flavor-x86_64`. With this change one job was created as expected. Of course that new job had the setting `VERSION=15.7:PR-1234` and not just `VERSION=15.7`. So if we wanted to use this in osado we might need to adjust test code to deal with the suffix `:PR-1234`.

Related ticket: https://progress.opensuse.org/issues/200991