### PR TITLE
fix(apparmor): Allow worker profile to use virt-fw-vars

### DIFF
--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -147,6 +147,7 @@
   /usr/bin/unixcmd rix,
   /usr/bin/unxz rix,
   /usr/bin/unzip-plain rix,
+  /usr/bin/virt-fw-vars rix,
   /usr/bin/x3270 cx,
   /usr/bin/xterm rix,
   /usr/bin/xterm-console rix,


### PR DESCRIPTION
After trying out the solution implemented in https://github.com/os-autoinst/os-autoinst/pull/2954 using [this job](https://openqa.opensuse.org/tests/6006484#details) from openSUSE staging:

```
backend died: open3: exec of virt-fw-vars -i /usr/share/qemu/ovmf-x86_64-ms-4m-vars.bin
 -o /var/lib/openqa/pool/32/ovmf-x86_64-ms-4m-vars-adjusted.bin --enroll-cert openSUSE-Factory-Staging.crt
 failed: Permission denied at /usr/lib/perl5/5.42.0/IPC/Open3.pm line 357
```

And here's the corresponding denial:

```
time->Wed Jun 10 11:52:50 2026
type=AVC msg=audit(1781092370.019:10854): apparmor="DENIED" operation="exec" class="file" profile="/usr/share/openqa/script/worker" name="/usr/bin/virt-fw-vars" pid=755092 comm="/usr/bin/isotov" requested_mask="x" denied_mask="x" fsuid=492 ouid=0
```
