### PR TITLE
fix: fix user namespace mapping errors in podman

### DIFF
--- a/container/systemd/openqa-llm-server.container
+++ b/container/systemd/openqa-llm-server.container
@@ -5,10 +5,9 @@ After=network-online.target
 [Container]
 Image=ghcr.io/ggml-org/llama.cpp:server
 ContainerName=openqa-llm-server
-Volume=/opt/llm/models:/models:U
+Volume=/opt/llm/models:/models
 PublishPort=8080:8080
 Exec=-hf unsloth/gemma-4-E4B-it-GGUF:UD-IQ2_M --temp 1.0 --top-p 0.95 --top-k 64 --ctx-size 65536
-UserNS=auto
 Environment=HF_HOME=/models
 Environment=LLAMA_CACHE=/models
 


### PR DESCRIPTION
Motivation:
The systemd quadlet container openqa-llm-server failed to start on openQA
workers with user namespace mapping and subuid exhaustion errors.

Design Choices:
- Remove UserNS=auto from the container definition.
- Remove the :U volume option to run in the default host user namespace.

Benefits:
- Restores startup of the openqa-llm-server on standard openQA workers.
- Avoids manual configuration of /etc/subuid and /etc/subgid for root.

Verification:
Verified on SUSE internal worker

Related issue: https://progress.opensuse.org/issues/199181