### PR TITLE
ci: Avoid error notifications from OBS

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,18 @@
+---
+pr:
+  steps:
+    - branch_package:
+        source_project: devel:openQA
+        source_package: openQA
+        target_project: devel:openQA:GitHub
+        add_repositories: disabled
+
+  filters:
+    event: pull_request
+    branches:
+      only:
+        - master
+
+# This is just a minimal file to prevent OBS from complaining when
+# creating a PR to gh-pages
+# https://progress.opensuse.org/issues/201978


### PR DESCRIPTION
Add .obs/workflows.yml from master branch

This is necessary to prevent OBS from complaining that .obs/workflows.yml cannot be found.

Issue: https://progress.opensuse.org/issues/201978