### PR TITLE
feat: implement category-specific ZIP downloads for jobs

### DIFF
--- a/lib/OpenQA/Archive.pm
+++ b/lib/OpenQA/Archive.pm
@@ -13,6 +13,8 @@ use File::Basename;
 use Feature::Compat::Try;
 use Fcntl qw(:flock);
 
+use constant VALID_CATEGORIES => qw(all resultfiles ulogs assets);
+
 sub archive_cache_dir () {
     return $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR} if $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR};
     my $config = OpenQA::App->singleton->config->{job_details_archive};
@@ -34,11 +36,15 @@ sub get_watermark_percentage () {
       // 80;
 }
 
-sub create_job_archive ($job) {
+sub job_archive_filename ($job_id, $category = 'all') {
+    return $category eq 'all' ? "job_$job_id.zip" : "job_${job_id}_$category.zip";
+}
+
+sub create_job_archive ($job, $category = 'all') {
     my $job_id = $job->id;
     my $cache_dir = path(archive_cache_dir());
     $cache_dir->make_path unless -d $cache_dir;
-    my $archive_name = "job_$job_id.zip";
+    my $archive_name = job_archive_filename($job_id, $category);
     my $archive_path = $cache_dir->child($archive_name);
     my $lock_path = $cache_dir->child("$archive_name.lock");
     open my $lock_fh, '>', $lock_path->to_string
@@ -48,20 +54,39 @@ sub create_job_archive ($job) {
         close $lock_fh;
         return $archive_path;
     }
-    log_info "Creating archive for job $job_id at $archive_path";
+    log_info "Creating archive for job $job_id (category: $category) at $archive_path";
     # Archive::Zip does not keep all member data in memory. When using addFile or
     # addTree, it only remembers the filenames. writeToFileNamed then streams
     # the content from the original files to the output zip.
     my $zip = Archive::Zip->new();
-    if (my $res_dir = $job->result_dir) {
-        log_debug "Adding results from $res_dir to archive";
-        $zip->addTree($res_dir, 'testresults/') if -d $res_dir;
+    my $res_dir = $job->result_dir;
+
+    if ($res_dir && -d $res_dir) {
+        if ($category eq 'all') {
+            log_debug "Adding results from $res_dir to archive";
+            $zip->addTree($res_dir, 'testresults/');
+        }
+        elsif ($category eq 'resultfiles') {
+            for my $file (@{$job->test_resultfile_list}) {
+                my $full_path = path($res_dir)->child($file);
+                $zip->addFile($full_path->to_string, "testresults/$file") if -e $full_path;
+            }
+        }
+        elsif ($category eq 'ulogs') {
+            my $ulogs_dir = path($res_dir)->child('ulogs');
+            for my $file (@{$job->test_uploadlog_list}) {
+                my $full_path = $ulogs_dir->child($file);
+                $zip->addFile($full_path->to_string, "testresults/ulogs/$file") if -e $full_path;
+            }
+        }
     }
-    my $assets = $job->jobs_assets;
-    while (my $ja = $assets->next) {
-        my $asset = $ja->asset;
-        my $disk_file = $asset->disk_file;
-        if ($disk_file && -e $disk_file) {
+
+    if ($category eq 'all' || $category eq 'assets') {
+        my $assets = $job->jobs_assets;
+        while (my $ja = $assets->next) {
+            my $asset = $ja->asset;
+            my $disk_file = $asset->disk_file;
+            next unless $disk_file && -e $disk_file;
             log_debug 'Adding asset ' . $asset->name . ' to archive';
             my $zip_path = $asset->type . '/' . $asset->name;
             if (-d $disk_file) {
@@ -72,6 +97,7 @@ sub create_job_archive ($job) {
             }
         }
     }
+
     cleanup_cache();
     my $temp_path = $cache_dir->child($archive_name . '.tmp.' . random_hex(8));
     my $status = $zip->writeToFileNamed($temp_path->to_string);
@@ -100,7 +126,8 @@ sub cleanup_cache () {
 
 sub _perform_cache_cleanup ($cache_dir) {
     my ($available, $total) = check_df($cache_dir->to_string);
-    my $archives = $cache_dir->list->grep(sub { $_->basename =~ /^job_\d+\.zip$/ })->map(
+    my $category_regex = join '|', VALID_CATEGORIES;
+    my $archives = $cache_dir->list->grep(sub { $_->basename =~ /^job_\d+(?:_(?:$category_regex))?\.zip$/ })->map(
         sub {
             my $stat = $_->stat;
             {path => $_, mtime => $stat->mtime, size => $stat->size};

--- a/lib/OpenQA/Task/Job/CreateZipArchive.pm
+++ b/lib/OpenQA/Task/Job/CreateZipArchive.pm
@@ -12,7 +12,7 @@ sub register ($self, $app, @args) {
     $app->minion->add_task(create_zip_archive => \&_create_zip_archive);
 }
 
-sub _create_zip_archive ($minion_job, $job_id) {
+sub _create_zip_archive ($minion_job, $job_id, $category = 'all') {
     my $app = $minion_job->app;
 
     # avoid running too many archive generation jobs in parallel
@@ -26,7 +26,7 @@ sub _create_zip_archive ($minion_job, $job_id) {
         return undef;
     }
     try {
-        OpenQA::Archive::create_job_archive($job);
+        OpenQA::Archive::create_job_archive($job, $category);
         $minion_job->finish;
     }
     catch ($e) {

--- a/lib/OpenQA/WebAPI/Controller/File.pm
+++ b/lib/OpenQA/WebAPI/Controller/File.pm
@@ -160,21 +160,24 @@ sub test_asset ($self) {
 
 sub archive ($self) {
     return $self->reply->not_found unless my $job = $self->schema->resultset('Jobs')->find($self->param('testid'));
+    my $category = $self->param('category') // 'all';
+    my %valid = map { $_ => 1 } OpenQA::Archive::VALID_CATEGORIES;
+    return $self->reply->not_found unless $valid{$category};
     my $job_id = $job->id;
-    my $archive_name = "job_$job_id.zip";
+    my $archive_name = OpenQA::Archive::job_archive_filename($job_id, $category);
     my $cache_dir = path(OpenQA::Archive::archive_cache_dir());
     my $archive_path = $cache_dir->child($archive_name);
     return $self->_redirect_to_archive($archive_path) if -e $archive_path;
     try {
         if (my $minion = $self->app->can('minion') ? $self->app->minion : undef) {
-            $self->app->log->info("Enqueuing create_zip_archive for job $job_id");
+            $self->app->log->info("Enqueuing create_zip_archive for job $job_id (category: $category)");
             $minion->enqueue(
-                create_zip_archive => [$job_id],
-                {notes => {job_id => $job_id}, priority => -10, expire => 3600});
+                create_zip_archive => [$job_id, $category],
+                {notes => {job_id => $job_id, category => $category}, priority => -10, expire => 3600});
         }
         else {
             # Fallback for environments without a fully-functional Minion (e.g. tests)
-            return $self->_redirect_to_archive(OpenQA::Archive::create_job_archive($job));
+            return $self->_redirect_to_archive(OpenQA::Archive::create_job_archive($job, $category));
         }
     }
     catch ($e) {

--- a/t/60-archive-download.t
+++ b/t/60-archive-download.t
@@ -332,4 +332,61 @@ subtest 'Controller extra tests' => sub {
     $t->get_ok('/tests/' . $job->id . '/archive')->status_is(500)->content_is('Internal Server Error');
 };
 
+subtest 'Category specific archives' => sub {
+    my $job = $schema->resultset('Jobs')->create(
+        {
+            DISTRI => 'archtest',
+            VERSION => '1.0',
+            FLAVOR => 'test',
+            ARCH => 'x86_64',
+            TEST => 'category_test',
+            state => 'done',
+            result => 'passed',
+        });
+    my $res_dir = path($job->create_result_dir);
+    $res_dir->child('vars.json')->spew('{}');    # COMMON_RESULT_FILES includes vars.json
+    $res_dir->child('ulogs')->make_path->child('ulog.txt')->spew('ulog data');
+    my $asset = $schema->resultset('Assets')->create({type => 'iso', name => 'asset.iso'});
+    $schema->resultset('JobsAssets')->create({job_id => $job->id, asset_id => $asset->id});
+    path(assetdir(), 'iso', 'asset.iso')->dirname->make_path->child('asset.iso')->spew('asset data');
+
+    $case->login($t, 'admin');
+
+    # Test resultfiles category
+    $t->get_ok('/tests/' . $job->id . '/archive?category=resultfiles')->status_is(302)
+      ->header_like('Location' => qr|/archives/job_\d+_resultfiles.zip|);
+    $t->get_ok($t->tx->res->headers->location)->status_is(200);
+    my $zip_file = $tmp->child('resultfiles.zip');
+    $zip_file->spew($t->tx->res->body);
+    my $zip = Archive::Zip->new();
+    is $zip->read($zip_file->to_string), AZ_OK, 'Resultfiles zip is valid';
+    ok $zip->memberNamed('testresults/vars.json'), 'Contains result file';
+    ok !$zip->memberNamed('testresults/ulogs/ulog.txt'), 'Does not contain ulog';
+    ok !$zip->memberNamed('iso/asset.iso'), 'Does not contain asset';
+
+    # Test ulogs category
+    $t->get_ok('/tests/' . $job->id . '/archive?category=ulogs')->status_is(302)
+      ->header_like('Location' => qr|/archives/job_\d+_ulogs.zip|);
+    $t->get_ok($t->tx->res->headers->location)->status_is(200);
+    $zip_file = $tmp->child('ulogs.zip');
+    $zip_file->spew($t->tx->res->body);
+    $zip = Archive::Zip->new();
+    is $zip->read($zip_file->to_string), AZ_OK, 'Ulogs zip is valid';
+    ok !$zip->memberNamed('testresults/vars.json'), 'Does not contain result file';
+    ok $zip->memberNamed('testresults/ulogs/ulog.txt'), 'Contains ulog';
+    ok !$zip->memberNamed('iso/asset.iso'), 'Does not contain asset';
+
+    # Test assets category
+    $t->get_ok('/tests/' . $job->id . '/archive?category=assets')->status_is(302)
+      ->header_like('Location' => qr|/archives/job_\d+_assets.zip|);
+    $t->get_ok($t->tx->res->headers->location)->status_is(200);
+    $zip_file = $tmp->child('assets.zip');
+    $zip_file->spew($t->tx->res->body);
+    $zip = Archive::Zip->new();
+    is $zip->read($zip_file->to_string), AZ_OK, 'Assets zip is valid';
+    ok !$zip->memberNamed('testresults/vars.json'), 'Does not contain result file';
+    ok !$zip->memberNamed('testresults/ulogs/ulog.txt'), 'Does not contain ulog';
+    ok $zip->memberNamed('iso/asset.iso'), 'Contains asset';
+};
+
 done_testing;

--- a/t/60-archive-download.t
+++ b/t/60-archive-download.t
@@ -34,7 +34,7 @@ $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR} = $tmp->child('cache')->to_string;
 my $cache_dir = path($ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR});
 $cache_dir->make_path;
 
-subtest 'Archive download' => sub {
+subtest 'ZIP archive download and categorization' => sub {
     my $job = $schema->resultset('Jobs')->create(
         {
             DISTRI => 'archtest',
@@ -45,47 +45,56 @@ subtest 'Archive download' => sub {
             state => 'done',
             result => 'passed',
         });
-    $job->create_result_dir;
-    $job->update({result_dir => $job->result_dir});
-    my $res_dir_str = $job->result_dir;
-    die 'result_dir is not set' unless $res_dir_str;
-    my $res_dir = path($res_dir_str);
-    $res_dir->make_path;
-    $res_dir->child('details-test.json')->spew('{"test": "data"}');
+    my $res_dir = path($job->create_result_dir);
+    $res_dir->child('vars.json')->spew('{"test": "data"}');
     $res_dir->child('ulogs')->make_path->child('test.log')->spew('log data');
-    my $asset = $schema->resultset('Assets')->create(
-        {
-            type => 'iso',
-            name => 'test.iso',
-        });
-    $schema->resultset('JobsAssets')->create(
-        {
-            job_id => $job->id,
-            asset_id => $asset->id,
-        });
-    my $asset_path = path(assetdir(), 'iso', 'test.iso');
-    $asset_path->dirname->make_path;
-    $asset_path->spew('iso data');
+    my $asset = $schema->resultset('Assets')->create({type => 'iso', name => 'test.iso'});
+    $schema->resultset('JobsAssets')->create({job_id => $job->id, asset_id => $asset->id});
+    path(assetdir(), 'iso', 'test.iso')->dirname->make_path->child('test.iso')->spew('iso data');
+
     $t->get_ok('/tests/' . $job->id . '/archive')->status_is(302)
       ->header_is('Location' => '/login?return_page=%2Ftests%2F' . $job->id . '%2Farchive');
     $t->get_ok('/');
-    ok $case->login($t, 'admin'), 'Logged in as admin';
-    $t->get_ok('/tests/' . $job->id . '/archive')->status_is(302)->header_like('Location' => qr|/archives/job_|);
-    my $archive_url = $t->tx->res->headers->location;
-    $t->get_ok('/tests/' . $job->id . '/downloads_ajax')->status_is(200)
-      ->element_exists('a[title="Download all test results and assets as a ZIP archive"]');
-    $t->get_ok($archive_url)->status_is(200)->content_type_is('application/zip')
-      ->header_is('Content-Disposition' => 'attachment; filename=job_' . $job->id . '.zip;');
-    my $zip_content = $t->tx->res->body;
-    my $zip_file = $tmp->child('downloaded.zip');
-    $zip_file->spew($zip_content);
-    my $zip = Archive::Zip->new();
-    is $zip->read($zip_file->to_string), AZ_OK, 'Zip is valid';
-    ok $zip->memberNamed('testresults/details-test.json'), 'Contains test results';
-    ok $zip->memberNamed('testresults/ulogs/test.log'), 'Contains ulogs';
-    ok $zip->memberNamed('iso/test.iso'), 'Contains assets';
-    is $zip->contents('testresults/details-test.json'), '{"test": "data"}', 'Result content is correct';
-    is $zip->contents('iso/test.iso'), 'iso data', 'Asset content is correct';
+    ok $case->login($t, 'admin'), 'Admin login succeeds';
+
+    my @test_cases = (
+        {
+            category => 'all',
+            expected => [qw(testresults/vars.json testresults/ulogs/test.log iso/test.iso)],
+        },
+        {
+            category => 'resultfiles',
+            expected => ['testresults/vars.json'],
+            unexpected => [qw(testresults/ulogs/test.log iso/test.iso)],
+        },
+        {
+            category => 'ulogs',
+            expected => ['testresults/ulogs/test.log'],
+            unexpected => [qw(testresults/vars.json iso/test.iso)],
+        },
+        {
+            category => 'assets',
+            expected => ['iso/test.iso'],
+            unexpected => [qw(testresults/vars.json testresults/ulogs/test.log)],
+        },
+    );
+
+    for my $tc (@test_cases) {
+        my $cat = $tc->{category};
+        my $url = '/tests/' . $job->id . '/archive' . ($cat eq 'all' ? '' : "?category=$cat");
+        my $suffix = $cat eq 'all' ? '' : "_$cat";
+
+        $t->get_ok($url)->status_is(302)->header_like('Location' => qr|/archives/job_@{[ $job->id ]}${suffix}\.zip|);
+        $t->get_ok($t->tx->res->headers->location)->status_is(200)->content_type_is('application/zip');
+
+        my $zip = Archive::Zip->new();
+        my $content = $t->tx->res->body;
+        open my $fh, '<', \$content;
+        is $zip->read($fh), AZ_OK, "ZIP archive for category '$cat' is structurally valid";
+
+        ok $zip->memberNamed($_), "Category '$cat' archive correctly includes: $_" for @{$tc->{expected}};
+        ok !$zip->memberNamed($_), "Category '$cat' archive correctly excludes: $_" for @{$tc->{unexpected} // []};
+    }
 };
 
 subtest 'Archive with large files' => sub {
@@ -101,32 +110,29 @@ subtest 'Archive with large files' => sub {
         });
     my $res_dir = path($job->create_result_dir);
     my $large_file = $res_dir->child('large.bin');
-    # 50MB is enough to test without taking too long
     my $fh = $large_file->open('>');
-    for (1 .. 50 * 1024) {
-        print $fh 'A' x 1024;
-    }
+    print $fh 'A' x 1024 for 1 .. 50 * 1024;
     $fh->close;
 
     my $archive_path = OpenQA::Archive::create_job_archive($job);
-    ok -e $archive_path, 'Archive with large file created';
+    ok -e $archive_path, 'Archive with 50MB file created successfully';
     my $zip = Archive::Zip->new();
-    is $zip->read($archive_path->to_string), AZ_OK, 'Large zip is valid';
+    is $zip->read($archive_path->to_string), AZ_OK, 'Large ZIP archive is readable';
     my $member = $zip->memberNamed('testresults/large.bin');
-    ok $member, 'Contains large file';
-    is $member->uncompressedSize, 50 * 1024 * 1024, 'Size is correct';
+    ok $member, 'ZIP archive contains the large file';
+    is $member->uncompressedSize, 50 * 1024 * 1024, 'Archived file size matches expected 50MB';
 };
 
 subtest 'Archive caching' => sub {
     my $job_id = $schema->resultset('Jobs')->first->id;
     my $cache_file = path($ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR})->child("job_$job_id.zip");
-    ok -e $cache_file, 'Archive is cached';
+    ok -e $cache_file, 'Initial archive exists in cache';
     my $mtime = $cache_file->stat->mtime;
     utime $mtime - 10, $mtime - 10, $cache_file->to_string;
     $mtime = $cache_file->stat->mtime;
     $t->get_ok('/tests/' . $job_id . '/archive')->status_is(302);
     $t->get_ok($t->tx->res->headers->location)->status_is(200);
-    is $cache_file->stat->mtime, $mtime, 'Cached file was reused';
+    is $cache_file->stat->mtime, $mtime, 'Archive request reuses existing cached file without regeneration';
 };
 
 subtest 'Hide "Download All" button when no content' => sub {
@@ -155,17 +161,20 @@ subtest 'Cache limit calculation' => sub {
     my $orig_env = $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR};
     delete $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR};
     is OpenQA::Archive::archive_cache_dir(), $app->config->{job_details_archive}->{job_details_archive_cache_dir},
-      'Cache dir from config';
-    is OpenQA::Archive::get_cache_limit(), 1024 * 1024 * 1024, 'Limit in bytes';
-    is OpenQA::Archive::get_min_free_percentage(), 20, 'Min free percentage';
-    is OpenQA::Archive::get_watermark_percentage(), 50, 'Watermark percentage';
-    ok OpenQA::Archive::is_cache_limit_exceeded(2 * 1024 * 1024 * 1024, 100, 1000), 'Limit exceeded by size';
-    ok OpenQA::Archive::is_cache_limit_exceeded(100, 10, 100), 'Limit exceeded by free percentage';
-    ok !OpenQA::Archive::is_cache_limit_exceeded(100, 30, 100), 'Limit not exceeded';
+      'Archive cache directory follows application config';
+    is OpenQA::Archive::get_cache_limit(), 1024 * 1024 * 1024, 'Cache size limit is correctly converted to bytes';
+    is OpenQA::Archive::get_min_free_percentage(), 20, 'Minimum free space percentage follows config';
+    is OpenQA::Archive::get_watermark_percentage(), 50, 'Cleanup watermark percentage follows config';
+    ok OpenQA::Archive::is_cache_limit_exceeded(2 * 1024 * 1024 * 1024, 100, 1000),
+      'Cache limit is exceeded when current size is over threshold';
+    ok OpenQA::Archive::is_cache_limit_exceeded(100, 10, 100),
+      'Cache limit is exceeded when free disk space is below minimum';
+    ok !OpenQA::Archive::is_cache_limit_exceeded(100, 30, 100),
+      'Cache limit is not exceeded when within safety thresholds';
     delete $app->config->{job_details_archive}->{job_details_archive_cache_dir};
-    like OpenQA::Archive::archive_cache_dir(), qr|/webui/cache/archives$|, 'Default cache dir';
+    like OpenQA::Archive::archive_cache_dir(), qr|/webui/cache/archives$|, 'Fallback to default cache directory works';
     delete $app->config->{job_details_archive};
-    is OpenQA::Archive::get_cache_limit(), 5 * 1024 * 1024 * 1024, 'Default limit';
+    is OpenQA::Archive::get_cache_limit(), 5 * 1024 * 1024 * 1024, 'Default cache limit is 5GB';
     $ENV{OPENQA_JOB_DETAILS_ARCHIVE_CACHE_DIR} = $orig_env;
     $app->config->{job_details_archive} = $orig_config;
 };
@@ -188,7 +197,7 @@ subtest 'Cache cleanup execution' => sub {
     my @initial = $cache_dir->list->grep(sub { $_->basename =~ /^job_\d+\.zip$/ })->each;
     OpenQA::Archive::cleanup_cache();
     my @remaining = $cache_dir->list->grep(sub { $_->basename =~ /^job_\d+\.zip$/ })->each;
-    ok scalar(@remaining) < scalar(@initial), 'Some archives were removed during cleanup';
+    ok scalar(@remaining) < scalar(@initial), 'Archive cache is rotated after exceeding limit';
     $app->config->{job_details_archive} = $orig_config;
 };
 
@@ -210,7 +219,8 @@ subtest 'Create archive details' => sub {
     $mock_assets_rs->mock(next => sub { shift @assets });
     $mock_job->set_always(jobs_assets => $mock_assets_rs);
     my $archive_path = OpenQA::Archive::create_job_archive($mock_job);
-    ok -e $archive_path, 'Archive created with directory asset';
+    ok -e $archive_path, 'Archive is created correctly when an asset is a directory';
+
     my $mock_asset_missing = Test::MockObject->new;
     $mock_asset_missing->set_always(disk_file => $tmp->child('nonexistent_asset')->to_string);
     $mock_asset_missing->set_always(name => 'missing_asset');
@@ -221,9 +231,10 @@ subtest 'Create archive details' => sub {
     $mock_assets_rs->mock(next => sub { shift @assets_missing });
     $mock_job->set_always(id => 7890);
     my $archive_path_missing = OpenQA::Archive::create_job_archive($mock_job);
-    ok -e $archive_path_missing, 'Archive created even with missing asset file';
+    ok -e $archive_path_missing, 'Archive creation succeeds even if an asset file is missing from disk';
     my $archive_path2 = OpenQA::Archive::create_job_archive($mock_job);
-    is $archive_path2->to_string, $archive_path_missing->to_string, 'Returned existing archive';
+    is $archive_path2->to_string, $archive_path_missing->to_string,
+      'Archive request returns existing file if already present in cache';
 };
 
 subtest 'Create archive failure' => sub {
@@ -238,33 +249,33 @@ subtest 'Create archive failure' => sub {
             path($file)->spew('dummy');
             return AZ_IO_ERROR;
         });
-    throws_ok { OpenQA::Archive::create_job_archive($mock_job) } qr/Failed to create archive/, 'Throws on zip failure';
+    throws_ok { OpenQA::Archive::create_job_archive($mock_job) } qr/Failed to create archive/,
+      'Archive creation throws error on ZIP library failure';
 };
 
-subtest 'CreateZipArchive task' => sub {
+subtest 'CreateZipArchive Minion task' => sub {
     require OpenQA::Task::Job::CreateZipArchive;
-    my $mock_minion_job = Test::MockObject->new;
-    $mock_minion_job->set_always(app => $app);
+    my $mock_minion_job = Test::MockObject->new->set_always(app => $app)->set_true('finish')->set_true('fail');
     my $mock_schema_obj = Test::MockObject->new;
     my $mock_rs = Test::MockObject->new;
     $mock_schema_obj->set_always(resultset => $mock_rs);
     $mock_rs->set_always(find => undef);
+
     my $mock_app_module = Test::MockModule->new('OpenQA::WebAPI');
     $mock_app_module->mock(schema => sub { $mock_schema_obj });
-    $mock_minion_job->set_true('finish');
     OpenQA::Task::Job::CreateZipArchive::_create_zip_archive($mock_minion_job, 4567);
-    $mock_minion_job->called_ok('finish', 'Finished with job not found message');
-    my $mock_job = Test::MockObject->new;
-    $mock_job->set_always(id => 4567);
+    $mock_minion_job->called_ok('finish', 'Task finishes gracefully if job is not found in database');
+
+    my $mock_job = Test::MockObject->new->set_always(id => 4567);
     $mock_rs->set_always(find => $mock_job);
     my $mock_archive_module = Test::MockModule->new('OpenQA::Archive');
     $mock_archive_module->mock(create_job_archive => sub { path('/tmp/dummy.zip') });
     OpenQA::Task::Job::CreateZipArchive::_create_zip_archive($mock_minion_job, 4567);
-    $mock_minion_job->called_ok('finish', 'Finished successfully');
+    $mock_minion_job->called_ok('finish', 'Task completes successfully after archive generation');
+
     $mock_archive_module->mock(create_job_archive => sub { die 'creation error' });
-    $mock_minion_job->set_true('fail');
     OpenQA::Task::Job::CreateZipArchive::_create_zip_archive($mock_minion_job, 4567);
-    $mock_minion_job->called_ok('fail', 'Failed correctly on error');
+    $mock_minion_job->called_ok('fail', 'Task fails correctly when archive generation logic throws an exception');
 
     # Verify create_zip_archive_limit config is respected
     my $mock_minion = Test::MockModule->new('Minion');
@@ -296,7 +307,7 @@ subtest 'CreateZipArchive task' => sub {
     $mock_minion->unmock_all;
 };
 
-subtest 'Controller extra tests' => sub {
+subtest 'Controller archive endpoint' => sub {
     my $job = $schema->resultset('Jobs')->create(
         {
             DISTRI => 'archtest',
@@ -309,7 +320,8 @@ subtest 'Controller extra tests' => sub {
         });
     $t->get_ok('/archives/..%2fetc%2fpasswd')->status_is(404);
     $t->get_ok('/archives/nonexistent.zip')->status_is(404);
-    my $mock_minion = Test::MockObject->new;
+
+    my $mock_minion = Test::MockObject->new->set_true('enqueue');
     my $mock_app_module = Test::MockModule->new('OpenQA::WebAPI');
     $mock_app_module->mock(minion => sub { $mock_minion });
     my $orig_can = $app->can('can');
@@ -321,12 +333,11 @@ subtest 'Controller extra tests' => sub {
     $mock_minion->set_true('enqueue');
 
     $case->login($t, 'admin');
-
     $t->get_ok('/tests/' . $job->id . '/archive')->status_is(200)->content_like(qr/Preparing Archive for Job/);
-    $mock_minion->called_ok('enqueue', 'Minion job enqueued');
+    $mock_minion->called_ok('enqueue', 'Archive generation is enqueued in Minion');
     $mock_minion->clear;
     $t->get_ok('/tests/' . $job->id . '/archive')->status_is(200);
-    $mock_minion->called_ok('enqueue', 'Minion job enqueued again');
+    $mock_minion->called_ok('enqueue', 'Repeated archive request re-enqueues generation task');
 
     $mock_minion->mock(enqueue => sub { die 'Enqueue failed' });
     $t->get_ok('/tests/' . $job->id . '/archive')->status_is(500)->content_is('Internal Server Error');

--- a/templates/webapi/test/downloads.html.ep
+++ b/templates/webapi/test/downloads.html.ep
@@ -8,11 +8,23 @@
 % }
 
 % if(@$resultfiles) {
-    <h5>Result files</h5>
+    <h5>Result files
+        % if (current_user) {
+            %= link_to url_for('test_archive', testid => $job->id)->query(category => 'resultfiles') => (class => 'btn btn-outline-primary btn-sm ms-2', title => 'Download result files as a ZIP archive', rel => 'nofollow') => begin
+                <i class="fa fa-download"></i> Download (ZIP)
+            % end
+        % }
+    </h5>
     %= include 'test/result_file_list', resultfiles => $resultfiles, is_userfile => 0
 % }
 % if (@$ulogs) {
-    <h6>Uploaded logs</h6>
+    <h6>Uploaded logs
+        % if (current_user) {
+            %= link_to url_for('test_archive', testid => $job->id)->query(category => 'ulogs') => (class => 'btn btn-outline-primary btn-sm ms-2', title => 'Download uploaded logs as a ZIP archive', rel => 'nofollow') => begin
+                <i class="fa fa-download"></i> Download (ZIP)
+            % end
+        % }
+    </h6>
     %= include 'test/result_file_list', resultfiles => $ulogs, is_userfile => 1
 % }
 
@@ -38,6 +50,12 @@
     % }
 % }
 % if (length(content('asset_box'))) {
-    <h5>Assets</h5>
+    <h5>Assets
+        % if (current_user) {
+            %= link_to url_for('test_archive', testid => $job->id)->query(category => 'assets') => (class => 'btn btn-outline-primary btn-sm ms-2', title => 'Download assets as a ZIP archive', rel => 'nofollow') => begin
+                <i class="fa fa-download"></i> Download (ZIP)
+            % end
+        % }
+    </h5>
     <ul id="asset-list"><%= content 'asset_box' %></ul>
 % }


### PR DESCRIPTION
## Motivation
Packaging multi-gigabyte assets into an archive just to access a few
kilobytes of text logs is highly inefficient and wastes both disk space
and bandwidth.

## Design Choices
- Refactored OpenQA::Archive::create_job_archive to support a 'category'
  parameter (all, resultfiles, ulogs, assets).
- Updated the create_zip_archive Minion task to pass the category.
- Added 'Download (ZIP)' buttons next to headers on the Downloads tab.
- Updated cache cleanup logic to handle category-specific archive names.
- Added comprehensive tests for each category.

## Benefits
- Users can selectively download only logs or results without fetching
  huge assets.
- Reduced server-side disk usage for temporary archives.
- Faster download times for targeted troubleshooting.

## Visual appearance
<img width="309" height="318" alt="Screenshot_20260618_092808_openqa_category_download_buttons" src="https://github.com/user-attachments/assets/9b234992-3c83-4101-8730-626032cff83f" />


## References
Related issue: gh7010