### PR TITLE
fix(obs_rsync): use scope guards to avoid stalls

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync.pm
@@ -100,8 +100,6 @@ sub register ($self, $app, $config) {
         $app->helper('obs_rsync.log_failure' => \&_log_failure);
         $app->helper('obs_rsync.concurrency_guard' => \&_concurrency_guard);
         $app->helper('obs_rsync.guard' => \&_guard);
-        $app->helper('obs_rsync.lock' => \&_lock);
-        $app->helper('obs_rsync.unlock' => \&_unlock);
 
         # Templates
         push @{$app->renderer->paths},
@@ -447,14 +445,6 @@ sub _concurrency_guard ($c) {
 
 sub _guard ($c, $project) {
     return $c->app->minion->guard('obs_rsync_project_' . $project . '_lock', LOCK_TIMEOUT);
-}
-
-sub _lock ($c, $project) {
-    return $c->app->minion->lock('obs_rsync_project_' . $project . '_lock', LOCK_TIMEOUT);
-}
-
-sub _unlock ($c, $project) {
-    return $c->app->minion->unlock('obs_rsync_project_' . $project . '_lock');
 }
 
 sub _log_job_id ($c, $project, $job_id) {

--- a/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
+++ b/lib/OpenQA/WebAPI/Plugin/ObsRsync/Task.pm
@@ -24,7 +24,6 @@ sub _retry_or_finish ($job, $helper, $project = undef, $retry_interval = undef, 
     return $job->retry({delay => $retry_interval})
       if !$retry_max_count || $job->retries < $retry_max_count;
 
-    $helper->unlock($project) if $project;
     return $job->finish(
         {code => 2, message => "Exceeded retry count $retry_max_count. Consider job will be re-triggered later"});
 }
@@ -46,18 +45,18 @@ sub run ($job, $args) {
     my $helper = $app->obs_rsync;
     my $home = $helper->home;
 
-    if ($job->info && !$job->info->{notes}{project_lock}) {
-        return _retry_or_finish($job, $helper) unless $helper->lock($project);
-        $job->note(project_lock => 1);
-    }
+    return _retry_or_finish($job, $helper)
+      unless my $project_guard = $helper->guard($project);
+    $job->note(project_lock => 1);
+
     my $dirty = 0;
     try { $dirty = $helper->is_status_dirty($project, 1) }
     catch ($e) {
-        return _retry_or_finish($job, $helper, $project, RETRY_INTERVAL_ON_EXCEPTION, RETRY_MAX_COUNT_ON_EXCEPTION);
+        return _retry_or_finish($job, $helper, undef, RETRY_INTERVAL_ON_EXCEPTION, RETRY_MAX_COUNT_ON_EXCEPTION);
     }
-    return _retry_or_finish($job, $helper, $project) if $dirty;
+    return _retry_or_finish($job, $helper) if $dirty;
 
-    return _retry_or_finish($job, $helper, $project)
+    return _retry_or_finish($job, $helper)
       unless my $concurrency_guard = $helper->concurrency_guard();
 
     $helper->log_job_id($project, $job->id);
@@ -68,7 +67,6 @@ sub run ($job, $args) {
     try { IPC::Run::run(\@cmd, \$stdin, \$stdout, \$error); $exit_code = $?; }
     catch ($e) { $error_from_exception = $e }
 
-    $helper->unlock($project);
     return $job->finish(0) if (!$exit_code);
 
     $error ||= $error_from_exception;

--- a/t/api/14-plugin_obs_rsync.t
+++ b/t/api/14-plugin_obs_rsync.t
@@ -102,13 +102,14 @@ subtest 'test_result' => sub {
 
 sub lock_test {
     # use BAIL_OUT because only first failure is important
-    BAIL_OUT('Cannot lock') unless $helper->lock('Proj1');
-    BAIL_OUT('Shouldnt lock') if $helper->lock('Proj1');
-    BAIL_OUT('Cannot unlock') unless $helper->unlock('Proj1');
-    BAIL_OUT('Cannot lock') unless $helper->lock('Proj1');
-    BAIL_OUT('Shouldnt lock') if $helper->lock('Proj1');
-    BAIL_OUT('Cannot unlock') unless $helper->unlock('Proj1');
-    ok 1, 'lock/unlock behaves as expected';
+    my $guard1 = $helper->guard('Proj1');
+    BAIL_OUT('Cannot lock via guard') unless $guard1;
+    BAIL_OUT('Shouldnt lock twice') if $helper->guard('Proj1');
+    undef $guard1;
+    my $guard2 = $helper->guard('Proj1');
+    BAIL_OUT('Cannot lock via guard after release') unless $guard2;
+    undef $guard2;
+    ok 1, 'guard behaves as expected';
 }
 
 subtest 'test lock smoke' => sub {

--- a/t/ui/27-plugin_obs_rsync_gru.t
+++ b/t/ui/27-plugin_obs_rsync_gru.t
@@ -22,7 +22,7 @@ package FakeMinionJob {
     has app => sub { $app };
     has retries => 200;
     sub finish ($self, $result) { $self->{state} = 'finished'; $self->{result} = $result }
-    sub info (@) { {notes => {project_lock => 1}} }
+    sub note ($self, @args) { }
 }    # uncoverable statement
 
 $t->post_ok('/admin/obs_rsync/Proj1/runs' => $params)->status_is(201, 'trigger rsync');
@@ -52,7 +52,10 @@ subtest 'process minion jobs' => sub {
 };
 
 subtest 'retrying' => sub {
-    my $obs_rsync = Test::MockObject->new->set_always(home => 'home')->set_true('unlock');
+    my $obs_rsync
+      = Test::MockObject->new->set_always(home => 'home')->set_true('unlock')
+      ->set_always(guard => Test::MockObject->new)->set_always(retry_interval => 120)
+      ->set_always(retry_max_count => 200);
     $obs_rsync->mock(is_status_dirty => sub { die "is_status_dirty failed\n" });
     my $job = FakeMinionJob->new(app => Test::MockObject->new->set_always(obs_rsync => $obs_rsync));
     OpenQA::WebAPI::Plugin::ObsRsync::Task::run($job, {project => 'foo'});


### PR DESCRIPTION
When an openQA worker is restarted or dies, manual project locks in `obs_rsync_run` leak because the `unlock` call at the end of the script is never reached. This causes subsequent jobs for the same project to get stuck in a retry loop continually cycling between `active` and `inactive` states.

* Use a scope-based guard (`$helper->guard`) in `ObsRsync/Task.pm` to have Perl's garbage collector automatically release the database lock when the job (scope) exits for any reason.
* The `$job->note(project_lock => 1)` assignment is retained because the `Gru` queue controller explicitly relies on this metadata note to differentiate between jobs that are actively syncing versus those waiting in the queue.

Related Progress Issue: https://progress.opensuse.org/issues/202725