### PR TITLE
build: Let package builds for Tumbleweed and Leap>16 fail on any warning

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -155,6 +155,9 @@ Requires(pre):  group(nogroup)
 BuildRequires:  sysuser-tools
 %sysusers_requires
 %endif
+%if 0%{?is_opensuse} && 0%{?suse_version} >= 1600
+BuildRequires:  rpmlint-strict
+%endif
 
 %description
 openQA is a testing framework that allows you to test GUI applications on one


### PR DESCRIPTION
* Depend on `rpmlint-strict` which makes many rpmlint checks fatal
* Note that this does not necessarily cover *all* warnings and errors

Related ticket: https://progress.opensuse.org/issues/201477