### PR TITLE
feat(container): prioritize openQA tests over LLM container

### DIFF
--- a/container/systemd/openqa-llm-server.container
+++ b/container/systemd/openqa-llm-server.container
@@ -12,6 +12,11 @@ Environment=HF_HOME=/models
 Environment=LLAMA_CACHE=/models
 
 [Service]
+Nice=12
+CPUWeight=50
+IOSchedulingClass=best-effort
+IOSchedulingPriority=5
+OOMScoreAdjust=500
 Restart=always
 TimeoutStartSec=900
 


### PR DESCRIPTION
Motivation:
Prevent the resource-heavy LLM container from starving latency-sensitive
openQA test execution workloads of CPU, disk I/O, and memory resources.

Design Choices:
Set nice level to 12, lower CPUWeight to 50, and use best-effort class 5
for disk I/O. Add OOMScoreAdjust=500 to keep openQA processes safe.

Benefits:
Guarantees a middle-ground resource share for the LLM container while keeping
the host system stable and openQA test environments responsive under load.