### PR TITLE
fix(rpm): eliminate systemd on-disk warnings during worker upgrade

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -596,9 +596,10 @@ fi
 # is running at the time of the update
 %service_del_postun %{openqa_worker_services}
 # restart running openqa-worker-auto-restart@.service units without interrupting jobs
-# notes: noop if no such units are running; daemon-reload already done by service_del_postun macro;
+# notes: noop if no such units are running; manual daemon-reload ensures systemd updates its state before reload
 #        "$1 -ge 1" checks for a package upgrade
 if [ -x /usr/bin/systemctl ] && [ $1 -ge 1 ]; then
+    /usr/bin/systemctl daemon-reload || :
     /usr/bin/systemctl reload 'openqa-worker-auto-restart@*.service' || :
 fi
 


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/201351

Add an explicit systemctl daemon-reload to the %postun worker scriptlet block.
This forces systemd to update its internal memory cache with the newly installed unit files before running the worker reload loop, preventing "changed on disk" warnings during zypper dup.