### PR TITLE
feat(worker): support containerized os-autoinst worker engine

### DIFF
--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -726,6 +726,16 @@ For example to run isotovideo from a custom container image one could use the
 test variable setting
 `ISOTOVIDEO=podman run --pull=always --rm -it registry.example.org/my/container/isotovideo /usr/bin/isotovideo -d`
 
+Alternatively, you can run the worker engine inside a rootless Podman
+container by setting `OS_AUTOINST_GIT_REPO` to a Git repository URL.
+openQA will construct a Podman command to clone, build, and execute
+`os-autoinst` from that repository.
+The following optional test variables are supported:
+* `OS_AUTOINST_GIT_BRANCH`: The branch to clone (defaults to `master`).
+* `OS_AUTOINST_CONTAINER_IMAGE`: A custom container image to use (defaults to
+  `registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest`).
+  `OS_AUTOINST_CONTAINER_IMAGE` requires `OS_AUTOINST_GIT_REPO` to be set.
+
 ### Automatic retries of jobs
 
 You might encounter flaky openQA tests that fail sporadically. The best way to

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -544,7 +544,7 @@ sub _construct_isotovideo_cmd ($job_settings, $isotovideo) {
           . "XDG_DATA_HOME=$podman_dir/data "
           . "XDG_RUNTIME_DIR=$podman_dir/run "
           . 'podman --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs '
-          . '--events-backend=file run --entrypoint "" --device /dev/kvm -v $(pwd):/pool '
+          . '--events-backend=file run --init --rm --entrypoint "" --device /dev/kvm -v $(pwd):/pool '
           . "-w /pool $image sh -c 'git clone --branch=$branch --depth=1 $repo && "
           . "make -C os-autoinst && os-autoinst/isotovideo -d'";
         return $cmd;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -7,7 +7,7 @@ use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_
 use OpenQA::JobSettings;
 use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle format_settings);
 use OpenQA::Utils
-  qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme effective_distri testcasedir productdir needledir);
+  qw(asset_type_from_setting base_host locate_asset looks_like_url_with_scheme effective_distri testcasedir productdir needledir prjdir);
 use POSIX qw(:sys_wait_h strftime uname _exit);
 use Mojo::JSON 'encode_json';    # booleans
 use Cpanel::JSON::XS ();
@@ -477,8 +477,8 @@ sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback)
             # them in the spawned process as it does not belong to openQA code
             local $ENV{PERL5OPT} = '';
             # Allow to override isotovideo executable with an arbitrary
-            # command line based on a config option
-            exec $job_settings->{ISOTOVIDEO} ? $job_settings->{ISOTOVIDEO} : ('perl', $isotovideo, '-d');
+            # command line based on a config option or environment variables
+            exec _construct_isotovideo_cmd($job_settings, $isotovideo);
             die "exec failed: $!\n";    # uncoverable statement
         });
     $child->on(
@@ -519,6 +519,38 @@ sub locate_local_assets ($vars, $assetkeys, $pooldir) {
         $vars->{$key} = $link_result->{basename};
     }
     return undef;
+}
+
+sub _construct_isotovideo_cmd ($job_settings, $isotovideo) {
+    if (my $custom_cmd = $job_settings->{ISOTOVIDEO}) {
+        return $custom_cmd;
+    }
+
+    if ($job_settings->{OS_AUTOINST_CONTAINER_IMAGE} && !$job_settings->{OS_AUTOINST_GIT_REPO}) {
+        die
+"OS_AUTOINST_CONTAINER_IMAGE requires OS_AUTOINST_GIT_REPO. To run a custom container command, use ISOTOVIDEO instead.\n";
+    }
+
+    if (my $repo = $job_settings->{OS_AUTOINST_GIT_REPO}) {
+        my $branch = $job_settings->{OS_AUTOINST_GIT_BRANCH} // 'master';
+        my $image = $job_settings->{OS_AUTOINST_CONTAINER_IMAGE}
+          // 'registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest';
+
+        my $podman_dir = prjdir() . '/cache/podman';
+        my $cmd
+          = "mkdir -p $podman_dir/run $podman_dir/config $podman_dir/data && "
+          . "env HOME=$podman_dir "
+          . "XDG_CONFIG_HOME=$podman_dir/config "
+          . "XDG_DATA_HOME=$podman_dir/data "
+          . "XDG_RUNTIME_DIR=$podman_dir/run "
+          . 'podman --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs '
+          . '--events-backend=file run --entrypoint "" --device /dev/kvm -v $(pwd):/pool '
+          . "-w /pool $image sh -c 'git clone --branch=$branch --depth=1 $repo && "
+          . "make -C os-autoinst && os-autoinst/isotovideo -d'";
+        return $cmd;
+    }
+
+    return ('perl', $isotovideo, '-d');
 }
 
 1;

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -15,7 +15,7 @@ use Fcntl;
 use File::Spec::Functions qw(abs2rel catdir file_name_is_absolute);
 use File::Basename qw(basename fileparse);
 use Errno;
-use Cwd 'abs_path';
+use Cwd qw(abs_path getcwd);
 use OpenQA::CacheService::Client;
 use OpenQA::CacheService::Request;
 use Time::HiRes 'sleep';
@@ -537,17 +537,26 @@ sub _construct_isotovideo_cmd ($job_settings, $isotovideo) {
           // 'registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest';
 
         my $podman_dir = prjdir() . '/cache/podman';
-        my $cmd
-          = "mkdir -p $podman_dir/run $podman_dir/config $podman_dir/data && "
-          . "env HOME=$podman_dir "
-          . "XDG_CONFIG_HOME=$podman_dir/config "
-          . "XDG_DATA_HOME=$podman_dir/data "
-          . "XDG_RUNTIME_DIR=$podman_dir/run "
-          . 'podman --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs '
-          . '--events-backend=file run --init --rm --entrypoint "" --device /dev/kvm -v $(pwd):/pool '
-          . "-w /pool $image sh -c 'git clone --branch=$branch --depth=1 $repo && "
-          . "make -C os-autoinst && os-autoinst/isotovideo -d'";
-        return $cmd;
+        my @cmd = (
+            'env',
+            "HOME=$podman_dir",
+            'podman',
+            '--root', "$podman_dir/data/containers/storage",
+            '--runroot', "$podman_dir/run/containers",
+            '--storage-opt', 'ignore_chown_errors=true',
+            '--cgroup-manager=cgroupfs',
+            '--events-backend=file',
+            'run',
+            '--init',
+            '--rm',
+            '--entrypoint', '',
+            '--device', '/dev/kvm',
+            '-v', getcwd() . ':/pool',
+            '-w', '/pool',
+            $image,
+            'sh', '-c', "git clone --branch=$branch --depth=1 $repo && make -C os-autoinst && os-autoinst/isotovideo -d"
+        );
+        return @cmd;
     }
 
     return ('perl', $isotovideo, '-d');

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -598,20 +598,34 @@ subtest '_construct_isotovideo_cmd' => sub {
     subtest 'containerized with OS_AUTOINST_GIT_REPO' => sub {
         my $settings = {OS_AUTOINST_GIT_REPO => 'https://github.com/foo/os-autoinst.git'};
         my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
-        is scalar(@cmd), 1, 'returns a single command string';
+        is scalar(@cmd), 26, 'returns a list of execution arguments';
         my $podman_dir = prjdir() . '/cache/podman';
-        like $cmd[0], qr/mkdir -p \Q$podman_dir\E\/run \Q$podman_dir\E\/config \Q$podman_dir\E\/data/,
-          'ensures podman cache directory exists';
-        like $cmd[0], qr/HOME=\Q$podman_dir\E/, 'sets correct home directory under openqa cache';
-        like $cmd[0], qr/XDG_CONFIG_HOME=\Q$podman_dir\E\/config/, 'sets correct config home';
-        like $cmd[0], qr/podman --storage-opt ignore_chown_errors=true/, 'uses podman';
-        like $cmd[0], qr/run --init --rm/, 'runs with --init and --rm for signal handling and cleanup';
-        like $cmd[0], qr/--device \/dev\/kvm/, 'passes kvm device';
-        like $cmd[0], qr/-v \$\(pwd\):\/pool/, 'mounts pwd to pool';
-        like $cmd[0], qr/-w \/pool/, 'sets pool working directory';
-        like $cmd[0], qr/registry.opensuse.org\/devel\/openqa\/containers\/os-autoinst_dev:latest/,
-          'uses default image';
-        like $cmd[0], qr/git clone --branch=master --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
+        is $cmd[0], 'env', 'uses env';
+        is $cmd[1], "HOME=$podman_dir", 'sets correct home directory under openqa cache';
+        is $cmd[2], 'podman', 'runs podman';
+        is $cmd[3], '--root', 'uses --root';
+        is $cmd[4], "$podman_dir/data/containers/storage", 'sets correct root directory';
+        is $cmd[5], '--runroot', 'uses --runroot';
+        is $cmd[6], "$podman_dir/run/containers", 'sets correct run root directory';
+        is $cmd[7], '--storage-opt', 'sets storage-opt';
+        is $cmd[8], 'ignore_chown_errors=true', 'ignores chown errors';
+        is $cmd[9], '--cgroup-manager=cgroupfs', 'uses cgroupfs manager';
+        is $cmd[10], '--events-backend=file', 'uses file events backend';
+        is $cmd[11], 'run', 'runs the container';
+        is $cmd[12], '--init', 'runs with --init for signal handling';
+        is $cmd[13], '--rm', 'runs with --rm for auto-cleanup';
+        is $cmd[14], '--entrypoint', 'specifies entrypoint';
+        is $cmd[15], '', 'clears entrypoint';
+        is $cmd[16], '--device', 'adds device';
+        is $cmd[17], '/dev/kvm', 'passes kvm';
+        is $cmd[18], '-v', 'mounts a volume';
+        is $cmd[19], getcwd() . ':/pool', 'mounts getcwd() to pool';
+        is $cmd[20], '-w', 'sets working dir flag';
+        is $cmd[21], '/pool', 'sets working dir';
+        is $cmd[22], 'registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest', 'uses default image';
+        is $cmd[23], 'sh', 'executes sh';
+        is $cmd[24], '-c', 'runs shell command';
+        like $cmd[25], qr/git clone --branch=master --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
           'clones master branch by default';
     };
 
@@ -622,9 +636,9 @@ subtest '_construct_isotovideo_cmd' => sub {
             OS_AUTOINST_CONTAINER_IMAGE => 'my_custom_image:latest'
         };
         my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
-        is scalar(@cmd), 1, 'returns a single command string';
-        like $cmd[0], qr/my_custom_image:latest/, 'uses custom image';
-        like $cmd[0], qr/git clone --branch=my_feature --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
+        is scalar(@cmd), 26, 'returns a list of execution arguments';
+        is $cmd[22], 'my_custom_image:latest', 'uses custom image';
+        like $cmd[25], qr/git clone --branch=my_feature --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
           'clones custom branch';
     };
 

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -25,7 +25,7 @@ use OpenQA::Worker::Engines::isotovideo;
 use OpenQA::Test::FakeWorker;
 use Mojo::File qw(path tempdir);
 use Mojo::JSON 'decode_json';
-use OpenQA::Utils qw(testcasedir productdir needledir locate_asset base_host);
+use OpenQA::Utils qw(testcasedir productdir needledir locate_asset base_host prjdir);
 use Cwd qw(getcwd);
 use Mojo::Util 'scope_guard';
 use File::Copy::Recursive qw(dircopy);
@@ -578,6 +578,62 @@ subtest 'using cgroupv2' => sub {
     $file_mock->noop('make_path');
     combined_like { OpenQA::Worker::Engines::isotovideo::_configure_cgroupv2({id => 42}) }
     qr|Using cgroup /sys/fs/cgroup/.*/42|, 'use of cgroup logged';
+};
+
+subtest '_construct_isotovideo_cmd' => sub {
+    my $isotovideo = '/usr/bin/isotovideo';
+
+    subtest 'default command' => sub {
+        my $settings = {};
+        my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
+        is_deeply \@cmd, ['perl', '/usr/bin/isotovideo', '-d'], 'returns default execution array';
+    };
+
+    subtest 'custom ISOTOVIDEO override' => sub {
+        my $settings = {ISOTOVIDEO => 'some custom command'};
+        my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
+        is_deeply \@cmd, ['some custom command'], 'returns custom command string';
+    };
+
+    subtest 'containerized with OS_AUTOINST_GIT_REPO' => sub {
+        my $settings = {OS_AUTOINST_GIT_REPO => 'https://github.com/foo/os-autoinst.git'};
+        my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
+        is scalar(@cmd), 1, 'returns a single command string';
+        my $podman_dir = prjdir() . '/cache/podman';
+        like $cmd[0], qr/mkdir -p \Q$podman_dir\E\/run \Q$podman_dir\E\/config \Q$podman_dir\E\/data/,
+          'ensures podman cache directory exists';
+        like $cmd[0], qr/HOME=\Q$podman_dir\E/, 'sets correct home directory under openqa cache';
+        like $cmd[0], qr/XDG_CONFIG_HOME=\Q$podman_dir\E\/config/, 'sets correct config home';
+        like $cmd[0], qr/podman --storage-opt ignore_chown_errors=true/, 'uses podman';
+        like $cmd[0], qr/--device \/dev\/kvm/, 'passes kvm device';
+        like $cmd[0], qr/-v \$\(pwd\):\/pool/, 'mounts pwd to pool';
+        like $cmd[0], qr/-w \/pool/, 'sets pool working directory';
+        like $cmd[0], qr/registry.opensuse.org\/devel\/openqa\/containers\/os-autoinst_dev:latest/,
+          'uses default image';
+        like $cmd[0], qr/git clone --branch=master --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
+          'clones master branch by default';
+    };
+
+    subtest 'containerized with OS_AUTOINST_GIT_BRANCH and custom image' => sub {
+        my $settings = {
+            OS_AUTOINST_GIT_REPO => 'https://github.com/foo/os-autoinst.git',
+            OS_AUTOINST_GIT_BRANCH => 'my_feature',
+            OS_AUTOINST_CONTAINER_IMAGE => 'my_custom_image:latest'
+        };
+        my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
+        is scalar(@cmd), 1, 'returns a single command string';
+        like $cmd[0], qr/my_custom_image:latest/, 'uses custom image';
+        like $cmd[0], qr/git clone --branch=my_feature --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
+          'clones custom branch';
+    };
+
+    subtest 'containerized without OS_AUTOINST_GIT_REPO' => sub {
+        my $settings = {OS_AUTOINST_CONTAINER_IMAGE => 'my_custom_image:latest'};
+        throws_ok {
+            OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
+        }
+        qr/OS_AUTOINST_CONTAINER_IMAGE requires OS_AUTOINST_GIT_REPO/, 'dies with helpful error message';
+    };
 };
 
 done_testing();

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -605,6 +605,7 @@ subtest '_construct_isotovideo_cmd' => sub {
         like $cmd[0], qr/HOME=\Q$podman_dir\E/, 'sets correct home directory under openqa cache';
         like $cmd[0], qr/XDG_CONFIG_HOME=\Q$podman_dir\E\/config/, 'sets correct config home';
         like $cmd[0], qr/podman --storage-opt ignore_chown_errors=true/, 'uses podman';
+        like $cmd[0], qr/run --init --rm/, 'runs with --init and --rm for signal handling and cleanup';
         like $cmd[0], qr/--device \/dev\/kvm/, 'passes kvm device';
         like $cmd[0], qr/-v \$\(pwd\):\/pool/, 'mounts pwd to pool';
         like $cmd[0], qr/-w \/pool/, 'sets pool working directory';


### PR DESCRIPTION
Motivation:
Provide a simple way for developers to test os-autoinst modifications
within existing openQA setups without AppArmor blocks or manual copying.

Design Choices:
Add OS_AUTOINST_GIT_REPO and related settings to automatically construct
and execute a rootless Podman container command in the worker engine.

Benefits:
Streamlines development, provides secure rootless isolation, and fulfills
the acceptance criteria for dynamic os-autoinst verification.

Related issue: https://progress.opensuse.org/issues/202488