### PR TITLE
fix(systemd): activate inactive workers and reload active ones safely

### DIFF
--- a/systemd/openqa-reload-worker-auto-restart@.service
+++ b/systemd/openqa-reload-worker-auto-restart@.service
@@ -3,5 +3,5 @@ Description=Restart openqa-worker-auto-restart@%i.service ASAP without interrupt
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl reload openqa-worker-auto-restart@%i.service
+ExecStart=/usr/bin/systemctl reload-or-restart openqa-worker-auto-restart@%i.service
 Slice=openqa-worker.slice


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/201351

Updates `openqa-reload-worker-auto-restart@.service` to use `reload-or-restart` instead of a strict `reload`.
This automatically boots up any inactive worker slots during updates while ensuring currently running workers are gracefully reloaded without killing jobs.