### PR TITLE
ci: Run OBS scm checks only for master branch

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -33,6 +33,9 @@ pr:
 
   filters:
     event: pull_request
+    branches:
+      only:
+        - master
 
 # Setup:
 # 1. Put this .obs/workflows.yml in the main branch of openQA


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/201978

I tried to test it in my fork, but somehow it complained about the secret, but this is the documented way to do it:
https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration#sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-filters-delimiters