### PR TITLE
Revert "fix: avoid permission denied on cgroup creation for v2"

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -341,26 +341,28 @@ sub engine_workit ($job, $callback) {
 }
 
 sub _configure_cgroupv2 ($job_info) {
-    # create cgroup for current job within detected slice
+    # create cgroup within /sys/fs/cgroup/systemd
     log_info('Preparing cgroup to start isotovideo');
     my $carp_guard;
     if (is_loaded('Carp::Always')) {
         $carp_guard = scope_guard sub { Carp::Always->import };    # uncoverable statement
         Carp::Always->unimport;    # uncoverable statement
     }
+    my $cgroup_name = 'systemd';
     my $cgroup_slice = CGROUP_SLICE;
     if (!defined $cgroup_slice) {
         # determine cgroup slice of the current process
         try {
-            my $cgroups = path('/proc/self/cgroup')->slurp;
-            ($cgroup_slice) = $cgroups =~ /name=systemd:(.*)/;
-            ($cgroup_slice) = $cgroups =~ /^0::(.*)/m unless defined $cgroup_slice;
+            my $pid = $$;
+            $cgroup_slice = (grep { /name=$cgroup_name:/ } split /\n/, path('/proc', $pid, 'cgroup')->slurp)[0]
+              if defined $pid;
+            $cgroup_slice =~ s/^.*name=$cgroup_name:/$cgroup_name/g if defined $cgroup_slice;
         }
         catch ($e) { }
     }
     my $cgroup;
     try {
-        $cgroup = cgroupv2(parent => path($cgroup_slice // '')->child($job_info->{id})->to_string);
+        $cgroup = cgroupv2(name => $cgroup_name)->from($cgroup_slice // '')->child($job_info->{id})->create;
         my $query_cgroup_path = $cgroup->can('_cgroup');
         log_info('Using cgroup ' . $query_cgroup_path->($cgroup)) if $query_cgroup_path;
     }


### PR DESCRIPTION
Reverts os-autoinst/openQA#7475 due to multiple issues on workers like

```
Jun 02 12:47:13 openqaworker21 worker[2543641]: Mojo::Reactor::Poll: I/O watcher failed: Can't open file "/sys/fs/cgroup/openqa.slice/openqa-worker.>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::File::slurp(Mojo::File=SCALAR(0x55d504ed64f8)) called at /usr/lib/perl5/vendor_perl/5.>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::CGroup::_list(Mojo::IOLoop::ReadWriteProcess::CGroup::v2=HAS>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::CGroup::_listarray(Mojo::IOLoop::ReadWriteProcess::CGroup::v>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::CGroup::v2::processes(Mojo::IOLoop::ReadWriteProcess::CGroup>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::Container::__ANON__(Mojo::IOLoop::ReadWriteProcess::CGroup::>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Collection::each(Mojo::Collection=ARRAY(0x55d504ec0988), CODE(0x55d504ecc848)) called >
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::Container::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x55>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::EventEmitter::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x55d504ecc170)) called at >
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::EventEmitter::emit(Mojo::IOLoop::ReadWriteProcess=HASH(0x55d504ecc170), "stop") called>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::Session::_collect(Mojo::IOLoop::ReadWriteProcess::Session=HA>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::Session::collect(Mojo::IOLoop::ReadWriteProcess::Session=HAS>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::Session::consume_collected_info(Mojo::IOLoop::ReadWriteProce>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::ReadWriteProcess::Session::__ANON__("CHLD") called at /usr/lib/perl5/vendor_pe>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         eval {...} called at /usr/lib/perl5/vendor_perl/5.42.0/IO/Socket/SSL.pm line 2524
Jun 02 12:47:13 openqaworker21 worker[2543641]:         IO::Socket::SSL::SSL_Context::new("IO::Socket::SSL::SSL_Context", HASH(0x55d504ed6630)) call>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         IO::Socket::SSL::configure_SSL(IO::Socket::SSL=GLOB(0x55d504ece268), HASH(0x55d504ed6630)) c>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         IO::Socket::SSL::start_SSL("IO::Socket::SSL", IO::Socket::SSL=GLOB(0x55d504ece268), "SSL_ver>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::TLS::negotiate(Mojo::IOLoop::TLS=HASH(0x55d5043992b0), "socket_options", HASH(>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::_try_tls(Mojo::IOLoop::Client=HASH(0x55d504ecf168), HASH(0x55d504ed3c6>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::_try_socks(Mojo::IOLoop::Client=HASH(0x55d504ecf168), HASH(0x55d504ed3>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::_ready(Mojo::IOLoop::Client=HASH(0x55d504ecf168), HASH(0x55d504ed3c68)>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::__ANON__(Mojo::Reactor::Poll=HASH(0x55d501412d58), 1) called at /usr/l>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         eval {...} called at /usr/lib/perl5/vendor_perl/5.42.0/Mojo/Reactor/Poll.pm line 141
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::_try(Mojo::Reactor::Poll=HASH(0x55d501412d58), "I/O watcher", CODE(0x55>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::one_tick(Mojo::Reactor::Poll=HASH(0x55d501412d58)) called at /usr/lib/p>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::start(Mojo::Reactor::Poll=HASH(0x55d501412d58)) called at /usr/lib/perl>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::start(Mojo::IOLoop=HASH(0x55d502ac3628)) called at /usr/share/openqa/script/..>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         OpenQA::Worker::exec(OpenQA::Worker=HASH(0x55d504360270)) called at /usr/share/openqa/script>
Jun 02 12:47:13 openqaworker21 worker[2543641]:  at /usr/lib/perl5/vendor_perl/5.42.0/IO/Socket/SSL.pm line 2524.
Jun 02 12:47:13 openqaworker21 worker[2543641]:         IO::Socket::SSL::SSL_Context::new("IO::Socket::SSL::SSL_Context", HASH(0x55d504ed6630)) call>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         IO::Socket::SSL::configure_SSL(IO::Socket::SSL=GLOB(0x55d504ece268), HASH(0x55d504ed6630)) c>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         IO::Socket::SSL::start_SSL("IO::Socket::SSL", IO::Socket::SSL=GLOB(0x55d504ece268), "SSL_ver>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::TLS::negotiate(Mojo::IOLoop::TLS=HASH(0x55d5043992b0), "socket_options", HASH(>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::_try_tls(Mojo::IOLoop::Client=HASH(0x55d504ecf168), HASH(0x55d504ed3c6>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::_try_socks(Mojo::IOLoop::Client=HASH(0x55d504ecf168), HASH(0x55d504ed3>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::_ready(Mojo::IOLoop::Client=HASH(0x55d504ecf168), HASH(0x55d504ed3c68)>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::Client::__ANON__(Mojo::Reactor::Poll=HASH(0x55d501412d58), 1) called at /usr/l>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         eval {...} called at /usr/lib/perl5/vendor_perl/5.42.0/Mojo/Reactor/Poll.pm line 141
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::_try(Mojo::Reactor::Poll=HASH(0x55d501412d58), "I/O watcher", CODE(0x55>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::one_tick(Mojo::Reactor::Poll=HASH(0x55d501412d58)) called at /usr/lib/p>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::start(Mojo::Reactor::Poll=HASH(0x55d501412d58)) called at /usr/lib/perl>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::start(Mojo::IOLoop=HASH(0x55d502ac3628)) called at /usr/share/openqa/script/..>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         OpenQA::Worker::exec(OpenQA::Worker=HASH(0x55d504360270)) called at /usr/share/openqa/script>
Jun 02 12:47:13 openqaworker21 worker[2543641]:  at /usr/lib/perl5/vendor_perl/5.42.0/Mojo/IOLoop.pm line 22.
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::__ANON__(Mojo::Reactor::Poll=HASH(0x55d501412d58), "I/O watcher failed: Can't >
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::EventEmitter::emit(Mojo::Reactor::Poll=HASH(0x55d501412d58), "error", "I/O watcher fai>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::_try(Mojo::Reactor::Poll=HASH(0x55d501412d58), "I/O watcher", CODE(0x55>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::one_tick(Mojo::Reactor::Poll=HASH(0x55d501412d58)) called at /usr/lib/p>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::Reactor::Poll::start(Mojo::Reactor::Poll=HASH(0x55d501412d58)) called at /usr/lib/perl>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         Mojo::IOLoop::start(Mojo::IOLoop=HASH(0x55d502ac3628)) called at /usr/share/openqa/script/..>
Jun 02 12:47:13 openqaworker21 worker[2543641]:         OpenQA::Worker::exec(OpenQA::Worker=HASH(0x55d504360270)) called at /usr/share/openqa/script>
Jun 02 12:47:13 openqaworker21 worker[2543641]: [error] Another error occurred when trying to stop gracefully due to an error
```