### PR TITLE
feat: Throttle jobs not using Git-URL as `CASEDIR`

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -700,6 +700,20 @@ Its scale only applies to jobs having that value exceeding
 configuration, administrators must explicitly include the `MAX_JOB_TIME` rule,
 to retain runtime-based throttling.
 
+It is also possible to define throttling patterns:
+
+    prio_throttling_patterns = parameter_n:adjustment_n:=~regex_n[,…]
+    prio_throttling_patterns = parameter_n:adjustment_n:!~regex_n[,…]
+
+where:
+
+- `parameter_n`: the name of the parameter
+- `adjustment_n`: a positive or negative number that is added to the job
+  priority
+- `=~` or `!~`: the former applies `adjustment_n` if `regex_n` matches, the
+  latter applies `adjustment_n` if `regex_n` does not match
+- `regex_n`: a regex to match the value of `parameter_n` against
+
 The final priority of a job is the sum of a base priority, defined in the job
 templates or scenario definitions, plus all adjustments calculated for the
 configured parameters that match the job settings.

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -412,6 +412,13 @@ concurrent = 0
 ## because ownership and purpose of a job group are unclear if the description is missing.
 #prio_group_parameters = full_name:Development:50
 
+## Throttling based on patterns in job settings: set a comma-separated list of
+## test parameters that trigger throttling of scheduled openQA jobs by priority.
+## syntax for positive matching: parameter_n:adjustment_n:!~regex_n[,…]
+## syntax for negative matching: parameter_n:adjustment_n:!=regex_n[,…]
+## Check out the "Job Priority Throttling" documentation for details.
+#prio_throttling_patterns = CASEDIR:15:!~^https?:
+
 ## Concurrency limit of archive generation (ZIP creation) jobs in parallel
 #create_zip_archive_limit = 2
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -212,6 +212,11 @@ sub _apply_max_job_time_prio ($factor, $time, $throt_config, $job_args) {
     return $info;
 }
 
+sub _change_prio_returning_sign ($new_job_args, $adjustment) {
+    $new_job_args->{priority} += $adjustment;
+    return $adjustment >= 0 ? '+' : '';
+}
+
 sub _apply_prio_throttling ($self, $settings, $new_job_args, $group = undef) {
     my $debug_msg;
     my $base_prio = $new_job_args->{priority} // 0;
@@ -238,8 +243,7 @@ sub _apply_prio_throttling ($self, $settings, $new_job_args, $group = undef) {
                 my $adj = $rule->{adjustment};
                 my $matches = $val =~ $regex;
                 if (($op eq '=~' && $matches) || ($op eq '!~' && !$matches)) {
-                    $new_job_args->{priority} += $adj;
-                    my $sign = $adj >= 0 ? '+' : '';
+                    my $sign = _change_prio_returning_sign($new_job_args, $adj);
                     push @throttling_info, sprintf '%s [%s%s: value %s %s %s]', $resource, $sign, $adj, $val, $op,
                       $rule->{regex_str};
                 }
@@ -251,8 +255,7 @@ sub _apply_prio_throttling ($self, $settings, $new_job_args, $group = undef) {
             my $prop = $rule->{property};
             my $val = $group->$prop // '';
             if ($val =~ $rule->{regex}) {
-                $new_job_args->{priority} += $rule->{increment};
-                my $sign = $rule->{increment} >= 0 ? '+' : '';
+                my $sign = _change_prio_returning_sign($new_job_args, $rule->{increment});
                 push @throttling_info, "$sign$rule->{increment} because job group $prop matches $rule->{regex}";
             }
         }

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -218,20 +218,32 @@ sub _apply_prio_throttling ($self, $settings, $new_job_args, $group = undef) {
     my @throttling_info;
     my $config = OpenQA::App->singleton && OpenQA::App->singleton->config;
     if ($config && (my $throttling = $config->{misc_limits}->{prio_throttling_data})) {
-        if (
-            my $mjt_info = _apply_max_job_time_prio(
-                $settings->{TIMEOUT_SCALE},
-                $settings->{MAX_JOB_TIME},
-                $throttling->{MAX_JOB_TIME},
-                $new_job_args
-            ))
-        {
-            push @throttling_info, $mjt_info;
+        my @timeout_settings = ($settings->{TIMEOUT_SCALE}, $settings->{MAX_JOB_TIME});
+        for my $mjt_rule (@{$throttling->{MAX_JOB_TIME} // []}) {
+            next if exists $mjt_rule->{operator};
+            my $info = _apply_max_job_time_prio(@timeout_settings, $mjt_rule, $new_job_args);
+            push @throttling_info, $info if $info;
         }
         for my $resource (keys %$throttling) {
-            next if (!defined $settings->{$resource} || $resource eq 'MAX_JOB_TIME');
-            push @throttling_info,
-              $resource . _update_priority($settings->{$resource}, $throttling->{$resource}, $new_job_args);
+            next unless defined(my $value = $settings->{$resource});
+            for my $rule (@{$throttling->{$resource}}) {
+                my $op = $rule->{operator};
+                if (!defined $op) {
+                    push @throttling_info, $resource . _update_priority($value, $rule, $new_job_args)
+                      if $resource ne 'MAX_JOB_TIME';
+                    next;
+                }
+                my $val = $value;
+                my $regex = $rule->{regex};
+                my $adj = $rule->{adjustment};
+                my $matches = $val =~ $regex;
+                if (($op eq '=~' && $matches) || ($op eq '!~' && !$matches)) {
+                    $new_job_args->{priority} += $adj;
+                    my $sign = $adj >= 0 ? '+' : '';
+                    push @throttling_info, sprintf '%s [%s%s: value %s %s %s]', $resource, $sign, $adj, $val, $op,
+                      $rule->{regex_str};
+                }
+            }
         }
     }
     if ($config && $group && (my $group_throttling = $config->{misc_limits}->{prio_group_data})) {

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -61,20 +61,41 @@ sub _load_config ($app, $defaults, $mode_specific_defaults) {
     return $config;
 }
 
-sub _load_prio_throttling ($app, $config) {
-    return undef unless my $throttling = $config->{misc_limits}->{prio_throttling_parameters};
-    # floating point number
-    my $n = qr/[+-]?(?:\d+\.?\d*|\.\d+)/;
-    # Unit format = Param.name: scale: reference(optional)
-    my $u = qr/([A-Z_][A-Z0-9_]*):($n)(?::($n))?/i;
+my $N = qr/[+-]?(?:\d+\.?\d*|\.\d+)/;    # floating point number
+my $U = qr/([A-Z_][A-Z0-9_]*):($N)(?::($N))?/i;    # Unit format = Param.name: scale: reference(optional)
+
+sub _load_throttling_parameters ($app, $res, $throttling) {
+    return undef unless $throttling;
     $throttling =~ s/\s+//g;
-    unless ($throttling =~ qr/^$u(?:,$u)*$/i) {
-        $app->log->warn("Wrong format in openqa.ini 'prio_throttling_parameters': $throttling");
-        return undef;
+    return $app->log->warn("Wrong format in openqa.ini 'prio_throttling_parameters': $throttling")
+      unless ($throttling =~ qr/^$U(?:,$U)*$/i);
+    for my $item (split /,/, $throttling) {
+        next unless $item;
+        my ($k, $s, $r) = $item =~ /$U/;
+        push @{$res->{$k} //= []}, {scale => $s, reference => $r // 0};
     }
-    my %hash = map { my ($k, $s, $r) = /$u/g; $k => {scale => $s, reference => $r // 0} }
-      split /,/, $throttling;
-    return \%hash;
+}
+
+sub _load_throttling_patterns ($app, $res, $throttling_patterns) {
+    return undef unless $throttling_patterns;
+    $throttling_patterns =~ s/^\s+|\s+$//g;
+    my $pattern_def = qr/([A-Z_][A-Z0-9_]*):($N):(([=!])~)(.+)/i;
+    return $app->log->warn("Wrong format in openqa.ini 'prio_throttling_patterns': $throttling_patterns")
+      unless $throttling_patterns =~ qr/^$pattern_def(?:\s*,\s*$pattern_def)*$/i;
+    for my $item (split /\s*,\s*/, $throttling_patterns) {
+        next unless $item;
+        my ($k, $adj, $op, $ignored, $regex_str) = $item =~ qr/^$pattern_def$/i;
+        push @{$res->{$k} //= []},
+          {adjustment => $adj, operator => $op, regex => qr/$regex_str/, regex_str => $regex_str};
+    }
+}
+
+sub _load_prio_throttling ($app, $config) {
+    my $misc_limits = $config->{misc_limits};
+    my %res;
+    _load_throttling_parameters($app, \%res, $misc_limits->{prio_throttling_parameters} // '');
+    _load_throttling_patterns($app, \%res, $misc_limits->{prio_throttling_patterns} // '');
+    return \%res;
 }
 
 sub _load_prio_group_throttling ($app, $config) {
@@ -292,6 +313,7 @@ sub default_config () {
             throttle_failing_job_prio_step => 10,
             throttle_failing_job_history_length => 20,
             prio_throttling_parameters => 'MAX_JOB_TIME:0.007',
+            prio_throttling_patterns => 'CASEDIR:15:!~^https?:',
             prio_throttling_data => undef,
             prio_group_parameters => 'full_name:Development:50',
             prio_group_data => undef,

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -737,12 +737,12 @@ subtest 'filter by state and result' => sub {
     $query->query(result => 'nonexistant_result');
     $t->get_ok($query->path_query)->status_is(200);
     my $res = $t->tx->res->json;
-    ok !@{$res->{jobs}}, 'no result for non-existant result';
+    ok !@{$res->{jobs}}, 'no result for non-existent result';
 
     $query->query(state => 'nonexistant_state');
     $t->get_ok($query->path_query)->status_is(200);
     $res = $t->tx->res->json;
-    ok !@{$res->{jobs}}, 'no result for non-existant state';
+    ok !@{$res->{jobs}}, 'no result for non-existent state';
 };
 
 subtest 'update job status' => sub {
@@ -1254,7 +1254,7 @@ subtest 'priority correctly assigned when posting job' => sub {
     $t->json_is('/job/group', 'opensuse test', 'group assigned (2)');
     $t->json_is('/job/priority', 42, 'default priority from group assigned');
 
-    # post new job with explicitely specified _PRIORITY setting
+    # post new job with explicitly specified _PRIORITY setting
     $jobs_post_params{_PRIORITY} = 43;
     $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(200);
     $t->get_ok('/api/v1/jobs/' . $t->tx->res->json->{id})->status_is(200);
@@ -1262,7 +1262,7 @@ subtest 'priority correctly assigned when posting job' => sub {
     $t->json_is('/job/priority', 43, 'explicitely specified priority assigned');
     $t->json_is('/job/settings/_PRIORITY', undef, 'priority not added as setting');
 
-    # post new job with invalid explicitely specified _PRIORITY setting
+    # post new job with invalid explicitly specified _PRIORITY setting
     $jobs_post_params{_PRIORITY} = 43.5;
     $t->post_ok('/api/v1/jobs', form => \%jobs_post_params)->status_is(400);
     $t->json_like('/error', qr/settings.*invalid.*_PRIORITY/, 'error returned');
@@ -1792,7 +1792,7 @@ subtest 'marking job as done' => sub {
         $t->json_like('/error', qr/Refusing.*because.*assigned to worker 1/, 'error message returned');
         $t->post_ok('/api/v1/jobs/99961/set_done?result=failed&reason=test&worker_id=1');
         $t->status_is(200, 'set_done accepted with correct worker_id');
-        $t->json_is('/result' => FAILED, 'post yields failed result (explicitely specified)');
+        $t->json_is('/result' => FAILED, 'post yields failed result (explicitly specified)');
         perform_minion_jobs($t->app->minion);
         my $job = $jobs->find(99961);
         is $job->clone_id, undef, 'job not cloned when reason does not match configured regex';
@@ -1804,7 +1804,7 @@ subtest 'marking job as done' => sub {
         $t->json_is('/result' => INCOMPLETE, 'post yields incomplete result (calculated)');
         $t->success or always_explain $t->tx->res->json;
         $job = $jobs->find(99961);
-        is $job->result, INCOMPLETE, 'result is incomplete (no modules and no reason explicitely specified)';
+        is $job->result, INCOMPLETE, 'result is incomplete (no modules and no reason explicitly specified)';
         is $job->reason, 'no test modules scheduled/uploaded', 'reason for incomplete set';
         $schema->txn_rollback;
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1193,6 +1193,36 @@ subtest 'priority correctly assigned when posting job' => sub {
         is $new_job_args{priority}, $default_prio + $add, 'increased prio value';
     };
 
+    subtest 'priority adjustment based on prio_throttling_patterns' => sub {
+        my $limits = $t->app->config->{misc_limits};
+        local $limits->{prio_throttling_parameters} = '';
+        local $limits->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:';
+        my $config = OpenQA::Setup::read_config($t->app);
+        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($t->app, $config);
+
+        subtest 'CASEDIR with local path: prio adjusted because CASEDIR does not match negative regex' => sub {
+            my %new_job_args = (priority => $default_prio);
+            local $jobs_post_params{CASEDIR} = 'local_casedir';
+            OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling($jobs, \%jobs_post_params, \%new_job_args);
+            is $new_job_args{priority}, $default_prio + 15, 'prio adjusted because CASEDIR does not match regex';
+        };
+        subtest 'CASEDIR with URL: prio not adjusted because CASEDIR does match negative regex' => sub {
+            my %new_job_args = (priority => $default_prio);
+            local $jobs_post_params{CASEDIR} = 'https://some-url/distri';
+            OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling($jobs, \%jobs_post_params, \%new_job_args);
+            is $new_job_args{priority}, $default_prio, 'prio not adjusted because CASEDIR matches https?:';
+        };
+        subtest 'CASEDIR with URL: prio adjusted because CASEDIR does match positive regex' => sub {
+            my %new_job_args = (priority => $default_prio);
+            local $jobs_post_params{CASEDIR} = 'https://some-url/distri';
+            local $limits->{prio_throttling_patterns} = 'CASEDIR:15:=~^https?:';
+            $config = OpenQA::Setup::read_config($t->app);
+            $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($t->app, $config);
+            OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling($jobs, \%jobs_post_params, \%new_job_args);
+            is $new_job_args{priority}, $default_prio + 15, 'prio adjusted because CASEDIR matches https?: with =~';
+        };
+    };
+
     subtest 'priority adjustment based on consecutive failures' => sub {
         my $add = 20;
         my %job_data = (

--- a/t/config.t
+++ b/t/config.t
@@ -261,7 +261,7 @@ subtest 'Multiple config files' => sub {
     $openqa_d->child('01-appname-and-scm.ini')->spew($data_01);
     $openqa_d->child('02-appname.ini')->spew($data_02);
     my $global_config = OpenQA::Setup::read_config($app)->{global};
-    is $global_config->{appname}, 'openQA override 2', 'appname overriden by config from openqa.ini.d, last one wins';
+    is $global_config->{appname}, 'openQA override 2', 'appname overridden by config from openqa.ini.d, last one wins';
     is $global_config->{branding}, 'fedora', 'scm set by config from openqa.ini.d, not overriden';
     is $global_config->{hide_asset_types}, 'repo iso', 'types set from main config, not overriden';
 };
@@ -294,7 +294,7 @@ subtest 'Lookup precedence/hiding' => sub {
 
     @expected = ("$t_dir/override/openqa.ini.d/override-drop-in.ini");
     $t_dir->child('override')->child('openqa.ini.d')->make_path->child('override-drop-in.ini')->touch;
-    is_deeply lookup_config_files(@args), \@expected, 'drop-in in overriden dir hides all other config';
+    is_deeply lookup_config_files(@args), \@expected, 'drop-in in overridden dir hides all other config';
 };
 
 subtest 'check throttling configuration validation and application' => sub {

--- a/t/config.t
+++ b/t/config.t
@@ -76,7 +76,9 @@ subtest 'Test configuration default modes' => sub {
     $test_config->{_openid_secret} = $config->{_openid_secret};
     $test_config->{logging}->{level} = 'debug';
     $test_config->{global}->{service_port_delta} = 2;
-    $test_config->{misc_limits}->{prio_throttling_data} = {MAX_JOB_TIME => {scale => '0.007', reference => 0}};
+    $test_config->{misc_limits}->{prio_throttling_data} = {
+        MAX_JOB_TIME => [{scale => '0.007', reference => 0}],
+        CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}]};
     $test_config->{misc_limits}->{prio_group_data}
       = [{property => 'full_name', regex => qr/Development/, increment => 50}];
     is ref delete $config->{global}->{auto_clone_regex}, 'Regexp', 'auto_clone_regex parsed as regex';
@@ -298,6 +300,7 @@ subtest 'Lookup precedence/hiding' => sub {
 subtest 'check throttling configuration validation and application' => sub {
     my $app = OpenQA::App->singleton();
     my $config = $app->config;
+    local $config->{misc_limits}->{prio_throttling_patterns} = '';
 
     subtest 'invalid prio_throttling_parameters' => sub {
         $config->{misc_limits}->{prio_throttling_parameters} = 'invalid';
@@ -305,24 +308,25 @@ subtest 'check throttling configuration validation and application' => sub {
             $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
         }
         qr/Wrong format/, 'warn expected';
-        is_deeply $config->{misc_limits}->{prio_throttling_data}, undef,
-          'prio_throttling_data is empty hash for invalid';
+        is_deeply $config->{misc_limits}->{prio_throttling_data}, {},
+          'prio_throttling_data is empty hash for invalid parameters';
     };
     subtest 'no prio_throttling_parameters' => sub {
         $config->{misc_limits}->{prio_throttling_parameters} = undef;
         $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is $config->{misc_limits}->{prio_throttling_data}, undef, 'prio_throttling_data is undef when no parameters';
+        is_deeply $config->{misc_limits}->{prio_throttling_data}, {},
+          'prio_throttling_data is empty when no parameters';
     };
     subtest 'empty string' => sub {
         $config->{misc_limits}->{prio_throttling_parameters} = '';
         $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is $config->{misc_limits}->{prio_throttling_data}, undef, 'prio_throttling_data is undef for empty string';
+        is_deeply $config->{misc_limits}->{prio_throttling_data}, {}, 'prio_throttling_data is empty for empty string';
     };
     subtest 'valid prio_throttling_parameter with space separators' => sub {
         $config->{misc_limits}->{prio_throttling_parameters} = 'KEY1ONE:  1.5';
         $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
         is_deeply $config->{misc_limits}->{prio_throttling_data},
-          {KEY1ONE => {scale => 1.5, reference => 0}},
+          {KEY1ONE => [{scale => 1.5, reference => 0}]},
           'prio_throttling_data parsed correctly';
     };
     subtest 'valid multiple prio_throttling_parameters keys' => sub {
@@ -330,11 +334,52 @@ subtest 'check throttling configuration validation and application' => sub {
         $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
         is_deeply $config->{misc_limits}->{prio_throttling_data},
           {
-            A => {scale => 1.04, reference => 0},
-            B => {scale => 2, reference => 3},
-            C => {scale => 0.04, reference => 5}
+            A => [{scale => 1.04, reference => 0}],
+            B => [{scale => 2, reference => 3}],
+            C => [{scale => 0.04, reference => 5}],
           },
           'prio_throttling_data parses multiple correctly';
+    };
+
+    subtest 'invalid prio_throttling_patterns' => sub {
+        local $config->{misc_limits}->{prio_throttling_parameters} = '';
+        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:invalid';
+        stderr_like {
+            $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
+        }
+        qr/Wrong format in openqa.ini 'prio_throttling_patterns'/, 'warn expected';
+        is_deeply $config->{misc_limits}->{prio_throttling_data}, {},
+          'prio_throttling_data is empty for invalid patterns';
+    };
+    subtest 'valid prio_throttling_patterns' => sub {
+        local $config->{misc_limits}->{prio_throttling_parameters} = '';
+        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:';
+        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
+        is_deeply $config->{misc_limits}->{prio_throttling_data},
+          {CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}]},
+          'prio_throttling_data parses patterns correctly';
+    };
+    subtest 'valid multiple prio_throttling_patterns keys with spaces' => sub {
+        local $config->{misc_limits}->{prio_throttling_parameters} = '';
+        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:,  FOO:-10:=~^bar$';
+        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
+        is_deeply $config->{misc_limits}->{prio_throttling_data},
+          {
+            CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}],
+            FOO => [{adjustment => -10, operator => '=~', regex => qr/^bar$/, regex_str => '^bar$'}],
+          },
+          'prio_throttling_data parses multiple patterns with spaces correctly';
+    };
+    subtest 'combining parameters and patterns' => sub {
+        local $config->{misc_limits}->{prio_throttling_parameters} = 'MAX_JOB_TIME:0.007';
+        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:';
+        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
+        is_deeply $config->{misc_limits}->{prio_throttling_data},
+          {
+            MAX_JOB_TIME => [{scale => 0.007, reference => 0}],
+            CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}],
+          },
+          'prio_throttling_data combines parameters and patterns correctly';
     };
 
     subtest 'prio_group_parameters' => sub {


### PR DESCRIPTION
* Throttle jobs that don't use a supported Git-URL as `CASEDIR` by default
* Allow throttling jobs based on any setting and regex pattern; this
  complements the existing throttling mechanism (which applies priority
  scaling for numerical settings)

Related ticket: https://progress.opensuse.org/issues/201276