### PR TITLE
fix: move tests/.../livelog and liveterminal below /liveviewhandler

### DIFF
--- a/container/webui/nginx.conf
+++ b/container/webui/nginx.conf
@@ -37,6 +37,7 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
+            proxy_buffering off;
         }
 
         location /assets/ {

--- a/etc/nginx/vhosts.d/openqa-endpoints.inc
+++ b/etc/nginx/vhosts.d/openqa-endpoints.inc
@@ -53,6 +53,7 @@ location /liveviewhandler/ {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_set_header Host $host;
+    proxy_buffering off;
 }
 
 location / {

--- a/lib/OpenQA/LiveHandler.pm
+++ b/lib/OpenQA/LiveHandler.pm
@@ -59,6 +59,8 @@ sub startup ($self) {
 
     # register route for live streaming of image
     $test_r->get('/streaming')->name('streaming')->to('running#streaming');
+    $test_r->get('/livelog')->name('streaming')->to('running#livelog');
+    $test_r->get('/liveterminal')->name('streaming')->to('running#liveterminal');
 
     OpenQA::Setup::setup_plain_exception_handler($self);
 }

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -167,8 +167,6 @@ sub startup ($self) {
     $test_r->get('/investigation_ajax')->name('test_investigation')->to('test#investigate');
     $test_r->get('/infopanel_ajax')->name('test_infopanel')->to('test#infopanel');
     $test_r->get('/status')->name('status')->to('running#status');
-    $test_r->get('/livelog')->name('livelog')->to('running#livelog');
-    $test_r->get('/liveterminal')->name('liveterminal')->to('running#liveterminal');
     $test_r->get('/edit')->name('edit_test')->to('running#edit');
     $test_r->get('/badge')->name('test_result_badge')->to('test#badge');
 

--- a/t/ui/12-needle-edit.t
+++ b/t/ui/12-needle-edit.t
@@ -651,6 +651,7 @@ subtest 'open needle editor for running test' => sub {
 
 subtest 'error handling when opening needle editor for running test' => sub {
     my $t = Test::Mojo->new('OpenQA::WebAPI');
+    my $l = Test::Mojo->new('OpenQA::LiveHandler');
 
     subtest 'no worker assigned' => sub {
         $t->get_ok('/tests/99946/edit')->status_is(404);
@@ -660,8 +661,8 @@ qr/Needle Editor.*The test opensuse-13\.1-DVD-i586-Build0091-textmode\@32bit has
         );
 
         # test error handling for other 'Running.pm' routes as well
-        $t->get_ok('/tests/99946/livelog')->status_is(404);
-        $t->content_like(
+        $l->get_ok('/liveviewhandler/tests/99946/livelog')->status_is(404);
+        $l->content_like(
 qr/Page not found.*The test opensuse-13\.1-DVD-i586-Build0091-textmode\@32bit has no worker assigned so this route is not available\./,
             'error message'
         );

--- a/templates/webapi/test/live.html.ep
+++ b/templates/webapi/test/live.html.ep
@@ -210,7 +210,7 @@
         <span>click to toggle</span>
     </div>
     <div class="card-body">
-        <pre id="livelog" data-url='<%= url_for("livelog", testid => $testid) %>'></pre>
+        <pre id="livelog" data-url='/liveviewhandler/tests/<%= $testid %>/livelog'></pre>
         <form action="#">
             <div>
                 <input type="checkbox" id="scrolldown" checked="checked">
@@ -226,6 +226,6 @@
         <span>click to toggle</span>
     </div>
     <div class="card-body">
-        <pre id="liveterminal" data-url='<%= url_for("liveterminal", testid => $testid) %>'></pre>
+        <pre id="liveterminal" data-url='/liveviewhandler/tests/<%= $testid %>/liveterminal'></pre>
     </div>
 </div>


### PR DESCRIPTION
The apache and nginx configs have special treatment for /liveviewhandler that makes it more suitable for event sources, like disabled buffering. Moving those endpoints to this location fixes an indeterminate delay due to buffering.