### PR TITLE
refactor: Calculate module category headings in frontend

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -240,6 +240,7 @@ function batchProcess(items, processor, options = {}) {
   const {batchSize = DEFAULT_BATCH_SIZE, shouldContinue = () => true} = options;
   let currentIndex = 0;
 
+  let category = '';
   return new Promise((resolve, reject) => {
     function processNextBatch() {
       if (!shouldContinue()) {
@@ -250,7 +251,7 @@ function batchProcess(items, processor, options = {}) {
       const end = Math.min(currentIndex + batchSize, items.length);
       try {
         for (; currentIndex < end; currentIndex++) {
-          processor(items[currentIndex], currentIndex);
+          category = processor(items[currentIndex], currentIndex, category);
         }
       } catch (err) {
         reject(err);
@@ -293,13 +294,14 @@ async function renderModuleTable(container, response, shouldContinue = () => tru
 
   return batchProcess(
     response.modules,
-    module => {
-      if (module.category) {
+    (module, i, category) => {
+      if (module.category !== category) {
         tbody.appendChild(
           E('tr', [E('td', [E('i', [], {class: 'fa-regular fa-folderpen'}), '\u00a0' + module.category], {colspan: 3})])
         );
       }
       tbody.appendChild(renderModuleRow(module, response.snippets));
+      return module.category;
     },
     {shouldContinue}
   );

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -619,7 +619,6 @@ sub human_readable_size ($size) {
 sub read_test_modules ($job) {
     return undef unless my $testresultdir = $job->result_dir;
 
-    my $category;
     my $has_parser_text_results = 0;
     my (@modlist, @errors);
 
@@ -655,6 +654,7 @@ sub read_test_modules ($job) {
           {
             name => $module->name,
             result => $module->result,
+            category => $module->category,
             details => \@details,
             milestone => $module->milestone,
             important => $module->important,
@@ -664,12 +664,6 @@ sub read_test_modules ($job) {
             has_parser_text_result => $has_module_parser_text_result,
             execution_time => change_sec_to_word($module_results->{execution_time}),
           };
-
-        if (!$category || $category ne $module->category) {
-            $category = $module->category;
-            $modlist[-1]->{category} = $category;
-        }
-
     }
 
     return {modules => \@modlist, errors => \@errors, has_parser_text_results => $has_parser_text_results};


### PR DESCRIPTION
This way it's easier to access each modules category.

Issue: https://progress.opensuse.org/issues/201840