### PR TITLE
feat: optionally fail ISO API if no jobs created

### DIFF
--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -26,6 +26,7 @@ use constant {
     ADDED => 'added',    # no jobs have been created yet
     SCHEDULING => 'scheduling',    # jobs are being created
     CANCELLING => 'cancelling',    # jobs are being cancelled (so far only possible as reaction to webhook event)
+    FATAL_ERROR => 'fatal_error',
 };
 
 __PACKAGE__->table('scheduled_products');
@@ -109,7 +110,7 @@ __PACKAGE__->inflate_column(
         deflate => sub { encode_json(shift) },
     });
 
-our @EXPORT_OK = qw(ADDED SCHEDULING SCHEDULED CANCELLING CANCELLED);
+our @EXPORT_OK = qw(ADDED SCHEDULING SCHEDULED CANCELLING CANCELLED FATAL_ERROR);
 our %EXPORT_TAGS = (STATE => [@EXPORT_OK]);
 
 sub sqlt_deploy_hook ($self, $sqlt_table, @) {
@@ -215,13 +216,14 @@ sub schedule_iso ($self, $args, $guard) {
 }
 
 sub set_done ($self, $result) {
+    my $status = ref $result eq 'HASH' ? (delete $result->{status} // SCHEDULED) : SCHEDULED;
     # set the status to be either …
     if ($self->_update_status_if(CANCELLED, status => CANCELLING)) {
         $self->update({results => $result});
         $self->cancel;    # … CANCELLED if meanwhile CANCELLING and invoke cancel again (as it backed off)
     }
     else {
-        $self->update({status => SCHEDULED, results => $result});    # … SCHEDULED if remained SCHEDULING
+        $self->update({status => $status, results => $result});    # … SCHEDULED if remained SCHEDULING
         $self->report_status_to_github;
     }
 }
@@ -333,6 +335,7 @@ sub _schedule_iso ($self, $args, $guard) {
 
     # read arguments for deprioritization and obsoleten
     my $deprioritize = delete $args->{_DEPRIORITIZEBUILD} // 0;
+    my $fail_if_no_jobs = delete $args->{_FAIL_IF_NO_JOBS} // 0;
     my $deprioritize_limit = delete $args->{_DEPRIORITIZE_LIMIT};
     my $obsolete = delete $args->{_OBSOLETE} // 0;
     my $onlysame = delete $args->{_ONLY_OBSOLETE_SAME_BUILD} // 0;
@@ -360,8 +363,10 @@ sub _schedule_iso ($self, $args, $guard) {
     else {
         $result = $self->_generate_jobs($args, \@notes, $skip_chained_deps, $include_children);
     }
-    return {error => $result->{error_message}, error_code => $result->{error_code} // HTTP_BAD_REQUEST}
-      if defined $result->{error_message};
+    if (defined $result->{error_message}) {
+        return $self->_fail_scheduling($result->{error_message}) if $fail_if_no_jobs;
+        return {error => $result->{error_message}, error_code => $result->{error_code} // HTTP_BAD_REQUEST};
+    }
     my $jobs = $result->{settings_result};
     # take some attributes from the first job to guess what old jobs to cancel
     # note: We should have distri object that decides which attributes are relevant here.
@@ -424,12 +429,23 @@ sub _schedule_iso ($self, $args, $guard) {
 
     OpenQA::Scheduler::Client->singleton->wakeup;
 
+    return $self->_fail_scheduling('No jobs scheduled.')
+      if $fail_if_no_jobs && !@successful_job_ids;
+
     my %results = (
         successful_job_ids => \@successful_job_ids,
         failed_job_info => \@failed_job_info,
     );
     $results{notes} = \@notes if (@notes);
     return \%results;
+}
+
+sub _fail_scheduling ($self, $error, $error_code = HTTP_BAD_REQUEST) {
+    return {
+        error => $error,
+        error_code => $error_code,
+        status => FATAL_ERROR,
+    };
 }
 
 =over 4

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Iso.pm
@@ -8,6 +8,7 @@ use File::Basename;
 use OpenQA::Utils;
 use DBIx::Class::Timestamps 'now';
 use OpenQA::Schema::Result::JobDependencies;
+use HTTP::Status qw(:constants);
 
 use constant MANDATORY_PARAMETERS => qw(DISTRI VERSION FLAVOR ARCH);
 use constant RESERVED_API_KEYS_RE => qr/^(?:async|scheduled_product_clone_id)$/;
@@ -157,6 +158,10 @@ sub validate_download_parameters ($self, $params) {
 Schedule jobs for assets matching the required settings DISTRI, VERSION, FLAVOR and ARCH
 passed to the method as arguments. Returns a JSON block containing the number of jobs
 created, their job ids and the information for jobs that could not be scheduled.
+
+Supports an optional C<_FAIL_IF_NO_JOBS> parameter. When set to C<1>, the request fails with
+a C<400 Bad Request> if no jobs are scheduled (unless C<async=1> is used). In either case, the
+scheduled product status is set to C<fatal_error>.
 
 =back
 

--- a/t/39-scheduled_products-table.t
+++ b/t/39-scheduled_products-table.t
@@ -12,11 +12,12 @@ use Test::MockModule;
 use Test::MockObject;
 use Test::Output qw(combined_like);
 use OpenQA::Jobs::Constants;
-use OpenQA::Schema::Result::ScheduledProducts qw(ADDED SCHEDULED SCHEDULING CANCELLING CANCELLED);
+use OpenQA::Schema::Result::ScheduledProducts qw(ADDED SCHEDULED SCHEDULING CANCELLING CANCELLED FATAL_ERROR);
 use OpenQA::Test::TimeLimit '6';
 use OpenQA::Test::Case;
 use OpenQA::Utils;
 use DateTime;
+use HTTP::Status qw(:constants);
 
 OpenQA::Test::Case->new->init_data;
 my $t = Test::Mojo->new('OpenQA::WebAPI');
@@ -40,8 +41,9 @@ my $scheduled_products_mock = Test::MockModule->new('OpenQA::Schema::Result::Sch
 $scheduled_products_mock->redefine(_generate_jobs => undef);    # prevent job creation
 
 my $scheduled_product;
+my ($sp1, $sp2, $sp3);
 subtest 'handling assets with invalid name' => sub {
-    $scheduled_product = $scheduled_products->create(\%settings);
+    $sp1 = $scheduled_product = $scheduled_products->create(\%settings);
     $schema->txn_begin;
     is_deeply
       $scheduled_product->schedule_iso({REPO_0 => ''}, $signal_guard),
@@ -57,7 +59,7 @@ subtest 'handling assets with invalid name' => sub {
     $scheduled_product->discard_changes;
     is $scheduled_product->status, SCHEDULED, 'product marked as scheduled, though';
 
-    $scheduled_product = $scheduled_products->create(\%settings);
+    $sp2 = $scheduled_product = $scheduled_products->create(\%settings);
     is_deeply
       $scheduled_product->schedule_iso({REPO_0 => 'invalid'}, $signal_guard),
       {
@@ -71,6 +73,19 @@ subtest 'handling assets with invalid name' => sub {
     is $scheduled_product->status, SCHEDULED, 'product marked as scheduled, though';
 };
 
+subtest '_FAIL_IF_NO_JOBS fails on empty schedule but preserves product' => sub {
+    my $fail_sp = $scheduled_products->create(\%settings);
+    my $sp_id = $fail_sp->id;
+    is_deeply
+      $fail_sp->schedule_iso({REPO_0 => 'invalid', _FAIL_IF_NO_JOBS => 1}, $signal_guard),
+      {error => 'No jobs scheduled.', error_code => HTTP_BAD_REQUEST},
+      'schedule_iso fails on no jobs scheduled when _FAIL_IF_NO_JOBS is set';
+    my $found = $scheduled_products->find($sp_id);
+    ok $found, 'scheduled product is not deleted from DB';
+    is $found->status, FATAL_ERROR, 'status is FATAL_ERROR';
+    is_deeply $found->results, {error => 'No jobs scheduled.', error_code => HTTP_BAD_REQUEST}, 'results contain error';
+};
+
 is $scheduled_product->schedule_iso(\%settings, $signal_guard), undef, 'scheduling the same product again prevented';
 
 subtest 'asset registration on scheduling' => sub {
@@ -78,7 +93,7 @@ subtest 'asset registration on scheduling' => sub {
     my %asset_info = (type => 'iso', name => 'dvdsize42.iso');
     $schema->storage->dbh->prepare('delete from assets where name = ? ')->execute('dvdsize42.iso');
     is $assets->find(\%asset_info), undef, 'dvdsize42.iso is not known yet';
-    $scheduled_product = $scheduled_products->create(\%settings);
+    $sp3 = $scheduled_product = $scheduled_products->create(\%settings);
     $scheduled_product->schedule_iso({ISO => 'dvdsize42.iso'}, $signal_guard);
     is $assets->find(\%asset_info)->size, 42, 'dvdsize42.iso has known size';
     $scheduled_product->discard_changes;
@@ -150,11 +165,11 @@ subtest 'settings not modified when creating jobs (so it can be retried)' => sub
 };
 
 subtest 'cleanup' => sub {
-    $scheduled_products->search({id => 1})->update({t_created => DateTime->now->subtract(days => 35)});
+    $scheduled_products->search({id => $sp1->id})->update({t_created => DateTime->now->subtract(days => 35)});
     $scheduled_products->delete_expired_entries;
-    ok !$scheduled_products->find(1), 'old scheduled product without jobs deleted';
-    ok $scheduled_products->find(2), 'new scheduled product without jobs still present)';
-    ok $scheduled_products->find(3), 'scheduled product with jobs still present';
+    ok !$scheduled_products->find($sp1->id), 'old scheduled product without jobs deleted';
+    ok $scheduled_products->find($sp2->id), 'new scheduled product without jobs still present)';
+    ok $scheduled_products->find($sp3->id), 'scheduled product with jobs still present';
 };
 
 subtest 'handling failed job cancellation' => sub {

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -395,6 +395,36 @@ is $t->tx->res->json->{job}->{state}, 'cancelled', "job $newid is cancelled";
 
 schedule_iso($t, {iso => $iso, tests => 'kde/usb'}, 400, {}, 'invalid parameters');
 schedule_iso($t, {%iso, FLAVOR => 'cherry'}, 200, {}, 'no product found');
+{
+    my $count_before = $scheduled_products->count;
+    my $res = schedule_iso($t, {%iso, FLAVOR => 'cherry', _FAIL_IF_NO_JOBS => 1}, 400, {}, 'fail on no jobs scheduled');
+    is $res->json->{error}, 'no products found for opensuse-cherry-i586', 'correct error message';
+    is $scheduled_products->count, $count_before + 1, 'scheduled product is preserved in DB';
+    my $sp_id = $res->json->{scheduled_product_id};
+    ok $sp_id, 'scheduled_product_id is returned';
+    my $sp = $scheduled_products->find($sp_id);
+    ok $sp, 'scheduled product exists in DB';
+    is $sp->status, 'fatal_error', 'status is fatal_error';
+    is $sp->results->{error}, 'no products found for opensuse-cherry-i586', 'results contain correct error';
+
+    my $res_async = schedule_iso(
+        $t, {%iso, FLAVOR => 'cherry', _FAIL_IF_NO_JOBS => 1},
+        200,
+        {async => 1},
+        '_FAIL_IF_NO_JOBS allowed with async'
+    );
+    my $sp_id_async = $res_async->json->{scheduled_product_id};
+    ok $sp_id_async, 'scheduled_product_id is returned for async';
+    my $sp_async = $scheduled_products->find($sp_id_async);
+    is $sp_async->status, 'added', 'status is added initially';
+
+    perform_minion_jobs($t->app->minion);
+
+    $sp_async->discard_changes;
+    is $sp_async->status, 'fatal_error', 'status becomes fatal_error after minion job';
+    is $sp_async->results->{error}, 'no products found for opensuse-cherry-i586',
+      'results contain correct error for async';
+}
 schedule_iso($t, {%iso, _GROUP_ID => 12345}, 404, {}, 'no templates found');
 
 # handle list of tests


### PR DESCRIPTION
Motivation:
Allow automation bots to strictly detect and fail when no jobs are scheduled for
a product, while keeping the failed record for investigation.

Design Choices:
Introduce an optional _FAIL_IF_NO_JOBS parameter that fails with 400 when no
jobs are created, while preserving the scheduled product record with error
details for later troubleshooting.

Benefits:
Automation bots can keep track of failures directly via the audit logs of
scheduled products.

Related issue: https://progress.opensuse.org/issues/194047