### PR TITLE
fix: use webui cache for download all archives

### DIFF
--- a/etc/apache2/vhosts.d/openqa-common.inc
+++ b/etc/apache2/vhosts.d/openqa-common.inc
@@ -18,11 +18,11 @@ DocumentRoot /usr/share/openqa/public
 </Directory>
 Alias /assets "/var/lib/openqa/share/factory"
 
-<Directory "/var/lib/openqa/cache/archives">
+<Directory "/var/lib/openqa/webui/cache/archives">
     AllowOverride None
     Require all granted
 </Directory>
-Alias /archives "/var/lib/openqa/cache/archives"
+Alias /archives "/var/lib/openqa/webui/cache/archives"
 
 <Directory "/var/lib/openqa/images">
   Options SymLinksIfOwnerMatch

--- a/etc/nginx/vhosts.d/openqa-archives.inc
+++ b/etc/nginx/vhosts.d/openqa-archives.inc
@@ -1,4 +1,4 @@
-alias /var/lib/openqa/cache/archives/;
+alias /var/lib/openqa/webui/cache/archives/;
 autoindex          on;
 tcp_nopush         on;
 sendfile           on;

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -423,7 +423,7 @@ concurrent = 0
 
 [job_details_archive]
 ## Directory to store cached ZIP archives
-#job_details_archive_cache_dir = /var/lib/openqa/cache/archives
+#job_details_archive_cache_dir = /var/lib/openqa/webui/cache/archives
 
 ## Maximum size for the archive cache in GB (on-demand archives for 'Download
 ## All')

--- a/lib/OpenQA/Archive.pm
+++ b/lib/OpenQA/Archive.pm
@@ -17,7 +17,7 @@ sub archive_cache_dir () {
     return $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR} if $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR};
     my $config = OpenQA::App->singleton->config->{job_details_archive};
     return $config->{job_details_archive_cache_dir} if $config->{job_details_archive_cache_dir};
-    return path(OpenQA::Utils::prjdir(), 'cache', 'archives')->to_string;
+    return path(OpenQA::Utils::prjdir(), 'webui', 'cache', 'archives')->to_string;
 }
 
 sub get_cache_limit () {

--- a/profiles/apparmor.d/usr.share.openqa.script.openqa
+++ b/profiles/apparmor.d/usr.share.openqa.script.openqa
@@ -99,6 +99,7 @@
   /var/lib/openqa/testresults/ r,
   /var/lib/openqa/testresults/** rw,
   /var/lib/openqa/webui/** rw,
+  /var/lib/openqa/webui/cache/archives/** rwk,
   /var/log/openqa rwk,
   /var/tmp/* rwk,
   owner /var/lib/openqa/share/tests/** rwl,

--- a/t/60-archive-download.t
+++ b/t/60-archive-download.t
@@ -163,7 +163,7 @@ subtest 'Cache limit calculation' => sub {
     ok OpenQA::Archive::is_cache_limit_exceeded(100, 10, 100), 'Limit exceeded by free percentage';
     ok !OpenQA::Archive::is_cache_limit_exceeded(100, 30, 100), 'Limit not exceeded';
     delete $app->config->{job_details_archive}->{job_details_archive_cache_dir};
-    like OpenQA::Archive::archive_cache_dir(), qr|/cache/archives$|, 'Default cache dir';
+    like OpenQA::Archive::archive_cache_dir(), qr|/webui/cache/archives$|, 'Default cache dir';
     delete $app->config->{job_details_archive};
     is OpenQA::Archive::get_cache_limit(), 5 * 1024 * 1024 * 1024, 'Default limit';
     $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR} = $orig_env;


### PR DESCRIPTION
Motivation:
Clicking "Download All" triggers an internal server error when the web UI
(running as geekotest) attempts to create /var/lib/openqa/cache/archives,
which is owned by _openqa-worker.

Design Choices:
Move the default archive cache directory to /var/lib/openqa/webui/cache/
archives, which is owned by geekotest, and update configurations, tests,
and AppArmor profiles with the new directory and locking permissions.

Benefits:
Fixes the internal server error during job archive generation and keeps
the worker's cache directory isolated from the WebUI.

Related issue: https://progress.opensuse.org/issues/202782