### PR TITLE
ci: Auto-import keys to avoid interactive prompt for devel_openQA

### DIFF
--- a/tools/ci/build-docs
+++ b/tools/ci/build-docs
@@ -2,7 +2,7 @@
 if [[ "${CIRCLE_JOB}" != *nightly ]]; then
     bash -xe tools/generate-documentation
 else
-    zypper -n install hub
+    zypper -n --gpg-auto-import-keys install hub
     export PULL_REQUEST_USER=${CIRCLE_PROJECT_USERNAME:-os-autoinst}
     export PUBLISH=1
     bash -xe tools/generate-documentation https://token@github.com/os-autoinst-bot/openQA.git gh-pages-"$(date +%y%m%d%H%M%S)"

--- a/tools/ci/prepare_dependency_pr.sh
+++ b/tools/ci/prepare_dependency_pr.sh
@@ -18,7 +18,7 @@ new_sha=$(curl -s https://api.github.com/repos/os-autoinst/os-autoinst/commits |
 
 echo -n "$new_sha" > "$sha_file"
 
-sudo zypper -n install git hub curl
+sudo zypper -n --gpg-auto-import-keys install git hub curl
 hub --version
 git add "$sha_file"
 git commit -m "$msg"


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/201858