### PR TITLE
fix: Use reload-or-restart for openQA auto restart worker slots

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -600,7 +600,7 @@ fi
 #        "$1 -ge 1" checks for a package upgrade
 if [ -x /usr/bin/systemctl ] && [ $1 -ge 1 ]; then
     /usr/bin/systemctl daemon-reload || :
-    /usr/bin/systemctl reload 'openqa-worker-auto-restart@*.service' || :
+    /usr/bin/systemctl reload-or-restart 'openqa-worker-auto-restart@*.service' || :
 fi
 
 %postun auto-update


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/201351

Use reload-or-restart for openQA auto restart worker slots after openQA-worker package uninstallation step to avoid Unit cannot be reloaded because it is inactive error