### PR TITLE
tests: Make parallel execution of the fullstack test more reliable

### DIFF
--- a/t/data/workers.ini
+++ b/t/data/workers.ini
@@ -7,6 +7,6 @@ WORKER_HOSTNAME = 127.0.0.1
 # the value set to 0 prevents jobs from being blocked in ci
 CRITICAL_LOAD_AVG_THRESHOLD = 0
 
-[1-99]
+[1-1024]
 WORKER_CLASS = qemu_i386,qemu_x86_64
 

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -304,6 +304,7 @@ subtest 'incomplete job because of setup failure' => sub {
 my $cache_location = path($ENV{OPENQA_BASEDIR}, 'cache')->make_path;
 ok -e $cache_location, 'Setting up Cache directory';
 
+my $max_instances = MAX_WORKER_INSTANCES;
 path($ENV{OPENQA_CONFIG})->child('workers.ini')->spew(<<"EOC");
 [global]
 CACHEDIRECTORY = $cache_location
@@ -313,7 +314,7 @@ LOCAL_UPLOAD = 0
 # Ensure fullstack tests run even under high load.
 CRITICAL_LOAD_AVG_THRESHOLD = 0
 
-[1-99]
+[1-$max_instances]
 WORKER_CLASS = qemu_i386,qemu_x86_64
 
 [http://localhost:$mojoport]

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -38,7 +38,11 @@ use OpenQA::Test::TimeLimit ();
 use Feature::Compat::Try;
 use Time::HiRes 'sleep';
 
-use constant MAX_WORKER_INSTANCES => 64;
+use constant MAX_WORKER_INSTANCES => 1024;
+# That is the highest power of two that still leaves os-autoinst enough headroom
+# to compute port numbers. This means there is only a < 0.1 % chance of running
+# into a conflict when running two fullstack tests in parallel and we still avoid
+# exceeding the maximum port number.
 
 BEGIN {
     if (!$ENV{MOJO_HOME}) {


### PR DESCRIPTION
Before there was a change of around 1.5625 % for choosing a conflicting worker instance number when running the developer and regular fullstack tests in parallel. This change does not fix the problem completely but now
the change is at least only 0.09765625 %.