### PR TITLE
fix: resolve openqa-llm-server crash on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ install-generic: generate-assets generate-completions ## Install generic compone
 	install -m 644 systemd/tmpfiles-openqa.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa.conf
 	install -m 644 systemd/tmpfiles-openqa-webui.conf "$(DESTDIR)"/usr/lib/tmpfiles.d/openqa-webui.conf
 	install -m 644 container/systemd/openqa-llm-server.container "$(DESTDIR)"/usr/share/containers/systemd/openqa-llm-server.container
+	install -d -m 755 "$(DESTDIR)"/opt/llm/models
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-gru.service.requires
 	ln -s ../postgresql.service "$(DESTDIR)"/usr/lib/systemd/system/openqa-gru.service.requires/postgresql.service
 	install -d -m 755 "$(DESTDIR)"/usr/lib/systemd/system/openqa-scheduler.service.requires

--- a/container/systemd/openqa-llm-server.container
+++ b/container/systemd/openqa-llm-server.container
@@ -5,10 +5,12 @@ After=network-online.target
 [Container]
 Image=ghcr.io/ggml-org/llama.cpp:server
 ContainerName=openqa-llm-server
-Volume=/opt/llm/models:/models
+Volume=/opt/llm/models:/models:U
 PublishPort=8080:8080
 Exec=-hf unsloth/gemma-4-E4B-it-GGUF:UD-IQ2_M --temp 1.0 --top-p 0.95 --top-k 64 --ctx-size 65536
-User=_openqa-worker
+UserNS=auto
+Environment=HF_HOME=/models
+Environment=LLAMA_CACHE=/models
 
 [Service]
 Restart=always

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -931,5 +931,7 @@ fi
 %dir %{_datadir}/containers
 %dir %{_datadir}/containers/systemd
 %{_datadir}/containers/systemd/openqa-llm-server.container
+%dir /opt/llm
+%dir /opt/llm/models
 
 %changelog


### PR DESCRIPTION
Motivation:
The systemd service failed to start on workers with an unable to find user
error, and huggingface models downloaded to the ephemeral container storage.

Design Choices:
- Remove User=_openqa-worker from the system Quadlet.
- Enable UserNS=auto with the :U volume option to isolate the container.
- Set Environment variables HF_HOME and LLAMA_CACHE to /models.
- Ensure /opt/llm/models is owned and packaged by the RPM.

Benefits:
- Resolves container crash while maintaining strong isolation security.
- Persists downloaded LLM models reliably under /opt/llm/models.

Verification:
Verified in a transient systemd container using openSUSE Tumbleweed and Podman:
1. Started nested environment:
   podman run --privileged --name env -d tumbleweed /usr/lib/systemd/systemd
2. Copied openqa-llm-server.container and populated /etc/subuid & /etc/subgid
3. Started and verified service:
   systemctl daemon-reload && systemctl start openqa-llm-server.service

Related issue: https://progress.opensuse.org/issues/199181