### PR TITLE
feat(scheduler): distinguish busy vs offline workers

### DIFF
--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -29,16 +29,15 @@ has scheduled_jobs => sub { {} };
 has shuffle_workers => 1;
 has dynamic_limit => sub { OpenQA::Scheduler::DynamicLimit->new };
 
-sub determine_free_workers ($shuffle = 0) {
-    my @free_workers = grep { !$_->dead } OpenQA::Schema->singleton->resultset('Workers')->search(
+sub determine_online_workers ($shuffle = 0) {
+    my @online_workers = grep { !$_->dead } OpenQA::Schema->singleton->resultset('Workers')->search(
         {
-            job_id => undef,
             error => undef,
             'properties.key' => 'WEBSOCKET_API_VERSION',
             'properties.value' => WEBSOCKET_API_VERSION
         },
         {join => 'properties'})->all;
-    return $shuffle ? shuffle(\@free_workers) : \@free_workers;
+    return $shuffle ? shuffle(\@online_workers) : \@online_workers;
 }
 
 sub determine_scheduled_jobs ($self) {
@@ -52,7 +51,8 @@ sub effective_job_limit ($self) {
     return $self->dynamic_limit->current_limit($config);
 }
 
-sub _allocate_jobs ($self, $free_workers) {
+sub _allocate_jobs ($self, $online_workers = undef) {
+    $online_workers //= determine_online_workers($self->shuffle_workers);
     my ($allocated_workers, $allocated_jobs) = ({}, {});
     my $scheduled_jobs = $self->scheduled_jobs;
     $scheduled_jobs->{$_}->{current_reason} = undef for keys %$scheduled_jobs;
@@ -76,10 +76,14 @@ sub _allocate_jobs ($self, $free_workers) {
     my %rejected;
     for my $id (keys %$scheduled_jobs) {
         my $jobinfo = $scheduled_jobs->{$id};
-        $jobinfo->{matching_workers} = _matching_workers($jobinfo, $free_workers, \%rejected);
+        my $has_matching_online = 0;
+        $jobinfo->{matching_workers} = _matching_workers($jobinfo, $online_workers, \%rejected, \$has_matching_online);
         if (!@{$jobinfo->{matching_workers}}) {
             my @needed = sort @{$jobinfo->{worker_classes}};
-            $jobinfo->{current_reason} = @needed ? "no free workers for class @needed" : 'no workers online';
+            $jobinfo->{current_reason}
+              = !@needed ? ($has_matching_online ? 'no free workers' : 'no workers online')
+              : $has_matching_online ? "no free workers for class @needed"
+              : "no workers online for requested class @needed at all";
         }
     }
     if (keys %rejected) {
@@ -99,6 +103,7 @@ sub _allocate_jobs ($self, $free_workers) {
 
     my @sorted = sort { $a->{priority} <=> $b->{priority} || $a->{id} <=> $b->{id} } values %$scheduled_jobs;
     my %checked_jobs;
+    my $free_workers = [grep { !$_->job_id } @$online_workers];
     for my $j (@sorted) {
         my $job_id = $j->{id};
         if ($checked_jobs{$job_id} || defined $allocated_jobs->{$job_id} || !@{$j->{matching_workers}}) {
@@ -218,7 +223,8 @@ sub _assign_jobs ($self, @args) {
 sub schedule ($self) {
     my $start_time = time;
     my $schema = OpenQA::Schema->singleton;
-    my $free_workers = determine_free_workers($self->shuffle_workers);
+    my $online_workers = determine_online_workers($self->shuffle_workers);
+    my $free_workers = [grep { !$_->job_id } @$online_workers];
     my $worker_count = $schema->resultset('Workers')->count;
     my $free_worker_count = @$free_workers;
 
@@ -226,7 +232,7 @@ sub schedule ($self) {
     log_debug("Scheduling: Free workers: $free_worker_count/$worker_count; Scheduled jobs: "
           . (scalar keys %$scheduled_jobs));
 
-    my ($allocated_workers, $allocated_jobs) = $self->_allocate_jobs($free_workers);
+    my ($allocated_workers, $allocated_jobs) = $self->_allocate_jobs($online_workers);
 
     $self->_update_job_reasons_in_db($schema, $scheduled_jobs);
     my @successfully_allocated;
@@ -374,15 +380,16 @@ sub _update_job_reasons_in_db ($self, $schema, $scheduled_jobs) {
 
 sub singleton ($class = undef) { state $jobs ||= ($class // __PACKAGE__)->new }
 
-sub _matching_workers ($jobinfo, $free_workers, $rejected = {}) {
-    my @filtered;
+sub _matching_workers ($jobinfo, $online_workers, $rejected = {}, $has_matching_online_ref = undef) {
+    my @free_matching;
     my @needed = sort @{$jobinfo->{worker_classes}};
-    for my $worker (@$free_workers) {
-        my $matched_all = all { $worker->check_class($_) } @needed;
-        push @filtered, $worker if $matched_all;
+    for my $worker (@$online_workers) {
+        next unless all { $worker->check_class($_) } @needed;
+        $$has_matching_online_ref = 1 if $has_matching_online_ref;
+        push @free_matching, $worker unless $worker->job_id;
     }
-    $rejected->{join ',', @needed}++ unless @filtered;
-    return \@filtered;
+    $rejected->{join ',', @needed}++ unless @free_matching;
+    return \@free_matching;
 }
 
 sub _jobs_in_execution ($need) {

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -40,6 +40,10 @@ sub determine_online_workers ($shuffle = 0) {
     return $shuffle ? shuffle(\@online_workers) : \@online_workers;
 }
 
+sub determine_free_workers ($online_workers) {
+    return [grep { !$_->job_id } @$online_workers];
+}
+
 sub determine_scheduled_jobs ($self) {
     $self->_update_scheduled_jobs;
     return $self->scheduled_jobs;
@@ -51,8 +55,9 @@ sub effective_job_limit ($self) {
     return $self->dynamic_limit->current_limit($config);
 }
 
-sub _allocate_jobs ($self, $online_workers = undef) {
+sub _allocate_jobs ($self, $online_workers = undef, $free_workers = undef) {
     $online_workers //= determine_online_workers($self->shuffle_workers);
+    $free_workers //= determine_free_workers($online_workers);
     my ($allocated_workers, $allocated_jobs) = ({}, {});
     my $scheduled_jobs = $self->scheduled_jobs;
     $scheduled_jobs->{$_}->{current_reason} = undef for keys %$scheduled_jobs;
@@ -81,7 +86,7 @@ sub _allocate_jobs ($self, $online_workers = undef) {
         if (!@{$jobinfo->{matching_workers}}) {
             my @needed = sort @{$jobinfo->{worker_classes}};
             $jobinfo->{current_reason}
-              = !@needed ? ($has_matching_online ? 'no free workers' : 'no workers online')
+              = !@needed ? 'job has no worker class'
               : $has_matching_online ? "no free workers for class @needed"
               : "no workers online for requested class @needed at all";
         }
@@ -103,7 +108,6 @@ sub _allocate_jobs ($self, $online_workers = undef) {
 
     my @sorted = sort { $a->{priority} <=> $b->{priority} || $a->{id} <=> $b->{id} } values %$scheduled_jobs;
     my %checked_jobs;
-    my $free_workers = [grep { !$_->job_id } @$online_workers];
     for my $j (@sorted) {
         my $job_id = $j->{id};
         if ($checked_jobs{$job_id} || defined $allocated_jobs->{$job_id} || !@{$j->{matching_workers}}) {
@@ -224,7 +228,7 @@ sub schedule ($self) {
     my $start_time = time;
     my $schema = OpenQA::Schema->singleton;
     my $online_workers = determine_online_workers($self->shuffle_workers);
-    my $free_workers = [grep { !$_->job_id } @$online_workers];
+    my $free_workers = determine_free_workers($online_workers);
     my $worker_count = $schema->resultset('Workers')->count;
     my $free_worker_count = @$free_workers;
 
@@ -232,7 +236,7 @@ sub schedule ($self) {
     log_debug("Scheduling: Free workers: $free_worker_count/$worker_count; Scheduled jobs: "
           . (scalar keys %$scheduled_jobs));
 
-    my ($allocated_workers, $allocated_jobs) = $self->_allocate_jobs($online_workers);
+    my ($allocated_workers, $allocated_jobs) = $self->_allocate_jobs($online_workers, $free_workers);
 
     $self->_update_job_reasons_in_db($schema, $scheduled_jobs);
     my @successfully_allocated;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -304,7 +304,7 @@ subtest 'getting sort criteria for job from cluster that is not scheduled' => su
     my $scheduler_mock = Test::MockModule->new('OpenQA::Scheduler::Model::Jobs');
     my $fake_allocated = {worker => 1, job => 1};
     $scheduler_mock->redefine(
-        _allocate_jobs => sub ($self, $free_workers, $online_workers = undef) { ({}, {1 => $fake_allocated}) });
+        _allocate_jobs => sub ($self, $online_workers = undef, $free_workers = undef) { ({}, {1 => $fake_allocated}) });
     my $running = $jobs->create({TEST => 'running', state => RUNNING});
     $job_dependencies->create({child_job_id => 1, parent_job_id => $running->id, dependency => PARALLEL});
     my $allocated = OpenQA::Scheduler::Model::Jobs->singleton->schedule();

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -303,7 +303,8 @@ subtest 'getting sort criteria for job from cluster that is not scheduled' => su
     my $rollback = scope_guard sub { $schema->txn_rollback };
     my $scheduler_mock = Test::MockModule->new('OpenQA::Scheduler::Model::Jobs');
     my $fake_allocated = {worker => 1, job => 1};
-    $scheduler_mock->redefine(_allocate_jobs => sub ($self, $free_workers) { ({}, {1 => $fake_allocated}) });
+    $scheduler_mock->redefine(
+        _allocate_jobs => sub ($self, $free_workers, $online_workers = undef) { ({}, {1 => $fake_allocated}) });
     my $running = $jobs->create({TEST => 'running', state => RUNNING});
     $job_dependencies->create({child_job_id => 1, parent_job_id => $running->id, dependency => PARALLEL});
     my $allocated = OpenQA::Scheduler::Model::Jobs->singleton->schedule();
@@ -440,11 +441,11 @@ subtest 'scheduler limits' => sub {
         my @classes = qw(atari c64 quantum);
         my $scheduler = OpenQA::Scheduler::Model::Jobs->singleton;
         my $scheduled_jobs = $scheduler->determine_scheduled_jobs;
-        my $free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers();
+        my $online_workers = OpenQA::Scheduler::Model::Jobs::determine_online_workers();
         my %rejected;
         for my $jobinfo (values %$scheduled_jobs) {
             $jobinfo->{matching_workers}
-              = OpenQA::Scheduler::Model::Jobs::_matching_workers($jobinfo, $free_workers, \%rejected);
+              = OpenQA::Scheduler::Model::Jobs::_matching_workers($jobinfo, $online_workers, \%rejected);
         }
         my $expected = {atari => 3, c64 => 3, quantum => 3};
         is_deeply \%rejected, $expected, 'Rejected worker classes statistics like expected';

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -114,7 +114,7 @@ subtest 'Scheduler worker job allocation' => sub {
     is @$allocated, 0, 'no jobs allocated for no active workers';
 
     my $jobs = $schema->resultset('Jobs');
-    is $jobs->search({state => SCHEDULED})->first->reason, 'no workers online',
+    is $jobs->search({state => SCHEDULED})->first->reason, 'job has no worker class',
       'unallocated job has a scheduling reason in the DB';
 
     note 'starting two workers';

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -133,7 +133,7 @@ subtest 'Scheduler worker job allocation' => sub {
     always_explain $allocated unless $different_workers && $different_jobs;
 
     note 'verify scheduling reason for unallocated jobs';
-    is $new_job->discard_changes->reason, 'no free workers for class foo',
+    is $new_job->discard_changes->reason, 'no workers online for requested class foo at all',
       'unallocated job has a scheduling reason in the DB';
 
     $allocated = $job_model->schedule;

--- a/t/05-scheduler-mocked.t
+++ b/t/05-scheduler-mocked.t
@@ -38,7 +38,7 @@ my %mocked_jobs = (1 => {id => 1, test => 'parallel-parent', @mocked_common_job_
 my @worker_fields = (host => 'testworker', properties => [{key => 'WORKER_CLASS', value => 'qemu_x86_64'}]);
 my @mocked_free_workers = map { $workers->create({@worker_fields, instance => $_}) } 1 .. 3;
 my $spare_worker = pop @mocked_free_workers;
-$mock->redefine(determine_free_workers => sub { \@mocked_free_workers });
+$mock->redefine(determine_online_workers => sub { \@mocked_free_workers });
 $mock->redefine(determine_scheduled_jobs => sub { shift->scheduled_jobs(\%mocked_jobs); \%mocked_jobs });
 
 # prevent writing to a log file to enable use of combined_like in the following tests
@@ -81,9 +81,9 @@ subtest 'starvation of parallel jobs prevented' => sub {
     my $second_child_job = $jobs->create({id => 3, state => SCHEDULED, TEST => $mocked_jobs{3}->{test}});
 
     # run the scheduler; parallel parent supposed to be prioritized
-    my $free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers();
+    my $online_workers = OpenQA::Scheduler::Model::Jobs::determine_online_workers();
     my $allocated_workers;
-    combined_like { $allocated_workers = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($free_workers) }
+    combined_like { $allocated_workers = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($online_workers) }
     qr/Need to schedule 3 parallel jobs for job 1.*Discarding job [123].*Discarding job [123]/s,
       'discarding jobs due to incomplete parallel cluster';
     is $mocked_jobs{1}->{priority_offset}, 10, 'priority of parallel parent increased (once per child)';
@@ -94,7 +94,7 @@ subtest 'starvation of parallel jobs prevented' => sub {
 
     # run the scheduler again assuming highest prio for parallel parent; worker supposed to be "held"
     $mocked_jobs{1}->{priority} = 0;
-    combined_like { ($allocated_workers) = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($free_workers) }
+    combined_like { ($allocated_workers) = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($online_workers) }
     qr/Holding worker .* for job [123] to avoid starvation.*Holding worker .* for job [123] to avoid starvation/s,
       'holding 2 workers (for 2 of our parallel jobs while 3rd worker is unavailable)';
     is_deeply [sort keys %$allocated_workers], [map { $_->id } @mocked_free_workers], 'both free workers "held"';
@@ -106,13 +106,32 @@ subtest 'partially blocked clusters are not scheduled' => sub {
     delete $mocked_jobs{2};
 
     my ($allocated_workers, $allocated_jobs);
-    my $free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers();
+    my $online_workers = OpenQA::Scheduler::Model::Jobs::determine_online_workers();
     combined_like {
-        ($allocated_workers, $allocated_jobs) = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($free_workers)
+        ($allocated_workers, $allocated_jobs)
+          = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs($online_workers)
     }
     qr/Skipping job .* because dependent jobs are not ready/, 'skipping job if dependent jobs not ready';
     is_deeply $allocated_jobs, {}, 'no jobs allocated' or always_explain $allocated_jobs;
     is_deeply $allocated_workers, {}, 'no workers allocated' or always_explain $allocated_workers;
+};
+
+subtest 'scheduling reason when workers are busy' => sub {
+    my $job_id = 1;
+    $_->update({job_id => $job_id++}) for @mocked_free_workers;
+    my ($allocated_workers, $allocated_jobs);
+    combined_like {
+        ($allocated_workers, $allocated_jobs) = OpenQA::Scheduler::Model::Jobs->singleton->_allocate_jobs()
+    }
+    qr/Skipping 2 jobs because of no free workers for requested worker classes/, 'logging busy workers';
+    is $mocked_jobs{1}->{current_reason}, 'no free workers for class qemu_x86_64',
+      'scheduling reason is busy workers when workers are online but not free';
+
+    $_->update({job_id => undef}) for @mocked_free_workers;
+    my $jobinfo = $mocked_jobs{1};
+    my $online_workers = OpenQA::Scheduler::Model::Jobs::determine_online_workers();
+    my $temp_matching = OpenQA::Scheduler::Model::Jobs::_matching_workers($jobinfo, $online_workers);
+    is_deeply $temp_matching, \@mocked_free_workers, 'matching workers found without optional parameters';
 };
 
 done_testing();

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -190,7 +190,9 @@ for my $job_count (@job_counts) {
 
             # ensure the scheduler also sees them as free
             for my $try (1 .. $polling_tries_workers) {
-                last if scalar @{OpenQA::Scheduler::Model::Jobs::determine_free_workers()} == $worker_count;
+                last
+                  if scalar @{[grep { !$_->job_id } @{OpenQA::Scheduler::Model::Jobs::determine_online_workers()}]}
+                  == $worker_count;
                 sleep $polling_interval;    # uncoverable statement
             }
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -66,7 +66,10 @@ my $ws;
 my $livehandler;
 
 sub turn_down_stack {
-    stop_service($_) for ($worker, $ws, $livehandler);
+    for my $service (grep { defined } $worker, $ws, $livehandler) {
+        stop_service($service);
+        $service->finish;
+    }
 }
 sub stop_worker { stop_service $worker }
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -123,8 +123,7 @@ sub check_scheduled_job_and_wait_for_free_worker ($worker_class) {
     for (; $elapsed <= $setup_timeout; $elapsed += sleep $setup_poll_interval) {
         $free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers(
             OpenQA::Scheduler::Model::Jobs::determine_online_workers());
-        for my $worker (@$free_workers) {
-            next unless $worker->check_class($worker_class);
+        if (List::Util::any { $_->check_class($worker_class) } @$free_workers) {
             pass "at least one free worker with class $worker_class registered";
             return ($relevant_jobs, $elapsed);
         }

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -121,7 +121,8 @@ sub check_scheduled_job_and_wait_for_free_worker ($worker_class) {
     #       properties (most importantly WEBSOCKET_API_VERSION and WORKER_CLASS) have not been populated yet.
     my ($elapsed, $free_workers) = (0, []);
     for (; $elapsed <= $setup_timeout; $elapsed += sleep $setup_poll_interval) {
-        for my $worker (@{$free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers}) {
+        $free_workers = [grep { !$_->job_id } @{OpenQA::Scheduler::Model::Jobs::determine_online_workers()}];
+        for my $worker (@$free_workers) {
             next unless $worker->check_class($worker_class);
             pass "at least one free worker with class $worker_class registered";
             return ($relevant_jobs, $elapsed);

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -121,7 +121,8 @@ sub check_scheduled_job_and_wait_for_free_worker ($worker_class) {
     #       properties (most importantly WEBSOCKET_API_VERSION and WORKER_CLASS) have not been populated yet.
     my ($elapsed, $free_workers) = (0, []);
     for (; $elapsed <= $setup_timeout; $elapsed += sleep $setup_poll_interval) {
-        $free_workers = [grep { !$_->job_id } @{OpenQA::Scheduler::Model::Jobs::determine_online_workers()}];
+        $free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers(
+            OpenQA::Scheduler::Model::Jobs::determine_online_workers());
         for my $worker (@$free_workers) {
             next unless $worker->check_class($worker_class);
             pass "at least one free worker with class $worker_class registered";

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -123,7 +123,7 @@ sub check_scheduled_job_and_wait_for_free_worker ($worker_class) {
     for (; $elapsed <= $setup_timeout; $elapsed += sleep $setup_poll_interval) {
         $free_workers = OpenQA::Scheduler::Model::Jobs::determine_free_workers(
             OpenQA::Scheduler::Model::Jobs::determine_online_workers());
-        if (List::Util::any { $_->check_class($worker_class) } @$free_workers) {
+        if (my @matching = grep { $_->check_class($worker_class) } @$free_workers) {
             pass "at least one free worker with class $worker_class registered";
             return ($relevant_jobs, $elapsed);
         }


### PR DESCRIPTION
Motivation:
Previously, unallocated jobs got the reason "no free workers for class
@needed" even if no online workers had that class. This made it hard to
diagnose if workers were busy or offline.

Design Choices:
- Introduced `determine_online_workers` to query the database once for all
  active workers.
- Refactored `determine_free_workers` to filter the active workers in memory.
- Updated `_allocate_jobs` signature and reason assignment to verify if a
  matching worker is online before claiming it is just busy.

Benefits:
- Users now get precise diagnostic feedback on whether workers are busy or
  completely offline.
- Performance remains optimal by avoiding multiple DB queries.

Screenshot:
<img width="538" height="300" alt="Screenshot_20260709_201749_oqa_no_worker_details" src="https://github.com/user-attachments/assets/93ac31af-b723-47fa-85e0-4b74b9fc5e40" />
